### PR TITLE
docs: real-time subscriptions plan (SSE events for multi-agent coordination)

### DIFF
--- a/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
+++ b/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
@@ -161,12 +161,12 @@ Example payloads:
 |-----------|------|---------|-------------|
 | `types` | comma-separated | all | Event types to subscribe to (e.g. `kc:confirmed,workspace:write`) |
 | `paranets` | comma-separated | all | Filter by paranet ID |
-| `since` | epoch ms | now | Replay events after this timestamp (bounded to last 5 min) |
+| `since` | integer (seq ID) | latest | Replay events after this sequence ID (bounded to last 1000 events / 5 min) |
 
 **Example:**
 
 ```
-GET /api/events?types=workspace:write,kc:confirmed&paranets=origin-trail-game&token=<jwt>
+GET /api/events?types=workspace:write,kc:confirmed&paranets=origin-trail-game&ticket=<opaque_ticket>
 Accept: text/event-stream
 ```
 
@@ -261,11 +261,13 @@ class SubscriptionManager {
   removeSubscription(res: ServerResponse): void { ... }
 
   private broadcast(eventType: string, data: unknown): void {
-    const payload = data as DKGEventPayload;
+    const raw = data as Record<string, unknown>;
+    const type = (raw.type as string) ?? eventType;
+    const paranetId = raw.paranetId as string | undefined;
     for (const sub of this.subscriptions) {
-      if (sub.filter.types && !sub.filter.types.has(payload.type)) continue;
-      if (sub.filter.paranets && (!payload.paranetId || !sub.filter.paranets.has(payload.paranetId))) continue;
-      sendSse(sub.res, payload);
+      if (sub.filter.types && !sub.filter.types.has(type)) continue;
+      if (sub.filter.paranets && (!paranetId || !sub.filter.paranets.has(paranetId))) continue;
+      sendSse(sub.res, { ...raw, type }, this.nextSeq++);
     }
   }
 }
