### PR TITLE
feat: unified privacy model — Visibility API, sync leak fix, workspace access policies

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -8,7 +8,8 @@ import {
   encodeFinalizationMessage, type FinalizationMessageMsg,
   getGenesisQuads, computeNetworkId, SYSTEM_PARANETS, DKG_ONTOLOGY,
   Logger, createOperationContext, withRetry,
-  type DKGNodeConfig, type OperationContext,
+  resolveVisibility,
+  type DKGNodeConfig, type OperationContext, type Visibility, type AccessPolicy,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateContextGraphResult } from '@origintrail-official/dkg-chain';
@@ -36,7 +37,10 @@ import { multiaddr } from '@multiformats/multiaddr';
 interface PublishOpts {
   onPhase?: PhaseCallback;
   operationCtx?: OperationContext;
-  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  visibility?: Visibility;
+  /** @deprecated Use visibility instead */
+  accessPolicy?: AccessPolicy;
+  /** @deprecated Use visibility: { peers: [...] } instead */
   allowedPeers?: string[];
 }
 
@@ -1273,13 +1277,17 @@ export class DKGAgent {
         );
       }
     }
+    const resolved = resolveVisibility(opts?.visibility, {
+      accessPolicy: opts?.accessPolicy,
+      allowedPeers: opts?.allowedPeers,
+    });
     const result = await this.publisher.publish({
       paranetId,
       quads,
       privateQuads,
       publisherPeerId: this.peerId,
-      accessPolicy: opts?.accessPolicy,
-      allowedPeers: opts?.allowedPeers,
+      accessPolicy: resolved.accessPolicy,
+      allowedPeers: resolved.allowedPeers,
       operationCtx: ctx,
       onPhase,
     });
@@ -1347,17 +1355,38 @@ export class DKGAgent {
 
   /**
    * Write quads to the paranet's workspace graph (no chain, no TRAC).
-   * When localOnly is false (default), replicates via GossipSub workspace topic.
-   * When localOnly is true, stores locally without broadcasting — use for private data.
+   *
+   * Visibility controls both broadcast and access policy:
+   * - `'private'` — local-only, no broadcast, ownerOnly access (new default)
+   * - `'public'` — broadcast to peers, public access
+   * - `{ peers: [...] }` — broadcast to peers, allowList access
+   *
+   * The legacy `localOnly` option is still supported for backward compatibility.
+   * When neither `visibility` nor `localOnly` is specified, defaults to `'private'`
+   * (no broadcast) — a deliberate change from the previous broadcast-by-default.
    */
-  async writeToWorkspace(paranetId: string, quads: Quad[], opts?: { localOnly?: boolean; operationCtx?: OperationContext }): Promise<{ workspaceOperationId: string }> {
+  async writeToWorkspace(
+    paranetId: string,
+    quads: Quad[],
+    opts?: {
+      visibility?: Visibility;
+      /** @deprecated Use visibility: 'private' instead */
+      localOnly?: boolean;
+      operationCtx?: OperationContext;
+    },
+  ): Promise<{ workspaceOperationId: string }> {
+    // When neither visibility nor localOnly is specified, default to private
+    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly === false ? 'public' : undefined);
+    const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly ?? true });
     const ctx = opts?.operationCtx ?? createOperationContext('workspace');
-    this.log.info(ctx, `Writing ${quads.length} quads to workspace for paranet ${paranetId}${opts?.localOnly ? ' (local-only)' : ''}`);
+    this.log.info(ctx, `Writing ${quads.length} quads to workspace for paranet ${paranetId} (visibility=${typeof effectiveVisibility === 'object' ? 'peers' : effectiveVisibility ?? 'private'})`);
     const { workspaceOperationId, message } = await this.publisher.writeToWorkspace(paranetId, quads, {
       publisherPeerId: this.node.peerId.toString(),
       operationCtx: ctx,
+      accessPolicy: resolved.accessPolicy,
+      allowedPeers: resolved.allowedPeers,
     });
