### PR TITLE
feat: ship MarkItDown binaries through release and install paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,73 @@ jobs:
         id: matrix
         shell: bash
         run: |
-          MATRIX="$(node -e "const fs = require('fs'); const targets = JSON.parse(fs.readFileSync('packages/cli/markitdown-targets.json', 'utf8')); const include = targets.map(({ runner, assetName }) => ({ runner, asset_name: assetName })); process.stdout.write(JSON.stringify({ include }));")"
+          MATRIX="$(node --input-type=module -e "import { SUPPORTED_TARGETS } from './packages/cli/scripts/bundle-markitdown-binaries.mjs'; const include = SUPPORTED_TARGETS.map(({ runner, assetName }, index) => { if (typeof runner !== 'string' || runner.length === 0) throw new Error(\`SUPPORTED_TARGETS[\${index}] is missing runner\`); if (typeof assetName !== 'string' || assetName.length === 0) throw new Error(\`SUPPORTED_TARGETS[\${index}] is missing assetName\`); return { runner, asset_name: assetName }; }); process.stdout.write(JSON.stringify({ include }));")"
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
+  release-preflight:
+    name: Validate release candidate
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+      is_prerelease: ${{ steps.prerelease.outputs.IS_PRERELEASE }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate tag format
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag '$TAG' does not match semver format v*.*.*"
+            exit 1
+          fi
+
+      - name: Set version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Detect pre-release
+        id: prerelease
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_PRERELEASE=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: pnpm setup
+        uses: pnpm/action-setup@v4
+
+      - name: Node setup
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Validate CLI package version matches tag
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
+          PKG_VERSION="$(node -p "require('./packages/cli/package.json').version")"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::packages/cli/package.json version ${PKG_VERSION} does not match pushed tag version ${TAG_VERSION}"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm turbo test --filter='!@origintrail-official/dkg-evm-module'
+
   markitdown-assets:
-    needs: markitdown-target-matrix
+    needs:
+      - markitdown-target-matrix
+      - release-preflight
     name: Build MarkItDown binary (${{ matrix.asset_name }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 40
@@ -169,7 +231,9 @@ jobs:
 
   release:
     name: Build, test, and create release
-    needs: markitdown-assets
+    needs:
+      - markitdown-assets
+      - release-preflight
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -178,55 +242,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Validate tag format
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Tag '$TAG' does not match semver format v*.*.*"
-            exit 1
-          fi
-
-      - name: Set version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-
-      - name: Detect pre-release
-        id: prerelease
-        run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
-          if [[ "$VERSION" == *-* ]]; then
-            echo "IS_PRERELEASE=true" >> $GITHUB_OUTPUT
-          else
-            echo "IS_PRERELEASE=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: pnpm setup
-        uses: pnpm/action-setup@v4
-
-      - name: Node setup
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Validate CLI package version matches tag
-        run: |
-          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
-          PKG_VERSION="$(node -p "require('./packages/cli/package.json').version")"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::packages/cli/package.json version ${PKG_VERSION} does not match pushed tag version ${TAG_VERSION}"
-            exit 1
-          fi
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: Run tests
-        run: pnpm turbo test --filter='!@origintrail-official/dkg-evm-module'
 
       - name: Download MarkItDown release assets
         uses: actions/download-artifact@v4
@@ -238,7 +253,7 @@ jobs:
       - name: Extract release notes
         id: notes
         run: |
-          V="${{ steps.version.outputs.VERSION }}"
+          V="${{ needs.release-preflight.outputs.version }}"
           if [ -f CHANGELOG.md ]; then
             sed -n "/^## \[$V\]/,/^## \[/p" CHANGELOG.md | sed '/^## \[/d' | sed '1d' > release_notes.md
           fi
@@ -251,10 +266,10 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ steps.version.outputs.VERSION }}
+          name: v${{ needs.release-preflight.outputs.version }}
           body_path: release_notes.md
           draft: false
-          prerelease: ${{ steps.prerelease.outputs.IS_PRERELEASE }}
+          prerelease: ${{ needs.release-preflight.outputs.is_prerelease }}
           generate_release_notes: true
           files: |
             release-assets/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,24 +66,33 @@ jobs:
           ASSET_NAME: ${{ matrix.asset_name }}
         run: |
           node - <<'NODE'
+          const fs = require('node:fs');
           const { spawnSync } = require('node:child_process');
           const path = require('node:path');
 
           const binaryPath = path.resolve('packages/cli/bin', process.env.ASSET_NAME);
-          const result = spawnSync(binaryPath, [], { encoding: 'utf8' });
+          const fixturePath = path.resolve('packages/cli/bin', 'markitdown-smoke.html');
+          fs.writeFileSync(
+            fixturePath,
+            '<html><body><h1>Smoke Test</h1><p>Hello from MarkItDown smoke test.</p></body></html>',
+            'utf8',
+          );
+
+          const result = spawnSync(binaryPath, [fixturePath], { encoding: 'utf8' });
 
           if (result.error) {
             throw result.error;
           }
-          if (result.status !== 2) {
+          if (result.status !== 0) {
             throw new Error(
-              `Expected ${binaryPath} to exit with code 2 on the no-arg usage path, got ${result.status}.\n`
+              `Expected ${binaryPath} to exit with code 0 on the smoke conversion path, got ${result.status}.\n`
               + `stdout:\n${result.stdout ?? ''}\n`
               + `stderr:\n${result.stderr ?? ''}`,
             );
           }
-          if (!String(result.stderr ?? '').includes('usage: markitdown <file-path>')) {
-            throw new Error(`Smoke test for ${binaryPath} did not print the expected usage text.`);
+          const output = String(result.stdout ?? '');
+          if (!output.includes('Smoke Test') || !output.includes('Hello from MarkItDown smoke test.')) {
+            throw new Error(`Smoke test for ${binaryPath} did not emit the expected Markdown content.\n${output}`);
           }
           NODE
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,52 @@ permissions:
   contents: write
 
 jobs:
+  markitdown-assets:
+    name: Build MarkItDown binary (${{ matrix.asset_name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            asset_name: markitdown-linux-x64
+          - runner: macos-14
+            asset_name: markitdown-darwin-arm64
+          - runner: windows-latest
+            asset_name: markitdown-win32-x64.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node setup
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Python setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build current-platform MarkItDown binary
+        run: node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --force
+
+      - name: Upload MarkItDown binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: markitdown-${{ matrix.asset_name }}
+          path: |
+            packages/cli/bin/${{ matrix.asset_name }}
+            packages/cli/bin/${{ matrix.asset_name }}.sha256
+          if-no-files-found: error
+
   release:
     name: Build, test, and create release
+    needs: markitdown-assets
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Checkout
@@ -63,6 +105,13 @@ jobs:
       - name: Run tests
         run: pnpm turbo test --filter='!@origintrail-official/dkg-evm-module'
 
+      - name: Download MarkItDown release assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: markitdown-*
+          merge-multiple: true
+          path: release-assets
+
       - name: Extract release notes
         id: notes
         run: |
@@ -84,5 +133,7 @@ jobs:
           draft: false
           prerelease: ${{ steps.prerelease.outputs.IS_PRERELEASE }}
           generate_release_notes: true
+          files: |
+            release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,33 @@ jobs:
       - name: Build current-platform MarkItDown binary
         run: node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --force
 
+      - name: Smoke test bundled MarkItDown binary
+        shell: bash
+        env:
+          ASSET_NAME: ${{ matrix.asset_name }}
+        run: |
+          node - <<'NODE'
+          const { spawnSync } = require('node:child_process');
+          const path = require('node:path');
+
+          const binaryPath = path.resolve('packages/cli/bin', process.env.ASSET_NAME);
+          const result = spawnSync(binaryPath, [], { encoding: 'utf8' });
+
+          if (result.error) {
+            throw result.error;
+          }
+          if (result.status !== 2) {
+            throw new Error(
+              `Expected ${binaryPath} to exit with code 2 on the no-arg usage path, got ${result.status}.\n`
+              + `stdout:\n${result.stdout ?? ''}\n`
+              + `stderr:\n${result.stderr ?? ''}`,
+            );
+          }
+          if (!String(result.stderr ?? '').includes('usage: markitdown <file-path>')) {
+            throw new Error(`Smoke test for ${binaryPath} did not print the expected usage text.`);
+          }
+          NODE
+
       - name: Upload MarkItDown binary artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,20 +12,36 @@ permissions:
   contents: write
 
 jobs:
+  markitdown-target-matrix:
+    name: Resolve MarkItDown target matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Node setup
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Build MarkItDown matrix from shared target metadata
+        id: matrix
+        shell: bash
+        run: |
+          MATRIX="$(node -e "const fs = require('fs'); const targets = JSON.parse(fs.readFileSync('packages/cli/markitdown-targets.json', 'utf8')); const include = targets.map(({ runner, assetName }) => ({ runner, asset_name: assetName })); process.stdout.write(JSON.stringify({ include }));")"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
   markitdown-assets:
+    needs: markitdown-target-matrix
     name: Build MarkItDown binary (${{ matrix.asset_name }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            asset_name: markitdown-linux-x64
-          - runner: macos-14
-            asset_name: markitdown-darwin-arm64
-          - runner: windows-latest
-            asset_name: markitdown-win32-x64.exe
+      matrix: ${{ fromJSON(needs.markitdown-target-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,34 +65,95 @@ jobs:
         env:
           ASSET_NAME: ${{ matrix.asset_name }}
         run: |
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZIP_DEFLATED, ZipFile
+
+          root = Path('packages/cli/bin')
+          root.mkdir(parents=True, exist_ok=True)
+          docx_path = root / 'markitdown-smoke.docx'
+
+          content_types = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+            <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+            <Default Extension="xml" ContentType="application/xml"/>
+            <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+          </Types>
+          """
+
+          rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+            <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+          </Relationships>
+          """
+
+          document = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+          <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:body>
+              <w:p><w:r><w:t>Smoke Docx</w:t></w:r></w:p>
+              <w:p><w:r><w:t>Hello from DOCX smoke test.</w:t></w:r></w:p>
+              <w:sectPr>
+                <w:pgSz w:w="12240" w:h="15840"/>
+                <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="708" w:footer="708" w:gutter="0"/>
+              </w:sectPr>
+            </w:body>
+          </w:document>
+          """
+
+          with ZipFile(docx_path, 'w', ZIP_DEFLATED) as archive:
+            archive.writestr('[Content_Types].xml', content_types)
+            archive.writestr('_rels/.rels', rels)
+            archive.writestr('word/document.xml', document)
+          PY
+
           node - <<'NODE'
           const fs = require('node:fs');
           const { spawnSync } = require('node:child_process');
           const path = require('node:path');
 
           const binaryPath = path.resolve('packages/cli/bin', process.env.ASSET_NAME);
-          const fixturePath = path.resolve('packages/cli/bin', 'markitdown-smoke.html');
+          const htmlFixturePath = path.resolve('packages/cli/bin', 'markitdown-smoke.html');
+          const docxFixturePath = path.resolve('packages/cli/bin', 'markitdown-smoke.docx');
           fs.writeFileSync(
-            fixturePath,
+            htmlFixturePath,
             '<html><body><h1>Smoke Test</h1><p>Hello from MarkItDown smoke test.</p></body></html>',
             'utf8',
           );
 
-          const result = spawnSync(binaryPath, [fixturePath], { encoding: 'utf8' });
+          const fixtures = [
+            {
+              fixturePath: htmlFixturePath,
+              expected: ['Smoke Test', 'Hello from MarkItDown smoke test.'],
+            },
+            {
+              fixturePath: docxFixturePath,
+              expected: ['Smoke Docx', 'Hello from DOCX smoke test.'],
+            },
+          ];
 
-          if (result.error) {
-            throw result.error;
-          }
-          if (result.status !== 0) {
-            throw new Error(
-              `Expected ${binaryPath} to exit with code 0 on the smoke conversion path, got ${result.status}.\n`
-              + `stdout:\n${result.stdout ?? ''}\n`
-              + `stderr:\n${result.stderr ?? ''}`,
-            );
-          }
-          const output = String(result.stdout ?? '');
-          if (!output.includes('Smoke Test') || !output.includes('Hello from MarkItDown smoke test.')) {
-            throw new Error(`Smoke test for ${binaryPath} did not emit the expected Markdown content.\n${output}`);
+          for (const fixture of fixtures) {
+            const result = spawnSync(binaryPath, [fixture.fixturePath], { encoding: 'utf8' });
+
+            if (result.error) {
+              throw result.error;
+            }
+            if (result.status !== 0) {
+              throw new Error(
+                `Expected ${binaryPath} to exit with code 0 on the smoke conversion path for ${fixture.fixturePath}, got ${result.status}.\n`
+                + `stdout:\n${result.stdout ?? ''}\n`
+                + `stderr:\n${result.stderr ?? ''}`,
+              );
+            }
+            const output = String(result.stdout ?? '');
+            for (const expectedChunk of fixture.expected) {
+              if (!output.includes(expectedChunk)) {
+                throw new Error(
+                  `Smoke test for ${binaryPath} did not emit the expected Markdown content for ${fixture.fixturePath}.\n`
+                  + `Missing chunk: ${expectedChunk}\n`
+                  + `${output}`,
+                );
+              }
+            }
           }
           NODE
 
@@ -103,6 +164,7 @@ jobs:
           path: |
             packages/cli/bin/${{ matrix.asset_name }}
             packages/cli/bin/${{ matrix.asset_name }}.sha256
+            packages/cli/bin/${{ matrix.asset_name }}.meta.json
           if-no-files-found: error
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,15 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Validate CLI package version matches tag
+        run: |
+          TAG_VERSION="${{ steps.version.outputs.VERSION }}"
+          PKG_VERSION="$(node -p "require('./packages/cli/package.json').version")"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::packages/cli/package.json version ${PKG_VERSION} does not match pushed tag version ${TAG_VERSION}"
+            exit 1
+          fi
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -90,8 +90,9 @@ published in one command. Private packages (`@origintrail-official/dkg-evm-modul
 
 The published `@origintrail-official/dkg` package now runs a best-effort postinstall
 step that downloads the current-platform MarkItDown binary from the matching GitHub
-Release into `packages/cli/bin`. Make sure the GitHub Release for the same version
-already exists before publishing to npm.
+Release into the installed package `bin/` directory (for example
+`node_modules/@origintrail-official/dkg/bin`). Make sure the GitHub Release for the
+same version already exists before publishing to npm.
 
 Verify after publishing:
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -66,7 +66,14 @@ git push origin v9.0.0-beta.2
 ## 5) Publishing to npm
 
 After pushing a tag, the GitHub Actions release workflow builds, tests, and creates a
-GitHub Release automatically. npm publishing is done manually to keep full control.
+GitHub Release automatically. It also builds and uploads the standalone MarkItDown
+binaries for the currently supported node platforms:
+
+- `markitdown-linux-x64`
+- `markitdown-darwin-arm64`
+- `markitdown-win32-x64.exe`
+
+npm publishing is done manually to keep full control.
 
 From a clean `main` checkout at the tagged commit:
 
@@ -80,6 +87,11 @@ pnpm -r publish --no-git-checks --tag latest
 npm will prompt for your OTP code. All publishable packages in the monorepo are
 published in one command. Private packages (`@origintrail-official/dkg-evm-module`,
 `@origintrail-official/dkg-network-sim`) are skipped automatically.
+
+The published `@origintrail-official/dkg` package now runs a best-effort postinstall
+step that downloads the current-platform MarkItDown binary from the matching GitHub
+Release into `packages/cli/bin`. Make sure the GitHub Release for the same version
+already exists before publishing to npm.
 
 Verify after publishing:
 
@@ -154,3 +166,4 @@ Promote only after successful:
 - automated tests
 - isolated local update run
 - canary network runtime validation
+- release-asset verification (`markitdown-*` binaries present on the GitHub Release)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -26,6 +26,14 @@ This document describes how to cut a new release of the DKG V9 node so that user
    pnpm dkg start
    ```
 
+   On supported platforms, source installs can also stage the standalone MarkItDown
+   converter into `packages/cli/bin` with:
+
+   ```bash
+   cd packages/cli
+   node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform
+   ```
+
 3. **Check version**  
    ```bash
    pnpm dkg --version
@@ -57,10 +65,17 @@ This document describes how to cut a new release of the DKG V9 node so that user
 
 - Pushing the tag triggers the **Release** workflow (`.github/workflows/release.yml`):
   - Checkout, install, build, run tests.
+  - Build and upload the standalone MarkItDown binaries for Linux x64, macOS arm64,
+    and Windows x64.
   - Create a GitHub Release with:
     - Name: `v9.0.1`
     - Body: section from CHANGELOG for that version (plus auto-generated release notes from commits).
-    - No artifacts are uploaded; the tag itself provides the source (download zip/tar from the release page).
+    - Release assets for the MarkItDown binaries plus the default source zip/tar downloads.
+
+- After the release exists, publish npm packages from the tagged commit. The
+  `@origintrail-official/dkg` package runs a best-effort postinstall hook that
+  downloads the matching current-platform MarkItDown binary from the GitHub Release
+  into the installed package `bin/` directory.
 
 ### 3. Verify
 

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,10 @@ if [ "$NODE_MAJOR" -lt 20 ]; then
 fi
 command -v pnpm >/dev/null 2>&1 || { red "Error: pnpm is not installed. Install with: npm install -g pnpm"; exit 1; }
 command -v git >/dev/null 2>&1 || { red "Error: git is not installed."; exit 1; }
+command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 || {
+  red "Error: python3 or python is required to build the bundled MarkItDown binary for source installs."
+  exit 1
+}
 
 green "Prerequisites OK (node v$(node -v | tr -d v), pnpm $(pnpm -v), git $(git --version | awk '{print $3}'))"
 echo ""
@@ -40,10 +44,23 @@ slot_ready() {
   [ -d "$slot_path/.git" ] && [ -f "$entry_path" ]
 }
 
+stage_markitdown() {
+  slot_path="$1"
+  slot_name="$2"
+  cli_dir="$slot_path/packages/cli"
+  if [ ! -d "$cli_dir" ]; then
+    return
+  fi
+  info "Staging MarkItDown binary in slot $slot_name ..."
+  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform)
+}
+
 mkdir -p "$RELEASES_DIR"
 
 if [ -L "$RELEASES_DIR/current" ] && slot_ready "$SLOT_A" "$SLOT_A_ENTRY" && slot_ready "$SLOT_B" "$SLOT_B_ENTRY"; then
   green "Blue-green slots already exist. Skipping clone."
+  stage_markitdown "$SLOT_A" "a"
+  stage_markitdown "$SLOT_B" "b"
 else
   if [ -L "$RELEASES_DIR/current" ]; then
     info "Detected incomplete slots. Rebuilding missing/broken slots..."
@@ -61,6 +78,7 @@ else
     info "Building slot a ..."
     (cd "$SLOT_A" && pnpm build)
   fi
+  stage_markitdown "$SLOT_A" "a"
 
   if slot_ready "$SLOT_B" "$SLOT_B_ENTRY"; then
     info "Slot b already exists and is ready."
@@ -73,6 +91,7 @@ else
     info "Building slot b ..."
     (cd "$SLOT_B" && pnpm build)
   fi
+  stage_markitdown "$SLOT_B" "b"
 
   # Ensure current points to a known-good active slot.
   ln -sfn a "$RELEASES_DIR/current"

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ stage_markitdown() {
     return
   fi
   info "Staging MarkItDown binary in slot $slot_name ..."
-  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform)
+  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort)
 }
 
 mkdir -p "$RELEASES_DIR"

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ stage_markitdown() {
     return
   fi
   info "Staging MarkItDown binary in slot $slot_name ..."
-  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort)
+  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform --force --best-effort)
 }
 
 mkdir -p "$RELEASES_DIR"

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ stage_markitdown() {
     return
   fi
   info "Staging MarkItDown binary in slot $slot_name ..."
-  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform --force --best-effort)
+  (cd "$cli_dir" && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort)
 }
 
 mkdir -p "$RELEASES_DIR"

--- a/install.sh
+++ b/install.sh
@@ -24,10 +24,6 @@ if [ "$NODE_MAJOR" -lt 20 ]; then
 fi
 command -v pnpm >/dev/null 2>&1 || { red "Error: pnpm is not installed. Install with: npm install -g pnpm"; exit 1; }
 command -v git >/dev/null 2>&1 || { red "Error: git is not installed."; exit 1; }
