### PR TITLE
fix: promote edge cases — size pre-check, owner-only upsert, empty selection

### DIFF
--- a/packages/cli/test/publisher-cli-smoke.test.ts
+++ b/packages/cli/test/publisher-cli-smoke.test.ts
@@ -102,9 +102,11 @@ describe.sequential('publisher CLI smoke', () => {
     // Use the /api/shutdown endpoint for an orderly exit, then wait for the
     // process to terminate — this gives the store's 50ms debounced flush time
     // to persist shared-memory data before the process exits.
-    await fetch(`http://127.0.0.1:${SMOKE_API_PORT}/api/shutdown`, { method: 'POST' }).catch(() => {});
-    const daemonExited = new Promise((resolve) => daemon?.once('exit', resolve));
+    const daemonExited = daemon.exitCode !== null
+      ? Promise.resolve()
+      : new Promise((resolve) => daemon?.once('exit', resolve));
     const killTimeout = setTimeout(() => { daemon?.kill('SIGKILL'); }, 5000);
+    await fetch(`http://127.0.0.1:${SMOKE_API_PORT}/api/shutdown`, { method: 'POST' }).catch(() => {});
     await daemonExited;
     clearTimeout(killTimeout);
     daemon = undefined;

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1595,11 +1595,23 @@ export class DKGPublisher implements Publisher {
       gossipMessage = encoded;
     }
 
-    // Delete-then-insert for entities owned by this peer (upsert), matching
+    // Rule 4: reject roots owned by a different peer before any mutations.
+    if (opts?.publisherPeerId) {
+      for (const root of rootEntities) {
+        const owner = swmOwned.get(root);
+        if (owner && owner !== opts.publisherPeerId) {
+          throw new Error(
+            `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
+          );
+        }
+      }
+    }
+
+    // Delete-then-insert for existing SWM entities (upsert), matching
     // _shareImpl and SharedMemoryHandler so re-promotes replace stale triples.
-    // Only overwrite entities owned by the same publisherPeerId (Rule 4).
+    // Safe after the ownership check above — only self-owned or unowned roots remain.
     for (const root of rootEntities) {
-      if (swmOwned.has(root) && swmOwned.get(root) === opts?.publisherPeerId) {
+      if (swmOwned.has(root)) {
         await this.store.deleteByPattern({ graph: swmGraphUri, subject: root });
         await this.store.deleteBySubjectPrefix(swmGraphUri, root + '/.well-known/genid/');
         await this.deleteMetaForRoot(swmMetaGraph, root);

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1538,6 +1538,8 @@ export class DKGPublisher implements Publisher {
       );
     }
 
+    if (quadsToPromote.length === 0) return { promotedCount: 0 };
+
     const operationId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Skolemize blank nodes so local SWM and gossip peers store identical data.
@@ -1555,10 +1557,49 @@ export class DKGPublisher implements Publisher {
     const ownershipKey = opts?.subGraphName ? `${contextGraphId}\0${opts.subGraphName}` : contextGraphId;
     const swmOwned = this.sharedMemoryOwnedEntities.get(ownershipKey) ?? new Map<string, string>();
 
-    // Delete-then-insert for already-owned entities (upsert), matching
+    // Pre-encode gossip message and enforce size limit BEFORE any destructive
+    // mutations, so oversized promotions are rejected cleanly while the
+    // assertion is still intact in WM.
+    let gossipMessage: Uint8Array | undefined;
+    if (opts?.publisherPeerId) {
+      const dataGraph = this.graphManager.dataGraphUri(contextGraphId);
+      const nquadsStr = normalizedQuads
+        .map(
+          (q) =>
+            `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${dataGraph}> .`,
+        )
+        .join('\n');
+      const manifestEntries = rootEntities.map((rootEntity) => ({
+        rootEntity,
+        privateMerkleRoot: undefined,
+        privateTripleCount: 0,
+      }));
+      const encoded = encodeWorkspacePublishRequest({
+        paranetId: contextGraphId,
+        nquads: new TextEncoder().encode(nquadsStr),
+        manifest: manifestEntries,
+        publisherPeerId: opts.publisherPeerId,
+        workspaceOperationId: operationId,
+        timestampMs: Date.now(),
+        operationId,
+        subGraphName: opts.subGraphName,
+      });
+
+      const MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024;
+      if (encoded.length > MAX_GOSSIP_MESSAGE_SIZE) {
+        throw new Error(
+          `Promoted assertion too large for gossip (${(encoded.length / 1024).toFixed(0)} KB, limit ${MAX_GOSSIP_MESSAGE_SIZE / 1024} KB). ` +
+          `Promote fewer entities per call.`,
+        );
+      }
+      gossipMessage = encoded;
+    }
+
+    // Delete-then-insert for entities owned by this peer (upsert), matching
     // _shareImpl and SharedMemoryHandler so re-promotes replace stale triples.
+    // Only overwrite entities owned by the same publisherPeerId (Rule 4).
     for (const root of rootEntities) {
-      if (swmOwned.has(root)) {
+      if (swmOwned.has(root) && swmOwned.get(root) === opts?.publisherPeerId) {
         await this.store.deleteByPattern({ graph: swmGraphUri, subject: root });
         await this.store.deleteBySubjectPrefix(swmGraphUri, root + '/.well-known/genid/');
         await this.deleteMetaForRoot(swmMetaGraph, root);
@@ -1613,40 +1654,6 @@ export class DKGPublisher implements Publisher {
         for (const entry of newOwnershipEntries) {
           liveOwned.set(entry.rootEntity, entry.creatorPeerId);
         }
-      }
-    }
-
-    // Build gossip message for the caller to broadcast. Best-effort: if the
-    // message exceeds the pubsub limit we skip gossip rather than failing,
-    // since the local promotion has already committed.
-    let gossipMessage: Uint8Array | undefined;
-    if (opts?.publisherPeerId) {
-      const dataGraph = this.graphManager.dataGraphUri(contextGraphId);
-      const nquadsStr = normalizedQuads
-        .map(
-          (q) =>
-            `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${dataGraph}> .`,
-        )
-        .join('\n');
-      const manifestEntries = rootEntities.map((rootEntity) => ({
-        rootEntity,
-        privateMerkleRoot: undefined,
-        privateTripleCount: 0,
-      }));
-      const encoded = encodeWorkspacePublishRequest({
-        paranetId: contextGraphId,
-        nquads: new TextEncoder().encode(nquadsStr),
-        manifest: manifestEntries,
-        publisherPeerId: opts.publisherPeerId,
-        workspaceOperationId: operationId,
-        timestampMs: Date.now(),
-        operationId,
-        subGraphName: opts.subGraphName,
-      });
-
-      const MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024;
-      if (encoded.length <= MAX_GOSSIP_MESSAGE_SIZE) {
-        gossipMessage = encoded;
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #111 addressing remaining review feedback on `assertionPromote`:

- **Gossip size pre-check**: Move the 512 KB message size check _before_ any destructive SWM mutations, so oversized promotions are rejected while the assertion is still intact in WM (recoverable). Previously, the local promotion committed and gossip was silently skipped, leaving peers out of sync.
- **Owner-only upsert (Rule 4)**: Delete-then-insert cleanup now only runs for entities owned by the same `publisherPeerId`, matching `_shareImpl` and `SharedMemoryHandler`. Previously, any existing SWM entity was overwritten regardless of owner, which peers would reject under Rule 4.
- **Empty entity selection fast path**: `promote({ entities: ['nonexistent'] })` now returns `{ promotedCount: 0 }` instead of throwing "no root entities found". The `quadsToPromote.length === 0` check runs before `autoPartition()`, preserving the original no-op behavior.
- **Test exit listener race**: Register the daemon `exit` listener before sending `/api/shutdown` so a fast exit doesn't fire before the listener is attached.

## Test plan

- [x] `npx vitest run packages/publisher/test/draft-lifecycle.test.ts` — 70/70 pass
- [x] `npx vitest run packages/cli/test/publisher-cli-smoke.test.ts` — passes consistently
- [x] `npx tsc --noEmit -p packages/agent/tsconfig.json` — clean


Made with [Cursor](https://cursor.com)