### PR TITLE
refactor: extract shared DKG home, API port, and auth token utilities to core

### DIFF
--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -6,9 +6,7 @@
  * triple store, and Node UI.
  */
 
-import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { loadAuthTokenSync } from '@origintrail-official/dkg-core';
 
 export interface DkgClientOptions {
   /** Base URL of the DKG daemon (default: "http://127.0.0.1:9200"). */
@@ -30,18 +28,8 @@ export class DkgDaemonClient {
     this.apiToken = opts?.apiToken ?? DkgDaemonClient.loadTokenFromFile();
   }
 
-  /** Try to read the default token file ($DKG_HOME/auth.token or ~/.dkg/auth.token). */
   private static loadTokenFromFile(): string | undefined {
-    try {
-      const dkgHome = process.env.DKG_HOME ?? join(homedir(), '.dkg');
-      const tokenPath = join(dkgHome, 'auth.token');
-      const raw = readFileSync(tokenPath, 'utf-8');
-      // Token file may have comments (lines starting with #) and blank lines
-      const token = raw.split('\n').map(l => l.trim()).find(l => l && !l.startsWith('#'));
-      return token || undefined;
-    } catch {
-      return undefined;
-    }
+    return loadAuthTokenSync();
   }
 
   private authHeaders(): Record<string, string> {

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -15,11 +15,11 @@ export function dkgHomeDir(): string {
   return process.env.DKG_HOME ?? join(homedir(), '.dkg');
 }
 
-/** Read the daemon PID from $DKG_HOME/daemon.pid. */
+/** Read the daemon PID from $DKG_HOME/daemon.pid. Returns null if missing or invalid. */
 export async function readDaemonPid(dkgHome?: string): Promise<number | null> {
   try {
     const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'daemon.pid'), 'utf-8');
-    return parseInt(raw.trim(), 10);
+    return parseStrictInt(raw.trim());
   } catch {
     return null;
   }
@@ -35,16 +35,16 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
-/** Read the API port from $DKG_API_PORT env or $DKG_HOME/api.port file. */
+/** Read the API port from $DKG_API_PORT env or $DKG_HOME/api.port file. Returns null if missing or invalid. */
 export async function readDkgApiPort(dkgHome?: string): Promise<number | null> {
   const envPort = process.env.DKG_API_PORT
-    ? parseInt(process.env.DKG_API_PORT, 10)
+    ? parsePort(process.env.DKG_API_PORT)
     : null;
   if (envPort) return envPort;
 
   try {
     const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'api.port'), 'utf-8');
-    return parseInt(raw.trim(), 10);
+    return parsePort(raw.trim());
   } catch {
     return null;
   }
@@ -65,6 +65,19 @@ export function loadAuthTokenSync(dkgHome?: string): string | undefined {
     }
   } catch { /* unreadable */ }
   return undefined;
+}
+
+/** Parse a string as a strict integer, returning null for NaN or non-integer values. */
+function parseStrictInt(value: string): number | null {
+  const n = Number(value);
+  return Number.isInteger(n) ? n : null;
+}
+
+/** Parse a string as a valid port number (1–65535), returning null for invalid values. */
+function parsePort(value: string): number | null {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) return null;
+  return n;
 }
 
 /** Async variant of loadAuthTokenSync. */

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -19,7 +19,7 @@ export function dkgHomeDir(): string {
 export async function readDaemonPid(dkgHome?: string): Promise<number | null> {
   try {
     const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'daemon.pid'), 'utf-8');
-    return parseStrictInt(raw.trim());
+    return parseStrictPosInt(raw.trim());
   } catch {
     return null;
   }
@@ -35,12 +35,14 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
-/** Read the API port from $DKG_API_PORT env or $DKG_HOME/api.port file. Returns null if missing or invalid. */
+/**
+ * Read the API port from $DKG_API_PORT env or $DKG_HOME/api.port file.
+ * If $DKG_API_PORT is set but invalid, returns null immediately (does not
+ * fall through to the file) to avoid silently connecting to a stale port.
+ */
 export async function readDkgApiPort(dkgHome?: string): Promise<number | null> {
-  const envPort = process.env.DKG_API_PORT
-    ? parsePort(process.env.DKG_API_PORT)
-    : null;
-  if (envPort) return envPort;
+  const envRaw = process.env.DKG_API_PORT?.trim();
+  if (envRaw) return parsePort(envRaw);
 
   try {
     const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'api.port'), 'utf-8');
@@ -67,16 +69,22 @@ export function loadAuthTokenSync(dkgHome?: string): string | undefined {
   return undefined;
 }
 
