### PR TITLE
test: harden V10 test coverage — assertions, publisher queue, memory layers, sub-graph gossip

### DIFF
--- a/packages/agent/test/e2e-assertion-lifecycle.test.ts
+++ b/packages/agent/test/e2e-assertion-lifecycle.test.ts
@@ -227,14 +227,19 @@ describe('Assertion promote gossip (2 nodes)', () => {
     ]);
 
     await nodeA.assertion.promote(CG_ID, 'gossip-draft');
-    await sleep(3000);
 
-    // Node B should have received the data via gossip
-    const result = await nodeB.query(
-      'SELECT ?name WHERE { <urn:gossip:item> <http://schema.org/name> ?name }',
-      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
-    );
-    expect(result.bindings.length).toBe(1);
-    expect(result.bindings[0]?.['name']).toBe('"Gossiped via promote"');
+    const deadline = Date.now() + 15_000;
+    let bindings: any[] = [];
+    while (Date.now() < deadline) {
+      const result = await nodeB.query(
+        'SELECT ?name WHERE { <urn:gossip:item> <http://schema.org/name> ?name }',
+        { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+      );
+      bindings = result.bindings;
+      if (bindings.length > 0) break;
+      await sleep(500);
+    }
+    expect(bindings.length).toBe(1);
+    expect(bindings[0]?.['name']).toBe('"Gossiped via promote"');
   }, 20_000);
 });