-    if (!opts?.localOnly) {
+    if (resolved.broadcast) {
       const topic = paranetWorkspaceTopic(paranetId);
       try {
         await this.gossip.publish(topic, message);
@@ -1372,21 +1401,32 @@ export class DKGAgent {
    * Compare-and-swap workspace write. Verifies each condition against the
    * current workspace graph before applying the write atomically.
    * Throws StaleWriteError if any condition fails.
+   *
+   * Visibility semantics are identical to writeToWorkspace().
    */
   async writeConditionalToWorkspace(
     paranetId: string,
     quads: Quad[],
     conditions: CASCondition[],
-    opts?: { localOnly?: boolean; operationCtx?: OperationContext },
+    opts?: {
+      visibility?: Visibility;
+      /** @deprecated Use visibility: 'private' instead */
+      localOnly?: boolean;
+      operationCtx?: OperationContext;
+    },
   ): Promise<{ workspaceOperationId: string }> {
+    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly === false ? 'public' : undefined);
+    const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly ?? true });
     const ctx = opts?.operationCtx ?? createOperationContext('workspace');
     this.log.info(ctx, `CAS write: ${quads.length} quads, ${conditions.length} conditions for ${paranetId}`);
     const { workspaceOperationId, message } = await this.publisher.writeConditionalToWorkspace(paranetId, quads, {
       publisherPeerId: this.node.peerId.toString(),
       operationCtx: ctx,
       conditions,
+      accessPolicy: resolved.accessPolicy,
+      allowedPeers: resolved.allowedPeers,
     });
-    if (!opts?.localOnly) {
+    if (resolved.broadcast) {
       const topic = paranetWorkspaceTopic(paranetId);
       try {
         await this.gossip.publish(topic, message);
@@ -1401,11 +1441,14 @@ export class DKGAgent {
    * Enshrine workspace content: read from workspace graph and publish with full finality (data graph + chain).
    * After on-chain confirmation, broadcasts a lightweight FinalizationMessage so peers with matching
    * workspace state can promote it to canonical without re-downloading the full payload.
+   *
+   * Default visibility is 'public' for enshrinement (it is the explicit "make permanent" action).
    */
   async enshrineFromWorkspace(
     paranetId: string,
     selection: 'all' | { rootEntities: string[] },
     options?: {
+      visibility?: Visibility;
       clearWorkspaceAfter?: boolean;
       operationCtx?: OperationContext;
       onPhase?: PhaseCallback;
@@ -1416,12 +1459,17 @@ export class DKGAgent {
     const ctx = options?.operationCtx ?? createOperationContext('enshrine');
     const ctxGraphIdStr = options?.contextGraphId != null ? String(options.contextGraphId) : undefined;
 
+    // Default to public for enshrinement — this is the deliberate "make permanent" action
+    const resolved = resolveVisibility(options?.visibility ?? 'public');
+
     const result = await this.publisher.enshrineFromWorkspace(paranetId, selection, {
       operationCtx: ctx,
       clearWorkspaceAfter: options?.clearWorkspaceAfter,
       onPhase: options?.onPhase,
       contextGraphId: ctxGraphIdStr,
       contextGraphSignatures: options?.contextGraphSignatures,
+      accessPolicy: resolved.accessPolicy,
+      allowedPeers: resolved.allowedPeers,
     });
 
     if (result.status === 'confirmed' && result.onChainResult) {
@@ -1758,7 +1806,8 @@ export class DKGAgent {
     replicationPolicy?: string;
     accessPolicy?: number;
     revealOnChain?: boolean;
-    /** When true, skips on-chain registration, gossip subscription, and broadcast. Data stays local-only. */
+    visibility?: Visibility;
+    /** @deprecated Use visibility: 'private' instead */
     private?: boolean;
   }): Promise<void> {
     const ctx = createOperationContext('system');
@@ -1766,6 +1815,9 @@ export class DKGAgent {
     const paranetUri = paranetDataGraphUri(opts.id);
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const now = new Date().toISOString();
+
+    const resolved = resolveVisibility(opts.visibility, { private: opts.private });
+    const isPrivate = resolved.accessPolicy === 'ownerOnly' && !resolved.broadcast;
 
     const exists = await this.paranetExists(opts.id);
     if (exists) {
@@ -1775,7 +1827,7 @@ export class DKGAgent {
     // Register on chain if a real chain adapter is configured.
     // Private paranets skip on-chain registration and gossip entirely.
     let onChainId: string | undefined;
-    if (opts.private) {
+    if (isPrivate) {
       this.log.info(ctx, `Creating private paranet "${opts.id}" (local-only, no chain, no gossip)`);
     } else if (this.chain.chainId !== 'none') {
       try {
@@ -1825,6 +1877,27 @@ export class DKGAgent {
       });
     }
 
+    // Store access policy in the paranet definition so sync/query can check it.
+    // Uses the same DKG ontology namespace as workspace/publish metadata.
+    if (resolved.accessPolicy !== 'public') {
+      quads.push({
+        subject: paranetUri,
+        predicate: 'http://dkg.io/ontology/accessPolicy',
+        object: `"${resolved.accessPolicy}"`,
+        graph: ontologyGraph,
+      });
+    }
+    if (resolved.allowedPeers.length > 0) {
+      for (const peer of resolved.allowedPeers) {
+        quads.push({
+          subject: paranetUri,
+          predicate: 'http://dkg.io/ontology/allowedPeer',
+          object: `"${peer}"`,
+          graph: ontologyGraph,
+        });
+      }
+    }
+
     // Provenance activity
     const activityUri = `did:dkg:activity:create-paranet:${opts.id}:${Date.now()}`;
     quads.push(
@@ -1842,12 +1915,12 @@ export class DKGAgent {
 
     this.subscribedParanets.set(opts.id, {
       name: opts.name,
-      subscribed: !opts.private,
+      subscribed: !isPrivate,
       synced: true,
       onChainId: onChainId,
     });
 
-    if (!opts.private) {
+    if (!isPrivate) {
       // Auto-subscribe to the new paranet's GossipSub topic
       this.subscribeToParanet(opts.id);
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1312,6 +1312,11 @@ export class DKGAgent {
         );
       }
     }
+    // NOTE: The inherited accessPolicy controls who can access `privateQuads` only.
+    // Public quads (the `quads` parameter) are always stored in the public data graph
+    // and served to any peer — regardless of accessPolicy. If ALL data should be
+    // access-controlled, the caller must put it in `privateQuads`.
+    //
     // Inherit paranet default visibility when no explicit visibility/accessPolicy is given
     const explicitVisibility = opts?.visibility ?? (opts?.accessPolicy ? undefined : this.getParanetDefaultVisibility(paranetId));
     const resolved = resolveVisibility(explicitVisibility, {
@@ -1529,14 +1534,77 @@ export class DKGAgent {
    * Returns undefined when no policy is stored (i.e. the paranet is public or pre-dates the
    * privacy model). Callers use this to inherit the paranet's default when the user omits
    * an explicit visibility parameter on a write/publish operation.
+   *
+   * If the in-memory map has no accessPolicy, falls back to a one-time store query
+   * (checking both the ontology graph and the paranet's _meta graph) and caches the result.
    */
   private getParanetDefaultVisibility(paranetId: string): Visibility | undefined {
     const sub = this.subscribedParanets.get(paranetId);
-    if (!sub?.accessPolicy || sub.accessPolicy === 'public') return undefined;
-    if (sub.accessPolicy === 'ownerOnly') return 'private';
-    if (sub.accessPolicy === 'allowList' && sub.allowedPeers && sub.allowedPeers.length > 0) {
-      return { peers: sub.allowedPeers };
+    if (!sub) return undefined;
+
+    // If accessPolicy is already populated, use it directly
+    if (sub.accessPolicy) {
+      if (sub.accessPolicy === 'public') return undefined;
+      if (sub.accessPolicy === 'ownerOnly') return 'private';
+      if (sub.accessPolicy === 'allowList' && sub.allowedPeers && sub.allowedPeers.length > 0) {
+        return { peers: sub.allowedPeers };
+      }
+      return undefined;
     }
+
+    // Store-backed fallback: query once and cache the result.
+    // This is a synchronous method, so we kick off an async rehydration and
+    // return undefined for this call. The next call will see the cached value.
+    // We mark the lookup in-progress with a sentinel to avoid repeated queries.
+    if ((sub as any)._policyLookupPending) return undefined;
+    (sub as any)._policyLookupPending = true;
+
+    const pUri = `did:dkg:paranet:${paranetId}`;
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const metaGraph = paranetMetaGraphUri(paranetId);
+    this.store.query(`
+      SELECT ?policy ?peer WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            <${pUri}> <http://dkg.io/ontology/accessPolicy> ?policy .
+          }
+        } UNION {
+          GRAPH <${metaGraph}> {
+            <${pUri}> <http://dkg.io/ontology/accessPolicy> ?policy .
+          }
+        }
+        OPTIONAL {
+          {
+            GRAPH <${ontologyGraph}> {
+              <${pUri}> <http://dkg.io/ontology/allowedPeer> ?peer .
+            }
+          } UNION {
+            GRAPH <${metaGraph}> {
+              <${pUri}> <http://dkg.io/ontology/allowedPeer> ?peer .
+            }
+          }
+        }
+      }
+    `).then((result) => {
+      delete (sub as any)._policyLookupPending;
+      if (result.type !== 'bindings' || result.bindings.length === 0) return;
+      const rows = result.bindings as Record<string, string>[];
+      const policy = rows[0]['policy'] ? stripLiteral(rows[0]['policy']) : undefined;
+      if (policy) {
+        sub.accessPolicy = policy as AccessPolicy;
+        const peers: string[] = [];
+        for (const r of rows) {
+          if (r['peer']) {
+            const p = stripLiteral(r['peer']);
+            if (p && !peers.includes(p)) peers.push(p);
+          }
+        }
+        if (peers.length > 0) sub.allowedPeers = peers;
+      }
+    }).catch(() => {
+      delete (sub as any)._policyLookupPending;
+    });
+
     return undefined;
   }
 
@@ -1970,13 +2038,18 @@ export class DKGAgent {
       }
     }
 
+    // Non-public paranets store their definition in the paranet's own _meta graph
+    // instead of the shared ontology graph, so that ontology sync doesn't leak their
+    // existence to other peers. Public paranets use the shared ontology graph as before.
+    const defGraph = skipDefinitionBroadcast ? paranetMetaGraphUri(opts.id) : ontologyGraph;
+
     const quads: Quad[] = [
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: ontologyGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: `"${opts.name}"`, graph: ontologyGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `did:dkg:agent:${this.peerId}`, graph: ontologyGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATED_AT, object: `"${now}"`, graph: ontologyGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_GOSSIP_TOPIC, object: `"${paranetPublishTopic(opts.id)}"`, graph: ontologyGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REPLICATION_POLICY, object: `"${opts.replicationPolicy ?? 'full'}"`, graph: ontologyGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: `"${opts.name}"`, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `did:dkg:agent:${this.peerId}`, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATED_AT, object: `"${now}"`, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_GOSSIP_TOPIC, object: `"${paranetPublishTopic(opts.id)}"`, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REPLICATION_POLICY, object: `"${opts.replicationPolicy ?? 'full'}"`, graph: defGraph },
     ];
 
     if (onChainId) {
@@ -1984,7 +2057,7 @@ export class DKGAgent {
         subject: paranetUri,
         predicate: `${DKG_ONTOLOGY.DKG_PARANET}OnChainId`,
         object: `"${onChainId}"`,
-        graph: ontologyGraph,
+        graph: defGraph,
       });
     }
 
@@ -1993,7 +2066,7 @@ export class DKGAgent {
         subject: paranetUri,
         predicate: DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
         object: `"${opts.description}"`,
-        graph: ontologyGraph,
+        graph: defGraph,
       });
     }
 
@@ -2004,7 +2077,7 @@ export class DKGAgent {
         subject: paranetUri,
         predicate: 'http://dkg.io/ontology/accessPolicy',
         object: `"${resolved.accessPolicy}"`,
-        graph: ontologyGraph,
+        graph: defGraph,
       });
     }
     if (resolved.allowedPeers.length > 0) {
@@ -2013,7 +2086,7 @@ export class DKGAgent {
           subject: paranetUri,
           predicate: 'http://dkg.io/ontology/allowedPeer',
           object: `"${peer}"`,
-          graph: ontologyGraph,
+          graph: defGraph,
         });
       }
     }
@@ -2021,10 +2094,10 @@ export class DKGAgent {
     // Provenance activity
     const activityUri = `did:dkg:activity:create-paranet:${opts.id}:${Date.now()}`;
     quads.push(
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.PROV_GENERATED_BY, object: activityUri, graph: ontologyGraph },
-      { subject: activityUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.PROV_ACTIVITY, graph: ontologyGraph },
-      { subject: activityUri, predicate: DKG_ONTOLOGY.PROV_ASSOCIATED_WITH, object: `did:dkg:agent:${this.peerId}`, graph: ontologyGraph },
-      { subject: activityUri, predicate: DKG_ONTOLOGY.PROV_ENDED_AT_TIME, object: `"${now}"`, graph: ontologyGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.PROV_GENERATED_BY, object: activityUri, graph: defGraph },
+      { subject: activityUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.PROV_ACTIVITY, graph: defGraph },
+      { subject: activityUri, predicate: DKG_ONTOLOGY.PROV_ASSOCIATED_WITH, object: `did:dkg:agent:${this.peerId}`, graph: defGraph },
+      { subject: activityUri, predicate: DKG_ONTOLOGY.PROV_ENDED_AT_TIME, object: `"${now}"`, graph: defGraph },
     );
 
     // Insert the definition triples
@@ -2423,33 +2496,64 @@ export class DKGAgent {
     const prefix = 'did:dkg:context-graph:';
     let discovered = 0;
 
+    // Only discover public paranets from the shared ontology graph.
+    // Non-public paranets store their definition in their own _meta graph
+    // and are NOT auto-discovered — they only appear if this node created them
+    // or was explicitly told about them.
+    // Also query accessPolicy and allowedPeer so we can rehydrate privacy
+    // settings on restart (a paranet may have multiple allowedPeer rows).
     const result = await this.store.query(`
-      SELECT ?paranet ?name WHERE {
+      SELECT ?paranet ?name ?policy ?peer WHERE {
         GRAPH <${ontologyGraph}> {
           ?paranet <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}> .
           OPTIONAL { ?paranet <${DKG_ONTOLOGY.SCHEMA_NAME}> ?name }
+          OPTIONAL { ?paranet <http://dkg.io/ontology/accessPolicy> ?policy }
+          OPTIONAL { ?paranet <http://dkg.io/ontology/allowedPeer> ?peer }
         }
       }
     `);
 
     if (result.type !== 'bindings') return 0;
 
+    // Group rows by paranet URI to collect multiple allowedPeer values
+    const grouped = new Map<string, { name?: string; policy?: string; peers: string[] }>();
     for (const row of result.bindings as Record<string, string>[]) {
       const uri = row['paranet'] ?? '';
+      if (!grouped.has(uri)) {
+        grouped.set(uri, {
+          name: row['name'] ? stripLiteral(row['name']) : undefined,
+          policy: row['policy'] ? stripLiteral(row['policy']) : undefined,
+          peers: [],
+        });
+      }
+      const entry = grouped.get(uri)!;
+      if (row['peer']) {
+        const peer = stripLiteral(row['peer']);
+        if (peer && !entry.peers.includes(peer)) entry.peers.push(peer);
+      }
+    }
+
+    for (const [uri, info] of grouped) {
       const id = uri.startsWith(prefix) ? uri.slice(prefix.length) : null;
       if (!id) continue;
 
       if (id === SYSTEM_PARANETS.AGENTS || id === SYSTEM_PARANETS.ONTOLOGY) continue;
 
+      // Skip non-public paranets that leaked into the ontology graph (legacy data).
+      // They should not be auto-discovered by other peers.
+      if (info.policy && info.policy !== 'public') continue;
+
       const existing = this.subscribedParanets.get(id);
       if (existing?.subscribed && existing?.synced) continue;
 
-      const name = row['name'] ? stripLiteral(row['name']) : id;
+      const name = info.name ?? id;
       this.subscribedParanets.set(id, {
         name,
         subscribed: true,
         synced: true,
         onChainId: existing?.onChainId,
+        accessPolicy: info.policy as AccessPolicy | undefined,
+        allowedPeers: info.peers.length > 0 ? info.peers : undefined,
       });
 
       if (!existing?.subscribed) {
@@ -2463,6 +2567,60 @@ export class DKGAgent {
     if (discovered > 0) {
       this.log.info(ctx, `Auto-subscribed to ${discovered} new paranet(s) from store`);
     }
+
+    // Rehydrate access policy for paranets already in the subscription registry
+    // whose accessPolicy/allowedPeers are missing (e.g. after restart).
+    // Check both the ontology graph (public) and the paranet's own _meta graph (non-public).
+    for (const [id, sub] of this.subscribedParanets) {
+      if (sub.accessPolicy !== undefined) continue; // already populated
+      if (id === SYSTEM_PARANETS.AGENTS || id === SYSTEM_PARANETS.ONTOLOGY) continue;
+
+      const pUri = `did:dkg:paranet:${id}`;
+      const metaGraph = paranetMetaGraphUri(id);
+      const policyResult = await this.store.query(`
+        SELECT ?policy ?peer WHERE {
+          {
+            GRAPH <${ontologyGraph}> {
+              <${pUri}> <http://dkg.io/ontology/accessPolicy> ?policy .
+            }
+          } UNION {
+            GRAPH <${metaGraph}> {
+              <${pUri}> <http://dkg.io/ontology/accessPolicy> ?policy .
+            }
+          }
+          OPTIONAL {
+            {
+              GRAPH <${ontologyGraph}> {
+                <${pUri}> <http://dkg.io/ontology/allowedPeer> ?peer .
+              }
+            } UNION {
+              GRAPH <${metaGraph}> {
+                <${pUri}> <http://dkg.io/ontology/allowedPeer> ?peer .
+              }
+            }
+          }
+        }
+      `);
+
+      if (policyResult.type === 'bindings' && policyResult.bindings.length > 0) {
+        const rows = policyResult.bindings as Record<string, string>[];
+        const policy = rows[0]['policy'] ? stripLiteral(rows[0]['policy']) : undefined;
+        const peers: string[] = [];
+        for (const r of rows) {
+          if (r['peer']) {
+            const p = stripLiteral(r['peer']);
+            if (p && !peers.includes(p)) peers.push(p);
+          }
+        }
+        if (policy) {
+          sub.accessPolicy = policy as AccessPolicy;
+          if (peers.length > 0) sub.allowedPeers = peers;
+          this.log.info(ctx, `Rehydrated access policy for paranet "${id}": ${policy}` +
+            (peers.length > 0 ? ` (${peers.length} allowed peer(s))` : ''));
+        }
+      }
+    }
+
     return discovered;
   }
 
@@ -2506,14 +2664,19 @@ export class DKGAgent {
         continue;
       }
 
+      // Map on-chain accessPolicy number: 0 = public (undefined), 1 = permissioned (allowList).
+      // Allowed peers are not available on-chain, only from the store.
+      const chainPolicy: AccessPolicy | undefined = p.accessPolicy === 1 ? 'allowList' : undefined;
       this.subscribedParanets.set(p.name, {
         name: p.name,
         subscribed: true,
         synced: false,
         onChainId: p.paranetId,
+        accessPolicy: chainPolicy,
       });
       this.subscribeToParanet(p.name, { trackSyncScope: false });
-      this.log.info(ctx, `Discovered on-chain paranet "${p.name}" (${p.paranetId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
+      this.log.info(ctx, `Discovered on-chain paranet "${p.name}" (${p.paranetId.slice(0, 16)}…) — auto-subscribed (synced=false)` +
+        (chainPolicy ? `, accessPolicy=${chainPolicy}` : ''));
       discovered++;
     }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1540,7 +1540,13 @@ export class DKGAgent {
    */
   private getParanetDefaultVisibility(paranetId: string): Visibility | undefined {
     const sub = this.subscribedParanets.get(paranetId);
-    if (!sub) return undefined;
+
+    // If the subscription entry is entirely absent, kick off a store lookup
+    // that may discover a non-public paranet from its _meta graph (e.g. after restart).
+    if (!sub) {
+      this._ensurePolicyLookup(paranetId);
+      return undefined;
+    }
 
     // If accessPolicy is already populated, use it directly
     if (sub.accessPolicy) {
@@ -1555,15 +1561,29 @@ export class DKGAgent {
     // Store-backed fallback: query once and cache the result.
     // This is a synchronous method, so we kick off an async rehydration and
     // return undefined for this call. The next call will see the cached value.
-    // We mark the lookup in-progress with a sentinel to avoid repeated queries.
-    if ((sub as any)._policyLookupPending) return undefined;
-    (sub as any)._policyLookupPending = true;
+    this._ensurePolicyLookup(paranetId, sub);
+
+    return undefined;
+  }
+
+  /**
+   * Fire-and-forget store lookup for a paranet's access policy.
+   * When `sub` is provided, populates its fields; when absent, creates a new
+   * subscription entry if the store contains a non-public definition in `_meta`.
+   */
+  private _ensurePolicyLookup(paranetId: string, sub?: ParanetSub): void {
+    // Use a sentinel on the subscription (or a module-level set for absent entries)
+    // to avoid repeated queries for the same paranet.
+    const sentinel = sub ?? (this as any);
+    const key = sub ? '_policyLookupPending' : `_policyLookup:${paranetId}`;
+    if ((sentinel as any)[key]) return;
+    (sentinel as any)[key] = true;
 
     const pUri = `did:dkg:paranet:${paranetId}`;
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const metaGraph = paranetMetaGraphUri(paranetId);
     this.store.query(`
-      SELECT ?policy ?peer WHERE {
+      SELECT ?policy ?peer ?name WHERE {
         {
           GRAPH <${ontologyGraph}> {
             <${pUri}> <http://dkg.io/ontology/accessPolicy> ?policy .
@@ -1584,28 +1604,55 @@ export class DKGAgent {
             }
           }
         }
+        OPTIONAL {
+          {
+            GRAPH <${ontologyGraph}> {
+              <${pUri}> <${DKG_ONTOLOGY.SCHEMA_NAME}> ?name .
+            }
+          } UNION {
+            GRAPH <${metaGraph}> {
+              <${pUri}> <${DKG_ONTOLOGY.SCHEMA_NAME}> ?name .
+            }
+          }
+        }
       }
     `).then((result) => {
-      delete (sub as any)._policyLookupPending;
+      delete (sentinel as any)[key];
       if (result.type !== 'bindings' || result.bindings.length === 0) return;
       const rows = result.bindings as Record<string, string>[];
       const policy = rows[0]['policy'] ? stripLiteral(rows[0]['policy']) : undefined;
-      if (policy) {
-        sub.accessPolicy = policy as AccessPolicy;
-        const peers: string[] = [];
-        for (const r of rows) {
-          if (r['peer']) {
-            const p = stripLiteral(r['peer']);
-            if (p && !peers.includes(p)) peers.push(p);
-          }
+      if (!policy) return;
+
+      const peers: string[] = [];
+      for (const r of rows) {
+        if (r['peer']) {
+          const p = stripLiteral(r['peer']);
+          if (p && !peers.includes(p)) peers.push(p);
         }
+      }
+      const name = rows[0]['name'] ? stripLiteral(rows[0]['name']) : undefined;
+
+      if (sub) {
+        // Update existing subscription entry
+        sub.accessPolicy = policy as AccessPolicy;
         if (peers.length > 0) sub.allowedPeers = peers;
+      } else {
+        // Create a new subscription entry for a non-public paranet found in _meta
+        const existing = this.subscribedParanets.get(paranetId);
+        if (!existing) {
+          this.subscribedParanets.set(paranetId, {
+            name: name ?? paranetId,
+            subscribed: true,
+            synced: true,
+            accessPolicy: policy as AccessPolicy,
+            allowedPeers: peers.length > 0 ? peers : undefined,
+          });
+          this.subscribeToParanet(paranetId, { trackSyncScope: false });
+        }
       }
     }).catch(() => {
-      delete (sub as any)._policyLookupPending;
+      delete (sentinel as any)[key];
     });
-
-    return undefined;
   }
 
   /**
@@ -2570,9 +2617,13 @@ export class DKGAgent {
 
     // Rehydrate access policy for paranets already in the subscription registry
     // whose accessPolicy/allowedPeers are missing (e.g. after restart).
+    // Also rehydrate when accessPolicy is 'allowList' but allowedPeers is absent
+    // (e.g. chain-discovered entries that set the policy but couldn't get peers).
     // Check both the ontology graph (public) and the paranet's own _meta graph (non-public).
     for (const [id, sub] of this.subscribedParanets) {
-      if (sub.accessPolicy !== undefined) continue; // already populated
+      const needsRehydration = sub.accessPolicy === undefined
+        || (sub.accessPolicy === 'allowList' && (!sub.allowedPeers || sub.allowedPeers.length === 0));
+      if (!needsRehydration) continue;
       if (id === SYSTEM_PARANETS.AGENTS || id === SYSTEM_PARANETS.ONTOLOGY) continue;
 
       const pUri = `did:dkg:paranet:${id}`;
@@ -2621,7 +2672,91 @@ export class DKGAgent {
       }
     }
 
+    // Rebuild subscriptions for non-public paranets whose definitions live in
+    // their own _meta graphs (not in the shared ontology graph). After restart,
+    // these entries would be entirely absent from subscribedParanets.
+    discovered += await this.rebuildNonPublicParanets(ctx);
+
     return discovered;
+  }
+
+  /**
+   * Scan all paranet `_meta` graphs in the store for `dkg:accessPolicy` triples
+   * and rebuild subscription entries for non-public paranets that are missing
+   * from `subscribedParanets`. This catches ownerOnly and allowList paranets
+   * created by this node that were persisted in `_meta` graphs (per 328a401)
+   * and would otherwise be invisible after a restart.
+   */
+  private async rebuildNonPublicParanets(ctx: OperationContext): Promise<number> {
+    // Query across ALL graphs for accessPolicy triples whose subject matches
+    // the paranet URI pattern. The GRAPH variable lets us identify which _meta
+    // graph each triple came from.
+    const prefix = 'did:dkg:paranet:';
+    const metaSuffix = '/_meta';
+    const result = await this.store.query(`
+      SELECT ?g ?paranet ?name ?policy ?peer WHERE {
+        GRAPH ?g {
+          ?paranet <http://dkg.io/ontology/accessPolicy> ?policy .
+          OPTIONAL { ?paranet <${DKG_ONTOLOGY.SCHEMA_NAME}> ?name }
+          OPTIONAL { ?paranet <http://dkg.io/ontology/allowedPeer> ?peer }
+        }
+        FILTER(STRENDS(STR(?g), "/_meta"))
+      }
+    `);
+
+    if (result.type !== 'bindings') return 0;
+
+    // Group by paranet URI
+    const grouped = new Map<string, { name?: string; policy?: string; peers: string[] }>();
+    for (const row of result.bindings as Record<string, string>[]) {
+      const uri = row['paranet'] ?? '';
+      if (!uri.startsWith(prefix)) continue;
+      if (!grouped.has(uri)) {
+        grouped.set(uri, {
+          name: row['name'] ? stripLiteral(row['name']) : undefined,
+          policy: row['policy'] ? stripLiteral(row['policy']) : undefined,
+          peers: [],
+        });
+      }
+      const entry = grouped.get(uri)!;
+      if (row['peer']) {
+        const peer = stripLiteral(row['peer']);
+        if (peer && !entry.peers.includes(peer)) entry.peers.push(peer);
+      }
+    }
+
+    let rebuilt = 0;
+    for (const [uri, info] of grouped) {
+      const id = uri.slice(prefix.length);
+      if (!id || id === SYSTEM_PARANETS.AGENTS || id === SYSTEM_PARANETS.ONTOLOGY) continue;
+      if (!info.policy || info.policy === 'public') continue;
+
+      const existing = this.subscribedParanets.get(id);
+      if (existing?.subscribed && existing?.synced) continue;
+
+      const name = info.name ?? id;
+      this.subscribedParanets.set(id, {
+        name,
+        subscribed: true,
+        synced: true,
+        onChainId: existing?.onChainId,
+        accessPolicy: info.policy as AccessPolicy,
+        allowedPeers: info.peers.length > 0 ? info.peers : undefined,
+      });
+
+      if (!existing?.subscribed) {
+        this.subscribeToParanet(id, { trackSyncScope: false });
+      }
+
+      this.log.info(ctx, `Rebuilt non-public paranet "${name}" (${id}) from _meta graph — policy=${info.policy}` +
+        (info.peers.length > 0 ? `, ${info.peers.length} peer(s)` : ''));
+      rebuilt++;
+    }
+
+    if (rebuilt > 0) {
+      this.log.info(ctx, `Rebuilt ${rebuilt} non-public paranet(s) from _meta graphs`);
+    }
+    return rebuilt;
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -75,6 +75,10 @@ export interface ParanetSub {
   synced: boolean;
   /** On-chain paranet ID (keccak256 hash), if known. */
   onChainId?: string;
+  /** Access policy stored at paranet creation time. Absent means public (default). */
+  accessPolicy?: AccessPolicy;
+  /** Allowed peer IDs when accessPolicy is 'allowList'. */
+  allowedPeers?: string[];
 }
 
 export interface DKGAgentConfig {
@@ -1308,7 +1312,9 @@ export class DKGAgent {
         );
       }
     }
-    const resolved = resolveVisibility(opts?.visibility, {
+    // Inherit paranet default visibility when no explicit visibility/accessPolicy is given
+    const explicitVisibility = opts?.visibility ?? (opts?.accessPolicy ? undefined : this.getParanetDefaultVisibility(paranetId));
+    const resolved = resolveVisibility(explicitVisibility, {
       accessPolicy: opts?.accessPolicy,
       allowedPeers: opts?.allowedPeers,
     });
@@ -1406,10 +1412,11 @@ export class DKGAgent {
       operationCtx?: OperationContext;
     },
   ): Promise<{ workspaceOperationId: string }> {
-    // Preserve backward compatibility: when neither visibility nor localOnly is
-    // specified, default to public/broadcast (matching pre-migration behavior).
-    // Only go private when the caller explicitly requests it.
-    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly != null ? undefined : 'public');
+    // Inherit paranet default visibility when neither visibility nor localOnly is
+    // specified. Falls back to 'public' (broadcast) when no paranet-level policy
+    // exists — preserving pre-migration behavior for existing callers.
+    const paranetDefault = this.getParanetDefaultVisibility(paranetId);
+    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly != null ? undefined : (paranetDefault ?? 'public'));
     const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly });
     const ctx = opts?.operationCtx ?? createOperationContext('workspace');
     this.log.info(ctx, `Writing ${quads.length} quads to workspace for paranet ${paranetId} (visibility=${typeof effectiveVisibility === 'object' ? 'peers' : effectiveVisibility ?? 'default'})`);
@@ -1456,8 +1463,9 @@ export class DKGAgent {
       operationCtx?: OperationContext;
     },
   ): Promise<{ workspaceOperationId: string }> {
-    // Same backward-compat default as writeToWorkspace
-    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly != null ? undefined : 'public');
+    // Inherit paranet default visibility (same logic as writeToWorkspace)
+    const paranetDefault = this.getParanetDefaultVisibility(paranetId);
+    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly != null ? undefined : (paranetDefault ?? 'public'));
     const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly });
     const ctx = opts?.operationCtx ?? createOperationContext('workspace');
     this.log.info(ctx, `CAS write: ${quads.length} quads, ${conditions.length} conditions for ${paranetId}`);
@@ -1517,6 +1525,22 @@ export class DKGAgent {
   }
 
   /**
+   * Look up the paranet's stored access policy from the in-memory subscribedParanets map.
+   * Returns undefined when no policy is stored (i.e. the paranet is public or pre-dates the
+   * privacy model). Callers use this to inherit the paranet's default when the user omits
+   * an explicit visibility parameter on a write/publish operation.
+   */
+  private getParanetDefaultVisibility(paranetId: string): Visibility | undefined {
+    const sub = this.subscribedParanets.get(paranetId);
+    if (!sub?.accessPolicy || sub.accessPolicy === 'public') return undefined;
+    if (sub.accessPolicy === 'ownerOnly') return 'private';
+    if (sub.accessPolicy === 'allowList' && sub.allowedPeers && sub.allowedPeers.length > 0) {
+      return { peers: sub.allowedPeers };
+    }
+    return undefined;
+  }
+
+  /**
    * Enshrine workspace content: read from workspace graph and publish with full finality (data graph + chain).
    * After on-chain confirmation, broadcasts a lightweight FinalizationMessage so peers with matching
    * workspace state can promote it to canonical without re-downloading the full payload.
@@ -1538,7 +1562,17 @@ export class DKGAgent {
     const ctx = options?.operationCtx ?? createOperationContext('enshrine');
     const ctxGraphIdStr = options?.contextGraphId != null ? String(options.contextGraphId) : undefined;
 
-    // Default to public for enshrinement — this is the deliberate "make permanent" action
+    // Default to public for enshrinement — this is the deliberate "make permanent" action.
+    // Warn if the paranet has a more restrictive policy and the caller is not explicitly
+    // setting visibility, so they don't accidentally widen access.
+    const paranetDefault = this.getParanetDefaultVisibility(paranetId);
+    if (!options?.visibility && paranetDefault) {
+      const policyLabel = typeof paranetDefault === 'string' ? paranetDefault : 'peers';
+      this.log.warn(ctx,
+        `Enshrining with default visibility "public" but paranet "${paranetId}" has access policy "${policyLabel}". ` +
+        `Pass visibility explicitly to suppress this warning.`,
+      );
+    }
     const resolved = resolveVisibility(options?.visibility ?? 'public');
 
     const result = await this.publisher.enshrineFromWorkspace(paranetId, selection, {
@@ -1897,7 +1931,12 @@ export class DKGAgent {
     const now = new Date().toISOString();
 
     const resolved = resolveVisibility(opts.visibility, { private: opts.private });
-    const isPrivate = resolved.accessPolicy === 'ownerOnly' && !resolved.broadcast;
+    // ownerOnly: fully local — no chain, no gossip, no subscription
+    const skipChain = resolved.accessPolicy === 'ownerOnly';
+    // Only public paranets broadcast their definition on the ontology topic;
+    // allowList paranets are registered on-chain for governance but their
+    // definition is NOT broadcast — allowed peers discover it directly.
+    const skipDefinitionBroadcast = resolved.accessPolicy !== 'public';
 
     const exists = await this.paranetExists(opts.id);
     if (exists) {
@@ -1905,9 +1944,10 @@ export class DKGAgent {
     }
 
     // Register on chain if a real chain adapter is configured.
-    // Private paranets skip on-chain registration and gossip entirely.
+    // ownerOnly paranets skip on-chain registration and gossip entirely.
+    // allowList paranets register on-chain (for governance/incentives).
     let onChainId: string | undefined;
-    if (isPrivate) {
+    if (skipChain) {
       this.log.info(ctx, `Creating private paranet "${opts.id}" (local-only, no chain, no gossip)`);
     } else if (this.chain.chainId !== 'none') {
       try {
@@ -1995,15 +2035,23 @@ export class DKGAgent {
 
     this.subscribedParanets.set(opts.id, {
       name: opts.name,
-      subscribed: !isPrivate,
+      subscribed: !skipChain,
       synced: true,
       onChainId: onChainId,
+      accessPolicy: resolved.accessPolicy !== 'public' ? resolved.accessPolicy : undefined,
+      allowedPeers: resolved.allowedPeers.length > 0 ? resolved.allowedPeers : undefined,
     });
 
-    if (!isPrivate) {
-      // Auto-subscribe to the new paranet's GossipSub topic
+    // ownerOnly: fully isolated — no gossip topics, no broadcast
+    // allowList: subscribe to paranet-specific topics (so allowed peers can gossip
+    //            within the paranet), but do NOT broadcast definition publicly
+    // public: full gossip subscription + public definition broadcast
+    if (!skipChain) {
+      // Subscribe to paranet-specific GossipSub topics (publish, workspace, app, etc.)
       this.subscribeToParanet(opts.id);
+    }
 
+    if (!skipDefinitionBroadcast) {
       // Broadcast via the ontology paranet so other nodes learn about it
       const ontologyTopic = paranetPublishTopic(SYSTEM_PARANETS.ONTOLOGY);
       const nquads = quads.map(q => {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1470,6 +1470,7 @@ export class DKGAgent {
       contextGraphSignatures: options?.contextGraphSignatures,
       accessPolicy: resolved.accessPolicy,
       allowedPeers: resolved.allowedPeers,
+      publisherPeerId: this.node.peerId.toString(),
     });
 
     if (result.status === 'confirmed' && result.onChainResult) {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -562,9 +562,17 @@ export class DKGAgent {
 
           const metaResult = await this.store.query(metaQuery);
           if (metaResult.type === 'bindings') {
+            const WORKSPACE_OWNER_PRED = `${DKG_NS}workspaceOwner`;
             for (const b of metaResult.bindings) {
-              // Filter metadata: only include triples whose subject is an accessible operation
-              if (accessibleOps.size > 0 && !accessibleOps.has(b['s'])) continue;
+              // Filter metadata: only include triples whose subject is an accessible operation.
+              // Also include dkg:workspaceOwner triples — these use the ROOT ENTITY as subject
+              // (e.g. <did:dkg:entity:X> dkg:workspaceOwner "peerId"), not the operation URI.
+              // Without them, reconstructWorkspaceOwnership() breaks on the receiving peer.
+              if (accessibleOps.size > 0) {
+                const isAccessibleOp = accessibleOps.has(b['s']);
+                const isOwnerTriple = b['p'] === WORKSPACE_OWNER_PRED && accessibleRoots.has(b['s']);
+                if (!isAccessibleOp && !isOwnerTriple) continue;
+              }
               const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
               nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${wsMetaGraph}> .`);
             }
@@ -1357,13 +1365,13 @@ export class DKGAgent {
    * Write quads to the paranet's workspace graph (no chain, no TRAC).
    *
    * Visibility controls both broadcast and access policy:
-   * - `'private'` — local-only, no broadcast, ownerOnly access (new default)
+   * - `'private'` — local-only, no broadcast, ownerOnly access
    * - `'public'` — broadcast to peers, public access
-   * - `{ peers: [...] }` — broadcast to peers, allowList access
+   * - `{ peers: [...] }` — sync-only to listed peers, allowList access (no gossip broadcast)
    *
    * The legacy `localOnly` option is still supported for backward compatibility.
-   * When neither `visibility` nor `localOnly` is specified, defaults to `'private'`
-   * (no broadcast) — a deliberate change from the previous broadcast-by-default.
+   * When neither `visibility` nor `localOnly` is specified, defaults to `'public'`
+   * (broadcast) — preserving pre-migration behavior for existing callers.
    */
   async writeToWorkspace(
     paranetId: string,
@@ -1375,18 +1383,23 @@ export class DKGAgent {
       operationCtx?: OperationContext;
     },
   ): Promise<{ workspaceOperationId: string }> {
-    // When neither visibility nor localOnly is specified, default to private
-    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly === false ? 'public' : undefined);
-    const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly ?? true });
+    // Preserve backward compatibility: when neither visibility nor localOnly is
+    // specified, default to public/broadcast (matching pre-migration behavior).
+    // Only go private when the caller explicitly requests it.
+    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly != null ? undefined : 'public');
+    const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly });
     const ctx = opts?.operationCtx ?? createOperationContext('workspace');
-    this.log.info(ctx, `Writing ${quads.length} quads to workspace for paranet ${paranetId} (visibility=${typeof effectiveVisibility === 'object' ? 'peers' : effectiveVisibility ?? 'private'})`);
+    this.log.info(ctx, `Writing ${quads.length} quads to workspace for paranet ${paranetId} (visibility=${typeof effectiveVisibility === 'object' ? 'peers' : effectiveVisibility ?? 'default'})`);
     const { workspaceOperationId, message } = await this.publisher.writeToWorkspace(paranetId, quads, {
       publisherPeerId: this.node.peerId.toString(),
       operationCtx: ctx,
       accessPolicy: resolved.accessPolicy,
       allowedPeers: resolved.allowedPeers,
     });
-    if (resolved.broadcast) {
+    // Only broadcast on GossipSub for public data. allowList data must NOT be
+    // gossipped because any subscribed peer can read raw gossip messages before
+    // the sync-side filter runs. allowList data reaches peers via sync only.
+    if (resolved.accessPolicy === 'public') {
       const topic = paranetWorkspaceTopic(paranetId);
       try {
         await this.gossip.publish(topic, message);
@@ -1415,8 +1428,9 @@ export class DKGAgent {
       operationCtx?: OperationContext;
     },
   ): Promise<{ workspaceOperationId: string }> {
-    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly === false ? 'public' : undefined);
-    const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly ?? true });
+    // Same backward-compat default as writeToWorkspace
+    const effectiveVisibility = opts?.visibility ?? (opts?.localOnly != null ? undefined : 'public');
+    const resolved = resolveVisibility(effectiveVisibility, { localOnly: opts?.localOnly });
     const ctx = opts?.operationCtx ?? createOperationContext('workspace');
     this.log.info(ctx, `CAS write: ${quads.length} quads, ${conditions.length} conditions for ${paranetId}`);
     const { workspaceOperationId, message } = await this.publisher.writeConditionalToWorkspace(paranetId, quads, {
@@ -1426,7 +1440,8 @@ export class DKGAgent {
       accessPolicy: resolved.accessPolicy,
       allowedPeers: resolved.allowedPeers,
     });
-    if (resolved.broadcast) {
+    // Only broadcast on GossipSub for public data (see writeToWorkspace comment)
+    if (resolved.accessPolicy === 'public') {
       const topic = paranetWorkspaceTopic(paranetId);
       try {
         await this.gossip.publish(topic, message);

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1,6 +1,6 @@
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus,
-  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE,
+  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_WORKSPACE_PUSH,
   paranetPublishTopic, paranetWorkspaceTopic, paranetAppTopic, paranetUpdateTopic, paranetFinalizationTopic,
   paranetDataGraphUri, paranetMetaGraphUri, paranetWorkspaceGraphUri, paranetWorkspaceMetaGraphUri,
   encodePublishRequest,
@@ -548,13 +548,23 @@ export class DKGAgent {
             }
           }
 
+          // Use UNION to fetch both non-expired operation metadata AND workspaceOwner
+          // triples. Owner triples have root entities as subjects (not operations) so
+          // they lack dkg:publishedAt and would be dropped by the TTL filter otherwise.
           const metaQuery = cutoff != null
             ? `SELECT ?s ?p ?o WHERE {
-                GRAPH <${wsMetaGraph}> { ?s ?p ?o }
-                FILTER EXISTS {
-                  GRAPH <${wsMetaGraph}> {
-                    ?s <${DKG_NS}publishedAt> ?ts .
-                    FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+                GRAPH <${wsMetaGraph}> {
+                  {
+                    ?s ?p ?o .
+                    FILTER EXISTS {
+                      ?s <${DKG_NS}publishedAt> ?ts .
+                      FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+                    }
+                  }
+                  UNION
+                  {
+                    ?s <${DKG_NS}workspaceOwner> ?o .
+                    BIND(<${DKG_NS}workspaceOwner> AS ?p)
                   }
                 }
               } ORDER BY ?s ?p ?o`
@@ -609,6 +619,19 @@ export class DKGAgent {
       }
 
       return new TextEncoder().encode(nquads.join('\n'));
+    });
+
+    // Register workspace push handler: receives targeted workspace messages
+    // from peers who wrote allowList data intended for us. Processes the
+    // message the same way as a gossip workspace message.
+    this.router.register(PROTOCOL_WORKSPACE_PUSH, async (data, fromPeerId) => {
+      const wh = this.getOrCreateWorkspaceHandler();
+      try {
+        await wh.handle(data, fromPeerId.toString());
+      } catch (err) {
+        this.log.warn(createOperationContext('workspace'), `Failed to handle workspace push from ${fromPeerId.toString().slice(-8)}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      return new Uint8Array(0); // ACK
     });
 
     // Subscribe to both system paranet GossipSub topics
@@ -1398,7 +1421,7 @@ export class DKGAgent {
     });
     // Only broadcast on GossipSub for public data. allowList data must NOT be
     // gossipped because any subscribed peer can read raw gossip messages before
-    // the sync-side filter runs. allowList data reaches peers via sync only.
+    // the sync-side filter runs. allowList data reaches peers via targeted push.
     if (resolved.accessPolicy === 'public') {
       const topic = paranetWorkspaceTopic(paranetId);
       try {
@@ -1406,6 +1429,11 @@ export class DKGAgent {
       } catch {
         this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
       }
+    } else if (resolved.accessPolicy === 'allowList' && resolved.allowedPeers.length > 0) {
+      // Targeted push to authorized peers that are currently connected
+      this.pushWorkspaceToAllowedPeers(resolved.allowedPeers, message, ctx).catch((err) => {
+        this.log.warn(ctx, `Targeted push failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
     }
     return { workspaceOperationId };
   }
@@ -1448,8 +1476,44 @@ export class DKGAgent {
       } catch {
         this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
       }
+    } else if (resolved.accessPolicy === 'allowList' && resolved.allowedPeers.length > 0) {
+      // Targeted push to authorized peers that are currently connected
+      this.pushWorkspaceToAllowedPeers(resolved.allowedPeers, message, ctx).catch((err) => {
+        this.log.warn(ctx, `Targeted push failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
     }
     return { workspaceOperationId };
+  }
+
+  /**
+   * After an allowList workspace write, push the workspace message directly to
+   * each allowed peer that is currently connected. This ensures authorized peers
+   * receive the data immediately without waiting for a reconnect or manual sync.
+   * Failures are logged but do not propagate — delivery is best-effort.
+   */
+  private async pushWorkspaceToAllowedPeers(
+    allowedPeers: string[],
+    message: Uint8Array,
+    ctx: OperationContext,
+  ): Promise<void> {
+    // Build a map of connected peer ID strings for fast lookup
+    const connectedPeerIds = new Set(
+      this.node.libp2p.getConnections().map((conn) => conn.remotePeer.toString()),
+    );
+
+    const targets = allowedPeers.filter(p => connectedPeerIds.has(p));
+    if (targets.length === 0) return;
+
+    this.log.info(ctx, `Pushing workspace data to ${targets.length} connected allowed peer(s)`);
+    await Promise.allSettled(
+      targets.map(async (peerId) => {
+        try {
+          await this.router.send(peerId, PROTOCOL_WORKSPACE_PUSH, message);
+        } catch (err) {
+          this.log.warn(ctx, `Workspace push to ${peerId.slice(-8)} failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }),
+    );
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -408,7 +408,7 @@ export class DKGAgent {
     //   or: "workspace:paranetId|offset|limit" for workspace graph sync
     // Response includes both the data graph and the meta graph so the
     // receiver can verify merkle roots before inserting.
-    this.router.register(PROTOCOL_SYNC, async (data) => {
+    this.router.register(PROTOCOL_SYNC, async (data, fromPeerId) => {
       const text = new TextDecoder().decode(data).trim();
       const [paranetPart, offsetStr, limitStr] = text.split('|');
       const offset = parseInt(offsetStr, 10) || 0;
@@ -422,25 +422,106 @@ export class DKGAgent {
         const wsGraph = paranetWorkspaceGraphUri(paranetId);
         const wsMetaGraph = paranetWorkspaceMetaGraphUri(paranetId);
         const wsTtl = this.config.workspaceTtlMs ?? DEFAULT_WORKSPACE_TTL_MS;
+        const requestingPeerId = fromPeerId.toString();
+
+        // --- Access filtering ---
+        // Query workspace_meta for per-operation access policies so we only
+        // serve root entities the requesting peer is authorized to see.
+        // Operations without an accessPolicy triple (pre-migration data) are
+        // treated as public for backward compatibility.
+        const DKG_NS = 'http://dkg.io/ontology/';
+        const PROV_NS = 'http://www.w3.org/ns/prov#';
+        const accessQuery = `SELECT ?op ?re ?policy ?publisher ?allowedPeer WHERE {
+  GRAPH <${wsMetaGraph}> {
+    ?op <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${DKG_NS}WorkspaceOperation> .
+    ?op <${DKG_NS}rootEntity> ?re .
+    OPTIONAL { ?op <${DKG_NS}accessPolicy> ?policy }
+    OPTIONAL { ?op <${PROV_NS}wasAttributedTo> ?publisher }
+    OPTIONAL { ?op <${DKG_NS}allowedPeer> ?allowedPeer }
+  }
+}`;
+        const accessResult = await this.store.query(accessQuery);
+        const accessibleRoots = new Set<string>();
+        if (accessResult.type === 'bindings') {
+          // Group results by operation+rootEntity to handle multiple allowedPeer rows
+          const opRoots = new Map<string, { policy?: string; publisher?: string; peers: Set<string> }>();
+          for (const row of accessResult.bindings) {
+            const re = row['re'];
+            const op = row['op'];
+            if (!re || !op) continue;
+            const key = `${op}\0${re}`;
+            let entry = opRoots.get(key);
+            if (!entry) {
+              const rawPolicy = row['policy'];
+              const policy = rawPolicy ? stripLiteral(rawPolicy) : undefined;
+              const rawPublisher = row['publisher'];
+              const publisher = rawPublisher ? stripLiteral(rawPublisher) : undefined;
+              entry = { policy, publisher, peers: new Set() };
+              opRoots.set(key, entry);
+            }
+            const rawPeer = row['allowedPeer'];
+            if (rawPeer) entry.peers.add(stripLiteral(rawPeer));
+          }
+
+          for (const [key, { policy, publisher, peers }] of opRoots) {
+            const re = key.split('\0')[1];
+            // No policy or explicit 'public' → accessible to everyone
+            if (!policy || policy === 'public') {
+              accessibleRoots.add(re);
+            } else if (policy === 'ownerOnly') {
+              if (publisher && requestingPeerId === publisher) {
+                accessibleRoots.add(re);
+              }
+            } else if (policy === 'allowList') {
+              if (peers.has(requestingPeerId)) {
+                accessibleRoots.add(re);
+              }
+            } else {
+              // Unknown policy — treat as public for forward compatibility
+              accessibleRoots.add(re);
+            }
+          }
+        }
+
+        // If no operations matched at all (empty workspace), return empty
+        if (accessResult.type === 'bindings' && accessResult.bindings.length > 0 && accessibleRoots.size === 0) {
+          return new TextEncoder().encode('');
+        }
 
         // Apply TTL/root-entity filter inside SPARQL before pagination so that
         // we return the first N non-expired triples. Only include exact root subject
         // or skolemized children (/.well-known/genid/...) to avoid pulling unrelated
         // entities that share a URI prefix (e.g. urn:x vs urn:x/other).
+        // Additionally filter by accessible root entities for access control.
         const cutoff = wsTtl > 0 ? new Date(Date.now() - wsTtl).toISOString() : null;
+        const rootValues = [...accessibleRoots].map(r => `<${r}>`).join(' ');
+        const hasAccessFilter = accessibleRoots.size > 0;
+        const accessFilterClause = hasAccessFilter ? `VALUES ?re { ${rootValues} }` : '';
+
         const wsQuery =
           cutoff != null
             ? `SELECT DISTINCT ?s ?p ?o WHERE {
   GRAPH <${wsMetaGraph}> {
-    ?op <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dkg.io/ontology/WorkspaceOperation> .
-    ?op <http://dkg.io/ontology/publishedAt> ?ts .
-    ?op <http://dkg.io/ontology/rootEntity> ?re .
+    ?op <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${DKG_NS}WorkspaceOperation> .
+    ?op <${DKG_NS}publishedAt> ?ts .
+    ?op <${DKG_NS}rootEntity> ?re .
+    ${accessFilterClause}
     FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
   }
   GRAPH <${wsGraph}> { ?s ?p ?o }
   FILTER(?s = ?re || STRSTARTS(STR(?s), CONCAT(STR(?re), "/.well-known/genid/")))
 } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
-            : `SELECT ?s ?p ?o WHERE { GRAPH <${wsGraph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
+            : hasAccessFilter
+              ? `SELECT DISTINCT ?s ?p ?o WHERE {
+  GRAPH <${wsMetaGraph}> {
+    ?op <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <${DKG_NS}WorkspaceOperation> .
+    ?op <${DKG_NS}rootEntity> ?re .
+    ${accessFilterClause}
+  }
+  GRAPH <${wsGraph}> { ?s ?p ?o }
+  FILTER(?s = ?re || STRSTARTS(STR(?s), CONCAT(STR(?re), "/.well-known/genid/")))
+} ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`
+              : `SELECT ?s ?p ?o WHERE { GRAPH <${wsGraph}> { ?s ?p ?o } } ORDER BY ?s ?p ?o OFFSET ${offset} LIMIT ${limit}`;
 
         const wsResult = await this.store.query(wsQuery);
         if (wsResult.type !== 'bindings' || wsResult.bindings.length === 0) {
@@ -452,13 +533,23 @@ export class DKGAgent {
         }
 
         if (offset === 0) {
-          // Only send meta for non-expired operations; reuse same cutoff as data query to avoid boundary skew
+          // Only send meta for non-expired operations whose root entities are accessible.
+          // Build a set of accessible operation URIs from the access query results.
+          const accessibleOps = new Set<string>();
+          if (accessResult.type === 'bindings') {
+            for (const row of accessResult.bindings) {
+              const re = row['re'];
+              const op = row['op'];
+              if (re && op && accessibleRoots.has(re)) accessibleOps.add(op);
+            }
+          }
+
           const metaQuery = cutoff != null
             ? `SELECT ?s ?p ?o WHERE {
                 GRAPH <${wsMetaGraph}> { ?s ?p ?o }
                 FILTER EXISTS {
                   GRAPH <${wsMetaGraph}> {
-                    ?s <http://dkg.io/ontology/publishedAt> ?ts .
+                    ?s <${DKG_NS}publishedAt> ?ts .
                     FILTER(?ts >= "${cutoff}"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
                   }
                 }
@@ -468,6 +559,8 @@ export class DKGAgent {
           const metaResult = await this.store.query(metaQuery);
           if (metaResult.type === 'bindings') {
             for (const b of metaResult.bindings) {
+              // Filter metadata: only include triples whose subject is an accessible operation
+              if (accessibleOps.size > 0 && !accessibleOps.has(b['s'])) continue;
               const obj = b['o'].startsWith('"') ? b['o'] : `<${b['o']}>`;
               nquads.push(`<${b['s']}> <${b['p']}> ${obj} <${wsMetaGraph}> .`);
             }

--- a/packages/agent/test/paranet-discovery.test.ts
+++ b/packages/agent/test/paranet-discovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { DKGAgent, type ParanetSub } from '../src/index.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
-import { SYSTEM_PARANETS, DKG_ONTOLOGY, paranetDataGraphUri } from '@origintrail-official/dkg-core';
+import { SYSTEM_PARANETS, DKG_ONTOLOGY, paranetDataGraphUri, paranetMetaGraphUri } from '@origintrail-official/dkg-core';
 import { MockChainAdapter, type ParanetOnChain } from '@origintrail-official/dkg-chain';
 
 class MockChainWithParanets extends MockChainAdapter {
@@ -433,5 +433,235 @@ describe('hash-vs-name duplication regression', () => {
     // No ghost 0x entries
     const ghosts = paranets.filter(p => p.id.startsWith('0x'));
     expect(ghosts.length).toBe(0);
+  }, 15000);
+});
+
+describe('access policy rehydration on restart (BUG 1)', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('discoverParanetsFromStore rehydrates accessPolicy and allowedPeers for existing subscriptions', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    // Simulate a paranet that was created with allowList policy.
+    // After restart, the in-memory subscribedParanets won't have accessPolicy.
+    // Insert the definition into the paranet's _meta graph (as createParanet now does for non-public).
+    const paranetId = 'private-rehydrate';
+    const paranetUri = paranetDataGraphUri(paranetId);
+    const metaGraph = paranetMetaGraphUri(paranetId);
+    await store.insert([
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: metaGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Private Rehydrate"', graph: metaGraph },
+      { subject: paranetUri, predicate: 'http://dkg.io/ontology/accessPolicy', object: '"allowList"', graph: metaGraph },
+      { subject: paranetUri, predicate: 'http://dkg.io/ontology/allowedPeer', object: '"peer-A"', graph: metaGraph },
+      { subject: paranetUri, predicate: 'http://dkg.io/ontology/allowedPeer', object: '"peer-B"', graph: metaGraph },
+    ]);
+
+    // Simulate a pre-existing subscription without accessPolicy (as after restart)
+    (agent as any).subscribedParanets.set(paranetId, {
+      name: 'Private Rehydrate',
+      subscribed: true,
+      synced: true,
+    });
+
+    // discoverParanetsFromStore should rehydrate the accessPolicy from the _meta graph
+    await agent.discoverParanetsFromStore();
+
+    const sub = agent.getSubscribedParanets().get(paranetId);
+    expect(sub).toBeDefined();
+    expect(sub!.accessPolicy).toBe('allowList');
+    expect(sub!.allowedPeers).toBeDefined();
+    expect(sub!.allowedPeers!.sort()).toEqual(['peer-A', 'peer-B']);
+  }, 15000);
+
+  it('discoverParanetsFromStore does NOT auto-discover non-public paranets from ontology graph', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    // Insert a non-public paranet definition into the shared ontology graph
+    // (simulating legacy data or a leak). It should NOT be auto-discovered.
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const paranetUri = paranetDataGraphUri('leaked-private');
+    await store.insert([
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: ontologyGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Leaked Private"', graph: ontologyGraph },
+      { subject: paranetUri, predicate: 'http://dkg.io/ontology/accessPolicy', object: '"allowList"', graph: ontologyGraph },
+    ]);
+
+    const discovered = await agent.discoverParanetsFromStore();
+    expect(discovered).toBe(0);
+
+    const sub = agent.getSubscribedParanets().get('leaked-private');
+    expect(sub).toBeUndefined();
+  }, 15000);
+
+  it('discoverParanetsFromChain maps on-chain accessPolicy=1 to allowList', async () => {
+    const chain = new MockChainWithParanets([
+      {
+        paranetId: '0xdeadbeef00000000000000000000000000000000000000000000000000000099',
+        name: 'permissioned-chain',
+        creator: '0x1234',
+        accessPolicy: 1,
+        blockNumber: 200,
+        metadataRevealed: true,
+      },
+    ]);
+
+    const result = await createTestAgent({ chainAdapter: chain });
+    agent = result.agent;
+    await agent.start();
+
+    const discovered = await agent.discoverParanetsFromChain();
+    expect(discovered).toBe(1);
+
+    const sub = agent.getSubscribedParanets().get('permissioned-chain');
+    expect(sub).toBeDefined();
+    expect(sub!.accessPolicy).toBe('allowList');
+  }, 15000);
+});
+
+describe('non-public paranet definition isolation (BUG 2)', () => {
+  let agent: DKGAgent | undefined;
+
+  afterEach(async () => {
+    await agent?.stop().catch(() => {});
+  });
+
+  it('createParanet with allowList stores definition in _meta graph, not ontology graph', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    await agent.createParanet({
+      id: 'allow-list-paranet',
+      name: 'Allow List Paranet',
+      visibility: { peers: ['peer-1', 'peer-2'] },
+    });
+
+    // Definition should NOT be in the shared ontology graph
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const paranetUri = paranetDataGraphUri('allow-list-paranet');
+    const ontologyResult = await store.query(`
+      SELECT ?p WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}>
+        }
+      } LIMIT 1
+    `);
+    expect(ontologyResult.type).toBe('bindings');
+    if (ontologyResult.type === 'bindings') {
+      expect(ontologyResult.bindings.length).toBe(0);
+    }
+
+    // Definition SHOULD be in the paranet's _meta graph
+    const metaGraph = paranetMetaGraphUri('allow-list-paranet');
+    const metaResult = await store.query(`
+      SELECT ?name WHERE {
+        GRAPH <${metaGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}> .
+          <${paranetUri}> <${DKG_ONTOLOGY.SCHEMA_NAME}> ?name .
+        }
+      }
+    `);
+    expect(metaResult.type).toBe('bindings');
+    if (metaResult.type === 'bindings') {
+      expect(metaResult.bindings.length).toBe(1);
+    }
+
+    // Access policy triples should also be in _meta graph
+    const policyResult = await store.query(`
+      SELECT ?policy ?peer WHERE {
+        GRAPH <${metaGraph}> {
+          <${paranetUri}> <http://dkg.io/ontology/accessPolicy> ?policy .
+          OPTIONAL { <${paranetUri}> <http://dkg.io/ontology/allowedPeer> ?peer }
+        }
+      }
+    `);
+    expect(policyResult.type).toBe('bindings');
+    if (policyResult.type === 'bindings') {
+      expect(policyResult.bindings.length).toBeGreaterThanOrEqual(1);
+    }
+  }, 15000);
+
+  it('createParanet with public visibility stores definition in ontology graph', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    await agent.createParanet({
+      id: 'public-paranet',
+      name: 'Public Paranet',
+    });
+
+    // Definition SHOULD be in the shared ontology graph
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const paranetUri = paranetDataGraphUri('public-paranet');
+    const ontologyResult = await store.query(`
+      SELECT ?p WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}>
+        }
+      } LIMIT 1
+    `);
+    expect(ontologyResult.type).toBe('bindings');
+    if (ontologyResult.type === 'bindings') {
+      expect(ontologyResult.bindings.length).toBe(1);
+    }
+  }, 15000);
+
+  it('createParanet with ownerOnly stores definition in _meta graph', async () => {
+    const store = new OxigraphStore();
+    const result = await createTestAgent({ store });
+    agent = result.agent;
+    await agent.start();
+
+    await agent.createParanet({
+      id: 'owner-only-paranet',
+      name: 'Owner Only',
+      visibility: 'private',
+    });
+
+    // Should NOT be in ontology graph
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const paranetUri = paranetDataGraphUri('owner-only-paranet');
+    const ontologyResult = await store.query(`
+      SELECT ?p WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}>
+        }
+      } LIMIT 1
+    `);
+    expect(ontologyResult.type).toBe('bindings');
+    if (ontologyResult.type === 'bindings') {
+      expect(ontologyResult.bindings.length).toBe(0);
+    }
+
+    // Should be in _meta graph
+    const metaGraph = paranetMetaGraphUri('owner-only-paranet');
+    const metaResult = await store.query(`
+      SELECT ?p WHERE {
+        GRAPH <${metaGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PARANET}>
+        }
+      } LIMIT 1
+    `);
+    expect(metaResult.type).toBe('bindings');
+    if (metaResult.type === 'bindings') {
+      expect(metaResult.bindings.length).toBe(1);
+    }
+
+    // paranetExists should still find it (uses GRAPH ?g)
+    const exists = await agent.paranetExists('owner-only-paranet');
+    expect(exists).toBe(true);
   }, 15000);
 });

--- a/packages/agent/test/sync-access-filtering.test.ts
+++ b/packages/agent/test/sync-access-filtering.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the PROTOCOL_SYNC handler's access filtering logic.
+ *
+ * When a peer requests workspace data via sync, the handler queries
+ * workspace_meta for per-operation access policies and filters data
+ * by what the requesting peer is authorized to see.
+ *
+ * These are E2E tests with two real nodes to exercise the full sync path.
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+
+const PARANET = 'sync-access-filter-e2e';
+const PUBLIC_ENTITY = 'urn:sync-access:public:1';
+const PRIVATE_ENTITY = 'urn:sync-access:private:1';
+const ALLOW_ENTITY = 'urn:sync-access:allow:1';
+const LEGACY_ENTITY = 'urn:sync-access:legacy:1';
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('PROTOCOL_SYNC access filtering (2 nodes)', () => {
+  let nodeA: DKGAgent;
+  let nodeB: DKGAgent;
+
+  afterAll(async () => {
+    try {
+      await nodeA?.stop();
+      await nodeB?.stop();
+    } catch (err) {
+      console.warn('Teardown:', err);
+    }
+  });
+
+  it('bootstraps two nodes, creates paranet, and writes mixed-visibility data', async () => {
+    nodeA = await DKGAgent.create({
+      name: 'SyncFilterA',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+      syncParanets: [PARANET],
+    });
+    nodeB = await DKGAgent.create({
+      name: 'SyncFilterB',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+      syncParanets: [PARANET],
+    });
+
+    await nodeA.start();
+    await nodeB.start();
+    await sleep(800);
+
+    await nodeA.createParanet({
+      id: PARANET,
+      name: 'Sync Access Filter Test',
+      description: 'Mixed visibility workspace',
+    });
+
+    // Write public data
+    await nodeA.writeToWorkspace(PARANET, [
+      { subject: PUBLIC_ENTITY, predicate: 'http://schema.org/name', object: '"Public Data"', graph: '' },
+    ], { visibility: 'public' });
+
+    // Write owner-only data (should NOT be visible to nodeB via sync)
+    await nodeA.writeToWorkspace(PARANET, [
+      { subject: PRIVATE_ENTITY, predicate: 'http://schema.org/name', object: '"Owner Secret"', graph: '' },
+    ], { visibility: 'private' });
+
+    // Write allow-list data (nodeB is on the list)
+    await nodeA.writeToWorkspace(PARANET, [
+      { subject: ALLOW_ENTITY, predicate: 'http://schema.org/name', object: '"Allow Listed"', graph: '' },
+    ], { visibility: { peers: [nodeB.peerId] } });
+
+    // Write legacy data (no access policy — should be treated as public)
+    // Use localOnly: false to trigger broadcast (legacy behavior)
+    await nodeA.writeToWorkspace(PARANET, [
+      { subject: LEGACY_ENTITY, predicate: 'http://schema.org/name', object: '"Legacy Pre-Migration"', graph: '' },
+    ], { localOnly: false });
+
+    // Verify all data exists on node A
+    const allOnA = await nodeA.query(
+      'SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { paranetId: PARANET, graphSuffix: '_workspace' },
+    );
+    expect(allOnA.bindings.length).toBe(4);
+  }, 15000);
+
+  it('nodeB syncs and gets only authorized data', async () => {
+    // Connect nodeB to nodeA so sync can occur
+    const addrA = nodeA.multiaddrs.find((a) => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodeB.connectTo(addrA);
+    await sleep(500);
+
+    // Subscribe nodeB to the paranet
+    nodeB.subscribeToParanet(PARANET);
+    await sleep(2000);
+
+    // Trigger sync by subscribing (the agent auto-syncs on connect)
+    // Wait for sync to complete
+    await sleep(5000);
+
+    // nodeB should have public data
+    const publicResult = await nodeB.query(
+      `SELECT ?name WHERE { <${PUBLIC_ENTITY}> <http://schema.org/name> ?name }`,
+      { paranetId: PARANET, graphSuffix: '_workspace' },
+    );
+    expect(publicResult.bindings.length).toBe(1);
+    expect(publicResult.bindings[0]['name']).toBe('"Public Data"');
+
+    // nodeB should NOT have owner-only data
+    const privateResult = await nodeB.query(
+      `SELECT ?name WHERE { <${PRIVATE_ENTITY}> <http://schema.org/name> ?name }`,
+      { paranetId: PARANET, graphSuffix: '_workspace' },
+    );
+    expect(privateResult.bindings.length).toBe(0);
+
+    // nodeB SHOULD have allow-listed data (nodeB's peerId is on the list)
+    const allowResult = await nodeB.query(
+      `SELECT ?name WHERE { <${ALLOW_ENTITY}> <http://schema.org/name> ?name }`,
+      { paranetId: PARANET, graphSuffix: '_workspace' },
+    );
+    expect(allowResult.bindings.length).toBe(1);
+    expect(allowResult.bindings[0]['name']).toBe('"Allow Listed"');
+
+    // nodeB should have legacy data (no access policy = public)
+    const legacyResult = await nodeB.query(
+      `SELECT ?name WHERE { <${LEGACY_ENTITY}> <http://schema.org/name> ?name }`,
+      { paranetId: PARANET, graphSuffix: '_workspace' },
+    );
+    expect(legacyResult.bindings.length).toBe(1);
+    expect(legacyResult.bindings[0]['name']).toBe('"Legacy Pre-Migration"');
+  }, 25000);
+
+  it('owner can sync their own ownerOnly data', async () => {
+    // nodeA should still see all its own data including private
+    const privateOnA = await nodeA.query(
+      `SELECT ?name WHERE { <${PRIVATE_ENTITY}> <http://schema.org/name> ?name }`,
+      { paranetId: PARANET, graphSuffix: '_workspace' },
+    );
+    expect(privateOnA.bindings.length).toBe(1);
+    expect(privateOnA.bindings[0]['name']).toBe('"Owner Secret"');
+  }, 5000);
+
+  it('nodeB does NOT see private data even with includeWorkspace broad query', async () => {
+    const broadResult = await nodeB.query(
+      `SELECT ?s ?p ?o WHERE { ?s ?p ?o . FILTER(CONTAINS(STR(?o), "Owner Secret")) }`,
+      { paranetId: PARANET, includeWorkspace: true },
+    );
+    expect(broadResult.bindings.length).toBe(0);
+  }, 5000);
+});

--- a/packages/agent/test/visibility-api.test.ts
+++ b/packages/agent/test/visibility-api.test.ts
@@ -39,15 +39,13 @@ describe('writeToWorkspace — Visibility API', () => {
     await agent.start();
     await sleep(500);
 
-    // Patch the gossip.publish to track broadcast calls
-    gossipSpy = vi.fn().mockResolvedValue(undefined);
-    const origGossip = (agent as any).gossip;
-    (agent as any).gossip = { ...origGossip, publish: gossipSpy };
+    // Spy on gossip.publish to track broadcast calls (vi.spyOn preserves prototype methods)
+    gossipSpy = vi.spyOn((agent as any).gossip, 'publish').mockResolvedValue(undefined);
   }, 10000);
 
-  it('writeToWorkspace with no options → broadcasts (public default, backward compat)', async () => {
+  it('writeToWorkspace with no options on public paranet → broadcasts (public default, backward compat)', async () => {
     const paranet = nextParanet();
-    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'public' });
 
     gossipSpy.mockClear();
     const entity = nextEntity();
@@ -56,6 +54,19 @@ describe('writeToWorkspace — Visibility API', () => {
     ]);
 
     expect(gossipSpy).toHaveBeenCalledTimes(1);
+  }, 10000);
+
+  it('writeToWorkspace with no options on private paranet → inherits private (no broadcast)', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Inherited Private"', graph: '' },
+    ]);
+
+    expect(gossipSpy).not.toHaveBeenCalled();
   }, 10000);
 
   it('writeToWorkspace with visibility: "public" → broadcasts', async () => {
@@ -258,5 +269,85 @@ describe('createParanet — Visibility API', () => {
     );
     // Default is public, and public doesn't store accessPolicy triple
     expect(result.bindings.length).toBe(0);
+  }, 10000);
+
+  it('createParanet with allowList → registers on chain but does NOT broadcast definition', async () => {
+    const paranet = nextParanet();
+    // Spy on gossip.publish (vi.spyOn preserves prototype methods like subscribe)
+    const publishSpy = vi.spyOn((agent as any).gossip, 'publish').mockResolvedValue(undefined);
+    publishSpy.mockClear();
+
+    await agent.createParanet({
+      id: paranet,
+      name: 'Allow List No Broadcast',
+      visibility: { peers: ['peerA'] },
+    });
+
+    // The definition should NOT be broadcast on the ontology topic
+    // (allowList paranets are discoverable only via direct sharing)
+    expect(publishSpy).not.toHaveBeenCalled();
+
+    // But the paranet should exist locally
+    const exists = await agent.paranetExists(paranet);
+    expect(exists).toBe(true);
+
+    publishSpy.mockRestore();
+  }, 10000);
+});
+
+describe('Paranet visibility inheritance', () => {
+  let agent: DKGAgent;
+  let gossipSpy: ReturnType<typeof vi.fn>;
+
+  afterAll(async () => {
+    try { await agent?.stop(); } catch { /* */ }
+  });
+
+  it('creates agent and patches gossip', async () => {
+    agent = await DKGAgent.create({
+      name: 'InheritVisTest',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+    });
+    await agent.start();
+    await sleep(500);
+
+    gossipSpy = vi.spyOn((agent as any).gossip, 'publish').mockResolvedValue(undefined);
+  }, 10000);
+
+  it('writeToWorkspace inherits allowList visibility from paranet when no opts given', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'AllowList Paranet',
+      visibility: { peers: ['peerX'] },
+    });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Inherited AllowList"', graph: '' },
+    ]);
+
+    // allowList → no gossip broadcast (targeted push only)
+    expect(gossipSpy).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('explicit visibility overrides paranet default', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Private Paranet Override',
+      visibility: 'private',
+    });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Override to Public"', graph: '' },
+    ], { visibility: 'public' });
+
+    // Explicit public overrides inherited private
+    expect(gossipSpy).toHaveBeenCalledTimes(1);
   }, 10000);
 });

