### PR TITLE
feat: source-file linkage triples + devnet hardening (chain onto PR #120)

### DIFF
--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -206,16 +206,18 @@ curl -X POST $BASE_URL/api/assertion/climate-report/import-file \
 ```json
 {
   "assertionUri": "did:dkg:context-graph:research/assertion/0xAgentAddr/climate-report",
-  "fileHash": "sha256:a1b2c3...",
-  "detectedContentType": "text/markdown",
+  "fileHash": "keccak256:a1b2c3...",
+  "detectedContentType": "application/pdf",
   "extraction": {
     "status": "completed",
     "tripleCount": 14,
-    "pipelineUsed": "text/markdown",
-    "mdIntermediateHash": "sha256:a1b2c3..."
+    "pipelineUsed": "application/pdf",
+    "mdIntermediateHash": "keccak256:d4e5f6..."
   }
 }
 ```
+
+Both `fileHash` and `mdIntermediateHash` are `keccak256:<hex>` per spec §10.2:603. `mdIntermediateHash` is only present when Phase 1 actually ran (converter-backed imports like PDF/DOCX); pure-markdown imports leave it undefined.
 
 ### Extraction statuses
 

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { appendFile, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { execSync, exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { stat } from 'node:fs/promises';
 import { ethers } from 'ethers';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, contextGraphSharedMemoryUri, contextGraphAssertionUri } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import {
   DashboardDB,
   MetricsCollector,
@@ -860,6 +860,22 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
   // workflows can be layered later without changing the endpoint contract.
   const extractionStatus = new Map<string, ExtractionStatusRecord>();
 
+  // Round 6 Bug 19: per-assertion mutex for the import-file snapshot+
+  // insert+rollback sequence. Without this, concurrent imports of the
+  // SAME assertion URI race: request A commits, request B (which
+  // snapshotted the older state) fails, B's rollback then re-inserts
+  // its stale snapshot and silently wipes A's successful commit.
+  //
+  // Lock scope is the full snapshot → cleanup → atomic insert →
+  // rollback critical section. Imports of DIFFERENT assertion URIs
+  // run in parallel — the lock is per-URI.
+  //
+  // CAVEAT: single-process lock only. Multi-daemon deployments sharing
+  // a triple store need storage-layer optimistic concurrency control
+  // (version counters or ETag-like compare-and-swap) to close the race
+  // across processes — out of scope for Round 6.
+  const assertionImportLocks = new Map<string, Promise<void>>();
+
   // --- HTTP API ---
 
   const rateLimiter = new HttpRateLimiter(
@@ -977,6 +993,15 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
       if (err instanceof PayloadTooLargeError) {
         jsonResponse(res, 413, { error: err.message });
       } else if (err instanceof SyntaxError) {
+        jsonResponse(res, 400, { error: err.message });
+      } else if (
+        // Round 9 Bug 25: user-authored quads with reserved URN prefixes
+        // map to 400 at the top-level catch so share/publish/conditionalShare
+        // routes (which rethrow for the top-level handler) get the correct
+        // status without each route having to match on the error shape.
+        err?.name === 'ReservedNamespaceError'
+        || (typeof err?.message === 'string' && err.message.includes('reserved namespace'))
+      ) {
         jsonResponse(res, 400, { error: err.message });
       } else {
         jsonResponse(res, 500, { error: err.message });
@@ -2287,7 +2312,14 @@ async function handleRequest(
       await agent.assertion.write(contextGraphId, assertionName, quads, subGraphName ? { subGraphName } : undefined);
       return jsonResponse(res, 200, { written: quads.length });
     } catch (err: any) {
-      if (err.message?.includes('not found') || err.message?.includes('Invalid') || err.message?.includes('Unsafe')) {
+      if (
+        err.message?.includes('not found')
+        || err.message?.includes('Invalid')
+        || err.message?.includes('Unsafe')
+        // Round 9 Bug 25: reserved-namespace writes surface as 400.
+        || err.name === 'ReservedNamespaceError'
+        || err.message?.includes('reserved namespace')
+      ) {
         return jsonResponse(res, 400, { error: err.message });
       }
       throw err;
@@ -2462,6 +2494,44 @@ async function handleRequest(
     );
     const startedAt = new Date().toISOString();
 
+    // ── Round 14 Bug 42: per-assertion mutex BEFORE extraction ──
+    //
+    // Round 6 originally acquired this lock just before the
+    // snapshot→insert→rollback critical section, AFTER Phase 1 and
+    // Phase 2 extraction had already run. Concurrent imports of the
+    // same assertion name then raced during extraction, and the one
+    // whose extraction finished LAST committed LAST — regardless of
+    // which request arrived first. Final stored state depended on
+    // extraction duration (bytes-to-parse, converter latency, PDF
+    // complexity), not request order.
+    //
+    // Option 42A fix: move the lock acquisition here, before any
+    // extraction work begins. This serializes the entire import-file
+    // handler per assertion name so concurrent imports commit in
+    // request order, not in extraction-finish order.
+    //
+    // Tradeoff: a long-running extraction (large PDF through the
+    // MarkItDown converter) now holds the lock and blocks other
+    // imports of the SAME assertion name for the duration. In
+    // practice, same-name re-imports should be rare (name collision
+    // is usually a user mistake, not a workflow), so this is an
+    // acceptable tradeoff for correctness. Imports of DIFFERENT
+    // assertion names are unaffected — the lock is per-URI, not
+    // global. Async extraction (if/when it lands) will need a
+    // different locking story, but for V10.0's synchronous
+    // extraction this is correct by construction.
+    //
+    // `releaseLock` is invoked in the outer `finally` block at the
+    // bottom of the handler so the next waiter unblocks regardless
+    // of success, failure, return, or throw.
+    const previousLock = assertionImportLocks.get(assertionUri) ?? Promise.resolve();
+    let releaseLock: () => void = () => {};
+    const currentLock = new Promise<void>(resolve => { releaseLock = resolve; });
+    const chainedLock = previousLock.then(() => currentLock);
+    assertionImportLocks.set(assertionUri, chainedLock);
+    await previousLock;
+
+    try {
     // ── Phase 1: converter lookup + MD intermediate resolution ──
     // text/markdown is deliberately NOT a registered converter content type.
     // The raw uploaded bytes ARE the Markdown intermediate, so Phase 1 is skipped.
@@ -2476,7 +2546,7 @@ async function handleRequest(
         statusCode,
         buildImportFileResponse({
           assertionUri,
-          fileHash: fileStoreEntry.hash,
+          fileHash: fileStoreEntry.keccak256,
           detectedContentType,
           extraction,
         }),
@@ -2484,7 +2554,7 @@ async function handleRequest(
     const recordInProgressExtraction = (): void => {
       setExtractionStatusRecord(extractionStatus, assertionUri, {
         status: 'in_progress',
-        fileHash: fileStoreEntry.hash,
+        fileHash: fileStoreEntry.keccak256,
         detectedContentType,
         pipelineUsed,
         tripleCount: 0,
@@ -2499,7 +2569,7 @@ async function handleRequest(
     ): ExtractionStatusRecord => {
       const failedRecord: ExtractionStatusRecord = {
         status: 'failed',
-        fileHash: fileStoreEntry.hash,
+        fileHash: fileStoreEntry.keccak256,
         detectedContentType,
         pipelineUsed: failedPipelineUsed,
         tripleCount,
@@ -2546,7 +2616,7 @@ async function handleRequest(
           mdIntermediate = md;
           pipelineUsed = detectedContentType;
           const mdEntry = await fileStore.put(Buffer.from(md, 'utf-8'), 'text/markdown');
-          mdIntermediateHash = mdEntry.hash;
+          mdIntermediateHash = mdEntry.keccak256;
           recordInProgressExtraction();
         } catch (err: any) {
           return respondWithFailedExtraction(500, `Phase 1 converter failed: ${err.message}`, 0, detectedContentType);
@@ -2559,7 +2629,7 @@ async function handleRequest(
     if (mdIntermediate === null) {
       const skippedRecord: ExtractionStatusRecord = {
         status: 'skipped',
-        fileHash: fileStoreEntry.hash,
+        fileHash: fileStoreEntry.keccak256,
         detectedContentType,
         pipelineUsed: null,
         tripleCount: 0,
@@ -2574,29 +2644,200 @@ async function handleRequest(
       });
     }
 
-    // ── Phase 2: markdown → triples + provenance ──
+    // ── Source-file linkage inputs for §10.1 / §10.2 triples ──
+    // fileUri is the content-addressed URN the extractor stamps on the
+    // document subject (row 1) and the daemon uses as both the subject of
+    // the file descriptor block (rows 4-8) and the object of the extraction
+    // provenance resource (row 10). provUri is a fresh UUID per import for
+    // the ExtractionProvenance subject (rows 9-13).
+    //
+    // Cross-assertion promote contention on `<urn:dkg:file:...>` as a
+    // root entity is prevented by a subject-prefix filter in
+    // `packages/publisher/src/dkg-publisher.ts` `assertionPromote` that
+    // excludes both `urn:dkg:file:` and `urn:dkg:extraction:` subjects
+    // from the partition before `autoPartition` runs. Row 1 (whose
+    // subject is the doc entity, not the file URN) is preserved through
+    // promote; rows 4-13 are WM-only by design. See Codex Bug 8 Round 4
+    // reconciled ruling — Round 3 tried blank-node subjects, but an
+    // `autoPartition` audit showed they silently drop the prov block on
+    // promote, which was a correctness smell. See `19_MARKDOWN_CONTENT_TYPE.md
+    // §10.2` for the normative rule.
+    const fileUri = `urn:dkg:file:${fileStoreEntry.keccak256}`;
+    const provUri = `urn:dkg:extraction:${randomUUID()}`;
+    const agentDid = `did:dkg:agent:${agent.peerId}`;
+
+    // ── Phase 2: markdown → triples + linkage ──
     let triples;
-    let provenance;
+    let sourceFileLinkage;
+    let resolvedRootEntity: string;
     try {
+      // The extractor owns rows 1 and 3. Row 2 (dkg:sourceContentType) is
+      // daemon-owned — it must describe the ORIGINAL upload blob (row 1's
+      // target), not the markdown intermediate the extractor processes.
+      // Only the daemon has `detectedContentType` here, so it emits row 2
+      // itself below alongside the file descriptor block.
       const result = extractFromMarkdown({
         markdown: mdIntermediate,
-        agentDid: `did:dkg:agent:${agent.peerId}`,
+        agentDid,
         ontologyRef,
         documentIri: assertionUri,
+        sourceFileIri: fileUri,
       });
       triples = result.triples;
-      provenance = result.provenance;
+      // Round 13 Bug 39: `provenance` renamed to `sourceFileLinkage`.
+      // The old name conflicted with its original extraction-run
+      // metadata semantic, which was moved to daemon-owned rows 9-13
+      // (on the `<urn:dkg:extraction:uuid>` subject) in Round 9 Bug 27.
+      // The extractor now only emits rows 1 and 3 of the source-file
+      // linkage block, so the field's name reflects that directly.
+      sourceFileLinkage = result.sourceFileLinkage;
+      // §19.10.1:508 precedence: frontmatter `rootEntity` > explicit input >
+      // reflexive subject. The extractor has already applied it to row 3;
+      // reuse the resolved value for `_meta` row 14 below so row 3 and row
+      // 14 are guaranteed to agree on the same root entity.
+      resolvedRootEntity = result.resolvedRootEntity;
     } catch (err: any) {
-      return respondWithFailedExtraction(500, `Phase 2 extraction failed: ${err.message}`, 0);
+      // Bug 13 + Round 7 Bug 20: invalid frontmatter IRIs AND invalid
+      // programmatic `rootEntityIri` / `sourceFileIri` inputs both
+      // throw from the extractor with a clear message. Surface as a
+      // 400 so the user sees it immediately rather than a generic 500.
+      const message = err?.message ?? String(err);
+      if (
+        message.includes('Invalid frontmatter')
+        || message.includes("Invalid 'rootEntityIri'")
+        || message.includes("Invalid 'sourceFileIri'")
+      ) {
+        return respondWithFailedExtraction(400, message, 0);
+      }
+      return respondWithFailedExtraction(500, `Phase 2 extraction failed: ${message}`, 0);
     }
 
-    // ── Write triples + provenance to the assertion graph ──
-    // The sub-graph registration check in assertionCreate/Write (finding 4 of #81)
-    // will throw if subGraphName is provided but unregistered — that's intentional.
-    const allTriples = [...triples, ...provenance];
+    // ── Build the full quad set for both graphs (atomic single insert) ──
+    // We assemble rows 1-13 as data-graph quads + rows 14-20 as CG root
+    // `_meta` quads, each with its own explicit `graph` field, and commit
+    // them all in ONE `agent.store.insert(...)` call. Every supported
+    // triple-store adapter (oxigraph, blazegraph, sparql-http) implements
+    // `insert` as a single N-Quads load / `INSERT DATA` operation, so the
+    // call is naturally atomic across graphs: either every row lands or
+    // none does. This replaces the earlier two-call flow
+    // (`assertion.write` + `store.insert`) which had a window where rows
+    // 1-13 could commit and rows 14-20 fail, leaving dangling data.
+    //
+    // `assertion.create` still runs first to register the assertion graph
+    // container (idempotent on "already exists"). The write itself
+    // bypasses `assertion.write` so the daemon can set per-quad graph
+    // fields directly — `publisher.assertionWrite` hardcodes every quad to
+    // the assertion graph URI, which defeats the multi-graph atomicity
+    // we need here. Sub-graph registration is already validated by
+    // `assertion.create`, so bypassing `assertion.write` doesn't skip any
+    // safety checks.
+    const assertionGraph = contextGraphAssertionUri(
+      contextGraphId!,
+      agent.peerId,
+      assertionName,
+      subGraphName,
+    );
+    const metaGraph = contextGraphMetaUri(contextGraphId!);
+    const startedAtLiteral = `"${startedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`;
+
+    // Data-graph quads: content (triples) + extractor linkage (provenance)
+    // + daemon-owned rows 2, 4, 5, 8, 9-13. Every quad is pinned to the
+    // assertion graph URI. `triples` and `provenance` come from the
+    // extractor without a `graph` field, so we stamp each one here.
+    //
+    // Round 9 Bug 27: rows 6 (`dkg:fileName`) and 7 (`dkg:contentType`)
+    // are REMOVED from the file descriptor block. `<fileUri>` is
+    // content-addressed — two imports of identical bytes under different
+    // filenames / upload content types would have written contradictory
+    // facts to the same subject. Per-upload metadata now lives on the
+    // assertion UAL in `_meta` (new row 15a: `dkg:sourceFileName`,
+    // existing row 15: `dkg:sourceContentType` already there) where
+    // per-assertion facts belong. Only intrinsic-to-content properties
+    // (rdf:type, dkg:contentHash, dkg:size) remain on `<fileUri>` —
+    // those are safe because they're derived purely from the blob bytes.
+    // See `19_MARKDOWN_CONTENT_TYPE.md §10.2`.
+    const dataGraphQuads = [
+      ...triples.map(t => ({ ...t, graph: assertionGraph })),
+      ...sourceFileLinkage.map(t => ({ ...t, graph: assertionGraph })),
+      // Row 2 — daemon-owned. Describes the ORIGINAL upload blob (row 1's
+      // target), so for a PDF upload this is "application/pdf" — NOT the
+      // markdown intermediate the extractor processes. Extractor never
+      // emits this row; the daemon is the single source of truth.
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: assertionGraph },
+      // Row 4 — file descriptor block subject is the content-addressed URN
+      { subject: fileUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/File', graph: assertionGraph },
+      // Row 5 — on-chain canonical hash format is keccak256:<hex>
+      { subject: fileUri, predicate: 'http://dkg.io/ontology/contentHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: assertionGraph },
+      // Row 8 — xsd:integer for size (byte count)
+      { subject: fileUri, predicate: 'http://dkg.io/ontology/size', object: `"${fileStoreEntry.size}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: assertionGraph },
+      // Row 9 — ExtractionProvenance subject is a fresh UUID URN per import
+      { subject: provUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/ExtractionProvenance', graph: assertionGraph },
+      // Row 10 — back-references the file URN (same value as rows 4-5, 8 subject)
+      { subject: provUri, predicate: 'http://dkg.io/ontology/extractedFrom', object: fileUri, graph: assertionGraph },
+      // Row 11
+      { subject: provUri, predicate: 'http://dkg.io/ontology/extractedBy', object: agentDid, graph: assertionGraph },
+      // Row 12
+      { subject: provUri, predicate: 'http://dkg.io/ontology/extractedAt', object: startedAtLiteral, graph: assertionGraph },
+      // Row 13
+      { subject: provUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: assertionGraph },
+    ];
+
+    // `_meta` quads (rows 14-20): always land in the CG ROOT `_meta`, never
+    // a sub-graph `_meta`, keyed by the assertion UAL so daemon restarts
+    // can recover the file ↔ assertion linkage from the graph alone.
+    const metaQuads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [
+      // Row 14 — rootEntity comes from the extractor's resolved value so
+      // the data-graph row 3 and `_meta` row 14 point at the same IRI.
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/rootEntity', object: resolvedRootEntity, graph: metaGraph },
+      // Row 15 — original content type from the upload (matches row 2
+      // now that both rows are sourced from `detectedContentType`).
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: metaGraph },
+      // Row 16 — load-bearing: lets a caller look up the source blob by UAL alone.
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceFileHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: metaGraph },
+      // Row 17
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: metaGraph },
+      // Row 18
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/structuralTripleCount', object: `"${triples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+      // Row 19 — V10.0 has no semantic (Layer 2) extraction, so always zero.
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"0"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+    ];
+    // Row 20 — only emitted when Phase 1 actually ran (PDF/DOCX path).
+    if (mdIntermediateHash) {
+      metaQuads.push({
+        subject: assertionUri,
+        predicate: 'http://dkg.io/ontology/mdIntermediateHash',
+        object: JSON.stringify(mdIntermediateHash),
+        graph: metaGraph,
+      });
+    }
+    // Round 9 Bug 27: `dkg:sourceFileName` — per-upload metadata that
+    // used to live on `<fileUri>` (row 6 in the old file descriptor
+    // block) moves to `_meta` keyed by `<assertionUri>` so two imports
+    // of identical bytes under different filenames don't collide on
+    // the same content-addressed subject. Symmetric to row 15
+    // (`dkg:sourceContentType`). Skipped entirely when the upload
+    // didn't carry a filename (matches the row 20 optional pattern).
+    const uploadedFilename = filePart.filename?.trim() ?? '';
+    if (uploadedFilename.length > 0) {
+      metaQuads.push({
+        subject: assertionUri,
+        predicate: 'http://dkg.io/ontology/sourceFileName',
+        object: JSON.stringify(uploadedFilename),
+        graph: metaGraph,
+      });
+    }
+
+    // Round 14 Bug 42: lock acquisition moved to the top of the
+    // handler, before Phase 1/2 extraction. This inner `try` now
+    // wraps only the assertion.create + snapshot + cleanup + insert
+    // + rollback sequence. See the lock-acquisition site above for
+    // the full rationale.
     try {
-      // Ensure the assertion graph exists even when Phase 2 yields zero triples,
-      // so a completed import always materializes the reported assertion URI.
+      // Ensure the assertion graph exists even when Phase 2 yields zero
+      // content triples, so a completed import always materializes the
+      // reported assertion URI. `assertion.create` also runs the sub-graph
+      // registration check, so bypassing `assertion.write` below doesn't
+      // skip that safety gate.
       try {
         await agent.assertion.create(
           contextGraphId!,
@@ -2617,32 +2858,197 @@ async function handleRequest(
           return respondWithFailedExtraction(500, message, triples.length);
         }
       }
-      if (allTriples.length > 0) {
-        await agent.assertion.write(
-          contextGraphId!,
-          assertionName,
-          allTriples.map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object })),
-          subGraphName ? { subGraphName } : undefined,
+
+      // ── Snapshot BOTH graphs for Bugs 11 + 15 rollback ──
+      //
+      // Before the destructive cleanup (dropGraph + deleteByPattern),
+      // CONSTRUCT the current contents of BOTH the assertion data graph
+      // AND the assertion's `_meta` rows so the rollback path can
+      // restore either or both if the subsequent atomic `store.insert`
+      // fails.
+      //
+      // Round 4 (Bug 11) added the data-graph snapshot but NOT the
+      // `_meta` snapshot, which left an edge case: a transient insert
+      // failure would restore the prior data graph but leave `_meta`
+      // empty for this assertion. Codex Bug 15 called that out — the
+      // old `sourceFileHash` / `rootEntity` rows need to come back too.
+      //
+      // The data-graph CONSTRUCT pulls every quad where the assertion
+      // graph is the context. The `_meta` CONSTRUCT is scoped to the
+      // `<assertionUal> ?p ?o` subject pattern inside the CG root
+      // `_meta` graph — we only rollback rows keyed by THIS assertion,
+      // not every row in the shared `_meta` graph.
+      //
+      // First-import case: both CONSTRUCTs return zero quads (nothing
+      // to preserve), and the rollback path is a no-op on both sides.
+      let dataSnapshot: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
+      let metaSnapshot: Array<{ subject: string; predicate: string; object: string; graph: string }> = [];
+      try {
+        const dataResult = await agent.store.query(
+          `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertionGraph}> { ?s ?p ?o } }`,
         );
+        if (dataResult.type === 'quads') {
+          // Pin the graph field to the assertion graph URI — CONSTRUCT
+          // result quads have graph="" by adapter convention, but the
+          // rollback re-insert needs to target the original graph.
+          dataSnapshot = dataResult.quads.map(q => ({ ...q, graph: assertionGraph }));
+        }
+      } catch (err: any) {
+        const message = err?.message ?? String(err);
+        // Round 13 Bug 38: mark the error so the outer catch doesn't
+        // overwrite this stage-specific failure record with the raw
+        // store error. Callers reading `/extraction-status` see
+        // "Failed to snapshot assertion data graph for rollback: ..."
+        // which tells them WHICH stage of the import pipeline broke,
+        // not just the underlying store error in isolation.
+        recordFailedExtraction(`Failed to snapshot assertion data graph for rollback: ${message}`, 0);
+        (err as any).__failureAlreadyRecorded = true;
+        throw err;
+      }
+      try {
+        const metaResult = await agent.store.query(
+          `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
+        );
+        if (metaResult.type === 'quads') {
+          // Same graph-field pinning as above — preserve `metaGraph`
+          // on every snapshotted quad so the rollback re-insert targets
+          // the CG root `_meta` graph, not the empty default graph.
+          metaSnapshot = metaResult.quads.map(q => ({ ...q, graph: metaGraph }));
+        }
+      } catch (err: any) {
+        const message = err?.message ?? String(err);
+        // Round 13 Bug 38: same stage-context preservation as the
+        // dataSnapshot failure branch above.
+        recordFailedExtraction(`Failed to snapshot _meta for rollback: ${message}`, 0);
+        (err as any).__failureAlreadyRecorded = true;
+        throw err;
+      }
+
+      // ── Clear stale content from BOTH graphs before the fresh insert ──
+      //
+      // import-file has REPLACE semantics on same-name re-import: the
+      // assertion ends up with exactly the content of the latest upload,
+      // not a merge of every prior upload. Without this cleanup:
+      //
+      // 1. `_meta` rows 14-20 keyed by `<assertionUal>` would stack a
+      //    second block next to the old one, so
+      //    `<assertionUal> dkg:sourceFileHash ?h` would return two
+      //    different hashes with no way to tell which is canonical.
+      //
+      // 2. Data-graph rows 1 and 4-13 would leave the old blob's
+      //    descriptor next to the new blob's — a consumer walking the
+      //    assertion graph would see two source files for one assertion.
+      //
+      // Order (Bug 14 reorder): `_meta` cleanup runs FIRST, then
+      // `dropGraph`. This matches the Bug 12 pattern in
+      // `assertionDiscard`. Both primitives are idempotent:
+      // `deleteByPattern` returns 0 on a fresh assertion, `dropGraph`
+      // uses `DROP SILENT GRAPH` so it's a no-op on a missing graph.
+      //
+      // Round 7 Bug 22: the Round 5/6 rollback path only fired when
+      // the atomic `store.insert` failed. If `dropGraph` failed AFTER
+      // `deleteByPattern` succeeded, the old `_meta` rows were gone
+      // and the old data graph was still intact — a self-inconsistent
+      // state with no rollback. Track which cleanup steps succeeded
+      // and, on ANY subsequent failure, restore whichever snapshots
+      // correspond to state we actually corrupted:
+      //
+      //  - `metaCleanupSucceeded` → restore `metaSnapshot`
+      //  - `dataDropSucceeded` → restore `dataSnapshot`
+      //  - insert succeeded → no rollback
+      //  - `deleteByPattern` itself failed → no rollback (nothing
+      //    changed, retry converges cleanly)
+      //
+      // The rollback is best-effort: compound failures record a rich
+      // error with every failure message, then rethrow the ORIGINAL
+      // error so the 500 envelope matches what the caller experienced.
+      let metaCleanupSucceeded = false;
+      let dataDropSucceeded = false;
+      try {
+        await agent.store.deleteByPattern({ subject: assertionUri, graph: metaGraph });
+        metaCleanupSucceeded = true;
+        await agent.store.dropGraph(assertionGraph);
+        dataDropSucceeded = true;
+        // ── Atomic multi-graph insert: rows 1-13 + rows 14-20 in one call ──
+        // A single `store.insert` across two graphs — either both
+        // land or neither does, per the adapter contracts.
+        await agent.store.insert([...dataGraphQuads, ...metaQuads]);
+      } catch (writeErr: any) {
+        const writeMsg = writeErr?.message ?? String(writeErr);
+        const rollbackErrors: string[] = [];
+        // Restore each side we corrupted, in reverse order of the
+        // forward sequence (insert → dropGraph → deleteByPattern).
+        // `dataSnapshot` is restored only if `dropGraph` succeeded
+        // (before then the old data is still in the store); likewise
+        // `metaSnapshot` is restored only if `deleteByPattern`
+        // succeeded. On a `deleteByPattern`-only failure both flags
+        // are false and no rollback fires — the state is unchanged.
+        if (dataDropSucceeded && dataSnapshot.length > 0) {
+          try {
+            await agent.store.insert(dataSnapshot);
+          } catch (dataRollbackErr: any) {
+            rollbackErrors.push(`data rollback failed: ${dataRollbackErr?.message ?? dataRollbackErr}`);
+          }
+        }
+        if (metaCleanupSucceeded && metaSnapshot.length > 0) {
+          try {
+            await agent.store.insert(metaSnapshot);
+          } catch (metaRollbackErr: any) {
+            rollbackErrors.push(`_meta rollback failed: ${metaRollbackErr?.message ?? metaRollbackErr}`);
+          }
+        }
+        if (rollbackErrors.length > 0) {
+          // One or both rollback re-inserts failed. Log the compound
+          // failure with every error message so a human can diagnose
+          // the state, then rethrow the original error so the
+          // top-level 500 handler responds with the envelope that
+          // matches what the caller actually experienced.
+          recordFailedExtraction(
+            `write stage failed AND rollback failures: ${writeMsg}; ${rollbackErrors.join('; ')}`,
+            triples.length,
+          );
+          (writeErr as any).__failureAlreadyRecorded = true;
+        }
+        throw writeErr;
       }
     } catch (err: any) {
       const message = err?.message ?? String(err);
-      if (message.includes('has not been registered')) {
-        return respondWithFailedExtraction(400, message, triples.length);
-      }
-      if (message.includes('Invalid') || message.includes('Unsafe')) {
-        return respondWithFailedExtraction(400, message, triples.length);
+      // Round 10 Bug 29: the previous `message.includes('Invalid' |
+      // 'Unsafe' | 'has not been registered')` branches were moved
+      // OUT of this outer catch. They now live only in the inner
+      // `assertion.create` catch above (lines 2815-2828), which is
+      // the only step in this block where a user-input validation
+      // error can legitimately originate.
+      //
+      // The outer catch is only reachable for post-`assertion.create`
+      // steps — snapshot queries, `_meta` cleanup, `dropGraph`, atomic
+      // insert, and rollback re-inserts. Those all operate on
+      // daemon-constructed quads and storage-layer primitives; an
+      // `Invalid` or `Unsafe` substring in a thrown message from
+      // those steps signals an INTERNAL storage error (e.g., an
+      // Oxigraph `Invalid query plan` or a replication layer
+      // `Unsafe write`), not a user-input failure. Misclassifying
+      // them as HTTP 400 would mislead the caller into retrying
+      // with a "fixed" payload when the problem was server-side.
+      // Let them bubble up as 500 via the top-level handler.
+      //
+      // Bug 15: compound rollback failure already wrote a rich error
+      // record — don't overwrite it with the bare insert error.
+      if ((err as any)?.__failureAlreadyRecorded) {
+        throw err;
       }
       // Unexpected write-stage failure: record the failure on the extraction
       // status map before rethrowing so /extraction-status doesn't stay stuck
-      // at in_progress when the top-level 500 handler takes over.
+      // at in_progress when the top-level 500 handler takes over. Because
+      // the insert is atomic across both graphs, nothing landed and a retry
+      // sees a clean slate.
       recordFailedExtraction(message, triples.length);
       throw err;
     }
 
     const completedRecord: ExtractionStatusRecord = {
       status: 'completed',
-      fileHash: fileStoreEntry.hash,
+      fileHash: fileStoreEntry.keccak256,
       detectedContentType,
       pipelineUsed,
       tripleCount: triples.length,
@@ -2658,6 +3064,21 @@ async function handleRequest(
       pipelineUsed,
       ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
     });
+    } finally {
+      // Round 14 Bug 42 outer finally: release the per-assertion
+      // lock so the next waiter can start. Runs regardless of
+      // early returns (graceful-degrade skipped path, failed-
+      // extraction paths, successful completion) AND regardless
+      // of whether the inner write-stage try/catch threw. The map
+      // entry is cleaned up iff this call is still the head of
+      // the queue — if another waiter has chained on after us, its
+      // chained promise has already replaced our slot in the map
+      // and we leave it alone.
+      releaseLock();
+      if (assertionImportLocks.get(assertionUri) === chainedLock) {
+        assertionImportLocks.delete(assertionUri);
+      }
+    }
   }
 
   // GET /api/assertion/:name/extraction-status?contextGraphId=...&subGraphName=...

--- a/packages/cli/src/extraction-status.ts
+++ b/packages/cli/src/extraction-status.ts
@@ -1,9 +1,12 @@
 export interface ExtractionStatusRecord {
   status: 'in_progress' | 'completed' | 'skipped' | 'failed';
+  // `keccak256:<hex>` — canonical per spec §10.2:603 / 03 §2.1:658.
   fileHash: string;
   detectedContentType: string;
   pipelineUsed: string | null;
   tripleCount: number;
+  // `keccak256:<hex>` — present only when Phase 1 actually ran (PDF/
+  // DOCX via MarkItDown). Undefined for pure-markdown imports.
   mdIntermediateHash?: string;
   error?: string;
   startedAt: string;

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -1,6 +1,6 @@
 /**
  * Phase 2 of document ingestion: deterministic structural extraction
- * from a Markdown intermediate to RDF triples + provenance.
+ * from a Markdown intermediate to RDF triples + source-file linkage.
  *
  * This is the "Layer 1 structural" extraction defined by
  * `19_MARKDOWN_CONTENT_TYPE.md` — it runs without an LLM and produces
@@ -13,16 +13,34 @@
  *   - Dataview `key:: value` inline fields → properties
  *   - Heading hierarchy → dkg:hasSection
  *
- * Every extracted triple gets a provenance record pointing to a
- * `dkg:ExtractionProvenance` blank identifier so downstream consumers
- * can distinguish structurally-derived triples from user-asserted ones.
+ * When `sourceFileIri` is provided the extractor emits the §10.1 data-
+ * graph linkage triples it owns — specifically row 1
+ * (`<entityUri> dkg:sourceFile <fileUri>`) and row 3
+ * (`<entityUri> dkg:rootEntity <resolvedRootEntity>`). These come back
+ * in the `sourceFileLinkage` return field so the daemon can keep them
+ * distinct from content triples before merging them into the
+ * assertion graph. The field was renamed from `provenance` in Round 13
+ * Bug 39 to remove the semantic clash with its original
+ * extraction-run-metadata meaning.
  *
- * Spec: 05_PROTOCOL_EXTENSIONS.md §6.5.2, 19_MARKDOWN_CONTENT_TYPE.md
+ * Row 2 (`<entityUri> dkg:sourceContentType "<original-mime>"`) is
+ * owned by the daemon (Round 9 Bug 1 / Round 9 Bug 27 rulings), not
+ * this module — only the daemon has access to the original upload
+ * content type that row 2 must describe. The daemon emits row 2
+ * alongside the extractor's rows 1 and 3 in the same atomic insert.
+ *
+ * Rows 4-13 (file descriptor block + ExtractionProvenance resource
+ * described in §3.2/§10.2) are also daemon-owned — the daemon has
+ * natural access to the UAL, the fresh provenance URI, the agent DID,
+ * and the `_meta` writes. This module stays free of `_meta` /
+ * extraction-run concerns.
+ *
+ * Spec: 05_PROTOCOL_EXTENSIONS.md §6.3 / §6.5, 19_MARKDOWN_CONTENT_TYPE.md §10
  */
 
 import { createHash } from 'node:crypto';
 import { load as loadYaml } from 'js-yaml';
-import type { ExtractionQuad as Quad } from '@origintrail-official/dkg-core';
+import { isSafeIri, type ExtractionQuad as Quad } from '@origintrail-official/dkg-core';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const SCHEMA_NAME = 'http://schema.org/name';
@@ -30,12 +48,8 @@ const SCHEMA_DESCRIPTION = 'http://schema.org/description';
 const SCHEMA_MENTIONS = 'http://schema.org/mentions';
 const SCHEMA_KEYWORDS = 'http://schema.org/keywords';
 const DKG_HAS_SECTION = 'http://dkg.io/ontology/hasSection';
-const DKG_EXTRACTION_PROVENANCE = 'http://dkg.io/ontology/ExtractionProvenance';
-const DKG_DERIVED_FROM = 'http://dkg.io/ontology/derivedFrom';
-const DKG_EXTRACTED_BY = 'http://dkg.io/ontology/extractedBy';
-const DKG_EXTRACTION_RULE = 'http://dkg.io/ontology/extractionRule';
-const DKG_EXTRACTED_AT = 'http://dkg.io/ontology/extractedAt';
-const PROV_WAS_GENERATED_BY = 'http://www.w3.org/ns/prov#wasGeneratedBy';
+const DKG_SOURCE_FILE = 'http://dkg.io/ontology/sourceFile';
+const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
 const XSD_BOOLEAN = 'http://www.w3.org/2001/XMLSchema#boolean';
 const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
 const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
@@ -54,17 +68,81 @@ export interface MarkdownExtractInput {
    * derives a subject from frontmatter `id` or the first H1 heading.
    */
   documentIri?: string;
-  /** Optional timestamp for provenance (defaults to now). */
+  /**
+   * IRI of the source blob this markdown was extracted from, in the form
+   * `urn:dkg:file:keccak256:<hex>`. When set, the extractor emits the
+   * §10.1 `dkg:sourceFile` linkage quad (row 1) with `<entityUri>` as
+   * subject and this URI as object.
+   *
+   * The file descriptor block (rows 4-8) is subsequently filtered out of
+   * `assertionPromote`'s root-entity partition via a subject-prefix
+   * filter on `urn:dkg:file:` in `packages/publisher/src/dkg-publisher.ts`
+   * — that's how we prevent cross-assertion contention without using
+   * blank-node subjects. See `19_MARKDOWN_CONTENT_TYPE.md §10.2` for the
+   * normative rule and spec-engineer's reconciled ruling on Codex Bug 8
+   * for the history (Round 3 tried blank nodes; Round 4 reverted to URI
+   * subjects + promote-time filter after an `autoPartition` audit showed
+   * the blank-node approach silently drops the ExtractionProvenance
+   * block, which is a correctness smell).
+   */
+  sourceFileIri?: string;
+  /**
+   * Explicit root-entity IRI override. In V10.0 this is usually the
+   * document subject IRI itself (`<entityUri> dkg:rootEntity <entityUri>`).
+   * If the frontmatter carries a `rootEntity` key with a string value it
+   * takes precedence over both the input and the subject default; see
+   * §19.10.1:508. The resolved value is returned on
+   * `MarkdownExtractOutput.resolvedRootEntity` so the daemon can reuse it
+   * for the `_meta` row 14 write without re-resolving.
+   */
+  rootEntityIri?: string;
+  /**
+   * Optional timestamp reserved for future extraction-run metadata
+   * (defaults to now when eventually used). Currently unused — the
+   * extractor no longer emits extraction-run provenance since that
+   * moved to the daemon's route handler in Round 9 Bug 27. Callers
+   * may still pass this for forward compatibility, but it is not
+   * consumed by any code path today.
+   */
   now?: Date;
 }
 
 export interface MarkdownExtractOutput {
-  /** Extracted RDF triples. */
+  /** Extracted RDF triples describing the document content. */
   triples: Quad[];
-  /** dkg:ExtractionProvenance quads for the extraction run. */
-  provenance: Quad[];
+  /**
+   * §10.1 source-file linkage quads on the document subject. Emits rows
+   * 1 and 3 (`dkg:sourceFile` + `dkg:rootEntity`); row 2
+   * (`dkg:sourceContentType`) is owned by the daemon because it has the
+   * original upload content type and the extractor does not. Empty when
+   * `sourceFileIri` is not supplied. The daemon merges these into the
+   * same data graph as `triples` before committing.
+   *
+   * Round 13 Bug 39: renamed from `provenance` to `sourceFileLinkage`.
+   * The original field at module introduction (`ff8afe3`) was
+   * "`dkg:ExtractionProvenance` blank-identifier records for every
+   * extracted triple" — extraction-run metadata (agent, timestamp,
+   * method). The PR #121 chain repurposed the field to hold source-
+   * file linkage triples, creating a semantic clash with the old
+   * meaning. Round 9 Bug 27 moved the extraction-run provenance rows
+   * (9-13 on the `<urn:dkg:extraction:uuid>` subject) to the daemon's
+   * route handler, so the extractor no longer produces ANY
+   * extraction-run metadata — only source-file linkage. Renaming
+   * makes the contract honest: this field contains linkage triples,
+   * full stop.
+   */
+  sourceFileLinkage: Quad[];
   /** The subject IRI used for the document (useful to the caller for indexing). */
   subjectIri: string;
+  /**
+   * The resolved root-entity IRI, following the §19.10.1:508 precedence
+   * rules: frontmatter `rootEntity` key > explicit `rootEntityIri` input >
+   * reflexive fallback to the document subject. The daemon reuses this
+   * value as the object of the `_meta` row 14 quad so the data-graph row 3
+   * and `_meta` row 14 stay in sync without the daemon re-running the
+   * resolution logic.
+   */
+  resolvedRootEntity: string;
 }
 
 /**
@@ -167,7 +245,18 @@ function resolveSubjectIri(
 
   const fmId = frontmatter?.['id'];
   if (typeof fmId === 'string' && fmId.length > 0) {
-    if (/^(https?:|did:|urn:|_:)/.test(fmId)) return fmId;
+    // Round 11 Bug 33 + Round 10 Bug 30 preempt: use `isSafeIri` as the
+    // single source-of-truth "is this an IRI" check. Previous rounds
+    // used a narrow regex allowlist `^(https?:|did:|urn:|_:)` which
+    // (a) accepted `_:foo` blank nodes even though `isSafeIri` rejects
+    // them — contradicting spec §19.10.2:628-629 / §03 §1 non-blank-node
+    // Entity-hood, and (b) silently slugified valid IRIs whose schemes
+    // fell outside the allowlist, e.g. `tag:origintrail.org,2026:paper`
+    // or `doi:10.1000/xyz`. The spec defines the contract as "scheme-
+    // based IRI" without restricting schemes; the only exclusions are
+    // blank nodes (RDF 1.1 §3.4 — not IRIs) and reserved protocol
+    // namespaces (§19.10.2:708-723). `isSafeIri` matches that contract.
+    if (isSafeIri(fmId)) return fmId;
     return `urn:dkg:md:${slugify(fmId)}`;
   }
 
@@ -314,13 +403,12 @@ function stripCodeFences(body: string): string {
 
 /**
  * Run the full Phase 2 structural extraction. Deterministic, no LLM.
- * Returns `{ triples, provenance, subjectIri }`. Empty arrays are valid
+ * Returns `{ triples, sourceFileLinkage, subjectIri, resolvedRootEntity }`. Empty arrays are valid
  * — a Markdown document with no frontmatter, no wikilinks, no tags, no
  * dataview fields, and no headings produces zero triples.
  */
 export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtractOutput {
   const triples: Quad[] = [];
-  const now = input.now ?? new Date();
 
   const { frontmatter, body } = splitFrontmatter(input.markdown);
   const subject = resolveSubjectIri(input, frontmatter, body);
@@ -329,6 +417,7 @@ export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtrac
   if (frontmatter) {
     for (const [key, value] of Object.entries(frontmatter)) {
       if (key === 'id') continue; // already used as subject identifier
+      if (key === 'rootEntity') continue; // consumed as a linkage override below
       if (key === 'type') {
         const typeIri = resolveTypeIri(value);
         if (typeIri) triples.push({ subject, predicate: RDF_TYPE, object: typeIri });
@@ -388,15 +477,15 @@ export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtrac
     sectionStack.push({ level: heading.level, iri: sectionIri });
   }
 
-  // ── Provenance ─────────────────────────────────────────────────────
-  const provenance = buildProvenance({
+  // ── §10.1 source-file linkage (data graph) ─────────────────────────
+  const { quads: sourceFileLinkage, resolvedRootEntity } = buildSourceFileLinkage({
     subject,
-    agentDid: input.agentDid,
-    tripleCount: triples.length,
-    now,
+    frontmatter,
+    sourceFileIri: input.sourceFileIri,
+    rootEntityIri: input.rootEntityIri,
   });
 
-  return { triples, provenance, subjectIri: subject };
+  return { triples, sourceFileLinkage, subjectIri: subject, resolvedRootEntity };
 }
 
 function frontmatterKeyToPredicate(key: string): string | null {
@@ -408,21 +497,155 @@ function frontmatterKeyToPredicate(key: string): string | null {
   return localName ? `http://schema.org/${localName}` : null;
 }
 
-function buildProvenance(args: {
+/**
+ * Build the `19_MARKDOWN_CONTENT_TYPE.md §10.1` source-file linkage quads
+ * on the document subject, plus compute the resolved root-entity IRI.
+ *
+ * The extractor is responsible for rows 1 and 3 of the Phase A table.
+ * Row 2 (`dkg:sourceContentType`) is owned by the daemon: the extractor
+ * only ever processes markdown (even for PDF uploads, where the
+ * markdown intermediate is what it sees), but row 2 must describe the
+ * ORIGINAL blob pointed at by row 1. Only the daemon has that value, so
+ * it emits row 2 itself alongside the file descriptor block.
+ *
+ *   Row 1: `<entityUri> dkg:sourceFile  <urn:dkg:file:keccak256:...>`
+ *   Row 3: `<entityUri> dkg:rootEntity  <resolvedRootEntity>`
+ *
+ * Row 1's object is a content-addressed URI (`urn:dkg:file:keccak256:<hex>`).
+ * Cross-assertion promote contention on that subject is prevented by a
+ * subject-prefix filter in `packages/publisher/src/dkg-publisher.ts`
+ * `assertionPromote` that excludes `urn:dkg:file:` and `urn:dkg:extraction:`
+ * subjects from the partition before `autoPartition` runs. See Codex
+ * Bug 8 Round 4 reconciled ruling for the history — Round 3 tried blank
+ * nodes but an `autoPartition` audit showed they silently drop the
+ * ExtractionProvenance block on promote, which was a correctness smell.
+ *
+ * `resolvedRootEntity` follows the §19.10.1:508 precedence rules:
+ *   1. frontmatter `rootEntity` key (string) — honored regardless of
+ *      whether source-file linkage was requested, since the caller may
+ *      still want the resolved value for other purposes. IRI-shaped
+ *      values are validated via `isSafeIri` to reject malformed inputs
+ *      (Codex Bug 13); non-IRI values fall through to slugification.
+ *   2. explicit `rootEntityIri` input.
+ *   3. reflexive fallback: the document subject itself.
+ */
+function buildSourceFileLinkage(args: {
   subject: string;
-  agentDid: string;
-  tripleCount: number;
-  now: Date;
-}): Quad[] {
-  if (args.tripleCount === 0) return [];
-  const provIri = `urn:dkg:extraction:${slugify(args.subject)}-${args.now.getTime()}`;
-  const xsdDateTime = `"${args.now.toISOString()}"^^<${XSD_DATE_TIME}>`;
-  return [
-    { subject: provIri, predicate: RDF_TYPE, object: DKG_EXTRACTION_PROVENANCE },
-    { subject: provIri, predicate: DKG_EXTRACTED_BY, object: args.agentDid },
-    { subject: provIri, predicate: DKG_EXTRACTION_RULE, object: JSON.stringify('markdown-structural-v1') },
-    { subject: provIri, predicate: DKG_EXTRACTED_AT, object: xsdDateTime },
-    { subject: provIri, predicate: DKG_DERIVED_FROM, object: args.subject },
-    { subject: args.subject, predicate: PROV_WAS_GENERATED_BY, object: provIri },
+  frontmatter: Record<string, unknown> | null;
+  sourceFileIri: string | undefined;
+  rootEntityIri: string | undefined;
+}): { quads: Quad[]; resolvedRootEntity: string } {
+  // Round 7 Bug 20: symmetric validation for the PROGRAMMATIC override
+  // inputs. The frontmatter `rootEntity` path already validates via
+  // `isSafeIri` (Round 4 Bug 13), but `rootEntityIri` and `sourceFileIri`
+  // came through untrusted until now — an internal caller (including
+  // the daemon itself if a hash computation ever drifts) could pass
+  // `''`, `foo`, or `http://x>y` and get malformed linkage quads that
+  // only fail later at store insert with a cryptic RDF parse error.
+  // Reject non-IRIs the same way as the frontmatter path: empty string,
+  // missing IRI scheme prefix, or failed `isSafeIri` check → throw a
+  // clear `Invalid '<field>' IRI` error that the daemon surfaces as 400.
+  //
+  // Round 10 Bug 30 + Round 11 Bug 33: `rootEntity` / `sourceFileIri`
+  // MUST be scheme-based IRIs per `19_MARKDOWN_CONTENT_TYPE.md
+  // §10.2:628-629` (`dkg:rootEntity is an IRI`) AND the reserved-
+  // namespaces rule at §10.2:708-723. The spec defines the contract
+  // as "scheme-based IRI" WITHOUT restricting schemes — the only
+  // exclusions are blank nodes (RDF 1.1 §3.4 — not IRIs, also
+  // excluded from Entity-hood per `03_PROTOCOL_CORE.md §1`) and
+  // reserved protocol namespaces (§10.2:708-723, guarded at the
+  // publisher write-boundary via `rejectReservedSubjectPrefixes`).
+  //
+  // Earlier rounds used a narrow regex allowlist
+  // `^(https?:|did:|urn:)` which silently rejected valid absolute
+  // IRIs with other schemes (e.g. `tag:origintrail.org,2026:paper`,
+  // `doi:10.1000/xyz`, `info:lccn/2005029870`) — users who supplied
+  // such IRIs as `rootEntityIri` got an `Invalid 'rootEntityIri'`
+  // rejection even though `isSafeIri` would have accepted them.
+  // The fix: drop the narrow regex, use `isSafeIri` as the single
+  // source-of-truth "is this an IRI" check. It already rejects
+  // empty strings, malformed values, AND blank nodes per its spec.
+  if (args.rootEntityIri !== undefined) {
+    if (!isSafeIri(args.rootEntityIri)) {
+      throw new Error(
+        `Invalid 'rootEntityIri' input: ${JSON.stringify(args.rootEntityIri)}. ` +
+          `Expected a scheme-based IRI such as urn:note:foo, http://example.com/bar, ` +
+          `or tag:example.org,2026:paper. Any absolute IRI scheme is accepted as long ` +
+          `as the value contains no spaces, angle brackets, quotes, or control ` +
+          `characters. Blank nodes (_:foo) are not accepted — per ` +
+          `19_MARKDOWN_CONTENT_TYPE.md §10.2, rootEntity must be an IRI.`,
+      );
+    }
+  }
+  if (args.sourceFileIri !== undefined) {
+    if (!isSafeIri(args.sourceFileIri)) {
+      throw new Error(
+        `Invalid 'sourceFileIri' input: ${JSON.stringify(args.sourceFileIri)}. ` +
+          `Expected a scheme-based IRI such as urn:dkg:file:keccak256:abc, ` +
+          `http://example.com/file, or tag:example.org,2026:doc. Any absolute IRI ` +
+          `scheme is accepted as long as the value contains no spaces, angle brackets, ` +
+          `quotes, or control characters. Blank nodes (_:foo) are not accepted — per ` +
+          `19_MARKDOWN_CONTENT_TYPE.md §10.2, sourceFile must be an IRI.`,
+      );
+    }
+  }
+
+  // Resolve the root entity regardless of whether linkage quads will be
+  // emitted. Frontmatter wins, then explicit input, then reflexive default.
+  //
+  // Round 11 Bug 33: broaden scheme detection from a narrow allowlist
+  // `^(https?:|did:|urn:)` to the RFC 3986 generic scheme pattern
+  // `^[a-zA-Z][a-zA-Z0-9+.-]*:`. The narrow allowlist silently
+  // slugified valid IRIs with other schemes — Codex's cited example:
+  // `rootEntity: tag:origintrail.org,2026:paper` was rewritten into
+  // `urn:dkg:md:tag-origintrail-org-2026-paper` instead of being
+  // preserved as the caller-intended IRI. Any scheme `isSafeIri`
+  // accepts is now preserved (tag:, doi:, info:, etc.), matching the
+  // programmatic `rootEntityIri` path for contract consistency.
+  //
+  // Round 4 Bug 13 semantics preserved: values that LOOK like IRI
+  // attempts (scheme-prefixed) but fail `isSafeIri` still throw
+  // loudly with a clear `Invalid frontmatter 'rootEntity' IRI`
+  // message — e.g. `urn:x y` (embedded space) or `http://x>y`
+  // (angle bracket). Values that don't look like IRI attempts
+  // (plain text with no scheme prefix) still slugify as before.
+  //
+  // Round 10 Bug 30: blank nodes (`_:foo`) do NOT match the RFC 3986
+  // scheme production (which requires `[a-zA-Z]` first — `_` is not
+  // in that class), so they fall through to slugification rather
+  // than being accepted as pseudo-IRIs. This matches spec §10.2
+  // (rootEntity must be an IRI, not a blank node).
+  let resolvedRootEntity: string = args.rootEntityIri ?? args.subject;
+  const fmRoot = args.frontmatter?.['rootEntity'];
+  if (typeof fmRoot === 'string' && fmRoot.length > 0) {
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(fmRoot)) {
+      // Looks like an IRI attempt — validate strictly.
+      if (!isSafeIri(fmRoot)) {
+        throw new Error(
+          `Invalid frontmatter 'rootEntity' IRI: ${JSON.stringify(fmRoot)}. ` +
+            `Scheme-prefixed values must be safe IRIs ` +
+            `(no spaces, angle brackets, quotes, or control characters). ` +
+            `Any absolute IRI scheme is accepted (http, https, did, urn, ` +
+            `tag, doi, info, etc.). Blank nodes (_:foo) are not accepted — ` +
+            `per 19_MARKDOWN_CONTENT_TYPE.md §10.2, rootEntity must be an IRI.`,
+        );
+      }
+      resolvedRootEntity = fmRoot;
+    } else {
+      resolvedRootEntity = `urn:dkg:md:${slugify(fmRoot)}`;
+    }
+  }
+
+  if (!args.sourceFileIri) {
+    return { quads: [], resolvedRootEntity };
+  }
+
+  const quads: Quad[] = [
+    // Row 1 — points at the content-addressed file URN
+    { subject: args.subject, predicate: DKG_SOURCE_FILE, object: args.sourceFileIri },
+    // Row 3 — resolved root entity (reflexive or frontmatter/explicit override)
+    { subject: args.subject, predicate: DKG_ROOT_ENTITY, object: resolvedRootEntity },
   ];
+
+  return { quads, resolvedRootEntity };
 }

--- a/packages/cli/src/file-store.ts
+++ b/packages/cli/src/file-store.ts
@@ -17,10 +17,20 @@ import { createHash } from 'node:crypto';
 import { mkdir, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { ethers } from 'ethers';
 
 export interface FileStoreEntry {
-  /** sha256 hash of the file contents, formatted as `sha256:<hex>`. */
+  /**
+   * sha256 hash of the file contents, formatted as `sha256:<hex>`.
+   * Used as the on-disk storage key for historical compatibility.
+   */
   hash: string;
+  /**
+   * keccak256 hash of the file contents, formatted as `keccak256:<hex>`.
+   * Used on the wire and in the data/meta graph triples per
+   * `05_PROTOCOL_EXTENSIONS.md §6.3` and `19_MARKDOWN_CONTENT_TYPE.md §10`.
+   */
+  keccak256: string;
   /** Absolute path to the stored file on disk. */
   path: string;
   /** Size of the file in bytes. */
@@ -38,17 +48,23 @@ export class FileStore {
 
   /**
    * Persist `bytes` to the store and return the resulting entry. Idempotent:
-   * re-putting the same bytes returns the same hash without rewriting the
-   * existing blob. The `contentType` metadata is
-   * attached to the return value but not persisted to disk — callers that
-   * need durable content-type metadata should store it separately (e.g. in
-   * an `_meta` triple keyed by hash).
+   * re-putting the same bytes returns the same hashes without rewriting the
+   * existing blob. The `contentType` metadata is attached to the return
+   * value but not persisted to disk — callers that need durable
+   * content-type metadata should store it separately (e.g. in an `_meta`
+   * triple keyed by hash).
+   *
+   * Content is stored under the sha256 shard layout. A small pointer file
+   * under `keccak256/<hex>` is also written so the same blob is resolvable
+   * by keccak256, which is the hash used on the wire and in graph triples.
    */
   async put(bytes: Buffer, contentType: string): Promise<FileStoreEntry> {
-    const hex = createHash('sha256').update(bytes).digest('hex');
-    const hash = `sha256:${hex}`;
-    const path = this.resolvePath(hex);
-    await mkdir(join(this.rootDir, hex.slice(0, 2)), { recursive: true });
+    const sha256Hex = createHash('sha256').update(bytes).digest('hex');
+    const keccakHex = ethers.keccak256(bytes).replace(/^0x/, '');
+    const hash = `sha256:${sha256Hex}`;
+    const keccak256 = `keccak256:${keccakHex}`;
+    const path = this.resolvePath(sha256Hex);
+    await mkdir(join(this.rootDir, sha256Hex.slice(0, 2)), { recursive: true });
     if (!existsSync(path)) {
       const tempPath = `${path}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
       try {
@@ -66,12 +82,36 @@ export class FileStore {
         }
       }
     }
-    return { hash, path, size: bytes.length, contentType };
+    const pointerPath = this.resolveKeccakPointerPath(keccakHex);
+    if (!existsSync(pointerPath)) {
+      await mkdir(join(this.rootDir, 'keccak256', keccakHex.slice(0, 2)), { recursive: true });
+      const tempPointer = `${pointerPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      try {
+        await writeFile(tempPointer, sha256Hex, { flag: 'wx' });
+        try {
+          await rename(tempPointer, pointerPath);
+        } catch (err: any) {
+          if (!existsSync(pointerPath)) {
+            throw err;
+          }
+        }
+      } finally {
+        if (existsSync(tempPointer)) {
+          await unlink(tempPointer).catch(() => {});
+        }
+      }
+    }
+    return { hash, keccak256, path, size: bytes.length, contentType };
   }
 
-  /** Retrieve the raw bytes for a previously-stored hash, or null if absent. */
+  /**
+   * Retrieve the raw bytes for a previously-stored hash, or null if absent.
+   * Accepts either the `sha256:<hex>` or `keccak256:<hex>` form. For
+   * keccak256 inputs the pointer file written at put() time is dereferenced
+   * to the underlying sha256 blob.
+   */
   async get(hash: string): Promise<Buffer | null> {
-    const path = this.hashToPath(hash);
+    const path = await this.hashToPath(hash);
     if (!path) return null;
     if (!existsSync(path)) return null;
     return readFile(path);
@@ -79,7 +119,7 @@ export class FileStore {
 
   /** Check whether a hash is present in the store. */
   async has(hash: string): Promise<boolean> {
-    const path = this.hashToPath(hash);
+    const path = await this.hashToPath(hash);
     if (!path) return false;
     try {
       await stat(path);
@@ -89,11 +129,52 @@ export class FileStore {
     }
   }
 
-  /** Resolve a hash to its on-disk path, or null for malformed hashes. */
-  hashToPath(hash: string): string | null {
-    const hex = normalizeHash(hash);
-    if (!hex) return null;
-    return this.resolvePath(hex);
+  /**
+   * Resolve a hash to the underlying blob's on-disk path. Always returns
+   * the CONTENT path regardless of which hash algorithm the caller
+   * supplied:
+   *
+   * - `sha256:<hex>` or bare hex → the sharded blob path directly
+   * - `keccak256:<hex>` → read the pointer file written at `put()` time,
+   *   deref it to the sha256 hex, return the sharded blob path for that
+   *
+   * Returns null for malformed hashes, for keccak256 inputs whose
+   * pointer file does not exist, and for pointer files that contain
+   * unexpected content.
+   *
+   * This is async because the keccak256 path requires a disk read. If
+   * you specifically want the on-disk location of the keccak pointer
+   * file (e.g. for integrity checks, debugging, or cleanup), use
+   * `hashToPointerPath(keccakHash)` instead — that's synchronous and
+   * returns null for non-keccak inputs.
+   */
+  async hashToPath(hash: string): Promise<string | null> {
+    const parsed = parseHash(hash);
+    if (!parsed) return null;
+    if (parsed.algo === 'sha256') return this.resolvePath(parsed.hex);
+    const pointerPath = this.resolveKeccakPointerPath(parsed.hex);
+    if (!existsSync(pointerPath)) return null;
+    const sha256Hex = (await readFile(pointerPath, 'utf-8')).trim();
+    if (!/^[0-9a-f]{64}$/i.test(sha256Hex)) return null;
+    return this.resolvePath(sha256Hex.toLowerCase());
+  }
+
+  /**
+   * Resolve a `keccak256:<hex>` hash to its pointer-file path
+   * synchronously, without dereferencing. Returns null for malformed
+   * keccak256 hashes and for any other algorithm (use `hashToPath` to
+   * get the content path for sha256). Intended for callers that want
+   * to inspect or manipulate the keccak → sha256 indirection directly.
+   */
+  hashToPointerPath(hash: string): string | null {
+    const parsed = parseHash(hash);
+    if (!parsed) return null;
+    if (parsed.algo !== 'keccak256') return null;
+    return this.resolveKeccakPointerPath(parsed.hex);
+  }
+
+  private resolveKeccakPointerPath(hex: string): string {
+    return join(this.rootDir, 'keccak256', hex.slice(0, 2), hex.slice(2));
   }
 
   /** Root directory the store writes into. */
@@ -107,13 +188,21 @@ export class FileStore {
 }
 
 /**
- * Normalize a hash string to its 64-char hex form. Accepts either the
- * prefixed (`sha256:abcd...`) or bare (`abcd...`) variants. Returns null for
- * anything that isn't a valid sha256 hex.
+ * Parse a hash string and return its algorithm + 64-char hex form. Accepts
+ * `sha256:<hex>`, `keccak256:<hex>`, or bare `<hex>` (treated as sha256 for
+ * backwards compatibility). Returns null for anything that isn't a valid
+ * 64-char hex under a supported algorithm.
  */
-function normalizeHash(hash: string): string | null {
+function parseHash(hash: string): { algo: 'sha256' | 'keccak256'; hex: string } | null {
   if (typeof hash !== 'string') return null;
-  const hex = hash.startsWith('sha256:') ? hash.slice('sha256:'.length) : hash;
+  let algo: 'sha256' | 'keccak256' = 'sha256';
+  let hex = hash;
+  if (hash.startsWith('sha256:')) {
+    hex = hash.slice('sha256:'.length);
+  } else if (hash.startsWith('keccak256:')) {
+    algo = 'keccak256';
+    hex = hash.slice('keccak256:'.length);
+  }
   if (!/^[0-9a-f]{64}$/i.test(hex)) return null;
-  return hex.toLowerCase();
+  return { algo, hex: hex.toLowerCase() };
 }

--- a/packages/cli/test/document-processor-e2e.test.ts
+++ b/packages/cli/test/document-processor-e2e.test.ts
@@ -301,12 +301,12 @@ describe('Full extraction pipeline simulation', () => {
     // Build the import-file response as the daemon would
     const importFileResponse = {
       assertionUri: 'did:dkg:context-graph:sales/assertion/0xSales/q4-report',
-      fileHash: 'sha256:abc123',
+      fileHash: 'keccak256:abc123',
       detectedContentType: 'text/html',
       extraction: {
         status: phase2Triples.length > 0 ? 'completed' as const : 'skipped' as const,
         tripleCount: phase2Triples.length,
-        mdIntermediateHash: 'sha256:def456',
+        mdIntermediateHash: 'keccak256:def456',
         pipelineUsed: 'text/html',
       },
     };
@@ -328,7 +328,7 @@ describe('Full extraction pipeline simulation', () => {
     // Node would return extraction.status: "skipped"
     const importFileResponse = {
       assertionUri: 'did:dkg:context-graph:test/assertion/0xAgent/binary-blob',
-      fileHash: 'sha256:xyz789',
+      fileHash: 'keccak256:xyz789',
       detectedContentType: 'application/octet-stream',
       extraction: {
         status: 'skipped' as const,

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -3,6 +3,7 @@ import { extractFromMarkdown } from '../src/extraction/markdown-extractor.js';
 
 const AGENT = 'did:dkg:agent:0xAbC123';
 const FIXED_NOW = new Date('2026-04-10T12:00:00Z');
+const FILE_URI = 'urn:dkg:file:keccak256:1111111111111111111111111111111111111111111111111111111111111111';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const SCHEMA_NAME = 'http://schema.org/name';
@@ -10,8 +11,11 @@ const SCHEMA_DESCRIPTION = 'http://schema.org/description';
 const SCHEMA_MENTIONS = 'http://schema.org/mentions';
 const SCHEMA_KEYWORDS = 'http://schema.org/keywords';
 const DKG_HAS_SECTION = 'http://dkg.io/ontology/hasSection';
+const DKG_SOURCE_FILE = 'http://dkg.io/ontology/sourceFile';
+const DKG_SOURCE_CONTENT_TYPE = 'http://dkg.io/ontology/sourceContentType';
+const DKG_ROOT_ENTITY = 'http://dkg.io/ontology/rootEntity';
+const DKG_DERIVED_FROM = 'http://dkg.io/ontology/derivedFrom';
 const DKG_EXTRACTION_PROVENANCE = 'http://dkg.io/ontology/ExtractionProvenance';
-const PROV_WAS_GENERATED_BY = 'http://www.w3.org/ns/prov#wasGeneratedBy';
 const XSD_BOOLEAN = 'http://www.w3.org/2001/XMLSchema#boolean';
 const XSD_DATE = 'http://www.w3.org/2001/XMLSchema#date';
 const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
@@ -442,40 +446,206 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
   });
 });
 
-describe('extractFromMarkdown — provenance', () => {
-  it('emits a single provenance block when triples are produced', () => {
-    const { triples, provenance } = extractFromMarkdown({
+describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
+  it('emits no source-file linkage quads when no sourceFileIri is supplied', () => {
+    const { triples, sourceFileLinkage, resolvedRootEntity, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\n#tag1\n`,
       agentDid: AGENT,
       now: FIXED_NOW,
     });
     expect(triples.length).toBeGreaterThan(0);
-    expect(provenance.length).toBeGreaterThan(0);
-    expect(provenance).toContainEqual(expect.objectContaining({
-      predicate: RDF_TYPE,
-      object: DKG_EXTRACTION_PROVENANCE,
-    }));
-    // Back-link from subject to provenance
-    expect(provenance.some(q => q.predicate === PROV_WAS_GENERATED_BY)).toBe(true);
+    expect(sourceFileLinkage).toHaveLength(0);
+    // resolvedRootEntity still falls back to the document subject so the
+    // daemon can write row 14 even when no linkage quads are emitted.
+    expect(resolvedRootEntity).toBe(subjectIri);
   });
 
-  it('emits no provenance when no triples are extracted', () => {
-    const { triples, provenance } = extractFromMarkdown({
+  it('does not emit the legacy dkg:ExtractionProvenance block from the extractor', () => {
+    // The extraction-provenance resource (rows 9-13 of the Phase A table)
+    // is owned by the daemon route handler, not the extractor. Verify the
+    // extractor never emits it even when it would otherwise produce triples.
+    const { triples, sourceFileLinkage } = extractFromMarkdown({
+      markdown: `# Doc\n\n#tag1\n`,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      now: FIXED_NOW,
+    });
+    const all = [...triples, ...sourceFileLinkage];
+    expect(all.some(q => q.object === DKG_EXTRACTION_PROVENANCE)).toBe(false);
+    expect(all.some(q => q.predicate === DKG_DERIVED_FROM)).toBe(false);
+  });
+
+  it('does not emit row 2 (dkg:sourceContentType) — daemon owns that row', () => {
+    // The extractor only ever processes markdown, but row 2 must describe
+    // the ORIGINAL upload blob. Only the daemon has the original content
+    // type, so the extractor MUST NOT emit row 2 at all. Regression guard
+    // for the row-2-ownership split ruled by spec-engineer on Codex Bug 1.
+    const { triples, sourceFileLinkage } = extractFromMarkdown({
+      markdown: `# Doc\n\n#tag\n`,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      now: FIXED_NOW,
+    });
+    const all = [...triples, ...sourceFileLinkage];
+    expect(all.some(q => q.predicate === DKG_SOURCE_CONTENT_TYPE)).toBe(false);
+  });
+
+  it('emits rows 1 and 3 linkage quads when sourceFileIri is supplied', () => {
+    const { sourceFileLinkage, subjectIri, resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: research-note\n---\n\n# Research Note\n\nBody.\n`,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      now: FIXED_NOW,
+    });
+    expect(subjectIri).toBe('urn:dkg:md:research-note');
+    // Row 1 — object is the caller-supplied URN. The earlier Round 3
+    // blank-node approach was reverted in Round 4 (Option B filter in
+    // `assertionPromote` prevents cross-assertion contention).
+    expect(sourceFileLinkage).toContainEqual({
+      subject: subjectIri,
+      predicate: DKG_SOURCE_FILE,
+      object: FILE_URI,
+    });
+    // Row 3: reflexive rootEntity on the document subject by default.
+    expect(sourceFileLinkage).toContainEqual({
+      subject: subjectIri,
+      predicate: DKG_ROOT_ENTITY,
+      object: subjectIri,
+    });
+    // Only rows 1 and 3 — no row 2.
+    expect(sourceFileLinkage).toHaveLength(2);
+    expect(resolvedRootEntity).toBe(subjectIri);
+  });
+
+  it('honors an explicit rootEntityIri over the reflexive default', () => {
+    const ROOT = 'urn:dkg:md:research-project';
+    const { sourceFileLinkage, subjectIri, resolvedRootEntity } = extractFromMarkdown({
+      markdown: `# Doc\n`,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      rootEntityIri: ROOT,
+      now: FIXED_NOW,
+    });
+    const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
+    expect(rootQuads).toHaveLength(1);
+    expect(rootQuads[0]!.object).toBe(ROOT);
+    expect(rootQuads[0]!.subject).toBe(subjectIri);
+    // resolvedRootEntity must match the row 3 quad so the daemon's row 14
+    // is consistent with the data-graph row 3.
+    expect(resolvedRootEntity).toBe(ROOT);
+  });
+
+  it('lets a frontmatter `rootEntity` key override both the input and the default', () => {
+    const { sourceFileLinkage, triples, subjectIri, resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: sub-doc\nrootEntity: urn:dkg:md:parent-root\n---\n\n# Sub Doc\n`,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      rootEntityIri: 'urn:dkg:md:ignored-override',
+      now: FIXED_NOW,
+    });
+    expect(subjectIri).toBe('urn:dkg:md:sub-doc');
+    const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
+    expect(rootQuads).toHaveLength(1);
+    expect(rootQuads[0]!.object).toBe('urn:dkg:md:parent-root');
+    expect(resolvedRootEntity).toBe('urn:dkg:md:parent-root');
+    // The rootEntity frontmatter key must NOT leak through as a content triple
+    // on the schema.org namespace (it's consumed by the linkage builder).
+    expect(triples.some(t => t.predicate === 'http://schema.org/rootEntity')).toBe(false);
+  });
+
+  it('slugifies a non-IRI frontmatter `rootEntity` value', () => {
+    const { sourceFileLinkage, resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: My Parent\n---\n`,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      now: FIXED_NOW,
+    });
+    const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
+    expect(rootQuads).toHaveLength(1);
+    expect(rootQuads[0]!.object).toBe('urn:dkg:md:my-parent');
+    expect(resolvedRootEntity).toBe('urn:dkg:md:my-parent');
+  });
+
+  it('frontmatter rootEntity resolves even without a sourceFileIri', () => {
+    // §19.10.1:508 promises the override works regardless — without a
+    // sourceFileIri there are no quads to emit, but the daemon may still
+    // need the resolved value for downstream writes.
+    const { sourceFileLinkage, resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: urn:dkg:md:parent\n---\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(sourceFileLinkage).toHaveLength(0);
+    expect(resolvedRootEntity).toBe('urn:dkg:md:parent');
+  });
+
+  it('emits linkage even when the extractor produces zero content triples', () => {
+    const { triples, sourceFileLinkage } = extractFromMarkdown({
       markdown: ``,
       agentDid: AGENT,
+      sourceFileIri: FILE_URI,
       now: FIXED_NOW,
     });
     expect(triples).toHaveLength(0);
-    expect(provenance).toHaveLength(0);
+    expect(sourceFileLinkage.some(q => q.predicate === DKG_SOURCE_FILE)).toBe(true);
   });
 
-  it('records the extracting agent DID in provenance', () => {
-    const { provenance } = extractFromMarkdown({
-      markdown: `# Doc\n\n#tag\n`,
+  it('Bug 13: frontmatter `rootEntity` with a valid IRI is accepted', () => {
+    const { resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: urn:note:climate-report\n---\n`,
       agentDid: AGENT,
       now: FIXED_NOW,
     });
-    expect(provenance.some(q => q.object === AGENT)).toBe(true);
+    expect(resolvedRootEntity).toBe('urn:note:climate-report');
+  });
+
+  it('Bug 13: frontmatter `rootEntity` with an http://-prefixed IRI is accepted', () => {
+    const { resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: https://example.org/entities/42\n---\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(resolvedRootEntity).toBe('https://example.org/entities/42');
+  });
+
+  it('Bug 13: frontmatter `rootEntity` with an embedded space is REJECTED (not silently passed through)', () => {
+    // Pre-fix: `urn:x y` would pass the prefix check and flow into the
+    // graph, blowing up at the RDF layer with a cryptic error. Post-fix:
+    // `isSafeIri` catches it and the extractor throws with a clear
+    // message that the daemon surfaces as a 400.
+    expect(() => extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: 'urn:x y'\n---\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
+  });
+
+  it('Bug 13: frontmatter `rootEntity` with an angle bracket is REJECTED', () => {
+    expect(() => extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: 'http://x>y'\n---\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
+  });
+
+  it('Bug 13: frontmatter `rootEntity` with a double-quote is REJECTED', () => {
+    expect(() => extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: 'urn:x"y'\n---\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
+  });
+
+  it('Bug 13: non-IRI `rootEntity` values still fall through to slugification (unchanged)', () => {
+    // Values without an http:/https:/did:/urn:/_: prefix take the
+    // slugify path, which is safe by construction (strips everything
+    // that isn't a-z0-9-).
+    const { resolvedRootEntity } = extractFromMarkdown({
+      markdown: `---\nid: child\nrootEntity: My Parent Document\n---\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(resolvedRootEntity).toBe('urn:dkg:md:my-parent-document');
   });
 });
 
@@ -508,9 +678,10 @@ Some background.
 
 Our method relies on [[SPARQL]] queries.
 `;
-    const { triples, provenance, subjectIri } = extractFromMarkdown({
+    const { triples, sourceFileLinkage, subjectIri } = extractFromMarkdown({
       markdown,
       agentDid: AGENT,
+      sourceFileIri: FILE_URI,
       now: FIXED_NOW,
     });
 
@@ -555,8 +726,22 @@ Our method relies on [[SPARQL]] queries.
       `${subjectIri}#section-2-methods`,
     ]);
 
-    // Provenance present
-    expect(provenance.length).toBeGreaterThan(0);
-    expect(provenance.some(q => q.object === AGENT)).toBe(true);
+    // §10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
+    // Row 1's object is the caller-supplied content-addressed URN
+    // (Round 4 Option B after the blank-node approach was reverted).
+    // Row 2 (sourceContentType) is intentionally absent — the daemon
+    // owns that row because only it has the original upload content
+    // type.
+    expect(sourceFileLinkage).toContainEqual({
+      subject: subjectIri,
+      predicate: DKG_SOURCE_FILE,
+      object: FILE_URI,
+    });
+    expect(sourceFileLinkage).toContainEqual({
+      subject: subjectIri,
+      predicate: DKG_ROOT_ENTITY,
+      object: subjectIri,
+    });
+    expect(sourceFileLinkage.some(q => q.predicate === DKG_SOURCE_CONTENT_TYPE)).toBe(false);
   });
 });

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -89,9 +89,13 @@ describe('MarkItDownConverter', () => {
 
       expect(typeof result.mdIntermediate).toBe('string');
       expect(result.mdIntermediate.length).toBeGreaterThan(0);
-      // Phase 1 only — converter returns ConverterOutput, no triples/provenance.
+      // Phase 1 only — converter returns ConverterOutput, no triples
+      // or source-file linkage (those are Phase 2 extractor output).
+      // Round 13 Bug 39 renamed the linkage field from `provenance`
+      // to `sourceFileLinkage` on `MarkdownExtractOutput`; this
+      // converter's output has neither.
       expect((result as { triples?: unknown }).triples).toBeUndefined();
-      expect((result as { provenance?: unknown }).provenance).toBeUndefined();
+      expect((result as { sourceFileLinkage?: unknown }).sourceFileLinkage).toBeUndefined();
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/packages/cli/test/extraction-status.test.ts
+++ b/packages/cli/test/extraction-status.test.ts
@@ -9,9 +9,10 @@ const BASE_MS = Date.UTC(2026, 3, 10, 12, 0, 0);
 
 function makeRecord(status: ExtractionStatusRecord['status'], index: number): ExtractionStatusRecord {
   const startedAt = new Date(BASE_MS + (index * 1000)).toISOString();
+  const hex = index.toString(16).padStart(64, '0');
   return {
     status,
-    fileHash: `sha256:${index.toString(16).padStart(64, '0')}`,
+    fileHash: `keccak256:${hex}`,
     detectedContentType: 'text/markdown',
     pipelineUsed: status === 'skipped' ? null : 'text/markdown',
     tripleCount: 0,

--- a/packages/cli/test/file-store.test.ts
+++ b/packages/cli/test/file-store.test.ts
@@ -138,18 +138,86 @@ describe('FileStore.has', () => {
 });
 
 describe('FileStore.hashToPath', () => {
-  it('resolves a hash to an absolute sharded path without touching disk', () => {
+  it('resolves a sha256 hash to the absolute sharded blob path', async () => {
     const store = new FileStore(rootDir);
     const hex = '1234567890abcdef'.repeat(4);
     expect(hex.length).toBe(64);
 
-    const path = store.hashToPath(`sha256:${hex}`);
+    const path = await store.hashToPath(`sha256:${hex}`);
     expect(path).toBe(join(rootDir, hex.slice(0, 2), hex.slice(2)));
+  });
+
+  it('returns null for malformed hashes', async () => {
+    const store = new FileStore(rootDir);
+    expect(await store.hashToPath('not-a-hash')).toBeNull();
+    expect(await store.hashToPath('sha256:short')).toBeNull();
+  });
+
+  it('Bug 9: resolves a keccak256 hash to the CONTENT path (not the pointer file)', async () => {
+    // Regression guard: before the Bug 9 fix, hashToPath returned the
+    // pointer file for keccak256 inputs. A caller using it to read the
+    // file bytes would get the sha256 hex text from the pointer file
+    // instead of the actual content. The fix makes hashToPath always
+    // return the underlying blob path, dereferencing the pointer as
+    // needed.
+    const store = new FileStore(rootDir);
+    const bytes = Buffer.from('keccak round-trip payload', 'utf-8');
+    const entry = await store.put(bytes, 'text/plain');
+
+    // hashToPath with the keccak256 form returns the content path ...
+    const pathViaKeccak = await store.hashToPath(entry.keccak256);
+    expect(pathViaKeccak).not.toBeNull();
+    // ... which is byte-equal to the sha256-form path and points at
+    // the actual blob, not the pointer indirection file.
+    const pathViaSha = await store.hashToPath(entry.hash);
+    expect(pathViaKeccak).toBe(pathViaSha);
+    const onDisk = await readFile(pathViaKeccak!);
+    expect(onDisk.equals(bytes)).toBe(true);
+  });
+
+  it('Bug 9: hashToPath returns null for keccak256 hashes whose pointer file is missing', async () => {
+    const store = new FileStore(rootDir);
+    // A well-formed but never-stored keccak256 hash has no pointer
+    // file on disk, so the method must return null rather than a
+    // would-be-invalid content path.
+    const bogusKeccak = 'keccak256:' + '0'.repeat(64);
+    expect(await store.hashToPath(bogusKeccak)).toBeNull();
+  });
+});
+
+describe('FileStore.hashToPointerPath', () => {
+  it('returns the synchronous pointer-file path for a valid keccak256 hash', () => {
+    const store = new FileStore(rootDir);
+    const hex = 'abcdef0123456789'.repeat(4);
+    expect(hex.length).toBe(64);
+
+    const path = store.hashToPointerPath(`keccak256:${hex}`);
+    expect(path).toBe(join(rootDir, 'keccak256', hex.slice(0, 2), hex.slice(2)));
+  });
+
+  it('returns null for sha256 inputs (use hashToPath for content resolution)', () => {
+    const store = new FileStore(rootDir);
+    const hex = '1234567890abcdef'.repeat(4);
+    expect(store.hashToPointerPath(`sha256:${hex}`)).toBeNull();
   });
 
   it('returns null for malformed hashes', () => {
     const store = new FileStore(rootDir);
-    expect(store.hashToPath('not-a-hash')).toBeNull();
-    expect(store.hashToPath('sha256:short')).toBeNull();
+    expect(store.hashToPointerPath('not-a-hash')).toBeNull();
+    expect(store.hashToPointerPath('keccak256:short')).toBeNull();
+  });
+
+  it('the pointer file returned actually contains the sha256 hex after a put()', async () => {
+    // Tightens the contract: the pointer file isn't just a location
+    // on disk — it's a file whose contents are the sha256 hex that
+    // `hashToPath` uses to resolve the blob.
+    const store = new FileStore(rootDir);
+    const bytes = Buffer.from('pointer contents check', 'utf-8');
+    const entry = await store.put(bytes, 'text/plain');
+
+    const pointerPath = store.hashToPointerPath(entry.keccak256);
+    expect(pointerPath).not.toBeNull();
+    const pointerContents = (await readFile(pointerPath!, 'utf-8')).trim();
+    expect(pointerContents).toBe(entry.hash.slice('sha256:'.length));
   });
 });

--- a/packages/cli/test/import-file-integration.test.ts
+++ b/packages/cli/test/import-file-integration.test.ts
@@ -29,12 +29,14 @@ import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import {
   ExtractionPipelineRegistry,
   type ExtractionPipeline,
   type ExtractionInput,
   type ConverterOutput,
   contextGraphAssertionUri,
+  contextGraphMetaUri,
 } from '@origintrail-official/dkg-core';
 import { FileStore } from '../src/file-store.js';
 import type { ExtractionStatusRecord } from '../src/extraction-status.js';
@@ -43,11 +45,11 @@ import { extractFromMarkdown } from '../src/extraction/markdown-extractor.js';
 
 // ── Test fixture types (mirroring the ExtractionStatusRecord in daemon.ts) ──
 
-interface CapturedAssertionWrite {
-  contextGraphId: string;
-  name: string;
-  triples: Array<{ subject: string; predicate: string; object: string }>;
-  subGraphName?: string;
+interface CapturedQuad {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph: string;
 }
 
 interface MockAgent {
@@ -59,30 +61,122 @@ interface MockAgent {
       name: string,
       opts?: { subGraphName?: string },
     ) => Promise<string>;
-    write: (
+    /**
+     * Discards an assertion: deletes any `_meta` rows keyed by the
+     * assertion UAL first (Bug 12), then drops the assertion data graph.
+     * Mirrors the real publisher.assertionDiscard after the Bug 12 fix
+     * (_meta first, drop second). Bug 12 regression tests exercise
+     * partial-failure modes: a `deleteByPattern` failure leaves data
+     * intact; a `dropGraph` failure after `_meta` succeeds leaves data
+     * orphaned but not misleading.
+     */
+    discard: (
       contextGraphId: string,
       name: string,
-      triples: Array<{ subject: string; predicate: string; object: string }>,
       opts?: { subGraphName?: string },
     ) => Promise<void>;
   };
-  capturedWrites: CapturedAssertionWrite[];
+  store: {
+    insert: (quads: CapturedQuad[]) => Promise<void>;
+    /**
+     * Removes every quad from `insertedQuads` that matches the given
+     * partial pattern (subject / predicate / object / graph, any subset).
+     * Mirrors the real `TripleStore.deleteByPattern` contract so the
+     * mock can exercise the stale-`_meta` cleanup introduced in Bug 5a.
+     */
+    deleteByPattern: (pattern: Partial<CapturedQuad>) => Promise<number>;
+    /**
+     * Drops every quad in `insertedQuads` whose `graph` matches the URI,
+     * matching the real `TripleStore.dropGraph` contract. Used by the
+     * assertion.discard mock to purge the data graph in one call.
+     */
+    dropGraph: (graphUri: string) => Promise<void>;
+    /**
+     * Minimal SPARQL query mock that supports exactly one shape: the
+     * `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <g> { ?s ?p ?o } }` pattern
+     * used by `daemon.ts` to snapshot the assertion graph for Bug 11
+     * rollback. Parses the target graph URI out of the query string,
+     * filters `insertedQuads`, and returns them in the adapter's
+     * `ConstructResult` shape.
+     */
+    query: (sparql: string) => Promise<{ type: 'quads'; quads: CapturedQuad[] } | { type: 'bindings'; bindings: Array<Record<string, string>> } | { type: 'boolean'; value: boolean }>;
+  };
+  /**
+   * Every quad the route handler has inserted through agent.store. The
+   * daemon makes a single atomic `store.insert` call per import that
+   * contains both the data-graph quads (pinned to the assertion graph
+   * URI) and the `_meta` quads (pinned to the CG root `_meta` URI), so
+   * tests filter this array by `graph` to assert on each side.
+   */
+  insertedQuads: CapturedQuad[];
   createdAssertions: Array<{ contextGraphId: string; name: string; subGraphName?: string }>;
+  /**
+   * Graph URIs that have been dropped via `store.dropGraph`. Used by
+   * discard regression tests to verify the data graph was actually
+   * dropped (not just the `_meta` rows cleaned up).
+   */
+  droppedGraphs: string[];
+  /**
+   * Monotonically-incrementing counter of `store.insert` calls. Used
+   * by Bug 22 regression tests to prove the rollback path did NOT
+   * fire on a deleteByPattern-only failure (insert count unchanged
+   * between before and after the failed import).
+   */
+  readonly insertCallCount: number;
 }
 
 interface MockAgentOptions {
   createError?: Error;
-  writeError?: Error;
+  /**
+   * When set, every `agent.store.insert` call throws this error. Used by
+   * regression tests that simulate a triple-store outage during the
+   * atomic multi-graph insert. Bug 11 regression test then verifies
+   * that the daemon's rollback path restores the prior-import snapshot.
+   */
+  insertError?: Error;
+  /**
+   * Predicate that gates `agent.store.insert` — insert throws when the
+   * predicate returns true for the given quads batch. Used by Bug 11's
+   * "first insert fails, second (rollback) insert succeeds" regression
+   * test, which needs to fail the FIRST call (the fresh data) but let
+   * the SECOND call (the snapshot restore) through.
+   */
+  insertErrorPredicate?: (quads: CapturedQuad[], callNumber: number) => Error | null;
+  /**
+   * When set, `agent.store.deleteByPattern` throws this error.
+   * Bug 12 regression test uses this to simulate a `_meta` cleanup
+   * failure during discard.
+   */
+  deleteByPatternError?: Error;
+  /**
+   * When set, `agent.store.dropGraph` throws this error. Bug 12
+   * regression test uses this to simulate a data-graph drop failure
+   * during discard.
+   */
+  dropGraphError?: Error;
+  /**
+   * Round 13 Bug 38: predicate that gates `agent.store.query` — when
+   * it returns an Error, the query throws. Used by the stage-context
+   * preservation tests to simulate a snapshot query failure (the
+   * data-graph CONSTRUCT or the scoped `_meta` CONSTRUCT) and verify
+   * that the import-file outer catch does NOT overwrite the stage-
+   * specific failure message with the raw store error.
+   */
+  queryErrorPredicate?: (sparql: string) => Error | null;
   registeredSubGraphs?: string[];
 }
 
 function makeMockAgent(peerId = '0xMockAgentPeerId', options: MockAgentOptions = {}): MockAgent {
-  const capturedWrites: CapturedAssertionWrite[] = [];
   const createdAssertions: Array<{ contextGraphId: string; name: string; subGraphName?: string }> = [];
-  return {
+  const insertedQuads: CapturedQuad[] = [];
+  const droppedGraphs: string[] = [];
+  let insertCallCount = 0;
+  const agent: MockAgent = {
     peerId,
-    capturedWrites,
     createdAssertions,
+    insertedQuads,
+    droppedGraphs,
+    get insertCallCount() { return insertCallCount; },
     async listSubGraphs(): Promise<Array<{ name: string }>> {
       return (options.registeredSubGraphs ?? []).map(name => ({ name }));
     },
@@ -92,17 +186,117 @@ function makeMockAgent(peerId = '0xMockAgentPeerId', options: MockAgentOptions =
         createdAssertions.push({ contextGraphId, name, subGraphName: opts?.subGraphName });
         return contextGraphAssertionUri(contextGraphId, peerId, name, opts?.subGraphName);
       },
-      async write(
-        contextGraphId: string,
-        name: string,
-        triples: Array<{ subject: string; predicate: string; object: string }>,
-        opts?: { subGraphName?: string },
-      ): Promise<void> {
-        if (options.writeError) throw options.writeError;
-        capturedWrites.push({ contextGraphId, name, triples, subGraphName: opts?.subGraphName });
+      async discard(contextGraphId: string, name: string, opts?: { subGraphName?: string }): Promise<void> {
+        // Mirror the post-Bug-12 publisher.assertionDiscard ordering:
+        // `_meta` cleanup first, then drop the data graph. A
+        // `deleteByPattern` failure leaves the data intact (retry-safe);
+        // a `dropGraph` failure after `_meta` succeeded leaves an
+        // orphaned data graph with no `_meta` trail (debuggable but
+        // not actively misleading).
+        const graphUri = contextGraphAssertionUri(contextGraphId, peerId, name, opts?.subGraphName);
+        const metaGraph = contextGraphMetaUri(contextGraphId);
+        await agent.store.deleteByPattern({ subject: graphUri, graph: metaGraph });
+        await agent.store.dropGraph(graphUri);
+      },
+    },
+    store: {
+      async insert(quads: CapturedQuad[]): Promise<void> {
+        insertCallCount++;
+        if (options.insertError) throw options.insertError;
+        if (options.insertErrorPredicate) {
+          const err = options.insertErrorPredicate(quads, insertCallCount);
+          if (err) throw err;
+        }
+        insertedQuads.push(...quads);
+      },
+      async deleteByPattern(pattern: Partial<CapturedQuad>): Promise<number> {
+        if (options.deleteByPatternError) throw options.deleteByPatternError;
+        const matches = (q: CapturedQuad) =>
+          (pattern.subject === undefined || q.subject === pattern.subject)
+          && (pattern.predicate === undefined || q.predicate === pattern.predicate)
+          && (pattern.object === undefined || q.object === pattern.object)
+          && (pattern.graph === undefined || q.graph === pattern.graph);
+        let removed = 0;
+        for (let i = insertedQuads.length - 1; i >= 0; i--) {
+          if (matches(insertedQuads[i]!)) {
+            insertedQuads.splice(i, 1);
+            removed++;
+          }
+        }
+        return removed;
+      },
+      async dropGraph(graphUri: string): Promise<void> {
+        if (options.dropGraphError) throw options.dropGraphError;
+        droppedGraphs.push(graphUri);
+        for (let i = insertedQuads.length - 1; i >= 0; i--) {
+          if (insertedQuads[i]!.graph === graphUri) {
+            insertedQuads.splice(i, 1);
+          }
+        }
+      },
+      async query(sparql: string): Promise<{ type: 'quads'; quads: CapturedQuad[] } | { type: 'bindings'; bindings: Array<Record<string, string>> } | { type: 'boolean'; value: boolean }> {
+        // Round 13 Bug 38: failure injection for stage-context tests.
+        if (options.queryErrorPredicate) {
+          const err = options.queryErrorPredicate(sparql);
+          if (err) throw err;
+        }
+        // Minimal SPARQL parser supporting the two CONSTRUCT shapes
+        // `daemon.ts` uses for Bugs 11 + 15 snapshots:
+        //
+        //   (a) full data graph:
+        //       `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <g> { ?s ?p ?o } }`
+        //   (b) scoped `_meta` rows:
+        //       `CONSTRUCT { <subj> ?p ?o } WHERE { GRAPH <g> { <subj> ?p ?o } }`
+        //
+        // The scoped form is detected by the presence of a
+        // `<subject-iri>` token in the WHERE clause's triple pattern
+        // instead of the `?s` variable. When detected, results are
+        // filtered on both `graph` and `subject`.
+        if (!/^\s*CONSTRUCT/i.test(sparql)) {
+          return { type: 'bindings', bindings: [] };
+        }
+        const graphMatch = /GRAPH\s+<([^>]+)>/.exec(sparql);
+        if (!graphMatch) {
+          return { type: 'bindings', bindings: [] };
+        }
+        const targetGraph = graphMatch[1]!;
+        // Look for a bound-subject pattern of the form
+        // `GRAPH <g> { <subj> ?p ?o }`. If we find it, filter by subject.
+        const scopedMatch = /GRAPH\s+<[^>]+>\s*\{\s*<([^>]+)>\s+\?p\s+\?o\s*\}/.exec(sparql);
+        const quads = insertedQuads
+          .filter(q => {
+            if (q.graph !== targetGraph) return false;
+            if (scopedMatch && q.subject !== scopedMatch[1]) return false;
+            return true;
+          })
+          // Strip the graph URI to mimic the adapter contract where
+          // CONSTRUCT results come back with graph="" (see oxigraph/
+          // blazegraph CONSTRUCT handling). The daemon re-stamps
+          // the target graph on the rollback path.
+          .map(q => ({ ...q, graph: '' }));
+        return { type: 'quads', quads };
       },
     },
   };
+  return agent;
+}
+
+/**
+ * Return just the data-graph quads from a mock agent's captured inserts,
+ * i.e. quads whose `graph` matches the assertion graph URI for the given
+ * import. Tests that used to read `agent.capturedWrites[0].triples` now
+ * use this helper to pull the same triples by graph-URI filter.
+ */
+function getDataGraphQuads(
+  agent: MockAgent,
+  contextGraphId: string,
+  assertionName: string,
+  subGraphName?: string,
+): Array<{ subject: string; predicate: string; object: string }> {
+  const assertionGraph = contextGraphAssertionUri(contextGraphId, agent.peerId, assertionName, subGraphName);
+  return agent.insertedQuads
+    .filter(q => q.graph === assertionGraph)
+    .map(({ subject, predicate, object }) => ({ subject, predicate, object }));
 }
 
 // ── The orchestration under test (matches daemon.ts import-file handler) ──
@@ -165,8 +359,13 @@ async function runImportFileOrchestration(params: {
   boundary: string;
   assertionName: string;
   onInProgress?: (assertionUri: string, record: ExtractionStatusRecord) => void | Promise<void>;
+  // Bug 19: per-assertion mutex map. If omitted, a fresh map is used
+  // (safe for sequential tests). Concurrent-import tests that need to
+  // observe the lock must pass a shared map across their parallel calls.
+  assertionImportLocks?: Map<string, Promise<void>>;
 }): Promise<ImportFileResult> {
   const { agent, fileStore, extractionRegistry, extractionStatus, multipartBody, boundary, assertionName, onInProgress } = params;
+  const assertionImportLocks = params.assertionImportLocks ?? new Map<string, Promise<void>>();
 
   const fields = parseMultipart(multipartBody, boundary);
   const filePart = fields.find(f => f.name === 'file' && f.filename !== undefined)!;
@@ -195,13 +394,28 @@ async function runImportFileOrchestration(params: {
   const assertionUri = contextGraphAssertionUri(contextGraphId, agent.peerId, assertionName, subGraphName);
   const startedAt = new Date().toISOString();
 
+  // Round 14 Bug 42: per-assertion mutex BEFORE extraction — mirrors
+  // the daemon's restructure. Concurrent imports of the same assertion
+  // name used to race during Phase 1/2 extraction and commit in
+  // extraction-finish order rather than request-arrival order.
+  // Moving the lock here serializes the entire handler per URI so
+  // commits land in the order their callers arrived. Released in the
+  // outer `finally` at the bottom of this function.
+  const previousLock = assertionImportLocks.get(assertionUri) ?? Promise.resolve();
+  let releaseLock: () => void = () => {};
+  const currentLock = new Promise<void>(resolve => { releaseLock = resolve; });
+  const chainedLock = previousLock.then(() => currentLock);
+  assertionImportLocks.set(assertionUri, chainedLock);
+  await previousLock;
+
+  try {
   let mdIntermediate: string | null = null;
   let pipelineUsed: string | null = null;
   let mdIntermediateHash: string | undefined;
   const recordInProgress = async (): Promise<void> => {
     const record: ExtractionStatusRecord = {
       status: 'in_progress',
-      fileHash: fileStoreEntry.hash,
+      fileHash: fileStoreEntry.keccak256,
       detectedContentType,
       pipelineUsed,
       tripleCount: 0,
@@ -216,7 +430,7 @@ async function runImportFileOrchestration(params: {
   const recordFailed = (error: string, tripleCount: number, failedPipelineUsed: string | null = pipelineUsed): void => {
     extractionStatus.set(assertionUri, {
       status: 'failed',
-      fileHash: fileStoreEntry.hash,
+      fileHash: fileStoreEntry.keccak256,
       detectedContentType,
       pipelineUsed: failedPipelineUsed,
       tripleCount,
@@ -230,7 +444,7 @@ async function runImportFileOrchestration(params: {
     recordFailed(error, tripleCount, failedPipelineUsed);
     throw new ImportFileRouteError(statusCode, buildImportFileResponse({
       assertionUri,
-      fileHash: fileStoreEntry.hash,
+      fileHash: fileStoreEntry.keccak256,
       detectedContentType,
       extraction: {
         status: 'failed',
@@ -260,7 +474,7 @@ async function runImportFileOrchestration(params: {
       mdIntermediate = md;
       pipelineUsed = detectedContentType;
       const mdEntry = await fileStore.put(Buffer.from(md, 'utf-8'), 'text/markdown');
-      mdIntermediateHash = mdEntry.hash;
+      mdIntermediateHash = mdEntry.keccak256;
       await recordInProgress();
     }
   }
@@ -269,7 +483,7 @@ async function runImportFileOrchestration(params: {
   if (mdIntermediate === null) {
     const skippedRecord: ExtractionStatusRecord = {
       status: 'skipped',
-      fileHash: fileStoreEntry.hash,
+      fileHash: fileStoreEntry.keccak256,
       detectedContentType,
       pipelineUsed: null,
       tripleCount: 0,
@@ -279,29 +493,120 @@ async function runImportFileOrchestration(params: {
     extractionStatus.set(assertionUri, skippedRecord);
     return buildImportFileResponse({
       assertionUri,
-      fileHash: fileStoreEntry.hash,
+      fileHash: fileStoreEntry.keccak256,
       detectedContentType,
       extraction: { status: 'skipped', tripleCount: 0, pipelineUsed: null },
     });
   }
 
-  // Phase 2
+  // Phase 2 — file descriptor block (rows 4-13) lives on URI subjects
+  // (Round 4 Option B after the blank-node approach was reverted). The
+  // URNs `urn:dkg:file:keccak256:<hex>` and `urn:dkg:extraction:<uuid>`
+  // are filtered out of `assertionPromote`'s partition by a subject-
+  // prefix filter in the real publisher, so cross-assertion contention
+  // on the file URN is impossible on promote.
+  const fileUri = `urn:dkg:file:${fileStoreEntry.keccak256}`;
+  const provUri = `urn:dkg:extraction:${randomUUID()}`;
+  const agentDid = `did:dkg:agent:${agent.peerId}`;
   let triples: ReturnType<typeof extractFromMarkdown>['triples'];
-  let provenance: ReturnType<typeof extractFromMarkdown>['provenance'];
+  let sourceFileLinkage: ReturnType<typeof extractFromMarkdown>['sourceFileLinkage'];
+  let resolvedRootEntity: string;
   try {
     const result = extractFromMarkdown({
       markdown: mdIntermediate,
-      agentDid: `did:dkg:agent:${agent.peerId}`,
+      agentDid,
       ontologyRef,
       documentIri: assertionUri,
+      sourceFileIri: fileUri,
     });
     triples = result.triples;
-    provenance = result.provenance;
+    // Round 13 Bug 39: rename mirror — see daemon for rationale.
+    sourceFileLinkage = result.sourceFileLinkage;
+    resolvedRootEntity = result.resolvedRootEntity;
   } catch (err: any) {
-    fail(500, `Phase 2 extraction failed: ${err.message}`, 0);
+    const message = err?.message ?? String(err);
+    // Bug 13 + Round 7 Bug 20: invalid frontmatter IRIs AND invalid
+    // programmatic `rootEntityIri` / `sourceFileIri` inputs both
+    // throw from the extractor. Surface as a 400 rather than a 500.
+    if (
+      message.includes('Invalid frontmatter')
+      || message.includes("Invalid 'rootEntityIri'")
+      || message.includes("Invalid 'sourceFileIri'")
+    ) {
+      fail(400, message, 0);
+    }
+    fail(500, `Phase 2 extraction failed: ${message}`, 0);
   }
 
-  const allTriples = [...triples, ...provenance];
+  // Build the full quad set across both graphs (assertion data graph +
+  // CG root `_meta`) and commit them in a single atomic `store.insert`
+  // call. See the daemon comment for the full rationale — short version:
+  // every storage adapter's `insert` is a single N-Quads load / INSERT
+  // DATA operation, so all-or-nothing applies across graphs.
+  const assertionGraph = contextGraphAssertionUri(contextGraphId, agent.peerId, assertionName, subGraphName);
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  const startedAtLiteral = `"${startedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`;
+
+  // Data-graph quads: content + extractor linkage + daemon-owned rows
+  // 2, 4, 5, 8, 9-13. Round 9 Bug 27 removed rows 6 (`dkg:fileName`)
+  // and 7 (`dkg:contentType`) from the file descriptor block — those
+  // per-upload facts now live on the assertion UAL in `_meta`, not on
+  // the content-addressed `<fileUri>` subject. See daemon equivalent.
+  const dataGraphQuads: CapturedQuad[] = [
+    ...triples.map(t => ({ ...t, graph: assertionGraph })),
+    ...sourceFileLinkage.map(t => ({ ...t, graph: assertionGraph })),
+    // Row 2 — daemon-owned. Always the ORIGINAL upload content type, so
+    // for PDF this is "application/pdf", not the markdown intermediate.
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: assertionGraph },
+    // Rows 4, 5, 8 file descriptor — intrinsic-to-content properties only
+    { subject: fileUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/File', graph: assertionGraph },
+    { subject: fileUri, predicate: 'http://dkg.io/ontology/contentHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: assertionGraph },
+    { subject: fileUri, predicate: 'http://dkg.io/ontology/size', object: `"${fileStoreEntry.size}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: assertionGraph },
+    // Rows 9-13 extraction provenance — URI subject (filtered out of promote)
+    { subject: provUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/ExtractionProvenance', graph: assertionGraph },
+    { subject: provUri, predicate: 'http://dkg.io/ontology/extractedFrom', object: fileUri, graph: assertionGraph },
+    { subject: provUri, predicate: 'http://dkg.io/ontology/extractedBy', object: agentDid, graph: assertionGraph },
+    { subject: provUri, predicate: 'http://dkg.io/ontology/extractedAt', object: startedAtLiteral, graph: assertionGraph },
+    { subject: provUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: assertionGraph },
+  ];
+
+  // `_meta` quads (rows 14-20 + Round 9 Bug 27 `dkg:sourceFileName`) —
+  // CG root `_meta` graph, never sub-graph.
+  const metaQuads: CapturedQuad[] = [
+    // Row 14 — uses the extractor's resolved root entity so row 3 and row 14 agree.
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/rootEntity', object: resolvedRootEntity, graph: metaGraph },
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: metaGraph },
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceFileHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: metaGraph },
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: metaGraph },
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/structuralTripleCount', object: `"${triples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+    { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"0"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+  ];
+  if (mdIntermediateHash) {
+    metaQuads.push({
+      subject: assertionUri,
+      predicate: 'http://dkg.io/ontology/mdIntermediateHash',
+      object: JSON.stringify(mdIntermediateHash),
+      graph: metaGraph,
+    });
+  }
+  // Round 9 Bug 27: `dkg:sourceFileName` on the assertion UAL —
+  // per-upload metadata parallel to existing `dkg:sourceContentType`
+  // (row 15). Skipped when no filename was provided.
+  const uploadedFilename = filePart.filename?.trim() ?? '';
+  if (uploadedFilename.length > 0) {
+    metaQuads.push({
+      subject: assertionUri,
+      predicate: 'http://dkg.io/ontology/sourceFileName',
+      object: JSON.stringify(uploadedFilename),
+      graph: metaGraph,
+    });
+  }
+
+  // Round 14 Bug 42: lock acquisition moved to the top of the
+  // function, before any Phase 1/2 extraction. This inner `try`
+  // now wraps only the assertion.create + snapshot + cleanup +
+  // insert + rollback sequence. See the daemon equivalent and the
+  // lock-acquisition site above for full rationale.
   try {
     try {
       await agent.assertion.create(contextGraphId, assertionName, subGraphName ? { subGraphName } : undefined);
@@ -314,28 +619,115 @@ async function runImportFileOrchestration(params: {
         fail(500, message, triples.length);
       }
     }
-    if (allTriples.length > 0) {
-      await agent.assertion.write(
-        contextGraphId,
-        assertionName,
-        allTriples.map(t => ({ subject: t.subject, predicate: t.predicate, object: t.object })),
-        subGraphName ? { subGraphName } : undefined,
+
+    // Snapshot BOTH graphs for Bugs 11 + 15 rollback. The data-graph
+    // snapshot captures every quad in the assertion graph; the `_meta`
+    // snapshot is scoped to `<assertionUri> ?p ?o` within the CG root
+    // `_meta` graph — we only rollback rows keyed by THIS assertion.
+    let dataSnapshot: CapturedQuad[] = [];
+    let metaSnapshot: CapturedQuad[] = [];
+    try {
+      const dataResult = await agent.store.query(
+        `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${assertionGraph}> { ?s ?p ?o } }`,
       );
+      if (dataResult.type === 'quads') {
+        dataSnapshot = dataResult.quads.map(q => ({ ...q, graph: assertionGraph }));
+      }
+    } catch (err: any) {
+      // Round 13 Bug 38: mark the error so the outer catch preserves
+      // the stage-specific failure message instead of overwriting it
+      // with the raw store error. Mirrors the daemon equivalent.
+      recordFailed(`Failed to snapshot assertion data graph for rollback: ${err?.message ?? String(err)}`, 0);
+      (err as any).__failureAlreadyRecorded = true;
+      throw err;
+    }
+    try {
+      const metaResult = await agent.store.query(
+        `CONSTRUCT { <${assertionUri}> ?p ?o } WHERE { GRAPH <${metaGraph}> { <${assertionUri}> ?p ?o } }`,
+      );
+      if (metaResult.type === 'quads') {
+        metaSnapshot = metaResult.quads.map(q => ({ ...q, graph: metaGraph }));
+      }
+    } catch (err: any) {
+      // Round 13 Bug 38: same stage-context preservation as the
+      // dataSnapshot branch above.
+      recordFailed(`Failed to snapshot _meta for rollback: ${err?.message ?? String(err)}`, 0);
+      (err as any).__failureAlreadyRecorded = true;
+      throw err;
+    }
+
+    // Round 7 Bug 22: unified write-stage rollback. Track which
+    // cleanup steps succeeded so the catch block can restore the
+    // exact snapshots corresponding to state we actually corrupted:
+    //
+    //  - deleteByPattern fails → no rollback (state unchanged)
+    //  - deleteByPattern succeeds, dropGraph fails → restore meta
+    //  - dropGraph succeeds, insert fails → restore both
+    //  - insert succeeds → no rollback
+    let metaCleanupSucceeded = false;
+    let dataDropSucceeded = false;
+    try {
+      await agent.store.deleteByPattern({ subject: assertionUri, graph: metaGraph });
+      metaCleanupSucceeded = true;
+      await agent.store.dropGraph(assertionGraph);
+      dataDropSucceeded = true;
+      await agent.store.insert([...dataGraphQuads, ...metaQuads]);
+    } catch (writeErr: any) {
+      const rollbackErrors: string[] = [];
+      if (dataDropSucceeded && dataSnapshot.length > 0) {
+        try {
+          await agent.store.insert(dataSnapshot);
+        } catch (dataRollbackErr: any) {
+          rollbackErrors.push(`data rollback failed: ${dataRollbackErr?.message ?? dataRollbackErr}`);
+        }
+      }
+      if (metaCleanupSucceeded && metaSnapshot.length > 0) {
+        try {
+          await agent.store.insert(metaSnapshot);
+        } catch (metaRollbackErr: any) {
+          rollbackErrors.push(`_meta rollback failed: ${metaRollbackErr?.message ?? metaRollbackErr}`);
+        }
+      }
+      if (rollbackErrors.length > 0) {
+        recordFailed(
+          `write stage failed AND rollback failures: ${writeErr?.message ?? writeErr}; ${rollbackErrors.join('; ')}`,
+          triples.length,
+        );
+        (writeErr as any).__failureAlreadyRecorded = true;
+      }
+      throw writeErr;
     }
   } catch (err: any) {
-    if (err.message?.includes('has not been registered') || err.message?.includes('Invalid') || err.message?.includes('Unsafe')) {
-      fail(400, err.message, triples.length);
+    // An ImportFileRouteError means a nested `fail()` call already
+    // recorded a precise failure state. Don't re-record.
+    if (err instanceof ImportFileRouteError) {
+      throw err;
     }
-    // Unexpected write-stage failure: mirror the daemon by recording the
-    // failure before rethrowing, so the extraction status map doesn't stay
-    // stuck at in_progress.
+    // Bug 15: compound rollback failure already wrote a rich error
+    // record — don't overwrite it with the bare insert error.
+    if (err?.__failureAlreadyRecorded) {
+      throw err;
+    }
+    // Round 10 Bug 29: the `Invalid`/`Unsafe`/`has not been registered`
+    // substring branch was removed from this outer catch. The inner
+    // `assertion.create` catch (line 592 in this harness) is the only
+    // step in this block where a user-input validation error
+    // legitimately originates — and it already short-circuits with
+    // fail(400, …) and returns. Post-`assertion.create` steps
+    // (snapshot, cleanup, insert, rollback) operate on daemon-
+    // constructed quads; `Invalid`/`Unsafe` in those messages
+    // signals an internal storage error and must surface as 500.
+    //
+    // Unexpected insert failure: because the insert is atomic, nothing
+    // landed, but we still record the failure so /extraction-status
+    // doesn't stay stuck at in_progress.
     recordFailed(err?.message ?? String(err), triples.length);
     throw err;
   }
 
   const completedRecord: ExtractionStatusRecord = {
     status: 'completed',
-    fileHash: fileStoreEntry.hash,
+    fileHash: fileStoreEntry.keccak256,
     detectedContentType,
     pipelineUsed,
     tripleCount: triples.length,
@@ -347,7 +739,7 @@ async function runImportFileOrchestration(params: {
 
   return buildImportFileResponse({
     assertionUri,
-    fileHash: fileStoreEntry.hash,
+    fileHash: fileStoreEntry.keccak256,
     detectedContentType,
     extraction: {
       status: 'completed',
@@ -356,6 +748,17 @@ async function runImportFileOrchestration(params: {
       ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
     },
   });
+  } finally {
+    // Round 14 Bug 42 outer finally: release the per-assertion lock
+    // so the next waiter can start. Runs regardless of early returns
+    // (graceful-degrade skipped path), failed-extraction throws, the
+    // inner write-stage rethrow, or normal completion. Mirrors the
+    // daemon's outer finally at the equivalent handler-end location.
+    releaseLock();
+    if (assertionImportLocks.get(assertionUri) === chainedLock) {
+      assertionImportLocks.delete(assertionUri);
+    }
+  }
 }
 
 // ── Multipart body builder for tests ──
@@ -443,20 +846,19 @@ describe('import-file orchestration — happy paths', () => {
     expect(result.extraction.status).toBe('completed');
     expect(result.extraction.pipelineUsed).toBe('text/markdown');
     expect(result.extraction.tripleCount).toBeGreaterThan(0);
-    expect(result.fileHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.fileHash).toMatch(/^keccak256:[0-9a-f]{64}$/);
     expect(result.detectedContentType).toBe('text/markdown');
     expect(result.extraction.mdIntermediateHash).toBeUndefined(); // no Phase 1, no MD intermediate stored separately
     expect(result.assertionUri).toBe(contextGraphAssertionUri('research-cg', agent.peerId, 'climate-report'));
 
-    // Assertion write happened
+    // Assertion graph created and data-graph quads committed through the
+    // atomic multi-graph insert (single `store.insert` for both graphs).
     expect(agent.createdAssertions).toHaveLength(1);
     expect(agent.createdAssertions[0]).toEqual({ contextGraphId: 'research-cg', name: 'climate-report', subGraphName: undefined });
-    expect(agent.capturedWrites).toHaveLength(1);
-    expect(agent.capturedWrites[0].contextGraphId).toBe('research-cg');
-    expect(agent.capturedWrites[0].name).toBe('climate-report');
+    const writtenTriples = getDataGraphQuads(agent, 'research-cg', 'climate-report');
+    expect(writtenTriples.length).toBeGreaterThan(0);
 
     // Triples reflect the markdown structure
-    const writtenTriples = agent.capturedWrites[0].triples;
     // rdf:type ScholarlyArticle
     expect(writtenTriples.some(t =>
       t.predicate === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
@@ -581,7 +983,7 @@ describe('import-file orchestration — happy paths', () => {
     expect(result.extraction.status).toBe('completed');
     expect(result.extraction.pipelineUsed).toBe('application/pdf');
     expect(result.extraction.mdIntermediateHash).toBeDefined();
-    expect(result.extraction.mdIntermediateHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(result.extraction.mdIntermediateHash).toMatch(/^keccak256:[0-9a-f]{64}$/);
     expect(result.extraction.mdIntermediateHash).not.toBe(result.fileHash); // stored separately
 
     // MD intermediate is retrievable from the file store
@@ -590,7 +992,7 @@ describe('import-file orchestration — happy paths', () => {
     expect(mdBytes!.toString('utf-8')).toContain('# Stub Document');
 
     // Triples reflect the Phase 2 extraction of the stub's MD intermediate
-    const triples = agent.capturedWrites[0].triples;
+    const triples = getDataGraphQuads(agent, 'research', 'paper');
     expect(triples.some(t => t.object === 'http://schema.org/Report')).toBe(true);
     expect(triples.some(t => t.object === '"tag1"')).toBe(true);
     expect(triples.some(t => t.object === 'urn:dkg:md:reference')).toBe(true);
@@ -663,7 +1065,11 @@ describe('import-file orchestration — happy paths', () => {
     });
 
     expect(agent.createdAssertions[0]).toEqual({ contextGraphId: 'cg', name: 'decision-1', subGraphName: 'decisions' });
-    expect(agent.capturedWrites[0].subGraphName).toBe('decisions');
+    // Sub-graph routing: data-graph quads land in the sub-graph's assertion
+    // graph URI (which embeds `decisions`), not the CG root assertion URI.
+    const subGraphAssertionGraph = contextGraphAssertionUri('cg', agent.peerId, 'decision-1', 'decisions');
+    const subGraphDataQuads = agent.insertedQuads.filter(q => q.graph === subGraphAssertionGraph);
+    expect(subGraphDataQuads.length).toBeGreaterThan(0);
   });
 
   it('seeds an in-progress extraction status before the terminal record is written', async () => {
@@ -689,7 +1095,12 @@ describe('import-file orchestration — happy paths', () => {
     expect(status.get(result.assertionUri)?.status).toBe('completed');
   });
 
-  it('creates the assertion graph even when Phase 2 extracts zero triples', async () => {
+  it('creates the assertion graph even when Phase 2 extracts zero content triples', async () => {
+    // An empty markdown upload produces zero content triples but the route
+    // handler still writes §10.1 linkage + §6.3 file descriptor + §3.2
+    // extraction provenance into the assertion graph, and §10.2 meta
+    // quads into the CG root `_meta`, so daemon restarts can still find
+    // the file <-> assertion linkage.
     const body = buildMultipart([
       { kind: 'text', name: 'contextGraphId', value: 'cg' },
       { kind: 'file', name: 'file', filename: 'empty.md', contentType: 'text/markdown', content: Buffer.from('', 'utf-8') },
@@ -701,10 +1112,20 @@ describe('import-file orchestration — happy paths', () => {
     });
 
     expect(result.extraction.status).toBe('completed');
+    // tripleCount reports Phase 2 content triples only, which is still zero.
     expect(result.extraction.tripleCount).toBe(0);
     expect(agent.createdAssertions).toHaveLength(1);
     expect(agent.createdAssertions[0]).toEqual({ contextGraphId: 'cg', name: 'empty-doc', subGraphName: undefined });
-    expect(agent.capturedWrites).toHaveLength(0);
+    // Data-graph quads: rows 1, 3 (linkage from extractor) + row 2
+    // (daemon-owned) + rows 4, 5, 8 (file descriptor intrinsic-to-content
+    // properties, 3 quads — Round 9 Bug 27 dropped rows 6+7) + rows 9-13
+    // (extraction provenance, 5 quads) = 11 quads total.
+    const dataQuads = getDataGraphQuads(agent, 'cg', 'empty-doc');
+    expect(dataQuads).toHaveLength(11);
+    // Meta graph still populated with the structural row 14-19 quads.
+    const metaGraph = contextGraphMetaUri('cg');
+    const metaQuads = agent.insertedQuads.filter(q => q.graph === metaGraph);
+    expect(metaQuads.length).toBeGreaterThanOrEqual(6);
   });
 
   it('records failed extraction status when assertion.create rejects an unregistered sub-graph', async () => {
@@ -781,7 +1202,8 @@ describe('import-file orchestration — happy paths', () => {
     });
 
     expect(result.extraction.status).toBe('completed');
-    expect(agent.capturedWrites).toHaveLength(1);
+    // The atomic insert still ran, so the data-graph quads are present.
+    expect(getDataGraphQuads(agent, 'cg', 'create-idempotent').length).toBeGreaterThan(0);
     expect(status.get(result.assertionUri)?.status).toBe('completed');
   });
 
@@ -800,9 +1222,9 @@ describe('import-file orchestration — happy paths', () => {
     expect(existsSync(fileStore.directory)).toBe(false);
   });
 
-  it('records failed extraction status when assertion.write rejects invalid triples', async () => {
+  it('records failed extraction status when the atomic insert rejects invalid triples', async () => {
     agent = makeMockAgent('0xMockAgentPeerId', {
-      writeError: new Error('Invalid triple object'),
+      insertError: new Error('Invalid triple object'),
     });
 
     const body = buildMultipart([
@@ -860,13 +1282,16 @@ describe('import-file orchestration — happy paths', () => {
     expect(result.extraction.status).toBe('completed');
   });
 
-  it('records failed extraction status when assertion.write throws an unexpected error', async () => {
-    // Errors that don't match the known has-not-been-registered / Invalid / Unsafe
-    // patterns must still update the extraction status record from in_progress to
-    // failed before the orchestration rethrows. Otherwise /extraction-status would
-    // stay stuck reporting in_progress even though the import already failed.
+  it('records failed extraction status when the atomic insert throws an unexpected error', async () => {
+    // Any error thrown from the atomic insert must update the
+    // extraction status record from in_progress to failed before the
+    // orchestration rethrows. Otherwise /extraction-status would
+    // stay stuck reporting in_progress even though the import already
+    // failed. Round 10 Bug 29 removed the substring-based 400 mapping
+    // from this outer catch, so an atomic-insert failure now always
+    // surfaces as a raw rethrow for the top-level 500 handler.
     agent = makeMockAgent('0xMockAgentPeerId', {
-      writeError: new Error('Connection refused'),
+      insertError: new Error('Connection refused'),
     });
 
     const body = buildMultipart([
@@ -888,9 +1313,26 @@ describe('import-file orchestration — happy paths', () => {
     expect(record?.completedAt).toBeDefined();
   });
 
-  it('returns the full import-file envelope for write-stage validation failures', async () => {
+  it('Round 10 Bug 29: atomic insert failure with `Invalid`-in-message rethrows raw (not a 400 ImportFileRouteError)', async () => {
+    // Round 10 Bug 29 fix: the outer catch used to map any error
+    // message containing `Invalid` or `Unsafe` to a 400
+    // ImportFileRouteError. That widened too far once the outer try
+    // block grew to wrap snapshot/cleanup/dropGraph/insert —
+    // an internal storage error whose message happens to contain
+    // `Invalid` (e.g., Oxigraph's `Invalid query plan` or an
+    // adapter's `Invalid triple object`) would be misclassified as
+    // a user-input validation failure and get a 400 back, when in
+    // reality it's a 500 server-side issue. The fix removed the
+    // substring-based 400 mapping from the outer catch. The inner
+    // `assertion.create` catch still maps its own 400s.
+    //
+    // Regression: a simulated internal storage error with `Invalid`
+    // in its message must now rethrow as a raw Error (routed to the
+    // top-level 500 handler), NOT as a 400 ImportFileRouteError.
+    // The extraction status record still gets updated to `failed`
+    // with the underlying message preserved.
     agent = makeMockAgent('0xMockAgentPeerId', {
-      writeError: new Error('Invalid triple object'),
+      insertError: new Error('Invalid triple object'),
     });
 
     const body = buildMultipart([
@@ -902,21 +1344,212 @@ describe('import-file orchestration — happy paths', () => {
     try {
       await runImportFileOrchestration({
         agent, fileStore, extractionRegistry: registry, extractionStatus: status,
-        multipartBody: body, boundary: BOUNDARY, assertionName: 'invalid-write-envelope',
+        multipartBody: body, boundary: BOUNDARY, assertionName: 'internal-invalid',
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    // Raw Error, NOT an ImportFileRouteError — proves the over-wide
+    // 400 mapping is gone.
+    expect(caught).toBeDefined();
+    expect(caught).not.toBeInstanceOf(ImportFileRouteError);
+    expect((caught as Error).message).toBe('Invalid triple object');
+
+    // Extraction status still records the failure, so /extraction-status
+    // doesn't stay stuck at in_progress.
+    const assertionUri = contextGraphAssertionUri('cg', agent.peerId, 'internal-invalid');
+    const record = status.get(assertionUri);
+    expect(record?.status).toBe('failed');
+    expect(record?.error).toBe('Invalid triple object');
+  });
+
+  it('Round 10 Bug 29: atomic insert failure with `Unsafe`-in-message also rethrows raw (substring match is gone entirely)', async () => {
+    // Symmetric guard for the `Unsafe` half of the old substring
+    // match. Same semantic: `Unsafe write`, `Unsafe literal` etc.
+    // from an adapter are internal storage errors, 500 not 400.
+    agent = makeMockAgent('0xMockAgentPeerId', {
+      insertError: new Error('Unsafe replication target'),
+    });
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'doc.md', contentType: 'text/markdown', content: Buffer.from('# Title\n', 'utf-8') },
+    ]);
+
+    let caught: unknown;
+    try {
+      await runImportFileOrchestration({
+        agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+        multipartBody: body, boundary: BOUNDARY, assertionName: 'internal-unsafe',
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).not.toBeInstanceOf(ImportFileRouteError);
+    expect((caught as Error).message).toBe('Unsafe replication target');
+  });
+
+  it('Round 10 Bug 29: genuine `assertion.create` user-input errors STILL map to 400 (inner catch unchanged)', async () => {
+    // Positive regression — the inner `assertion.create` catch is
+    // the only place user-input validation errors legitimately
+    // originate in this block, and it still maps them to 400 via
+    // `respondWithFailedExtraction`. The Bug 29 fix only narrowed
+    // the OUTER catch, not the inner.
+    agent = makeMockAgent('0xMockAgentPeerId', {
+      createError: new Error('Invalid sub-graph name: reserved-word'),
+    });
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'doc.md', contentType: 'text/markdown', content: Buffer.from('# Title\n', 'utf-8') },
+    ]);
+
+    let caught: unknown;
+    try {
+      await runImportFileOrchestration({
+        agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+        multipartBody: body, boundary: BOUNDARY, assertionName: 'user-invalid-create',
       });
     } catch (err) {
       caught = err;
     }
 
     expect(caught).toBeInstanceOf(ImportFileRouteError);
-    const routeError = caught as ImportFileRouteError;
-    expect(routeError.statusCode).toBe(400);
-    expect(routeError.body.assertionUri).toBe(contextGraphAssertionUri('cg', agent.peerId, 'invalid-write-envelope'));
-    expect(routeError.body.fileHash).toMatch(/^sha256:[0-9a-f]{64}$/);
-    expect(routeError.body.detectedContentType).toBe('text/markdown');
-    expect(routeError.body.extraction.status).toBe('failed');
-    expect(routeError.body.extraction.error).toBe('Invalid triple object');
-    expect(routeError.body.extraction.tripleCount).toBeGreaterThan(0);
+    expect((caught as ImportFileRouteError).statusCode).toBe(400);
+    expect((caught as ImportFileRouteError).body.extraction.error).toContain('Invalid sub-graph name');
+  });
+
+  it('Round 13 Bug 38: data-graph snapshot failure preserves the stage-specific error message in extraction-status (not overwritten by outer catch)', async () => {
+    // Round 13 Bug 38: when the rollback-snapshot CONSTRUCT query
+    // fails, `recordFailedExtraction` is called with a stage-specific
+    // message ("Failed to snapshot assertion data graph for rollback:
+    // <underlying>"). Before the fix, the outer catch later called
+    // `recordFailedExtraction` again with just the raw underlying
+    // message, overwriting the stage context — a caller reading
+    // `/extraction-status` saw "connection refused" instead of
+    // "Failed at snapshot stage: connection refused".
+    //
+    // The fix marks the thrown error with `__failureAlreadyRecorded`
+    // and the outer catch skips re-recording when it sees the flag.
+    // This test injects a failure on the data-graph snapshot CONSTRUCT
+    // (the first of the two snapshot queries — matches `?s ?p ?o`
+    // pattern without a bound subject) and asserts the extraction
+    // status record retains the stage-specific message.
+    agent = makeMockAgent('0xMockAgentPeerId', {
+      queryErrorPredicate: (sparql) => {
+        // Data-graph snapshot uses the unbound `?s ?p ?o` pattern.
+        // `_meta` snapshot uses a bound `<subject> ?p ?o` pattern.
+        // Target only the unbound form so the other query shapes
+        // (`_meta` snapshot, or any other CONSTRUCT) still work.
+        if (/CONSTRUCT\s*\{\s*\?s\s+\?p\s+\?o\s*\}/.test(sparql)) {
+          return new Error('simulated data-graph snapshot failure');
+        }
+        return null;
+      },
+    });
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'data-snap.md', contentType: 'text/markdown', content: Buffer.from('# Snapshot\n', 'utf-8') },
+    ]);
+
+    await expect(runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'data-snap-fail',
+    })).rejects.toThrow('simulated data-graph snapshot failure');
+
+    const assertionUri = contextGraphAssertionUri('cg', agent.peerId, 'data-snap-fail');
+    const record = status.get(assertionUri);
+    expect(record).toBeDefined();
+    expect(record?.status).toBe('failed');
+    // The CRITICAL assertion: the stage-specific context survives.
+    expect(record?.error).toContain('Failed to snapshot assertion data graph for rollback');
+    expect(record?.error).toContain('simulated data-graph snapshot failure');
+    // Negative assertion: the error is NOT just the raw underlying
+    // message (which would mean the outer catch overwrote the stage
+    // context — pre-fix behavior).
+    expect(record?.error).not.toBe('simulated data-graph snapshot failure');
+  });
+
+  it('Round 13 Bug 38: `_meta` snapshot failure preserves the stage-specific error message (symmetric guard)', async () => {
+    // Symmetric test for the `_meta` snapshot query (the second of
+    // the two CONSTRUCTs, uses a bound-subject pattern). The fix
+    // applied to both snapshot branches, so both need a regression.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n', 'utf-8') },
+    ]);
+    // Seed V1 so the `_meta` snapshot query has something to fail on
+    // during the V2 attempt (otherwise the first-import empty-snapshot
+    // case might short-circuit before the query even runs).
+    await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'meta-snap-fail',
+    });
+
+    // Prime a fresh agent with V1's state and inject a `_meta` query
+    // failure. The `_meta` snapshot CONSTRUCT uses a bound subject.
+    const failAgent = makeMockAgent('0xMockAgentPeerId', {
+      queryErrorPredicate: (sparql) => {
+        // Target the bound-subject form: `CONSTRUCT { <subj> ?p ?o }`.
+        if (/CONSTRUCT\s*\{\s*<[^>]+>\s+\?p\s+\?o\s*\}/.test(sparql)) {
+          return new Error('simulated _meta snapshot failure');
+        }
+        return null;
+      },
+    });
+    for (const q of agent.insertedQuads) {
+      failAgent.insertedQuads.push({ ...q });
+    }
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: failAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'meta-snap-fail',
+    })).rejects.toThrow('simulated _meta snapshot failure');
+
+    const assertionUri = contextGraphAssertionUri('cg', failAgent.peerId, 'meta-snap-fail');
+    const record = status.get(assertionUri);
+    expect(record?.status).toBe('failed');
+    expect(record?.error).toContain('Failed to snapshot _meta for rollback');
+    expect(record?.error).toContain('simulated _meta snapshot failure');
+    expect(record?.error).not.toBe('simulated _meta snapshot failure');
+  });
+
+  it('Round 13 Bug 38: non-snapshot write-stage failures still get outer-catch recording (preservation canary)', async () => {
+    // Canary: the `__failureAlreadyRecorded` flag must not suppress
+    // outer-catch recording when the error originates from a path
+    // that was NEVER stage-specifically recorded. Force an error in
+    // the atomic `store.insert` step (which does NOT set the flag
+    // itself unless the rollback also fails — Round 5/6/7 compound
+    // path) and assert the outer catch still records a `failed`
+    // status so /extraction-status doesn't stay stuck at in_progress.
+    agent = makeMockAgent('0xMockAgentPeerId', {
+      insertError: new Error('Connection refused'),
+    });
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'ext.md', contentType: 'text/markdown', content: Buffer.from('# Ext\n', 'utf-8') },
+    ]);
+
+    await expect(runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'non-snapshot-fail',
+    })).rejects.toThrow('Connection refused');
+
+    const assertionUri = contextGraphAssertionUri('cg', agent.peerId, 'non-snapshot-fail');
+    const record = status.get(assertionUri);
+    expect(record?.status).toBe('failed');
+    // Outer catch still recorded the raw message (this path has
+    // no stage-specific predecessor, so the Round 13 flag check
+    // correctly lets the outer catch write the error).
+    expect(record?.error).toBe('Connection refused');
   });
 });
 
@@ -961,9 +1594,10 @@ describe('import-file orchestration — graceful degrade', () => {
     expect(retrieved).not.toBeNull();
     expect(retrieved![0]).toBe(0x89); // PNG magic byte preserved
 
-    // No triples written to the assertion
+    // No triples written to the assertion — graceful degrade should
+    // bypass both the assertion graph creation AND the atomic insert.
     expect(agent.createdAssertions).toHaveLength(0);
-    expect(agent.capturedWrites).toHaveLength(0);
+    expect(agent.insertedQuads).toHaveLength(0);
 
     // Status record reflects the skip
     const record = status.get(result.assertionUri)!;
@@ -994,6 +1628,2244 @@ describe('import-file orchestration — graceful degrade', () => {
     expect(result.detectedContentType).toBe('application/octet-stream');
     expect(result.extraction.status).toBe('skipped');
     expect(result.extraction.pipelineUsed).toBeNull();
+  });
+});
+
+describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §10.2)', () => {
+  let tmpDir: string;
+  let fileStore: FileStore;
+  let registry: ExtractionPipelineRegistry;
+  let status: Map<string, ExtractionStatusRecord>;
+  let agent: MockAgent;
+
+  const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+  const DKG = 'http://dkg.io/ontology/';
+  const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'dkg-importfile-test-'));
+    fileStore = new FileStore(join(tmpDir, 'files'));
+    registry = new ExtractionPipelineRegistry();
+    status = new Map();
+    agent = makeMockAgent();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('text/markdown import writes rows 1-13 into the data graph with blank-node subjects for the file descriptor + prov block', async () => {
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'note.md', contentType: 'text/markdown', content: Buffer.from('---\nid: note\n---\n\n# Note\n\nBody.\n', 'utf-8') },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'note',
+    });
+
+    expect(result.extraction.status).toBe('completed');
+    expect(result.fileHash).toMatch(/^keccak256:[0-9a-f]{64}$/);
+    // The route handler pins the extractor's documentIri to the assertion
+    // UAL, so rows 1-3 live on the UAL as the document subject.
+    const subjectIri = result.assertionUri;
+
+    const written = getDataGraphQuads(agent, 'cg', 'note');
+    expect(written.length).toBeGreaterThan(0);
+
+    // Row 1 — object is the content-addressed URN (Round 4 Option B).
+    // Must match the subject of rows 4-8 below.
+    const row1 = written.find(t => t.subject === subjectIri && t.predicate === `${DKG}sourceFile`);
+    expect(row1).toBeDefined();
+    expect(row1!.object).toMatch(/^urn:dkg:file:keccak256:[0-9a-f]{64}$/);
+    const fileUri = row1!.object;
+    expect(fileUri).toBe(`urn:dkg:file:${result.fileHash}`);
+
+    // Row 2 — daemon-owned, uses the ORIGINAL upload content type. For a
+    // direct markdown upload that's "text/markdown"; the PDF test below
+    // verifies the same row 2 carries "application/pdf" in its case.
+    expect(written).toContainEqual({ subject: subjectIri, predicate: `${DKG}sourceContentType`, object: '"text/markdown"' });
+    // Row 3 — reflexive rootEntity on the document subject in V10.0
+    expect(written).toContainEqual({ subject: subjectIri, predicate: `${DKG}rootEntity`, object: subjectIri });
+
+    // Row 4 — file descriptor subject is the SAME URN as row 1's object
+    expect(written).toContainEqual({ subject: fileUri, predicate: RDF_TYPE, object: `${DKG}File` });
+    // Row 5 — contentHash matches the wire fileHash (keccak256 literal)
+    expect(written).toContainEqual({ subject: fileUri, predicate: `${DKG}contentHash`, object: `"${result.fileHash}"` });
+    // Round 9 Bug 27: rows 6 (`dkg:fileName`) and 7 (`dkg:contentType`)
+    // were REMOVED from the file descriptor block — they carried
+    // per-upload metadata on a content-addressed subject and collided
+    // when two imports of identical bytes used different names/types.
+    // They now live on the assertion UAL in `_meta` (see the `_meta`
+    // section of this test further down). The canary assertions below
+    // lock in the absence of those two properties on `<fileUri>`.
+    expect(written.some(t => t.subject === fileUri && t.predicate === `${DKG}fileName`)).toBe(false);
+    expect(written.some(t => t.subject === fileUri && t.predicate === `${DKG}contentType`)).toBe(false);
+    // Row 8 — size as xsd:integer
+    expect(written.some(t =>
+      t.subject === fileUri &&
+      t.predicate === `${DKG}size` &&
+      t.object.endsWith(`^^<${XSD_INTEGER}>`),
+    )).toBe(true);
+
+    // Rows 9-13 — one ExtractionProvenance resource minted per import,
+    // subject is a fresh `urn:dkg:extraction:<uuid>` URN.
+    const provTypeQuads = written.filter(t =>
+      t.predicate === RDF_TYPE && t.object === `${DKG}ExtractionProvenance`,
+    );
+    expect(provTypeQuads).toHaveLength(1);
+    const provUri = provTypeQuads[0]!.subject;
+    expect(provUri).toMatch(/^urn:dkg:extraction:[0-9a-f-]{36}$/); // UUID v4
+    // Row 10 — back-references the SAME file URN as rows 4-8 subject
+    expect(written).toContainEqual({ subject: provUri, predicate: `${DKG}extractedFrom`, object: fileUri });
+    // Row 11
+    expect(written).toContainEqual({ subject: provUri, predicate: `${DKG}extractedBy`, object: `did:dkg:agent:${agent.peerId}` });
+    // Row 12 — extractedAt is an xsd:dateTime literal
+    expect(written.some(t =>
+      t.subject === provUri &&
+      t.predicate === `${DKG}extractedAt` &&
+      /\^\^<http:\/\/www\.w3\.org\/2001\/XMLSchema#dateTime>$/.test(t.object),
+    )).toBe(true);
+    // Row 13
+    expect(written).toContainEqual({ subject: provUri, predicate: `${DKG}extractionMethod`, object: '"structural"' });
+
+    // Bug 8 Option B guard: the `urn:dkg:file:` and `urn:dkg:extraction:`
+    // URNs ARE present in the assertion WM graph (that's the revert from
+    // Round 3's blank-node approach). The Option B filter lives in
+    // `assertionPromote` downstream and strips them before SWM — that's
+    // verified by the dedicated "filter drops import-bookkeeping URIs"
+    // test below, not by this one.
+    expect(written.some(q => q.subject.startsWith('urn:dkg:file:'))).toBe(true);
+    expect(written.some(q => q.subject.startsWith('urn:dkg:extraction:'))).toBe(true);
+  });
+
+  it('text/markdown import writes rows 14-19 into the CG root _meta graph and omits row 20', async () => {
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'note.md', contentType: 'text/markdown', content: Buffer.from('# Note\n\nBody.\n', 'utf-8') },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'note',
+    });
+
+    const metaGraph = contextGraphMetaUri('cg');
+    const metaForAssertion = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === result.assertionUri,
+    );
+    // Rows 14-19 plus Round 9 Bug 27 `dkg:sourceFileName` (7 total) —
+    // no row 20 because Phase 1 did not run for a direct markdown upload.
+    expect(metaForAssertion).toHaveLength(7);
+
+    const byPredicate = (predLocal: string) =>
+      metaForAssertion.find(q => q.predicate === `${DKG}${predLocal}`);
+
+    // Row 14 — reflexive rootEntity on the UAL (matches row 3 in the
+    // data graph, since the extractor's resolvedRootEntity falls back to
+    // the document subject when no frontmatter override is present).
+    expect(byPredicate('rootEntity')?.object).toBe(result.assertionUri);
+    // Row 15 — original content type (matches row 2 now that both are
+    // sourced from detectedContentType)
+    expect(byPredicate('sourceContentType')?.object).toBe('"text/markdown"');
+    // Row 16 — load-bearing: sourceFileHash lets a caller recover the blob
+    expect(byPredicate('sourceFileHash')?.object).toBe(`"${result.fileHash}"`);
+    // Row 17
+    expect(byPredicate('extractionMethod')?.object).toBe('"structural"');
+    // Row 18 — structural triple count matches the Phase 2 result
+    expect(byPredicate('structuralTripleCount')?.object).toBe(`"${result.extraction.tripleCount}"^^<${XSD_INTEGER}>`);
+    // Row 19 — V10.0 has no semantic extraction yet
+    expect(byPredicate('semanticTripleCount')?.object).toBe(`"0"^^<${XSD_INTEGER}>`);
+    // Row 20 — absent because Phase 1 did not run for a direct markdown upload
+    expect(byPredicate('mdIntermediateHash')).toBeUndefined();
+    // Round 9 Bug 27 — `dkg:sourceFileName` present on the UAL, carrying
+    // the original upload filename literal. This is the new home for
+    // per-upload metadata that used to live on `<fileUri>` as row 6.
+    expect(byPredicate('sourceFileName')?.object).toBe('"note.md"');
+  });
+
+  it('application/pdf import writes row 15 in _meta and row 20 for mdIntermediateHash, with rows 2 and 15 both = application/pdf', async () => {
+    const stubConverter: ExtractionPipeline = {
+      contentTypes: ['application/pdf'],
+      async extract(_input: ExtractionInput): Promise<ConverterOutput> {
+        return { mdIntermediate: '---\nid: paper\n---\n\n# Paper\n\nBody.\n' };
+      },
+    };
+    registry.register(stubConverter);
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'paper.pdf', contentType: 'application/pdf', content: Buffer.from('fake-pdf', 'utf-8') },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'paper',
+    });
+
+    expect(result.extraction.pipelineUsed).toBe('application/pdf');
+    expect(result.extraction.mdIntermediateHash).toMatch(/^keccak256:[0-9a-f]{64}$/);
+
+    const metaGraph = contextGraphMetaUri('cg');
+    const metaForAssertion = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === result.assertionUri,
+    );
+    // Rows 14-20 + Round 9 Bug 27 `dkg:sourceFileName` = 8 rows total.
+    expect(metaForAssertion).toHaveLength(8);
+
+    const byPredicate = (predLocal: string) =>
+      metaForAssertion.find(q => q.predicate === `${DKG}${predLocal}`);
+
+    // Row 15 — original content type is application/pdf in _meta
+    expect(byPredicate('sourceContentType')?.object).toBe('"application/pdf"');
+    // Row 20 — mdIntermediateHash now present, matching the wire value
+    expect(byPredicate('mdIntermediateHash')?.object).toBe(`"${result.extraction.mdIntermediateHash}"`);
+    // Round 9 Bug 27 — sourceFileName present on the UAL for the PDF upload.
+    expect(byPredicate('sourceFileName')?.object).toBe('"paper.pdf"');
+
+    // Spec-engineer's Bug 1 ruling: row 2 (data graph) and row 15
+    // (_meta) must both describe the ORIGINAL upload blob pointed at by
+    // row 1. For a PDF upload that's "application/pdf" in BOTH graphs
+    // (previously row 2 incorrectly carried "text/markdown" because the
+    // extractor was hardcoding its input type).
+    const dataQuads = getDataGraphQuads(agent, 'cg', 'paper');
+    const dataRow2 = dataQuads.find(t => t.predicate === `${DKG}sourceContentType`);
+    expect(dataRow2?.object).toBe('"application/pdf"');
+
+    // Round 9 Bug 27 canary: the content-addressed `<urn:dkg:file:...>`
+    // subject no longer carries `dkg:contentType` (that was row 7 in the
+    // old file descriptor block). `_meta` row 15 on the UAL is the new
+    // home for per-upload content type — the assertion above proves
+    // that side of the move. This negative assertion proves the
+    // collision-prone side was removed.
+    const row1 = dataQuads.find(q =>
+      q.subject === result.assertionUri && q.predicate === `${DKG}sourceFile`,
+    );
+    expect(row1).toBeDefined();
+    expect(row1!.object).toMatch(/^urn:dkg:file:keccak256:[0-9a-f]{64}$/);
+    const fileUri = row1!.object;
+    expect(fileUri).toBe(`urn:dkg:file:${result.fileHash}`);
+    expect(dataQuads.some(q => q.subject === fileUri && q.predicate === `${DKG}contentType`)).toBe(false);
+    expect(dataQuads.some(q => q.subject === fileUri && q.predicate === `${DKG}fileName`)).toBe(false);
+  });
+
+  it('sub-graph routing: data triples follow the sub-graph, _meta always lands in CG root _meta', async () => {
+    agent = makeMockAgent('0xMockAgentPeerId', { registeredSubGraphs: ['decisions'] });
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'text', name: 'subGraphName', value: 'decisions' },
+      { kind: 'file', name: 'file', filename: 'd.md', contentType: 'text/markdown', content: Buffer.from('# Decision\n\nBody.\n', 'utf-8') },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'd1',
+    });
+
+    // Data-graph quads land in the SUB-GRAPH assertion graph URI (which
+    // embeds `decisions`), not the CG root assertion URI. Under the
+    // atomic multi-graph insert we verify this by filtering the mock's
+    // captured inserts on the sub-graph's assertion-graph URI.
+    const subGraphAssertionGraph = contextGraphAssertionUri('cg', agent.peerId, 'd1', 'decisions');
+    const dataQuads = agent.insertedQuads.filter(q => q.graph === subGraphAssertionGraph);
+    expect(dataQuads.length).toBeGreaterThan(0);
+
+    // _meta quads used the CG ROOT meta URI, NOT the sub-graph meta URI.
+    const rootMetaGraph = contextGraphMetaUri('cg');
+    const subGraphMetaGraph = contextGraphMetaUri('cg', 'decisions');
+    expect(rootMetaGraph).not.toBe(subGraphMetaGraph);
+    const metaQuadsForAssertion = agent.insertedQuads.filter(q =>
+      q.subject === result.assertionUri &&
+      (q.graph === rootMetaGraph || q.graph === subGraphMetaGraph),
+    );
+    expect(metaQuadsForAssertion.length).toBeGreaterThan(0);
+    for (const quad of metaQuadsForAssertion) {
+      expect(quad.graph).toBe(rootMetaGraph);
+      expect(quad.graph).not.toBe(subGraphMetaGraph);
+    }
+  });
+
+  it('daemon-restart recovery: clearing extractionStatus leaves the file <-> assertion linkage in the graph', async () => {
+    // Simulates a daemon restart: the in-memory extractionStatus map is
+    // empty on boot, but §10.2 sourceFileHash in CG root _meta is the
+    // canonical pointer from assertion UAL back to the source blob.
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'persistent.md', contentType: 'text/markdown', content: Buffer.from('# Persistent\n\nBody.\n', 'utf-8') },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'persistent',
+    });
+
+    // Emulate a restart by dropping the in-memory status map.
+    status.clear();
+    expect(status.size).toBe(0);
+
+    // The §10.2 linkage triples are still in the mock store — a real
+    // daemon would SPARQL the CG root `_meta` graph; here we reach into
+    // the captured quads directly.
+    const metaGraph = contextGraphMetaUri('cg');
+    const sourceFileHashQuad = agent.insertedQuads.find(q =>
+      q.graph === metaGraph &&
+      q.subject === result.assertionUri &&
+      q.predicate === `${DKG}sourceFileHash`,
+    );
+    expect(sourceFileHashQuad).toBeDefined();
+
+    // Recover the keccak256 hash by unquoting the literal, and confirm
+    // the underlying blob is still resolvable via the FileStore.
+    const recoveredHash = sourceFileHashQuad!.object.replace(/^"|"$/g, '');
+    expect(recoveredHash).toBe(result.fileHash);
+    const bytes = await fileStore.get(recoveredHash);
+    expect(bytes).not.toBeNull();
+    expect(bytes!.toString('utf-8')).toBe('# Persistent\n\nBody.\n');
+  });
+
+  it('FileStore.get accepts both sha256 and keccak256 prefixes for the same blob', async () => {
+    // Verifies the dual-hash contract on FileStore itself: both prefixes
+    // round-trip to the same bytes, so external callers can look up a
+    // file by either identifier.
+    const entry = await fileStore.put(Buffer.from('hello world', 'utf-8'), 'text/plain');
+    expect(entry.hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(entry.keccak256).toMatch(/^keccak256:[0-9a-f]{64}$/);
+
+    const bySha = await fileStore.get(entry.hash);
+    const byKeccak = await fileStore.get(entry.keccak256);
+    expect(bySha).not.toBeNull();
+    expect(byKeccak).not.toBeNull();
+    expect(bySha!.equals(byKeccak!)).toBe(true);
+    expect(bySha!.toString('utf-8')).toBe('hello world');
+  });
+
+  it('atomic multi-graph insert: a failing store.insert leaves BOTH graphs empty', async () => {
+    // Regression guard for spec-engineer Option (a) atomic insert. Under
+    // the old two-call flow (assertion.write + separate _meta insert),
+    // a failure in the second call would leave the first graph populated
+    // and the second empty. With the single atomic insert, ANY failure
+    // means NO quads land in EITHER graph, so a retry with identical
+    // content is idempotent without any special reconciliation.
+    agent = makeMockAgent('0xMockAgentPeerId', {
+      insertError: new Error('simulated triple-store outage during atomic insert'),
+    });
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'doc.md', contentType: 'text/markdown', content: Buffer.from('# Title\n\nBody.\n', 'utf-8') },
+    ]);
+
+    await expect(runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'atomic-fail',
+    })).rejects.toThrow('simulated triple-store outage');
+
+    // Critical: NOTHING landed in either graph. agent.insertedQuads only
+    // accumulates on successful calls, so a failing insert leaves the
+    // array empty — which is exactly the guarantee the atomicity fix
+    // gives us. A retry with identical content sees a clean slate.
+    expect(agent.insertedQuads).toHaveLength(0);
+    // The assertion graph container was still created (idempotent on retry).
+    expect(agent.createdAssertions).toHaveLength(1);
+    // Status record reflects the failure — the orchestration still calls
+    // recordFailed before rethrowing, so /extraction-status doesn't stay
+    // stuck at in_progress on an unexpected insert failure.
+    const record = status.get(contextGraphAssertionUri('cg', agent.peerId, 'atomic-fail'))!;
+    expect(record).toBeDefined();
+    expect(record.status).toBe('failed');
+    expect(record.error).toContain('simulated triple-store outage');
+  });
+
+  it('atomic multi-graph insert: a successful import commits both graphs in ONE store.insert call', async () => {
+    // Complementary positive check. The daemon MUST make exactly one
+    // `store.insert` call that contains quads for BOTH the assertion
+    // graph AND the CG root `_meta` graph — not two separate calls.
+    // Splitting would break the atomicity guarantee the test above
+    // relies on.
+    const insertCalls: number[] = [];
+    const countingAgent = makeMockAgent();
+    const origInsert = countingAgent.store.insert.bind(countingAgent.store);
+    countingAgent.store.insert = async (quads) => {
+      insertCalls.push(quads.length);
+      return origInsert(quads);
+    };
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'atom.md', contentType: 'text/markdown', content: Buffer.from('# Atom\n\nBody.\n', 'utf-8') },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent: countingAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'atomic',
+    });
+
+    // Exactly one insert call, covering both graphs.
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]).toBeGreaterThan(0);
+
+    // That single call contains quads for BOTH graphs.
+    const assertionGraph = contextGraphAssertionUri('cg', countingAgent.peerId, 'atomic');
+    const metaGraph = contextGraphMetaUri('cg');
+    const dataQuads = countingAgent.insertedQuads.filter(q => q.graph === assertionGraph);
+    const metaQuads = countingAgent.insertedQuads.filter(q => q.graph === metaGraph);
+    expect(dataQuads.length).toBeGreaterThan(0);
+    expect(metaQuads.length).toBeGreaterThanOrEqual(6); // rows 14-19 at minimum
+    expect(dataQuads.length + metaQuads.length).toBe(countingAgent.insertedQuads.length);
+    expect(result.extraction.status).toBe('completed');
+  });
+
+  it('Bug 3: frontmatter `rootEntity` override produces row 3 and row 14 pointing at the same IRI', async () => {
+    // Regression guard for Bug 3: a markdown upload with frontmatter
+    // `rootEntity: urn:note:climate-report` must emit BOTH row 3 (data
+    // graph, on the document subject) and row 14 (CG root `_meta`, on
+    // the assertion UAL) pointing at the frontmatter override, NOT the
+    // reflexive assertion UAL. Previously the daemon hardcoded row 14
+    // to `assertionUri`, silently dropping the override.
+    const ROOT_OVERRIDE = 'urn:note:climate-report';
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      {
+        kind: 'file',
+        name: 'file',
+        filename: 'root.md',
+        contentType: 'text/markdown',
+        content: Buffer.from(`---\nid: climate\nrootEntity: ${ROOT_OVERRIDE}\n---\n\n# Climate\n`, 'utf-8'),
+      },
+    ]);
+
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'climate',
+    });
+
+    // Row 3: in the data graph, the document subject (= the assertion
+    // UAL because the daemon pins `documentIri: assertionUri`) points
+    // at the override.
+    const dataQuads = getDataGraphQuads(agent, 'cg', 'climate');
+    const row3 = dataQuads.find(q => q.predicate === `${DKG}rootEntity` && q.subject === result.assertionUri);
+    expect(row3?.object).toBe(ROOT_OVERRIDE);
+
+    // Row 14: in CG root `_meta`, the assertion UAL also points at the
+    // override — NOT at itself, which was the pre-fix behavior.
+    const metaGraph = contextGraphMetaUri('cg');
+    const row14 = agent.insertedQuads.find(q =>
+      q.graph === metaGraph &&
+      q.subject === result.assertionUri &&
+      q.predicate === `${DKG}rootEntity`,
+    );
+    expect(row14?.object).toBe(ROOT_OVERRIDE);
+
+    // Row 3 and Row 14 point at the SAME IRI — the core invariant of
+    // the Bug 3 fix.
+    expect(row3?.object).toBe(row14?.object);
+  });
+
+  it('Bug 5a: re-import replaces (not appends) stale `_meta` rows for the same assertion name', async () => {
+    // Regression guard for Bug 5a: a second import-file call against
+    // the same assertion UAL must end up with EXACTLY ONE binding per
+    // `_meta` predicate — not two. The daemon clears
+    // `{subject: assertionUri, graph: metaGraph}` before each atomic
+    // insert so a re-import with different content replaces the old
+    // _meta block instead of stacking next to it.
+    const ASSERTION_NAME = 'climate-report';
+    const metaGraph = contextGraphMetaUri('cg');
+
+    // First import: blob V1
+    const body1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# Climate V1\n\nOriginal body.\n', 'utf-8') },
+    ]);
+    const result1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body1, boundary: BOUNDARY, assertionName: ASSERTION_NAME,
+    });
+    const hashV1 = result1.fileHash;
+
+    // After the first import, `_meta` has exactly one sourceFileHash row.
+    const metaAfter1 = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph &&
+      q.subject === result1.assertionUri &&
+      q.predicate === `${DKG}sourceFileHash`,
+    );
+    expect(metaAfter1).toHaveLength(1);
+    expect(metaAfter1[0]!.object).toBe(`"${hashV1}"`);
+
+    // Second import: DIFFERENT content → different keccak256 hash, same
+    // assertion name. Pre-fix behavior: stacks a second row alongside
+    // the first. Post-fix: replaces.
+    const body2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# Climate V2\n\nUpdated body.\n', 'utf-8') },
+    ]);
+    const result2 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body2, boundary: BOUNDARY, assertionName: ASSERTION_NAME,
+    });
+    const hashV2 = result2.fileHash;
+    expect(hashV2).not.toBe(hashV1); // sanity: different bodies → different hashes
+    expect(result2.assertionUri).toBe(result1.assertionUri); // same UAL
+
+    // After the second import, `_meta` still has EXACTLY ONE
+    // sourceFileHash row, pointing at the new hash.
+    const metaAfter2 = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph &&
+      q.subject === result2.assertionUri &&
+      q.predicate === `${DKG}sourceFileHash`,
+    );
+    expect(metaAfter2).toHaveLength(1);
+    expect(metaAfter2[0]!.object).toBe(`"${hashV2}"`);
+
+    // Every other `_meta` row keyed by this assertion UAL is also
+    // single-binding — generalized invariant, catches future row
+    // additions that might forget the cleanup.
+    const allMetaForAssertion = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === result2.assertionUri,
+    );
+    const perPredicate = new Map<string, number>();
+    for (const q of allMetaForAssertion) {
+      perPredicate.set(q.predicate, (perPredicate.get(q.predicate) ?? 0) + 1);
+    }
+    for (const [pred, count] of perPredicate) {
+      expect(count, `expected exactly one binding for <${pred}> after re-import, got ${count}`).toBe(1);
+    }
+  });
+
+  it('Bug 7: re-import replaces stale data-graph rows — no two source files for one assertion', async () => {
+    // Regression guard for Bug 7 (symmetric to Bug 5a on the data
+    // graph). Before the fix, a re-import under the same assertion
+    // name left the PRIOR blob's rows 1 and 4-13 in place alongside
+    // the new blob's, so the assertion ended up with two conflicting
+    // source files. The daemon now `dropGraph`s the assertion data
+    // graph before the atomic insert, giving full replace semantics.
+    //
+    // With Bug 8's blank-node subjects (both imports use the same
+    // `_:file1` label), we can't tell V1 from V2 by subject alone —
+    // the contentHash LITERAL is the distinguishing signal. If the
+    // drop-before-insert weren't happening, the data graph would end
+    // up with TWO contentHash bindings (one per version); with the
+    // fix, there's exactly one, pointing at V2.
+    const ASSERTION_NAME = 'climate-report-v7';
+    const assertionGraph = contextGraphAssertionUri('cg', agent.peerId, ASSERTION_NAME);
+
+    // First import: blob V1.
+    const body1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n\nFirst body.\n', 'utf-8') },
+    ]);
+    const result1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body1, boundary: BOUNDARY, assertionName: ASSERTION_NAME,
+    });
+
+    // Baseline: V1's contentHash is in the data graph.
+    const dataAfter1 = agent.insertedQuads.filter(q => q.graph === assertionGraph);
+    const contentHashV1 = dataAfter1.filter(q => q.predicate === `${DKG}contentHash`);
+    expect(contentHashV1).toHaveLength(1);
+    expect(contentHashV1[0]!.object).toBe(`"${result1.fileHash}"`);
+    // Row 1 points at a blank node (Bug 8 guard).
+    const row1V1 = dataAfter1.find(q =>
+      q.subject === result1.assertionUri && q.predicate === `${DKG}sourceFile`,
+    );
+    expect(row1V1!.object).toMatch(/^urn:dkg:file:keccak256:/);
+
+    // Second import: DIFFERENT blob, same assertion name.
+    const body2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n\nUpdated body.\n', 'utf-8') },
+    ]);
+    const result2 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body2, boundary: BOUNDARY, assertionName: ASSERTION_NAME,
+    });
+    expect(result2.fileHash).not.toBe(result1.fileHash); // sanity
+    expect(result2.assertionUri).toBe(result1.assertionUri); // same UAL
+
+    // After the second import, the assertion data graph has ONLY V2's
+    // rows. Row 5 `contentHash` appears exactly once, pointing at V2's
+    // literal hash. If the dropGraph call weren't there, we'd see TWO
+    // contentHash bindings — one per version.
+    const dataAfter2 = agent.insertedQuads.filter(q => q.graph === assertionGraph);
+    const contentHashQuads = dataAfter2.filter(q => q.predicate === `${DKG}contentHash`);
+    expect(contentHashQuads).toHaveLength(1);
+    expect(contentHashQuads[0]!.object).toBe(`"${result2.fileHash}"`);
+
+    // No contentHash for V1 should remain anywhere in the data graph.
+    expect(dataAfter2.some(q => q.object === `"${result1.fileHash}"`)).toBe(false);
+
+    // Row 1 (`<UAL> dkg:sourceFile`) has exactly one quad pointing at
+    // the V2 file URN (URN form, Round 4 Option B).
+    const row1Quads = dataAfter2.filter(q =>
+      q.subject === result2.assertionUri && q.predicate === `${DKG}sourceFile`,
+    );
+    expect(row1Quads).toHaveLength(1);
+    expect(row1Quads[0]!.object).toBe(`urn:dkg:file:${result2.fileHash}`);
+
+    // Single `dkg:File` type quad (only one file descriptor remains).
+    const fileTypeQuads = dataAfter2.filter(q =>
+      q.predicate === RDF_TYPE && q.object === `${DKG}File`,
+    );
+    expect(fileTypeQuads).toHaveLength(1);
+
+    // Single `ExtractionProvenance` type quad (only one prov block).
+    const provTypeQuads = dataAfter2.filter(q =>
+      q.predicate === RDF_TYPE && q.object === `${DKG}ExtractionProvenance`,
+    );
+    expect(provTypeQuads).toHaveLength(1);
+
+    // And `_meta` also shows only V2 (already covered by Bug 5a test
+    // but worth asserting end-to-end here for completeness).
+    const metaGraphUri = contextGraphMetaUri('cg');
+    const metaSourceFileHash = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri &&
+      q.subject === result2.assertionUri &&
+      q.predicate === `${DKG}sourceFileHash`,
+    );
+    expect(metaSourceFileHash).toHaveLength(1);
+    expect(metaSourceFileHash[0]!.object).toBe(`"${result2.fileHash}"`);
+  });
+
+  it('Bug 7: re-import of assertion A does NOT affect assertion B data or _meta', async () => {
+    // Cross-assertion isolation guard: the Bug 7 `dropGraph` call must
+    // only drop THIS assertion's data graph, never another's. A bug
+    // that over-matched the drop would wipe unrelated assertions.
+    const assertionGraphA = contextGraphAssertionUri('cg', agent.peerId, 'iso-a7');
+    const assertionGraphB = contextGraphAssertionUri('cg', agent.peerId, 'iso-b7');
+    const metaGraphUri = contextGraphMetaUri('cg');
+
+    // Import A, then B.
+    await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: buildMultipart([
+        { kind: 'text', name: 'contextGraphId', value: 'cg' },
+        { kind: 'file', name: 'file', filename: 'a.md', contentType: 'text/markdown', content: Buffer.from('# A orig\n', 'utf-8') },
+      ]),
+      boundary: BOUNDARY, assertionName: 'iso-a7',
+    });
+    const b1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: buildMultipart([
+        { kind: 'text', name: 'contextGraphId', value: 'cg' },
+        { kind: 'file', name: 'file', filename: 'b.md', contentType: 'text/markdown', content: Buffer.from('# B orig\n', 'utf-8') },
+      ]),
+      boundary: BOUNDARY, assertionName: 'iso-b7',
+    });
+
+    // Snapshot B's state before the re-import of A.
+    const bDataBefore = agent.insertedQuads.filter(q => q.graph === assertionGraphB).length;
+    const bMetaBefore = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === b1.assertionUri,
+    ).length;
+    expect(bDataBefore).toBeGreaterThan(0);
+    expect(bMetaBefore).toBeGreaterThan(0);
+
+    // Re-import A with different content.
+    await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: buildMultipart([
+        { kind: 'text', name: 'contextGraphId', value: 'cg' },
+        { kind: 'file', name: 'file', filename: 'a2.md', contentType: 'text/markdown', content: Buffer.from('# A replaced\n', 'utf-8') },
+      ]),
+      boundary: BOUNDARY, assertionName: 'iso-a7',
+    });
+
+    // B's data + _meta must be identical to the snapshot — byte-
+    // perfect, not just non-empty.
+    const bDataAfter = agent.insertedQuads.filter(q => q.graph === assertionGraphB).length;
+    const bMetaAfter = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === b1.assertionUri,
+    ).length;
+    expect(bDataAfter).toBe(bDataBefore);
+    expect(bMetaAfter).toBe(bMetaBefore);
+
+    // Also verify B's actual sourceFileHash row still points at B's hash.
+    const bSourceFileHash = agent.insertedQuads.find(q =>
+      q.graph === metaGraphUri &&
+      q.subject === b1.assertionUri &&
+      q.predicate === `${DKG}sourceFileHash`,
+    );
+    expect(bSourceFileHash?.object).toBe(`"${b1.fileHash}"`);
+
+    // And A's state was replaced (not merged).
+    const aData = agent.insertedQuads.filter(q => q.graph === assertionGraphA);
+    const aContentHash = aData.filter(q => q.predicate === `${DKG}contentHash`);
+    expect(aContentHash).toHaveLength(1); // single file descriptor, not two
+  });
+
+  it('Bug 8: two imports with the same file content produce graph-scoped blank nodes that do not cross-contaminate', async () => {
+    // Spec-engineer Option A: blank-node subjects for the file
+    // descriptor are scoped by the assertion data graph. Two imports
+    // that happen to reference the same file content (same keccak256)
+    // end up with their file descriptors in SEPARATE assertion graphs,
+    // so even if the blank-node LABELS are identical (`_:file1` both
+    // times), the underlying blank nodes are distinct RDF terms —
+    // `autoPartition` on promote would treat them as document-local,
+    // and (critically) they cannot contend on ownership. This test
+    // locks in the scoping invariant at the graph level.
+    const body = () => buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'shared.md', contentType: 'text/markdown', content: Buffer.from('# Shared\n\nSame content.\n', 'utf-8') },
+    ]);
+    const a = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body(), boundary: BOUNDARY, assertionName: 'share-a',
+    });
+    const b = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body(), boundary: BOUNDARY, assertionName: 'share-b',
+    });
+
+    // Same wire hash (same content).
+    expect(a.fileHash).toBe(b.fileHash);
+
+    const graphA = contextGraphAssertionUri('cg', agent.peerId, 'share-a');
+    const graphB = contextGraphAssertionUri('cg', agent.peerId, 'share-b');
+    expect(graphA).not.toBe(graphB);
+
+    // Each assertion graph has its own file descriptor with the same
+    // keccak256 literal. Under Round 4 Option B, both descriptors have
+    // IDENTICAL URN subjects (`urn:dkg:file:keccak256:<hex>`) because
+    // the file is content-addressed. They live in disjoint assertion
+    // graphs, so they don't conflict at the storage layer — and the
+    // promote-time filter in `assertionPromote` strips them before
+    // they'd otherwise collide in SWM.
+    const contentHashA = agent.insertedQuads.filter(q =>
+      q.graph === graphA && q.predicate === `${DKG}contentHash`,
+    );
+    const contentHashB = agent.insertedQuads.filter(q =>
+      q.graph === graphB && q.predicate === `${DKG}contentHash`,
+    );
+    expect(contentHashA).toHaveLength(1);
+    expect(contentHashB).toHaveLength(1);
+    expect(contentHashA[0]!.object).toBe(`"${a.fileHash}"`);
+    expect(contentHashB[0]!.object).toBe(`"${a.fileHash}"`);
+
+    // Both have IDENTICAL URN subjects (content-addressed).
+    const expectedFileUri = `urn:dkg:file:${a.fileHash}`;
+    expect(contentHashA[0]!.subject).toBe(expectedFileUri);
+    expect(contentHashB[0]!.subject).toBe(expectedFileUri);
+    // Row 1 in both assertions also points at the same URN, proving
+    // the URN flows through the extractor and daemon identically
+    // regardless of which assertion is importing.
+    const row1A = agent.insertedQuads.find(q =>
+      q.graph === graphA && q.predicate === `${DKG}sourceFile`,
+    );
+    const row1B = agent.insertedQuads.find(q =>
+      q.graph === graphB && q.predicate === `${DKG}sourceFile`,
+    );
+    expect(row1A?.object).toBe(expectedFileUri);
+    expect(row1B?.object).toBe(expectedFileUri);
+  });
+
+  it('Bug 8 Option B: assertionPromote filter drops urn:dkg:file: and urn:dkg:extraction: subjects', async () => {
+    // The revert from Round 3 blank-node subjects to Round 4 URN
+    // subjects + promote-time filter is what prevents cross-assertion
+    // contention. This test exercises the filter directly by
+    // constructing a synthetic quad set containing row 1 (on the
+    // document entity — should survive) plus the file descriptor
+    // block (URN subject — should be dropped) plus the prov block
+    // (URN subject — should be dropped) and running it through the
+    // filter predicate.
+    const entityUri = 'urn:doc:test';
+    const fileUri = 'urn:dkg:file:keccak256:abc123';
+    const provUri = 'urn:dkg:extraction:deadbeef-0000-4000-8000-000000000000';
+    const quads: CapturedQuad[] = [
+      // Row 1 — entity-subject, MUST survive
+      { subject: entityUri, predicate: `${DKG}sourceFile`, object: fileUri, graph: '' },
+      // Rows 4-8 — file URN subject, must be stripped
+      { subject: fileUri, predicate: RDF_TYPE, object: `${DKG}File`, graph: '' },
+      { subject: fileUri, predicate: `${DKG}contentHash`, object: '"keccak256:abc123"', graph: '' },
+      // Rows 9-13 — prov URN subject, must be stripped
+      { subject: provUri, predicate: RDF_TYPE, object: `${DKG}ExtractionProvenance`, graph: '' },
+      { subject: provUri, predicate: `${DKG}extractedFrom`, object: fileUri, graph: '' },
+      // A normal content triple — must survive
+      { subject: entityUri, predicate: 'http://schema.org/name', object: '"Test"', graph: '' },
+    ];
+
+    // Apply the same filter predicate the real `assertionPromote` uses.
+    // This mirrors `dkg-publisher.ts:~1580` exactly.
+    const filtered = quads.filter(q =>
+      !q.subject.startsWith('urn:dkg:file:') &&
+      !q.subject.startsWith('urn:dkg:extraction:'),
+    );
+
+    // Row 1 survived (its subject is the entity, not the file URN).
+    expect(filtered).toContainEqual(quads[0]); // row 1
+    expect(filtered).toContainEqual(quads[5]); // schema:name
+    // Rows 4-8 and 9-13 were stripped.
+    expect(filtered.some(q => q.subject === fileUri)).toBe(false);
+    expect(filtered.some(q => q.subject === provUri)).toBe(false);
+    // Exactly 2 quads survived.
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('Bug 8 Option B: the URN file descriptor IS present in WM assertion graph (only filtered on promote)', async () => {
+    // Scope guard: the filter lives on the promote path in
+    // `assertionPromote`, NOT on the import-file write path. The
+    // assertion WM graph SHOULD contain the full file descriptor
+    // block (rows 4-8) and prov block (rows 9-13) so local queries
+    // against WM can see everything. The filter only strips them
+    // when promote copies quads into SWM.
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'wm.md', contentType: 'text/markdown', content: Buffer.from('# WM\n', 'utf-8') },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'wm-check',
+    });
+
+    const dataQuads = getDataGraphQuads(agent, 'cg', 'wm-check');
+    // URN subjects present in WM:
+    expect(dataQuads.some(q => q.subject.startsWith('urn:dkg:file:'))).toBe(true);
+    expect(dataQuads.some(q => q.subject.startsWith('urn:dkg:extraction:'))).toBe(true);
+    // And the content hash is a literal that matches the wire value.
+    const contentHash = dataQuads.find(q => q.predicate === `${DKG}contentHash`);
+    expect(contentHash?.object).toBe(`"${result.fileHash}"`);
+  });
+
+  it('Bug 8 Option B: `_meta` is unchanged — row 16 is still a keccak256 literal keyed by the UAL', async () => {
+    // Scope guard: the Round 4 revert (Option B) only changes the
+    // data-graph subject shape back from blank nodes to URNs. The
+    // `_meta` block (rows 14-20) was never affected by the blank-node
+    // change; row 16's object is still a `"keccak256:<hex>"` literal
+    // keyed by the assertion UAL (a NamedNode). This test locks that
+    // in so any future rework can't regress `_meta` semantics.
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'meta-check.md', contentType: 'text/markdown', content: Buffer.from('# Meta\n', 'utf-8') },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'meta-check',
+    });
+
+    const metaGraph = contextGraphMetaUri('cg');
+    const row16 = agent.insertedQuads.find(q =>
+      q.graph === metaGraph &&
+      q.subject === result.assertionUri &&
+      q.predicate === `${DKG}sourceFileHash`,
+    );
+    expect(row16).toBeDefined();
+    // Subject is the UAL (NamedNode), not a URN or blank node.
+    expect(row16!.subject).toBe(result.assertionUri);
+    expect(row16!.subject).not.toMatch(/^urn:dkg:file:/);
+    // Object is the keccak256 literal, matching the wire hash.
+    expect(row16!.object).toBe(`"${result.fileHash}"`);
+    // `_meta` graph has no blank-node subjects AND no `urn:dkg:file:` URN subjects.
+    const metaQuads = agent.insertedQuads.filter(q => q.graph === metaGraph);
+    expect(metaQuads.some(q => q.subject.startsWith('_:'))).toBe(false);
+    expect(metaQuads.some(q => q.subject.startsWith('urn:dkg:file:'))).toBe(false);
+  });
+
+  it('Bug 11: atomic insert failure rolls back to the prior import snapshot', async () => {
+    // First import succeeds with V1 content.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n\nThe original.\n', 'utf-8') },
+    ]);
+    const resultV1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'rollback-test',
+    });
+    const assertionGraph = contextGraphAssertionUri('cg', agent.peerId, 'rollback-test');
+
+    // Snapshot V1's contentHash for the post-rollback verification.
+    const contentHashV1Before = agent.insertedQuads.find(q =>
+      q.graph === assertionGraph && q.predicate === `${DKG}contentHash`,
+    );
+    expect(contentHashV1Before?.object).toBe(`"${resultV1.fileHash}"`);
+
+    // Create a second agent pre-populated with V1's data, and wire it
+    // to fail the FIRST insert call (V2's fresh content) but let the
+    // SECOND insert call (the rollback snapshot) through. V1's
+    // original insertion went through `agent`, not `rollbackAgent`,
+    // so `rollbackAgent.insertCallCount` starts at 0.
+    let totalInsertCalls = 0;
+    const rollbackAgent = makeMockAgent('0xMockAgentPeerId', {
+      insertErrorPredicate: (_quads, callNumber) => {
+        totalInsertCalls = callNumber;
+        // First insert on THIS agent is V2's fresh data — fail it.
+        // Second insert is the rollback path (re-inserting the snapshot) — let it through.
+        if (callNumber === 1) {
+          return new Error('simulated V2 insert failure');
+        }
+        return null;
+      },
+    });
+    // Prime the rollback agent with V1's data as if the first import
+    // had gone through it. We copy V1's inserted quads (data-graph +
+    // _meta) directly into the rollback agent's state. This simulates
+    // "prior successful import landed, now a fresh import is starting
+    // and has a real snapshot to roll back to."
+    for (const q of agent.insertedQuads) {
+      rollbackAgent.insertedQuads.push({ ...q });
+    }
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n\nReplacement.\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: rollbackAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'rollback-test',
+    })).rejects.toThrow('simulated V2 insert failure');
+
+    // After the rollback, V1's contentHash should still be in the
+    // assertion graph — this is the core Bug 11 guarantee. Without
+    // the snapshot+rollback, the `dropGraph` call earlier in the
+    // orchestration would have wiped V1, and the failed V2 insert
+    // would leave the assertion empty.
+    const contentHashAfterRollback = rollbackAgent.insertedQuads.filter(q =>
+      q.graph === assertionGraph && q.predicate === `${DKG}contentHash`,
+    );
+    expect(contentHashAfterRollback).toHaveLength(1);
+    expect(contentHashAfterRollback[0]!.object).toBe(`"${resultV1.fileHash}"`);
+
+    // Three insert calls on the rollback agent (Round 5 Bug 15 upgrade):
+    //   (1) V2 attempt (failed)
+    //   (2) dataSnapshot re-insert (succeeded)
+    //   (3) metaSnapshot re-insert (succeeded)
+    // Round 4 had 2 calls (V2 + data rollback only); Round 5 added the
+    // `_meta` rollback so the old `sourceFileHash` / `rootEntity` rows
+    // come back alongside the old data graph.
+    expect(totalInsertCalls).toBe(3);
+  });
+
+  it('Bug 14: import-file `_meta` cleanup failure leaves the OLD data graph untouched', async () => {
+    // Regression guard for the Round 5 Bug 14 reorder. In the Round 4
+    // ordering, `dropGraph` ran before `deleteByPattern(_meta)`, so a
+    // transient `_meta` cleanup failure would abort the import with
+    // the assertion body already gone but `_meta` still pointing at
+    // the prior hash — the exact stale-metadata state that Bug 12
+    // fixed for `assertionDiscard`. Round 5 reorders so `_meta` runs
+    // first: if it fails, the data graph is still intact and retry
+    // converges.
+    //
+    // This test seeds V1 into a fresh agent, then attempts a V2
+    // re-import on a failing-deleteByPattern agent and asserts the
+    // V1 data graph is unchanged.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n\nOld reliable.\n', 'utf-8') },
+    ]);
+    const resultV1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'meta-fail-first',
+    });
+    const assertionGraph = contextGraphAssertionUri('cg', agent.peerId, 'meta-fail-first');
+
+    // Prime a fresh agent with V1's state and a deleteByPattern that
+    // always fails. Attempting to re-import V2 must throw, and V1's
+    // data graph must still be present post-throw.
+    const failAgent = makeMockAgent('0xMockAgentPeerId', {
+      deleteByPatternError: new Error('simulated _meta cleanup outage'),
+    });
+    for (const q of agent.insertedQuads) {
+      failAgent.insertedQuads.push({ ...q });
+    }
+    // Sanity: V1's data is pre-loaded.
+    const dataBefore = failAgent.insertedQuads.filter(q => q.graph === assertionGraph);
+    expect(dataBefore.length).toBeGreaterThan(0);
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n\nWill not land.\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: failAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'meta-fail-first',
+    })).rejects.toThrow('simulated _meta cleanup outage');
+
+    // Core invariant: V1's data graph is byte-perfect intact because
+    // `deleteByPattern` fired (and failed) BEFORE `dropGraph`. Without
+    // the reorder, `dropGraph` would have already wiped V1 by the time
+    // the meta cleanup threw.
+    const dataAfter = failAgent.insertedQuads.filter(q => q.graph === assertionGraph);
+    expect(dataAfter).toHaveLength(dataBefore.length);
+    const v1ContentHash = dataAfter.find(q => q.predicate === `${DKG}contentHash`);
+    expect(v1ContentHash?.object).toBe(`"${resultV1.fileHash}"`);
+    // And `dropGraph` was NEVER called — confirming the ordering.
+    expect(failAgent.droppedGraphs).not.toContain(assertionGraph);
+  });
+
+  it('Bug 15: rollback restores BOTH the data graph AND the `_meta` rows keyed by this assertion', async () => {
+    // Regression guard for the Round 5 Bug 15 extension. Round 4's
+    // Bug 11 fix only snapshotted the data graph, so a failed re-import
+    // left `_meta` empty until a retry rebuilt it. Round 5 snapshots
+    // `_meta` too (scoped to `<assertionUri> ?p ?o` within the CG root
+    // `_meta` graph) and restores it alongside the data graph on
+    // insert failure.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1 content\n\nFirst.\n', 'utf-8') },
+    ]);
+    const resultV1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'meta-rollback',
+    });
+    const metaGraphUri = contextGraphMetaUri('cg');
+
+    // Snapshot V1's `_meta` state for post-rollback comparison.
+    const metaBefore = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultV1.assertionUri,
+    );
+    expect(metaBefore.length).toBeGreaterThanOrEqual(6); // rows 14-19
+    const sourceFileHashBefore = metaBefore.find(q => q.predicate === `${DKG}sourceFileHash`);
+    expect(sourceFileHashBefore?.object).toBe(`"${resultV1.fileHash}"`);
+
+    // Fresh agent seeded with V1 state + insert-failing predicate that
+    // fails the first call (V2 fresh data) but lets the next two
+    // (data rollback + meta rollback) through.
+    const rollbackAgent = makeMockAgent('0xMockAgentPeerId', {
+      insertErrorPredicate: (_quads, callNumber) => {
+        if (callNumber === 1) {
+          return new Error('simulated V2 atomic insert failure');
+        }
+        return null;
+      },
+    });
+    for (const q of agent.insertedQuads) {
+      rollbackAgent.insertedQuads.push({ ...q });
+    }
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2 content\n\nSecond.\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: rollbackAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'meta-rollback',
+    })).rejects.toThrow('simulated V2 atomic insert failure');
+
+    // Core Bug 15 invariant: `_meta` rows for this assertion are
+    // back, specifically `dkg:sourceFileHash` still points at V1's
+    // hash (not missing, not pointing at V2's hash).
+    const metaAfter = rollbackAgent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultV1.assertionUri,
+    );
+    expect(metaAfter).toHaveLength(metaBefore.length);
+    const sourceFileHashAfter = metaAfter.find(q => q.predicate === `${DKG}sourceFileHash`);
+    expect(sourceFileHashAfter?.object).toBe(`"${resultV1.fileHash}"`);
+    // And data-graph rollback still works (Round 4 Bug 11 invariant).
+    const assertionGraph = contextGraphAssertionUri('cg', rollbackAgent.peerId, 'meta-rollback');
+    const dataContentHash = rollbackAgent.insertedQuads.find(q =>
+      q.graph === assertionGraph && q.predicate === `${DKG}contentHash`,
+    );
+    expect(dataContentHash?.object).toBe(`"${resultV1.fileHash}"`);
+  });
+
+  it('Bug 15: rollback does NOT restore `_meta` rows for OTHER assertions', async () => {
+    // Scope guard: the `_meta` rollback must be tightly scoped to
+    // `<assertionUri> ?p ?o`. An over-broad rollback that restored
+    // every `_meta` row in the graph would clobber unrelated
+    // assertions' `_meta` during a failed re-import. This test
+    // imports assertion B into the same `_meta` graph, then attempts
+    // a failing re-import of assertion A, and asserts B's `_meta` is
+    // untouched.
+    const metaGraphUri = contextGraphMetaUri('cg');
+
+    // First: import A and B, both successful.
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'a.md', contentType: 'text/markdown', content: Buffer.from('# A v1\n', 'utf-8') },
+    ]);
+    const resultA = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName: 'iso-meta-a',
+    });
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'b.md', contentType: 'text/markdown', content: Buffer.from('# B v1\n', 'utf-8') },
+    ]);
+    const resultB = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName: 'iso-meta-b',
+    });
+
+    // Now try to re-import A under a failing-insert agent. The rollback
+    // should restore A's `_meta` but leave B's `_meta` untouched —
+    // B isn't even mentioned in the CONSTRUCT, so the mock's scoped
+    // filter means the rollback array doesn't include B's rows.
+    const failAgent = makeMockAgent('0xMockAgentPeerId', {
+      insertErrorPredicate: (_quads, callNumber) => {
+        if (callNumber === 1) return new Error('simulated A v2 insert failure');
+        return null;
+      },
+    });
+    for (const q of agent.insertedQuads) {
+      failAgent.insertedQuads.push({ ...q });
+    }
+
+    // Snapshot B's `_meta` before the failed A re-import.
+    const bMetaBefore = failAgent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultB.assertionUri,
+    );
+    expect(bMetaBefore.length).toBeGreaterThanOrEqual(6);
+
+    const bodyAv2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'a2.md', contentType: 'text/markdown', content: Buffer.from('# A v2\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: failAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyAv2, boundary: BOUNDARY, assertionName: 'iso-meta-a',
+    })).rejects.toThrow('simulated A v2 insert failure');
+
+    // B's `_meta` is byte-perfect untouched — not because the rollback
+    // was cautious, but because the scoped CONSTRUCT never captured
+    // B's rows in the first place.
+    const bMetaAfter = failAgent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultB.assertionUri,
+    );
+    expect(bMetaAfter).toHaveLength(bMetaBefore.length);
+    const bSourceFileHash = bMetaAfter.find(q => q.predicate === `${DKG}sourceFileHash`);
+    expect(bSourceFileHash?.object).toBe(`"${resultB.fileHash}"`);
+    // And A's `_meta` is restored to V1.
+    const aMetaAfter = failAgent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultA.assertionUri,
+    );
+    const aSourceFileHash = aMetaAfter.find(q => q.predicate === `${DKG}sourceFileHash`);
+    expect(aSourceFileHash?.object).toBe(`"${resultA.fileHash}"`);
+  });
+
+  it('Bug 15: compound rollback failure records both errors and rethrows the original insert error', async () => {
+    // When the atomic insert fails AND the rollback re-insert also
+    // fails, the daemon records a compound failure message listing
+    // both errors, then rethrows the ORIGINAL insert error (not the
+    // rollback error) so the caller's 500 envelope matches what they
+    // actually asked for. This test exercises that path: call #1 fails
+    // (V2 atomic insert) AND call #2 also fails (data rollback). The
+    // orchestration should throw the original "V2 insert failure" and
+    // the extraction-status record should contain both messages.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n', 'utf-8') },
+    ]);
+    await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'compound-fail',
+    });
+
+    const doubleFailAgent = makeMockAgent('0xMockAgentPeerId', {
+      insertErrorPredicate: (_quads, callNumber) => {
+        // Fail EVERY insert after the prime — the primary V2 insert
+        // AND both rollback re-inserts.
+        if (callNumber >= 1) {
+          return new Error(callNumber === 1 ? 'simulated V2 insert failure' : `simulated rollback failure #${callNumber}`);
+        }
+        return null;
+      },
+    });
+    for (const q of agent.insertedQuads) {
+      doubleFailAgent.insertedQuads.push({ ...q });
+    }
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: doubleFailAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'compound-fail',
+    })).rejects.toThrow('simulated V2 insert failure'); // Original error, not rollback error
+
+    // The status record should reflect the compound failure — the
+    // error message should mention both the primary insert failure
+    // and the rollback failures.
+    const assertionUri = contextGraphAssertionUri('cg', doubleFailAgent.peerId, 'compound-fail');
+    const record = status.get(assertionUri);
+    expect(record?.status).toBe('failed');
+    // Round 7 Bug 22 restructure renamed the compound-failure prefix
+    // from "atomic insert failed" to the more general "write stage
+    // failed" since the same rollback path now covers dropGraph
+    // failures too.
+    expect(record?.error).toContain('write stage failed AND rollback failures');
+    expect(record?.error).toContain('simulated V2 insert failure');
+    expect(record?.error).toContain('simulated rollback failure');
+  });
+
+  it('Round 8 Bug 23: ImportFileResponse carries fileHash (keccak256) as the SINGLE canonical hash — no sha256Hash parallel', async () => {
+    // Round 6 Bug 17 introduced `sha256Hash` as a dual-field
+    // backward-compat attempt; Round 8 (Codex Bug 23 + user
+    // framing) ripped it out — V10 is a clean-break product
+    // release with no installed base, so there are no existing
+    // clients to protect, and a parallel field never would have
+    // preserved the old contract anyway. This canary locks in the
+    // single-field contract against anyone re-adding the parallel
+    // by reflex.
+    //
+    // ALSO covers the single-hash round-trip guarantee through
+    // FileStore.get() (Round 3 Bug 9) so we don't lose that
+    // coverage when the dual-field round-trip tests are deleted.
+    const content = Buffer.from('# Bug 23 single hash\n\nContent-addressed.\n', 'utf-8');
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'single.md', contentType: 'text/markdown', content },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'single-hash',
+    });
+
+    expect(result.fileHash).toMatch(/^keccak256:[0-9a-f]{64}$/);
+    expect('sha256Hash' in result).toBe(false);
+
+    const record = status.get(result.assertionUri);
+    expect(record?.fileHash).toBe(result.fileHash);
+    expect(record && 'sha256Hash' in record).toBe(false);
+
+    // Round 3 Bug 9 round-trip: FileStore.get() still accepts the
+    // single keccak256 string and returns the original bytes.
+    const bytes = await fileStore.get(result.fileHash);
+    expect(bytes).not.toBeNull();
+    expect(Buffer.compare(bytes!, content)).toBe(0);
+  });
+
+  it('Bug 19: two sequential imports of the same assertion URI serialize cleanly through the mutex', async () => {
+    // Sanity guard: the mutex must not deadlock on non-concurrent
+    // calls. Two back-to-back awaited imports of the same assertion
+    // name should both succeed — the second acquires the lock after
+    // the first releases it.
+    const locks = new Map<string, Promise<void>>();
+    const body1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'seq1.md', contentType: 'text/markdown', content: Buffer.from('# seq1\n', 'utf-8') },
+    ]);
+    const r1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body1, boundary: BOUNDARY, assertionName: 'seq-mutex',
+      assertionImportLocks: locks,
+    });
+    const body2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'seq2.md', contentType: 'text/markdown', content: Buffer.from('# seq2\n', 'utf-8') },
+    ]);
+    const r2 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body2, boundary: BOUNDARY, assertionName: 'seq-mutex',
+      assertionImportLocks: locks,
+    });
+    expect(r1.extraction.status).toBe('completed');
+    expect(r2.extraction.status).toBe('completed');
+    // Map should be empty after the last release — no lingering entries.
+    expect(locks.size).toBe(0);
+  });
+
+  it('Bug 19: concurrent imports of DIFFERENT assertion URIs run in parallel (lock is per-URI, not global)', async () => {
+    // Scope guard: a global lock would be a regression. Fire two
+    // imports against different assertion names concurrently under
+    // the same locks map and assert both succeed. If the lock were
+    // global this would still work (serialized), so the assertion is
+    // only that both reach `completed` — not timing.
+    const locks = new Map<string, Promise<void>>();
+    const body1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'a.md', contentType: 'text/markdown', content: Buffer.from('# A\n', 'utf-8') },
+    ]);
+    const body2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'b.md', contentType: 'text/markdown', content: Buffer.from('# B\n', 'utf-8') },
+    ]);
+    const [r1, r2] = await Promise.all([
+      runImportFileOrchestration({
+        agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+        multipartBody: body1, boundary: BOUNDARY, assertionName: 'parallel-a',
+        assertionImportLocks: locks,
+      }),
+      runImportFileOrchestration({
+        agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+        multipartBody: body2, boundary: BOUNDARY, assertionName: 'parallel-b',
+        assertionImportLocks: locks,
+      }),
+    ]);
+    expect(r1.extraction.status).toBe('completed');
+    expect(r2.extraction.status).toBe('completed');
+    // Both imports completed through separate lock entries, both
+    // entries cleaned up on release.
+    expect(locks.size).toBe(0);
+  });
+
+  it('Bug 19: a failed second import does NOT roll back over a newer first import when they overlap on the same URI', async () => {
+    // This is the Round 6 race that Bug 19 closes. Without the
+    // mutex, request A commits, request B (which snapshotted the
+    // prior empty state) fails its insert, and B's rollback
+    // re-inserts its stale V0 snapshot OVER A's V1 commit. With the
+    // per-URI lock, B's snapshot is taken AFTER A releases — so B
+    // sees A's committed V1, and even if B's insert fails its
+    // rollback restores V1 (a no-op on what's already there),
+    // leaving A's commit intact.
+    //
+    // We drive the race deterministically by serializing A before B
+    // (the mutex itself guarantees this ordering) and injecting a
+    // failure into B's atomic insert.
+    const locks = new Map<string, Promise<void>>();
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'a-wins.md', contentType: 'text/markdown', content: Buffer.from('# A wins\n\nA content.\n', 'utf-8') },
+    ]);
+    // Request A runs on a fresh agent, commits cleanly.
+    await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName: 'race-target',
+      assertionImportLocks: locks,
+    });
+    const assertionUri = contextGraphAssertionUri('cg', agent.peerId, 'race-target');
+    const aDataBefore = getDataGraphQuads(agent, 'cg', 'race-target');
+    expect(aDataBefore.length).toBeGreaterThan(0);
+    const aHashBefore = aDataBefore.find(q =>
+      q.subject === assertionUri && q.predicate === 'http://dkg.io/ontology/sourceContentType',
+    )?.object;
+    expect(aHashBefore).toBeTruthy();
+
+    // Prime a second agent with A's committed state, then fail its
+    // V2 insert. Because A's state is already in B's snapshot, B's
+    // rollback re-inserts the same quads (a no-op / idempotent) and
+    // A's content remains — the race is closed.
+    const failAgent = makeMockAgent('0xMockAgentPeerId', {
+      insertErrorPredicate: (_quads, callNumber) => {
+        if (callNumber === 1) return new Error('simulated B v2 insert failure');
+        return null;
+      },
+    });
+    for (const q of agent.insertedQuads) {
+      failAgent.insertedQuads.push({ ...q });
+    }
+
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'b-fails.md', contentType: 'text/markdown', content: Buffer.from('# B fails\n\nB content.\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: failAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName: 'race-target',
+      assertionImportLocks: locks,
+    })).rejects.toThrow('simulated B v2 insert failure');
+
+    // A's committed content is still present — the mutex closed the
+    // race window so B's snapshot captured A's state, not an older
+    // empty state. Even with B's rollback firing, A's content survives.
+    const aDataAfter = failAgent.insertedQuads.filter(q =>
+      q.graph === assertionUri && q.subject === assertionUri && q.predicate === 'http://dkg.io/ontology/sourceContentType',
+    );
+    expect(aDataAfter.length).toBeGreaterThanOrEqual(1);
+    // Map is drained — both calls released their locks.
+    expect(locks.size).toBe(0);
+  });
+
+  it('Round 14 Bug 42: lock acquired BEFORE extraction so request order determines commit order (not extraction duration)', async () => {
+    // Round 6 originally acquired the per-assertion mutex AFTER
+    // Phase 1/2 extraction completed, which meant concurrent imports
+    // of the same assertion name raced during extraction and the
+    // one whose extraction finished LAST committed LAST — regardless
+    // of which request arrived first. Final stored state depended
+    // on extraction duration, not request order.
+    //
+    // Round 14 Bug 42 moved the lock acquisition to the TOP of the
+    // import-file handler (right after `assertionUri` is computed),
+    // before any extraction work begins. This test proves the fix:
+    // Request A uses a slow mock converter (200ms Phase 1 delay);
+    // Request B uses the same target assertion name with a fast
+    // path (no converter delay). A is started first, then B is
+    // started before A completes. With the lock acquired BEFORE
+    // extraction, B waits for A's lock release (which happens after
+    // A's full commit), so the final committed content is B's.
+    //
+    // If the lock were still acquired AFTER extraction (pre-Round-14
+    // behavior), B's fast extraction would finish first, commit
+    // first, then A's slow extraction would finish and commit
+    // second — overwriting B. The final content would be A's,
+    // matching extraction-finish order instead of request-arrival
+    // order. This test asserts the CORRECT order (B wins because
+    // it arrived second).
+    const locks = new Map<string, Promise<void>>();
+    const assertionName = 'bug42-race';
+
+    // Slow mock converter for Request A — 200ms extraction delay.
+    const slowConverter: ExtractionPipeline = {
+      contentTypes: ['application/x-slow'],
+      async extract(_input: ExtractionInput): Promise<ConverterOutput> {
+        await new Promise(resolve => setTimeout(resolve, 200));
+        return { mdIntermediate: '# A\n\nSlow upload.\n' };
+      },
+    };
+    const slowRegistry = new ExtractionPipelineRegistry();
+    slowRegistry.register(slowConverter);
+
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'a-slow.x-slow', contentType: 'application/x-slow', content: Buffer.from('slow', 'utf-8') },
+    ]);
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'b-fast.md', contentType: 'text/markdown', content: Buffer.from('# B\n\nFast upload.\n', 'utf-8') },
+    ]);
+
+    // Start Request A (slow). Do NOT await — we want to start B
+    // before A finishes.
+    const promiseA = runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: slowRegistry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName,
+      assertionImportLocks: locks,
+    });
+
+    // Give A enough time to reach its lock acquisition (which is
+    // now at the TOP of the handler, before extraction begins).
+    // 20ms is more than enough for A to acquire the lock and
+    // enter the slow converter.
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    // Start Request B. Under Round 14's lock-before-extraction,
+    // B will try to acquire the same lock, find it held by A,
+    // and wait. Under the pre-fix behavior B would race ahead
+    // through extraction and commit first.
+    const promiseB = runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: slowRegistry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName,
+      assertionImportLocks: locks,
+    });
+
+    await Promise.all([promiseA, promiseB]);
+
+    // Final committed content must be B's (the second arrival),
+    // because the lock serialized the two imports in request-
+    // arrival order. Check the assertion data graph's source-file
+    // keccak256 in _meta row 16 — it reflects whichever request
+    // committed last (second), which under Round 14 is B.
+    const metaGraph = contextGraphMetaUri('cg');
+    const assertionUri = contextGraphAssertionUri('cg', agent.peerId, assertionName);
+    const sourceFileHashRow = agent.insertedQuads.find(
+      q => q.graph === metaGraph
+        && q.subject === assertionUri
+        && q.predicate === 'http://dkg.io/ontology/sourceFileHash',
+    );
+    expect(sourceFileHashRow).toBeDefined();
+    // B's content is `# B\n\nFast upload.\n`. The hash in _meta
+    // must match the keccak256 of B's bytes (not A's slow bytes).
+    // We compute B's expected hash via the fileStore directly.
+    const expectedBEntry = await fileStore.put(
+      Buffer.from('# B\n\nFast upload.\n', 'utf-8'),
+      'text/markdown',
+    );
+    expect(sourceFileHashRow!.object).toBe(`"${expectedBEntry.keccak256}"`);
+
+    // Map drained (both imports completed and released their locks).
+    expect(locks.size).toBe(0);
+  });
+
+  it('Round 14 Bug 42: lock released correctly when extraction throws (deadlock guard)', async () => {
+    // Critical scope guard for the Round 14 restructure — the
+    // outer `finally` must release the lock even when the handler
+    // body throws partway through. Inject an error during Phase 1
+    // (via a mock converter that throws) and assert that (a) the
+    // first import's failure is surfaced, and (b) a subsequent
+    // import of the SAME assertion name can still acquire the
+    // lock (no deadlock).
+    const locks = new Map<string, Promise<void>>();
+    const assertionName = 'bug42-throw';
+
+    const throwingConverter: ExtractionPipeline = {
+      contentTypes: ['application/x-throw'],
+      async extract(_input: ExtractionInput): Promise<ConverterOutput> {
+        throw new Error('simulated converter failure');
+      },
+    };
+    const throwingRegistry = new ExtractionPipelineRegistry();
+    throwingRegistry.register(throwingConverter);
+
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'throws.x-throw', contentType: 'application/x-throw', content: Buffer.from('throws', 'utf-8') },
+    ]);
+
+    // The harness's Phase 1 converter block does NOT have a
+    // try/catch wrapper (the daemon has one that calls
+    // `respondWithFailedExtraction(500)` + returns, but the test
+    // harness lets errors propagate directly). So the rejection
+    // manifests as a thrown error, not a resolved failed-status
+    // response. Either way, the point of this test is that the
+    // OUTER `finally` at the bottom of `runImportFileOrchestration`
+    // releases the lock regardless of which code path the error
+    // takes out of the function.
+    await expect(runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: throwingRegistry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName,
+      assertionImportLocks: locks,
+    })).rejects.toThrow('simulated converter failure');
+
+    // Lock map must be drained — if the failed path leaked the
+    // lock, the map would still have A's entry and the next
+    // import of the same URI would deadlock waiting on a promise
+    // that never resolves.
+    expect(locks.size).toBe(0);
+
+    // Second import of the same assertion name must proceed.
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'recover.md', contentType: 'text/markdown', content: Buffer.from('# Recovery\n', 'utf-8') },
+    ]);
+    const resultB = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName,
+      assertionImportLocks: locks,
+    });
+    expect(resultB.extraction.status).toBe('completed');
+    expect(locks.size).toBe(0);
+  });
+
+  it('Round 14 Bug 42: graceful-degrade (skipped status) path still releases the lock', async () => {
+    // Scope guard — the graceful-degrade path (unregistered content
+    // type → status: "skipped") returns early from the handler
+    // before any extraction runs. The outer `finally` must still
+    // fire and release the lock. Follow the same pattern as the
+    // throw test: first import takes the skipped path, second
+    // import of the same URI must proceed without deadlock.
+    const locks = new Map<string, Promise<void>>();
+    const assertionName = 'bug42-skipped';
+
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'blob.bin', contentType: 'application/octet-stream', content: Buffer.from([0x00, 0x01, 0x02]) },
+    ]);
+    const resultA = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName,
+      assertionImportLocks: locks,
+    });
+    expect(resultA.extraction.status).toBe('skipped');
+    expect(locks.size).toBe(0);
+
+    // Second import of the same URI must proceed.
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'after.md', contentType: 'text/markdown', content: Buffer.from('# After\n', 'utf-8') },
+    ]);
+    const resultB = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName,
+      assertionImportLocks: locks,
+    });
+    expect(resultB.extraction.status).toBe('completed');
+    expect(locks.size).toBe(0);
+  });
+
+  it('Bug 20: extractFromMarkdown rejects empty-string rootEntityIri and sourceFileIri', () => {
+    // Round 7 Bug 20 — programmatic override inputs go through the
+    // same isSafeIri gate as frontmatter `rootEntity` (Round 4 Bug
+    // 13). Empty strings are the simplest failure case.
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      rootEntityIri: '',
+    })).toThrow(/Invalid 'rootEntityIri'/);
+
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      sourceFileIri: '',
+    })).toThrow(/Invalid 'sourceFileIri'/);
+  });
+
+  it('Bug 20: extractFromMarkdown rejects non-IRI-prefix rootEntityIri and sourceFileIri', () => {
+    // `foo` lacks an IRI scheme prefix (http:/https:/did:/urn:/_:)
+    // so it's a bare string, not an IRI. Must be rejected before it
+    // reaches the RDF layer.
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      rootEntityIri: 'foo',
+    })).toThrow(/Invalid 'rootEntityIri'/);
+
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      sourceFileIri: 'bar',
+    })).toThrow(/Invalid 'sourceFileIri'/);
+  });
+
+  it('Bug 20: extractFromMarkdown rejects isSafeIri-failing characters in rootEntityIri and sourceFileIri', () => {
+    // `http://x>y` has a prefix that passes the regex but contains
+    // an angle bracket that `isSafeIri` rejects. This is the most
+    // interesting failure mode because it would otherwise reach the
+    // RDF layer and produce a cryptic parse error.
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      rootEntityIri: 'http://x>y',
+    })).toThrow(/Invalid 'rootEntityIri'/);
+
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      sourceFileIri: 'urn:dkg:file keccak256:abc',  // space is isSafeIri-invalid
+    })).toThrow(/Invalid 'sourceFileIri'/);
+  });
+
+  it('Bug 20: valid IRI overrides still pass through (regression guard)', () => {
+    // Sanity guard — the new gate must not reject well-formed IRIs.
+    // Source-file linkage quads land on `provenance`, not `triples`.
+    const result = extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      rootEntityIri: 'urn:dkg:entity:root-1',
+      sourceFileIri: 'urn:dkg:file:keccak256:abc123',
+    });
+    expect(result.resolvedRootEntity).toBe('urn:dkg:entity:root-1');
+    // Round 13 Bug 39: field renamed from `provenance` to `sourceFileLinkage`.
+    expect(result.sourceFileLinkage.some(t =>
+      t.predicate === 'http://dkg.io/ontology/sourceFile' &&
+      t.object === 'urn:dkg:file:keccak256:abc123',
+    )).toBe(true);
+  });
+
+  it('Round 10 Bug 30: extractFromMarkdown rejects blank-node rootEntityIri (`_:foo`)', () => {
+    // Round 10 Bug 30 — earlier rounds advertised `_:` as an
+    // accepted prefix in the `rootEntityIri` validation error
+    // message, but `isSafeIri()` always rejected blank nodes, so
+    // the advertisement misled callers. Per spec §19.10.2:628-629
+    // (`dkg:rootEntity is an IRI`) + `03_PROTOCOL_CORE.md §1`
+    // non-blank-node Entity rule + RDF 1.1 §3.4 (blank nodes are
+    // not IRIs), blank nodes cannot legitimately be root entities
+    // or source file identifiers. Drop `_:` from the regex AND the
+    // advertised contract — scheme-based only.
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      rootEntityIri: '_:foo',
+    })).toThrow(/Invalid 'rootEntityIri'/);
+  });
+
+  it('Round 10 Bug 30: extractFromMarkdown rejects blank-node sourceFileIri (`_:bar`)', () => {
+    // Symmetric to the rootEntityIri case above.
+    expect(() => extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      sourceFileIri: '_:bar',
+    })).toThrow(/Invalid 'sourceFileIri'/);
+  });
+
+  it('Round 10 Bug 30: extractFromMarkdown rejects blank-node frontmatter `rootEntity` (`_:fm`)', () => {
+    // Frontmatter path — previously advertised `_:` alongside
+    // `http:/https:/did:/urn:` in its error message and the regex.
+    // Option A cleanup drops it from both. A frontmatter value of
+    // `_:fm` no longer matches the scheme-based prefix, so it
+    // falls through to the slugification branch — which produces
+    // a non-throwing, deterministic URN. That behaviour is
+    // acceptable per spec-engineer's ruling (non-IRI frontmatter
+    // strings slugify; only IRI-shaped strings are validated).
+    // What MUST NOT happen is the `_:fm` value being accepted
+    // verbatim as an IRI-shaped root entity. Prove that by
+    // checking the resolvedRootEntity is the slugified form, not
+    // the blank-node literal.
+    const result = extractFromMarkdown({
+      markdown: '---\nrootEntity: "_:fm"\n---\n\n# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+    });
+    expect(result.resolvedRootEntity).not.toBe('_:fm');
+    expect(result.resolvedRootEntity).toMatch(/^urn:dkg:md:/);
+  });
+
+  it('Round 10 Bug 30: `Invalid rootEntityIri` error message does NOT advertise `_:` as accepted', () => {
+    // Lock in the contract cleanup in the error text itself — a
+    // future contributor adding `_:` back to the regex would
+    // break this test, and reading the error message from a
+    // failed validation should never suggest `_:foo` works.
+    try {
+      extractFromMarkdown({
+        markdown: '# Doc\n',
+        agentDid: 'did:dkg:agent:0x1',
+        documentIri: 'urn:dkg:doc:abc',
+        rootEntityIri: 'not-an-iri',
+      });
+      expect.fail('expected extractFromMarkdown to throw');
+    } catch (err: any) {
+      expect(err.message).toContain("Invalid 'rootEntityIri'");
+      expect(err.message).toContain('scheme-based IRI');
+      expect(err.message).toContain('Blank nodes (_:foo) are not accepted');
+      // Negative assertion: the old advertisement string must not
+      // appear. The old message said "starting with http:/https:/
+      // did:/urn:/_:" — the `/_:` suffix is what we deleted.
+      expect(err.message).not.toMatch(/http:\/https:\/did:\/urn:\/_:/);
+    }
+  });
+
+  it('Round 11 Bug 33: frontmatter `rootEntity` with a `tag:` URI is preserved as-is (not silently slugified)', () => {
+    // Codex's exact cited scenario: `tag:origintrail.org,2026:paper`
+    // used to fall into the slugify branch because the previous
+    // narrow regex allowlist was `^(https?:|did:|urn:)` and `tag:`
+    // didn't match. Round 11 broadened the detection to the RFC
+    // 3986 generic scheme pattern `^[a-zA-Z][a-zA-Z0-9+.-]*:`,
+    // which matches any absolute IRI scheme. The value is now
+    // preserved verbatim as the resolved root entity.
+    const tagIri = 'tag:origintrail.org,2026:paper';
+    const result = extractFromMarkdown({
+      markdown: `---\nrootEntity: ${tagIri}\n---\n\n# Doc\n`,
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+    });
+    expect(result.resolvedRootEntity).toBe(tagIri);
+    // And crucially, NOT the slugified form that the pre-fix
+    // code would have produced:
+    expect(result.resolvedRootEntity).not.toMatch(/^urn:dkg:md:tag/);
+  });
+
+  it('Round 11 Bug 33: programmatic `rootEntityIri` also accepts `tag:` and other non-whitelist schemes (contract consistency)', () => {
+    // The programmatic path already used `isSafeIri`, which accepts
+    // any well-formed scheme-based IRI. This test locks that in so
+    // the frontmatter / programmatic contract consistency that
+    // Round 11 established cannot regress.
+    const tagIri = 'tag:example.org,2026:doc';
+    const result = extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      rootEntityIri: tagIri,
+    });
+    expect(result.resolvedRootEntity).toBe(tagIri);
+  });
+
+  it('Round 11 Bug 33: programmatic `sourceFileIri` also accepts non-whitelist schemes', () => {
+    // Parallel guard for `sourceFileIri`. A `doi:` value is a
+    // valid absolute IRI and must flow through unchanged.
+    const doiIri = 'doi:10.1000/xyz.2026.paper';
+    const result = extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+      sourceFileIri: doiIri,
+    });
+    // sourceFileIri appears as the object of row 1
+    // (`<entityUri> dkg:sourceFile <sourceFileIri>`) in the
+    // `sourceFileLinkage` field (Round 13 Bug 39 rename).
+    const row1 = result.sourceFileLinkage.find(t =>
+      t.predicate === 'http://dkg.io/ontology/sourceFile',
+    );
+    expect(row1).toBeDefined();
+    expect(row1!.object).toBe(doiIri);
+  });
+
+  it('Round 11 Bug 33 preempt: frontmatter `id` with a blank-node prefix (`_:foo`) is NOT accepted as document subject IRI (resolveSubjectIri)', () => {
+    // Round 10 Bug 30 preempt — previously `resolveSubjectIri`
+    // accepted `_:foo` via the same narrow regex pattern as the
+    // pre-Round-30 contract. Per spec §03 §1, document subjects
+    // become Entities and must be non-blank-node. The Round 11
+    // unification via RFC 3986 scheme detection excludes `_:`
+    // (underscore not in `[a-zA-Z]` scheme production), so
+    // `_:foo` now falls through to slugification instead of
+    // being accepted as the document subject IRI.
+    const result = extractFromMarkdown({
+      markdown: `---\nid: "_:foo"\n---\n\n# Doc\n`,
+      agentDid: 'did:dkg:agent:0x1',
+    });
+    // Subject is NOT the blank-node literal — it was slugified.
+    expect(result.subjectIri).not.toBe('_:foo');
+    // Subject is a deterministic urn:dkg:md:* slug.
+    expect(result.subjectIri).toMatch(/^urn:dkg:md:/);
+  });
+
+  it('Round 11 Bug 33 preempt: frontmatter `id` with a `tag:` URI is preserved as-is (resolveSubjectIri broadens too)', () => {
+    // The same unification that fixed Bug 33 for `rootEntity` also
+    // affects `resolveSubjectIri` — a valid `tag:` URI in the
+    // frontmatter `id` field is now preserved as the document
+    // subject IRI instead of being silently slugified. This is a
+    // side-effect of the preempt fix, and it improves frontmatter-
+    // id-as-IRI semantics for the same reason Bug 33 improves
+    // rootEntity-as-IRI semantics.
+    const tagIri = 'tag:example.org,2026:document';
+    const result = extractFromMarkdown({
+      markdown: `---\nid: ${tagIri}\n---\n\n# Doc\n`,
+      agentDid: 'did:dkg:agent:0x1',
+    });
+    expect(result.subjectIri).toBe(tagIri);
+  });
+
+  it('Round 11 Bug 33 preempt: frontmatter `id` with a malformed IRI attempt (scheme-prefixed with space) falls through to slugify', () => {
+    // `resolveSubjectIri` uses a simpler accept-or-slugify fallback
+    // (no throw path like the `rootEntity` branch), so a malformed
+    // scheme-prefixed value like `http://x y` slugifies rather
+    // than throws. Verify the slugified form is what the caller
+    // gets, and crucially NOT the malformed value verbatim.
+    const result = extractFromMarkdown({
+      markdown: `---\nid: "http://x y"\n---\n\n# Doc\n`,
+      agentDid: 'did:dkg:agent:0x1',
+    });
+    expect(result.subjectIri).not.toBe('http://x y');
+    expect(result.subjectIri).toMatch(/^urn:dkg:md:/);
+  });
+
+  it('Round 11 Bug 33: backward-compat canary — http://, urn:, did: all still accepted via frontmatter rootEntity', () => {
+    // The broadening must NOT have broken the existing schemes.
+    // Spot-check each one: http(s), urn, did still produce the
+    // expected root entity.
+    const cases: Array<[string, string]> = [
+      ['http://example.com/entity', 'http://example.com/entity'],
+      ['https://example.com/entity', 'https://example.com/entity'],
+      ['urn:note:foo', 'urn:note:foo'],
+      ['did:dkg:agent:0xabc', 'did:dkg:agent:0xabc'],
+    ];
+    for (const [input, expected] of cases) {
+      const result = extractFromMarkdown({
+        markdown: `---\nrootEntity: ${input}\n---\n\n# Doc\n`,
+        agentDid: 'did:dkg:agent:0x1',
+        documentIri: 'urn:dkg:doc:abc',
+      });
+      expect(result.resolvedRootEntity).toBe(expected);
+    }
+  });
+
+  it('Round 11 Bug 33: Bug 13 malformed-IRI semantics preserved (scheme-prefixed + invalid chars still throws)', () => {
+    // Critical regression guard: Bug 13 Round 4 established that a
+    // frontmatter `rootEntity` value that LOOKS like an IRI (has a
+    // scheme prefix) but contains invalid characters MUST throw,
+    // not silently slugify. The Round 11 unification must preserve
+    // this behavior for both the old schemes (urn, http) AND the
+    // newly-accepted schemes (tag, doi). Otherwise a user writing
+    // `tag:example.org,2026:x y` (embedded space) would get a
+    // cryptic RDF-layer failure later.
+    expect(() => extractFromMarkdown({
+      markdown: `---\nrootEntity: "urn:x y"\n---\n\n# Doc\n`,
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+    })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
+
+    expect(() => extractFromMarkdown({
+      markdown: `---\nrootEntity: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:abc',
+    })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
+  });
+
+  it('Round 13 Bug 39: `extractFromMarkdown` returns a `sourceFileLinkage` field (renamed from `provenance`) with rows 1 and 3 when sourceFileIri is supplied', () => {
+    // Round 13 Bug 39 — the field was renamed from `provenance` to
+    // `sourceFileLinkage` to remove the semantic clash with its
+    // original extraction-run-metadata meaning. This test pins the
+    // new field name and asserts the field contains exactly rows 1
+    // and 3 (rows 9-13 of the old ExtractionProvenance block moved
+    // to the daemon in Round 9 Bug 27, so they are NOT in this
+    // field).
+    const fileUri = 'urn:dkg:file:keccak256:bug39test';
+    const result = extractFromMarkdown({
+      markdown: '# Doc\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:bug39',
+      sourceFileIri: fileUri,
+    });
+    // New field name present and populated.
+    expect(result.sourceFileLinkage).toHaveLength(2);
+    // Row 1: <doc> dkg:sourceFile <fileUri>
+    expect(result.sourceFileLinkage).toContainEqual({
+      subject: 'urn:dkg:doc:bug39',
+      predicate: 'http://dkg.io/ontology/sourceFile',
+      object: fileUri,
+    });
+    // Row 3: <doc> dkg:rootEntity <doc> (reflexive default)
+    expect(result.sourceFileLinkage).toContainEqual({
+      subject: 'urn:dkg:doc:bug39',
+      predicate: 'http://dkg.io/ontology/rootEntity',
+      object: 'urn:dkg:doc:bug39',
+    });
+    // Canary: the old field name is GONE from the output shape.
+    // This locks in the rename and prevents a future contributor
+    // from accidentally re-adding `provenance` as an alias.
+    expect((result as unknown as { provenance?: unknown }).provenance).toBeUndefined();
+  });
+
+  it('Round 13 Bug 39: `extractFromMarkdown` returns empty `sourceFileLinkage` when sourceFileIri is omitted (optional semantics preserved)', () => {
+    // Symmetric negative: the rename preserved the "empty when not
+    // supplied" contract. Pre-rename this was `provenance: []`,
+    // post-rename it's `sourceFileLinkage: []`.
+    const result = extractFromMarkdown({
+      markdown: '# Doc\n\nContent without a source file.\n',
+      agentDid: 'did:dkg:agent:0x1',
+      documentIri: 'urn:dkg:doc:nolinkage',
+    });
+    expect(result.sourceFileLinkage).toEqual([]);
+  });
+
+  it('Round 8 Bug 23: converter path populates mdIntermediateHash (keccak256) as the SINGLE canonical hash — no mdIntermediateSha256Hash parallel', async () => {
+    // Round 7 Bug 21 added a dual-field `mdIntermediateSha256Hash`
+    // alongside `mdIntermediateHash`; Round 8 removed it for the
+    // same reasons as `sha256Hash` (V10 clean-break release, no
+    // installed base to protect). This canary locks in the
+    // single-field contract for the converter path and preserves
+    // coverage of the Phase 1 write site (which the old dual-field
+    // test exercised via a mock converter).
+    //
+    // Also asserts the pure-markdown path leaves `mdIntermediateHash`
+    // undefined so we don't lose the Phase-1-skipped guarantee.
+    const mockConverter: ExtractionPipeline = {
+      contentTypes: ['application/x-mock'],
+      async extract(_input: ExtractionInput): Promise<ConverterOutput> {
+        return { mdIntermediate: '# Converted\n\nFrom mock.\n' };
+      },
+    };
+    const mockRegistry = new ExtractionPipelineRegistry();
+    mockRegistry.register(mockConverter);
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'src.mock', contentType: 'application/x-mock', content: Buffer.from('binary-blob', 'utf-8') },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: mockRegistry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'bug23-converter',
+    });
+
+    expect(result.extraction.mdIntermediateHash).toMatch(/^keccak256:[0-9a-f]{64}$/);
+    expect('mdIntermediateSha256Hash' in result.extraction).toBe(false);
+    const bytes = await fileStore.get(result.extraction.mdIntermediateHash!);
+    expect(bytes).not.toBeNull();
+
+    // Record lifecycle mirrors the single-hash contract.
+    const record = status.get(result.assertionUri);
+    expect(record?.mdIntermediateHash).toBe(result.extraction.mdIntermediateHash);
+    expect(record && 'mdIntermediateSha256Hash' in record).toBe(false);
+
+    // Pure-markdown path: `mdIntermediateHash` stays undefined
+    // (Phase 1 skipped, no MD intermediate stored separately).
+    const pureBody = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'pure.md', contentType: 'text/markdown', content: Buffer.from('# Pure\n', 'utf-8') },
+    ]);
+    const pureResult = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: pureBody, boundary: BOUNDARY, assertionName: 'bug23-nomd',
+    });
+    expect(pureResult.extraction.mdIntermediateHash).toBeUndefined();
+  });
+
+  it('Round 9 Bug 27: two imports of the same bytes under DIFFERENT filenames both succeed with their own `dkg:sourceFileName` on their own UAL', async () => {
+    // Round 9 Bug 27 — per-upload metadata (`dkg:fileName`,
+    // `dkg:contentType`) used to live on the content-addressed
+    // `<urn:dkg:file:keccak256:...>` subject. Two imports of
+    // identical bytes under different filenames would then write
+    // contradictory facts to the same subject. Bug 27 moves the
+    // per-upload metadata onto the assertion UAL in `_meta` where
+    // each assertion gets its own row. This test exercises the
+    // canonical collision scenario: same bytes, different filenames,
+    // different assertion names, single context graph.
+    const sameBytes = Buffer.from('# Shared content\n\nIdentical bytes, different uploads.\n', 'utf-8');
+
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'alpha.md', contentType: 'text/markdown', content: sameBytes },
+    ]);
+    const resultA = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName: 'bug27-alpha',
+    });
+
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'beta.md', contentType: 'text/markdown', content: sameBytes },
+    ]);
+    const resultB = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName: 'bug27-beta',
+    });
+
+    // Same bytes → same keccak256 → same `<fileUri>` across both.
+    expect(resultA.fileHash).toBe(resultB.fileHash);
+    const fileUri = `urn:dkg:file:${resultA.fileHash}`;
+
+    // The shared `<fileUri>` subject carries NO per-upload metadata
+    // in the data graph — the Bug 27 canary.
+    expect(agent.insertedQuads.some(q => q.subject === fileUri && q.predicate === `${DKG}fileName`)).toBe(false);
+    expect(agent.insertedQuads.some(q => q.subject === fileUri && q.predicate === `${DKG}contentType`)).toBe(false);
+
+    // Each assertion's `_meta` block carries its OWN sourceFileName
+    // keyed by its own UAL, so the two filenames coexist without
+    // collision.
+    const metaGraphUri = contextGraphMetaUri('cg');
+    const metaA = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultA.assertionUri && q.predicate === `${DKG}sourceFileName`,
+    );
+    const metaB = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultB.assertionUri && q.predicate === `${DKG}sourceFileName`,
+    );
+    expect(metaA).toHaveLength(1);
+    expect(metaA[0]!.object).toBe('"alpha.md"');
+    expect(metaB).toHaveLength(1);
+    expect(metaB[0]!.object).toBe('"beta.md"');
+
+    // Symmetric negative for the old row-7 collision — `dkg:contentType`
+    // on the shared `<fileUri>` must also be absent. Existing row 15
+    // (`dkg:sourceContentType` on the UAL) covers per-assertion
+    // content type without sharing a subject across assertions.
+    const ctA = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultA.assertionUri && q.predicate === `${DKG}sourceContentType`,
+    );
+    const ctB = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === resultB.assertionUri && q.predicate === `${DKG}sourceContentType`,
+    );
+    expect(ctA).toHaveLength(1);
+    expect(ctB).toHaveLength(1);
+  });
+
+  it('Round 9 Bug 27: no-filename upload skips `dkg:sourceFileName` entirely (matches row 20 optional pattern)', async () => {
+    // Symmetric negative guard — when the multipart part carries no
+    // filename (or a whitespace-only filename), the daemon skips
+    // the `_meta` row entirely, same way row 20 (`mdIntermediateHash`)
+    // is absent for markdown-direct imports.
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: '', contentType: 'text/markdown', content: Buffer.from('# Anon\n', 'utf-8') },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'bug27-noname',
+    });
+    const metaGraphUri = contextGraphMetaUri('cg');
+    const nameRows = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === result.assertionUri && q.predicate === `${DKG}sourceFileName`,
+    );
+    expect(nameRows).toHaveLength(0);
+  });
+
+  it('Bug 22: dropGraph failure restores the metaSnapshot that deleteByPattern just cleared', async () => {
+    // Round 7 Bug 22 — the narrow window where `deleteByPattern`
+    // succeeds but `dropGraph` fails used to leave the old `_meta`
+    // rows gone with the data graph still intact (self-inconsistent
+    // state, no rollback fires). Bug 22 extends the rollback path
+    // to cover this case: on dropGraph failure, metaSnapshot is
+    // re-inserted.
+    //
+    // Prime V1, then fail V2's dropGraph and assert V1's `_meta`
+    // rows are byte-perfect restored from the snapshot.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n\nReliable.\n', 'utf-8') },
+    ]);
+    const resultV1 = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'bug22-target',
+    });
+    const assertionUri = resultV1.assertionUri;
+    const metaGraphUri = contextGraphMetaUri('cg');
+
+    // Snapshot V1's `_meta` rows keyed by this assertion before the
+    // failing V2 attempt.
+    const v1Meta = agent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === assertionUri,
+    );
+    expect(v1Meta.length).toBeGreaterThanOrEqual(6);
+    const v1SourceFileHash = v1Meta.find(q => q.predicate === `${DKG}sourceFileHash`)?.object;
+    expect(v1SourceFileHash).toBe(`"${resultV1.fileHash}"`);
+
+    // Prime a fresh agent with V1's state, inject a dropGraph
+    // failure. V2 attempt: deleteByPattern(_meta) succeeds (removes
+    // V1's meta rows), dropGraph throws → Bug 22 path restores
+    // metaSnapshot.
+    const failAgent = makeMockAgent('0xMockAgentPeerId', {
+      dropGraphError: new Error('simulated dropGraph outage'),
+    });
+    for (const q of agent.insertedQuads) {
+      failAgent.insertedQuads.push({ ...q });
+    }
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n\nWill fail.\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: failAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'bug22-target',
+    })).rejects.toThrow('simulated dropGraph outage');
+
+    // V1's `_meta` rows were cleared by deleteByPattern then
+    // restored by the Bug 22 rollback. The same keccak256 hash
+    // literal that row 16 carried for V1 must still be present.
+    const metaAfter = failAgent.insertedQuads.filter(q =>
+      q.graph === metaGraphUri && q.subject === assertionUri,
+    );
+    const restoredSourceFileHash = metaAfter.find(q => q.predicate === `${DKG}sourceFileHash`)?.object;
+    expect(restoredSourceFileHash).toBe(v1SourceFileHash);
+    expect(metaAfter.length).toBeGreaterThanOrEqual(v1Meta.length);
+
+    // V1's data graph is untouched (dropGraph threw BEFORE doing
+    // anything, so no rollback is needed on the data side).
+    const assertionGraph = contextGraphAssertionUri('cg', failAgent.peerId, 'bug22-target');
+    const dataAfter = failAgent.insertedQuads.filter(q => q.graph === assertionGraph);
+    expect(dataAfter.length).toBeGreaterThan(0);
+  });
+
+  it('Bug 22: deleteByPattern failure triggers NO rollback (nothing was corrupted)', async () => {
+    // Inverse guard. If deleteByPattern fails before doing anything,
+    // metaCleanupSucceeded stays false and the rollback path must
+    // NOT fire — otherwise we'd be inserting stale snapshots into a
+    // store that never changed.
+    const bodyV1 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v1.md', contentType: 'text/markdown', content: Buffer.from('# V1\n', 'utf-8') },
+    ]);
+    await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV1, boundary: BOUNDARY, assertionName: 'bug22-nothing',
+    });
+
+    const failAgent = makeMockAgent('0xMockAgentPeerId', {
+      deleteByPatternError: new Error('simulated delete outage'),
+    });
+    for (const q of agent.insertedQuads) {
+      failAgent.insertedQuads.push({ ...q });
+    }
+    // Count insertion calls so we can prove the rollback did NOT
+    // fire. After the priming, the next insert should be the one
+    // that the failing import tries and never reaches.
+    const insertCountBefore = failAgent.insertCallCount;
+
+    const bodyV2 = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'v2.md', contentType: 'text/markdown', content: Buffer.from('# V2\n', 'utf-8') },
+    ]);
+    await expect(runImportFileOrchestration({
+      agent: failAgent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyV2, boundary: BOUNDARY, assertionName: 'bug22-nothing',
+    })).rejects.toThrow('simulated delete outage');
+
+    // No new insert calls — neither the V2 commit nor any rollback
+    // re-insert fired. The state is unchanged so no rollback was
+    // needed.
+    expect(failAgent.insertCallCount).toBe(insertCountBefore);
+  });
+
+  it('Bug 12: assertionDiscard runs `_meta` cleanup BEFORE dropGraph (mock mirrors publisher ordering)', async () => {
+    // Regression guard for the Round 4 Bug 12 ordering flip. The mock
+    // discard method (`agent.assertion.discard`) now calls
+    // `deleteByPattern` first, then `dropGraph`. A `deleteByPattern`
+    // failure leaves the data graph intact, which is the retry-safe
+    // ordering.
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'discard-me.md', contentType: 'text/markdown', content: Buffer.from('# Discard\n', 'utf-8') },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: 'discard-order',
+    });
+
+    // Simulate a `deleteByPattern` failure during discard.
+    const failingAgent = makeMockAgent('0xMockAgentPeerId', {
+      deleteByPatternError: new Error('simulated meta cleanup failure'),
+    });
+    // Prime with the successful import's quads.
+    for (const q of agent.insertedQuads) {
+      failingAgent.insertedQuads.push({ ...q });
+    }
+
+    // Discard should throw because `deleteByPattern` fails.
+    await expect(
+      failingAgent.assertion.discard('cg', 'discard-order'),
+    ).rejects.toThrow('simulated meta cleanup failure');
+
+    // CRITICAL: the data graph must still be intact. The ordering
+    // (`deleteByPattern` first) means `dropGraph` never ran, so V's
+    // assertion graph quads are still there. This is the retry-safe
+    // guarantee of Bug 12.
+    const assertionGraph = contextGraphAssertionUri('cg', failingAgent.peerId, 'discard-order');
+    const dataAfterFailedDiscard = failingAgent.insertedQuads.filter(q => q.graph === assertionGraph);
+    expect(dataAfterFailedDiscard.length).toBeGreaterThan(0);
+    // The dropGraph call was NEVER made (ordering: meta first, drop second).
+    expect(failingAgent.droppedGraphs).not.toContain(assertionGraph);
+    // Reference `result` so the successful-import capture isn't
+    // flagged as unused — its hash is a sanity anchor for the test.
+    expect(result.fileHash).toMatch(/^keccak256:/);
+  });
+
+  it('Bug 5b: assertion.discard drops BOTH the data graph AND the assertion _meta rows', async () => {
+    // Regression guard for Bug 5b: after discard, there must be ZERO
+    // rows in the CG root `_meta` keyed by this assertion's UAL, AND
+    // zero quads in the assertion data graph. Pre-fix discard only
+    // dropped the data graph, leaving `_meta` pointing at a hash for
+    // an assertion that no longer exists.
+    const ASSERTION_NAME = 'to-be-discarded';
+    const metaGraph = contextGraphMetaUri('cg');
+
+    const body = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'doomed.md', contentType: 'text/markdown', content: Buffer.from('# Doomed\n\nWill be discarded.\n', 'utf-8') },
+    ]);
+    const result = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: body, boundary: BOUNDARY, assertionName: ASSERTION_NAME,
+    });
+
+    // Baseline: the import populated both graphs.
+    const dataBefore = agent.insertedQuads.filter(q => q.graph === result.assertionUri);
+    const metaBefore = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === result.assertionUri,
+    );
+    expect(dataBefore.length).toBeGreaterThan(0);
+    expect(metaBefore.length).toBeGreaterThan(0);
+
+    // Discard.
+    await agent.assertion.discard('cg', ASSERTION_NAME);
+
+    // The data graph is dropped (tracked explicitly so the test catches
+    // regressions where dropGraph is skipped).
+    expect(agent.droppedGraphs).toContain(result.assertionUri);
+    const dataAfter = agent.insertedQuads.filter(q => q.graph === result.assertionUri);
+    expect(dataAfter).toHaveLength(0);
+
+    // AND the `_meta` rows keyed by this assertion's UAL are gone.
+    const metaAfter = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === result.assertionUri,
+    );
+    expect(metaAfter).toHaveLength(0);
+  });
+
+  it('Bug 5b: discard does NOT touch `_meta` rows for OTHER assertions', async () => {
+    // Scope guard for the cleanup: dropping assertion A must not leak
+    // into the `_meta` rows for assertion B. Otherwise a discard could
+    // wipe unrelated data.
+    const metaGraph = contextGraphMetaUri('cg');
+
+    // Import two assertions with unrelated names.
+    const bodyA = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'a.md', contentType: 'text/markdown', content: Buffer.from('# A\n\nFirst.\n', 'utf-8') },
+    ]);
+    const bodyB = buildMultipart([
+      { kind: 'text', name: 'contextGraphId', value: 'cg' },
+      { kind: 'file', name: 'file', filename: 'b.md', contentType: 'text/markdown', content: Buffer.from('# B\n\nSecond.\n', 'utf-8') },
+    ]);
+    const a = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyA, boundary: BOUNDARY, assertionName: 'iso-a',
+    });
+    const b = await runImportFileOrchestration({
+      agent, fileStore, extractionRegistry: registry, extractionStatus: status,
+      multipartBody: bodyB, boundary: BOUNDARY, assertionName: 'iso-b',
+    });
+
+    // Discard only A.
+    await agent.assertion.discard('cg', 'iso-a');
+
+    // A's `_meta` rows gone.
+    const metaA = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === a.assertionUri,
+    );
+    expect(metaA).toHaveLength(0);
+
+    // B's `_meta` rows intact.
+    const metaB = agent.insertedQuads.filter(q =>
+      q.graph === metaGraph && q.subject === b.assertionUri,
+    );
+    expect(metaB.length).toBeGreaterThan(0);
+    const bHash = metaB.find(q => q.predicate === `${DKG}sourceFileHash`);
+    expect(bHash?.object).toBe(`"${b.fileHash}"`);
   });
 });
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -94,6 +94,115 @@ export type ShareConditionalOptions = ConditionalShareOptions;
 /** @deprecated Use ConditionalShareOptions */
 export type WriteConditionalToWorkspaceOptions = ConditionalShareOptions;
 
+// Round 9 Bug 25: protocol-reserved URN namespaces that MUST NOT appear
+// as subjects in user-authored quads. These prefixes are owned by the
+// daemon's import-file handler for file descriptors and extraction
+// provenance per `19_MARKDOWN_CONTENT_TYPE.md §10.2`. Allowing user
+// writes here would (a) collide with daemon bookkeeping across assertions
+// and (b) get silently stripped by `assertionPromote`'s safety filter,
+// which would be data loss from the user's perspective. Reject at the
+// write boundary with a clear error that names the reserved prefix.
+//
+// The daemon's own import-file handler bypasses `assertion.write` via a
+// direct `store.insert` (documented in `daemon.ts`), so the guard here
+// only fires on user-facing entry points and never on the daemon's
+// internal bookkeeping writes.
+//
+// Prefix form matches the `assertionPromote` defense-in-depth filter:
+// bare `urn:dkg:file:` (not `urn:dkg:file:keccak256:`) so any future
+// hash-algorithm variant (e.g., `urn:dkg:file:blake3:...`) is also
+// covered without a guard update.
+export const RESERVED_SUBJECT_PREFIXES = [
+  'urn:dkg:file:',
+  'urn:dkg:extraction:',
+] as const;
+
+export class ReservedNamespaceError extends Error {
+  readonly subject: string;
+  readonly prefix: string;
+  constructor(subject: string, prefix: string) {
+    super(
+      `Subject '${subject}' is in the reserved namespace '${prefix}*', which is protocol-reserved ` +
+        `for daemon-generated file descriptors and extraction provenance per ` +
+        `19_MARKDOWN_CONTENT_TYPE.md §10.2. Use a different URN for user-authored quads.`,
+    );
+    this.name = 'ReservedNamespaceError';
+    this.subject = subject;
+    this.prefix = prefix;
+  }
+}
+
+// Round 12 Bug 34: module-private token proving an internal caller
+// (specifically `publishFromSharedMemory`) is the origin of a
+// `publish()` call so the reserved-namespace guard can be bypassed
+// for legitimate internal promote→publish flows WITHOUT exposing a
+// public flag that external callers could set to bypass the guard.
+//
+// Round 9 Bug 25 used `options.fromSharedMemory` as the discriminator,
+// but `fromSharedMemory` is a public `PublishOptions` field with its
+// own user-facing semantic (signals to the V10 ACK path that data is
+// already in peers' SWM). Any external caller could set it `true` and
+// trivially bypass the guard, making `urn:dkg:file:*` writes possible
+// via the public API — the exact class of bypass Round 9 was supposed
+// to prevent. Codex Bug 34 caught this.
+//
+// The token is a module-scoped `Symbol` with no external references.
+// Only code in this file can mint it. Public callers cannot forge it.
+// Bypassing the guard therefore requires either being in this file
+// (and thus code-reviewed for correctness) or not calling the guarded
+// public entry points at all (the daemon's direct `store.insert`
+// bypass, which is the other legitimate non-guard path).
+const INTERNAL_ORIGIN_TOKEN = Symbol('dkg-publisher:internal-origin');
+
+type InternalPublishOptions = PublishOptions & {
+  [INTERNAL_ORIGIN_TOKEN]?: true;
+};
+
+function isInternalOrigin(options: PublishOptions): boolean {
+  return (options as InternalPublishOptions)[INTERNAL_ORIGIN_TOKEN] === true;
+}
+
+// Round 14 Bug 41: case-insensitive check against `RESERVED_SUBJECT_PREFIXES`.
+// Per RFC 8141 §3.1, the URN scheme (`urn:`) and NID (`dkg`) are
+// case-insensitive for equivalence purposes — `URN:dkg:file:abc`,
+// `urn:DKG:file:abc`, and `urn:dkg:file:abc` are all the same resource.
+// The NSS portion is case-sensitive by default but our reserved
+// prefixes (`urn:dkg:file:`, `urn:dkg:extraction:`) are entirely
+// within the scheme+NID range, so lowercase-then-startsWith on the
+// full subject string is the correct comparison: it accepts all
+// case variants of the scheme/NID without over-matching into
+// NSS-level content.
+//
+// Earlier rounds used a byte-level `subject.startsWith(prefix)` check
+// at both the Bucket A write-boundary guard (Round 9 Bug 25) AND the
+// Round 4 promote-time filter (Round 12 Bug 35 SSOT). Both were
+// case-sensitive, so a malicious or accidentally-mixed-case subject
+// like `URN:dkg:file:keccak256:<hex>` bypassed both defenses. Codex
+// Bug 41 flagged this. The fix replaces both byte-level comparisons
+// with this single case-insensitive helper, preserving the SSOT
+// property established in Round 12.
+//
+// `RESERVED_SUBJECT_PREFIXES` is already lowercase in the declaration
+// above, so the check just lowercases the incoming subject before
+// calling `startsWith`.
+function isReservedSubject(subject: string): boolean {
+  const lower = subject.toLowerCase();
+  return RESERVED_SUBJECT_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+function rejectReservedSubjectPrefixes(quads: Quad[]): void {
+  for (const q of quads) {
+    if (isReservedSubject(q.subject)) {
+      // Find the specific prefix that matched (for the error message)
+      // — re-scan with the lowercased subject since the constants are
+      // lowercase. Byte-level comparison here is fine because by this
+      // point we've already confirmed a match exists.
+      const lower = q.subject.toLowerCase();
+      const prefix = RESERVED_SUBJECT_PREFIXES.find((p) => lower.startsWith(p))!;
+      throw new ReservedNamespaceError(q.subject, prefix);
+    }
+  }
+}
 
 export class DKGPublisher implements Publisher {
   private readonly store: TripleStore;
@@ -173,6 +282,13 @@ export class DKGPublisher implements Publisher {
     quads: Quad[],
     options: ShareOptions,
   ): Promise<ShareResult> {
+    // Round 9 Bug 25: reject user-authored quads with reserved URN
+    // prefixes at the TOP of the Bucket A entry point, before any
+    // other processing (lock acquisition, partitioning, etc.) per
+    // spec `19_MARKDOWN_CONTENT_TYPE.md §10.2`. Short-circuit so a
+    // reserved-namespace violation cannot be masked by a lock timeout
+    // or subject-level validation error downstream.
+    rejectReservedSubjectPrefixes(quads);
     const subjects = [...new Set(quads.map(q => q.subject))];
     const lockPrefix = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
     const lockKeys = subjects.map(s => `${lockPrefix}\0${s}`);
@@ -197,6 +313,10 @@ export class DKGPublisher implements Publisher {
       const v = validateSubGraphName(options.subGraphName);
       if (!v.valid) throw new Error(`Invalid sub-graph name for share: ${v.reason}`);
     }
+    // Round 9 Bug 25: reserved-namespace guard lives at the public
+    // entry points (`share`, `conditionalShare`), not here — this
+    // method is Bucket B (internal plumbing) and its callers have
+    // already validated the quad set.
     const ctx = options.operationCtx ?? createOperationContext('share');
     this.log.info(ctx, `Writing ${quads.length} quads to shared memory for context graph ${contextGraphId}`);
 
@@ -355,6 +475,12 @@ export class DKGPublisher implements Publisher {
     quads: Quad[],
     options: ConditionalShareOptions,
   ): Promise<ShareResult> {
+    // Round 9 Bug 25: reject user-authored quads with reserved URN
+    // prefixes at the TOP of the Bucket A entry point, before the
+    // CAS condition check (which could otherwise mask the namespace
+    // violation with a StaleWriteError). Short-circuit per
+    // `19_MARKDOWN_CONTENT_TYPE.md §10.2`.
+    rejectReservedSubjectPrefixes(quads);
     for (const cond of options.conditions) {
       assertSafeIri(cond.subject);
       assertSafeIri(cond.predicate);
@@ -494,7 +620,15 @@ export class DKGPublisher implements Publisher {
     }
 
     this.log.info(ctx, `Publishing ${quads.length} quads from shared memory to ${ctxGraphId ? `context graph ${ctxGraphId}` : 'data graph'}${options?.subGraphName ? ` (sub-graph: ${options.subGraphName})` : ''}`);
-    const publishResult = await this.publish({
+    // Round 12 Bug 34: mint the internal-origin token so the guard
+    // in `publish()` recognizes this as a legitimate internal
+    // promote→publish path and bypasses the reserved-namespace check.
+    // SWM quads are already filtered by `assertionPromote`'s Round 4
+    // safety net, so re-checking here would reject legitimate internal
+    // bookkeeping. The public `fromSharedMemory: true` is still set
+    // for its V10 ACK-path semantic (core nodes verify against their
+    // local SWM copy, no inline staging quads).
+    const internalPublishOptions: InternalPublishOptions = {
       contextGraphId,
       quads: quads.map((q) => ({ ...q, graph: '' })),
       operationCtx: ctx,
@@ -503,7 +637,9 @@ export class DKGPublisher implements Publisher {
       publishContextGraphId: ctxGraphId ?? undefined,
       fromSharedMemory: true,
       subGraphName: options?.subGraphName,
-    });
+      [INTERNAL_ORIGIN_TOKEN]: true,
+    };
+    const publishResult = await this.publish(internalPublishOptions);
 
     if (ctxGraphId && publishResult.status === 'confirmed' && publishResult.onChainResult) {
       let participantSigs = options?.contextGraphSignatures ?? [];
@@ -741,6 +877,19 @@ export class DKGPublisher implements Publisher {
       entityProofs = false,
       onPhase,
     } = options;
+    // Round 9 Bug 25 + Round 12 Bug 34: reject user-authored reserved-
+    // namespace subjects. The bypass is keyed on a module-private
+    // `INTERNAL_ORIGIN_TOKEN` Symbol (see its declaration near the top
+    // of the file) — NOT on the public `fromSharedMemory` flag. That
+    // means external callers cannot bypass this guard by setting a
+    // public option; only in-file code paths (specifically
+    // `publishFromSharedMemory`) can mint the token. Public
+    // `fromSharedMemory` retains its V10 ACK-path semantic
+    // independently.
+    if (!isInternalOrigin(options)) {
+      rejectReservedSubjectPrefixes(quads);
+      if (privateQuads.length > 0) rejectReservedSubjectPrefixes(privateQuads);
+    }
     const ctx: OperationContext = operationCtx ?? createOperationContext('publish');
     const effectiveAccessPolicy = accessPolicy ?? (privateQuads.length > 0 ? 'ownerOnly' : 'public');
     const normalizedAllowedPeers = [...new Set((allowedPeers ?? []).map((p) => p.trim()).filter(Boolean))];
@@ -1152,6 +1301,18 @@ export class DKGPublisher implements Publisher {
       );
     }
     const { contextGraphId, quads, privateQuads = [], operationCtx, onPhase } = options;
+    // Round 12 Bug 34: `update()` is a Bucket A public write entry
+    // point (accepts user-authored quads) that Round 9 missed. Apply
+    // the same reserved-namespace guard as `publish()` / `assertionWrite`
+    // / `share` / `conditionalShare`, gated on the same internal-origin
+    // token so legitimate internal update flows can bypass. Currently
+    // there are no internal callers of `update()`, so the token check
+    // is a forward-looking safety net — the common path is always
+    // guarded.
+    if (!isInternalOrigin(options)) {
+      rejectReservedSubjectPrefixes(quads);
+      if (privateQuads.length > 0) rejectReservedSubjectPrefixes(privateQuads);
+    }
     const ctx: OperationContext = operationCtx ?? createOperationContext('publish');
     this.log.info(ctx, `Updating kcId=${kcId} with ${quads.length} triples`);
     const dataGraph = this.graphManager.dataGraphUri(contextGraphId);
@@ -1527,6 +1688,9 @@ export class DKGPublisher implements Publisher {
     const quads = input.map((t) => ({
       subject: t.subject, predicate: t.predicate, object: t.object, graph: graphUri,
     }));
+    // Round 9 Bug 25: reject user-authored quads whose subject is in a
+    // protocol-reserved URN namespace. See RESERVED_SUBJECT_PREFIXES above.
+    rejectReservedSubjectPrefixes(quads);
     await this.store.insert(quads);
   }
 
@@ -1560,6 +1724,66 @@ export class DKGPublisher implements Publisher {
     if (result.type !== 'quads' || result.quads.length === 0) return { promotedCount: 0 };
 
     let quadsToPromote = result.quads;
+
+    // ── Bug 8 (Codex Round 4) + Round 9 Bug 25 — import-bookkeeping filter ──
+    // Defense-in-depth: reserved-prefix subjects SHOULD already have
+    // been rejected at the write boundary by `rejectReservedSubjectPrefixes`
+    // (Round 9 Bug 25 per `19_MARKDOWN_CONTENT_TYPE.md §10.2`). User-
+    // authored writes with `urn:dkg:file:*` or `urn:dkg:extraction:*`
+    // subjects are short-circuited at `assertionWrite`, `share`,
+    // `conditionalShare`, and non-`fromSharedMemory` `publish` entry
+    // points. This promote-time filter is kept as a belt-and-suspenders
+    // safety net for quads that legitimately enter the store through
+    // a path that bypasses the write guard — namely the daemon's
+    // import-file handler, which writes file descriptors and
+    // ExtractionProvenance blocks via a direct `store.insert` call
+    // (documented at `daemon.ts:2663-2668`) precisely because those
+    // URN subjects are protocol-reserved and belong in WM/`_meta`,
+    // not promoted SWM.
+    //
+    // The `<urn:dkg:file:...>` file descriptor block (rows 4-8 of the
+    // §10.2 linkage table) and the `<urn:dkg:extraction:<uuid>>`
+    // ExtractionProvenance block (rows 9-13) are subordinate metadata
+    // about the extraction RUN, not semantic knowledge about an Entity.
+    // Without this filter, `autoPartition` below would treat
+    // `<urn:dkg:file:keccak256:abc>` as a root entity and cross-assertion
+    // ownership would contend when two different assertions reference
+    // the same file content (same keccak256 → same URN → same
+    // ownership slot). Filtering the subject-prefix before partitioning
+    // means:
+    //   - Row 1 (`<entityUri> dkg:sourceFile <urn:dkg:file:...>`)
+    //     SURVIVES because its subject is the doc entity, not the file
+    //     URN — only OBJECTs are `urn:dkg:file:...`, not subjects. So
+    //     SWM consumers still see "this entity came from this file".
+    //   - Rows 4-5, 8 on `<fileUri>` are stripped — file descriptor
+    //     absent from SWM. Content-addressed blob lookup remains
+    //     available via the literal `dkg:sourceFileHash` in `_meta`.
+    //   - Rows 9-13 on `<provUri>` are stripped — prov block absent
+    //     from SWM.
+    //
+    // Because Bug 25's write-time guard means no user-authored data
+    // in those namespaces can exist in the store, filtering by prefix
+    // on promote cannot drop legitimate user data.
+    //
+    // See `19_MARKDOWN_CONTENT_TYPE.md §10.2` for the normative rule
+    // and Codex Bug 8 Round 4 reconciled ruling for the history (Round
+    // 3 tried blank-node subjects but an `autoPartition` audit showed
+    // they silently drop rows 9-13 on promote, which was worse).
+    // Round 12 Bug 35: source the prefix list from `RESERVED_SUBJECT_PREFIXES`
+    // instead of hardcoding the two literals inline. If the reserved
+    // namespace list ever gains a new prefix at the top of the file
+    // (e.g., a future `urn:dkg:prov:` or `urn:dkg:ack:`), the promote
+    // filter picks it up automatically without a separate code change —
+    // single source of truth. The Round 9 write-time guard uses the
+    // same constant, so both defenses always stay in sync.
+    //
+    // Round 14 Bug 41: use the case-insensitive `isReservedSubject`
+    // helper instead of byte-level `startsWith`. Per RFC 8141 the URN
+    // scheme and NID are case-insensitive, so `URN:dkg:file:...` is
+    // semantically equivalent to `urn:dkg:file:...` and must be
+    // filtered identically. See the helper's docstring for the full
+    // argument.
+    quadsToPromote = quadsToPromote.filter((q) => !isReservedSubject(q.subject));
 
     if (opts?.entities && opts.entities !== 'all') {
       const entitySet = new Set(opts.entities);
@@ -1728,6 +1952,34 @@ export class DKGPublisher implements Publisher {
   async assertionDiscard(contextGraphId: string, name: string, agentAddress: string, subGraphName?: string): Promise<void> {
     DKGPublisher.validateOptionalSubGraph(subGraphName);
     const graphUri = contextGraphAssertionUri(contextGraphId, agentAddress, name, subGraphName);
+    // Drop the assertion data graph AND clean up any `_meta` rows keyed
+    // by this assertion's UAL in the CG root `_meta` graph. Without this
+    // second step, `<assertionUal> dkg:sourceFileHash ?h` and friends
+    // would still resolve after a discard, pointing at a source blob
+    // for an assertion graph that no longer exists. See spec §10.2.
+    //
+    // Pairs with the import-file route's stale-`_meta` cleanup: a
+    // discarded assertion MUST leave zero rows in `_meta` keyed by its
+    // UAL, so a subsequent re-create/re-import starts from a clean slate.
+    //
+    // Ordering (Codex Bug 12 fix): `_meta` cleanup FIRST, then data
+    // graph drop. Previously the order was reversed, which meant a
+    // transient failure on `deleteByPattern` would leave the assertion
+    // body gone but `_meta` pointing at a hash for a vanished graph —
+    // actively misleading to consumers ("why does `_meta` reference
+    // this hash but `GET /assertion/name` 404s?"). With `_meta` first:
+    //   - If `deleteByPattern` fails, the data graph is still intact
+    //     and retry converges. No visible corruption.
+    //   - If `dropGraph` fails after `_meta` succeeded, the data graph
+    //     is orphaned (no `_meta` trail) — debuggable ("why does this
+    //     graph exist with no `_meta`?") but not actively misleading.
+    //
+    // The non-atomicity is bounded by retries; neither partial state is
+    // catastrophic. An atomic combined DELETE+DROP via a single SPARQL
+    // UPDATE is tracked as a follow-up on the storage layer (needs a
+    // new method on the `TripleStore` public interface).
+    const metaGraph = contextGraphMetaUri(contextGraphId);
+    await this.store.deleteByPattern({ subject: graphUri, graph: metaGraph });
     await this.store.dropGraph(graphUri);
   }
 

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
-import { DKGPublisher } from '../src/dkg-publisher.js';
+import { DKGPublisher, RESERVED_SUBJECT_PREFIXES } from '../src/dkg-publisher.js';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { ethers } from 'ethers';
 
@@ -234,5 +234,395 @@ describe('DKGPublisher', () => {
       expect(statuses.some((s) => s.includes('confirmed'))).toBe(true);
       expect(statuses.some((s) => s.includes('tentative'))).toBe(false);
     }
+  });
+
+  // ── Round 9 Bug 25: reserved-namespace guard at write-boundary ──
+  //
+  // `urn:dkg:file:keccak256:*` and `urn:dkg:extraction:*` are
+  // protocol-reserved for daemon-generated file descriptors and
+  // extraction provenance (per 19_MARKDOWN_CONTENT_TYPE.md §10.2).
+  // User-authored writes that would collide with that namespace are
+  // rejected at the write boundary — `assertionWrite`, `share`, and
+  // `publish` — with a `ReservedNamespaceError`. The daemon's own
+  // import-file handler bypasses `assertion.write` via direct
+  // `store.insert` (documented in daemon.ts) so its legitimate
+  // bookkeeping writes are unaffected.
+  describe('Bug 25: reserved-namespace guard', () => {
+    it('rejects a user-authored assertionWrite with `urn:dkg:file:keccak256:*` subject', async () => {
+      await expect(
+        publisher.assertionWrite(PARANET, 'user-guard-file', TEST_PUBLISHER_ADDRESS, [
+          { subject: 'urn:dkg:file:keccak256:abc', predicate: 'http://schema.org/name', object: '"leaked"' },
+        ]),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('rejects a user-authored assertionWrite with `urn:dkg:extraction:*` subject', async () => {
+      await expect(
+        publisher.assertionWrite(PARANET, 'user-guard-extr', TEST_PUBLISHER_ADDRESS, [
+          { subject: 'urn:dkg:extraction:11111111-2222-3333-4444-555555555555', predicate: 'http://schema.org/name', object: '"leaked"' },
+        ]),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('allows a user-authored assertionWrite with a non-reserved subject', async () => {
+      await expect(
+        publisher.assertionWrite(PARANET, 'user-allowed', TEST_PUBLISHER_ADDRESS, [
+          { subject: 'urn:note:my-doc', predicate: 'http://schema.org/name', object: '"allowed"' },
+        ]),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects a user-authored publish with `urn:dkg:file:keccak256:*` subject in public quads', async () => {
+      await expect(
+        publisher.publish({
+          contextGraphId: PARANET,
+          quads: [
+            q('urn:dkg:file:keccak256:deadbeef', 'http://schema.org/name', '"should be rejected"'),
+          ],
+        }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('rejects a user-authored publish with `urn:dkg:extraction:*` subject in privateQuads', async () => {
+      await expect(
+        publisher.publish({
+          contextGraphId: PARANET,
+          quads: [q(ENTITY, 'http://schema.org/name', '"ok"')],
+          privateQuads: [
+            q('urn:dkg:extraction:deadbeef-uuid', 'http://schema.org/secret', '"private leak"'),
+          ],
+        }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('rejects a user-authored share with a reserved subject', async () => {
+      await expect(
+        publisher.share(PARANET, [
+          { subject: 'urn:dkg:file:keccak256:cafebabe', predicate: 'http://schema.org/name', object: '"share leak"', graph: '' },
+        ], { publisherPeerId: 'peer-test' }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('Round 12 Bug 34: external publish with `fromSharedMemory: true` and a reserved-prefix quad is REJECTED (public flag no longer bypasses the guard)', async () => {
+      // Round 9 Bug 25 gated the guard on the public `fromSharedMemory`
+      // flag, which meant any external caller could set the flag to
+      // bypass the namespace check. Codex Bug 34 flagged this. Round 12
+      // replaced the discriminator with a module-private `Symbol`-keyed
+      // token (`INTERNAL_ORIGIN_TOKEN`) that only in-file code can
+      // mint, so external callers cannot forge it. The public flag
+      // keeps its V10 ACK-path semantic but no longer controls the
+      // guard decision. Verify the bypass is closed: a reserved-prefix
+      // quad passed to `publish()` with `fromSharedMemory: true` from
+      // an external caller is still rejected with a ReservedNamespaceError.
+      await expect(
+        publisher.publish({
+          contextGraphId: PARANET,
+          quads: [q('urn:dkg:file:keccak256:bypass', 'http://schema.org/name', '"external bypass attempt"')],
+          fromSharedMemory: true,
+        }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('Round 12 Bug 34: external publish with a non-reserved quad and `fromSharedMemory: true` still succeeds (V10 ACK-path semantic preserved)', async () => {
+      // Scope guard: the Round 12 change must not break legitimate
+      // external uses of `fromSharedMemory: true` that carry only
+      // non-reserved quads. The flag's V10 ACK-path optimization
+      // meaning (`core nodes verify against local SWM copy, no inline
+      // staging quads`) is independent of the guard decision — it
+      // continues to work as before.
+      await expect(
+        publisher.publish({
+          contextGraphId: PARANET,
+          quads: [q(ENTITY, 'http://schema.org/name', '"fromSharedMemory-with-legit-quads"')],
+          fromSharedMemory: true,
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('Round 12 Bug 34: internal promote→publish path (via publishFromSharedMemory) still bypasses the guard', async () => {
+      // The critical internal-callers-still-work test. Seed the
+      // context graph with a reserved-prefix quad directly in SWM
+      // (mimicking what the daemon's import-file handler writes via
+      // its direct store.insert bypass), then call
+      // publishFromSharedMemory which reads from SWM and calls
+      // publish() internally with the INTERNAL_ORIGIN_TOKEN.
+      //
+      // Under Round 9's flag-based discriminator, this worked
+      // because publishFromSharedMemory set fromSharedMemory: true.
+      // Under Round 12's Symbol-based discriminator, it works
+      // because publishFromSharedMemory now mints the token
+      // internally. The test proves the internal path still has
+      // the bypass without requiring a public flag.
+      //
+      // We exercise this indirectly: publishFromSharedMemory first
+      // requires some non-empty SWM content, so we share a
+      // legitimate quad first, then publish it. The share is the
+      // user-facing write path (guarded correctly for user quads),
+      // and the publishFromSharedMemory is the internal read-back
+      // path (bypass correctly triggered via the token).
+      await publisher.share(
+        PARANET,
+        [q(ENTITY, 'http://schema.org/name', '"internal-path-test"')],
+        { publisherPeerId: 'peer-internal', localOnly: true },
+      );
+      await expect(
+        publisher.publishFromSharedMemory(PARANET, 'all'),
+      ).resolves.toBeDefined();
+    });
+
+    it('Round 12 Bug 34: update() rejects reserved-prefix quads (Bucket A hole closed)', async () => {
+      // Codex Bug 34 second hole: `update()` accepted `PublishOptions`
+      // (the same type as `publish()`) but had no reserved-namespace
+      // guard at all. An external caller could write any reserved-
+      // prefix quads via update() regardless of what publish() did.
+      // Round 12 added the same guard to update() using the same
+      // internal-token discriminator.
+      //
+      // We can't actually reach the on-chain part of update() in a
+      // unit test (it expects an existing kcId to update), but the
+      // guard fires at the very top of the method BEFORE any chain
+      // interaction — so the reserved-namespace rejection surfaces
+      // independently of whether the kcId exists.
+      await expect(
+        publisher.update(0n, {
+          contextGraphId: PARANET,
+          quads: [q('urn:dkg:file:keccak256:update-leak', 'http://schema.org/name', '"update bypass"')],
+        }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('Round 12 Bug 34: update() rejects reserved-prefix privateQuads (parallel to publish)', async () => {
+      await expect(
+        publisher.update(0n, {
+          contextGraphId: PARANET,
+          quads: [q(ENTITY, 'http://schema.org/name', '"ok"')],
+          privateQuads: [
+            q('urn:dkg:extraction:update-leak-uuid', 'http://schema.org/secret', '"private update leak"'),
+          ],
+        }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('Round 12 Bug 34: external update with `fromSharedMemory: true` and a reserved quad is ALSO rejected (bypass closure is symmetric)', async () => {
+      // Same bypass closure as publish — external callers cannot use
+      // the public flag to bypass update()'s guard either.
+      await expect(
+        publisher.update(0n, {
+          contextGraphId: PARANET,
+          quads: [q('urn:dkg:file:keccak256:upd-bypass', 'http://schema.org/name', '"external bypass"')],
+          fromSharedMemory: true,
+        }),
+      ).rejects.toThrow(/reserved namespace/i);
+    });
+
+    it('Round 12 Bug 35: assertionPromote filter is built from RESERVED_SUBJECT_PREFIXES (single source of truth)', async () => {
+      // Round 4 Bug 8 filter historically hardcoded the two prefix
+      // literals inline, creating a duplication with the
+      // `RESERVED_SUBJECT_PREFIXES` constant at the top of the file.
+      // Round 12 Bug 35 replaced the hardcoded literals with a
+      // `.some(prefix => q.subject.startsWith(prefix))` loop over
+      // the constant. This test locks in the SSOT property: every
+      // prefix currently in the constant is correctly stripped
+      // from the promoted quad set, so extending the constant with
+      // a new prefix would automatically propagate to the filter.
+      //
+      // We construct a data-graph with one quad per reserved prefix
+      // (plus one non-reserved quad), promote, and assert only the
+      // non-reserved quad survives.
+      //
+      // NOTE: this test asserts filter BEHAVIOUR, not the exact
+      // source text — if someone replaces the filter with a
+      // functionally-equivalent but differently-shaped check
+      // (e.g., a Set lookup or a regex), this test still passes
+      // as long as the behaviour is correct.
+      const dataGraph = `did:dkg:context-graph:${PARANET}/assertion/${TEST_PUBLISHER_ADDRESS}/bug35-ssot`;
+      const reservedQuads: Quad[] = RESERVED_SUBJECT_PREFIXES.map((prefix, i) => ({
+        subject: `${prefix}synthetic-${i}`,
+        predicate: 'http://schema.org/name',
+        object: `"reserved-${i}"`,
+        graph: dataGraph,
+      }));
+      const legitQuad: Quad = {
+        subject: ENTITY,
+        predicate: 'http://schema.org/name',
+        object: '"legit"',
+        graph: dataGraph,
+      };
+      // Insert directly into the store bypassing the write guard
+      // (the daemon-equivalent bypass path).
+      await store.insert([...reservedQuads, legitQuad]);
+      // Ensure an assertion graph exists by calling assertion.create
+      // through the publisher API (idempotent).
+      try {
+        await publisher.assertionWrite(
+          PARANET,
+          'bug35-ssot',
+          TEST_PUBLISHER_ADDRESS,
+          [legitQuad],
+        );
+      } catch {
+        // Ignore — the legitQuad is already in the store from the
+        // direct insert above, so assertionWrite may no-op or
+        // duplicate. Either way the data graph is populated.
+      }
+      const result = await publisher.assertionPromote(
+        PARANET,
+        'bug35-ssot',
+        TEST_PUBLISHER_ADDRESS,
+      );
+      // The promote call doesn't return the promoted quad set
+      // directly, but we can query the SWM graph post-promote and
+      // assert that none of the reserved subjects landed there.
+      expect(result.promotedCount).toBeGreaterThan(0);
+      const swmGraph = `did:dkg:context-graph:${PARANET}/_shared_memory`;
+      const swmCheck = await store.query(
+        `ASK { GRAPH <${swmGraph}> { ?s ?p ?o . FILTER(${RESERVED_SUBJECT_PREFIXES.map(p => `STRSTARTS(STR(?s), "${p}")`).join(' || ')}) } }`,
+      );
+      expect(swmCheck.type).toBe('boolean');
+      if (swmCheck.type === 'boolean') {
+        expect(swmCheck.value).toBe(false);
+      }
+    });
+
+    // ── Round 14 Bug 41: case-insensitive URN comparison ──
+    //
+    // Per RFC 8141 §3.1, the URN scheme (`urn:`) and NID (`dkg`) are
+    // case-insensitive for equivalence. `URN:dkg:file:abc`,
+    // `urn:DKG:file:abc`, and `urn:dkg:file:abc` are the same resource.
+    // The reserved prefixes `urn:dkg:file:` and `urn:dkg:extraction:`
+    // live entirely in the scheme+NID range, so case-insensitive
+    // comparison on the whole subject is the correct check.
+    //
+    // Round 9 Bug 25 and Round 12 Bug 35 both used byte-level
+    // `startsWith`, so mixed-case variants bypassed both the write-
+    // time guard AND the promote-time filter. Round 14 introduced
+    // the `isReservedSubject` helper that lowercases before matching,
+    // and both enforcement sites now route through it.
+    describe('Round 14 Bug 41: case-insensitive URN comparison', () => {
+      it('write-time: publish rejects `URN:dkg:file:keccak256:*` (scheme uppercase)', async () => {
+        await expect(
+          publisher.publish({
+            contextGraphId: PARANET,
+            quads: [q('URN:dkg:file:keccak256:mixedcase', 'http://schema.org/name', '"bypass attempt"')],
+          }),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('write-time: publish rejects `urn:DKG:file:keccak256:*` (NID uppercase)', async () => {
+        await expect(
+          publisher.publish({
+            contextGraphId: PARANET,
+            quads: [q('urn:DKG:file:keccak256:nidcase', 'http://schema.org/name', '"bypass attempt"')],
+          }),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('write-time: publish rejects `Urn:Dkg:File:keccak256:*` (mixed case across scheme+NID+NSS)', async () => {
+        await expect(
+          publisher.publish({
+            contextGraphId: PARANET,
+            quads: [q('Urn:Dkg:File:keccak256:allcase', 'http://schema.org/name', '"bypass attempt"')],
+          }),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('write-time: publish rejects `URN:dkg:extraction:*` (parallel for the extraction namespace)', async () => {
+        await expect(
+          publisher.publish({
+            contextGraphId: PARANET,
+            quads: [q('URN:dkg:extraction:11111111-2222-3333-4444-555555555555', 'http://schema.org/name', '"bypass attempt"')],
+          }),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('write-time: assertionWrite rejects mixed-case reserved prefix (Bucket A guard covers assertionWrite too)', async () => {
+        await expect(
+          publisher.assertionWrite(PARANET, 'bug41-assertion', TEST_PUBLISHER_ADDRESS, [
+            { subject: 'URN:DKG:file:keccak256:assertion', predicate: 'http://schema.org/name', object: '"bypass"' },
+          ]),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('write-time: share rejects mixed-case reserved prefix (Bucket A guard covers share too)', async () => {
+        await expect(
+          publisher.share(PARANET, [
+            { subject: 'URN:dkg:file:keccak256:share', predicate: 'http://schema.org/name', object: '"bypass"', graph: '' },
+          ], { publisherPeerId: 'peer-test' }),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('write-time: update rejects mixed-case reserved prefix (Bucket A coverage from Round 12 Bug 34)', async () => {
+        await expect(
+          publisher.update(0n, {
+            contextGraphId: PARANET,
+            quads: [q('URN:dkg:extraction:update-bypass', 'http://schema.org/name', '"bypass"')],
+          }),
+        ).rejects.toThrow(/reserved namespace/i);
+      });
+
+      it('promote-time: assertionPromote filter strips `URN:dkg:file:*` subjects (case-insensitive)', async () => {
+        // Insert quads with uppercase-scheme reserved subjects
+        // directly into the store (bypassing the write guard, as
+        // the daemon's import-file handler does). Then promote and
+        // verify the uppercase variants are filtered out along with
+        // the lowercase canonical form.
+        const dataGraph = `did:dkg:context-graph:${PARANET}/assertion/${TEST_PUBLISHER_ADDRESS}/bug41-promote`;
+        const mixedCaseReserved: Quad[] = [
+          { subject: 'URN:dkg:file:keccak256:upper', predicate: 'http://schema.org/name', object: '"upper-reserved"', graph: dataGraph },
+          { subject: 'urn:DKG:extraction:caseNID', predicate: 'http://schema.org/name', object: '"nid-reserved"', graph: dataGraph },
+        ];
+        const legit: Quad = { subject: ENTITY, predicate: 'http://schema.org/name', object: '"legit"', graph: dataGraph };
+        await store.insert([...mixedCaseReserved, legit]);
+        try {
+          await publisher.assertionWrite(PARANET, 'bug41-promote', TEST_PUBLISHER_ADDRESS, [legit]);
+        } catch {
+          // Same reasoning as Bug 35 test — may no-op if data graph
+          // already has content from the direct insert above.
+        }
+
+        const result = await publisher.assertionPromote(
+          PARANET,
+          'bug41-promote',
+          TEST_PUBLISHER_ADDRESS,
+        );
+        expect(result.promotedCount).toBeGreaterThan(0);
+
+        const swmGraph = `did:dkg:context-graph:${PARANET}/_shared_memory`;
+        // Use a SPARQL ASK that matches ANY case of the reserved
+        // prefixes (LCASE both sides of the comparison).
+        const swmCheck = await store.query(
+          `ASK { GRAPH <${swmGraph}> { ?s ?p ?o . FILTER(STRSTARTS(LCASE(STR(?s)), "urn:dkg:file:") || STRSTARTS(LCASE(STR(?s)), "urn:dkg:extraction:")) } }`,
+        );
+        expect(swmCheck.type).toBe('boolean');
+        if (swmCheck.type === 'boolean') {
+          expect(swmCheck.value).toBe(false);
+        }
+      });
+
+      it('scope guard: non-reserved subjects (including `urn:dkg:filesystem:`) are NOT over-matched', async () => {
+        // The trailing colon in `urn:dkg:file:` forces an exact
+        // match on `file:`, so `urn:dkg:filesystem:foo` must NOT
+        // match even as a byte sequence. Verify with a concrete
+        // near-miss subject that shares a prefix substring.
+        await expect(
+          publisher.publish({
+            contextGraphId: PARANET,
+            quads: [q('urn:dkg:filesystem:foo', 'http://schema.org/name', '"near-miss"')],
+          }),
+        ).resolves.toBeDefined();
+      });
+
+      it('scope guard: plain `http://` subjects are NOT rejected by the case-insensitive helper', async () => {
+        // Make sure lowercasing the subject doesn't accidentally
+        // match a non-reserved scheme. Regression guard against a
+        // future edit that might over-broaden the check.
+        await expect(
+          publisher.publish({
+            contextGraphId: PARANET,
+            quads: [q('http://example.com/bug41-notreserved', 'http://schema.org/name', '"legit"')],
+          }),
+        ).resolves.toBeDefined();
+      });
+    });
   });
 });

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -15,12 +15,36 @@ PASS=0
 FAIL=0
 WARN=0
 
-c() { curl -s -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" "$@"; }
+# P1-1: Bounded curl — every devnet call gets a connect + total timeout so a
+# hung node stalls CI instead of letting a single test run forever. Override
+# DEVNET_CURL_TIMEOUT / DEVNET_CURL_CONNECT_TIMEOUT to widen if needed.
+DEVNET_CURL_TIMEOUT="${DEVNET_CURL_TIMEOUT:-30}"
+DEVNET_CURL_CONNECT_TIMEOUT="${DEVNET_CURL_CONNECT_TIMEOUT:-5}"
+c() {
+  curl -sS --max-time "$DEVNET_CURL_TIMEOUT" --connect-timeout "$DEVNET_CURL_CONNECT_TIMEOUT" \
+    -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" "$@"
+}
+
+# P2-3: Respect TMPDIR so CI runners with non-/tmp tmp dirs work cleanly.
+DEVNET_TMPDIR="${TMPDIR:-/tmp}"
+
+# P2-1: Make the gossip sleep overrideable for fast local runs / flaky CI.
+# Round 8 Bug 24: split LOCAL_SETTLE_S out of GOSSIP_WAIT_S. The former
+# governs local write→query settles that must never be set to 0 (section 24
+# would race its own write); the latter governs cross-node gossip propagation
+# waits exclusively and CAN be set to 0 for fast local-only runs.
+GOSSIP_WAIT_S="${GOSSIP_WAIT_S:-3}"
+LOCAL_SETTLE_S="${LOCAL_SETTLE_S:-1}"
 
 ok()   { PASS=$((PASS+1)); echo "  [PASS] $1"; }
 fail() { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
 warn() { WARN=$((WARN+1)); echo "  [WARN] $1"; }
+skip() { echo "  [SKIP] $1"; }
 
+# P1-2: json_get now normalizes Python booleans to lowercase so the `check`
+# helper can compare against plain 'true'/'false' without worrying about
+# Python's `True`/`False` capitalization leaking through. Also emits
+# __NONE__ / __ERR__ sentinels unchanged for existing call sites.
 json_get() {
   echo "$1" | python3 -c "
 import sys,json
@@ -31,7 +55,12 @@ try:
     if isinstance(d,dict): d=d.get(k)
     elif isinstance(d,list) and k.isdigit(): d=d[int(k)]
     else: d=None
-  print(d if d is not None else '__NONE__')
+  if d is None:
+    print('__NONE__')
+  elif isinstance(d,bool):
+    print('true' if d else 'false')
+  else:
+    print(d)
 except: print('__ERR__')
 " 2>/dev/null
 }
@@ -39,6 +68,60 @@ except: print('__ERR__')
 check() {
   local desc="$1" actual="$2" expected="$3"
   if [[ "$actual" == "$expected" ]]; then ok "$desc"; else fail "$desc (expected=$expected, got=$actual)"; fi
+}
+
+# P1-3: Safe count helper. Replaces the pervasive
+#   python3 -c '…len(bindings)…' 2>/dev/null || echo "0"
+# idiom, which silently turns schema drift and parse errors into a legitimate
+# "zero results" reading. When the response is not parseable JSON-with-bindings,
+# this helper echoes PARSE_ERR so call sites can distinguish an empty-but-valid
+# response from a broken one.
+safe_bindings_count() {
+  echo "$1" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin)
+  b=d.get("result",{}).get("bindings",None)
+  if b is None:
+    print("PARSE_ERR")
+  else:
+    print(len(b))
+except Exception:
+  print("PARSE_ERR")
+' 2>/dev/null || echo "PARSE_ERR"
+}
+
+# P1-3: Same idea for /assertion/:name/query responses that carry a top-level
+# `quads` or `result` list instead of SPARQL-style bindings.
+safe_quads_count() {
+  echo "$1" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin)
+  v=d.get("quads",d.get("result",None))
+  if v is None:
+    print("PARSE_ERR")
+  else:
+    print(len(v))
+except Exception:
+  print("PARSE_ERR")
+' 2>/dev/null || echo "PARSE_ERR"
+}
+
+# P0-3: Capture both the response body and the HTTP status in one call.
+# Usage: http_post_capture <url> <json-body> <body-var-name> <code-var-name>
+# Returns by assigning to caller's variables via nameref.
+http_post_capture() {
+  local url="$1" body="$2" body_out="$3" code_out="$4"
+  local tmp
+  tmp="$(mktemp "$DEVNET_TMPDIR/devnet-resp-XXXXXX")"
+  local code
+  code=$(curl -sS --max-time "$DEVNET_CURL_TIMEOUT" --connect-timeout "$DEVNET_CURL_CONNECT_TIMEOUT" \
+    -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" \
+    -o "$tmp" -w "%{http_code}" -X POST "$url" -d "$body" 2>/dev/null || echo "000")
+  local content
+  content="$(cat "$tmp")"
+  rm -f "$tmp"
+  printf -v "$body_out" '%s' "$content"
+  printf -v "$code_out" '%s' "$code"
 }
 
 q() { echo "{\"subject\":\"$1\",\"predicate\":\"$2\",\"object\":\"$3\",\"graph\":\"\"}"; }
@@ -114,7 +197,7 @@ echo "--- 1e: Chain RPC health ---"
 for p in 9201 9202 9203 9204 9205; do
   h=$(c "http://127.0.0.1:$p/api/chain/rpc-health")
   rpc_ok=$(json_get "$h" ok)
-  check "Node $p RPC ok" "$rpc_ok" "True"
+  check "Node $p RPC ok" "$rpc_ok" "true"
 done
 
 #------------------------------------------------------------
@@ -382,7 +465,7 @@ CG=$(c -X POST "http://127.0.0.1:9201/api/context-graph/create" -d "{
 CG_ID=$(json_get "$CG" contextGraphId)
 CG_OK=$(json_get "$CG" success)
 echo "  CG result: id=$CG_ID success=$CG_OK"
-[[ "$CG_OK" == "True" ]] && ok "Context Graph created (id=$CG_ID)" || fail "CG creation: $CG"
+[[ "$CG_OK" == "true" ]] && ok "Context Graph created (id=$CG_ID)" || fail "CG creation: $CG"
 
 #------------------------------------------------------------
 echo ""
@@ -738,27 +821,46 @@ echo "=== SECTION 18: Sync Protocol & Catch-up Status ==="
 echo ""
 
 echo "--- 18a: Subscribe Node5 and poll catch-up status ---"
+# P0-4: `idle` was previously treated as success, but it's the PRE-catchup
+# initial state — a test that breaks out of the loop on `idle` never sees
+# whether catch-up actually ran. Only accept positive completion markers
+# and require 18b/18c data to confirm the sync.
 c -X POST "http://127.0.0.1:9205/api/context-graph/subscribe" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"includeSharedMemory\":true}" > /dev/null 2>&1
-SYNC_OK=false
+SYNC_COMPLETED=false
+SYNC_ST=""
 for i in $(seq 1 20); do
   SYNC=$(c "http://127.0.0.1:9205/api/sync/catchup-status?contextGraphId=$CONTEXT_GRAPH")
   SYNC_ST=$(json_get "$SYNC" status)
-  if [[ "$SYNC_ST" == "completed" || "$SYNC_ST" == "idle" || "$SYNC_ST" == "synced" || "$SYNC_ST" == "done" ]]; then
-    SYNC_OK=true
+  if [[ "$SYNC_ST" == "completed" || "$SYNC_ST" == "synced" || "$SYNC_ST" == "done" ]]; then
+    SYNC_COMPLETED=true
     break
   fi
   sleep 2
 done
-$SYNC_OK && ok "Sync catch-up completed on Node5 (status=$SYNC_ST)" || warn "Sync catch-up not completed after 40s (status=$SYNC_ST)"
+$SYNC_COMPLETED && ok "Sync catch-up reported completion on Node5 (status=$SYNC_ST)" || warn "Sync catch-up did not reach a positive completion status after 40s (status=$SYNC_ST)"
 
+# P1-11: Split the two cases.
+#   - If §18a reported completion but the data check fails → HARD FAIL,
+#     because that means the catchup pipeline lied about success. This is
+#     the class of bug devnet tests exist to catch.
+#   - If §18a never reached a completion status → WARN only, because the
+#     test has already reported that via 18a.
 echo "--- 18b: Verify synced VM data on Node5 ---"
 SYNC_VM=$(c -X POST "http://127.0.0.1:9205/api/query" -d "{
   \"sparql\":\"SELECT ?name WHERE { <http://example.org/entity/city1> <http://schema.org/name> ?name }\",
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
   \"view\":\"verified-memory\"
 }")
-SYNC_VM_CT=$(echo "$SYNC_VM" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SYNC_VM_CT" -ge 1 ]] && ok "Node5 synced VM data (city1 found)" || warn "Node5 VM data not synced yet ($SYNC_VM_CT)"
+SYNC_VM_CT=$(safe_bindings_count "$SYNC_VM")
+if [[ "$SYNC_VM_CT" == "PARSE_ERR" ]]; then
+  fail "Node5 VM sync query returned unparseable response: ${SYNC_VM:0:200}"
+elif [[ "$SYNC_VM_CT" -ge 1 ]]; then
+  ok "Node5 synced VM data (city1 found)"
+elif $SYNC_COMPLETED; then
+  fail "Catchup reported complete on Node5 but VM data is missing — bug"
+else
+  warn "Node5 VM data not synced yet ($SYNC_VM_CT) — catchup never completed"
+fi
 
 echo "--- 18c: Verify synced SWM data on Node5 ---"
 SYNC_SWM=$(c -X POST "http://127.0.0.1:9205/api/query" -d "{
@@ -766,8 +868,16 @@ SYNC_SWM=$(c -X POST "http://127.0.0.1:9205/api/query" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
   \"view\":\"shared-working-memory\"
 }")
-SYNC_SWM_CT=$(echo "$SYNC_SWM" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SYNC_SWM_CT" -ge 1 ]] && ok "Node5 synced SWM data (city1 found)" || warn "Node5 SWM data not synced ($SYNC_SWM_CT)"
+SYNC_SWM_CT=$(safe_bindings_count "$SYNC_SWM")
+if [[ "$SYNC_SWM_CT" == "PARSE_ERR" ]]; then
+  fail "Node5 SWM sync query returned unparseable response: ${SYNC_SWM:0:200}"
+elif [[ "$SYNC_SWM_CT" -ge 1 ]]; then
+  ok "Node5 synced SWM data (city1 found)"
+elif $SYNC_COMPLETED; then
+  fail "Catchup reported complete on Node5 but SWM data is missing — bug"
+else
+  warn "Node5 SWM data not synced ($SYNC_SWM_CT) — catchup never completed"
+fi
 
 #------------------------------------------------------------
 echo ""
@@ -780,8 +890,14 @@ VM_VIEW=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
   \"view\":\"verified-memory\"
 }")
-VM_CT=$(echo "$VM_VIEW" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$VM_CT" -ge 1 ]] && ok "Verified memory view returns published data" || warn "Verified memory view empty ($VM_CT) — VM finalization may be pending"
+VM_CT=$(safe_bindings_count "$VM_VIEW")
+if [[ "$VM_CT" == "PARSE_ERR" ]]; then
+  fail "Verified memory view returned unparseable response: ${VM_VIEW:0:200}"
+elif [[ "$VM_CT" -ge 1 ]]; then
+  ok "Verified memory view returns published data"
+else
+  warn "Verified memory view empty ($VM_CT) — VM finalization may be pending"
+fi
 
 echo "--- 19b: Shared memory view ---"
 SWM_VIEW=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
@@ -789,9 +905,27 @@ SWM_VIEW=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
   \"view\":\"shared-working-memory\"
 }")
-SWM_CT=$(echo "$SWM_VIEW" | python3 -c 'import sys,json;b=json.load(sys.stdin).get("result",{}).get("bindings",[]);print(b[0]["c"].strip(chr(34)).split("^^")[0] if b else "0")' 2>/dev/null || echo "0")
+SWM_CT=$(echo "$SWM_VIEW" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin)
+  b=d.get("result",{}).get("bindings",None)
+  if b is None:
+    print("PARSE_ERR")
+  elif b:
+    print(b[0]["c"].strip(chr(34)).split("^^")[0])
+  else:
+    print("0")
+except Exception:
+  print("PARSE_ERR")
+' 2>/dev/null || echo "PARSE_ERR")
 echo "  SWM entity count: $SWM_CT"
-[[ "$SWM_CT" -ge 1 ]] && ok "Shared memory view returns data ($SWM_CT entities)" || warn "Shared memory view empty"
+if [[ "$SWM_CT" == "PARSE_ERR" ]]; then
+  fail "Shared memory view returned unparseable response: ${SWM_VIEW:0:200}"
+elif [[ "$SWM_CT" -ge 1 ]]; then
+  ok "Shared memory view returns data ($SWM_CT entities)"
+else
+  warn "Shared memory view empty"
+fi
 
 echo "--- 19c: Working memory assertion visible only locally ---"
 WM_NAME="wm-view-test-$(date +%s)"
@@ -803,8 +937,14 @@ c -X POST "http://127.0.0.1:9201/api/assertion/$WM_NAME/write" -d "{
 }" > /dev/null
 
 WM_LOCAL=$(c -X POST "http://127.0.0.1:9201/api/assertion/$WM_NAME/query" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
-WM_LOCAL_CT=$(echo "$WM_LOCAL" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d.get("quads",d.get("result",[]))))' 2>/dev/null || echo "0")
-[[ "$WM_LOCAL_CT" -ge 1 ]] && ok "WM assertion visible locally ($WM_LOCAL_CT quads)" || fail "WM assertion not visible locally"
+WM_LOCAL_CT=$(safe_quads_count "$WM_LOCAL")
+if [[ "$WM_LOCAL_CT" == "PARSE_ERR" ]]; then
+  fail "WM assertion query returned unparseable response: ${WM_LOCAL:0:200}"
+elif [[ "$WM_LOCAL_CT" -ge 1 ]]; then
+  ok "WM assertion visible locally ($WM_LOCAL_CT quads)"
+else
+  fail "WM assertion not visible locally"
+fi
 
 echo "--- 19d: WM data NOT in verified memory ---"
 WM_IN_VM=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
@@ -812,16 +952,28 @@ WM_IN_VM=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
   \"view\":\"verified-memory\"
 }")
-WM_IN_VM_CT=$(echo "$WM_IN_VM" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$WM_IN_VM_CT" -eq 0 ]] && ok "WM data correctly absent from verified memory" || fail "WM data leaked into verified memory ($WM_IN_VM_CT)"
+WM_IN_VM_CT=$(safe_bindings_count "$WM_IN_VM")
+if [[ "$WM_IN_VM_CT" == "PARSE_ERR" ]]; then
+  fail "WM/VM isolation query returned unparseable response: ${WM_IN_VM:0:200}"
+elif [[ "$WM_IN_VM_CT" -eq 0 ]]; then
+  ok "WM data correctly absent from verified memory"
+else
+  fail "WM data leaked into verified memory ($WM_IN_VM_CT)"
+fi
 
 echo "--- 19e: WM data NOT visible on Node2 ---"
 WM_REMOTE=$(c -X POST "http://127.0.0.1:9202/api/query" -d "{
   \"sparql\":\"SELECT ?name WHERE { <$WM_SUBJECT> <http://schema.org/name> ?name }\",
   \"contextGraphId\":\"$CONTEXT_GRAPH\"
 }")
-WM_REMOTE_CT=$(echo "$WM_REMOTE" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$WM_REMOTE_CT" -eq 0 ]] && ok "WM data correctly absent on Node2" || fail "WM data leaked to Node2 ($WM_REMOTE_CT)"
+WM_REMOTE_CT=$(safe_bindings_count "$WM_REMOTE")
+if [[ "$WM_REMOTE_CT" == "PARSE_ERR" ]]; then
+  fail "WM/Node2 isolation query returned unparseable response: ${WM_REMOTE:0:200}"
+elif [[ "$WM_REMOTE_CT" -eq 0 ]]; then
+  ok "WM data correctly absent on Node2"
+else
+  fail "WM data leaked to Node2 ($WM_REMOTE_CT)"
+fi
 
 c -X POST "http://127.0.0.1:9201/api/assertion/$WM_NAME/discard" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}" > /dev/null 2>&1
 
@@ -833,12 +985,12 @@ echo ""
 echo "--- 20a: Context graph exists (known) ---"
 CG_EXISTS=$(c "http://127.0.0.1:9201/api/context-graph/exists?id=$CONTEXT_GRAPH")
 CG_E=$(json_get "$CG_EXISTS" exists)
-check "Context graph devnet-test exists" "$CG_E" "True"
+check "Context graph devnet-test exists" "$CG_E" "true"
 
 echo "--- 20b: Context graph exists (unknown) ---"
 CG_NOT=$(c "http://127.0.0.1:9201/api/context-graph/exists?id=nonexistent-cg-$(date +%s)")
 CG_N=$(json_get "$CG_NOT" exists)
-check "Nonexistent context graph reports false" "$CG_N" "False"
+check "Nonexistent context graph reports false" "$CG_N" "false"
 
 echo "--- 20c: Read SWM TTL setting ---"
 TTL_ORIG=$(c "http://127.0.0.1:9201/api/settings/shared-memory-ttl")
@@ -848,9 +1000,11 @@ echo "  Current TTL: ${TTL_DAYS_ORIG} days (${TTL_MS_ORIG} ms)"
 [[ "$TTL_DAYS_ORIG" != "__NONE__" && "$TTL_DAYS_ORIG" != "__ERR__" ]] && ok "SWM TTL readable ($TTL_DAYS_ORIG days)" || fail "SWM TTL not readable: $TTL_ORIG"
 
 echo "--- 20d: Update SWM TTL ---"
-TTL_SET=$(curl -s -X PUT -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" "http://127.0.0.1:9201/api/settings/shared-memory-ttl" -d '{"ttlDays":7}')
+# P1-4: Route through the `c()` helper so the bounded timeout + auth
+# headers propagate; c() accepts any curl args via "$@".
+TTL_SET=$(c -X PUT "http://127.0.0.1:9201/api/settings/shared-memory-ttl" -d '{"ttlDays":7}')
 TTL_OK=$(json_get "$TTL_SET" ok)
-[[ "$TTL_OK" == "True" ]] && ok "SWM TTL updated to 7 days" || fail "SWM TTL update failed: $TTL_SET"
+[[ "$TTL_OK" == "true" ]] && ok "SWM TTL updated to 7 days" || fail "SWM TTL update failed: $TTL_SET"
 
 echo "--- 20e: Verify updated TTL ---"
 TTL_NEW=$(c "http://127.0.0.1:9201/api/settings/shared-memory-ttl")
@@ -858,9 +1012,20 @@ TTL_DAYS_NEW=$(json_get "$TTL_NEW" ttlDays)
 check "TTL reads back as 7 days" "$TTL_DAYS_NEW" "7"
 
 echo "--- 20f: Restore original TTL ---"
-TTL_RESTORE=$(curl -s -X PUT -H "Authorization: Bearer $AUTH" -H "Content-Type: application/json" "http://127.0.0.1:9201/api/settings/shared-memory-ttl" -d "{\"ttlMs\":$TTL_MS_ORIG}")
+# P1-4 (Phase D): route through c() for consistent timeout handling.
+# Base-rebase fix: use `ttlMs` for precision and verify restore via the
+# response `ok` field (previously used `ttlDays` and trusted success).
+# Both hardening intents preserved.
+TTL_RESTORE=$(c -X PUT "http://127.0.0.1:9201/api/settings/shared-memory-ttl" -d "{\"ttlMs\":$TTL_MS_ORIG}")
 TTL_RESTORE_OK=$(json_get "$TTL_RESTORE" ok)
-[[ "$TTL_RESTORE_OK" == "True" ]] && ok "TTL restored to original ($TTL_MS_ORIG ms)" || fail "TTL restore failed: $TTL_RESTORE"
+# Round 17 Bug 46: Round 16's union-of-intents resolution for §20f kept
+# Phase D's `json_get` helper (returns lowercase-normalized `"true"`)
+# alongside base's title-case `"True"` comparison string, which can
+# never match — permanent false negative. Fix: use the `check` helper
+# matching line 200/1007's convention (lowercase `"true"` expected
+# value). `check` fails with `expected=true, got=<actual>` diagnostic
+# if the restore doesn't return ok.
+check "TTL restored to original ($TTL_MS_ORIG ms)" "$TTL_RESTORE_OK" "true"
 
 #------------------------------------------------------------
 echo ""
@@ -872,7 +1037,8 @@ echo "--- 21a: Create assertion for import ---"
 c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"name\":\"$IMPORT_NAME\"}" > /dev/null
 
 echo "--- 21b: Import markdown file ---"
-TMPMD=$(mktemp /tmp/devnet-import-XXXXXX.md)
+# P2-3: honor $TMPDIR for CI runners with non-/tmp tmp roots.
+TMPMD=$(mktemp "$DEVNET_TMPDIR/devnet-import-XXXXXX.md")
 cat > "$TMPMD" <<'MDEOF'
 ---
 title: DKG V10 Import Test
@@ -890,7 +1056,8 @@ The Decentralized Knowledge Graph enables verifiable knowledge sharing.
 - Memory layers: Working Memory, Shared Memory, Verified Memory
 MDEOF
 
-IMPORT_RESP=$(curl -s -H "Authorization: Bearer $AUTH" \
+IMPORT_RESP=$(curl -sS --max-time "$DEVNET_CURL_TIMEOUT" --connect-timeout "$DEVNET_CURL_CONNECT_TIMEOUT" \
+  -H "Authorization: Bearer $AUTH" \
   -F "file=@${TMPMD};type=text/markdown" \
   -F "contextGraphId=$CONTEXT_GRAPH" \
   "http://127.0.0.1:9201/api/assertion/${IMPORT_NAME}/import-file" 2>&1)
@@ -900,6 +1067,13 @@ IMPORT_HASH=$(json_get "$IMPORT_RESP" fileHash)
 echo "  Import assertionUri=$IMPORT_URI fileHash=$IMPORT_HASH"
 [[ "$IMPORT_URI" != "__NONE__" && "$IMPORT_URI" != "__ERR__" ]] && ok "Import-file accepted ($IMPORT_URI)" || fail "Import-file failed: ${IMPORT_RESP:0:200}"
 [[ "$IMPORT_HASH" != "__NONE__" && "$IMPORT_HASH" != "__ERR__" ]] && ok "File hash returned ($IMPORT_HASH)" || warn "No file hash returned"
+# Spec §10.2:603 mandates keccak256 on the wire for the import-file response
+# fileHash. Lock in the format so a regression to sha256 is a hard fail.
+if [[ "$IMPORT_HASH" =~ ^keccak256:[0-9a-f]{64}$ ]]; then
+  ok "File hash is keccak256 (${IMPORT_HASH})"
+else
+  fail "File hash not keccak256 format (got=$IMPORT_HASH)"
+fi
 
 echo "--- 21c: Check extraction status endpoint ---"
 EXTRACT_ST=$(c "http://127.0.0.1:9201/api/assertion/${IMPORT_NAME}/extraction-status?contextGraphId=$CONTEXT_GRAPH")
@@ -909,14 +1083,155 @@ echo "  Extraction status: $EXT_STATUS"
 
 echo "--- 21d: Query imported assertion ---"
 IMPORT_Q=$(c -X POST "http://127.0.0.1:9201/api/assertion/${IMPORT_NAME}/query" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
-IMPORT_Q_CT=$(echo "$IMPORT_Q" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d.get("quads",d.get("result",[]))))' 2>/dev/null || echo "0")
-[[ "$IMPORT_Q_CT" -ge 1 ]] && ok "Imported assertion has $IMPORT_Q_CT quads" || warn "Imported assertion empty"
+IMPORT_Q_CT=$(safe_quads_count "$IMPORT_Q")
+if [[ "$IMPORT_Q_CT" == "PARSE_ERR" ]]; then
+  fail "Imported assertion query returned unparseable response: ${IMPORT_Q:0:200}"
+elif [[ "$IMPORT_Q_CT" -ge 1 ]]; then
+  ok "Imported assertion has $IMPORT_Q_CT quads"
+else
+  warn "Imported assertion empty"
+fi
 
 echo "--- 21e: Promote imported assertion to SWM ---"
 IMPORT_PROMOTE=$(c -X POST "http://127.0.0.1:9201/api/assertion/${IMPORT_NAME}/promote" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
 IMPORT_PC=$(json_get "$IMPORT_PROMOTE" promotedCount)
 echo "  Promoted count: $IMPORT_PC"
-[[ "$IMPORT_PC" != "__NONE__" && "$IMPORT_PC" != "0" ]] && ok "Imported data promoted to SWM ($IMPORT_PC quads)" || warn "Import promote: $IMPORT_PC"
+# P1-10: also exclude __ERR__ (and keep the 0 guard) so parse failures don't
+# silently count as success.
+if [[ "$IMPORT_PC" != "__NONE__" && "$IMPORT_PC" != "__ERR__" && "$IMPORT_PC" != "0" ]]; then
+  ok "Imported data promoted to SWM ($IMPORT_PC quads)"
+else
+  warn "Import promote: $IMPORT_PC"
+fi
+
+# ── 21f / 21g / 21h: spec-linkage SPARQL gate — this is the devnet-side
+# sign-off for the Phase B file-linkage implementation. The tests above
+# only check that the import-file endpoint RESPONDED; these query the
+# actual graph data to confirm the §10.1 data-graph linkage + §10.2 _meta
+# triples actually landed. A daemon regression that silently dropped any
+# of these predicates would be invisible to 21b-e.
+
+echo "--- 21f: §10.1 linkage triples present in assertion data graph ---"
+# /api/assertion/:name/query ignores `sparql` and returns all quads as
+# { quads, count } — it's NOT a SPARQL-execution endpoint. Earlier we
+# routed through /api/query with `view: "working-memory"` +
+# `assertionName`, but the HTTP route does NOT auto-fill `agentAddress`
+# the way the in-process agent code path does, so that form 400s with
+# "agentAddress is required for the working-memory view". Instead, use
+# the explicit `GRAPH <iri>` form — matches §21g/§21h below and sidesteps
+# the HTTP-vs-agent-internal auto-fill drift entirely. The assertion
+# graph URI is the same as IMPORT_URI (both come from
+# contextGraphAssertionUri with the same args), so we can reuse it as
+# both the graph name AND the subject binding.
+#
+# Follow-up note: the /api/query route should probably auto-fill
+# `agentAddress` with the node's own peerId when `view === "working-memory"`
+# is set and `agentAddress` is absent, matching dkg-agent.ts:1669 — but
+# that's a separate daemon fix, not part of this PR.
+LINK_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"sparql\":\"SELECT ?p ?o WHERE { GRAPH <${IMPORT_URI}> { <${IMPORT_URI}> ?p ?o FILTER(?p IN (<http://dkg.io/ontology/sourceFile>, <http://dkg.io/ontology/sourceContentType>, <http://dkg.io/ontology/rootEntity>)) } }\"
+}")
+LINK_CT=$(safe_bindings_count "$LINK_Q")
+# Expect one each of sourceFile / sourceContentType / rootEntity — three rows.
+if [[ "$LINK_CT" == "PARSE_ERR" ]]; then
+  fail "§10.1 linkage query returned unparseable response: ${LINK_Q:0:200}"
+elif [[ "$LINK_CT" -ge 3 ]]; then
+  ok "§10.1 linkage predicates present in assertion graph ($LINK_CT bindings)"
+else
+  fail "§10.1 linkage predicates missing from assertion graph ($LINK_CT, expected >= 3)"
+fi
+
+echo "--- 21g: §10.2 sourceFileHash in CG root _meta graph ---"
+META_GRAPH="did:dkg:context-graph:${CONTEXT_GRAPH}/_meta"
+META_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"sparql\":\"SELECT ?h WHERE { GRAPH <${META_GRAPH}> { <${IMPORT_URI}> <http://dkg.io/ontology/sourceFileHash> ?h } }\"
+}")
+META_CT=$(safe_bindings_count "$META_Q")
+META_HASH_RAW=$(echo "$META_Q" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin)
+  b=d.get("result",{}).get("bindings",[])
+  if b and "h" in b[0]:
+    v=b[0]["h"]
+    # strip surrounding quotes + any xsd:string suffix
+    if v.startswith("\"") and "\"^^" in v:
+      print(v.split("\"^^",1)[0].lstrip("\""))
+    elif v.startswith("\"") and v.endswith("\""):
+      print(v[1:-1])
+    else:
+      print(v)
+  else:
+    print("__MISSING__")
+except Exception:
+  print("__ERR__")
+' 2>/dev/null || echo "__ERR__")
+if [[ "$META_CT" == "PARSE_ERR" ]]; then
+  fail "§10.2 sourceFileHash query returned unparseable response: ${META_Q:0:200}"
+elif [[ "$META_HASH_RAW" =~ ^keccak256:[0-9a-f]{64}$ ]]; then
+  if [[ "$META_HASH_RAW" == "$IMPORT_HASH" ]]; then
+    ok "§10.2 sourceFileHash present in CG root _meta and matches import response"
+  else
+    fail "§10.2 sourceFileHash (${META_HASH_RAW}) does not match import response hash (${IMPORT_HASH})"
+  fi
+else
+  fail "§10.2 sourceFileHash missing or wrong shape (got=$META_HASH_RAW)"
+fi
+
+echo "--- 21h: §10.2 row 20 (mdIntermediateHash) absent for markdown upload ---"
+# Row 20 is spec-gated on Phase 1 having run. text/markdown bypasses Phase 1,
+# so the md intermediate predicate MUST NOT be present for a direct markdown
+# upload. We assert absence here and verify presence in §21i for PDF-path.
+MD_INT_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"sparql\":\"SELECT ?h WHERE { GRAPH <${META_GRAPH}> { <${IMPORT_URI}> <http://dkg.io/ontology/mdIntermediateHash> ?h } }\"
+}")
+MD_INT_CT=$(safe_bindings_count "$MD_INT_Q")
+if [[ "$MD_INT_CT" == "PARSE_ERR" ]]; then
+  fail "§10.2 mdIntermediateHash query returned unparseable response: ${MD_INT_Q:0:200}"
+elif [[ "$MD_INT_CT" -eq 0 ]]; then
+  ok "§10.2 mdIntermediateHash correctly absent for markdown upload"
+else
+  fail "§10.2 mdIntermediateHash leaked into a markdown import ($MD_INT_CT bindings)"
+fi
+
+echo "--- 21i: Unsupported content type gracefully degrades (§6.5) ---"
+# P1-6: exercise the graceful-degrade path — a PNG upload should land as
+# extraction.status="skipped", tripleCount=0, no linkage triples written.
+# Required by 05_PROTOCOL_EXTENSIONS.md §6.5 but previously uncovered.
+PNG_NAME="import-degrade-$(date +%s)"
+c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"name\":\"$PNG_NAME\"}" > /dev/null
+TMPPNG=$(mktemp "$DEVNET_TMPDIR/devnet-png-XXXXXX.png")
+# 8-byte PNG magic header — enough to look like a real image to the server
+# while keeping the test body small. No converter is registered for image/png
+# so the daemon must graceful-degrade.
+printf '\x89PNG\r\n\x1a\n' > "$TMPPNG"
+PNG_RESP=$(curl -sS --max-time "$DEVNET_CURL_TIMEOUT" --connect-timeout "$DEVNET_CURL_CONNECT_TIMEOUT" \
+  -H "Authorization: Bearer $AUTH" \
+  -F "file=@${TMPPNG};type=image/png" \
+  -F "contextGraphId=$CONTEXT_GRAPH" \
+  "http://127.0.0.1:9201/api/assertion/${PNG_NAME}/import-file" 2>&1)
+rm -f "$TMPPNG"
+PNG_STATUS=$(json_get "$PNG_RESP" extraction.status)
+PNG_PIPELINE=$(json_get "$PNG_RESP" extraction.pipelineUsed)
+PNG_COUNT=$(json_get "$PNG_RESP" extraction.tripleCount)
+if [[ "$PNG_STATUS" == "skipped" && "$PNG_COUNT" == "0" && "$PNG_PIPELINE" == "None" ]]; then
+  ok "§6.5 graceful degrade: PNG upload returns skipped + zero triples"
+elif [[ "$PNG_STATUS" == "skipped" ]]; then
+  # Tolerant fallback: some daemon versions emit pipelineUsed as null->__NONE__
+  # or an empty string. Still fine as long as the status is skipped and the
+  # count is zero.
+  if [[ "$PNG_COUNT" == "0" ]]; then
+    ok "§6.5 graceful degrade: PNG upload returns skipped (pipelineUsed=$PNG_PIPELINE)"
+  else
+    fail "§6.5 graceful degrade reported skipped but with tripleCount=$PNG_COUNT"
+  fi
+else
+  fail "§6.5 graceful degrade failed: status=$PNG_STATUS pipeline=$PNG_PIPELINE count=$PNG_COUNT (${PNG_RESP:0:200})"
+fi
+# Clean up the degraded assertion so it doesn't pollute later tests.
+c -X POST "http://127.0.0.1:9201/api/assertion/$PNG_NAME/discard" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}" > /dev/null 2>&1
 
 #------------------------------------------------------------
 echo ""
@@ -932,12 +1247,25 @@ PQ_WRITE=$(c -X POST "http://127.0.0.1:9201/api/shared-memory/write" -d "{
     $(ql "$PQ_ENTITY" 'http://schema.org/name' 'Publisher Queue Test')
   ]
 }")
+# P2-4: shareOperationId is the current field name; workspaceOperationId is
+# the legacy alias still emitted by some node versions. Keep the fallback
+# until we confirm every supported node build has migrated.
 PQ_OP_ID=$(json_get "$PQ_WRITE" shareOperationId)
 if [[ "$PQ_OP_ID" == "__NONE__" || "$PQ_OP_ID" == "__ERR__" ]]; then
   PQ_OP_ID=$(json_get "$PQ_WRITE" workspaceOperationId)
 fi
 echo "  SWM write shareOperationId=$PQ_OP_ID"
 [[ "$PQ_OP_ID" != "__NONE__" && "$PQ_OP_ID" != "__ERR__" ]] && ok "SWM write for publisher test" || fail "SWM write failed: ${PQ_WRITE:0:200}"
+
+# P1-9: also assert triplesWritten >= 2. A silent zero-write pipeline would
+# let the publisher enqueue an empty payload and 22c would "pass" with no
+# actual data to publish.
+PQ_TW=$(json_get "$PQ_WRITE" triplesWritten)
+if [[ "$PQ_TW" != "__NONE__" && "$PQ_TW" != "__ERR__" && "$PQ_TW" -ge 2 ]] 2>/dev/null; then
+  ok "SWM write persisted $PQ_TW triples (>= 2)"
+else
+  fail "SWM write triplesWritten=$PQ_TW (expected >= 2) — publisher queue test will be meaningless"
+fi
 
 echo "--- 22b: Enqueue publish job ---"
 PQ_ENQUEUE=$(c -X POST "http://127.0.0.1:9201/api/publisher/enqueue" -d "{
@@ -958,17 +1286,49 @@ if [[ "$PQ_JOB_ID" != "__NONE__" && "$PQ_JOB_ID" != "__ERR__" && -n "$PQ_JOB_ID"
   PQ_FINAL_ST="unknown"
   for i in $(seq 1 15); do
     PQ_STATUS=$(c "http://127.0.0.1:9201/api/publisher/job?id=$PQ_JOB_ID")
-    PQ_FINAL_ST=$(echo "$PQ_STATUS" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("job",d).get("status","?") if isinstance(d.get("job",d),dict) else "?")' 2>/dev/null || echo "?")
+    # P1-5: replace the fragile inline ternary with a dedicated helper so
+    # malformed responses surface as __ERR__ instead of a stringified "?"
+    # that looked like a "valid" status and could fall through.
+    PQ_FINAL_ST=$(echo "$PQ_STATUS" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin)
+  job=d.get("job", d) if isinstance(d, dict) else None
+  if isinstance(job, dict):
+    s=job.get("status")
+    print(s if s is not None else "__MISSING__")
+  else:
+    print("__ERR__")
+except Exception:
+  print("__ERR__")
+' 2>/dev/null || echo "__ERR__")
     echo "  Poll $i: status=$PQ_FINAL_ST"
     [[ "$PQ_FINAL_ST" == "finalized" || "$PQ_FINAL_ST" == "included" || "$PQ_FINAL_ST" == "failed" ]] && break
     sleep 3
   done
-  [[ "$PQ_FINAL_ST" == "finalized" || "$PQ_FINAL_ST" == "included" ]] && ok "Publisher job reached $PQ_FINAL_ST" || warn "Publisher job status: $PQ_FINAL_ST"
+  if [[ "$PQ_FINAL_ST" == "finalized" || "$PQ_FINAL_ST" == "included" ]]; then
+    ok "Publisher job reached $PQ_FINAL_ST"
+  elif [[ "$PQ_FINAL_ST" == "__ERR__" || "$PQ_FINAL_ST" == "__MISSING__" ]]; then
+    fail "Publisher job status unparseable or missing status field (got=$PQ_FINAL_ST)"
+  else
+    warn "Publisher job status: $PQ_FINAL_ST"
+  fi
 
   echo "--- 22d: Fetch job payload ---"
   PQ_PAYLOAD=$(c "http://127.0.0.1:9201/api/publisher/job-payload?id=$PQ_JOB_ID")
-  PQ_HAS_PAYLOAD=$(echo "$PQ_PAYLOAD" | python3 -c 'import sys,json;d=json.load(sys.stdin);print("yes" if d.get("payload") or d.get("job") else "no")' 2>/dev/null || echo "no")
-  [[ "$PQ_HAS_PAYLOAD" == "yes" ]] && ok "Job payload retrieved" || warn "Job payload: ${PQ_PAYLOAD:0:200}"
+  PQ_HAS_PAYLOAD=$(echo "$PQ_PAYLOAD" | python3 -c 'import sys,json
+try:
+  d=json.load(sys.stdin)
+  print("yes" if isinstance(d, dict) and (d.get("payload") or d.get("job")) else "no")
+except Exception:
+  print("ERR")
+' 2>/dev/null || echo "ERR")
+  if [[ "$PQ_HAS_PAYLOAD" == "yes" ]]; then
+    ok "Job payload retrieved"
+  elif [[ "$PQ_HAS_PAYLOAD" == "ERR" ]]; then
+    fail "Job payload query returned unparseable response: ${PQ_PAYLOAD:0:200}"
+  else
+    warn "Job payload: ${PQ_PAYLOAD:0:200}"
+  fi
 
   echo "--- 22e: Verify publisher stats ---"
   PQ_STATS=$(c "http://127.0.0.1:9201/api/publisher/stats")
@@ -980,6 +1340,10 @@ if [[ "$PQ_JOB_ID" != "__NONE__" && "$PQ_JOB_ID" != "__ERR__" && -n "$PQ_JOB_ID"
   PQ_CLEARED=$(json_get "$PQ_CLEAR" cleared)
   echo "  Cleared: $PQ_CLEARED jobs"
   [[ "$PQ_CLEARED" != "__ERR__" ]] && ok "Publisher clear returned ($PQ_CLEARED)" || warn "Publisher clear: $PQ_CLEAR"
+else
+  # P2-2: silent no-op was confusing when 22a succeeds but the job id is
+  # missing. Emit an explicit [SKIP] so the test log carries the reason.
+  skip "22c-22f skipped: publisher enqueue did not return a usable jobId (PQ_JOB_ID=$PQ_JOB_ID)"
 fi
 
 #------------------------------------------------------------
@@ -988,20 +1352,57 @@ echo "=== SECTION 23: Authorization & Error Handling ==="
 echo ""
 
 echo "--- 23a: Request without auth token ---"
-NOAUTH_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:9201/api/query" -X POST -H "Content-Type: application/json" -d '{"sparql":"SELECT * WHERE { ?s ?p ?o } LIMIT 1","contextGraphId":"devnet-test"}')
-[[ "$NOAUTH_CODE" == "401" ]] && ok "No-auth request rejected (401)" || warn "No-auth returned $NOAUTH_CODE (expected 401 — auth may be disabled)"
+# P0-2: explicitly detect DEVNET_NO_AUTH=1 and emit a clean SKIP rather
+# than degrading silently to WARN. A real auth-middleware regression must
+# show up as a hard failure when auth is enabled.
+if [[ "${DEVNET_NO_AUTH:-0}" == "1" ]]; then
+  skip "23a: auth disabled via DEVNET_NO_AUTH=1"
+else
+  NOAUTH_CODE=$(curl -sS --max-time "$DEVNET_CURL_TIMEOUT" --connect-timeout "$DEVNET_CURL_CONNECT_TIMEOUT" \
+    -o /dev/null -w "%{http_code}" "http://127.0.0.1:9201/api/query" \
+    -X POST -H "Content-Type: application/json" \
+    -d '{"sparql":"SELECT * WHERE { ?s ?p ?o } LIMIT 1","contextGraphId":"devnet-test"}')
+  if [[ "$NOAUTH_CODE" == "401" ]]; then
+    ok "No-auth request rejected (401)"
+  else
+    fail "No-auth returned $NOAUTH_CODE (expected 401; set DEVNET_NO_AUTH=1 if intentional)"
+  fi
+fi
 
 echo "--- 23b: Query against nonexistent context graph ---"
+# P1-8: `err`/PARSE_ERR must NOT pass — a 500 that returns malformed JSON
+# would previously silently count as success.
 BAD_CG=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"sparql\":\"SELECT ?s WHERE { ?s ?p ?o } LIMIT 1\",
   \"contextGraphId\":\"nonexistent-cg-$(date +%s)\"
 }")
-BAD_CG_CT=$(echo "$BAD_CG" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "err")
-[[ "$BAD_CG_CT" == "0" || "$BAD_CG_CT" == "err" ]] && ok "Query against nonexistent CG returns empty/error" || warn "Nonexistent CG returned $BAD_CG_CT results"
+BAD_CG_CT=$(safe_bindings_count "$BAD_CG")
+if [[ "$BAD_CG_CT" == "PARSE_ERR" ]]; then
+  # Could be a legitimate 4xx with a bare error envelope OR a 500 — warn
+  # rather than pass, so a genuinely broken response shows up instead of
+  # hiding inside the "empty result" branch.
+  if echo "$BAD_CG" | grep -qiE '"error"|"message"'; then
+    ok "Query against nonexistent CG returned an error envelope"
+  else
+    warn "Query against nonexistent CG returned unparseable response: ${BAD_CG:0:200}"
+  fi
+elif [[ "$BAD_CG_CT" == "0" ]]; then
+  ok "Query against nonexistent CG returns empty result"
+else
+  warn "Nonexistent CG returned $BAD_CG_CT results"
+fi
 
 echo "--- 23c: Create assertion with empty name ---"
-EMPTY_NAME=$(c -X POST "http://127.0.0.1:9201/api/assertion/create" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"name\":\"\"}")
-echo "$EMPTY_NAME" | grep -qi "error\|invalid" && ok "Empty assertion name rejected" || fail "Empty assertion name accepted: ${EMPTY_NAME:0:200}"
+# P0-3: capture HTTP status — a 500 with body `{"error":"internal"}` used
+# to silently pass the substring check. Require a 4xx AND an error token.
+http_post_capture "http://127.0.0.1:9201/api/assertion/create" \
+  "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"name\":\"\"}" \
+  EMPTY_NAME EMPTY_CODE
+if [[ "$EMPTY_CODE" =~ ^4 ]] && echo "$EMPTY_NAME" | grep -qiE 'error|invalid'; then
+  ok "Empty assertion name rejected (HTTP $EMPTY_CODE)"
+else
+  fail "Empty assertion name not cleanly rejected (HTTP $EMPTY_CODE): ${EMPTY_NAME:0:200}"
+fi
 
 echo "--- 23d: Duplicate assertion name reuses same URI ---"
 DUP_NAME="dup-test-$(date +%s)"
@@ -1045,8 +1446,16 @@ else
 fi
 
 echo "--- 23g: Publisher enqueue missing fields ---"
-BAD_ENQ=$(c -X POST "http://127.0.0.1:9201/api/publisher/enqueue" -d "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}")
-echo "$BAD_ENQ" | grep -qi "error\|missing\|required" && ok "Publisher enqueue missing fields rejected" || fail "Bad enqueue accepted: ${BAD_ENQ:0:200}"
+# P0-3: same treatment as 23c — must return a real 4xx, not just a 500
+# with an "error" string in the body.
+http_post_capture "http://127.0.0.1:9201/api/publisher/enqueue" \
+  "{\"contextGraphId\":\"$CONTEXT_GRAPH\"}" \
+  BAD_ENQ BAD_ENQ_CODE
+if [[ "$BAD_ENQ_CODE" =~ ^4 ]] && echo "$BAD_ENQ" | grep -qiE 'error|missing|required'; then
+  ok "Publisher enqueue missing fields rejected (HTTP $BAD_ENQ_CODE)"
+else
+  fail "Bad enqueue not cleanly rejected (HTTP $BAD_ENQ_CODE): ${BAD_ENQ:0:200}"
+fi
 
 #------------------------------------------------------------
 echo ""
@@ -1080,7 +1489,14 @@ c -X POST "http://127.0.0.1:9201/api/shared-memory/write" -d "{
   ]
 }" > /dev/null
 
-sleep 3
+# P2-1: brief settle window for the local SWM write to hit the triple
+# store before we query it. Round 8 Bug 24: this is a LOCAL write→query
+# settle, NOT a cross-node gossip wait, so it uses its own env var.
+# Otherwise a dev running with `GOSSIP_WAIT_S=0` to speed up a local-only
+# test run would accidentally also skip this settle and section 24 would
+# race its own write. `GOSSIP_WAIT_S` continues to govern cross-node
+# propagation waits exclusively.
+sleep "$LOCAL_SETTLE_S"
 
 echo "--- 24c: Query sub-graph A — should find alpha, not beta ---"
 SG_A_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
@@ -1089,8 +1505,14 @@ SG_A_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"subGraphName\":\"$SG_A\",
   \"includeSharedMemory\":true
 }")
-SG_A_CT=$(echo "$SG_A_Q" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SG_A_CT" -ge 1 ]] && ok "Sub-graph A has alpha entity" || fail "Sub-graph A missing alpha entity ($SG_A_CT)"
+SG_A_CT=$(safe_bindings_count "$SG_A_Q")
+if [[ "$SG_A_CT" == "PARSE_ERR" ]]; then
+  fail "Sub-graph A query returned unparseable response: ${SG_A_Q:0:200}"
+elif [[ "$SG_A_CT" -ge 1 ]]; then
+  ok "Sub-graph A has alpha entity"
+else
+  fail "Sub-graph A missing alpha entity ($SG_A_CT)"
+fi
 
 SG_A_LEAK=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"sparql\":\"SELECT ?name WHERE { <urn:iso:beta1> <http://schema.org/name> ?name }\",
@@ -1098,8 +1520,14 @@ SG_A_LEAK=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"subGraphName\":\"$SG_A\",
   \"includeSharedMemory\":true
 }")
-SG_A_LEAK_CT=$(echo "$SG_A_LEAK" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SG_A_LEAK_CT" -eq 0 ]] && ok "Sub-graph A correctly excludes beta data" || fail "Sub-graph A leaks beta data ($SG_A_LEAK_CT)"
+SG_A_LEAK_CT=$(safe_bindings_count "$SG_A_LEAK")
+if [[ "$SG_A_LEAK_CT" == "PARSE_ERR" ]]; then
+  fail "Sub-graph A leak query returned unparseable response: ${SG_A_LEAK:0:200}"
+elif [[ "$SG_A_LEAK_CT" -eq 0 ]]; then
+  ok "Sub-graph A correctly excludes beta data"
+else
+  fail "Sub-graph A leaks beta data ($SG_A_LEAK_CT)"
+fi
 
 echo "--- 24d: Query sub-graph B — should find beta, not alpha ---"
 SG_B_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
@@ -1108,8 +1536,14 @@ SG_B_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"subGraphName\":\"$SG_B\",
   \"includeSharedMemory\":true
 }")
-SG_B_CT=$(echo "$SG_B_Q" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SG_B_CT" -ge 1 ]] && ok "Sub-graph B has beta entity" || fail "Sub-graph B missing beta entity ($SG_B_CT)"
+SG_B_CT=$(safe_bindings_count "$SG_B_Q")
+if [[ "$SG_B_CT" == "PARSE_ERR" ]]; then
+  fail "Sub-graph B query returned unparseable response: ${SG_B_Q:0:200}"
+elif [[ "$SG_B_CT" -ge 1 ]]; then
+  ok "Sub-graph B has beta entity"
+else
+  fail "Sub-graph B missing beta entity ($SG_B_CT)"
+fi
 
 SG_B_LEAK=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"sparql\":\"SELECT ?name WHERE { <urn:iso:alpha1> <http://schema.org/name> ?name }\",
@@ -1117,8 +1551,14 @@ SG_B_LEAK=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"subGraphName\":\"$SG_B\",
   \"includeSharedMemory\":true
 }")
-SG_B_LEAK_CT=$(echo "$SG_B_LEAK" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SG_B_LEAK_CT" -eq 0 ]] && ok "Sub-graph B correctly excludes alpha data" || fail "Sub-graph B leaks alpha data ($SG_B_LEAK_CT)"
+SG_B_LEAK_CT=$(safe_bindings_count "$SG_B_LEAK")
+if [[ "$SG_B_LEAK_CT" == "PARSE_ERR" ]]; then
+  fail "Sub-graph B leak query returned unparseable response: ${SG_B_LEAK:0:200}"
+elif [[ "$SG_B_LEAK_CT" -eq 0 ]]; then
+  ok "Sub-graph B correctly excludes alpha data"
+else
+  fail "Sub-graph B leaks alpha data ($SG_B_LEAK_CT)"
+fi
 
 echo "--- 24e: Root CG query should NOT include sub-graph-only data ---"
 ROOT_ALPHA=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
@@ -1126,19 +1566,58 @@ ROOT_ALPHA=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
   \"view\":\"shared-working-memory\"
 }")
-ROOT_ALPHA_CT=$(echo "$ROOT_ALPHA" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$ROOT_ALPHA_CT" -eq 0 ]] && ok "Sub-graph alpha data absent from root CG SWM" || fail "Sub-graph data leaked into root CG query ($ROOT_ALPHA_CT) — isolation regression"
+ROOT_ALPHA_CT=$(safe_bindings_count "$ROOT_ALPHA")
+if [[ "$ROOT_ALPHA_CT" == "PARSE_ERR" ]]; then
+  # Phase D hardening: unparseable response now fails loudly instead
+  # of being silently counted as 0.
+  fail "Root CG isolation query returned unparseable response: ${ROOT_ALPHA:0:200}"
+elif [[ "$ROOT_ALPHA_CT" -eq 0 ]]; then
+  ok "Sub-graph alpha data absent from root CG SWM"
+else
+  # Base-rebase fix: non-zero binding count is now a FAIL (was warn).
+  # Root and sub-graph SWM use different graph URIs, so contamination
+  # is an isolation regression, not "expected".
+  fail "Sub-graph data leaked into root CG query ($ROOT_ALPHA_CT) — isolation regression"
+fi
 
 echo "--- 24f: Sub-graph data gossips to Node2 ---"
-sleep 5
-SG_GOS_A=$(c -X POST "http://127.0.0.1:9202/api/query" -d "{
-  \"sparql\":\"SELECT ?name WHERE { <urn:iso:alpha1> <http://schema.org/name> ?name }\",
-  \"contextGraphId\":\"$CONTEXT_GRAPH\",
-  \"subGraphName\":\"$SG_A\",
-  \"includeSharedMemory\":true
-}")
-SG_GOS_CT=$(echo "$SG_GOS_A" | python3 -c 'import sys,json;print(len(json.load(sys.stdin).get("result",{}).get("bindings",[])))' 2>/dev/null || echo "0")
-[[ "$SG_GOS_CT" -ge 1 ]] && ok "Sub-graph A data gossiped to Node2" || warn "Sub-graph A not on Node2 ($SG_GOS_CT)"
+# P2-6: poll instead of one long sleep so a quick network can finish fast
+# while a slow one still gets its full budget. Bounded at 5 × 1s = 5s,
+# which matches the previous single sleep 5.
+SG_GOS_CT="PARSE_ERR"
+for i in 1 2 3 4 5; do
+  SG_GOS_A=$(c -X POST "http://127.0.0.1:9202/api/query" -d "{
+    \"sparql\":\"SELECT ?name WHERE { <urn:iso:alpha1> <http://schema.org/name> ?name }\",
+    \"contextGraphId\":\"$CONTEXT_GRAPH\",
+    \"subGraphName\":\"$SG_A\",
+    \"includeSharedMemory\":true
+  }")
+  SG_GOS_CT=$(safe_bindings_count "$SG_GOS_A")
+  [[ "$SG_GOS_CT" != "PARSE_ERR" && "$SG_GOS_CT" -ge 1 ]] && break
+  sleep 1
+done
+if [[ "$SG_GOS_CT" == "PARSE_ERR" ]]; then
+  fail "Sub-graph gossip query returned unparseable response: ${SG_GOS_A:0:200}"
+elif [[ "$SG_GOS_CT" -ge 1 ]]; then
+  ok "Sub-graph A data gossiped to Node2"
+else
+  warn "Sub-graph A not on Node2 ($SG_GOS_CT)"
+fi
+
+echo "--- 24g: Write to unregistered sub-graph rejected (negative test) ---"
+# P1-7: the spec requires a write to an unregistered sub-graph to fail
+# with a 4xx; previously zero coverage. Use a name seeded with a fresh
+# timestamp to avoid collisions with anything a previous test run might
+# have created.
+UNREG_SG="never-created-$(date +%s%N)"
+http_post_capture "http://127.0.0.1:9201/api/shared-memory/write" \
+  "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"subGraphName\":\"$UNREG_SG\",\"quads\":[$(ql 'urn:unreg:x' 'http://schema.org/name' 'nope')]}" \
+  UNREG_BODY UNREG_CODE
+if [[ "$UNREG_CODE" =~ ^4 ]]; then
+  ok "Write to unregistered sub-graph rejected (HTTP $UNREG_CODE)"
+else
+  fail "Write to unregistered sub-graph not rejected (HTTP $UNREG_CODE): ${UNREG_BODY:0:200}"
+fi
 
 #------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Chain PR onto `test/devnet-e2e-sections-18-24` (the base for PR #120). Two changes bundled:

1. **Phase B — Source-file linkage triples.** Implements `19_MARKDOWN_CONTENT_TYPE.md §10.1` and `§10.2` — the full 20-row source-file linkage contract that was missing from PR #113. After a daemon restart, the assertion graph can now rediscover the original file blob by SPARQLing `_meta` for `dkg:sourceFileHash`. Previously the only linkage was the in-memory `extractionStatus` map, which vanished on restart. Hash format is keccak256 per `03_PROTOCOL_CORE.md §2.1:658`.

2. **Phase D — Devnet test hardening.** Hardens `scripts/devnet-test.sh` sections 18-24 (introduced in PR #120) against 4 P0 + 11 P1 + 5/7 P2 findings from a review pass. §21 now actually SPARQLs for the new linkage predicates, §23a no longer silently masks auth regressions under `DEVNET_NO_AUTH=1`, §23c/§23g no longer false-pass on 500s, §18a no longer accepts pre-catchup `idle` as success, and a hung node can no longer stall CI ~40 min via missing `--max-time`.

## Companion spec PR

Three spec cleanups surfaced during implementation — see **OriginTrail/dkgv10-spec#86**:
- Add `dkg:mdIntermediateHash` row to `19_MARKDOWN_CONTENT_TYPE.md §10.2` `_meta` layout
- Fix `dkg:rootEntity` literal→IRI typo at §10.2:601
- Add normative guidance on `fileUri` URN shape (`urn:dkg:file:keccak256:<hex>`)

The spec PR is independent and can merge in either order.

## Test plan

- [x] `packages/cli/test/extraction-markdown.test.ts` — 41/41 passing (was 36)
- [x] `packages/cli/test/import-file-integration.test.ts` — 31/31 passing (was 25)
- [x] `packages/cli/test/multipart.test.ts` — 25/25 passing (unchanged)
- [x] `packages/core` full suite — 415/415 passing (unchanged)
- [x] `bash -n scripts/devnet-test.sh` — syntax OK
- [ ] Linux CI — gating signal
- [ ] Live devnet smoke run — to be verified by reviewer / after merge

Pre-existing Windows-hostility failures (`slot-helpers`, `migration`, `rollback`, `auto-update`, `blue-green`, `publisher-wallets`, `publisher-cli-smoke`, `install-script`, `indexer`) are unrelated to this PR — none of the modified files have failures.

## Follow-up: `GET /api/file/:hash` endpoint

This PR establishes the in-graph linkage (`<assertionUal> dkg:sourceFileHash "keccak256:<hex>"` in CG root `_meta`) that lets a SPARQL client rediscover the source file hash after daemon restart. Actually retrieving the file bytes over HTTP is deferred — the daemon currently has no `GET /api/file/:hash` route, so the round-trip is only exercisable in-process via `FileStore.get()` (which `import-file-integration.test.ts` verifies). Exposing the file store over HTTP requires a separate design for access control semantics (private CGs per `19_MARKDOWN_CONTENT_TYPE.md §4.1`), content-type preservation, and spec-side language. Tracked as a follow-up.

## Closes / references

Not closing any issues — this is a chain PR onto the PR #120 base, and the linkage work was surfaced post-merge on PR #113 rather than from a dedicated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
