### PR TITLE
refactor: introduce shared DKGError hierarchy and deduplicate PayloadTooLargeError

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { stat } from 'node:fs/promises';
 import { ethers } from 'ethers';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError } from '@origintrail-official/dkg-core';
 import {
   DashboardDB,
   MetricsCollector,
@@ -2316,12 +2316,6 @@ function jsonResponse(res: ServerResponse, status: number, data: unknown): void 
 const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB — default for data-heavy endpoints (publish, update)
 const SMALL_BODY_BYTES = 256 * 1024; // 256 KB — for settings, connect, chat, and other small payloads
 
-class PayloadTooLargeError extends Error {
-  constructor(maxBytes: number) {
-    super(`Request body too large (>${maxBytes} bytes)`);
-    this.name = 'PayloadTooLargeError';
-  }
-}
 
 function readBody(req: IncomingMessage, maxBytes = MAX_BODY_BYTES): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared error hierarchy for the DKG V9 stack.
+ *
+ * DKGError is the base class for all domain-specific errors. Subclasses
+ * distinguish between user-facing errors (nice message, no stack) and
+ * internal errors (full diagnostic info).
+ */
+
+/** Base class for all DKG domain errors. */
+export class DKGError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DKGError';
+  }
+}
+
+/**
+ * An error caused by invalid user input or a pre-condition that the user
+ * can fix. CLI handlers can show these messages directly without a stack trace.
+ */
+export class DKGUserError extends DKGError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DKGUserError';
+  }
+}
+
+/**
+ * An internal/unexpected error. These should be logged with full context
+ * and typically indicate a bug or infrastructure issue.
+ */
+export class DKGInternalError extends DKGError {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'DKGInternalError';
+  }
+}
+
+/** HTTP request body exceeded the size limit. */
+export class PayloadTooLargeError extends DKGUserError {
+  constructor(maxBytes?: number) {
+    super(
+      maxBytes != null
+        ? `Request body too large (>${maxBytes} bytes)`
+        : 'Payload too large',
+    );
+    this.name = 'PayloadTooLargeError';
+  }
+}
+
+/**
+ * Safely extract a human-readable error message from an unknown thrown value.
+ * Prefer this over `catch (err: any) { err.message }` to maintain type safety.
+ */
+export function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return String(err);
+}
+
+/**
+ * Check whether an unknown value is an Error with a specific `code` property
+ * (common in Node.js system errors like ENOENT, ECONNREFUSED, etc.).
+ */
+export function hasErrorCode(err: unknown, code: string): boolean {
+  return (
+    err instanceof Error &&
+    'code' in err &&
+    (err as NodeJS.ErrnoException).code === code
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,3 +26,11 @@ export {
   sparqlInt,
   assertSafeRdfTerm,
 } from './sparql-safe.js';
+export {
+  DKGError,
+  DKGUserError,
+  DKGInternalError,
+  PayloadTooLargeError,
+  toErrorMessage,
+  hasErrorCode,
+} from './errors.js';

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DKGError,
+  DKGUserError,
+  DKGInternalError,
+  PayloadTooLargeError,
+  toErrorMessage,
+  hasErrorCode,
+} from '../src/errors.js';
+
+describe('DKGError hierarchy', () => {
+  it('DKGUserError extends DKGError', () => {
+    const err = new DKGUserError('bad input');
+    expect(err).toBeInstanceOf(DKGError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('DKGUserError');
+    expect(err.message).toBe('bad input');
+  });
+
+  it('DKGInternalError extends DKGError and preserves cause', () => {
+    const cause = new TypeError('null ref');
+    const err = new DKGInternalError('unexpected', cause);
+    expect(err).toBeInstanceOf(DKGError);
+    expect(err.name).toBe('DKGInternalError');
+    expect(err.cause).toBe(cause);
+  });
+
+  it('PayloadTooLargeError extends DKGUserError', () => {
+    const err = new PayloadTooLargeError(1024);
+    expect(err).toBeInstanceOf(DKGUserError);
+    expect(err).toBeInstanceOf(DKGError);
+    expect(err.name).toBe('PayloadTooLargeError');
+    expect(err.message).toContain('1024');
+  });
+
+  it('PayloadTooLargeError works without maxBytes', () => {
+    const err = new PayloadTooLargeError();
+    expect(err.message).toBe('Payload too large');
+  });
+});
+
+describe('toErrorMessage', () => {
+  it('extracts message from Error instances', () => {
+    expect(toErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns string values as-is', () => {
+    expect(toErrorMessage('raw string')).toBe('raw string');
+  });
+
+  it('stringifies non-Error objects', () => {
+    expect(toErrorMessage(42)).toBe('42');
+    expect(toErrorMessage(null)).toBe('null');
+    expect(toErrorMessage(undefined)).toBe('undefined');
+  });
+
+  it('handles Error subclasses', () => {
+    expect(toErrorMessage(new TypeError('bad type'))).toBe('bad type');
+  });
+});
+
+describe('hasErrorCode', () => {
+  it('returns true for matching error code', () => {
+    const err = Object.assign(new Error('not found'), { code: 'ENOENT' });
+    expect(hasErrorCode(err, 'ENOENT')).toBe(true);
+  });
+
+  it('returns false for non-matching code', () => {
+    const err = Object.assign(new Error('denied'), { code: 'EACCES' });
+    expect(hasErrorCode(err, 'ENOENT')).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(hasErrorCode('string', 'ENOENT')).toBe(false);
+    expect(hasErrorCode(null, 'ENOENT')).toBe(false);
+  });
+});

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -2,6 +2,7 @@ import { type IncomingMessage, type ServerResponse } from 'node:http';
 import { join } from 'node:path';
 import { createReadStream, existsSync } from 'node:fs';
 import { readFile, stat } from 'node:fs/promises';
+import { PayloadTooLargeError } from '@origintrail-official/dkg-core';
 import type { DashboardDB } from './db.js';
 import type { ChatAssistant, ChatLlmDiagnostics, ChatResponse } from './chat-assistant.js';
 import { type ChatMemoryManager, IMPORT_SOURCES } from './chat-memory.js';
@@ -882,6 +883,3 @@ function readBody(req: IncomingMessage, maxBytes?: number): Promise<string> {
 
 const IMPORT_MAX_BYTES = 2 * 1024 * 1024; // 2 MB
 
-class PayloadTooLargeError extends Error {
-  constructor() { super('Payload too large'); }
-}


### PR DESCRIPTION
> _Migrated from dkg-v9 PR #204_

## Summary
- Introduces a shared error class hierarchy in `@origintrail-official/dkg-core`:
  - `DKGError` — base class for all domain errors
  - `DKGUserError` — for user-fixable issues (shown without stack trace)
  - `DKGInternalError` — for bugs/infra issues (logged with full context)
  - `PayloadTooLargeError` — shared HTTP body limit error
- Deduplicates `PayloadTooLargeError` from `cli/daemon.ts` and `node-ui/api.ts` — both now import from core
- Includes `toErrorMessage()` and `hasErrorCode()` utilities (pairs with PR #202)

This establishes a foundation for consistent error handling. Future work can migrate `StaleWriteError` and other domain errors to extend `DKGError`, and CLI catch blocks can pattern-match on `DKGUserError` vs `DKGInternalError` to decide whether to show a friendly message or a full stack trace.

## Test plan
- [x] `packages/core/test/errors.test.ts` — 11 tests passing
- [ ] Verify daemon 413 responses still work for oversized payloads
- [ ] CI build and test pass

Made with [Cursor](https://cursor.com)