### PR TITLE
chore: remove dead markdown extractor now field

### DIFF
--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -96,15 +96,6 @@ export interface MarkdownExtractInput {
    * for the `_meta` row 14 write without re-resolving.
    */
   rootEntityIri?: string;
-  /**
-   * Optional timestamp reserved for future extraction-run metadata
-   * (defaults to now when eventually used). Currently unused — the
-   * extractor no longer emits extraction-run provenance since that
-   * moved to the daemon's route handler in Round 9 Bug 27. Callers
-   * may still pass this for forward compatibility, but it is not
-   * consumed by any code path today.
-   */
-  now?: Date;
 }
 
 export interface MarkdownExtractOutput {

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -96,13 +96,6 @@ export interface MarkdownExtractInput {
    * for the `_meta` row 14 write without re-resolving.
    */
   rootEntityIri?: string;
-  /**
-   * @deprecated Unused compatibility shim. Extraction-run timestamps moved
-   * to the daemon route handler in Round 9 Bug 27, so the extractor no
-   * longer consumes this field. It remains accepted to avoid breaking
-   * TypeScript callers that still pass `now`.
-   */
-  now?: Date;
 }
 
 export interface MarkdownExtractOutput {

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -96,6 +96,13 @@ export interface MarkdownExtractInput {
    * for the `_meta` row 14 write without re-resolving.
    */
   rootEntityIri?: string;
+  /**
+   * @deprecated Unused compatibility shim. Extraction-run timestamps moved
+   * to the daemon route handler in Round 9 Bug 27, so the extractor no
+   * longer consumes this field. It remains accepted to avoid breaking
+   * TypeScript callers that still pass `now`.
+   */
+  now?: Date;
 }
 
 export interface MarkdownExtractOutput {

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { extractFromMarkdown } from '../src/extraction/markdown-extractor.js';
 
 const AGENT = 'did:dkg:agent:0xAbC123';
-const FIXED_NOW = new Date('2026-04-10T12:00:00Z');
 const FILE_URI = 'urn:dkg:file:keccak256:1111111111111111111111111111111111111111111111111111111111111111';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -22,12 +21,11 @@ const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
 const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-describe('extractFromMarkdown — frontmatter', () => {
+describe('extractFromMarkdown â€” frontmatter', () => {
   it('extracts rdf:type from frontmatter `type` key (schema.org convention)', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: climate-report-2026\ntype: Report\n---\n\n# Climate Report\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:climate-report-2026');
     expect(triples).toContainEqual({
@@ -41,7 +39,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: x\ntype: https://example.org/ontology/Thing\n---\n\n# X\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.some(t => t.predicate === RDF_TYPE && t.object === 'https://example.org/ontology/Thing')).toBe(true);
   });
@@ -50,7 +47,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc\ntype: tag:origintrail.org,2026:Document\nauthor: doi:10.1234/example\nhomepage: https://example.org/home\n---\n\n# Doc\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -73,7 +69,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc-1\ntitle: Hello World\ndescription: A short doc\n---\n\nBody.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: 'urn:dkg:md:doc-1', predicate: SCHEMA_NAME, object: '"Hello World"' });
     expect(triples).toContainEqual({ subject: 'urn:dkg:md:doc-1', predicate: SCHEMA_DESCRIPTION, object: '"A short doc"' });
@@ -83,7 +78,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc-1\ntype: Research Report\nrelease date: 2026-04-10\nauthor(s): Alice\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -106,7 +100,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc\ntype: "urn:x y"\nhomepage: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.some(t => t.subject === subjectIri && t.predicate === RDF_TYPE)).toBe(false);
     expect(triples).toContainEqual({
@@ -122,7 +115,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc\nauthors:\n  - Alice\n  - Bob\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const authors = triples.filter(t => t.predicate === 'http://schema.org/authors');
     expect(authors.map(t => t.object).sort()).toEqual(['"Alice"', '"Bob"']);
@@ -132,7 +124,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc\npageCount: 42\nscore: 3.14\npublished: true\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: 'urn:dkg:md:doc',
@@ -155,7 +146,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc\nupdatedAt: 2026-04-10T15:45:30Z\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: 'urn:dkg:md:doc',
@@ -168,7 +158,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: {broken yaml\n---\n\n# Fallback\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     // Subject should derive from the H1 because frontmatter is rejected
     expect(subjectIri).toBe('urn:dkg:md:fallback');
@@ -176,12 +165,11 @@ describe('extractFromMarkdown — frontmatter', () => {
   });
 });
 
-describe('extractFromMarkdown — wikilinks', () => {
+describe('extractFromMarkdown â€” wikilinks', () => {
   it('extracts bare wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSee [[Alice]] and [[Bob]] for details.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_MENTIONS, object: 'urn:dkg:md:alice' });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_MENTIONS, object: 'urn:dkg:md:bob' });
@@ -191,7 +179,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\nSee [[Charlie Chocolate|Charlie]].\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.some(t => t.predicate === SCHEMA_MENTIONS && t.object === 'urn:dkg:md:charlie-chocolate')).toBe(true);
   });
@@ -200,7 +187,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\n[[Alice]] [[Alice]] [[Alice]]\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS);
     expect(mentions).toHaveLength(1);
@@ -210,7 +196,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `\`\`\`md\n# Hidden Title\n[[Hidden Target]]\n\`\`\`\n\n# Visible Title\n\nSee [[Visible Target]].\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:visible-title');
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object);
@@ -221,7 +206,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `\`\`\`\`md\n# Hidden Title\n[[Hidden Target]]\n#hidden\nfield:: hidden\n\`\`\`\`\n\n# Visible Title\n\n[[Visible Target]] #visible\nfield:: shown\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:visible-title');
     expect(triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object)).toEqual([
@@ -246,7 +230,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `  \`\`\`md\n  # Hidden Title\n  [[Hidden Target]]\n  #hidden\n  field:: hidden\n  \`\`\`\n\n# Visible Title\n\n[[Visible Target]] #visible\nfield:: shown\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:visible-title');
     expect(triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object)).toEqual([
@@ -268,12 +251,11 @@ describe('extractFromMarkdown — wikilinks', () => {
   });
 });
 
-describe('extractFromMarkdown — hashtags', () => {
+describe('extractFromMarkdown â€” hashtags', () => {
   it('extracts hashtags as schema:keywords', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSome text #climate #policy and more.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_KEYWORDS, object: '"climate"' });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_KEYWORDS, object: '"policy"' });
@@ -283,7 +265,6 @@ describe('extractFromMarkdown — hashtags', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Title\n\n## Section\n\nBody without tags.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const keywords = triples.filter(t => t.predicate === SCHEMA_KEYWORDS);
     expect(keywords).toHaveLength(0);
@@ -293,7 +274,6 @@ describe('extractFromMarkdown — hashtags', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\n\`\`\`bash\n# a comment #notatag\n\`\`\`\n\nBody #realtag here.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const keywords = triples.filter(t => t.predicate === SCHEMA_KEYWORDS).map(t => t.object);
     expect(keywords).toContain('"realtag"');
@@ -302,12 +282,11 @@ describe('extractFromMarkdown — hashtags', () => {
   });
 });
 
-describe('extractFromMarkdown — Dataview inline fields', () => {
+describe('extractFromMarkdown â€” Dataview inline fields', () => {
   it('extracts `key:: value` lines', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nauthor:: Alice\nstatus:: draft\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/author', object: '"Alice"' });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/status', object: '"draft"' });
@@ -317,7 +296,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSentence with status:: draft\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -330,7 +308,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nhomepage:: https://example.org/home\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/homepage', object: 'https://example.org/home' });
   });
@@ -339,7 +316,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nref:: ark:/12025/654xz321\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -352,7 +328,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nref:: tag:example.org,2026:x y\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -366,7 +341,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\n\`\`\`\nfake:: not a field\n\`\`\`\n\nreal:: value\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const dataview = triples.filter(t => t.predicate.startsWith('http://schema.org/'));
     expect(dataview.some(t => t.predicate === 'http://schema.org/real')).toBe(true);
@@ -374,12 +348,11 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
   });
 });
 
-describe('extractFromMarkdown — headings', () => {
+describe('extractFromMarkdown â€” headings', () => {
   it('preserves heading nesting by attaching deeper headings to their nearest parent section', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Intro\n\n## Methods\n\n### Sub-method\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const rootSections = triples.filter(t => t.subject === subjectIri && t.predicate === DKG_HAS_SECTION);
     expect(rootSections).toHaveLength(2);
@@ -405,7 +378,6 @@ describe('extractFromMarkdown — headings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Overview\n\nText.\n\n## Overview\n\nMore text.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const sections = triples.filter(t => t.predicate === DKG_HAS_SECTION).map(t => t.object);
     expect(sections).toEqual([
@@ -418,7 +390,6 @@ describe('extractFromMarkdown — headings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# My Document\n\nBody.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_NAME, object: '"My Document"' });
   });
@@ -427,7 +398,6 @@ describe('extractFromMarkdown — headings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: x\ntitle: Explicit Title\n---\n\n# Different H1\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const names = triples.filter(t => t.subject === subjectIri && t.predicate === SCHEMA_NAME);
     expect(names).toHaveLength(1);
@@ -435,13 +405,12 @@ describe('extractFromMarkdown — headings', () => {
   });
 });
 
-describe('extractFromMarkdown — subject IRI resolution', () => {
+describe('extractFromMarkdown â€” subject IRI resolution', () => {
   it('prefers explicit documentIri input', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: ignored\n---\n\n# H1 Also Ignored\n`,
       agentDid: AGENT,
       documentIri: 'did:dkg:context-graph:foo/assertion/0xabc/mydoc',
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('did:dkg:context-graph:foo/assertion/0xabc/mydoc');
   });
@@ -450,7 +419,6 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: https://example.org/thing/42\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('https://example.org/thing/42');
   });
@@ -459,7 +427,6 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: My Great Document!\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:my-great-document');
   });
@@ -468,16 +435,14 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `# A Title of Things\n\nBody.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:a-title-of-things');
   });
 
   it('uses a hash fallback when non-ASCII titles and headings would slugify to empty strings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
-      markdown: `# 東京\n\nSee [[大阪]].\n\n## 感想\n`,
+      markdown: `# æ±äº¬\n\nSee [[å¤§é˜ª]].\n\n## æ„Ÿæƒ³\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toMatch(/^urn:dkg:md:hash-[0-9a-f]{12}$/);
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object);
@@ -490,7 +455,6 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `Just a body. No headings, no frontmatter.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri.startsWith('urn:dkg:md:anonymous-')).toBe(true);
   });
