### PR TITLE
feat: sync test/devnet-e2e-sections-18-24 into v10-rc

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2777,9 +2777,12 @@ async function handleRequest(
     );
     const metaGraph = contextGraphMetaUri(contextGraphId!);
     const startedAtLiteral = `"${startedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`;
+    const markdownFormUri = mdIntermediateHash
+      ? `urn:dkg:file:${mdIntermediateHash}`
+      : fileUri;
 
     // Data-graph quads: content (triples) + extractor linkage (provenance)
-    // + daemon-owned rows 2, 4, 5, 8, 9-13. Every quad is pinned to the
+    // + daemon-owned rows 2, markdownForm, 4, 5, 8, 9-13. Every quad is pinned to the
     // assertion graph URI. `triples` and `provenance` come from the
     // extractor without a `graph` field, so we stamp each one here.
     //
@@ -2803,6 +2806,10 @@ async function handleRequest(
       // emits this row; the daemon is the single source of truth. Its
       // subject matches rows 1 and 3 on the resolved document entity.
       { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: assertionGraph },
+      // Graph-level link to the markdown bytes structural extraction ran
+      // against. For markdown-native uploads this equals row 1's object;
+      // for converter-backed uploads it points at the stored intermediate.
+      { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/markdownForm', object: markdownFormUri, graph: assertionGraph },
       // Row 4 — file descriptor block subject is the content-addressed URN
       { subject: fileUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/File', graph: assertionGraph },
       // Row 5 — on-chain canonical hash format is keccak256:<hex>
@@ -2811,7 +2818,9 @@ async function handleRequest(
       { subject: fileUri, predicate: 'http://dkg.io/ontology/size', object: `"${fileStoreEntry.size}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: assertionGraph },
       // Row 9 — ExtractionProvenance subject is a fresh UUID URN per import
       { subject: provUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/ExtractionProvenance', graph: assertionGraph },
-      // Row 10 — back-references the file URN (same value as rows 4-5, 8 subject)
+      // Row 10 — back-references the ORIGINAL upload file URN (same value
+      // as rows 4-5, 8 subject). The new `dkg:markdownForm` entity link
+      // above separately exposes the markdown bytes Phase 2 actually read.
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedFrom', object: fileUri, graph: assertionGraph },
       // Row 11
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedBy', object: agentDid, graph: assertionGraph },

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -96,15 +96,6 @@ export interface MarkdownExtractInput {
    * for the `_meta` row 14 write without re-resolving.
    */
   rootEntityIri?: string;
-  /**
-   * Optional timestamp reserved for future extraction-run metadata
-   * (defaults to now when eventually used). Currently unused — the
-   * extractor no longer emits extraction-run provenance since that
-   * moved to the daemon's route handler in Round 9 Bug 27. Callers
-   * may still pass this for forward compatibility, but it is not
-   * consumed by any code path today.
-   */
-  now?: Date;
 }
 
 export interface MarkdownExtractOutput {

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -96,13 +96,6 @@ export interface MarkdownExtractInput {
    * for the `_meta` row 14 write without re-resolving.
    */
   rootEntityIri?: string;
-  /**
-   * @deprecated Unused compatibility shim. Extraction-run timestamps moved
-   * to the daemon route handler in Round 9 Bug 27, so the extractor no
-   * longer consumes this field. It remains accepted to avoid breaking
-   * TypeScript callers that still pass `now`.
-   */
-  now?: Date;
 }
 
 export interface MarkdownExtractOutput {

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -205,6 +205,19 @@ function shortHash(input: string): string {
   return createHash('sha256').update(input).digest('hex').slice(0, 12);
 }
 
+// Issue #123 / Round 11 Bug 33 follow-up: user-content extraction paths
+// (`type`, generic frontmatter scalars, Dataview inline values) should
+// treat ANY absolute scheme-based IRI as eligible, then use `isSafeIri`
+// as the strictness gate. Narrow allowlists silently rewrote valid IRIs
+// like `tag:` / `doi:` / `ark:`, while unchecked allowlist hits could
+// pass malformed `urn:x y` values through raw.
+const ABSOLUTE_IRI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+function resolveSafeAbsoluteIri(value: string): string | null {
+  if (!ABSOLUTE_IRI_SCHEME_RE.test(value)) return null;
+  return isSafeIri(value) ? value : null;
+}
+
 function typedLiteral(lexicalForm: string, datatypeIri: string): string {
   return `${JSON.stringify(lexicalForm)}^^<${datatypeIri}>`;
 }
@@ -269,7 +282,8 @@ function resolveSubjectIri(
 /** Resolve a value from a frontmatter `type` field to a full IRI. */
 function resolveTypeIri(typeValue: unknown): string | null {
   if (typeof typeValue !== 'string' || typeValue.length === 0) return null;
-  if (/^(https?:|did:|urn:)/.test(typeValue)) return typeValue;
+  const iri = resolveSafeAbsoluteIri(typeValue);
+  if (iri) return iri;
   // Treat bare identifiers as schema.org classes by convention (Report, Person, etc.)
   const localName = normalizeSchemaLocalName(typeValue, 'class');
   return localName ? `http://schema.org/${localName}` : null;
@@ -279,7 +293,8 @@ function resolveTypeIri(typeValue: unknown): string | null {
 function resolveFrontmatterValue(value: unknown): string | null {
   if (value === null || value === undefined) return null;
   if (typeof value === 'string') {
-    if (/^(https?:|did:|urn:)/.test(value)) return value;
+    const iri = resolveSafeAbsoluteIri(value);
+    if (iri) return iri;
     return JSON.stringify(value);
   }
   if (value instanceof Date) {
@@ -455,7 +470,7 @@ export function extractFromMarkdown(input: MarkdownExtractInput): MarkdownExtrac
   for (const { key, value } of extractDataviewFields(body)) {
     const predicate = frontmatterKeyToPredicate(key);
     if (predicate === null) continue;
-    const obj = /^(https?:|did:|urn:)/.test(value) ? value : JSON.stringify(value);
+    const obj = resolveSafeAbsoluteIri(value) ?? JSON.stringify(value);
     triples.push({ subject, predicate, object: obj });
   }
 

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -96,6 +96,13 @@ export interface MarkdownExtractInput {
    * for the `_meta` row 14 write without re-resolving.
    */
   rootEntityIri?: string;
+  /**
+   * @deprecated Unused compatibility shim. Extraction-run timestamps moved
+   * to the daemon route handler in Round 9 Bug 27, so the extractor no
+   * longer consumes this field. It remains accepted to avoid breaking
+   * TypeScript callers that still pass `now`.
+   */
+  now?: Date;
 }
 
 export interface MarkdownExtractOutput {

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -213,8 +213,12 @@ function shortHash(input: string): string {
 // pass malformed `urn:x y` values through raw.
 const ABSOLUTE_IRI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 
+function looksLikeAbsoluteIri(value: string): boolean {
+  return ABSOLUTE_IRI_SCHEME_RE.test(value);
+}
+
 function resolveSafeAbsoluteIri(value: string): string | null {
-  if (!ABSOLUTE_IRI_SCHEME_RE.test(value)) return null;
+  if (!looksLikeAbsoluteIri(value)) return null;
   return isSafeIri(value) ? value : null;
 }
 
@@ -282,8 +286,7 @@ function resolveSubjectIri(
 /** Resolve a value from a frontmatter `type` field to a full IRI. */
 function resolveTypeIri(typeValue: unknown): string | null {
   if (typeof typeValue !== 'string' || typeValue.length === 0) return null;
-  const iri = resolveSafeAbsoluteIri(typeValue);
-  if (iri) return iri;
+  if (looksLikeAbsoluteIri(typeValue)) return resolveSafeAbsoluteIri(typeValue);
   // Treat bare identifiers as schema.org classes by convention (Report, Person, etc.)
   const localName = normalizeSchemaLocalName(typeValue, 'class');
   return localName ? `http://schema.org/${localName}` : null;

--- a/packages/cli/src/extraction/markdown-extractor.ts
+++ b/packages/cli/src/extraction/markdown-extractor.ts
@@ -636,7 +636,7 @@ function buildSourceFileLinkage(args: {
   let resolvedRootEntity: string = args.rootEntityIri ?? args.subject;
   const fmRoot = args.frontmatter?.['rootEntity'];
   if (typeof fmRoot === 'string' && fmRoot.length > 0) {
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(fmRoot)) {
+    if (looksLikeAbsoluteIri(fmRoot)) {
       // Looks like an IRI attempt — validate strictly.
       if (!isSafeIri(fmRoot)) {
         throw new Error(

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -46,6 +46,29 @@ describe('extractFromMarkdown — frontmatter', () => {
     expect(triples.some(t => t.predicate === RDF_TYPE && t.object === 'https://example.org/ontology/Thing')).toBe(true);
   });
 
+  it('Issue 123: preserves safe absolute-scheme IRIs in `type` and generic frontmatter scalars', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `---\nid: doc\ntype: tag:origintrail.org,2026:Document\nauthor: doi:10.1234/example\nhomepage: https://example.org/home\n---\n\n# Doc\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: RDF_TYPE,
+      object: 'tag:origintrail.org,2026:Document',
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/author',
+      object: 'doi:10.1234/example',
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/homepage',
+      object: 'https://example.org/home',
+    });
+  });
+
   it('maps `title` to schema:name and `description` to schema:description', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc-1\ntitle: Hello World\ndescription: A short doc\n---\n\nBody.\n`,
@@ -77,6 +100,26 @@ describe('extractFromMarkdown — frontmatter', () => {
       predicate: 'http://schema.org/authors',
       object: '"Alice"',
     });
+  });
+
+  it('Issue 123: malformed scheme-prefixed frontmatter values fall back instead of emitting unsafe IRIs', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `---\nid: doc\ntype: "urn:x y"\nhomepage: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: RDF_TYPE,
+      object: 'http://schema.org/UrnXY',
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/homepage',
+      object: '"tag:example.org,2026:x y"',
+    });
+    expect(triples.some(t => t.object === 'urn:x y')).toBe(false);
+    expect(triples.some(t => t.object === 'tag:example.org,2026:x y')).toBe(false);
   });
 
   it('emits one triple per element for array values in frontmatter', () => {
@@ -294,6 +337,33 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
       now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/homepage', object: 'https://example.org/home' });
+  });
+
+  it('Issue 123: preserves safe non-whitelist scheme IRIs in Dataview fields', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `# Doc\n\nref:: ark:/12025/654xz321\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/ref',
+      object: 'ark:/12025/654xz321',
+    });
+  });
+
+  it('Issue 123: malformed scheme-prefixed Dataview values fall back to literals', () => {
+    const { triples, subjectIri } = extractFromMarkdown({
+      markdown: `# Doc\n\nref:: tag:example.org,2026:x y\n`,
+      agentDid: AGENT,
+      now: FIXED_NOW,
+    });
+    expect(triples).toContainEqual({
+      subject: subjectIri,
+      predicate: 'http://schema.org/ref',
+      object: '"tag:example.org,2026:x y"',
+    });
+    expect(triples.some(t => t.object === 'tag:example.org,2026:x y')).toBe(false);
   });
 
   it('ignores dataview-like syntax inside code fences', () => {

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { extractFromMarkdown } from '../src/extraction/markdown-extractor.js';
 
 const AGENT = 'did:dkg:agent:0xAbC123';
-const FIXED_NOW = new Date('2026-04-10T12:00:00Z');
 const FILE_URI = 'urn:dkg:file:keccak256:1111111111111111111111111111111111111111111111111111111111111111';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
@@ -22,12 +21,11 @@ const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
 const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-describe('extractFromMarkdown — frontmatter', () => {
+describe('extractFromMarkdown â€” frontmatter', () => {
   it('extracts rdf:type from frontmatter `type` key (schema.org convention)', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: climate-report-2026\ntype: Report\n---\n\n# Climate Report\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:climate-report-2026');
     expect(triples).toContainEqual({
@@ -41,7 +39,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: x\ntype: https://example.org/ontology/Thing\n---\n\n# X\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.some(t => t.predicate === RDF_TYPE && t.object === 'https://example.org/ontology/Thing')).toBe(true);
   });
@@ -50,7 +47,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc\ntype: tag:origintrail.org,2026:Document\nauthor: doi:10.1234/example\nhomepage: https://example.org/home\n---\n\n# Doc\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -73,7 +69,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc-1\ntitle: Hello World\ndescription: A short doc\n---\n\nBody.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: 'urn:dkg:md:doc-1', predicate: SCHEMA_NAME, object: '"Hello World"' });
     expect(triples).toContainEqual({ subject: 'urn:dkg:md:doc-1', predicate: SCHEMA_DESCRIPTION, object: '"A short doc"' });
@@ -83,7 +78,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc-1\ntype: Research Report\nrelease date: 2026-04-10\nauthor(s): Alice\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -106,7 +100,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc\ntype: "urn:x y"\nhomepage: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.some(t => t.subject === subjectIri && t.predicate === RDF_TYPE)).toBe(false);
     expect(triples).toContainEqual({
@@ -122,7 +115,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc\nauthors:\n  - Alice\n  - Bob\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const authors = triples.filter(t => t.predicate === 'http://schema.org/authors');
     expect(authors.map(t => t.object).sort()).toEqual(['"Alice"', '"Bob"']);
@@ -132,7 +124,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc\npageCount: 42\nscore: 3.14\npublished: true\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: 'urn:dkg:md:doc',
@@ -155,7 +146,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples } = extractFromMarkdown({
       markdown: `---\nid: doc\nupdatedAt: 2026-04-10T15:45:30Z\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: 'urn:dkg:md:doc',
@@ -168,7 +158,6 @@ describe('extractFromMarkdown — frontmatter', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: {broken yaml\n---\n\n# Fallback\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     // Subject should derive from the H1 because frontmatter is rejected
     expect(subjectIri).toBe('urn:dkg:md:fallback');
@@ -176,12 +165,11 @@ describe('extractFromMarkdown — frontmatter', () => {
   });
 });
 
-describe('extractFromMarkdown — wikilinks', () => {
+describe('extractFromMarkdown â€” wikilinks', () => {
   it('extracts bare wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSee [[Alice]] and [[Bob]] for details.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_MENTIONS, object: 'urn:dkg:md:alice' });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_MENTIONS, object: 'urn:dkg:md:bob' });
@@ -191,7 +179,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\nSee [[Charlie Chocolate|Charlie]].\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.some(t => t.predicate === SCHEMA_MENTIONS && t.object === 'urn:dkg:md:charlie-chocolate')).toBe(true);
   });
@@ -200,7 +187,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\n[[Alice]] [[Alice]] [[Alice]]\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS);
     expect(mentions).toHaveLength(1);
@@ -210,7 +196,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `\`\`\`md\n# Hidden Title\n[[Hidden Target]]\n\`\`\`\n\n# Visible Title\n\nSee [[Visible Target]].\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:visible-title');
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object);
@@ -221,7 +206,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `\`\`\`\`md\n# Hidden Title\n[[Hidden Target]]\n#hidden\nfield:: hidden\n\`\`\`\`\n\n# Visible Title\n\n[[Visible Target]] #visible\nfield:: shown\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:visible-title');
     expect(triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object)).toEqual([
@@ -246,7 +230,6 @@ describe('extractFromMarkdown — wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `  \`\`\`md\n  # Hidden Title\n  [[Hidden Target]]\n  #hidden\n  field:: hidden\n  \`\`\`\n\n# Visible Title\n\n[[Visible Target]] #visible\nfield:: shown\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:visible-title');
     expect(triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object)).toEqual([
@@ -268,12 +251,11 @@ describe('extractFromMarkdown — wikilinks', () => {
   });
 });
 
-describe('extractFromMarkdown — hashtags', () => {
+describe('extractFromMarkdown â€” hashtags', () => {
   it('extracts hashtags as schema:keywords', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSome text #climate #policy and more.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_KEYWORDS, object: '"climate"' });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_KEYWORDS, object: '"policy"' });
@@ -283,7 +265,6 @@ describe('extractFromMarkdown — hashtags', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Title\n\n## Section\n\nBody without tags.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const keywords = triples.filter(t => t.predicate === SCHEMA_KEYWORDS);
     expect(keywords).toHaveLength(0);
@@ -293,7 +274,6 @@ describe('extractFromMarkdown — hashtags', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\n\`\`\`bash\n# a comment #notatag\n\`\`\`\n\nBody #realtag here.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const keywords = triples.filter(t => t.predicate === SCHEMA_KEYWORDS).map(t => t.object);
     expect(keywords).toContain('"realtag"');
@@ -302,12 +282,11 @@ describe('extractFromMarkdown — hashtags', () => {
   });
 });
 
-describe('extractFromMarkdown — Dataview inline fields', () => {
+describe('extractFromMarkdown â€” Dataview inline fields', () => {
   it('extracts `key:: value` lines', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nauthor:: Alice\nstatus:: draft\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/author', object: '"Alice"' });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/status', object: '"draft"' });
@@ -317,7 +296,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSentence with status:: draft\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -330,7 +308,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nhomepage:: https://example.org/home\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: 'http://schema.org/homepage', object: 'https://example.org/home' });
   });
@@ -339,7 +316,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nref:: ark:/12025/654xz321\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -352,7 +328,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nref:: tag:example.org,2026:x y\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({
       subject: subjectIri,
@@ -366,7 +341,6 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
     const { triples } = extractFromMarkdown({
       markdown: `# Doc\n\n\`\`\`\nfake:: not a field\n\`\`\`\n\nreal:: value\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const dataview = triples.filter(t => t.predicate.startsWith('http://schema.org/'));
     expect(dataview.some(t => t.predicate === 'http://schema.org/real')).toBe(true);
@@ -374,12 +348,11 @@ describe('extractFromMarkdown — Dataview inline fields', () => {
   });
 });
 
-describe('extractFromMarkdown — headings', () => {
+describe('extractFromMarkdown â€” headings', () => {
   it('preserves heading nesting by attaching deeper headings to their nearest parent section', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Intro\n\n## Methods\n\n### Sub-method\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const rootSections = triples.filter(t => t.subject === subjectIri && t.predicate === DKG_HAS_SECTION);
     expect(rootSections).toHaveLength(2);
@@ -405,7 +378,6 @@ describe('extractFromMarkdown — headings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Overview\n\nText.\n\n## Overview\n\nMore text.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const sections = triples.filter(t => t.predicate === DKG_HAS_SECTION).map(t => t.object);
     expect(sections).toEqual([
@@ -418,7 +390,6 @@ describe('extractFromMarkdown — headings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# My Document\n\nBody.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples).toContainEqual({ subject: subjectIri, predicate: SCHEMA_NAME, object: '"My Document"' });
   });
@@ -427,7 +398,6 @@ describe('extractFromMarkdown — headings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: x\ntitle: Explicit Title\n---\n\n# Different H1\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const names = triples.filter(t => t.subject === subjectIri && t.predicate === SCHEMA_NAME);
     expect(names).toHaveLength(1);
@@ -435,13 +405,12 @@ describe('extractFromMarkdown — headings', () => {
   });
 });
 
-describe('extractFromMarkdown — subject IRI resolution', () => {
+describe('extractFromMarkdown â€” subject IRI resolution', () => {
   it('prefers explicit documentIri input', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: ignored\n---\n\n# H1 Also Ignored\n`,
       agentDid: AGENT,
       documentIri: 'did:dkg:context-graph:foo/assertion/0xabc/mydoc',
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('did:dkg:context-graph:foo/assertion/0xabc/mydoc');
   });
@@ -450,7 +419,6 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: https://example.org/thing/42\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('https://example.org/thing/42');
   });
@@ -459,7 +427,6 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: My Great Document!\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:my-great-document');
   });
@@ -468,16 +435,14 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `# A Title of Things\n\nBody.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:a-title-of-things');
   });
 
   it('uses a hash fallback when non-ASCII titles and headings would slugify to empty strings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
-      markdown: `# 東京\n\nSee [[大阪]].\n\n## 感想\n`,
+      markdown: `# æ±äº¬\n\nSee [[å¤§é˜ª]].\n\n## æ„Ÿæƒ³\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toMatch(/^urn:dkg:md:hash-[0-9a-f]{12}$/);
     const mentions = triples.filter(t => t.predicate === SCHEMA_MENTIONS).map(t => t.object);
@@ -490,7 +455,6 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `Just a body. No headings, no frontmatter.\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(subjectIri.startsWith('urn:dkg:md:anonymous-')).toBe(true);
   });
@@ -499,12 +463,10 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
     const first = extractFromMarkdown({
       markdown: `Shared prefix line\nBut a different ending A\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     const second = extractFromMarkdown({
       markdown: `Shared prefix line\nBut a different ending B\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(first.subjectIri).not.toBe(second.subjectIri);
     expect(first.subjectIri).toMatch(/^urn:dkg:md:anonymous-[0-9a-f]{12}$/);
@@ -512,12 +474,11 @@ describe('extractFromMarkdown — subject IRI resolution', () => {
   });
 });
 
-describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
+describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
   it('emits no source-file linkage quads when no sourceFileIri is supplied', () => {
     const { triples, sourceFileLinkage, resolvedRootEntity, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\n#tag1\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(triples.length).toBeGreaterThan(0);
     expect(sourceFileLinkage).toHaveLength(0);
@@ -534,14 +495,13 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `# Doc\n\n#tag1\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     const all = [...triples, ...sourceFileLinkage];
     expect(all.some(q => q.object === DKG_EXTRACTION_PROVENANCE)).toBe(false);
     expect(all.some(q => q.predicate === DKG_DERIVED_FROM)).toBe(false);
   });
 
-  it('does not emit row 2 (dkg:sourceContentType) — daemon owns that row', () => {
+  it('does not emit row 2 (dkg:sourceContentType) â€” daemon owns that row', () => {
     // The extractor only ever processes markdown, but row 2 must describe
     // the ORIGINAL upload blob. Only the daemon has the original content
     // type, so the extractor MUST NOT emit row 2 at all. Regression guard
@@ -550,7 +510,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `# Doc\n\n#tag\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     const all = [...triples, ...sourceFileLinkage];
     expect(all.some(q => q.predicate === DKG_SOURCE_CONTENT_TYPE)).toBe(false);
@@ -561,10 +520,9 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `---\nid: research-note\n---\n\n# Research Note\n\nBody.\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:research-note');
-    // Row 1 — object is the caller-supplied URN. The earlier Round 3
+    // Row 1 â€” object is the caller-supplied URN. The earlier Round 3
     // blank-node approach was reverted in Round 4 (Option B filter in
     // `assertionPromote` prevents cross-assertion contention).
     expect(sourceFileLinkage).toContainEqual({
@@ -578,7 +536,7 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       predicate: DKG_ROOT_ENTITY,
       object: subjectIri,
     });
-    // Only rows 1 and 3 — no row 2.
+    // Only rows 1 and 3 â€” no row 2.
     expect(sourceFileLinkage).toHaveLength(2);
     expect(resolvedRootEntity).toBe(subjectIri);
   });
@@ -590,7 +548,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
       rootEntityIri: ROOT,
-      now: FIXED_NOW,
     });
     const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
     expect(rootQuads).toHaveLength(1);
@@ -607,7 +564,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
       rootEntityIri: 'urn:dkg:md:ignored-override',
-      now: FIXED_NOW,
     });
     expect(subjectIri).toBe('urn:dkg:md:sub-doc');
     const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
@@ -624,7 +580,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: `---\nid: child\nrootEntity: My Parent\n---\n`,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     const rootQuads = sourceFileLinkage.filter(q => q.predicate === DKG_ROOT_ENTITY);
     expect(rootQuads).toHaveLength(1);
@@ -633,13 +588,12 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
   });
 
   it('frontmatter rootEntity resolves even without a sourceFileIri', () => {
-    // §19.10.1:508 promises the override works regardless — without a
+    // Â§19.10.1:508 promises the override works regardless â€” without a
     // sourceFileIri there are no quads to emit, but the daemon may still
     // need the resolved value for downstream writes.
     const { sourceFileLinkage, resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: urn:dkg:md:parent\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(sourceFileLinkage).toHaveLength(0);
     expect(resolvedRootEntity).toBe('urn:dkg:md:parent');
@@ -650,7 +604,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
       markdown: ``,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
     expect(triples).toHaveLength(0);
     expect(sourceFileLinkage.some(q => q.predicate === DKG_SOURCE_FILE)).toBe(true);
@@ -660,7 +613,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     const { resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: urn:note:climate-report\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(resolvedRootEntity).toBe('urn:note:climate-report');
   });
@@ -669,7 +621,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     const { resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: https://example.org/entities/42\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(resolvedRootEntity).toBe('https://example.org/entities/42');
   });
@@ -682,7 +633,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     expect(() => extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: 'urn:x y'\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
   });
 
@@ -690,7 +640,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     expect(() => extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: 'http://x>y'\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
   });
 
@@ -698,7 +647,6 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     expect(() => extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: 'urn:x"y'\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     })).toThrow(/Invalid frontmatter 'rootEntity' IRI/);
   });
 
@@ -709,13 +657,12 @@ describe('extractFromMarkdown — source-file linkage (§10.1)', () => {
     const { resolvedRootEntity } = extractFromMarkdown({
       markdown: `---\nid: child\nrootEntity: My Parent Document\n---\n`,
       agentDid: AGENT,
-      now: FIXED_NOW,
     });
     expect(resolvedRootEntity).toBe('urn:dkg:md:my-parent-document');
   });
 });
 
-describe('extractFromMarkdown — end-to-end', () => {
+describe('extractFromMarkdown â€” end-to-end', () => {
   it('handles a full document with frontmatter, H1, tags, wikilinks, dataview, and sections', () => {
     const markdown = `---
 id: research-note
@@ -748,7 +695,6 @@ Our method relies on [[SPARQL]] queries.
       markdown,
       agentDid: AGENT,
       sourceFileIri: FILE_URI,
-      now: FIXED_NOW,
     });
 
     expect(subjectIri).toBe('urn:dkg:md:research-note');
@@ -792,10 +738,10 @@ Our method relies on [[SPARQL]] queries.
       `${subjectIri}#section-2-methods`,
     ]);
 
-    // §10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
+    // Â§10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
     // Row 1's object is the caller-supplied content-addressed URN
     // (Round 4 Option B after the blank-node approach was reverted).
-    // Row 2 (sourceContentType) is intentionally absent — the daemon
+    // Row 2 (sourceContentType) is intentionally absent â€” the daemon
     // owns that row because only it has the original upload content
     // type.
     expect(sourceFileLinkage).toContainEqual({

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -415,22 +415,6 @@ describe('extractFromMarkdown - subject IRI resolution', () => {
     expect(subjectIri).toBe('did:dkg:context-graph:foo/assertion/0xabc/mydoc');
   });
 
-  it('accepts deprecated `now` input without affecting extraction output', () => {
-    const markdown = `---\nid: doc\n---\n\n# Doc\n\nref:: value\n`;
-    const withoutNow = extractFromMarkdown({
-      markdown,
-      agentDid: AGENT,
-      sourceFileIri: FILE_URI,
-    });
-    const withNow = extractFromMarkdown({
-      markdown,
-      agentDid: AGENT,
-      sourceFileIri: FILE_URI,
-      now: new Date('2026-01-01T00:00:00.000Z'),
-    });
-    expect(withNow).toEqual(withoutNow);
-  });
-
   it('uses frontmatter id as-is when it looks like an IRI', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: https://example.org/thing/42\n---\n`,

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -102,17 +102,13 @@ describe('extractFromMarkdown — frontmatter', () => {
     });
   });
 
-  it('Issue 123: malformed scheme-prefixed frontmatter values fall back instead of emitting unsafe IRIs', () => {
+  it('Issue 123: malformed scheme-prefixed frontmatter values never emit unsafe IRIs', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: doc\ntype: "urn:x y"\nhomepage: "tag:example.org,2026:x y"\n---\n\n# Doc\n`,
       agentDid: AGENT,
       now: FIXED_NOW,
     });
-    expect(triples).toContainEqual({
-      subject: subjectIri,
-      predicate: RDF_TYPE,
-      object: 'http://schema.org/UrnXY',
-    });
+    expect(triples.some(t => t.subject === subjectIri && t.predicate === RDF_TYPE)).toBe(false);
     expect(triples).toContainEqual({
       subject: subjectIri,
       predicate: 'http://schema.org/homepage',

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -441,7 +441,7 @@ describe('extractFromMarkdown â€” subject IRI resolution', () => {
 
   it('uses a hash fallback when non-ASCII titles and headings would slugify to empty strings', () => {
     const { triples, subjectIri } = extractFromMarkdown({
-      markdown: `# æ±äº¬\n\nSee [[å¤§é˜ª]].\n\n## æ„Ÿæƒ³\n`,
+      markdown: `# 東京\n\nSee [[大阪]].\n\n## 感想\n`,
       agentDid: AGENT,
     });
     expect(subjectIri).toMatch(/^urn:dkg:md:hash-[0-9a-f]{12}$/);

--- a/packages/cli/test/extraction-markdown.test.ts
+++ b/packages/cli/test/extraction-markdown.test.ts
@@ -21,7 +21,7 @@ const XSD_DATE_TIME = 'http://www.w3.org/2001/XMLSchema#dateTime';
 const XSD_DECIMAL = 'http://www.w3.org/2001/XMLSchema#decimal';
 const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
-describe('extractFromMarkdown â€” frontmatter', () => {
+describe('extractFromMarkdown - frontmatter', () => {
   it('extracts rdf:type from frontmatter `type` key (schema.org convention)', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `---\nid: climate-report-2026\ntype: Report\n---\n\n# Climate Report\n`,
@@ -165,7 +165,7 @@ describe('extractFromMarkdown â€” frontmatter', () => {
   });
 });
 
-describe('extractFromMarkdown â€” wikilinks', () => {
+describe('extractFromMarkdown - wikilinks', () => {
   it('extracts bare wikilinks', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSee [[Alice]] and [[Bob]] for details.\n`,
@@ -251,7 +251,7 @@ describe('extractFromMarkdown â€” wikilinks', () => {
   });
 });
 
-describe('extractFromMarkdown â€” hashtags', () => {
+describe('extractFromMarkdown - hashtags', () => {
   it('extracts hashtags as schema:keywords', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nSome text #climate #policy and more.\n`,
@@ -282,7 +282,7 @@ describe('extractFromMarkdown â€” hashtags', () => {
   });
 });
 
-describe('extractFromMarkdown â€” Dataview inline fields', () => {
+describe('extractFromMarkdown - Dataview inline fields', () => {
   it('extracts `key:: value` lines', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\nauthor:: Alice\nstatus:: draft\n`,
@@ -348,7 +348,7 @@ describe('extractFromMarkdown â€” Dataview inline fields', () => {
   });
 });
 
-describe('extractFromMarkdown â€” headings', () => {
+describe('extractFromMarkdown - headings', () => {
   it('preserves heading nesting by attaching deeper headings to their nearest parent section', () => {
     const { triples, subjectIri } = extractFromMarkdown({
       markdown: `# Title\n\n## Intro\n\n## Methods\n\n### Sub-method\n`,
@@ -405,7 +405,7 @@ describe('extractFromMarkdown â€” headings', () => {
   });
 });
 
-describe('extractFromMarkdown â€” subject IRI resolution', () => {
+describe('extractFromMarkdown - subject IRI resolution', () => {
   it('prefers explicit documentIri input', () => {
     const { subjectIri } = extractFromMarkdown({
       markdown: `---\nid: ignored\n---\n\n# H1 Also Ignored\n`,
@@ -413,6 +413,22 @@ describe('extractFromMarkdown â€” subject IRI resolution', () => {
       documentIri: 'did:dkg:context-graph:foo/assertion/0xabc/mydoc',
     });
     expect(subjectIri).toBe('did:dkg:context-graph:foo/assertion/0xabc/mydoc');
+  });
+
+  it('accepts deprecated `now` input without affecting extraction output', () => {
+    const markdown = `---\nid: doc\n---\n\n# Doc\n\nref:: value\n`;
+    const withoutNow = extractFromMarkdown({
+      markdown,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+    });
+    const withNow = extractFromMarkdown({
+      markdown,
+      agentDid: AGENT,
+      sourceFileIri: FILE_URI,
+      now: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    expect(withNow).toEqual(withoutNow);
   });
 
   it('uses frontmatter id as-is when it looks like an IRI', () => {
@@ -474,7 +490,7 @@ describe('extractFromMarkdown â€” subject IRI resolution', () => {
   });
 });
 
-describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
+describe('extractFromMarkdown - source-file linkage (Section 10.1)', () => {
   it('emits no source-file linkage quads when no sourceFileIri is supplied', () => {
     const { triples, sourceFileLinkage, resolvedRootEntity, subjectIri } = extractFromMarkdown({
       markdown: `# Doc\n\n#tag1\n`,
@@ -501,7 +517,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
     expect(all.some(q => q.predicate === DKG_DERIVED_FROM)).toBe(false);
   });
 
-  it('does not emit row 2 (dkg:sourceContentType) â€” daemon owns that row', () => {
+  it('does not emit row 2 (dkg:sourceContentType) - daemon owns that row', () => {
     // The extractor only ever processes markdown, but row 2 must describe
     // the ORIGINAL upload blob. Only the daemon has the original content
     // type, so the extractor MUST NOT emit row 2 at all. Regression guard
@@ -522,7 +538,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
       sourceFileIri: FILE_URI,
     });
     expect(subjectIri).toBe('urn:dkg:md:research-note');
-    // Row 1 â€” object is the caller-supplied URN. The earlier Round 3
+    // Row 1 - object is the caller-supplied URN. The earlier Round 3
     // blank-node approach was reverted in Round 4 (Option B filter in
     // `assertionPromote` prevents cross-assertion contention).
     expect(sourceFileLinkage).toContainEqual({
@@ -536,7 +552,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
       predicate: DKG_ROOT_ENTITY,
       object: subjectIri,
     });
-    // Only rows 1 and 3 â€” no row 2.
+    // Only rows 1 and 3 - no row 2.
     expect(sourceFileLinkage).toHaveLength(2);
     expect(resolvedRootEntity).toBe(subjectIri);
   });
@@ -588,7 +604,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
   });
 
   it('frontmatter rootEntity resolves even without a sourceFileIri', () => {
-    // Â§19.10.1:508 promises the override works regardless â€” without a
+    // Section 19.10.1:508 promises the override works regardless - without a
     // sourceFileIri there are no quads to emit, but the daemon may still
     // need the resolved value for downstream writes.
     const { sourceFileLinkage, resolvedRootEntity } = extractFromMarkdown({
@@ -662,7 +678,7 @@ describe('extractFromMarkdown â€” source-file linkage (Â§10.1)', () => {
   });
 });
 
-describe('extractFromMarkdown â€” end-to-end', () => {
+describe('extractFromMarkdown - end-to-end', () => {
   it('handles a full document with frontmatter, H1, tags, wikilinks, dataview, and sections', () => {
     const markdown = `---
 id: research-note
@@ -738,10 +754,10 @@ Our method relies on [[SPARQL]] queries.
       `${subjectIri}#section-2-methods`,
     ]);
 
-    // Â§10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
+    // Section 10.1 linkage present: rows 1 (sourceFile) and 3 (rootEntity).
     // Row 1's object is the caller-supplied content-addressed URN
     // (Round 4 Option B after the blank-node approach was reverted).
-    // Row 2 (sourceContentType) is intentionally absent â€” the daemon
+    // Row 2 (sourceContentType) is intentionally absent - the daemon
     // owns that row because only it has the original upload content
     // type.
     expect(sourceFileLinkage).toContainEqual({

--- a/packages/cli/test/import-file-integration.test.ts
+++ b/packages/cli/test/import-file-integration.test.ts
@@ -590,9 +590,12 @@ async function runImportFileOrchestration(params: {
   const assertionGraph = contextGraphAssertionUri(contextGraphId, agent.peerId, assertionName, subGraphName);
   const metaGraph = contextGraphMetaUri(contextGraphId);
   const startedAtLiteral = `"${startedAt}"^^<http://www.w3.org/2001/XMLSchema#dateTime>`;
+  const markdownFormUri = mdIntermediateHash
+    ? `urn:dkg:file:${mdIntermediateHash}`
+    : fileUri;
 
   // Data-graph quads: content + extractor linkage + daemon-owned rows
-  // 2, 4, 5, 8, 9-13. Round 9 Bug 27 removed rows 6 (`dkg:fileName`)
+  // 2, markdownForm, 4, 5, 8, 9-13. Round 9 Bug 27 removed rows 6 (`dkg:fileName`)
   // and 7 (`dkg:contentType`) from the file descriptor block — those
   // per-upload facts now live on the assertion UAL in `_meta`, not on
   // the content-addressed `<fileUri>` subject. See daemon equivalent.
@@ -603,12 +606,16 @@ async function runImportFileOrchestration(params: {
     // for PDF this is "application/pdf", not the markdown intermediate.
     // Its subject matches rows 1 and 3 on the resolved document entity.
     { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: assertionGraph },
+    // Graph-level link to the markdown bytes structural extraction ran against.
+    { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/markdownForm', object: markdownFormUri, graph: assertionGraph },
     // Rows 4, 5, 8 file descriptor — intrinsic-to-content properties only
     { subject: fileUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/File', graph: assertionGraph },
     { subject: fileUri, predicate: 'http://dkg.io/ontology/contentHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: assertionGraph },
     { subject: fileUri, predicate: 'http://dkg.io/ontology/size', object: `"${fileStoreEntry.size}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: assertionGraph },
     // Rows 9-13 extraction provenance — URI subject (filtered out of promote)
     { subject: provUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/ExtractionProvenance', graph: assertionGraph },
+    // Provenance still points at the ORIGINAL upload file URN; the new
+    // entity-level `dkg:markdownForm` link exposes the Phase 2 markdown input.
     { subject: provUri, predicate: 'http://dkg.io/ontology/extractedFrom', object: fileUri, graph: assertionGraph },
     { subject: provUri, predicate: 'http://dkg.io/ontology/extractedBy', object: agentDid, graph: assertionGraph },
     { subject: provUri, predicate: 'http://dkg.io/ontology/extractedAt', object: startedAtLiteral, graph: assertionGraph },
@@ -1164,11 +1171,12 @@ describe('import-file orchestration — happy paths', () => {
     expect(agent.createdAssertions).toHaveLength(1);
     expect(agent.createdAssertions[0]).toEqual({ contextGraphId: 'cg', name: 'empty-doc', subGraphName: undefined });
     // Data-graph quads: rows 1, 3 (linkage from extractor) + row 2
-    // (daemon-owned) + rows 4, 5, 8 (file descriptor intrinsic-to-content
-    // properties, 3 quads — Round 9 Bug 27 dropped rows 6+7) + rows 9-13
-    // (extraction provenance, 5 quads) = 11 quads total.
+    // (daemon-owned original content type) + `dkg:markdownForm`
+    // (daemon-owned markdown-input link) + rows 4, 5, 8 (file descriptor
+    // intrinsic-to-content properties, 3 quads — Round 9 Bug 27 dropped
+    // rows 6+7) + rows 9-13 (extraction provenance, 5 quads) = 12 total.
     const dataQuads = getDataGraphQuads(agent, 'cg', 'empty-doc');
-    expect(dataQuads).toHaveLength(11);
+    expect(dataQuads).toHaveLength(12);
     // Meta graph still populated with the structural row 14-19 quads.
     const metaGraph = contextGraphMetaUri('cg');
     const metaQuads = agent.insertedQuads.filter(q => q.graph === metaGraph);
@@ -1687,6 +1695,7 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
 
   const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
   const DKG = 'http://dkg.io/ontology/';
+  const DKG_MARKDOWN_FORM = `${DKG}markdownForm`;
   const XSD_INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
 
   beforeEach(async () => {
@@ -1728,6 +1737,11 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(row1!.object).toMatch(/^urn:dkg:file:keccak256:[0-9a-f]{64}$/);
     const fileUri = row1!.object;
     expect(fileUri).toBe(`urn:dkg:file:${result.fileHash}`);
+    // New graph-level link to the markdown bytes structural extraction
+    // actually read. For markdown-native uploads it matches row 1.
+    const markdownFormRow = written.find(t => t.subject === subjectIri && t.predicate === DKG_MARKDOWN_FORM);
+    expect(markdownFormRow).toBeDefined();
+    expect(markdownFormRow!.object).toBe(fileUri);
 
     // Row 2 — daemon-owned, uses the ORIGINAL upload content type. For a
     // direct markdown upload that's "text/markdown"; the PDF test below
@@ -1764,7 +1778,9 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(provTypeQuads).toHaveLength(1);
     const provUri = provTypeQuads[0]!.subject;
     expect(provUri).toMatch(/^urn:dkg:extraction:[0-9a-f-]{36}$/); // UUID v4
-    // Row 10 — back-references the SAME file URN as rows 4-8 subject
+    // Row 10 — still back-references the ORIGINAL upload file URN, while
+    // the new `dkg:markdownForm` row above points at the markdown bytes
+    // structural extraction consumed.
     expect(written).toContainEqual({ subject: provUri, predicate: `${DKG}extractedFrom`, object: fileUri });
     // Row 11
     expect(written).toContainEqual({ subject: provUri, predicate: `${DKG}extractedBy`, object: `did:dkg:agent:${agent.peerId}` });
@@ -1833,10 +1849,11 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
   });
 
   it('application/pdf import writes row 15 in _meta and row 20 for mdIntermediateHash, with rows 2 and 15 both = application/pdf', async () => {
+    const convertedMarkdown = '---\nid: paper\n---\n\n# Paper\n\nBody.\n';
     const stubConverter: ExtractionPipeline = {
       contentTypes: ['application/pdf'],
       async extract(_input: ExtractionInput): Promise<ConverterOutput> {
-        return { mdIntermediate: '---\nid: paper\n---\n\n# Paper\n\nBody.\n' };
+        return { mdIntermediate: convertedMarkdown };
       },
     };
     registry.register(stubConverter);
@@ -1893,6 +1910,18 @@ describe('import-file orchestration — source-file linkage (§10.1 / §6.3 / §
     expect(row1!.object).toMatch(/^urn:dkg:file:keccak256:[0-9a-f]{64}$/);
     const fileUri = row1!.object;
     expect(fileUri).toBe(`urn:dkg:file:${result.fileHash}`);
+    const markdownFormRow = dataQuads.find(q =>
+      q.subject === result.assertionUri && q.predicate === DKG_MARKDOWN_FORM,
+    );
+    expect(markdownFormRow).toBeDefined();
+    expect(markdownFormRow!.object).toBe(`urn:dkg:file:${result.extraction.mdIntermediateHash}`);
+    const markdownFormHash = markdownFormRow!.object.replace(/^urn:dkg:file:/, '');
+    const markdownFormBytes = await fileStore.get(markdownFormHash);
+    expect(markdownFormBytes?.toString('utf-8')).toBe(convertedMarkdown);
+    const row10 = dataQuads.find(q =>
+      q.subject.startsWith('urn:dkg:extraction:') && q.predicate === `${DKG}extractedFrom`,
+    );
+    expect(row10?.object).toBe(fileUri);
     expect(dataQuads.some(q => q.subject === fileUri && q.predicate === `${DKG}contentType`)).toBe(false);
     expect(dataQuads.some(q => q.subject === fileUri && q.predicate === `${DKG}fileName`)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- sync `test/devnet-e2e-sections-18-24` into `v10-rc` after the earlier merge in #120
- bring in the later markdown/import follow-up work merged on the source branch
- carry the issue `#123`, `#124`, and `#125` fixes that landed after `v10-rc` last merged this branch

## Included work
- issue `#123`: broaden markdown extractor IRI handling to use the generic absolute-scheme + safety gate
- issue `#124`: remove the dead `MarkdownExtractInput.now` surface
- issue `#125`: add `dkg:markdownForm` linkage for the markdown bytes Phase 2 actually consumed

## Compare notes
- current remote base: `origin/v10-rc` at `baf4fdb` (merge of #120)
- current remote head: `origin/test/devnet-e2e-sections-18-24` at `53865c0`
- changed files in this sync PR:
  - `packages/cli/src/daemon.ts`
  - `packages/cli/src/extraction/markdown-extractor.ts`
  - `packages/cli/test/extraction-markdown.test.ts`
  - `packages/cli/test/import-file-integration.test.ts`

## Verification
- already verified on the source-branch issue PRs before merge:
  - `pnpm exec vitest run test/extraction-markdown.test.ts`
  - `pnpm exec vitest run test/import-file-integration.test.ts`