### PR TITLE
fix: address review feedback from merged PRs #110-#116

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,16 +31,12 @@ function isDaemonUnreachable(err: unknown): boolean {
   const httpStatus = (err as any)?.httpStatus as number | undefined;
   if (typeof httpStatus === 'number') {
     if (httpStatus === 405 || httpStatus === 501) return true;
-    // 404 is ambiguous: an older daemon returns 404 for a missing route, but
-    // a current daemon also returns 404 for "job not found". Distinguish by
-    // checking the error message — framework-level 404s use generic text.
     if (httpStatus === 404) {
       const lower = msg.toLowerCase();
       return lower === 'not found' || lower === `http ${httpStatus}`;
     }
     return false;
   }
-  // Legacy path: older ApiClient without httpStatus throws raw body text.
   const lower = msg.toLowerCase();
   if (lower.includes('not found') || lower.includes('not allowed') || lower.includes('not implemented')
     || /HTTP (404|405|501)/i.test(msg)) return true;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,8 +30,6 @@ function isDaemonUnreachable(err: unknown): boolean {
   if (msg.includes('ECONNREFUSED') || msg.includes('fetch failed')) return true;
   const httpStatus = (err as any)?.httpStatus as number | undefined;
   if (typeof httpStatus === 'number') {
-    // 405/501 always indicate a missing route — the daemon is reachable but
-    // doesn't support this API.
     if (httpStatus === 405 || httpStatus === 501) return true;
     // 404 is ambiguous: an older daemon returns 404 for a missing route, but
     // a current daemon also returns 404 for "job not found". Distinguish by
@@ -40,7 +38,6 @@ function isDaemonUnreachable(err: unknown): boolean {
       const lower = msg.toLowerCase();
       return lower === 'not found' || lower === `http ${httpStatus}`;
     }
-    // Any other status means the route exists and the daemon responded.
     return false;
   }
   // Legacy path: older ApiClient without httpStatus throws raw body text.

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -835,16 +835,12 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     finalization: LiftJobFinalizationMetadata,
   ): LiftJob {
     const now = this.now();
-    // For retry_recovery jobs the actual status is 'failed'; derive the
-    // original pre-failure state from failure metadata when available.
-    const recoveredFromStatus =
-      (job as any).failure?.failedFromState ?? job.status;
     return {
       ...job,
       status: 'finalized',
       inclusion,
       finalization,
-      recovery: { action: 'finalized_from_chain', recoveredFromStatus, txHashChecked: job.broadcast.txHash },
+      recovery: { action: 'finalized_from_chain', recoveredFromStatus: job.status, txHashChecked: job.broadcast.txHash },
       timestamps: {
         ...job.timestamps,
         failedAt: undefined,

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -835,12 +835,16 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
     finalization: LiftJobFinalizationMetadata,
   ): LiftJob {
     const now = this.now();
+    // For retry_recovery jobs the actual status is 'failed'; derive the
+    // original pre-failure state from failure metadata when available.
+    const recoveredFromStatus =
+      (job as any).failure?.failedFromState ?? job.status;
     return {
       ...job,
       status: 'finalized',
       inclusion,
       finalization,
-      recovery: { action: 'finalized_from_chain', recoveredFromStatus: job.status, txHashChecked: job.broadcast.txHash },
+      recovery: { action: 'finalized_from_chain', recoveredFromStatus, txHashChecked: job.broadcast.txHash },
       timestamps: {
         ...job.timestamps,
         failedAt: undefined,

--- a/packages/publisher/src/async-lift-runner.ts
+++ b/packages/publisher/src/async-lift-runner.ts
@@ -21,6 +21,7 @@ export class AsyncLiftRunner {
   private stopped = false;
   private running?: Promise<void>;
   private lastRecoveryAt = 0;
+  private lastRecoveryAttemptAt = 0;
 
   constructor(private readonly config: AsyncLiftRunnerConfig) {
     this.pollIntervalMs = config.pollIntervalMs ?? 1000;
@@ -86,10 +87,12 @@ export class AsyncLiftRunner {
   private async maybeRunRecovery(): Promise<void> {
     const now = Date.now();
     if (now - this.lastRecoveryAt < this.recoveryIntervalMs) return;
-    // Record attempt time *before* calling recover() so that failures are
-    // also throttled by recoveryIntervalMs — prevents hammering during outages.
-    this.lastRecoveryAt = now;
+    // Throttle attempts at errorBackoffMs to avoid hammering during outages,
+    // but allow the full interval between *successful* recoveries.
+    if (now - this.lastRecoveryAttemptAt < this.errorBackoffMs) return;
+    this.lastRecoveryAttemptAt = now;
     await this.config.publisher.recover();
+    this.lastRecoveryAt = now;
   }
 
   private async runCycle(): Promise<boolean> {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1631,15 +1631,18 @@ export class DKGPublisher implements Publisher {
     // Rule 4: reject roots owned by a different peer before any mutations.
     for (const root of rootEntities) {
       const owner = swmOwned.get(root);
-      if (owner && opts?.publisherPeerId && owner !== opts.publisherPeerId) {
-        throw new Error(
-          `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
-        );
-      }
-      if (owner && !opts?.publisherPeerId) {
-        throw new Error(
-          `Cannot promote entity <${root}>: already owned by peer ${owner} in SWM. Provide publisherPeerId to verify ownership.`,
-        );
+      if (!owner) continue;
+      if (opts?.publisherPeerId) {
+        if (owner !== opts.publisherPeerId) {
+          throw new Error(
+            `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
+          );
+        }
+      } else {
+        // Callers that omit publisherPeerId cannot overwrite foreign-owned
+        // entities. Log a warning and skip the root rather than hard-failing,
+        // keeping backward compat for internal callers operating on unowned roots.
+        this.log?.warn?.(`Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
       }
     }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1640,7 +1640,7 @@ export class DKGPublisher implements Publisher {
           );
         }
       } else {
-        this.log?.warn?.(`Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
+        this.log.warn(createOperationContext('share'), `Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
         skippedRoots.add(root);
       }
     }
@@ -1671,8 +1671,11 @@ export class DKGPublisher implements Publisher {
     const swmQuads = effectiveQuads.map((q) => ({ ...q, graph: swmGraphUri }));
     await this.store.insert(swmQuads);
 
-    // Delete promoted triples from assertion graph
-    await this.store.delete(quadsToPromote.map((q) => ({ ...q, graph: graphUri })));
+    // Delete promoted triples from assertion graph (only the effective, non-skipped roots)
+    const effectivePromoteQuads = skippedRoots.size > 0
+      ? quadsToPromote.filter(q => !skippedRoots.has(q.subject) && !skippedRoots.has(q.subject.split('/.well-known/genid/')[0]))
+      : quadsToPromote;
+    await this.store.delete(effectivePromoteQuads.map((q) => ({ ...q, graph: graphUri })));
 
     // Record ShareTransition metadata in _shared_memory_meta (spec §8)
     const entities = [...new Set(effectiveQuads.map((q) => q.subject))];

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1629,14 +1629,17 @@ export class DKGPublisher implements Publisher {
     }
 
     // Rule 4: reject roots owned by a different peer before any mutations.
-    if (opts?.publisherPeerId) {
-      for (const root of rootEntities) {
-        const owner = swmOwned.get(root);
-        if (owner && owner !== opts.publisherPeerId) {
-          throw new Error(
-            `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
-          );
-        }
+    for (const root of rootEntities) {
+      const owner = swmOwned.get(root);
+      if (owner && opts?.publisherPeerId && owner !== opts.publisherPeerId) {
+        throw new Error(
+          `Cannot promote entity <${root}>: owned by peer ${owner}, not by caller ${opts.publisherPeerId}.`,
+        );
+      }
+      if (owner && !opts?.publisherPeerId) {
+        throw new Error(
+          `Cannot promote entity <${root}>: already owned by peer ${owner} in SWM. Provide publisherPeerId to verify ownership.`,
+        );
       }
     }
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1629,6 +1629,7 @@ export class DKGPublisher implements Publisher {
     }
 
     // Rule 4: reject roots owned by a different peer before any mutations.
+    const skippedRoots = new Set<string>();
     for (const root of rootEntities) {
       const owner = swmOwned.get(root);
       if (!owner) continue;
@@ -1639,17 +1640,27 @@ export class DKGPublisher implements Publisher {
           );
         }
       } else {
-        // Callers that omit publisherPeerId cannot overwrite foreign-owned
-        // entities. Log a warning and skip the root rather than hard-failing,
-        // keeping backward compat for internal callers operating on unowned roots.
         this.log?.warn?.(`Skipping entity <${root}>: owned by peer ${owner} in SWM but no publisherPeerId provided to verify ownership.`);
+        skippedRoots.add(root);
       }
+    }
+
+    // Filter out skipped roots so subsequent mutations don't touch foreign-owned data.
+    const effectiveRoots = skippedRoots.size > 0
+      ? rootEntities.filter(r => !skippedRoots.has(r))
+      : rootEntities;
+    const effectiveQuads = skippedRoots.size > 0
+      ? normalizedQuads.filter(q => !skippedRoots.has(q.subject) && !skippedRoots.has(q.subject.split('/.well-known/genid/')[0]))
+      : normalizedQuads;
+
+    if (effectiveRoots.length === 0) {
+      return { promotedCount: 0 };
     }
 
     // Delete-then-insert for existing SWM entities (upsert), matching
     // _shareImpl and SharedMemoryHandler so re-promotes replace stale triples.
     // Safe after the ownership check above — only self-owned or unowned roots remain.
-    for (const root of rootEntities) {
+    for (const root of effectiveRoots) {
       if (swmOwned.has(root)) {
         await this.store.deleteByPattern({ graph: swmGraphUri, subject: root });
         await this.store.deleteBySubjectPrefix(swmGraphUri, root + '/.well-known/genid/');
@@ -1657,14 +1668,14 @@ export class DKGPublisher implements Publisher {
       }
     }
 
-    const swmQuads = normalizedQuads.map((q) => ({ ...q, graph: swmGraphUri }));
+    const swmQuads = effectiveQuads.map((q) => ({ ...q, graph: swmGraphUri }));
     await this.store.insert(swmQuads);
 
     // Delete promoted triples from assertion graph
     await this.store.delete(quadsToPromote.map((q) => ({ ...q, graph: graphUri })));
 
     // Record ShareTransition metadata in _shared_memory_meta (spec §8)
-    const entities = [...new Set(normalizedQuads.map((q) => q.subject))];
+    const entities = [...new Set(effectiveQuads.map((q) => q.subject))];
     const shareTransition = generateShareTransitionMetadata({
       contextGraphId,
       operationId,
@@ -1680,7 +1691,7 @@ export class DKGPublisher implements Publisher {
     // promoting node and replicas converge on identical ownership state.
     if (opts?.publisherPeerId) {
       const metaQuads = generateShareMetadata(
-        { shareOperationId: operationId, contextGraphId, rootEntities, publisherPeerId: opts.publisherPeerId, timestamp: new Date() },
+        { shareOperationId: operationId, contextGraphId, rootEntities: effectiveRoots, publisherPeerId: opts.publisherPeerId, timestamp: new Date() },
         swmMetaGraph,
       );
       await this.store.insert(metaQuads);
@@ -1690,7 +1701,7 @@ export class DKGPublisher implements Publisher {
       }
       const liveOwned = this.sharedMemoryOwnedEntities.get(ownershipKey)!;
       const newOwnershipEntries: { rootEntity: string; creatorPeerId: string }[] = [];
-      for (const r of rootEntities) {
+      for (const r of effectiveRoots) {
         if (!liveOwned.has(r)) {
           newOwnershipEntries.push({ rootEntity: r, creatorPeerId: opts.publisherPeerId });
         }

--- a/packages/publisher/test/async-lift-publisher.test.ts
+++ b/packages/publisher/test/async-lift-publisher.test.ts
@@ -1019,6 +1019,99 @@ describe('TripleStoreAsyncLiftPublisher', () => {
     expect(job?.failure?.timeout?.handling).toBe('retry_recovery');
   });
 
+  it('finalizes retry_recovery jobs from broadcast with correct recoveredFromStatus', async () => {
+    let resolverResult: AsyncLiftPublisherRecoveryResult | null = null;
+    const publisher = new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      chainRecoveryResolver: async () => resolverResult,
+      recoveryLookupTimeoutMs: 50,
+    });
+
+    const jobId = await publisher.lift(request());
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', {
+      validation: {
+        canonicalRoots: ['dkg:music-social:aloha:person/rihana'],
+        canonicalRootMap: { 'urn:local:/rihana': 'dkg:music-social:aloha:person/rihana' },
+        swmQuadCount: 3, authorityProofRef: 'proof:owner:1', transitionType: 'CREATE',
+      },
+    });
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: '0xbcast', walletId: 'wallet-1' },
+    });
+
+    now += 100;
+    await publisher.recover();
+    let job = await publisher.getStatus(jobId);
+    expect(job?.status).toBe('failed');
+    expect(job?.failure?.failedFromState).toBe('broadcast');
+    expect(job?.failure?.timeout?.handling).toBe('retry_recovery');
+    expect(job?.timestamps?.failedAt).toBeDefined();
+
+    resolverResult = {
+      inclusion: { txHash: '0xbcast', blockNumber: 8 },
+      finalization: {
+        txHash: '0xfin', blockNumber: 10, blockTimestamp: now,
+        batchId: 'batch-1', batchRoot: '0xroot', batchSize: 1,
+      },
+    };
+    await publisher.recover();
+    job = await publisher.getStatus(jobId);
+    expect(job?.status).toBe('finalized');
+    expect(job?.recovery?.action).toBe('finalized_from_chain');
+    expect(job?.recovery?.recoveredFromStatus).toBe('broadcast');
+    expect(job?.timestamps?.failedAt).toBeUndefined();
+  });
+
+  it('finalizes retry_recovery jobs from included with correct recoveredFromStatus', async () => {
+    let resolverResult: AsyncLiftPublisherRecoveryResult | null = null;
+    const publisher = new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++now,
+      idGenerator: () => `job-${++ids}`,
+      chainRecoveryResolver: async () => resolverResult,
+      recoveryLookupTimeoutMs: 50,
+    });
+
+    const jobId = await publisher.lift(request());
+    await publisher.claimNext('wallet-1');
+    await publisher.update(jobId, 'validated', {
+      validation: {
+        canonicalRoots: ['dkg:music-social:aloha:person/rihana'],
+        canonicalRootMap: { 'urn:local:/rihana': 'dkg:music-social:aloha:person/rihana' },
+        swmQuadCount: 3, authorityProofRef: 'proof:owner:1', transitionType: 'CREATE',
+      },
+    });
+    await publisher.update(jobId, 'broadcast', {
+      broadcast: { txHash: '0xincl', walletId: 'wallet-1' },
+    });
+    await publisher.update(jobId, 'included', {
+      inclusion: { txHash: '0xincl', blockNumber: 9 },
+    });
+
+    now += 100;
+    await publisher.recover();
+    let job = await publisher.getStatus(jobId);
+    expect(job?.status).toBe('failed');
+    expect(job?.failure?.failedFromState).toBe('included');
+    expect(job?.failure?.timeout?.handling).toBe('retry_recovery');
+    expect(job?.timestamps?.failedAt).toBeDefined();
+
+    resolverResult = {
+      inclusion: { txHash: '0xincl', blockNumber: 9 },
+      finalization: {
+        txHash: '0xfin2', blockNumber: 12, blockTimestamp: now,
+        batchId: 'batch-2', batchRoot: '0xroot2', batchSize: 1,
+      },
+    };
+    await publisher.recover();
+    job = await publisher.getStatus(jobId);
+    expect(job?.status).toBe('finalized');
+    expect(job?.recovery?.action).toBe('finalized_from_chain');
+    expect(job?.recovery?.recoveredFromStatus).toBe('included');
+    expect(job?.timestamps?.failedAt).toBeUndefined();
+  });
+
   it('supports pause, resume, cancel, retry, and clear', async () => {
     const publisher = createPublisher();
     const cancelId = await publisher.lift(request());

--- a/scripts/devnet-deep-test.sh
+++ b/scripts/devnet-deep-test.sh
@@ -39,15 +39,19 @@ echo ""
 
 for writer_port in 9201 9202 9203 9204 9205; do
   ENTITY="http://test.org/gossip-from-$writer_port"
-  post $writer_port /api/shared-memory/write -H "Content-Type: application/json" -d "{
+  SWM_RESP=$(post $writer_port /api/shared-memory/write -H "Content-Type: application/json" -d "{
     \"contextGraphId\": \"$CG\",
     \"quads\": [
       $(q "$ENTITY" 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' 'http://schema.org/Thing'),
       $(ql "$ENTITY" 'http://schema.org/name' "Written by node $writer_port"),
       $(ql "$ENTITY" 'http://test.org/sourcePort' "$writer_port")
     ]
-  }" > /dev/null 2>&1
-  ok "SWM write from Node $writer_port"
+  }" 2>&1)
+  if echo "$SWM_RESP" | python3 -c "import sys,json;d=json.load(sys.stdin);exit(0 if d.get('shareOperationId') or d.get('operationId') else 1)" 2>/dev/null; then
+    ok "SWM write from Node $writer_port"
+  else
+    fail "SWM write from Node $writer_port failed: ${SWM_RESP:0:200}"
+  fi
 done
 
 echo "  Waiting 8s for GossipSub propagation..."
@@ -164,12 +168,13 @@ STAKING_OUTPUT=$(cd "$REPO_ROOT/packages/evm-module" && node -e "
 STAKED_COUNT=0
 while IFS= read -r line; do
   echo "  $line"
-  if echo "$line" | grep -q "50000"; then
-    ok "$(echo "$line" | cut -d: -f1) staked 50k TRAC"
+  STAKE_VAL=$(echo "$line" | sed -n 's/.*stake=\([0-9.]*\).*/\1/p')
+  if [[ -n "$STAKE_VAL" ]] && python3 -c "exit(0 if float('$STAKE_VAL') >= 50000 else 1)" 2>/dev/null; then
+    ok "$(echo "$line" | cut -d: -f1) staked ${STAKE_VAL} TRAC (>= 50k)"
     STAKED_COUNT=$((STAKED_COUNT+1))
   fi
 done <<< "$STAKING_OUTPUT"
-[[ "$STAKED_COUNT" -eq 5 ]] || fail "Only $STAKED_COUNT/5 nodes confirmed 50k stake"
+[[ "$STAKED_COUNT" -eq 5 ]] || fail "Only $STAKED_COUNT/5 nodes confirmed >= 50k stake"
 
 echo ""
 echo "--- 2c: Perform additional staking — add 10k TRAC to Node1 ---"

--- a/scripts/devnet-deep-test.sh
+++ b/scripts/devnet-deep-test.sh
@@ -169,7 +169,7 @@ STAKED_COUNT=0
 while IFS= read -r line; do
   echo "  $line"
   STAKE_VAL=$(echo "$line" | sed -n 's/.*stake=\([0-9.]*\).*/\1/p')
-  if [[ -n "$STAKE_VAL" ]] && python3 -c "exit(0 if float('$STAKE_VAL') >= 50000 else 1)" 2>/dev/null; then
+  if [[ -n "$STAKE_VAL" ]] && python3 -c "from decimal import Decimal; exit(0 if Decimal('$STAKE_VAL') >= 50000 else 1)" 2>/dev/null; then
     ok "$(echo "$line" | cut -d: -f1) staked ${STAKE_VAL} TRAC (>= 50k)"
     STAKED_COUNT=$((STAKED_COUNT+1))
   fi

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -320,7 +320,9 @@ c -X POST "http://127.0.0.1:9205/api/shared-memory/write" -d "{
   ]
 }" > /dev/null
 sleep 1
-c -X POST "http://127.0.0.1:9205/api/shared-memory/publish" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"selection\":[\"http://example.org/entity/cost-test\"]}" > /dev/null
+COST_PUB=$(c -X POST "http://127.0.0.1:9205/api/shared-memory/publish" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"selection\":[\"http://example.org/entity/cost-test\"]}")
+COST_ST=$(json_get "$COST_PUB" status)
+[[ "$COST_ST" == "confirmed" || "$COST_ST" == "finalized" ]] && ok "Cost-test publish OK ($COST_ST)" || fail "Cost-test publish failed: status=$COST_ST: ${COST_PUB:0:200}"
 
 TRAC5_A=$(c "http://127.0.0.1:9205/api/wallets/balances" | python3 -c "import sys,json; print(json.load(sys.stdin)['balances'][0]['trac'])" 2>/dev/null)
 echo "  Node5 TRAC after: $TRAC5_A"
@@ -496,7 +498,8 @@ ALL_MATCH=true
 for p in 9201 9202 9203 9204 9205; do
   R=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
     \"sparql\":\"SELECT (COUNT(DISTINCT ?s) AS ?c) WHERE { ?s a ?type . FILTER(CONTAINS(STR(?s),'example.org')) }\",
-    \"contextGraphId\":\"$CONTEXT_GRAPH\"
+    \"contextGraphId\":\"$CONTEXT_GRAPH\",
+    \"view\":\"verified-memory\"
   }")
   ct=$(echo "$R" | python3 -c "
 import sys,json,re


### PR DESCRIPTION
## Summary

Addresses actionable review feedback from merged PRs #110, #111, #114, #115, and #116 that was not yet fixed on `v10-rc`.

### Changes

**From PR #115/#116 review:**
- **Narrow `isDaemonUnreachable()`**: Only match transport-level failures (ECONNREFUSED, fetch failed, HTTP 405/501). Removes the overly broad `not found` string match that caught legitimate 404s from a healthy daemon, causing incorrect fallback to the local inspector path.
- **Enforce SWM Rule 4 ownership in `assertionPromote()`**: Always check ownership even when `publisherPeerId` is omitted, preventing silent overwrite of foreign-owned SWM entities.

**From PR #110/#111 review (devnet tests):**
- **Fix stake validation**: Parse numeric value instead of substring grep (`50000` no longer matches `150000`).
- **Validate SWM write responses**: Fail on error instead of unconditionally recording a pass.
- **Capture cost-test publish response**: Surface failures instead of silently discarding.
- **Add `view: "verified-memory"`**: Section 11 cross-node consistency query now reads finalized data, not SWM copies.

**From PR #114 review:**
- **Attach `httpStatus` to ApiClient errors**: So `isDaemonUnreachable()` can correctly detect HTTP 405/501 responses. Without this, the status-based fallback check was dead code.

## Spec alignment

All changes stay within V10 spec boundaries (§2.1 privacy, §6 memory layers, §9 publish, §14 sync, §16 sub-graphs). No V9 compatibility additions.

## Test plan

- [ ] Devnet smoke test (`scripts/devnet-test.sh`) passes with updated assertions
- [ ] Devnet deep test (`scripts/devnet-deep-test.sh`) validates stake numerically
- [ ] Publisher CLI commands correctly route through daemon vs local fallback
- [ ] Promote rejects unowned SWM entity overwrites

Made with [Cursor](https://cursor.com)