@@ -499,12 +463,10 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const first = extractFromMarkdown({
       markdown: `Shared prefix line\nBut a different ending A\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const second = extractFromMarkdown({
       markdown: `Shared prefix line\nBut a different ending B\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(first.subjectIri).not.toBe(second.subjectIri);
     expect(first.subjectIri).toMatch(/^urn:dkg:md:anonymous-[0-9a-f]{12}$/);
@@ -512,12 +474,11 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
   });
 });
 
-describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
+describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
   it('emits no source-file linkage quads when no sourceFileIri is supplied', () => {
     const { triples, sourceFileLinkage, resolvedRootEntity, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\n#tag1\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.length).toBeGreaterThan(0);
     expect(sourceFileLinkage).toHaveLength(0);
@@ -534,14 +495,13 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `# Doc\n\n#tag1\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     const all = [...triples, ...sourceFileLinkage];
     expect(all.some(q => q.object === DKG_EXTRACTION_PROVENANCE)).toBe(false);
     expect(all.some(q => q.predicate === DKG_DERIVED_FROM)).toBe(false);
   });
 
-  it('does not emit row 2 (dkg:sourceContentType) — daemon owns that row', () => {
+  it('does not emit row 2 (dkg:sourceContentType) â€” daemon owns that row', () => {
     // The extractor only ever processes markdown, but row 2 must describe
     // the ORIGINAL upload blob. Only the daemon has the original content
     // type, so the extractor MUST NOT emit row 2 at all. Regression guard
@@ -550,7 +510,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `# Doc\n\n#tag\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     const all = [...triples, ...sourceFileLinkage];
     expect(all.some(q => q.predicate === DKG_SOURCE_CONTENT_TYPE)).toBe(false);
@@ -561,10 +520,9 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `---\nid: research-note\n---\n\n# Research Note\n\nBody.\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:research-note');
-    // Row 1 — object is the caller-supplied URN. The earlier Round 3
+    // Row 1 â€” object is the caller-supplied URN. The earlier Round 3
     // blank-node approach was reverted in Round 4 (Option B filter in
     // `assertionPromote` prevents cross-assertion contention).
     expect(sourceFileLinkage).toContainEqual({
@@ -578,7 +536,7 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       predicate: DKG_ROOT_ENTITY,
       object: subjectIri,
     });
-    // Only rows 1 and 3 — no row 2.
+    // Only rows 1 and 3 â€” no row 2.
     expect(sourceFileLinkage).toHaveLength(2);
     expect(resolvedRootEntity).toBe(subjectIri);
   });
@@ -590,7 +548,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
       rootEntityIri: ROOT,
-      now: FIXED_NOW,
     });
     const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
     expect(rootQuads).toHaveLength(1);
@@ -607,7 +564,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
       rootEntityIri: 'urn:dkg:md:ignored-override',
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:sub-doc');
     const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
@@ -624,7 +580,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `---\nid: child\nrootEntity: My Parent\n---\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
     expect(rootQuads).toHaveLength(1);
@@ -633,13 +588,12 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
   });
 
   it('frontmatter rootEntity resolves even without a sourceFileIri', () => {
-    // §19.10.1:508 promises the override works regardless — without a
+    // Â§19.10.1:508 promises the override works regardless â€” without a
     // sourceFileIri there are no quads to emit, but the daemon may still
     // need the resolved value for downstream writes.
     const { sourceFileLinkage, resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: urn:dkg:md:parent\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(sourceFileLinkage).toHaveLength(0);
     expect(resolvedRootEntity).toBe('urn:dkg:md:parent');
@@ -650,7 +604,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: ``,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     expect(triples).toHaveLength(0);
     expect(sourceFileLinkage.some(q => q.predicate === DKG_SOURCE_FILE)).toBe(true);
@@ -660,7 +613,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     const { resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: urn:note:climate-report\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(resolvedRootEntity).toBe('urn:note:climate-report');
   });
@@ -669,7 +621,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     const { resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: https://example.org/entities/42\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(resolvedRootEntity).toBe('https://example.org/entities/42');
   });
@@ -682,7 +633,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     expect(() => extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: 'urn:x y'\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
   });
 
@@ -690,7 +640,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     expect(() => extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: 'http://x>y'\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
   });
 