--- a/packages/agent/test/visibility-api.test.ts
+++ b/packages/agent/test/visibility-api.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, afterAll, vi } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { paranetMetaGraphUri } from '@origintrail-official/dkg-core';
 
 const PARANET_BASE = 'vis-api-test';
 const ENTITY_BASE = 'urn:vis-api:entity';
@@ -221,10 +222,10 @@ describe('createParanet — Visibility API', () => {
     });
 
     const DKG_NS = 'http://dkg.io/ontology/';
-    const ontologyGraph = 'did:dkg:paranet:ontology';
+    const metaGraph = paranetMetaGraphUri(paranet);
     const paranetUri = `did:dkg:paranet:${paranet}`;
     const result = await agent.query(
-      `SELECT ?policy WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
+      `SELECT ?policy WHERE { GRAPH <${metaGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
     );
     expect(result.bindings.length).toBe(1);
     expect(result.bindings[0]['policy']).toBe('"ownerOnly"');
@@ -239,17 +240,17 @@ describe('createParanet — Visibility API', () => {
     });
 
     const DKG_NS = 'http://dkg.io/ontology/';
-    const ontologyGraph = 'did:dkg:paranet:ontology';
+    const metaGraph = paranetMetaGraphUri(paranet);
     const paranetUri = `did:dkg:paranet:${paranet}`;
 
     const policyResult = await agent.query(
-      `SELECT ?policy WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
+      `SELECT ?policy WHERE { GRAPH <${metaGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
     );
     expect(policyResult.bindings.length).toBe(1);
     expect(policyResult.bindings[0]['policy']).toBe('"allowList"');
 
     const peerResult = await agent.query(
-      `SELECT ?peer WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}allowedPeer> ?peer } }`,
+      `SELECT ?peer WHERE { GRAPH <${metaGraph}> { <${paranetUri}> <${DKG_NS}allowedPeer> ?peer } }`,
     );
     expect(peerResult.bindings.length).toBe(2);
   }, 10000);

--- a/packages/agent/test/visibility-api.test.ts
+++ b/packages/agent/test/visibility-api.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for the unified Visibility API on DKGAgent methods:
+ * - writeToWorkspace: default private, visibility option, legacy localOnly
+ * - writeConditionalToWorkspace: same visibility semantics
+ * - createParanet: visibility option, legacy private flag
+ * - enshrineFromWorkspace: default public
+ *
+ * These tests use a real single-node agent to verify the API surface
+ * integrates correctly with resolveVisibility.
+ */
+import { describe, it, expect, afterAll, vi } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+
+const PARANET_BASE = 'vis-api-test';
+const ENTITY_BASE = 'urn:vis-api:entity';
+let counter = 0;
+function nextParanet() { return `${PARANET_BASE}-${++counter}`; }
+function nextEntity() { return `${ENTITY_BASE}:${++counter}`; }
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('writeToWorkspace — Visibility API', () => {
+  let agent: DKGAgent;
+  let gossipSpy: ReturnType<typeof vi.fn>;
+
+  afterAll(async () => {
+    try { await agent?.stop(); } catch { /* */ }
+  });
+
+  it('creates agent and patches gossip for inspection', async () => {
+    agent = await DKGAgent.create({
+      name: 'VisApiTest',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+    });
+    await agent.start();
+    await sleep(500);
+
+    // Patch the gossip.publish to track broadcast calls
+    gossipSpy = vi.fn().mockResolvedValue(undefined);
+    const origGossip = (agent as any).gossip;
+    (agent as any).gossip = { ...origGossip, publish: gossipSpy };
+  }, 10000);
+
+  it('writeToWorkspace with no options → does NOT broadcast (private default)', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Default Private"', graph: '' },
+    ]);
+
+    expect(gossipSpy).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('writeToWorkspace with visibility: "public" → broadcasts', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Public Write"', graph: '' },
+    ], { visibility: 'public' });
+
+    expect(gossipSpy).toHaveBeenCalledTimes(1);
+  }, 10000);
+
+  it('writeToWorkspace with visibility: "private" → does NOT broadcast', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Explicit Private"', graph: '' },
+    ], { visibility: 'private' });
+
+    expect(gossipSpy).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('writeToWorkspace with visibility: { peers: ["X"] } → broadcasts', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Allow List Write"', graph: '' },
+    ], { visibility: { peers: ['12D3KooWPeerX'] } });
+
+    expect(gossipSpy).toHaveBeenCalledTimes(1);
+  }, 10000);
+
+  it('writeToWorkspace with legacy localOnly: true → does NOT broadcast (backward compat)', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Legacy Local"', graph: '' },
+    ], { localOnly: true });
+
+    expect(gossipSpy).not.toHaveBeenCalled();
+  }, 10000);
+
+  it('writeToWorkspace with legacy localOnly: false → broadcasts (backward compat)', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    gossipSpy.mockClear();
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Legacy Broadcast"', graph: '' },
+    ], { localOnly: false });
+
+    expect(gossipSpy).toHaveBeenCalledTimes(1);
+  }, 10000);
+
+  it('writeToWorkspace stores access policy metadata when visibility is set', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
+
+    const entity = nextEntity();
+    await agent.writeToWorkspace(paranet, [
+      { subject: entity, predicate: 'http://schema.org/name', object: '"With Policy"', graph: '' },
+    ], { visibility: { peers: ['peerA'] } });
+
+    const DKG_NS = 'http://dkg.io/ontology/';
+    const wsMetaGraph = `did:dkg:paranet:${paranet}/_workspace_meta`;
+    // Query the workspace_meta graph directly using a GRAPH clause
+    const result = await agent.query(
+      `SELECT ?policy ?peer WHERE {
+        GRAPH <${wsMetaGraph}> {
+          ?op <${DKG_NS}accessPolicy> ?policy .
+          OPTIONAL { ?op <${DKG_NS}allowedPeer> ?peer }
+        }
+      }`,
+    );
+    expect(result.bindings.length).toBeGreaterThanOrEqual(1);
+    expect(result.bindings[0]['policy']).toBe('"allowList"');
+  }, 10000);
+});
+
+describe('createParanet — Visibility API', () => {
+  let agent: DKGAgent;
+
+  afterAll(async () => {
+    try { await agent?.stop(); } catch { /* */ }
+  });
+
+  it('creates agent', async () => {
+    agent = await DKGAgent.create({
+      name: 'ParanetVisTest',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter('mock:31337'),
+    });
+    await agent.start();
+    await sleep(500);
+  }, 10000);
+
+  it('createParanet with visibility: "private" → local only, no gossip', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Private Paranet',
+      visibility: 'private',
+    });
+
+    const exists = await agent.paranetExists(paranet);
+    expect(exists).toBe(true);
+  }, 10000);
+
+  it('createParanet with visibility: "public" → chain registration + gossip (default)', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Public Paranet',
+      visibility: 'public',
+    });
+
+    const exists = await agent.paranetExists(paranet);
+    expect(exists).toBe(true);
+  }, 10000);
+
+  it('createParanet with legacy private: true → same as visibility: "private" (backward compat)', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Legacy Private',
+      private: true,
+    });
+
+    const exists = await agent.paranetExists(paranet);
+    expect(exists).toBe(true);
+  }, 10000);
+
+  it('createParanet stores dkg:accessPolicy triple for non-public visibility', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Private With Policy',
+      visibility: 'private',
+    });
+
+    const DKG_NS = 'http://dkg.io/ontology/';
+    const ontologyGraph = 'did:dkg:paranet:ontology';
+    const paranetUri = `did:dkg:paranet:${paranet}`;
+    const result = await agent.query(
+      `SELECT ?policy WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(result.bindings.length).toBe(1);
+    expect(result.bindings[0]['policy']).toBe('"ownerOnly"');
+  }, 10000);
+
+  it('createParanet with visibility: { peers: [...] } stores allowList + allowedPeer triples', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Allow List Paranet',
+      visibility: { peers: ['peerA', 'peerB'] },
+    });
+
+    const DKG_NS = 'http://dkg.io/ontology/';
+    const ontologyGraph = 'did:dkg:paranet:ontology';
+    const paranetUri = `did:dkg:paranet:${paranet}`;
+
+    const policyResult = await agent.query(
+      `SELECT ?policy WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(policyResult.bindings.length).toBe(1);
+    expect(policyResult.bindings[0]['policy']).toBe('"allowList"');
+
+    const peerResult = await agent.query(
+      `SELECT ?peer WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}allowedPeer> ?peer } }`,
+    );
+    expect(peerResult.bindings.length).toBe(2);
+  }, 10000);
+
+  it('createParanet with default (no visibility) → public, no accessPolicy triple', async () => {
+    const paranet = nextParanet();
+    await agent.createParanet({
+      id: paranet,
+      name: 'Default Public',
+    });
+
+    const DKG_NS = 'http://dkg.io/ontology/';
+    const ontologyGraph = 'did:dkg:paranet:ontology';
+    const paranetUri = `did:dkg:paranet:${paranet}`;
+    const result = await agent.query(
+      `SELECT ?policy WHERE { GRAPH <${ontologyGraph}> { <${paranetUri}> <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    // Default is public, and public doesn't store accessPolicy triple
+    expect(result.bindings.length).toBe(0);
+  }, 10000);
+});

--- a/packages/agent/test/visibility-api.test.ts
+++ b/packages/agent/test/visibility-api.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the unified Visibility API on DKGAgent methods:
- * - writeToWorkspace: default private, visibility option, legacy localOnly
+ * - writeToWorkspace: default public (broadcast), visibility option, legacy localOnly
  * - writeConditionalToWorkspace: same visibility semantics
  * - createParanet: visibility option, legacy private flag
  * - enshrineFromWorkspace: default public
@@ -45,17 +45,17 @@ describe('writeToWorkspace — Visibility API', () => {
     (agent as any).gossip = { ...origGossip, publish: gossipSpy };
   }, 10000);
 
-  it('writeToWorkspace with no options → does NOT broadcast (private default)', async () => {
+  it('writeToWorkspace with no options → broadcasts (public default, backward compat)', async () => {
     const paranet = nextParanet();
     await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
 
     gossipSpy.mockClear();
     const entity = nextEntity();
     await agent.writeToWorkspace(paranet, [
-      { subject: entity, predicate: 'http://schema.org/name', object: '"Default Private"', graph: '' },
+      { subject: entity, predicate: 'http://schema.org/name', object: '"Default Public"', graph: '' },
     ]);
 
-    expect(gossipSpy).not.toHaveBeenCalled();
+    expect(gossipSpy).toHaveBeenCalledTimes(1);
   }, 10000);
 
   it('writeToWorkspace with visibility: "public" → broadcasts', async () => {
@@ -84,7 +84,7 @@ describe('writeToWorkspace — Visibility API', () => {
     expect(gossipSpy).not.toHaveBeenCalled();
   }, 10000);
 
-  it('writeToWorkspace with visibility: { peers: ["X"] } → broadcasts', async () => {
+  it('writeToWorkspace with visibility: { peers: ["X"] } → does NOT broadcast (sync only)', async () => {
     const paranet = nextParanet();
     await agent.createParanet({ id: paranet, name: 'Test', visibility: 'private' });
 
@@ -94,7 +94,7 @@ describe('writeToWorkspace — Visibility API', () => {
       { subject: entity, predicate: 'http://schema.org/name', object: '"Allow List Write"', graph: '' },
     ], { visibility: { peers: ['12D3KooWPeerX'] } });
 
-    expect(gossipSpy).toHaveBeenCalledTimes(1);
+    expect(gossipSpy).not.toHaveBeenCalled();
   }, 10000);
 
   it('writeToWorkspace with legacy localOnly: true → does NOT broadcast (backward compat)', async () => {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -7,6 +7,7 @@ export const PROTOCOL_SYNC = '/dkg/10.0.0/sync';
 export const PROTOCOL_MESSAGE = '/dkg/10.0.0/message';
 export const PROTOCOL_ACCESS = '/dkg/10.0.0/private-access';
 export const PROTOCOL_QUERY_REMOTE = '/dkg/10.0.0/query-remote';
+export const PROTOCOL_WORKSPACE_PUSH = '/dkg/10.0.0/workspace-push';
 
 export const PROTOCOL_VERIFY_PROPOSAL = '/dkg/10.0.0/verify-proposal';
 export const PROTOCOL_VERIFY_APPROVAL = '/dkg/10.0.0/verify-approval';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types.js';
+export { resolveVisibility, type ResolvedVisibility } from './visibility.js';
 export * from './constants.js';
 export * from './memory-model.js';
 export * from './event-bus.js';

--- a/packages/core/src/proto/workspace.ts
+++ b/packages/core/src/proto/workspace.ts
@@ -24,6 +24,8 @@ export const WorkspacePublishRequestSchema = new Type('WorkspacePublishRequest')
   .add(new Field('timestampMs', 6, 'uint64'))
   .add(new Field('operationId', 7, 'string'))
   .add(new Field('casConditions', 8, 'WorkspaceCASCondition', 'repeated'))
+  .add(new Field('accessPolicy', 9, 'string'))
+  .add(new Field('allowedPeers', 10, 'string', 'repeated'))
   .add(WorkspaceManifestEntrySchema)
   .add(WorkspaceCASConditionSchema);
 
@@ -53,6 +55,10 @@ export interface WorkspacePublishRequestMsg {
   operationId?: string;
   /** CAS conditions that receiving peers must enforce before applying this write. */
   casConditions?: WorkspaceCASConditionMsg[];
+  /** Access policy for this workspace write: 'public' | 'ownerOnly' | 'allowList'. */
+  accessPolicy?: string;
+  /** Peer IDs permitted to read this write when accessPolicy is 'allowList'. */
+  allowedPeers?: string[];
 }
 
 export function encodeWorkspacePublishRequest(msg: WorkspacePublishRequestMsg): Uint8Array {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,3 +60,24 @@ export interface ConnectionInfo {
 export interface StreamHandler {
   (data: Uint8Array, peerId: PeerId): Promise<Uint8Array>;
 }
+
+/**
+ * KC-level access policy controlling who can read private triples.
+ * - `public`: anyone can read
+ * - `ownerOnly`: only the publisher peer can read
+ * - `allowList`: only explicitly listed peers can read
+ */
+export type AccessPolicy = 'public' | 'ownerOnly' | 'allowList';
+
+/**
+ * Unified visibility control. Used consistently across paranet creation,
+ * workspace writes, and publishing.
+ *
+ * - `'private'` — Only this node (no broadcast, ownerOnly access)
+ * - `'public'` — Anyone can read (broadcast, public access)
+ * - `{ peers: string[] }` — Only listed peer IDs can read (broadcast, allowList access)
+ */
+export type Visibility =
+  | 'private'
+  | 'public'
+  | { peers: string[] };

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -33,7 +33,9 @@ export function resolveVisibility(
       return { accessPolicy: 'public', allowedPeers: [], broadcast: true };
     }
     if (typeof visibility === 'object' && 'peers' in visibility) {
-      return { accessPolicy: 'allowList', allowedPeers: visibility.peers, broadcast: true };
+      // allowList must NOT broadcast on GossipSub — any subscribed peer can
+      // read raw gossip messages. allowList data reaches peers via sync only.
+      return { accessPolicy: 'allowList', allowedPeers: visibility.peers, broadcast: false };
     }
   }
 
@@ -45,7 +47,7 @@ export function resolveVisibility(
     return { accessPolicy: 'ownerOnly', allowedPeers: legacy.allowedPeers ?? [], broadcast: false };
   }
   if (legacy?.accessPolicy === 'allowList') {
-    return { accessPolicy: 'allowList', allowedPeers: legacy.allowedPeers ?? [], broadcast: true };
+    return { accessPolicy: 'allowList', allowedPeers: legacy.allowedPeers ?? [], broadcast: false };
   }
   if (legacy?.accessPolicy === 'public') {
     return { accessPolicy: 'public', allowedPeers: [], broadcast: true };

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -1,0 +1,56 @@
+import type { AccessPolicy, Visibility } from './types.js';
+
+export interface ResolvedVisibility {
+  accessPolicy: AccessPolicy;
+  allowedPeers: string[];
+  broadcast: boolean;
+}
+
+/**
+ * Resolves the unified Visibility type to internal access control parameters.
+ * Handles backward compatibility with legacy parameters.
+ *
+ * Precedence:
+ *  1. `visibility` (new unified parameter) takes priority
+ *  2. Legacy parameters (`private`, `localOnly`, `accessPolicy`) are used as fallback
+ *  3. Default: public (broadcast, public access) — matches pre-migration behavior
+ */
+export function resolveVisibility(
+  visibility: Visibility | undefined,
+  legacy?: {
+    accessPolicy?: AccessPolicy;
+    allowedPeers?: string[];
+    localOnly?: boolean;
+    private?: boolean;
+  },
+): ResolvedVisibility {
+  // New parameter takes precedence
+  if (visibility !== undefined) {
+    if (visibility === 'private') {
+      return { accessPolicy: 'ownerOnly', allowedPeers: [], broadcast: false };
+    }
+    if (visibility === 'public') {
+      return { accessPolicy: 'public', allowedPeers: [], broadcast: true };
+    }
+    if (typeof visibility === 'object' && 'peers' in visibility) {
+      return { accessPolicy: 'allowList', allowedPeers: visibility.peers, broadcast: true };
+    }
+  }
+
+  // Fall back to legacy parameters
+  if (legacy?.private || legacy?.localOnly) {
+    return { accessPolicy: 'ownerOnly', allowedPeers: [], broadcast: false };
+  }
+  if (legacy?.accessPolicy === 'ownerOnly') {
+    return { accessPolicy: 'ownerOnly', allowedPeers: legacy.allowedPeers ?? [], broadcast: false };
+  }
+  if (legacy?.accessPolicy === 'allowList') {
+    return { accessPolicy: 'allowList', allowedPeers: legacy.allowedPeers ?? [], broadcast: true };
+  }
+  if (legacy?.accessPolicy === 'public') {
+    return { accessPolicy: 'public', allowedPeers: [], broadcast: true };
+  }
+
+  // Default: public (matches current behavior for pre-migration callers)
+  return { accessPolicy: 'public', allowedPeers: [], broadcast: true };
+}

--- a/packages/core/src/visibility.ts
+++ b/packages/core/src/visibility.ts
@@ -33,9 +33,14 @@ export function resolveVisibility(
       return { accessPolicy: 'public', allowedPeers: [], broadcast: true };
     }
     if (typeof visibility === 'object' && 'peers' in visibility) {
+      // Validate peer list: trim whitespace, remove empty strings, deduplicate
+      const cleaned = [...new Set(visibility.peers.map(p => p.trim()).filter(p => p.length > 0))];
+      if (cleaned.length === 0) {
+        throw new Error('visibility { peers: [...] } requires at least one valid peer ID');
+      }
       // allowList must NOT broadcast on GossipSub — any subscribed peer can
       // read raw gossip messages. allowList data reaches peers via sync only.
-      return { accessPolicy: 'allowList', allowedPeers: visibility.peers, broadcast: false };
+      return { accessPolicy: 'allowList', allowedPeers: cleaned, broadcast: false };
     }
   }
 

--- a/packages/core/test/visibility.test.ts
+++ b/packages/core/test/visibility.test.ts
@@ -22,21 +22,21 @@ describe('resolveVisibility()', () => {
       });
     });
 
-    it('visibility: { peers: ["A", "B"] } → allowList with peers, broadcast', () => {
+    it('visibility: { peers: ["A", "B"] } → allowList with peers, no broadcast (sync only)', () => {
       const result = resolveVisibility({ peers: ['A', 'B'] });
       expect(result).toEqual<ResolvedVisibility>({
         accessPolicy: 'allowList',
         allowedPeers: ['A', 'B'],
-        broadcast: true,
+        broadcast: false,
       });
     });
 
-    it('visibility: { peers: [] } → allowList with empty peers, broadcast', () => {
+    it('visibility: { peers: [] } → allowList with empty peers, no broadcast (sync only)', () => {
       const result = resolveVisibility({ peers: [] });
       expect(result).toEqual<ResolvedVisibility>({
         accessPolicy: 'allowList',
         allowedPeers: [],
-        broadcast: true,
+        broadcast: false,
       });
     });
   });
@@ -79,7 +79,7 @@ describe('resolveVisibility()', () => {
       expect(result.broadcast).toBe(false);
     });
 
-    it('accessPolicy: "allowList" with allowedPeers → allowList, broadcast', () => {
+    it('accessPolicy: "allowList" with allowedPeers → allowList, no broadcast (sync only)', () => {
       const result = resolveVisibility(undefined, {
         accessPolicy: 'allowList',
         allowedPeers: ['A'],
@@ -87,16 +87,16 @@ describe('resolveVisibility()', () => {
       expect(result).toEqual<ResolvedVisibility>({
         accessPolicy: 'allowList',
         allowedPeers: ['A'],
-        broadcast: true,
+        broadcast: false,
       });
     });
 
-    it('accessPolicy: "allowList" without peers → empty peers, broadcast', () => {
+    it('accessPolicy: "allowList" without peers → empty peers, no broadcast (sync only)', () => {
       const result = resolveVisibility(undefined, { accessPolicy: 'allowList' });
       expect(result).toEqual<ResolvedVisibility>({
         accessPolicy: 'allowList',
         allowedPeers: [],
-        broadcast: true,
+        broadcast: false,
       });
     });
 
@@ -131,7 +131,7 @@ describe('resolveVisibility()', () => {
       const result = resolveVisibility({ peers: ['X'] }, { accessPolicy: 'ownerOnly' });
       expect(result.accessPolicy).toBe('allowList');
       expect(result.allowedPeers).toEqual(['X']);
-      expect(result.broadcast).toBe(true);
+      expect(result.broadcast).toBe(false);
     });
   });
 

--- a/packages/core/test/visibility.test.ts
+++ b/packages/core/test/visibility.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { resolveVisibility, type ResolvedVisibility } from '../src/visibility.js';
+import type { AccessPolicy, Visibility } from '../src/types.js';
+
+describe('resolveVisibility()', () => {
+  describe('new Visibility parameter', () => {
+    it('visibility: "private" → ownerOnly, no broadcast', () => {
+      const result = resolveVisibility('private');
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'ownerOnly',
+        allowedPeers: [],
+        broadcast: false,
+      });
+    });
+
+    it('visibility: "public" → public, broadcast', () => {
+      const result = resolveVisibility('public');
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'public',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+
+    it('visibility: { peers: ["A", "B"] } → allowList with peers, broadcast', () => {
+      const result = resolveVisibility({ peers: ['A', 'B'] });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'allowList',
+        allowedPeers: ['A', 'B'],
+        broadcast: true,
+      });
+    });
+
+    it('visibility: { peers: [] } → allowList with empty peers, broadcast', () => {
+      const result = resolveVisibility({ peers: [] });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'allowList',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+  });
+
+  describe('legacy parameters', () => {
+    it('localOnly: true → ownerOnly, no broadcast', () => {
+      const result = resolveVisibility(undefined, { localOnly: true });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'ownerOnly',
+        allowedPeers: [],
+        broadcast: false,
+      });
+    });
+
+    it('private: true → ownerOnly, no broadcast', () => {
+      const result = resolveVisibility(undefined, { private: true });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'ownerOnly',
+        allowedPeers: [],
+        broadcast: false,
+      });
+    });
+
+    it('accessPolicy: "ownerOnly" → ownerOnly, no broadcast', () => {
+      const result = resolveVisibility(undefined, { accessPolicy: 'ownerOnly' });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'ownerOnly',
+        allowedPeers: [],
+        broadcast: false,
+      });
+    });
+
+    it('accessPolicy: "ownerOnly" with allowedPeers → preserves peers', () => {
+      const result = resolveVisibility(undefined, {
+        accessPolicy: 'ownerOnly',
+        allowedPeers: ['peer1'],
+      });
+      expect(result.accessPolicy).toBe('ownerOnly');
+      expect(result.allowedPeers).toEqual(['peer1']);
+      expect(result.broadcast).toBe(false);
+    });
+
+    it('accessPolicy: "allowList" with allowedPeers → allowList, broadcast', () => {
+      const result = resolveVisibility(undefined, {
+        accessPolicy: 'allowList',
+        allowedPeers: ['A'],
+      });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'allowList',
+        allowedPeers: ['A'],
+        broadcast: true,
+      });
+    });
+
+    it('accessPolicy: "allowList" without peers → empty peers, broadcast', () => {
+      const result = resolveVisibility(undefined, { accessPolicy: 'allowList' });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'allowList',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+
+    it('accessPolicy: "public" → public, broadcast', () => {
+      const result = resolveVisibility(undefined, { accessPolicy: 'public' });
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'public',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+  });
+
+  describe('precedence', () => {
+    it('visibility takes precedence over legacy params', () => {
+      const result = resolveVisibility('public', {
+        accessPolicy: 'ownerOnly',
+        localOnly: true,
+        private: true,
+      });
+      expect(result.accessPolicy).toBe('public');
+      expect(result.broadcast).toBe(true);
+    });
+
+    it('visibility: "private" overrides legacy public', () => {
+      const result = resolveVisibility('private', { accessPolicy: 'public' });
+      expect(result.accessPolicy).toBe('ownerOnly');
+      expect(result.broadcast).toBe(false);
+    });
+
+    it('visibility peers override legacy ownerOnly', () => {
+      const result = resolveVisibility({ peers: ['X'] }, { accessPolicy: 'ownerOnly' });
+      expect(result.accessPolicy).toBe('allowList');
+      expect(result.allowedPeers).toEqual(['X']);
+      expect(result.broadcast).toBe(true);
+    });
+  });
+
+  describe('defaults', () => {
+    it('no params → public, broadcast (matches pre-migration behavior)', () => {
+      const result = resolveVisibility(undefined);
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'public',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+
+    it('undefined visibility with empty legacy → public, broadcast', () => {
+      const result = resolveVisibility(undefined, {});
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'public',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+
+    it('undefined visibility with undefined legacy → public, broadcast', () => {
+      const result = resolveVisibility(undefined, undefined);
+      expect(result).toEqual<ResolvedVisibility>({
+        accessPolicy: 'public',
+        allowedPeers: [],
+        broadcast: true,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('legacy private: false does not trigger ownerOnly', () => {
+      const result = resolveVisibility(undefined, { private: false });
+      expect(result.accessPolicy).toBe('public');
+      expect(result.broadcast).toBe(true);
+    });
+
+    it('legacy localOnly: false does not trigger ownerOnly', () => {
+      const result = resolveVisibility(undefined, { localOnly: false });
+      expect(result.accessPolicy).toBe('public');
+      expect(result.broadcast).toBe(true);
+    });
+
+    it('legacy private + localOnly both true → ownerOnly', () => {
+      const result = resolveVisibility(undefined, { private: true, localOnly: true });
+      expect(result.accessPolicy).toBe('ownerOnly');
+      expect(result.broadcast).toBe(false);
+    });
+  });
+});

--- a/packages/core/test/visibility.test.ts
+++ b/packages/core/test/visibility.test.ts
@@ -31,13 +31,10 @@ describe('resolveVisibility()', () => {
       });
     });
 
-    it('visibility: { peers: [] } → allowList with empty peers, no broadcast (sync only)', () => {
-      const result = resolveVisibility({ peers: [] });
-      expect(result).toEqual<ResolvedVisibility>({
-        accessPolicy: 'allowList',
-        allowedPeers: [],
-        broadcast: false,
-      });
+    it('visibility: { peers: [] } → throws (empty peer list)', () => {
+      expect(() => resolveVisibility({ peers: [] })).toThrow(
+        'visibility { peers: [...] } requires at least one valid peer ID',
+      );
     });
   });
 
@@ -180,6 +177,42 @@ describe('resolveVisibility()', () => {
     it('legacy private + localOnly both true → ownerOnly', () => {
       const result = resolveVisibility(undefined, { private: true, localOnly: true });
       expect(result.accessPolicy).toBe('ownerOnly');
+      expect(result.broadcast).toBe(false);
+    });
+  });
+
+  describe('peer list validation', () => {
+    it('trims whitespace from peer IDs', () => {
+      const result = resolveVisibility({ peers: ['  peerA  ', ' peerB'] });
+      expect(result.allowedPeers).toEqual(['peerA', 'peerB']);
+    });
+
+    it('deduplicates peer IDs', () => {
+      const result = resolveVisibility({ peers: ['peerA', 'peerB', 'peerA'] });
+      expect(result.allowedPeers).toEqual(['peerA', 'peerB']);
+    });
+
+    it('deduplicates after trimming', () => {
+      const result = resolveVisibility({ peers: ['peerA', ' peerA ', 'peerB'] });
+      expect(result.allowedPeers).toEqual(['peerA', 'peerB']);
+    });
+
+    it('throws when all entries are empty strings', () => {
+      expect(() => resolveVisibility({ peers: ['', '  ', ''] })).toThrow(
+        'visibility { peers: [...] } requires at least one valid peer ID',
+      );
+    });
+
+    it('throws when peers array is empty', () => {
+      expect(() => resolveVisibility({ peers: [] })).toThrow(
+        'visibility { peers: [...] } requires at least one valid peer ID',
+      );
+    });
+
+    it('filters empty strings but keeps valid peers', () => {
+      const result = resolveVisibility({ peers: ['', 'peerA', '  ', 'peerB', ''] });
+      expect(result.allowedPeers).toEqual(['peerA', 'peerB']);
+      expect(result.accessPolicy).toBe('allowList');
       expect(result.broadcast).toBe(false);
     });
   });

--- a/packages/core/test/workspace-proto-privacy.test.ts
+++ b/packages/core/test/workspace-proto-privacy.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  encodeWorkspacePublishRequest,
+  decodeWorkspacePublishRequest,
+} from '../src/index.js';
+
+describe('Protobuf: WorkspacePublishRequest accessPolicy/allowedPeers (fields 9/10)', () => {
+  const BASE_MSG = {
+    paranetId: 'test-privacy',
+    nquads: new TextEncoder().encode('<urn:e> <http://schema.org/name> "Test" .'),
+    manifest: [{ rootEntity: 'urn:e', privateTripleCount: 0 }],
+    publisherPeerId: '12D3KooWTest',
+    workspaceOperationId: 'ws-priv-001',
+    timestampMs: Date.now(),
+  };
+
+  it('round-trips accessPolicy and allowedPeers', () => {
+    const original = {
+      ...BASE_MSG,
+      accessPolicy: 'allowList',
+      allowedPeers: ['peerA', 'peerB', 'peerC'],
+    };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['peerA', 'peerB', 'peerC']);
+  });
+
+  it('round-trips accessPolicy: "ownerOnly" with no allowedPeers', () => {
+    const original = {
+      ...BASE_MSG,
+      accessPolicy: 'ownerOnly',
+    };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    expect(decoded.accessPolicy).toBe('ownerOnly');
+    expect(decoded.allowedPeers ?? []).toEqual([]);
+  });
+
+  it('round-trips accessPolicy: "public" with no allowedPeers', () => {
+    const original = {
+      ...BASE_MSG,
+      accessPolicy: 'public',
+    };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    expect(decoded.accessPolicy).toBe('public');
+    expect(decoded.allowedPeers ?? []).toEqual([]);
+  });
+
+  it('encodes without accessPolicy — decode returns empty/undefined (backward compat)', () => {
+    const original = { ...BASE_MSG };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    // Protobuf default for string is empty string, for repeated is empty array
+    expect(decoded.accessPolicy || undefined).toBeUndefined();
+    expect(decoded.allowedPeers ?? []).toEqual([]);
+  });
+
+  it('decodes old message format (no fields 9/10) without error', () => {
+    // Simulate a message from a pre-privacy-model node by encoding without the new fields
+    const oldFormatMsg = {
+      paranetId: 'legacy-paranet',
+      nquads: new TextEncoder().encode('<urn:old> <http://schema.org/name> "Legacy" .'),
+      manifest: [{ rootEntity: 'urn:old', privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWOld',
+      workspaceOperationId: 'ws-old-001',
+      timestampMs: 1700000000000,
+    };
+    const encoded = encodeWorkspacePublishRequest(oldFormatMsg);
+    const decoded = decodeWorkspacePublishRequest(encoded);
+
+    // The message should decode fine with defaults
+    expect(decoded.paranetId).toBe('legacy-paranet');
+    expect(decoded.publisherPeerId).toBe('12D3KooWOld');
+    expect(decoded.accessPolicy || undefined).toBeUndefined();
+    expect(decoded.allowedPeers ?? []).toEqual([]);
+  });
+
+  it('preserves other fields alongside accessPolicy/allowedPeers', () => {
+    const original = {
+      ...BASE_MSG,
+      operationId: 'op-uuid-123',
+      casConditions: [
+        { subject: 'urn:e', predicate: 'http://ex.org/status', expectedValue: '"active"', expectAbsent: false },
+      ],
+      accessPolicy: 'allowList',
+      allowedPeers: ['peerX'],
+    };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    expect(decoded.operationId).toBe('op-uuid-123');
+    expect(decoded.casConditions).toHaveLength(1);
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['peerX']);
+  });
+
+  it('handles single allowedPeer', () => {
+    const original = {
+      ...BASE_MSG,
+      accessPolicy: 'allowList',
+      allowedPeers: ['soloePeer'],
+    };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    expect(decoded.allowedPeers).toEqual(['soloePeer']);
+  });
+
+  it('handles many allowedPeers', () => {
+    const peers = Array.from({ length: 50 }, (_, i) => `peer-${i}`);
+    const original = {
+      ...BASE_MSG,
+      accessPolicy: 'allowList',
+      allowedPeers: peers,
+    };
+    const decoded = decodeWorkspacePublishRequest(encodeWorkspacePublishRequest(original));
+    expect(decoded.allowedPeers).toEqual(peers);
+  });
+});

--- a/packages/publisher/src/access-handler.ts
+++ b/packages/publisher/src/access-handler.ts
@@ -1,4 +1,4 @@
-import type { StreamHandler, EventBus } from '@origintrail-official/dkg-core';
+import type { StreamHandler, EventBus, AccessPolicy } from '@origintrail-official/dkg-core';
 import {
   DKGEvent,
   decodeAccessRequest,
@@ -12,7 +12,7 @@ import { computePrivateRoot } from './merkle.js';
 
 const DKG_NS = 'http://dkg.io/ontology/';
 
-export type AccessPolicy = 'public' | 'ownerOnly' | 'allowList';
+export type { AccessPolicy };
 
 interface KAMeta {
   rootEntity: string;

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -397,6 +397,10 @@ export class DKGPublisher implements Publisher {
       onPhase?: PhaseCallback;
       contextGraphId?: string;
       contextGraphSignatures?: Array<{ identityId: bigint; r: Uint8Array; vs: Uint8Array }>;
+      /** Access policy for the enshrined KC. Default: 'public'. */
+      accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+      /** Allowed peer IDs when accessPolicy is 'allowList'. */
+      allowedPeers?: string[];
     },
   ): Promise<PublishResult> {
     const ctx = options?.operationCtx ?? createOperationContext('enshrine');
@@ -453,6 +457,8 @@ export class DKGPublisher implements Publisher {
       quads: quads.map((q) => ({ ...q, graph: '' })),
       operationCtx: ctx,
       onPhase: options?.onPhase,
+      accessPolicy: options?.accessPolicy,
+      allowedPeers: options?.allowedPeers,
     });
 
     if (ctxGraphId && publishResult.status === 'confirmed' && publishResult.onChainResult) {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -44,6 +44,10 @@ export interface DKGPublisherConfig {
 export interface WriteToWorkspaceOptions {
   publisherPeerId: string;
   operationCtx?: OperationContext;
+  /** Access policy for this workspace write. Default: 'public'. */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  /** Peer IDs permitted to read when accessPolicy is 'allowList'. */
+  allowedPeers?: string[];
 }
 
 export interface WriteToWorkspaceResult {
@@ -249,6 +253,8 @@ export class DKGPublisher implements Publisher {
       timestampMs: Date.now(),
       operationId: ctx.operationId,
       casConditions,
+      accessPolicy: options.accessPolicy,
+      allowedPeers: options.allowedPeers,
     });
 
     const MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024; // 512 KB
@@ -279,6 +285,8 @@ export class DKGPublisher implements Publisher {
         rootEntities,
         publisherPeerId: options.publisherPeerId,
         timestamp: new Date(),
+        accessPolicy: options.accessPolicy,
+        allowedPeers: options.allowedPeers,
       },
       workspaceMetaGraph,
     );

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -173,6 +173,25 @@ export class DKGPublisher implements Publisher {
     options: WriteToWorkspaceOptions & { conditions?: CASCondition[] },
   ): Promise<WriteToWorkspaceResult> {
     const ctx = options.operationCtx ?? createOperationContext('workspace');
+
+    // Validate access policy metadata (same invariants as publish())
+    const VALID_POLICIES = new Set<string | undefined>(['public', 'ownerOnly', 'allowList', undefined]);
+    if (!VALID_POLICIES.has(options.accessPolicy)) {
+      throw new Error(
+        `Workspace write rejected: invalid accessPolicy "${String(options.accessPolicy)}" (must be "public", "ownerOnly", or "allowList")`,
+      );
+    }
+    if (options.accessPolicy === 'allowList') {
+      if (!options.allowedPeers || options.allowedPeers.length === 0) {
+        throw new Error('Workspace write rejected: accessPolicy "allowList" requires non-empty "allowedPeers"');
+      }
+    }
+    if (options.accessPolicy !== 'allowList' && options.allowedPeers && options.allowedPeers.length > 0) {
+      // ownerOnly with allowedPeers is contradictory — strip silently (matches publish() intent)
+      this.log.warn(ctx, `Ignoring allowedPeers for accessPolicy "${options.accessPolicy ?? 'public'}" — only valid with "allowList"`);
+      options = { ...options, allowedPeers: undefined };
+    }
+
     this.log.info(ctx, `Writing ${quads.length} quads to workspace for paranet ${paranetId}`);
 
     await this.graphManager.ensureParanet(paranetId);

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -401,6 +401,8 @@ export class DKGPublisher implements Publisher {
       accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
       /** Allowed peer IDs when accessPolicy is 'allowList'. */
       allowedPeers?: string[];
+      /** Publisher peer ID for KC ownership metadata. Required when accessPolicy is not 'public'. */
+      publisherPeerId?: string;
     },
   ): Promise<PublishResult> {
     const ctx = options?.operationCtx ?? createOperationContext('enshrine');
@@ -459,6 +461,7 @@ export class DKGPublisher implements Publisher {
       onPhase: options?.onPhase,
       accessPolicy: options?.accessPolicy,
       allowedPeers: options?.allowedPeers,
+      publisherPeerId: options?.publisherPeerId,
     });
 
     if (ctxGraphId && publishResult.status === 'confirmed' && publishResult.onChainResult) {

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -237,6 +237,10 @@ export interface WorkspaceMetadata {
   rootEntities: string[];
   publisherPeerId: string;
   timestamp: Date;
+  /** Access policy for this workspace write. Omitted means public (backward-compatible). */
+  accessPolicy?: 'public' | 'ownerOnly' | 'allowList';
+  /** Peer IDs permitted to read this write when accessPolicy is 'allowList'. */
+  allowedPeers?: string[];
 }
 
 /**
@@ -270,6 +274,22 @@ export function generateWorkspaceMetadata(
     quads.push(
       mq(subject, `${DKG}rootEntity`, rootEntity, workspaceMetaGraph),
     );
+  }
+
+  // Emit access policy metadata when present (omit for 'public' to keep
+  // backward compatibility — absence is treated as public by consumers).
+  if (meta.accessPolicy && meta.accessPolicy !== 'public') {
+    quads.push(
+      mq(subject, `${DKG}accessPolicy`, lit(meta.accessPolicy), workspaceMetaGraph),
+    );
+  }
+
+  if (meta.allowedPeers?.length) {
+    for (const peerId of meta.allowedPeers) {
+      quads.push(
+        mq(subject, `${DKG}allowedPeer`, lit(peerId), workspaceMetaGraph),
+      );
+    }
   }
 
   return quads;

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -124,7 +124,7 @@ export class WorkspaceHandler {
       if (request.operationId) {
         ctx = createOperationContext('workspace', request.operationId);
       }
-      const { paranetId, nquads, manifest, publisherPeerId, workspaceOperationId, timestampMs, casConditions } = request;
+      const { paranetId, nquads, manifest, publisherPeerId, workspaceOperationId, timestampMs, casConditions, accessPolicy, allowedPeers } = request;
       this.log.info(ctx, `Workspace write from ${fromPeerId} for paranet ${paranetId} op=${workspaceOperationId}`);
 
       if (publisherPeerId !== fromPeerId) {
@@ -200,6 +200,11 @@ export class WorkspaceHandler {
         await this.store.insert(normalized);
 
         const rootEntities = manifestForValidation.map((m) => m.rootEntity);
+        // Validate accessPolicy from the wire — only accept known values
+        const validPolicies = ['public', 'ownerOnly', 'allowList'] as const;
+        const decodedPolicy = accessPolicy && validPolicies.includes(accessPolicy as typeof validPolicies[number])
+          ? (accessPolicy as 'public' | 'ownerOnly' | 'allowList')
+          : undefined;
         const metaQuads = generateWorkspaceMetadata(
           {
             workspaceOperationId,
@@ -207,6 +212,8 @@ export class WorkspaceHandler {
             rootEntities,
             publisherPeerId,
             timestamp: new Date(Number(timestampMs)),
+            accessPolicy: decodedPolicy,
+            allowedPeers: allowedPeers?.length ? allowedPeers : undefined,
           },
           workspaceMetaGraph,
         );

--- a/packages/publisher/test/workspace-metadata-privacy.test.ts
+++ b/packages/publisher/test/workspace-metadata-privacy.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateWorkspaceMetadata,
+  generateKCMetadata,
+  type WorkspaceMetadata,
+  type KCMetadata,
+} from '../src/metadata.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const PARANET = 'privacy-test';
+const WS_META_GRAPH = `did:dkg:paranet:${PARANET}/_workspace_meta`;
+const META_GRAPH = `did:dkg:paranet:${PARANET}/_meta`;
+
+function makeWsMeta(overrides?: Partial<WorkspaceMetadata>): WorkspaceMetadata {
+  return {
+    workspaceOperationId: 'ws-priv-001',
+    paranetId: PARANET,
+    rootEntities: ['urn:entity:1'],
+    publisherPeerId: '12D3KooWTest',
+    timestamp: new Date('2026-03-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('generateWorkspaceMetadata — access policy triples', () => {
+  it('accessPolicy: "ownerOnly" → emits dkg:accessPolicy quad', () => {
+    const quads = generateWorkspaceMetadata(makeWsMeta({ accessPolicy: 'ownerOnly' }), WS_META_GRAPH);
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeDefined();
+    expect(policyQuad!.object).toBe('"ownerOnly"');
+    expect(policyQuad!.graph).toBe(WS_META_GRAPH);
+  });
+
+  it('accessPolicy: "allowList" → emits dkg:accessPolicy quad', () => {
+    const quads = generateWorkspaceMetadata(makeWsMeta({ accessPolicy: 'allowList' }), WS_META_GRAPH);
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeDefined();
+    expect(policyQuad!.object).toBe('"allowList"');
+  });
+
+  it('accessPolicy: "allowList" + allowedPeers → emits dkg:allowedPeer quads', () => {
+    const quads = generateWorkspaceMetadata(
+      makeWsMeta({ accessPolicy: 'allowList', allowedPeers: ['peerA', 'peerB'] }),
+      WS_META_GRAPH,
+    );
+    const peerQuads = quads.filter(q => q.predicate === `${DKG}allowedPeer`);
+    expect(peerQuads).toHaveLength(2);
+    const peerValues = peerQuads.map(q => q.object);
+    expect(peerValues).toContain('"peerA"');
+    expect(peerValues).toContain('"peerB"');
+  });
+
+  it('accessPolicy: "public" → does NOT emit dkg:accessPolicy quad (backward compat)', () => {
+    const quads = generateWorkspaceMetadata(makeWsMeta({ accessPolicy: 'public' }), WS_META_GRAPH);
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeUndefined();
+  });
+
+  it('no accessPolicy → does NOT emit dkg:accessPolicy quad (backward compat)', () => {
+    const quads = generateWorkspaceMetadata(makeWsMeta(), WS_META_GRAPH);
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeUndefined();
+  });
+
+  it('no accessPolicy, no allowedPeers → no access-related quads', () => {
+    const quads = generateWorkspaceMetadata(makeWsMeta(), WS_META_GRAPH);
+    const accessQuads = quads.filter(
+      q => q.predicate === `${DKG}accessPolicy` || q.predicate === `${DKG}allowedPeer`,
+    );
+    expect(accessQuads).toHaveLength(0);
+  });
+
+  it('allowedPeers with empty array → no dkg:allowedPeer quads', () => {
+    const quads = generateWorkspaceMetadata(
+      makeWsMeta({ accessPolicy: 'allowList', allowedPeers: [] }),
+      WS_META_GRAPH,
+    );
+    const peerQuads = quads.filter(q => q.predicate === `${DKG}allowedPeer`);
+    expect(peerQuads).toHaveLength(0);
+  });
+
+  it('ownerOnly with allowedPeers → emits both policy and peer quads', () => {
+    // This is technically inconsistent but the metadata layer shouldn't block it
+    const quads = generateWorkspaceMetadata(
+      makeWsMeta({ accessPolicy: 'ownerOnly', allowedPeers: ['peer1'] }),
+      WS_META_GRAPH,
+    );
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeDefined();
+    expect(policyQuad!.object).toBe('"ownerOnly"');
+    const peerQuads = quads.filter(q => q.predicate === `${DKG}allowedPeer`);
+    expect(peerQuads).toHaveLength(1);
+  });
+});
+
+describe('generateKCMetadata — access policy triples', () => {
+  function makeKCMeta(overrides?: Partial<KCMetadata>): KCMetadata {
+    return {
+      ual: 'did:dkg:kc:priv-001',
+      paranetId: PARANET,
+      merkleRoot: new Uint8Array([0xab, 0xcd]),
+      kaCount: 1,
+      publisherPeerId: '12D3KooWTest',
+      timestamp: new Date('2026-03-01T00:00:00Z'),
+      ...overrides,
+    };
+  }
+
+  it('always emits dkg:accessPolicy (defaults to "public")', () => {
+    const quads = generateKCMetadata(makeKCMeta(), []);
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeDefined();
+    expect(policyQuad!.object).toBe('"public"');
+  });
+
+  it('accessPolicy: "ownerOnly" emits correct value', () => {
+    const quads = generateKCMetadata(makeKCMeta({ accessPolicy: 'ownerOnly' }), []);
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad).toBeDefined();
+    expect(policyQuad!.object).toBe('"ownerOnly"');
+  });
+
+  it('accessPolicy: "allowList" + allowedPeers emits both', () => {
+    const quads = generateKCMetadata(
+      makeKCMeta({ accessPolicy: 'allowList', allowedPeers: ['p1', 'p2'] }),
+      [],
+    );
+    const policyQuad = quads.find(q => q.predicate === `${DKG}accessPolicy`);
+    expect(policyQuad!.object).toBe('"allowList"');
+    const peerQuads = quads.filter(q => q.predicate === `${DKG}allowedPeer`);
+    expect(peerQuads).toHaveLength(2);
+  });
+});

--- a/packages/publisher/test/workspace-privacy.test.ts
+++ b/packages/publisher/test/workspace-privacy.test.ts
@@ -127,6 +127,56 @@ describe('Workspace writeToWorkspace — access policy propagation', () => {
     expect(decoded.accessPolicy).toBe('allowList');
     expect(decoded.allowedPeers).toEqual(['peerX']);
   });
+
+  it('rejects allowList with empty allowedPeers', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"No Peers"')];
+    await expect(
+      publisher.writeToWorkspace(PARANET, quads, {
+        publisherPeerId: '12D3KooWTest',
+        accessPolicy: 'allowList',
+        allowedPeers: [],
+      }),
+    ).rejects.toThrow(/allowList.*requires non-empty.*allowedPeers/);
+  });
+
+  it('rejects allowList with undefined allowedPeers', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"No Peers 2"')];
+    await expect(
+      publisher.writeToWorkspace(PARANET, quads, {
+        publisherPeerId: '12D3KooWTest',
+        accessPolicy: 'allowList',
+      }),
+    ).rejects.toThrow(/allowList.*requires non-empty.*allowedPeers/);
+  });
+
+  it('strips allowedPeers when accessPolicy is ownerOnly (contradictory)', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Owner Only With Peers"')];
+    const { workspaceOperationId } = await publisher.writeToWorkspace(PARANET, quads, {
+      publisherPeerId: '12D3KooWTest',
+      accessPolicy: 'ownerOnly',
+      allowedPeers: ['peerShouldBeIgnored'],
+    });
+    expect(workspaceOperationId).toBeTruthy();
+
+    // Verify allowedPeers were NOT stored in metadata
+    const result = await store.query(
+      `SELECT ?peer WHERE { GRAPH <${WORKSPACE_META_GRAPH}> { ?op <${DKG_NS}allowedPeer> ?peer } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings.length).toBe(0);
+    }
+  });
+
+  it('rejects invalid accessPolicy value', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Bad Policy"')];
+    await expect(
+      publisher.writeToWorkspace(PARANET, quads, {
+        publisherPeerId: '12D3KooWTest',
+        accessPolicy: 'banana' as any,
+      }),
+    ).rejects.toThrow(/invalid accessPolicy/);
+  });
 });
 
 describe('WorkspaceHandler — access policy from gossip message', () => {
@@ -205,26 +255,14 @@ describe('WorkspaceHandler — access policy from gossip message', () => {
     }
   });
 
-  it('handler ignores invalid access policy from gossip', async () => {
+  it('writeToWorkspace rejects invalid access policy', async () => {
     const quads = [q('urn:gossip:entity3', 'http://schema.org/name', '"Invalid Policy"')];
-    const { message } = await publisher.writeToWorkspace('gossip-paranet-3', quads, {
-      publisherPeerId: '12D3KooWSender',
-      accessPolicy: 'invalidPolicy' as any,
-    });
-
-    const receiverStore = new OxigraphStore();
-    const receiverHandler = new WorkspaceHandler(receiverStore, new TypedEventBus());
-    await receiverHandler.handle(message, '12D3KooWSender');
-
-    const WS_META = 'did:dkg:paranet:gossip-paranet-3/_workspace_meta';
-    const result = await receiverStore.query(
-      `SELECT ?policy WHERE { GRAPH <${WS_META}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
-    );
-    expect(result.type).toBe('bindings');
-    if (result.type === 'bindings') {
-      // Invalid policy should be dropped (not stored)
-      expect(result.bindings.length).toBe(0);
-    }
+    await expect(
+      publisher.writeToWorkspace('gossip-paranet-3', quads, {
+        publisherPeerId: '12D3KooWSender',
+        accessPolicy: 'invalidPolicy' as any,
+      }),
+    ).rejects.toThrow(/invalid accessPolicy/);
   });
 });
 

--- a/packages/publisher/test/workspace-privacy.test.ts
+++ b/packages/publisher/test/workspace-privacy.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  DKGPublisher,
+  WorkspaceHandler,
+  type WriteToWorkspaceOptions,
+} from '../src/index.js';
+import { ethers } from 'ethers';
+
+const PARANET = 'privacy-ws-test';
+const WORKSPACE_META_GRAPH = `did:dkg:paranet:${PARANET}/_workspace_meta`;
+const ENTITY = 'urn:test:priv:entity';
+const DKG_NS = 'http://dkg.io/ontology/';
+
+function q(s: string, p: string, o: string, g = ''): Quad {
+  return { subject: s, predicate: p, object: o, graph: g };
+}
+
+describe('Workspace writeToWorkspace — access policy propagation', () => {
+  let store: OxigraphStore;
+  let publisher: DKGPublisher;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    const wallet = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', wallet.address);
+    const keypair = await generateEd25519Keypair();
+    publisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: wallet.privateKey,
+      publisherNodeIdentityId: 1n,
+    });
+  });
+
+  it('writes with accessPolicy: "ownerOnly" → metadata includes accessPolicy quad', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Private Data"')];
+    const opts: WriteToWorkspaceOptions = {
+      publisherPeerId: '12D3KooWTest',
+      accessPolicy: 'ownerOnly',
+    };
+    await publisher.writeToWorkspace(PARANET, quads, opts);
+
+    const result = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${WORKSPACE_META_GRAPH}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings.length).toBe(1);
+      expect(result.bindings[0]['policy']).toBe('"ownerOnly"');
+    }
+  });
+
+  it('writes with accessPolicy: "allowList" + allowedPeers → metadata includes both', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Allow List Data"')];
+    const opts: WriteToWorkspaceOptions = {
+      publisherPeerId: '12D3KooWTest',
+      accessPolicy: 'allowList',
+      allowedPeers: ['peerA', 'peerB'],
+    };
+    await publisher.writeToWorkspace(PARANET, quads, opts);
+
+    const policyResult = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${WORKSPACE_META_GRAPH}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(policyResult.type).toBe('bindings');
+    if (policyResult.type === 'bindings') {
+      expect(policyResult.bindings[0]['policy']).toBe('"allowList"');
+    }
+
+    const peerResult = await store.query(
+      `SELECT ?peer WHERE { GRAPH <${WORKSPACE_META_GRAPH}> { ?op <${DKG_NS}allowedPeer> ?peer } }`,
+    );
+    expect(peerResult.type).toBe('bindings');
+    if (peerResult.type === 'bindings') {
+      expect(peerResult.bindings.length).toBe(2);
+      const peers = peerResult.bindings.map(b => b['peer']);
+      expect(peers).toContain('"peerA"');
+      expect(peers).toContain('"peerB"');
+    }
+  });
+
+  it('writes with no accessPolicy → no accessPolicy quad in metadata (backward compat)', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Default Data"')];
+    await publisher.writeToWorkspace(PARANET, quads, { publisherPeerId: '12D3KooWTest' });
+
+    const result = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${WORKSPACE_META_GRAPH}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings.length).toBe(0);
+    }
+  });
+
+  it('writes with accessPolicy: "public" → no accessPolicy quad in metadata (backward compat)', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Public Data"')];
+    await publisher.writeToWorkspace(PARANET, quads, {
+      publisherPeerId: '12D3KooWTest',
+      accessPolicy: 'public',
+    });
+
+    const result = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${WORKSPACE_META_GRAPH}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings.length).toBe(0);
+    }
+  });
+
+  it('accessPolicy and allowedPeers are encoded in the returned gossip message', async () => {
+    const quads = [q(ENTITY, 'http://schema.org/name', '"Gossip Data"')];
+    const { message } = await publisher.writeToWorkspace(PARANET, quads, {
+      publisherPeerId: '12D3KooWTest',
+      accessPolicy: 'allowList',
+      allowedPeers: ['peerX'],
+    });
+
+    // Decode the returned message and verify it carries the access policy
+    const { decodeWorkspacePublishRequest } = await import('@origintrail-official/dkg-core');
+    const decoded = decodeWorkspacePublishRequest(message);
+    expect(decoded.accessPolicy).toBe('allowList');
+    expect(decoded.allowedPeers).toEqual(['peerX']);
+  });
+});
+
+describe('WorkspaceHandler — access policy from gossip message', () => {
+  let store: OxigraphStore;
+  let handler: WorkspaceHandler;
+  let publisher: DKGPublisher;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    const wallet = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', wallet.address);
+    const keypair = await generateEd25519Keypair();
+    const workspaceOwnedEntities = new Map<string, Map<string, string>>();
+    const writeLocks = new Map<string, Promise<void>>();
+
+    publisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: wallet.privateKey,
+      publisherNodeIdentityId: 1n,
+      workspaceOwnedEntities,
+      writeLocks,
+    });
+
+    handler = new WorkspaceHandler(store, new TypedEventBus(), {
+      workspaceOwnedEntities,
+      writeLocks,
+    });
+  });
+
+  it('handler stores access policy from incoming gossip (ownerOnly)', async () => {
+    // Simulate publisher creating a message with ownerOnly policy
+    const quads = [q('urn:gossip:entity', 'http://schema.org/name', '"Gossip Test"')];
+    const { message } = await publisher.writeToWorkspace('gossip-paranet', quads, {
+      publisherPeerId: '12D3KooWSender',
+      accessPolicy: 'ownerOnly',
+    });
+
+    // Feed the message to a different handler (simulating the receiver)
+    const receiverStore = new OxigraphStore();
+    const receiverHandler = new WorkspaceHandler(receiverStore, new TypedEventBus());
+    await receiverHandler.handle(message, '12D3KooWSender');
+
+    const WS_META = 'did:dkg:paranet:gossip-paranet/_workspace_meta';
+    const result = await receiverStore.query(
+      `SELECT ?policy WHERE { GRAPH <${WS_META}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings.length).toBe(1);
+      expect(result.bindings[0]['policy']).toBe('"ownerOnly"');
+    }
+  });
+
+  it('handler stores allowed peers from incoming gossip (allowList)', async () => {
+    const quads = [q('urn:gossip:entity2', 'http://schema.org/name', '"Gossip Test 2"')];
+    const { message } = await publisher.writeToWorkspace('gossip-paranet-2', quads, {
+      publisherPeerId: '12D3KooWSender',
+      accessPolicy: 'allowList',
+      allowedPeers: ['peerA', 'peerB'],
+    });
+
+    const receiverStore = new OxigraphStore();
+    const receiverHandler = new WorkspaceHandler(receiverStore, new TypedEventBus());
+    await receiverHandler.handle(message, '12D3KooWSender');
+
+    const WS_META = 'did:dkg:paranet:gossip-paranet-2/_workspace_meta';
+    const peerResult = await receiverStore.query(
+      `SELECT ?peer WHERE { GRAPH <${WS_META}> { ?op <${DKG_NS}allowedPeer> ?peer } }`,
+    );
+    expect(peerResult.type).toBe('bindings');
+    if (peerResult.type === 'bindings') {
+      expect(peerResult.bindings.length).toBe(2);
+    }
+  });
+
+  it('handler ignores invalid access policy from gossip', async () => {
+    const quads = [q('urn:gossip:entity3', 'http://schema.org/name', '"Invalid Policy"')];
+    const { message } = await publisher.writeToWorkspace('gossip-paranet-3', quads, {
+      publisherPeerId: '12D3KooWSender',
+      accessPolicy: 'invalidPolicy' as any,
+    });
+
+    const receiverStore = new OxigraphStore();
+    const receiverHandler = new WorkspaceHandler(receiverStore, new TypedEventBus());
+    await receiverHandler.handle(message, '12D3KooWSender');
+
+    const WS_META = 'did:dkg:paranet:gossip-paranet-3/_workspace_meta';
+    const result = await receiverStore.query(
+      `SELECT ?policy WHERE { GRAPH <${WS_META}> { ?op <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      // Invalid policy should be dropped (not stored)
+      expect(result.bindings.length).toBe(0);
+    }
+  });
+});
+
+describe('Workspace enshrineFromWorkspace — access policy pass-through', () => {
+  let store: OxigraphStore;
+  let publisher: DKGPublisher;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    const wallet = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', wallet.address);
+    const keypair = await generateEd25519Keypair();
+    publisher = new DKGPublisher({
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: wallet.privateKey,
+      publisherNodeIdentityId: 1n,
+    });
+  });
+
+  it('enshrineFromWorkspace passes accessPolicy to publish', async () => {
+    const quads = [q('urn:enshrine:entity', 'http://schema.org/name', '"Enshrine Test"')];
+    await publisher.writeToWorkspace('enshrine-paranet', quads, { publisherPeerId: 'peer1' });
+
+    const result = await publisher.enshrineFromWorkspace('enshrine-paranet', 'all', {
+      accessPolicy: 'ownerOnly',
+      publisherPeerId: 'peer1',
+    });
+    expect(result.status).toBe('confirmed');
+
+    // Verify the KC metadata includes the access policy
+    const META_GRAPH = 'did:dkg:paranet:enshrine-paranet/_meta';
+    const policyResult = await store.query(
+      `SELECT ?policy WHERE { GRAPH <${META_GRAPH}> { ?kc <${DKG_NS}accessPolicy> ?policy } }`,
+    );
+    expect(policyResult.type).toBe('bindings');
+    if (policyResult.type === 'bindings') {
+      expect(policyResult.bindings.length).toBeGreaterThanOrEqual(1);
+      expect(policyResult.bindings[0]['policy']).toBe('"ownerOnly"');
+    }
+  });
+
+  it('enshrineFromWorkspace passes allowedPeers to publish', async () => {
+    const quads = [q('urn:enshrine:entity2', 'http://schema.org/name', '"Enshrine AllowList"')];
+    await publisher.writeToWorkspace('enshrine-paranet-2', quads, { publisherPeerId: 'peer1' });
+
+    const result = await publisher.enshrineFromWorkspace('enshrine-paranet-2', 'all', {
+      accessPolicy: 'allowList',
+      allowedPeers: ['peerZ'],
+      publisherPeerId: 'peer1',
+    });
+    expect(result.status).toBe('confirmed');
+
+    const META_GRAPH = 'did:dkg:paranet:enshrine-paranet-2/_meta';
+    const peerResult = await store.query(
+      `SELECT ?peer WHERE { GRAPH <${META_GRAPH}> { ?kc <${DKG_NS}allowedPeer> ?peer } }`,
+    );
+    expect(peerResult.type).toBe('bindings');
+    if (peerResult.type === 'bindings') {
+      expect(peerResult.bindings.length).toBe(1);
+      expect(peerResult.bindings[0]['peer']).toBe('"peerZ"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR unifies the three separate privacy mechanisms in DKG-V9 (paranet `private` flag, workspace `localOnly` flag, publish-time `accessPolicy`) into a single, consistent `Visibility` type used across all operations. It also fixes a **critical data leak** where the sync protocol served workspace data to any peer regardless of privacy settings.

### Problem

Privacy in DKG-V9 was configured through three independent mechanisms with different APIs:

| Mechanism | Flag | Actual Protection |
|---|---|---|
| Paranet creation | `private: true` | All-or-nothing isolation (no sharing with specific peers) |
| Workspace writes | `localOnly: true` | **False privacy**: only suppressed broadcast, sync still served data to anyone |
| Published data | `accessPolicy: 'ownerOnly' \| 'allowList'` | Real enforcement via Ed25519 signatures |

Key issues:
- **Sync protocol data leak**: `localOnly` workspace data was served to any peer via `/dkg/sync/1.0.0`
- **No workspace access policies**: workspace data was either broadcast to all or local-only, with no per-peer control
- **Inconsistent APIs**: three different parameter names (`private`, `localOnly`, `accessPolicy`) for the same concept
- **Unsafe defaults**: workspace writes broadcast to all subscribers by default

### Solution

#### New unified `Visibility` type
```typescript
type Visibility =
  | 'private'           // Only this node
  | 'public'            // Anyone can read
  | { peers: string[] } // Only listed peer IDs

// Used consistently on ALL operations:
await agent.createParanet({ id: 'x', name: 'X', visibility: 'private' });
await agent.writeToWorkspace('x', quads, { visibility: { peers: ['12D3KooW...'] } });
await agent.publish('x', quads, { visibility: 'public' });
await agent.enshrineFromWorkspace('x', 'all', { visibility: { peers: ['12D3KooW...'] } });
```

#### `resolveVisibility()` helper
Maps the new `Visibility` type to internal `AccessPolicy`/`allowedPeers`/`broadcast` with full backward compatibility for legacy parameters.

#### Critical sync fix
The `PROTOCOL_SYNC` handler now:
1. Accepts the requesting peer's ID
2. Queries `_workspace_meta` for per-operation access policies
3. Filters workspace responses — only serves data the requesting peer is authorized to see
4. Treats pre-migration data (no access policy triple) as public for backward compatibility

#### Workspace access policy plumbing
- Protobuf: new fields `accessPolicy` (field 9) and `allowedPeers` (field 10) on `WorkspacePublishRequest` — additive, backward compatible
- Metadata: `generateWorkspaceMetadata()` emits `dkg:accessPolicy` and `dkg:allowedPeer` triples
- Publisher: threads access policy through workspace write pipeline
- Handler: extracts and stores access policy from incoming gossip messages

#### Default behavior changes
| Operation | Old Default | New Default | Rationale |
|---|---|---|---|
| `writeToWorkspace()` | Broadcast to all (`localOnly: false`) | Private (`visibility: 'private'`) | Drafts should not leak |
| `createParanet()` | Public | Public (unchanged) | Paranets are collaboration containers |
| `enshrineFromWorkspace()` | Public (no option) | Public (now configurable) | Enshrinement is explicit "share" |
| `publish()` | Context-dependent | Uses `resolveVisibility()` | Consistent resolution |

#### Full backward compatibility
All legacy parameters continue to work:
- `localOnly: true` → maps to `visibility: 'private'`
- `private: true` → maps to `visibility: 'private'`
- `accessPolicy: 'ownerOnly'` → maps to `visibility: 'private'`
- `accessPolicy: 'allowList', allowedPeers: [...]` → maps to `visibility: { peers: [...] }`

When both `visibility` and legacy params are provided, `visibility` takes precedence.

## Changes by commit

1. **`2a9285e` feat: add AccessPolicy, Visibility types and resolveVisibility() to core**
   - New types in `packages/core/src/types.ts`
   - New `resolveVisibility()` in `packages/core/src/visibility.ts`
   - `access-handler.ts` imports AccessPolicy from core (re-exports for compat)

2. **`c8d06b1` fix: filter workspace data by access policy in PROTOCOL_SYNC handler**
   - Sync handler accepts `peerId`, queries workspace_meta, filters by policy
   - Pre-migration data without policy triples treated as public

3. **`90aa3d9` feat: thread accessPolicy and allowedPeers through workspace publish pipeline**
   - Protobuf fields 9/10 added
   - Metadata generation emits access policy triples
   - Publisher and handler thread the new fields

4. **`9304b76` feat: unify API surface with Visibility parameter across all agent methods**
   - `writeToWorkspace`, `writeConditionalToWorkspace`, `publish`, `createParanet`, `enshrineFromWorkspace` all accept `visibility`
   - Legacy params deprecated but functional

5. **`aa332f2` fix: pass publisherPeerId through enshrineFromWorkspace to publish**
   - Bug found by QA: enshrine with non-public policy failed because publisherPeerId wasn't forwarded

6. **`39e6c26` test: comprehensive QA for unified privacy model — 69 new tests**
   - 6 new test files across core, publisher, and agent packages
   - Covers: resolveVisibility, protobuf round-trip, metadata emission, sync filtering, API defaults, backward compat

## Files changed

**Core (foundation):**
- `packages/core/src/types.ts` — `AccessPolicy`, `Visibility` types
- `packages/core/src/visibility.ts` — `resolveVisibility()` helper
- `packages/core/src/index.ts` — Exports
- `packages/core/src/proto/workspace.ts` — Protobuf fields 9/10

**Publisher (plumbing):**
- `packages/publisher/src/access-handler.ts` — Import from core
- `packages/publisher/src/dkg-publisher.ts` — Workspace + enshrine options
- `packages/publisher/src/metadata.ts` — Access policy quads in workspace metadata
- `packages/publisher/src/workspace-handler.ts` — Extract policy from gossip

**Agent (API + enforcement):**
- `packages/agent/src/dkg-agent.ts` — Sync filter, visibility on all methods

**Tests (69 new):**
- `packages/core/test/visibility.test.ts` (20 tests)
- `packages/core/test/workspace-proto-privacy.test.ts` (8 tests)
- `packages/publisher/test/workspace-metadata-privacy.test.ts` (11 tests)
- `packages/publisher/test/workspace-privacy.test.ts` (10 tests)
- `packages/agent/test/visibility-api.test.ts` (15 tests)
- `packages/agent/test/sync-access-filtering.test.ts` (5 tests)

## Test plan

- [x] `resolveVisibility()` — all visibility/legacy combos, precedence, defaults, edge cases (20 tests)
- [x] Protobuf round-trip — fields 9/10 encode/decode, backward compat with old messages (8 tests)
- [x] Workspace metadata — access policy quad emission for all policy types (11 tests)
- [x] Publisher pipeline — workspace write + handler + enshrine with access policies (10 tests)
- [x] Agent API — broadcast control, paranet policy storage, default changes, legacy compat (15 tests)
- [x] Sync filtering — mixed-visibility workspace data filtered correctly by peer (5 tests)
- [x] All existing tests pass (core: 198, publisher: 335, agent: 129)
- [ ] Manual testing: create paranet with `visibility: { peers: [...] }`, write to workspace, verify sync filters correctly
- [ ] Manual testing: verify legacy `localOnly: true` and `private: true` still work identically

## Out of scope (future work)

- Gossip message encryption for non-public workspace broadcasts (residual eavesdropping risk)
- GossipSub topic validators for paranet-level membership
- Revocation mechanism for access lists
- New OpenClaw agent tools (`dkg_workspace_write`, `dkg_publish_from_workspace`)
- Removal of deprecated legacy parameters (next major version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)