--- a/packages/agent/test/e2e-assertion-lifecycle.test.ts
+++ b/packages/agent/test/e2e-assertion-lifecycle.test.ts
@@ -1,0 +1,240 @@
+/**
+ * E2E tests for the Working Memory assertion lifecycle through DKGAgent:
+ *
+ * 1. assertion.create — creates a named assertion in a context graph
+ * 2. assertion.write — writes triples to the assertion
+ * 3. assertion.query — reads back the assertion's triples
+ * 4. assertion.promote — promotes WM data to SWM
+ * 5. assertion.discard — discards an assertion cleanly
+ * 6. Multi-assertion isolation — two assertions don't leak data
+ * 7. Promote with entity selection — only specified entities promoted
+ * 8. Sub-graph assertions — assertion lifecycle within a sub-graph
+ * 9. Two-node promote gossip — promoted data replicates via gossip
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+
+const agents: DKGAgent[] = [];
+
+afterEach(async () => {
+  for (const a of agents) {
+    try { await a.stop(); } catch {}
+  }
+  agents.length = 0;
+});
+
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
+
+const CG_ID = 'assertion-e2e';
+
+async function createAgent(name: string, chainId = 'mock:31337') {
+  const agent = await DKGAgent.create({
+    name,
+    listenPort: 0,
+    chainAdapter: new MockChainAdapter(chainId),
+  });
+  agents.push(agent);
+  await agent.start();
+  await agent.createContextGraph({ id: CG_ID, name: 'Assertion E2E' });
+  return agent;
+}
+
+describe('Assertion lifecycle (single agent)', () => {
+  it('create → write → query → discard', async () => {
+    const agent = await createAgent('AssertionBot');
+
+    const uri = await agent.assertion.create(CG_ID, 'draft-1');
+    expect(uri).toContain(CG_ID);
+    expect(uri).toContain('draft-1');
+
+    await agent.assertion.write(CG_ID, 'draft-1', [
+      { subject: 'urn:alice', predicate: 'http://schema.org/name', object: '"Alice"' },
+      { subject: 'urn:bob', predicate: 'http://schema.org/name', object: '"Bob"' },
+    ]);
+
+    const quads = await agent.assertion.query(CG_ID, 'draft-1');
+    expect(quads.length).toBe(2);
+    const names = quads.map(q => q.object).sort();
+    expect(names).toEqual(['"Alice"', '"Bob"']);
+
+    await agent.assertion.discard(CG_ID, 'draft-1');
+
+    const afterDiscard = await agent.assertion.query(CG_ID, 'draft-1');
+    expect(afterDiscard.length).toBe(0);
+  }, 15_000);
+
+  it('promote moves triples from WM to SWM', async () => {
+    const agent = await createAgent('PromoteBot');
+
+    await agent.assertion.create(CG_ID, 'to-promote');
+    await agent.assertion.write(CG_ID, 'to-promote', [
+      { subject: 'urn:paper:1', predicate: 'http://schema.org/name', object: '"Quantum Computing Survey"' },
+      { subject: 'urn:paper:1', predicate: 'http://schema.org/author', object: '"Dr. Smith"' },
+    ]);
+
+    const beforePromote = await agent.query(
+      'SELECT ?name WHERE { <urn:paper:1> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(beforePromote.bindings.length).toBe(0);
+
+    const result = await agent.assertion.promote(CG_ID, 'to-promote');
+    expect(result.promotedCount).toBeGreaterThan(0);
+
+    const afterPromote = await agent.query(
+      'SELECT ?name WHERE { <urn:paper:1> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(afterPromote.bindings.length).toBe(1);
+    expect(afterPromote.bindings[0]?.['name']).toBe('"Quantum Computing Survey"');
+
+    // WM assertion is cleaned up after promote
+    const wmAfter = await agent.assertion.query(CG_ID, 'to-promote');
+    expect(wmAfter.length).toBe(0);
+  }, 15_000);
+
+  it('promote with entity selection only promotes specified entities', async () => {
+    const agent = await createAgent('SelectivePromote');
+
+    await agent.assertion.create(CG_ID, 'selective');
+    await agent.assertion.write(CG_ID, 'selective', [
+      { subject: 'urn:entity:keep', predicate: 'http://schema.org/name', object: '"Keep Me"' },
+      { subject: 'urn:entity:skip', predicate: 'http://schema.org/name', object: '"Skip Me"' },
+    ]);
+
+    await agent.assertion.promote(CG_ID, 'selective', {
+      entities: ['urn:entity:keep'],
+    });
+
+    const kept = await agent.query(
+      'SELECT ?name WHERE { <urn:entity:keep> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    const skipped = await agent.query(
+      'SELECT ?name WHERE { <urn:entity:skip> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+
+    expect(kept.bindings.length).toBe(1);
+    expect(kept.bindings[0]?.['name']).toBe('"Keep Me"');
+    expect(skipped.bindings.length).toBe(0);
+  }, 15_000);
+
+  it('multiple assertions are isolated from each other', async () => {
+    const agent = await createAgent('IsolationBot');
+
+    await agent.assertion.create(CG_ID, 'draft-a');
+    await agent.assertion.create(CG_ID, 'draft-b');
+
+    await agent.assertion.write(CG_ID, 'draft-a', [
+      { subject: 'urn:a:1', predicate: 'http://schema.org/name', object: '"From A"' },
+    ]);
+    await agent.assertion.write(CG_ID, 'draft-b', [
+      { subject: 'urn:b:1', predicate: 'http://schema.org/name', object: '"From B"' },
+    ]);
+
+    const quadsA = await agent.assertion.query(CG_ID, 'draft-a');
+    const quadsB = await agent.assertion.query(CG_ID, 'draft-b');
+
+    expect(quadsA.length).toBe(1);
+    expect(quadsA[0].subject).toBe('urn:a:1');
+    expect(quadsB.length).toBe(1);
+    expect(quadsB[0].subject).toBe('urn:b:1');
+  }, 15_000);
+
+  it('discard is idempotent — second discard does not throw', async () => {
+    const agent = await createAgent('IdempotentDiscard');
+
+    await agent.assertion.create(CG_ID, 'ephemeral');
+    await agent.assertion.write(CG_ID, 'ephemeral', [
+      { subject: 'urn:temp', predicate: 'http://schema.org/name', object: '"Temporary"' },
+    ]);
+
+    await agent.assertion.discard(CG_ID, 'ephemeral');
+    // Should not throw
+    await agent.assertion.discard(CG_ID, 'ephemeral');
+
+    const quads = await agent.assertion.query(CG_ID, 'ephemeral');
+    expect(quads.length).toBe(0);
+  }, 15_000);
+});
+
+describe('Assertion lifecycle with sub-graphs', () => {
+  it('assertion in sub-graph is isolated from root graph', async () => {
+    const agent = await createAgent('SubGraphAssertion');
+    await agent.createSubGraph(CG_ID, 'research');
+
+    await agent.assertion.create(CG_ID, 'sg-draft', { subGraphName: 'research' });
+    await agent.assertion.write(CG_ID, 'sg-draft', [
+      { subject: 'urn:sg:1', predicate: 'http://schema.org/name', object: '"Sub-graph Data"' },
+    ], { subGraphName: 'research' });
+
+    // Queryable within sub-graph
+    const sgQuads = await agent.assertion.query(CG_ID, 'sg-draft', { subGraphName: 'research' });
+    expect(sgQuads.length).toBe(1);
+
+    // Promote to sub-graph SWM
+    const result = await agent.assertion.promote(CG_ID, 'sg-draft', { subGraphName: 'research' });
+    expect(result.promotedCount).toBeGreaterThan(0);
+
+    // Data in sub-graph SWM
+    const sgSwm = await agent.query(
+      'SELECT ?name WHERE { <urn:sg:1> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, subGraphName: 'research', graphSuffix: '_shared_memory' },
+    );
+    expect(sgSwm.bindings.length).toBe(1);
+
+    // NOT in root SWM
+    const rootSwm = await agent.query(
+      'SELECT ?name WHERE { <urn:sg:1> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(rootSwm.bindings.length).toBe(0);
+  }, 15_000);
+});
+
+describe('Assertion promote gossip (2 nodes)', () => {
+  it('promoted data replicates to connected peer via gossip', async () => {
+    const nodeA = await DKGAgent.create({
+      name: 'PromoteGossipA',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter(),
+    });
+    agents.push(nodeA);
+    const nodeB = await DKGAgent.create({
+      name: 'PromoteGossipB',
+      listenPort: 0,
+      chainAdapter: new MockChainAdapter(),
+    });
+    agents.push(nodeB);
+
+    await nodeA.start();
+    await nodeB.start();
+    await sleep(500);
+
+    const addrA = nodeA.multiaddrs.find(a => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodeB.connectTo(addrA);
+    await sleep(500);
+
+    await nodeA.createContextGraph({ id: CG_ID, name: 'Gossip Promote' });
+    nodeB.subscribeToContextGraph(CG_ID);
+    await sleep(500);
+
+    await nodeA.assertion.create(CG_ID, 'gossip-draft');
+    await nodeA.assertion.write(CG_ID, 'gossip-draft', [
+      { subject: 'urn:gossip:item', predicate: 'http://schema.org/name', object: '"Gossiped via promote"' },
+    ]);
+
+    await nodeA.assertion.promote(CG_ID, 'gossip-draft');
+    await sleep(3000);
+
+    // Node B should have received the data via gossip
+    const result = await nodeB.query(
+      'SELECT ?name WHERE { <urn:gossip:item> <http://schema.org/name> ?name }',
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(result.bindings.length).toBe(1);
+    expect(result.bindings[0]?.['name']).toBe('"Gossiped via promote"');
+  }, 20_000);
+});

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -1,0 +1,301 @@
+/**
+ * E2E tests for the DKG V10 memory layer progression:
+ *
+ * 1. Working Memory → SWM: assertion promote moves data to shared memory
+ * 2. SWM → Verified Memory: publishFromSharedMemory anchors on-chain
+ * 3. Full pipeline: WM → promote → SWM gossip → publishFromSharedMemory → VM
+ * 4. Memory layer isolation: data in one layer doesn't leak to another
+ * 5. Two-node flow: A promotes to SWM → gossip to B → A publishes → B finalizes
+ * 6. SWM query view vs default view
+ * 7. Working memory view
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+
+const agents: DKGAgent[] = [];
+
+afterEach(async () => {
+  for (const a of agents) {
+    try { await a.stop(); } catch {}
+  }
+  agents.length = 0;
+});
+
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
+
+const CG_ID = 'memory-layers-e2e';
+const ENTITY_BASE = 'urn:mem:entity';
+
+async function createAgent(name: string) {
+  const chain = new MockChainAdapter();
+  const agent = await DKGAgent.create({
+    name,
+    listenPort: 0,
+    chainAdapter: chain,
+  });
+  agents.push(agent);
+  await agent.start();
+  return agent;
+}
+
+describe('Memory layer isolation (single agent)', () => {
+  it('WM data is not visible in SWM or default data graph', async () => {
+    const agent = await createAgent('IsolationBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Memory Layers E2E' });
+
+    // Write to working memory
+    await agent.assertion.create(CG_ID, 'wm-only');
+    await agent.assertion.write(CG_ID, 'wm-only', [
+      { subject: `${ENTITY_BASE}:wm`, predicate: 'http://schema.org/name', object: '"WM Only"' },
+    ]);
+
+    // Visible in WM
+    const wmQuads = await agent.assertion.query(CG_ID, 'wm-only');
+    expect(wmQuads.length).toBe(1);
+
+    // Not in SWM
+    const swm = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:wm> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(swm.bindings.length).toBe(0);
+
+    // Not in default data graph
+    const data = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:wm> <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    expect(data.bindings.length).toBe(0);
+  }, 15_000);
+
+  it('SWM data is not visible in default data graph', async () => {
+    const agent = await createAgent('SWMIsolationBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Memory Layers E2E' });
+
+    await agent.share(CG_ID, [
+      { subject: `${ENTITY_BASE}:swm`, predicate: 'http://schema.org/name', object: '"SWM Only"', graph: '' },
+    ], { localOnly: true });
+
+    // Visible in SWM
+    const swm = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:swm> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(swm.bindings.length).toBe(1);
+
+    // Not in default data graph
+    const data = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:swm> <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    expect(data.bindings.length).toBe(0);
+  }, 15_000);
+
+  it('published data is in data graph but not SWM', async () => {
+    const agent = await createAgent('PublishedBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Memory Layers E2E' });
+
+    const quads = [
+      { subject: `${ENTITY_BASE}:pub`, predicate: 'http://schema.org/name', object: '"Published"', graph: '' },
+    ];
+    await agent.publish(CG_ID, quads);
+
+    // Visible in data graph
+    const data = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:pub> <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    expect(data.bindings.length).toBe(1);
+  }, 15_000);
+});
+
+describe('WM → SWM → VM pipeline (single agent)', () => {
+  it('promotes assertion to SWM, then publishes SWM to verified memory', async () => {
+    const agent = await createAgent('PipelineBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Pipeline E2E' });
+
+    // Step 1: Write to working memory
+    await agent.assertion.create(CG_ID, 'pipeline');
+    await agent.assertion.write(CG_ID, 'pipeline', [
+      { subject: `${ENTITY_BASE}:pipeline`, predicate: 'http://schema.org/name', object: '"Pipeline Entity"' },
+      { subject: `${ENTITY_BASE}:pipeline`, predicate: 'http://schema.org/version', object: '"v1"' },
+    ]);
+
+    const wmQuads = await agent.assertion.query(CG_ID, 'pipeline');
+    expect(wmQuads.length).toBe(2);
+
+    // Step 2: Promote to SWM
+    const promoteResult = await agent.assertion.promote(CG_ID, 'pipeline');
+    expect(promoteResult.promotedCount).toBeGreaterThan(0);
+
+    const swmResult = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:pipeline> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(swmResult.bindings.length).toBe(1);
+    expect(swmResult.bindings[0]?.['name']).toBe('"Pipeline Entity"');
+
+    // Step 3: Publish from SWM to verified memory (mock chain)
+    const pubResult = await agent.publishFromSharedMemory(CG_ID, 'all');
+    expect(pubResult.status).toBe('confirmed');
+    expect(pubResult.ual).toBeDefined();
+
+    // Verify data is now in the canonical data graph
+    const dataResult = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:pipeline> <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    expect(dataResult.bindings.length).toBe(1);
+  }, 20_000);
+
+  it('WM is empty after promote; SWM clear after publishFromSWM with flag', async () => {
+    const agent = await createAgent('CleanupBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'Cleanup E2E' });
+
+    await agent.assertion.create(CG_ID, 'cleanup');
+    await agent.assertion.write(CG_ID, 'cleanup', [
+      { subject: `${ENTITY_BASE}:cleanup`, predicate: 'http://schema.org/name', object: '"Cleanup"' },
+    ]);
+    await agent.assertion.promote(CG_ID, 'cleanup');
+
+    // WM should be empty
+    const wmAfterPromote = await agent.assertion.query(CG_ID, 'cleanup');
+    expect(wmAfterPromote.length).toBe(0);
+
+    await agent.publishFromSharedMemory(CG_ID, 'all', { clearSharedMemoryAfter: true });
+
+    // SWM should be empty after publish with clear flag
+    const swmAfterPublish = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:cleanup> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(swmAfterPublish.bindings.length).toBe(0);
+
+    // Data should be in canonical graph
+    const data = await agent.query(
+      `SELECT ?name WHERE { <${ENTITY_BASE}:cleanup> <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    expect(data.bindings.length).toBe(1);
+  }, 20_000);
+});
+
+describe('WM → SWM gossip → VM (2 nodes)', () => {
+  async function pollUntil(
+    queryFn: () => Promise<{ bindings: any[] }>,
+    predicate: (bindings: any[]) => boolean,
+    timeoutMs: number,
+  ): Promise<any[]> {
+    const deadline = Date.now() + timeoutMs;
+    let lastResult: any[] = [];
+    while (Date.now() < deadline) {
+      const result = await queryFn();
+      lastResult = result.bindings;
+      if (predicate(lastResult)) return lastResult;
+      await sleep(500);
+    }
+    return lastResult;
+  }
+
+  it('A drafts in WM → promotes to SWM → gossips to B → publishes → B finalizes', async () => {
+    const sharedChain = new MockChainAdapter('mock:31337');
+    const nodeA = await DKGAgent.create({
+      name: 'LayersA',
+      listenPort: 0,
+      chainAdapter: sharedChain,
+    });
+    agents.push(nodeA);
+
+    const nodeB = await DKGAgent.create({
+      name: 'LayersB',
+      listenPort: 0,
+      chainAdapter: sharedChain,
+    });
+    agents.push(nodeB);
+
+    await nodeA.start();
+    await nodeB.start();
+    await sleep(500);
+
+    const addrA = nodeA.multiaddrs.find(a => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodeB.connectTo(addrA);
+    await sleep(2000);
+
+    await nodeA.createContextGraph({ id: CG_ID, name: 'Two-Node Memory Layers' });
+    nodeA.subscribeToContextGraph(CG_ID);
+    nodeB.subscribeToContextGraph(CG_ID);
+    await sleep(1500);
+
+    // Step 1: A creates assertion in WM
+    await nodeA.assertion.create(CG_ID, 'two-node-draft');
+    await nodeA.assertion.write(CG_ID, 'two-node-draft', [
+      { subject: `${ENTITY_BASE}:two-node`, predicate: 'http://schema.org/name', object: '"Two Node Entity"' },
+    ]);
+
+    // Step 2: A promotes to SWM (gossips to B)
+    await nodeA.assertion.promote(CG_ID, 'two-node-draft');
+
+    // Step 3: B receives via gossip
+    const bSwm = await pollUntil(
+      () => nodeB.query(
+        `SELECT ?name WHERE { <${ENTITY_BASE}:two-node> <http://schema.org/name> ?name }`,
+        { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+      ),
+      (b) => b.length > 0,
+      15_000,
+    );
+    expect(bSwm.length).toBe(1);
+    expect(bSwm[0]?.['name']).toBe('"Two Node Entity"');
+
+    // Step 4: A publishes from SWM → chain
+    const pubResult = await nodeA.publishFromSharedMemory(CG_ID, 'all');
+    expect(pubResult.status).toBe('confirmed');
+
+    // Step 5: B receives finalization → promotes to data graph
+    const bData = await pollUntil(
+      () => nodeB.query(
+        `SELECT ?name WHERE { <${ENTITY_BASE}:two-node> <http://schema.org/name> ?name }`,
+        CG_ID,
+      ),
+      (b) => b.length > 0,
+      20_000,
+    );
+    expect(bData.length).toBe(1);
+    expect(bData[0]?.['name']).toBe('"Two Node Entity"');
+  }, 60_000);
+});
+
+describe('Query views', () => {
+  it('includeSharedMemory merges SWM data into query results', async () => {
+    const agent = await createAgent('ViewBot');
+    await agent.createContextGraph({ id: CG_ID, name: 'View E2E' });
+
+    // Put data in canonical graph via publish
+    await agent.publish(CG_ID, [
+      { subject: `${ENTITY_BASE}:canonical`, predicate: 'http://schema.org/name', object: '"Canonical"', graph: '' },
+    ]);
+
+    // Put data in SWM
+    await agent.share(CG_ID, [
+      { subject: `${ENTITY_BASE}:shared`, predicate: 'http://schema.org/name', object: '"Shared"', graph: '' },
+    ], { localOnly: true });
+
+    // Default query (data graph only) — should see canonical
+    const defaultResult = await agent.query(
+      `SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    const defaultSubjects = defaultResult.bindings.map((b: any) => b['s']);
+    expect(defaultSubjects.some((s: string) => s.includes('canonical'))).toBe(true);
+
+    // includeSharedMemory — should see both
+    const mergedResult = await agent.query(
+      `SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, includeSharedMemory: true },
+    );
+    const mergedSubjects = mergedResult.bindings.map((b: any) => b['s']);
+    expect(mergedSubjects.some((s: string) => s.includes('canonical'))).toBe(true);
+    expect(mergedSubjects.some((s: string) => s.includes('shared'))).toBe(true);
+  }, 15_000);
+});

--- a/packages/agent/test/e2e-sub-graph-gossip.test.ts
+++ b/packages/agent/test/e2e-sub-graph-gossip.test.ts
@@ -7,7 +7,7 @@
  * 4. Sub-graph isolation in gossip: data in one sub-graph doesn't appear in another
  * 5. Sub-graph data doesn't leak to root CG queries
  */