@@ -698,7 +647,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     expect(() => extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: 'urn:x"y'\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
   });
 
@@ -709,13 +657,12 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     const { resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: My Parent Document\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(resolvedRootEntity).toBe('urn:dkg:md:my-parent-document');
   });
 });
 
-describe('extractFromMarkdown — end-to-end', () => {
+describe('extractFromMarkdown â€” end-to-end', () => {
   it('handles a full document with frontmatter, H1, tags, wikilinks, dataview, and sections', () => {
     const markdown = `---
 id: research-note
@@ -748,7 +695,6 @@ Our method relies on [[SPARQL]] queries.
       markdown,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
 
     expect(subjectIri).toBe('urn:dkg:md:research-note');
@@ -792,10 +738,10 @@ Our method relies on [[SPARQL]] queries.
       `${subjectIri}#section-2-methods`,
     ]);
 
-    // §10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
+    // Â§10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
     // Row 1's object is the caller-supplied content-addressed URN
     // (Round 4 Option B after the blank-node approach was reverted).
-    // Row 2 (sourceContentType) is intentionally absent — the daemon
+    // Row 2 (sourceContentType) is intentionally absent â€” the daemon
     // owns that row because only it has the original upload content
     // type.
     expect(sourceFileLinkage).toContainEqual({

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -415,22 +415,6 @@ describe('extractFromMarkdown - subject IRI resolution', () => {
     expect(subjectIri).toBe('did:dkg:context-graph:foo/assertion/0xabc/mydoc');
   });
 
-  it('accepts deprecated `now` input without affecting extraction output', () => {
-    const markdown = `---\nid: doc\n---\n\n# Doc\n\nref:: value\n`;
-    const withoutNow = extractFromMarkdown({
-      markdown,
-      agentDid: AGENT,
-      sourceFileIri: FILE_URI,
-    });
-    const withNow = extractFromMarkdown({
-      markdown,
-      agentDid: AGENT,
-      sourceFileIri: FILE_URI,
-      now: new Date('2026-01-01T00:00:00.000Z'),
-    });
-    expect(withNow).toEqual(withoutNow);
-  });
-
   it('uses frontmatter id as-is when it looks like an IRI', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: https://example.org/thing/42\n---\n`,

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -441,7 +441,7 @@ describe('extractFromMarkdown â€” subject IRI resolution', () => {
 
   it('uses a hash fallback when non-ASCII titles and headings would slugify to empty strings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
-      markdown: `# æ±äº¬\n\nSee [[å¤§é˜ª]].\n\n## æ„Ÿæƒ³\n`,
+      markdown: `# 東京\n\nSee [[大阪]].\n\n## 感想\n`,
       agentDid: AGENT,
     });
     expect(subjectIri).toMatch(/^urn:dkg:md:hash-[0-9a-f]{12}$/);

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -21,7 +21,7 @@ const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
 const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-describe('extractFromMarkdown â€” frontmatter', () => {
+describe('extractFromMarkdown - frontmatter', () => {
   it('extracts rdf:type from frontmatter `type` key (schema.org convention)', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: climate-report-2026\ntype: Report\n---\n\n# Climate Report\n`,
@@ -165,7 +165,7 @@ describe('extractFromMarkdown â€” frontmatter', () => {
   });
 });
 
-describe('extractFromMarkdown â€” wikilinks', () => {
+describe('extractFromMarkdown - wikilinks', () => {
   it('extracts bare wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSee [[Alice]] and [[Bob]] for details.\n`,
@@ -251,7 +251,7 @@ describe('extractFromMarkdown â€” wikilinks', () => {
   });
 });
 
-describe('extractFromMarkdown â€” hashtags', () => {
+describe('extractFromMarkdown - hashtags', () => {
   it('extracts hashtags as schema:keywords', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSome text #climate #policy and more.\n`,
@@ -282,7 +282,7 @@ describe('extractFromMarkdown â€” hashtags', () => {
   });
 });
 
-describe('extractFromMarkdown â€” Dataview inline fields', () => {
+describe('extractFromMarkdown - Dataview inline fields', () => {
   it('extracts `key:: value` lines', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nauthor:: Alice\nstatus:: draft\n`,
@@ -348,7 +348,7 @@ describe('extractFromMarkdown â€” Dataview inline fields', () => {
   });
 });
 
-describe('extractFromMarkdown â€” headings', () => {
+describe('extractFromMarkdown - headings', () => {
   it('preserves heading nesting by attaching deeper headings to their nearest parent section', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Intro\n\n## Methods\n\n### Sub-method\n`,
@@ -405,7 +405,7 @@ describe('extractFromMarkdown â€” headings', () => {
   });
 });
 
-describe('extractFromMarkdown â€” subject IRI resolution', () => {
+describe('extractFromMarkdown - subject IRI resolution', () => {
   it('prefers explicit documentIri input', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: ignored\n---\n\n# H1 Also Ignored\n`,
@@ -413,6 +413,22 @@ describe('extractFromMarkdown â€” subject IRI resolution', () => {
       documentIri: 'did:dkg:context-graph:foo/assertion/0xabc/mydoc',
     });
     expect(subjectIri).toBe('did:dkg:context-graph:foo/assertion/0xabc/mydoc');
+  });
+
+  it('accepts deprecated `now` input without affecting extraction output', () => {
+    const markdown = `---\nid: doc\n---\n\n# Doc\n\nref:: value\n`;
+    const withoutNow = extractFromMarkdown({
+      markdown,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+    });
+    const withNow = extractFromMarkdown({
+      markdown,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    expect(withNow).toEqual(withoutNow);
   });
 
   it('uses frontmatter id as-is when it looks like an IRI', () => {
@@ -474,7 +490,7 @@ describe('extractFromMarkdown â€” subject IRI resolution', () => {
   });
 });
 
-describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
+describe('extractFromMarkdown - source-file linkage (Section 10.1)', () => {
   it('emits no source-file linkage quads when no sourceFileIri is supplied', () => {
     const { triples, sourceFileLinkage, resolvedRootEntity, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\n#tag1\n`,
@@ -501,7 +517,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
     expect(all.some(q => q.predicate === DKG_DERIVED_FROM)).toBe(false);
   });
 
-  it('does not emit row 2 (dkg:sourceContentType) â€” daemon owns that row', () => {
+  it('does not emit row 2 (dkg:sourceContentType) - daemon owns that row', () => {
     // The extractor only ever processes markdown, but row 2 must describe
     // the ORIGINAL upload blob. Only the daemon has the original content
     // type, so the extractor MUST NOT emit row 2 at all. Regression guard
@@ -522,7 +538,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
       sourceFileIri: FILE_URI,
     });
     expect(subjectIri).toBe('urn:dkg:md:research-note');
-    // Row 1 â€” object is the caller-supplied URN. The earlier Round 3
+    // Row 1 - object is the caller-supplied URN. The earlier Round 3
     // blank-node approach was reverted in Round 4 (Option B filter in
     // `assertionPromote` prevents cross-assertion contention).
     expect(sourceFileLinkage).toContainEqual({
@@ -536,7 +552,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
       predicate: DKG_ROOT_ENTITY,
       object: subjectIri,
     });
-    // Only rows 1 and 3 â€” no row 2.
+    // Only rows 1 and 3 - no row 2.
     expect(sourceFileLinkage).toHaveLength(2);
     expect(resolvedRootEntity).toBe(subjectIri);
   });
@@ -588,7 +604,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
   });
 
   it('frontmatter rootEntity resolves even without a sourceFileIri', () => {
-    // Â§19.10.1:508 promises the override works regardless â€” without a
+    // Section 19.10.1:508 promises the override works regardless - without a
     // sourceFileIri there are no quads to emit, but the daemon may still
     // need the resolved value for downstream writes.
     const { sourceFileLinkage, resolvedRootEntity } = extractFromMarkdown({
@@ -662,7 +678,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
   });
 });
 
-describe('extractFromMarkdown â€” end-to-end', () => {
+describe('extractFromMarkdown - end-to-end', () => {
   it('handles a full document with frontmatter, H1, tags, wikilinks, dataview, and sections', () => {
     const markdown = `---
 id: research-note
@@ -738,10 +754,10 @@ Our method relies on [[SPARQL]] queries.
       `${subjectIri}#section-2-methods`,
     ]);
 
-    // Â§10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
+    // Section 10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
     // Row 1's object is the caller-supplied content-addressed URN
     // (Round 4 Option B after the blank-node approach was reverted).
-    // Row 2 (sourceContentType) is intentionally absent â€” the daemon
+    // Row 2 (sourceContentType) is intentionally absent - the daemon
     // owns that row because only it has the original upload content
     // type.
     expect(sourceFileLinkage).toContainEqual({


### PR DESCRIPTION
## Summary
- remove the dead `MarkdownExtractInput.now` field from the exported extractor input type
- remove the stale `FIXED_NOW` / `now: FIXED_NOW` test-only usage from `packages/cli/test/extraction-markdown.test.ts`
- keep the reviewed test-file cleanup from this PR: restored UTF-8 markdown fixture content and ASCII-only suite/comment labels where mojibake had appeared

## Verification
- `rg -n "FIXED_NOW|\bnow:\s*|\bnow\?: Date\b|input\.now\b" packages/cli/src/extraction packages/cli/test/extraction-markdown.test.ts`
- `pnpm exec vitest run test/extraction-markdown.test.ts`

## Docs
- No separate `dkgv10-spec` PR needed. This is internal extractor cleanup, not a protocol or API-spec change.