-command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 || {
-  red "Error: python3 or python is required to build the bundled MarkItDown binary for source installs."
-  exit 1
-}
 
 green "Prerequisites OK (node v$(node -v | tr -d v), pnpm $(pnpm -v), git $(git --version | awk '{print $3}'))"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,12 @@ stage_markitdown() {
   slot_path="$1"
   slot_name="$2"
   cli_dir="$slot_path/packages/cli"
+  script_path="$cli_dir/scripts/bundle-markitdown-binaries.mjs"
   if [ ! -d "$cli_dir" ]; then
+    return
+  fi
+  if [ ! -f "$script_path" ]; then
+    info "Skipping MarkItDown staging in slot $slot_name (this checkout predates bundled MarkItDown support)."
     return
   fi
   info "Staging MarkItDown binary in slot $slot_name ..."

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,10 +8,16 @@ Command-line interface and daemon for DKG V9. This is the main entry point for r
 npm install -g @origintrail-official/dkg
 ```
 
+On supported platforms, the package performs a best-effort postinstall fetch of
+the standalone MarkItDown converter into the package `bin/` directory so PDF,
+DOCX, PPTX, XLSX, CSV, HTML, EPUB, and XML imports work without a separate
+system-level install.
+
 **From source** (monorepo development):
 
 ```bash
 pnpm build
+cd packages/cli && node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform
 pnpm link --global --filter @origintrail-official/dkg
 
 # Binary is now available as `dkg`

--- a/packages/cli/markitdown-build-info.json
+++ b/packages/cli/markitdown-build-info.json
@@ -1,0 +1,4 @@
+{
+  "markItDownUpstreamVersion": "0.1.5",
+  "pyInstallerVersion": "6.19.0"
+}

--- a/packages/cli/markitdown-targets.json
+++ b/packages/cli/markitdown-targets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "platform": "linux",
+    "arch": "x64",
+    "assetName": "markitdown-linux-x64",
+    "runner": "ubuntu-latest"
+  },
+  {
+    "platform": "darwin",
+    "arch": "arm64",
+    "assetName": "markitdown-darwin-arm64",
+    "runner": "macos-14"
+  },
+  {
+    "platform": "win32",
+    "arch": "x64",
+    "assetName": "markitdown-win32-x64.exe",
+    "runner": "windows-latest"
+  }
+]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,8 @@
   },
   "scripts": {
     "build": "tsc && node -e \"const fs=require('fs');fs.mkdirSync('network',{recursive:true});fs.copyFileSync('../../network/testnet.json','network/testnet.json')\"",
+    "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
+    "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "clean": "node -e \"const fs=require('fs');for(const d of['dist','network']){fs.rmSync(d,{recursive:true,force:true})};fs.rmSync('tsconfig.tsbuildinfo',{force:true})\""
@@ -38,6 +40,7 @@
   "files": [
     "dist",
     "network",
+    "scripts",
     "skills",
     "README.md",
     "LICENSE"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "files": [
     "dist",
     "network",
+    "markitdown-build-info.json",
     "markitdown-targets.json",
     "scripts",
     "skills",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
   "files": [
     "dist",
     "network",
+    "markitdown-targets.json",
     "scripts",
     "skills",
     "README.md",

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -1,0 +1,427 @@
+import { createHash } from 'node:crypto';
+import { execFile as execFileCb } from 'node:child_process';
+import { chmodSync, existsSync, readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';
+export const PYINSTALLER_VERSION = '6.19.0';
+export const DEFAULT_RELEASE_REPO = 'OriginTrail/dkg-v9';
+
+export const SUPPORTED_TARGETS = [
+  { platform: 'linux', arch: 'x64', assetName: 'markitdown-linux-x64' },
+  { platform: 'darwin', arch: 'arm64', assetName: 'markitdown-darwin-arm64' },
+  { platform: 'win32', arch: 'x64', assetName: 'markitdown-win32-x64.exe' },
+];
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DEFAULT_PACKAGE_DIR = resolve(__dirname, '..');
+
+function logLine(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function warnLine(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    packageDir: DEFAULT_PACKAGE_DIR,
+    outputDir: null,
+    version: null,
+    all: false,
+    currentPlatform: false,
+    buildCurrentPlatform: false,
+    bestEffort: false,
+    force: false,
+    releaseBaseUrl: null,
+    releaseRepo: DEFAULT_RELEASE_REPO,
+    quiet: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--all') {
+      opts.all = true;
+    } else if (arg === '--current-platform') {
+      opts.currentPlatform = true;
+    } else if (arg === '--build-current-platform') {
+      opts.buildCurrentPlatform = true;
+    } else if (arg === '--best-effort') {
+      opts.bestEffort = true;
+    } else if (arg === '--force') {
+      opts.force = true;
+    } else if (arg === '--quiet') {
+      opts.quiet = true;
+    } else if (arg === '--package-dir') {
+      opts.packageDir = resolve(argv[++i]);
+    } else if (arg === '--output-dir') {
+      opts.outputDir = resolve(argv[++i]);
+    } else if (arg === '--version') {
+      opts.version = argv[++i];
+    } else if (arg === '--release-base-url') {
+      opts.releaseBaseUrl = argv[++i];
+    } else if (arg === '--release-repo') {
+      opts.releaseRepo = argv[++i];
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!opts.all && !opts.currentPlatform && !opts.buildCurrentPlatform) {
+    opts.currentPlatform = true;
+  }
+
+  return opts;
+}
+
+export function resolvePackageDir(packageDir = DEFAULT_PACKAGE_DIR) {
+  return resolve(packageDir);
+}
+
+export function resolveBinDir(packageDir = DEFAULT_PACKAGE_DIR, outputDir = null) {
+  return outputDir ? resolve(outputDir) : join(resolvePackageDir(packageDir), 'bin');
+}
+
+export function readCliVersion(packageDir = DEFAULT_PACKAGE_DIR) {
+  const raw = readFileSync(join(resolvePackageDir(packageDir), 'package.json'), 'utf-8');
+  const pkg = JSON.parse(raw);
+  return String(pkg.version ?? '').trim();
+}
+
+export function isWorkspaceCheckout(packageDir = DEFAULT_PACKAGE_DIR) {
+  const dir = resolvePackageDir(packageDir);
+  return existsSync(join(dir, 'src')) && existsSync(join(dir, 'tsconfig.json'));
+}
+
+export function getSupportedTarget(platform = process.platform, arch = process.arch) {
+  return SUPPORTED_TARGETS.find((target) => target.platform === platform && target.arch === arch) ?? null;
+}
+
+export function targetBinaryPath(target, packageDir = DEFAULT_PACKAGE_DIR, outputDir = null) {
+  return join(resolveBinDir(packageDir, outputDir), target.assetName);
+}
+
+export function checksumPathFor(binaryPath) {
+  return `${binaryPath}.sha256`;
+}
+
+export function releaseTagForVersion(version) {
+  return `v${version.replace(/^v/, '')}`;
+}
+
+export function releaseBaseUrl(version, releaseRepo = DEFAULT_RELEASE_REPO) {
+  return `https://github.com/${releaseRepo}/releases/download/${releaseTagForVersion(version)}`;
+}
+
+export function releaseAssetUrl(baseUrl, assetName) {
+  return `${baseUrl}/${assetName}`;
+}
+
+export function sha256Hex(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function parseSha256File(text) {
+  const [hash] = text.trim().split(/\s+/);
+  if (!hash) throw new Error('Malformed sha256 file');
+  return hash.toLowerCase();
+}
+
+async function fetchBytes(url) {
+  const res = await fetch(url, {
+    headers: { Accept: 'application/octet-stream' },
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) {
+    throw new Error(`${url} returned ${res.status}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+async function fetchText(url) {
+  const res = await fetch(url, {
+    headers: { Accept: 'text/plain' },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new Error(`${url} returned ${res.status}`);
+  }
+  return await res.text();
+}
+
+async function ensureDir(path) {
+  await mkdir(path, { recursive: true });
+}
+
+function ensureExecutable(path) {
+  if (process.platform === 'win32') return;
+  chmodSync(path, 0o755);
+}
+
+async function writeChecksumFile(binaryPath, hash) {
+  const assetName = binaryPath.split(/[\\/]/).pop();
+  await writeFile(checksumPathFor(binaryPath), `${hash}  ${assetName}\n`, 'utf-8');
+}
+
+async function verifyChecksum(binaryPath, expectedHash) {
+  const bytes = await readFile(binaryPath);
+  const actualHash = sha256Hex(bytes);
+  if (actualHash !== expectedHash.toLowerCase()) {
+    throw new Error(`Checksum mismatch for ${binaryPath}: expected ${expectedHash}, got ${actualHash}`);
+  }
+  return actualHash;
+}
+
+export async function downloadBinaryAsset({
+  assetName,
+  destinationDir,
+  baseUrl,
+  force = false,
+}) {
+  const destination = join(destinationDir, assetName);
+  if (!force && existsSync(destination)) {
+    return { status: 'present', binaryPath: destination };
+  }
+
+  await ensureDir(destinationDir);
+  const assetUrl = releaseAssetUrl(baseUrl, assetName);
+  const checksumUrl = `${assetUrl}.sha256`;
+  const [bytes, checksumText] = await Promise.all([
+    fetchBytes(assetUrl),
+    fetchText(checksumUrl),
+  ]);
+  const expectedHash = parseSha256File(checksumText);
+  const actualHash = sha256Hex(bytes);
+  if (actualHash !== expectedHash) {
+    throw new Error(`Checksum mismatch for ${assetName}: expected ${expectedHash}, got ${actualHash}`);
+  }
+
+  await writeFile(destination, bytes);
+  ensureExecutable(destination);
+  await writeFile(checksumPathFor(destination), checksumText, 'utf-8');
+  return { status: 'downloaded', binaryPath: destination, hash: actualHash };
+}
+
+function resolvePythonCommand() {
+  if (process.env.PYTHON) return process.env.PYTHON;
+  return process.platform === 'win32' ? 'python' : 'python3';
+}
+
+function venvPythonPath(venvDir) {
+  return process.platform === 'win32'
+    ? join(venvDir, 'Scripts', 'python.exe')
+    : join(venvDir, 'bin', 'python');
+}
+
+export async function buildCurrentPlatformBinary({
+  packageDir = DEFAULT_PACKAGE_DIR,
+  outputDir = null,
+  force = false,
+}) {
+  const target = getSupportedTarget();
+  if (!target) {
+    throw new Error(`Unsupported MarkItDown bundle target: ${process.platform}-${process.arch}`);
+  }
+
+  const binDir = resolveBinDir(packageDir, outputDir);
+  const binaryPath = targetBinaryPath(target, packageDir, outputDir);
+  if (!force && existsSync(binaryPath)) {
+    return { status: 'present', binaryPath };
+  }
+
+  await ensureDir(binDir);
+
+  const tmpRoot = await mkdtemp(join(tmpdir(), 'dkg-markitdown-build-'));
+  const venvDir = join(tmpRoot, 'venv');
+  const workDir = join(tmpRoot, 'pyi-work');
+  const specDir = join(tmpRoot, 'pyi-spec');
+  const python = resolvePythonCommand();
+
+  try {
+    await execFile(python, ['-m', 'venv', venvDir], { cwd: tmpRoot, timeout: 120_000 });
+    const venvPython = venvPythonPath(venvDir);
+
+    await execFile(venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], {
+      cwd: tmpRoot,
+      timeout: 300_000,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    await execFile(venvPython, [
+      '-m',
+      'pip',
+      'install',
+      `pyinstaller==${PYINSTALLER_VERSION}`,
+      `markitdown[pdf,docx,pptx,xlsx]==${MARKITDOWN_UPSTREAM_VERSION}`,
+    ], {
+      cwd: tmpRoot,
+      timeout: 600_000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    await execFile(venvPython, [
+      '-m',
+      'PyInstaller',
+      '--clean',
+      '--onefile',
+      '--name',
+      target.assetName,
+      '--collect-data',
+      'magika',
+      '--distpath',
+      binDir,
+      '--workpath',
+      workDir,
+      '--specpath',
+      specDir,
+      join(resolvePackageDir(packageDir), 'scripts', 'markitdown-entry.py'),
+    ], {
+      cwd: tmpRoot,
+      timeout: 900_000,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+
+    if (!existsSync(binaryPath)) {
+      throw new Error(`PyInstaller completed without producing ${binaryPath}`);
+    }
+    ensureExecutable(binaryPath);
+    const hash = await verifyChecksum(binaryPath, sha256Hex(await readFile(binaryPath)));
+    await writeChecksumFile(binaryPath, hash);
+    return { status: 'built', binaryPath, hash };
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+export async function bundleReleasedBinaries({
+  packageDir = DEFAULT_PACKAGE_DIR,
+  outputDir = null,
+  version,
+  releaseBaseUrlOverride = null,
+  releaseRepo = DEFAULT_RELEASE_REPO,
+  force = false,
+}) {
+  const resolvedVersion = version ?? readCliVersion(packageDir);
+  const baseUrl = releaseBaseUrlOverride ?? releaseBaseUrl(resolvedVersion, releaseRepo);
+  const binDir = resolveBinDir(packageDir, outputDir);
+  await ensureDir(binDir);
+  const results = [];
+  for (const target of SUPPORTED_TARGETS) {
+    results.push(await downloadBinaryAsset({
+      assetName: target.assetName,
+      destinationDir: binDir,
+      baseUrl,
+      force,
+    }));
+  }
+  return { status: 'downloaded-all', version: resolvedVersion, results };
+}
+
+export async function ensureCurrentPlatformBinary({
+  packageDir = DEFAULT_PACKAGE_DIR,
+  outputDir = null,
+  version = null,
+  releaseBaseUrlOverride = null,
+  releaseRepo = DEFAULT_RELEASE_REPO,
+  force = false,
+  allowBuildFromSource = false,
+}) {
+  const target = getSupportedTarget();
+  if (!target) {
+    return { status: 'unsupported' };
+  }
+
+  const binaryPath = targetBinaryPath(target, packageDir, outputDir);
+  if (!force && existsSync(binaryPath)) {
+    return { status: 'present', binaryPath };
+  }
+
+  const resolvedVersion = version ?? readCliVersion(packageDir);
+  const baseUrl = releaseBaseUrlOverride ?? releaseBaseUrl(resolvedVersion, releaseRepo);
+  try {
+    const result = await downloadBinaryAsset({
+      assetName: target.assetName,
+      destinationDir: resolveBinDir(packageDir, outputDir),
+      baseUrl,
+      force,
+    });
+    return { ...result, source: 'release' };
+  } catch (downloadErr) {
+    if (!allowBuildFromSource) throw downloadErr;
+    const built = await buildCurrentPlatformBinary({ packageDir, outputDir, force });
+    return { ...built, source: 'build' };
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const packageDir = resolvePackageDir(opts.packageDir);
+  const version = opts.version ?? readCliVersion(packageDir);
+  const workspace = isWorkspaceCheckout(packageDir);
+  const log = opts.quiet ? () => {} : logLine;
+
+  if (workspace && !opts.all && !opts.buildCurrentPlatform) {
+    log('MarkItDown bundle: workspace checkout detected; skipping implicit release-asset download.');
+    return;
+  }
+
+  if (opts.all) {
+    const result = await bundleReleasedBinaries({
+      packageDir,
+      outputDir: opts.outputDir,
+      version,
+      releaseBaseUrlOverride: opts.releaseBaseUrl,
+      releaseRepo: opts.releaseRepo,
+      force: opts.force,
+    });
+    log(`MarkItDown bundle: staged ${result.results.length} release asset(s) for v${version}.`);
+    return;
+  }
+
+  if (opts.buildCurrentPlatform) {
+    const result = await buildCurrentPlatformBinary({
+      packageDir,
+      outputDir: opts.outputDir,
+      force: opts.force,
+    });
+    log(`MarkItDown bundle: built ${result.binaryPath}.`);
+    return;
+  }
+
+  const result = await ensureCurrentPlatformBinary({
+    packageDir,
+    outputDir: opts.outputDir,
+    version,
+    releaseBaseUrlOverride: opts.releaseBaseUrl,
+    releaseRepo: opts.releaseRepo,
+    force: opts.force,
+    allowBuildFromSource: workspace,
+  });
+  if (result.status === 'unsupported') {
+    log(`MarkItDown bundle: ${process.platform}-${process.arch} is not a supported bundled target.`);
+    return;
+  }
+  log(`MarkItDown bundle: staged ${result.binaryPath} (${result.source ?? result.status}).`);
+}
+
+const isMainModule = process.argv[1] && resolve(process.argv[1]) === __filename;
+if (isMainModule) {
+  main().catch((err) => {
+    const args = process.argv.slice(2);
+    const bestEffort = args.includes('--best-effort');
+    const message = `MarkItDown bundle: ${err?.message ?? String(err)}`;
+    if (bestEffort) {
+      warnLine(`${message} (continuing without a bundled binary)`);
+      process.exit(0);
+    }
+    warnLine(message);
+    process.exit(1);
+  });
+}

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { execFile as execFileCb, execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, readFileSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
@@ -13,16 +13,35 @@ const execFile = promisify(execFileCb);
 export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';
 export const PYINSTALLER_VERSION = '6.19.0';
 export const DEFAULT_RELEASE_REPO = 'OriginTrail/dkg-v9';
-
-export const SUPPORTED_TARGETS = [
-  { platform: 'linux', arch: 'x64', assetName: 'markitdown-linux-x64' },
-  { platform: 'darwin', arch: 'arm64', assetName: 'markitdown-darwin-arm64' },
-  { platform: 'win32', arch: 'x64', assetName: 'markitdown-win32-x64.exe' },
-];
+export const RELEASE_BINARY_FETCH_TIMEOUT_MS = 15_000;
+export const RELEASE_CHECKSUM_FETCH_TIMEOUT_MS = 5_000;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const DEFAULT_PACKAGE_DIR = resolve(__dirname, '..');
+
+function loadSupportedTargets(packageDir = DEFAULT_PACKAGE_DIR) {
+  const raw = readFileSync(join(resolvePackageDir(packageDir), 'markitdown-targets.json'), 'utf-8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error('markitdown-targets.json must contain an array');
+  }
+  return parsed.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error(`markitdown-targets.json entry ${index} must be an object`);
+    }
+    const { platform, arch, assetName, runner } = entry;
+    if (typeof platform !== 'string' || typeof arch !== 'string' || typeof assetName !== 'string') {
+      throw new Error(`markitdown-targets.json entry ${index} is missing platform/arch/assetName`);
+    }
+    if (runner != null && typeof runner !== 'string') {
+      throw new Error(`markitdown-targets.json entry ${index} has an invalid runner`);
+    }
+    return { platform, arch, assetName, ...(runner ? { runner } : {}) };
+  });
+}
+
+export const SUPPORTED_TARGETS = loadSupportedTargets();
 
 function logLine(message) {
   process.stdout.write(`${message}\n`);
@@ -143,7 +162,7 @@ export function parseSha256File(text) {
 async function fetchBytes(url) {
   const res = await fetch(url, {
     headers: { Accept: 'application/octet-stream' },
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(RELEASE_BINARY_FETCH_TIMEOUT_MS),
   });
   if (!res.ok) {
     throw new Error(`${url} returned ${res.status}`);
@@ -154,7 +173,7 @@ async function fetchBytes(url) {
 async function fetchText(url) {
   const res = await fetch(url, {
     headers: { Accept: 'text/plain' },
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(RELEASE_CHECKSUM_FETCH_TIMEOUT_MS),
   });
   if (!res.ok) {
     throw new Error(`${url} returned ${res.status}`);
@@ -185,6 +204,25 @@ async function verifyChecksum(binaryPath, expectedHash) {
   return actualHash;
 }
 
+async function hasVerifiedBinary(binaryPath) {
+  const binaryChecksumPath = checksumPathFor(binaryPath);
+  if (!existsSync(binaryPath) || !existsSync(binaryChecksumPath)) {
+    return false;
+  }
+  try {
+    const checksumText = await readFile(binaryChecksumPath, 'utf-8');
+    const expectedHash = parseSha256File(checksumText);
+    await verifyChecksum(binaryPath, expectedHash);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function removeIfExists(path) {
+  await rm(path, { force: true });
+}
+
 export async function downloadBinaryAsset({
   assetName,
   destinationDir,
@@ -192,8 +230,15 @@ export async function downloadBinaryAsset({
   force = false,
 }) {
   const destination = join(destinationDir, assetName);
+  const destinationChecksumPath = checksumPathFor(destination);
   if (!force && existsSync(destination)) {
-    return { status: 'present', binaryPath: destination };
+    if (await hasVerifiedBinary(destination)) {
+      return { status: 'present', binaryPath: destination };
+    }
+    await Promise.all([
+      removeIfExists(destination),
+      removeIfExists(destinationChecksumPath),
+    ]);
   }
 
   await ensureDir(destinationDir);
@@ -209,9 +254,26 @@ export async function downloadBinaryAsset({
     throw new Error(`Checksum mismatch for ${assetName}: expected ${expectedHash}, got ${actualHash}`);
   }
 
-  await writeFile(destination, bytes);
-  ensureExecutable(destination);
-  await writeFile(checksumPathFor(destination), checksumText, 'utf-8');
+  const tempSuffix = `.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const tempDestination = `${destination}${tempSuffix}`;
+  const tempChecksumPath = `${destinationChecksumPath}${tempSuffix}`;
+  try {
+    await writeFile(tempDestination, bytes);
+    ensureExecutable(tempDestination);
+    await writeFile(tempChecksumPath, `${expectedHash}  ${assetName}\n`, 'utf-8');
+    await Promise.all([
+      removeIfExists(destination),
+      removeIfExists(destinationChecksumPath),
+    ]);
+    await rename(tempDestination, destination);
+    await rename(tempChecksumPath, destinationChecksumPath);
+  } catch (err) {
+    await Promise.all([
+      removeIfExists(tempDestination),
+      removeIfExists(tempChecksumPath),
+    ]);
+    throw err;
+  }
   return { status: 'downloaded', binaryPath: destination, hash: actualHash };
 }
 
@@ -250,7 +312,13 @@ export async function buildCurrentPlatformBinary({
   const binDir = resolveBinDir(packageDir, outputDir);
   const binaryPath = targetBinaryPath(target, packageDir, outputDir);
   if (!force && existsSync(binaryPath)) {
-    return { status: 'present', binaryPath };
+    if (await hasVerifiedBinary(binaryPath)) {
+      return { status: 'present', binaryPath };
+    }
+    await Promise.all([
+      removeIfExists(binaryPath),
+      removeIfExists(checksumPathFor(binaryPath)),
+    ]);
   }
 
   await ensureDir(binDir);
@@ -355,7 +423,13 @@ export async function ensureCurrentPlatformBinary({
 
   const binaryPath = targetBinaryPath(target, packageDir, outputDir);
   if (!force && existsSync(binaryPath)) {
-    return { status: 'present', binaryPath };
+    if (await hasVerifiedBinary(binaryPath)) {
+      return { status: 'present', binaryPath };
+    }
+    await Promise.all([
+      removeIfExists(binaryPath),
+      removeIfExists(checksumPathFor(binaryPath)),
+    ]);
   }
 
   const resolvedVersion = version ?? readCliVersion(packageDir);

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -110,6 +110,10 @@ export function targetBinaryPath(target, packageDir = DEFAULT_PACKAGE_DIR, outpu
   return join(resolveBinDir(packageDir, outputDir), target.assetName);
 }
 
+export function pyInstallerNameForTarget(target) {
+  return target.assetName.replace(/\.exe$/i, '');
+}
+
 export function checksumPathFor(binaryPath) {
   return `${binaryPath}.sha256`;
 }
@@ -283,7 +287,7 @@ export async function buildCurrentPlatformBinary({
       '--clean',
       '--onefile',
       '--name',
-      target.assetName,
+      pyInstallerNameForTarget(target),
       '--collect-data',
       'magika',
       '--distpath',

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -175,6 +175,14 @@ function metadataMatchesExpected(actualMetadata, expectedMetadata) {
   return Object.entries(expectedMetadata).every(([key, value]) => actualMetadata[key] === value);
 }
 
+function parseMetadataText(text) {
+  const parsed = JSON.parse(text);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Malformed metadata file');
+  }
+  return parsed;
+}
+
 async function writeMetadataFile(binaryPath, metadata) {
   await writeFile(metadataPathFor(binaryPath), `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8');
 }
@@ -283,14 +291,22 @@ export async function downloadBinaryAsset({
   await ensureDir(destinationDir);
   const assetUrl = releaseAssetUrl(baseUrl, assetName);
   const checksumUrl = `${assetUrl}.sha256`;
-  const [bytes, checksumText] = await Promise.all([
+  const metadataUrl = `${assetUrl}.meta.json`;
+  const [bytes, checksumText, metadataText] = await Promise.all([
     fetchBytes(assetUrl),
     fetchText(checksumUrl),
+    fetchText(metadataUrl),
   ]);
   const expectedHash = parseSha256File(checksumText);
   const actualHash = sha256Hex(bytes);
   if (actualHash !== expectedHash) {
     throw new Error(`Checksum mismatch for ${assetName}: expected ${expectedHash}, got ${actualHash}`);
+  }
+  const releaseMetadata = parseMetadataText(metadataText);
+  if (!metadataMatchesExpected(releaseMetadata, expectedMetadata)) {
+    throw new Error(
+      `Metadata mismatch for ${assetName}: expected ${JSON.stringify(expectedMetadata)}, got ${JSON.stringify(releaseMetadata)}`,
+    );
   }
 
   const tempSuffix = `.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -311,7 +327,7 @@ export async function downloadBinaryAsset({
     await writeFile(tempDestination, bytes);
     ensureExecutable(tempDestination);
     await writeFile(tempChecksumPath, `${expectedHash}  ${assetName}\n`, 'utf-8');
-    await writeFile(tempMetadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`, 'utf-8');
+    await writeFile(tempMetadataPath, metadataText.endsWith('\n') ? metadataText : `${metadataText}\n`, 'utf-8');
     if (backupDestination) {
       await rename(destination, backupDestination);
       movedDestinationToBackup = true;

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -160,10 +160,12 @@ export function sha256Hex(bytes) {
 function buildFingerprintForPackage(packageDir = DEFAULT_PACKAGE_DIR) {
   const resolvedPackageDir = resolvePackageDir(packageDir);
   const entryScript = readFileSync(join(resolvedPackageDir, 'scripts', 'markitdown-entry.py'));
+  const bundlerScript = readFileSync(__filename);
   return sha256Hex([
     MARKITDOWN_UPSTREAM_VERSION,
     PYINSTALLER_VERSION,
     sha256Hex(entryScript),
+    sha256Hex(bundlerScript),
   ].join('\n'));
 }
 
@@ -313,6 +315,9 @@ export async function downloadBinaryAsset({
       removeIfExists(tempDestination),
       removeIfExists(tempChecksumPath),
       removeIfExists(tempMetadataPath),
+      removeIfExists(destination),
+      removeIfExists(destinationChecksumPath),
+      removeIfExists(destinationMetadataPath),
     ]);
     throw err;
   }

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { execFile as execFileCb } from 'node:child_process';
+import { execFile as execFileCb, execFileSync } from 'node:child_process';
 import { chmodSync, existsSync, readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -213,7 +213,16 @@ export async function downloadBinaryAsset({
 
 function resolvePythonCommand() {
   if (process.env.PYTHON) return process.env.PYTHON;
-  return process.platform === 'win32' ? 'python' : 'python3';
+  const candidates = process.platform === 'win32' ? ['python'] : ['python3', 'python'];
+  for (const candidate of candidates) {
+    try {
+      execFileSync(candidate, ['--version'], { stdio: 'pipe' });
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  throw new Error('Python executable not found. Install python3/python or set the PYTHON environment variable.');
 }
 
 function venvPythonPath(venvDir) {
@@ -229,7 +238,7 @@ export async function buildCurrentPlatformBinary({
 }) {
   const target = getSupportedTarget();
   if (!target) {
-    throw new Error(`Unsupported MarkItDown bundle target: ${process.platform}-${process.arch}`);
+    return { status: 'unsupported' };
   }
 
   const binDir = resolveBinDir(packageDir, outputDir);
@@ -356,6 +365,9 @@ export async function ensureCurrentPlatformBinary({
   } catch (downloadErr) {
     if (!allowBuildFromSource) throw downloadErr;
     const built = await buildCurrentPlatformBinary({ packageDir, outputDir, force });
+    if (built.status === 'unsupported') {
+      return built;
+    }
     return { ...built, source: 'build' };
   }
 }
@@ -391,6 +403,10 @@ async function main() {
       outputDir: opts.outputDir,
       force: opts.force,
     });
+    if (result.status === 'unsupported') {
+      log(`MarkItDown bundle: ${process.platform}-${process.arch} is not a supported bundled target.`);
+      return;
+    }
     log(`MarkItDown bundle: built ${result.binaryPath}.`);
     return;
   }

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -7,6 +7,13 @@ import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import {
+  checksumPathFor,
+  hasVerifiedBundledBinary,
+  metadataMatchesExpected,
+  metadataPathFor,
+  parseSha256File,
+} from './markitdown-bundle-validation.mjs';
 
 const execFile = promisify(execFileCb);
 
@@ -142,13 +149,7 @@ export function pyInstallerNameForTarget(target) {
   return target.assetName.replace(/\.exe$/i, '');
 }
 
-export function checksumPathFor(binaryPath) {
-  return `${binaryPath}.sha256`;
-}
-
-export function metadataPathFor(binaryPath) {
-  return `${binaryPath}.meta.json`;
-}
+export { checksumPathFor, metadataPathFor, parseSha256File };
 
 export function releaseTagForVersion(version) {
   return `v${version.replace(/^v/, '')}`;
@@ -178,18 +179,6 @@ function buildFingerprintForPackage(packageDir = DEFAULT_PACKAGE_DIR) {
   ].join('\n'));
 }
 
-function metadataMatchesExpected(actualMetadata, expectedMetadata) {
-  if (!expectedMetadata) return true;
-  if (!actualMetadata || typeof actualMetadata !== 'object') return false;
-  if (expectedMetadata.buildFingerprint) {
-    if (actualMetadata.buildFingerprint) return actualMetadata.buildFingerprint === expectedMetadata.buildFingerprint;
-    if (expectedMetadata.cliVersion) return actualMetadata.cliVersion === expectedMetadata.cliVersion;
-    return false;
-  }
-  if (expectedMetadata.cliVersion) return actualMetadata.cliVersion === expectedMetadata.cliVersion;
-  return true;
-}
-
 function parseMetadataText(text) {
   const parsed = JSON.parse(text);
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -200,22 +189,6 @@ function parseMetadataText(text) {
 
 async function writeMetadataFile(binaryPath, metadata) {
   await writeFile(metadataPathFor(binaryPath), `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8');
-}
-
-async function readMetadataFile(binaryPath) {
-  const path = metadataPathFor(binaryPath);
-  if (!existsSync(path)) return null;
-  try {
-    return JSON.parse(await readFile(path, 'utf-8'));
-  } catch {
-    return null;
-  }
-}
-
-export function parseSha256File(text) {
-  const [hash] = text.trim().split(/\s+/);
-  if (!hash) throw new Error('Malformed sha256 file');
-  return hash.toLowerCase();
 }
 
 async function fetchBytes(url) {
@@ -263,25 +236,6 @@ async function verifyChecksum(binaryPath, expectedHash) {
   return actualHash;
 }
 
-async function hasVerifiedBinary(binaryPath, expectedMetadata = null) {
-  const binaryChecksumPath = checksumPathFor(binaryPath);
-  if (!existsSync(binaryPath) || !existsSync(binaryChecksumPath)) {
-    return false;
-  }
-  try {
-    const checksumText = await readFile(binaryChecksumPath, 'utf-8');
-    const expectedHash = parseSha256File(checksumText);
-    await verifyChecksum(binaryPath, expectedHash);
-    const metadata = await readMetadataFile(binaryPath);
-    if (!metadataMatchesExpected(metadata, expectedMetadata)) {
-      return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function removeIfExists(path) {
   await rm(path, { force: true });
 }
@@ -298,7 +252,7 @@ export async function downloadBinaryAsset({
   const destinationMetadataPath = metadataPathFor(destination);
   const expectedMetadata = { source: 'release', cliVersion };
   if (!force && existsSync(destination)) {
-    if (await hasVerifiedBinary(destination, expectedMetadata)) {
+    if (await hasVerifiedBundledBinary(destination, expectedMetadata)) {
       return { status: 'present', binaryPath: destination };
     }
   }
@@ -429,7 +383,7 @@ export async function buildCurrentPlatformBinary({
     buildFingerprint: buildFingerprintForPackage(packageDir),
   };
   if (!force && existsSync(binaryPath)) {
-    if (await hasVerifiedBinary(binaryPath, expectedMetadata)) {
+    if (await hasVerifiedBundledBinary(binaryPath, expectedMetadata)) {
       return { status: 'present', binaryPath };
     }
   }
@@ -540,7 +494,7 @@ export async function ensureCurrentPlatformBinary({
   const resolvedVersion = version ?? readCliVersion(packageDir);
   const expectedMetadata = { source: 'release', cliVersion: resolvedVersion };
   if (!force && existsSync(binaryPath)) {
-    if (await hasVerifiedBinary(binaryPath, expectedMetadata)) {
+    if (await hasVerifiedBundledBinary(binaryPath, expectedMetadata)) {
       return { status: 'present', binaryPath };
     }
   }

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -10,8 +10,17 @@ import { promisify } from 'node:util';
 
 const execFile = promisify(execFileCb);
 
-export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';
-export const PYINSTALLER_VERSION = '6.19.0';
+const MARKITDOWN_BUILD_INFO = JSON.parse(readFileSync(new URL('../markitdown-build-info.json', import.meta.url), 'utf-8'));
+if (
+  typeof MARKITDOWN_BUILD_INFO.markItDownUpstreamVersion !== 'string'
+  || MARKITDOWN_BUILD_INFO.markItDownUpstreamVersion.length === 0
+  || typeof MARKITDOWN_BUILD_INFO.pyInstallerVersion !== 'string'
+  || MARKITDOWN_BUILD_INFO.pyInstallerVersion.length === 0
+) {
+  throw new Error('markitdown-build-info.json must define non-empty markItDownUpstreamVersion and pyInstallerVersion strings');
+}
+export const MARKITDOWN_UPSTREAM_VERSION = MARKITDOWN_BUILD_INFO.markItDownUpstreamVersion;
+export const PYINSTALLER_VERSION = MARKITDOWN_BUILD_INFO.pyInstallerVersion;
 export const DEFAULT_RELEASE_REPO = 'OriginTrail/dkg-v9';
 export const RELEASE_BINARY_FETCH_TIMEOUT_MS = 15_000;
 export const RELEASE_CHECKSUM_FETCH_TIMEOUT_MS = 5_000;
@@ -172,7 +181,13 @@ function buildFingerprintForPackage(packageDir = DEFAULT_PACKAGE_DIR) {
 function metadataMatchesExpected(actualMetadata, expectedMetadata) {
   if (!expectedMetadata) return true;
   if (!actualMetadata || typeof actualMetadata !== 'object') return false;
-  return Object.entries(expectedMetadata).every(([key, value]) => actualMetadata[key] === value);
+  if (expectedMetadata.buildFingerprint) {
+    if (actualMetadata.buildFingerprint) return actualMetadata.buildFingerprint === expectedMetadata.buildFingerprint;
+    if (expectedMetadata.cliVersion) return actualMetadata.cliVersion === expectedMetadata.cliVersion;
+    return false;
+  }
+  if (expectedMetadata.cliVersion) return actualMetadata.cliVersion === expectedMetadata.cliVersion;
+  return true;
 }
 
 function parseMetadataText(text) {

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -212,11 +212,13 @@ export async function downloadBinaryAsset({
 }
 
 function resolvePythonCommand() {
-  if (process.env.PYTHON) return process.env.PYTHON;
-  const candidates = process.platform === 'win32' ? ['python'] : ['python3', 'python'];
+  if (process.env.PYTHON) return { command: process.env.PYTHON, args: [] };
+  const candidates = process.platform === 'win32'
+    ? [{ command: 'python', args: [] }, { command: 'py', args: ['-3'] }]
+    : [{ command: 'python3', args: [] }, { command: 'python', args: [] }];
   for (const candidate of candidates) {
     try {
-      execFileSync(candidate, ['--version'], { stdio: 'pipe' });
+      execFileSync(candidate.command, [...candidate.args, '--version'], { stdio: 'pipe' });
       return candidate;
     } catch {
       // Try the next candidate.
@@ -256,7 +258,7 @@ export async function buildCurrentPlatformBinary({
   const python = resolvePythonCommand();
 
   try {
-    await execFile(python, ['-m', 'venv', venvDir], { cwd: tmpRoot, timeout: 120_000 });
+    await execFile(python.command, [...python.args, '-m', 'venv', venvDir], { cwd: tmpRoot, timeout: 120_000 });
     const venvPython = venvPythonPath(venvDir);
 
     await execFile(venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], {

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -297,19 +297,26 @@ export async function downloadBinaryAsset({
   const tempDestination = `${destination}${tempSuffix}`;
   const tempChecksumPath = `${destinationChecksumPath}${tempSuffix}`;
   const tempMetadataPath = `${destinationMetadataPath}${tempSuffix}`;
+  const backupSuffix = `.bak-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const backupDestination = existsSync(destination) ? `${destination}${backupSuffix}` : null;
+  const backupChecksumPath = existsSync(destinationChecksumPath) ? `${destinationChecksumPath}${backupSuffix}` : null;
+  const backupMetadataPath = existsSync(destinationMetadataPath) ? `${destinationMetadataPath}${backupSuffix}` : null;
   try {
     await writeFile(tempDestination, bytes);
     ensureExecutable(tempDestination);
     await writeFile(tempChecksumPath, `${expectedHash}  ${assetName}\n`, 'utf-8');
     await writeFile(tempMetadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`, 'utf-8');
-    await Promise.all([
-      removeIfExists(destination),
-      removeIfExists(destinationChecksumPath),
-      removeIfExists(destinationMetadataPath),
-    ]);
+    if (backupDestination) await rename(destination, backupDestination);
+    if (backupChecksumPath) await rename(destinationChecksumPath, backupChecksumPath);
+    if (backupMetadataPath) await rename(destinationMetadataPath, backupMetadataPath);
     await rename(tempDestination, destination);
     await rename(tempChecksumPath, destinationChecksumPath);
     await rename(tempMetadataPath, destinationMetadataPath);
+    await Promise.all([
+      backupDestination ? removeIfExists(backupDestination) : Promise.resolve(),
+      backupChecksumPath ? removeIfExists(backupChecksumPath) : Promise.resolve(),
+      backupMetadataPath ? removeIfExists(backupMetadataPath) : Promise.resolve(),
+    ]);
   } catch (err) {
     await Promise.all([
       removeIfExists(tempDestination),
@@ -319,6 +326,9 @@ export async function downloadBinaryAsset({
       removeIfExists(destinationChecksumPath),
       removeIfExists(destinationMetadataPath),
     ]);
+    if (backupDestination && existsSync(backupDestination)) await rename(backupDestination, destination);
+    if (backupChecksumPath && existsSync(backupChecksumPath)) await rename(backupChecksumPath, destinationChecksumPath);
+    if (backupMetadataPath && existsSync(backupMetadataPath)) await rename(backupMetadataPath, destinationMetadataPath);
     throw err;
   }
   return { status: 'downloaded', binaryPath: destination, hash: actualHash };

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -235,10 +235,6 @@ export async function downloadBinaryAsset({
     if (await hasVerifiedBinary(destination)) {
       return { status: 'present', binaryPath: destination };
     }
-    await Promise.all([
-      removeIfExists(destination),
-      removeIfExists(destinationChecksumPath),
-    ]);
   }
 
   await ensureDir(destinationDir);
@@ -315,10 +311,6 @@ export async function buildCurrentPlatformBinary({
     if (await hasVerifiedBinary(binaryPath)) {
       return { status: 'present', binaryPath };
     }
-    await Promise.all([
-      removeIfExists(binaryPath),
-      removeIfExists(checksumPathFor(binaryPath)),
-    ]);
   }
 
   await ensureDir(binDir);
@@ -426,10 +418,6 @@ export async function ensureCurrentPlatformBinary({
     if (await hasVerifiedBinary(binaryPath)) {
       return { status: 'present', binaryPath };
     }
-    await Promise.all([
-      removeIfExists(binaryPath),
-      removeIfExists(checksumPathFor(binaryPath)),
-    ]);
   }
 
   const resolvedVersion = version ?? readCliVersion(packageDir);

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -137,6 +137,10 @@ export function checksumPathFor(binaryPath) {
   return `${binaryPath}.sha256`;
 }
 
+export function metadataPathFor(binaryPath) {
+  return `${binaryPath}.meta.json`;
+}
+
 export function releaseTagForVersion(version) {
   return `v${version.replace(/^v/, '')}`;
 }
@@ -151,6 +155,36 @@ export function releaseAssetUrl(baseUrl, assetName) {
 
 export function sha256Hex(bytes) {
   return createHash('sha256').update(bytes).digest('hex');
+}
+
+function buildFingerprintForPackage(packageDir = DEFAULT_PACKAGE_DIR) {
+  const resolvedPackageDir = resolvePackageDir(packageDir);
+  const entryScript = readFileSync(join(resolvedPackageDir, 'scripts', 'markitdown-entry.py'));
+  return sha256Hex([
+    MARKITDOWN_UPSTREAM_VERSION,
+    PYINSTALLER_VERSION,
+    sha256Hex(entryScript),
+  ].join('\n'));
+}
+
+function metadataMatchesExpected(actualMetadata, expectedMetadata) {
+  if (!expectedMetadata) return true;
+  if (!actualMetadata || typeof actualMetadata !== 'object') return false;
+  return Object.entries(expectedMetadata).every(([key, value]) => actualMetadata[key] === value);
+}
+
+async function writeMetadataFile(binaryPath, metadata) {
+  await writeFile(metadataPathFor(binaryPath), `${JSON.stringify(metadata, null, 2)}\n`, 'utf-8');
+}
+
+async function readMetadataFile(binaryPath) {
+  const path = metadataPathFor(binaryPath);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8'));
+  } catch {
+    return null;
+  }
 }
 
 export function parseSha256File(text) {
@@ -204,7 +238,7 @@ async function verifyChecksum(binaryPath, expectedHash) {
   return actualHash;
 }
 
-async function hasVerifiedBinary(binaryPath) {
+async function hasVerifiedBinary(binaryPath, expectedMetadata = null) {
   const binaryChecksumPath = checksumPathFor(binaryPath);
   if (!existsSync(binaryPath) || !existsSync(binaryChecksumPath)) {
     return false;
@@ -213,6 +247,10 @@ async function hasVerifiedBinary(binaryPath) {
     const checksumText = await readFile(binaryChecksumPath, 'utf-8');
     const expectedHash = parseSha256File(checksumText);
     await verifyChecksum(binaryPath, expectedHash);
+    const metadata = await readMetadataFile(binaryPath);
+    if (!metadataMatchesExpected(metadata, expectedMetadata)) {
+      return false;
+    }
     return true;
   } catch {
     return false;
@@ -227,12 +265,15 @@ export async function downloadBinaryAsset({
   assetName,
   destinationDir,
   baseUrl,
+  cliVersion,
   force = false,
 }) {
   const destination = join(destinationDir, assetName);
   const destinationChecksumPath = checksumPathFor(destination);
+  const destinationMetadataPath = metadataPathFor(destination);
+  const expectedMetadata = { source: 'release', cliVersion };
   if (!force && existsSync(destination)) {
-    if (await hasVerifiedBinary(destination)) {
+    if (await hasVerifiedBinary(destination, expectedMetadata)) {
       return { status: 'present', binaryPath: destination };
     }
   }
@@ -253,20 +294,25 @@ export async function downloadBinaryAsset({
   const tempSuffix = `.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const tempDestination = `${destination}${tempSuffix}`;
   const tempChecksumPath = `${destinationChecksumPath}${tempSuffix}`;
+  const tempMetadataPath = `${destinationMetadataPath}${tempSuffix}`;
   try {
     await writeFile(tempDestination, bytes);
     ensureExecutable(tempDestination);
     await writeFile(tempChecksumPath, `${expectedHash}  ${assetName}\n`, 'utf-8');
+    await writeFile(tempMetadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`, 'utf-8');
     await Promise.all([
       removeIfExists(destination),
       removeIfExists(destinationChecksumPath),
+      removeIfExists(destinationMetadataPath),
     ]);
     await rename(tempDestination, destination);
     await rename(tempChecksumPath, destinationChecksumPath);
+    await rename(tempMetadataPath, destinationMetadataPath);
   } catch (err) {
     await Promise.all([
       removeIfExists(tempDestination),
       removeIfExists(tempChecksumPath),
+      removeIfExists(tempMetadataPath),
     ]);
     throw err;
   }
@@ -307,8 +353,13 @@ export async function buildCurrentPlatformBinary({
 
   const binDir = resolveBinDir(packageDir, outputDir);
   const binaryPath = targetBinaryPath(target, packageDir, outputDir);
+  const expectedMetadata = {
+    source: 'build',
+    cliVersion: readCliVersion(packageDir),
+    buildFingerprint: buildFingerprintForPackage(packageDir),
+  };
   if (!force && existsSync(binaryPath)) {
-    if (await hasVerifiedBinary(binaryPath)) {
+    if (await hasVerifiedBinary(binaryPath, expectedMetadata)) {
       return { status: 'present', binaryPath };
     }
   }
@@ -369,6 +420,7 @@ export async function buildCurrentPlatformBinary({
     ensureExecutable(binaryPath);
     const hash = await verifyChecksum(binaryPath, sha256Hex(await readFile(binaryPath)));
     await writeChecksumFile(binaryPath, hash);
+    await writeMetadataFile(binaryPath, expectedMetadata);
     return { status: 'built', binaryPath, hash };
   } finally {
     await rm(tmpRoot, { recursive: true, force: true });
@@ -393,6 +445,7 @@ export async function bundleReleasedBinaries({
       assetName: target.assetName,
       destinationDir: binDir,
       baseUrl,
+      cliVersion: resolvedVersion,
       force,
     }));
   }
@@ -414,19 +467,20 @@ export async function ensureCurrentPlatformBinary({
   }
 
   const binaryPath = targetBinaryPath(target, packageDir, outputDir);
+  const resolvedVersion = version ?? readCliVersion(packageDir);
+  const expectedMetadata = { source: 'release', cliVersion: resolvedVersion };
   if (!force && existsSync(binaryPath)) {
-    if (await hasVerifiedBinary(binaryPath)) {
+    if (await hasVerifiedBinary(binaryPath, expectedMetadata)) {
       return { status: 'present', binaryPath };
     }
   }
-
-  const resolvedVersion = version ?? readCliVersion(packageDir);
   const baseUrl = releaseBaseUrlOverride ?? releaseBaseUrl(resolvedVersion, releaseRepo);
   try {
     const result = await downloadBinaryAsset({
       assetName: target.assetName,
       destinationDir: resolveBinDir(packageDir, outputDir),
       baseUrl,
+      cliVersion: resolvedVersion,
       force,
     });
     return { ...result, source: 'release' };

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -301,34 +301,58 @@ export async function downloadBinaryAsset({
   const backupDestination = existsSync(destination) ? `${destination}${backupSuffix}` : null;
   const backupChecksumPath = existsSync(destinationChecksumPath) ? `${destinationChecksumPath}${backupSuffix}` : null;
   const backupMetadataPath = existsSync(destinationMetadataPath) ? `${destinationMetadataPath}${backupSuffix}` : null;
+  let movedDestinationToBackup = false;
+  let movedChecksumToBackup = false;
+  let movedMetadataToBackup = false;
+  let promotedDestination = false;
+  let promotedChecksum = false;
+  let promotedMetadata = false;
   try {
     await writeFile(tempDestination, bytes);
     ensureExecutable(tempDestination);
     await writeFile(tempChecksumPath, `${expectedHash}  ${assetName}\n`, 'utf-8');
     await writeFile(tempMetadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`, 'utf-8');
-    if (backupDestination) await rename(destination, backupDestination);
-    if (backupChecksumPath) await rename(destinationChecksumPath, backupChecksumPath);
-    if (backupMetadataPath) await rename(destinationMetadataPath, backupMetadataPath);
+    if (backupDestination) {
+      await rename(destination, backupDestination);
+      movedDestinationToBackup = true;
+    }
+    if (backupChecksumPath) {
+      await rename(destinationChecksumPath, backupChecksumPath);
+      movedChecksumToBackup = true;
+    }
+    if (backupMetadataPath) {
+      await rename(destinationMetadataPath, backupMetadataPath);
+      movedMetadataToBackup = true;
+    }
     await rename(tempDestination, destination);
+    promotedDestination = true;
     await rename(tempChecksumPath, destinationChecksumPath);
+    promotedChecksum = true;
     await rename(tempMetadataPath, destinationMetadataPath);
+    promotedMetadata = true;
     await Promise.all([
-      backupDestination ? removeIfExists(backupDestination) : Promise.resolve(),
-      backupChecksumPath ? removeIfExists(backupChecksumPath) : Promise.resolve(),
-      backupMetadataPath ? removeIfExists(backupMetadataPath) : Promise.resolve(),
+      movedDestinationToBackup && backupDestination ? removeIfExists(backupDestination) : Promise.resolve(),
+      movedChecksumToBackup && backupChecksumPath ? removeIfExists(backupChecksumPath) : Promise.resolve(),
+      movedMetadataToBackup && backupMetadataPath ? removeIfExists(backupMetadataPath) : Promise.resolve(),
     ]);
   } catch (err) {
     await Promise.all([
       removeIfExists(tempDestination),
       removeIfExists(tempChecksumPath),
       removeIfExists(tempMetadataPath),
-      removeIfExists(destination),
-      removeIfExists(destinationChecksumPath),
-      removeIfExists(destinationMetadataPath),
+      promotedDestination ? removeIfExists(destination) : Promise.resolve(),
+      promotedChecksum ? removeIfExists(destinationChecksumPath) : Promise.resolve(),
+      promotedMetadata ? removeIfExists(destinationMetadataPath) : Promise.resolve(),
     ]);
-    if (backupDestination && existsSync(backupDestination)) await rename(backupDestination, destination);
-    if (backupChecksumPath && existsSync(backupChecksumPath)) await rename(backupChecksumPath, destinationChecksumPath);
-    if (backupMetadataPath && existsSync(backupMetadataPath)) await rename(backupMetadataPath, destinationMetadataPath);
+    if (movedDestinationToBackup && backupDestination && existsSync(backupDestination)) {
+      await rename(backupDestination, destination);
+    }
+    if (movedChecksumToBackup && backupChecksumPath && existsSync(backupChecksumPath)) {
+      await rename(backupChecksumPath, destinationChecksumPath);
+    }
+    if (movedMetadataToBackup && backupMetadataPath && existsSync(backupMetadataPath)) {
+      await rename(backupMetadataPath, destinationMetadataPath);
+    }
     throw err;
   }
   return { status: 'downloaded', binaryPath: destination, hash: actualHash };

--- a/packages/cli/scripts/markitdown-bundle-validation.d.mts
+++ b/packages/cli/scripts/markitdown-bundle-validation.d.mts
@@ -1,0 +1,31 @@
+export type BundledMarkItDownMetadata = {
+  source?: 'release' | 'build';
+  cliVersion?: string;
+  buildFingerprint?: string;
+};
+
+export function checksumPathFor(binaryPath: string): string;
+export function metadataPathFor(binaryPath: string): string;
+export function parseSha256File(text: string): string;
+export function metadataMatchesExpected(
+  actualMetadata: BundledMarkItDownMetadata | null,
+  expectedMetadata: BundledMarkItDownMetadata | null,
+): boolean;
+export function readMetadataFile(binaryPath: string): Promise<BundledMarkItDownMetadata | null>;
+export function readMetadataFileSync(binaryPath: string): BundledMarkItDownMetadata | null;
+export function bundledBinaryValidationFailure(
+  binaryPath: string,
+  expectedMetadata?: BundledMarkItDownMetadata | null,
+): Promise<'checksum' | 'metadata' | null>;
+export function bundledBinaryValidationFailureSync(
+  binaryPath: string,
+  expectedMetadata?: BundledMarkItDownMetadata | null,
+): 'checksum' | 'metadata' | null;
+export function hasVerifiedBundledBinary(
+  binaryPath: string,
+  expectedMetadata?: BundledMarkItDownMetadata | null,
+): Promise<boolean>;
+export function hasVerifiedBundledBinarySync(
+  binaryPath: string,
+  expectedMetadata?: BundledMarkItDownMetadata | null,
+): boolean;

--- a/packages/cli/scripts/markitdown-bundle-validation.mjs
+++ b/packages/cli/scripts/markitdown-bundle-validation.mjs
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+export function checksumPathFor(binaryPath) {
+  return `${binaryPath}.sha256`;
+}
+
+export function metadataPathFor(binaryPath) {
+  return `${binaryPath}.meta.json`;
+}
+
+export function parseSha256File(text) {
+  const [hash] = text.trim().split(/\s+/);
+  if (!hash) throw new Error('Malformed sha256 file');
+  return hash.toLowerCase();
+}
+
+export function metadataMatchesExpected(actualMetadata, expectedMetadata) {
+  if (!expectedMetadata) return true;
+  if (!actualMetadata || typeof actualMetadata !== 'object') return false;
+  if (expectedMetadata.buildFingerprint) {
+    if (actualMetadata.buildFingerprint) return actualMetadata.buildFingerprint === expectedMetadata.buildFingerprint;
+    if (expectedMetadata.cliVersion) return actualMetadata.cliVersion === expectedMetadata.cliVersion;
+    return false;
+  }
+  if (expectedMetadata.cliVersion) return actualMetadata.cliVersion === expectedMetadata.cliVersion;
+  return true;
+}
+
+export async function readMetadataFile(binaryPath) {
+  const path = metadataPathFor(binaryPath);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(await readFile(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function readMetadataFileSync(binaryPath) {
+  const path = metadataPathFor(binaryPath);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function sha256Hex(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export async function bundledBinaryValidationFailure(binaryPath, expectedMetadata = null) {
+  const binaryChecksumPath = checksumPathFor(binaryPath);
+  if (!existsSync(binaryPath) || !existsSync(binaryChecksumPath)) {
+    return 'checksum';
+  }
+  try {
+    const expectedHash = parseSha256File(await readFile(binaryChecksumPath, 'utf-8'));
+    const actualHash = sha256Hex(await readFile(binaryPath));
+    if (actualHash !== expectedHash) return 'checksum';
+    const metadata = await readMetadataFile(binaryPath);
+    return metadataMatchesExpected(metadata, expectedMetadata) ? null : 'metadata';
+  } catch {
+    return 'checksum';
+  }
+}
+
+export function bundledBinaryValidationFailureSync(binaryPath, expectedMetadata = null) {
+  const binaryChecksumPath = checksumPathFor(binaryPath);
+  if (!existsSync(binaryPath) || !existsSync(binaryChecksumPath)) {
+    return 'checksum';
+  }
+  try {
+    const expectedHash = parseSha256File(readFileSync(binaryChecksumPath, 'utf-8'));
+    const actualHash = sha256Hex(readFileSync(binaryPath));
+    if (actualHash !== expectedHash) return 'checksum';
+    const metadata = readMetadataFileSync(binaryPath);
+    return metadataMatchesExpected(metadata, expectedMetadata) ? null : 'metadata';
+  } catch {
+    return 'checksum';
+  }
+}
+
+export async function hasVerifiedBundledBinary(binaryPath, expectedMetadata = null) {
+  return (await bundledBinaryValidationFailure(binaryPath, expectedMetadata)) === null;
+}
+
+export function hasVerifiedBundledBinarySync(binaryPath, expectedMetadata = null) {
+  return bundledBinaryValidationFailureSync(binaryPath, expectedMetadata) === null;
+}

--- a/packages/cli/scripts/markitdown-entry.py
+++ b/packages/cli/scripts/markitdown-entry.py
@@ -18,6 +18,11 @@ def main() -> int:
         sys.stderr.write("usage: markitdown <file-path>\n")
         return 2
 
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8")
+
     file_path = sys.argv[1]
     result = MarkItDown(enable_plugins=False).convert(file_path)
     sys.stdout.write(result.text_content)

--- a/packages/cli/scripts/markitdown-entry.py
+++ b/packages/cli/scripts/markitdown-entry.py
@@ -1,0 +1,28 @@
+"""Standalone entry point for the bundled MarkItDown binary.
+
+This wrapper keeps the DKG-facing CLI contract intentionally narrow:
+- exactly one positional argument: the source file path
+- markdown emitted to stdout
+- errors emitted to stderr with a non-zero exit code
+"""
+
+from __future__ import annotations
+
+import sys
+
+from markitdown import MarkItDown
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: markitdown <file-path>\n")
+        return 2
+
+    file_path = sys.argv[1]
+    result = MarkItDown(enable_plugins=False).convert(file_path)
+    sys.stdout.write(result.text_content)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createHash, randomUUID } from 'node:crypto';
-import { appendFile, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { appendFile, copyFile, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { execSync, exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
@@ -159,6 +159,29 @@ function currentBundledMarkItDownAssetName(): string | null {
     || (process.platform === 'win32' && process.arch === 'x64');
   if (!supported) return null;
   return `markitdown-${process.platform}-${process.arch}${process.platform === 'win32' ? '.exe' : ''}`;
+}
+
+async function carryForwardBundledMarkItDownBinary(opts: {
+  sourceCandidates: string[];
+  targetBinaryPath: string;
+  log: (msg: string) => void;
+  context: string;
+}): Promise<boolean> {
+  for (const sourceBinaryPath of opts.sourceCandidates) {
+    if (!existsSync(sourceBinaryPath)) continue;
+    await mkdir(dirname(opts.targetBinaryPath), { recursive: true });
+    await copyFile(sourceBinaryPath, opts.targetBinaryPath);
+
+    const sourceChecksumPath = `${sourceBinaryPath}.sha256`;
+    const targetChecksumPath = `${opts.targetBinaryPath}.sha256`;
+    if (existsSync(sourceChecksumPath)) {
+      await copyFile(sourceChecksumPath, targetChecksumPath);
+    }
+
+    opts.log(`${opts.context}: reused bundled MarkItDown binary from the active slot (${sourceBinaryPath}).`);
+    return true;
+  }
+  return false;
 }
 
 const lastUpdateCheck = { upToDate: true, checkedAt: 0, latestCommit: '', latestVersion: '' };
@@ -4433,6 +4456,7 @@ async function _performNpmUpdateInner(
   }
 
   const active = await activeSlot();
+  const activeDir = join(rDir, active);
   const target = active === 'a' ? 'b' : (active === 'b' ? 'a' : 'a');
   const targetDir = join(rDir, target);
 
@@ -4475,7 +4499,18 @@ async function _performNpmUpdateInner(
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
     if (!existsSync(bundledMarkItDownPath)) {
-      log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
+      const reused = await carryForwardBundledMarkItDownBinary({
+        sourceCandidates: [
+          join(activeDir, 'node_modules', '@origintrail-official', 'dkg', 'bin', bundledMarkItDownAsset),
+          join(activeDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset),
+        ],
+        targetBinaryPath: bundledMarkItDownPath,
+        log,
+        context: 'Auto-update (npm)',
+      });
+      if (!reused) {
+        log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
+      }
     }
   }
 
@@ -4881,7 +4916,18 @@ async function _performUpdateInner(
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(targetDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset);
     if (!existsSync(bundledMarkItDownPath)) {
-      log(`Auto-update: bundled MarkItDown binary missing (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
+      const reused = await carryForwardBundledMarkItDownBinary({
+        sourceCandidates: [
+          join(activeDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset),
+          join(activeDir, 'node_modules', '@origintrail-official', 'dkg', 'bin', bundledMarkItDownAsset),
+        ],
+        targetBinaryPath: bundledMarkItDownPath,
+        log,
+        context: 'Auto-update',
+      });
+      if (!reused) {
+        log(`Auto-update: bundled MarkItDown binary missing (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
+      }
     }
   }
 

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -152,6 +152,15 @@ function normalizeDetectedContentType(contentType: string | undefined): string {
   return normalized && normalized.length > 0 ? normalized : 'application/octet-stream';
 }
 
+function currentBundledMarkItDownAssetName(): string | null {
+  const supported =
+    (process.platform === 'linux' && process.arch === 'x64')
+    || (process.platform === 'darwin' && process.arch === 'arm64')
+    || (process.platform === 'win32' && process.arch === 'x64');
+  if (!supported) return null;
+  return `markitdown-${process.platform}-${process.arch}${process.platform === 'win32' ? '.exe' : ''}`;
+}
+
 const lastUpdateCheck = { upToDate: true, checkedAt: 0, latestCommit: '', latestVersion: '' };
 let isUpdating = false;
 
@@ -4462,6 +4471,14 @@ async function _performNpmUpdateInner(
     log(`Auto-update (npm): entry point missing after install. Aborting swap.`);
     return 'failed';
   }
+  const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
+  if (bundledMarkItDownAsset) {
+    const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
+    if (!existsSync(bundledMarkItDownPath)) {
+      log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Aborting swap.`);
+      return 'failed';
+    }
+  }
 
   let resolvedVersion = targetVersion;
   try {
@@ -4844,6 +4861,13 @@ async function _performUpdateInner(
         log('Auto-update: no contract folder changes detected; skipping @origintrail-official/dkg-evm-module build.');
       }
     }
+
+    log('Auto-update: staging MarkItDown binary for the inactive slot...');
+    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform', {
+      cwd: targetDir,
+      encoding: 'utf-8',
+      timeout: 900_000,
+    });
   } catch (err: any) {
     log(`Auto-update: build failed in slot ${target} — ${err.message}. Active slot untouched.`);
     return 'failed';
@@ -4853,6 +4877,14 @@ async function _performUpdateInner(
   if (!existsSync(entryFile)) {
     log(`Auto-update: build output missing (${entryFile}). Aborting swap.`);
     return 'failed';
+  }
+  const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
+  if (bundledMarkItDownAsset) {
+    const bundledMarkItDownPath = join(targetDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset);
+    if (!existsSync(bundledMarkItDownPath)) {
+      log(`Auto-update: bundled MarkItDown binary missing (${bundledMarkItDownPath}). Aborting swap.`);
+      return 'failed';
+    }
   }
 
   let nextVersion = '';

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -4475,8 +4475,7 @@ async function _performNpmUpdateInner(
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
     if (!existsSync(bundledMarkItDownPath)) {
-      log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Aborting swap.`);
-      return 'failed';
+      log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
     }
   }
 
@@ -4863,7 +4862,7 @@ async function _performUpdateInner(
     }
 
     log('Auto-update: staging MarkItDown binary for the inactive slot...');
-    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform', {
+    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort', {
       cwd: targetDir,
       encoding: 'utf-8',
       timeout: 900_000,
@@ -4882,8 +4881,7 @@ async function _performUpdateInner(
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(targetDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset);
     if (!existsSync(bundledMarkItDownPath)) {
-      log(`Auto-update: bundled MarkItDown binary missing (${bundledMarkItDownPath}). Aborting swap.`);
-      return 'failed';
+      log(`Auto-update: bundled MarkItDown binary missing (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
     }
   }
 

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -190,8 +190,18 @@ function currentBundledMarkItDownAssetName(): string | null {
   ))?.assetName ?? null;
 }
 
+type BundledMarkItDownMetadata = {
+  source?: string;
+  cliVersion?: string;
+  buildFingerprint?: string;
+};
+
 function markItDownChecksumPath(binaryPath: string): string {
   return `${binaryPath}.sha256`;
+}
+
+function markItDownMetadataPath(binaryPath: string): string {
+  return `${binaryPath}.meta.json`;
 }
 
 function parseSha256Sidecar(text: string): string | null {
@@ -199,7 +209,63 @@ function parseSha256Sidecar(text: string): string | null {
   return hash ? hash.toLowerCase() : null;
 }
 
-async function hasVerifiedBundledMarkItDownBinary(binaryPath: string): Promise<boolean> {
+function bundledMarkItDownMetadataMatchesExpected(
+  actual: BundledMarkItDownMetadata | null,
+  expected: BundledMarkItDownMetadata | null,
+): boolean {
+  if (!expected) return true;
+  if (!actual || typeof actual !== 'object') return false;
+  return Object.entries(expected).every(([key, value]) => actual[key as keyof BundledMarkItDownMetadata] === value);
+}
+
+async function readBundledMarkItDownMetadata(binaryPath: string): Promise<BundledMarkItDownMetadata | null> {
+  const metadataPath = markItDownMetadataPath(binaryPath);
+  if (!existsSync(metadataPath)) return null;
+  try {
+    return JSON.parse(await readFile(metadataPath, 'utf-8')) as BundledMarkItDownMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function bundledMarkItDownBuildFingerprint(cliDir: string): string | null {
+  try {
+    const entryScript = readFileSync(join(cliDir, 'scripts', 'markitdown-entry.py'));
+    const bundlerScript = readFileSync(join(cliDir, 'scripts', 'bundle-markitdown-binaries.mjs'), 'utf-8');
+    const upstreamVersion = bundlerScript.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)'/)?.[1];
+    const pyInstallerVersion = bundlerScript.match(/export const PYINSTALLER_VERSION = '([^']+)'/)?.[1];
+    if (!upstreamVersion || !pyInstallerVersion) return null;
+    return createHash('sha256').update([
+      upstreamVersion,
+      pyInstallerVersion,
+      createHash('sha256').update(entryScript).digest('hex'),
+      createHash('sha256').update(bundlerScript).digest('hex'),
+    ].join('\n')).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function readCliPackageVersion(cliDir: string): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(cliDir, 'package.json'), 'utf-8')) as { version?: unknown };
+    return typeof pkg.version === 'string' && pkg.version.trim().length > 0 ? pkg.version.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function expectedBundledMarkItDownBuildMetadata(cliDir: string): BundledMarkItDownMetadata | null {
+  const cliVersion = readCliPackageVersion(cliDir);
+  const buildFingerprint = bundledMarkItDownBuildFingerprint(cliDir);
+  if (!cliVersion || !buildFingerprint) return null;
+  return { source: 'build', cliVersion, buildFingerprint };
+}
+
+async function hasVerifiedBundledMarkItDownBinary(
+  binaryPath: string,
+  expectedMetadata: BundledMarkItDownMetadata | null = null,
+): Promise<boolean> {
   const checksumPath = markItDownChecksumPath(binaryPath);
   if (!existsSync(binaryPath) || !existsSync(checksumPath)) return false;
   try {
@@ -207,7 +273,9 @@ async function hasVerifiedBundledMarkItDownBinary(binaryPath: string): Promise<b
     const expectedHash = parseSha256Sidecar(checksumText);
     if (!expectedHash) return false;
     const actualHash = createHash('sha256').update(await readFile(binaryPath)).digest('hex');
-    return actualHash === expectedHash;
+    if (actualHash !== expectedHash) return false;
+    const metadata = await readBundledMarkItDownMetadata(binaryPath);
+    return bundledMarkItDownMetadataMatchesExpected(metadata, expectedMetadata);
   } catch {
     return false;
   }
@@ -218,6 +286,7 @@ async function carryForwardBundledMarkItDownBinary(opts: {
   targetBinaryPath: string;
   log: (msg: string) => void;
   context: string;
+  expectedMetadata: BundledMarkItDownMetadata | null;
 }): Promise<boolean> {
   for (const sourceBinaryPath of opts.sourceCandidates) {
     if (!existsSync(sourceBinaryPath)) continue;
@@ -225,30 +294,41 @@ async function carryForwardBundledMarkItDownBinary(opts: {
       opts.log(`${opts.context}: skipping active-slot bundled MarkItDown binary without a valid checksum sidecar (${sourceBinaryPath}).`);
       continue;
     }
+    if (!(await hasVerifiedBundledMarkItDownBinary(sourceBinaryPath, opts.expectedMetadata))) {
+      opts.log(`${opts.context}: skipping active-slot bundled MarkItDown binary with incompatible metadata (${sourceBinaryPath}).`);
+      continue;
+    }
     await mkdir(dirname(opts.targetBinaryPath), { recursive: true });
 
     const sourceChecksumPath = markItDownChecksumPath(sourceBinaryPath);
+    const sourceMetadataPath = markItDownMetadataPath(sourceBinaryPath);
     const targetChecksumPath = markItDownChecksumPath(opts.targetBinaryPath);
+    const targetMetadataPath = markItDownMetadataPath(opts.targetBinaryPath);
     const tempSuffix = `.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const tempTargetBinaryPath = `${opts.targetBinaryPath}${tempSuffix}`;
     const tempTargetChecksumPath = `${targetChecksumPath}${tempSuffix}`;
+    const tempTargetMetadataPath = `${targetMetadataPath}${tempSuffix}`;
     try {
       await copyFile(sourceBinaryPath, tempTargetBinaryPath);
       await copyFile(sourceChecksumPath, tempTargetChecksumPath);
+      await copyFile(sourceMetadataPath, tempTargetMetadataPath);
       const sourceMode = (await stat(sourceBinaryPath)).mode & 0o777;
       await chmod(tempTargetBinaryPath, sourceMode || 0o755);
       await Promise.all([
         rm(opts.targetBinaryPath, { force: true }),
         rm(targetChecksumPath, { force: true }),
+        rm(targetMetadataPath, { force: true }),
       ]);
       await rename(tempTargetBinaryPath, opts.targetBinaryPath);
       await rename(tempTargetChecksumPath, targetChecksumPath);
+      await rename(tempTargetMetadataPath, targetMetadataPath);
       opts.log(`${opts.context}: reused bundled MarkItDown binary from the active slot (${sourceBinaryPath}).`);
       return true;
     } catch (err: any) {
       await Promise.all([
         rm(tempTargetBinaryPath, { force: true }),
         rm(tempTargetChecksumPath, { force: true }),
+        rm(tempTargetMetadataPath, { force: true }),
       ]);
       opts.log(`${opts.context}: failed to reuse bundled MarkItDown binary from the active slot (${sourceBinaryPath}) - ${err?.message ?? String(err)}.`);
     }
@@ -4570,7 +4650,8 @@ async function _performNpmUpdateInner(
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
-    if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath))) {
+    const expectedMetadata: BundledMarkItDownMetadata = { source: 'release', cliVersion: targetVersion };
+    if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath, expectedMetadata))) {
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [
           join(activeDir, 'node_modules', '@origintrail-official', 'dkg', 'bin', bundledMarkItDownAsset),
@@ -4579,6 +4660,7 @@ async function _performNpmUpdateInner(
         targetBinaryPath: bundledMarkItDownPath,
         log,
         context: 'Auto-update (npm)',
+        expectedMetadata,
       });
       if (!reused) {
         log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
@@ -4987,7 +5069,8 @@ async function _performUpdateInner(
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(targetDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset);
-    if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath))) {
+    const expectedMetadata = expectedBundledMarkItDownBuildMetadata(join(targetDir, 'packages', 'cli'));
+    if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath, expectedMetadata))) {
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [
           join(activeDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset),
@@ -4996,6 +5079,7 @@ async function _performUpdateInner(
         targetBinaryPath: bundledMarkItDownPath,
         log,
         context: 'Auto-update',
+        expectedMetadata,
       });
       if (!reused) {
         log(`Auto-update: bundled MarkItDown binary missing (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -4897,7 +4897,7 @@ async function _performUpdateInner(
     }
 
     log('Auto-update: staging MarkItDown binary for the inactive slot...');
-    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort', {
+    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --force --best-effort', {
       cwd: targetDir,
       encoding: 'utf-8',
       timeout: 900_000,

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createHash, randomUUID } from 'node:crypto';
-import { appendFile, copyFile, mkdir, readFile, rename, rm, unlink, writeFile } from 'node:fs/promises';
+import { appendFile, chmod, copyFile, mkdir, readFile, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { execSync, exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
@@ -9,7 +9,6 @@ const execFileAsync = promisify(execFile);
 import { join, dirname, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { stat } from 'node:fs/promises';
 import { ethers } from 'ethers';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
@@ -236,6 +235,8 @@ async function carryForwardBundledMarkItDownBinary(opts: {
     try {
       await copyFile(sourceBinaryPath, tempTargetBinaryPath);
       await copyFile(sourceChecksumPath, tempTargetChecksumPath);
+      const sourceMode = (await stat(sourceBinaryPath)).mode & 0o777;
+      await chmod(tempTargetBinaryPath, sourceMode || 0o755);
       await Promise.all([
         rm(opts.targetBinaryPath, { force: true }),
         rm(targetChecksumPath, { force: true }),

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -5050,11 +5050,15 @@ async function _performUpdateInner(
     }
 
     log('Auto-update: staging MarkItDown binary for the inactive slot...');
-    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort', {
-      cwd: targetDir,
-      encoding: 'utf-8',
-      timeout: 900_000,
-    });
+    try {
+      await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort', {
+        cwd: targetDir,
+        encoding: 'utf-8',
+        timeout: 900_000,
+      });
+    } catch (markItDownErr: any) {
+      log(`Auto-update: MarkItDown staging failed in slot ${target} â€” ${markItDownErr.message}. Continuing without document conversion on this node.`);
+    }
   } catch (err: any) {
     log(`Auto-update: build failed in slot ${target} — ${err.message}. Active slot untouched.`);
     return 'failed';

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -60,6 +60,11 @@ import {
   readCliPackageVersion,
   type BundledMarkItDownMetadata,
 } from './extraction/markitdown-bundle-metadata.js';
+import {
+  checksumPathFor as markItDownChecksumPath,
+  hasVerifiedBundledBinary as hasVerifiedBundledMarkItDownBinary,
+  metadataPathFor as markItDownMetadataPath,
+} from '../scripts/markitdown-bundle-validation.mjs';
 import { type ExtractionStatusRecord, getExtractionStatusRecord, setExtractionStatusRecord } from './extraction-status.js';
 import { FileStore } from './file-store.js';
 import { parseBoundary, parseMultipart, MultipartParseError } from './http/multipart.js';
@@ -193,63 +198,6 @@ function currentBundledMarkItDownAssetName(): string | null {
     target.platform === process.platform
     && target.arch === process.arch
   ))?.assetName ?? null;
-}
-
-function markItDownChecksumPath(binaryPath: string): string {
-  return `${binaryPath}.sha256`;
-}
-
-function markItDownMetadataPath(binaryPath: string): string {
-  return `${binaryPath}.meta.json`;
-}
-
-function parseSha256Sidecar(text: string): string | null {
-  const [hash] = text.trim().split(/\s+/);
-  return hash ? hash.toLowerCase() : null;
-}
-
-function bundledMarkItDownMetadataMatchesExpected(
-  actual: BundledMarkItDownMetadata | null,
-  expected: BundledMarkItDownMetadata | null,
-): boolean {
-  if (!expected) return true;
-  if (!actual || typeof actual !== 'object') return false;
-  if (expected.buildFingerprint) {
-    if (actual.buildFingerprint) return actual.buildFingerprint === expected.buildFingerprint;
-    if (expected.cliVersion) return actual.cliVersion === expected.cliVersion;
-    return false;
-  }
-  if (expected.cliVersion) return actual.cliVersion === expected.cliVersion;
-  return true;
-}
-
-async function readBundledMarkItDownMetadata(binaryPath: string): Promise<BundledMarkItDownMetadata | null> {
-  const metadataPath = markItDownMetadataPath(binaryPath);
-  if (!existsSync(metadataPath)) return null;
-  try {
-    return JSON.parse(await readFile(metadataPath, 'utf-8')) as BundledMarkItDownMetadata;
-  } catch {
-    return null;
-  }
-}
-
-async function hasVerifiedBundledMarkItDownBinary(
-  binaryPath: string,
-  expectedMetadata: BundledMarkItDownMetadata | null = null,
-): Promise<boolean> {
-  const checksumPath = markItDownChecksumPath(binaryPath);
-  if (!existsSync(binaryPath) || !existsSync(checksumPath)) return false;
-  try {
-    const checksumText = await readFile(checksumPath, 'utf-8');
-    const expectedHash = parseSha256Sidecar(checksumText);
-    if (!expectedHash) return false;
-    const actualHash = createHash('sha256').update(await readFile(binaryPath)).digest('hex');
-    if (actualHash !== expectedHash) return false;
-    const metadata = await readBundledMarkItDownMetadata(binaryPath);
-    return bundledMarkItDownMetadataMatchesExpected(metadata, expectedMetadata);
-  } catch {
-    return false;
-  }
 }
 
 async function carryForwardBundledMarkItDownBinary(opts: {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -62,6 +62,38 @@ import { parseBoundary, parseMultipart, MultipartParseError } from './http/multi
 import { handleCapture, EpcisValidationError, handleEventsQuery, EpcisQueryError, type Publisher as EpcisPublisher } from '@origintrail-official/dkg-epcis';
 import { readFileSync } from 'node:fs';
 
+type MarkItDownTarget = {
+  platform: string;
+  arch: string;
+  assetName: string;
+  runner?: string;
+};
+
+let cachedMarkItDownTargets: MarkItDownTarget[] | null = null;
+
+function loadMarkItDownTargets(): MarkItDownTarget[] {
+  if (cachedMarkItDownTargets) return cachedMarkItDownTargets;
+  try {
+    const raw = readFileSync(new URL('../markitdown-targets.json', import.meta.url), 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      cachedMarkItDownTargets = [];
+      return cachedMarkItDownTargets;
+    }
+    cachedMarkItDownTargets = parsed.filter((entry): entry is MarkItDownTarget => (
+      !!entry
+      && typeof entry === 'object'
+      && typeof entry.platform === 'string'
+      && typeof entry.arch === 'string'
+      && typeof entry.assetName === 'string'
+    ));
+    return cachedMarkItDownTargets;
+  } catch {
+    cachedMarkItDownTargets = [];
+    return cachedMarkItDownTargets;
+  }
+}
+
 function getNodeVersion(): string {
   try {
     const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
@@ -153,12 +185,10 @@ function normalizeDetectedContentType(contentType: string | undefined): string {
 }
 
 function currentBundledMarkItDownAssetName(): string | null {
-  const supported =
-    (process.platform === 'linux' && process.arch === 'x64')
-    || (process.platform === 'darwin' && process.arch === 'arm64')
-    || (process.platform === 'win32' && process.arch === 'x64');
-  if (!supported) return null;
-  return `markitdown-${process.platform}-${process.arch}${process.platform === 'win32' ? '.exe' : ''}`;
+  return loadMarkItDownTargets().find((target) => (
+    target.platform === process.platform
+    && target.arch === process.arch
+  ))?.assetName ?? null;
 }
 
 async function carryForwardBundledMarkItDownBinary(opts: {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -4968,7 +4968,7 @@ async function _performUpdateInner(
     }
 
     log('Auto-update: staging MarkItDown binary for the inactive slot...');
-    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --force --best-effort', {
+    await execAsync('node packages/cli/scripts/bundle-markitdown-binaries.mjs --build-current-platform --best-effort', {
       cwd: targetDir,
       encoding: 'utf-8',
       timeout: 900_000,

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -214,7 +214,13 @@ function bundledMarkItDownMetadataMatchesExpected(
 ): boolean {
   if (!expected) return true;
   if (!actual || typeof actual !== 'object') return false;
-  return Object.entries(expected).every(([key, value]) => actual[key as keyof BundledMarkItDownMetadata] === value);
+  if (expected.buildFingerprint) {
+    if (actual.buildFingerprint) return actual.buildFingerprint === expected.buildFingerprint;
+    if (expected.cliVersion) return actual.cliVersion === expected.cliVersion;
+    return false;
+  }
+  if (expected.cliVersion) return actual.cliVersion === expected.cliVersion;
+  return true;
 }
 
 async function readBundledMarkItDownMetadata(binaryPath: string): Promise<BundledMarkItDownMetadata | null> {
@@ -4620,7 +4626,7 @@ async function _performNpmUpdateInner(
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
-    const expectedMetadata: BundledMarkItDownMetadata = { source: 'release', cliVersion: resolvedVersion };
+    const expectedMetadata = expectedBundledMarkItDownBuildMetadata(npmPkgDir) ?? { cliVersion: resolvedVersion };
     if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath, expectedMetadata))) {
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -4655,7 +4655,6 @@ async function _performNpmUpdateInner(
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [
           join(activeDir, 'node_modules', '@origintrail-official', 'dkg', 'bin', bundledMarkItDownAsset),
-          join(activeDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset),
         ],
         targetBinaryPath: bundledMarkItDownPath,
         log,

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -4569,7 +4569,7 @@ async function _performNpmUpdateInner(
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
-    if (!existsSync(bundledMarkItDownPath)) {
+    if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath))) {
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [
           join(activeDir, 'node_modules', '@origintrail-official', 'dkg', 'bin', bundledMarkItDownAsset),
@@ -4986,7 +4986,7 @@ async function _performUpdateInner(
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(targetDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset);
-    if (!existsSync(bundledMarkItDownPath)) {
+    if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath))) {
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [
           join(activeDir, 'packages', 'cli', 'bin', bundledMarkItDownAsset),

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -55,6 +55,11 @@ import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type P
 import { loadTokens, httpAuthGuard, extractBearerToken } from './auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
 import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown } from './extraction/index.js';
+import {
+  expectedBundledMarkItDownBuildMetadata,
+  readCliPackageVersion,
+  type BundledMarkItDownMetadata,
+} from './extraction/markitdown-bundle-metadata.js';
 import { type ExtractionStatusRecord, getExtractionStatusRecord, setExtractionStatusRecord } from './extraction-status.js';
 import { FileStore } from './file-store.js';
 import { parseBoundary, parseMultipart, MultipartParseError } from './http/multipart.js';
@@ -190,12 +195,6 @@ function currentBundledMarkItDownAssetName(): string | null {
   ))?.assetName ?? null;
 }
 
-type BundledMarkItDownMetadata = {
-  source?: string;
-  cliVersion?: string;
-  buildFingerprint?: string;
-};
-
 function markItDownChecksumPath(binaryPath: string): string {
   return `${binaryPath}.sha256`;
 }
@@ -226,40 +225,6 @@ async function readBundledMarkItDownMetadata(binaryPath: string): Promise<Bundle
   } catch {
     return null;
   }
-}
-
-function bundledMarkItDownBuildFingerprint(cliDir: string): string | null {
-  try {
-    const entryScript = readFileSync(join(cliDir, 'scripts', 'markitdown-entry.py'));
-    const bundlerScript = readFileSync(join(cliDir, 'scripts', 'bundle-markitdown-binaries.mjs'), 'utf-8');
-    const upstreamVersion = bundlerScript.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)'/)?.[1];
-    const pyInstallerVersion = bundlerScript.match(/export const PYINSTALLER_VERSION = '([^']+)'/)?.[1];
-    if (!upstreamVersion || !pyInstallerVersion) return null;
-    return createHash('sha256').update([
-      upstreamVersion,
-      pyInstallerVersion,
-      createHash('sha256').update(entryScript).digest('hex'),
-      createHash('sha256').update(bundlerScript).digest('hex'),
-    ].join('\n')).digest('hex');
-  } catch {
-    return null;
-  }
-}
-
-function readCliPackageVersion(cliDir: string): string | null {
-  try {
-    const pkg = JSON.parse(readFileSync(join(cliDir, 'package.json'), 'utf-8')) as { version?: unknown };
-    return typeof pkg.version === 'string' && pkg.version.trim().length > 0 ? pkg.version.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
-function expectedBundledMarkItDownBuildMetadata(cliDir: string): BundledMarkItDownMetadata | null {
-  const cliVersion = readCliPackageVersion(cliDir);
-  const buildFingerprint = bundledMarkItDownBuildFingerprint(cliDir);
-  if (!cliVersion || !buildFingerprint) return null;
-  return { source: 'build', cliVersion, buildFingerprint };
 }
 
 async function hasVerifiedBundledMarkItDownBinary(
@@ -4647,10 +4612,15 @@ async function _performNpmUpdateInner(
     log(`Auto-update (npm): entry point missing after install. Aborting swap.`);
     return 'failed';
   }
+  let resolvedVersion = readCliPackageVersion(npmPkgDir);
+  if (!resolvedVersion) {
+    resolvedVersion = targetVersion;
+    log(`Auto-update (npm): could not read installed package version, using spec "${targetVersion}"`);
+  }
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();
   if (bundledMarkItDownAsset) {
     const bundledMarkItDownPath = join(npmPkgDir, 'bin', bundledMarkItDownAsset);
-    const expectedMetadata: BundledMarkItDownMetadata = { source: 'release', cliVersion: targetVersion };
+    const expectedMetadata: BundledMarkItDownMetadata = { source: 'release', cliVersion: resolvedVersion };
     if (!(await hasVerifiedBundledMarkItDownBinary(bundledMarkItDownPath, expectedMetadata))) {
       const reused = await carryForwardBundledMarkItDownBinary({
         sourceCandidates: [
@@ -4665,16 +4635,6 @@ async function _performNpmUpdateInner(
         log(`Auto-update (npm): bundled MarkItDown binary missing after install (${bundledMarkItDownPath}). Continuing without document conversion on this node.`);
       }
     }
-  }
-
-  let resolvedVersion = targetVersion;
-  try {
-    const installedPkg = JSON.parse(await readFile(join(npmPkgDir, 'package.json'), 'utf-8'));
-    if (installedPkg.version && typeof installedPkg.version === 'string') {
-      resolvedVersion = installedPkg.version;
-    }
-  } catch {
-    log(`Auto-update (npm): could not read installed package version, using spec "${targetVersion}"`);
   }
 
   await writePendingUpdateState({

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createHash, randomUUID } from 'node:crypto';
-import { appendFile, copyFile, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { appendFile, copyFile, mkdir, readFile, rename, rm, unlink, writeFile } from 'node:fs/promises';
 import { execSync, exec, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
@@ -191,6 +191,29 @@ function currentBundledMarkItDownAssetName(): string | null {
   ))?.assetName ?? null;
 }
 
+function markItDownChecksumPath(binaryPath: string): string {
+  return `${binaryPath}.sha256`;
+}
+
+function parseSha256Sidecar(text: string): string | null {
+  const [hash] = text.trim().split(/\s+/);
+  return hash ? hash.toLowerCase() : null;
+}
+
+async function hasVerifiedBundledMarkItDownBinary(binaryPath: string): Promise<boolean> {
+  const checksumPath = markItDownChecksumPath(binaryPath);
+  if (!existsSync(binaryPath) || !existsSync(checksumPath)) return false;
+  try {
+    const checksumText = await readFile(checksumPath, 'utf-8');
+    const expectedHash = parseSha256Sidecar(checksumText);
+    if (!expectedHash) return false;
+    const actualHash = createHash('sha256').update(await readFile(binaryPath)).digest('hex');
+    return actualHash === expectedHash;
+  } catch {
+    return false;
+  }
+}
+
 async function carryForwardBundledMarkItDownBinary(opts: {
   sourceCandidates: string[];
   targetBinaryPath: string;
@@ -199,17 +222,35 @@ async function carryForwardBundledMarkItDownBinary(opts: {
 }): Promise<boolean> {
   for (const sourceBinaryPath of opts.sourceCandidates) {
     if (!existsSync(sourceBinaryPath)) continue;
-    await mkdir(dirname(opts.targetBinaryPath), { recursive: true });
-    await copyFile(sourceBinaryPath, opts.targetBinaryPath);
-
-    const sourceChecksumPath = `${sourceBinaryPath}.sha256`;
-    const targetChecksumPath = `${opts.targetBinaryPath}.sha256`;
-    if (existsSync(sourceChecksumPath)) {
-      await copyFile(sourceChecksumPath, targetChecksumPath);
+    if (!(await hasVerifiedBundledMarkItDownBinary(sourceBinaryPath))) {
+      opts.log(`${opts.context}: skipping active-slot bundled MarkItDown binary without a valid checksum sidecar (${sourceBinaryPath}).`);
+      continue;
     }
+    await mkdir(dirname(opts.targetBinaryPath), { recursive: true });
 
-    opts.log(`${opts.context}: reused bundled MarkItDown binary from the active slot (${sourceBinaryPath}).`);
-    return true;
+    const sourceChecksumPath = markItDownChecksumPath(sourceBinaryPath);
+    const targetChecksumPath = markItDownChecksumPath(opts.targetBinaryPath);
+    const tempSuffix = `.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const tempTargetBinaryPath = `${opts.targetBinaryPath}${tempSuffix}`;
+    const tempTargetChecksumPath = `${targetChecksumPath}${tempSuffix}`;
+    try {
+      await copyFile(sourceBinaryPath, tempTargetBinaryPath);
+      await copyFile(sourceChecksumPath, tempTargetChecksumPath);
+      await Promise.all([
+        rm(opts.targetBinaryPath, { force: true }),
+        rm(targetChecksumPath, { force: true }),
+      ]);
+      await rename(tempTargetBinaryPath, opts.targetBinaryPath);
+      await rename(tempTargetChecksumPath, targetChecksumPath);
+      opts.log(`${opts.context}: reused bundled MarkItDown binary from the active slot (${sourceBinaryPath}).`);
+      return true;
+    } catch (err: any) {
+      await Promise.all([
+        rm(tempTargetBinaryPath, { force: true }),
+        rm(tempTargetChecksumPath, { force: true }),
+      ]);
+      opts.log(`${opts.context}: failed to reuse bundled MarkItDown binary from the active slot (${sourceBinaryPath}) - ${err?.message ?? String(err)}.`);
+    }
   }
   return false;
 }

--- a/packages/cli/src/extraction/markitdown-bundle-metadata.ts
+++ b/packages/cli/src/extraction/markitdown-bundle-metadata.ts
@@ -8,9 +8,12 @@ export type BundledMarkItDownMetadata = {
   buildFingerprint?: string;
 };
 
-type BundledMarkItDownBuildConfig = {
+type MarkItDownBuildInfo = {
   markItDownUpstreamVersion: string;
   pyInstallerVersion: string;
+};
+
+type BundledMarkItDownBuildConfig = MarkItDownBuildInfo & {
   bundlerScriptBytes: Buffer;
 };
 
@@ -30,12 +33,17 @@ export function readCliPackageVersion(cliDir: string): string | null {
 function readBundledMarkItDownBuildConfig(cliDir: string): BundledMarkItDownBuildConfig | null {
   try {
     const resolvedCliDir = resolve(cliDir);
+    const buildInfo = JSON.parse(readFileSync(join(resolvedCliDir, 'markitdown-build-info.json'), 'utf-8')) as MarkItDownBuildInfo;
     const bundlerScriptBytes = readFileSync(join(resolvedCliDir, 'scripts', 'bundle-markitdown-binaries.mjs'));
-    const bundlerScriptText = bundlerScriptBytes.toString('utf-8');
-    const markItDownUpstreamVersion = bundlerScriptText.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)';/)?.[1];
-    const pyInstallerVersion = bundlerScriptText.match(/export const PYINSTALLER_VERSION = '([^']+)';/)?.[1];
-    if (!markItDownUpstreamVersion || !pyInstallerVersion) return null;
-    return { markItDownUpstreamVersion, pyInstallerVersion, bundlerScriptBytes };
+    if (
+      typeof buildInfo.markItDownUpstreamVersion !== 'string'
+      || buildInfo.markItDownUpstreamVersion.length === 0
+      || typeof buildInfo.pyInstallerVersion !== 'string'
+      || buildInfo.pyInstallerVersion.length === 0
+    ) {
+      return null;
+    }
+    return { ...buildInfo, bundlerScriptBytes };
   } catch {
     return null;
   }

--- a/packages/cli/src/extraction/markitdown-bundle-metadata.ts
+++ b/packages/cli/src/extraction/markitdown-bundle-metadata.ts
@@ -1,0 +1,65 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+export type BundledMarkItDownMetadata = {
+  source?: 'release' | 'build';
+  cliVersion?: string;
+  buildFingerprint?: string;
+};
+
+type BundledMarkItDownBuildConfig = {
+  markItDownUpstreamVersion: string;
+  pyInstallerVersion: string;
+  bundlerScriptBytes: Buffer;
+};
+
+export function sha256Hex(bytes: string | Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function readCliPackageVersion(cliDir: string): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(resolve(cliDir), 'package.json'), 'utf-8')) as { version?: unknown };
+    return typeof pkg.version === 'string' && pkg.version.trim().length > 0 ? pkg.version.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function readBundledMarkItDownBuildConfig(cliDir: string): BundledMarkItDownBuildConfig | null {
+  try {
+    const resolvedCliDir = resolve(cliDir);
+    const bundlerScriptBytes = readFileSync(join(resolvedCliDir, 'scripts', 'bundle-markitdown-binaries.mjs'));
+    const bundlerScriptText = bundlerScriptBytes.toString('utf-8');
+    const markItDownUpstreamVersion = bundlerScriptText.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)';/)?.[1];
+    const pyInstallerVersion = bundlerScriptText.match(/export const PYINSTALLER_VERSION = '([^']+)';/)?.[1];
+    if (!markItDownUpstreamVersion || !pyInstallerVersion) return null;
+    return { markItDownUpstreamVersion, pyInstallerVersion, bundlerScriptBytes };
+  } catch {
+    return null;
+  }
+}
+
+export function bundledMarkItDownBuildFingerprint(cliDir: string): string | null {
+  try {
+    const buildConfig = readBundledMarkItDownBuildConfig(cliDir);
+    if (!buildConfig) return null;
+    const entryScript = readFileSync(join(resolve(cliDir), 'scripts', 'markitdown-entry.py'));
+    return sha256Hex([
+      buildConfig.markItDownUpstreamVersion,
+      buildConfig.pyInstallerVersion,
+      sha256Hex(entryScript),
+      sha256Hex(buildConfig.bundlerScriptBytes),
+    ].join('\n'));
+  } catch {
+    return null;
+  }
+}
+
+export function expectedBundledMarkItDownBuildMetadata(cliDir: string): BundledMarkItDownMetadata | null {
+  const cliVersion = readCliPackageVersion(cliDir);
+  const buildFingerprint = bundledMarkItDownBuildFingerprint(cliDir);
+  if (!cliVersion || !buildFingerprint) return null;
+  return { source: 'build', cliVersion, buildFingerprint };
+}

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -50,12 +50,10 @@ function readBundledMetadata(candidate: string): BundledMarkItDownMetadata | nul
 
 function bundledMetadataMatchesCurrentPackage(metadata: BundledMarkItDownMetadata | null): boolean {
   if (!metadata || typeof metadata !== 'object') return false;
-  const cliVersion = readCliPackageVersion(CLI_DIR);
-  if (!cliVersion || metadata.cliVersion !== cliVersion) return false;
-  if (metadata.source === 'release') return true;
-  if (metadata.source !== 'build') return false;
   const buildFingerprint = bundledMarkItDownBuildFingerprint(CLI_DIR);
-  return !!buildFingerprint && metadata.buildFingerprint === buildFingerprint;
+  if (buildFingerprint && metadata.buildFingerprint) return metadata.buildFingerprint === buildFingerprint;
+  const cliVersion = readCliPackageVersion(CLI_DIR);
+  return !!cliVersion && metadata.cliVersion === cliVersion;
 }
 
 function bundledBinaryValidationFailure(candidate: string): 'checksum' | 'metadata' | null {

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFile, execFileSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { platform, arch } from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -17,62 +17,27 @@ import type { ExtractionPipeline, ExtractionInput, ConverterOutput } from '@orig
 import {
   bundledMarkItDownBuildFingerprint,
   readCliPackageVersion,
-  sha256Hex,
-  type BundledMarkItDownMetadata,
 } from './markitdown-bundle-metadata.js';
+import { bundledBinaryValidationFailureSync, hasVerifiedBundledBinarySync } from '../../scripts/markitdown-bundle-validation.mjs';
 
 const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
 
-function checksumPathFor(binaryPath: string): string {
-  return `${binaryPath}.sha256`;
-}
-
-function metadataPathFor(binaryPath: string): string {
-  return `${binaryPath}.meta.json`;
-}
-
-function parseSha256Sidecar(text: string): string | null {
-  const [hash] = text.trim().split(/\s+/);
-  return hash ? hash.toLowerCase() : null;
-}
-
 const CLI_DIR = fileURLToPath(new URL('../../', import.meta.url));
 
-function readBundledMetadata(candidate: string): BundledMarkItDownMetadata | null {
-  const metadataPath = metadataPathFor(candidate);
-  if (!existsSync(metadataPath)) return null;
-  try {
-    return JSON.parse(readFileSync(metadataPath, 'utf-8')) as BundledMarkItDownMetadata;
-  } catch {
-    return null;
-  }
-}
-
-function bundledMetadataMatchesCurrentPackage(metadata: BundledMarkItDownMetadata | null): boolean {
-  if (!metadata || typeof metadata !== 'object') return false;
+function expectedBundledMetadataForCurrentPackage(): { buildFingerprint?: string; cliVersion?: string } | null {
   const buildFingerprint = bundledMarkItDownBuildFingerprint(CLI_DIR);
-  if (buildFingerprint && metadata.buildFingerprint) return metadata.buildFingerprint === buildFingerprint;
   const cliVersion = readCliPackageVersion(CLI_DIR);
-  return !!cliVersion && metadata.cliVersion === cliVersion;
+  if (buildFingerprint) return { buildFingerprint, ...(cliVersion ? { cliVersion } : {}) };
+  if (cliVersion) return { cliVersion };
+  return null;
 }
 
 function bundledBinaryValidationFailure(candidate: string): 'checksum' | 'metadata' | null {
-  const checksumPath = checksumPathFor(candidate);
-  if (!existsSync(candidate) || !existsSync(checksumPath)) return 'checksum';
-  try {
-    const expectedHash = parseSha256Sidecar(readFileSync(checksumPath, 'utf-8'));
-    if (!expectedHash) return 'checksum';
-    const actualHash = sha256Hex(readFileSync(candidate));
-    if (actualHash !== expectedHash) return 'checksum';
-    const metadata = readBundledMetadata(candidate);
-    return bundledMetadataMatchesCurrentPackage(metadata) ? null : 'metadata';
-  } catch {
-    return 'checksum';
-  }
+  return bundledBinaryValidationFailureSync(candidate, expectedBundledMetadataForCurrentPackage());
 }
 
 function hasVerifiedBundledBinary(candidate: string): boolean {
-  return bundledBinaryValidationFailure(candidate) === null;
+  return hasVerifiedBundledBinarySync(candidate, expectedBundledMetadataForCurrentPackage());
 }
 
 function resolveMarkItDownBin(): string | null {

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -8,27 +8,20 @@
  * Spec: 05_PROTOCOL_EXTENSIONS.md §6.5.1
  */
 
-import { createHash } from 'node:crypto';
 import { execFile, execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { platform, arch } from 'node:process';
 import { fileURLToPath } from 'node:url';
 import type { ExtractionPipeline, ExtractionInput, ConverterOutput } from '@origintrail-official/dkg-core';
+import {
+  bundledMarkItDownBuildFingerprint,
+  readCliPackageVersion,
+  sha256Hex,
+  type BundledMarkItDownMetadata,
+} from './markitdown-bundle-metadata.js';
 
 const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
-
-type BundledMarkItDownMetadata = {
-  source?: 'release' | 'build';
-  cliVersion?: string;
-  buildFingerprint?: string;
-};
-
-type BundledMarkItDownBuildConfig = {
-  markItDownUpstreamVersion: string;
-  pyInstallerVersion: string;
-  bundlerScriptBytes: Buffer;
-};
 
 function checksumPathFor(binaryPath: string): string {
   return `${binaryPath}.sha256`;
@@ -43,48 +36,7 @@ function parseSha256Sidecar(text: string): string | null {
   return hash ? hash.toLowerCase() : null;
 }
 
-function sha256Hex(bytes: string | Buffer): string {
-  return createHash('sha256').update(bytes).digest('hex');
-}
-
-function readCliVersion(): string | null {
-  try {
-    const raw = readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf-8');
-    const pkg = JSON.parse(raw) as { version?: unknown };
-    return typeof pkg.version === 'string' && pkg.version.trim().length > 0 ? pkg.version.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
-function readBundledMarkItDownBuildConfig(): BundledMarkItDownBuildConfig | null {
-  try {
-    const bundlerScriptBytes = readFileSync(fileURLToPath(new URL('../../scripts/bundle-markitdown-binaries.mjs', import.meta.url)));
-    const bundlerScriptText = bundlerScriptBytes.toString('utf-8');
-    const markItDownUpstreamVersion = bundlerScriptText.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)';/)?.[1];
-    const pyInstallerVersion = bundlerScriptText.match(/export const PYINSTALLER_VERSION = '([^']+)';/)?.[1];
-    if (!markItDownUpstreamVersion || !pyInstallerVersion) return null;
-    return { markItDownUpstreamVersion, pyInstallerVersion, bundlerScriptBytes };
-  } catch {
-    return null;
-  }
-}
-
-function bundledMarkItDownBuildFingerprint(): string | null {
-  try {
-    const buildConfig = readBundledMarkItDownBuildConfig();
-    if (!buildConfig) return null;
-    const entryScript = readFileSync(fileURLToPath(new URL('../../scripts/markitdown-entry.py', import.meta.url)));
-    return sha256Hex([
-      buildConfig.markItDownUpstreamVersion,
-      buildConfig.pyInstallerVersion,
-      sha256Hex(entryScript),
-      sha256Hex(buildConfig.bundlerScriptBytes),
-    ].join('\n'));
-  } catch {
-    return null;
-  }
-}
+const CLI_DIR = fileURLToPath(new URL('../../', import.meta.url));
 
 function readBundledMetadata(candidate: string): BundledMarkItDownMetadata | null {
   const metadataPath = metadataPathFor(candidate);
@@ -98,11 +50,11 @@ function readBundledMetadata(candidate: string): BundledMarkItDownMetadata | nul
 
 function bundledMetadataMatchesCurrentPackage(metadata: BundledMarkItDownMetadata | null): boolean {
   if (!metadata || typeof metadata !== 'object') return false;
-  const cliVersion = readCliVersion();
+  const cliVersion = readCliPackageVersion(CLI_DIR);
   if (!cliVersion || metadata.cliVersion !== cliVersion) return false;
   if (metadata.source === 'release') return true;
   if (metadata.source !== 'build') return false;
-  const buildFingerprint = bundledMarkItDownBuildFingerprint();
+  const buildFingerprint = bundledMarkItDownBuildFingerprint(CLI_DIR);
   return !!buildFingerprint && metadata.buildFingerprint === buildFingerprint;
 }
 
@@ -174,7 +126,7 @@ async function runMarkItDown(filePath: string): Promise<string> {
   if (!bin) {
     throw new Error(
       'MarkItDown binary not found. Document extraction unavailable. '
-      + 'Install markitdown or place the standalone binary in the node bin/ directory.',
+      + 'Install markitdown on PATH or stage a verified standalone binary with node ./scripts/bundle-markitdown-binaries.mjs.',
     );
   }
 

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -8,8 +8,9 @@
  * Spec: 05_PROTOCOL_EXTENSIONS.md §6.5.1
  */
 
+import { createHash } from 'node:crypto';
 import { execFile, execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { platform, arch } from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -17,12 +18,34 @@ import type { ExtractionPipeline, ExtractionInput, ConverterOutput } from '@orig
 
 const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
 
+function checksumPathFor(binaryPath: string): string {
+  return `${binaryPath}.sha256`;
+}
+
+function parseSha256Sidecar(text: string): string | null {
+  const [hash] = text.trim().split(/\s+/);
+  return hash ? hash.toLowerCase() : null;
+}
+
+function hasVerifiedBundledBinary(candidate: string): boolean {
+  const checksumPath = checksumPathFor(candidate);
+  if (!existsSync(candidate) || !existsSync(checksumPath)) return false;
+  try {
+    const expectedHash = parseSha256Sidecar(readFileSync(checksumPath, 'utf-8'));
+    if (!expectedHash) return false;
+    const actualHash = createHash('sha256').update(readFileSync(candidate)).digest('hex');
+    return actualHash === expectedHash;
+  } catch {
+    return false;
+  }
+}
+
 function resolveMarkItDownBin(): string | null {
   const suffix = platform === 'win32' ? '.exe' : '';
   const binaryName = `markitdown-${platform}-${arch}${suffix}`;
   const binDir = resolve(fileURLToPath(new URL('../../bin', import.meta.url)));
   const candidate = join(binDir, binaryName);
-  if (existsSync(candidate)) return candidate;
+  if (hasVerifiedBundledBinary(candidate)) return candidate;
 
   // Fallback: check if markitdown is on PATH
   const pathBin = `markitdown${suffix}`;

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -17,13 +17,17 @@ import { fileURLToPath } from 'node:url';
 import type { ExtractionPipeline, ExtractionInput, ConverterOutput } from '@origintrail-official/dkg-core';
 
 const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
-const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';
-const PYINSTALLER_VERSION = '6.19.0';
 
 type BundledMarkItDownMetadata = {
   source?: 'release' | 'build';
   cliVersion?: string;
   buildFingerprint?: string;
+};
+
+type BundledMarkItDownBuildConfig = {
+  markItDownUpstreamVersion: string;
+  pyInstallerVersion: string;
+  bundlerScriptBytes: Buffer;
 };
 
 function checksumPathFor(binaryPath: string): string {
@@ -53,15 +57,29 @@ function readCliVersion(): string | null {
   }
 }
 
+function readBundledMarkItDownBuildConfig(): BundledMarkItDownBuildConfig | null {
+  try {
+    const bundlerScriptBytes = readFileSync(fileURLToPath(new URL('../../scripts/bundle-markitdown-binaries.mjs', import.meta.url)));
+    const bundlerScriptText = bundlerScriptBytes.toString('utf-8');
+    const markItDownUpstreamVersion = bundlerScriptText.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)';/)?.[1];
+    const pyInstallerVersion = bundlerScriptText.match(/export const PYINSTALLER_VERSION = '([^']+)';/)?.[1];
+    if (!markItDownUpstreamVersion || !pyInstallerVersion) return null;
+    return { markItDownUpstreamVersion, pyInstallerVersion, bundlerScriptBytes };
+  } catch {
+    return null;
+  }
+}
+
 function bundledMarkItDownBuildFingerprint(): string | null {
   try {
+    const buildConfig = readBundledMarkItDownBuildConfig();
+    if (!buildConfig) return null;
     const entryScript = readFileSync(fileURLToPath(new URL('../../scripts/markitdown-entry.py', import.meta.url)));
-    const bundlerScript = readFileSync(fileURLToPath(new URL('../../scripts/bundle-markitdown-binaries.mjs', import.meta.url)));
     return sha256Hex([
-      MARKITDOWN_UPSTREAM_VERSION,
-      PYINSTALLER_VERSION,
+      buildConfig.markItDownUpstreamVersion,
+      buildConfig.pyInstallerVersion,
       sha256Hex(entryScript),
-      sha256Hex(bundlerScript),
+      sha256Hex(buildConfig.bundlerScriptBytes),
     ].join('\n'));
   } catch {
     return null;

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -17,9 +17,21 @@ import { fileURLToPath } from 'node:url';
 import type { ExtractionPipeline, ExtractionInput, ConverterOutput } from '@origintrail-official/dkg-core';
 
 const MAX_OUTPUT_BYTES = 50 * 1024 * 1024; // 50 MB
+const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';
+const PYINSTALLER_VERSION = '6.19.0';
+
+type BundledMarkItDownMetadata = {
+  source?: 'release' | 'build';
+  cliVersion?: string;
+  buildFingerprint?: string;
+};
 
 function checksumPathFor(binaryPath: string): string {
   return `${binaryPath}.sha256`;
+}
+
+function metadataPathFor(binaryPath: string): string {
+  return `${binaryPath}.meta.json`;
 }
 
 function parseSha256Sidecar(text: string): string | null {
@@ -27,17 +39,72 @@ function parseSha256Sidecar(text: string): string | null {
   return hash ? hash.toLowerCase() : null;
 }
 
-function hasVerifiedBundledBinary(candidate: string): boolean {
+function sha256Hex(bytes: string | Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function readCliVersion(): string | null {
+  try {
+    const raw = readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf-8');
+    const pkg = JSON.parse(raw) as { version?: unknown };
+    return typeof pkg.version === 'string' && pkg.version.trim().length > 0 ? pkg.version.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function bundledMarkItDownBuildFingerprint(): string | null {
+  try {
+    const entryScript = readFileSync(fileURLToPath(new URL('../../scripts/markitdown-entry.py', import.meta.url)));
+    const bundlerScript = readFileSync(fileURLToPath(new URL('../../scripts/bundle-markitdown-binaries.mjs', import.meta.url)));
+    return sha256Hex([
+      MARKITDOWN_UPSTREAM_VERSION,
+      PYINSTALLER_VERSION,
+      sha256Hex(entryScript),
+      sha256Hex(bundlerScript),
+    ].join('\n'));
+  } catch {
+    return null;
+  }
+}
+
+function readBundledMetadata(candidate: string): BundledMarkItDownMetadata | null {
+  const metadataPath = metadataPathFor(candidate);
+  if (!existsSync(metadataPath)) return null;
+  try {
+    return JSON.parse(readFileSync(metadataPath, 'utf-8')) as BundledMarkItDownMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function bundledMetadataMatchesCurrentPackage(metadata: BundledMarkItDownMetadata | null): boolean {
+  if (!metadata || typeof metadata !== 'object') return false;
+  const cliVersion = readCliVersion();
+  if (!cliVersion || metadata.cliVersion !== cliVersion) return false;
+  if (metadata.source === 'release') return true;
+  if (metadata.source !== 'build') return false;
+  const buildFingerprint = bundledMarkItDownBuildFingerprint();
+  return !!buildFingerprint && metadata.buildFingerprint === buildFingerprint;
+}
+
+function bundledBinaryValidationFailure(candidate: string): 'checksum' | 'metadata' | null {
   const checksumPath = checksumPathFor(candidate);
-  if (!existsSync(candidate) || !existsSync(checksumPath)) return false;
+  if (!existsSync(candidate) || !existsSync(checksumPath)) return 'checksum';
   try {
     const expectedHash = parseSha256Sidecar(readFileSync(checksumPath, 'utf-8'));
-    if (!expectedHash) return false;
-    const actualHash = createHash('sha256').update(readFileSync(candidate)).digest('hex');
-    return actualHash === expectedHash;
+    if (!expectedHash) return 'checksum';
+    const actualHash = sha256Hex(readFileSync(candidate));
+    if (actualHash !== expectedHash) return 'checksum';
+    const metadata = readBundledMetadata(candidate);
+    return bundledMetadataMatchesCurrentPackage(metadata) ? null : 'metadata';
   } catch {
-    return false;
+    return 'checksum';
   }
+}
+
+function hasVerifiedBundledBinary(candidate: string): boolean {
+  return bundledBinaryValidationFailure(candidate) === null;
 }
 
 function resolveMarkItDownBin(): string | null {
@@ -47,10 +114,18 @@ function resolveMarkItDownBin(): string | null {
   const candidate = join(binDir, binaryName);
   if (hasVerifiedBundledBinary(candidate)) return candidate;
   if (existsSync(candidate)) {
-    console.warn(
-      `Ignoring bundled MarkItDown binary without a valid checksum sidecar (${candidate}). `
-      + 'Rerun the staging flow or remove the stale file to use a verified bundled converter.',
-    );
+    const failure = bundledBinaryValidationFailure(candidate);
+    if (failure === 'metadata') {
+      console.warn(
+        `Ignoring bundled MarkItDown binary with incompatible metadata sidecar (${candidate}). `
+        + 'Rerun the staging flow or remove the stale file to use a bundled converter that matches this package version.',
+      );
+    } else {
+      console.warn(
+        `Ignoring bundled MarkItDown binary without a valid checksum sidecar (${candidate}). `
+        + 'Rerun the staging flow or remove the stale file to use a verified bundled converter.',
+      );
+    }
   }
 
   // Fallback: check if markitdown is on PATH

--- a/packages/cli/src/extraction/markitdown-converter.ts
+++ b/packages/cli/src/extraction/markitdown-converter.ts
@@ -46,6 +46,12 @@ function resolveMarkItDownBin(): string | null {
   const binDir = resolve(fileURLToPath(new URL('../../bin', import.meta.url)));
   const candidate = join(binDir, binaryName);
   if (hasVerifiedBundledBinary(candidate)) return candidate;
+  if (existsSync(candidate)) {
+    console.warn(
+      `Ignoring bundled MarkItDown binary without a valid checksum sidecar (${candidate}). `
+      + 'Rerun the staging flow or remove the stale file to use a verified bundled converter.',
+    );
+  }
 
   // Fallback: check if markitdown is on PATH
   const pathBin = `markitdown${suffix}`;

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -11,6 +11,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
   return {
     ...actual,
+    copyFile: vi.fn(),
     readFile: vi.fn(),
     writeFile: vi.fn(),
     mkdir: vi.fn(),
@@ -51,12 +52,13 @@ vi.mock('../src/config.js', async (importOriginal) => {
   };
 });
 
-import { readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { copyFile, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
 import { existsSync, openSync, closeSync, writeFileSync as fsWriteFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { exec, execFile } from 'node:child_process';
 import { checkForNewCommitWithStatus, checkForUpdate, performUpdate, performNpmUpdate } from '../src/daemon.js';
 import { swapSlot } from '../src/config.js';
 
+const mockedCopyFile = vi.mocked(copyFile);
 const mockedReadFile = vi.mocked(readFile);
 const mockedWriteFile = vi.mocked(writeFile);
 const mockedMkdir = vi.mocked(mkdir);
@@ -110,6 +112,7 @@ describe('blue-green checkForUpdate', () => {
     vi.resetAllMocks();
     mockActiveSlot = 'a';
     mockedExistsSync.mockReturnValue(true);
+    mockedCopyFile.mockResolvedValue(undefined as any);
     mockedMkdir.mockResolvedValue(undefined as any);
     mockedRm.mockResolvedValue(undefined as any);
     mockedOpenSync.mockReturnValue(99 as any);
@@ -381,6 +384,24 @@ describe('blue-green checkForUpdate', () => {
     expect(result).toBe(true);
     expect(mockedSwapSlot).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
+  });
+
+  it('reuses the active-slot MarkItDown binary when staging misses it during git update', async () => {
+    mockedReadFile.mockResolvedValueOnce('aaa111' as any);
+    makeFetchOk('newcommit');
+
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/packages/cli/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/packages/cli/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performUpdate(AU, log);
+    expect(result).toBe(true);
+    expect(mockedCopyFile).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
   });
 
   it('self-heals when target slot has no .git directory (empty dir from failed migration)', async () => {
@@ -742,6 +763,21 @@ describe('performNpmUpdate', () => {
     expect(result).toBe('updated');
     expect(mockedSwapSlot).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
+  });
+
+  it('reuses the active-slot MarkItDown binary when npm install leaves it missing', async () => {
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performNpmUpdate('9.0.0-beta.5', log);
+    expect(result).toBe('updated');
+    expect(mockedCopyFile).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
   });
 
   it('recovers pending state if swap succeeded but version was not written', async () => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -7,12 +7,29 @@ const MARKITDOWN_TARGETS_JSON = JSON.stringify([
   { platform: 'darwin', arch: 'arm64', assetName: 'markitdown-darwin-arm64', runner: 'macos-14' },
   { platform: 'win32', arch: 'x64', assetName: 'markitdown-win32-x64.exe', runner: 'windows-latest' },
 ]);
+const CLI_VERSION = '9.0.0-beta.6';
+const MOCK_MARKITDOWN_ENTRY_SCRIPT = '# mock markitdown entry script\n';
+const MOCK_BUNDLER_SCRIPT = [
+  "export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';",
+  "export const PYINSTALLER_VERSION = '6.19.0';",
+].join('\n');
+
+function buildFingerprintForTest(): string {
+  return sha256HexForTest([
+    '0.1.5',
+    '6.19.0',
+    sha256HexForTest(MOCK_MARKITDOWN_ENTRY_SCRIPT),
+    sha256HexForTest(MOCK_BUNDLER_SCRIPT),
+  ].join('\n'));
+}
 
 function mockReadFileSyncValue(path: unknown): string {
   const normalized = String(path).replace(/\\/g, '/');
   if (normalized.endsWith('/markitdown-targets.json')) return MARKITDOWN_TARGETS_JSON;
-  if (normalized.endsWith('/package.json')) return JSON.stringify({ version: '9.0.0-beta.6' });
-  return `${process.pid}:${Date.now()}:testtoken`;
+  if (normalized.endsWith('/scripts/markitdown-entry.py')) return MOCK_MARKITDOWN_ENTRY_SCRIPT;
+  if (normalized.endsWith('/scripts/bundle-markitdown-binaries.mjs')) return MOCK_BUNDLER_SCRIPT;
+  if (normalized.endsWith('/package.json')) return JSON.stringify({ version: CLI_VERSION });
+  return 'testtoken';
 }
 
 vi.mock('node:child_process', () => ({
@@ -417,6 +434,9 @@ describe('blue-green checkForUpdate', () => {
     mockedReadFile.mockImplementation(async (path: any) => {
       const normalized = normalizePathString(path);
       if (normalized.endsWith('.current-commit')) return 'aaa111' as any;
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+        return JSON.stringify({ source: 'build', cliVersion: CLI_VERSION, buildFingerprint: buildFingerprintForTest() }) as any;
+      }
       if (normalized.includes('/releases/a/packages/cli/bin/markitdown-') && normalized.endsWith('.sha256')) {
         const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
         return `${sourceHash}  ${assetName}\n` as any;
@@ -447,6 +467,9 @@ describe('blue-green checkForUpdate', () => {
     mockedReadFile.mockImplementation(async (path: any) => {
       const normalized = normalizePathString(path);
       if (normalized.endsWith('.current-commit')) return 'aaa111' as any;
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+        return JSON.stringify({ source: 'build', cliVersion: CLI_VERSION, buildFingerprint: buildFingerprintForTest() }) as any;
+      }
       if (normalized.includes('/releases/a/packages/cli/bin/markitdown-') && normalized.endsWith('.sha256')) {
         const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
         return `${sourceHash}  ${assetName}\n` as any;
@@ -838,6 +861,9 @@ describe('performNpmUpdate', () => {
     mockedReadFile.mockImplementation(async (path: any) => {
       const normalized = normalizePathString(path);
       if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+        return JSON.stringify({ source: 'release', cliVersion: '9.0.0-beta.5' }) as any;
+      }
       if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.sha256')) {
         const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
         return `${sourceHash}  ${assetName}\n` as any;
@@ -859,6 +885,38 @@ describe('performNpmUpdate', () => {
     expect(mockedCopyFile).toHaveBeenCalled();
     expect(mockedChmod).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
+  });
+
+  it('skips active-slot MarkItDown reuse when metadata targets a different npm version', async () => {
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+        return JSON.stringify({ source: 'release', cliVersion: '9.0.0-beta.4' }) as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.sha256')) {
+        const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+        return `${sha256HexForTest(Buffer.from('active-slot-markitdown', 'utf-8'))}  ${assetName}\n` as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) {
+        return Buffer.from('active-slot-markitdown', 'utf-8') as any;
+      }
+      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    });
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performNpmUpdate('9.0.0-beta.5', log);
+    expect(result).toBe('updated');
+    expect(mockedCopyFile).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('incompatible metadata'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
   });
 
   it('skips active-slot MarkItDown reuse when the checksum sidecar is missing', async () => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -240,7 +240,7 @@ describe('blue-green checkForUpdate', () => {
     expect(allCmds.some(c => c.cmd.includes('pnpm install') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm build') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('bundle-markitdown-binaries.mjs') && c.cwd === targetDir)).toBe(true);
-    expect(allCmds.some(c => c.cmd.includes('--force') && c.cwd === targetDir)).toBe(true);
+    expect(allCmds.some(c => c.cmd.includes('--force') && c.cwd === targetDir)).toBe(false);
     expect(allCmds.some(c => c.cmd.includes('--best-effort') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm --filter @origintrail-official/dkg-evm-module build') && c.cwd === targetDir)).toBe(false);
 

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AutoUpdateConfig } from '../src/config.js';
 
+const MARKITDOWN_TARGETS_JSON = JSON.stringify([
+  { platform: 'linux', arch: 'x64', assetName: 'markitdown-linux-x64', runner: 'ubuntu-latest' },
+  { platform: 'darwin', arch: 'arm64', assetName: 'markitdown-darwin-arm64', runner: 'macos-14' },
+  { platform: 'win32', arch: 'x64', assetName: 'markitdown-win32-x64.exe', runner: 'windows-latest' },
+]);
+
+function mockReadFileSyncValue(path: unknown): string {
+  const normalized = String(path).replace(/\\/g, '/');
+  if (normalized.endsWith('/markitdown-targets.json')) return MARKITDOWN_TARGETS_JSON;
+  if (normalized.endsWith('/package.json')) return JSON.stringify({ version: '9.0.0-beta.6' });
+  return `${process.pid}:${Date.now()}:testtoken`;
+}
+
 vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
   exec: vi.fn((_cmd: string, _opts: any, cb: Function) => cb(null, '', '')),
@@ -31,7 +44,7 @@ vi.mock('node:fs', async (importOriginal) => {
     openSync: vi.fn(() => 99),
     closeSync: vi.fn(),
     writeFileSync: vi.fn(),
-    readFileSync: vi.fn(() => `${process.pid}:${Date.now()}:testtoken`),
+    readFileSync: vi.fn((path: unknown) => mockReadFileSyncValue(path)),
     unlinkSync: vi.fn(),
   };
 });
@@ -118,7 +131,7 @@ describe('blue-green checkForUpdate', () => {
     mockedOpenSync.mockReturnValue(99 as any);
     mockedCloseSync.mockReturnValue(undefined as any);
     mockedFsWriteFileSync.mockReturnValue(undefined as any);
-    mockedReadFileSync.mockReturnValue(`${process.pid}:${Date.now()}:testtoken` as any);
+    mockedReadFileSync.mockImplementation((path: unknown) => mockReadFileSyncValue(path) as any);
     mockedUnlinkSync.mockReturnValue(undefined as any);
     (mockedExec as any).mockImplementation((_cmd: string, _opts: any, cb: Function) => cb(null, '', ''));
     (mockedExecFile as any).mockImplementation((_file: string, _args: string[], _opts: any, cb: Function) => cb(null, '', ''));

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -222,6 +222,7 @@ describe('blue-green checkForUpdate', () => {
     expect(allCmds.some(c => c.cmd.includes('pnpm install') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm build') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('bundle-markitdown-binaries.mjs') && c.cwd === targetDir)).toBe(true);
+    expect(allCmds.some(c => c.cmd.includes('--force') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('--best-effort') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm --filter @origintrail-official/dkg-evm-module build') && c.cwd === targetDir)).toBe(false);
 

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -78,6 +78,10 @@ const AU: AutoUpdateConfig = {
   checkIntervalMinutes: 30,
 };
 
+function normalizePathString(value: unknown): string {
+  return String(value).replace(/\\/g, '/');
+}
+
 function makeFetchOk(sha: string) {
   fetchMock.mockResolvedValueOnce({
     ok: true,
@@ -88,7 +92,7 @@ function makeFetchOk(sha: string) {
 function getExecCalls() {
   return mockedExec.mock.calls.map(c => ({
     cmd: String(c[0]),
-    cwd: (c[1] as any)?.cwd,
+    cwd: normalizePathString((c[1] as any)?.cwd),
   }));
 }
 
@@ -96,7 +100,7 @@ function getExecFileCalls() {
   return mockedExecFile.mock.calls.map(c => ({
     file: String(c[0]),
     args: (c[1] as string[]) ?? [],
-    cwd: (c[2] as any)?.cwd,
+    cwd: normalizePathString((c[2] as any)?.cwd),
     env: (c[2] as any)?.env,
   }));
 }
@@ -128,7 +132,7 @@ describe('blue-green checkForUpdate', () => {
 
   it('reinitializes missing target slot git metadata before fetch', async () => {
     mockedExistsSync.mockImplementation((p: any) => {
-      const path = String(p);
+      const path = normalizePathString(p);
       if (path.endsWith('/releases/a')) return true; // active slot path
       if (path.endsWith('/releases/b/.git')) return false; // target slot missing git metadata
       if (path.includes('cli.js')) return true;
@@ -214,6 +218,7 @@ describe('blue-green checkForUpdate', () => {
     expect(gitCmds.some(c => c.file === 'git' && c.args[0] === 'checkout' && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm install') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm build') && c.cwd === targetDir)).toBe(true);
+    expect(allCmds.some(c => c.cmd.includes('bundle-markitdown-binaries.mjs') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm --filter @origintrail-official/dkg-evm-module build') && c.cwd === targetDir)).toBe(false);
 
     const activeDir = '/tmp/dkg-test/releases/a';
@@ -229,10 +234,10 @@ describe('blue-green checkForUpdate', () => {
     await performUpdate(AU, vi.fn());
 
     expect(mockedSwapSlot).toHaveBeenCalledWith('b');
-    expect(mockedWriteFile).toHaveBeenCalledWith(
-      '/tmp/dkg-test/.current-commit',
-      latest,
-    );
+    expect(
+      mockedWriteFile.mock.calls.some((call) =>
+        normalizePathString(call[0]).endsWith('/tmp/dkg-test/.current-commit') && call[1] === latest)
+    ).toBe(true);
   });
 
   it('returns true after swap via checkForUpdate', async () => {
@@ -348,7 +353,7 @@ describe('blue-green checkForUpdate', () => {
 
     // existsSync returns true for dirs but false for cli.js entry file
     mockedExistsSync.mockImplementation((p: any) => {
-      const path = String(p);
+      const path = normalizePathString(p);
       if (path.includes('cli.js')) return false;
       return true;
     });
@@ -360,9 +365,26 @@ describe('blue-green checkForUpdate', () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining('build output missing'));
   });
 
+  it('aborts swap when the bundled MarkItDown binary is missing after build', async () => {
+    mockedReadFile.mockResolvedValueOnce('aaa111' as any);
+    makeFetchOk('newcommit');
+
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performUpdate(AU, log);
+    expect(result).toBe(false);
+    expect(mockedSwapSlot).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('bundled MarkItDown binary missing'));
+  });
+
   it('self-heals when target slot has no .git directory (empty dir from failed migration)', async () => {
     mockedExistsSync.mockImplementation((p: any) => {
-      const path = String(p);
+      const path = normalizePathString(p);
       if (path.endsWith('/releases/a')) return true;
       if (path.endsWith('/releases/b/.git')) return false;
       if (path.includes('cli.js')) return true;
@@ -545,7 +567,7 @@ describe('blue-green checkForUpdate', () => {
 
   it('blocks pre-release versions unless allowPrerelease is true', async () => {
     mockedReadFile.mockImplementation(async (path: any) => {
-      const p = String(path);
+      const p = normalizePathString(path);
       if (p.endsWith('.current-commit')) return 'aaa111' as any;
       if (p.endsWith('.update-pending.json')) throw new Error('ENOENT');
       if (p.endsWith('/packages/cli/package.json')) return JSON.stringify({ version: '9.0.5-rc.1' }) as any;
@@ -562,7 +584,7 @@ describe('blue-green checkForUpdate', () => {
 
   it('allows pre-release versions when allowPrerelease=true', async () => {
     mockedReadFile.mockImplementation(async (path: any) => {
-      const p = String(path);
+      const p = normalizePathString(path);
       if (p.endsWith('.current-commit')) return 'aaa111' as any;
       if (p.endsWith('.update-pending.json')) throw new Error('ENOENT');
       if (p.endsWith('/packages/cli/package.json')) return JSON.stringify({ version: '9.0.5-rc.1' }) as any;
@@ -706,6 +728,19 @@ describe('performNpmUpdate', () => {
     const result = await performNpmUpdate('9.0.0-beta.5', log);
     expect(result).toBe('failed');
     expect(mockedSwapSlot).not.toHaveBeenCalled();
+  });
+
+  it('returns failed when the bundled MarkItDown binary is missing after install', async () => {
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = String(p);
+      if (path.includes('markitdown-')) return false;
+      return true;
+    });
+    const log = vi.fn();
+    const result = await performNpmUpdate('9.0.0-beta.5', log);
+    expect(result).toBe('failed');
+    expect(mockedSwapSlot).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('bundled MarkItDown binary missing'));
   });
 
   it('recovers pending state if swap succeeded but version was not written', async () => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -8,6 +8,10 @@ const MARKITDOWN_TARGETS_JSON = JSON.stringify([
   { platform: 'win32', arch: 'x64', assetName: 'markitdown-win32-x64.exe', runner: 'windows-latest' },
 ]);
 const CLI_VERSION = '9.0.0-beta.6';
+const MARKITDOWN_BUILD_INFO_JSON = JSON.stringify({
+  markItDownUpstreamVersion: '0.1.5',
+  pyInstallerVersion: '6.19.0',
+});
 const MOCK_MARKITDOWN_ENTRY_SCRIPT = '# mock markitdown entry script\n';
 const MOCK_BUNDLER_SCRIPT = [
   "export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';",
@@ -28,6 +32,7 @@ function buildFingerprintForTest(): string {
 function mockReadFileSyncValue(path: unknown): string {
   const normalized = String(path).replace(/\\/g, '/');
   if (normalized.endsWith('/markitdown-targets.json')) return MARKITDOWN_TARGETS_JSON;
+  if (normalized.endsWith('/markitdown-build-info.json')) return MARKITDOWN_BUILD_INFO_JSON;
   if (normalized.endsWith('/scripts/markitdown-entry.py')) return MOCK_MARKITDOWN_ENTRY_SCRIPT;
   if (normalized.endsWith('/scripts/bundle-markitdown-binaries.mjs')) return MOCK_BUNDLER_SCRIPT;
   if (normalized.includes('/node_modules/@origintrail-official/dkg/package.json')) {
@@ -1032,6 +1037,41 @@ describe('performNpmUpdate', () => {
       expect.stringContaining('.current-version'),
       '9.0.0-beta.6',
     );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
+  });
+
+  it('reuses a fingerprint-compatible active-slot MarkItDown binary across CLI version bumps', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.6';
+    const sourceBytes = Buffer.from('active-slot-markitdown', 'utf-8');
+    const sourceHash = sha256HexForTest(sourceBytes);
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+        return JSON.stringify({
+          source: 'release',
+          cliVersion: '9.0.0-beta.5',
+          buildFingerprint: buildFingerprintForTest(),
+        }) as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.sha256')) {
+        const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+        return `${sourceHash}  ${assetName}\n` as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return sourceBytes as any;
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    });
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performNpmUpdate('9.0.0-beta.6', log);
+    expect(result).toBe('updated');
+    expect(mockedCopyFile).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
   });
 

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -271,6 +271,26 @@ describe('blue-green checkForUpdate', () => {
     expect(allCmds.every(c => c.cwd !== activeDir)).toBe(true);
   });
 
+  it('continues the update when MarkItDown staging fails inside the best-effort git-update step', async () => {
+    const current = 'aaa111';
+    const latest = 'bbb223';
+    mockedReadFile.mockResolvedValueOnce(current as any);
+    makeFetchOk(latest);
+    (mockedExec as any).mockImplementation((cmd: string, _opts: any, cb: Function) => {
+      if (String(cmd).includes('bundle-markitdown-binaries.mjs')) {
+        return cb(new Error('markitdown staging spawn failed'), '', '');
+      }
+      return cb(null, '', '');
+    });
+
+    const log = vi.fn();
+    const result = await performUpdate(AU, log);
+    expect(result).toBe(true);
+    expect(mockedSwapSlot).toHaveBeenCalledWith('b');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('MarkItDown staging failed in slot b'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
+  });
+
   it('swaps symlink after successful build', async () => {
     const current = 'aaa111';
     const latest = 'ccc333';

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -219,6 +219,7 @@ describe('blue-green checkForUpdate', () => {
     expect(allCmds.some(c => c.cmd.includes('pnpm install') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm build') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('bundle-markitdown-binaries.mjs') && c.cwd === targetDir)).toBe(true);
+    expect(allCmds.some(c => c.cmd.includes('--best-effort') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm --filter @origintrail-official/dkg-evm-module build') && c.cwd === targetDir)).toBe(false);
 
     const activeDir = '/tmp/dkg-test/releases/a';
@@ -365,7 +366,7 @@ describe('blue-green checkForUpdate', () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining('build output missing'));
   });
 
-  it('aborts swap when the bundled MarkItDown binary is missing after build', async () => {
+  it('continues the swap when the bundled MarkItDown binary is missing after build', async () => {
     mockedReadFile.mockResolvedValueOnce('aaa111' as any);
     makeFetchOk('newcommit');
 
@@ -377,9 +378,9 @@ describe('blue-green checkForUpdate', () => {
 
     const log = vi.fn();
     const result = await performUpdate(AU, log);
-    expect(result).toBe(false);
-    expect(mockedSwapSlot).not.toHaveBeenCalled();
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('bundled MarkItDown binary missing'));
+    expect(result).toBe(true);
+    expect(mockedSwapSlot).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
   });
 
   it('self-heals when target slot has no .git directory (empty dir from failed migration)', async () => {
@@ -730,7 +731,7 @@ describe('performNpmUpdate', () => {
     expect(mockedSwapSlot).not.toHaveBeenCalled();
   });
 
-  it('returns failed when the bundled MarkItDown binary is missing after install', async () => {
+  it('continues when the bundled MarkItDown binary is missing after install', async () => {
     mockedExistsSync.mockImplementation((p: any) => {
       const path = String(p);
       if (path.includes('markitdown-')) return false;
@@ -738,9 +739,9 @@ describe('performNpmUpdate', () => {
     });
     const log = vi.fn();
     const result = await performNpmUpdate('9.0.0-beta.5', log);
-    expect(result).toBe('failed');
-    expect(mockedSwapSlot).not.toHaveBeenCalled();
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('bundled MarkItDown binary missing'));
+    expect(result).toBe('updated');
+    expect(mockedSwapSlot).toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
   });
 
   it('recovers pending state if swap succeeded but version was not written', async () => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -25,8 +25,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>();
   return {
     ...actual,
+    chmod: vi.fn(),
     copyFile: vi.fn(),
     readFile: vi.fn(),
+    stat: vi.fn(),
     writeFile: vi.fn(),
     mkdir: vi.fn(),
     rm: vi.fn(),
@@ -66,14 +68,16 @@ vi.mock('../src/config.js', async (importOriginal) => {
   };
 });
 
-import { copyFile, readFile, writeFile, mkdir, rm } from 'node:fs/promises';
+import { chmod, copyFile, readFile, stat, writeFile, mkdir, rm } from 'node:fs/promises';
 import { existsSync, openSync, closeSync, writeFileSync as fsWriteFileSync, readFileSync, unlinkSync } from 'node:fs';
 import { exec, execFile } from 'node:child_process';
 import { checkForNewCommitWithStatus, checkForUpdate, performUpdate, performNpmUpdate } from '../src/daemon.js';
 import { swapSlot } from '../src/config.js';
 
+const mockedChmod = vi.mocked(chmod);
 const mockedCopyFile = vi.mocked(copyFile);
 const mockedReadFile = vi.mocked(readFile);
+const mockedStat = vi.mocked(stat);
 const mockedWriteFile = vi.mocked(writeFile);
 const mockedMkdir = vi.mocked(mkdir);
 const mockedRm = vi.mocked(rm);
@@ -130,7 +134,9 @@ describe('blue-green checkForUpdate', () => {
     vi.resetAllMocks();
     mockActiveSlot = 'a';
     mockedExistsSync.mockReturnValue(true);
+    mockedChmod.mockResolvedValue(undefined as any);
     mockedCopyFile.mockResolvedValue(undefined as any);
+    mockedStat.mockResolvedValue({ mode: 0o755 } as any);
     mockedMkdir.mockResolvedValue(undefined as any);
     mockedRm.mockResolvedValue(undefined as any);
     mockedOpenSync.mockReturnValue(99 as any);
@@ -431,6 +437,7 @@ describe('blue-green checkForUpdate', () => {
     const result = await performUpdate(AU, log);
     expect(result).toBe(true);
     expect(mockedCopyFile).toHaveBeenCalled();
+    expect(mockedChmod).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
   });
 
@@ -850,6 +857,7 @@ describe('performNpmUpdate', () => {
     const result = await performNpmUpdate('9.0.0-beta.5', log);
     expect(result).toBe('updated');
     expect(mockedCopyFile).toHaveBeenCalled();
+    expect(mockedChmod).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
   });
 

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -13,6 +13,8 @@ const MOCK_BUNDLER_SCRIPT = [
   "export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';",
   "export const PYINSTALLER_VERSION = '6.19.0';",
 ].join('\n');
+let mockBundledCliPackageVersion = CLI_VERSION;
+let mockInstalledPackageVersion = '9.0.0-beta.4-dev.100.abc1234';
 
 function buildFingerprintForTest(): string {
   return sha256HexForTest([
@@ -28,7 +30,12 @@ function mockReadFileSyncValue(path: unknown): string {
   if (normalized.endsWith('/markitdown-targets.json')) return MARKITDOWN_TARGETS_JSON;
   if (normalized.endsWith('/scripts/markitdown-entry.py')) return MOCK_MARKITDOWN_ENTRY_SCRIPT;
   if (normalized.endsWith('/scripts/bundle-markitdown-binaries.mjs')) return MOCK_BUNDLER_SCRIPT;
-  if (normalized.endsWith('/package.json')) return JSON.stringify({ version: CLI_VERSION });
+  if (normalized.includes('/node_modules/@origintrail-official/dkg/package.json')) {
+    return JSON.stringify({ version: mockInstalledPackageVersion });
+  }
+  if (normalized.endsWith('/packages/cli/package.json')) {
+    return JSON.stringify({ version: mockBundledCliPackageVersion });
+  }
   return 'testtoken';
 }
 
@@ -818,6 +825,8 @@ describe('performNpmUpdate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockActiveSlot = 'a';
+    mockBundledCliPackageVersion = CLI_VERSION;
+    mockInstalledPackageVersion = '9.0.0-beta.4-dev.100.abc1234';
     mockedExistsSync.mockReturnValue(true);
     mockedMkdir.mockResolvedValue(undefined as any);
     mockedRm.mockResolvedValue(undefined as any);
@@ -863,6 +872,7 @@ describe('performNpmUpdate', () => {
   });
 
   it('continues when the bundled MarkItDown binary is missing after install', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.5';
     mockedExistsSync.mockImplementation((p: any) => {
       const path = String(p);
       if (path.includes('markitdown-')) return false;
@@ -876,6 +886,7 @@ describe('performNpmUpdate', () => {
   });
 
   it('reuses the active-slot MarkItDown binary when npm install leaves it missing', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.5';
     const sourceBytes = Buffer.from('active-slot-markitdown', 'utf-8');
     const sourceHash = sha256HexForTest(sourceBytes);
     mockedReadFile.mockImplementation(async (path: any) => {
@@ -889,7 +900,6 @@ describe('performNpmUpdate', () => {
         return `${sourceHash}  ${assetName}\n` as any;
       }
       if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return sourceBytes as any;
-      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
       throw new Error(`Unexpected readFile: ${normalized}`);
     });
     mockedExistsSync.mockImplementation((p: any) => {
@@ -908,6 +918,7 @@ describe('performNpmUpdate', () => {
   });
 
   it('skips active-slot MarkItDown reuse when metadata targets a different npm version', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.5';
     mockedReadFile.mockImplementation(async (path: any) => {
       const normalized = normalizePathString(path);
       if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
@@ -921,7 +932,6 @@ describe('performNpmUpdate', () => {
       if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) {
         return Buffer.from('active-slot-markitdown', 'utf-8') as any;
       }
-      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
       throw new Error(`Unexpected readFile: ${normalized}`);
     });
     mockedExistsSync.mockImplementation((p: any) => {
@@ -940,10 +950,10 @@ describe('performNpmUpdate', () => {
   });
 
   it('skips active-slot MarkItDown reuse when the checksum sidecar is missing', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.5';
     mockedReadFile.mockImplementation(async (path: any) => {
       const normalized = normalizePathString(path);
       if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
-      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
       throw new Error(`Unexpected readFile: ${normalized}`);
     });
     mockedExistsSync.mockImplementation((p: any) => {
@@ -963,13 +973,13 @@ describe('performNpmUpdate', () => {
   });
 
   it('does not probe a source-slot build binary as an npm reuse candidate', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.5';
     mockedReadFile.mockImplementation(async (path: any) => {
       const normalized = normalizePathString(path);
       if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
       if (normalized.includes('/releases/a/packages/cli/bin/markitdown-')) {
         throw new Error(`npm update should not inspect source-slot MarkItDown candidates: ${normalized}`);
       }
-      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
       throw new Error(`Unexpected readFile: ${normalized}`);
     });
     mockedExistsSync.mockImplementation((p: any) => {
@@ -988,6 +998,41 @@ describe('performNpmUpdate', () => {
       ([path]) => normalizePathString(path).includes('/releases/a/packages/cli/bin/markitdown-'),
     )).toBe(false);
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
+  });
+
+  it('validates npm-installed MarkItDown metadata against the resolved package version instead of the requested spec', async () => {
+    mockInstalledPackageVersion = '9.0.0-beta.6';
+    const sourceBytes = Buffer.from('active-slot-markitdown', 'utf-8');
+    const sourceHash = sha256HexForTest(sourceBytes);
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+        return JSON.stringify({ source: 'release', cliVersion: '9.0.0-beta.6' }) as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.sha256')) {
+        const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+        return `${sourceHash}  ${assetName}\n` as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return sourceBytes as any;
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    });
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performNpmUpdate('latest', log);
+    expect(result).toBe('updated');
+    expect(mockedCopyFile).toHaveBeenCalled();
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('.current-version'),
+      '9.0.0-beta.6',
+    );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
   });
 
   it('recovers pending state if swap succeeded but version was not written', async () => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -942,6 +942,34 @@ describe('performNpmUpdate', () => {
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
   });
 
+  it('does not probe a source-slot build binary as an npm reuse candidate', async () => {
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-')) {
+        throw new Error(`npm update should not inspect source-slot MarkItDown candidates: ${normalized}`);
+      }
+      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    });
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/packages/cli/bin/markitdown-')) return true;
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      if (path.includes('/releases/b/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performNpmUpdate('9.0.0-beta.5', log);
+    expect(result).toBe('updated');
+    expect(mockedCopyFile).not.toHaveBeenCalled();
+    expect(mockedExistsSync.mock.calls.some(
+      ([path]) => normalizePathString(path).includes('/releases/a/packages/cli/bin/markitdown-'),
+    )).toBe(false);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
+  });
+
   it('recovers pending state if swap succeeded but version was not written', async () => {
     mockActiveSlot = 'b';
     mockedReadFile.mockImplementation(async (path: any) => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { AutoUpdateConfig } from '../src/config.js';
 
@@ -95,6 +96,10 @@ const AU: AutoUpdateConfig = {
 
 function normalizePathString(value: unknown): string {
   return String(value).replace(/\\/g, '/');
+}
+
+function sha256HexForTest(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
 }
 
 function makeFetchOk(sha: string) {
@@ -401,7 +406,18 @@ describe('blue-green checkForUpdate', () => {
   });
 
   it('reuses the active-slot MarkItDown binary when staging misses it during git update', async () => {
-    mockedReadFile.mockResolvedValueOnce('aaa111' as any);
+    const sourceBytes = Buffer.from('active-slot-markitdown', 'utf-8');
+    const sourceHash = sha256HexForTest(sourceBytes);
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.current-commit')) return 'aaa111' as any;
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-') && normalized.endsWith('.sha256')) {
+        const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+        return `${sourceHash}  ${assetName}\n` as any;
+      }
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-')) return sourceBytes as any;
+      throw new Error(`Unexpected readFile path: ${normalized}`);
+    });
     makeFetchOk('newcommit');
 
     mockedExistsSync.mockImplementation((p: any) => {
@@ -416,6 +432,36 @@ describe('blue-green checkForUpdate', () => {
     expect(result).toBe(true);
     expect(mockedCopyFile).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
+  });
+
+  it('continues the update when active-slot MarkItDown reuse copy fails', async () => {
+    const sourceBytes = Buffer.from('active-slot-markitdown', 'utf-8');
+    const sourceHash = sha256HexForTest(sourceBytes);
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.current-commit')) return 'aaa111' as any;
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-') && normalized.endsWith('.sha256')) {
+        const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+        return `${sourceHash}  ${assetName}\n` as any;
+      }
+      if (normalized.includes('/releases/a/packages/cli/bin/markitdown-')) return sourceBytes as any;
+      throw new Error(`Unexpected readFile path: ${normalized}`);
+    });
+    makeFetchOk('newcommit');
+    mockedCopyFile.mockRejectedValueOnce(new Error('disk full') as any);
+
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/packages/cli/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/packages/cli/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performUpdate(AU, log);
+    expect(result).toBe(true);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('failed to reuse bundled MarkItDown binary from the active slot'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
   });
 
   it('self-heals when target slot has no .git directory (empty dir from failed migration)', async () => {
@@ -780,6 +826,19 @@ describe('performNpmUpdate', () => {
   });
 
   it('reuses the active-slot MarkItDown binary when npm install leaves it missing', async () => {
+    const sourceBytes = Buffer.from('active-slot-markitdown', 'utf-8');
+    const sourceHash = sha256HexForTest(sourceBytes);
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && normalized.endsWith('.sha256')) {
+        const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+        return `${sourceHash}  ${assetName}\n` as any;
+      }
+      if (normalized.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return sourceBytes as any;
+      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    });
     mockedExistsSync.mockImplementation((p: any) => {
       const path = normalizePathString(p);
       if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return true;
@@ -792,6 +851,29 @@ describe('performNpmUpdate', () => {
     expect(result).toBe('updated');
     expect(mockedCopyFile).toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining('reused bundled MarkItDown binary from the active slot'));
+  });
+
+  it('skips active-slot MarkItDown reuse when the checksum sidecar is missing', async () => {
+    mockedReadFile.mockImplementation(async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.4-dev.100.abc1234' }) as any;
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    });
+    mockedExistsSync.mockImplementation((p: any) => {
+      const path = normalizePathString(p);
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-') && path.endsWith('.sha256')) return false;
+      if (path.includes('/releases/a/node_modules/@origintrail-official/dkg/bin/markitdown-')) return true;
+      if (path.includes('/releases/b/node_modules/@origintrail-official/dkg/bin/markitdown-')) return false;
+      return true;
+    });
+
+    const log = vi.fn();
+    const result = await performNpmUpdate('9.0.0-beta.5', log);
+    expect(result).toBe('updated');
+    expect(mockedCopyFile).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('skipping active-slot bundled MarkItDown binary without a valid checksum sidecar'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Continuing without document conversion'));
   });
 
   it('recovers pending state if swap succeeded but version was not written', async () => {

--- a/packages/cli/test/document-processor-e2e.test.ts
+++ b/packages/cli/test/document-processor-e2e.test.ts
@@ -113,7 +113,7 @@ describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion',
     expect(result.mdIntermediate).toBeTruthy();
     expect(result.mdIntermediate).toContain('Research Paper');
     expect(result.mdIntermediate).toContain('decentralized knowledge graphs');
-  });
+  }, 30_000);
 
   it('converts a CSV file to Markdown', async () => {
     const csvFile = join(tmpDir, 'data.csv');
@@ -129,7 +129,7 @@ describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion',
     expect(result.mdIntermediate).toContain('Alice');
     expect(result.mdIntermediate).toContain('Bob');
     expect(result.mdIntermediate).toContain('Researcher');
-  });
+  }, 30_000);
 
   it('handles empty file gracefully', async () => {
     const emptyFile = join(tmpDir, 'empty.html');
@@ -142,7 +142,7 @@ describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion',
     });
 
     expect(typeof result.mdIntermediate).toBe('string');
-  });
+  }, 30_000);
 
   it('processes file through registry lookup → extract', async () => {
     const registry = new ExtractionPipelineRegistry();
@@ -162,7 +162,7 @@ describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion',
 
     expect(result.mdIntermediate).toContain('Title');
     expect(result.mdIntermediate).toContain('Body text');
-  });
+  }, 30_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/document-processor-e2e.test.ts
+++ b/packages/cli/test/document-processor-e2e.test.ts
@@ -93,6 +93,7 @@ describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion',
       <body>
         <h1>Research Paper</h1>
         <p>This paper discusses <strong>decentralized knowledge graphs</strong>.</p>
+        <p>Unicode canary: čćž 日本語</p>
         <h2>Introduction</h2>
         <p>The DKG protocol enables verifiable AI memory.</p>
         <ul>
@@ -113,6 +114,7 @@ describe.skipIf(!markitdownAvailable)('MarkItDown E2E — real file conversion',
     expect(result.mdIntermediate).toBeTruthy();
     expect(result.mdIntermediate).toContain('Research Paper');
     expect(result.mdIntermediate).toContain('decentralized knowledge graphs');
+    expect(result.mdIntermediate).toContain('čćž 日本語');
   }, 30_000);
 
   it('converts a CSV file to Markdown', async () => {

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -11,12 +11,15 @@ let isMarkItDownAvailable: typeof import('../src/extraction/markitdown-converter
 let MARKITDOWN_CONTENT_TYPES: typeof import('../src/extraction/markitdown-converter.js').MARKITDOWN_CONTENT_TYPES;
 
 const CLI_VERSION = JSON.parse(nativeReadFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as { version: string };
+const BUILD_INFO = JSON.parse(nativeReadFileSync(new URL('../markitdown-build-info.json', import.meta.url), 'utf-8')) as {
+  markItDownUpstreamVersion: string;
+  pyInstallerVersion: string;
+};
 const BUNDLER_SCRIPT_BYTES = nativeReadFileSync(new URL('../scripts/bundle-markitdown-binaries.mjs', import.meta.url));
-const BUNDLER_SCRIPT_TEXT = BUNDLER_SCRIPT_BYTES.toString('utf-8');
-const MARKITDOWN_UPSTREAM_VERSION = BUNDLER_SCRIPT_TEXT.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)';/)?.[1];
-const PYINSTALLER_VERSION = BUNDLER_SCRIPT_TEXT.match(/export const PYINSTALLER_VERSION = '([^']+)';/)?.[1];
+const MARKITDOWN_UPSTREAM_VERSION = BUILD_INFO.markItDownUpstreamVersion;
+const PYINSTALLER_VERSION = BUILD_INFO.pyInstallerVersion;
 if (!MARKITDOWN_UPSTREAM_VERSION || !PYINSTALLER_VERSION) {
-  throw new Error('Unable to parse MarkItDown build versions from bundle-markitdown-binaries.mjs');
+  throw new Error('Unable to read MarkItDown build versions from markitdown-build-info.json');
 }
 const MARKITDOWN_BUILD_FINGERPRINT = createHash('sha256').update([
   MARKITDOWN_UPSTREAM_VERSION,
@@ -223,7 +226,52 @@ describe('isMarkItDownAvailable', () => {
             return `${binaryHash}  ${assetName}\n`;
           }
           if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.meta.json')) {
-            return JSON.stringify({ source: 'release', cliVersion: CLI_VERSION.version });
+            return JSON.stringify({
+              source: 'release',
+              cliVersion: CLI_VERSION.version,
+              buildFingerprint: MARKITDOWN_BUILD_FINGERPRINT,
+            });
+          }
+          if (normalized.includes('/bin/markitdown-')) return binaryBytes;
+          return actual.readFileSync(path as any);
+        }),
+      };
+    });
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => { throw new Error('path fallback should not be used'); }),
+      execFile: vi.fn(),
+    }));
+
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    expect(mod.isMarkItDownAvailable()).toBe(true);
+  });
+
+  it('accepts a bundled binary when the build fingerprint matches across CLI version changes', async () => {
+    const binaryBytes = Buffer.from('verified markitdown binary', 'utf-8');
+    const binaryHash = createHash('sha256').update(binaryBytes).digest('hex');
+
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-')) return true;
+          return actual.existsSync(path as any);
+        }),
+        readFileSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.sha256')) {
+            const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+            return `${binaryHash}  ${assetName}\n`;
+          }
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+            return JSON.stringify({
+              source: 'release',
+              cliVersion: '0.0.0-test',
+              buildFingerprint: MARKITDOWN_BUILD_FINGERPRINT,
+            });
           }
           if (normalized.includes('/bin/markitdown-')) return binaryBytes;
           return actual.readFileSync(path as any);

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -99,7 +99,7 @@ describe('MarkItDownConverter', () => {
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });
 
 describe('isMarkItDownAvailable', () => {

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
 import { writeFile, rm, mkdtemp } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -109,8 +110,72 @@ describe('isMarkItDownAvailable', () => {
     isMarkItDownAvailable = mod.isMarkItDownAvailable;
   });
 
+  afterEach(() => {
+    vi.doUnmock('node:fs');
+    vi.doUnmock('node:child_process');
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
   it('returns a boolean', () => {
     const result = isMarkItDownAvailable();
     expect(typeof result).toBe('boolean');
+  });
+
+  it('ignores a bundled binary when the checksum sidecar is missing', async () => {
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.sha256')) return false;
+          if (normalized.includes('/bin/markitdown-')) return true;
+          return actual.existsSync(path as any);
+        }),
+      };
+    });
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => { throw new Error('not on path'); }),
+      execFile: vi.fn(),
+    }));
+
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    expect(mod.isMarkItDownAvailable()).toBe(false);
+  });
+
+  it('accepts a bundled binary when the checksum sidecar matches', async () => {
+    const binaryBytes = Buffer.from('verified markitdown binary', 'utf-8');
+    const binaryHash = createHash('sha256').update(binaryBytes).digest('hex');
+
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-')) return true;
+          return actual.existsSync(path as any);
+        }),
+        readFileSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.sha256')) {
+            const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+            return `${binaryHash}  ${assetName}\n`;
+          }
+          if (normalized.includes('/bin/markitdown-')) return binaryBytes;
+          return actual.readFileSync(path as any);
+        }),
+      };
+    });
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => { throw new Error('path fallback should not be used'); }),
+      execFile: vi.fn(),
+    }));
+
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    expect(mod.isMarkItDownAvailable()).toBe(true);
   });
 });

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -11,11 +11,18 @@ let isMarkItDownAvailable: typeof import('../src/extraction/markitdown-converter
 let MARKITDOWN_CONTENT_TYPES: typeof import('../src/extraction/markitdown-converter.js').MARKITDOWN_CONTENT_TYPES;
 
 const CLI_VERSION = JSON.parse(nativeReadFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as { version: string };
+const BUNDLER_SCRIPT_BYTES = nativeReadFileSync(new URL('../scripts/bundle-markitdown-binaries.mjs', import.meta.url));
+const BUNDLER_SCRIPT_TEXT = BUNDLER_SCRIPT_BYTES.toString('utf-8');
+const MARKITDOWN_UPSTREAM_VERSION = BUNDLER_SCRIPT_TEXT.match(/export const MARKITDOWN_UPSTREAM_VERSION = '([^']+)';/)?.[1];
+const PYINSTALLER_VERSION = BUNDLER_SCRIPT_TEXT.match(/export const PYINSTALLER_VERSION = '([^']+)';/)?.[1];
+if (!MARKITDOWN_UPSTREAM_VERSION || !PYINSTALLER_VERSION) {
+  throw new Error('Unable to parse MarkItDown build versions from bundle-markitdown-binaries.mjs');
+}
 const MARKITDOWN_BUILD_FINGERPRINT = createHash('sha256').update([
-  '0.1.5',
-  '6.19.0',
+  MARKITDOWN_UPSTREAM_VERSION,
+  PYINSTALLER_VERSION,
   createHash('sha256').update(nativeReadFileSync(new URL('../scripts/markitdown-entry.py', import.meta.url))).digest('hex'),
-  createHash('sha256').update(nativeReadFileSync(new URL('../scripts/bundle-markitdown-binaries.mjs', import.meta.url))).digest('hex'),
+  createHash('sha256').update(BUNDLER_SCRIPT_BYTES).digest('hex'),
 ].join('\n')).digest('hex');
 
 describe('MARKITDOWN_CONTENT_TYPES', () => {

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHash } from 'node:crypto';
+import { readFileSync as nativeReadFileSync } from 'node:fs';
 import { writeFile, rm, mkdtemp } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -8,6 +9,14 @@ import { tmpdir } from 'node:os';
 let MarkItDownConverter: typeof import('../src/extraction/markitdown-converter.js').MarkItDownConverter;
 let isMarkItDownAvailable: typeof import('../src/extraction/markitdown-converter.js').isMarkItDownAvailable;
 let MARKITDOWN_CONTENT_TYPES: typeof import('../src/extraction/markitdown-converter.js').MARKITDOWN_CONTENT_TYPES;
+
+const CLI_VERSION = JSON.parse(nativeReadFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as { version: string };
+const MARKITDOWN_BUILD_FINGERPRINT = createHash('sha256').update([
+  '0.1.5',
+  '6.19.0',
+  createHash('sha256').update(nativeReadFileSync(new URL('../scripts/markitdown-entry.py', import.meta.url))).digest('hex'),
+  createHash('sha256').update(nativeReadFileSync(new URL('../scripts/bundle-markitdown-binaries.mjs', import.meta.url))).digest('hex'),
+].join('\n')).digest('hex');
 
 describe('MARKITDOWN_CONTENT_TYPES', () => {
   beforeEach(async () => {
@@ -147,7 +156,8 @@ describe('isMarkItDownAvailable', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ignoring bundled MarkItDown binary without a valid checksum sidecar'));
   });
 
-  it('accepts a bundled binary when the checksum sidecar matches', async () => {
+  it('ignores a bundled binary when the metadata sidecar targets a different package version', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const binaryBytes = Buffer.from('verified markitdown binary', 'utf-8');
     const binaryHash = createHash('sha256').update(binaryBytes).digest('hex');
 
@@ -166,6 +176,88 @@ describe('isMarkItDownAvailable', () => {
           if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.sha256')) {
             const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
             return `${binaryHash}  ${assetName}\n`;
+          }
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+            return JSON.stringify({ source: 'release', cliVersion: '0.0.0-test' });
+          }
+          if (normalized.includes('/bin/markitdown-')) return binaryBytes;
+          return actual.readFileSync(path as any);
+        }),
+      };
+    });
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => { throw new Error('not on path'); }),
+      execFile: vi.fn(),
+    }));
+
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    expect(mod.isMarkItDownAvailable()).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ignoring bundled MarkItDown binary with incompatible metadata sidecar'));
+  });
+
+  it('accepts a bundled binary when the checksum and release metadata match', async () => {
+    const binaryBytes = Buffer.from('verified markitdown binary', 'utf-8');
+    const binaryHash = createHash('sha256').update(binaryBytes).digest('hex');
+
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-')) return true;
+          return actual.existsSync(path as any);
+        }),
+        readFileSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.sha256')) {
+            const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+            return `${binaryHash}  ${assetName}\n`;
+          }
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+            return JSON.stringify({ source: 'release', cliVersion: CLI_VERSION.version });
+          }
+          if (normalized.includes('/bin/markitdown-')) return binaryBytes;
+          return actual.readFileSync(path as any);
+        }),
+      };
+    });
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => { throw new Error('path fallback should not be used'); }),
+      execFile: vi.fn(),
+    }));
+
+    const mod = await import('../src/extraction/markitdown-converter.js');
+    expect(mod.isMarkItDownAvailable()).toBe(true);
+  });
+
+  it('accepts a bundled binary when the checksum and build metadata match the current package', async () => {
+    const binaryBytes = Buffer.from('verified markitdown build binary', 'utf-8');
+    const binaryHash = createHash('sha256').update(binaryBytes).digest('hex');
+
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...actual,
+        existsSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-')) return true;
+          return actual.existsSync(path as any);
+        }),
+        readFileSync: vi.fn((path: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.sha256')) {
+            const assetName = normalized.split('/').pop()?.replace(/\.sha256$/, '') ?? 'markitdown-test';
+            return `${binaryHash}  ${assetName}\n`;
+          }
+          if (normalized.includes('/bin/markitdown-') && normalized.endsWith('.meta.json')) {
+            return JSON.stringify({
+              source: 'build',
+              cliVersion: CLI_VERSION.version,
+              buildFingerprint: MARKITDOWN_BUILD_FINGERPRINT,
+            });
           }
           if (normalized.includes('/bin/markitdown-')) return binaryBytes;
           return actual.readFileSync(path as any);

--- a/packages/cli/test/extraction-markitdown.test.ts
+++ b/packages/cli/test/extraction-markitdown.test.ts
@@ -123,6 +123,7 @@ describe('isMarkItDownAvailable', () => {
   });
 
   it('ignores a bundled binary when the checksum sidecar is missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.resetModules();
     vi.doMock('node:fs', async (importOriginal) => {
       const actual = await importOriginal<typeof import('node:fs')>();
@@ -143,6 +144,7 @@ describe('isMarkItDownAvailable', () => {
 
     const mod = await import('../src/extraction/markitdown-converter.js');
     expect(mod.isMarkItDownAvailable()).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Ignoring bundled MarkItDown binary without a valid checksum sidecar'));
   });
 
   it('accepts a bundled binary when the checksum sidecar matches', async () => {

--- a/packages/cli/test/install-script.test.ts
+++ b/packages/cli/test/install-script.test.ts
@@ -34,7 +34,6 @@ describe('install.sh validation', () => {
     expect(content).toContain('command -v node');
     expect(content).toContain('command -v pnpm');
     expect(content).toContain('command -v git');
-    expect(content).toContain('command -v python3');
   });
 
   it('script creates correct directory structure markers', async () => {

--- a/packages/cli/test/install-script.test.ts
+++ b/packages/cli/test/install-script.test.ts
@@ -88,5 +88,6 @@ describe('install.sh validation', () => {
     const content = await readFile(INSTALL_SCRIPT, 'utf-8');
     expect(content).toContain('bundle-markitdown-binaries.mjs');
     expect(content).toContain('--build-current-platform');
+    expect(content).toContain('--best-effort');
   });
 });

--- a/packages/cli/test/install-script.test.ts
+++ b/packages/cli/test/install-script.test.ts
@@ -88,6 +88,7 @@ describe('install.sh validation', () => {
     const content = await readFile(INSTALL_SCRIPT, 'utf-8');
     expect(content).toContain('bundle-markitdown-binaries.mjs');
     expect(content).toContain('--build-current-platform');
+    expect(content).toContain('--force');
     expect(content).toContain('--best-effort');
   });
 });

--- a/packages/cli/test/install-script.test.ts
+++ b/packages/cli/test/install-script.test.ts
@@ -89,7 +89,6 @@ describe('install.sh validation', () => {
     expect(content).toContain('bundle-markitdown-binaries.mjs');
     expect(content).toContain('this checkout predates bundled MarkItDown support');
     expect(content).toContain('--build-current-platform');
-    expect(content).toContain('--force');
     expect(content).toContain('--best-effort');
   });
 });

--- a/packages/cli/test/install-script.test.ts
+++ b/packages/cli/test/install-script.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import { existsSync } from 'node:fs';
+import process from 'node:process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -23,7 +24,9 @@ describe('install.sh validation', () => {
   it('install script exists and is executable', async () => {
     expect(existsSync(INSTALL_SCRIPT)).toBe(true);
     const s = await stat(INSTALL_SCRIPT);
-    expect(s.mode & 0o111).toBeGreaterThan(0);
+    if (process.platform !== 'win32') {
+      expect(s.mode & 0o111).toBeGreaterThan(0);
+    }
   });
 
   it('script contains required prerequisite checks', async () => {
@@ -31,6 +34,7 @@ describe('install.sh validation', () => {
     expect(content).toContain('command -v node');
     expect(content).toContain('command -v pnpm');
     expect(content).toContain('command -v git');
+    expect(content).toContain('command -v python3');
   });
 
   it('script creates correct directory structure markers', async () => {
@@ -79,5 +83,11 @@ describe('install.sh validation', () => {
     expect(content).toContain('slot_ready');
     expect(content).toContain('packages/cli/dist/cli.js');
     expect(content).toContain('Detected incomplete slots');
+  });
+
+  it('stages the current-platform MarkItDown binary into each slot', async () => {
+    const content = await readFile(INSTALL_SCRIPT, 'utf-8');
+    expect(content).toContain('bundle-markitdown-binaries.mjs');
+    expect(content).toContain('--build-current-platform');
   });
 });

--- a/packages/cli/test/install-script.test.ts
+++ b/packages/cli/test/install-script.test.ts
@@ -87,6 +87,7 @@ describe('install.sh validation', () => {
   it('stages the current-platform MarkItDown binary into each slot', async () => {
     const content = await readFile(INSTALL_SCRIPT, 'utf-8');
     expect(content).toContain('bundle-markitdown-binaries.mjs');
+    expect(content).toContain('this checkout predates bundled MarkItDown support');
     expect(content).toContain('--build-current-platform');
     expect(content).toContain('--force');
     expect(content).toContain('--best-effort');

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -486,6 +486,7 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(pkg.scripts?.postinstall).toContain('bundle-markitdown-binaries.mjs');
     expect(pkg.scripts?.postinstall).toContain('--current-platform');
     expect(pkg.scripts?.postinstall).toContain('--best-effort');
+    expect(pkg.files).toContain('markitdown-build-info.json');
     expect(pkg.files).toContain('markitdown-targets.json');
     expect(pkg.files).toContain('scripts');
   });
@@ -496,7 +497,7 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(targets.map((target) => target.assetName)).toEqual(SUPPORTED_TARGETS.map((target) => target.assetName));
 
     const workflowRaw = await readFile(new URL('../../../.github/workflows/release.yml', import.meta.url), 'utf-8');
-    expect(workflowRaw).toContain('markitdown-targets.json');
+    expect(workflowRaw).toContain("import { SUPPORTED_TARGETS } from './packages/cli/scripts/bundle-markitdown-binaries.mjs'");
     expect(workflowRaw).toContain('fromJSON(needs.markitdown-target-matrix.outputs.matrix)');
     expect(workflowRaw).toContain('Smoke test bundled MarkItDown binary');
     expect(workflowRaw).toContain('markitdown-smoke.html');

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -1,0 +1,184 @@
+import { createServer } from 'node:http';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  checksumPathFor,
+  downloadBinaryAsset,
+  ensureCurrentPlatformBinary,
+  getSupportedTarget,
+  parseSha256File,
+  readCliVersion,
+  releaseAssetUrl,
+  releaseBaseUrl,
+  releaseTagForVersion,
+  sha256Hex,
+} from '../scripts/bundle-markitdown-binaries.mjs';
+
+describe('bundle-markitdown-binaries helpers', () => {
+  let tmpPaths: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tmpPaths.map((path) => rm(path, { recursive: true, force: true })));
+    tmpPaths = [];
+  });
+
+  it('reads the CLI version from package.json', async () => {
+    const pkgDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-pkg-'));
+    tmpPaths.push(pkgDir);
+    await writeFile(join(pkgDir, 'package.json'), JSON.stringify({ version: '9.0.0-rc.2' }, null, 2));
+
+    expect(readCliVersion(pkgDir)).toBe('9.0.0-rc.2');
+  });
+
+  it('parses standard sha256 files', () => {
+    expect(parseSha256File('abc123  markitdown-linux-x64\n')).toBe('abc123');
+    expect(releaseTagForVersion('9.0.0-rc.2')).toBe('v9.0.0-rc.2');
+    expect(releaseBaseUrl('9.0.0-rc.2')).toBe(
+      'https://github.com/OriginTrail/dkg-v9/releases/download/v9.0.0-rc.2',
+    );
+    expect(releaseAssetUrl('https://example.invalid/release', 'markitdown-linux-x64')).toBe(
+      'https://example.invalid/release/markitdown-linux-x64',
+    );
+  });
+
+  it('downloads an asset and writes its checksum sidecar', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-bin-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const bytes = Buffer.from('# test markdown\n', 'utf-8');
+    const hash = sha256Hex(bytes);
+
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(bytes);
+        return;
+      }
+      if (req.url === `/release/${assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${hash}  ${assetName}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+    const baseUrl = `http://127.0.0.1:${port}/release`;
+
+    try {
+      const result = await downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl,
+      });
+
+      expect(result.status).toBe('downloaded');
+      expect(await readFile(join(destinationDir, assetName))).toEqual(bytes);
+      expect(await readFile(checksumPathFor(join(destinationDir, assetName)), 'utf-8')).toContain(hash);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('rejects checksum mismatches from the release asset feed', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-bad-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const bytes = Buffer.from('bad checksum case', 'utf-8');
+
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(bytes);
+        return;
+      }
+      if (req.url === `/release/${assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`deadbeef  ${assetName}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await expect(downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl: `http://127.0.0.1:${port}/release`,
+      })).rejects.toThrow(/Checksum mismatch/);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('stages the current-platform asset from a matching release URL', async () => {
+    const target = getSupportedTarget();
+    expect(target).not.toBeNull();
+    if (!target) return;
+
+    const packageDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-package-'));
+    const outputDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-output-'));
+    tmpPaths.push(packageDir, outputDir);
+    await writeFile(join(packageDir, 'package.json'), JSON.stringify({ version: '9.0.0-rc.3' }, null, 2));
+
+    const bytes = Buffer.from('platform-specific binary', 'utf-8');
+    const hash = sha256Hex(bytes);
+
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${target.assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(bytes);
+        return;
+      }
+      if (req.url === `/release/${target.assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${hash}  ${target.assetName}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      const result = await ensureCurrentPlatformBinary({
+        packageDir,
+        outputDir,
+        releaseBaseUrlOverride: `http://127.0.0.1:${port}/release`,
+      });
+
+      expect(result.status).toBe('downloaded');
+      expect(result.source).toBe('release');
+      expect(existsSync(join(outputDir, target.assetName))).toBe(true);
+      expect(await readFile(join(outputDir, target.assetName))).toEqual(bytes);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('declares npm postinstall staging in the CLI package manifest', async () => {
+    const pkgRaw = await readFile(new URL('../package.json', import.meta.url), 'utf-8');
+    const pkg = JSON.parse(pkgRaw) as {
+      scripts?: Record<string, string>;
+      files?: string[];
+    };
+
+    expect(pkg.scripts?.postinstall).toContain('bundle-markitdown-binaries.mjs');
+    expect(pkg.scripts?.postinstall).toContain('--current-platform');
+    expect(pkg.scripts?.postinstall).toContain('--best-effort');
+    expect(pkg.files).toContain('scripts');
+  });
+});

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -353,5 +353,7 @@ describe('bundle-markitdown-binaries helpers', () => {
     const workflowRaw = await readFile(new URL('../../../.github/workflows/release.yml', import.meta.url), 'utf-8');
     expect(workflowRaw).toContain('markitdown-targets.json');
     expect(workflowRaw).toContain('fromJSON(needs.markitdown-target-matrix.outputs.matrix)');
+    expect(workflowRaw).toContain('Smoke test bundled MarkItDown binary');
+    expect(workflowRaw).toContain('usage: markitdown <file-path>');
   });
 });

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -354,6 +354,7 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(workflowRaw).toContain('markitdown-targets.json');
     expect(workflowRaw).toContain('fromJSON(needs.markitdown-target-matrix.outputs.matrix)');
     expect(workflowRaw).toContain('Smoke test bundled MarkItDown binary');
-    expect(workflowRaw).toContain('usage: markitdown <file-path>');
+    expect(workflowRaw).toContain('markitdown-smoke.html');
+    expect(workflowRaw).toContain('Hello from MarkItDown smoke test.');
   });
 });

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -22,6 +22,7 @@ import {
 
 describe('bundle-markitdown-binaries helpers', () => {
   const CLI_VERSION = '9.0.0-rc.3';
+  const RELEASE_METADATA_TEXT = `${JSON.stringify({ source: 'release', cliVersion: CLI_VERSION }, null, 2)}\n`;
   let tmpPaths: string[] = [];
 
   afterEach(async () => {
@@ -67,6 +68,11 @@ describe('bundle-markitdown-binaries helpers', () => {
       if (req.url === `/release/${assetName}.sha256`) {
         res.writeHead(200, { 'content-type': 'text/plain' });
         res.end(`${hash}  ${assetName}\n`);
+        return;
+      }
+      if (req.url === `/release/${assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT);
         return;
       }
       res.writeHead(404);
@@ -140,6 +146,11 @@ describe('bundle-markitdown-binaries helpers', () => {
         res.end(`${hash}  ${assetName}\n`);
         return;
       }
+      if (req.url === `/release/${assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT);
+        return;
+      }
       res.writeHead(404);
       res.end();
     });
@@ -188,6 +199,11 @@ describe('bundle-markitdown-binaries helpers', () => {
       if (req.url === `/release/${assetName}.sha256`) {
         res.writeHead(200, { 'content-type': 'text/plain' });
         res.end(`${refreshedHash}  ${assetName}\n`);
+        return;
+      }
+      if (req.url === `/release/${assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT);
         return;
       }
       res.writeHead(404);
@@ -275,6 +291,11 @@ describe('bundle-markitdown-binaries helpers', () => {
         res.end(`${refreshedHash}  ${assetName}\n`);
         return;
       }
+      if (req.url === `/release/${assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT);
+        return;
+      }
       res.writeHead(404);
       res.end();
     });
@@ -335,6 +356,11 @@ describe('bundle-markitdown-binaries helpers', () => {
         res.end(`deadbeef  ${assetName}\n`);
         return;
       }
+      if (req.url === `/release/${assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT);
+        return;
+      }
       res.writeHead(404);
       res.end();
     });
@@ -349,6 +375,49 @@ describe('bundle-markitdown-binaries helpers', () => {
         baseUrl: `http://127.0.0.1:${port}/release`,
         cliVersion: CLI_VERSION,
       })).rejects.toThrow(/Checksum mismatch/);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('rejects release assets whose published metadata targets a different CLI version', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-bad-meta-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const bytes = Buffer.from('bad metadata case', 'utf-8');
+    const hash = sha256Hex(bytes);
+
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(bytes);
+        return;
+      }
+      if (req.url === `/release/${assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${hash}  ${assetName}\n`);
+        return;
+      }
+      if (req.url === `/release/${assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(`${JSON.stringify({ source: 'release', cliVersion: '9.0.0-rc.2' }, null, 2)}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await expect(downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl: `http://127.0.0.1:${port}/release`,
+        cliVersion: CLI_VERSION,
+      })).rejects.toThrow(/Metadata mismatch/);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }
@@ -376,6 +445,11 @@ describe('bundle-markitdown-binaries helpers', () => {
       if (req.url === `/release/${target.assetName}.sha256`) {
         res.writeHead(200, { 'content-type': 'text/plain' });
         res.end(`${hash}  ${target.assetName}\n`);
+        return;
+      }
+      if (req.url === `/release/${target.assetName}.meta.json`) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(RELEASE_METADATA_TEXT);
         return;
       }
       res.writeHead(404);

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -10,6 +10,7 @@ import {
   ensureCurrentPlatformBinary,
   getSupportedTarget,
   parseSha256File,
+  pyInstallerNameForTarget,
   readCliVersion,
   releaseAssetUrl,
   releaseBaseUrl,
@@ -42,6 +43,8 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(releaseAssetUrl('https://example.invalid/release', 'markitdown-linux-x64')).toBe(
       'https://example.invalid/release/markitdown-linux-x64',
     );
+    expect(pyInstallerNameForTarget({ assetName: 'markitdown-win32-x64.exe' })).toBe('markitdown-win32-x64');
+    expect(pyInstallerNameForTarget({ assetName: 'markitdown-linux-x64' })).toBe('markitdown-linux-x64');
   });
 
   it('downloads an asset and writes its checksum sidecar', async () => {

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -16,6 +16,7 @@ import {
   releaseBaseUrl,
   releaseTagForVersion,
   sha256Hex,
+  SUPPORTED_TARGETS,
 } from '../scripts/bundle-markitdown-binaries.mjs';
 
 describe('bundle-markitdown-binaries helpers', () => {
@@ -84,6 +85,71 @@ describe('bundle-markitdown-binaries helpers', () => {
       expect(result.status).toBe('downloaded');
       expect(await readFile(join(destinationDir, assetName))).toEqual(bytes);
       expect(await readFile(checksumPathFor(join(destinationDir, assetName)), 'utf-8')).toContain(hash);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('keeps a verified existing asset without hitting the network', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-present-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const bytes = Buffer.from('# verified markdown\n', 'utf-8');
+    const hash = sha256Hex(bytes);
+    const binaryPath = join(destinationDir, assetName);
+    await writeFile(binaryPath, bytes);
+    await writeFile(checksumPathFor(binaryPath), `${hash}  ${assetName}\n`, 'utf-8');
+
+    const result = await downloadBinaryAsset({
+      assetName,
+      destinationDir,
+      baseUrl: 'http://127.0.0.1:1/release',
+    });
+
+    expect(result.status).toBe('present');
+    expect(await readFile(binaryPath)).toEqual(bytes);
+  });
+
+  it('re-downloads an existing asset when its checksum sidecar is missing', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-redownload-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const binaryPath = join(destinationDir, assetName);
+    await writeFile(binaryPath, Buffer.from('stale bytes', 'utf-8'));
+
+    const bytes = Buffer.from('# refreshed markdown\n', 'utf-8');
+    const hash = sha256Hex(bytes);
+
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(bytes);
+        return;
+      }
+      if (req.url === `/release/${assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${hash}  ${assetName}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      const result = await downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl: `http://127.0.0.1:${port}/release`,
+      });
+
+      expect(result.status).toBe('downloaded');
+      expect(await readFile(binaryPath)).toEqual(bytes);
+      expect(await readFile(checksumPathFor(binaryPath), 'utf-8')).toContain(hash);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }
@@ -182,6 +248,17 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(pkg.scripts?.postinstall).toContain('bundle-markitdown-binaries.mjs');
     expect(pkg.scripts?.postinstall).toContain('--current-platform');
     expect(pkg.scripts?.postinstall).toContain('--best-effort');
+    expect(pkg.files).toContain('markitdown-targets.json');
     expect(pkg.files).toContain('scripts');
+  });
+
+  it('keeps MarkItDown target metadata in a shared JSON file that the release workflow reads', async () => {
+    const targetsRaw = await readFile(new URL('../markitdown-targets.json', import.meta.url), 'utf-8');
+    const targets = JSON.parse(targetsRaw) as Array<{ assetName: string; runner: string }>;
+    expect(targets.map((target) => target.assetName)).toEqual(SUPPORTED_TARGETS.map((target) => target.assetName));
+
+    const workflowRaw = await readFile(new URL('../../../.github/workflows/release.yml', import.meta.url), 'utf-8');
+    expect(workflowRaw).toContain('markitdown-targets.json');
+    expect(workflowRaw).toContain('fromJSON(needs.markitdown-target-matrix.outputs.matrix)');
   });
 });

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -155,6 +155,37 @@ describe('bundle-markitdown-binaries helpers', () => {
     }
   });
 
+  it('keeps the existing asset in place when replacement fetch fails', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-keep-old-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const binaryPath = join(destinationDir, assetName);
+    const staleBytes = Buffer.from('manual stage without sidecar', 'utf-8');
+    await writeFile(binaryPath, staleBytes);
+
+    const server = createServer((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await expect(downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl: `http://127.0.0.1:${port}/release`,
+      })).rejects.toThrow(/returned 404/);
+
+      expect(await readFile(binaryPath)).toEqual(staleBytes);
+      expect(existsSync(checksumPathFor(binaryPath))).toBe(false);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
   it('rejects checksum mismatches from the release asset feed', async () => {
     const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-bad-'));
     tmpPaths.push(destinationDir);

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -9,6 +9,7 @@ import {
   downloadBinaryAsset,
   ensureCurrentPlatformBinary,
   getSupportedTarget,
+  metadataPathFor,
   parseSha256File,
   pyInstallerNameForTarget,
   readCliVersion,
@@ -20,6 +21,7 @@ import {
 } from '../scripts/bundle-markitdown-binaries.mjs';
 
 describe('bundle-markitdown-binaries helpers', () => {
+  const CLI_VERSION = '9.0.0-rc.3';
   let tmpPaths: string[] = [];
 
   afterEach(async () => {
@@ -80,11 +82,14 @@ describe('bundle-markitdown-binaries helpers', () => {
         assetName,
         destinationDir,
         baseUrl,
+        cliVersion: CLI_VERSION,
       });
 
       expect(result.status).toBe('downloaded');
       expect(await readFile(join(destinationDir, assetName))).toEqual(bytes);
       expect(await readFile(checksumPathFor(join(destinationDir, assetName)), 'utf-8')).toContain(hash);
+      await expect(readFile(metadataPathFor(join(destinationDir, assetName)), 'utf-8')).resolves.toContain(CLI_VERSION);
+      await expect(readFile(metadataPathFor(join(destinationDir, assetName)), 'utf-8')).resolves.toContain('"source": "release"');
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }
@@ -100,11 +105,13 @@ describe('bundle-markitdown-binaries helpers', () => {
     const binaryPath = join(destinationDir, assetName);
     await writeFile(binaryPath, bytes);
     await writeFile(checksumPathFor(binaryPath), `${hash}  ${assetName}\n`, 'utf-8');
+    await writeFile(metadataPathFor(binaryPath), `${JSON.stringify({ source: 'release', cliVersion: CLI_VERSION }, null, 2)}\n`, 'utf-8');
 
     const result = await downloadBinaryAsset({
       assetName,
       destinationDir,
       baseUrl: 'http://127.0.0.1:1/release',
+      cliVersion: CLI_VERSION,
     });
 
     expect(result.status).toBe('present');
@@ -145,11 +152,62 @@ describe('bundle-markitdown-binaries helpers', () => {
         assetName,
         destinationDir,
         baseUrl: `http://127.0.0.1:${port}/release`,
+        cliVersion: CLI_VERSION,
       });
 
       expect(result.status).toBe('downloaded');
       expect(await readFile(binaryPath)).toEqual(bytes);
       expect(await readFile(checksumPathFor(binaryPath), 'utf-8')).toContain(hash);
+      await expect(readFile(metadataPathFor(binaryPath), 'utf-8')).resolves.toContain(CLI_VERSION);
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('re-downloads an existing asset when its metadata sidecar is stale', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-stale-meta-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const binaryPath = join(destinationDir, assetName);
+    const staleBytes = Buffer.from('stale but checksum-valid bytes', 'utf-8');
+    const staleHash = sha256Hex(staleBytes);
+    await writeFile(binaryPath, staleBytes);
+    await writeFile(checksumPathFor(binaryPath), `${staleHash}  ${assetName}\n`, 'utf-8');
+    await writeFile(metadataPathFor(binaryPath), `${JSON.stringify({ source: 'release', cliVersion: '9.0.0-rc.2' }, null, 2)}\n`, 'utf-8');
+
+    const refreshedBytes = Buffer.from('# refreshed markdown\n', 'utf-8');
+    const refreshedHash = sha256Hex(refreshedBytes);
+
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(refreshedBytes);
+        return;
+      }
+      if (req.url === `/release/${assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${refreshedHash}  ${assetName}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      const result = await downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl: `http://127.0.0.1:${port}/release`,
+        cliVersion: CLI_VERSION,
+      });
+
+      expect(result.status).toBe('downloaded');
+      expect(await readFile(binaryPath)).toEqual(refreshedBytes);
+      await expect(readFile(metadataPathFor(binaryPath), 'utf-8')).resolves.toContain(CLI_VERSION);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }
@@ -177,10 +235,12 @@ describe('bundle-markitdown-binaries helpers', () => {
         assetName,
         destinationDir,
         baseUrl: `http://127.0.0.1:${port}/release`,
+        cliVersion: CLI_VERSION,
       })).rejects.toThrow(/returned 404/);
 
       expect(await readFile(binaryPath)).toEqual(staleBytes);
       expect(existsSync(checksumPathFor(binaryPath))).toBe(false);
+      expect(existsSync(metadataPathFor(binaryPath))).toBe(false);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }
@@ -216,6 +276,7 @@ describe('bundle-markitdown-binaries helpers', () => {
         assetName,
         destinationDir,
         baseUrl: `http://127.0.0.1:${port}/release`,
+        cliVersion: CLI_VERSION,
       })).rejects.toThrow(/Checksum mismatch/);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
@@ -230,7 +291,7 @@ describe('bundle-markitdown-binaries helpers', () => {
     const packageDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-package-'));
     const outputDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-output-'));
     tmpPaths.push(packageDir, outputDir);
-    await writeFile(join(packageDir, 'package.json'), JSON.stringify({ version: '9.0.0-rc.3' }, null, 2));
+    await writeFile(join(packageDir, 'package.json'), JSON.stringify({ version: CLI_VERSION }, null, 2));
 
     const bytes = Buffer.from('platform-specific binary', 'utf-8');
     const hash = sha256Hex(bytes);
@@ -264,6 +325,7 @@ describe('bundle-markitdown-binaries helpers', () => {
       expect(result.source).toBe('release');
       expect(existsSync(join(outputDir, target.assetName))).toBe(true);
       expect(await readFile(join(outputDir, target.assetName))).toEqual(bytes);
+      await expect(readFile(metadataPathFor(join(outputDir, target.assetName)), 'utf-8')).resolves.toContain(CLI_VERSION);
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
     }

--- a/packages/cli/test/markitdown-binaries.test.ts
+++ b/packages/cli/test/markitdown-binaries.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   checksumPathFor,
   downloadBinaryAsset,
@@ -246,6 +246,77 @@ describe('bundle-markitdown-binaries helpers', () => {
     }
   });
 
+  it('keeps the existing verified asset in place when temp staging fails before backup renames', async () => {
+    const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-write-fail-'));
+    tmpPaths.push(destinationDir);
+
+    const assetName = 'markitdown-test';
+    const binaryPath = join(destinationDir, assetName);
+    const existingBytes = Buffer.from('existing verified binary', 'utf-8');
+    const existingHash = sha256Hex(existingBytes);
+    await writeFile(binaryPath, existingBytes);
+    await writeFile(checksumPathFor(binaryPath), `${existingHash}  ${assetName}\n`, 'utf-8');
+    await writeFile(
+      metadataPathFor(binaryPath),
+      `${JSON.stringify({ source: 'release', cliVersion: CLI_VERSION }, null, 2)}\n`,
+      'utf-8',
+    );
+
+    const refreshedBytes = Buffer.from('# refreshed markdown\n', 'utf-8');
+    const refreshedHash = sha256Hex(refreshedBytes);
+    const server = createServer((req, res) => {
+      if (req.url === `/release/${assetName}`) {
+        res.writeHead(200, { 'content-type': 'application/octet-stream' });
+        res.end(refreshedBytes);
+        return;
+      }
+      if (req.url === `/release/${assetName}.sha256`) {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(`${refreshedHash}  ${assetName}\n`);
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as { port: number }).port;
+
+    vi.resetModules();
+    vi.doMock('node:fs/promises', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs/promises')>();
+      return {
+        ...actual,
+        writeFile: vi.fn((path: unknown, data: unknown, options?: unknown) => {
+          const normalized = String(path).replace(/\\/g, '/');
+          if (normalized.includes(`/${assetName}.tmp-`)) {
+            throw new Error('ENOSPC temp staging failure');
+          }
+          return actual.writeFile(path as never, data as never, options as never);
+        }),
+      };
+    });
+
+    try {
+      const mod = await import('../scripts/bundle-markitdown-binaries.mjs');
+      await expect(mod.downloadBinaryAsset({
+        assetName,
+        destinationDir,
+        baseUrl: `http://127.0.0.1:${port}/release`,
+        cliVersion: CLI_VERSION,
+        force: true,
+      })).rejects.toThrow(/ENOSPC temp staging failure/);
+
+      expect(await readFile(binaryPath)).toEqual(existingBytes);
+      expect(await readFile(checksumPathFor(binaryPath), 'utf-8')).toContain(existingHash);
+      await expect(readFile(metadataPathFor(binaryPath), 'utf-8')).resolves.toContain(CLI_VERSION);
+    } finally {
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
   it('rejects checksum mismatches from the release asset feed', async () => {
     const destinationDir = await mkdtemp(join(tmpdir(), 'dkg-markitdown-bad-'));
     tmpPaths.push(destinationDir);
@@ -355,6 +426,9 @@ describe('bundle-markitdown-binaries helpers', () => {
     expect(workflowRaw).toContain('fromJSON(needs.markitdown-target-matrix.outputs.matrix)');
     expect(workflowRaw).toContain('Smoke test bundled MarkItDown binary');
     expect(workflowRaw).toContain('markitdown-smoke.html');
+    expect(workflowRaw).toContain('markitdown-smoke.docx');
     expect(workflowRaw).toContain('Hello from MarkItDown smoke test.');
+    expect(workflowRaw).toContain('Hello from DOCX smoke test.');
+    expect(workflowRaw).toContain('.meta.json');
   });
 });


### PR DESCRIPTION
## Summary
- add a repo-owned MarkItDown build/staging helper for current-platform builds and release-asset downloads with checksum verification
- wire MarkItDown staging into tagged releases, npm installs, source installs, and git auto-update
- keep install/update staging best-effort so the node still runs and updates cleanly when document conversion is unavailable, while tightening the focused docs/tests around the new distribution path

## Verification
- `pnpm exec vitest run test/markitdown-binaries.test.ts`
- `pnpm exec vitest run test/install-script.test.ts`
- `pnpm exec vitest run test/auto-update.test.ts`
- `pnpm exec vitest run test/extraction-markitdown.test.ts`
- `pnpm exec vitest run test/document-processor-e2e.test.ts`
- `npm pack --dry-run --json --ignore-scripts`
- `git diff --check`

## Notes
- A full `pnpm --filter @origintrail-official/dkg run build` still fails on pre-existing `v10-rc` TypeScript drift in `packages/cli/src/daemon.ts` and `packages/cli/src/extraction/markitdown-converter.ts`; this PR does not resolve those older branch-level type errors.
- Companion spec-doc sync PR: https://github.com/OriginTrail/dkgv10-spec/pull/89