### PR TITLE
fix: broaden markdown extractor IRI validation

### DIFF
--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -205,6 +205,19 @@ function shortHash(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 12);
 }
 
+// Issue #123 / Round 11 Bug 33 follow-up: user-content extraction paths
+// (`type`, generic frontmatter scalars, Dataview inline values) should
+// treat ANY absolute scheme-based IRI as eligible, then use `isSafeIri`
+// as the strictness gate. Narrow allowlists silently rewrote valid IRIs
+// like `tag:` / `doi:` / `ark:`, while unchecked allowlist hits could
+// pass malformed `urn:x y` values through raw.
+const ABSOLUTE_IRI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+function resolveSafeAbsoluteIri(value: string): string | null {
+  if (!ABSOLUTE_IRI_SCHEME_RE.test(value)) return null;
+  return isSafeIri(value) ? value : null;
+}
+
 function typedLiteral(lexicalForm: string, datatypeIri: string): string {
   return `${JSON.stringify(lexicalForm)}^^<${datatypeIri}>`;
 }
@@ -269,7 +282,8 @@ function resolveSubjectIri(
 /** Resolve a value from a frontmatter `type` field to a full IRI. */
 function resolveTypeIri(typeValue: unknown): string | null {
   if (typeof typeValue !== 'string' || typeValue.length === 0) return null;
-  if (/^(https?:|did:|urn:)/.test(typeValue)) return typeValue;
+  const iri = resolveSafeAbsoluteIri(typeValue);
+  if (iri) return iri;
   // Treat bare identifiers as schema.org classes by convention (Report, Person, etc.)
   const localName = normalizeSchemaLocalName(typeValue, 'class');
   return localName ? `http://schema.org/${localName}` : null;
@@ -279,7 +293,8 @@ function resolveTypeIri(typeValue: unknown): string | null {
 function resolveFrontmatterValue(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   if (typeof value === 'string') {
-    if (/^(https?:|did:|urn:)/.test(value)) return value;
+    const iri = resolveSafeAbsoluteIri(value);
+    if (iri) return iri;
     return JSON.stringify(value);
   }
   if (value instanceof Date) {
@@ -455,7 +470,7 @@ export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtrac
   for (const { key, value } of extractDataviewFields(body)) {
     const predicate = frontmatterKeyToPredicate(key);
     if (predicate === null) continue;
-    const obj = /^(https?:|did:|urn:)/.test(value) ? value : JSON.stringify(value);
+    const obj = resolveSafeAbsoluteIri(value) ?? JSON.stringify(value);
     triples.push({ subject, predicate, object: obj });
   }
 

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -213,8 +213,12 @@ function shortHash(input: string): string {
 // pass malformed `urn:x y` values through raw.
 const ABSOLUTE_IRI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 
+function looksLikeAbsoluteIri(value: string): boolean {
+  return ABSOLUTE_IRI_SCHEME_RE.test(value);
+}
+
 function resolveSafeAbsoluteIri(value: string): string | null {
-  if (!ABSOLUTE_IRI_SCHEME_RE.test(value)) return null;
+  if (!looksLikeAbsoluteIri(value)) return null;
   return isSafeIri(value) ? value : null;
 }
 
@@ -282,8 +286,7 @@ function resolveSubjectIri(
 /** Resolve a value from a frontmatter `type` field to a full IRI. */
 function resolveTypeIri(typeValue: unknown): string | null {
   if (typeof typeValue !== 'string' || typeValue.length === 0) return null;
-  const iri = resolveSafeAbsoluteIri(typeValue);
-  if (iri) return iri;
+  if (looksLikeAbsoluteIri(typeValue)) return resolveSafeAbsoluteIri(typeValue);
   // Treat bare identifiers as schema.org classes by convention (Report, Person, etc.)
   const localName = normalizeSchemaLocalName(typeValue, 'class');
   return localName ? `http://schema.org/${localName}` : null;

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -636,7 +636,7 @@ function buildSourceFileLinkage(args: {
   let resolvedRootEntity: string = args.rootEntityIri ?? args.subject;
   const fmRoot = args.frontmatter?.['rootEntity'];
   if (typeof fmRoot === 'string' && fmRoot.length > 0) {
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(fmRoot)) {
+    if (looksLikeAbsoluteIri(fmRoot)) {
       // Looks like an IRI attempt — validate strictly.
       if (!isSafeIri(fmRoot)) {
         throw new Error(

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -46,6 +46,29 @@ describe('extractFromMarkdown — frontmatter', () => {
     expect(triples.some(t => t.predicate === RDF_TYPE && t.object === 'https://example.org/ontology/Thing')).toBe(true);
   });
 
+  it('Issue 123: preserves safe absolute-scheme IRIs in `type` and generic frontmatter scalars', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `---\nid: doc\ntype: tag:origintrail.org,2026:Document\nauthor: doi:10.1234/example\nhomepage: https://example.org/home\n---\n\n# Doc\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: RDF_TYPE,
+      object: 'tag:origintrail.org,2026:Document',
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/author',
+      object: 'doi:10.1234/example',
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/homepage',
+      object: 'https://example.org/home',
+    });
+  });
+
   it('maps `title` to schema:name and `description` to schema:description', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc-1\ntitle: Hello World\ndescription: A short doc\n---\n\nBody.\n`,
@@ -77,6 +100,26 @@ describe('extractFromMarkdown — frontmatter', () => {
       predicate: 'http://schema.org/authors',
       object: '"Alice"',
     });
+  });
+
+  it('Issue 123: malformed scheme-prefixed frontmatter values fall back instead of emitting unsafe IRIs', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `---\nid: doc\ntype: "urn:x y"\nhomepage: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: RDF_TYPE,
+      object: 'http://schema.org/UrnXY',
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/homepage',
+      object: '"tag:example.org,2026:x y"',
+    });
+    expect(triples.some(t => t.object === 'urn:x y')).toBe(false);
+    expect(triples.some(t => t.object === 'tag:example.org,2026:x y')).toBe(false);
   });
 
   it('emits one triple per element for array values in frontmatter', () => {
@@ -294,6 +337,33 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
       now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/homepage', object: 'https://example.org/home' });
+  });
+
+  it('Issue 123: preserves safe non-whitelist scheme IRIs in Dataview fields', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `# Doc\n\nref:: ark:/12025/654xz321\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/ref',
+      object: 'ark:/12025/654xz321',
+    });
+  });
+
+  it('Issue 123: malformed scheme-prefixed Dataview values fall back to literals', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `# Doc\n\nref:: tag:example.org,2026:x y\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/ref',
+      object: '"tag:example.org,2026:x y"',
+    });
+    expect(triples.some(t => t.object === 'tag:example.org,2026:x y')).toBe(false);
   });
 
   it('ignores dataview-like syntax inside code fences', () => {

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -102,17 +102,13 @@ describe('extractFromMarkdown — frontmatter', () => {
     });
   });
 
-  it('Issue 123: malformed scheme-prefixed frontmatter values fall back instead of emitting unsafe IRIs', () => {
+  it('Issue 123: malformed scheme-prefixed frontmatter values never emit unsafe IRIs', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc\ntype: "urn:x y"\nhomepage: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
       agentDid: AGENT,
       now: FIXED_NOW,
     });
-    expect(triples).toContainEqual({
-      subject: subjectIri,
-      predicate: RDF_TYPE,
-      object: 'http://schema.org/UrnXY',
-    });
+    expect(triples.some(t => t.subject === subjectIri && t.predicate === RDF_TYPE)).toBe(false);
     expect(triples).toContainEqual({
       subject: subjectIri,
       predicate: 'http://schema.org/homepage',


### PR DESCRIPTION
## Summary
- replace the remaining narrow `http/https/did/urn` IRI allowlists in `markdown-extractor.ts` with a shared absolute-scheme + `isSafeIri` helper
- preserve valid non-whitelist IRIs like `tag:`, `doi:`, and `ark:` in frontmatter `type`, generic frontmatter scalar values, and Dataview field values
- stop passing malformed scheme-prefixed values through as raw IRIs by falling back to the existing schema-class or literal branches
- add focused extractor regressions for the three issue-123 sites

## Verification
- `pnpm exec vitest run test/extraction-markdown.test.ts`
- `pnpm exec vitest run test/import-file-integration.test.ts`

## Docs
- No separate `dkgv10-spec` PR needed for this fix. The current spec already describes these values generically and does not define the narrow implementation allowlist that this PR removes.
