### PR TITLE
V10 private sync auth

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -118,6 +118,8 @@ export interface ContextGraphSub {
   synced: boolean;
   /** On-chain context graph ID (keccak256 hash), if known. */
   onChainId?: string;
+  /** Local participant identities used for private SWM authorization before anchoring. */
+  participantIdentityIds?: bigint[];
 }
 
 /** @deprecated Use ContextGraphSub */
@@ -1620,6 +1622,12 @@ export class DKGAgent {
     const ctx = opts.operationCtx ?? createOperationContext('query');
     const viewLabel = opts.view ? ` view=${opts.view}` : '';
     this.log.info(ctx, `Query on contextGraph="${opts.contextGraphId ?? 'all'}"${viewLabel} sparql="${sparql.slice(0, 80)}"`);
+
+    if (opts.contextGraphId && !(await this.canReadContextGraph(opts.contextGraphId))) {
+      this.log.info(ctx, `Query denied for private context graph "${opts.contextGraphId}"`);
+      return { bindings: [] };
+    }
+
     const result = await this.queryEngine.query(sparql, {
       paranetId: opts.contextGraphId,
       graphSuffix: opts.graphSuffix,
@@ -1630,6 +1638,24 @@ export class DKGAgent {
     });
     this.log.info(ctx, `Query returned ${result.bindings?.length ?? 0} bindings`);
     return result;
+  }
+
+  private async canReadContextGraph(contextGraphId: string): Promise<boolean> {
+    if (!(await this.isPrivateContextGraph(contextGraphId))) {
+      return true;
+    }
+
+    const participants = await this.getPrivateContextGraphParticipants(contextGraphId);
+    if (!participants || participants.length === 0) {
+      return false;
+    }
+
+    const identityId = await this.chain.getIdentityId();
+    if (identityId === 0n) {
+      return false;
+    }
+
+    return participants.some((id) => id === identityId);
   }
 
   /**
@@ -1842,6 +1868,7 @@ export class DKGAgent {
     replicationPolicy?: string;
     accessPolicy?: number;
     revealOnChain?: boolean;
+    participantIdentityIds?: bigint[];
     /** When true, skips on-chain registration, gossip subscription, and broadcast. Data stays local-only. */
     private?: boolean;
   }): Promise<void> {
@@ -1892,6 +1919,19 @@ export class DKGAgent {
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: `"${opts.private ? 'private' : 'public'}"`, graph: ontologyGraph },
     ];
 
