### PR TITLE
Update testnet relays and auto-update branch for V10-rc

### DIFF
--- a/network/testnet.json
+++ b/network/testnet.json
@@ -1,19 +1,17 @@
 {
-  "networkName": "DKG V9 Testnet",
+  "networkName": "DKG V10 Testnet",
   "networkId": "f81f9df2e9604fcaa0aaeb34d07171434199d2bc70d9f35680614453300d9b9d",
   "genesisVersion": 1,
   "relays": [
-    "/ip4/167.71.33.105/tcp/9090/p2p/12D3KooWEpSGSVRZx3DqBijai85PLitzWjMzyFVMP4qeqSBUinxj",
-    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
-    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
-    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge"
+    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
+    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
   ],
   "defaultParanets": ["testing", "origin-trail-game"],
   "defaultNodeRole": "edge",
   "autoUpdate": {
     "enabled": true,
     "repo": "OriginTrail/dkg-v9",
-    "branch": "main",
+    "branch": "v10-rc",
     "checkIntervalMinutes": 5
   },
   "chain": {


### PR DESCRIPTION
## Summary

- Replace V9 relay addresses with V10 relays in `network/testnet.json`
- Set `autoUpdate.branch` to `v10-rc`
- Rename network to "DKG V10 Testnet"

### V10 Relays
| Relay | Beacon | IP | Peer ID |
|---|---|---|---|
| relay-03 | beacon-03 | 178.156.252.147 | `12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge` |
| relay-04 | beacon-04 | 49.12.4.64 | `12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ` |

V9 relays (relay-01, relay-02) remain on `main` branch. V10 relays are isolated to prevent protocol mismatch (confirmed: V10 sync protocol incompatible with V9 peers).

Once merged, V10 nodes will auto-update and connect to V10 relays only.