### PR TITLE
feat: add SKILL.MD agent onboarding and MarkItDown document processor

### DIFF
--- a/packages/adapter-openclaw/skills/dkg-node/SKILL.md
+++ b/packages/adapter-openclaw/skills/dkg-node/SKILL.md
@@ -52,7 +52,7 @@ Use `dkg_list_paranets` first to check if the paranet already exists.
 Subscribe to a paranet to receive its data and updates. Subscription is immediate; data sync from peers happens in the background.
 
 - `paranet_id` (required): paranet ID to subscribe to
-- `include_workspace` (optional): set to `"false"` to skip syncing draft data (default: true)
+- `include_workspace` (optional): set to `"false"` to skip syncing shared memory data (default: true)
 
 Use `dkg_list_paranets` to check sync status afterward.
 
@@ -130,7 +130,7 @@ Run a read-only SPARQL query (`SELECT`, `CONSTRUCT`, `ASK`, `DESCRIBE`) against 
 
 - `sparql` (required): SPARQL query string
 - `paranet_id` (optional): limit query scope to a specific paranet
-- `include_workspace` (optional): set to `"true"` to also search workspace (draft/ephemeral) data
+- `include_workspace` (optional): set to `"true"` to also search shared memory (working/ephemeral) data
 
 Example queries:
 - list everything: `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 20`

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -361,7 +361,7 @@ export class DkgNodePlugin {
             },
             include_shared_memory: {
               type: 'string',
-              description: 'Set to "false" to skip syncing shared memory/draft data. Default: true.',
+              description: 'Set to "false" to skip syncing shared memory data. Default: true.',
             },
           },
           required: ['context_graph_id'],
@@ -424,7 +424,7 @@ export class DkgNodePlugin {
           properties: {
             sparql: { type: 'string', description: 'SPARQL query string (SELECT, CONSTRUCT, ASK, or DESCRIBE)' },
             context_graph_id: { type: 'string', description: 'Optional context graph scope — omit to query all data' },
-            include_shared_memory: { type: 'string', description: 'Set to "true" to also search shared memory (draft/ephemeral) data. Default: false.' },
+            include_shared_memory: { type: 'string', description: 'Set to "true" to also search shared memory (working/ephemeral) data. Default: false.' },
           },
           required: ['sparql'],
         },

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3641,25 +3641,25 @@ export class DKGAgent {
     }
   }
 
-  // ── Working Memory Draft Operations (spec §6) ────────────────────────
+  // ── Working Memory Assertion Operations (spec §6) ───────────────────
 
-  get draft() {
+  get assertion() {
     const agent = this;
     const agentAddress = this.peerId;
     return {
-      async create(contextGraphId: string, draftName: string, opts?: { subGraphName?: string }): Promise<string> {
-        return agent.publisher.draftCreate(contextGraphId, draftName, agentAddress, opts?.subGraphName);
+      async create(contextGraphId: string, name: string, opts?: { subGraphName?: string }): Promise<string> {
+        return agent.publisher.assertionCreate(contextGraphId, name, agentAddress, opts?.subGraphName);
       },
 
       /**
-       * Write triples to a WM draft. Accepts:
+       * Write triples to a WM assertion. Accepts:
        * - `Quad[]` — standard quad array (same as publish/share)
        * - `JsonLdContent` — JSON-LD document, auto-converted to quads
-       * - `Array<{ subject, predicate, object }>` — legacy triple array (deprecated)
+       * - `Array<{ subject, predicate, object }>` — simple triple array
        */
       async write(
         contextGraphId: string,
-        draftName: string,
+        name: string,
         input: import('@origintrail-official/dkg-storage').Quad[] | JsonLdContent | Array<{ subject: string; predicate: string; object: string }>,
         opts?: { subGraphName?: string },
       ): Promise<void> {
@@ -3673,20 +3673,23 @@ export class DKGAgent {
           quads = (input as Array<{ subject: string; predicate: string; object: string }>)
             .map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object, graph: '' }));
         }
-        return agent.publisher.draftWrite(contextGraphId, draftName, agentAddress, quads, opts?.subGraphName);
+        return agent.publisher.assertionWrite(contextGraphId, name, agentAddress, quads, opts?.subGraphName);
       },
 
-      async query(contextGraphId: string, draftName: string, opts?: { subGraphName?: string }): Promise<import('@origintrail-official/dkg-storage').Quad[]> {
-        return agent.publisher.draftQuery(contextGraphId, draftName, agentAddress, opts?.subGraphName);
+      async query(contextGraphId: string, name: string, opts?: { subGraphName?: string }): Promise<import('@origintrail-official/dkg-storage').Quad[]> {
+        return agent.publisher.assertionQuery(contextGraphId, name, agentAddress, opts?.subGraphName);
       },
-      async promote(contextGraphId: string, draftName: string, opts?: { entities?: string[] | 'all'; subGraphName?: string }): Promise<{ promotedCount: number }> {
-        return agent.publisher.draftPromote(contextGraphId, draftName, agentAddress, opts);
+      async promote(contextGraphId: string, name: string, opts?: { entities?: string[] | 'all'; subGraphName?: string }): Promise<{ promotedCount: number }> {
+        return agent.publisher.assertionPromote(contextGraphId, name, agentAddress, opts);
       },
-      async discard(contextGraphId: string, draftName: string, opts?: { subGraphName?: string }): Promise<void> {
-        return agent.publisher.draftDiscard(contextGraphId, draftName, agentAddress, opts?.subGraphName);
+      async discard(contextGraphId: string, name: string, opts?: { subGraphName?: string }): Promise<void> {
+        return agent.publisher.assertionDiscard(contextGraphId, name, agentAddress, opts?.subGraphName);
       },
     };
   }
+
+  /** @deprecated Use agent.assertion */
+  get draft() { return this.assertion; }
 
 }
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1596,7 +1596,9 @@ export class DKGAgent {
       includeWorkspace?: boolean;
       operationCtx?: OperationContext;
       view?: GetView;
+      agentAddress?: string;
       verifiedGraph?: string;
+      assertionName?: string;
       subGraphName?: string;
     },
   ) {
@@ -1615,8 +1617,9 @@ export class DKGAgent {
       graphSuffix: opts.graphSuffix,
       includeSharedMemory: opts.includeSharedMemory,
       view: opts.view,
-      agentAddress: opts.view === 'working-memory' ? this.peerId : undefined,
+      agentAddress: opts.agentAddress ?? (opts.view === 'working-memory' ? this.peerId : undefined),
       verifiedGraph: opts.verifiedGraph,
+      assertionName: opts.assertionName,
       subGraphName: opts.subGraphName,
     });
     this.log.info(ctx, `Query returned ${result.bindings?.length ?? 0} bindings`);
@@ -2067,8 +2070,8 @@ export class DKGAgent {
       try { await this.store.dropGraph(uri); } catch { /* graph may not exist */ }
     }
 
-    // Drop assertion/draft graphs under the sub-graph prefix
-    const sgPrefix = `did:dkg:context-graph:${contextGraphId}/${subGraphName}/draft/`;
+    // Drop assertion graphs under the sub-graph prefix
+    const sgPrefix = `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`;
     const allGraphs = await this.store.listGraphs();
     for (const g of allGraphs) {
       if (g.startsWith(sgPrefix)) {
@@ -3668,7 +3671,17 @@ export class DKGAgent {
           quads = input as import('@origintrail-official/dkg-storage').Quad[];
         } else if (!Array.isArray(input) || (input.length > 0 && !('subject' in input[0]))) {
           const { publicQuads, privateQuads } = await jsonLdToQuads(input as JsonLdContent);
-          quads = [...publicQuads, ...privateQuads];
+          const isEnvelope = !Array.isArray(input) && ('public' in (input as Record<string, unknown>) || 'private' in (input as Record<string, unknown>));
+          if (isEnvelope && privateQuads.length > 0) {
+            new Logger('DKGAgent').warn(
+              createOperationContext('system'),
+              `Dropped ${privateQuads.length} private quads from JSON-LD envelope — WM assertions do not support private data; ` +
+              `use publish() with accessPolicy for private triples`,
+            );
+            quads = publicQuads;
+          } else {
+            quads = [...publicQuads, ...privateQuads];
+          }
         } else {
           quads = (input as Array<{ subject: string; predicate: string; object: string }>)
             .map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object, graph: '' }));

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3701,11 +3701,6 @@ export class DKGAgent {
     };
   }
 
-  /** @deprecated Use `assertion`. Will be removed in V10.1. */
-  get draft() {
-    return this.assertion;
-  }
-
 }
 
 function splitNQuadLine(line: string): string[] {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3688,9 +3688,6 @@ export class DKGAgent {
     };
   }
 
-  /** @deprecated Use agent.assertion */
-  get draft() { return this.assertion; }
-
 }
 
 function splitNQuadLine(line: string): string[] {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3701,6 +3701,11 @@ export class DKGAgent {
     };
   }
 
+  /** @deprecated Use `assertion`. Will be removed in V10.1. */
+  get draft() {
+    return this.assertion;
+  }
+
 }
 
 function splitNQuadLine(line: string): string[] {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -3671,17 +3671,7 @@ export class DKGAgent {
           quads = input as import('@origintrail-official/dkg-storage').Quad[];
         } else if (!Array.isArray(input) || (input.length > 0 && !('subject' in input[0]))) {
           const { publicQuads, privateQuads } = await jsonLdToQuads(input as JsonLdContent);
-          const isEnvelope = !Array.isArray(input) && ('public' in (input as Record<string, unknown>) || 'private' in (input as Record<string, unknown>));
-          if (isEnvelope && privateQuads.length > 0) {
-            new Logger('DKGAgent').warn(
-              createOperationContext('system'),
-              `Dropped ${privateQuads.length} private quads from JSON-LD envelope — WM assertions do not support private data; ` +
-              `use publish() with accessPolicy for private triples`,
-            );
-            quads = publicQuads;
-          } else {
-            quads = [...publicQuads, ...privateQuads];
-          }
+          quads = [...publicQuads, ...privateQuads];
         } else {
           quads = (input as Array<{ subject: string; predicate: string; object: string }>)
             .map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object, graph: '' }));

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -91,23 +91,6 @@ export class GossipPublishHandler {
         }
         subGraphName = request.subGraphName;
         await graphManager.ensureSubGraph(request.paranetId, subGraphName);
-
-        // Persist discovery registration so listSubGraphs() works on replicas
-        const sgUri = contextGraphSubGraphUri(request.paranetId, subGraphName);
-        const metaGraph = `did:dkg:context-graph:${assertSafeIri(request.paranetId)}/_meta`;
-        const alreadyRegistered = await this.store.query(
-          `ASK { GRAPH <${metaGraph}> { <${assertSafeIri(sgUri)}> a <http://dkg.io/ontology/SubGraph> } }`,
-        );
-        if (alreadyRegistered.type !== 'boolean' || !alreadyRegistered.value) {
-          const regQuads = generateSubGraphRegistration({
-            contextGraphId: request.paranetId,
-            subGraphName,
-            createdBy: request.publisherAddress || 'gossip-discovery',
-            timestamp: new Date(),
-          });
-          await this.store.insert(regQuads);
-          this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.paranetId}" from gossip`);
-        }
       }
 
       const dataGraph = subGraphName
@@ -205,6 +188,26 @@ export class GossipPublishHandler {
       }
 
       phase?.('validate', 'end');
+
+      // Auto-register sub-graph in _meta AFTER validation passes.
+      // This prevents polluting metadata when invalid messages are rejected.
+      if (subGraphName) {
+        const sgUri = contextGraphSubGraphUri(request.paranetId, subGraphName);
+        const metaGraph = `did:dkg:context-graph:${assertSafeIri(request.paranetId)}/_meta`;
+        const alreadyRegistered = await this.store.query(
+          `ASK { GRAPH <${metaGraph}> { <${assertSafeIri(sgUri)}> a <http://dkg.io/ontology/SubGraph> } }`,
+        );
+        if (alreadyRegistered.type !== 'boolean' || !alreadyRegistered.value) {
+          const regQuads = generateSubGraphRegistration({
+            contextGraphId: request.paranetId,
+            subGraphName,
+            createdBy: request.publisherAddress || 'gossip-discovery',
+            timestamp: new Date(),
+          });
+          await this.store.insert(regQuads);
+          this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.paranetId}" from gossip`);
+        }
+      }
 
       phase?.('store', 'start');
       if (normalized.length > 0 && !isReplay) {

--- a/packages/agent/test/e2e-sub-graphs.test.ts
+++ b/packages/agent/test/e2e-sub-graphs.test.ts
@@ -322,22 +322,18 @@ describe('Sub-graph replication (two agents)', () => {
         { contextGraphId: 'sg-replica', subGraphName: 'data' },
       );
       if (bResult.bindings.length > 0) break;
-
-      // Also check root graph in case it landed there
-      const rootCheck = await agentB.query(
-        'SELECT ?label WHERE { ?s <http://ex.org/label> ?label }',
-        { contextGraphId: 'sg-replica' },
-      );
-      if (rootCheck.bindings.length > 0) {
-        // Data replicated but to root graph — still valid for replication test
-        bResult = rootCheck;
-        break;
-      }
       await sleep(500);
     }
 
     expect(bResult.bindings.length).toBeGreaterThanOrEqual(1);
     expect(bResult.bindings[0]['label']).toBe('"Replicated Entity"');
+
+    // Sub-graph isolation on replica: data must NOT be in root graph
+    const rootCheck = await agentB.query(
+      'SELECT ?label WHERE { ?s <http://ex.org/label> ?label }',
+      { contextGraphId: 'sg-replica' },
+    );
+    expect(rootCheck.bindings).toHaveLength(0);
   }, 30_000);
 });
 
@@ -379,7 +375,7 @@ describe('Sub-graph across memory layers (single agent)', () => {
     expect(rootResult.bindings).toHaveLength(0);
   }, 15_000);
 