+    const creatorIdentityId = await this.chain.getIdentityId();
+    const participantIdentityIds = new Set<bigint>(opts.participantIdentityIds ?? []);
+    if (creatorIdentityId > 0n) {
+      participantIdentityIds.add(creatorIdentityId);
+    }
+    for (const participantIdentityId of participantIdentityIds) {
+      quads.push({
+        subject: paranetUri,
+        predicate: DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID,
+        object: `"${participantIdentityId.toString()}"`,
+        graph: ontologyGraph,
+      });
+    }
     if (onChainId) {
       quads.push({
         subject: paranetUri,
@@ -1930,6 +1970,7 @@ export class DKGAgent {
       subscribed: !opts.private,
       synced: true,
       onChainId: onChainId,
+      participantIdentityIds: participantIdentityIds.size > 0 ? [...participantIdentityIds] : undefined,
     });
 
     if (!opts.private) {
@@ -2990,11 +3031,6 @@ export class DKGAgent {
       return false;
     }
 
-    const onChainId = this.subscribedContextGraphs.get(request.contextGraphId)?.onChainId;
-    if (!onChainId || typeof this.chain.getContextGraphParticipants !== 'function') {
-      return false;
-    }
-
     const digest = this.computeSyncDigest(
       request.contextGraphId,
       request.offset,
@@ -3021,7 +3057,7 @@ export class DKGAgent {
       return false;
     }
 
-    const participants = await this.chain.getContextGraphParticipants(BigInt(onChainId));
+    const participants = await this.getPrivateContextGraphParticipants(request.contextGraphId);
     const allowed = participants?.some((id) => id === requesterIdentityId) ?? false;
     if (allowed) {
       this.seenPrivateSyncRequestIds.set(request.requestId, now);
@@ -3050,6 +3086,37 @@ export class DKGAgent {
     );
 
     return result.type === 'bindings' && result.bindings[0]?.['policy'] === '"private"';
+  }
+
+  private async getPrivateContextGraphParticipants(contextGraphId: string): Promise<bigint[] | null> {
+    const localParticipants = this.subscribedContextGraphs.get(contextGraphId)?.participantIdentityIds;
+    if (localParticipants && localParticipants.length > 0) {
+      return localParticipants;
+    }
+
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const contextGraphUri = paranetDataGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?identityId WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
+        }
+      }`,
+    );
+
+    if (result.type === 'bindings' && result.bindings.length > 0) {
+      return result.bindings
+        .map((row) => row['identityId'])
+        .filter((value): value is string => typeof value === 'string')
+        .map((value) => BigInt(value.replace(/^"|"$/g, '')));
+    }
+
+    const onChainId = this.subscribedContextGraphs.get(contextGraphId)?.onChainId;
+    if (!onChainId || typeof this.chain.getContextGraphParticipants !== 'function') {
+      return null;
+    }
+
+    return this.chain.getContextGraphParticipants(BigInt(onChainId));
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -85,6 +85,16 @@ const SYNC_ROUTER_ATTEMPTS = 3;
 const DEFAULT_SWM_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const SWM_CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // run cleanup every 15 minutes
 
+interface SyncRequestEnvelope {
+  contextGraphId: string;
+  offset: number;
+  limit: number;
+  includeSharedMemory: boolean;
+  requesterIdentityId?: string;
+  requesterSignatureR?: string;
+  requesterSignatureVS?: string;
+}
+
 /** Health status of a peer from the last ping round. */
 export interface PeerHealth {
   peerId: string;
@@ -519,16 +529,14 @@ export class DKGAgent {
     // Response includes both the data graph and the meta graph so the
     // receiver can verify merkle roots before inserting.
     this.router.register(PROTOCOL_SYNC, async (data) => {
-      const text = new TextDecoder().decode(data).trim();
-      const [ctxGraphPart, offsetStr, limitStr] = text.split('|');
-      const offset = parseInt(offsetStr, 10) || 0;
-      const limit = Math.min(parseInt(limitStr, 10) || SYNC_PAGE_SIZE, SYNC_PAGE_SIZE);
-
-      const isWorkspace = ctxGraphPart.startsWith('workspace:');
-      const contextGraphId = isWorkspace ? ctxGraphPart.slice('workspace:'.length) : (ctxGraphPart || SYSTEM_PARANETS.AGENTS);
+      const request = this.parseSyncRequest(data);
+      const offset = request.offset;
+      const limit = request.limit;
+      const isWorkspace = request.includeSharedMemory;
+      const contextGraphId = request.contextGraphId;
       const nquads: string[] = [];
 
-      if (await this.isPrivateContextGraph(contextGraphId)) {
+      if (!(await this.authorizeSyncRequest(request))) {
         return new TextEncoder().encode('');
       }
 
@@ -759,6 +767,7 @@ export class DKGAgent {
           }
 
           const payload = new TextEncoder().encode(`${pid}|${offset}|${SYNC_PAGE_SIZE}`);
+          const requestBytes = await this.buildSyncRequest(pid, offset, SYNC_PAGE_SIZE, false);
 
           // Cap per-call timeout so ProtocolRouter.send (3 internal retries) stays within deadline
           const remainingMs = Math.max(0, deadline - Date.now());
@@ -768,7 +777,7 @@ export class DKGAgent {
           );
 
           const responseBytes = await withRetry(
-            () => this.router.send(remotePeerId, PROTOCOL_SYNC, payload, timeoutMs),
+            () => this.router.send(remotePeerId, PROTOCOL_SYNC, requestBytes, timeoutMs),
             {
               maxAttempts: SYNC_PAGE_RETRY_ATTEMPTS,
               baseDelayMs: 1000,
@@ -855,7 +864,7 @@ export class DKGAgent {
             break;
           }
 
-          const payload = new TextEncoder().encode(`workspace:${pid}|${offset}|${SYNC_PAGE_SIZE}`);
+          const requestBytes = await this.buildSyncRequest(pid, offset, SYNC_PAGE_SIZE, true);
 
           const remainingMs = Math.max(0, deadline - Date.now());
           const timeoutMs = Math.min(
@@ -864,7 +873,7 @@ export class DKGAgent {
           );
 
           const responseBytes = await withRetry(
-            () => this.router.send(remotePeerId, PROTOCOL_SYNC, payload, timeoutMs),
+            () => this.router.send(remotePeerId, PROTOCOL_SYNC, requestBytes, timeoutMs),
             {
               maxAttempts: SYNC_PAGE_RETRY_ATTEMPTS,
               baseDelayMs: 1000,
@@ -2842,6 +2851,120 @@ export class DKGAgent {
       } LIMIT 1`,
     );
     return result.type === 'bindings' && result.bindings.length > 0;
+  }
+
+  private parseSyncRequest(data: Uint8Array): SyncRequestEnvelope {
+    const text = new TextDecoder().decode(data).trim();
+    if (text.startsWith('{')) {
+      const parsed = JSON.parse(text) as SyncRequestEnvelope;
+      return {
+        contextGraphId: parsed.contextGraphId,
+        offset: parsed.offset ?? 0,
+        limit: Math.min(parsed.limit ?? SYNC_PAGE_SIZE, SYNC_PAGE_SIZE),
+        includeSharedMemory: parsed.includeSharedMemory ?? false,
+        requesterIdentityId: parsed.requesterIdentityId,
+        requesterSignatureR: parsed.requesterSignatureR,
+        requesterSignatureVS: parsed.requesterSignatureVS,
+      };
+    }
+
+    const [ctxGraphPart, offsetStr, limitStr] = text.split('|');
+    const includeSharedMemory = ctxGraphPart.startsWith('workspace:');
+    const contextGraphId = includeSharedMemory ? ctxGraphPart.slice('workspace:'.length) : (ctxGraphPart || SYSTEM_PARANETS.AGENTS);
+    return {
+      contextGraphId,
+      offset: parseInt(offsetStr, 10) || 0,
+      limit: Math.min(parseInt(limitStr, 10) || SYNC_PAGE_SIZE, SYNC_PAGE_SIZE),
+      includeSharedMemory,
+    };
+  }
+
+  private async buildSyncRequest(
+    contextGraphId: string,
+    offset: number,
+    limit: number,
+    includeSharedMemory: boolean,
+  ): Promise<Uint8Array> {
+    const request: SyncRequestEnvelope = {
+      contextGraphId,
+      offset,
+      limit,
+      includeSharedMemory,
+    };
+
+    if (await this.isPrivateContextGraph(contextGraphId)) {
+      const identityId = await this.chain.getIdentityId();
+      if (identityId > 0n && typeof this.chain.signMessage === 'function') {
+        const digest = this.computeSyncDigest(contextGraphId, offset, limit, includeSharedMemory);
+        const signature = await this.chain.signMessage(digest);
+        request.requesterIdentityId = identityId.toString();
+        request.requesterSignatureR = ethers.hexlify(signature.r);
+        request.requesterSignatureVS = ethers.hexlify(signature.vs);
+      }
+    }
+
+    return new TextEncoder().encode(JSON.stringify(request));
+  }
+
+  private computeSyncDigest(
+    contextGraphId: string,
+    offset: number,
+    limit: number,
+    includeSharedMemory: boolean,
+  ): Uint8Array {
+    return ethers.getBytes(
+      ethers.solidityPackedKeccak256(
+        ['string', 'uint256', 'uint256', 'bool'],
+        [contextGraphId, BigInt(offset), BigInt(limit), includeSharedMemory],
+      ),
+    );
+  }
+
+  private async authorizeSyncRequest(request: SyncRequestEnvelope): Promise<boolean> {
+    const isPrivate = await this.isPrivateContextGraph(request.contextGraphId);
+    if (!isPrivate) {
+      return true;
+    }
+
+    const requesterIdentityId = request.requesterIdentityId ? BigInt(request.requesterIdentityId) : 0n;
+    if (
+      requesterIdentityId === 0n ||
+      !request.requesterSignatureR ||
+      !request.requesterSignatureVS ||
+      typeof this.chain.verifyACKIdentity !== 'function'
+    ) {
+      return false;
+    }
+
+    const onChainId = this.subscribedContextGraphs.get(request.contextGraphId)?.onChainId;
+    if (!onChainId || typeof this.chain.getContextGraphParticipants !== 'function') {
+      return false;
+    }
+
+    const digest = this.computeSyncDigest(
+      request.contextGraphId,
+      request.offset,
+      request.limit,
+      request.includeSharedMemory,
+    );
+
+    let recoveredAddress: string;
+    try {
+      recoveredAddress = ethers.recoverAddress(ethers.hashMessage(digest), {
+        r: request.requesterSignatureR,
+        yParityAndS: request.requesterSignatureVS,
+      });
+    } catch {
+      return false;
+    }
+
+    const validIdentity = await this.chain.verifyACKIdentity(recoveredAddress, requesterIdentityId);
+    if (!validIdentity) {
+      return false;
+    }
+
+    const participants = await this.chain.getContextGraphParticipants(BigInt(onChainId));
+    return participants?.some((id) => id === requesterIdentityId) ?? false;
   }
 
   private async isPrivateContextGraph(contextGraphId: string): Promise<boolean> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -528,6 +528,10 @@ export class DKGAgent {
       const contextGraphId = isWorkspace ? ctxGraphPart.slice('workspace:'.length) : (ctxGraphPart || SYSTEM_PARANETS.AGENTS);
       const nquads: string[] = [];
 
+      if (await this.isPrivateContextGraph(contextGraphId)) {
+        return new TextEncoder().encode('');
+      }
+
       if (isWorkspace) {
         const wsGraph = paranetWorkspaceGraphUri(contextGraphId);
         const wsMetaGraph = paranetWorkspaceMetaGraphUri(contextGraphId);
@@ -1870,6 +1874,7 @@ export class DKGAgent {
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATED_AT, object: `"${now}"`, graph: ontologyGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_GOSSIP_TOPIC, object: `"${paranetPublishTopic(opts.id)}"`, graph: ontologyGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REPLICATION_POLICY, object: `"${opts.replicationPolicy ?? 'full'}"`, graph: ontologyGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: `"${opts.private ? 'private' : 'public'}"`, graph: ontologyGraph },
     ];
 
     if (onChainId) {
@@ -2837,6 +2842,29 @@ export class DKGAgent {
       } LIMIT 1`,
     );
     return result.type === 'bindings' && result.bindings.length > 0;
+  }
+
+  private async isPrivateContextGraph(contextGraphId: string): Promise<boolean> {
+    if ((Object.values(SYSTEM_PARANETS) as string[]).includes(contextGraphId)) {
+      return false;
+    }
+
+    const local = this.subscribedContextGraphs.get(contextGraphId);
+    if (local?.subscribed === false && local?.synced) {
+      return true;
+    }
+
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const contextGraphUri = paranetDataGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?policy WHERE {
+        GRAPH <${ontologyGraph}> {
+          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+        }
+      } LIMIT 1`,
+    );
+
+    return result.type === 'bindings' && result.bindings[0]?.['policy'] === '"private"';
   }
 
   /**

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -82,6 +82,7 @@ const SYNC_TOTAL_TIMEOUT_MS = 120_000;
 const SYNC_PAGE_TIMEOUT_MS = 30_000;
 /** ProtocolRouter.send retries internally 3 times with the same timeout; cap so 3× fits in remaining budget. */
 const SYNC_ROUTER_ATTEMPTS = 3;
+const SYNC_AUTH_MAX_AGE_MS = 30_000;
 const DEFAULT_SWM_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const SWM_CLEANUP_INTERVAL_MS = 15 * 60 * 1000; // run cleanup every 15 minutes
 
@@ -90,6 +91,10 @@ interface SyncRequestEnvelope {
   offset: number;
   limit: number;
   includeSharedMemory: boolean;
+  targetPeerId?: string;
+  requesterPeerId?: string;
+  requestId?: string;
+  issuedAtMs?: number;
   requesterIdentityId?: string;
   requesterSignatureR?: string;
   requesterSignatureVS?: string;
@@ -209,6 +214,7 @@ export class DKGAgent {
   private readonly peerHealth = new Map<string, PeerHealth>();
   private readonly knownCorePeerIds = new Set<string>();
   private readonly syncingPeers = new Set<string>();
+  private readonly seenPrivateSyncRequestIds = new Map<string, number>();
 
   private constructor(
     config: DKGAgentConfig,
@@ -528,7 +534,7 @@ export class DKGAgent {
     //   or: "workspace:contextGraphId|offset|limit" for shared memory graph sync
     // Response includes both the data graph and the meta graph so the
     // receiver can verify merkle roots before inserting.
-    this.router.register(PROTOCOL_SYNC, async (data) => {
+    this.router.register(PROTOCOL_SYNC, async (data, peerId) => {
       const request = this.parseSyncRequest(data);
       const offset = request.offset;
       const limit = request.limit;
@@ -536,7 +542,7 @@ export class DKGAgent {
       const contextGraphId = request.contextGraphId;
       const nquads: string[] = [];
 
-      if (!(await this.authorizeSyncRequest(request))) {
+      if (!(await this.authorizeSyncRequest(request, peerId.toString()))) {
         return new TextEncoder().encode('');
       }
 
@@ -767,7 +773,7 @@ export class DKGAgent {
           }
 
           const payload = new TextEncoder().encode(`${pid}|${offset}|${SYNC_PAGE_SIZE}`);
-          const requestBytes = await this.buildSyncRequest(pid, offset, SYNC_PAGE_SIZE, false);
+          const requestBytes = await this.buildSyncRequest(pid, offset, SYNC_PAGE_SIZE, false, remotePeerId);
 
           // Cap per-call timeout so ProtocolRouter.send (3 internal retries) stays within deadline
           const remainingMs = Math.max(0, deadline - Date.now());
@@ -864,7 +870,7 @@ export class DKGAgent {
             break;
           }
 
-          const requestBytes = await this.buildSyncRequest(pid, offset, SYNC_PAGE_SIZE, true);
+          const requestBytes = await this.buildSyncRequest(pid, offset, SYNC_PAGE_SIZE, true, remotePeerId);
 
           const remainingMs = Math.max(0, deadline - Date.now());
           const timeoutMs = Math.min(
@@ -2862,6 +2868,10 @@ export class DKGAgent {
         offset: parsed.offset ?? 0,
         limit: Math.min(parsed.limit ?? SYNC_PAGE_SIZE, SYNC_PAGE_SIZE),
         includeSharedMemory: parsed.includeSharedMemory ?? false,
+        targetPeerId: parsed.targetPeerId,
+        requesterPeerId: parsed.requesterPeerId,
+        requestId: parsed.requestId,
+        issuedAtMs: parsed.issuedAtMs,
         requesterIdentityId: parsed.requesterIdentityId,
         requesterSignatureR: parsed.requesterSignatureR,
         requesterSignatureVS: parsed.requesterSignatureVS,
@@ -2884,6 +2894,7 @@ export class DKGAgent {
     offset: number,
     limit: number,
     includeSharedMemory: boolean,
+    responderPeerId: string,
   ): Promise<Uint8Array> {
     const request: SyncRequestEnvelope = {
       contextGraphId,
@@ -2893,9 +2904,22 @@ export class DKGAgent {
     };
 
     if (await this.isPrivateContextGraph(contextGraphId)) {
+      request.targetPeerId = responderPeerId;
+      request.requesterPeerId = this.peerId;
+      request.requestId = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      request.issuedAtMs = Date.now();
       const identityId = await this.chain.getIdentityId();
       if (identityId > 0n && typeof this.chain.signMessage === 'function') {
-        const digest = this.computeSyncDigest(contextGraphId, offset, limit, includeSharedMemory);
+        const digest = this.computeSyncDigest(
+          contextGraphId,
+          offset,
+          limit,
+          includeSharedMemory,
+          responderPeerId,
+          request.requesterPeerId,
+          request.requestId,
+          request.issuedAtMs,
+        );
         const signature = await this.chain.signMessage(digest);
         request.requesterIdentityId = identityId.toString();
         request.requesterSignatureR = ethers.hexlify(signature.r);
@@ -2911,28 +2935,58 @@ export class DKGAgent {
     offset: number,
     limit: number,
     includeSharedMemory: boolean,
+    targetPeerId: string,
+    requesterPeerId: string | undefined,
+    requestId: string | undefined,
+    issuedAtMs: number | undefined,
   ): Uint8Array {
     return ethers.getBytes(
       ethers.solidityPackedKeccak256(
-        ['string', 'uint256', 'uint256', 'bool'],
-        [contextGraphId, BigInt(offset), BigInt(limit), includeSharedMemory],
+        ['string', 'uint256', 'uint256', 'bool', 'string', 'string', 'string', 'uint256'],
+        [
+          contextGraphId,
+          BigInt(offset),
+          BigInt(limit),
+          includeSharedMemory,
+          targetPeerId,
+          requesterPeerId ?? '',
+          requestId ?? '',
+          BigInt(issuedAtMs ?? 0),
+        ],
       ),
     );
   }
 
-  private async authorizeSyncRequest(request: SyncRequestEnvelope): Promise<boolean> {
+  private async authorizeSyncRequest(request: SyncRequestEnvelope, remotePeerId: string): Promise<boolean> {
     const isPrivate = await this.isPrivateContextGraph(request.contextGraphId);
     if (!isPrivate) {
       return true;
     }
 
+    const now = Date.now();
+    for (const [requestId, seenAt] of this.seenPrivateSyncRequestIds) {
+      if (now - seenAt > SYNC_AUTH_MAX_AGE_MS) {
+        this.seenPrivateSyncRequestIds.delete(requestId);
+      }
+    }
+
     const requesterIdentityId = request.requesterIdentityId ? BigInt(request.requesterIdentityId) : 0n;
     if (
+      request.targetPeerId !== this.peerId ||
+      request.requesterPeerId !== remotePeerId ||
+      !request.requestId ||
+      request.issuedAtMs == null ||
+      now - request.issuedAtMs > SYNC_AUTH_MAX_AGE_MS ||
+      now < request.issuedAtMs - 5000 ||
       requesterIdentityId === 0n ||
       !request.requesterSignatureR ||
       !request.requesterSignatureVS ||
       typeof this.chain.verifyACKIdentity !== 'function'
     ) {
+      return false;
+    }
+
+    if (this.seenPrivateSyncRequestIds.has(request.requestId)) {
       return false;
     }
 
@@ -2946,6 +3000,10 @@ export class DKGAgent {
       request.offset,
       request.limit,
       request.includeSharedMemory,
+      request.targetPeerId,
+      request.requesterPeerId,
+      request.requestId,
+      request.issuedAtMs,
     );
 
     let recoveredAddress: string;
@@ -2964,7 +3022,11 @@ export class DKGAgent {
     }
 
     const participants = await this.chain.getContextGraphParticipants(BigInt(onChainId));
-    return participants?.some((id) => id === requesterIdentityId) ?? false;
+    const allowed = participants?.some((id) => id === requesterIdentityId) ?? false;
+    if (allowed) {
+      this.seenPrivateSyncRequestIds.set(request.requestId, now);
+    }
+    return allowed;
   }
 
   private async isPrivateContextGraph(contextGraphId: string): Promise<boolean> {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1390,6 +1390,80 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
     }
   });
 
+  it('builds authenticated sync requests for private context graphs', async () => {
+    const agent = await DKGAgent.create({
+      name: 'PrivateSyncAuthRequest',
+      listenHost: '127.0.0.1',
+      chainAdapter: new MockChainAdapter(),
+    });
+    try {
+      await agent.start();
+      (agent as any).subscribedContextGraphs.set('private-cg', {
+        name: 'private-cg',
+        subscribed: false,
+        synced: true,
+        onChainId: '1',
+      });
+
+      const chain = (agent as any).chain as MockChainAdapter;
+      const identityId = await chain.ensureProfile();
+      vi.spyOn(chain, 'signMessage').mockResolvedValue({ r: new Uint8Array(32), vs: new Uint8Array(32) });
+
+      const encoded = await (agent as any).buildSyncRequest('private-cg', 0, 50, false);
+      const parsed = JSON.parse(new TextDecoder().decode(encoded));
+
+      expect(parsed.contextGraphId).toBe('private-cg');
+      expect(parsed.requesterIdentityId).toBe(identityId.toString());
+      expect(parsed.requesterSignatureR).toBeDefined();
+      expect(parsed.requesterSignatureVS).toBeDefined();
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('denies private sync requests when requester is not an allowed participant', async () => {
+    const chain = new MockChainAdapter();
+    const agent = await DKGAgent.create({
+      name: 'PrivateSyncAuthDeny',
+      listenHost: '127.0.0.1',
+      chainAdapter: chain,
+    });
+    try {
+      await agent.start();
+      await chain.ensureProfile();
+      (chain as any).contextGraphs.set(1n, {
+        manager: chain.signerAddress,
+        participantIdentityIds: [999n],
+        requiredSignatures: 1,
+        metadataBatchId: 0n,
+        active: true,
+        batches: [],
+      });
+      (agent as any).subscribedContextGraphs.set('private-cg', {
+        name: 'private-cg',
+        subscribed: false,
+        synced: true,
+        onChainId: '1',
+      });
+
+      vi.spyOn(chain, 'verifyACKIdentity').mockResolvedValue(true);
+
+      const allowed = await (agent as any).authorizeSyncRequest({
+        contextGraphId: 'private-cg',
+        offset: 0,
+        limit: 10,
+        includeSharedMemory: false,
+        requesterIdentityId: '1',
+        requesterSignatureR: '0x' + '00'.repeat(32),
+        requesterSignatureVS: '0x' + '00'.repeat(32),
+      });
+
+      expect(allowed).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('emits warning when queryAccess.defaultPolicy is explicitly "public"', async () => {
     const { Logger } = await import('@origintrail-official/dkg-core');
     const logs: Array<{ level: string; message: string }> = [];

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -19,6 +19,7 @@ import { getGenesisQuads, computeNetworkId, PROTOCOL_SYNC, SYSTEM_PARANETS, DKG_
 import { DKGQueryEngine } from '@origintrail-official/dkg-query';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
 import { tmpdir } from 'node:os';
 import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
 import { createRequire } from 'node:module';
@@ -1409,10 +1410,14 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
       const identityId = await chain.ensureProfile();
       vi.spyOn(chain, 'signMessage').mockResolvedValue({ r: new Uint8Array(32), vs: new Uint8Array(32) });
 
-      const encoded = await (agent as any).buildSyncRequest('private-cg', 0, 50, false);
+      const encoded = await (agent as any).buildSyncRequest('private-cg', 0, 50, false, 'peer-remote');
       const parsed = JSON.parse(new TextDecoder().decode(encoded));
 
       expect(parsed.contextGraphId).toBe('private-cg');
+      expect(parsed.targetPeerId).toBe('peer-remote');
+      expect(parsed.requesterPeerId).toBe(agent.peerId);
+      expect(parsed.requestId).toBeDefined();
+      expect(parsed.issuedAtMs).toBeDefined();
       expect(parsed.requesterIdentityId).toBe(identityId.toString());
       expect(parsed.requesterSignatureR).toBeDefined();
       expect(parsed.requesterSignatureVS).toBeDefined();
@@ -1453,14 +1458,79 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         offset: 0,
         limit: 10,
         includeSharedMemory: false,
+        targetPeerId: agent.peerId,
+        requesterPeerId: agent.peerId,
+        requestId: 'req-1',
+        issuedAtMs: Date.now(),
         requesterIdentityId: '1',
         requesterSignatureR: '0x' + '00'.repeat(32),
         requesterSignatureVS: '0x' + '00'.repeat(32),
-      });
+      }, agent.peerId);
 
       expect(allowed).toBe(false);
     } finally {
       await agent.stop().catch(() => {});
+    }
+  });
+
+  it('rejects replayed private sync requests', async () => {
+    const chain = new MockChainAdapter();
+    const wallet = ethers.Wallet.createRandom();
+    const agent = await DKGAgent.create({
+      name: 'PrivateSyncReplay',
+      listenHost: '127.0.0.1',
+      chainAdapter: chain,
+    });
+    try {
+      await agent.start();
+      (agent as any).subscribedContextGraphs.set('private-cg', {
+        name: 'private-cg',
+        subscribed: false,
+        synced: true,
+        onChainId: '1',
+      });
+      vi.spyOn(agent as any, 'isPrivateContextGraph').mockResolvedValue(true);
+      vi.spyOn(chain, 'getContextGraphParticipants').mockResolvedValue([1n]);
+      vi.spyOn(chain, 'verifyACKIdentity').mockResolvedValue(true);
+
+      const request = {
+        contextGraphId: 'private-cg',
+        offset: 0,
+        limit: 10,
+        includeSharedMemory: false,
+        targetPeerId: agent.peerId,
+        requesterPeerId: 'peer-requester',
+        requestId: 'req-1',
+        issuedAtMs: Date.now(),
+        requesterIdentityId: '1',
+      } as const;
+
+      const digest = (agent as any).computeSyncDigest(
+        request.contextGraphId,
+        request.offset,
+        request.limit,
+        request.includeSharedMemory,
+        request.targetPeerId,
+        request.requesterPeerId,
+        request.requestId,
+        request.issuedAtMs,
+      );
+      const sig = ethers.Signature.from(await wallet.signMessage(digest));
+
+      const signedRequest = {
+        ...request,
+        requesterSignatureR: sig.r,
+        requesterSignatureVS: sig.yParityAndS,
+      };
+
+      const first = await (agent as any).authorizeSyncRequest(signedRequest, 'peer-requester');
+      const second = await (agent as any).authorizeSyncRequest(signedRequest, 'peer-requester');
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+    } finally {
+      await agent.stop().catch(() => {});
+      vi.restoreAllMocks();
     }
   });
 

--- a/packages/agent/test/e2e-privacy.test.ts
+++ b/packages/agent/test/e2e-privacy.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, afterAll } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { contextGraphDataUri } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
 
 const PRIVATE_PARANET = 'agent-memory-test';
 const PUBLIC_PARANET = 'public-e2e';
@@ -163,4 +165,152 @@ describe('Private data isolation (2 nodes)', () => {
     const synced = await nodeB.syncSharedMemoryFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
     expect(synced).toBe(0);
   }, 10000);
+});
+
+describe('Private context graph sync auth (3 nodes)', () => {
+  let nodeA: DKGAgent;
+  let nodeB: DKGAgent;
+  let nodeC: DKGAgent;
+  let walletA: ethers.Wallet;
+  let walletB: ethers.Wallet;
+  let walletC: ethers.Wallet;
+
+  afterAll(async () => {
+    try {
+      await nodeA?.stop();
+      await nodeB?.stop();
+      await nodeC?.stop();
+    } catch (err) {
+      console.warn('Teardown:', err);
+    }
+  });
+
+  it('allows an authorized node to sync a private context graph and blocks a bad actor', async () => {
+    walletA = ethers.Wallet.createRandom();
+    walletB = ethers.Wallet.createRandom();
+    walletC = ethers.Wallet.createRandom();
+
+    const chainA = new MockChainAdapter('mock:31337', walletA.address);
+    const chainB = new MockChainAdapter('mock:31337', walletB.address);
+    const chainC = new MockChainAdapter('mock:31337', walletC.address);
+
+    chainA.signMessage = async (digest: Uint8Array) => {
+      const sig = ethers.Signature.from(await walletA.signMessage(digest));
+      return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+    };
+    chainB.signMessage = async (digest: Uint8Array) => {
+      const sig = ethers.Signature.from(await walletB.signMessage(digest));
+      return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+    };
+    chainC.signMessage = async (digest: Uint8Array) => {
+      const sig = ethers.Signature.from(await walletC.signMessage(digest));
+      return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+    };
+
+    nodeA = await DKGAgent.create({ name: 'PrivateSyncA', listenPort: 0, chainAdapter: chainA });
+    nodeB = await DKGAgent.create({ name: 'PrivateSyncB', listenPort: 0, chainAdapter: chainB });
+    nodeC = await DKGAgent.create({ name: 'PrivateSyncC', listenPort: 0, chainAdapter: chainC });
+
+    await nodeA.start();
+    await nodeB.start();
+    await nodeC.start();
+    await sleep(800);
+
+    const addrA = nodeA.multiaddrs.find((a) => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodeB.connectTo(addrA);
+    await nodeC.connectTo(addrA);
+    await sleep(500);
+
+    await nodeA.createContextGraph({
+      id: PRIVATE_PARANET,
+      name: 'Private Sync Graph',
+      description: 'A and B only',
+      private: true,
+    });
+
+    // B and C know the graph id and try to participate locally, but only B is allowlisted on A.
+    await nodeB.createContextGraph({ id: PRIVATE_PARANET, name: 'Private Sync Graph', private: true });
+    await nodeC.createContextGraph({ id: PRIVATE_PARANET, name: 'Private Sync Graph', private: true });
+
+    const idA = 1n;
+    const idB = 2n;
+    const idC = 3n;
+    const contextGraphOnChainId = '1';
+
+    (chainA as any).identities.set(walletA.address, idA);
+    (chainA as any).identities.set(walletB.address, idB);
+    (chainA as any).identities.set(walletC.address, idC);
+    (chainB as any).identities.set(walletB.address, idB);
+    (chainC as any).identities.set(walletC.address, idC);
+
+    const cgRecord = {
+      manager: walletA.address,
+      participantIdentityIds: [idA, idB],
+      requiredSignatures: 1,
+      metadataBatchId: 0n,
+      active: true,
+      batches: [],
+    };
+    (chainA as any).contextGraphs.set(1n, cgRecord);
+
+    for (const node of [nodeA, nodeB, nodeC]) {
+      const sub = (node as any).subscribedContextGraphs.get(PRIVATE_PARANET);
+      (node as any).subscribedContextGraphs.set(PRIVATE_PARANET, {
+        ...sub,
+        onChainId: contextGraphOnChainId,
+      });
+    }
+
+    const privateQuads = [
+      { subject: PRIVATE_ENTITY, predicate: 'http://schema.org/text', object: '"Shared only with B"', graph: '' as const },
+    ];
+    await nodeA.share(PRIVATE_PARANET, privateQuads, { localOnly: true });
+
+    await (nodeA as any).store.insert([
+      {
+        subject: PRIVATE_ENTITY,
+        predicate: 'http://schema.org/name',
+        object: '"Private durable data"',
+        graph: contextGraphDataUri(PRIVATE_PARANET),
+      },
+    ]);
+
+    const requestB = JSON.parse(new TextDecoder().decode(await (nodeB as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false)));
+    expect(requestB.requesterIdentityId).toBe(idB.toString());
+    expect(requestB.requesterSignatureR).toBeDefined();
+    expect(requestB.requesterSignatureVS).toBeDefined();
+    const digestB = (nodeA as any).computeSyncDigest(PRIVATE_PARANET, 0, 50, false);
+    const recoveredB = ethers.recoverAddress(ethers.hashMessage(digestB), {
+      r: requestB.requesterSignatureR,
+      yParityAndS: requestB.requesterSignatureVS,
+    });
+    expect(recoveredB.toLowerCase()).toBe(walletB.address.toLowerCase());
+    expect(await chainA.verifyACKIdentity(recoveredB, idB)).toBe(true);
+    expect(await chainA.getContextGraphParticipants(1n)).toEqual([idA, idB]);
+    expect(await (nodeA as any).authorizeSyncRequest(requestB)).toBe(true);
+
+    const requestC = JSON.parse(new TextDecoder().decode(await (nodeC as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false)));
+    expect(await (nodeA as any).authorizeSyncRequest(requestC)).toBe(false);
+
+    const syncedDataB = await nodeB.syncFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
+    expect(syncedDataB).toBeGreaterThan(0);
+
+    const onB = await nodeB.query(
+      `SELECT ?name WHERE { <${PRIVATE_ENTITY}> <http://schema.org/name> ?name }`,
+      { contextGraphId: PRIVATE_PARANET },
+    );
+    expect(onB.bindings.length).toBe(1);
+    expect(onB.bindings[0]?.['name']).toBe('"Private durable data"');
+
+    const syncedDataC = await nodeC.syncFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
+    const syncedSwmC = await nodeC.syncSharedMemoryFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
+    expect(syncedDataC).toBe(0);
+    expect(syncedSwmC).toBe(0);
+
+    const onC = await nodeC.query(
+      `SELECT ?text WHERE { <${PRIVATE_ENTITY}> <http://schema.org/text> ?text }`,
+      { contextGraphId: PRIVATE_PARANET, graphSuffix: '_shared_memory' },
+    );
+    expect(onC.bindings.length).toBe(0);
+  }, 30000);
 });

--- a/packages/agent/test/e2e-privacy.test.ts
+++ b/packages/agent/test/e2e-privacy.test.ts
@@ -8,13 +8,19 @@
 import { describe, it, expect, afterAll } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { contextGraphDataUri } from '@origintrail-official/dkg-core';
+import { contextGraphDataUri, SYSTEM_PARANETS } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 
 const PRIVATE_PARANET = 'agent-memory-test';
 const PUBLIC_PARANET = 'public-e2e';
 const PRIVATE_ENTITY = 'urn:e2e:private:secret-message:1';
 const PUBLIC_ENTITY = 'urn:e2e:public:visible-entity:1';
+const MATRIX_PUBLIC_PARANET = 'matrix-public';
+const MATRIX_PRIVATE_PARANET = 'matrix-private';
+const MATRIX_PUBLIC_SWM_ENTITY = 'urn:e2e:matrix:public:swm:1';
+const MATRIX_PUBLIC_DATA_ENTITY = 'urn:e2e:matrix:public:data:1';
+const MATRIX_PRIVATE_SWM_ENTITY = 'urn:e2e:matrix:private:swm:1';
+const MATRIX_PRIVATE_DATA_ENTITY = 'urn:e2e:matrix:private:data:1';
 
 function sleep(ms: number) {
   return new Promise((r) => setTimeout(r, ms));
@@ -221,21 +227,9 @@ describe('Private context graph sync auth (3 nodes)', () => {
     await nodeC.connectTo(addrA);
     await sleep(500);
 
-    await nodeA.createContextGraph({
-      id: PRIVATE_PARANET,
-      name: 'Private Sync Graph',
-      description: 'A and B only',
-      private: true,
-    });
-
-    // B and C know the graph id and try to participate locally, but only B is allowlisted on A.
-    await nodeB.createContextGraph({ id: PRIVATE_PARANET, name: 'Private Sync Graph', private: true });
-    await nodeC.createContextGraph({ id: PRIVATE_PARANET, name: 'Private Sync Graph', private: true });
-
     const idA = 1n;
     const idB = 2n;
     const idC = 3n;
-    const contextGraphOnChainId = '1';
 
     (chainA as any).identities.set(walletA.address, idA);
     (chainA as any).identities.set(walletB.address, idB);
@@ -243,23 +237,17 @@ describe('Private context graph sync auth (3 nodes)', () => {
     (chainB as any).identities.set(walletB.address, idB);
     (chainC as any).identities.set(walletC.address, idC);
 
-    const cgRecord = {
-      manager: walletA.address,
+    await nodeA.createContextGraph({
+      id: PRIVATE_PARANET,
+      name: 'Private Sync Graph',
+      description: 'A and B only',
+      private: true,
       participantIdentityIds: [idA, idB],
-      requiredSignatures: 1,
-      metadataBatchId: 0n,
-      active: true,
-      batches: [],
-    };
-    (chainA as any).contextGraphs.set(1n, cgRecord);
+    });
 
-    for (const node of [nodeA, nodeB, nodeC]) {
-      const sub = (node as any).subscribedContextGraphs.get(PRIVATE_PARANET);
-      (node as any).subscribedContextGraphs.set(PRIVATE_PARANET, {
-        ...sub,
-        onChainId: contextGraphOnChainId,
-      });
-    }
+    // B and C learn about the private graph through synced ontology metadata, not by creating their own competing definitions.
+    await nodeB.syncFromPeer(nodeA.peerId, [SYSTEM_PARANETS.ONTOLOGY]);
+    await nodeC.syncFromPeer(nodeA.peerId, [SYSTEM_PARANETS.ONTOLOGY]);
 
     const privateQuads = [
       { subject: PRIVATE_ENTITY, predicate: 'http://schema.org/text', object: '"Shared only with B"', graph: '' as const },
@@ -287,7 +275,6 @@ describe('Private context graph sync auth (3 nodes)', () => {
     });
     expect(recoveredB.toLowerCase()).toBe(walletB.address.toLowerCase());
     expect(await chainA.verifyACKIdentity(recoveredB, idB)).toBe(true);
-    expect(await chainA.getContextGraphParticipants(1n)).toEqual([idA, idB]);
     expect(await (nodeA as any).authorizeSyncRequest(requestB, nodeB.peerId)).toBe(true);
 
     const requestC = JSON.parse(new TextDecoder().decode(await (nodeC as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false, nodeA.peerId)));
@@ -314,4 +301,158 @@ describe('Private context graph sync auth (3 nodes)', () => {
     );
     expect(onC.bindings.length).toBe(0);
   }, 30000);
+});
+
+describe('Context graph access matrix (3 nodes)', () => {
+  let nodeA: DKGAgent;
+  let nodeB: DKGAgent;
+  let nodeC: DKGAgent;
+  let walletA: ethers.Wallet;
+  let walletB: ethers.Wallet;
+  let walletC: ethers.Wallet;
+
+  afterAll(async () => {
+    try {
+      await nodeA?.stop();
+      await nodeB?.stop();
+      await nodeC?.stop();
+    } catch (err) {
+      console.warn('Teardown:', err);
+    }
+  });
+
+  it('enforces public/private x durable/SWM x authorized/unauthorized sync matrix', async () => {
+    walletA = ethers.Wallet.createRandom();
+    walletB = ethers.Wallet.createRandom();
+    walletC = ethers.Wallet.createRandom();
+
+    const chainA = new MockChainAdapter('mock:31337', walletA.address);
+    const chainB = new MockChainAdapter('mock:31337', walletB.address);
+    const chainC = new MockChainAdapter('mock:31337', walletC.address);
+
+    chainA.signMessage = async (digest: Uint8Array) => {
+      const sig = ethers.Signature.from(await walletA.signMessage(digest));
+      return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+    };
+    chainB.signMessage = async (digest: Uint8Array) => {
+      const sig = ethers.Signature.from(await walletB.signMessage(digest));
+      return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+    };
+    chainC.signMessage = async (digest: Uint8Array) => {
+      const sig = ethers.Signature.from(await walletC.signMessage(digest));
+      return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+    };
+
+    nodeA = await DKGAgent.create({ name: 'MatrixA', listenPort: 0, chainAdapter: chainA });
+    nodeB = await DKGAgent.create({ name: 'MatrixB', listenPort: 0, chainAdapter: chainB });
+    nodeC = await DKGAgent.create({ name: 'MatrixC', listenPort: 0, chainAdapter: chainC });
+
+    await nodeA.start();
+    await nodeB.start();
+    await nodeC.start();
+    await sleep(800);
+
+    const addrA = nodeA.multiaddrs.find((a) => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodeB.connectTo(addrA);
+    await nodeC.connectTo(addrA);
+    await sleep(500);
+
+    const idA = 1n;
+    const idB = 2n;
+    const idC = 3n;
+    (chainA as any).identities.set(walletA.address, idA);
+    (chainA as any).identities.set(walletB.address, idB);
+    (chainA as any).identities.set(walletC.address, idC);
+    (chainB as any).identities.set(walletB.address, idB);
+    (chainC as any).identities.set(walletC.address, idC);
+
+    await nodeA.createContextGraph({ id: MATRIX_PUBLIC_PARANET, name: 'Matrix Public' });
+    nodeB.subscribeToContextGraph(MATRIX_PUBLIC_PARANET);
+    nodeC.subscribeToContextGraph(MATRIX_PUBLIC_PARANET);
+
+    await nodeA.createContextGraph({
+      id: MATRIX_PRIVATE_PARANET,
+      name: 'Matrix Private',
+      private: true,
+      participantIdentityIds: [idA, idB],
+    });
+    await nodeB.syncFromPeer(nodeA.peerId, [SYSTEM_PARANETS.ONTOLOGY]);
+    await nodeC.syncFromPeer(nodeA.peerId, [SYSTEM_PARANETS.ONTOLOGY]);
+
+    await sleep(1000);
+
+    await nodeA.share(MATRIX_PUBLIC_PARANET, [
+      { subject: MATRIX_PUBLIC_SWM_ENTITY, predicate: 'http://schema.org/name', object: '"Public SWM"', graph: '' },
+    ]);
+    await nodeA.share(MATRIX_PRIVATE_PARANET, [
+      { subject: MATRIX_PRIVATE_SWM_ENTITY, predicate: 'http://schema.org/name', object: '"Private SWM"', graph: '' },
+    ], { localOnly: true });
+
+    await (nodeA as any).store.insert([
+      { subject: MATRIX_PUBLIC_DATA_ENTITY, predicate: 'http://schema.org/name', object: '"Public Data"', graph: contextGraphDataUri(MATRIX_PUBLIC_PARANET) },
+      { subject: MATRIX_PRIVATE_DATA_ENTITY, predicate: 'http://schema.org/name', object: '"Private Data"', graph: contextGraphDataUri(MATRIX_PRIVATE_PARANET) },
+    ]);
+
+    await sleep(3000);
+
+    const publicDataB = await nodeB.syncFromPeer(nodeA.peerId, [MATRIX_PUBLIC_PARANET]);
+    const publicSwmB = await nodeB.syncSharedMemoryFromPeer(nodeA.peerId, [MATRIX_PUBLIC_PARANET]);
+    const publicDataC = await nodeC.syncFromPeer(nodeA.peerId, [MATRIX_PUBLIC_PARANET]);
+    const publicSwmC = await nodeC.syncSharedMemoryFromPeer(nodeA.peerId, [MATRIX_PUBLIC_PARANET]);
+
+    expect(publicDataB).toBeGreaterThan(0);
+    expect(publicSwmB).toBeGreaterThanOrEqual(0);
+    expect(publicDataC).toBeGreaterThan(0);
+    expect(publicSwmC).toBeGreaterThanOrEqual(0);
+
+    const privateDataB = await nodeB.syncFromPeer(nodeA.peerId, [MATRIX_PRIVATE_PARANET]);
+    const privateSwmB = await nodeB.syncSharedMemoryFromPeer(nodeA.peerId, [MATRIX_PRIVATE_PARANET]);
+    const privateDataC = await nodeC.syncFromPeer(nodeA.peerId, [MATRIX_PRIVATE_PARANET]);
+    const privateSwmC = await nodeC.syncSharedMemoryFromPeer(nodeA.peerId, [MATRIX_PRIVATE_PARANET]);
+
+    expect(privateDataB).toBeGreaterThan(0);
+    expect(privateSwmB).toBeGreaterThan(0);
+    expect(privateDataC).toBeGreaterThanOrEqual(0);
+    expect(privateSwmC).toBeGreaterThanOrEqual(0);
+
+    const queryMatrix = [
+      { node: nodeB, contextGraphId: MATRIX_PUBLIC_PARANET, entity: MATRIX_PUBLIC_DATA_ENTITY, expected: '"Public Data"' },
+      { node: nodeC, contextGraphId: MATRIX_PUBLIC_PARANET, entity: MATRIX_PUBLIC_DATA_ENTITY, expected: '"Public Data"' },
+      { node: nodeB, contextGraphId: MATRIX_PRIVATE_PARANET, entity: MATRIX_PRIVATE_DATA_ENTITY, expected: '"Private Data"' },
+      { node: nodeC, contextGraphId: MATRIX_PRIVATE_PARANET, entity: MATRIX_PRIVATE_DATA_ENTITY, expected: null },
+    ] as const;
+
+    for (const entry of queryMatrix) {
+      const result = await entry.node.query(
+        `SELECT ?name WHERE { <${entry.entity}> <http://schema.org/name> ?name }`,
+        { contextGraphId: entry.contextGraphId },
+      );
+      if (entry.expected === null) {
+        expect(result.bindings.length).toBe(0);
+      } else {
+        expect(result.bindings.length).toBe(1);
+        expect(result.bindings[0]?.['name']).toBe(entry.expected);
+      }
+    }
+
+    const swmMatrix = [
+      { node: nodeB, contextGraphId: MATRIX_PUBLIC_PARANET, entity: MATRIX_PUBLIC_SWM_ENTITY, expected: '"Public SWM"' },
+      { node: nodeC, contextGraphId: MATRIX_PUBLIC_PARANET, entity: MATRIX_PUBLIC_SWM_ENTITY, expected: '"Public SWM"' },
+      { node: nodeB, contextGraphId: MATRIX_PRIVATE_PARANET, entity: MATRIX_PRIVATE_SWM_ENTITY, expected: '"Private SWM"' },
+      { node: nodeC, contextGraphId: MATRIX_PRIVATE_PARANET, entity: MATRIX_PRIVATE_SWM_ENTITY, expected: null },
+    ] as const;
+
+    for (const entry of swmMatrix) {
+      const result = await entry.node.query(
+        `SELECT ?name WHERE { <${entry.entity}> <http://schema.org/name> ?name }`,
+        { contextGraphId: entry.contextGraphId, graphSuffix: '_shared_memory' },
+      );
+      if (entry.expected === null) {
+        expect(result.bindings.length).toBe(0);
+      } else {
+        expect(result.bindings.length).toBe(1);
+        expect(result.bindings[0]?.['name']).toBe(entry.expected);
+      }
+    }
+  }, 40000);
 });

--- a/packages/agent/test/e2e-privacy.test.ts
+++ b/packages/agent/test/e2e-privacy.test.ts
@@ -153,4 +153,14 @@ describe('Private data isolation (2 nodes)', () => {
     );
     expect(attempt.bindings.length).toBe(0);
   }, 5000);
+
+  it('node B cannot sync private verified memory explicitly from node A', async () => {
+    const synced = await nodeB.syncFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
+    expect(synced).toBe(0);
+  }, 10000);
+
+  it('node B cannot sync private shared memory explicitly from node A', async () => {
+    const synced = await nodeB.syncSharedMemoryFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
+    expect(synced).toBe(0);
+  }, 10000);
 });

--- a/packages/agent/test/e2e-privacy.test.ts
+++ b/packages/agent/test/e2e-privacy.test.ts
@@ -275,11 +275,12 @@ describe('Private context graph sync auth (3 nodes)', () => {
       },
     ]);
 
-    const requestB = JSON.parse(new TextDecoder().decode(await (nodeB as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false)));
+    const requestB = JSON.parse(new TextDecoder().decode(await (nodeB as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false, nodeA.peerId)));
+    expect(requestB.targetPeerId).toBe(nodeA.peerId);
     expect(requestB.requesterIdentityId).toBe(idB.toString());
     expect(requestB.requesterSignatureR).toBeDefined();
     expect(requestB.requesterSignatureVS).toBeDefined();
-    const digestB = (nodeA as any).computeSyncDigest(PRIVATE_PARANET, 0, 50, false);
+    const digestB = (nodeA as any).computeSyncDigest(PRIVATE_PARANET, 0, 50, false, nodeA.peerId, nodeB.peerId, requestB.requestId, requestB.issuedAtMs);
     const recoveredB = ethers.recoverAddress(ethers.hashMessage(digestB), {
       r: requestB.requesterSignatureR,
       yParityAndS: requestB.requesterSignatureVS,
@@ -287,10 +288,10 @@ describe('Private context graph sync auth (3 nodes)', () => {
     expect(recoveredB.toLowerCase()).toBe(walletB.address.toLowerCase());
     expect(await chainA.verifyACKIdentity(recoveredB, idB)).toBe(true);
     expect(await chainA.getContextGraphParticipants(1n)).toEqual([idA, idB]);
-    expect(await (nodeA as any).authorizeSyncRequest(requestB)).toBe(true);
+    expect(await (nodeA as any).authorizeSyncRequest(requestB, nodeB.peerId)).toBe(true);
 
-    const requestC = JSON.parse(new TextDecoder().decode(await (nodeC as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false)));
-    expect(await (nodeA as any).authorizeSyncRequest(requestC)).toBe(false);
+    const requestC = JSON.parse(new TextDecoder().decode(await (nodeC as any).buildSyncRequest(PRIVATE_PARANET, 0, 50, false, nodeA.peerId)));
+    expect(await (nodeA as any).authorizeSyncRequest(requestC, nodeC.peerId)).toBe(false);
 
     const syncedDataB = await nodeB.syncFromPeer(nodeA.peerId, [PRIVATE_PARANET]);
     expect(syncedDataB).toBeGreaterThan(0);

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -316,6 +316,7 @@ export interface ChainAdapter {
 
   // On-Chain Context Graphs (ContextGraphs contract)
   createOnChainContextGraph?(params: CreateOnChainContextGraphParams): Promise<CreateOnChainContextGraphResult>;
+  getContextGraphParticipants?(contextGraphId: bigint): Promise<bigint[] | null>;
   verify?(params: VerifyParams): Promise<TxResult>;
   publishToContextGraph?(params: PublishToContextGraphParams): Promise<OnChainPublishResult>;
 

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -975,6 +975,20 @@ export class EVMChainAdapter implements ChainAdapter {
     };
   }
 
+  async getContextGraphParticipants(contextGraphId: bigint): Promise<bigint[] | null> {
+    await this.init();
+    if (!this.contracts.contextGraphStorage) {
+      return null;
+    }
+
+    try {
+      const participants: bigint[] = await this.contracts.contextGraphStorage.getContextGraphParticipants(contextGraphId);
+      return participants.map((id) => BigInt(id));
+    } catch {
+      return null;
+    }
+  }
+
   async verify(params: VerifyParams): Promise<TxResult> {
     await this.init();
     if (!this.contracts.contextGraphs) {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -711,6 +711,11 @@ export class MockChainAdapter implements ChainAdapter {
     return this.contextGraphs.get(contextGraphId);
   }
 
+  async getContextGraphParticipants(contextGraphId: bigint): Promise<bigint[] | null> {
+    const cg = this.contextGraphs.get(contextGraphId);
+    return cg ? [...cg.participantIdentityIds] : null;
+  }
+
   // --- V10 Publish (KnowledgeAssetsV10 → KnowledgeCollectionStorage) ---
 
   async createKnowledgeAssetsV10(params: V10PublishParams): Promise<OnChainPublishResult> {

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -179,6 +179,7 @@ export const DKG_ONTOLOGY = {
   DKG_GOSSIP_TOPIC: `${DKG}gossipTopic`,
   DKG_REPLICATION_POLICY: `${DKG}replicationPolicy`,
   DKG_ACCESS_POLICY: `${DKG}accessPolicy`,
+  DKG_PARTICIPANT_IDENTITY_ID: `${DKG}participantIdentityId`,
   DKG_CCL_POLICY: `${DKG}CCLPolicy`,
   DKG_POLICY_BINDING: `${DKG}PolicyBinding`,
   DKG_POLICY_APPLIES_TO_PARANET: `${DKG}appliesToParanet`,

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -178,6 +178,7 @@ export const DKG_ONTOLOGY = {
   DKG_CREATED_AT: `${DKG}createdAt`,
   DKG_GOSSIP_TOPIC: `${DKG}gossipTopic`,
   DKG_REPLICATION_POLICY: `${DKG}replicationPolicy`,
+  DKG_ACCESS_POLICY: `${DKG}accessPolicy`,
   DKG_CCL_POLICY: `${DKG}CCLPolicy`,
   DKG_POLICY_BINDING: `${DKG}PolicyBinding`,
   DKG_POLICY_APPLIES_TO_PARANET: `${DKG}appliesToParanet`,


### PR DESCRIPTION
## Summary
- deny unauthenticated sync for private context graphs and persist local access-policy metadata for private/public graphs
- add authenticated private sync requests and responder-side participant verification using context-graph participant identities
- add privacy regressions proving an authorized node can sync a private graph while an unauthorized bad actor cannot fetch private graph data or SWM
## Verification
- `pnpm --filter @origintrail-official/dkg-query build`
- `pnpm exec vitest run packages/agent/test/agent.test.ts packages/agent/test/e2e-privacy.test.ts`
## Test Results
- `2` test files passed
- `64` tests passed
## Notes
- this keeps the minimal deny-by-default protection in place for private graphs while adding the authenticated path for authorized participants