### PR TITLE
fix: add major-version guard to auto-update — block V9→V10 silent upgrades

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2675,6 +2675,23 @@ function getCurrentCliVersion(): string {
   } catch { return ''; }
 }
 
+export function parseMajorVersion(version: string): number | null {
+  const m = version.match(/^(\d+)\./);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/**
+ * Refuse to auto-update across major versions. A major version bump
+ * (e.g. 9.x → 10.x) indicates breaking protocol changes that require
+ * manual operator intervention — not a silent background update.
+ */
+export function isMajorVersionBump(currentVersion: string, targetVersion: string): boolean {
+  const currentMajor = parseMajorVersion(currentVersion);
+  const targetMajor = parseMajorVersion(targetVersion);
+  if (currentMajor === null || targetMajor === null) return false;
+  return targetMajor !== currentMajor;
+}
+
 export type NpmVersionStatus = {
   status: 'available' | 'up-to-date' | 'error';
   version?: string;
@@ -2702,6 +2719,14 @@ export async function checkForNpmVersionUpdate(
 
   if (result.version === currentVersion) return { status: 'up-to-date' };
   if (compareSemver(result.version, currentVersion) <= 0) return { status: 'up-to-date' };
+
+  if (isMajorVersionBump(currentVersion, result.version)) {
+    log(
+      `Auto-update (npm): major version change detected (${currentVersion} → ${result.version}). ` +
+      `Major upgrades require manual intervention. Skipping.`,
+    );
+    return { status: 'up-to-date' };
+  }
 
   return { status: 'available', version: result.version };
 }
@@ -3095,6 +3120,27 @@ async function _performUpdateInner(
   } catch (fetchErr: any) {
     log(`Auto-update: git fetch/checkout/verify failed in slot ${target} — ${fetchErr.message}`);
     return 'failed';
+  }
+
+  // Major-version guard: refuse to auto-update across major versions.
+  const currentMajorVersion = getCurrentCliVersion();
+  try {
+    const fetchedPkgRaw = await readFile(join(targetDir, 'packages', 'cli', 'package.json'), 'utf-8');
+    const fetchedPkg = JSON.parse(fetchedPkgRaw) as { version?: string };
+    const fetchedVersion = String(fetchedPkg.version ?? '').trim();
+    if (currentMajorVersion && fetchedVersion && isMajorVersionBump(currentMajorVersion, fetchedVersion)) {
+      log(
+        `Auto-update: BLOCKED — major version change detected (${currentMajorVersion} → ${fetchedVersion}). ` +
+        `Major upgrades (e.g. V9 → V10) require manual operator intervention. ` +
+        `See https://docs.origintrail.io/upgrade for instructions.`,
+      );
+      return 'failed';
+    }
+    if (fetchedVersion) {
+      log(`Auto-update: version check passed (${currentMajorVersion || 'unknown'} → ${fetchedVersion}).`);
+    }
+  } catch {
+    log('Auto-update: could not read version from fetched code; proceeding with caution.');
   }
 
   try {

--- a/packages/cli/test/version-guard.test.ts
+++ b/packages/cli/test/version-guard.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { parseMajorVersion, isMajorVersionBump } from '../src/daemon.js';
+
+describe('parseMajorVersion', () => {
+  it('extracts major from stable version', () => {
+    expect(parseMajorVersion('9.0.0')).toBe(9);
+    expect(parseMajorVersion('10.0.0')).toBe(10);
+    expect(parseMajorVersion('1.2.3')).toBe(1);
+  });
+
+  it('extracts major from prerelease version', () => {
+    expect(parseMajorVersion('9.0.0-beta.6')).toBe(9);
+    expect(parseMajorVersion('10.0.0-rc.1')).toBe(10);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseMajorVersion('')).toBeNull();
+    expect(parseMajorVersion('abc')).toBeNull();
+    expect(parseMajorVersion('latest')).toBeNull();
+  });
+});
+
+describe('isMajorVersionBump', () => {
+  it('detects major version upgrade', () => {
+    expect(isMajorVersionBump('9.0.0-beta.6', '10.0.0')).toBe(true);
+    expect(isMajorVersionBump('9.1.2', '10.0.0-rc.1')).toBe(true);
+  });
+
+  it('detects major version downgrade', () => {
+    expect(isMajorVersionBump('10.0.0', '9.0.0')).toBe(true);
+  });
+
+  it('allows minor/patch updates within same major', () => {
+    expect(isMajorVersionBump('9.0.0', '9.0.1')).toBe(false);
+    expect(isMajorVersionBump('9.0.0', '9.1.0')).toBe(false);
+    expect(isMajorVersionBump('9.0.0-beta.5', '9.0.0-beta.6')).toBe(false);
+  });
+
+  it('allows same version', () => {
+    expect(isMajorVersionBump('9.0.0', '9.0.0')).toBe(false);
+  });
+
+  it('returns false when versions are unparseable', () => {
+    expect(isMajorVersionBump('', '10.0.0')).toBe(false);
+    expect(isMajorVersionBump('9.0.0', '')).toBe(false);
+    expect(isMajorVersionBump('abc', '10.0.0')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a safety guard to both auto-update paths (Git-based and NPM-based) that **blocks automatic updates across major versions**. This prevents V9 testnet nodes from silently upgrading to V10 code, which would be a breaking change (new protocol IDs, renamed graph URIs, changed genesis hash).

### What it does

**Git-based auto-update:**
After fetching and checking out the target commit, the guard reads `packages/cli/package.json` from the fetched code and compares its major version against the running node. If the major version differs (e.g. `9.x` → `10.x`), the update is blocked with a clear log message and the active slot remains untouched.

**NPM-based auto-update:**
Before marking an update as `available`, the guard compares the major version of the latest registry tag against the current running version. Major version bumps are treated as `up-to-date` (skipped) with a log explaining the skip.

### Log output when blocked

```
Auto-update: BLOCKED — major version change detected (9.0.0-beta.6 → 10.0.0).
Major upgrades (e.g. V9 → V10) require manual operator intervention.
See https://docs.origintrail.io/upgrade for instructions.
```

### Why this matters

The current auto-update mechanism has **no version awareness** — it simply compares commit SHAs (Git) or semver ordering (NPM) and applies any newer code. This is dangerous for major version boundaries where protocol-level breaking changes require coordinated network upgrades, not silent background updates.

## Test plan

- [x] Unit tests for `parseMajorVersion` and `isMajorVersionBump` (8 tests)
- [x] Build passes
- [ ] Verify on a test node that V9→V10 update is blocked
- [ ] Verify that V9 patch updates (9.0.0-beta.6 → 9.0.0-beta.7) still work


Made with [Cursor](https://cursor.com)