### PR TITLE
Reorg V9 relays 

### DIFF
--- a/network/testnet.json
+++ b/network/testnet.json
@@ -3,10 +3,8 @@
   "networkId": "6f63f485c6cce67e677f7844ec835024c6d97f13fe8cacaf0ceedfd3ad658510",
   "genesisVersion": 1,
   "relays": [
-    "/ip4/167.71.33.105/tcp/9090/p2p/12D3KooWEpSGSVRZx3DqBijai85PLitzWjMzyFVMP4qeqSBUinxj",
     "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
-    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
-    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge"
+    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw"
   ],
   "defaultParanets": ["testing", "origin-trail-game"],
   "defaultNodeRole": "edge",


### PR DESCRIPTION
- Remove relay-03 (beacon-03) from the V9 testnet relay list — it has been migrated to v10-rc. 
- Clean up a stale relay entry that no longer exists

Outcome: V9 testnet now runs 2 active relays: beacon-01 and beacon-02.