### PR TITLE
feat: add paranet unsubscribe with deny-list to prevent auto-re-subsc…

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -105,6 +105,8 @@ export interface DKGAgentConfig {
   queryAccess?: QueryAccessConfig;
   /** Additional paranet IDs to sync on peer connect (beyond system paranets). */
   syncParanets?: string[];
+  /** Paranet IDs that have been explicitly unsubscribed. Prevents auto-re-subscribe by discovery/sync paths. */
+  unsubscribedParanets?: string[];
   /** TTL for workspace data in milliseconds. Expired operations are periodically cleaned up. Default: 48 hours. Set to 0 to disable. */
   workspaceTtlMs?: number;
 }
@@ -147,6 +149,7 @@ export class DKGAgent {
   private readonly config: DKGAgentConfig;
   private started = false;
   private readonly subscribedParanets = new Map<string, ParanetSub>();
+  private readonly unsubscribedParanets = new Set<string>();
   private readonly gossipRegistered = new Set<string>();
   private readonly seenOnChainIds = new Set<string>();
   private readonly peerHealth = new Map<string, PeerHealth>();
@@ -175,6 +178,11 @@ export class DKGAgent {
     this.chain = chain;
     this.discovery = new DiscoveryClient(queryEngine);
     this.profileManager = new ProfileManager(publisher, store);
+
+    // Populate deny list from config so it's active before start()/discovery runs
+    for (const id of config.unsubscribedParanets ?? []) {
+      this.unsubscribedParanets.add(id);
+    }
   }
 
   static async create(config: DKGAgentConfig): Promise<DKGAgent> {
@@ -583,6 +591,9 @@ export class DKGAgent {
     const deadline = Date.now() + SYNC_TOTAL_TIMEOUT_MS;
     let totalSynced = 0;
 
+    // Filter out deny-listed paranets before syncing
+    paranetIds = paranetIds.filter(id => !this.unsubscribedParanets.has(id));
+
     try {
       for (const pid of paranetIds) {
         const dataGraph = paranetDataGraphUri(pid);
@@ -839,6 +850,9 @@ export class DKGAgent {
     dataSynced: number;
     workspaceSynced: number;
   }> {
+    if (this.unsubscribedParanets.has(paranetId)) {
+      return { connectedPeers: 0, syncCapablePeers: 0, peersTried: 0, dataSynced: 0, workspaceSynced: 0 };
+    }
     const ctx = createOperationContext('sync');
     const includeWorkspace = options?.includeWorkspace ?? false;
 
@@ -1534,10 +1548,63 @@ export class DKGAgent {
   }
 
   /**
+   * Unsubscribe from a paranet: add to deny list, remove from sync scope,
+   * mark as unsubscribed, and tear down GossipSub topics if active.
+   * System paranets (agents, ontology) cannot be unsubscribed.
+   */
+  unsubscribeFromParanet(paranetId: string): void {
+    const systemParanets = new Set<string>(Object.values(SYSTEM_PARANETS) as string[]);
+    if (systemParanets.has(paranetId)) {
+      throw new Error(`Cannot unsubscribe from system paranet "${paranetId}"`);
+    }
+
+    // Always: add to deny list
+    this.unsubscribedParanets.add(paranetId);
+
+    // Always: remove from sync scope
+    this.untrackSyncParanet(paranetId);
+
+    // Always: mark as unsubscribed in the registry
+    const existing = this.subscribedParanets.get(paranetId);
+    this.subscribedParanets.set(paranetId, {
+      ...existing,
+      subscribed: false,
+      synced: existing?.synced ?? false,
+    });
+
+    // Only if gossip handlers were active: tear down GossipSub topics
+    if (this.gossipRegistered.has(paranetId)) {
+      this.gossip.unsubscribe(paranetPublishTopic(paranetId));
+      this.gossip.unsubscribe(paranetWorkspaceTopic(paranetId));
+      this.gossip.unsubscribe(paranetAppTopic(paranetId));
+      this.gossip.unsubscribe(paranetUpdateTopic(paranetId));
+      this.gossip.unsubscribe(paranetFinalizationTopic(paranetId));
+      this.gossipRegistered.delete(paranetId);
+    }
+
+    this.log.info(
+      createOperationContext('system'),
+      `Unsubscribed from paranet "${paranetId}" — added to deny list`,
+    );
+  }
+
+  /** Remove a paranet from the deny list so it can be re-subscribed. */
+  clearUnsubscribed(paranetId: string): void {
+    this.unsubscribedParanets.delete(paranetId);
+  }
+
+  /** Returns true if the paranet is on the deny list. */
+  isUnsubscribed(paranetId: string): boolean {
+    return this.unsubscribedParanets.has(paranetId);
+  }
+
+  /**
    * Add a paranet to runtime sync scope so sync-on-connect includes it.
    * System paranets are already included by default and are skipped here.
    */
   private trackSyncParanet(paranetId: string): void {
+    if (this.unsubscribedParanets.has(paranetId)) return;
+
     const systemParanets = new Set<string>(Object.values(SYSTEM_PARANETS) as string[]);
     if (systemParanets.has(paranetId)) return;
 
@@ -1545,6 +1612,12 @@ export class DKGAgent {
     if (syncSet.has(paranetId)) return;
     syncSet.add(paranetId);
     this.config.syncParanets = [...syncSet];
+  }
+
+  /** Remove a paranet from the runtime sync scope. */
+  private untrackSyncParanet(paranetId: string): void {
+    if (!this.config.syncParanets) return;
+    this.config.syncParanets = this.config.syncParanets.filter(id => id !== paranetId);
   }
 
   private getOrCreateGossipPublishHandler(): GossipPublishHandler {
@@ -1557,6 +1630,7 @@ export class DKGAgent {
           paranetExists: (id) => this.paranetExists(id),
           subscribeToParanet: (id, options) => this.subscribeToParanet(id, options),
         },
+        this.unsubscribedParanets,
       );
     }
     return this.gossipPublishHandler;
@@ -1702,7 +1776,9 @@ export class DKGAgent {
     });
 
     if (!opts.private) {
-      // Auto-subscribe to the new paranet's GossipSub topic
+      // Explicit create is a deliberate action — clear deny list so
+      // subscribeToParanet and trackSyncParanet work correctly.
+      this.unsubscribedParanets.delete(opts.id);
       this.subscribeToParanet(opts.id);
 
       // Broadcast via the ontology paranet so other nodes learn about it
@@ -1752,6 +1828,16 @@ export class DKGAgent {
 
     const exists = await this.paranetExists(opts.id);
     if (exists) {
+      if (this.unsubscribedParanets.has(opts.id)) {
+        // Deny-listed — record locally but do not re-subscribe
+        this.subscribedParanets.set(opts.id, {
+          name: opts.name,
+          subscribed: false,
+          synced: true,
+          onChainId: this.subscribedParanets.get(opts.id)?.onChainId,
+        });
+        return;
+      }
       // Already synced locally — just make sure we're subscribed
       this.subscribeToParanet(opts.id);
       this.subscribedParanets.set(opts.id, {
@@ -1827,6 +1913,18 @@ export class DKGAgent {
     await this.store.insert(quads);
     await gm.ensureParanet(opts.id);
 
+    if (this.unsubscribedParanets.has(opts.id)) {
+      // Deny-listed — record locally but do not subscribe
+      this.subscribedParanets.set(opts.id, {
+        name: opts.name,
+        subscribed: false,
+        synced: true,
+        onChainId,
+      });
+      this.log.info(ctx, `Ensured paranet "${opts.id}" locally (deny-listed, not subscribing)`);
+      return;
+    }
+
     this.subscribeToParanet(opts.id);
     this.subscribedParanets.set(opts.id, {
       name: opts.name,
@@ -1895,6 +1993,8 @@ export class DKGAgent {
     isSystem: boolean;
     subscribed: boolean;
     synced: boolean;
+    /** True if the paranet was explicitly unsubscribed (on the deny list). */
+    denyListed: boolean;
   }>> {
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const agentsGraph = paranetDataGraphUri(SYSTEM_PARANETS.AGENTS);
@@ -1926,7 +2026,7 @@ export class DKGAgent {
     const seen = new Map<string, {
       id: string; uri: string; name: string; description?: string;
       creator?: string; createdAt?: string; isSystem: boolean;
-      subscribed: boolean; synced: boolean;
+      subscribed: boolean; synced: boolean; denyListed: boolean;
     }>();
 
     if (result.type === 'bindings') {
@@ -1945,6 +2045,7 @@ export class DKGAgent {
           isSystem: !!row['isSystem'],
           subscribed: sub?.subscribed ?? false,
           synced: true,
+          denyListed: this.unsubscribedParanets.has(id),
         });
       }
     }
@@ -1961,6 +2062,7 @@ export class DKGAgent {
         isSystem: false,
         subscribed: sub.subscribed,
         synced: sub.synced,
+        denyListed: this.unsubscribedParanets.has(id),
       });
     }
 
@@ -2093,6 +2195,7 @@ export class DKGAgent {
       if (!id) continue;
 
       if (id === SYSTEM_PARANETS.AGENTS || id === SYSTEM_PARANETS.ONTOLOGY) continue;
+      if (this.unsubscribedParanets.has(id)) continue;
 
       const existing = this.subscribedParanets.get(id);
       if (existing?.subscribed && existing?.synced) continue;
@@ -2150,6 +2253,7 @@ export class DKGAgent {
     let discovered = 0;
     for (const p of onChainParanets) {
       if (knownOnChainIds.has(p.paranetId)) continue;
+      if (p.name && this.unsubscribedParanets.has(p.name)) continue;
 
       if (!p.name) {
         // Hash-only entry (metadata not revealed) — record for dedup but don't

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -26,6 +26,7 @@ export class GossipPublishHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
   private readonly subscribedParanets: Map<string, any>;
+  private readonly unsubscribedParanets: Set<string>;
   private readonly callbacks: GossipPublishHandlerCallbacks;
   private readonly log = new Logger('GossipPublishHandler');
 
@@ -34,10 +35,12 @@ export class GossipPublishHandler {
     chain: ChainAdapter | undefined,
     subscribedParanets: Map<string, any>,
     callbacks: GossipPublishHandlerCallbacks,
+    unsubscribedParanets?: Set<string>,
   ) {
     this.store = store;
     this.chain = chain;
     this.subscribedParanets = subscribedParanets;
+    this.unsubscribedParanets = unsubscribedParanets ?? new Set();
     this.callbacks = callbacks;
   }
 
@@ -96,7 +99,7 @@ export class GossipPublishHandler {
             if (!id) continue;
             if (await this.callbacks.paranetExists(id)) {
               duplicateUris.add(uri);
-            } else if (id !== SYSTEM_PARANETS.AGENTS && id !== SYSTEM_PARANETS.ONTOLOGY) {
+            } else if (id !== SYSTEM_PARANETS.AGENTS && id !== SYSTEM_PARANETS.ONTOLOGY && !this.unsubscribedParanets.has(id)) {
               newParanetIds.push(id);
             }
           }

--- a/packages/agent/test/unsubscribe.test.ts
+++ b/packages/agent/test/unsubscribe.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { DKGAgent, type ParanetSub } from '../src/index.js';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { SYSTEM_PARANETS, DKG_ONTOLOGY, paranetDataGraphUri } from '@origintrail-official/dkg-core';
+import { MockChainAdapter, type ParanetOnChain } from '@origintrail-official/dkg-chain';
+import { GossipPublishHandler } from '../src/gossip-publish-handler.js';
+
+class MockChainWithParanets extends MockChainAdapter {
+  private readonly onChainList: ParanetOnChain[];
+
+  constructor(list: ParanetOnChain[] = []) {
+    super();
+    this.onChainList = list;
+  }
+
+  override async listParanetsFromChain(): Promise<ParanetOnChain[]> {
+    return this.onChainList;
+  }
+}
+
+async function createTestAgent(opts?: {
+  chainAdapter?: MockChainAdapter | MockChainWithParanets;
+  store?: OxigraphStore;
+  unsubscribedParanets?: string[];
+  syncParanets?: string[];
+}) {
+  const store = opts?.store ?? new OxigraphStore();
+  const agent = await DKGAgent.create({
+    name: 'UnsubscribeTestAgent',
+    listenPort: 0,
+    listenHost: '127.0.0.1',
+    store,
+    chainAdapter: opts?.chainAdapter ?? new MockChainAdapter(),
+    unsubscribedParanets: opts?.unsubscribedParanets,
+    syncParanets: opts?.syncParanets,
+  });
+  return { agent, store };
+}
+
+describe('unsubscribeFromParanet', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('subscribe then unsubscribe sets subscribed=false and adds to deny list', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToParanet('my-paranet');
+    expect(agent.getSubscribedParanets().get('my-paranet')?.subscribed).toBe(true);
+    expect(agent.isUnsubscribed('my-paranet')).toBe(false);
+
+    agent.unsubscribeFromParanet('my-paranet');
+
+    expect(agent.getSubscribedParanets().get('my-paranet')?.subscribed).toBe(false);
+    expect(agent.isUnsubscribed('my-paranet')).toBe(true);
+  }, 15000);
+
+  it('removes paranet from syncParanets', async () => {
+    const result = await createTestAgent({ syncParanets: ['my-paranet'] });
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToParanet('my-paranet');
+    // syncParanets should include it
+    expect((agent as any).config.syncParanets).toContain('my-paranet');
+
+    agent.unsubscribeFromParanet('my-paranet');
+    expect((agent as any).config.syncParanets).not.toContain('my-paranet');
+  }, 15000);
+
+  it('throws when trying to unsubscribe from system paranet', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    expect(() => agent!.unsubscribeFromParanet(SYSTEM_PARANETS.AGENTS))
+      .toThrow('Cannot unsubscribe from system paranet');
+    expect(() => agent!.unsubscribeFromParanet(SYSTEM_PARANETS.ONTOLOGY))
+      .toThrow('Cannot unsubscribe from system paranet');
+  }, 15000);
+
+  it('unsubscribe on not-currently-subscribed paranet still sets deny list', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    // Paranet is known but not subscribed — unsubscribe should still work
+    agent.unsubscribeFromParanet('unknown-paranet');
+
+    expect(agent.isUnsubscribed('unknown-paranet')).toBe(true);
+    expect(agent.getSubscribedParanets().get('unknown-paranet')?.subscribed).toBe(false);
+  }, 15000);
+});
+
+describe('re-subscribe after unsubscribe', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('clearUnsubscribed then subscribeToParanet works', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToParanet('cycle-paranet');
+    agent.unsubscribeFromParanet('cycle-paranet');
+    expect(agent.isUnsubscribed('cycle-paranet')).toBe(true);
+    expect(agent.getSubscribedParanets().get('cycle-paranet')?.subscribed).toBe(false);
+
+    // Clear deny list first, then re-subscribe
+    agent.clearUnsubscribed('cycle-paranet');
+    expect(agent.isUnsubscribed('cycle-paranet')).toBe(false);
+
+    agent.subscribeToParanet('cycle-paranet');
+    expect(agent.getSubscribedParanets().get('cycle-paranet')?.subscribed).toBe(true);
+    // trackSyncParanet should work now that deny list is cleared
+    expect((agent as any).config.syncParanets).toContain('cycle-paranet');
+  }, 15000);
+});
+
+describe('deny list guards — trackSyncParanet', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('trackSyncParanet does not add deny-listed paranet', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.subscribeToParanet('guarded');
+    agent.unsubscribeFromParanet('guarded');
+
+    // Try to track it again — should be blocked by deny list
+    (agent as any).trackSyncParanet('guarded');
+    expect((agent as any).config.syncParanets).not.toContain('guarded');
+  }, 15000);
+});
+
+describe('deny list guards — discoverParanetsFromStore', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('skips deny-listed paranets during store discovery', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    // Subscribe then unsubscribe
+    agent.subscribeToParanet('deny-store');
+    agent.unsubscribeFromParanet('deny-store');
+
+    // Insert paranet definition into ontology graph (simulating sync)
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const paranetUri = paranetDataGraphUri('deny-store');
+    await store.insert([
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: ontologyGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Deny Store"', graph: ontologyGraph },
+    ]);
+
+    const discovered = await agent.discoverParanetsFromStore();
+    expect(discovered).toBe(0);
+
+    // Should remain unsubscribed
+    expect(agent.getSubscribedParanets().get('deny-store')?.subscribed).toBe(false);
+  }, 15000);
+});
+
+describe('deny list guards — discoverParanetsFromChain', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('skips deny-listed paranets during chain discovery', async () => {
+    const chain = new MockChainWithParanets([
+      {
+        paranetId: '0xdeadbeef00000000000000000000000000000000000000000000000000000099',
+        name: 'deny-chain',
+        creator: '0x1234',
+        accessPolicy: 0,
+        blockNumber: 100,
+        metadataRevealed: true,
+      },
+    ]);
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    // Pre-unsubscribe from the paranet
+    agent.unsubscribeFromParanet('deny-chain');
+
+    const discovered = await agent.discoverParanetsFromChain();
+    expect(discovered).toBe(0);
+  }, 15000);
+});
+
+describe('deny list guards — syncParanetFromConnectedPeers', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('returns zeros for deny-listed paranet', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    agent.unsubscribeFromParanet('deny-sync');
+
+    const syncResult = await agent.syncParanetFromConnectedPeers('deny-sync');
+    expect(syncResult.connectedPeers).toBe(0);
+    expect(syncResult.dataSynced).toBe(0);
+  }, 15000);
+});
+
+describe('deny list guards — syncFromPeer', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('filters deny-listed paranets from sync list', async () => {
+    const result = await createTestAgent({ syncParanets: ['allowed', 'denied'] });
+    agent = result.agent;
+    await agent.start();
+
+    agent.unsubscribeFromParanet('denied');
+
+    // syncFromPeer will filter out 'denied' before iterating
+    // We can't easily call syncFromPeer without a real peer, but we can
+    // verify the config.syncParanets was cleaned
+    expect((agent as any).config.syncParanets).not.toContain('denied');
+  }, 15000);
+});
+
+describe('deny list guards — ensureParanetLocal', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('"already exists" branch: deny-listed paranet not re-subscribed', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    // Create the paranet first
+    await agent.ensureParanetLocal({ id: 'ensure-deny', name: 'Ensure Deny' });
+    expect(agent.getSubscribedParanets().get('ensure-deny')?.subscribed).toBe(true);
+
+    // Now unsubscribe
+    agent.unsubscribeFromParanet('ensure-deny');
+    expect(agent.getSubscribedParanets().get('ensure-deny')?.subscribed).toBe(false);
+
+    // Call ensureParanetLocal again — should NOT re-subscribe
+    await agent.ensureParanetLocal({ id: 'ensure-deny', name: 'Ensure Deny' });
+    expect(agent.getSubscribedParanets().get('ensure-deny')?.subscribed).toBe(false);
+    expect(agent.isUnsubscribed('ensure-deny')).toBe(true);
+  }, 15000);
+
+  it('"create" branch: deny-listed paranet not subscribed', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    // Pre-add to deny list
+    agent.unsubscribeFromParanet('ensure-create-deny');
+
+    // ensureParanetLocal should insert triples but not subscribe
+    await agent.ensureParanetLocal({ id: 'ensure-create-deny', name: 'Create Deny' });
+
+    const sub = agent.getSubscribedParanets().get('ensure-create-deny');
+    expect(sub?.subscribed).toBe(false);
+    expect(sub?.synced).toBe(true);
+    expect(agent.isUnsubscribed('ensure-create-deny')).toBe(true);
+  }, 15000);
+});
+
+describe('createParanet clears deny list', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('createParanet clears deny list so sync/discovery is not blocked', async () => {
+    const result = await createTestAgent({
+      unsubscribedParanets: ['create-clear'],
+    });
+    agent = result.agent;
+    await agent.start();
+
+    expect(agent.isUnsubscribed('create-clear')).toBe(true);
+
+    await agent.createParanet({ id: 'create-clear', name: 'Create Clear' });
+
+    // Deny list should be cleared by createParanet
+    expect(agent.isUnsubscribed('create-clear')).toBe(false);
+    expect(agent.getSubscribedParanets().get('create-clear')?.subscribed).toBe(true);
+    // Should be in syncParanets
+    expect((agent as any).config.syncParanets).toContain('create-clear');
+  }, 15000);
+});
+
+describe('deny list guards — GossipPublishHandler', () => {
+  it('does not auto-subscribe deny-listed paranets from ontology gossip', async () => {
+    const store = new OxigraphStore();
+    const subscribedParanets = new Map<string, any>();
+    const unsubscribedParanets = new Set(['denied-gossip']);
+    const subscribeCalls: string[] = [];
+
+    const handler = new GossipPublishHandler(
+      store,
+      undefined,
+      subscribedParanets,
+      {
+        paranetExists: async () => false,
+        subscribeToParanet: (id) => { subscribeCalls.push(id); },
+      },
+      unsubscribedParanets,
+    );
+
+    // Simulate an ontology gossip message that contains a new paranet definition
+    const paranetUri = 'did:dkg:paranet:denied-gossip';
+    const nquads = [
+      `<${paranetUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}> <${paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY)}> .`,
+      `<${paranetUri}> <${DKG_ONTOLOGY.SCHEMA_NAME}> "Denied Gossip" <${paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY)}> .`,
+    ].join('\n');
+
+    const { encodePublishRequest } = await import('@origintrail-official/dkg-core');
+    const msg = encodePublishRequest({
+      ual: '',
+      nquads: new TextEncoder().encode(nquads),
+      paranetId: SYSTEM_PARANETS.ONTOLOGY,
+      kas: [],
+      publisherIdentity: new Uint8Array(32),
+      publisherAddress: '',
+      startKAId: 0,
+      endKAId: 0,
+      chainId: '',
+      publisherSignatureR: new Uint8Array(0),
+      publisherSignatureVs: new Uint8Array(0),
+    });
+
+    await handler.handlePublishMessage(msg, SYSTEM_PARANETS.ONTOLOGY);
+
+    // Should NOT have called subscribeToParanet for the deny-listed paranet
+    expect(subscribeCalls).not.toContain('denied-gossip');
+    // Should NOT be in subscribedParanets map
+    expect(subscribedParanets.has('denied-gossip')).toBe(false);
+  });
+});
+
+describe('config persistence', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('unsubscribedParanets from config populates deny list on create', async () => {
+    const result = await createTestAgent({
+      unsubscribedParanets: ['pre-denied'],
+    });
+    agent = result.agent;
+
+    // Deny list should be populated before start()
+    expect(agent.isUnsubscribed('pre-denied')).toBe(true);
+  }, 15000);
+
+  it('deny list from config prevents discovery before start()', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({
+      store,
+      unsubscribedParanets: ['config-denied'],
+    });
+    agent = result.agent;
+    await agent.start();
+
+    // Insert paranet into store
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const paranetUri = paranetDataGraphUri('config-denied');
+    await store.insert([
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: ontologyGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Config Denied"', graph: ontologyGraph },
+    ]);
+
+    const discovered = await agent.discoverParanetsFromStore();
+    expect(discovered).toBe(0);
+  }, 15000);
+});

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -167,6 +167,10 @@ export class ApiClient {
     return this.post('/api/subscribe', { paranetId, ...options });
   }
 