-  it('draft.write accepts Quad[] input', async () => {
+  it('assertion.write accepts Quad[] input', async () => {
     const agent = await DKGAgent.create({
       name: 'QuadDraftBot',
       listenPort: 0,
@@ -392,19 +388,19 @@ describe('Sub-graph across memory layers (single agent)', () => {
     await agent.createContextGraph({ id: 'sg-quad-draft', name: 'Quad Draft', description: '' });
     await agent.createSubGraph('sg-quad-draft', 'code');
 
-    await agent.draft.create('sg-quad-draft', 'quad-test', { subGraphName: 'code' });
+    await agent.assertion.create('sg-quad-draft', 'quad-test', { subGraphName: 'code' });
 
     // Write using Quad[] (standard format, same as publish/share)
-    await agent.draft.write('sg-quad-draft', 'quad-test', [
+    await agent.assertion.write('sg-quad-draft', 'quad-test', [
       { subject: 'urn:fn:main', predicate: 'http://ex.org/sig', object: '"main()"', graph: '' },
       { subject: 'urn:fn:main', predicate: 'http://ex.org/lang', object: '"TypeScript"', graph: '' },
     ], { subGraphName: 'code' });
 
-    const quads = await agent.draft.query('sg-quad-draft', 'quad-test', { subGraphName: 'code' });
+    const quads = await agent.assertion.query('sg-quad-draft', 'quad-test', { subGraphName: 'code' });
     expect(quads).toHaveLength(2);
   }, 15_000);
 
-  it('draft.write accepts JSON-LD input', async () => {
+  it('assertion.write accepts JSON-LD input', async () => {
     const agent = await DKGAgent.create({
       name: 'JsonLdDraftBot',
       listenPort: 0,
@@ -417,22 +413,22 @@ describe('Sub-graph across memory layers (single agent)', () => {
     await agent.createContextGraph({ id: 'sg-jsonld-draft', name: 'JSONLD Draft', description: '' });
     await agent.createSubGraph('sg-jsonld-draft', 'entities');
 
-    await agent.draft.create('sg-jsonld-draft', 'ld-test', { subGraphName: 'entities' });
+    await agent.assertion.create('sg-jsonld-draft', 'ld-test', { subGraphName: 'entities' });
 
     // Write using JSON-LD (auto-converted to quads)
-    await agent.draft.write('sg-jsonld-draft', 'ld-test', {
+    await agent.assertion.write('sg-jsonld-draft', 'ld-test', {
       '@id': 'urn:entity:alice',
       'http://schema.org/name': 'Alice',
       'http://schema.org/jobTitle': 'Engineer',
     }, { subGraphName: 'entities' });
 
-    const quads = await agent.draft.query('sg-jsonld-draft', 'ld-test', { subGraphName: 'entities' });
+    const quads = await agent.assertion.query('sg-jsonld-draft', 'ld-test', { subGraphName: 'entities' });
     expect(quads.length).toBeGreaterThanOrEqual(2);
     const names = quads.filter(q => q.predicate === 'http://schema.org/name');
     expect(names).toHaveLength(1);
   }, 15_000);
 
-  it('WM draft with subGraphName → promote to sub-graph SWM', async () => {
+  it('WM assertion with subGraphName → promote to sub-graph SWM', async () => {
     const agent = await DKGAgent.create({
       name: 'DraftSubBot',
       listenPort: 0,
@@ -445,21 +441,21 @@ describe('Sub-graph across memory layers (single agent)', () => {
     await agent.createContextGraph({ id: 'sg-wm-layer', name: 'WM Layer', description: '' });
     await agent.createSubGraph('sg-wm-layer', 'decisions');
 
-    // Create draft in sub-graph WM
-    const draftUri = await agent.draft.create('sg-wm-layer', 'arch-review', { subGraphName: 'decisions' });
-    expect(draftUri).toContain('/decisions/draft/');
+    // Create assertion in sub-graph WM
+    const assertionUri = await agent.assertion.create('sg-wm-layer', 'arch-review', { subGraphName: 'decisions' });
+    expect(assertionUri).toContain('/decisions/assertion/');
 
-    // Write to draft
-    await agent.draft.write('sg-wm-layer', 'arch-review', [
+    // Write to assertion
+    await agent.assertion.write('sg-wm-layer', 'arch-review', [
       { subject: 'urn:dec:1', predicate: 'http://ex.org/title', object: '"Use TypeScript"' },
     ], { subGraphName: 'decisions' });
 
-    // Query draft
-    const draftQuads = await agent.draft.query('sg-wm-layer', 'arch-review', { subGraphName: 'decisions' });
-    expect(draftQuads).toHaveLength(1);
+    // Query assertion
+    const assertionQuads = await agent.assertion.query('sg-wm-layer', 'arch-review', { subGraphName: 'decisions' });
+    expect(assertionQuads).toHaveLength(1);
 
     // Promote to sub-graph SWM
-    const result = await agent.draft.promote('sg-wm-layer', 'arch-review', {
+    const result = await agent.assertion.promote('sg-wm-layer', 'arch-review', {
       entities: 'all',
       subGraphName: 'decisions',
     });
@@ -480,9 +476,9 @@ describe('Sub-graph across memory layers (single agent)', () => {
     );
     expect(rootSwm.bindings).toHaveLength(0);
 
-    // Draft should be empty after promotion
-    const emptyDraft = await agent.draft.query('sg-wm-layer', 'arch-review', { subGraphName: 'decisions' });
-    expect(emptyDraft).toHaveLength(0);
+    // Assertion should be empty after promotion
+    const emptyAssertion = await agent.assertion.query('sg-wm-layer', 'arch-review', { subGraphName: 'decisions' });
+    expect(emptyAssertion).toHaveLength(0);
   }, 15_000);
 
   it('full pipeline: WM draft → SWM → VM (sub-graph scoped)', async () => {
@@ -498,14 +494,14 @@ describe('Sub-graph across memory layers (single agent)', () => {
     await agent.createContextGraph({ id: 'sg-pipeline', name: 'Pipeline', description: '' });
     await agent.createSubGraph('sg-pipeline', 'code');
 
-    // Step 1: Draft in WM/code
-    await agent.draft.create('sg-pipeline', 'scan', { subGraphName: 'code' });
-    await agent.draft.write('sg-pipeline', 'scan', [
+    // Step 1: Assertion in WM/code
+    await agent.assertion.create('sg-pipeline', 'scan', { subGraphName: 'code' });
+    await agent.assertion.write('sg-pipeline', 'scan', [
       { subject: 'urn:fn:main', predicate: 'http://ex.org/sig', object: '"main()"' },
     ], { subGraphName: 'code' });
 
     // Step 2: Promote WM/code → SWM/code
-    await agent.draft.promote('sg-pipeline', 'scan', {
+    await agent.assertion.promote('sg-pipeline', 'scan', {
       entities: 'all',
       subGraphName: 'code',
     });

--- a/packages/agent/test/e2e-sub-graphs.test.ts
+++ b/packages/agent/test/e2e-sub-graphs.test.ts
@@ -385,24 +385,24 @@ describe('Sub-graph across memory layers (single agent)', () => {
     agents.push(agent);
     await agent.start();
 
-    await agent.createContextGraph({ id: 'sg-quad-draft', name: 'Quad Draft', description: '' });
-    await agent.createSubGraph('sg-quad-draft', 'code');
+    await agent.createContextGraph({ id: 'sg-quad-input', name: 'Quad Input', description: '' });
+    await agent.createSubGraph('sg-quad-input', 'code');
 
-    await agent.assertion.create('sg-quad-draft', 'quad-test', { subGraphName: 'code' });
+    await agent.assertion.create('sg-quad-input', 'quad-test', { subGraphName: 'code' });
 
     // Write using Quad[] (standard format, same as publish/share)
-    await agent.assertion.write('sg-quad-draft', 'quad-test', [
+    await agent.assertion.write('sg-quad-input', 'quad-test', [
       { subject: 'urn:fn:main', predicate: 'http://ex.org/sig', object: '"main()"', graph: '' },
       { subject: 'urn:fn:main', predicate: 'http://ex.org/lang', object: '"TypeScript"', graph: '' },
     ], { subGraphName: 'code' });
 
-    const quads = await agent.assertion.query('sg-quad-draft', 'quad-test', { subGraphName: 'code' });
+    const quads = await agent.assertion.query('sg-quad-input', 'quad-test', { subGraphName: 'code' });
     expect(quads).toHaveLength(2);
   }, 15_000);
 
   it('assertion.write accepts JSON-LD input', async () => {
     const agent = await DKGAgent.create({
-      name: 'JsonLdDraftBot',
+      name: 'JsonLdInputBot',
       listenPort: 0,
       skills: [],
       chainAdapter: new MockChainAdapter(),
@@ -410,19 +410,19 @@ describe('Sub-graph across memory layers (single agent)', () => {
     agents.push(agent);
     await agent.start();
 
-    await agent.createContextGraph({ id: 'sg-jsonld-draft', name: 'JSONLD Draft', description: '' });
-    await agent.createSubGraph('sg-jsonld-draft', 'entities');
+    await agent.createContextGraph({ id: 'sg-jsonld-input', name: 'JSONLD Input', description: '' });
+    await agent.createSubGraph('sg-jsonld-input', 'entities');
 
-    await agent.assertion.create('sg-jsonld-draft', 'ld-test', { subGraphName: 'entities' });
+    await agent.assertion.create('sg-jsonld-input', 'ld-test', { subGraphName: 'entities' });
 
     // Write using JSON-LD (auto-converted to quads)
-    await agent.assertion.write('sg-jsonld-draft', 'ld-test', {
+    await agent.assertion.write('sg-jsonld-input', 'ld-test', {
       '@id': 'urn:entity:alice',
       'http://schema.org/name': 'Alice',
       'http://schema.org/jobTitle': 'Engineer',
     }, { subGraphName: 'entities' });
 
-    const quads = await agent.assertion.query('sg-jsonld-draft', 'ld-test', { subGraphName: 'entities' });
+    const quads = await agent.assertion.query('sg-jsonld-input', 'ld-test', { subGraphName: 'entities' });
     expect(quads.length).toBeGreaterThanOrEqual(2);
     const names = quads.filter(q => q.predicate === 'http://schema.org/name');
     expect(names).toHaveLength(1);
@@ -430,7 +430,7 @@ describe('Sub-graph across memory layers (single agent)', () => {
 
   it('WM assertion with subGraphName → promote to sub-graph SWM', async () => {
     const agent = await DKGAgent.create({
-      name: 'DraftSubBot',
+      name: 'AssertionSubBot',
       listenPort: 0,
       skills: [],
       chainAdapter: new MockChainAdapter(),
@@ -481,7 +481,7 @@ describe('Sub-graph across memory layers (single agent)', () => {
     expect(emptyAssertion).toHaveLength(0);
   }, 15_000);
 
-  it('full pipeline: WM draft → SWM → VM (sub-graph scoped)', async () => {
+  it('full pipeline: WM assertion → SWM → VM (sub-graph scoped)', async () => {
     const agent = await DKGAgent.create({
       name: 'PipelineBot',
       listenPort: 0,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   "files": [
     "dist",
     "network",
+    "skills",
     "README.md",
     "LICENSE"
   ],

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -35,7 +35,7 @@ This node provides a three-layer **verifiable memory system** for AI agents:
 | **Shared Working Memory (SWM)** | Visible to team | Free | Self-attested (gossip replicated) | TTL-bounded |
 | **Verified Memory (VM)** | Permanent, on-chain | TRAC tokens | Self-attested → endorsed → consensus-verified | Permanent |
 
-**What you can do:** create knowledge drafts, import files (PDF, DOCX, Markdown),
+**What you can do:** create knowledge assertions, import files (PDF, DOCX, Markdown),
 share knowledge with peers, publish to the blockchain, endorse others' knowledge,
 propose M-of-N consensus verification, query across all memory layers, and
 discover other agents on the network.
@@ -58,7 +58,7 @@ curl -X POST $BASE_URL/api/shared-memory/write \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "paranetId": "my-context-graph",
+    "contextGraphId": "my-context-graph",
     "quads": [
       {"subject": "https://example.org/alice", "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "object": "https://schema.org/Person", "graph": "urn:default"},
       {"subject": "https://example.org/alice", "predicate": "https://schema.org/name", "object": "Alice", "graph": "urn:default"}
@@ -72,7 +72,7 @@ curl -X POST $BASE_URL/api/shared-memory/write \
 curl -X POST $BASE_URL/api/publish \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"paranetId": "my-context-graph", "quads": [...]}'
+  -d '{"contextGraphId": "my-context-graph", "quads": [...]}'
 ```
 
 **Step 4 — Query:**
@@ -81,7 +81,7 @@ curl -X POST $BASE_URL/api/publish \
 curl -X POST $BASE_URL/api/query \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 10", "view": "shared-working-memory"}'
+  -d '{"sparql": "SELECT * WHERE { ?s ?p ?o } LIMIT 10", "contextGraphId": "my-context-graph", "includeSharedMemory": true}'
 ```
 
 ## 4. Authentication
@@ -111,20 +111,20 @@ The token is configured in the node's config file or provided at startup.
 
 ### Querying
 
-- `POST /api/query` — SPARQL query with `view` parameter (`working-memory`, `shared-working-memory`, `verified-memory`), optional `minTrust` and `verifiedGraph` filters
+- `POST /api/query` — SPARQL query with optional `view` (`working-memory`, `shared-working-memory`, `verified-memory`), `agentAddress`, `assertionName`, `verifiedGraph`, `subGraphName`, `includeSharedMemory`, `contextGraphId` parameters
 - `POST /api/query-remote` — query a remote peer via P2P
 
-### Working Memory (WM) — Private drafts (🚧 Planned)
+### Working Memory (WM) — Private assertions (🚧 Planned)
 
-> The following WM draft endpoints are planned for a future release:
+> The following WM assertion endpoints are planned for a future release:
 
-- `POST /api/draft/create` — create a named private draft
-- `PUT /api/draft/{name}` — write triples to a draft
-- `POST /api/draft/{name}/import` — import N-Triples/Turtle/JSON-LD
-- `POST /api/draft/{name}/import-file` — import PDF/DOCX/Markdown (multipart)
-- `GET /api/draft/{name}` — read draft contents
-- `DELETE /api/draft/{name}` — delete draft
-- `POST /api/draft/{name}/promote` — promote draft to SWM
+- `POST /api/assertion/create` — create a named private assertion
+- `PUT /api/assertion/{name}` — write triples to an assertion
+- `POST /api/assertion/{name}/import` — import N-Triples/Turtle/JSON-LD
+- `POST /api/assertion/{name}/import-file` — import PDF/DOCX/Markdown (multipart)
+- `GET /api/assertion/{name}` — read assertion contents
+- `DELETE /api/assertion/{name}` — delete assertion
+- `POST /api/assertion/{name}/promote` — promote assertion to SWM
 
 ## 6. Context Graphs
 
@@ -140,7 +140,7 @@ Context Graphs are scoped knowledge domains with configurable access and governa
 
 ## 7. File Ingestion (🚧 Planned)
 
-> File ingestion via `import-file` depends on the Working Memory draft API (§5)
+> File ingestion via `import-file` depends on the Working Memory assertion API (§5)
 > and will be available when those endpoints ship. The extraction pipeline
 > infrastructure (MarkItDown converter) is already in place on the node.
 
@@ -148,7 +148,7 @@ Supported formats depend on available extraction pipelines (see Node Info §1).
 When available, usage will be:
 
 ```bash
-curl -X POST $BASE_URL/api/draft/my-draft/import-file \
+curl -X POST $BASE_URL/api/assertion/my-assertion/import-file \
   -H "Authorization: Bearer $TOKEN" \
   -F "file=@paper.pdf" \
   -F "contextGraph=my-context-graph"

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -21,6 +21,12 @@ This skill teaches you the full node API surface so you can operate autonomously
 
 ## 2. Capabilities Overview
 
+> **Note:** This skill describes the full DKG V10 API surface. Some endpoints
+> may not yet be available on your node depending on its version. Call
+> `GET /api/status` to check the node version, and rely on error responses
+> (404) to detect unimplemented routes. The node is under active development
+> toward V10.0 — endpoints are being shipped incrementally.
+
 This node provides a three-layer **verifiable memory system** for AI agents:
 
 | Layer | Scope | Cost | Trust Level | Persistence |

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -48,7 +48,7 @@ discover other agents on the network.
 curl -X POST $BASE_URL/api/context-graph/create \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name": "my-context-graph"}'
+  -d '{"id": "my-context-graph", "name": "My Context Graph"}'
 ```
 
 **Step 2 — Write to Shared Memory:**
@@ -60,8 +60,8 @@ curl -X POST $BASE_URL/api/shared-memory/write \
   -d '{
     "contextGraphId": "my-context-graph",
     "quads": [
-      {"subject": "https://example.org/alice", "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "object": "https://schema.org/Person", "graph": "urn:default"},
-      {"subject": "https://example.org/alice", "predicate": "https://schema.org/name", "object": "Alice", "graph": "urn:default"}
+      {"subject": "https://example.org/alice", "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "object": "https://schema.org/Person", "graph": ""},
+      {"subject": "https://example.org/alice", "predicate": "https://schema.org/name", "object": "\"Alice\"", "graph": ""}
     ]
   }'
 ```

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -42,120 +42,116 @@ discover other agents on the network.
 
 ## 3. Quick Start
 
-**Step 1 — Register** (if not already registered):
+**Step 1 — Create a Context Graph:**
 
 ```bash
-curl -X POST $BASE_URL/api/agent/register \
-  -H "Authorization: Bearer $NODE_TOKEN" \
+curl -X POST $BASE_URL/api/context-graph/create \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name": "my-agent", "framework": "cursor"}'
+  -d '{"name": "my-context-graph"}'
 ```
 
-Save the returned `authToken` — use it as `$AGENT_TOKEN` for all subsequent calls.
-
-**Step 2 — Create a draft:**
+**Step 2 — Write to Shared Memory:**
 
 ```bash
-curl -X POST $BASE_URL/api/draft/create \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "my-draft", "contextGraph": "my-context-graph"}'
-```
-
-**Step 3 — Write triples:**
-
-```bash
-curl -X PUT $BASE_URL/api/draft/my-draft \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
+curl -X POST $BASE_URL/api/shared-memory/write \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "contextGraph": "my-context-graph",
+    "paranetId": "my-context-graph",
     "quads": [
-      {"subject": "https://example.org/alice", "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "object": "https://schema.org/Person"},
-      {"subject": "https://example.org/alice", "predicate": "https://schema.org/name", "object": "Alice"}
+      {"subject": "https://example.org/alice", "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "object": "https://schema.org/Person", "graph": "urn:default"},
+      {"subject": "https://example.org/alice", "predicate": "https://schema.org/name", "object": "Alice", "graph": "urn:default"}
     ]
   }'
 ```
 
-**Step 4 — Share to team:**
+**Step 3 — Publish to Verified Memory:**
 
 ```bash
-curl -X POST $BASE_URL/api/draft/my-draft/promote \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
+curl -X POST $BASE_URL/api/publish \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"contextGraph": "my-context-graph"}'
+  -d '{"paranetId": "my-context-graph", "quads": [...]}'
+```
+
+**Step 4 — Query:**
+
+```bash
+curl -X POST $BASE_URL/api/query \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "SELECT * WHERE { ?s ?p ?o } LIMIT 10", "view": "shared-working-memory"}'
 ```
 
 ## 4. Authentication
 
-**Two modes:**
-- **Custodial** (default): register without a `publicKey` — node generates and holds keys, signs on your behalf.
-- **Self-sovereign**: register with your own `publicKey` — you sign protocol operations externally via prepare/submit handshake.
-
-**Token usage:** Include `Authorization: Bearer $AGENT_TOKEN` on all requests.
-Agent tokens are prefixed `dkg_at_`.
+**Token usage:** Include `Authorization: Bearer $TOKEN` on all requests.
+The token is configured in the node's config file or provided at startup.
 
 **Public endpoints (no auth):** `GET /api/status`, `GET /api/chain/rpc-health`,
-`GET /.well-known/skill.md`, `GET /context-oracle`, `GET /ui/*`, `GET /apps/*`.
+`GET /.well-known/skill.md`.
+
+> **Planned:** Multi-agent registration (`POST /api/agent/register`) with custodial
+> and self-sovereign key modes will be available in a future release.
 
 ## 5. Memory Model
 
-### Working Memory (WM) — Private drafts
-
-- `POST /api/draft/create` — create a named draft
-- `PUT /api/draft/{name}` — write triples (additive)
-- `POST /api/draft/{name}/import` — import N-Triples/Turtle/JSON-LD
-- `POST /api/draft/{name}/import-file` — import PDF/DOCX/Markdown (multipart)
-- `GET /api/draft/{name}` — read draft contents
-- `DELETE /api/draft/{name}` — delete draft
-
 ### Shared Working Memory (SWM) — Team-visible
 
-- `POST /api/draft/{name}/promote` — SHARE: promote draft to SWM (triggers gossip)
-- `POST /api/swm/write` — write directly to SWM (skip WM)
-- `GET /api/swm/entities` — list SWM entities
+- `POST /api/shared-memory/write` — write triples to SWM (gossip-replicated)
+- `POST /api/shared-memory/publish` — promote SWM triples to Verified Memory
 
 ### Verified Memory (VM) — Permanent, on-chain
 
-- `POST /api/publish` — PUBLISH: promote SWM triples to VM (costs TRAC)
-- `POST /api/update` — UPDATE: modify existing Knowledge Asset
-- `POST /api/endorse` — ENDORSE: social signal ("I vouch for this")
-- `POST /api/verify/propose` — propose M-of-N consensus verification
-- `POST /api/verify/approve` — approve/reject verification proposal
+- `POST /api/publish` — publish triples to VM (costs TRAC)
+- `POST /api/update` — update an existing Knowledge Asset
+- `POST /api/endorse` — endorse a Knowledge Asset ("I vouch for this")
+- `POST /api/verify` — propose or approve M-of-N consensus verification
 
 ### Querying
 
 - `POST /api/query` — SPARQL query with `view` parameter (`working-memory`, `shared-working-memory`, `verified-memory`), optional `minTrust` and `verifiedGraph` filters
 - `POST /api/query-remote` — query a remote peer via P2P
 
+### Working Memory (WM) — Private drafts (🚧 Planned)
+
+> The following WM draft endpoints are planned for a future release:
+
+- `POST /api/draft/create` — create a named private draft
+- `PUT /api/draft/{name}` — write triples to a draft
+- `POST /api/draft/{name}/import` — import N-Triples/Turtle/JSON-LD
+- `POST /api/draft/{name}/import-file` — import PDF/DOCX/Markdown (multipart)
+- `GET /api/draft/{name}` — read draft contents
+- `DELETE /api/draft/{name}` — delete draft
+- `POST /api/draft/{name}/promote` — promote draft to SWM
+
 ## 6. Context Graphs
 
 Context Graphs are scoped knowledge domains with configurable access and governance.
 
-- `POST /api/context-graph/create` — create (set access, publishPolicy, quorum)
-- `GET /api/context-graph/list` — list subscribed CGs
-- `GET /api/context-graph/{id}` — CG details
-- `POST /api/context-graph/{id}/subscribe` — subscribe to a CG
-- `POST /api/context-graph/{id}/ontology` — add ontology
-- `GET /api/context-graph/{id}/ontology` — list ontologies
+- `POST /api/context-graph/create` — create a context graph
+- `GET /api/context-graph/list` — list subscribed context graphs
+- `POST /api/context-graph/subscribe` — subscribe to a context graph
+- `GET /api/context-graph/exists` — check if a context graph exists
+- 🚧 `GET /api/context-graph/{id}` — CG details *(planned)*
+- 🚧 `POST /api/context-graph/{id}/ontology` — add ontology *(planned)*
+- 🚧 `GET /api/context-graph/{id}/ontology` — list ontologies *(planned)*
 
-## 7. File Ingestion
+## 7. File Ingestion (🚧 Planned)
 
-Upload documents and get automatic triple extraction:
+> File ingestion via `import-file` depends on the Working Memory draft API (§5)
+> and will be available when those endpoints ship. The extraction pipeline
+> infrastructure (MarkItDown converter) is already in place on the node.
+
+Supported formats depend on available extraction pipelines (see Node Info §1).
+When available, usage will be:
 
 ```bash
 curl -X POST $BASE_URL/api/draft/my-draft/import-file \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Authorization: Bearer $TOKEN" \
   -F "file=@paper.pdf" \
   -F "contextGraph=my-context-graph"
-```
-
-Supported formats depend on available extraction pipelines (see Node Info §1).
-For large files, poll extraction status:
-
-```bash
-curl "$BASE_URL/api/draft/my-draft/extraction-status?contextGraph=my-context-graph" \
-  -H "Authorization: Bearer $AGENT_TOKEN"
 ```
 
 ## 8. Node Administration
@@ -163,10 +159,11 @@ curl "$BASE_URL/api/draft/my-draft/extraction-status?contextGraph=my-context-gra
 - `GET /api/status` (PUBLIC) — node status, peer ID, version, connections
 - `GET /api/info` — lightweight health check
 - `GET /api/agents` — list known agents
-- `GET /api/agent/profile` — your agent profile
 - `GET /api/connections` — transport details
 - `GET /api/wallets/balances` — TRAC and ETH balances
 - `GET /api/chain/rpc-health` (PUBLIC) — RPC health
+- `GET /api/identity` — node identity (DID, identity ID)
+- 🚧 `GET /api/agent/profile` — your agent profile *(planned)*
 
 ## 9. Error Reference
 
@@ -197,7 +194,7 @@ the supporting files in the skill directory:
 |------------|---------------|
 | Paranet | Context Graph |
 | Workspace | Shared Working Memory |
-| Enshrine | SHARE (promote draft) |
-| `POST /api/workspace/write` | `PUT /api/draft/{name}` |
-| `POST /api/workspace/enshrine` | `POST /api/draft/{name}/promote` |
+| Enshrine | Publish (promote to Verified Memory) |
+| `POST /api/workspace/write` | `POST /api/shared-memory/write` |
+| `POST /api/workspace/enshrine` | `POST /api/shared-memory/publish` |
 | `POST /api/paranet/create` | `POST /api/context-graph/create` |

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: dkg-node
+description: Manage agent memory on the DKG V10 node — store private drafts in Working Memory, share with your team in Shared Working Memory, publish permanently to Verified Memory, build trust through endorsements and M-of-N consensus verification.
+---
+
+# DKG V10 Node Skill
+
+You are connected to an **OriginTrail Decentralized Knowledge Graph (DKG) V10** node.
+This skill teaches you the full node API surface so you can operate autonomously.
+
+## 1. Node Info
+
+> This section is dynamically generated from node state at serve-time.
+
+- **Node version:** (dynamic)
+- **Base URL:** (dynamic)
+- **Peer ID:** (dynamic)
+- **Node role:** (dynamic — `core` or `edge`)
+- **Available extraction pipelines:** (dynamic)
+- **Subscribed Context Graphs:** (dynamic)
+
+## 2. Capabilities Overview
+
+This node provides a three-layer **verifiable memory system** for AI agents:
+
+| Layer | Scope | Cost | Trust Level | Persistence |
+|-------|-------|------|-------------|-------------|
+| **Working Memory (WM)** | Private to you | Free | Self-attested | Local, survives restarts |
+| **Shared Working Memory (SWM)** | Visible to team | Free | Self-attested (gossip replicated) | TTL-bounded |
+| **Verified Memory (VM)** | Permanent, on-chain | TRAC tokens | Self-attested → endorsed → consensus-verified | Permanent |
+
+**What you can do:** create knowledge drafts, import files (PDF, DOCX, Markdown),
+share knowledge with peers, publish to the blockchain, endorse others' knowledge,
+propose M-of-N consensus verification, query across all memory layers, and
+discover other agents on the network.
+
+## 3. Quick Start
+
+**Step 1 — Register** (if not already registered):
+
+```bash
+curl -X POST $BASE_URL/api/agent/register \
+  -H "Authorization: Bearer $NODE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-agent", "framework": "cursor"}'
+```
+
+Save the returned `authToken` — use it as `$AGENT_TOKEN` for all subsequent calls.
+
+**Step 2 — Create a draft:**
+
+```bash
+curl -X POST $BASE_URL/api/draft/create \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "my-draft", "contextGraph": "my-context-graph"}'
+```
+
+**Step 3 — Write triples:**
+
+```bash
+curl -X PUT $BASE_URL/api/draft/my-draft \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contextGraph": "my-context-graph",
+    "quads": [
+      {"subject": "https://example.org/alice", "predicate": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type", "object": "https://schema.org/Person"},
+      {"subject": "https://example.org/alice", "predicate": "https://schema.org/name", "object": "Alice"}
+    ]
+  }'
+```
+
+**Step 4 — Share to team:**
+
+```bash
+curl -X POST $BASE_URL/api/draft/my-draft/promote \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"contextGraph": "my-context-graph"}'
+```
+
+## 4. Authentication
+
+**Two modes:**
+- **Custodial** (default): register without a `publicKey` — node generates and holds keys, signs on your behalf.
+- **Self-sovereign**: register with your own `publicKey` — you sign protocol operations externally via prepare/submit handshake.
+
+**Token usage:** Include `Authorization: Bearer $AGENT_TOKEN` on all requests.
+Agent tokens are prefixed `dkg_at_`.
+
+**Public endpoints (no auth):** `GET /api/status`, `GET /api/chain/rpc-health`,
+`GET /.well-known/skill.md`, `GET /context-oracle`, `GET /ui/*`, `GET /apps/*`.
+
+## 5. Memory Model
+
+### Working Memory (WM) — Private drafts
+
+- `POST /api/draft/create` — create a named draft
+- `PUT /api/draft/{name}` — write triples (additive)
+- `POST /api/draft/{name}/import` — import N-Triples/Turtle/JSON-LD
+- `POST /api/draft/{name}/import-file` — import PDF/DOCX/Markdown (multipart)
+- `GET /api/draft/{name}` — read draft contents
+- `DELETE /api/draft/{name}` — delete draft
+
+### Shared Working Memory (SWM) — Team-visible
+
+- `POST /api/draft/{name}/promote` — SHARE: promote draft to SWM (triggers gossip)
+- `POST /api/swm/write` — write directly to SWM (skip WM)
+- `GET /api/swm/entities` — list SWM entities
+
+### Verified Memory (VM) — Permanent, on-chain
+
+- `POST /api/publish` — PUBLISH: promote SWM triples to VM (costs TRAC)
+- `POST /api/update` — UPDATE: modify existing Knowledge Asset
+- `POST /api/endorse` — ENDORSE: social signal ("I vouch for this")
+- `POST /api/verify/propose` — propose M-of-N consensus verification
+- `POST /api/verify/approve` — approve/reject verification proposal
+
+### Querying
+
+- `POST /api/query` — SPARQL query with `view` parameter (`working-memory`, `shared-working-memory`, `verified-memory`), optional `minTrust` and `verifiedGraph` filters
+- `POST /api/query-remote` — query a remote peer via P2P
+
+## 6. Context Graphs
+
+Context Graphs are scoped knowledge domains with configurable access and governance.
+
+- `POST /api/context-graph/create` — create (set access, publishPolicy, quorum)
+- `GET /api/context-graph/list` — list subscribed CGs
+- `GET /api/context-graph/{id}` — CG details
+- `POST /api/context-graph/{id}/subscribe` — subscribe to a CG
+- `POST /api/context-graph/{id}/ontology` — add ontology
+- `GET /api/context-graph/{id}/ontology` — list ontologies
+
+## 7. File Ingestion
+
+Upload documents and get automatic triple extraction:
+
+```bash
+curl -X POST $BASE_URL/api/draft/my-draft/import-file \
+  -H "Authorization: Bearer $AGENT_TOKEN" \
+  -F "file=@paper.pdf" \
+  -F "contextGraph=my-context-graph"
+```
+
+Supported formats depend on available extraction pipelines (see Node Info §1).
+For large files, poll extraction status:
+
+```bash
+curl "$BASE_URL/api/draft/my-draft/extraction-status?contextGraph=my-context-graph" \
+  -H "Authorization: Bearer $AGENT_TOKEN"
+```
+
+## 8. Node Administration
+
+- `GET /api/status` (PUBLIC) — node status, peer ID, version, connections
+- `GET /api/info` — lightweight health check
+- `GET /api/agents` — list known agents
+- `GET /api/agent/profile` — your agent profile
+- `GET /api/connections` — transport details
+- `GET /api/wallets/balances` — TRAC and ETH balances
+- `GET /api/chain/rpc-health` (PUBLIC) — RPC health
+
+## 9. Error Reference
+
+| Status | Meaning | Recovery |
+|--------|---------|----------|
+| 400 | Bad request — missing fields, invalid SPARQL | Fix the request body |
+| 401 | Unauthorized — invalid or missing token | Re-authenticate or refresh token |
+| 402 | Insufficient TRAC for publication | Check balances, notify node operator |
+| 403 | Forbidden — publishPolicy or allowList violation | Verify CG membership and publish authority |
+| 404 | Resource not found | Verify resource identifiers (draft name, CG ID, UAL) |
+| 409 | Conflict — name collision or concurrent modification | Retry with a different name |
+| 429 | Rate limited | Wait and retry with backoff |
+| 502 | Chain/upstream error | Retry — transient blockchain issue |
+| 503 | Service unavailable | Node is starting up or shutting down |
+
+## 10. Workflow Recipes
+
+For detailed step-by-step workflow recipes and the full endpoint reference, see
+the supporting files in the skill directory:
+
+- `workflows.md` — 10 workflow recipes with curl examples
+- `api-reference.md` — full endpoint reference grouped by workflow
+- `examples/sparql-recipes.md` — SPARQL query patterns
+
+## Appendix: V9 → V10 Migration
+
+| V9 Concept | V10 Equivalent |
+|------------|---------------|
+| Paranet | Context Graph |
+| Workspace | Shared Working Memory |
+| Enshrine | SHARE (promote draft) |
+| `POST /api/workspace/write` | `PUT /api/draft/{name}` |
+| `POST /api/workspace/enshrine` | `POST /api/draft/{name}/promote` |
+| `POST /api/paranet/create` | `POST /api/context-graph/create` |

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dkg-node
-description: Manage agent memory on the DKG V10 node — store private drafts in Working Memory, share with your team in Shared Working Memory, publish permanently to Verified Memory, build trust through endorsements and M-of-N consensus verification.
+description: Manage agent memory on the DKG V10 node — store private assertions in Working Memory, share with your team in Shared Working Memory, publish permanently to Verified Memory, build trust through endorsements and M-of-N consensus verification.
 ---
 
 # DKG V10 Node Skill
@@ -173,7 +173,7 @@ curl -X POST $BASE_URL/api/assertion/my-assertion/import-file \
 | 401 | Unauthorized — invalid or missing token | Re-authenticate or refresh token |
 | 402 | Insufficient TRAC for publication | Check balances, notify node operator |
 | 403 | Forbidden — publishPolicy or allowList violation | Verify CG membership and publish authority |
-| 404 | Resource not found | Verify resource identifiers (draft name, CG ID, UAL) |
+| 404 | Resource not found | Verify resource identifiers (assertion name, CG ID, UAL) |
 | 409 | Conflict — name collision or concurrent modification | Retry with a different name |
 | 429 | Rate limited | Wait and retry with backoff |
 | 502 | Chain/upstream error | Retry — transient blockchain issue |

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -106,6 +106,7 @@ export function extractBearerToken(headerValue: string | undefined): string | un
 const PUBLIC_PATHS = new Set([
   '/api/status',
   '/api/chain/rpc-health',
+  '/.well-known/skill.md',
 ]);
 
 const PUBLIC_PREFIXES = [

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2088,6 +2088,11 @@ async function handleRequest(
     const contextGraphId = parsed.contextGraphId ?? parsed.paranetId;
     const graphSuffix = parsed.graphSuffix;
     const includeSharedMemory = parsed.includeSharedMemory ?? parsed.includeWorkspace;
+    const view = parsed.view;
+    const agentAddress = parsed.agentAddress;
+    const verifiedGraph = parsed.verifiedGraph;
+    const assertionName = parsed.assertionName;
+    const subGraphName = parsed.subGraphName;
     if (!sparql || !String(sparql).trim()) return jsonResponse(res, 400, { error: 'Missing "sparql"' });
     const ctx = createOperationContext('query');
     tracker.start(ctx, { contextGraphId, details: { sparql: sparql.slice(0, 200) } });
@@ -2096,7 +2101,7 @@ async function handleRequest(
       tracker.completePhase(ctx, 'parse');
       tracker.startPhase(ctx, 'execute');
       const execT0 = Date.now();
-      const result = await agent.query(sparql, { contextGraphId, graphSuffix, includeSharedMemory, operationCtx: ctx });
+      const result = await agent.query(sparql, { contextGraphId, graphSuffix, includeSharedMemory, view, agentAddress, verifiedGraph, assertionName, subGraphName, operationCtx: ctx });
       const execDur = Date.now() - execT0;
       tracker.completePhase(ctx, 'execute');
       tracker.complete(ctx, { tripleCount: result?.bindings?.length ?? 0 });

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -89,8 +89,9 @@ let cachedSkillEtag: string | null = null;
 function loadSkillTemplate(): string {
   if (cachedSkillMd) return cachedSkillMd;
   const skillPath = new URL('../skills/dkg-node/SKILL.md', import.meta.url);
-  cachedSkillMd = readFileSync(skillPath, 'utf-8');
-  return cachedSkillMd;
+  const content = readFileSync(skillPath, 'utf-8');
+  cachedSkillMd = content;
+  return content;
 }
 
 function buildSkillMd(opts: {
@@ -1224,10 +1225,11 @@ async function handleRequest(
 
   // GET /.well-known/skill.md — Agent Skills document (PUBLIC, no auth)
   if (req.method === 'GET' && path === '/.well-known/skill.md') {
-    const listenPort = config.listenPort ?? 9200;
-    const baseUrl = `http://localhost:${listenPort}`;
+    const proto = req.headers['x-forwarded-proto'] ?? 'http';
+    const host = req.headers['x-forwarded-host'] ?? req.headers.host ?? `localhost:${config.listenPort ?? 9200}`;
+    const baseUrl = `${proto}://${host}`;
     const cgMap = agent.getSubscribedContextGraphs();
-    const cgNames = [...cgMap.keys()];
+    const cgNames = [...cgMap.keys()].filter(n => !n.startsWith('_'));
     const pipelines = ['text/markdown', ...extractionRegistry.availableContentTypes()];
     const content = buildSkillMd({
       version: nodeVersion,

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { stat } from 'node:fs/promises';
 import { ethers } from 'ethers';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS } from '@origintrail-official/dkg-core';
 import {
   DashboardDB,
   MetricsCollector,
@@ -2094,6 +2094,9 @@ async function handleRequest(
     const assertionName = parsed.assertionName;
     const subGraphName = parsed.subGraphName;
     if (!sparql || !String(sparql).trim()) return jsonResponse(res, 400, { error: 'Missing "sparql"' });
+    if (view && !(GET_VIEWS as readonly string[]).includes(view)) {
+      return jsonResponse(res, 400, { error: `Invalid view "${view}". Supported: ${GET_VIEWS.join(', ')}` });
+    }
     const ctx = createOperationContext('query');
     tracker.start(ctx, { contextGraphId, details: { sparql: sparql.slice(0, 200) } });
     tracker.startPhase(ctx, 'parse');

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2112,7 +2112,13 @@ async function handleRequest(
     } catch (err: any) {
       tracker.fail(ctx, err);
       const msg = err?.message ?? '';
-      if (msg.startsWith('SPARQL rejected:') || msg.startsWith('Parse error') || /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg)) {
+      if (
+        msg.startsWith('SPARQL rejected:') || msg.startsWith('Parse error') ||
+        /must start with (SELECT|CONSTRUCT|ASK|DESCRIBE)/i.test(msg) ||
+        msg.includes('was removed in V10') ||
+        msg.includes('requires agentAddress') || msg.includes('requires contextGraphId') ||
+        msg.includes('cannot be combined with')
+      ) {
         return jsonResponse(res, 400, { error: msg });
       }
       throw err;

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { createHash } from 'node:crypto';
 import { appendFile, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { execSync, exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -51,6 +52,8 @@ import {
   CLI_NPM_PACKAGE,
 } from './config.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from './auth.js';
+import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
+import { MarkItDownConverter, isMarkItDownAvailable } from './extraction/index.js';
 import { handleCapture, EpcisValidationError, handleEventsQuery, EpcisQueryError, type Publisher as EpcisPublisher } from '@origintrail-official/dkg-epcis';
 import { readFileSync } from 'node:fs';
 
@@ -75,6 +78,55 @@ function getCurrentCommitShort(): string {
     } catch { return ''; }
   }
 }
+
+// ---------------------------------------------------------------------------
+// SKILL.MD serving — Agent Skills standard (https://agentskills.io)
+// ---------------------------------------------------------------------------
+
+let cachedSkillMd: string | null = null;
+let cachedSkillEtag: string | null = null;
+
+function loadSkillTemplate(): string {
+  if (cachedSkillMd) return cachedSkillMd;
+  const skillPath = new URL('../skills/dkg-node/SKILL.md', import.meta.url);
+  cachedSkillMd = readFileSync(skillPath, 'utf-8');
+  return cachedSkillMd;
+}
+
+function buildSkillMd(opts: {
+  version: string;
+  baseUrl: string;
+  peerId: string;
+  nodeRole: string;
+  extractionPipelines: string[];
+  contextGraphs: string[];
+}): string {
+  const template = loadSkillTemplate();
+  const dynamicSection = [
+    `- **Node version:** ${opts.version}`,
+    `- **Base URL:** ${opts.baseUrl}`,
+    `- **Peer ID:** ${opts.peerId}`,
+    `- **Node role:** ${opts.nodeRole}`,
+    `- **Available extraction pipelines:** ${opts.extractionPipelines.length > 0 ? opts.extractionPipelines.join(', ') : 'text/markdown'}`,
+    `- **Subscribed Context Graphs:** ${opts.contextGraphs.length > 0 ? opts.contextGraphs.join(', ') : '(none)'}`,
+  ].join('\n');
+
+  const staticPlaceholder =
+    '> This section is dynamically generated from node state at serve-time.\n\n'
+    + '- **Node version:** (dynamic)\n'
+    + '- **Base URL:** (dynamic)\n'
+    + '- **Peer ID:** (dynamic)\n'
+    + '- **Node role:** (dynamic — `core` or `edge`)\n'
+    + '- **Available extraction pipelines:** (dynamic)\n'
+    + '- **Subscribed Context Graphs:** (dynamic)';
+
+  return template.replace(staticPlaceholder, dynamicSection);
+}
+
+function skillEtag(content: string): string {
+  return '"' + createHash('md5').update(content).digest('hex').slice(0, 16) + '"';
+}
+
 import { loadApps, handleAppRequest, startAppStaticServer, type LoadedApp } from './app-loader.js';
 
 export const DAEMON_EXIT_CODE_RESTART = 75;
@@ -741,11 +793,21 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
     latestByParanet: new Map(),
   };
 
+  // --- Extraction Pipelines ---
+
+  const extractionRegistry = new ExtractionPipelineRegistry();
+  if (isMarkItDownAvailable()) {
+    extractionRegistry.register(new MarkItDownConverter());
+    log(`Extraction pipelines: ${extractionRegistry.availableContentTypes().join(', ')}`);
+  } else {
+    log('MarkItDown binary not found — document extraction unavailable (files stored as blobs)');
+  }
+
   // --- HTTP API ---
 
   const rateLimiter = new HttpRateLimiter(
     config.rateLimit?.requestsPerMinute ?? 120,
-    config.rateLimit?.exempt ?? ['/api/status', '/api/chain/rpc-health'],
+    config.rateLimit?.exempt ?? ['/api/status', '/api/chain/rpc-health', '/.well-known/skill.md'],
   );
   let corsAllowed: CorsAllowlist = '*';
 
@@ -848,6 +910,7 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
         nodeVersion,
         nodeCommit,
         catchupTracker,
+        extractionRegistry,
       );
     } catch (err: any) {
       if (res.headersSent || res.writableEnded) return;
@@ -1154,9 +1217,39 @@ async function handleRequest(
   nodeVersion: string,
   nodeCommit: string,
   catchupTracker: CatchupTracker,
+  extractionRegistry: ExtractionPipelineRegistry,
 ): Promise<void> {
   const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
   const path = url.pathname;
+
+  // GET /.well-known/skill.md — Agent Skills document (PUBLIC, no auth)
+  if (req.method === 'GET' && path === '/.well-known/skill.md') {
+    const listenPort = config.listenPort ?? 9200;
+    const baseUrl = `http://localhost:${listenPort}`;
+    const cgMap = agent.getSubscribedContextGraphs();
+    const cgNames = [...cgMap.keys()];
+    const pipelines = ['text/markdown', ...extractionRegistry.availableContentTypes()];
+    const content = buildSkillMd({
+      version: nodeVersion,
+      baseUrl,
+      peerId: agent.peerId,
+      nodeRole: config.nodeRole ?? 'edge',
+      extractionPipelines: [...new Set(pipelines)],
+      contextGraphs: cgNames,
+    });
+    const etag = skillEtag(content);
+    if (req.headers['if-none-match'] === etag) {
+      res.writeHead(304).end();
+      return;
+    }
+    res.writeHead(200, {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'ETag': etag,
+      'Cache-Control': 'public, max-age=300',
+    });
+    res.end(content);
+    return;
+  }
 
   // GET /api/status
   if (req.method === 'GET' && path === '/api/status') {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -100,7 +100,6 @@ function buildSkillMd(opts: {
   peerId: string;
   nodeRole: string;
   extractionPipelines: string[];
-  contextGraphs: string[];
 }): string {
   const template = loadSkillTemplate();
   const dynamicSection = [
@@ -109,7 +108,7 @@ function buildSkillMd(opts: {
     `- **Peer ID:** ${opts.peerId}`,
     `- **Node role:** ${opts.nodeRole}`,
     `- **Available extraction pipelines:** ${opts.extractionPipelines.length > 0 ? opts.extractionPipelines.join(', ') : 'text/markdown'}`,
-    `- **Subscribed Context Graphs:** ${opts.contextGraphs.length > 0 ? opts.contextGraphs.join(', ') : '(none)'}`,
+    `- **Subscribed Context Graphs:** use \`GET /api/context-graph/list\` (requires auth)`,
   ].join('\n');
 
   const staticPlaceholder =
@@ -1228,8 +1227,6 @@ async function handleRequest(
     const proto = req.headers['x-forwarded-proto'] ?? 'http';
     const host = req.headers['x-forwarded-host'] ?? req.headers.host ?? `localhost:${config.listenPort ?? 9200}`;
     const baseUrl = `${proto}://${host}`;
-    const cgMap = agent.getSubscribedContextGraphs();
-    const cgNames = [...cgMap.keys()].filter(n => !n.startsWith('_'));
     const pipelines = ['text/markdown', ...extractionRegistry.availableContentTypes()];
     const content = buildSkillMd({
       version: nodeVersion,
@@ -1237,7 +1234,6 @@ async function handleRequest(
       peerId: agent.peerId,
       nodeRole: config.nodeRole ?? 'edge',
       extractionPipelines: [...new Set(pipelines)],
-      contextGraphs: cgNames,
     });
     const etag = skillEtag(content);
     if (req.headers['if-none-match'] === etag) {

--- a/packages/cli/src/extraction/index.ts
+++ b/packages/cli/src/extraction/index.ts
@@ -1,0 +1,1 @@
+export { MarkItDownConverter, isMarkItDownAvailable, MARKITDOWN_CONTENT_TYPES } from './markitdown-converter.js';

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -12,6 +12,7 @@ import { execFile, execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { platform, arch } from 'node:process';
+import { fileURLToPath } from 'node:url';
 import type { ExtractionPipeline, ExtractionInput, ExtractionOutput } from '@origintrail-official/dkg-core';
 
 const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
@@ -19,7 +20,7 @@ const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
 function resolveMarkItDownBin(): string | null {
   const suffix = platform === 'win32' ? '.exe' : '';
   const binaryName = `markitdown-${platform}-${arch}${suffix}`;
-  const binDir = resolve(new URL('../../bin', import.meta.url).pathname);
+  const binDir = resolve(fileURLToPath(new URL('../../bin', import.meta.url)));
   const candidate = join(binDir, binaryName);
   if (existsSync(candidate)) return candidate;
 

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -1,0 +1,97 @@
+/**
+ * MarkItDown converter — file-to-Markdown using the standalone MarkItDown binary.
+ *
+ * Microsoft MarkItDown (MIT license) converts PDF, DOCX, PPTX, XLSX, CSV, HTML,
+ * images, EPUB, XML, and JSON to Markdown. The binary is a PyInstaller-compiled
+ * standalone executable shipped with the DKG node.
+ *
+ * Spec: 05_PROTOCOL_EXTENSIONS.md §6.5.1
+ */
+
+import { execFile, execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { platform, arch } from 'node:process';
+import type { ExtractionPipeline, ExtractionInput, ExtractionOutput } from '@origintrail-official/dkg-core';
+
+const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
+
+function resolveMarkItDownBin(): string | null {
+  const suffix = platform === 'win32' ? '.exe' : '';
+  const binaryName = `markitdown-${platform}-${arch}${suffix}`;
+  const binDir = resolve(new URL('../../bin', import.meta.url).pathname);
+  const candidate = join(binDir, binaryName);
+  if (existsSync(candidate)) return candidate;
+
+  // Fallback: check if markitdown is on PATH
+  const pathBin = `markitdown${suffix}`;
+  try {
+    const whichCmd = platform === 'win32' ? 'where' : 'which';
+    execFileSync(whichCmd, [pathBin], { encoding: 'utf-8', stdio: 'pipe' });
+    return pathBin;
+  } catch {
+    return null;
+  }
+}
+
+let cachedBinPath: string | null | undefined;
+
+function getMarkItDownBin(): string | null {
+  if (cachedBinPath !== undefined) return cachedBinPath;
+  cachedBinPath = resolveMarkItDownBin();
+  return cachedBinPath;
+}
+
+export function isMarkItDownAvailable(): boolean {
+  return getMarkItDownBin() !== null;
+}
+
+async function runMarkItDown(filePath: string): Promise<string> {
+  const bin = getMarkItDownBin();
+  if (!bin) {
+    throw new Error(
+      'MarkItDown binary not found. Document extraction unavailable. '
+      + 'Install markitdown or place the standalone binary in the node bin/ directory.',
+    );
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    execFile(bin, [filePath], { maxBuffer: MAX_OUTPUT_BYTES }, (err, stdout, stderr) => {
+      if (err) {
+        const msg = stderr?.trim() || err.message;
+        reject(new Error(`MarkItDown conversion failed: ${msg}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+export const MARKITDOWN_CONTENT_TYPES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'text/csv',
+  'text/html',
+  'application/epub+zip',
+  'application/xml',
+  'text/xml',
+] as const;
+
+export class MarkItDownConverter implements ExtractionPipeline {
+  readonly contentTypes = [...MARKITDOWN_CONTENT_TYPES];
+
+  async extract(input: ExtractionInput): Promise<ExtractionOutput> {
+    const markdown = await runMarkItDown(input.filePath);
+
+    // Phase 2 (markdown → triples) is handled by the Markdown extraction pipeline
+    // which runs separately. This converter only does phase 1: file → Markdown.
+    // Return the intermediate with empty triples; the caller chains the MD pipeline.
+    return {
+      mdIntermediate: markdown,
+      triples: [],
+      provenance: [],
+    };
+  }
+}

--- a/packages/cli/test/document-processor-e2e.test.ts
+++ b/packages/cli/test/document-processor-e2e.test.ts
@@ -1,0 +1,340 @@
+/**
+ * E2E tests for the document processing pipeline.
+ *
+ * Tests the full flow: file on disk → ExtractionPipeline → Markdown intermediate.
+ * When MarkItDown is available, tests real conversion of HTML/CSV/Markdown files.
+ * When unavailable, tests graceful degradation and the pipeline registry plumbing.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, rm, mkdtemp, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  ExtractionPipelineRegistry,
+  type ExtractionPipeline,
+  type ExtractionInput,
+  type ExtractionOutput,
+} from '@origintrail-official/dkg-core';
+import { MarkItDownConverter, isMarkItDownAvailable } from '../src/extraction/index.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'dkg-docproc-e2e-'));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Registry-level E2E: register → lookup → extract
+// ---------------------------------------------------------------------------
+
+describe('ExtractionPipelineRegistry E2E', () => {
+  it('registers MarkItDownConverter and resolves content types', () => {
+    const registry = new ExtractionPipelineRegistry();
+    const converter = new MarkItDownConverter();
+    registry.register(converter);
+
+    expect(registry.has('application/pdf')).toBe(true);
+    expect(registry.has('text/csv')).toBe(true);
+    expect(registry.has('text/html')).toBe(true);
+    expect(registry.has('text/plain')).toBe(false);
+    expect(registry.get('application/pdf')).toBe(converter);
+  });
+
+  it('reports all available content types after MarkItDown registration', () => {
+    const registry = new ExtractionPipelineRegistry();
+    registry.register(new MarkItDownConverter());
+
+    const types = registry.availableContentTypes();
+    expect(types.length).toBeGreaterThanOrEqual(6);
+    expect(types).toContain('application/pdf');
+    expect(types).toContain('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+  });
+
+  it('supports multiple pipelines: custom markdown + MarkItDown', () => {
+    const registry = new ExtractionPipelineRegistry();
+
+    const customMdPipeline: ExtractionPipeline = {
+      contentTypes: ['text/markdown'],
+      async extract(input: ExtractionInput): Promise<ExtractionOutput> {
+        const md = await readFile(input.filePath, 'utf-8');
+        return { mdIntermediate: md, triples: [], provenance: [] };
+      },
+    };
+
+    registry.register(customMdPipeline);
+    registry.register(new MarkItDownConverter());
+
+    expect(registry.get('text/markdown')).toBe(customMdPipeline);
+    expect(registry.get('application/pdf')).toBeInstanceOf(MarkItDownConverter);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Document conversion E2E (requires MarkItDown binary)
+// ---------------------------------------------------------------------------
+
+const markitdownAvailable = isMarkItDownAvailable();
+
+describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion', () => {
+  let converter: MarkItDownConverter;
+
+  beforeEach(() => {
+    converter = new MarkItDownConverter();
+  });
+
+  it('converts an HTML file to Markdown', async () => {
+    const htmlFile = join(tmpDir, 'page.html');
+    await writeFile(htmlFile, `
+      <html>
+      <body>
+        <h1>Research Paper</h1>
+        <p>This paper discusses <strong>decentralized knowledge graphs</strong>.</p>
+        <h2>Introduction</h2>
+        <p>The DKG protocol enables verifiable AI memory.</p>
+        <ul>
+          <li>Working Memory</li>
+          <li>Shared Working Memory</li>
+          <li>Verified Memory</li>
+        </ul>
+      </body>
+      </html>
+    `);
+
+    const result = await converter.extract({
+      filePath: htmlFile,
+      contentType: 'text/html',
+      agentDid: 'did:dkg:agent:0xTest',
+    });
+
+    expect(result.mdIntermediate).toBeTruthy();
+    expect(result.mdIntermediate).toContain('Research Paper');
+    expect(result.mdIntermediate).toContain('decentralized knowledge graphs');
+    expect(result.triples).toEqual([]);
+    expect(result.provenance).toEqual([]);
+  });
+
+  it('converts a CSV file to Markdown', async () => {
+    const csvFile = join(tmpDir, 'data.csv');
+    await writeFile(csvFile, 'Name,Role,Trust\nAlice,Researcher,endorsed\nBob,Validator,consensus-verified\n');
+
+    const result = await converter.extract({
+      filePath: csvFile,
+      contentType: 'text/csv',
+      agentDid: 'did:dkg:agent:0xTest',
+    });
+
+    expect(result.mdIntermediate).toBeTruthy();
+    expect(result.mdIntermediate).toContain('Alice');
+    expect(result.mdIntermediate).toContain('Bob');
+    expect(result.mdIntermediate).toContain('Researcher');
+  });
+
+  it('handles empty file gracefully', async () => {
+    const emptyFile = join(tmpDir, 'empty.html');
+    await writeFile(emptyFile, '');
+
+    const result = await converter.extract({
+      filePath: emptyFile,
+      contentType: 'text/html',
+      agentDid: 'did:dkg:agent:0xTest',
+    });
+
+    expect(typeof result.mdIntermediate).toBe('string');
+    expect(result.triples).toEqual([]);
+  });
+
+  it('processes file through registry lookup → extract', async () => {
+    const registry = new ExtractionPipelineRegistry();
+    registry.register(converter);
+
+    const htmlFile = join(tmpDir, 'test.html');
+    await writeFile(htmlFile, '<h1>Title</h1><p>Body text</p>');
+
+    const pipeline = registry.get('text/html');
+    expect(pipeline).toBeDefined();
+
+    const result = await pipeline!.extract({
+      filePath: htmlFile,
+      contentType: 'text/html',
+      agentDid: 'did:dkg:agent:0xTest',
+    });
+
+    expect(result.mdIntermediate).toContain('Title');
+    expect(result.mdIntermediate).toContain('Body text');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graceful degradation (MarkItDown unavailable)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(markitdownAvailable)('MarkItDown unavailable — graceful degradation', () => {
+  it('isMarkItDownAvailable returns false', () => {
+    expect(isMarkItDownAvailable()).toBe(false);
+  });
+
+  it('extract throws descriptive error when binary is missing', async () => {
+    const converter = new MarkItDownConverter();
+    await expect(converter.extract({
+      filePath: '/tmp/fake.pdf',
+      contentType: 'application/pdf',
+      agentDid: 'did:dkg:agent:0xTest',
+    })).rejects.toThrow(/MarkItDown binary not found/);
+  });
+
+  it('registry still works — returns undefined for unregistered types', () => {
+    const registry = new ExtractionPipelineRegistry();
+    expect(registry.get('application/pdf')).toBeUndefined();
+    expect(registry.availableContentTypes()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full pipeline simulation: file → markdown → mock triples
+// ---------------------------------------------------------------------------
+
+describe('Full extraction pipeline simulation', () => {
+  it('processes a file through phase 1 (file→MD) and phase 2 (MD→triples)', async () => {
+    const testFile = join(tmpDir, 'input.md');
+    await writeFile(testFile, '# Climate Report\n\nGlobal temperature rose by 1.2°C.\n');
+
+    // Phase 1: file → markdown intermediate (simulated as direct read for .md files)
+    const phase1: ExtractionPipeline = {
+      contentTypes: ['text/markdown'],
+      async extract(input) {
+        const md = await readFile(input.filePath, 'utf-8');
+        return { mdIntermediate: md, triples: [], provenance: [] };
+      },
+    };
+
+    const phase1Result = await phase1.extract({
+      filePath: testFile,
+      contentType: 'text/markdown',
+      agentDid: 'did:dkg:agent:0xClimate',
+    });
+
+    expect(phase1Result.mdIntermediate).toContain('Climate Report');
+    expect(phase1Result.mdIntermediate).toContain('1.2°C');
+
+    // Phase 2: markdown → RDF triples (simulated extraction)
+    const extractedTriples = [
+      {
+        subject: 'urn:climate:report:2026',
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'https://schema.org/Report',
+      },
+      {
+        subject: 'urn:climate:report:2026',
+        predicate: 'https://schema.org/name',
+        object: 'Climate Report',
+      },
+      {
+        subject: 'urn:climate:report:2026',
+        predicate: 'https://schema.org/description',
+        object: 'Global temperature rose by 1.2°C.',
+      },
+    ];
+
+    const provenanceTriples = [
+      {
+        subject: 'urn:extraction:1',
+        predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+        object: 'dkg:ExtractionProvenance',
+      },
+      {
+        subject: 'urn:extraction:1',
+        predicate: 'dkg:extractedBy',
+        object: 'did:dkg:agent:0xClimate',
+      },
+    ];
+
+    // Verify the full pipeline output
+    expect(extractedTriples).toHaveLength(3);
+    expect(extractedTriples[0].subject).toBe('urn:climate:report:2026');
+    expect(provenanceTriples).toHaveLength(2);
+    expect(provenanceTriples[1].object).toBe('did:dkg:agent:0xClimate');
+
+    // Simulate what the node does: store all artifacts
+    const artifacts = {
+      originalFile: testFile,
+      mdIntermediate: phase1Result.mdIntermediate,
+      triples: extractedTriples,
+      provenance: provenanceTriples,
+      totalTripleCount: extractedTriples.length + provenanceTriples.length,
+    };
+
+    expect(artifacts.totalTripleCount).toBe(5);
+    expect(artifacts.mdIntermediate).toContain('Climate Report');
+  });
+
+  it('simulates import-file response shape', async () => {
+    const testFile = join(tmpDir, 'report.html');
+    await writeFile(testFile, '<h1>Q4 Sales</h1><p>Revenue: $1.2M</p>');
+
+    const registry = new ExtractionPipelineRegistry();
+
+    // Register a mock HTML pipeline
+    registry.register({
+      contentTypes: ['text/html'],
+      async extract(input) {
+        const content = await readFile(input.filePath, 'utf-8');
+        return {
+          mdIntermediate: content.replace(/<[^>]+>/g, ''),
+          triples: [{ subject: 'urn:sales:q4', predicate: 'rdf:type', object: 'schema:Report' }],
+          provenance: [],
+        };
+      },
+    });
+
+    const pipeline = registry.get('text/html');
+    expect(pipeline).toBeDefined();
+
+    const result = await pipeline!.extract({
+      filePath: testFile,
+      contentType: 'text/html',
+      agentDid: 'did:dkg:agent:0xSales',
+    });
+
+    // Build the import-file response as the daemon would
+    const importFileResponse = {
+      draftUri: 'did:dkg:context-graph:sales/draft/0xSales/q4-report',
+      fileHash: 'sha256:abc123',
+      detectedContentType: 'text/html',
+      extraction: {
+        status: result.triples.length > 0 ? 'completed' as const : 'skipped' as const,
+        tripleCount: result.triples.length,
+        mdIntermediateHash: 'sha256:def456',
+        pipelineUsed: 'text/html',
+      },
+    };
+
+    expect(importFileResponse.extraction.status).toBe('completed');
+    expect(importFileResponse.extraction.tripleCount).toBe(1);
+    expect(importFileResponse.extraction.pipelineUsed).toBe('text/html');
+    expect(importFileResponse.detectedContentType).toBe('text/html');
+  });
+
+  it('simulates skipped extraction for unknown content type', () => {
+    const registry = new ExtractionPipelineRegistry();
+    registry.register(new MarkItDownConverter());
+
+    const pipeline = registry.get('application/octet-stream');
+    expect(pipeline).toBeUndefined();
+
+    // Node would return extraction.status: "skipped"
+    const importFileResponse = {
+      draftUri: 'did:dkg:context-graph:test/draft/0xAgent/binary-blob',
+      fileHash: 'sha256:xyz789',
+      detectedContentType: 'application/octet-stream',
+      extraction: {
+        status: 'skipped' as const,
+      },
+    };
+
+    expect(importFileResponse.extraction.status).toBe('skipped');
+  });
+});

--- a/packages/cli/test/document-processor-e2e.test.ts
+++ b/packages/cli/test/document-processor-e2e.test.ts
@@ -301,7 +301,7 @@ describe('Full extraction pipeline simulation', () => {
 
     // Build the import-file response as the daemon would
     const importFileResponse = {
-      draftUri: 'did:dkg:context-graph:sales/draft/0xSales/q4-report',
+      assertionUri: 'did:dkg:context-graph:sales/assertion/0xSales/q4-report',
       fileHash: 'sha256:abc123',
       detectedContentType: 'text/html',
       extraction: {
@@ -327,7 +327,7 @@ describe('Full extraction pipeline simulation', () => {
 
     // Node would return extraction.status: "skipped"
     const importFileResponse = {
-      draftUri: 'did:dkg:context-graph:test/draft/0xAgent/binary-blob',
+      assertionUri: 'did:dkg:context-graph:test/assertion/0xAgent/binary-blob',
       fileHash: 'sha256:xyz789',
       detectedContentType: 'application/octet-stream',
       extraction: {

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { writeFile, rm, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Dynamic import so vi.mock takes effect before module loads
+let MarkItDownConverter: typeof import('../src/extraction/markitdown-converter.js').MarkItDownConverter;
+let isMarkItDownAvailable: typeof import('../src/extraction/markitdown-converter.js').isMarkItDownAvailable;
+let MARKITDOWN_CONTENT_TYPES: typeof import('../src/extraction/markitdown-converter.js').MARKITDOWN_CONTENT_TYPES;
+
+describe('MARKITDOWN_CONTENT_TYPES', () => {
+  beforeEach(async () => {
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    MARKITDOWN_CONTENT_TYPES = mod.MARKITDOWN_CONTENT_TYPES;
+  });
+
+  it('includes PDF', () => {
+    expect(MARKITDOWN_CONTENT_TYPES).toContain('application/pdf');
+  });
+
+  it('includes DOCX', () => {
+    expect(MARKITDOWN_CONTENT_TYPES).toContain(
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    );
+  });
+
+  it('includes PPTX', () => {
+    expect(MARKITDOWN_CONTENT_TYPES).toContain(
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    );
+  });
+
+  it('includes XLSX', () => {
+    expect(MARKITDOWN_CONTENT_TYPES).toContain(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+  });
+
+  it('includes CSV and HTML', () => {
+    expect(MARKITDOWN_CONTENT_TYPES).toContain('text/csv');
+    expect(MARKITDOWN_CONTENT_TYPES).toContain('text/html');
+  });
+});
+
+describe('MarkItDownConverter', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    MarkItDownConverter = mod.MarkItDownConverter;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes all supported content types', () => {
+    const converter = new MarkItDownConverter();
+    expect(converter.contentTypes).toContain('application/pdf');
+    expect(converter.contentTypes).toContain('text/csv');
+    expect(converter.contentTypes.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('extract returns mdIntermediate with empty triples (phase 1 only)', async () => {
+    const converter = new MarkItDownConverter();
+
+    // If markitdown is not available, the extract call should throw
+    // with a helpful error message rather than silently failing
+    const available = (await import('../src/extraction/markitdown-converter.js')).isMarkItDownAvailable();
+    if (!available) {
+      await expect(converter.extract({
+        filePath: '/tmp/nonexistent.pdf',
+        contentType: 'application/pdf',
+        agentDid: 'did:dkg:agent:0xAbc',
+      })).rejects.toThrow(/MarkItDown binary not found/);
+      return;
+    }
+
+    // If available, test the actual conversion (only runs if binary is present)
+    const tmpDir = await mkdtemp(join(tmpdir(), 'markitdown-test-'));
+    const testFile = join(tmpDir, 'test.html');
+    await writeFile(testFile, '<html><body><h1>Hello</h1><p>World</p></body></html>');
+
+    try {
+      const result = await converter.extract({
+        filePath: testFile,
+        contentType: 'text/html',
+        agentDid: 'did:dkg:agent:0xTest',
+      });
+
+      expect(typeof result.mdIntermediate).toBe('string');
+      expect(result.mdIntermediate.length).toBeGreaterThan(0);
+      // Phase 1 only — triples are produced by the Markdown extraction pipeline
+      expect(result.triples).toEqual([]);
+      expect(result.provenance).toEqual([]);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isMarkItDownAvailable', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    isMarkItDownAvailable = mod.isMarkItDownAvailable;
+  });
+
+  it('returns a boolean', () => {
+    const result = isMarkItDownAvailable();
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/packages/cli/test/skill-endpoint.test.ts
+++ b/packages/cli/test/skill-endpoint.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { httpAuthGuard } from '../src/auth.js';
+
+// ---------------------------------------------------------------------------
+// Auth: /.well-known/skill.md is a public path
+// ---------------------------------------------------------------------------
+
+describe('httpAuthGuard — /.well-known/skill.md', () => {
+  const VALID_TOKEN = 'secret';
+  const validTokens = new Set([VALID_TOKEN]);
+  let server: Server;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (!httpAuthGuard(req, res, true, validTokens)) return;
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const addr = server.address() as { port: number };
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it('allows /.well-known/skill.md without a token (public endpoint)', async () => {
+    const res = await fetch(`${baseUrl}/.well-known/skill.md`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toBe('ok');
+  });
+
+  it('still rejects other protected endpoints without token', async () => {
+    const res = await fetch(`${baseUrl}/api/publish`, { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SKILL.md file content
+// ---------------------------------------------------------------------------
+
+describe('SKILL.md file', () => {
+  let skillContent: string;
+
+  beforeEach(() => {
+    const skillPath = new URL('../skills/dkg-node/SKILL.md', import.meta.url);
+    skillContent = readFileSync(skillPath, 'utf-8');
+  });
+
+  it('starts with Agent Skills YAML frontmatter', () => {
+    expect(skillContent).toMatch(/^---\n/);
+    expect(skillContent).toContain('name: dkg-node');
+    expect(skillContent).toContain('description:');
+    expect(skillContent).toMatch(/---\n\n/);
+  });
+
+  it('contains the required DKG V10 sections', () => {
+    expect(skillContent).toContain('## 1. Node Info');
+    expect(skillContent).toContain('## 2. Capabilities Overview');
+    expect(skillContent).toContain('## 3. Quick Start');
+    expect(skillContent).toContain('## 4. Authentication');
+    expect(skillContent).toContain('## 5. Memory Model');
+    expect(skillContent).toContain('## 6. Context Graphs');
+    expect(skillContent).toContain('## 7. File Ingestion');
+    expect(skillContent).toContain('## 8. Node Administration');
+    expect(skillContent).toContain('## 9. Error Reference');
+  });
+
+  it('contains dynamic placeholders for node info', () => {
+    expect(skillContent).toContain('(dynamic)');
+    expect(skillContent).toContain('**Node version:**');
+    expect(skillContent).toContain('**Base URL:**');
+    expect(skillContent).toContain('**Peer ID:**');
+  });
+
+  it('documents the three memory layers', () => {
+    expect(skillContent).toContain('Working Memory (WM)');
+    expect(skillContent).toContain('Shared Working Memory (SWM)');
+    expect(skillContent).toContain('Verified Memory (VM)');
+  });
+
+  it('includes key API endpoints', () => {
+    expect(skillContent).toContain('/api/agent/register');
+    expect(skillContent).toContain('/api/draft/create');
+    expect(skillContent).toContain('/api/draft/{name}');
+    expect(skillContent).toContain('/api/draft/{name}/promote');
+    expect(skillContent).toContain('/api/publish');
+    expect(skillContent).toContain('/api/query');
+    expect(skillContent).toContain('/api/draft/{name}/import-file');
+  });
+
+  it('documents error status codes', () => {
+    expect(skillContent).toContain('| 400 |');
+    expect(skillContent).toContain('| 401 |');
+    expect(skillContent).toContain('| 403 |');
+    expect(skillContent).toContain('| 404 |');
+    expect(skillContent).toContain('| 409 |');
+  });
+
+  it('includes V9 to V10 migration table', () => {
+    expect(skillContent).toContain('V9 → V10 Migration');
+    expect(skillContent).toContain('Paranet');
+    expect(skillContent).toContain('Context Graph');
+  });
+
+  it('is under 500 lines (Agent Skills best practice)', () => {
+    const lines = skillContent.split('\n').length;
+    expect(lines).toBeLessThan(500);
+  });
+});

--- a/packages/cli/test/skill-endpoint.test.ts
+++ b/packages/cli/test/skill-endpoint.test.ts
@@ -98,8 +98,8 @@ describe('SKILL.md file', () => {
 
   it('marks planned endpoints clearly', () => {
     expect(skillContent).toContain('🚧 Planned');
-    expect(skillContent).toContain('/api/draft/create');
-    expect(skillContent).toContain('/api/draft/{name}/import-file');
+    expect(skillContent).toContain('/api/assertion/create');
+    expect(skillContent).toContain('/api/assertion/{name}/import-file');
   });
 
   it('documents error status codes', () => {

--- a/packages/cli/test/skill-endpoint.test.ts
+++ b/packages/cli/test/skill-endpoint.test.ts
@@ -70,6 +70,7 @@ describe('SKILL.md file', () => {
     expect(skillContent).toContain('## 7. File Ingestion');
     expect(skillContent).toContain('## 8. Node Administration');
     expect(skillContent).toContain('## 9. Error Reference');
+    expect(skillContent).toContain('## 10. Workflow Recipes');
   });
 
   it('contains dynamic placeholders for node info', () => {
@@ -85,13 +86,19 @@ describe('SKILL.md file', () => {
     expect(skillContent).toContain('Verified Memory (VM)');
   });
 
-  it('includes key API endpoints', () => {
-    expect(skillContent).toContain('/api/agent/register');
-    expect(skillContent).toContain('/api/draft/create');
-    expect(skillContent).toContain('/api/draft/{name}');
-    expect(skillContent).toContain('/api/draft/{name}/promote');
+  it('includes key available API endpoints', () => {
+    expect(skillContent).toContain('/api/shared-memory/write');
+    expect(skillContent).toContain('/api/shared-memory/publish');
     expect(skillContent).toContain('/api/publish');
     expect(skillContent).toContain('/api/query');
+    expect(skillContent).toContain('/api/context-graph/create');
+    expect(skillContent).toContain('/api/context-graph/list');
+    expect(skillContent).toContain('/api/status');
+  });
+
+  it('marks planned endpoints clearly', () => {
+    expect(skillContent).toContain('🚧 Planned');
+    expect(skillContent).toContain('/api/draft/create');
     expect(skillContent).toContain('/api/draft/{name}/import-file');
   });
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -90,9 +90,6 @@ export function contextGraphAssertionUri(contextGraphId: string, agentAddress: s
   return `did:dkg:context-graph:${contextGraphId}/assertion/${agentAddress}/${name}`;
 }
 
-/** @deprecated Use contextGraphAssertionUri */
-export const contextGraphDraftUri = contextGraphAssertionUri;
-
 export function contextGraphRulesUri(contextGraphId: string): string {
   return `did:dkg:context-graph:${contextGraphId}/_rules`;
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -85,10 +85,13 @@ export function contextGraphVerifiedMemoryMetaUri(contextGraphId: string, verifi
   return `did:dkg:context-graph:${contextGraphId}/_verified_memory/${verifiedMemoryId}/_meta`;
 }
 
-export function contextGraphDraftUri(contextGraphId: string, agentAddress: string, name: string, subGraphName?: string): string {
-  if (subGraphName) return `did:dkg:context-graph:${contextGraphId}/${subGraphName}/draft/${agentAddress}/${name}`;
-  return `did:dkg:context-graph:${contextGraphId}/draft/${agentAddress}/${name}`;
+export function contextGraphAssertionUri(contextGraphId: string, agentAddress: string, name: string, subGraphName?: string): string {
+  if (subGraphName) return `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/${agentAddress}/${name}`;
+  return `did:dkg:context-graph:${contextGraphId}/assertion/${agentAddress}/${name}`;
 }
+
+/** @deprecated Use contextGraphAssertionUri */
+export const contextGraphDraftUri = contextGraphAssertionUri;
 
 export function contextGraphRulesUri(contextGraphId: string): string {
   return `did:dkg:context-graph:${contextGraphId}/_rules`;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -90,6 +90,8 @@ export function contextGraphAssertionUri(contextGraphId: string, agentAddress: s
   return `did:dkg:context-graph:${contextGraphId}/assertion/${agentAddress}/${name}`;
 }
 
+/** @deprecated Use contextGraphAssertionUri */
+export const contextGraphDraftUri = contextGraphAssertionUri;
 
 export function contextGraphRulesUri(contextGraphId: string): string {
   return `did:dkg:context-graph:${contextGraphId}/_rules`;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -90,8 +90,6 @@ export function contextGraphAssertionUri(contextGraphId: string, agentAddress: s
   return `did:dkg:context-graph:${contextGraphId}/assertion/${agentAddress}/${name}`;
 }
 
-/** @deprecated Use contextGraphAssertionUri */
-export const contextGraphDraftUri = contextGraphAssertionUri;
 
 export function contextGraphRulesUri(contextGraphId: string): string {
   return `did:dkg:context-graph:${contextGraphId}/_rules`;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -118,7 +118,7 @@ export function validateSubGraphName(name: string): { valid: boolean; reason?: s
   if (name.startsWith('_')) return { valid: false, reason: 'Sub-graph names starting with "_" are reserved for protocol graphs' };
   if (name.includes('/')) return { valid: false, reason: 'Sub-graph names cannot contain "/"' };
   if (/[<>"{}|^`\\\s]/.test(name)) return { valid: false, reason: 'Sub-graph name contains characters unsafe for IRIs' };
-  if (name === 'context' || name === 'draft') return { valid: false, reason: `"${name}" is a reserved path segment` };
+  if (name === 'context' || name === 'assertion' || name === 'draft') return { valid: false, reason: `"${name}" is a reserved path segment` };
   return { valid: true };
 }
 

--- a/packages/core/src/extraction-pipeline.ts
+++ b/packages/core/src/extraction-pipeline.ts
@@ -1,0 +1,67 @@
+/**
+ * Pluggable extraction pipeline interface for converting non-RDF files
+ * (PDF, DOCX, etc.) into Markdown intermediates and RDF triples.
+ *
+ * Spec: 05_PROTOCOL_EXTENSIONS.md §6.5
+ */
+
+export interface Quad {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph?: string;
+}
+
+export interface ExtractionInput {
+  /** Path to the file on disk (temp file from multipart upload). */
+  filePath: string;
+  /** Detected or user-specified MIME content type. */
+  contentType: string;
+  /** Optional: CG's _ontology graph URI for guided extraction. */
+  ontologyRef?: string;
+  /** Extracting agent's DID (for provenance tracking). */
+  agentDid: string;
+}
+
+export interface ExtractionOutput {
+  /** Markdown intermediate (stored alongside original, inspectable). */
+  mdIntermediate: string;
+  /** Extracted RDF triples. */
+  triples: Quad[];
+  /** dkg:ExtractionProvenance quads for semantically extracted triples. */
+  provenance: Quad[];
+}
+
+export interface ExtractionPipeline {
+  /** MIME content types this pipeline handles. */
+  readonly contentTypes: string[];
+  /** Convert a file to Markdown intermediate + RDF triples. */
+  extract(input: ExtractionInput): Promise<ExtractionOutput>;
+}
+
+/**
+ * Registry that maps content types to extraction pipelines.
+ * Nodes register pipelines at startup; the import-file endpoint
+ * looks up the pipeline for the detected content type.
+ */
+export class ExtractionPipelineRegistry {
+  private readonly pipelines = new Map<string, ExtractionPipeline>();
+
+  register(pipeline: ExtractionPipeline): void {
+    for (const ct of pipeline.contentTypes) {
+      this.pipelines.set(ct, pipeline);
+    }
+  }
+
+  get(contentType: string): ExtractionPipeline | undefined {
+    return this.pipelines.get(contentType);
+  }
+
+  has(contentType: string): boolean {
+    return this.pipelines.has(contentType);
+  }
+
+  availableContentTypes(): string[] {
+    return [...this.pipelines.keys()];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,3 +44,10 @@ export {
   loadAuthTokenSync,
   loadAuthToken,
 } from './dkg-home.js';
+export {
+  type Quad as ExtractionQuad,
+  type ExtractionInput,
+  type ExtractionOutput,
+  type ExtractionPipeline,
+  ExtractionPipelineRegistry,
+} from './extraction-pipeline.js';

--- a/packages/core/src/memory-model.ts
+++ b/packages/core/src/memory-model.ts
@@ -5,7 +5,7 @@
  * for the DKG V10 protocol.
  *
  * Memory layers (ordered by trust/permanence):
- *   WM  → Working Memory: local agent drafts, not shared
+ *   WM  → Working Memory: local agent assertions, not shared
  *   SWM → Shared Working Memory: published to peers, not anchored
  *   VM  → Verified Memory: anchored on-chain and M-of-N verified
  */
@@ -41,12 +41,15 @@ export interface MemoryTransition {
   timestamp: string;
 }
 
-export interface DraftDescriptor {
+export interface AssertionDescriptor {
   contextGraphId: string;
   agentAddress: string;
   name: string;
   createdAt: string;
 }
+
+/** @deprecated Use AssertionDescriptor */
+export type DraftDescriptor = AssertionDescriptor;
 
 export interface ShareRecord {
   contextGraphId: string;
@@ -105,7 +108,7 @@ export interface Publication {
 /**
  * V10 GET view selectors — each declares which memory layer(s) a query targets.
  *
- *   working-memory        → WM  (agent's own draft graphs, local-only)
+ *   working-memory        → WM  (agent's own assertion graphs, local-only)
  *   shared-working-memory → SWM (provisional, gossip-replicated)
  *   verified-memory       → VM  (on-chain anchored, M-of-N quorum verified)
  */

--- a/packages/core/src/memory-model.ts
+++ b/packages/core/src/memory-model.ts
@@ -48,8 +48,6 @@ export interface AssertionDescriptor {
   createdAt: string;
 }
 
-/** @deprecated Use AssertionDescriptor */
-export type DraftDescriptor = AssertionDescriptor;
 
 export interface ShareRecord {
   contextGraphId: string;

--- a/packages/core/test/extraction-pipeline.test.ts
+++ b/packages/core/test/extraction-pipeline.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ExtractionPipelineRegistry,
+  type ExtractionPipeline,
+  type ExtractionInput,
+  type ExtractionOutput,
+} from '../src/extraction-pipeline.js';
+
+function makePipeline(contentTypes: string[], output?: Partial<ExtractionOutput>): ExtractionPipeline {
+  return {
+    contentTypes,
+    async extract(_input: ExtractionInput): Promise<ExtractionOutput> {
+      return {
+        mdIntermediate: output?.mdIntermediate ?? '# Test',
+        triples: output?.triples ?? [],
+        provenance: output?.provenance ?? [],
+      };
+    },
+  };
+}
+
+describe('ExtractionPipelineRegistry', () => {
+  it('starts empty', () => {
+    const registry = new ExtractionPipelineRegistry();
+    expect(registry.availableContentTypes()).toEqual([]);
+    expect(registry.has('text/markdown')).toBe(false);
+    expect(registry.get('text/markdown')).toBeUndefined();
+  });
+
+  it('registers a pipeline for its content types', () => {
+    const registry = new ExtractionPipelineRegistry();
+    const pipeline = makePipeline(['application/pdf', 'text/html']);
+    registry.register(pipeline);
+
+    expect(registry.has('application/pdf')).toBe(true);
+    expect(registry.has('text/html')).toBe(true);
+    expect(registry.has('text/plain')).toBe(false);
+    expect(registry.get('application/pdf')).toBe(pipeline);
+    expect(registry.get('text/html')).toBe(pipeline);
+  });
+
+  it('lists all available content types', () => {
+    const registry = new ExtractionPipelineRegistry();
+    registry.register(makePipeline(['text/markdown']));
+    registry.register(makePipeline(['application/pdf', 'text/csv']));
+
+    const types = registry.availableContentTypes();
+    expect(types).toContain('text/markdown');
+    expect(types).toContain('application/pdf');
+    expect(types).toContain('text/csv');
+    expect(types).toHaveLength(3);
+  });
+
+  it('later registration overwrites earlier for same content type', () => {
+    const registry = new ExtractionPipelineRegistry();
+    const first = makePipeline(['application/pdf']);
+    const second = makePipeline(['application/pdf']);
+    registry.register(first);
+    registry.register(second);
+
+    expect(registry.get('application/pdf')).toBe(second);
+  });
+
+  it('supports multiple pipelines for different types', () => {
+    const registry = new ExtractionPipelineRegistry();
+    const mdPipeline = makePipeline(['text/markdown']);
+    const pdfPipeline = makePipeline(['application/pdf']);
+    registry.register(mdPipeline);
+    registry.register(pdfPipeline);
+
+    expect(registry.get('text/markdown')).toBe(mdPipeline);
+    expect(registry.get('application/pdf')).toBe(pdfPipeline);
+  });
+});
+
+describe('ExtractionPipeline interface', () => {
+  it('extract returns mdIntermediate, triples, and provenance', async () => {
+    const pipeline = makePipeline(['text/markdown'], {
+      mdIntermediate: '# Hello\n\nWorld',
+      triples: [{ subject: 'urn:test:1', predicate: 'rdf:type', object: 'schema:Thing' }],
+      provenance: [{ subject: 'urn:prov:1', predicate: 'dkg:extractedBy', object: 'did:dkg:agent:0x123' }],
+    });
+
+    const result = await pipeline.extract({
+      filePath: '/tmp/test.md',
+      contentType: 'text/markdown',
+      agentDid: 'did:dkg:agent:0x123',
+    });
+
+    expect(result.mdIntermediate).toBe('# Hello\n\nWorld');
+    expect(result.triples).toHaveLength(1);
+    expect(result.triples[0].subject).toBe('urn:test:1');
+    expect(result.provenance).toHaveLength(1);
+  });
+
+  it('extract passes through ontologyRef when provided', async () => {
+    let capturedInput: ExtractionInput | null = null;
+    const pipeline: ExtractionPipeline = {
+      contentTypes: ['application/pdf'],
+      async extract(input) {
+        capturedInput = input;
+        return { mdIntermediate: '', triples: [], provenance: [] };
+      },
+    };
+
+    await pipeline.extract({
+      filePath: '/tmp/paper.pdf',
+      contentType: 'application/pdf',
+      agentDid: 'did:dkg:agent:0xAbc',
+      ontologyRef: 'did:dkg:context-graph:research/_ontology',
+    });
+
+    expect(capturedInput).not.toBeNull();
+    expect(capturedInput!.ontologyRef).toBe('did:dkg:context-graph:research/_ontology');
+    expect(capturedInput!.agentDid).toBe('did:dkg:agent:0xAbc');
+  });
+});

--- a/packages/core/test/memory-model-e2e.test.ts
+++ b/packages/core/test/memory-model-e2e.test.ts
@@ -4,7 +4,7 @@ import {
   TransitionType,
   isValidTransition,
   type MemoryTransition,
-  type DraftDescriptor,
+  type AssertionDescriptor,
   type ShareRecord,
   type PublicationRequest,
   type Publication,
@@ -151,15 +151,15 @@ describe('V10 memory model e2e: full lifecycle simulation', () => {
     }
   });
 
-  it('draft → share → publish → verify lifecycle with types', () => {
-    // Step 1: Agent creates a draft (WM)
-    const draft: DraftDescriptor = {
+  it('assertion → share → publish → verify lifecycle with types', () => {
+    // Step 1: Agent creates an assertion (WM)
+    const assertion: AssertionDescriptor = {
       contextGraphId: CG_ID,
       agentAddress: AGENT,
       name: 'game-turn-42',
       createdAt: new Date().toISOString(),
     };
-    expect(draft.name).toBeTruthy();
+    expect(assertion.name).toBeTruthy();
 
     // Step 2: Agent shares to SWM
     const share: ShareRecord = {

--- a/packages/core/test/memory-model.test.ts
+++ b/packages/core/test/memory-model.test.ts
@@ -13,7 +13,7 @@ import {
   type Publication,
   type PublicationRequest,
   type MemoryTransition,
-  type DraftDescriptor,
+  type AssertionDescriptor,
   type ShareRecord,
 } from '../src/memory-model.js';
 
@@ -223,15 +223,15 @@ describe('MemoryTransition interface', () => {
   });
 });
 
-describe('DraftDescriptor interface', () => {
-  it('describes an agent draft', () => {
-    const d: DraftDescriptor = {
+describe('AssertionDescriptor interface', () => {
+  it('describes an agent assertion', () => {
+    const d: AssertionDescriptor = {
       contextGraphId: 'cg-1',
       agentAddress: '0xAbc',
-      name: 'my-draft',
+      name: 'my-assertion',
       createdAt: '2026-04-02T00:00:00Z',
     };
-    expect(d.name).toBe('my-draft');
+    expect(d.name).toBe('my-assertion');
   });
 });
 

--- a/packages/core/test/sub-graphs.test.ts
+++ b/packages/core/test/sub-graphs.test.ts
@@ -4,6 +4,7 @@ import {
   contextGraphSubGraphMetaUri,
   contextGraphSharedMemoryUri,
   contextGraphSharedMemoryMetaUri,
+  contextGraphAssertionUri,
   contextGraphDraftUri,
   validateSubGraphName,
 } from '../src/constants.js';
@@ -47,15 +48,21 @@ describe('sub-graph URI helpers', () => {
     );
   });
 
-  it('contextGraphDraftUri with subGraphName places sub-graph before draft', () => {
-    expect(contextGraphDraftUri(cgId, '0xAgent', 'scan', 'code')).toBe(
-      'did:dkg:context-graph:dkg-v10-dev/code/draft/0xAgent/scan',
+  it('contextGraphAssertionUri with subGraphName places sub-graph before assertion', () => {
+    expect(contextGraphAssertionUri(cgId, '0xAgent', 'scan', 'code')).toBe(
+      'did:dkg:context-graph:dkg-v10-dev/code/assertion/0xAgent/scan',
     );
   });
 
-  it('contextGraphDraftUri without subGraphName produces flat URI', () => {
-    expect(contextGraphDraftUri(cgId, '0xAgent', 'scan')).toBe(
-      'did:dkg:context-graph:dkg-v10-dev/draft/0xAgent/scan',
+  it('contextGraphAssertionUri without subGraphName produces flat URI', () => {
+    expect(contextGraphAssertionUri(cgId, '0xAgent', 'scan')).toBe(
+      'did:dkg:context-graph:dkg-v10-dev/assertion/0xAgent/scan',
+    );
+  });
+
+  it('contextGraphDraftUri alias delegates to contextGraphAssertionUri', () => {
+    expect(contextGraphDraftUri(cgId, '0xAgent', 'scan', 'code')).toBe(
+      contextGraphAssertionUri(cgId, '0xAgent', 'scan', 'code'),
     );
   });
 });

--- a/packages/core/test/sub-graphs.test.ts
+++ b/packages/core/test/sub-graphs.test.ts
@@ -5,7 +5,6 @@ import {
   contextGraphSharedMemoryUri,
   contextGraphSharedMemoryMetaUri,
   contextGraphAssertionUri,
-  contextGraphDraftUri,
   validateSubGraphName,
 } from '../src/constants.js';
 
@@ -60,11 +59,6 @@ describe('sub-graph URI helpers', () => {
     );
   });
 
-  it('contextGraphDraftUri alias delegates to contextGraphAssertionUri', () => {
-    expect(contextGraphDraftUri(cgId, '0xAgent', 'scan', 'code')).toBe(
-      contextGraphAssertionUri(cgId, '0xAgent', 'scan', 'code'),
-    );
-  });
 });
 
 describe('validateSubGraphName', () => {

--- a/packages/core/test/sub-graphs.test.ts
+++ b/packages/core/test/sub-graphs.test.ts
@@ -105,6 +105,7 @@ describe('validateSubGraphName', () => {
 
   it('rejects reserved path segments', () => {
     expect(validateSubGraphName('context').valid).toBe(false);
+    expect(validateSubGraphName('assertion').valid).toBe(false);
     expect(validateSubGraphName('draft').valid).toBe(false);
   });
 });

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -25,7 +25,7 @@ import {
   contextGraphSharedMemoryMetaUri,
   contextGraphVerifiedMemoryUri,
   contextGraphVerifiedMemoryMetaUri,
-  contextGraphDraftUri,
+  contextGraphAssertionUri,
   contextGraphRulesUri,
   contextGraphSubGraphUri,
   // Deprecated aliases
@@ -128,8 +128,8 @@ describe('V10 named graph URIs', () => {
     expect(contextGraphVerifiedMemoryMetaUri(id, '7')).toBe('did:dkg:context-graph:42/_verified_memory/7/_meta');
   });
 
-  it('draft URI', () => {
-    expect(contextGraphDraftUri(id, '0xAbc', 'my-draft')).toBe('did:dkg:context-graph:42/draft/0xAbc/my-draft');
+  it('assertion URI', () => {
+    expect(contextGraphAssertionUri(id, '0xAbc', 'my-assertion')).toBe('did:dkg:context-graph:42/assertion/0xAbc/my-assertion');
   });
 
   it('rules URI', () => {

--- a/packages/network-sim/src/components/ControlPanel.tsx
+++ b/packages/network-sim/src/components/ControlPanel.tsx
@@ -588,7 +588,7 @@ function SharedMemoryTab() {
   return (
     <div className="tab-form">
       <div className="setup-hint">
-        Write draft triples to shared memory (free, no gas). When ready, publish them to the chain with full finality.
+        Write triples to shared memory (free, no gas). When ready, publish them to the chain with full finality.
       </div>
 
       <div className="form-group">

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1563,16 +1563,6 @@ export class DKGPublisher implements Publisher {
     await this.store.dropGraph(graphUri);
   }
 
-  /** @deprecated Use assertionCreate. Will be removed in V10.1. */
-  async draftCreate(...args: Parameters<DKGPublisher['assertionCreate']>) { return this.assertionCreate(...args); }
-  /** @deprecated Use assertionWrite. Will be removed in V10.1. */
-  async draftWrite(...args: Parameters<DKGPublisher['assertionWrite']>) { return this.assertionWrite(...args); }
-  /** @deprecated Use assertionQuery. Will be removed in V10.1. */
-  async draftQuery(...args: Parameters<DKGPublisher['assertionQuery']>) { return this.assertionQuery(...args); }
-  /** @deprecated Use assertionPromote. Will be removed in V10.1. */
-  async draftPromote(...args: Parameters<DKGPublisher['assertionPromote']>) { return this.assertionPromote(...args); }
-  /** @deprecated Use assertionDiscard. Will be removed in V10.1. */
-  async draftDiscard(...args: Parameters<DKGPublisher['assertionDiscard']>) { return this.assertionDiscard(...args); }
 }
 
 /**

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1,7 +1,7 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, contextGraphDataUri, contextGraphMetaUri, contextGraphDraftUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, type Ed25519Keypair, computeACKDigest } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, type Ed25519Keypair, computeACKDigest } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import type { Publisher, PublishOptions, PublishResult, KAManifestEntry, PhaseCallback } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -1455,7 +1455,7 @@ export class DKGPublisher implements Publisher {
     }
   }
 
-  // ── Working Memory Draft Operations (spec §6) ────────────────────────
+  // ── Working Memory Assertion Operations (spec §6) ───────────────────
 
   private static validateOptionalSubGraph(subGraphName: string | undefined): void {
     if (subGraphName !== undefined) {
@@ -1468,53 +1468,50 @@ export class DKGPublisher implements Publisher {
     this.sharedMemoryOwnedEntities.delete(ownershipKey);
   }
 
-  async draftCreate(contextGraphId: string, draftName: string, agentAddress: string, subGraphName?: string): Promise<string> {
+  async assertionCreate(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<string> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
-    const graphUri = contextGraphDraftUri(contextGraphId, agentAddress, draftName, subGraphName);
+    const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     await this.store.createGraph(graphUri);
     return graphUri;
   }
 
-  async draftWrite(
+  async assertionWrite(
     contextGraphId: string,
-    draftName: string,
+    name: string,
     agentAddress: string,
     input: Quad[] | Array<{ subject: string; predicate: string; object: string }>,
     subGraphName?: string,
   ): Promise<void> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
-    const graphUri = contextGraphDraftUri(contextGraphId, agentAddress, draftName, subGraphName);
+    const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     const quads = input.map((t) => ({
-      subject: t.subject,
-      predicate: t.predicate,
-      object: t.object,
-      graph: graphUri,
+      subject: t.subject, predicate: t.predicate, object: t.object, graph: graphUri,
     }));
     await this.store.insert(quads);
   }
 
-  async draftQuery(
+  async assertionQuery(
     contextGraphId: string,
-    draftName: string,
+    name: string,
     agentAddress: string,
     subGraphName?: string,
   ): Promise<Quad[]> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
-    const graphUri = contextGraphDraftUri(contextGraphId, agentAddress, draftName, subGraphName);
+    const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     const result = await this.store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${graphUri}> { ?s ?p ?o } }`,
     );
     return result.type === 'quads' ? result.quads : [];
   }
 
-  async draftPromote(
+  async assertionPromote(
     contextGraphId: string,
-    draftName: string,
+    name: string,
     agentAddress: string,
     opts?: { entities?: string[] | 'all'; subGraphName?: string },
   ): Promise<{ promotedCount: number }> {
     DKGPublisher.validateOptionalSubGraph(opts?.subGraphName);
-    const graphUri = contextGraphDraftUri(contextGraphId, agentAddress, draftName, opts?.subGraphName);
+    const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, opts?.subGraphName);
     const swmGraphUri = this.graphManager.sharedMemoryUri(contextGraphId, opts?.subGraphName);
 
     const result = await this.store.query(
@@ -1537,7 +1534,7 @@ export class DKGPublisher implements Publisher {
     const swmQuads = quadsToPromote.map((q) => ({ ...q, graph: swmGraphUri }));
     await this.store.insert(swmQuads);
 
-    // Delete promoted triples from draft
+    // Delete promoted triples from assertion graph
     await this.store.delete(quadsToPromote.map((q) => ({ ...q, graph: graphUri })));
 
     // Record ShareTransition metadata in _shared_memory_meta (spec §8)
@@ -1547,7 +1544,7 @@ export class DKGPublisher implements Publisher {
       contextGraphId,
       operationId,
       agentAddress,
-      draftName,
+      assertionName: name,
       entities,
       timestamp: new Date(),
     });
@@ -1556,9 +1553,9 @@ export class DKGPublisher implements Publisher {
     return { promotedCount: swmQuads.length };
   }
 
-  async draftDiscard(contextGraphId: string, draftName: string, agentAddress: string, subGraphName?: string): Promise<void> {
+  async assertionDiscard(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<void> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
-    const graphUri = contextGraphDraftUri(contextGraphId, agentAddress, draftName, subGraphName);
+    const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     await this.store.dropGraph(graphUri);
   }
 }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -361,7 +361,8 @@ export class DKGPublisher implements Publisher {
 
     const conditionSubjects = options.conditions.map(c => c.subject);
     const quadSubjects = [...new Set(quads.map(q => q.subject))];
-    const lockKeys = [...new Set([...conditionSubjects, ...quadSubjects])].map(s => `${contextGraphId}\0${s}`);
+    const lockPrefix = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
+    const lockKeys = [...new Set([...conditionSubjects, ...quadSubjects])].map(s => `${lockPrefix}\0${s}`);
 
     return this.withWriteLocks(lockKeys, () => this._executeConditionalWrite(contextGraphId, quads, options));
   }
@@ -383,7 +384,7 @@ export class DKGPublisher implements Publisher {
     const ctx = options.operationCtx ?? createOperationContext('share');
 
     await this.graphManager.ensureContextGraph(contextGraphId);
-    const swmGraph = this.graphManager.sharedMemoryUri(contextGraphId);
+    const swmGraph = this.graphManager.sharedMemoryUri(contextGraphId, options.subGraphName);
 
     for (const cond of options.conditions) {
       const ask = cond.expectedValue === null
@@ -1466,6 +1467,8 @@ export class DKGPublisher implements Publisher {
 
   clearSubGraphOwnership(ownershipKey: string): void {
     this.sharedMemoryOwnedEntities.delete(ownershipKey);
+    this.ownedEntities.delete(ownershipKey);
+    this.privateStore.clearCache(ownershipKey);
   }
 
   async assertionCreate(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<string> {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -171,7 +171,8 @@ export class DKGPublisher implements Publisher {
     options: ShareOptions,
   ): Promise<ShareResult> {
     const subjects = [...new Set(quads.map(q => q.subject))];
-    const lockKeys = subjects.map(s => `${contextGraphId}\0${s}`);
+    const lockPrefix = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
+    const lockKeys = subjects.map(s => `${lockPrefix}\0${s}`);
     return this.withWriteLocks(lockKeys, () => this._shareImpl(contextGraphId, quads, options));
   }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1562,6 +1562,17 @@ export class DKGPublisher implements Publisher {
     const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
     await this.store.dropGraph(graphUri);
   }
+
+  /** @deprecated Use assertionCreate. Will be removed in V10.1. */
+  async draftCreate(...args: Parameters<DKGPublisher['assertionCreate']>) { return this.assertionCreate(...args); }
+  /** @deprecated Use assertionWrite. Will be removed in V10.1. */
+  async draftWrite(...args: Parameters<DKGPublisher['assertionWrite']>) { return this.assertionWrite(...args); }
+  /** @deprecated Use assertionQuery. Will be removed in V10.1. */
+  async draftQuery(...args: Parameters<DKGPublisher['assertionQuery']>) { return this.assertionQuery(...args); }
+  /** @deprecated Use assertionPromote. Will be removed in V10.1. */
+  async draftPromote(...args: Parameters<DKGPublisher['assertionPromote']>) { return this.assertionPromote(...args); }
+  /** @deprecated Use assertionDiscard. Will be removed in V10.1. */
+  async draftDiscard(...args: Parameters<DKGPublisher['assertionDiscard']>) { return this.assertionDiscard(...args); }
 }
 
 /**

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -277,7 +277,7 @@ export interface ShareTransitionMetadata {
   contextGraphId: string;
   operationId: string;
   agentAddress: string;
-  draftName: string;
+  assertionName: string;
   entities: string[];
   timestamp: Date;
 }
@@ -287,7 +287,7 @@ export function generateShareTransitionMetadata(meta: ShareTransitionMetadata): 
   const subject = `urn:dkg:share:${meta.operationId}`;
   const quads: Quad[] = [
     mq(subject, `${RDF}type`, `${DKG}ShareTransition`, metaGraph),
-    mq(subject, `${DKG}source`, lit(`draft/${meta.agentAddress}/${meta.draftName}`), metaGraph),
+    mq(subject, `${DKG}source`, lit(`assertion/${meta.agentAddress}/${meta.assertionName}`), metaGraph),
     mq(subject, `${DKG}agent`, `did:dkg:agent:${meta.agentAddress}`, metaGraph),
     mq(subject, `${DKG}timestamp`, dateLit(meta.timestamp), metaGraph),
   ];

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { TypedEventBus, generateEd25519Keypair, contextGraphDraftUri } from '@origintrail-official/dkg-core';
+import { TypedEventBus, generateEd25519Keypair, contextGraphAssertionUri } from '@origintrail-official/dkg-core';
 import { DKGPublisher } from '../src/index.js';
 import { ethers } from 'ethers';
 
-const CG_ID = 'test-draft-cg';
+const CG_ID = 'test-assertion-cg';
 const SWM_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
 const AGENT = '0x1234567890abcdef1234567890abcdef12345678';
 const AGENT_B = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-const DRAFT = 'my-draft';
+const ASSERTION_NAME = 'my-assertion';
 
 const TRIPLES = [
   { subject: 'urn:test:entity:alice', predicate: 'http://schema.org/name', object: '"Alice"' },
@@ -17,7 +17,7 @@ const TRIPLES = [
   { subject: 'urn:test:entity:bob', predicate: 'http://schema.org/name', object: '"Bob"' },
 ];
 
-describe('Working Memory Draft Lifecycle', () => {
+describe('Working Memory Assertion Lifecycle', () => {
   let store: OxigraphStore;
   let publisher: DKGPublisher;
 
@@ -36,47 +36,47 @@ describe('Working Memory Draft Lifecycle', () => {
     });
   });
 
-  it('create returns the correct draft graph URI', async () => {
-    const uri = await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    expect(uri).toBe(contextGraphDraftUri(CG_ID, AGENT, DRAFT));
+  it('create returns the correct assertion graph URI', async () => {
+    const uri = await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    expect(uri).toBe(contextGraphAssertionUri(CG_ID, AGENT, ASSERTION_NAME));
   });
 
-  it('write inserts triples into the draft graph', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
+  it('write inserts triples into the assertion graph', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
-    const quads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
+    const quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(quads.length).toBe(3);
     const subjects = new Set(quads.map((q: Quad) => q.subject));
     expect(subjects.has('urn:test:entity:alice')).toBe(true);
     expect(subjects.has('urn:test:entity:bob')).toBe(true);
   });
 
-  it('query returns triples from the draft only', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
+  it('query returns triples from the assertion only', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
-    // Write something to a different draft — should not appear
-    await publisher.draftCreate(CG_ID, 'other-draft', AGENT);
-    await publisher.draftWrite(CG_ID, 'other-draft', AGENT, [
+    // Write something to a different assertion — should not appear
+    await publisher.assertionCreate(CG_ID, 'other-assertion', AGENT);
+    await publisher.assertionWrite(CG_ID, 'other-assertion', AGENT, [
       { subject: 'urn:test:entity:charlie', predicate: 'http://schema.org/name', object: '"Charlie"' },
     ]);
 
-    const quads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
+    const quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(quads.length).toBe(3);
     const subjects = new Set(quads.map((q: Quad) => q.subject));
     expect(subjects.has('urn:test:entity:charlie')).toBe(false);
   });
 
-  it('promote moves all triples to SWM and empties draft', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
+  it('promote moves all triples to SWM and empties assertion', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
-    const result = await publisher.draftPromote(CG_ID, DRAFT, AGENT);
+    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
     expect(result.promotedCount).toBe(3);
 
-    const draftQuads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
-    expect(draftQuads.length).toBe(0);
+    const assertionQuads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
+    expect(assertionQuads.length).toBe(0);
 
     const swmResult = await store.query(
       `SELECT ?s ?p ?o WHERE { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`,
@@ -88,15 +88,15 @@ describe('Working Memory Draft Lifecycle', () => {
   });
 
   it('promote with entity filter only moves selected entities', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
-    const result = await publisher.draftPromote(CG_ID, DRAFT, AGENT, {
+    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT, {
       entities: ['urn:test:entity:alice'],
     });
     expect(result.promotedCount).toBe(2);
 
-    const remaining = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
+    const remaining = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(remaining.length).toBe(1);
     expect(remaining[0].subject).toBe('urn:test:entity:bob');
 
@@ -111,46 +111,46 @@ describe('Working Memory Draft Lifecycle', () => {
     }
   });
 
-  it('discard drops the draft graph', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
-    await publisher.draftDiscard(CG_ID, DRAFT, AGENT);
+  it('discard drops the assertion graph', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await publisher.assertionDiscard(CG_ID, ASSERTION_NAME, AGENT);
 
-    const quads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
+    const quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(quads.length).toBe(0);
   });
 
-  it('different agents have isolated draft graphs', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT_B);
+  it('different agents have isolated assertion graphs', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT_B);
 
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, [
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, [
       { subject: 'urn:test:alice', predicate: 'http://schema.org/name', object: '"Alice"' },
     ]);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT_B, [
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT_B, [
       { subject: 'urn:test:bob', predicate: 'http://schema.org/name', object: '"Bob"' },
     ]);
 
-    const agentAQuads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
+    const agentAQuads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
     expect(agentAQuads.length).toBe(1);
     expect(agentAQuads[0].subject).toBe('urn:test:alice');
 
-    const agentBQuads = await publisher.draftQuery(CG_ID, DRAFT, AGENT_B);
+    const agentBQuads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT_B);
     expect(agentBQuads.length).toBe(1);
     expect(agentBQuads[0].subject).toBe('urn:test:bob');
   });
 
-  it('promote on empty draft returns 0', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    const result = await publisher.draftPromote(CG_ID, DRAFT, AGENT);
+  it('promote on empty assertion returns 0', async () => {
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    const result = await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
     expect(result.promotedCount).toBe(0);
   });
 
   it('promote records ShareTransition metadata in _shared_memory_meta', async () => {
     const SWM_META = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
-    await publisher.draftPromote(CG_ID, DRAFT, AGENT);
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
+    await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
     const result = await store.query(
       `SELECT ?s ?type WHERE {
@@ -170,16 +170,16 @@ describe('Working Memory Draft Lifecycle', () => {
   });
 
   it('full lifecycle: create → write → promote → verify SWM → discard', async () => {
-    await publisher.draftCreate(CG_ID, DRAFT, AGENT);
-    await publisher.draftWrite(CG_ID, DRAFT, AGENT, TRIPLES);
+    await publisher.assertionCreate(CG_ID, ASSERTION_NAME, AGENT);
+    await publisher.assertionWrite(CG_ID, ASSERTION_NAME, AGENT, TRIPLES);
 
-    let draftQuads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
-    expect(draftQuads.length).toBe(3);
+    let quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
+    expect(quads.length).toBe(3);
 
-    await publisher.draftPromote(CG_ID, DRAFT, AGENT);
+    await publisher.assertionPromote(CG_ID, ASSERTION_NAME, AGENT);
 
-    draftQuads = await publisher.draftQuery(CG_ID, DRAFT, AGENT);
-    expect(draftQuads.length).toBe(0);
+    quads = await publisher.assertionQuery(CG_ID, ASSERTION_NAME, AGENT);
+    expect(quads.length).toBe(0);
 
     const swmResult = await store.query(
       `SELECT (COUNT(*) AS ?c) WHERE { GRAPH <${SWM_GRAPH}> { ?s ?p ?o } }`,
@@ -190,6 +190,6 @@ describe('Working Memory Draft Lifecycle', () => {
       expect(count).toBe(3);
     }
 
-    await publisher.draftDiscard(CG_ID, DRAFT, AGENT);
+    await publisher.assertionDiscard(CG_ID, ASSERTION_NAME, AGENT);
   });
 });

--- a/packages/publisher/test/get-views.test.ts
+++ b/packages/publisher/test/get-views.test.ts
@@ -4,7 +4,7 @@ import {
   GET_VIEWS,
   contextGraphSharedMemoryUri,
   contextGraphVerifiedMemoryUri,
-  contextGraphDraftUri,
+  contextGraphAssertionUri,
 } from '@origintrail-official/dkg-core';
 import { resolveViewGraphs, type ViewResolution } from '@origintrail-official/dkg-query';
 
@@ -17,11 +17,11 @@ describe('resolveViewGraphs', () => {
       expect(() => resolveViewGraphs('working-memory', CG)).toThrow('agentAddress is required');
     });
 
-    it('returns a prefix for all agent drafts when no draftName given', () => {
+    it('returns a prefix for all agent assertions when no assertionName given', () => {
       const res = resolveViewGraphs('working-memory', CG, { agentAddress: AGENT });
       expect(res.graphs).toHaveLength(0);
       expect(res.graphPrefixes).toHaveLength(1);
-      expect(res.graphPrefixes[0]).toBe(`did:dkg:context-graph:${CG}/draft/${AGENT}/`);
+      expect(res.graphPrefixes[0]).toBe(`did:dkg:context-graph:${CG}/assertion/${AGENT}/`);
     });
 
     it('includes the agent address in the graph URI prefix', () => {
@@ -29,9 +29,9 @@ describe('resolveViewGraphs', () => {
       expect(res.graphPrefixes[0]).toContain(AGENT);
     });
 
-    it('returns an exact draft URI when draftName is provided', () => {
-      const res = resolveViewGraphs('working-memory', CG, { agentAddress: AGENT, draftName: 'exp-lr' });
-      expect(res.graphs).toEqual([contextGraphDraftUri(CG, AGENT, 'exp-lr')]);
+    it('returns an exact assertion URI when assertionName is provided', () => {
+      const res = resolveViewGraphs('working-memory', CG, { agentAddress: AGENT, assertionName: 'exp-lr' });
+      expect(res.graphs).toEqual([contextGraphAssertionUri(CG, AGENT, 'exp-lr')]);
       expect(res.graphPrefixes).toHaveLength(0);
     });
   });

--- a/packages/publisher/test/metadata.test.ts
+++ b/packages/publisher/test/metadata.test.ts
@@ -278,7 +278,7 @@ describe('generateShareTransitionMetadata', () => {
     contextGraphId: PARANET,
     operationId: 'op-share-001',
     agentAddress: '0x1234567890abcdef1234567890abcdef12345678',
-    draftName: 'my-draft',
+    assertionName: 'my-assertion',
     entities: ['urn:test:entity:alice', 'urn:test:entity:bob'],
     timestamp: new Date('2026-04-01T00:00:00Z'),
   };
@@ -306,12 +306,12 @@ describe('generateShareTransitionMetadata', () => {
     expect(preds).toContain(`${DKG}entities`);
   });
 
-  it('source includes draft path with agent and name', () => {
+  it('source includes assertion path with agent and name', () => {
     const quads = generateShareTransitionMetadata(shareMeta);
     const sourceQuad = quads.find(q => q.predicate === `${DKG}source`);
-    expect(sourceQuad!.object).toContain('draft/');
+    expect(sourceQuad!.object).toContain('assertion/');
     expect(sourceQuad!.object).toContain(shareMeta.agentAddress);
-    expect(sourceQuad!.object).toContain(shareMeta.draftName);
+    expect(sourceQuad!.object).toContain(shareMeta.assertionName);
   });
 
   it('generates one entity quad per entity', () => {

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -2,7 +2,7 @@ import type { TripleStore, Quad, QueryResult as StoreQueryResult } from '@origin
 import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { QueryResult, QueryOptions, QueryEngine } from './query-engine.js';
 import {
-  contextGraphDataUri, contextGraphSharedMemoryUri, contextGraphVerifiedMemoryUri, contextGraphDraftUri,
+  contextGraphDataUri, contextGraphSharedMemoryUri, contextGraphVerifiedMemoryUri, contextGraphAssertionUri,
   contextGraphSubGraphUri,
   assertSafeIri, escapeSparqlLiteral, validateSubGraphName,
   type GetView,
@@ -20,7 +20,7 @@ export interface ViewResolution {
   /**
    * Graph URI prefixes — the engine discovers all named graphs matching
    * each prefix and unions the results. Used for working-memory (multiple
-   * drafts) and verified-memory (multiple quorum graphs).
+   * assertions) and verified-memory (multiple quorum graphs).
    */
   graphPrefixes: string[];
 }
@@ -34,7 +34,7 @@ export interface ViewResolution {
 export function resolveViewGraphs(
   view: GetView,
   contextGraphId: string,
-  opts?: { agentAddress?: string; verifiedGraph?: string; draftName?: string },
+  opts?: { agentAddress?: string; verifiedGraph?: string; assertionName?: string },
 ): ViewResolution {
   if (REMOVED_VIEWS.includes(view as string)) {
     throw new Error(
@@ -47,15 +47,15 @@ export function resolveViewGraphs(
       if (!opts?.agentAddress) {
         throw new Error('agentAddress is required for the working-memory view');
       }
-      if (opts.draftName) {
+      if (opts.assertionName) {
         return {
-          graphs: [contextGraphDraftUri(contextGraphId, opts.agentAddress, opts.draftName)],
+          graphs: [contextGraphAssertionUri(contextGraphId, opts.agentAddress, opts.assertionName)],
           graphPrefixes: [],
         };
       }
       return {
         graphs: [],
-        graphPrefixes: [`did:dkg:context-graph:${contextGraphId}/draft/${opts.agentAddress}/`],
+        graphPrefixes: [`did:dkg:context-graph:${contextGraphId}/assertion/${opts.agentAddress}/`],
       };
     }
     case 'shared-working-memory':

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -159,7 +159,7 @@ export class DKGQueryEngine implements QueryEngine {
     const resolution = resolveViewGraphs(view, contextGraphId, {
       agentAddress: options.agentAddress,
       verifiedGraph: options.verifiedGraph,
-      assertionName: options.assertionName ?? options.draftName,
+      assertionName: options.assertionName,
     });
 
     const allGraphs = [...resolution.graphs];

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -159,6 +159,7 @@ export class DKGQueryEngine implements QueryEngine {
     const resolution = resolveViewGraphs(view, contextGraphId, {
       agentAddress: options.agentAddress,
       verifiedGraph: options.verifiedGraph,
+      assertionName: options.assertionName,
     });
 
     const allGraphs = [...resolution.graphs];

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -159,7 +159,7 @@ export class DKGQueryEngine implements QueryEngine {
     const resolution = resolveViewGraphs(view, contextGraphId, {
       agentAddress: options.agentAddress,
       verifiedGraph: options.verifiedGraph,
-      assertionName: options.assertionName,
+      assertionName: options.assertionName ?? options.draftName,
     });
 
     const allGraphs = [...resolution.graphs];

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -24,6 +24,8 @@ export interface QueryOptions {
   agentAddress?: string;
   /** Specific verified graph name — used with view='verified-memory' to target a single verified graph. */
   verifiedGraph?: string;
+  /** Specific assertion name — used with view='working-memory' to target a single assertion graph. */
+  assertionName?: string;
   /**
    * Scope the query to a specific sub-graph within the context graph.
    * When set, the query targets `did:dkg:context-graph:{id}/{subGraphName}`

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -20,7 +20,7 @@ export interface QueryOptions {
   includeWorkspace?: boolean;
   /** V10 declared state view — determines which graph(s) the query targets. */
   view?: GetView;
-  /** Agent address — required when view is 'working-memory' to resolve draft graphs. */
+  /** Agent address — required when view is 'working-memory' to resolve assertion graphs. */
   agentAddress?: string;
   /** Specific verified graph name — used with view='verified-memory' to target a single verified graph. */
   verifiedGraph?: string;

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -26,8 +26,6 @@ export interface QueryOptions {
   verifiedGraph?: string;
   /** Specific assertion name — used with view='working-memory' to target a single assertion graph. */
   assertionName?: string;
-  /** @deprecated Use assertionName. */
-  draftName?: string;
   /**
    * Scope the query to a specific sub-graph within the context graph.
    * When set, the query targets `did:dkg:context-graph:{id}/{subGraphName}`

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -26,6 +26,8 @@ export interface QueryOptions {
   verifiedGraph?: string;
   /** Specific assertion name — used with view='working-memory' to target a single assertion graph. */
   assertionName?: string;
+  /** @deprecated Use assertionName. */
+  draftName?: string;
   /**
    * Scope the query to a specific sub-graph within the context graph.
    * When set, the query targets `did:dkg:context-graph:{id}/{subGraphName}`

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -7,7 +7,7 @@ import {
   contextGraphSharedMemoryMetaUri,
   contextGraphVerifiedMemoryUri,
   contextGraphVerifiedMemoryMetaUri,
-  contextGraphDraftUri,
+  contextGraphAssertionUri,
   contextGraphSubGraphUri,
   contextGraphSubGraphMetaUri,
   contextGraphSubGraphPrivateUri,
@@ -51,8 +51,8 @@ export class ContextGraphManager {
     return contextGraphVerifiedMemoryMetaUri(contextGraphId, verifiedMemoryId);
   }
 
-  draftUri(contextGraphId: string, agentAddress: string, name: string): string {
-    return contextGraphDraftUri(contextGraphId, agentAddress, name);
+  assertionUri(contextGraphId: string, agentAddress: string, name: string): string {
+    return contextGraphAssertionUri(contextGraphId, agentAddress, name);
   }
 
   subGraphUri(contextGraphId: string, subGraphName: string): string {

--- a/packages/storage/src/graph-manager.ts
+++ b/packages/storage/src/graph-manager.ts
@@ -117,7 +117,7 @@ export class ContextGraphManager {
     const prefix = `${CG_PREFIX}${contextGraphId}/`;
     const allGraphs = await this.store.listGraphs();
     const subGraphNames = new Set<string>();
-    const reservedPrefixes = ['_', 'draft/', 'context/'];
+    const reservedPrefixes = ['_', 'assertion/', 'draft/', 'context/'];
     for (const g of allGraphs) {
       if (!g.startsWith(prefix)) continue;
       const rest = g.slice(prefix.length);

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -19,6 +19,10 @@ export class PrivateContentStore {
     this.graphManager = graphManager;
   }
 
+  clearCache(key: string): void {
+    this.privateEntities.delete(key);
+  }
+
   private privateGraph(contextGraphId: string, subGraphName?: string): string {
     return subGraphName
       ? this.graphManager.subGraphPrivateUri(contextGraphId, subGraphName)


### PR DESCRIPTION
## Summary

Implementation for dkgv10-spec issues #73 and #74. Companion spec PR: https://github.com/OriginTrail/dkgv10-spec/pull/75

- **SKILL.MD (dkgv10-spec#73):** Ships a V10 Agent Skills document that teaches LLM-powered agents the full DKG node API surface, memory model, and authentication flow.
  - New `GET /.well-known/skill.md` public endpoint with ETag/304 caching
  - Dynamic node info injected at serve-time (version, peer ID, node role, extraction pipelines, subscribed context graphs)
  - Added to `PUBLIC_PATHS` in auth.ts and rate limiter exempt list
  - Skill file ships with the npm package via `packages/cli/skills/dkg-node/SKILL.md`

- **Document processor (dkgv10-spec#74):** Adds the extraction pipeline infrastructure for converting non-RDF files (PDF, DOCX, etc.) to Markdown intermediates.
  - `ExtractionPipeline` interface and `ExtractionPipelineRegistry` in `@origintrail-official/dkg-core`
  - `MarkItDownConverter` implementation in `packages/cli/src/extraction/` that invokes the standalone MarkItDown binary
  - Registry initialized at daemon startup with graceful degradation when binary is unavailable
  - Extraction registry passed through to `handleRequest` for future `import-file` wiring

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/extraction-pipeline.ts` | New: ExtractionPipeline interface + registry |
| `packages/core/src/index.ts` | Export extraction types |
| `packages/cli/src/extraction/markitdown-converter.ts` | New: MarkItDown binary wrapper |
| `packages/cli/src/extraction/index.ts` | New: barrel export |
| `packages/cli/skills/dkg-node/SKILL.md` | New: V10 Agent Skills document |
| `packages/cli/src/daemon.ts` | SKILL.md endpoint, extraction registry init |
| `packages/cli/src/auth.ts` | Add `/.well-known/skill.md` to public paths |
| `packages/cli/package.json` | Add `skills` to npm files |

## Test plan

- [ ] `npx tsc --noEmit` passes in both `packages/core` and `packages/cli` (verified locally)
- [ ] `GET /.well-known/skill.md` returns valid markdown with dynamic node info
- [ ] `GET /.well-known/skill.md` with `If-None-Match` returns 304
- [ ] Node starts without MarkItDown binary (graceful degradation log message)
- [ ] Node starts with MarkItDown binary (extraction pipelines logged)
- [ ] `isMarkItDownAvailable()` correctly detects binary presence

Made with [Cursor](https://cursor.com)