### PR TITLE
fix(core): fix MerkleTree.leafCount, export compareBytes, add proof round-trip tests

### DIFF
--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -8,6 +8,6 @@ export {
 
 export { sha256 } from './hashing.js';
 
-export { MerkleTree } from './merkle.js';
+export { MerkleTree, compareBytes } from './merkle.js';
 
 export { canonicalize, hashTriple } from './canonicalize.js';

--- a/packages/core/src/crypto/merkle.ts
+++ b/packages/core/src/crypto/merkle.ts
@@ -1,6 +1,6 @@
 import { sha256 } from './hashing.js';
 
-function compareBytes(a: Uint8Array, b: Uint8Array): number {
+export function compareBytes(a: Uint8Array, b: Uint8Array): number {
   const len = Math.min(a.length, b.length);
   for (let i = 0; i < len; i++) {
     if (a[i] !== b[i]) return a[i] - b[i];
@@ -17,14 +17,17 @@ function hashPair(left: Uint8Array, right: Uint8Array): Uint8Array {
 
 export class MerkleTree {
   private readonly layers: Uint8Array[][];
+  private readonly _originalLeafCount: number;
 
   constructor(leaves: Uint8Array[]) {
     if (leaves.length === 0) {
       this.layers = [[]];
+      this._originalLeafCount = 0;
       return;
     }
 
     const sorted = [...leaves].sort(compareBytes);
+    this._originalLeafCount = sorted.length;
     this.layers = [sorted];
     this.buildTree();
   }
@@ -52,7 +55,7 @@ export class MerkleTree {
   }
 
   get leafCount(): number {
-    return this.layers[0].length;
+    return this._originalLeafCount;
   }
 
   proof(leafIndex: number): Uint8Array[] {

--- a/packages/core/src/crypto/merkle.ts
+++ b/packages/core/src/crypto/merkle.ts
@@ -59,7 +59,7 @@ export class MerkleTree {
   }
 
   proof(leafIndex: number): Uint8Array[] {
-    if (leafIndex < 0 || leafIndex >= this.layers[0].length) {
+    if (leafIndex < 0 || leafIndex >= this._originalLeafCount) {
       throw new RangeError(`Leaf index ${leafIndex} out of range`);
     }
 

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -64,6 +64,22 @@ describe('MerkleTree', () => {
     expect(tree.root).toHaveLength(32);
   });
 
+  it('leafCount returns original count, not padded (odd leaves)', () => {
+    const leaves = ['a', 'b', 'c', 'd', 'e'].map(s =>
+      sha256(new TextEncoder().encode(s)),
+    );
+    const tree = new MerkleTree(leaves);
+    expect(tree.leafCount).toBe(5);
+  });
+
+  it('leafCount returns original count for even leaves', () => {
+    const leaves = ['a', 'b', 'c', 'd'].map(s =>
+      sha256(new TextEncoder().encode(s)),
+    );
+    const tree = new MerkleTree(leaves);
+    expect(tree.leafCount).toBe(4);
+  });
+
   it('is order-independent (sorted internally)', () => {
     const a = sha256(new TextEncoder().encode('a'));
     const b = sha256(new TextEncoder().encode('b'));

--- a/packages/core/test/crypto.test.ts
+++ b/packages/core/test/crypto.test.ts
@@ -64,6 +64,17 @@ describe('MerkleTree', () => {
     expect(tree.root).toHaveLength(32);
   });
 
+  it('proof() rejects index at padding boundary for odd-leaf trees', () => {
+    const leaves = ['a', 'b', 'c'].map(s =>
+      sha256(new TextEncoder().encode(s)),
+    );
+    const tree = new MerkleTree(leaves);
+    expect(tree.leafCount).toBe(3);
+    // Index 0-2 are valid, index 3 is the synthetic duplicate padding leaf
+    expect(() => tree.proof(2)).not.toThrow();
+    expect(() => tree.proof(3)).toThrow(RangeError);
+  });
+
   it('leafCount returns original count, not padded (odd leaves)', () => {
     const leaves = ['a', 'b', 'c', 'd', 'e'].map(s =>
       sha256(new TextEncoder().encode(s)),

--- a/packages/publisher/src/proof-index.ts
+++ b/packages/publisher/src/proof-index.ts
@@ -1,4 +1,4 @@
-import { MerkleTree, hashTriple } from '@origintrail-official/dkg-core';
+import { MerkleTree, hashTriple, compareBytes } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 
 export interface TripleProof {
@@ -16,14 +16,6 @@ interface BatchEntry {
 
 function toHex(bytes: Uint8Array): string {
   return '0x' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
-}
-
-function compareBytes(a: Uint8Array, b: Uint8Array): number {
-  const len = Math.min(a.length, b.length);
-  for (let i = 0; i < len; i++) {
-    if (a[i] !== b[i]) return a[i] - b[i];
-  }
-  return a.length - b.length;
 }
 
 /**

--- a/packages/publisher/test/merkle.test.ts
+++ b/packages/publisher/test/merkle.test.ts
@@ -25,14 +25,16 @@
  */
 import { describe, it, expect } from 'vitest';
 import type { Quad } from '@origintrail-official/dkg-storage';
-import { MerkleTree, hashTriple, sha256 } from '@origintrail-official/dkg-core';
+import { MerkleTree, hashTriple, sha256, compareBytes } from '@origintrail-official/dkg-core';
 import {
   computeTripleHash,
   computePublicRoot,
   computePrivateRoot,
   computeKARoot,
   computeKCRoot,
+  computeFlatKCRoot,
 } from '../src/merkle.js';
+import { ProofIndex } from '../src/proof-index.js';
 
 const GRAPH = 'did:dkg:paranet:test';
 
@@ -402,6 +404,70 @@ describe('Merkle / triple hashing (robust)', () => {
       const rootWithout = computePublicRoot([normal]);
       expect(rootWithSynthetic).not.toEqual(rootWithout);
       expect(rootWithSynthetic).toHaveLength(32);
+    });
+  });
+
+  describe('round-trip proof verification', () => {
+    it('computeFlatKCRoot and MerkleTree produce identical roots for the same quads', () => {
+      const quads = [
+        q('urn:a', 'urn:p', '"v1"'),
+        q('urn:b', 'urn:p', '"v2"'),
+        q('urn:c', 'urn:p', '"v3"'),
+      ];
+      const rootFromFlat = computeFlatKCRoot(quads, []);
+      const hashes = quads.map(computeTripleHash);
+      const rootFromTree = new MerkleTree(hashes).root;
+      expect(hex(rootFromFlat)).toBe(hex(rootFromTree));
+    });
+
+    it('ProofIndex generates proofs verifiable against computeFlatKCRoot', () => {
+      const quads = [
+        q('urn:entity:1', 'urn:prop:a', '"alpha"'),
+        q('urn:entity:2', 'urn:prop:b', '"beta"'),
+        q('urn:entity:3', 'urn:prop:c', '"gamma"'),
+        q('urn:entity:4', 'urn:prop:d', '"delta"'),
+        q('urn:entity:5', 'urn:prop:e', '"epsilon"'),
+      ];
+
+      const root = computeFlatKCRoot(quads, []);
+      const proofIdx = new ProofIndex();
+      proofIdx.storeBatch('ctx-graph-1', 'batch-1', quads);
+
+      for (const quad of quads) {
+        const proof = proofIdx.generateProof('ctx-graph-1', quad.subject, quad.predicate, quad.object);
+        expect(proof).toBeDefined();
+        const tripleHash = computeTripleHash(quad);
+        const ok = MerkleTree.verify(
+          root,
+          tripleHash,
+          proof!.siblings.map(h => Buffer.from(h.slice(2), 'hex')),
+          proof!.leafIndex,
+        );
+        expect(ok).toBe(true);
+      }
+    });
+
+    it('proof fails against a tampered root', () => {
+      const quads = [
+        q('urn:x', 'urn:p', '"one"'),
+        q('urn:y', 'urn:p', '"two"'),
+      ];
+
+      const proofIdx = new ProofIndex();
+      proofIdx.storeBatch('ctx', 'b1', quads);
+
+      const proof = proofIdx.generateProof('ctx', quads[0].subject, quads[0].predicate, quads[0].object);
+      expect(proof).toBeDefined();
+
+      const fakeRoot = sha256(new TextEncoder().encode('tampered'));
+      const tripleHash = computeTripleHash(quads[0]);
+      const ok = MerkleTree.verify(
+        fakeRoot,
+        tripleHash,
+        proof!.siblings.map(h => Buffer.from(h.slice(2), 'hex')),
+        proof!.leafIndex,
+      );
+      expect(ok).toBe(false);
     });
   });
 });


### PR DESCRIPTION
> _Migrated from dkg-v9 PR #142_

## Summary

- `MerkleTree.leafCount` returned the padded layer-0 length (odd leaf counts get +1 for padding), not the original count. Fixed by storing the pre-padding count separately.
- Exports `compareBytes` from `@dkg/core` so consumers (like `ProofIndex`) don't duplicate it.
- Removes the local `compareBytes` copy from `publisher/src/proof-index.ts`.
- Adds round-trip proof tests that verify the full chain: `computeFlatKCRoot` -> `ProofIndex.generateProof` -> `MerkleTree.verify`.

Addresses audit item **1.3** from `PLAN_CODE_AUDIT_REMEDIATION.md`.

Note: the original audit claimed `computeFlatKCRoot` and `ProofIndex` produce different roots due to sorting mismatch. Investigation showed this is not the case — `MerkleTree` always sorts leaves internally, so both paths produce identical roots for the same leaf set. The real issues were `leafCount` and missing round-trip tests.

## Test plan

- [x] `leafCount returns original count, not padded (odd leaves)` — 5 leaves, expect 5
- [x] `leafCount returns original count for even leaves` — 4 leaves, expect 4
- [x] `computeFlatKCRoot and MerkleTree produce identical roots for the same quads`
- [x] `ProofIndex generates proofs verifiable against computeFlatKCRoot` — full round-trip
- [x] `proof fails against a tampered root` — negative test
- [x] All 17 existing crypto tests + 35 existing merkle tests still pass


Made with [Cursor](https://cursor.com)