@@ -286,7 +288,7 @@ Maintain a bounded ring buffer (last 1000 events, max 5 minutes) in `Subscriptio
 2. Replay matching events from the ring buffer where `seq > since`.
 3. Deduplicate on the client using the `id` field in SSE (`EventSource` handles this natively via `lastEventId`).
 
-This ensures zero event loss on reconnection. The `since` parameter accepts either an epoch-ms timestamp or a sequence ID; the server resolves whichever is provided to the nearest ring-buffer offset.
+This ensures zero event loss on reconnection. The `since` parameter accepts a **sequence ID** (monotonic integer assigned by the server). Clients should persist `lastEventId` from SSE and pass it on reconnect. The server resolves the sequence to the ring-buffer offset. Epoch-ms timestamps are not supported for `since` to avoid ambiguity.
 
 ---
 
@@ -302,25 +304,44 @@ Replace the `setInterval(refreshLobby, 4000)` and `setInterval(refreshSwarm, 300
 
 ```typescript
 useEffect(() => {
-  const nodeUrl = getBaseUrl().replace(/\/api\/apps\/.*$/, '');
-  // Obtain a short-lived, opaque SSE ticket (see auth note in §2.1)
-  const { ticket } = await api.getSseTicket();
-  const es = new EventSource(`${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game&ticket=${ticket}`);
+  let es: EventSource | null = null;
+  let cancelled = false;
 
-  es.addEventListener('game:turn_resolved', (e) => {
-    const data = JSON.parse(e.data);
-    if (data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
-  });
+  async function connect() {
+    const nodeUrl = getBaseUrl().replace(/\/api\/apps\/.*$/, '');
+    const { ticket } = await api.getSseTicket();
+    if (cancelled) return;
+    const url = `${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game&ticket=${ticket}`;
+    es = new EventSource(url);
 
-  es.addEventListener('game:swarm_created', () => refreshLobby());
-  es.addEventListener('game:player_joined', (e) => {
-    const data = JSON.parse(e.data);
-    if (data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
-  });
+    es.addEventListener('game:turn_resolved', (e) => {
+      const data = JSON.parse(e.data);
+      if (data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
+    });
+    es.addEventListener('game:swarm_created', () => refreshLobby());
+    es.addEventListener('game:player_joined', (e) => {
+      const data = JSON.parse(e.data);
+      if (data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
+    });
 
-  return () => es.close();
+    // Reconnect with a fresh ticket on connection loss.
+    // Disable native EventSource reconnect since the ticket is single-use.
+    es.onerror = () => {
+      es?.close();
+      if (!cancelled) setTimeout(connect, 2000);
+    };
+  }
+
+  connect();
+  return () => { cancelled = true; es?.close(); };
 }, [swarm?.id]);
 ```
+
+> **Note on deduplication:** The server assigns monotonic sequence IDs
+> (`id:` field in SSE). On reconnect, the subscribe-then-replay strategy
+> (§2.4) uses the last-seen sequence to avoid overlap. If any duplicate
+> does slip through (e.g., during failover), clients should track the
+> last processed `id` and skip events with `id <= lastSeen`.
 
 **Benefits:**
 - Instant turn resolution (0ms vs 3-4s poll)

--- a/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
+++ b/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
@@ -166,10 +166,16 @@ Example payloads:
 **Example:**
 
 ```
-GET /api/events?types=workspace:write,kc:confirmed&paranets=origin-trail-game
-Authorization: Bearer <token>
+GET /api/events?types=workspace:write,kc:confirmed&paranets=origin-trail-game&token=<jwt>
 Accept: text/event-stream
 ```
+
+> **Auth note:** Browser `EventSource` cannot set custom headers, so SSE
+> endpoints must accept auth via a `token` query parameter (signed JWT or
+> short-lived HMAC token) in addition to the `Authorization` header. The
+> query-param token should be single-use or time-bounded (≤5 min) to
+> limit replay risk. Cookie-based auth is also acceptable when the client
+> and API share the same origin.
 
 **Response:**
 
@@ -247,7 +253,7 @@ class SubscriptionManager {
     const payload = data as DKGEventPayload;
     for (const sub of this.subscriptions) {
       if (sub.filter.types && !sub.filter.types.has(payload.type)) continue;
-      if (sub.filter.paranets && payload.paranetId && !sub.filter.paranets.has(payload.paranetId)) continue;
+      if (sub.filter.paranets && (!payload.paranetId || !sub.filter.paranets.has(payload.paranetId))) continue;
       sendSse(sub.res, payload);
     }
   }
@@ -262,7 +268,14 @@ class SubscriptionManager {
 
 ### 2.4 Event replay
 
-Maintain a bounded ring buffer (last 1000 events, max 5 minutes) in `SubscriptionManager`. When a client connects with `since=<timestamp>`, replay matching events before switching to live streaming. This handles reconnection without missing events.
+Maintain a bounded ring buffer (last 1000 events, max 5 minutes) in `SubscriptionManager`. Each event is assigned an incrementing sequence ID.
+
+**Subscribe-then-replay** to avoid losing events between replay and live attach:
+1. Register the subscription first (live events start buffering to the client's queue).
+2. Replay matching events from the ring buffer where `seq > since`.
+3. Deduplicate on the client using the `id` field in SSE (`EventSource` handles this natively via `lastEventId`).
+
+This ensures zero event loss on reconnection. The `since` parameter accepts either an epoch-ms timestamp or a sequence ID; the server resolves whichever is provided to the nearest ring-buffer offset.
 
 ---
 
@@ -278,7 +291,8 @@ Replace the `setInterval(refreshLobby, 4000)` and `setInterval(refreshSwarm, 300
 
 ```typescript
 useEffect(() => {
-  const es = new EventSource(`${getBaseUrl()}/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game`);
+  const nodeUrl = getBaseUrl().replace(/\/api\/apps\/.*$/, '');
+  const es = new EventSource(`${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game`);
 
   es.addEventListener('game:turn_resolved', (e) => {
     const data = JSON.parse(e.data);

--- a/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
+++ b/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
@@ -316,18 +316,23 @@ useEffect(() => {
     const nodeUrl = getBaseUrl().replace(/\/api\/apps\/.*$/, '');
     const { ticket } = await api.getSseTicket();
     if (cancelled) return;
-    let url = `${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game&ticket=${ticket}`;
-    if (lastSeq) url += `&since=${lastSeq}`;
-    es = new EventSource(url);
+    const params = new URLSearchParams({
+      types: 'game:swarm_created,game:turn_resolved,game:player_joined',
+      paranets: 'origin-trail-game',
+      ticket,
+    });
+    if (lastSeq) params.set('since', lastSeq);
+    es = new EventSource(`${nodeUrl}/api/events?${params}`);
 
     function onEvent(e: MessageEvent) {
       if (e.lastEventId) lastSeq = e.lastEventId;
       const data = JSON.parse(e.data);
-      if (data.type === 'game:turn_resolved' && data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
-      if (data.type === 'game:swarm_created') refreshLobby();
-      if (data.type === 'game:player_joined' && data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
+      if (data.data?.swarmId === swarm?.id && swarm) refreshSwarm(swarm.id);
+      else if (data.type === 'game:swarm_created') refreshLobby();
     }
-    es.onmessage = onEvent;
+    es.addEventListener('game:turn_resolved', onEvent);
+    es.addEventListener('game:swarm_created', onEvent);
+    es.addEventListener('game:player_joined', onEvent);
 
     // Reconnect with a fresh ticket on connection loss.
     // Disable native EventSource reconnect since the ticket is single-use.
@@ -342,11 +347,13 @@ useEffect(() => {
 }, [swarm?.id]);
 ```
 
-> **Note on deduplication:** The server assigns monotonic sequence IDs
-> (`id:` field in SSE). On reconnect, the subscribe-then-replay strategy
-> (§2.4) uses the last-seen sequence to avoid overlap. If any duplicate
-> does slip through (e.g., during failover), clients should track the
-> last processed `id` and skip events with `id <= lastSeen`.
+> **Note on deduplication:** `EventSource` does **not** deduplicate
+> events natively — it only tracks `lastEventId` for reconnect resume.
+> Clients **must** implement explicit dedup: track the last processed
+> sequence ID and skip events where `id <= lastSeen`. The server
+> guarantees monotonic sequence IDs and non-overlapping replay
+> (subscribe-then-replay, §2.4), but edge cases during failover may
+> still produce duplicates that clients must handle.
 
 **Benefits:**
 - Instant turn resolution (0ms vs 3-4s poll)

--- a/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
+++ b/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
@@ -180,6 +180,14 @@ Accept: text/event-stream
 > if unused. Server-side logs must redact the `ticket` query parameter.
 > Cookie-based auth is also acceptable when the client and API share
 > the same origin.
+>
+> **Ticket binding:** Each issued ticket must be bound to the authenticated
+> subject (user/node identity) and the requested scope (event types,
+> paranet filter). The server stores `{ subject, scope, expiresAt,
+> consumed: false }` per ticket. On first `/api/events` use the server
+> atomically marks the ticket as consumed — subsequent uses are rejected.
+> This prevents a leaked-but-unused ticket from being replayed by another
+> client during its TTL.
 
 **Response:**
 
@@ -288,11 +296,22 @@ class SubscriptionManager {
 Maintain a bounded ring buffer (last 1000 events, max 5 minutes) in `SubscriptionManager`. Each event is assigned an incrementing sequence ID.
 
 **Subscribe-then-replay** to avoid losing events between replay and live attach:
-1. Register the subscription first (live events start buffering to the client's queue).
-2. Replay matching events from the ring buffer where `seq > since`.
-3. Deduplicate on the client using the `id` field in SSE (`EventSource` handles this natively via `lastEventId`).
+1. Register the subscription first. Live events start accumulating in a **per-connection queue** (not sent immediately).
+2. Replay matching events from the ring buffer where `seq > since`, writing them to the client.
+3. Flush the per-connection queue. Any live events that arrived during step 2 are sent in order.
+4. Switch to direct delivery — new events are written to the client immediately.
 
-This ensures zero event loss on reconnection. The `since` parameter accepts a **sequence ID** (monotonic integer assigned by the server). Clients should persist `lastEventId` from SSE and pass it on reconnect. The server resolves the sequence to the ring-buffer offset. Epoch-ms timestamps are not supported for `since` to avoid ambiguity.
+This gating step prevents interleaving newer live events before older replayed ones. The client must still perform explicit dedup (track last processed `seq`, skip events where `id <= lastSeen`), since `EventSource` does **not** deduplicate natively — it only tracks `lastEventId` for reconnect resume.
+
+The `since` parameter accepts a **sequence ID** (monotonic integer assigned by the server). Clients should persist `lastEventId` from SSE and pass it on reconnect. The server resolves the sequence to the ring-buffer offset. Epoch-ms timestamps are not supported for `since` to avoid ambiguity.
+
+> **Durability caveat:** The ring buffer and sequence IDs are in-memory
+> and process-local. A node restart or failover resets replay state, so
+> clients may miss events despite sending `since`. Semantics are
+> **best-effort**; after a reconnect that returns no replay data (or a
+> `system:missed_events` signal), clients should re-sync full state from
+> the REST API. Durable replay (WAL-backed buffer or persistent sequence)
+> may be added in a future phase.
 
 ---
 
@@ -325,6 +344,8 @@ useEffect(() => {
     es = new EventSource(`${nodeUrl}/api/events?${params}`);
 
     function onEvent(e: MessageEvent) {
+      // Explicit dedup: skip replayed/duplicate events
+      if (e.lastEventId && lastSeq && Number(e.lastEventId) <= Number(lastSeq)) return;
       if (e.lastEventId) lastSeq = e.lastEventId;
       const data = JSON.parse(e.data);
       if (data.data?.swarmId === swarm?.id && swarm) refreshSwarm(swarm.id);

--- a/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
+++ b/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
@@ -264,10 +264,14 @@ class SubscriptionManager {
     const raw = data as Record<string, unknown>;
     const type = (raw.type as string) ?? eventType;
     const paranetId = raw.paranetId as string | undefined;
+    const seq = this.nextSeq++;
+    const payload = { ...raw, type };
+    this.ringBuffer.push({ seq, payload });
+    const isSystem = type.startsWith('system:');
     for (const sub of this.subscriptions) {
-      if (sub.filter.types && !sub.filter.types.has(type)) continue;
-      if (sub.filter.paranets && (!paranetId || !sub.filter.paranets.has(paranetId))) continue;
-      sendSse(sub.res, { ...raw, type }, this.nextSeq++);
+      if (!isSystem && sub.filter.types && !sub.filter.types.has(type)) continue;
+      if (!isSystem && sub.filter.paranets && (!paranetId || !sub.filter.paranets.has(paranetId))) continue;
+      sendSse(sub.res, payload, seq);
     }
   }
 }
@@ -306,23 +310,24 @@ Replace the `setInterval(refreshLobby, 4000)` and `setInterval(refreshSwarm, 300
 useEffect(() => {
   let es: EventSource | null = null;
   let cancelled = false;
+  let lastSeq: string | null = null;
 
   async function connect() {
     const nodeUrl = getBaseUrl().replace(/\/api\/apps\/.*$/, '');
     const { ticket } = await api.getSseTicket();
     if (cancelled) return;
-    const url = `${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game&ticket=${ticket}`;
+    let url = `${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game&ticket=${ticket}`;
+    if (lastSeq) url += `&since=${lastSeq}`;
     es = new EventSource(url);
 
-    es.addEventListener('game:turn_resolved', (e) => {
+    function onEvent(e: MessageEvent) {
+      if (e.lastEventId) lastSeq = e.lastEventId;
       const data = JSON.parse(e.data);
-      if (data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
-    });
-    es.addEventListener('game:swarm_created', () => refreshLobby());
-    es.addEventListener('game:player_joined', (e) => {
-      const data = JSON.parse(e.data);
-      if (data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
-    });
+      if (data.type === 'game:turn_resolved' && data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
+      if (data.type === 'game:swarm_created') refreshLobby();
+      if (data.type === 'game:player_joined' && data.data.swarmId === swarm?.id) refreshSwarm(swarm.id);
+    }
+    es.onmessage = onEvent;
 
     // Reconnect with a fresh ticket on connection loss.
     // Disable native EventSource reconnect since the ticket is single-use.

--- a/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
+++ b/docs/plans/PLAN_REALTIME_SUBSCRIPTIONS.md
@@ -171,11 +171,15 @@ Accept: text/event-stream
 ```
 
 > **Auth note:** Browser `EventSource` cannot set custom headers, so SSE
-> endpoints must accept auth via a `token` query parameter (signed JWT or
-> short-lived HMAC token) in addition to the `Authorization` header. The
-> query-param token should be single-use or time-bounded (≤5 min) to
-> limit replay risk. Cookie-based auth is also acceptable when the client
-> and API share the same origin.
+> endpoints must accept auth via a `ticket` query parameter in addition
+> to the `Authorization` header. The ticket should be an **opaque,
+> single-use SSE ticket** (not a reusable JWT, which would leak
+> credentials into URL logs/history). The server issues tickets via
+> `POST /api/events/ticket` (authenticated, returns `{ ticket, expiresIn }`).
+> Tickets are valid for a single SSE connection and expire after ≤60s
+> if unused. Server-side logs must redact the `ticket` query parameter.
+> Cookie-based auth is also acceptable when the client and API share
+> the same origin.
 
 **Response:**
 
@@ -240,9 +244,16 @@ class SubscriptionManager {
   private subscriptions = new Set<Subscription>();
 
   constructor(private eventBus: TypedEventBus) {
-    // Listen to all DKGEvents and fan out to matching subscribers
+    // Listen to all DKGEvents (core) and fan out to matching subscribers
     for (const eventType of Object.values(DKGEvent)) {
       eventBus.on(eventType, (data) => this.broadcast(eventType, data));
+    }
+  }
+
+  /** Register an app-scoped event source (e.g., game:* events from gossip). */
+  registerAppEvents(appBus: TypedEventBus, eventTypes: string[]): void {
+    for (const eventType of eventTypes) {
+      appBus.on(eventType, (data) => this.broadcast(eventType, data));
     }
   }
 
@@ -262,7 +273,7 @@ class SubscriptionManager {
 
 **Keepalive:** Send `: keepalive\n\n` every 15s to prevent proxies from closing idle connections.
 
-**Backpressure:** If a client's TCP buffer is full (`res.writableNeedsDrain`), skip events for that client and send a `missed_events` notification when it drains.
+**Backpressure:** If a client's TCP buffer is full (`res.writableNeedsDrain`), skip events for that client and send a `system:missed_events` notification when it drains. Clients should treat this as a signal to re-fetch state (e.g., refresh lobby/swarm from the REST API).
 
 **Max connections:** Limit to 50 concurrent SSE connections per node. Return 503 if exceeded.
 
@@ -292,7 +303,9 @@ Replace the `setInterval(refreshLobby, 4000)` and `setInterval(refreshSwarm, 300
 ```typescript
 useEffect(() => {
   const nodeUrl = getBaseUrl().replace(/\/api\/apps\/.*$/, '');
-  const es = new EventSource(`${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game`);
+  // Obtain a short-lived, opaque SSE ticket (see auth note in §2.1)
+  const { ticket } = await api.getSseTicket();
+  const es = new EventSource(`${nodeUrl}/api/events?types=game:swarm_created,game:turn_resolved,game:player_joined&paranets=origin-trail-game&ticket=${ticket}`);
 
   es.addEventListener('game:turn_resolved', (e) => {
     const data = JSON.parse(e.data);
@@ -378,8 +391,8 @@ This phase is optional and can be implemented later once SSE proves the event mo
 | `kc:confirmed` | `{ual, batchId, txHash, blockNumber}` | Chain confirmation received |
 | `workspace:write` | `{operationId, quadCount, fromPeerId, rootEntities}` | Workspace data stored (local or remote) |
 | `workspace:enshrine` | `{ual, contextGraphId, quadCount, txHash}` | Data enshrined to context graph |
-| `context_graph:created` | `{contextGraphId, m, n, participants}` | New context graph registered |
-| `context_graph:signed` | `{contextGraphId, signerPeerId, signatureCount, threshold}` | Signature received |
+| `context-graph:created` | `{contextGraphId, m, n, participants}` | New context graph registered |
+| `context-graph:signed` | `{contextGraphId, signerPeerId, signatureCount, threshold}` | Signature received |
 | `peer:connected` | `{peerId, name, transport}` | New peer connected |
 | `peer:disconnected` | `{peerId, name}` | Peer disconnected |
 | `message:received` | `{fromPeerId, fromName, preview}` | Encrypted message received |
@@ -395,6 +408,12 @@ This phase is optional and can be implemented later once SSE proves the event mo
 | `game:expedition_started` | `{swarmId, playerCount}` |
 | `game:turn_resolved` | `{swarmId, turn, outcome, survivorCount}` |
 | `game:swarm_completed` | `{swarmId, finalScore, outcome}` |
+
+### System events (always delivered, not filterable)
+
+| Event type | Payload | Trigger |
+|------------|---------|---------|
+| `system:missed_events` | `{missedCount, oldestSeq, newestSeq}` | Client TCP buffer was full; events were skipped. Client should re-fetch state. |
 
 ---
 


### PR DESCRIPTION
> _Migrated from dkg-v9 PR #170_

Detailed plan for adding a real-time event subscription layer to the DKG node.

**The core problem:** Every consumer today (game UI, MCP tools, adapters, external agents) must poll REST endpoints on a timer. This adds 3-12s latency to every interaction and wastes requests when nothing changes.

**The solution:** An SSE endpoint (`GET /api/events`) that streams filtered events in real time, built on the existing `TypedEventBus` and GossipSub infrastructure.

### Four phases:

1. **EventBus completeness** — Add missing events (`WORKSPACE_WRITE`, `CONTEXT_GRAPH_SIGNED`, `AGENT_DISCOVERED`, etc.)
2. **SubscriptionManager + SSE endpoint** — Core infrastructure with type/paranet filtering, replay on reconnect, keepalive, backpressure
3. **Consumer integration** — Replace polling in game UI, add `subscribe_events` MCP tool, add `dkg.onEvent()` to OpenClaw adapter
4. **Webhook delivery** (future) — For serverless/mobile agents

Includes mermaid sequence diagrams, event type catalog (11 core + 5 game events), payload schemas, and acceptance criteria.


Made with [Cursor](https://cursor.com)