-/** Parse a string as a strict integer, returning null for NaN or non-integer values. */
-function parseStrictInt(value: string): number | null {
+const DECIMAL_INT_RE = /^[0-9]+$/;
+
+/**
+ * Parse a string as a strict positive decimal integer.
+ * Rejects empty strings, hex (0x...), scientific notation (1e3), floats, and negative values.
+ */
+function parseStrictPosInt(value: string): number | null {
+  if (!DECIMAL_INT_RE.test(value)) return null;
   const n = Number(value);
-  return Number.isInteger(n) ? n : null;
+  return n > 0 ? n : null;
 }
 
-/** Parse a string as a valid port number (1–65535), returning null for invalid values. */
+/** Parse a string as a valid TCP port (1–65535). Only accepts decimal digit strings. */
 function parsePort(value: string): number | null {
-  const n = Number(value);
-  if (!Number.isInteger(n) || n < 1 || n > 65535) return null;
+  const n = parseStrictPosInt(value);
+  if (n === null || n > 65535) return null;
   return n;
 }
 

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -41,8 +41,9 @@ export function isProcessAlive(pid: number): boolean {
  * fall through to the file) to avoid silently connecting to a stale port.
  */
 export async function readDkgApiPort(dkgHome?: string): Promise<number | null> {
-  const envRaw = process.env.DKG_API_PORT?.trim();
-  if (envRaw) return parsePort(envRaw);
+  if (process.env.DKG_API_PORT !== undefined) {
+    return parsePort(process.env.DKG_API_PORT.trim());
+  }
 
   try {
     const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'api.port'), 'utf-8');

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared helpers for resolving DKG_HOME, API port, PID, and auth tokens.
+ *
+ * These were previously duplicated across cli, mcp-server, and adapter-openclaw.
+ * Centralizing them here ensures consistent behavior everywhere.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/** Resolve the DKG home directory ($DKG_HOME or ~/.dkg). */
+export function dkgHomeDir(): string {
+  return process.env.DKG_HOME ?? join(homedir(), '.dkg');
+}
+
+/** Read the daemon PID from $DKG_HOME/daemon.pid. */
+export async function readDaemonPid(dkgHome?: string): Promise<number | null> {
+  try {
+    const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'daemon.pid'), 'utf-8');
+    return parseInt(raw.trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+/** Check whether a process with the given PID is alive. */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the API port from $DKG_API_PORT env or $DKG_HOME/api.port file. */
+export async function readDkgApiPort(dkgHome?: string): Promise<number | null> {
+  const envPort = process.env.DKG_API_PORT
+    ? parseInt(process.env.DKG_API_PORT, 10)
+    : null;
+  if (envPort) return envPort;
+
+  try {
+    const raw = await readFile(join(dkgHome ?? dkgHomeDir(), 'api.port'), 'utf-8');
+    return parseInt(raw.trim(), 10);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the first non-comment, non-blank line from $DKG_HOME/auth.token.
+ * Returns undefined if the file does not exist or is unreadable.
+ */
+export function loadAuthTokenSync(dkgHome?: string): string | undefined {
+  const filePath = join(dkgHome ?? dkgHomeDir(), 'auth.token');
+  if (!existsSync(filePath)) return undefined;
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    for (const line of raw.split('\n')) {
+      const t = line.trim();
+      if (t.length > 0 && !t.startsWith('#')) return t;
+    }
+  } catch { /* unreadable */ }
+  return undefined;
+}
+
+/** Async variant of loadAuthTokenSync. */
+export async function loadAuthToken(dkgHome?: string): Promise<string | undefined> {
+  const filePath = join(dkgHome ?? dkgHomeDir(), 'auth.token');
+  if (!existsSync(filePath)) return undefined;
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    for (const line of raw.split('\n')) {
+      const t = line.trim();
+      if (t.length > 0 && !t.startsWith('#')) return t;
+    }
+  } catch { /* unreadable */ }
+  return undefined;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,3 +26,11 @@ export {
   sparqlInt,
   assertSafeRdfTerm,
 } from './sparql-safe.js';
+export {
+  dkgHomeDir,
+  readDaemonPid,
+  isProcessAlive,
+  readDkgApiPort,
+  loadAuthTokenSync,
+  loadAuthToken,
+} from './dkg-home.js';

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { dkgHomeDir, isProcessAlive, readDkgApiPort } from '../src/dkg-home.js';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { homedir } from 'node:os';
+import { dkgHomeDir, isProcessAlive, readDaemonPid, readDkgApiPort, loadAuthToken, loadAuthTokenSync } from '../src/dkg-home.js';
 
 describe('dkgHomeDir', () => {
   const originalEnv = process.env.DKG_HOME;
@@ -29,5 +31,120 @@ describe('isProcessAlive', () => {
 
   it('returns false for a non-existent PID', () => {
     expect(isProcessAlive(999999999)).toBe(false);
+  });
+});
+
+describe('readDaemonPid', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `dkg-test-pid-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads a valid PID from file', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), '12345');
+    expect(await readDaemonPid(tempDir)).toBe(12345);
+  });
+
+  it('returns null for non-numeric content', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), 'abc');
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
+
+  it('returns null for partial numeric content like "123abc"', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), '123abc');
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
+
+  it('returns null when file does not exist', async () => {
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
+});
+
+describe('readDkgApiPort', () => {
+  let tempDir: string;
+  const originalEnv = process.env.DKG_API_PORT;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `dkg-test-port-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+    delete process.env.DKG_API_PORT;
+  });
+
+  afterEach(async () => {
+    if (originalEnv === undefined) delete process.env.DKG_API_PORT;
+    else process.env.DKG_API_PORT = originalEnv;
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('prefers $DKG_API_PORT over file', async () => {
+    process.env.DKG_API_PORT = '8888';
+    await writeFile(join(tempDir, 'api.port'), '9200');
+    expect(await readDkgApiPort(tempDir)).toBe(8888);
+  });
+
+  it('reads port from file when env is not set', async () => {
+    await writeFile(join(tempDir, 'api.port'), '9200');
+    expect(await readDkgApiPort(tempDir)).toBe(9200);
+  });
+
+  it('returns null for invalid env value', async () => {
+    process.env.DKG_API_PORT = 'notanumber';
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('returns null for out-of-range port', async () => {
+    process.env.DKG_API_PORT = '99999';
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('returns null for port 0', async () => {
+    process.env.DKG_API_PORT = '0';
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('returns null when neither env nor file exist', async () => {
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+});
+
+describe('loadAuthToken / loadAuthTokenSync', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `dkg-test-token-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('loads a token from file', async () => {
+    await writeFile(join(tempDir, 'auth.token'), 'my-secret-token\n');
+    expect(await loadAuthToken(tempDir)).toBe('my-secret-token');
+    expect(loadAuthTokenSync(tempDir)).toBe('my-secret-token');
+  });
+
+  it('skips comment lines and blank lines', async () => {
+    await writeFile(join(tempDir, 'auth.token'), '# comment\n\n  \nactual-token\n');
+    expect(await loadAuthToken(tempDir)).toBe('actual-token');
+    expect(loadAuthTokenSync(tempDir)).toBe('actual-token');
+  });
+
+  it('returns undefined when file does not exist', async () => {
+    expect(await loadAuthToken(tempDir)).toBeUndefined();
+    expect(loadAuthTokenSync(tempDir)).toBeUndefined();
+  });
+
+  it('returns undefined for file with only comments', async () => {
+    await writeFile(join(tempDir, 'auth.token'), '# comment only\n');
+    expect(await loadAuthToken(tempDir)).toBeUndefined();
+    expect(loadAuthTokenSync(tempDir)).toBeUndefined();
   });
 });

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -134,6 +134,18 @@ describe('readDkgApiPort', () => {
     expect(await readDkgApiPort(tempDir)).toBeNull();
   });
 
+  it('does NOT fall through to file when env is whitespace-only', async () => {
+    process.env.DKG_API_PORT = '   ';
+    await writeFile(join(tempDir, 'api.port'), '9200');
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('does NOT fall through to file when env is empty string', async () => {
+    process.env.DKG_API_PORT = '';
+    await writeFile(join(tempDir, 'api.port'), '9200');
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
   it('rejects hex port like "0x2390"', async () => {
     process.env.DKG_API_PORT = '0x2390';
     expect(await readDkgApiPort(tempDir)).toBeNull();

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { dkgHomeDir, isProcessAlive, readDkgApiPort } from '../src/dkg-home.js';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+describe('dkgHomeDir', () => {
+  const originalEnv = process.env.DKG_HOME;
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalEnv;
+  });
+
+  it('returns $DKG_HOME when set', () => {
+    process.env.DKG_HOME = '/custom/path';
+    expect(dkgHomeDir()).toBe('/custom/path');
+  });
+
+  it('defaults to ~/.dkg', () => {
+    delete process.env.DKG_HOME;
+    expect(dkgHomeDir()).toBe(join(homedir(), '.dkg'));
+  });
+});
+
+describe('isProcessAlive', () => {
+  it('returns true for the current process', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('returns false for a non-existent PID', () => {
+    expect(isProcessAlive(999999999)).toBe(false);
+  });
+});

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -64,6 +64,26 @@ describe('readDaemonPid', () => {
   it('returns null when file does not exist', async () => {
     expect(await readDaemonPid(tempDir)).toBeNull();
   });
+
+  it('returns null for empty file', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), '');
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
+
+  it('returns null for hex notation like "0x1234"', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), '0x1234');
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
+
+  it('returns null for scientific notation like "1e3"', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), '1e3');
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
+
+  it('returns null for "0"', async () => {
+    await writeFile(join(tempDir, 'daemon.pid'), '0');
+    expect(await readDaemonPid(tempDir)).toBeNull();
+  });
 });
 
 describe('readDkgApiPort', () => {
@@ -105,6 +125,22 @@ describe('readDkgApiPort', () => {
 
   it('returns null for port 0', async () => {
     process.env.DKG_API_PORT = '0';
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('does NOT fall through to file when env is set but invalid', async () => {
+    process.env.DKG_API_PORT = 'invalid';
+    await writeFile(join(tempDir, 'api.port'), '9200');
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('rejects hex port like "0x2390"', async () => {
+    process.env.DKG_API_PORT = '0x2390';
+    expect(await readDkgApiPort(tempDir)).toBeNull();
+  });
+
+  it('rejects scientific notation like "1e3"', async () => {
+    process.env.DKG_API_PORT = '1e3';
     expect(await readDkgApiPort(tempDir)).toBeNull();
   });
 

--- a/packages/mcp-server/src/connection.ts
+++ b/packages/mcp-server/src/connection.ts
@@ -1,5 +1,4 @@
 import {
-  dkgHomeDir,
   readDaemonPid,
   isProcessAlive,
   readDkgApiPort,

--- a/packages/mcp-server/src/connection.ts
+++ b/packages/mcp-server/src/connection.ts
@@ -1,51 +1,10 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
-import { existsSync } from 'node:fs';
-
-function dkgDir(): string {
-  return process.env.DKG_HOME ?? join(homedir(), '.dkg');
-}
-
-async function readPid(): Promise<number | null> {
-  try {
-    const raw = await readFile(join(dkgDir(), 'daemon.pid'), 'utf-8');
-    return parseInt(raw.trim(), 10);
-  } catch {
-    return null;
-  }
-}
-
-function isProcessRunning(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function readApiPort(): Promise<number | null> {
-  try {
-    const raw = await readFile(join(dkgDir(), 'api.port'), 'utf-8');
-    return parseInt(raw.trim(), 10);
-  } catch {
-    return null;
-  }
-}
-
-async function loadAuthToken(): Promise<string | undefined> {
-  const filePath = join(dkgDir(), 'auth.token');
-  if (!existsSync(filePath)) return undefined;
-  try {
-    const raw = await readFile(filePath, 'utf-8');
-    for (const line of raw.split('\n')) {
-      const t = line.trim();
-      if (t.length > 0 && !t.startsWith('#')) return t;
-    }
-  } catch { /* unreadable */ }
-  return undefined;
-}
+import {
+  dkgHomeDir,
+  readDaemonPid,
+  isProcessAlive,
+  readDkgApiPort,
+  loadAuthToken,
+} from '@origintrail-official/dkg-core';
 
 export class DkgClient {
   private baseUrl: string;
@@ -57,15 +16,11 @@ export class DkgClient {
   }
 
   static async connect(): Promise<DkgClient> {
-    const envPort = process.env.DKG_API_PORT
-      ? parseInt(process.env.DKG_API_PORT, 10)
-      : null;
-
-    let port = envPort ?? (await readApiPort());
+    const port = await readDkgApiPort();
 
     if (!port) {
-      const pid = await readPid();
-      if (!pid || !isProcessRunning(pid)) {
+      const pid = await readDaemonPid();
+      if (!pid || !isProcessAlive(pid)) {
         throw new Error('DKG daemon is not running. Start it with: dkg start');
       }
       throw new Error('Cannot read API port. Set DKG_API_PORT or restart: dkg stop && dkg start');


### PR DESCRIPTION
> _Migrated from dkg-v9 PR #203_

## Summary
- Adds `dkgHomeDir()`, `readDaemonPid()`, `isProcessAlive()`, `readDkgApiPort()`, `loadAuthToken()`, and `loadAuthTokenSync()` to `@origintrail-official/dkg-core`
- Replaces duplicate implementations in `packages/mcp-server/src/connection.ts` (~40 lines removed) and `packages/adapter-openclaw/src/dkg-client.ts` (~10 lines removed)
- Single source of truth for DKG_HOME resolution, API port discovery, and auth token loading

These utilities were previously copy-pasted across 3-4 packages with subtle differences. Centralizing them prevents behavioral drift and makes it easier to add features (e.g., custom config paths) in one place.

## Test plan
- [x] `packages/core/test/dkg-home.test.ts` — 4 tests passing
- [ ] MCP server still connects to running daemon
- [ ] OpenClaw adapter still resolves auth tokens
- [ ] CI build and test pass

Made with [Cursor](https://cursor.com)