### PR TITLE
fix: EpochStorage guards for over-distribution and backdated writes (M-16, M-17)

### DIFF
--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -152,6 +152,11 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         uint256 endEpoch,
         uint96 tokenAmount
     ) external onlyContracts {
+        require(
+            startEpoch > lastFinalizedEpoch[shardId],
+            "EpochStorage: start epoch already finalized"
+        );
+
         uint256 numEpochs = endEpoch - startEpoch + 1;
 
         uint96 totalTokens = tokenAmount + accumulatedRemainder[shardId];
@@ -183,6 +188,11 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         if (currentEpoch > 1) {
             _finalizeEpochsUpTo(shardId, currentEpoch - 1);
         }
+
+        require(
+            amount <= getEpochRemainingPool(shardId, epoch),
+            "EpochStorage: payout exceeds remaining pool"
+        );
 
         distributed[shardId][epoch] += amount;
         nodesPaidOut[identityId][shardId][epoch] += amount;

--- a/packages/evm-module/contracts/storage/EpochStorage.sol
+++ b/packages/evm-module/contracts/storage/EpochStorage.sol
@@ -152,6 +152,11 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
         uint256 endEpoch,
         uint96 tokenAmount
     ) external onlyContracts {
+        uint256 currentEpoch = chronos.getCurrentEpoch();
+        if (currentEpoch > 1) {
+            _finalizeEpochsUpTo(shardId, currentEpoch - 1);
+        }
+
         require(
             startEpoch > lastFinalizedEpoch[shardId],
             "EpochStorage: start epoch already finalized"
@@ -169,11 +174,6 @@ contract EpochStorage is INamed, IVersioned, HubDependent {
 
         diff[shardId][startEpoch] += tokensPerEpoch;
         diff[shardId][endEpoch + 1] -= tokensPerEpoch;
-
-        uint256 currentEpoch = chronos.getCurrentEpoch();
-        if (currentEpoch > 1) {
-            _finalizeEpochsUpTo(shardId, currentEpoch - 1);
-        }
 
         emit TokensAddedToEpochRange(shardId, startEpoch, endEpoch, tokenAmount, remainder);
     }

--- a/packages/evm-module/test/unit/EpochStorage.test.ts
+++ b/packages/evm-module/test/unit/EpochStorage.test.ts
@@ -366,6 +366,55 @@ describe('@unit EpochStorage', () => {
     ).to.equal(1000);
   });
 
+  it('payOutEpochTokens reverts when payout exceeds remaining pool (M-16)', async () => {
+    const shardId = 19;
+    // Allocate 1000 tokens to epoch 5
+    await EpochStorage.addTokensToEpochRange(shardId, 5, 5, 1000);
+
+    // Pay out exactly 1000 — should succeed
+    await EpochStorage.payOutEpochTokens(shardId, 5, 42, 1000);
+    expect(await EpochStorage.getEpochDistributedPool(shardId, 5)).to.equal(
+      1000,
+    );
+
+    // Pay out 1 more — should revert (pool exhausted)
+    await expect(
+      EpochStorage.payOutEpochTokens(shardId, 5, 42, 1),
+    ).to.be.revertedWith('EpochStorage: payout exceeds remaining pool');
+  });
+
+  it('addTokensToEpochRange reverts if startEpoch <= lastFinalizedEpoch (M-17)', async () => {
+    const shardId = 21;
+    // Allocate tokens to epoch 2-4
+    await EpochStorage.addTokensToEpochRange(shardId, 2, 4, 3000);
+
+    // Advance time so currentEpoch becomes 2, which means epoch 1 gets finalized on next call
+    await time.increase(3601);
+
+    // Trigger finalization of epoch 1 by adding to a future range
+    await EpochStorage.addTokensToEpochRange(shardId, 10, 10, 100);
+
+    // Now lastFinalizedEpoch[shardId] >= 1.
+    // Advance again so currentEpoch becomes 3, finalizing epoch 2 on next write
+    await time.increase(3601);
+    await EpochStorage.addTokensToEpochRange(shardId, 20, 20, 100);
+
+    // lastFinalizedEpoch[shardId] should now be >= 2
+    // Try to add tokens starting at epoch 2 — should revert
+    await expect(
+      EpochStorage.addTokensToEpochRange(shardId, 2, 5, 500),
+    ).to.be.revertedWith('EpochStorage: start epoch already finalized');
+  });
+
+  it('payOutEpochTokens reverts on first call if amount > pool (M-16)', async () => {
+    const shardId = 20;
+    await EpochStorage.addTokensToEpochRange(shardId, 3, 3, 500);
+
+    await expect(
+      EpochStorage.payOutEpochTokens(shardId, 3, 77, 501),
+    ).to.be.revertedWith('EpochStorage: payout exceeds remaining pool');
+  });
+
   it('getNodeCurrentEpochProducedKnowledgeValuePercentage, getNodePreviousEpochProducedKnowledgeValuePercentage', async () => {
     await EpochStorage.addEpochProducedKnowledgeValue(1111, 1, 500);
     await EpochStorage.addEpochProducedKnowledgeValue(2222, 1, 1500);

--- a/packages/evm-module/test/unit/EpochStorage.test.ts
+++ b/packages/evm-module/test/unit/EpochStorage.test.ts
@@ -406,6 +406,22 @@ describe('@unit EpochStorage', () => {
     ).to.be.revertedWith('EpochStorage: start epoch already finalized');
   });
 
+  it('addTokensToEpochRange reverts even when lastFinalizedEpoch is stale (M-17)', async () => {
+    const shardId = 22;
+    // No prior writes to this shard — lastFinalizedEpoch[22] == 0.
+    // Advance time so currentEpoch becomes 3 (two epoch advances).
+    await time.increase(3601);
+    await time.increase(3601);
+
+    // At this point currentEpoch == 3, but lastFinalizedEpoch[22] is still 0
+    // because no write has triggered finalization for this shard yet.
+    // Attempting startEpoch=1 should revert — epoch 1 is in the past
+    // (currentEpoch-1 == 2, so epochs 1 and 2 should be considered finalized).
+    await expect(
+      EpochStorage.addTokensToEpochRange(shardId, 1, 1, 1000),
+    ).to.be.revertedWith('EpochStorage: start epoch already finalized');
+  });
+
   it('payOutEpochTokens reverts on first call if amount > pool (M-16)', async () => {
     const shardId = 20;
     await EpochStorage.addTokensToEpochRange(shardId, 3, 3, 500);


### PR DESCRIPTION
## Summary
- **M-16**: `payOutEpochTokens()` now reverts if the payout amount exceeds `getEpochRemainingPool()`, preventing over-distribution and underflow in remaining-pool reads.
- **M-17**: `addTokensToEpochRange()` now finalizes epochs up to `currentEpoch - 1` **before** checking `startEpoch > lastFinalizedEpoch[shardId]`, then reverts if the start epoch falls at or before the finalization frontier. This closes the stale-finalization bypass where elapsed but un-finalized epochs could be written to.

## Test plan
- [x] Over-distribution: exact pool payout succeeds, then +1 wei reverts
- [x] First-call excess: amount > pool reverts immediately
- [x] Backdated write (already-finalized shard): reverts
- [x] Backdated write (stale-finalized shard, no prior writes): reverts
- [x] All 26 pre-existing EpochStorage tests pass unchanged (30 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)