### PR TITLE
feat: tracer bullet — conviction stake → NFT → score end-to-end

### DIFF
--- a/packages/evm-module/abi/ConvictionStakeStorage.json
+++ b/packages/evm-module/abi/ConvictionStakeStorage.json
@@ -1,0 +1,283 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "hubAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "msg",
+        "type": "string"
+      }
+    ],
+    "name": "UnauthorizedAccess",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddressHub",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "effectiveStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "EffectiveNodeStakeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "effectiveTotalStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "EffectiveTotalStakeUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint256",
+        "name": "removedStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseEffectiveNodeStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "removedStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseEffectiveTotalStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "",
+        "type": "uint72"
+      }
+    ],
+    "name": "effectiveNodeStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "effectiveTotalStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "getEffectiveNodeStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getEffectiveTotalStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hub",
+    "outputs": [
+      {
+        "internalType": "contract Hub",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseEffectiveNodeStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "addedStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseEffectiveTotalStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setEffectiveNodeStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setEffectiveTotalStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_status",
+        "type": "bool"
+      }
+    ],
+    "name": "setStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "status",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/packages/evm-module/abi/ConvictionStaking.json
+++ b/packages/evm-module/abi/ConvictionStaking.json
@@ -1,0 +1,967 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "hubAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "ERC721EnumerableForbiddenBatchMint",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721IncorrectOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721InsufficientApproval",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidOperator",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721NonexistentToken",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721OutOfBoundsIndex",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "tier",
+        "type": "uint8"
+      }
+    ],
+    "name": "InvalidLockTier",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "maximum",
+        "type": "uint96"
+      }
+    ],
+    "name": "MaximumStakeExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "ProfileDoesntExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "msg",
+        "type": "string"
+      }
+    ],
+    "name": "UnauthorizedAccess",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddressHub",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroStakeAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "nodeId",
+        "type": "uint72"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "lockTier",
+        "type": "uint8"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "askContract",
+    "outputs": [
+      {
+        "internalType": "contract Ask",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chronos",
+    "outputs": [
+      {
+        "internalType": "contract Chronos",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "convictionStakeStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakeStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPosition",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint96",
+            "name": "principal",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint8",
+            "name": "lockTier",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint40",
+            "name": "startEpoch",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint72",
+            "name": "nodeId",
+            "type": "uint72"
+          },
+          {
+            "internalType": "uint96",
+            "name": "claimableRewards",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint40",
+            "name": "lastClaimedEpoch",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastSettledScorePerStake",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint96",
+            "name": "withdrawalAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint256",
+            "name": "withdrawalTimestamp",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ConvictionStaking.Position",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hub",
+    "outputs": [
+      {
+        "internalType": "contract Hub",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "identityStorage",
+    "outputs": [
+      {
+        "internalType": "contract IdentityStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "parametersStorage",
+    "outputs": [
+      {
+        "internalType": "contract ParametersStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "positions",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "principal",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint8",
+        "name": "lockTier",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint40",
+        "name": "startEpoch",
+        "type": "uint40"
+      },
+      {
+        "internalType": "uint72",
+        "name": "nodeId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint96",
+        "name": "claimableRewards",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint40",
+        "name": "lastClaimedEpoch",
+        "type": "uint40"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastSettledScorePerStake",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint96",
+        "name": "withdrawalAmount",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint256",
+        "name": "withdrawalTimestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "profileStorage",
+    "outputs": [
+      {
+        "internalType": "contract ProfileStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_status",
+        "type": "bool"
+      }
+    ],
+    "name": "setStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shardingTableContract",
+    "outputs": [
+      {
+        "internalType": "contract ShardingTable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shardingTableStorage",
+    "outputs": [
+      {
+        "internalType": "contract ShardingTableStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "nodeId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint8",
+        "name": "lockTier",
+        "type": "uint8"
+      }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingStorage",
+    "outputs": [
+      {
+        "internalType": "contract StakingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "status",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenContract",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenOfOwnerByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/packages/evm-module/abi/ConvictionStaking.json
+++ b/packages/evm-module/abi/ConvictionStaking.json
@@ -184,6 +184,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ShardingTableIsFull",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "string",
@@ -385,6 +390,19 @@
     "outputs": [
       {
         "internalType": "contract ConvictionStakeStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegatorsInfo",
+    "outputs": [
+      {
+        "internalType": "contract DelegatorsInfo",
         "name": "",
         "type": "address"
       }
@@ -644,6 +662,19 @@
     "outputs": [
       {
         "internalType": "contract ProfileStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "randomSamplingStorage",
+    "outputs": [
+      {
+        "internalType": "contract RandomSamplingStorage",
         "name": "",
         "type": "address"
       }

--- a/packages/evm-module/abi/RandomSampling.json
+++ b/packages/evm-module/abi/RandomSampling.json
@@ -113,6 +113,19 @@
   },
   {
     "inputs": [],
+    "name": "convictionStakeStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakeStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "createChallenge",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/packages/evm-module/contracts/ConvictionStaking.sol
+++ b/packages/evm-module/contracts/ConvictionStaking.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {INamed} from "./interfaces/INamed.sol";
+import {IVersioned} from "./interfaces/IVersioned.sol";
+import {IInitializable} from "./interfaces/IInitializable.sol";
+import {ContractStatus} from "./abstract/ContractStatus.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {StakingStorage} from "./storage/StakingStorage.sol";
+import {ConvictionStakeStorage} from "./storage/ConvictionStakeStorage.sol";
+import {ParametersStorage} from "./storage/ParametersStorage.sol";
+import {ProfileStorage} from "./storage/ProfileStorage.sol";
+import {IdentityStorage} from "./storage/IdentityStorage.sol";
+import {ShardingTable} from "./ShardingTable.sol";
+import {ShardingTableStorage} from "./storage/ShardingTableStorage.sol";
+import {Ask} from "./Ask.sol";
+import {Chronos} from "./storage/Chronos.sol";
+import {ProfileLib} from "./libraries/ProfileLib.sol";
+import {StakingLib} from "./libraries/StakingLib.sol";
+
+contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable, ERC721Enumerable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    string private constant _NAME = "ConvictionStaking";
+    string private constant _VERSION = "1.0.0";
+
+    struct Position {
+        uint96 principal;
+        uint8 lockTier; // {0, 1, 3, 6, 12}
+        uint40 startEpoch;
+        uint72 nodeId;
+        uint96 claimableRewards;
+        uint40 lastClaimedEpoch;
+        uint256 lastSettledScorePerStake;
+        uint96 withdrawalAmount;
+        uint256 withdrawalTimestamp;
+    }
+
+    uint256 private _nextTokenId;
+    mapping(uint256 => Position) public positions;
+
+    IERC20 public tokenContract;
+    StakingStorage public stakingStorage;
+    ConvictionStakeStorage public convictionStakeStorage;
+    ParametersStorage public parametersStorage;
+    ProfileStorage public profileStorage;
+    IdentityStorage public identityStorage;
+    ShardingTable public shardingTableContract;
+    ShardingTableStorage public shardingTableStorage;
+    Ask public askContract;
+    Chronos public chronos;
+
+    event Staked(
+        uint256 indexed tokenId,
+        address indexed staker,
+        uint72 indexed nodeId,
+        uint96 amount,
+        uint8 lockTier
+    );
+
+    error InvalidLockTier(uint8 tier);
+    error ZeroStakeAmount();
+    error MaximumStakeExceeded(uint96 maximum);
+
+    constructor(address hubAddress) ContractStatus(hubAddress) ERC721("ConvictionStaking", "CSTAKE") {}
+
+    function initialize() external onlyHub {
+        tokenContract = IERC20(hub.getContractAddress("Token"));
+        stakingStorage = StakingStorage(hub.getContractAddress("StakingStorage"));
+        convictionStakeStorage = ConvictionStakeStorage(hub.getContractAddress("ConvictionStakeStorage"));
+        parametersStorage = ParametersStorage(hub.getContractAddress("ParametersStorage"));
+        profileStorage = ProfileStorage(hub.getContractAddress("ProfileStorage"));
+        identityStorage = IdentityStorage(hub.getContractAddress("IdentityStorage"));
+        shardingTableContract = ShardingTable(hub.getContractAddress("ShardingTable"));
+        shardingTableStorage = ShardingTableStorage(hub.getContractAddress("ShardingTableStorage"));
+        askContract = Ask(hub.getContractAddress("Ask"));
+        chronos = Chronos(hub.getContractAddress("Chronos"));
+    }
+
+    function name() public pure override(INamed, ERC721) returns (string memory) {
+        return _NAME;
+    }
+
+    function version() external pure virtual override returns (string memory) {
+        return _VERSION;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721Enumerable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _update(address to, uint256 tokenId, address auth) internal override(ERC721Enumerable) returns (address) {
+        return super._update(to, tokenId, auth);
+    }
+
+    function _increaseBalance(address account, uint128 value) internal override(ERC721Enumerable) {
+        super._increaseBalance(account, value);
+    }
+
+    /**
+     * @notice Stake TRAC to a node and receive an NFT position.
+     * @param nodeId Identity ID of the node to delegate to
+     * @param amount Amount of TRAC to stake
+     * @param lockTier Lock tier (only 0 supported in this version)
+     */
+    function stake(uint72 nodeId, uint96 amount, uint8 lockTier) external nonReentrant {
+        if (amount == 0) revert ZeroStakeAmount();
+        if (lockTier != 0) revert InvalidLockTier(lockTier);
+        if (!profileStorage.profileExists(nodeId)) revert ProfileLib.ProfileDoesntExist(nodeId);
+
+        // Check maximum stake on raw principal
+        uint96 currentNodeStake = stakingStorage.getNodeStake(nodeId);
+        uint96 maximumStake = parametersStorage.maximumStake();
+        if (currentNodeStake + amount > maximumStake) {
+            revert MaximumStakeExceeded(maximumStake);
+        }
+
+        // Mint NFT
+        uint256 tokenId = _nextTokenId++;
+        _mint(msg.sender, tokenId);
+
+        // Store position
+        uint40 currentEpoch = uint40(chronos.getCurrentEpoch());
+        positions[tokenId] = Position({
+            principal: amount,
+            lockTier: lockTier,
+            startEpoch: currentEpoch,
+            nodeId: nodeId,
+            claimableRewards: 0,
+            lastClaimedEpoch: currentEpoch,
+            lastSettledScorePerStake: 0,
+            withdrawalAmount: 0,
+            withdrawalTimestamp: 0
+        });
+
+        // Update raw stake in StakingStorage
+        stakingStorage.increaseNodeStake(nodeId, amount);
+        stakingStorage.increaseTotalStake(amount);
+
+        // Update effective stake in ConvictionStakeStorage (1x for tier 0)
+        convictionStakeStorage.increaseEffectiveNodeStake(nodeId, uint256(amount));
+        convictionStakeStorage.increaseEffectiveTotalStake(uint256(amount));
+
+        // Add to sharding table if not already present
+        if (!shardingTableStorage.nodeExists(nodeId)) {
+            shardingTableContract.insertNode(nodeId);
+        }
+
+        // Recalculate active set
+        askContract.recalculateActiveSet();
+
+        // Transfer TRAC from staker to StakingStorage (SafeERC20)
+        tokenContract.safeTransferFrom(msg.sender, address(stakingStorage), amount);
+
+        emit Staked(tokenId, msg.sender, nodeId, amount, lockTier);
+    }
+
+    /**
+     * @notice Get full position data for a token.
+     * @param tokenId The NFT token ID
+     * @return position The position struct
+     */
+    function getPosition(uint256 tokenId) external view returns (Position memory) {
+        return positions[tokenId];
+    }
+}

--- a/packages/evm-module/contracts/ConvictionStaking.sol
+++ b/packages/evm-module/contracts/ConvictionStaking.sol
@@ -189,6 +189,7 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
      * @return position The position struct
      */
     function getPosition(uint256 tokenId) external view returns (Position memory) {
+        _requireOwned(tokenId);
         return positions[tokenId];
     }
 

--- a/packages/evm-module/contracts/ConvictionStaking.sol
+++ b/packages/evm-module/contracts/ConvictionStaking.sol
@@ -13,6 +13,8 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {StakingStorage} from "./storage/StakingStorage.sol";
 import {ConvictionStakeStorage} from "./storage/ConvictionStakeStorage.sol";
+import {RandomSamplingStorage} from "./storage/RandomSamplingStorage.sol";
+import {DelegatorsInfo} from "./storage/DelegatorsInfo.sol";
 import {ParametersStorage} from "./storage/ParametersStorage.sol";
 import {ProfileStorage} from "./storage/ProfileStorage.sol";
 import {IdentityStorage} from "./storage/IdentityStorage.sol";
@@ -21,13 +23,14 @@ import {ShardingTableStorage} from "./storage/ShardingTableStorage.sol";
 import {Ask} from "./Ask.sol";
 import {Chronos} from "./storage/Chronos.sol";
 import {ProfileLib} from "./libraries/ProfileLib.sol";
-import {StakingLib} from "./libraries/StakingLib.sol";
+import {ShardingTableLib} from "./libraries/ShardingTableLib.sol";
 
 contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable, ERC721Enumerable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     string private constant _NAME = "ConvictionStaking";
     string private constant _VERSION = "1.0.0";
+    uint256 private constant SCALE18 = 1e18;
 
     struct Position {
         uint96 principal;
@@ -47,6 +50,8 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
     IERC20 public tokenContract;
     StakingStorage public stakingStorage;
     ConvictionStakeStorage public convictionStakeStorage;
+    RandomSamplingStorage public randomSamplingStorage;
+    DelegatorsInfo public delegatorsInfo;
     ParametersStorage public parametersStorage;
     ProfileStorage public profileStorage;
     IdentityStorage public identityStorage;
@@ -73,6 +78,8 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
         tokenContract = IERC20(hub.getContractAddress("Token"));
         stakingStorage = StakingStorage(hub.getContractAddress("StakingStorage"));
         convictionStakeStorage = ConvictionStakeStorage(hub.getContractAddress("ConvictionStakeStorage"));
+        randomSamplingStorage = RandomSamplingStorage(hub.getContractAddress("RandomSamplingStorage"));
+        delegatorsInfo = DelegatorsInfo(hub.getContractAddress("DelegatorsInfo"));
         parametersStorage = ParametersStorage(hub.getContractAddress("ParametersStorage"));
         profileStorage = ProfileStorage(hub.getContractAddress("ProfileStorage"));
         identityStorage = IdentityStorage(hub.getContractAddress("IdentityStorage"));
@@ -120,12 +127,17 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
             revert MaximumStakeExceeded(maximumStake);
         }
 
+        // Validate delegator epoch claims and settle pending score before changing stake
+        bytes32 delegatorKey = _getDelegatorKey(msg.sender);
+        uint40 currentEpoch = uint40(chronos.getCurrentEpoch());
+        _validateDelegatorEpochClaims(nodeId, msg.sender, delegatorKey, currentEpoch);
+        _prepareForStakeChange(currentEpoch, nodeId, delegatorKey);
+
         // Mint NFT
         uint256 tokenId = _nextTokenId++;
         _mint(msg.sender, tokenId);
 
         // Store position
-        uint40 currentEpoch = uint40(chronos.getCurrentEpoch());
         positions[tokenId] = Position({
             principal: amount,
             lockTier: lockTier,
@@ -138,18 +150,24 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
             withdrawalTimestamp: 0
         });
 
-        // Update raw stake in StakingStorage
-        stakingStorage.increaseNodeStake(nodeId, amount);
+        // Update per-delegator stakeBase in StakingStorage (address-keyed for reward claim compatibility)
+        uint96 existingStakeBase = stakingStorage.getDelegatorStakeBase(nodeId, delegatorKey);
+        stakingStorage.setDelegatorStakeBase(nodeId, delegatorKey, existingStakeBase + amount);
+
+        // Update raw node-level stake in StakingStorage
+        uint96 newNodeStake = currentNodeStake + amount;
+        stakingStorage.setNodeStake(nodeId, newNodeStake);
         stakingStorage.increaseTotalStake(amount);
 
         // Update effective stake in ConvictionStakeStorage (1x for tier 0)
         convictionStakeStorage.increaseEffectiveNodeStake(nodeId, uint256(amount));
         convictionStakeStorage.increaseEffectiveTotalStake(uint256(amount));
 
-        // Add to sharding table if not already present
-        if (!shardingTableStorage.nodeExists(nodeId)) {
-            shardingTableContract.insertNode(nodeId);
-        }
+        // Register delegator in DelegatorsInfo (for reward claiming)
+        _manageDelegatorStatus(nodeId, msg.sender);
+
+        // Add to sharding table if stake meets minimum and table has capacity
+        _addNodeToShardingTable(nodeId, newNodeStake);
 
         // Recalculate active set
         askContract.recalculateActiveSet();
@@ -167,5 +185,150 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
      */
     function getPosition(uint256 tokenId) external view returns (Position memory) {
         return positions[tokenId];
+    }
+
+    // ========================================================================
+    // Internal: Delegator management
+    // ========================================================================
+
+    function _getDelegatorKey(address delegator) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(delegator));
+    }
+
+    /**
+     * @dev Registers delegator in DelegatorsInfo if not already present.
+     *      Resets lastStakeHeldEpoch when delegator becomes active again.
+     */
+    function _manageDelegatorStatus(uint72 identityId, address delegator) internal {
+        if (!delegatorsInfo.isNodeDelegator(identityId, delegator)) {
+            delegatorsInfo.addDelegator(identityId, delegator);
+        }
+        uint256 lastStakeHeld = delegatorsInfo.getLastStakeHeldEpoch(identityId, delegator);
+        if (lastStakeHeld > 0) {
+            delegatorsInfo.setLastStakeHeldEpoch(identityId, delegator, 0);
+        }
+    }
+
+    /**
+     * @dev Validates that all required epoch rewards have been claimed before stake changes.
+     *      For first-time delegators, sets initial claim tracking state.
+     */
+    function _validateDelegatorEpochClaims(
+        uint72 identityId,
+        address delegator,
+        bytes32 delegatorKey,
+        uint256 currentEpoch
+    ) internal {
+        uint256 previousEpoch = currentEpoch - 1;
+
+        if (delegatorsInfo.hasEverDelegatedToNode(identityId, delegator)) {
+            if (stakingStorage.getDelegatorStakeBase(identityId, delegatorKey) == 0) {
+                uint256 lastStakeHeld = delegatorsInfo.getLastStakeHeldEpoch(identityId, delegator);
+                if (lastStakeHeld > 0 && lastStakeHeld < currentEpoch) {
+                    revert("Must claim rewards up to the lastStakeHeldEpoch before changing stake");
+                }
+                delegatorsInfo.setLastClaimedEpoch(identityId, delegator, previousEpoch);
+            }
+        } else {
+            delegatorsInfo.setHasEverDelegatedToNode(identityId, delegator, true);
+            delegatorsInfo.setLastClaimedEpoch(identityId, delegator, previousEpoch);
+        }
+
+        uint256 lastClaimed = delegatorsInfo.getLastClaimedEpoch(identityId, delegator);
+        if (lastClaimed == previousEpoch) return;
+
+        if (lastClaimed < previousEpoch - 1) {
+            revert("Must claim all previous epoch rewards before changing stake");
+        }
+
+        // Exactly one unclaimed epoch (previousEpoch) — check if there are actually rewards
+        uint256 delegatorScore = randomSamplingStorage.getEpochNodeDelegatorScore(
+            previousEpoch,
+            identityId,
+            delegatorKey
+        );
+        uint256 nodeScorePerStake = randomSamplingStorage.getNodeEpochScorePerStake(previousEpoch, identityId);
+        uint256 delegatorLastSettled = randomSamplingStorage.getDelegatorLastSettledNodeEpochScorePerStake(
+            previousEpoch,
+            identityId,
+            delegatorKey
+        );
+
+        if (delegatorScore == 0 && nodeScorePerStake == delegatorLastSettled) {
+            delegatorsInfo.setLastClaimedEpoch(identityId, delegator, previousEpoch);
+            return;
+        }
+
+        revert("Must claim the previous epoch rewards before changing stake");
+    }
+
+    /**
+     * @dev Settles pending scorePerStake changes for a delegator before any stake mutation.
+     *      Calculates and records newly earned score since the last settlement.
+     */
+    function _prepareForStakeChange(
+        uint256 epoch,
+        uint72 identityId,
+        bytes32 delegatorKey
+    ) internal returns (uint256 delegatorEpochScore) {
+        uint256 nodeScorePerStake36 = randomSamplingStorage.getNodeEpochScorePerStake(epoch, identityId);
+        uint256 currentDelegatorScore18 = randomSamplingStorage.getEpochNodeDelegatorScore(
+            epoch,
+            identityId,
+            delegatorKey
+        );
+        uint256 delegatorLastSettled36 = randomSamplingStorage.getDelegatorLastSettledNodeEpochScorePerStake(
+            epoch,
+            identityId,
+            delegatorKey
+        );
+
+        if (nodeScorePerStake36 == delegatorLastSettled36) {
+            return currentDelegatorScore18;
+        }
+
+        uint96 stakeBase = stakingStorage.getDelegatorStakeBase(identityId, delegatorKey);
+        if (stakeBase == 0) {
+            randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
+                epoch,
+                identityId,
+                delegatorKey,
+                nodeScorePerStake36
+            );
+            return currentDelegatorScore18;
+        }
+
+        uint256 scorePerStakeDiff36 = nodeScorePerStake36 - delegatorLastSettled36;
+        uint256 scoreEarned18 = (uint256(stakeBase) * scorePerStakeDiff36) / SCALE18;
+
+        if (scoreEarned18 > 0) {
+            randomSamplingStorage.addToEpochNodeDelegatorScore(epoch, identityId, delegatorKey, scoreEarned18);
+        }
+
+        randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
+            epoch,
+            identityId,
+            delegatorKey,
+            nodeScorePerStake36
+        );
+
+        return currentDelegatorScore18 + scoreEarned18;
+    }
+
+    // ========================================================================
+    // Internal: Sharding table admission
+    // ========================================================================
+
+    /**
+     * @dev Adds node to sharding table only when stake meets minimum and table has capacity.
+     *      Matches the admission rules in Staking._addNodeToShardingTable.
+     */
+    function _addNodeToShardingTable(uint72 identityId, uint96 newStake) internal {
+        if (!shardingTableStorage.nodeExists(identityId) && newStake >= parametersStorage.minimumStake()) {
+            if (shardingTableStorage.nodesCount() >= parametersStorage.shardingTableSizeLimit()) {
+                revert ShardingTableLib.ShardingTableIsFull();
+            }
+            shardingTableContract.insertNode(identityId);
+        }
     }
 }

--- a/packages/evm-module/contracts/ConvictionStaking.sol
+++ b/packages/evm-module/contracts/ConvictionStaking.sol
@@ -102,6 +102,11 @@ contract ConvictionStaking is INamed, IVersioned, ContractStatus, IInitializable
     }
 
     function _update(address to, uint256 tokenId, address auth) internal override(ERC721Enumerable) returns (address) {
+        address from = _ownerOf(tokenId);
+        // Soulbound: allow mint (from == 0) and burn (to == 0), block transfers
+        if (from != address(0) && to != address(0)) {
+            revert("ConvictionStaking: position is soulbound");
+        }
         return super._update(to, tokenId, auth);
     }
 

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -12,6 +12,7 @@ import {IdentityStorage} from "./storage/IdentityStorage.sol";
 import {RandomSamplingStorage} from "./storage/RandomSamplingStorage.sol";
 import {KnowledgeCollectionStorage} from "./storage/KnowledgeCollectionStorage.sol";
 import {StakingStorage} from "./storage/StakingStorage.sol";
+import {ConvictionStakeStorage} from "./storage/ConvictionStakeStorage.sol";
 import {ProfileStorage} from "./storage/ProfileStorage.sol";
 import {EpochStorage} from "./storage/EpochStorage.sol";
 import {Chronos} from "./storage/Chronos.sol";
@@ -39,6 +40,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     DelegatorsInfo public delegatorsInfo;
     ParametersStorage public parametersStorage;
     ShardingTableStorage public shardingTableStorage;
+    ConvictionStakeStorage public convictionStakeStorage;
 
     error MerkleRootMismatchError(bytes32 computedMerkleRoot, bytes32 expectedMerkleRoot);
 
@@ -90,6 +92,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         delegatorsInfo = DelegatorsInfo(hub.getContractAddress("DelegatorsInfo"));
         parametersStorage = ParametersStorage(hub.getContractAddress("ParametersStorage"));
         shardingTableStorage = ShardingTableStorage(hub.getContractAddress("ShardingTableStorage"));
+        convictionStakeStorage = ConvictionStakeStorage(hub.getContractAddress("ConvictionStakeStorage"));
     }
 
     /**
@@ -228,8 +231,12 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
             randomSamplingStorage.addToNodeEpochScore(epoch, identityId, score18);
             randomSamplingStorage.addToAllNodesEpochScore(epoch, score18);
 
-            // Calculate and add to nodeEpochScorePerStake
-            uint96 totalNodeStake = stakingStorage.getNodeStake(identityId);
+            // Calculate and add to nodeEpochScorePerStake (uses effective stake for conviction)
+            uint256 totalNodeStake = convictionStakeStorage.getEffectiveNodeStake(identityId);
+            // Fallback to raw stake for backward compatibility (pre-migration nodes)
+            if (totalNodeStake == 0) {
+                totalNodeStake = uint256(stakingStorage.getNodeStake(identityId));
+            }
             if (totalNodeStake > 0) {
                 uint256 nodeScorePerStake36 = (score18 * SCALE18) / totalNodeStake;
                 randomSamplingStorage.addToNodeEpochScorePerStake(epoch, identityId, nodeScorePerStake36);
@@ -437,7 +444,11 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         // 1. Stake factor S(t) = sqrt(nodeStake / stakeCap)
         // Using sublinear scaling to reduce stake dominance (RFC-26 Section 4.1)
         uint256 stakeCap = uint256(parametersStorage.maximumStake());
-        uint256 nodeStake = uint256(stakingStorage.getNodeStake(identityId));
+        uint256 nodeStake = convictionStakeStorage.getEffectiveNodeStake(identityId);
+        // Fallback to raw stake for backward compatibility (pre-migration nodes)
+        if (nodeStake == 0) {
+            nodeStake = uint256(stakingStorage.getNodeStake(identityId));
+        }
         nodeStake = nodeStake > stakeCap ? stakeCap : nodeStake;
         // S18 = sqrt((nodeStake / stakeCap) * SCALE18) * sqrt(SCALE18)
         uint256 stakeRatio18 = (nodeStake * SCALE18) / stakeCap;

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -231,12 +231,11 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
             randomSamplingStorage.addToNodeEpochScore(epoch, identityId, score18);
             randomSamplingStorage.addToAllNodesEpochScore(epoch, score18);
 
-            // Calculate and add to nodeEpochScorePerStake (uses effective stake for conviction)
-            uint256 totalNodeStake = convictionStakeStorage.getEffectiveNodeStake(identityId);
-            // Fallback to raw stake for backward compatibility (pre-migration nodes)
-            if (totalNodeStake == 0) {
-                totalNodeStake = uint256(stakingStorage.getNodeStake(identityId));
-            }
+            // Calculate and add to nodeEpochScorePerStake
+            // Use max(effective, raw): effective tracks conviction multiplier, raw catches reward restakes
+            uint256 effectiveNodeStake = convictionStakeStorage.getEffectiveNodeStake(identityId);
+            uint256 rawNodeStake = uint256(stakingStorage.getNodeStake(identityId));
+            uint256 totalNodeStake = effectiveNodeStake > rawNodeStake ? effectiveNodeStake : rawNodeStake;
             if (totalNodeStake > 0) {
                 uint256 nodeScorePerStake36 = (score18 * SCALE18) / totalNodeStake;
                 randomSamplingStorage.addToNodeEpochScorePerStake(epoch, identityId, nodeScorePerStake36);
@@ -444,11 +443,10 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         // 1. Stake factor S(t) = sqrt(nodeStake / stakeCap)
         // Using sublinear scaling to reduce stake dominance (RFC-26 Section 4.1)
         uint256 stakeCap = uint256(parametersStorage.maximumStake());
-        uint256 nodeStake = convictionStakeStorage.getEffectiveNodeStake(identityId);
-        // Fallback to raw stake for backward compatibility (pre-migration nodes)
-        if (nodeStake == 0) {
-            nodeStake = uint256(stakingStorage.getNodeStake(identityId));
-        }
+        uint256 effectiveStake = convictionStakeStorage.getEffectiveNodeStake(identityId);
+        uint256 rawStake = uint256(stakingStorage.getNodeStake(identityId));
+        // Use max(effective, raw): effective tracks conviction multiplier, raw catches reward restakes
+        uint256 nodeStake = effectiveStake > rawStake ? effectiveStake : rawStake;
         nodeStake = nodeStake > stakeCap ? stakeCap : nodeStake;
         // S18 = sqrt((nodeStake / stakeCap) * SCALE18) * sqrt(SCALE18)
         uint256 stakeRatio18 = (nodeStake * SCALE18) / stakeCap;

--- a/packages/evm-module/contracts/storage/ConvictionStakeStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakeStorage.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {INamed} from "../interfaces/INamed.sol";
+import {IVersioned} from "../interfaces/IVersioned.sol";
+import {ContractStatus} from "../abstract/ContractStatus.sol";
+
+contract ConvictionStakeStorage is INamed, IVersioned, ContractStatus {
+    string private constant _NAME = "ConvictionStakeStorage";
+    string private constant _VERSION = "1.0.0";
+
+    // identityId => effective (multiplied) node stake: sum of (principal * multiplier) per node
+    mapping(uint72 => uint256) public effectiveNodeStake;
+    // network-wide sum of all effective stake
+    uint256 public effectiveTotalStake;
+
+    event EffectiveNodeStakeUpdated(uint72 indexed identityId, uint256 effectiveStake);
+    event EffectiveTotalStakeUpdated(uint256 effectiveTotalStake);
+
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address hubAddress) ContractStatus(hubAddress) {}
+
+    function name() external pure virtual override returns (string memory) {
+        return _NAME;
+    }
+
+    function version() external pure virtual override returns (string memory) {
+        return _VERSION;
+    }
+
+    function getEffectiveNodeStake(uint72 identityId) external view returns (uint256) {
+        return effectiveNodeStake[identityId];
+    }
+
+    function setEffectiveNodeStake(uint72 identityId, uint256 amount) external onlyContracts {
+        effectiveNodeStake[identityId] = amount;
+        emit EffectiveNodeStakeUpdated(identityId, amount);
+    }
+
+    function increaseEffectiveNodeStake(uint72 identityId, uint256 addedStake) external onlyContracts {
+        effectiveNodeStake[identityId] += addedStake;
+        emit EffectiveNodeStakeUpdated(identityId, effectiveNodeStake[identityId]);
+    }
+
+    function decreaseEffectiveNodeStake(uint72 identityId, uint256 removedStake) external onlyContracts {
+        effectiveNodeStake[identityId] -= removedStake;
+        emit EffectiveNodeStakeUpdated(identityId, effectiveNodeStake[identityId]);
+    }
+
+    function getEffectiveTotalStake() external view returns (uint256) {
+        return effectiveTotalStake;
+    }
+
+    function setEffectiveTotalStake(uint256 amount) external onlyContracts {
+        effectiveTotalStake = amount;
+        emit EffectiveTotalStakeUpdated(amount);
+    }
+
+    function increaseEffectiveTotalStake(uint256 addedStake) external onlyContracts {
+        effectiveTotalStake += addedStake;
+        emit EffectiveTotalStakeUpdated(effectiveTotalStake);
+    }
+
+    function decreaseEffectiveTotalStake(uint256 removedStake) external onlyContracts {
+        effectiveTotalStake -= removedStake;
+        emit EffectiveTotalStakeUpdated(effectiveTotalStake);
+    }
+}

--- a/packages/evm-module/deploy/060_deploy_conviction_stake_storage.ts
+++ b/packages/evm-module/deploy/060_deploy_conviction_stake_storage.ts
@@ -1,0 +1,12 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  await hre.helpers.deploy({
+    newContractName: 'ConvictionStakeStorage',
+  });
+};
+
+export default func;
+func.tags = ['ConvictionStakeStorage'];
+func.dependencies = ['Hub'];

--- a/packages/evm-module/deploy/061_deploy_conviction_staking.ts
+++ b/packages/evm-module/deploy/061_deploy_conviction_staking.ts
@@ -3,24 +3,22 @@ import { DeployFunction } from 'hardhat-deploy/types';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   await hre.helpers.deploy({
-    newContractName: 'RandomSampling',
+    newContractName: 'ConvictionStaking',
   });
 };
 
 export default func;
-func.tags = ['RandomSampling'];
+func.tags = ['ConvictionStaking'];
 func.dependencies = [
   'Hub',
-  'Chronos',
-  'RandomSamplingStorage',
+  'Token',
   'StakingStorage',
-  'ProfileStorage',
-  'EpochStorage',
-  'AskStorage',
-  'DelegatorsInfo',
-  'KnowledgeCollectionStorage',
-  'IdentityStorage',
-  'ShardingTableStorage',
-  'ParametersStorage',
   'ConvictionStakeStorage',
+  'ParametersStorage',
+  'ProfileStorage',
+  'IdentityStorage',
+  'ShardingTable',
+  'ShardingTableStorage',
+  'Ask',
+  'Chronos',
 ];

--- a/packages/evm-module/deploy/061_deploy_conviction_staking.ts
+++ b/packages/evm-module/deploy/061_deploy_conviction_staking.ts
@@ -14,6 +14,8 @@ func.dependencies = [
   'Token',
   'StakingStorage',
   'ConvictionStakeStorage',
+  'RandomSamplingStorage',
+  'DelegatorsInfo',
   'ParametersStorage',
   'ProfileStorage',
   'IdentityStorage',

--- a/packages/evm-module/test/integration/ConvictionStakingRewards.test.ts
+++ b/packages/evm-module/test/integration/ConvictionStakingRewards.test.ts
@@ -299,6 +299,8 @@ describe('ConvictionStaking — stake -> proof -> score -> reward', function () 
         node1Id,
         delegatorKey,
       );
+    const effectiveBefore =
+      await contracts.convictionStakeStorage.getEffectiveNodeStake(node1Id);
 
     await contracts.staking.claimDelegatorRewards(
       node1Id,
@@ -313,6 +315,24 @@ describe('ConvictionStaking — stake -> proof -> score -> reward', function () 
         delegatorKey,
       );
     expect(stakeBaseAfter).to.be.gt(stakeBaseBefore);
+
+    // After claim restake: raw nodeStake increased, effective stays at original
+    // RandomSampling uses max(effective, raw), so scoring picks up the restaked reward
+    const effectiveAfter =
+      await contracts.convictionStakeStorage.getEffectiveNodeStake(node1Id);
+    const rawNodeStakeAfter = await contracts.stakingStorage.getNodeStake(
+      node1Id,
+    );
+    const rewardAmount = stakeBaseAfter - stakeBaseBefore;
+
+    // Effective didn't change (old Staking doesn't sync it)
+    expect(effectiveAfter).to.equal(effectiveBefore);
+    // Raw increased by the reward
+    expect(rawNodeStakeAfter).to.equal(
+      BigInt(stakeAmount) + rewardAmount,
+    );
+    // For tier 0: raw > effective after restake, so max(eff, raw) = raw — scoring is correct
+    expect(rawNodeStakeAfter).to.be.gte(effectiveAfter);
 
     // Cumulative earned rewards tracked
     const cumulativeEarned =

--- a/packages/evm-module/test/integration/ConvictionStakingRewards.test.ts
+++ b/packages/evm-module/test/integration/ConvictionStakingRewards.test.ts
@@ -342,4 +342,112 @@ describe('ConvictionStaking — stake -> proof -> score -> reward', function () 
       );
     expect(cumulativeEarned).to.be.gt(0);
   });
+
+  it('should use effective stake (not raw) as submitProof scorePerStake divisor', async () => {
+    // This test creates divergence: effective = 2x raw, then submits a proof and
+    // verifies the scorePerStake stored in RandomSamplingStorage uses effective.
+
+    // ── Setup: create a fresh node with a second delegator ──
+    const signers = await hre.ethers.getSigners();
+    const node4 = { operational: signers[7], admin: signers[8] };
+    const delegator2 = signers[11];
+    const p4 = await createProfile(contracts.profile, node4);
+    const node4Id = p4.identityId;
+
+    // @ts-expect-error – hub owner insert for test setup
+    await contracts.shardingTable.connect(owner).insertNode(node4Id);
+    const nodeAsk = hre.ethers.parseUnits('0.2', 18);
+    await contracts.profile
+      .connect(node4.operational)
+      .updateAsk(node4Id, nodeAsk);
+    await contracts.ask.connect(owner).recalculateActiveSet();
+
+    // Mint tokens and stake via ConvictionStaking
+    await contracts.token.mint(delegator2.address, toTRAC(1_000_000));
+    const stakeAmount = toTRAC(50_000);
+    await contracts.token
+      .connect(delegator2)
+      .approve(await contracts.convictionStaking.getAddress(), stakeAmount);
+    await contracts.convictionStaking
+      .connect(delegator2)
+      .stake(node4Id, stakeAmount, 0);
+
+    // Create divergence: set effective to 2x raw (simulates future multiplier)
+    const boostedEffective = stakeAmount * 2n;
+    await contracts.convictionStakeStorage.setEffectiveNodeStake(
+      node4Id,
+      boostedEffective,
+    );
+
+    // Advance to a new epoch for fresh scoring
+    await time.increase(
+      (await contracts.chronos.timeUntilNextEpoch()) + 1n,
+    );
+    const proofEpoch = await contracts.chronos.getCurrentEpoch();
+
+    // Publish a KC so the node can generate challenges
+    const allNodes = [node1, node2, node3, node4];
+    const allNodeIds = [node1Id, node2Id, node3Id, node4Id];
+
+    // @ts-expect-error – dynamic CJS import
+    const { kcTools } = await import('assertion-tools');
+    const merkleRoot = kcTools.calculateMerkleRoot(quads, 32);
+
+    await createKnowledgeCollection(
+      owner,
+      node4,
+      node4Id,
+      allNodes,
+      allNodeIds,
+      { KnowledgeCollection: contracts.kc, Token: contracts.token },
+      merkleRoot,
+      `divisor-test-kc-${Date.now()}`,
+      3,
+      chunkSize * 3,
+      5,
+      toTRAC(500),
+    );
+
+    // ── Submit proof ──
+    await advanceToNextProofingPeriod(contracts);
+
+    await contracts.randomSampling
+      .connect(node4.operational)
+      .createChallenge();
+
+    const challenge =
+      await contracts.randomSamplingStorage.getNodeChallenge(node4Id);
+    const chunks = kcTools.splitIntoChunks(quads, 32);
+    const chunkId = Number(challenge[1]);
+    const { proof } = kcTools.calculateMerkleProof(quads, 32, chunkId);
+
+    await contracts.randomSampling
+      .connect(node4.operational)
+      .submitProof(chunks[chunkId], proof);
+
+    // ── Verify scorePerStake uses effective stake as divisor ──
+    const nodeScore = await contracts.randomSamplingStorage.getNodeEpochScore(
+      proofEpoch,
+      node4Id,
+    );
+    const scorePerStake =
+      await contracts.randomSamplingStorage.getNodeEpochScorePerStake(
+        proofEpoch,
+        node4Id,
+      );
+    expect(nodeScore).to.be.gt(0);
+    expect(scorePerStake).to.be.gt(0);
+
+    // scorePerStake should equal score * 1e18 / max(effective, raw)
+    // max(100K, 50K) = 100K = boostedEffective
+    const SCALE18 = 10n ** 18n;
+    const expectedScorePerStake = (nodeScore * SCALE18) / boostedEffective;
+
+    // If code were using raw stake (50K), scorePerStake would be 2x larger
+    const wrongScorePerStake = (nodeScore * SCALE18) / stakeAmount;
+
+    // Verify actual matches expected (effective-based), not wrong (raw-based)
+    expect(scorePerStake).to.equal(expectedScorePerStake);
+    expect(scorePerStake).to.not.equal(wrongScorePerStake);
+  });
 });

--- a/packages/evm-module/test/integration/ConvictionStakingRewards.test.ts
+++ b/packages/evm-module/test/integration/ConvictionStakingRewards.test.ts
@@ -1,0 +1,325 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  Token,
+  Profile,
+  Staking,
+  StakingStorage,
+  Chronos,
+  RandomSamplingStorage,
+  RandomSampling,
+  EpochStorage,
+  KnowledgeCollection,
+  Hub,
+  Ask,
+  AskStorage,
+  ParametersStorage,
+  ProfileStorage,
+  DelegatorsInfo,
+  ShardingTable,
+  ConvictionStaking,
+  ConvictionStakeStorage,
+} from '../../typechain';
+import { createKnowledgeCollection } from '../helpers/kc-helpers';
+import { createProfile } from '../helpers/profile-helpers';
+import { NodeAccounts } from '../helpers/types';
+
+const toTRAC = (x: number) => hre.ethers.parseEther(x.toString());
+
+const quads = [
+  '<urn:test:s> <urn:test:p> <urn:test:o> .',
+  ...Array(1000).fill(
+    '<urn:fake:quad> <urn:fake:predicate> <urn:fake:object> .',
+  ),
+];
+
+async function advanceToNextProofingPeriod(contracts: {
+  randomSampling: RandomSampling;
+}): Promise<void> {
+  const dur =
+    await contracts.randomSampling.getActiveProofingPeriodDurationInBlocks();
+  const { activeProofPeriodStartBlock, isValid } =
+    await contracts.randomSampling.getActiveProofPeriodStatus();
+  if (isValid) {
+    const blocksLeft =
+      Number(activeProofPeriodStartBlock) +
+      Number(dur) -
+      Number(await hre.network.provider.send('eth_blockNumber')) +
+      1;
+    for (let i = 0; i < blocksLeft; i++) {
+      await hre.network.provider.send('evm_mine');
+    }
+  }
+  await contracts.randomSampling.updateAndGetActiveProofPeriodStartBlock();
+}
+
+describe('ConvictionStaking — stake -> proof -> score -> reward', function () {
+  let contracts: {
+    hub: Hub;
+    token: Token;
+    chronos: Chronos;
+    profile: Profile;
+    staking: Staking;
+    stakingStorage: StakingStorage;
+    delegatorsInfo: DelegatorsInfo;
+    randomSamplingStorage: RandomSamplingStorage;
+    randomSampling: RandomSampling;
+    epochStorage: EpochStorage;
+    kc: KnowledgeCollection;
+    ask: Ask;
+    askStorage: AskStorage;
+    parametersStorage: ParametersStorage;
+    profileStorage: ProfileStorage;
+    shardingTable: ShardingTable;
+    convictionStaking: ConvictionStaking;
+    convictionStakeStorage: ConvictionStakeStorage;
+  };
+  let owner: SignerWithAddress;
+  let node1: NodeAccounts;
+  let node2: NodeAccounts;
+  let node3: NodeAccounts;
+  let delegator: SignerWithAddress;
+  let node1Id: number;
+  let node2Id: number;
+  let node3Id: number;
+  let chunkSize: number;
+  let receivingNodes: NodeAccounts[];
+  let receivingNodeIds: number[];
+
+  before(async () => {
+    hre.helpers.resetDeploymentsJson();
+    await hre.deployments.fixture();
+
+    const signers = await hre.ethers.getSigners();
+    owner = signers[0];
+    node1 = { operational: signers[1], admin: signers[2] };
+    node2 = { operational: signers[3], admin: signers[4] };
+    node3 = { operational: signers[5], admin: signers[6] };
+    delegator = signers[10];
+
+    contracts = {
+      hub: await hre.ethers.getContract<Hub>('Hub'),
+      token: await hre.ethers.getContract<Token>('Token'),
+      chronos: await hre.ethers.getContract<Chronos>('Chronos'),
+      profile: await hre.ethers.getContract<Profile>('Profile'),
+      staking: await hre.ethers.getContract<Staking>('Staking'),
+      stakingStorage:
+        await hre.ethers.getContract<StakingStorage>('StakingStorage'),
+      delegatorsInfo:
+        await hre.ethers.getContract<DelegatorsInfo>('DelegatorsInfo'),
+      randomSamplingStorage:
+        await hre.ethers.getContract<RandomSamplingStorage>(
+          'RandomSamplingStorage',
+        ),
+      randomSampling:
+        await hre.ethers.getContract<RandomSampling>('RandomSampling'),
+      epochStorage:
+        await hre.ethers.getContract<EpochStorage>('EpochStorageV8'),
+      kc: await hre.ethers.getContract<KnowledgeCollection>(
+        'KnowledgeCollection',
+      ),
+      ask: await hre.ethers.getContract<Ask>('Ask'),
+      askStorage: await hre.ethers.getContract<AskStorage>('AskStorage'),
+      parametersStorage:
+        await hre.ethers.getContract<ParametersStorage>('ParametersStorage'),
+      profileStorage:
+        await hre.ethers.getContract<ProfileStorage>('ProfileStorage'),
+      shardingTable:
+        await hre.ethers.getContract<ShardingTable>('ShardingTable'),
+      convictionStaking:
+        await hre.ethers.getContract<ConvictionStaking>('ConvictionStaking'),
+      convictionStakeStorage:
+        await hre.ethers.getContract<ConvictionStakeStorage>(
+          'ConvictionStakeStorage',
+        ),
+    };
+
+    chunkSize = Number(
+      await contracts.randomSamplingStorage.CHUNK_BYTE_SIZE(),
+    );
+
+    await contracts.hub.setContractAddress('HubOwner', owner.address);
+    await contracts.parametersStorage.setMinimumStake(toTRAC(100));
+    await contracts.parametersStorage
+      .connect(owner)
+      .setOperatorFeeUpdateDelay(0);
+
+    // Mint tokens
+    await contracts.token.mint(delegator.address, toTRAC(1_000_000));
+    await contracts.token.mint(owner.address, toTRAC(1_000_000));
+
+    // Create 3 node profiles (KC creation requires min 3 receiving signatures)
+    const p1 = await createProfile(contracts.profile, node1);
+    const p2 = await createProfile(contracts.profile, node2);
+    const p3 = await createProfile(contracts.profile, node3);
+    node1Id = p1.identityId;
+    node2Id = p2.identityId;
+    node3Id = p3.identityId;
+
+    // Add nodes to sharding table (required for KC assignment)
+    // @ts-expect-error – hub owner direct insert for test setup
+    await contracts.shardingTable.connect(owner).insertNode(node1Id);
+    // @ts-expect-error – hub owner direct insert for test setup
+    await contracts.shardingTable.connect(owner).insertNode(node2Id);
+    // @ts-expect-error – hub owner direct insert for test setup
+    await contracts.shardingTable.connect(owner).insertNode(node3Id);
+
+    // Set node asks
+    const nodeAsk = hre.ethers.parseUnits('0.2', 18);
+    await contracts.profile
+      .connect(node1.operational)
+      .updateAsk(node1Id, nodeAsk);
+    await contracts.profile
+      .connect(node2.operational)
+      .updateAsk(node2Id, nodeAsk);
+    await contracts.profile
+      .connect(node3.operational)
+      .updateAsk(node3Id, nodeAsk);
+    await contracts.ask.connect(owner).recalculateActiveSet();
+
+    receivingNodes = [node1, node2, node3];
+    receivingNodeIds = [node1Id, node2Id, node3Id];
+
+    // Advance to epoch 2 (same pattern as StakingRewards.test.ts)
+    const timeUntilNextEpoch = await contracts.chronos.timeUntilNextEpoch();
+    await time.increase(timeUntilNextEpoch + 1n);
+    while ((await contracts.chronos.getCurrentEpoch()) < 2n) {
+      await time.increase(
+        (await contracts.chronos.timeUntilNextEpoch()) + 1n,
+      );
+    }
+  });
+
+  it('should complete: stake via ConvictionStaking -> publish KC -> submit proof -> advance epoch -> claim rewards', async () => {
+    const stakingEpoch = await contracts.chronos.getCurrentEpoch();
+
+    // ── Step 1: Stake via ConvictionStaking in stakingEpoch ──
+    const stakeAmount = toTRAC(50_000);
+    await contracts.token
+      .connect(delegator)
+      .approve(await contracts.convictionStaking.getAddress(), stakeAmount);
+    await contracts.convictionStaking
+      .connect(delegator)
+      .stake(node1Id, stakeAmount, 0);
+
+    // Verify NFT minted
+    expect(
+      await contracts.convictionStaking.balanceOf(delegator.address),
+    ).to.equal(1);
+
+    // Verify delegator registered
+    expect(
+      await contracts.delegatorsInfo.isNodeDelegator(
+        node1Id,
+        delegator.address,
+      ),
+    ).to.equal(true);
+
+    // Verify per-delegator stakeBase
+    const delegatorKey = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [delegator.address]),
+    );
+    expect(
+      await contracts.stakingStorage.getDelegatorStakeBase(
+        node1Id,
+        delegatorKey,
+      ),
+    ).to.equal(stakeAmount);
+
+    // Verify effectiveNodeStake
+    expect(
+      await contracts.convictionStakeStorage.getEffectiveNodeStake(node1Id),
+    ).to.equal(stakeAmount);
+
+    // ── Step 2: Publish KC in same epoch ──
+    // @ts-expect-error – dynamic CJS import
+    const { kcTools } = await import('assertion-tools');
+    const merkleRoot = kcTools.calculateMerkleRoot(quads, 32);
+
+    await createKnowledgeCollection(
+      owner,
+      node1,
+      node1Id,
+      receivingNodes,
+      receivingNodeIds,
+      { KnowledgeCollection: contracts.kc, Token: contracts.token },
+      merkleRoot,
+      `conviction-test-kc-${Date.now()}`,
+      3,
+      chunkSize * 3,
+      5,
+      toTRAC(500),
+    );
+
+    // ── Step 3: Submit proof for node1 ──
+    await advanceToNextProofingPeriod(contracts);
+
+    await contracts.randomSampling
+      .connect(node1.operational)
+      .createChallenge();
+
+    const challenge =
+      await contracts.randomSamplingStorage.getNodeChallenge(node1Id);
+    const chunks = kcTools.splitIntoChunks(quads, 32);
+    const chunkId = Number(challenge[1]);
+    const { proof } = kcTools.calculateMerkleProof(quads, 32, chunkId);
+
+    await contracts.randomSampling
+      .connect(node1.operational)
+      .submitProof(chunks[chunkId], proof);
+
+    // Verify node score was recorded
+    const nodeScore = await contracts.randomSamplingStorage.getNodeEpochScore(
+      stakingEpoch,
+      node1Id,
+    );
+    expect(nodeScore).to.be.gt(0);
+
+    // Verify scorePerStake was computed using effectiveNodeStake
+    const scorePerStake =
+      await contracts.randomSamplingStorage.getNodeEpochScorePerStake(
+        stakingEpoch,
+        node1Id,
+      );
+    expect(scorePerStake).to.be.gt(0);
+
+    // ── Step 4: Advance epoch so stakingEpoch becomes claimable ──
+    await time.increase(
+      (await contracts.chronos.timeUntilNextEpoch()) + 1n,
+    );
+    const claimEpoch = await contracts.chronos.getCurrentEpoch();
+    expect(claimEpoch).to.be.gt(stakingEpoch);
+
+    // ── Step 5: Claim rewards via Staking.claimDelegatorRewards ──
+    const stakeBaseBefore =
+      await contracts.stakingStorage.getDelegatorStakeBase(
+        node1Id,
+        delegatorKey,
+      );
+
+    await contracts.staking.claimDelegatorRewards(
+      node1Id,
+      stakingEpoch,
+      delegator.address,
+    );
+
+    // Rewards should be restaked (stakeBase increased)
+    const stakeBaseAfter =
+      await contracts.stakingStorage.getDelegatorStakeBase(
+        node1Id,
+        delegatorKey,
+      );
+    expect(stakeBaseAfter).to.be.gt(stakeBaseBefore);
+
+    // Cumulative earned rewards tracked
+    const cumulativeEarned =
+      await contracts.stakingStorage.getDelegatorCumulativeEarnedRewards(
+        node1Id,
+        delegatorKey,
+      );
+    expect(cumulativeEarned).to.be.gt(0);
+  });
+});

--- a/packages/evm-module/test/unit/ConvictionStaking.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStaking.test.ts
@@ -468,5 +468,63 @@ describe('ConvictionStaking - Tracer Bullet', function () {
       const score = await RandSampling.calculateNodeScore(identityId);
       expect(score).to.equal(0);
     });
+
+    it('Should change score when effectiveNodeStake diverges from raw nodeStake', async () => {
+      // Stake via ConvictionStaking: raw = 50K, effective = 50K
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      const scoreAtBase = await RandSampling.calculateNodeScore(identityId);
+      expect(scoreAtBase).to.be.gt(0);
+
+      // Hub owner sets effectiveNodeStake to 4x (200K), raw stays 50K
+      const boostedEffective = STAKE_AMOUNT * 4n;
+      await ConvStakeStorage.setEffectiveNodeStake(
+        identityId,
+        boostedEffective,
+      );
+
+      const scoreAtBoosted =
+        await RandSampling.calculateNodeScore(identityId);
+
+      // Score must increase: sqrt(200K/2M) > sqrt(50K/2M)
+      // If RandomSampling were still reading raw nodeStake, score would be unchanged
+      expect(scoreAtBoosted).to.be.gt(scoreAtBase);
+    });
+
+    it('Should use effectiveNodeStake (not raw) as scorePerStake divisor', async () => {
+      // Stake via ConvictionStaking: raw = 50K, effective = 50K
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      // Set effective to 2x raw (simulate future multiplier)
+      const doubledEffective = STAKE_AMOUNT * 2n;
+      await ConvStakeStorage.setEffectiveNodeStake(
+        identityId,
+        doubledEffective,
+      );
+
+      // Verify the calculateNodeScore uses the boosted value
+      const scoreAtDoubled =
+        await RandSampling.calculateNodeScore(identityId);
+
+      // Now set effective back to base
+      await ConvStakeStorage.setEffectiveNodeStake(
+        identityId,
+        STAKE_AMOUNT,
+      );
+      const scoreAtBase = await RandSampling.calculateNodeScore(identityId);
+
+      // scoreAtDoubled > scoreAtBase proves effective is used for scoring
+      // (sqrt(100K/2M) > sqrt(50K/2M))
+      expect(scoreAtDoubled).to.be.gt(scoreAtBase);
+
+      // The ratio should be sqrt(2) ≈ 1.414 (within 1% tolerance)
+      const ratio =
+        Number((scoreAtDoubled * 10000n) / scoreAtBase) / 10000;
+      expect(ratio).to.be.closeTo(Math.sqrt(2), 0.01);
+    });
   });
 });

--- a/packages/evm-module/test/unit/ConvictionStaking.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStaking.test.ts
@@ -1,0 +1,422 @@
+import { randomBytes } from 'crypto';
+
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  Token,
+  Profile,
+  StakingStorage,
+  ParametersStorage,
+  ProfileStorage,
+  ShardingTable,
+  ShardingTableStorage,
+  AskStorage,
+  Hub,
+  Chronos,
+  RandomSamplingStorage,
+  RandomSampling,
+  EpochStorage,
+  ConvictionStaking,
+  ConvictionStakeStorage,
+} from '../../typechain';
+
+type Fixture = {
+  accounts: SignerWithAddress[];
+  Token: Token;
+  Profile: Profile;
+  ConvictionStaking: ConvictionStaking;
+  ConvictionStakeStorage: ConvictionStakeStorage;
+  StakingStorage: StakingStorage;
+  ParametersStorage: ParametersStorage;
+  ProfileStorage: ProfileStorage;
+  ShardingTable: ShardingTable;
+  ShardingTableStorage: ShardingTableStorage;
+  AskStorage: AskStorage;
+  Hub: Hub;
+  Chronos: Chronos;
+  RandomSamplingStorage: RandomSamplingStorage;
+  RandomSampling: RandomSampling;
+  EpochStorage: EpochStorage;
+};
+
+async function deployFixture(): Promise<Fixture> {
+  await hre.deployments.fixture([
+    'Profile',
+    'ConvictionStaking',
+    'ConvictionStakeStorage',
+    'RandomSampling',
+    'EpochStorage',
+    'Chronos',
+    'RandomSamplingStorage',
+  ]);
+
+  const accounts = await hre.ethers.getSigners();
+  const Token = await hre.ethers.getContract<Token>('Token');
+  const Profile = await hre.ethers.getContract<Profile>('Profile');
+  const ConvictionStaking =
+    await hre.ethers.getContract<ConvictionStaking>('ConvictionStaking');
+  const ConvictionStakeStorage =
+    await hre.ethers.getContract<ConvictionStakeStorage>(
+      'ConvictionStakeStorage',
+    );
+  const StakingStorage =
+    await hre.ethers.getContract<StakingStorage>('StakingStorage');
+  const ParametersStorage =
+    await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+  const ProfileStorage =
+    await hre.ethers.getContract<ProfileStorage>('ProfileStorage');
+  const ShardingTable =
+    await hre.ethers.getContract<ShardingTable>('ShardingTable');
+  const ShardingTableStorage =
+    await hre.ethers.getContract<ShardingTableStorage>('ShardingTableStorage');
+  const AskStorage = await hre.ethers.getContract<AskStorage>('AskStorage');
+  const Hub = await hre.ethers.getContract<Hub>('Hub');
+  const Chronos = await hre.ethers.getContract<Chronos>('Chronos');
+  const RandomSamplingStorage =
+    await hre.ethers.getContract<RandomSamplingStorage>(
+      'RandomSamplingStorage',
+    );
+  const RandomSampling =
+    await hre.ethers.getContract<RandomSampling>('RandomSampling');
+  const EpochStorage =
+    await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
+
+  await Hub.setContractAddress('HubOwner', accounts[0].address);
+
+  return {
+    accounts,
+    Token,
+    Profile,
+    ConvictionStaking,
+    ConvictionStakeStorage,
+    StakingStorage,
+    ParametersStorage,
+    ProfileStorage,
+    ShardingTable,
+    ShardingTableStorage,
+    AskStorage,
+    Hub,
+    Chronos,
+    RandomSamplingStorage,
+    RandomSampling,
+    EpochStorage,
+  };
+}
+
+describe('ConvictionStaking - Tracer Bullet', function () {
+  let accounts: SignerWithAddress[];
+  let Token: Token;
+  let Profile: Profile;
+  let ConvStaking: ConvictionStaking;
+  let ConvStakeStorage: ConvictionStakeStorage;
+  let StkStorage: StakingStorage;
+  let ParametersStor: ParametersStorage;
+  let Hub_: Hub;
+  let Chronos_: Chronos;
+  let RandSampling: RandomSampling;
+  let RandSamplingStorage: RandomSamplingStorage;
+
+  const STAKE_AMOUNT = hre.ethers.parseUnits('50000', 18); // 50K TRAC
+
+  const createProfile = async (
+    admin?: SignerWithAddress,
+    operational?: SignerWithAddress,
+  ) => {
+    const node = '0x' + randomBytes(32).toString('hex');
+    const tx = await Profile.connect(
+      operational ?? accounts[1],
+    ).createProfile(
+      admin ? admin.address : accounts[0],
+      [],
+      `Node ${Math.floor(Math.random() * 1000)}`,
+      node,
+      0n,
+    );
+    const receipt = await tx.wait();
+    const identityId = Number(receipt?.logs[0].topics[1]);
+    return { nodeId: node, identityId };
+  };
+
+  beforeEach(async () => {
+    hre.helpers.resetDeploymentsJson();
+    ({
+      accounts,
+      Token,
+      Profile,
+      ConvictionStaking: ConvStaking,
+      ConvictionStakeStorage: ConvStakeStorage,
+      StakingStorage: StkStorage,
+      ParametersStorage: ParametersStor,
+      Hub: Hub_,
+      Chronos: Chronos_,
+      RandomSampling: RandSampling,
+      RandomSamplingStorage: RandSamplingStorage,
+    } = await loadFixture(deployFixture));
+  });
+
+  // -------------------------------------------------------------------------
+  // ConvictionStakeStorage
+  // -------------------------------------------------------------------------
+  describe('ConvictionStakeStorage', () => {
+    it('Should have correct name and version', async () => {
+      expect(await ConvStakeStorage.name()).to.equal('ConvictionStakeStorage');
+      expect(await ConvStakeStorage.version()).to.equal('1.0.0');
+    });
+
+    it('Should allow hub-registered contracts to set effectiveNodeStake', async () => {
+      // Hub owner can call onlyContracts functions
+      await ConvStakeStorage.setEffectiveNodeStake(1, 1000n);
+      expect(await ConvStakeStorage.getEffectiveNodeStake(1)).to.equal(1000n);
+    });
+
+    it('Should allow hub-registered contracts to set effectiveTotalStake', async () => {
+      await ConvStakeStorage.setEffectiveTotalStake(5000n);
+      expect(await ConvStakeStorage.getEffectiveTotalStake()).to.equal(5000n);
+    });
+
+    it('Should revert if non-contract calls setter', async () => {
+      await expect(
+        ConvStakeStorage.connect(accounts[5]).setEffectiveNodeStake(1, 1000n),
+      ).to.be.reverted;
+    });
+
+    it('Should support increase/decrease for effectiveNodeStake', async () => {
+      await ConvStakeStorage.increaseEffectiveNodeStake(1, 1000n);
+      expect(await ConvStakeStorage.getEffectiveNodeStake(1)).to.equal(1000n);
+
+      await ConvStakeStorage.increaseEffectiveNodeStake(1, 500n);
+      expect(await ConvStakeStorage.getEffectiveNodeStake(1)).to.equal(1500n);
+
+      await ConvStakeStorage.decreaseEffectiveNodeStake(1, 300n);
+      expect(await ConvStakeStorage.getEffectiveNodeStake(1)).to.equal(1200n);
+    });
+
+    it('Should support increase/decrease for effectiveTotalStake', async () => {
+      await ConvStakeStorage.increaseEffectiveTotalStake(2000n);
+      expect(await ConvStakeStorage.getEffectiveTotalStake()).to.equal(2000n);
+
+      await ConvStakeStorage.decreaseEffectiveTotalStake(500n);
+      expect(await ConvStakeStorage.getEffectiveTotalStake()).to.equal(1500n);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ConvictionStaking identity
+  // -------------------------------------------------------------------------
+  describe('ConvictionStaking contract metadata', () => {
+    it('Should have correct name and version', async () => {
+      expect(await ConvStaking.name()).to.equal('ConvictionStaking');
+      expect(await ConvStaking.version()).to.equal('1.0.0');
+    });
+
+    it('Should support ERC-721 interface', async () => {
+      // ERC-721 interface ID: 0x80ac58cd
+      expect(await ConvStaking.supportsInterface('0x80ac58cd')).to.equal(true);
+    });
+
+    it('Should support ERC-721 Enumerable interface', async () => {
+      // ERC-721 Enumerable interface ID: 0x780e9d63
+      expect(await ConvStaking.supportsInterface('0x780e9d63')).to.equal(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ConvictionStaking.stake()
+  // -------------------------------------------------------------------------
+  describe('ConvictionStaking.stake()', () => {
+    it('Should revert if staking 0 tokens', async () => {
+      const { identityId } = await createProfile();
+      await expect(
+        ConvStaking.stake(identityId, 0, 0),
+      ).to.be.revertedWithCustomError(ConvStaking, 'ZeroStakeAmount');
+    });
+
+    it('Should revert if profile does not exist', async () => {
+      await expect(
+        ConvStaking.stake(9999, STAKE_AMOUNT, 0),
+      ).to.be.revertedWithCustomError(ConvStaking, 'ProfileDoesntExist');
+    });
+
+    it('Should revert if lock tier is not 0', async () => {
+      const { identityId } = await createProfile();
+      await expect(
+        ConvStaking.stake(identityId, STAKE_AMOUNT, 1),
+      ).to.be.revertedWithCustomError(ConvStaking, 'InvalidLockTier');
+    });
+
+    it('Should revert if maximum stake exceeded', async () => {
+      const { identityId } = await createProfile();
+      const maxStake = await ParametersStor.maximumStake();
+      const overMax = maxStake + 1n;
+      await Token.mint(accounts[0].address, overMax);
+      await Token.approve(await ConvStaking.getAddress(), overMax);
+      await expect(
+        ConvStaking.stake(identityId, overMax, 0),
+      ).to.be.revertedWithCustomError(ConvStaking, 'MaximumStakeExceeded');
+    });
+
+    it('Should mint an NFT to the staker', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      expect(await ConvStaking.balanceOf(accounts[0].address)).to.equal(1);
+      expect(await ConvStaking.ownerOf(0)).to.equal(accounts[0].address);
+      expect(await ConvStaking.totalSupply()).to.equal(1);
+    });
+
+    it('Should transfer TRAC from staker to StakingStorage', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+
+      const stakingStorageAddr = await StkStorage.getAddress();
+      const balBefore = await Token.balanceOf(stakingStorageAddr);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+      const balAfter = await Token.balanceOf(stakingStorageAddr);
+
+      expect(balAfter - balBefore).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should update StakingStorage.nodeStake with raw principal', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+
+      const stakeBefore = await StkStorage.getNodeStake(identityId);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+      const stakeAfter = await StkStorage.getNodeStake(identityId);
+
+      expect(stakeAfter - stakeBefore).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should update StakingStorage.totalStake', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+
+      const totalBefore = await StkStorage.getTotalStake();
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+      const totalAfter = await StkStorage.getTotalStake();
+
+      expect(totalAfter - totalBefore).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should update ConvictionStakeStorage.effectiveNodeStake (1x for tier 0)', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      const effectiveStake = await ConvStakeStorage.getEffectiveNodeStake(
+        identityId,
+      );
+      // Tier 0 = 1x multiplier, so effective == raw
+      expect(effectiveStake).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should update ConvictionStakeStorage.effectiveTotalStake', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      expect(await ConvStakeStorage.getEffectiveTotalStake()).to.equal(
+        STAKE_AMOUNT,
+      );
+    });
+
+    it('Should store correct position data', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      const pos = await ConvStaking.getPosition(0);
+      expect(pos.principal).to.equal(STAKE_AMOUNT);
+      expect(pos.lockTier).to.equal(0);
+      expect(pos.nodeId).to.equal(identityId);
+      expect(pos.claimableRewards).to.equal(0);
+      expect(pos.withdrawalAmount).to.equal(0);
+    });
+
+    it('Should emit Staked event', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+
+      await expect(ConvStaking.stake(identityId, STAKE_AMOUNT, 0))
+        .to.emit(ConvStaking, 'Staked')
+        .withArgs(0, accounts[0].address, identityId, STAKE_AMOUNT, 0);
+    });
+
+    it('Should mint sequential NFT IDs for multiple stakes', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseUnits('10000', 18);
+      await Token.approve(await ConvStaking.getAddress(), amount * 3n);
+
+      await ConvStaking.stake(identityId, amount, 0);
+      await ConvStaking.stake(identityId, amount, 0);
+      await ConvStaking.stake(identityId, amount, 0);
+
+      expect(await ConvStaking.totalSupply()).to.equal(3);
+      expect(await ConvStaking.ownerOf(0)).to.equal(accounts[0].address);
+      expect(await ConvStaking.ownerOf(1)).to.equal(accounts[0].address);
+      expect(await ConvStaking.ownerOf(2)).to.equal(accounts[0].address);
+    });
+
+    it('Should accumulate effectiveNodeStake for multiple positions on same node', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseUnits('10000', 18);
+      await Token.approve(await ConvStaking.getAddress(), amount * 3n);
+
+      await ConvStaking.stake(identityId, amount, 0);
+      await ConvStaking.stake(identityId, amount, 0);
+      await ConvStaking.stake(identityId, amount, 0);
+
+      expect(
+        await ConvStakeStorage.getEffectiveNodeStake(identityId),
+      ).to.equal(amount * 3n);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // RandomSampling scoring integration
+  // -------------------------------------------------------------------------
+  describe('RandomSampling scoring integration', () => {
+    it('Should use effectiveNodeStake for calculateNodeScore', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      // calculateNodeScore should return a non-zero value since node is staked
+      const score = await RandSampling.calculateNodeScore(identityId);
+      expect(score).to.be.gt(0);
+    });
+
+    it('Should return 0 score for unstaked node', async () => {
+      const { identityId } = await createProfile();
+
+      // Node has no stake and no effectiveNodeStake → score should be 0
+      const score = await RandSampling.calculateNodeScore(identityId);
+      expect(score).to.equal(0);
+    });
+
+    it('Should produce same score via effectiveNodeStake as raw stake would for tier 0', async () => {
+      // With tier 0, effectiveNodeStake == raw nodeStake
+      // Score should be consistent: sqrt(stake/cap) * baseline
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      const score = await RandSampling.calculateNodeScore(identityId);
+
+      // Manual calculation: S(t) = sqrt(50K/2M) * 0.002 = sqrt(0.025) * 0.002
+      // sqrt(0.025) ≈ 0.158, * 0.002 ≈ 0.000316
+      // Exact: stakeCap = 2M (default), stakeRatio18 = (50K * 1e18) / 2M = 25e15
+      // stakeFactor18 = sqrt(25e15 * 1e18) = sqrt(25e33) = 5e16 = 158113883...
+      // baselineComponent18 = 2e15
+      // innerScore18 = 2e15 (no publishing/ask)
+      // finalScore18 = stakeFactor18 * 2e15 / 1e18
+      expect(score).to.be.gt(0);
+    });
+  });
+});

--- a/packages/evm-module/test/unit/ConvictionStaking.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStaking.test.ts
@@ -493,8 +493,7 @@ describe('ConvictionStaking - Tracer Bullet', function () {
       expect(scoreAtBoosted).to.be.gt(scoreAtBase);
     });
 
-    it('Should use effectiveNodeStake (not raw) as scorePerStake divisor', async () => {
-      // Stake via ConvictionStaking: raw = 50K, effective = 50K
+    it('Should track exact sqrt ratio when effective stake changes in calculateNodeScore', async () => {
       const { identityId } = await createProfile();
       await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
       await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
@@ -506,19 +505,16 @@ describe('ConvictionStaking - Tracer Bullet', function () {
         doubledEffective,
       );
 
-      // Verify the calculateNodeScore uses the boosted value
       const scoreAtDoubled =
         await RandSampling.calculateNodeScore(identityId);
 
-      // Now set effective back to base
+      // Set effective back to base
       await ConvStakeStorage.setEffectiveNodeStake(
         identityId,
         STAKE_AMOUNT,
       );
       const scoreAtBase = await RandSampling.calculateNodeScore(identityId);
 
-      // scoreAtDoubled > scoreAtBase proves effective is used for scoring
-      // (sqrt(100K/2M) > sqrt(50K/2M))
       expect(scoreAtDoubled).to.be.gt(scoreAtBase);
 
       // The ratio should be sqrt(2) ≈ 1.414 (within 1% tolerance)

--- a/packages/evm-module/test/unit/ConvictionStaking.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStaking.test.ts
@@ -357,6 +357,10 @@ describe('ConvictionStaking - Tracer Bullet', function () {
       expect(pos.withdrawalAmount).to.equal(0);
     });
 
+    it('Should revert getPosition for nonexistent token', async () => {
+      await expect(ConvStaking.getPosition(999)).to.be.reverted;
+    });
+
     it('Should emit Staked event', async () => {
       const { identityId } = await createProfile();
       await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);

--- a/packages/evm-module/test/unit/ConvictionStaking.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStaking.test.ts
@@ -19,6 +19,7 @@ import {
   RandomSamplingStorage,
   RandomSampling,
   EpochStorage,
+  DelegatorsInfo,
   ConvictionStaking,
   ConvictionStakeStorage,
 } from '../../typechain';
@@ -40,6 +41,7 @@ type Fixture = {
   RandomSamplingStorage: RandomSamplingStorage;
   RandomSampling: RandomSampling;
   EpochStorage: EpochStorage;
+  DelegatorsInfo: DelegatorsInfo;
 };
 
 async function deployFixture(): Promise<Fixture> {
@@ -51,6 +53,7 @@ async function deployFixture(): Promise<Fixture> {
     'EpochStorage',
     'Chronos',
     'RandomSamplingStorage',
+    'DelegatorsInfo',
   ]);
 
   const accounts = await hre.ethers.getSigners();
@@ -83,6 +86,8 @@ async function deployFixture(): Promise<Fixture> {
     await hre.ethers.getContract<RandomSampling>('RandomSampling');
   const EpochStorage =
     await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
+  const DelegatorsInfo =
+    await hre.ethers.getContract<DelegatorsInfo>('DelegatorsInfo');
 
   await Hub.setContractAddress('HubOwner', accounts[0].address);
 
@@ -103,6 +108,7 @@ async function deployFixture(): Promise<Fixture> {
     RandomSamplingStorage,
     RandomSampling,
     EpochStorage,
+    DelegatorsInfo,
   };
 }
 
@@ -114,10 +120,12 @@ describe('ConvictionStaking - Tracer Bullet', function () {
   let ConvStakeStorage: ConvictionStakeStorage;
   let StkStorage: StakingStorage;
   let ParametersStor: ParametersStorage;
+  let ShardingTableStor: ShardingTableStorage;
   let Hub_: Hub;
   let Chronos_: Chronos;
   let RandSampling: RandomSampling;
   let RandSamplingStorage: RandomSamplingStorage;
+  let DelInfo: DelegatorsInfo;
 
   const STAKE_AMOUNT = hre.ethers.parseUnits('50000', 18); // 50K TRAC
 
@@ -150,10 +158,12 @@ describe('ConvictionStaking - Tracer Bullet', function () {
       ConvictionStakeStorage: ConvStakeStorage,
       StakingStorage: StkStorage,
       ParametersStorage: ParametersStor,
+      ShardingTableStorage: ShardingTableStor,
       Hub: Hub_,
       Chronos: Chronos_,
       RandomSampling: RandSampling,
       RandomSamplingStorage: RandSamplingStorage,
+      DelegatorsInfo: DelInfo,
     } = await loadFixture(deployFixture));
   });
 
@@ -167,7 +177,6 @@ describe('ConvictionStaking - Tracer Bullet', function () {
     });
 
     it('Should allow hub-registered contracts to set effectiveNodeStake', async () => {
-      // Hub owner can call onlyContracts functions
       await ConvStakeStorage.setEffectiveNodeStake(1, 1000n);
       expect(await ConvStakeStorage.getEffectiveNodeStake(1)).to.equal(1000n);
     });
@@ -213,12 +222,10 @@ describe('ConvictionStaking - Tracer Bullet', function () {
     });
 
     it('Should support ERC-721 interface', async () => {
-      // ERC-721 interface ID: 0x80ac58cd
       expect(await ConvStaking.supportsInterface('0x80ac58cd')).to.equal(true);
     });
 
     it('Should support ERC-721 Enumerable interface', async () => {
-      // ERC-721 Enumerable interface ID: 0x780e9d63
       expect(await ConvStaking.supportsInterface('0x780e9d63')).to.equal(true);
     });
   });
@@ -305,20 +312,17 @@ describe('ConvictionStaking - Tracer Bullet', function () {
     it('Should update ConvictionStakeStorage.effectiveNodeStake (1x for tier 0)', async () => {
       const { identityId } = await createProfile();
       await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
-
       await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
 
       const effectiveStake = await ConvStakeStorage.getEffectiveNodeStake(
         identityId,
       );
-      // Tier 0 = 1x multiplier, so effective == raw
       expect(effectiveStake).to.equal(STAKE_AMOUNT);
     });
 
     it('Should update ConvictionStakeStorage.effectiveTotalStake', async () => {
       const { identityId } = await createProfile();
       await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
-
       await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
 
       expect(await ConvStakeStorage.getEffectiveTotalStake()).to.equal(
@@ -346,6 +350,57 @@ describe('ConvictionStaking - Tracer Bullet', function () {
       await expect(ConvStaking.stake(identityId, STAKE_AMOUNT, 0))
         .to.emit(ConvStaking, 'Staked')
         .withArgs(0, accounts[0].address, identityId, STAKE_AMOUNT, 0);
+    });
+
+    it('Should write delegator stakeBase to StakingStorage', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      const delegatorKey = hre.ethers.keccak256(
+        hre.ethers.solidityPacked(['address'], [accounts[0].address]),
+      );
+      const stakeBase = await StkStorage.getDelegatorStakeBase(
+        identityId,
+        delegatorKey,
+      );
+      expect(stakeBase).to.equal(STAKE_AMOUNT);
+    });
+
+    it('Should register delegator in DelegatorsInfo', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      expect(
+        await DelInfo.isNodeDelegator(identityId, accounts[0].address),
+      ).to.equal(true);
+      expect(
+        await DelInfo.hasEverDelegatedToNode(identityId, accounts[0].address),
+      ).to.equal(true);
+    });
+
+    it('Should only insert node in sharding table when stake >= minimumStake', async () => {
+      const { identityId } = await createProfile();
+      const minStake = await ParametersStor.minimumStake();
+
+      // Stake below minimum
+      const belowMin = minStake - 1n;
+      await Token.approve(await ConvStaking.getAddress(), belowMin);
+      await ConvStaking.stake(identityId, belowMin, 0);
+
+      // Node should NOT be in sharding table
+      expect(await ShardingTableStor.nodeExists(identityId)).to.equal(false);
+    });
+
+    it('Should insert node in sharding table when stake >= minimumStake', async () => {
+      const { identityId } = await createProfile();
+
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      // Node should be in sharding table (50K > minimumStake)
+      expect(await ShardingTableStor.nodeExists(identityId)).to.equal(true);
     });
 
     it('Should mint sequential NFT IDs for multiple stakes', async () => {
@@ -376,6 +431,23 @@ describe('ConvictionStaking - Tracer Bullet', function () {
         await ConvStakeStorage.getEffectiveNodeStake(identityId),
       ).to.equal(amount * 3n);
     });
+
+    it('Should accumulate delegator stakeBase for multiple stakes on same node', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseUnits('10000', 18);
+      await Token.approve(await ConvStaking.getAddress(), amount * 3n);
+
+      await ConvStaking.stake(identityId, amount, 0);
+      await ConvStaking.stake(identityId, amount, 0);
+      await ConvStaking.stake(identityId, amount, 0);
+
+      const delegatorKey = hre.ethers.keccak256(
+        hre.ethers.solidityPacked(['address'], [accounts[0].address]),
+      );
+      expect(
+        await StkStorage.getDelegatorStakeBase(identityId, delegatorKey),
+      ).to.equal(amount * 3n);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -387,36 +459,14 @@ describe('ConvictionStaking - Tracer Bullet', function () {
       await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
       await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
 
-      // calculateNodeScore should return a non-zero value since node is staked
       const score = await RandSampling.calculateNodeScore(identityId);
       expect(score).to.be.gt(0);
     });
 
     it('Should return 0 score for unstaked node', async () => {
       const { identityId } = await createProfile();
-
-      // Node has no stake and no effectiveNodeStake → score should be 0
       const score = await RandSampling.calculateNodeScore(identityId);
       expect(score).to.equal(0);
-    });
-
-    it('Should produce same score via effectiveNodeStake as raw stake would for tier 0', async () => {
-      // With tier 0, effectiveNodeStake == raw nodeStake
-      // Score should be consistent: sqrt(stake/cap) * baseline
-      const { identityId } = await createProfile();
-      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
-      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
-
-      const score = await RandSampling.calculateNodeScore(identityId);
-
-      // Manual calculation: S(t) = sqrt(50K/2M) * 0.002 = sqrt(0.025) * 0.002
-      // sqrt(0.025) ≈ 0.158, * 0.002 ≈ 0.000316
-      // Exact: stakeCap = 2M (default), stakeRatio18 = (50K * 1e18) / 2M = 25e15
-      // stakeFactor18 = sqrt(25e15 * 1e18) = sqrt(25e33) = 5e16 = 158113883...
-      // baselineComponent18 = 2e15
-      // innerScore18 = 2e15 (no publishing/ask)
-      // finalScore18 = stakeFactor18 * 2e15 / 1e18
-      expect(score).to.be.gt(0);
     });
   });
 });

--- a/packages/evm-module/test/unit/ConvictionStaking.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStaking.test.ts
@@ -228,6 +228,20 @@ describe('ConvictionStaking - Tracer Bullet', function () {
     it('Should support ERC-721 Enumerable interface', async () => {
       expect(await ConvStaking.supportsInterface('0x780e9d63')).to.equal(true);
     });
+
+    it('Should be soulbound (block transfers)', async () => {
+      const { identityId } = await createProfile();
+      await Token.approve(await ConvStaking.getAddress(), STAKE_AMOUNT);
+      await ConvStaking.stake(identityId, STAKE_AMOUNT, 0);
+
+      await expect(
+        ConvStaking.transferFrom(
+          accounts[0].address,
+          accounts[5].address,
+          0,
+        ),
+      ).to.be.revertedWith('ConvictionStaking: position is soulbound');
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **ConvictionStakeStorage.sol** — new storage contract with `effectiveNodeStake` (per-node multiplied stake) and `effectiveTotalStake`, onlyContracts setters/getters
- **ConvictionStaking.sol** — new ERC-721 (Enumerable, soulbound) staking contract with `stake(nodeId, amount, lockTier=0)`. Mints NFT, writes per-delegator stakeBase to StakingStorage, registers in DelegatorsInfo, updates both raw and effective stake, enforces minimumStake/shardingTableSizeLimit for sharding table admission. SafeERC20 + ReentrancyGuard.
- **RandomSampling.sol** — `calculateNodeScore()` and `submitProof()` scorePerStake divisor now use `max(effectiveNodeStake, rawNodeStake)` for conviction-weighted scoring with backward compatibility during transition

## Known limitations (deferred to subtask 5)

1. **`max(effective, raw)` instead of `effective` directly** — Staking.sol is at the 24KB EVM contract size limit and cannot be modified to sync ConvictionStakeStorage on reward restake. `max()` is correct for tier 0 (raw catches restakes) and for future higher tiers (effective > raw due to multiplier). Will be resolved when ConvictionStaking gets its own claim function and becomes the sole entry point.

2. **Legacy Staking mutation paths not blocked** — A delegator who stakes via ConvictionStaking can still call `Staking.requestWithdrawal`/`redelegate` on the same address-keyed stakeBase. This would reduce raw stake while effective stays stale, causing `max()` to return the higher (stale) effective value and over-score the node. Resolved when old Staking is deprecated from Hub after migration.

## Test plan

- [x] 34 unit tests: storage CRUD + ACL, ERC-721 metadata + soulbound transfer block, stake validation, NFT minting, TRAC transfer, raw + effective stake updates, delegator registration, sharding table admission with minimumStake enforcement, scoring divergence proofs (sqrt(2) ratio), getPosition revert for nonexistent tokens
- [x] 2 integration tests: full e2e stake→proof→score→claim→reward, and submitProof scorePerStake divisor verification with exact arithmetic against divergent effective/raw stake
- [x] 687 total tests passing, 0 regressions


🤖 Generated with [Claude Code](https://claude.com/claude-code)