-import { describe, it, expect, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 
@@ -38,12 +38,7 @@ describe('Sub-graph gossip replication (2 nodes)', () => {
   let nodeA: DKGAgent;
   let nodeB: DKGAgent;
 
-  afterAll(async () => {
-    try { await nodeA?.stop(); } catch {}
-    try { await nodeB?.stop(); } catch {}
-  });
-
-  it('bootstraps two agents and connects', async () => {
+  beforeAll(async () => {
     nodeA = await DKGAgent.create({
       name: 'SubGossipA',
       listenPort: 0,
@@ -71,6 +66,11 @@ describe('Sub-graph gossip replication (2 nodes)', () => {
     await nodeA.createSubGraph(CG_ID, SG_RESEARCH, { description: 'Papers' });
     await nodeA.createSubGraph(CG_ID, SG_CODE, { description: 'Source code' });
   }, 20_000);
+
+  afterAll(async () => {
+    try { await nodeA?.stop(); } catch {}
+    try { await nodeB?.stop(); } catch {}
+  });
 
   it('SWM write to sub-graph replicates via gossip', async () => {
     await nodeA.share(CG_ID, [

--- a/packages/agent/test/e2e-sub-graph-gossip.test.ts
+++ b/packages/agent/test/e2e-sub-graph-gossip.test.ts
@@ -1,0 +1,242 @@
+/**
+ * E2E tests for sub-graph replication and gossip:
+ *
+ * 1. Sub-graph SWM write replicates via gossip to peer
+ * 2. Sub-graph publish from SWM → finalization → peer promotes
+ * 3. Assertion promote to sub-graph SWM → gossips to peer
+ * 4. Sub-graph isolation in gossip: data in one sub-graph doesn't appear in another
+ * 5. Sub-graph data doesn't leak to root CG queries
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { DKGAgent } from '../src/index.js';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+
+const CG_ID = 'sg-gossip-e2e';
+const SG_RESEARCH = 'research';
+const SG_CODE = 'code';
+
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
+
+async function pollUntil(
+  queryFn: () => Promise<{ bindings: any[] }>,
+  predicate: (bindings: any[]) => boolean,
+  timeoutMs: number,
+): Promise<any[]> {
+  const deadline = Date.now() + timeoutMs;
+  let lastResult: any[] = [];
+  while (Date.now() < deadline) {
+    const result = await queryFn();
+    lastResult = result.bindings;
+    if (predicate(lastResult)) return lastResult;
+    await sleep(500);
+  }
+  return lastResult;
+}
+
+describe('Sub-graph gossip replication (2 nodes)', () => {
+  const sharedChain = new MockChainAdapter('mock:31337');
+  let nodeA: DKGAgent;
+  let nodeB: DKGAgent;
+
+  afterAll(async () => {
+    try { await nodeA?.stop(); } catch {}
+    try { await nodeB?.stop(); } catch {}
+  });
+
+  it('bootstraps two agents and connects', async () => {
+    nodeA = await DKGAgent.create({
+      name: 'SubGossipA',
+      listenPort: 0,
+      chainAdapter: sharedChain,
+    });
+    nodeB = await DKGAgent.create({
+      name: 'SubGossipB',
+      listenPort: 0,
+      chainAdapter: sharedChain,
+    });
+
+    await nodeA.start();
+    await nodeB.start();
+    await sleep(800);
+
+    const addrA = nodeA.multiaddrs.find(a => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodeB.connectTo(addrA);
+    await sleep(2000);
+
+    await nodeA.createContextGraph({ id: CG_ID, name: 'Sub-graph Gossip E2E' });
+    nodeA.subscribeToContextGraph(CG_ID);
+    nodeB.subscribeToContextGraph(CG_ID);
+    await sleep(1500);
+
+    await nodeA.createSubGraph(CG_ID, SG_RESEARCH, { description: 'Papers' });
+    await nodeA.createSubGraph(CG_ID, SG_CODE, { description: 'Source code' });
+  }, 20_000);
+
+  it('SWM write to sub-graph replicates via gossip', async () => {
+    await nodeA.share(CG_ID, [
+      { subject: 'urn:sg:paper:1', predicate: 'http://schema.org/name', object: '"DKG V10 Paper"', graph: '' },
+      { subject: 'urn:sg:paper:1', predicate: 'http://schema.org/author', object: '"Research Team"', graph: '' },
+    ], { subGraphName: SG_RESEARCH });
+
+    const bBindings = await pollUntil(
+      () => nodeB.query(
+        `SELECT ?name WHERE { <urn:sg:paper:1> <http://schema.org/name> ?name }`,
+        { contextGraphId: CG_ID, subGraphName: SG_RESEARCH, graphSuffix: '_shared_memory' },
+      ),
+      (b) => b.length > 0,
+      15_000,
+    );
+    expect(bBindings.length).toBe(1);
+    expect(bBindings[0]?.['name']).toBe('"DKG V10 Paper"');
+  }, 25_000);
+
+  it('sub-graph data doesn\'t leak to a different sub-graph SWM', async () => {
+    const codeSwm = await nodeB.query(
+      `SELECT ?name WHERE { <urn:sg:paper:1> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, subGraphName: SG_CODE, graphSuffix: '_shared_memory' },
+    );
+    expect(codeSwm.bindings.length).toBe(0);
+  }, 10_000);
+
+  it('sub-graph data doesn\'t appear in root CG SWM query', async () => {
+    const rootSwm = await nodeA.query(
+      `SELECT ?name WHERE { <urn:sg:paper:1> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, graphSuffix: '_shared_memory' },
+    );
+    expect(rootSwm.bindings.length).toBe(0);
+  }, 10_000);
+
+  it('assertion promote to sub-graph SWM gossips to peer', async () => {
+    await nodeA.assertion.create(CG_ID, 'code-draft', { subGraphName: SG_CODE });
+    await nodeA.assertion.write(CG_ID, 'code-draft', [
+      { subject: 'urn:sg:module:parser', predicate: 'http://schema.org/name', object: '"Parser Module"' },
+    ], { subGraphName: SG_CODE });
+
+    await nodeA.assertion.promote(CG_ID, 'code-draft', { subGraphName: SG_CODE });
+
+    const bCode = await pollUntil(
+      () => nodeB.query(
+        `SELECT ?name WHERE { <urn:sg:module:parser> <http://schema.org/name> ?name }`,
+        { contextGraphId: CG_ID, subGraphName: SG_CODE, graphSuffix: '_shared_memory' },
+      ),
+      (b) => b.length > 0,
+      15_000,
+    );
+    expect(bCode.length).toBe(1);
+    expect(bCode[0]?.['name']).toBe('"Parser Module"');
+  }, 25_000);
+
+  it('publish sub-graph SWM → finalization → B promotes to data graph', async () => {
+    const result = await nodeA.publishFromSharedMemory(CG_ID, 'all', {
+      subGraphName: SG_RESEARCH,
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(result.ual).toBeDefined();
+
+    // A's data graph should have the research paper
+    const aData = await nodeA.query(
+      `SELECT ?name WHERE { <urn:sg:paper:1> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG_ID, subGraphName: SG_RESEARCH },
+    );
+    expect(aData.bindings.length).toBe(1);
+
+    // B should receive finalization and promote
+    const bData = await pollUntil(
+      () => nodeB.query(
+        `SELECT ?name WHERE { <urn:sg:paper:1> <http://schema.org/name> ?name }`,
+        { contextGraphId: CG_ID, subGraphName: SG_RESEARCH },
+      ),
+      (b) => b.length > 0,
+      20_000,
+    );
+    expect(bData.length).toBe(1);
+    expect(bData[0]?.['name']).toBe('"DKG V10 Paper"');
+  }, 30_000);
+
+  it('published sub-graph data still not in root CG data graph', async () => {
+    const rootData = await nodeA.query(
+      `SELECT ?name WHERE { <urn:sg:paper:1> <http://schema.org/name> ?name }`,
+      CG_ID,
+    );
+    expect(rootData.bindings.length).toBe(0);
+  }, 10_000);
+});
+
+describe('Multiple sub-graphs with concurrent writes (3 nodes)', () => {
+  const sharedChain = new MockChainAdapter('mock:31337');
+  const agents: DKGAgent[] = [];
+
+  afterAll(async () => {
+    for (const a of agents) {
+      try { await a.stop(); } catch {}
+    }
+  });
+
+  it('concurrent SWM writes to different sub-graphs replicate correctly', async () => {
+    const nodes = await Promise.all(
+      ['ConcA', 'ConcB', 'ConcC'].map(async (name) => {
+        const agent = await DKGAgent.create({
+          name,
+          listenPort: 0,
+          chainAdapter: sharedChain,
+        });
+        agents.push(agent);
+        await agent.start();
+        return agent;
+      }),
+    );
+    await sleep(500);
+
+    const addrA = nodes[0].multiaddrs.find(a => a.includes('/tcp/') && !a.includes('/p2p-circuit'))!;
+    await nodes[1].connectTo(addrA);
+    await nodes[2].connectTo(addrA);
+    await sleep(2000);
+
+    const CG = 'concurrent-sg-e2e';
+    await nodes[0].createContextGraph({ id: CG, name: 'Concurrent Sub-graph E2E' });
+    for (const n of nodes) n.subscribeToContextGraph(CG);
+    await sleep(1500);
+
+    await nodes[0].createSubGraph(CG, 'alpha');
+    await nodes[0].createSubGraph(CG, 'beta');
+
+    // Node A writes to alpha, Node B writes to beta
+    await Promise.all([
+      nodes[0].share(CG, [
+        { subject: 'urn:conc:alpha:1', predicate: 'http://schema.org/name', object: '"Alpha Data"', graph: '' },
+      ], { subGraphName: 'alpha' }),
+      nodes[1].share(CG, [
+        { subject: 'urn:conc:beta:1', predicate: 'http://schema.org/name', object: '"Beta Data"', graph: '' },
+      ], { subGraphName: 'beta' }),
+    ]);
+
+    // Node C should eventually see both
+    const cAlpha = await pollUntil(
+      () => nodes[2].query(
+        `SELECT ?name WHERE { <urn:conc:alpha:1> <http://schema.org/name> ?name }`,
+        { contextGraphId: CG, subGraphName: 'alpha', graphSuffix: '_shared_memory' },
+      ),
+      (b) => b.length > 0,
+      15_000,
+    );
+    expect(cAlpha.length).toBe(1);
+
+    const cBeta = await pollUntil(
+      () => nodes[2].query(
+        `SELECT ?name WHERE { <urn:conc:beta:1> <http://schema.org/name> ?name }`,
+        { contextGraphId: CG, subGraphName: 'beta', graphSuffix: '_shared_memory' },
+      ),
+      (b) => b.length > 0,
+      15_000,
+    );
+    expect(cBeta.length).toBe(1);
+
+    // Cross-isolation: alpha data not in beta
+    const betaCheck = await nodes[2].query(
+      `SELECT ?name WHERE { <urn:conc:alpha:1> <http://schema.org/name> ?name }`,
+      { contextGraphId: CG, subGraphName: 'beta', graphSuffix: '_shared_memory' },
+    );
+    expect(betaCheck.bindings.length).toBe(0);
+  }, 45_000);
+});

--- a/packages/publisher/test/e2e-publisher-queue.test.ts
+++ b/packages/publisher/test/e2e-publisher-queue.test.ts
@@ -1,0 +1,304 @@
+/**
+ * E2E tests for the async lift publisher queue:
+ *
+ * 1. lift → claimNext → processNext (full pipeline with mock chain)
+ * 2. Multiple jobs — FIFO ordering
+ * 3. Pause/resume — paused queue does not yield jobs
+ * 4. Cancel a pending job
+ * 5. Retry failed jobs — re-enters the queue
+ * 6. Clear finalized/failed jobs
+ * 7. Stats reflect live queue state
+ * 8. Wallet lock contention — two wallets claim independently
+ * 9. Recovery from broadcast state when chainRecoveryResolver succeeds
+ * 10. Recovery from broadcast state when chainRecoveryResolver returns null → fails
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
+import {
+  DKGPublisher,
+  TripleStoreAsyncLiftPublisher,
+  type AsyncLiftPublisherConfig,
+  type AsyncLiftPublisherRecoveryResult,
+  type LiftRequest,
+} from '../src/index.js';
+
+function makeLiftRequest(overrides: Partial<LiftRequest> = {}): LiftRequest {
+  return {
+    swmId: `swm-${Math.random().toString(36).slice(2, 8)}`,
+    shareOperationId: `op-${Math.random().toString(36).slice(2, 8)}`,
+    roots: ['urn:test:entity:1'],
+    contextGraphId: 'test-cg',
+    namespace: 'default',
+    scope: 'full',
+    transitionType: 'CREATE',
+    authority: { type: 'owner', proofRef: 'proof:owner:test' },
+    ...overrides,
+  };
+}
+
+describe('Async Lift Publisher Queue — E2E Pipeline', () => {
+  let store: OxigraphStore;
+  let time: number;
+  let ids: number;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    time = 1_000;
+    ids = 0;
+  });
+
+  function create(opts: {
+    recoveryResult?: AsyncLiftPublisherRecoveryResult | null;
+    publishExecutor?: AsyncLiftPublisherConfig['publishExecutor'];
+  } = {}) {
+    return new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++time,
+      idGenerator: () => `job-${++ids}`,
+      chainRecoveryResolver: opts.recoveryResult === undefined
+        ? undefined
+        : async () => opts.recoveryResult ?? null,
+      publishExecutor: opts.publishExecutor,
+    });
+  }
+
+  it('lift → claimNext → status transitions accepted→claimed', async () => {
+    const pub = create();
+    const jobId = await pub.lift(makeLiftRequest());
+    expect(jobId).toBe('job-1');
+
+    const status = await pub.getStatus(jobId);
+    expect(status?.status).toBe('accepted');
+
+    const claimed = await pub.claimNext('wallet-1');
+    expect(claimed).not.toBeNull();
+    expect(claimed!.jobId).toBe(jobId);
+    expect(claimed!.status).toBe('claimed');
+  });
+
+  it('multiple jobs are claimed in FIFO order by different wallets', async () => {
+    const pub = create();
+    const id1 = await pub.lift(makeLiftRequest({ contextGraphId: 'cg-1' }));
+    const id2 = await pub.lift(makeLiftRequest({ contextGraphId: 'cg-2' }));
+    const id3 = await pub.lift(makeLiftRequest({ contextGraphId: 'cg-3' }));
+
+    // Each wallet can only hold one active lock, so use different wallets
+    const c1 = await pub.claimNext('wallet-1');
+    const c2 = await pub.claimNext('wallet-2');
+    const c3 = await pub.claimNext('wallet-3');
+
+    expect(c1!.jobId).toBe(id1);
+    expect(c2!.jobId).toBe(id2);
+    expect(c3!.jobId).toBe(id3);
+
+    const c4 = await pub.claimNext('wallet-4');
+    expect(c4).toBeNull();
+  });
+
+  it('pause prevents claiming; resume re-enables', async () => {
+    const pub = create();
+    await pub.lift(makeLiftRequest());
+
+    await pub.pause();
+    const duringPause = await pub.claimNext('wallet-1');
+    expect(duringPause).toBeNull();
+
+    await pub.resume();
+    const afterResume = await pub.claimNext('wallet-1');
+    expect(afterResume).not.toBeNull();
+  });
+
+  it('cancel removes a pending job', async () => {
+    const pub = create();
+    const jobId = await pub.lift(makeLiftRequest());
+
+    await pub.cancel(jobId);
+    const status = await pub.getStatus(jobId);
+    // Cancelled jobs either have 'failed' status or are gone
+    expect(status === null || status.status === 'failed').toBe(true);
+
+    const claimed = await pub.claimNext('wallet-1');
+    expect(claimed).toBeNull();
+  });
+
+  it('stats reflect live queue composition', async () => {
+    const pub = create();
+    await pub.lift(makeLiftRequest());
+    await pub.lift(makeLiftRequest());
+
+    let stats = await pub.getStats();
+    expect(stats['accepted']).toBe(2);
+
+    await pub.claimNext('wallet-1');
+    stats = await pub.getStats();
+    expect(stats['accepted']).toBe(1);
+    expect(stats['claimed']).toBe(1);
+  });
+
+  it('clear removes finalized jobs', async () => {
+    const pub = create({
+      publishExecutor: async () => ({
+        status: 'confirmed' as const,
+        merkleRoot: new Uint8Array(32),
+        ual: 'did:dkg:mock/test/1',
+        kcId: 1n,
+        kaManifest: [],
+        publicQuads: [],
+      }),
+    });
+
+    const jobId = await pub.lift(makeLiftRequest());
+    const claimed = await pub.claimNext('wallet-1');
+    expect(claimed).not.toBeNull();
+
+    const VALIDATION_META = {
+      validation: {
+        canonicalRoots: ['urn:test:entity:1'],
+        canonicalRootMap: { 'urn:test:entity:1': 'urn:test:entity:1' },
+        swmQuadCount: 1,
+        authorityProofRef: 'proof:owner:test',
+        transitionType: 'CREATE' as const,
+      },
+    };
+    const BROADCAST_META = {
+      broadcast: { txHash: '0xabc', walletId: 'wallet-1' },
+    };
+
+    await pub.update(jobId, 'validated', VALIDATION_META);
+    await pub.update(jobId, 'broadcast', BROADCAST_META);
+    await pub.update(jobId, 'included', {
+      inclusion: { txHash: '0xabc', blockNumber: 42 },
+    });
+    await pub.update(jobId, 'finalized', {
+      finalization: { confirmedByChain: true, finalizedAtMs: time, proofRef: '' },
+    });
+
+    let stats = await pub.getStats();
+    expect(stats['finalized']).toBe(1);
+
+    const cleared = await pub.clear('finalized');
+    expect(cleared).toBe(1);
+
+    stats = await pub.getStats();
+    expect(stats['finalized']).toBe(0);
+  });
+
+  it('two wallets claim different jobs in parallel', async () => {
+    const pub = create();
+    await pub.lift(makeLiftRequest());
+    await pub.lift(makeLiftRequest());
+
+    const c1 = await pub.claimNext('wallet-A');
+    const c2 = await pub.claimNext('wallet-B');
+
+    expect(c1).not.toBeNull();
+    expect(c2).not.toBeNull();
+    expect(c1!.jobId).not.toBe(c2!.jobId);
+  });
+});
+
+describe('Async Lift Publisher Queue — Recovery', () => {
+  let store: OxigraphStore;
+  let time: number;
+  let ids: number;
+
+  const VALIDATION_META = {
+    validation: {
+      canonicalRoots: ['urn:test:entity:1'],
+      canonicalRootMap: { 'urn:test:entity:1': 'urn:test:entity:1' },
+      swmQuadCount: 1,
+      authorityProofRef: 'proof:owner:test',
+      transitionType: 'CREATE' as const,
+    },
+  };
+  const BROADCAST_META = {
+    broadcast: { txHash: '0xabc', walletId: 'wallet-1' },
+  };
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    time = 1_000;
+    ids = 0;
+  });
+
+  function create(opts: { recoveryResult?: AsyncLiftPublisherRecoveryResult | null } = {}) {
+    return new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++time,
+      idGenerator: () => `job-${++ids}`,
+      chainRecoveryResolver: opts.recoveryResult === undefined
+        ? undefined
+        : async () => opts.recoveryResult ?? null,
+    });
+  }
+
+  it('recover finalizes broadcast jobs when resolver succeeds', async () => {
+    const pub = create({
+      recoveryResult: {
+        inclusion: { txHash: '0xrecovered' as `0x${string}`, blockNumber: 100 },
+        finalization: { mode: 'published', txHash: '0xrecovered' as `0x${string}` },
+      },
+    });
+
+    const jobId = await pub.lift(makeLiftRequest());
+    await pub.claimNext('wallet-1');
+    await pub.update(jobId, 'validated', VALIDATION_META);
+    await pub.update(jobId, 'broadcast', BROADCAST_META);
+
+    const recoveredCount = await pub.recover();
+    expect(recoveredCount).toBeGreaterThanOrEqual(1);
+
+    const status = await pub.getStatus(jobId);
+    expect(status?.status).toBe('finalized');
+  });
+
+  it('recover fails broadcast jobs when resolver returns null and timeout elapses', async () => {
+    const pub = create({ recoveryResult: null });
+
+    const jobId = await pub.lift(makeLiftRequest());
+    await pub.claimNext('wallet-1');
+    await pub.update(jobId, 'validated', VALIDATION_META);
+    await pub.update(jobId, 'broadcast', BROADCAST_META);
+
+    // Advance past the 15-minute recovery lookup timeout
+    time += 16 * 60 * 1000;
+
+    const recoveredCount = await pub.recover();
+    expect(recoveredCount).toBeGreaterThanOrEqual(1);
+
+    const status = await pub.getStatus(jobId);
+    expect(status?.status).toBe('failed');
+  });
+
+  it('retry re-queues retryable failed jobs (workspace_unavailable)', async () => {
+    // Manually create a failed job with workspace_unavailable (retryable)
+    const pub = create();
+    const jobId = await pub.lift(makeLiftRequest());
+    await pub.claimNext('wallet-1');
+
+    // Simulate a retryable failure by walking through internal update
+    // workspace_unavailable is retryable with resolution: 'reset_to_accepted'
+    await pub.update(jobId, 'failed', {
+      failure: {
+        failedFromState: 'claimed',
+        code: 'workspace_unavailable',
+        message: 'Store temporarily unavailable',
+        errorPayloadRef: `urn:error:${jobId}`,
+        phase: 'validation',
+        mode: 'retryable',
+        retryable: true,
+        resolution: 'reset_to_accepted',
+      },
+    } as any);
+
+    const failedJob = await pub.getStatus(jobId);
+    expect(failedJob?.status).toBe('failed');
+
+    const retried = await pub.retry({ status: 'failed' });
+    expect(retried).toBeGreaterThanOrEqual(1);
+
+    const afterRetry = await pub.list({ status: 'accepted' });
+    expect(afterRetry.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/scripts/devnet-deep-test.sh
+++ b/scripts/devnet-deep-test.sh
@@ -429,23 +429,165 @@ LOCAL_CHECK=$(post 9205 /api/query -H "Content-Type: application/json" -d "{
 
 # ================================================================
 echo ""
-echo "=== TEST 9: Context Graph Operations ==="
+echo "=== TEST 9: Assertion Lifecycle ==="
 echo ""
 
-echo "--- 9a: List context graphs ---"
+echo "--- 9a: Create, write, query, promote a working memory assertion ---"
+ASSERT_CREATE=$(post 9201 /api/assertion/create -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"name\": \"deep-draft\"
+}")
+ASSERT_URI=$(echo "$ASSERT_CREATE" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("uri",""))' 2>/dev/null)
+[[ -n "$ASSERT_URI" ]] && ok "Assertion created: $ASSERT_URI" || fail "Assertion create: $ASSERT_CREATE"
+
+post 9201 /api/assertion/deep-draft/write -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"quads\": [
+    $(ql 'urn:deep:assert:1' 'http://schema.org/name' 'Deep Assertion Entity'),
+    $(ql 'urn:deep:assert:1' 'http://schema.org/version' 'v2'),
+    $(q 'urn:deep:assert:1' 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' 'http://schema.org/Thing')
+  ]
+}" > /dev/null
+ok "Assertion write OK"
+
+ASSERT_Q=$(post 9201 /api/assertion/deep-draft/query -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\"
+}")
+AQ_CT=$(echo "$ASSERT_Q" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d.get("quads",d.get("result",[]))))' 2>/dev/null || echo "0")
+[[ "$AQ_CT" -ge 2 ]] && ok "Assertion query returned $AQ_CT quads" || fail "Assertion query: $AQ_CT quads (expected >=2)"
+
+echo "--- 9b: Promote assertion to SWM ---"
+ASSERT_P=$(post 9201 /api/assertion/deep-draft/promote -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\"
+}")
+AP_CT=$(echo "$ASSERT_P" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("promotedCount",0))' 2>/dev/null || echo "0")
+[[ "$AP_CT" -ge 1 ]] && ok "Assertion promoted ($AP_CT quads)" || fail "Assertion promote: $ASSERT_P"
+
+echo "--- 9c: Promoted data gossips to all 5 nodes ---"
+sleep 6
+ASSERT_GOSSIP_OK=true
+for p in 9201 9202 9203 9204 9205; do
+  CT=$(post $p /api/query -H "Content-Type: application/json" -d "{
+    \"sparql\": \"SELECT ?name WHERE { GRAPH ?g { <urn:deep:assert:1> <http://schema.org/name> ?name } . FILTER(CONTAINS(STR(?g),'_shared_memory')) }\",
+    \"contextGraphId\": \"$CG\"
+  }" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
+  if [ "$CT" -ge 1 ]; then
+    ok "Promoted assertion on Node $p"
+  else
+    warn "Promoted assertion NOT on Node $p"
+    ASSERT_GOSSIP_OK=false
+  fi
+done
+
+echo "--- 9d: Publish promoted assertion from SWM ---"
+ASSERT_PUB=$(post 9201 /api/shared-memory/publish -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"selection\": [\"urn:deep:assert:1\"]
+}")
+ASSERT_PUB_ST=$(echo "$ASSERT_PUB" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("status","?"))' 2>/dev/null)
+[[ "$ASSERT_PUB_ST" == "confirmed" || "$ASSERT_PUB_ST" == "finalized" ]] && ok "Assertion SWM→VM publish ($ASSERT_PUB_ST)" || fail "Assertion SWM publish=$ASSERT_PUB_ST"
+
+echo "--- 9e: Verify WM→SWM→VM data in canonical graph ---"
+sleep 8
+for p in 9201 9202 9203; do
+  VM_CT=$(post $p /api/query -H "Content-Type: application/json" -d "{
+    \"sparql\": \"SELECT ?name WHERE { <urn:deep:assert:1> <http://schema.org/name> ?name }\",
+    \"contextGraphId\": \"$CG\"
+  }" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
+  [[ "$VM_CT" -ge 1 ]] && ok "VM assertion data on Node $p" || warn "VM assertion data missing on Node $p ($VM_CT)"
+done
+
+echo ""
+echo "--- 9f: Sub-graph assertions ---"
+post 9201 /api/sub-graph/create -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"subGraphName\": \"deep-sg-test\"
+}" > /dev/null
+ok "Sub-graph 'deep-sg-test' created"
+
+post 9201 /api/assertion/create -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"name\": \"sg-assertion\",
+  \"subGraphName\": \"deep-sg-test\"
+}" > /dev/null
+post 9201 /api/assertion/sg-assertion/write -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"subGraphName\": \"deep-sg-test\",
+  \"quads\": [$(ql 'urn:deep:sg:item' 'http://schema.org/name' 'Sub-graph Deep Item')]
+}" > /dev/null
+SG_PROMOTE=$(post 9201 /api/assertion/sg-assertion/promote -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"subGraphName\": \"deep-sg-test\"
+}")
+SG_P_CT=$(echo "$SG_PROMOTE" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("promotedCount",0))' 2>/dev/null || echo "0")
+[[ "$SG_P_CT" -ge 1 ]] && ok "Sub-graph assertion promoted ($SG_P_CT)" || fail "Sub-graph assertion promote: $SG_PROMOTE"
+
+sleep 4
+SG_GOS=$(post 9203 /api/query -H "Content-Type: application/json" -d "{
+  \"sparql\": \"SELECT ?name WHERE { <urn:deep:sg:item> <http://schema.org/name> ?name }\",
+  \"contextGraphId\": \"$CG\",
+  \"subGraphName\": \"deep-sg-test\",
+  \"graphSuffix\": \"_shared_memory\"
+}")
+SG_GOS_CT=$(echo "$SG_GOS" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
+[[ "$SG_GOS_CT" -ge 1 ]] && ok "Sub-graph assertion gossiped to Node3" || warn "Sub-graph not on Node3 ($SG_GOS_CT)"
+
+# ================================================================
+echo ""
+echo "=== TEST 10: Publisher Queue ==="
+echo ""
+
+echo "--- 10a: Publisher stats ---"
+PUB_STATS=$(get 9201 /api/publisher/stats)
+echo "  Stats: $(echo "$PUB_STATS" | head -c 300)"
+echo "$PUB_STATS" | python3 -c 'import sys,json;d=json.load(sys.stdin);assert isinstance(d,dict)' 2>/dev/null && ok "Publisher stats valid" || warn "Publisher stats: $PUB_STATS"
+
+echo "--- 10b: Publisher jobs list ---"
+PUB_JOBS=$(get 9201 /api/publisher/jobs)
+echo "$PUB_JOBS" | python3 -c 'import sys,json;json.load(sys.stdin)' 2>/dev/null && ok "Publisher jobs valid JSON" || warn "Publisher jobs: $PUB_JOBS"
+
+echo "--- 10c: Enqueue via API ---"
+PUB_ENQ=$(post 9201 /api/publisher/enqueue -H "Content-Type: application/json" -d "{
+  \"contextGraphId\": \"$CG\",
+  \"selection\": [\"urn:deep:assert:1\"]
+}")
+echo "  Enqueue: $(echo "$PUB_ENQ" | head -c 300)"
+JOB_ID=$(echo "$PUB_ENQ" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("jobId",""))' 2>/dev/null)
+[[ -n "$JOB_ID" ]] && ok "Publisher job enqueued: $JOB_ID" || warn "Enqueue: $PUB_ENQ"
+
+if [[ -n "$JOB_ID" ]]; then
+  echo "--- 10d: Check job status ---"
+  sleep 8
+  JOB_CHECK=$(get 9201 "/api/publisher/job?id=$JOB_ID")
+  JOB_ST=$(echo "$JOB_CHECK" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("status","?"))' 2>/dev/null)
+  echo "  Job $JOB_ID status: $JOB_ST"
+  ok "Job status: $JOB_ST"
+fi
+
+echo "--- 10e: Clear finalized ---"
+CLR=$(post 9201 /api/publisher/clear -H "Content-Type: application/json" -d '{"status":"finalized"}')
+echo "  Clear: $(echo "$CLR" | head -c 200)"
+ok "Publisher clear executed"
+
+# ================================================================
+echo ""
+echo "=== TEST 11: Context Graph Operations ==="
+echo ""
+
+echo "--- 11a: List context graphs ---"
 CG_LIST=$(get 9201 /api/context-graph/list)
 CG_COUNT=$(echo "$CG_LIST" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d) if isinstance(d,list) else len(d.get("contextGraphs",d.get("paranets",[]))))' 2>/dev/null || echo "0")
 echo "  Context graphs: $CG_COUNT"
 [[ "$CG_COUNT" -ge 1 ]] && ok "Context graphs listed ($CG_COUNT)" || warn "No context graphs"
 
-echo "--- 9b: Subscribe Node5 to devnet-test ---"
+echo "--- 11b: Subscribe Node5 to devnet-test ---"
 SUB=$(post 9205 /api/context-graph/subscribe -H "Content-Type: application/json" -d '{"contextGraphId":"devnet-test"}')
 echo "  Subscribe: $(echo "$SUB" | head -c 200)"
 ok "Subscribe requested"
 
 # ================================================================
 echo ""
-echo "=== TEST 10: SKILL.md Validation ==="
+echo "=== TEST 12: SKILL.md Validation ==="
 echo ""
 
 for p in 9201 9202 9203 9204 9205; do
@@ -465,7 +607,7 @@ done
 
 # ================================================================
 echo ""
-echo "=== TEST 11: Node UI Accessibility ==="
+echo "=== TEST 13: Node UI Accessibility ==="
 echo ""
 
 for p in 9201 9202 9203 9204 9205; do

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -568,7 +568,7 @@ ASSERT_CREATE=$(c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{
   \"contextGraphId\":\"$ASSERT_CG\",
   \"name\":\"devnet-draft\"
 }")
-ASSERT_URI=$(json_get "$ASSERT_CREATE" uri)
+ASSERT_URI=$(json_get "$ASSERT_CREATE" assertionUri)
 echo "  Assertion URI: $ASSERT_URI"
 [[ "$ASSERT_URI" != "__NONE__" && "$ASSERT_URI" != "__ERR__" ]] && ok "Assertion created: $ASSERT_URI" || fail "Assertion create failed: $ASSERT_CREATE"
 
@@ -645,9 +645,15 @@ echo "  Jobs: $(echo "$PUB_JOBS" | head -c 300)"
 echo "$PUB_JOBS" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d) if isinstance(d,list) else len(d.get("jobs",[])))' 2>/dev/null && ok "Publisher jobs endpoint works" || warn "Publisher jobs: $PUB_JOBS"
 
 echo "--- 15c: Enqueue a publish job ---"
+ENQUEUE_OP_ID="devnet-enqueue-test-$(date +%s)"
 PUB_ENQUEUE=$(c -X POST "http://127.0.0.1:9201/api/publisher/enqueue" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
-  \"selection\":[\"urn:devnet:assert:entity1\"]
+  \"shareOperationId\":\"$ENQUEUE_OP_ID\",
+  \"roots\":[{\"rootEntity\":\"urn:devnet:assert:entity1\",\"privateMerkleRoot\":null,\"privateTripleCount\":0}],
+  \"namespace\":\"did:dkg:context-graph:$CONTEXT_GRAPH\",
+  \"scope\":\"full\",
+  \"authorityType\":\"owner\",
+  \"authorityProofRef\":\"urn:dkg:proof:devnet-test\"
 }")
 echo "  Enqueue: $(echo "$PUB_ENQUEUE" | head -c 300)"
 PUB_JOB_ID=$(json_get "$PUB_ENQUEUE" jobId)
@@ -657,9 +663,9 @@ if [[ "$PUB_JOB_ID" != "__NONE__" && "$PUB_JOB_ID" != "__ERR__" && -n "$PUB_JOB_
   echo "--- 15d: Check job status ---"
   sleep 5
   JOB_STATUS=$(c "http://127.0.0.1:9201/api/publisher/job?id=$PUB_JOB_ID")
-  JOB_ST=$(json_get "$JOB_STATUS" status)
+  JOB_ST=$(echo "$JOB_STATUS" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("job",d).get("status","?") if isinstance(d.get("job",d),dict) else "?")' 2>/dev/null)
   echo "  Job status: $JOB_ST"
-  [[ -n "$JOB_ST" && "$JOB_ST" != "__NONE__" ]] && ok "Job status retrieved: $JOB_ST" || warn "Job status check: $JOB_STATUS"
+  [[ -n "$JOB_ST" && "$JOB_ST" != "?" ]] && ok "Job status retrieved: $JOB_ST" || warn "Job status check: $JOB_STATUS"
 fi
 
 echo "--- 15e: Clear finalized jobs ---"

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -558,12 +558,170 @@ echo "$EMPTY_PUB" | grep -qi "error\|empty\|nothing\|no.*triple" && ok "Empty SW
 
 #------------------------------------------------------------
 echo ""
-echo "=== SECTION 14: SKILL.md Endpoint ==="
+echo "=== SECTION 14: Assertion Lifecycle (Working Memory) ==="
+echo ""
+
+ASSERT_CG="devnet-test"
+
+echo "--- 14a: Create an assertion ---"
+ASSERT_CREATE=$(c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{
+  \"contextGraphId\":\"$ASSERT_CG\",
+  \"name\":\"devnet-draft\"
+}")
+ASSERT_URI=$(json_get "$ASSERT_CREATE" uri)
+echo "  Assertion URI: $ASSERT_URI"
+[[ "$ASSERT_URI" != "__NONE__" && "$ASSERT_URI" != "__ERR__" ]] && ok "Assertion created: $ASSERT_URI" || fail "Assertion create failed: $ASSERT_CREATE"
+
+echo "--- 14b: Write triples to the assertion ---"
+ASSERT_WRITE=$(c -X POST "http://127.0.0.1:9201/api/assertion/devnet-draft/write" -d "{
+  \"contextGraphId\":\"$ASSERT_CG\",
+  \"quads\":[
+    $(ql 'urn:devnet:assert:entity1' 'http://schema.org/name' 'Assertion Entity'),
+    $(ql 'urn:devnet:assert:entity1' 'http://schema.org/version' '1')
+  ]
+}")
+echo "  Write response: $(echo "$ASSERT_WRITE" | head -c 200)"
+echo "$ASSERT_WRITE" | grep -qi "error" && fail "Assertion write failed: $ASSERT_WRITE" || ok "Assertion write OK"
+
+echo "--- 14c: Query the assertion ---"
+ASSERT_QUERY=$(c -X POST "http://127.0.0.1:9201/api/assertion/devnet-draft/query" -d "{
+  \"contextGraphId\":\"$ASSERT_CG\"
+}")
+ASSERT_Q_CT=$(echo "$ASSERT_QUERY" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d.get("quads",d.get("result",[]))))' 2>/dev/null || echo "0")
+echo "  Assertion has $ASSERT_Q_CT quads"
+[[ "$ASSERT_Q_CT" -ge 1 ]] && ok "Assertion query returned $ASSERT_Q_CT quads" || fail "Assertion query returned 0 quads"
+
+echo "--- 14d: Promote the assertion to SWM ---"
+ASSERT_PROMOTE=$(c -X POST "http://127.0.0.1:9201/api/assertion/devnet-draft/promote" -d "{
+  \"contextGraphId\":\"$ASSERT_CG\"
+}")
+PROMOTED_CT=$(json_get "$ASSERT_PROMOTE" promotedCount)
+echo "  Promoted count: $PROMOTED_CT"
+[[ "$PROMOTED_CT" != "__NONE__" && "$PROMOTED_CT" != "0" ]] && ok "Assertion promoted ($PROMOTED_CT quads)" || fail "Assertion promote failed: $ASSERT_PROMOTE"
+
+echo "--- 14e: Verify promoted data in SWM ---"
+sleep 1
+SWM_CHECK=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+  \"sparql\":\"SELECT ?name WHERE { <urn:devnet:assert:entity1> <http://schema.org/name> ?name }\",
+  \"contextGraphId\":\"$ASSERT_CG\",
+  \"graphSuffix\":\"_shared_memory\"
+}")
+SWM_CT=$(echo "$SWM_CHECK" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
+[[ "$SWM_CT" -ge 1 ]] && ok "Promoted data visible in SWM" || fail "Promoted data not in SWM ($SWM_CT)"
+
+echo "--- 14f: Create and immediately discard another assertion ---"
+c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{\"contextGraphId\":\"$ASSERT_CG\",\"name\":\"discard-me\"}" > /dev/null
+c -X POST "http://127.0.0.1:9201/api/assertion/discard-me/write" -d "{
+  \"contextGraphId\":\"$ASSERT_CG\",
+  \"quads\":[$(ql 'urn:devnet:assert:discard' 'http://schema.org/name' 'Discard Me')]
+}" > /dev/null
+DISCARD_RESP=$(c -X POST "http://127.0.0.1:9201/api/assertion/discard-me/discard" -d "{\"contextGraphId\":\"$ASSERT_CG\"}")
+echo "$DISCARD_RESP" | grep -qi "error" && fail "Discard failed: $DISCARD_RESP" || ok "Assertion discard OK"
+
+echo "--- 14g: Promoted assertion gossips to other nodes ---"
+sleep 4
+for p in 9202 9203 9204; do
+  GOS_CT=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
+    \"sparql\":\"SELECT ?name WHERE { <urn:devnet:assert:entity1> <http://schema.org/name> ?name }\",
+    \"contextGraphId\":\"$ASSERT_CG\",
+    \"graphSuffix\":\"_shared_memory\"
+  }" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
+  [[ "$GOS_CT" -ge 1 ]] && ok "Promoted data gossiped to Node $p" || warn "Promoted data not on Node $p ($GOS_CT)"
+done
+
+#------------------------------------------------------------
+echo ""
+echo "=== SECTION 15: Publisher Queue (async lift) ==="
+echo ""
+
+echo "--- 15a: Publisher stats ---"
+PUB_STATS=$(c "http://127.0.0.1:9201/api/publisher/stats")
+echo "  Stats: $(echo "$PUB_STATS" | head -c 300)"
+echo "$PUB_STATS" | python3 -c 'import sys,json;json.load(sys.stdin)' 2>/dev/null && ok "Publisher stats returned valid JSON" || warn "Publisher stats: $PUB_STATS"
+
+echo "--- 15b: Publisher jobs list ---"
+PUB_JOBS=$(c "http://127.0.0.1:9201/api/publisher/jobs")
+echo "  Jobs: $(echo "$PUB_JOBS" | head -c 300)"
+echo "$PUB_JOBS" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d) if isinstance(d,list) else len(d.get("jobs",[])))' 2>/dev/null && ok "Publisher jobs endpoint works" || warn "Publisher jobs: $PUB_JOBS"
+
+echo "--- 15c: Enqueue a publish job ---"
+PUB_ENQUEUE=$(c -X POST "http://127.0.0.1:9201/api/publisher/enqueue" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"selection\":[\"urn:devnet:assert:entity1\"]
+}")
+echo "  Enqueue: $(echo "$PUB_ENQUEUE" | head -c 300)"
+PUB_JOB_ID=$(json_get "$PUB_ENQUEUE" jobId)
+[[ "$PUB_JOB_ID" != "__NONE__" && "$PUB_JOB_ID" != "__ERR__" ]] && ok "Publisher job enqueued: $PUB_JOB_ID" || warn "Enqueue response: $PUB_ENQUEUE"
+
+if [[ "$PUB_JOB_ID" != "__NONE__" && "$PUB_JOB_ID" != "__ERR__" && -n "$PUB_JOB_ID" ]]; then
+  echo "--- 15d: Check job status ---"
+  sleep 5
+  JOB_STATUS=$(c "http://127.0.0.1:9201/api/publisher/job?id=$PUB_JOB_ID")
+  JOB_ST=$(json_get "$JOB_STATUS" status)
+  echo "  Job status: $JOB_ST"
+  [[ -n "$JOB_ST" && "$JOB_ST" != "__NONE__" ]] && ok "Job status retrieved: $JOB_ST" || warn "Job status check: $JOB_STATUS"
+fi
+
+echo "--- 15e: Clear finalized jobs ---"
+PUB_CLEAR=$(c -X POST "http://127.0.0.1:9201/api/publisher/clear" -d '{"status":"finalized"}')
+echo "  Clear: $(echo "$PUB_CLEAR" | head -c 200)"
+echo "$PUB_CLEAR" | python3 -c 'import sys,json;json.load(sys.stdin)' 2>/dev/null && ok "Publisher clear returned valid JSON" || warn "Publisher clear: $PUB_CLEAR"
+
+#------------------------------------------------------------
+echo ""
+echo "=== SECTION 16: Sub-graph Assertions ==="
+echo ""
+
+echo "--- 16a: Create a sub-graph ---"
+SG_CREATE=$(c -X POST "http://127.0.0.1:9201/api/sub-graph/create" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"subGraphName\":\"test-assertions\"
+}")
+echo "  Sub-graph create: $(echo "$SG_CREATE" | head -c 200)"
+echo "$SG_CREATE" | grep -qi "error" && warn "Sub-graph create: $SG_CREATE" || ok "Sub-graph 'test-assertions' created"
+
+echo "--- 16b: Write assertion to sub-graph ---"
+c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"name\":\"sg-draft\",
+  \"subGraphName\":\"test-assertions\"
+}" > /dev/null
+SG_AW=$(c -X POST "http://127.0.0.1:9201/api/assertion/sg-draft/write" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"subGraphName\":\"test-assertions\",
+  \"quads\":[$(ql 'urn:sg:assert:item1' 'http://schema.org/name' 'Sub-graph Assertion')]
+}")
+echo "$SG_AW" | grep -qi "error" && fail "Sub-graph assertion write failed: $SG_AW" || ok "Sub-graph assertion write OK"
+
+echo "--- 16c: Promote sub-graph assertion ---"
+SG_PROMOTE=$(c -X POST "http://127.0.0.1:9201/api/assertion/sg-draft/promote" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"subGraphName\":\"test-assertions\"
+}")
+SG_PROMOTED=$(json_get "$SG_PROMOTE" promotedCount)
+[[ "$SG_PROMOTED" != "__NONE__" && "$SG_PROMOTED" != "0" ]] && ok "Sub-graph assertion promoted ($SG_PROMOTED quads)" || fail "Sub-graph promote: $SG_PROMOTE"
+
+echo "--- 16d: Sub-graph SWM gossip to Node3 ---"
+sleep 5
+SG_GOS=$(c -X POST "http://127.0.0.1:9203/api/query" -d "{
+  \"sparql\":\"SELECT ?name WHERE { <urn:sg:assert:item1> <http://schema.org/name> ?name }\",
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"subGraphName\":\"test-assertions\",
+  \"graphSuffix\":\"_shared_memory\"
+}")
+SG_GOS_CT=$(echo "$SG_GOS" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
+[[ "$SG_GOS_CT" -ge 1 ]] && ok "Sub-graph assertion gossiped to Node3" || warn "Sub-graph assertion not on Node3 ($SG_GOS_CT)"
+
+#------------------------------------------------------------
+echo ""
+echo "=== SECTION 17: SKILL.md Endpoint ==="
 echo ""
 
 SKILL=$(curl -s "http://127.0.0.1:9201/.well-known/skill.md")
 echo "$SKILL" | grep -q "shared-memory" && ok "SKILL.md references SWM flow" || fail "SKILL.md missing SWM references"
 echo "$SKILL" | grep -q "/api/publish" && fail "SKILL.md still references removed /api/publish" || ok "SKILL.md correctly omits /api/publish"
+echo "$SKILL" | grep -q "assertion" && ok "SKILL.md references assertion API" || warn "SKILL.md doesn't mention assertion API"
+echo "$SKILL" | grep -q "sub-graph\|subGraph" && ok "SKILL.md references sub-graphs" || warn "SKILL.md doesn't mention sub-graphs"
 
 #------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

- **4 new e2e test files** covering critical V10 features that had insufficient test coverage (32 new tests total)
- **Devnet script enhancements** adding assertion lifecycle, publisher queue, and sub-graph assertion tests to both `devnet-test.sh` and `devnet-deep-test.sh`

### New test files

| File | Tests | Coverage |
|------|------:|----------|
| `packages/agent/test/e2e-assertion-lifecycle.test.ts` | 7 | WM assertion create/write/query/promote/discard, entity-selective promote, sub-graph assertions, two-node promote gossip |
| `packages/publisher/test/e2e-publisher-queue.test.ts` | 10 | Async lift pipeline, FIFO ordering, pause/resume, cancel, stats, wallet contention, chain recovery, retry flow |
| `packages/agent/test/e2e-memory-layers.test.ts` | 7 | WM→SWM→VM pipeline, memory layer isolation, includeSharedMemory view, clearSharedMemoryAfter, two-node full pipeline |
| `packages/agent/test/e2e-sub-graph-gossip.test.ts` | 8 | Sub-graph SWM gossip, promote gossip, publish finalization, cross-sub-graph isolation, concurrent 3-node multi-sub-graph writes |

### Devnet script enhancements

- `devnet-test.sh`: Added sections 14 (Assertion Lifecycle), 15 (Publisher Queue), 16 (Sub-graph Assertions), plus SKILL.md assertion/sub-graph checks
- `devnet-deep-test.sh`: Added tests 9 (Assertion Lifecycle with 5-node gossip + SWM→VM publish), 10 (Publisher Queue API)

### Rationale (TORNADO/BURA/KOSAVA)

These tests target the **TORNADO** tier — core V10 features (assertions, publisher queue, memory layers, sub-graphs) that had unit/integration coverage but lacked end-to-end tests through the DKGAgent API and multi-node gossip paths.

## Test plan

- [x] All 278 agent tests pass (including 32 new)
- [x] All 629 publisher tests pass (including 10 new)
- [x] Build passes cleanly
- [x] No new lint errors
- [ ] Run devnet and execute `devnet-test.sh` + `devnet-deep-test.sh` with new sections


Made with [Cursor](https://cursor.com)