+  async unsubscribe(paranetId: string): Promise<{ unsubscribed: string }> {
+    return this.post('/api/unsubscribe', { paranetId });
+  }
+
   async catchupStatus(paranetId: string): Promise<{
     jobId: string;
     paranetId: string;
@@ -207,6 +211,9 @@ export class ApiClient {
       creator?: string;
       createdAt?: string;
       isSystem: boolean;
+      subscribed?: boolean;
+      synced?: boolean;
+      denyListed?: boolean;
     }>;
   }> {
     return this.get('/api/paranet/list');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -890,9 +890,29 @@ program
         const paranets = new Set(config.paranets ?? []);
         paranets.add(paranet);
         config.paranets = [...paranets];
+        // Clear any unsubscribe tombstone so restart doesn't filter it out
+        config.unsubscribedParanets = (config.unsubscribedParanets ?? []).filter(p => p !== paranet);
         await saveConfig(config);
         console.log('Saved to config (will auto-subscribe on restart).');
       }
+    } catch (err: any) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  });
+
+// ─── dkg unsubscribe <paranet> ──────────────────────────────────────
+
+program
+  .command('unsubscribe <paranet>')
+  .description('Unsubscribe from a paranet (stops receiving new data; synced data is preserved)')
+  .action(async (paranet: string) => {
+    try {
+      const client = await ApiClient.connect();
+      await client.unsubscribe(paranet);
+      console.log(`Unsubscribed from paranet: ${paranet}`);
+      console.log('  Previously synced data is preserved.');
+      console.log('  Use "dkg subscribe" to re-subscribe.');
     } catch (err: any) {
       console.error(err.message);
       process.exit(1);
@@ -961,6 +981,8 @@ paranetCmd
         const paranets = new Set(config.paranets ?? []);
         paranets.add(id);
         config.paranets = [...paranets];
+        // Clear any unsubscribe tombstone so restart doesn't filter it out
+        config.unsubscribedParanets = (config.unsubscribedParanets ?? []).filter(p => p !== id);
         await saveConfig(config);
         console.log('  Saved to config (will auto-subscribe on restart).');
       }
@@ -986,16 +1008,17 @@ paranetCmd
       const idW = Math.max(4, ...paranets.map(p => p.id.length));
       const nameW = Math.max(4, ...paranets.map(p => p.name.length));
 
-      const header = `  ${'ID'.padEnd(idW)}   ${'Name'.padEnd(nameW)}   Type       Creator`;
+      const header = `  ${'ID'.padEnd(idW)}   ${'Name'.padEnd(nameW)}   Type       Status         Creator`;
       console.log(header);
       console.log('  ' + '─'.repeat(header.length - 2));
 
       for (const p of paranets) {
         const type = p.isSystem ? 'system' : 'user';
+        const status = p.denyListed ? 'unsubscribed' : p.subscribed ? 'subscribed' : (p.synced === false ? 'not synced' : 'discovered');
         const creator = p.creator
           ? (p.creator.length > 24 ? p.creator.slice(0, 12) + '...' + p.creator.slice(-8) : p.creator)
           : '—';
-        console.log(`  ${p.id.padEnd(idW)}   ${p.name.padEnd(nameW)}   ${type.padEnd(9)}  ${creator}`);
+        console.log(`  ${p.id.padEnd(idW)}   ${p.name.padEnd(nameW)}   ${type.padEnd(9)}  ${status.padEnd(13)}  ${creator}`);
       }
       console.log(`\n  ${paranets.length} paranet(s)`);
     } catch (err: any) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -79,6 +79,8 @@ export interface DkgConfig {
   /** Bootstrap peer multiaddrs to connect to on startup (for direct peer discovery without relay). */
   bootstrapPeers?: string[];
   paranets?: string[];
+  /** Paranet IDs that have been explicitly unsubscribed (deny list). */
+  unsubscribedParanets?: string[];
   autoUpdate?: AutoUpdateConfig;
   chain?: ChainConfig;
   /** Optional LLM for the Node UI chatbot (natural language → SPARQL, answers). */

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -222,10 +222,11 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
   log(`Starting DKG ${role} node "${config.name}" (${versionTag})...`);
 
   const network = await loadNetworkConfig();
+  const unsubSet = new Set(config.unsubscribedParanets ?? []);
   const syncParanets = [...new Set([
     ...(config.paranets ?? []),
     ...(network?.defaultParanets ?? []),
-  ])];
+  ])].filter(p => !unsubSet.has(p));
 
   // Load operational wallets from ~/.dkg/wallets.json (auto-generated on first run)
   const opWallets = await loadOpWallets(dkgDir());
