### PR TITLE
fix origintrail game swarm sync and runtime regressions

### DIFF
--- a/packages/origin-trail-game/src/api/handler.ts
+++ b/packages/origin-trail-game/src/api/handler.ts
@@ -62,9 +62,23 @@ export default function createHandler(agent?: any, config?: any, _options?: unkn
 
       if (req.method === 'GET' && subpath.startsWith('/swarm/')) {
         if (!coordinator) return json(res, 503, { error: 'DKG agent not available' });
-        const swarmId = subpath.slice('/swarm/'.length);
+        const snapshot = subpath.endsWith('/snapshot');
+        const swarmId = snapshot
+          ? subpath.slice('/swarm/'.length, -'/snapshot'.length)
+          : subpath.slice('/swarm/'.length);
         const wagon = coordinator.getSwarm(swarmId);
         if (!wagon) return json(res, 404, { error: 'Swarm not found' });
+        if (snapshot) {
+          return json(res, 200, {
+            swarmId: wagon.id,
+            status: wagon.status,
+            currentTurn: wagon.currentTurn,
+            stateRoot: wagon.stateRoot ?? null,
+            gameState: wagon.gameState,
+            players: wagon.players.map((p) => ({ id: p.peerId, name: p.displayName, isLeader: p.isLeader })),
+            turnHistory: wagon.turnHistory,
+          });
+        }
         return json(res, 200, coordinator.formatSwarmState(wagon));
       }
 

--- a/packages/origin-trail-game/src/dkg/coordinator.ts
+++ b/packages/origin-trail-game/src/dkg/coordinator.ts
@@ -91,6 +91,8 @@ export interface ParticipantSignature {
 export interface TurnProposal {
   turn: number;
   hash: string;
+  previousStateRoot?: string;
+  newStateRoot?: string;
   winningAction: string;
   newStateJson: string;
   resultMessage: string;
@@ -123,6 +125,7 @@ export interface SwarmState {
   createdAt: number;
   finishedAt?: number;
   playerIndexMap: Map<string, number>;
+  stateRoot?: string;
   contextGraphId?: string;
   requiredSignatures?: number;
 }
@@ -141,6 +144,15 @@ export interface ResolvedTurn {
 
 function hashProposal(swarmId: string, turn: number, stateJson: string): string {
   return createHash('sha256').update(`${swarmId}:${turn}:${stateJson}`).digest('hex');
+}
+
+function hashStateJson(stateJson: string): string {
+  return createHash('sha256').update(stateJson).digest('hex');
+}
+
+function stateRootFromState(state: GameState | null): string | undefined {
+  if (!state) return undefined;
+  return hashStateJson(JSON.stringify(state));
 }
 
 function detectDeaths(
@@ -235,8 +247,10 @@ export class OriginTrailGameCoordinator {
   private readonly swarmMemberTombstones = new Map<string, Map<string, number>>();
   private topologyTimer: ReturnType<typeof setInterval> | null = null;
   private workspaceOps = new Map<string, Array<{ workspaceOperationId: string; rootEntities: string[] }>>();
+  private snapshotRequestCooldowns = new Map<string, number>();
   private notifications: GameNotification[] = [];
   private static readonly MAX_NOTIFICATIONS = 200;
+  private static readonly SNAPSHOT_REQUEST_COOLDOWN_MS = 5_000;
 
   constructor(agent: DKGAgent, config: CoordinatorConfig, log?: (msg: string) => void) {
     this.agent = agent;
@@ -318,6 +332,7 @@ export class OriginTrailGameCoordinator {
     this.graphSyncInFlight = true;
     try {
       await this.loadLobbyFromGraph();
+      await this.requestLeaderSnapshotsForActiveFollowers();
     } catch (err) {
       const now = Date.now();
       if (now - this.graphSyncLastErrorLogAt >= OriginTrailGameCoordinator.GRAPH_SYNC_ERROR_LOG_INTERVAL_MS) {
@@ -555,9 +570,23 @@ export class OriginTrailGameCoordinator {
         turnHistory: [],
         createdAt,
         playerIndexMap: new Map(),
+        stateRoot: undefined,
       };
       this.swarms.set(swarmId, swarm);
       this.log(`Graph sync: restored swarm "${swarmName}" (${swarmId}) with ${players.length} players`);
+    }
+  }
+
+  private async requestLeaderSnapshotsForActiveFollowers(): Promise<void> {
+    const now = Date.now();
+    for (const swarm of this.swarms.values()) {
+      if (swarm.status !== 'traveling') continue;
+      if (swarm.leaderPeerId === this.myPeerId) continue;
+      const key = `${swarm.id}:reconnect`;
+      const last = this.snapshotRequestCooldowns.get(key) ?? 0;
+      if (now - last < OriginTrailGameCoordinator.SNAPSHOT_REQUEST_COOLDOWN_MS) continue;
+      this.snapshotRequestCooldowns.set(key, now);
+      await this.requestAuthoritativeSnapshot(swarm, 'reconnect');
     }
   }
 
@@ -612,6 +641,7 @@ export class OriginTrailGameCoordinator {
       turnHistory: [],
       createdAt: now,
       playerIndexMap: new Map(),
+      stateRoot: undefined,
     };
 
     this.swarms.set(swarmId, swarm);
@@ -716,6 +746,7 @@ export class OriginTrailGameCoordinator {
     const partyNames = swarm.players.map(p => p.displayName);
     const newGameState = gameEngine.createGame(partyNames, this.myPeerId);
     const gameStateJson = JSON.stringify(newGameState);
+    const stateRoot = hashStateJson(gameStateJson);
     const now = Date.now();
 
     const launchQuads = rdf.expeditionLaunchedQuads(this.paranetId, swarmId, gameStateJson, now);
@@ -771,6 +802,7 @@ export class OriginTrailGameCoordinator {
     swarm.currentTurn = 1;
     swarm.votes = [];
     swarm.turnDeadline = Date.now() + 30_000;
+    swarm.stateRoot = stateRoot;
 
     const msg: proto.ExpeditionLaunchedMsg = {
       app: proto.APP_ID,
@@ -779,6 +811,7 @@ export class OriginTrailGameCoordinator {
       peerId: this.myPeerId,
       timestamp: now,
       gameStateJson,
+      stateRoot,
       partyOrder: swarm.players.map(p => p.peerId),
       contextGraphId: swarm.contextGraphId,
       requiredSignatures: swarm.requiredSignatures,
@@ -906,6 +939,8 @@ export class OriginTrailGameCoordinator {
     const result = gameEngine.executeAction(swarm.gameState, { type: winningAction as any, params });
 
     const newStateJson = JSON.stringify(result.newState);
+    const previousStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const newStateRoot = hashStateJson(newStateJson);
     const hash = hashProposal(swarm.id, swarm.currentTurn, newStateJson);
     const votes = swarm.votes.map(v => ({ peerId: v.peerId, action: v.action }));
     const resolution = tieBreaker === 'leader' ? 'leader-tiebreak' as const : 'consensus' as const;
@@ -938,6 +973,8 @@ export class OriginTrailGameCoordinator {
     swarm.pendingProposal = {
       turn: swarm.currentTurn,
       hash,
+      previousStateRoot,
+      newStateRoot,
       winningAction,
       newStateJson,
       resultMessage: result.message,
@@ -962,6 +999,8 @@ export class OriginTrailGameCoordinator {
       timestamp: proposalTimestamp,
       turn: swarm.currentTurn,
       proposalHash: hash,
+      previousStateRoot,
+      newStateRoot,
       winningAction,
       newStateJson,
       resultMessage: result.message,
@@ -1032,7 +1071,10 @@ export class OriginTrailGameCoordinator {
     this.stopVoteHeartbeat(swarm.id);
 
     const newState: GameState = JSON.parse(proposal.newStateJson);
-    if (proposal.winningAction) swarm.gameState = newState;
+    if (proposal.winningAction) {
+      swarm.gameState = newState;
+      swarm.stateRoot = proposal.newStateRoot ?? hashStateJson(proposal.newStateJson);
+    }
 
     swarm.turnHistory.push({
       turn: proposal.turn,
@@ -1134,6 +1176,16 @@ export class OriginTrailGameCoordinator {
         timestamp: Date.now(),
         turn: proposal.turn,
         proposalHash: proposal.hash,
+        previousStateRoot: proposal.previousStateRoot,
+        newStateRoot: proposal.newStateRoot,
+        winningAction: proposal.winningAction,
+        newStateJson: proposal.newStateJson,
+        resultMessage: proposal.resultMessage,
+        votes: proposal.votes,
+        approvers: [...proposal.approvals],
+        resolution: proposal.resolution,
+        deaths: proposal.deaths,
+        event: proposal.event,
       };
       await this.broadcast(resolvedMsg);
     }
@@ -1160,6 +1212,8 @@ export class OriginTrailGameCoordinator {
     const result = gameEngine.executeAction(swarm.gameState, { type: winningAction as any, params });
 
     const newStateJson = JSON.stringify(result.newState);
+    const previousStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const newStateRoot = hashStateJson(newStateJson);
     const hash = hashProposal(swarm.id, swarm.currentTurn, newStateJson);
     const votes = swarm.votes.map(v => ({ peerId: v.peerId, action: v.action }));
     const event = result.event ? { type: result.event.type, description: result.event.description, affectedMember: result.event.affectedMember } : undefined;
@@ -1174,6 +1228,7 @@ export class OriginTrailGameCoordinator {
     this.stopVoteHeartbeat(swarm.id);
 
     swarm.gameState = result.newState;
+    swarm.stateRoot = newStateRoot;
 
     swarm.turnHistory.push({
       turn: turnNumber,
@@ -1204,6 +1259,8 @@ export class OriginTrailGameCoordinator {
       timestamp: Date.now(),
       turn: turnNumber,
       proposalHash: hash,
+      previousStateRoot,
+      newStateRoot,
       winningAction,
       newStateJson,
       resultMessage: result.message,
@@ -1263,6 +1320,16 @@ export class OriginTrailGameCoordinator {
       timestamp: Date.now(),
       turn: turnNumber,
       proposalHash: hash,
+      previousStateRoot,
+      newStateRoot,
+      winningAction,
+      newStateJson,
+      resultMessage: result.message,
+      votes,
+      approvers: [this.myPeerId],
+      resolution: 'force-resolved',
+      deaths,
+      event: turnEvent,
     };
     await this.broadcast(resolvedMsg);
 
@@ -1361,6 +1428,8 @@ export class OriginTrailGameCoordinator {
           case 'swarm:joined': this.onRemotePlayerJoined(msg as proto.SwarmJoinedMsg); break;
           case 'swarm:left': this.onRemotePlayerLeft(msg as proto.SwarmLeftMsg); break;
           case 'expedition:launched': await this.onRemoteExpeditionLaunched(msg as proto.ExpeditionLaunchedMsg); break;
+          case 'state:request': await this.onRemoteStateRequest(msg as proto.StateRequestMsg); break;
+          case 'state:snapshot': this.onRemoteStateSnapshot(msg as proto.StateSnapshotMsg); break;
           case 'vote:cast': this.onRemoteVoteCast(msg as proto.VoteCastMsg); break;
           case 'turn:proposal': await this.onRemoteTurnProposal(msg as proto.TurnProposalMsg); break;
           case 'turn:approve': await this.onRemoteTurnApproval(msg as proto.TurnApproveMsg); break;
@@ -1395,6 +1464,7 @@ export class OriginTrailGameCoordinator {
       turnHistory: [],
       createdAt: msg.timestamp,
       playerIndexMap: new Map(),
+      stateRoot: undefined,
     };
     this.swarms.set(msg.swarmId, swarm);
     this.pushNotification({
@@ -1455,6 +1525,11 @@ export class OriginTrailGameCoordinator {
     if (!swarm) return;
     if (msg.peerId !== swarm.leaderPeerId) return;
     if (swarm.status !== 'recruiting') return;
+    const derivedStateRoot = hashStateJson(msg.gameStateJson);
+    if (msg.stateRoot && msg.stateRoot !== derivedStateRoot) {
+      this.log(`Rejected expedition launch for ${msg.swarmId}: stateRoot mismatch`);
+      return;
+    }
     swarm.gameState = JSON.parse(msg.gameStateJson);
     if (msg.partyOrder) {
       let appliedPartyOrder = false;
@@ -1483,6 +1558,7 @@ export class OriginTrailGameCoordinator {
     swarm.currentTurn = 1;
     swarm.votes = [];
     swarm.turnDeadline = Date.now() + 30_000;
+    swarm.stateRoot = msg.stateRoot ?? derivedStateRoot;
     if (msg.contextGraphId) swarm.contextGraphId = msg.contextGraphId;
     if (msg.requiredSignatures != null) swarm.requiredSignatures = msg.requiredSignatures;
 
@@ -1535,6 +1611,116 @@ export class OriginTrailGameCoordinator {
     this.reorderPlayersToPartyOrder(swarm, partyOrder);
   }
 
+  private async requestAuthoritativeSnapshot(
+    swarm: SwarmState,
+    reason: 'proposal-mismatch' | 'reconnect' | 'manual',
+  ): Promise<void> {
+    const msg: proto.StateRequestMsg = {
+      app: proto.APP_ID,
+      type: 'state:request',
+      swarmId: swarm.id,
+      peerId: this.myPeerId,
+      timestamp: Date.now(),
+      turn: swarm.currentTurn,
+      knownStateRoot: swarm.stateRoot,
+      reason,
+    };
+    await this.broadcast(msg);
+    this.log(`Requested authoritative snapshot for ${swarm.id} (${reason})`);
+  }
+
+  private async onRemoteStateRequest(msg: proto.StateRequestMsg): Promise<void> {
+    const swarm = this.swarms.get(msg.swarmId);
+    if (!swarm) return;
+    if (this.myPeerId !== swarm.leaderPeerId) return;
+    if (!swarm.players.some(p => p.peerId === msg.peerId)) return;
+
+    const gameStateJson = swarm.gameState ? JSON.stringify(swarm.gameState) : undefined;
+    const lastResolvedTurn = swarm.turnHistory[swarm.turnHistory.length - 1];
+    const snapshotMsg: proto.StateSnapshotMsg = {
+      app: proto.APP_ID,
+      type: 'state:snapshot',
+      swarmId: swarm.id,
+      peerId: this.myPeerId,
+      targetPeerId: msg.peerId,
+      timestamp: Date.now(),
+      status: swarm.status,
+      currentTurn: swarm.currentTurn,
+      stateRoot: swarm.stateRoot,
+      gameStateJson,
+      partyOrder: swarm.players.map((p) => p.peerId),
+      resultMessage: swarm.turnHistory[swarm.turnHistory.length - 1]?.resultMessage,
+      lastResolvedTurn,
+    };
+    await this.broadcast(snapshotMsg);
+    this.log(`Broadcast authoritative snapshot for ${swarm.id} to ${msg.peerId.slice(0, 8)}`);
+  }
+
+  private onRemoteStateSnapshot(msg: proto.StateSnapshotMsg): void {
+    const swarm = this.swarms.get(msg.swarmId);
+    if (!swarm) return;
+    if (msg.peerId !== swarm.leaderPeerId) return;
+    if (msg.targetPeerId && msg.targetPeerId !== this.myPeerId) return;
+
+    const localTurn = swarm.currentTurn;
+    const localRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const localLastResolvedTurn = swarm.turnHistory[swarm.turnHistory.length - 1]?.turn ?? 0;
+    const msgLastResolvedTurn = msg.lastResolvedTurn?.turn ?? 0;
+    if (msg.currentTurn < localTurn) {
+      this.log(`Ignoring authoritative snapshot for ${swarm.id}: stale turn ${msg.currentTurn} < ${localTurn}`);
+      return;
+    }
+    if (msg.currentTurn === localTurn && msgLastResolvedTurn < localLastResolvedTurn) {
+      this.log(`Ignoring authoritative snapshot for ${swarm.id}: stale resolved turn ${msgLastResolvedTurn} < ${localLastResolvedTurn}`);
+      return;
+    }
+    const sameTurn = msg.currentTurn === localTurn;
+    const sameRoot = (!msg.stateRoot && !localRoot) || (!!msg.stateRoot && !!localRoot && msg.stateRoot === localRoot);
+    if (sameTurn && sameRoot) return;
+
+    if (msg.gameStateJson) {
+      const derivedRoot = hashStateJson(msg.gameStateJson);
+      if (msg.stateRoot && msg.stateRoot !== derivedRoot) {
+        this.log(`Ignoring authoritative snapshot for ${swarm.id}: stateRoot mismatch`);
+        return;
+      }
+      swarm.gameState = JSON.parse(msg.gameStateJson);
+      swarm.stateRoot = msg.stateRoot ?? derivedRoot;
+    } else {
+      swarm.gameState = null;
+      swarm.stateRoot = msg.stateRoot;
+    }
+
+    if (msg.partyOrder && this.canBackfillPlayersFromPartyOrder(msg.partyOrder, swarm)) {
+      this.backfillPlayersFromPartyOrder(swarm, msg.partyOrder, msg.timestamp);
+      if (this.isValidPartyOrder(msg.partyOrder, swarm)) {
+        swarm.playerIndexMap = new Map(msg.partyOrder.map((pid, i) => [pid, i]));
+        this.reorderPlayersToPartyOrder(swarm, msg.partyOrder);
+      }
+    }
+
+    swarm.status = msg.status;
+    swarm.currentTurn = msg.currentTurn;
+    swarm.pendingProposal = null;
+    if (msg.lastResolvedTurn) {
+      const existingIndex = swarm.turnHistory.findIndex((turn) => turn.turn === msg.lastResolvedTurn!.turn);
+      if (existingIndex >= 0) {
+        swarm.turnHistory[existingIndex] = msg.lastResolvedTurn;
+      } else {
+        swarm.turnHistory.push(msg.lastResolvedTurn);
+        swarm.turnHistory.sort((a, b) => a.turn - b.turn);
+      }
+    }
+    if (swarm.status === 'traveling') {
+      swarm.turnDeadline = Date.now() + 30_000;
+      swarm.votes = swarm.votes.filter(v => v.turn === swarm.currentTurn);
+    } else {
+      swarm.turnDeadline = null;
+      swarm.votes = [];
+    }
+    this.log(`Applied authoritative snapshot for ${swarm.id} (turn ${msg.currentTurn})`);
+  }
+
   private reorderPlayersToPartyOrder(swarm: SwarmState, partyOrder: string[]): void {
     const playersByPeerId = new Map(swarm.players.map(p => [p.peerId, p]));
     const ordered: SwarmMember[] = [];
@@ -1570,7 +1756,13 @@ export class OriginTrailGameCoordinator {
 
   private onRemoteVoteCast(msg: proto.VoteCastMsg): void {
     const swarm = this.swarms.get(msg.swarmId);
-    if (!swarm || swarm.currentTurn !== msg.turn) return;
+    if (!swarm) return;
+    if (swarm.currentTurn !== msg.turn) {
+      if (msg.turn > swarm.currentTurn && swarm.leaderPeerId !== this.myPeerId) {
+        void this.requestAuthoritativeSnapshot(swarm, 'reconnect');
+      }
+      return;
+    }
     if (!swarm.players.some(p => p.peerId === msg.peerId)) return;
     if (!this.isPeerAlive(swarm, msg.peerId)) {
       this.log(`Rejected vote from dead peer ${msg.peerId.slice(0, 8)} on ${msg.swarmId}`);
@@ -1666,6 +1858,13 @@ export class OriginTrailGameCoordinator {
     const resolution = msg.resolution ?? 'consensus';
     const votes = msg.votes ?? swarm.votes.map(v => ({ peerId: v.peerId, action: v.action }));
     const deaths = msg.deaths ?? [];
+    const localStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const stateRootMismatch = !!(msg.previousStateRoot && localStateRoot && msg.previousStateRoot !== localStateRoot);
+    const derivedNewStateRoot = hashStateJson(msg.newStateJson);
+    if (msg.newStateRoot && msg.newStateRoot !== derivedNewStateRoot) {
+      this.log(`Proposal state root mismatch for ${msg.swarmId} turn ${msg.turn} - rejecting`);
+      return;
+    }
 
     // Leader force-resolved proposals bypass both tally validation and quorum.
     // Followers may have partial/lagging vote state, so comparing the local
@@ -1677,10 +1876,14 @@ export class OriginTrailGameCoordinator {
         this.log(`Invalid game state in force-resolved proposal for ${msg.swarmId} turn ${msg.turn} — rejecting`);
         return;
       }
+      if (stateRootMismatch) {
+        this.log(`Force-resolved turn ${msg.turn} for ${msg.swarmId} replaces diverged local state`);
+      }
       swarm.pendingProposal = null;
       this.stopVoteHeartbeat(swarm.id);
       this.workspaceOps.delete(msg.swarmId);
       swarm.gameState = newState;
+      swarm.stateRoot = msg.newStateRoot ?? hashStateJson(msg.newStateJson);
 
       swarm.turnHistory.push({
         turn: msg.turn,
@@ -1710,7 +1913,10 @@ export class OriginTrailGameCoordinator {
     // We do NOT replay through the game engine because it contains
     // non-deterministic elements (Math.random for events, loot, etc.)
     // that would produce different state on each node.
-    if (swarm.gameState && swarm.votes.length > 0) {
+    if (stateRootMismatch) {
+      this.log(`Authoritative proposal for ${msg.swarmId} turn ${msg.turn} detected local state mismatch - skipping local tally validation`);
+      void this.requestAuthoritativeSnapshot(swarm, 'proposal-mismatch');
+    } else if (swarm.gameState && swarm.votes.length > 0) {
       const { winningAction } = this.tallyVotes(swarm);
       if (winningAction !== msg.winningAction) {
         this.log(`Proposal winning action mismatch: local=${winningAction} proposed=${msg.winningAction} — rejecting`);
@@ -1767,6 +1973,8 @@ export class OriginTrailGameCoordinator {
     swarm.pendingProposal = {
       turn: msg.turn,
       hash: msg.proposalHash,
+      previousStateRoot: msg.previousStateRoot,
+      newStateRoot: msg.newStateRoot ?? derivedNewStateRoot,
       winningAction: msg.winningAction,
       newStateJson: msg.newStateJson,
       resultMessage: msg.resultMessage,
@@ -1839,6 +2047,64 @@ export class OriginTrailGameCoordinator {
     await this.checkProposalThreshold(swarm);
   }
 
+  private applyResolvedTurnSnapshot(
+    swarm: SwarmState,
+    data: {
+      turn: number;
+      proposalHash: string;
+      previousStateRoot?: string;
+      newStateJson: string;
+      newStateRoot?: string;
+      winningAction: string;
+      resultMessage: string;
+      votes: Array<{ peerId: string; action: string }>;
+      resolution: 'consensus' | 'leader-tiebreak' | 'force-resolved';
+      deaths: Array<{ name: string; cause: string; partyIndex?: number }>;
+      event?: { type: string; description: string };
+      approvers: string[];
+      timestamp: number;
+    },
+    source: 'proposal' | 'resolved',
+  ): void {
+    const localStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    if (data.previousStateRoot && localStateRoot && data.previousStateRoot !== localStateRoot) {
+      this.log(`Authoritative ${source} state mismatch for ${swarm.id} turn ${data.turn}: local root differs, replacing local state`);
+    }
+
+    const newState: GameState = JSON.parse(data.newStateJson);
+    swarm.pendingProposal = null;
+    this.stopVoteHeartbeat(swarm.id);
+    this.workspaceOps.delete(swarm.id);
+    swarm.gameState = newState;
+    swarm.stateRoot = data.newStateRoot ?? hashStateJson(data.newStateJson);
+    swarm.turnHistory.push({
+      turn: data.turn,
+      winningAction: data.winningAction,
+      resultMessage: data.resultMessage,
+      approvers: data.approvers,
+      votes: data.votes,
+      resolution: data.resolution,
+      deaths: data.deaths,
+      event: data.event,
+      timestamp: Date.now(),
+    });
+
+    if (newState.status !== 'active') {
+      swarm.status = 'finished';
+    } else {
+      swarm.currentTurn = data.turn + 1;
+      swarm.votes = [];
+      swarm.turnDeadline = Date.now() + 30_000;
+    }
+
+    this.pushNotification({
+      type: 'turn_resolved', swarmId: swarm.id, swarmName: swarm.name,
+      peerId: swarm.leaderPeerId, timestamp: data.timestamp, turn: data.turn,
+      action: data.winningAction,
+      message: `Turn ${data.turn} resolved - ${data.winningAction}`,
+    });
+  }
+
   private onRemoteTurnResolved(msg: proto.TurnResolvedMsg): void {
     const swarm = this.swarms.get(msg.swarmId);
     if (!swarm) return;
@@ -1846,40 +2112,48 @@ export class OriginTrailGameCoordinator {
     // If we have a matching pending proposal but haven't resolved yet, apply it
     if (swarm.pendingProposal && swarm.pendingProposal.hash === msg.proposalHash) {
       const proposal = swarm.pendingProposal;
-      swarm.pendingProposal = null;
-      this.stopVoteHeartbeat(swarm.id);
-      this.workspaceOps.delete(msg.swarmId);
-
-      const newState: GameState = JSON.parse(proposal.newStateJson);
-      swarm.gameState = newState;
-      swarm.turnHistory.push({
+      this.applyResolvedTurnSnapshot(swarm, {
         turn: proposal.turn,
+        proposalHash: proposal.hash,
+        previousStateRoot: proposal.previousStateRoot,
+        newStateJson: proposal.newStateJson,
+        newStateRoot: proposal.newStateRoot,
         winningAction: proposal.winningAction,
         resultMessage: proposal.resultMessage,
-        approvers: [...proposal.approvals],
         votes: proposal.votes,
         resolution: proposal.resolution,
         deaths: proposal.deaths,
         event: proposal.event,
-        timestamp: Date.now(),
-      });
-
-      if (newState.status !== 'active') {
-        swarm.status = 'finished';
-        swarm.finishedAt = Date.now();
-      } else {
-        swarm.currentTurn++;
-        swarm.votes = [];
-        swarm.turnDeadline = Date.now() + 30_000;
-      }
-      this.pushNotification({
-        type: 'turn_resolved', swarmId: swarm.id, swarmName: swarm.name,
-        peerId: msg.peerId, timestamp: msg.timestamp, turn: proposal.turn,
-        action: proposal.winningAction,
-        message: `Turn ${proposal.turn} resolved — ${proposal.winningAction}`,
-      });
+        approvers: [...proposal.approvals],
+        timestamp: msg.timestamp,
+      }, 'proposal');
       this.log(`Applied resolved turn ${proposal.turn} for ${swarm.id} (via turn:resolved)`);
+      return;
     }
+
+    if (msg.peerId !== swarm.leaderPeerId) return;
+    if (msg.turn !== swarm.currentTurn) return;
+    if (!msg.newStateJson || !msg.winningAction || !msg.resultMessage || !msg.resolution || !msg.votes || !msg.deaths) {
+      this.log(`Ignoring turn:resolved for ${swarm.id} turn ${msg.turn}: missing authoritative snapshot`);
+      return;
+    }
+
+    this.applyResolvedTurnSnapshot(swarm, {
+      turn: msg.turn,
+      proposalHash: msg.proposalHash,
+      previousStateRoot: msg.previousStateRoot,
+      newStateJson: msg.newStateJson,
+      newStateRoot: msg.newStateRoot,
+      winningAction: msg.winningAction,
+      resultMessage: msg.resultMessage,
+      votes: msg.votes,
+      resolution: msg.resolution,
+      deaths: msg.deaths,
+      event: msg.event,
+      approvers: msg.approvers ?? [msg.peerId],
+      timestamp: msg.timestamp,
+    }, 'resolved');
+    this.log(`Recovered turn ${msg.turn} for ${swarm.id} from authoritative turn:resolved snapshot`);
   }
 
   // ── Query helpers ─────────────────────────────────────────────────
@@ -1962,11 +2236,14 @@ export class OriginTrailGameCoordinator {
       players: swarm.players.map(p => ({ id: p.peerId, name: p.displayName, isLeader: p.isLeader })),
       status: swarm.status,
       currentTurn: swarm.currentTurn,
+      stateRoot: swarm.stateRoot ?? null,
       gameState: swarm.gameState,
       voteStatus,
       pendingProposal: swarm.pendingProposal ? {
         turn: swarm.pendingProposal.turn,
         hash: swarm.pendingProposal.hash.slice(0, 12),
+        previousStateRoot: swarm.pendingProposal.previousStateRoot ?? null,
+        newStateRoot: swarm.pendingProposal.newStateRoot ?? null,
         approvals: swarm.pendingProposal.approvals.size,
         threshold: signatureThreshold(swarm.players.length),
       } : null,

--- a/packages/origin-trail-game/src/dkg/coordinator.ts
+++ b/packages/origin-trail-game/src/dkg/coordinator.ts
@@ -155,6 +155,10 @@ function stateRootFromState(state: GameState | null): string | undefined {
   return hashStateJson(JSON.stringify(state));
 }
 
+function currentStateRoot(swarm: SwarmState): string | undefined {
+  return swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+}
+
 function detectDeaths(
   oldState: GameState | null,
   newState: GameState,
@@ -939,7 +943,7 @@ export class OriginTrailGameCoordinator {
     const result = gameEngine.executeAction(swarm.gameState, { type: winningAction as any, params });
 
     const newStateJson = JSON.stringify(result.newState);
-    const previousStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const previousStateRoot = currentStateRoot(swarm);
     const newStateRoot = hashStateJson(newStateJson);
     const hash = hashProposal(swarm.id, swarm.currentTurn, newStateJson);
     const votes = swarm.votes.map(v => ({ peerId: v.peerId, action: v.action }));
@@ -1212,7 +1216,7 @@ export class OriginTrailGameCoordinator {
     const result = gameEngine.executeAction(swarm.gameState, { type: winningAction as any, params });
 
     const newStateJson = JSON.stringify(result.newState);
-    const previousStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const previousStateRoot = currentStateRoot(swarm);
     const newStateRoot = hashStateJson(newStateJson);
     const hash = hashProposal(swarm.id, swarm.currentTurn, newStateJson);
     const votes = swarm.votes.map(v => ({ peerId: v.peerId, action: v.action }));
@@ -1531,29 +1535,7 @@ export class OriginTrailGameCoordinator {
       return;
     }
     swarm.gameState = JSON.parse(msg.gameStateJson);
-    if (msg.partyOrder) {
-      let appliedPartyOrder = false;
-      if (this.isValidPartyOrder(msg.partyOrder, swarm)) {
-        swarm.playerIndexMap = new Map(msg.partyOrder.map((pid: string, i: number) => [pid, i]));
-        this.reorderPlayersToPartyOrder(swarm, msg.partyOrder);
-        appliedPartyOrder = true;
-      } else if (this.canBackfillPlayersFromPartyOrder(msg.partyOrder, swarm)) {
-        // Join gossip can be delayed. Backfill only from a safe partyOrder shape
-        // so malformed payloads cannot mutate existing local membership.
-        this.backfillPlayersFromPartyOrder(swarm, msg.partyOrder, msg.timestamp);
-        if (this.isValidPartyOrder(msg.partyOrder, swarm)) {
-          swarm.playerIndexMap = new Map(msg.partyOrder.map((pid: string, i: number) => [pid, i]));
-          this.reorderPlayersToPartyOrder(swarm, msg.partyOrder);
-          appliedPartyOrder = true;
-        }
-      }
-      if (!appliedPartyOrder) {
-        this.log(`Invalid partyOrder for ${msg.swarmId}, falling back to local order`);
-        swarm.playerIndexMap = new Map(swarm.players.map((p, i) => [p.peerId, i]));
-      }
-    } else {
-      swarm.playerIndexMap = new Map(swarm.players.map((p, i) => [p.peerId, i]));
-    }
+    this.applyAuthoritativePartyOrder(swarm, msg.partyOrder, msg.timestamp, { allowFallbackToLocalOrder: true });
     swarm.status = 'traveling';
     swarm.currentTurn = 1;
     swarm.votes = [];
@@ -1611,6 +1593,52 @@ export class OriginTrailGameCoordinator {
     this.reorderPlayersToPartyOrder(swarm, partyOrder);
   }
 
+  private applyAuthoritativePartyOrder(
+    swarm: SwarmState,
+    partyOrder: string[] | undefined,
+    timestamp: number,
+    options?: { allowFallbackToLocalOrder?: boolean },
+  ): void {
+    if (!partyOrder) {
+      if (options?.allowFallbackToLocalOrder) {
+        swarm.playerIndexMap = new Map(swarm.players.map((p, i) => [p.peerId, i]));
+      }
+      return;
+    }
+
+    let appliedPartyOrder = false;
+    if (this.isValidPartyOrder(partyOrder, swarm)) {
+      swarm.playerIndexMap = new Map(partyOrder.map((pid, i) => [pid, i]));
+      this.reorderPlayersToPartyOrder(swarm, partyOrder);
+      appliedPartyOrder = true;
+    } else if (this.canBackfillPlayersFromPartyOrder(partyOrder, swarm)) {
+      this.backfillPlayersFromPartyOrder(swarm, partyOrder, timestamp);
+      if (this.isValidPartyOrder(partyOrder, swarm)) {
+        swarm.playerIndexMap = new Map(partyOrder.map((pid, i) => [pid, i]));
+        this.reorderPlayersToPartyOrder(swarm, partyOrder);
+        appliedPartyOrder = true;
+      }
+    }
+
+    if (!appliedPartyOrder && options?.allowFallbackToLocalOrder) {
+      this.log(`Invalid partyOrder for ${swarm.id}, falling back to local order`);
+      swarm.playerIndexMap = new Map(swarm.players.map((p, i) => [p.peerId, i]));
+    }
+  }
+
+  private applySnapshotLifecycleState(swarm: SwarmState, msg: proto.StateSnapshotMsg): void {
+    swarm.status = msg.status;
+    swarm.currentTurn = msg.currentTurn;
+    swarm.pendingProposal = null;
+    if (swarm.status === 'traveling') {
+      swarm.turnDeadline = Date.now() + 30_000;
+      swarm.votes = swarm.votes.filter(v => v.turn === swarm.currentTurn);
+    } else {
+      swarm.turnDeadline = null;
+      swarm.votes = [];
+    }
+  }
+
   private async requestAuthoritativeSnapshot(
     swarm: SwarmState,
     reason: 'proposal-mismatch' | 'reconnect' | 'manual',
@@ -1663,7 +1691,7 @@ export class OriginTrailGameCoordinator {
     if (msg.targetPeerId && msg.targetPeerId !== this.myPeerId) return;
 
     const localTurn = swarm.currentTurn;
-    const localRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const localRoot = currentStateRoot(swarm);
     const localLastResolvedTurn = swarm.turnHistory[swarm.turnHistory.length - 1]?.turn ?? 0;
     const msgLastResolvedTurn = msg.lastResolvedTurn?.turn ?? 0;
     if (msg.currentTurn < localTurn) {
@@ -1691,17 +1719,8 @@ export class OriginTrailGameCoordinator {
       swarm.stateRoot = msg.stateRoot;
     }
 
-    if (msg.partyOrder && this.canBackfillPlayersFromPartyOrder(msg.partyOrder, swarm)) {
-      this.backfillPlayersFromPartyOrder(swarm, msg.partyOrder, msg.timestamp);
-      if (this.isValidPartyOrder(msg.partyOrder, swarm)) {
-        swarm.playerIndexMap = new Map(msg.partyOrder.map((pid, i) => [pid, i]));
-        this.reorderPlayersToPartyOrder(swarm, msg.partyOrder);
-      }
-    }
-
-    swarm.status = msg.status;
-    swarm.currentTurn = msg.currentTurn;
-    swarm.pendingProposal = null;
+    this.applyAuthoritativePartyOrder(swarm, msg.partyOrder, msg.timestamp);
+    this.applySnapshotLifecycleState(swarm, msg);
     if (msg.lastResolvedTurn) {
       const existingIndex = swarm.turnHistory.findIndex((turn) => turn.turn === msg.lastResolvedTurn!.turn);
       if (existingIndex >= 0) {
@@ -1710,13 +1729,6 @@ export class OriginTrailGameCoordinator {
         swarm.turnHistory.push(msg.lastResolvedTurn);
         swarm.turnHistory.sort((a, b) => a.turn - b.turn);
       }
-    }
-    if (swarm.status === 'traveling') {
-      swarm.turnDeadline = Date.now() + 30_000;
-      swarm.votes = swarm.votes.filter(v => v.turn === swarm.currentTurn);
-    } else {
-      swarm.turnDeadline = null;
-      swarm.votes = [];
     }
     this.log(`Applied authoritative snapshot for ${swarm.id} (turn ${msg.currentTurn})`);
   }
@@ -1858,7 +1870,7 @@ export class OriginTrailGameCoordinator {
     const resolution = msg.resolution ?? 'consensus';
     const votes = msg.votes ?? swarm.votes.map(v => ({ peerId: v.peerId, action: v.action }));
     const deaths = msg.deaths ?? [];
-    const localStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const localStateRoot = currentStateRoot(swarm);
     const stateRootMismatch = !!(msg.previousStateRoot && localStateRoot && msg.previousStateRoot !== localStateRoot);
     const derivedNewStateRoot = hashStateJson(msg.newStateJson);
     if (msg.newStateRoot && msg.newStateRoot !== derivedNewStateRoot) {
@@ -2066,7 +2078,7 @@ export class OriginTrailGameCoordinator {
     },
     source: 'proposal' | 'resolved',
   ): void {
-    const localStateRoot = swarm.stateRoot ?? stateRootFromState(swarm.gameState);
+    const localStateRoot = currentStateRoot(swarm);
     if (data.previousStateRoot && localStateRoot && data.previousStateRoot !== localStateRoot) {
       this.log(`Authoritative ${source} state mismatch for ${swarm.id} turn ${data.turn}: local root differs, replacing local state`);
     }

--- a/packages/origin-trail-game/src/dkg/protocol.ts
+++ b/packages/origin-trail-game/src/dkg/protocol.ts
@@ -23,6 +23,8 @@ export type MessageType =
   | 'swarm:joined'
   | 'swarm:left'
   | 'expedition:launched'
+  | 'state:request'
+  | 'state:snapshot'
   | 'vote:cast'
   | 'turn:proposal'
   | 'turn:approve'
@@ -58,6 +60,7 @@ export interface SwarmLeftMsg extends BaseMessage {
 export interface ExpeditionLaunchedMsg extends BaseMessage {
   type: 'expedition:launched';
   gameStateJson: string;
+  stateRoot?: string;
   partyOrder?: string[];
   contextGraphId?: string;
   requiredSignatures?: number;
@@ -70,10 +73,41 @@ export interface VoteCastMsg extends BaseMessage {
   params?: Record<string, any>;
 }
 
+export interface StateRequestMsg extends BaseMessage {
+  type: 'state:request';
+  turn?: number;
+  knownStateRoot?: string;
+  reason?: 'proposal-mismatch' | 'reconnect' | 'manual';
+}
+
+export interface StateSnapshotMsg extends BaseMessage {
+  type: 'state:snapshot';
+  targetPeerId?: string;
+  status: 'recruiting' | 'traveling' | 'finished';
+  currentTurn: number;
+  stateRoot?: string;
+  gameStateJson?: string;
+  partyOrder?: string[];
+  resultMessage?: string;
+  lastResolvedTurn?: {
+    turn: number;
+    winningAction: string;
+    resultMessage: string;
+    approvers: string[];
+    votes: Array<{ peerId: string; action: string }>;
+    resolution: 'consensus' | 'leader-tiebreak' | 'force-resolved';
+    deaths: Array<{ name: string; cause: string; partyIndex?: number }>;
+    event?: { type: string; description: string };
+    timestamp: number;
+  };
+}
+
 export interface TurnProposalMsg extends BaseMessage {
   type: 'turn:proposal';
   turn: number;
   proposalHash: string;
+  previousStateRoot?: string;
+  newStateRoot?: string;
   winningAction: string;
   newStateJson: string;
   resultMessage: string;
@@ -98,6 +132,16 @@ export interface TurnResolvedMsg extends BaseMessage {
   type: 'turn:resolved';
   turn: number;
   proposalHash: string;
+  previousStateRoot?: string;
+  newStateRoot?: string;
+  winningAction?: string;
+  newStateJson?: string;
+  resultMessage?: string;
+  votes?: Array<{ peerId: string; action: string }>;
+  approvers?: string[];
+  resolution?: 'consensus' | 'leader-tiebreak' | 'force-resolved';
+  deaths?: Array<{ name: string; cause: string; partyIndex?: number }>;
+  event?: { type: string; description: string };
 }
 
 export interface ChatMsg extends BaseMessage {
@@ -112,6 +156,8 @@ export type OTMessage =
   | SwarmJoinedMsg
   | SwarmLeftMsg
   | ExpeditionLaunchedMsg
+  | StateRequestMsg
+  | StateSnapshotMsg
   | VoteCastMsg
   | TurnProposalMsg
   | TurnApproveMsg

--- a/packages/origin-trail-game/test/context-graph-integration.test.ts
+++ b/packages/origin-trail-game/test/context-graph-integration.test.ts
@@ -83,6 +83,21 @@ function createCoordinator(agent: MockAgent) {
   );
 }
 
+function bridgeAgents(agents: MockAgent[], options?: { canDeliver?: (from: string, to: string, msg: proto.OTMessage) => boolean }) {
+  const topic = proto.appTopic('origin-trail-game');
+  for (const agent of agents) {
+    agent.gossip.publish = async (_topic: string, data: Uint8Array) => {
+      const msg = proto.decode(data);
+      if (msg) agent._broadcasts.push(msg);
+      for (const other of agents) {
+        if (other.peerId === agent.peerId) continue;
+        if (msg && options?.canDeliver && !options.canDeliver(agent.peerId, other.peerId, msg)) continue;
+        other._injectMessage(topic, data, agent.peerId);
+      }
+    };
+  }
+}
+
 async function setupThreePlayerGame(leaderAgent: MockAgent) {
   const coord = createCoordinator(leaderAgent);
 
@@ -688,6 +703,62 @@ describe('Context Graph Integration', () => {
       expect(formatted.contextGraphId).toBeNull();
 
       coord.destroy();
+    });
+  });
+
+  describe('authoritative snapshot repair', () => {
+    it('repairs a follower that missed a resolved turn after reconnect', async () => {
+      const leaderAgent = makeMockAgent('peer-A', 1n);
+      const followerAgent = makeMockAgent('peer-B', 2n);
+      let followerConnected = true;
+
+      bridgeAgents([leaderAgent, followerAgent], {
+        canDeliver: (_from, to) => !(to === followerAgent.peerId && !followerConnected),
+      });
+
+      const leader = createCoordinator(leaderAgent);
+      const follower = createCoordinator(followerAgent);
+
+      const swarm = await leader.createSwarm('Alice', 'RepairSwarm', 2);
+      await new Promise(r => setTimeout(r, 50));
+
+      await follower.joinSwarm(swarm.id, 'Bob');
+      await new Promise(r => setTimeout(r, 50));
+
+      await leader.launchExpedition(swarm.id);
+      await new Promise(r => setTimeout(r, 100));
+
+      const followerBefore = follower.getSwarm(swarm.id);
+      expect(followerBefore?.currentTurn).toBe(1);
+      expect(typeof followerBefore?.stateRoot).toBe('string');
+
+      followerConnected = false;
+
+      await leader.castVote(swarm.id, 'syncMemory');
+      await new Promise(r => setTimeout(r, 50));
+      await leader.forceResolveTurn(swarm.id);
+      await new Promise(r => setTimeout(r, 100));
+
+      const leaderAfterResolve = leader.getSwarm(swarm.id);
+      expect(leaderAfterResolve?.currentTurn).toBe(2);
+
+      followerConnected = true;
+      await leader.castVote(swarm.id, 'advance', { pace: 2 });
+      await new Promise(r => setTimeout(r, 250));
+
+      const leaderFinal = leader.getSwarm(swarm.id);
+      const followerFinal = follower.getSwarm(swarm.id);
+      expect(followerFinal?.currentTurn).toBe(leaderFinal?.currentTurn);
+      expect(followerFinal?.stateRoot).toBe(leaderFinal?.stateRoot);
+      expect(followerFinal?.gameState).toEqual(leaderFinal?.gameState);
+      expect(followerFinal?.turnHistory.at(-1)?.approvers).toEqual(leaderFinal?.turnHistory.at(-1)?.approvers);
+
+      expect(followerAgent._broadcasts.some((m) => m.type === 'state:request')).toBe(true);
+      expect(leaderAgent._broadcasts.some((m) => m.type === 'state:snapshot' && m.targetPeerId === followerAgent.peerId)).toBe(true);
+      expect(followerAgent._broadcasts.some((m) => m.type === 'state:snapshot')).toBe(false);
+
+      leader.destroy();
+      follower.destroy();
     });
   });
 

--- a/packages/origin-trail-game/test/e2e/helpers.ts
+++ b/packages/origin-trail-game/test/e2e/helpers.ts
@@ -60,7 +60,7 @@ async function httpPost(url: string, body: any, token?: string): Promise<any> {
   return res.json();
 }
 
-async function waitForReady(port: number, maxWaitMs = 60_000): Promise<void> {
+async function waitForReady(port: number, maxWaitMs = 120_000): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < maxWaitMs) {
     try {
@@ -379,6 +379,7 @@ export function nodeApi(node: TestNode) {
     info: () => httpGet(`${game}/info`, token),
     lobby: () => httpGet(`${game}/lobby`, token),
     swarm: (id: string) => httpGet(`${game}/swarm/${id}`, token),
+    swarmSnapshot: (id: string) => httpGet(`${game}/swarm/${id}/snapshot`, token),
     leaderboard: () => httpGet(`${game}/leaderboard`, token),
     notifications: () => httpGet(`${game}/notifications`, token),
     players: () => httpGet(`${game}/players`, token),

--- a/packages/origin-trail-game/test/handler.test.ts
+++ b/packages/origin-trail-game/test/handler.test.ts
@@ -124,6 +124,23 @@ describe('OriginTrail Game API handler', () => {
     expect(lobby.mySwarms[0].players[0].isLeader).toBe(true);
   });
 
+  it('GET /swarm/:id/snapshot returns authoritative swarm snapshot metadata', async () => {
+    const reqCreate = createMockReq('POST', '/api/apps/origin-trail-game/create', { playerName: 'Alice', swarmName: 'Snapshot Swarm' });
+    const mockCreate = createMockRes();
+    await handler(reqCreate, mockCreate.res, new URL(reqCreate.url, 'http://localhost'));
+    const created = JSON.parse(mockCreate.body);
+
+    const reqSnapshot = createMockReq('GET', `/api/apps/origin-trail-game/swarm/${created.id}/snapshot`);
+    const mockSnapshot = createMockRes();
+    await handler(reqSnapshot, mockSnapshot.res, new URL(reqSnapshot.url, 'http://localhost'));
+    const snapshot = JSON.parse(mockSnapshot.body);
+
+    expect(snapshot.swarmId).toBe(created.id);
+    expect(snapshot.currentTurn).toBe(0);
+    expect(snapshot.stateRoot).toBeNull();
+    expect(snapshot.gameState).toBeNull();
+  });
+
   it('allows creating multiple active swarms for the same player', async () => {
     const req1 = createMockReq('POST', '/api/apps/origin-trail-game/create', { playerName: 'Alice', swarmName: 'Swarm A' });
     const mock1 = createMockRes();
@@ -2597,6 +2614,69 @@ describe('Turn proposal accepts non-deterministic state', () => {
     expect(actionMismatchLogs).toHaveLength(1);
   });
 
+  it('follower requests authoritative snapshot when proposal previousStateRoot mismatches local root', async () => {
+    const leaderPeerId = 'leader-root-mismatch-1';
+    const followerPeerId = 'follower-root-mismatch-1';
+    const broadcasts: any[] = [];
+
+    const followerAgent = makeMockAgent(followerPeerId);
+    followerAgent.gossip.publish = async (_topic: string, data: Uint8Array) => {
+      broadcasts.push(JSON.parse(new TextDecoder().decode(data)));
+    };
+    const { OriginTrailGameCoordinator } = await import('../src/dkg/coordinator.js');
+    const coordinator = new OriginTrailGameCoordinator(followerAgent as any, { paranetId: 'root-mismatch-test' });
+
+    const { encode } = await import('../src/dkg/protocol.js');
+    const handlers = followerAgent._messageHandlers.get('dkg/paranet/root-mismatch-test/app');
+    const handle = handlers![0];
+
+    handle('dkg/paranet/root-mismatch-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:created', swarmId: 'swarm-root-mismatch',
+      peerId: leaderPeerId, timestamp: Date.now(), swarmName: 'Mismatch', playerName: 'Leader', maxPlayers: 4,
+    }), leaderPeerId);
+    handle('dkg/paranet/root-mismatch-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:joined', swarmId: 'swarm-root-mismatch',
+      peerId: followerPeerId, timestamp: Date.now(), playerName: 'Follower',
+    }), followerPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const { GameEngine } = await import('../src/engine/game-engine.js');
+    const engine = new GameEngine();
+    const gameState = engine.createGame(['Leader', 'Follower'], leaderPeerId);
+    const launchStateJson = JSON.stringify(gameState);
+    const { createHash } = await import('node:crypto');
+    const launchStateRoot = createHash('sha256').update(launchStateJson).digest('hex');
+
+    handle('dkg/paranet/root-mismatch-test/app', encode({
+      app: 'origin-trail-game', type: 'expedition:launched', swarmId: 'swarm-root-mismatch',
+      peerId: leaderPeerId, timestamp: Date.now(), gameStateJson: launchStateJson, stateRoot: launchStateRoot,
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const swarm = coordinator.getSwarm('swarm-root-mismatch')!;
+    swarm.stateRoot = 'deadbeef';
+
+    const leaderResult = engine.executeAction(gameState, { type: 'advance' });
+    const newStateJson = JSON.stringify(leaderResult.newState);
+    const proposalHash = createHash('sha256').update(`swarm-root-mismatch:1:${newStateJson}`).digest('hex');
+
+    handle('dkg/paranet/root-mismatch-test/app', encode({
+      app: 'origin-trail-game', type: 'turn:proposal', swarmId: 'swarm-root-mismatch',
+      peerId: leaderPeerId, timestamp: Date.now(), turn: 1,
+      proposalHash, previousStateRoot: launchStateRoot,
+      newStateRoot: createHash('sha256').update(newStateJson).digest('hex'),
+      winningAction: 'advance', newStateJson,
+      resultMessage: leaderResult.message,
+      votes: [{ peerId: leaderPeerId, action: 'advance' }],
+      resolution: 'consensus', deaths: [],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const snapshotReq = broadcasts.find((b: any) => b.type === 'state:request');
+    expect(snapshotReq).toBeDefined();
+    expect(snapshotReq.reason).toBe('proposal-mismatch');
+  });
+
   it('leader force-resolved proposal bypasses tally validation (no action mismatch rejection)', async () => {
     const leaderPeerId = 'leader-force-1';
     const followerPeerId = 'follower-force-1';
@@ -2716,6 +2796,270 @@ describe('Turn proposal accepts non-deterministic state', () => {
 
     const appliedLogs = logs.filter(l => l.includes('Applied force-resolved'));
     expect(appliedLogs).toHaveLength(0);
+  });
+
+  it('follower recovers from authoritative turn:resolved snapshot after missing proposal', async () => {
+    const leaderPeerId = 'leader-recover-1';
+    const followerPeerId = 'follower-recover-1';
+
+    const logs: string[] = [];
+    const followerAgent = makeMockAgent(followerPeerId);
+    const { OriginTrailGameCoordinator } = await import('../src/dkg/coordinator.js');
+    const coordinator = new OriginTrailGameCoordinator(followerAgent as any, { paranetId: 'recover-test' }, (msg) => logs.push(msg));
+
+    const { encode } = await import('../src/dkg/protocol.js');
+    const handlers = followerAgent._messageHandlers.get('dkg/paranet/recover-test/app');
+    const handle = handlers![0];
+
+    handle('dkg/paranet/recover-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:created', swarmId: 'swarm-recover',
+      peerId: leaderPeerId, timestamp: Date.now(), swarmName: 'Recover', playerName: 'Leader', maxPlayers: 4,
+    }), leaderPeerId);
+    handle('dkg/paranet/recover-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:joined', swarmId: 'swarm-recover',
+      peerId: followerPeerId, timestamp: Date.now(), playerName: 'Follower',
+    }), followerPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const { GameEngine } = await import('../src/engine/game-engine.js');
+    const engine = new GameEngine();
+    const gameState = engine.createGame(['Leader', 'Follower'], leaderPeerId);
+    const launchStateJson = JSON.stringify(gameState);
+    const { createHash } = await import('node:crypto');
+    const launchStateRoot = createHash('sha256').update(launchStateJson).digest('hex');
+
+    handle('dkg/paranet/recover-test/app', encode({
+      app: 'origin-trail-game', type: 'expedition:launched', swarmId: 'swarm-recover',
+      peerId: leaderPeerId, timestamp: Date.now(), gameStateJson: launchStateJson, stateRoot: launchStateRoot,
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const leaderResult = engine.executeAction(gameState, { type: 'advance' });
+    const newStateJson = JSON.stringify(leaderResult.newState);
+    const newStateRoot = createHash('sha256').update(newStateJson).digest('hex');
+    const proposalHash = createHash('sha256').update(`swarm-recover:1:${newStateJson}`).digest('hex');
+
+    handle('dkg/paranet/recover-test/app', encode({
+      app: 'origin-trail-game', type: 'turn:resolved', swarmId: 'swarm-recover',
+      peerId: leaderPeerId, timestamp: Date.now(), turn: 1, proposalHash,
+      previousStateRoot: launchStateRoot,
+      newStateRoot,
+      winningAction: 'advance',
+      newStateJson,
+      resultMessage: leaderResult.message,
+      votes: [{ peerId: leaderPeerId, action: 'advance' }],
+      resolution: 'consensus',
+      deaths: [],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const swarm = coordinator.getSwarm('swarm-recover');
+    expect(swarm).not.toBeNull();
+    expect(swarm!.currentTurn).toBe(2);
+    expect(swarm!.stateRoot).toBe(newStateRoot);
+    expect(swarm!.turnHistory).toHaveLength(1);
+    expect(swarm!.gameState).toEqual(leaderResult.newState);
+    expect(swarm!.turnHistory[0].approvers).toEqual([leaderPeerId]);
+
+    const recoveryLogs = logs.filter(l => l.includes('Recovered turn 1'));
+    expect(recoveryLogs).toHaveLength(1);
+  });
+
+  it('follower applies authoritative state:snapshot from leader to repair local state', async () => {
+    const leaderPeerId = 'leader-snapshot-1';
+    const followerPeerId = 'follower-snapshot-1';
+
+    const followerAgent = makeMockAgent(followerPeerId);
+    const { OriginTrailGameCoordinator } = await import('../src/dkg/coordinator.js');
+    const coordinator = new OriginTrailGameCoordinator(followerAgent as any, { paranetId: 'snapshot-repair-test' });
+
+    const { encode } = await import('../src/dkg/protocol.js');
+    const handlers = followerAgent._messageHandlers.get('dkg/paranet/snapshot-repair-test/app');
+    const handle = handlers![0];
+
+    handle('dkg/paranet/snapshot-repair-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:created', swarmId: 'swarm-snapshot-repair',
+      peerId: leaderPeerId, timestamp: Date.now(), swarmName: 'SnapshotRepair', playerName: 'Leader', maxPlayers: 4,
+    }), leaderPeerId);
+    handle('dkg/paranet/snapshot-repair-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:joined', swarmId: 'swarm-snapshot-repair',
+      peerId: followerPeerId, timestamp: Date.now(), playerName: 'Follower',
+    }), followerPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const { GameEngine } = await import('../src/engine/game-engine.js');
+    const engine = new GameEngine();
+    const initial = engine.createGame(['Leader', 'Follower'], leaderPeerId);
+    const initialJson = JSON.stringify(initial);
+    const { createHash } = await import('node:crypto');
+    const initialRoot = createHash('sha256').update(initialJson).digest('hex');
+
+    handle('dkg/paranet/snapshot-repair-test/app', encode({
+      app: 'origin-trail-game', type: 'expedition:launched', swarmId: 'swarm-snapshot-repair',
+      peerId: leaderPeerId, timestamp: Date.now(), gameStateJson: initialJson, stateRoot: initialRoot,
+      partyOrder: [leaderPeerId, followerPeerId],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const repairedState = engine.executeAction(initial, { type: 'advance' }).newState;
+    const repairedJson = JSON.stringify(repairedState);
+    const repairedRoot = createHash('sha256').update(repairedJson).digest('hex');
+
+    handle('dkg/paranet/snapshot-repair-test/app', encode({
+      app: 'origin-trail-game', type: 'state:snapshot', swarmId: 'swarm-snapshot-repair',
+      peerId: leaderPeerId, timestamp: Date.now(), status: 'traveling', currentTurn: 2,
+      stateRoot: repairedRoot, gameStateJson: repairedJson,
+      partyOrder: [leaderPeerId, followerPeerId],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const swarm = coordinator.getSwarm('swarm-snapshot-repair')!;
+    expect(swarm.currentTurn).toBe(2);
+    expect(swarm.stateRoot).toBe(repairedRoot);
+    expect(swarm.gameState).toEqual(repairedState);
+  });
+
+  it('follower ignores state:snapshot targeted at another peer', async () => {
+    const leaderPeerId = 'leader-snapshot-target-1';
+    const followerPeerId = 'follower-snapshot-target-1';
+
+    const followerAgent = makeMockAgent(followerPeerId);
+    const { OriginTrailGameCoordinator } = await import('../src/dkg/coordinator.js');
+    const coordinator = new OriginTrailGameCoordinator(followerAgent as any, { paranetId: 'snapshot-target-test' });
+
+    const { encode } = await import('../src/dkg/protocol.js');
+    const handlers = followerAgent._messageHandlers.get('dkg/paranet/snapshot-target-test/app');
+    const handle = handlers![0];
+
+    handle('dkg/paranet/snapshot-target-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:created', swarmId: 'swarm-snapshot-target',
+      peerId: leaderPeerId, timestamp: Date.now(), swarmName: 'SnapshotTarget', playerName: 'Leader', maxPlayers: 4,
+    }), leaderPeerId);
+    handle('dkg/paranet/snapshot-target-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:joined', swarmId: 'swarm-snapshot-target',
+      peerId: followerPeerId, timestamp: Date.now(), playerName: 'Follower',
+    }), followerPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const { GameEngine } = await import('../src/engine/game-engine.js');
+    const engine = new GameEngine();
+    const initial = engine.createGame(['Leader', 'Follower'], leaderPeerId);
+    const initialJson = JSON.stringify(initial);
+    const { createHash } = await import('node:crypto');
+    const initialRoot = createHash('sha256').update(initialJson).digest('hex');
+
+    handle('dkg/paranet/snapshot-target-test/app', encode({
+      app: 'origin-trail-game', type: 'expedition:launched', swarmId: 'swarm-snapshot-target',
+      peerId: leaderPeerId, timestamp: Date.now(), gameStateJson: initialJson, stateRoot: initialRoot,
+      partyOrder: [leaderPeerId, followerPeerId],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const repairedState = engine.executeAction(initial, { type: 'advance' }).newState;
+    const repairedJson = JSON.stringify(repairedState);
+    const repairedRoot = createHash('sha256').update(repairedJson).digest('hex');
+
+    handle('dkg/paranet/snapshot-target-test/app', encode({
+      app: 'origin-trail-game', type: 'state:snapshot', swarmId: 'swarm-snapshot-target',
+      peerId: leaderPeerId, targetPeerId: 'someone-else', timestamp: Date.now(), status: 'traveling', currentTurn: 2,
+      stateRoot: repairedRoot, gameStateJson: repairedJson,
+      partyOrder: [leaderPeerId, followerPeerId],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const swarm = coordinator.getSwarm('swarm-snapshot-target')!;
+    expect(swarm.currentTurn).toBe(1);
+    expect(swarm.stateRoot).toBe(initialRoot);
+    expect(swarm.gameState).toEqual(initial);
+  });
+
+  it('follower ignores stale authoritative snapshot from an older turn', async () => {
+    const leaderPeerId = 'leader-stale-snapshot-1';
+    const followerPeerId = 'follower-stale-snapshot-1';
+
+    const followerAgent = makeMockAgent(followerPeerId);
+    const { OriginTrailGameCoordinator } = await import('../src/dkg/coordinator.js');
+    const coordinator = new OriginTrailGameCoordinator(followerAgent as any, { paranetId: 'stale-snapshot-test' });
+
+    const { encode } = await import('../src/dkg/protocol.js');
+    const handlers = followerAgent._messageHandlers.get('dkg/paranet/stale-snapshot-test/app');
+    const handle = handlers![0];
+
+    handle('dkg/paranet/stale-snapshot-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:created', swarmId: 'swarm-stale-snapshot',
+      peerId: leaderPeerId, timestamp: Date.now(), swarmName: 'StaleSnapshot', playerName: 'Leader', maxPlayers: 4,
+    }), leaderPeerId);
+    handle('dkg/paranet/stale-snapshot-test/app', encode({
+      app: 'origin-trail-game', type: 'swarm:joined', swarmId: 'swarm-stale-snapshot',
+      peerId: followerPeerId, timestamp: Date.now(), playerName: 'Follower',
+    }), followerPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const { GameEngine } = await import('../src/engine/game-engine.js');
+    const engine = new GameEngine();
+    const initial = engine.createGame(['Leader', 'Follower'], leaderPeerId);
+    const initialJson = JSON.stringify(initial);
+    const { createHash } = await import('node:crypto');
+    const initialRoot = createHash('sha256').update(initialJson).digest('hex');
+
+    handle('dkg/paranet/stale-snapshot-test/app', encode({
+      app: 'origin-trail-game', type: 'expedition:launched', swarmId: 'swarm-stale-snapshot',
+      peerId: leaderPeerId, timestamp: Date.now(), gameStateJson: initialJson, stateRoot: initialRoot,
+      partyOrder: [leaderPeerId, followerPeerId],
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const resolvedState = engine.executeAction(initial, { type: 'advance' }).newState;
+    const resolvedJson = JSON.stringify(resolvedState);
+    const resolvedRoot = createHash('sha256').update(resolvedJson).digest('hex');
+    const resolvedTurnTimestamp = Date.now();
+
+    handle('dkg/paranet/stale-snapshot-test/app', encode({
+      app: 'origin-trail-game', type: 'state:snapshot', swarmId: 'swarm-stale-snapshot',
+      peerId: leaderPeerId, targetPeerId: followerPeerId, timestamp: Date.now(), status: 'traveling', currentTurn: 2,
+      stateRoot: resolvedRoot, gameStateJson: resolvedJson,
+      partyOrder: [leaderPeerId, followerPeerId],
+      lastResolvedTurn: {
+        turn: 1,
+        winningAction: 'advance',
+        resultMessage: 'resolved',
+        approvers: [leaderPeerId],
+        votes: [{ peerId: leaderPeerId, action: 'advance' }],
+        resolution: 'consensus',
+        deaths: [],
+        timestamp: resolvedTurnTimestamp,
+      },
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const staleState = engine.createGame(['Leader', 'Follower'], leaderPeerId);
+    staleState.epochs = 999;
+    const staleJson = JSON.stringify(staleState);
+    const staleRoot = createHash('sha256').update(staleJson).digest('hex');
+
+    handle('dkg/paranet/stale-snapshot-test/app', encode({
+      app: 'origin-trail-game', type: 'state:snapshot', swarmId: 'swarm-stale-snapshot',
+      peerId: leaderPeerId, targetPeerId: followerPeerId, timestamp: Date.now(), status: 'traveling', currentTurn: 1,
+      stateRoot: staleRoot, gameStateJson: staleJson,
+      partyOrder: [leaderPeerId, followerPeerId],
+      lastResolvedTurn: {
+        turn: 0,
+        winningAction: 'launch',
+        resultMessage: 'launch',
+        approvers: [leaderPeerId],
+        votes: [],
+        resolution: 'force-resolved',
+        deaths: [],
+        timestamp: resolvedTurnTimestamp - 1000,
+      },
+    }), leaderPeerId);
+    await new Promise(r => setTimeout(r, 50));
+
+    const swarm = coordinator.getSwarm('swarm-stale-snapshot')!;
+    expect(swarm.currentTurn).toBe(2);
+    expect(swarm.stateRoot).toBe(resolvedRoot);
+    expect(swarm.gameState).toEqual(resolvedState);
+    expect(swarm.turnHistory.at(-1)?.turn).toBe(1);
   });
 });
 


### PR DESCRIPTION
> _Migrated from dkg-v9 PR #208_

Summary
This PR hardens the OriginTrail Game swarm lifecycle across UI, graph sync, and update/runtime paths. It fixes several regressions and edge cases discovered during real usage and review, especially around foreground auto-update, bundled app builds, recruiting swarm UX, and graph-based membership recovery.
Changes
- Fix foreground auto-update restart to relaunch via start --foreground instead of the brittle internal daemon-foreground-worker command.
- Include dkg-app-origin-trail-game in build:runtime so auto-update/migration builds the bundled game app artifacts.
- Improve game UI recruiting flow:
  - replace the fragile max-player selector with a clearer stepper control
  - show recruiting swarms as current/max capacity instead of implying a 1-player session
  - keep leave-swarm confirmation inside the app instead of relying on browser confirm()
- Harden graph-based swarm restoration in packages/origin-trail-game/src/dkg/coordinator.ts:
  - store membership joinedAt in RDF
  - track member tombstones with timestamps instead of permanent peer blocking
  - restore rejoined members when graph evidence is newer than the leave tombstone
  - make roster reconstruction deterministic using stable join ordering
  - dedupe duplicate graph membership rows by peerId
- Resolve rebase/concurrency overlap in turn resolution by keeping the newer authoritative snapshot flow from main.
Test Plan
- [x] Targeted game UI tests pass locally (pnpm --filter dkg-app-origin-trail-game exec vitest run test/ui/journey-panel.test.tsx --config vitest.ui.config.ts)
- [x] Targeted game graph sync tests pass locally (pnpm --filter dkg-app-origin-trail-game exec vitest run test/handler.test.ts -t "Graph-based lobby sync|duplicate membership rows|deterministic join ordering|rejoined member")
- [x] Bundled game app build succeeds (pnpm --filter dkg-app-origin-trail-game build)
- [x] Full workspace tests pass locally (pnpm test)
- [x] Full workspace build succeeds (pnpm build)

Related Issues
- Addresses review findings around OriginTrail Game graph sync roster recovery and duplicate membership handling.
- Addresses foreground auto-update restart failure and missing bundled app runtime build artifacts