@@ -265,6 +266,7 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
     announceAddresses: config.announceAddresses,
     nodeRole: role,
     syncParanets,
+    unsubscribedParanets: config.unsubscribedParanets,
     storeConfig: config.store ? {
       backend: config.store.backend,
       options: config.store.options,
@@ -329,7 +331,7 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
   // Ensure configured paranets + network defaults are subscribed and available.
   // Uses ensureParanetLocal (idempotent) instead of createParanet to avoid
   // duplicate creator claims and to survive "already exists" gracefully.
-  const paranetsToSubscribe = new Set(syncParanets);
+  const paranetsToSubscribe = new Set([...syncParanets].filter(p => !unsubSet.has(p)));
   for (const p of paranetsToSubscribe) {
     try {
       await agent.ensureParanetLocal({
@@ -1988,12 +1990,44 @@ async function handleRequest(
     }
   }
 
+  // POST /api/unsubscribe  { paranetId: "..." }
+  if (req.method === 'POST' && path === '/api/unsubscribe') {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    let parsed: Record<string, unknown>;
+    try { parsed = JSON.parse(body); } catch { return jsonResponse(res, 400, { error: 'Invalid JSON body' }); }
+    const { paranetId } = parsed;
+    if (!paranetId || typeof paranetId !== 'string') {
+      return jsonResponse(res, 400, { error: 'Missing "paranetId"' });
+    }
+    try {
+      agent.unsubscribeFromParanet(paranetId);
+    } catch (err) {
+      return jsonResponse(res, 400, { error: err instanceof Error ? err.message : String(err) });
+    }
+    // Persist: remove from paranets, add to unsubscribedParanets
+    config.paranets = (config.paranets ?? []).filter(p => p !== paranetId);
+    const unsubs = new Set(config.unsubscribedParanets ?? []);
+    unsubs.add(paranetId);
+    config.unsubscribedParanets = [...unsubs];
+    await saveConfig(config);
+    return jsonResponse(res, 200, { unsubscribed: paranetId });
+  }
+
   // POST /api/subscribe  { paranetId: "...", includeWorkspace?: boolean }
   if (req.method === 'POST' && path === '/api/subscribe') {
     const body = await readBody(req, SMALL_BODY_BYTES);
     const { paranetId, includeWorkspace } = JSON.parse(body);
     if (!paranetId) return jsonResponse(res, 400, { error: 'Missing "paranetId"' });
     const shouldSyncWorkspace = includeWorkspace !== false;
+    // Clear deny list before subscribing so trackSyncParanet works.
+    // Only remove the unsubscribe tombstone — do NOT add to config.paranets
+    // here; that is the CLI --save flag's responsibility.
+    agent.clearUnsubscribed(paranetId);
+    const hadTombstone = (config.unsubscribedParanets ?? []).includes(paranetId);
+    if (hadTombstone) {
+      config.unsubscribedParanets = config.unsubscribedParanets!.filter(p => p !== paranetId);
+      await saveConfig(config);
+    }
     agent.subscribeToParanet(paranetId);
 
     const jobId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;


### PR DESCRIPTION
> _Migrated from dkg-v9 PR #212_

  ## Summary
  - Adds `dkg unsubscribe <paranet>` command and `POST /api/unsubscribe` endpoint
  - Deny list (`config.unsubscribedParanets`) guards all 7 auto-subscribe paths so
   unsubscribed paranets stay unsubscribed across restarts and discovery
  - `dkg paranet list` now shows a Status column
  (subscribed/unsubscribed/discovered)
  - Re-subscribe via `dkg subscribe` clears the deny list and restores normal
  operation

  ## Test plan
  - [x] Unit tests: 16 new tests covering deny list, all guard points,
  re-subscribe, config persistence
  - [x] Manual: unsubscribe → verify status → restart → still unsubscribed →
  re-subscribe → works
  - [x] System paranet rejection (`dkg unsubscribe agents` → error)
  - [x] Discovery does not re-subscribe after 30s wait
  - [x] Full build passes, all 38 related tests green
