### PR TITLE
feat: V10 node UI, Hermes adapter, and LLM extraction pipeline

### DIFF
--- a/docs/dkg-v10-prototype-v5.1-jurij-feedback-populated (1).html
+++ b/docs/dkg-v10-prototype-v5.1-jurij-feedback-populated (1).html
@@ -1,0 +1,5902 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DKG v10 — Node UI</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* ══════════════════════════════════════════
+   DESIGN TOKENS
+   ══════════════════════════════════════════ */
+:root {
+  /* Surface hierarchy — true black base */
+  --bg-root: #000000;
+  --bg-panel: #0a0a0a;
+  --bg-surface: #111111;
+  --bg-elevated: #181818;
+  --bg-hover: #1f1f1f;
+  --bg-active: #262626;
+  
+  /* Borders */
+  --border-subtle: #1a1a1a;
+  --border-default: #222222;
+  --border-strong: #333333;
+  
+  /* Text */
+  --text-primary: #e8e8e8;
+  --text-secondary: #888888;
+  --text-tertiary: #555555;
+  --text-ghost: #333333;
+  
+  /* Accent — reserved for signals */
+  --accent-red: #ef4444;
+  --accent-amber: #f59e0b;
+  --accent-green: #22c55e;
+  --accent-blue: #3b82f6;
+  
+  /* Layer identity — muted, used as subtle badges only */
+  --layer-working: #555555;
+  --layer-shared: #777777;
+  --layer-verified: #bbbbbb;
+  
+  /* Typography */
+  --font-sans: 'Instrument Sans', -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  
+  /* Sizing */
+  --header-h: 44px;
+  --tab-h: 36px;
+  --toolbar-h: 38px;
+  --bottom-panel-h: 200px;
+  --tree-w: 240px;
+  --agent-w: 360px;
+}
+
+/* ══════════════════════════════════════════
+   RESET & BASE
+   ══════════════════════════════════════════ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { 
+  height: 100%; 
+  background: var(--bg-root); 
+  color: var(--text-primary); 
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+button { 
+  font-family: inherit; 
+  font-size: inherit; 
+  background: none; 
+  border: none; 
+  color: inherit; 
+  cursor: pointer; 
+  outline: none;
+}
+input, textarea {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  border-radius: 4px;
+  padding: 6px 10px;
+  outline: none;
+}
+input:focus, textarea:focus { border-color: var(--border-strong); }
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+/* ══════════════════════════════════════════
+   APP SHELL
+   ══════════════════════════════════════════ */
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* ── TOP HEADER ── */
+.app-header {
+  height: var(--header-h);
+  min-height: var(--header-h);
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 2px;
+  z-index: 100;
+}
+.app-logo {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+  margin-right: 24px;
+  color: var(--text-primary);
+  user-select: none;
+}
+.app-logo span { color: var(--text-tertiary); font-weight: 300; }
+.logo-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border-default);
+  margin: 0 12px 0 16px;
+}
+.agent-header-tab {
+  height: 30px;
+  padding: 0 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+  letter-spacing: 0.2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.agent-header-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.agent-header-tab.active { color: var(--text-primary); background: var(--bg-active); }
+.agent-header-tab .aht-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent-green);
+}
+.nav-btn {
+  height: 30px;
+  padding: 0 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+  letter-spacing: 0.2px;
+}
+.nav-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.nav-btn.active { color: var(--text-primary); background: var(--bg-active); }
+.header-spacer { flex: 1; }
+.header-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.header-meta .status-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  display: inline-block;
+  margin-right: 4px;
+}
+.quick-switch-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-ghost);
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  padding: 2px 6px;
+}
+
+/* ── MAIN LAYOUT ── */
+.app-body {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ── LEFT PANEL: FILE TREE ── */
+.panel-left {
+  width: var(--tree-w);
+  min-width: var(--tree-w);
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: width 0.2s, min-width 0.2s;
+}
+.panel-left.collapsed { width: 0; min-width: 0; border-right: none; }
+
+.tree-header {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.tree-header .collapse-btn {
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: 14px;
+  transition: color 0.15s;
+}
+.tree-header .collapse-btn:hover { color: var(--text-primary); }
+
+.tree-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.tree-dashboard {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background 0.1s;
+  margin-bottom: 4px;
+}
+.tree-dashboard:hover { background: var(--bg-hover); color: var(--text-primary); }
+.tree-dashboard.active { background: var(--bg-active); color: var(--text-primary); }
+
+.tree-section {
+  margin-bottom: 4px;
+}
+.tree-section-header {
+  display: flex;
+  align-items: center;
+  padding: 4px 12px;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 0.1s;
+  user-select: none;
+}
+.tree-section-header:hover { background: var(--bg-hover); }
+.tree-chevron {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  transition: transform 0.15s;
+  width: 12px;
+  text-align: center;
+}
+.tree-section.open > .tree-section-header .tree-chevron { transform: rotate(90deg); }
+.tree-layer-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.tree-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: var(--text-secondary);
+  flex: 1;
+}
+.tree-section-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  min-width: 18px;
+  text-align: right;
+}
+.tree-items { display: none; }
+.tree-section.open > .tree-items { display: block; }
+
+.tree-item {
+  display: flex;
+  align-items: center;
+  padding: 3px 12px 3px 38px;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 0.1s;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.tree-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+.tree-item.active { background: var(--bg-active); color: var(--text-primary); }
+.tree-item-icon {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  width: 14px;
+  text-align: center;
+  flex-shrink: 0;
+}
+.tree-item-label { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tree-item-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 0px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.badge-count { color: var(--text-tertiary); }
+.badge-pending { background: rgba(245, 158, 11, 0.15); color: var(--accent-amber); }
+.badge-quorum { color: var(--text-tertiary); }
+.badge-status-confirmed { color: var(--text-secondary); }
+.badge-status-pending { color: var(--accent-amber); }
+.badge-status-finalized { color: var(--accent-green); }
+
+.tree-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 8px 12px;
+}
+
+/* ── CENTER CONSOLE ── */
+.panel-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Tabs */
+.center-tabs {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: stretch;
+  overflow-x: auto;
+  padding: 0 4px;
+}
+.center-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  transition: all 0.15s;
+  cursor: pointer;
+}
+.center-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.center-tab.active { 
+  color: var(--text-primary); 
+  border-bottom-color: var(--text-primary);
+}
+.center-tab .tab-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.center-tab .tab-close {
+  font-size: 14px;
+  color: var(--text-ghost);
+  margin-left: 4px;
+  transition: color 0.1s;
+  line-height: 1;
+}
+.center-tab .tab-close:hover { color: var(--text-primary); }
+
+/* Toolbar */
+.center-toolbar {
+  height: var(--toolbar-h);
+  min-height: var(--toolbar-h);
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 12px;
+}
+.toolbar-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.toolbar-breadcrumb .bc-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+}
+.toolbar-breadcrumb .bc-sep { color: var(--text-ghost); }
+.toolbar-breadcrumb .bc-label { font-weight: 500; }
+.toolbar-spacer { flex: 1; }
+.toolbar-action {
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.toolbar-action:hover { 
+  color: var(--text-primary); 
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+.toolbar-action.primary {
+  background: var(--text-primary);
+  color: var(--bg-root);
+  border-color: var(--text-primary);
+}
+.toolbar-action.primary:hover { opacity: 0.9; }
+
+/* Content area */
+.center-content {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--bg-root);
+  min-height: 0;
+}
+
+/* ── RIGHT PANEL: AGENT ── */
+.panel-right {
+  width: var(--agent-w);
+  min-width: var(--agent-w);
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: width 0.2s, min-width 0.2s;
+}
+.panel-right.collapsed { width: 0; min-width: 0; border-left: none; }
+
+.agent-header {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 4px;
+}
+.agent-mode-btn {
+  flex: 1;
+  height: 100%;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  color: var(--text-tertiary);
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
+}
+.agent-mode-btn:hover { color: var(--text-secondary); }
+.agent-mode-btn.active { color: var(--text-primary); border-bottom-color: var(--text-primary); }
+
+.agent-tabs {
+  height: 32px;
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 8px;
+  gap: 2px;
+  overflow-x: auto;
+}
+.agent-tab {
+  padding: 4px 10px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  border-radius: 3px;
+  transition: all 0.15s;
+  white-space: nowrap;
+  position: relative;
+}
+.agent-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.agent-tab.active { color: var(--text-primary); background: var(--bg-active); }
+.agent-tab .notif-dot {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--accent-red);
+  position: absolute;
+  top: 3px;
+  right: 3px;
+}
+
+.agent-task-bar {
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+.task-progress {
+  flex: 1;
+  height: 3px;
+  background: var(--border-default);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.task-progress-fill {
+  height: 100%;
+  width: 42%;
+  background: var(--text-secondary);
+  border-radius: 2px;
+  transition: width 0.3s;
+}
+.task-label { color: var(--text-secondary); font-family: var(--font-mono); font-size: 10px; }
+.task-cancel {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  padding: 2px 6px;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+}
+.task-cancel:hover { color: var(--accent-red); border-color: var(--accent-red); }
+
+.agent-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agent-msg {
+  font-size: 12px;
+  line-height: 1.6;
+}
+.agent-msg.user {
+  align-self: flex-end;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 10px 10px 2px 10px;
+  padding: 8px 12px;
+  max-width: 85%;
+  color: var(--text-primary);
+}
+.agent-msg.assistant {
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+.agent-msg .msg-action {
+  display: inline;
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.agent-msg .msg-action:hover { color: #fff; }
+
+/* Transaction card */
+.tx-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  padding: 12px;
+  margin: 4px 0;
+}
+.tx-card-header {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.tx-card-header .tx-icon { color: var(--accent-amber); }
+.tx-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 3px 0;
+  font-size: 12px;
+}
+.tx-row .tx-label { color: var(--text-tertiary); }
+.tx-row .tx-value { color: var(--text-primary); font-family: var(--font-mono); font-size: 11px; }
+.tx-divider { height: 1px; background: var(--border-subtle); margin: 8px 0; }
+.tx-total .tx-value { font-weight: 600; }
+.tx-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+.tx-btn {
+  flex: 1;
+  height: 32px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: all 0.15s;
+  letter-spacing: 0.2px;
+}
+.tx-btn.confirm {
+  background: var(--text-primary);
+  color: var(--bg-root);
+}
+.tx-btn.confirm:hover { opacity: 0.85; }
+.tx-btn.cancel {
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+}
+.tx-btn.cancel:hover { color: var(--text-primary); border-color: var(--text-primary); }
+
+.agent-input-area {
+  padding: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+.agent-input-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+.agent-input-row input {
+  flex: 1;
+  height: 36px;
+  border-radius: 6px;
+  font-size: 12px;
+  background: var(--bg-surface);
+}
+.agent-send-btn {
+  height: 36px;
+  width: 36px;
+  border-radius: 6px;
+  background: var(--text-primary);
+  color: var(--bg-root);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+.agent-send-btn:hover { opacity: 0.85; }
+
+/* ── BOTTOM PANEL: TELEMETRY ── */
+.panel-bottom {
+  height: var(--bottom-panel-h);
+  min-height: var(--bottom-panel-h);
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: height 0.2s, min-height 0.2s;
+}
+.panel-bottom.collapsed { height: 0; min-height: 0; border-top: none; }
+
+.bottom-tabs {
+  height: 30px;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 8px;
+  gap: 2px;
+}
+.bottom-tab {
+  padding: 4px 12px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  border-radius: 3px;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.bottom-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.bottom-tab.active { color: var(--text-primary); background: var(--bg-active); }
+.bottom-tab .btab-badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 0 4px;
+  border-radius: 2px;
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--accent-red);
+}
+.bottom-spacer { flex: 1; }
+.bottom-toggle {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  padding: 4px 8px;
+  transition: color 0.15s;
+}
+.bottom-toggle:hover { color: var(--text-primary); }
+
+.bottom-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+.log-line {
+  display: flex;
+  gap: 12px;
+  padding: 1px 0;
+}
+.log-line:hover { background: var(--bg-hover); }
+.log-ts { color: var(--text-ghost); min-width: 70px; }
+.log-level { min-width: 40px; font-weight: 500; }
+.log-level.info { color: var(--text-tertiary); }
+.log-level.warn { color: var(--accent-amber); }
+.log-level.ok { color: var(--accent-green); }
+.log-level.err { color: var(--accent-red); }
+.log-msg { color: var(--text-secondary); }
+
+/* ═══════════════════════════════════════════
+   CENTER CONTENT VIEWS
+   ═══════════════════════════════════════════ */
+
+/* ── DASHBOARD ── */
+.dashboard-view {
+  padding: 24px;
+  display: none;
+}
+.dashboard-view.visible { display: block; }
+
+.dash-row {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.dash-row.r1 { grid-template-columns: repeat(4, 1fr); }
+.dash-row.r2 { grid-template-columns: 1fr 1fr; }
+.dash-row.r3 { grid-template-columns: 1fr; }
+
+.dash-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 16px;
+}
+.dash-card-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 8px;
+}
+.dash-card-value {
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 300;
+  color: var(--text-primary);
+  letter-spacing: -0.5px;
+}
+.dash-card-sub {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.dash-card-sub .status-dot-sm {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+/* Mini memory stack */
+.mini-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+.mini-stack-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.mini-stack-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.mini-stack-name { color: var(--text-secondary); flex: 1; }
+.mini-stack-count { font-family: var(--font-mono); color: var(--text-primary); min-width: 30px; text-align: right; }
+.mini-stack-pct { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); min-width: 30px; text-align: right; }
+.mini-stack-bar {
+  flex: 1;
+  max-width: 80px;
+  height: 3px;
+  background: var(--border-default);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.mini-stack-bar-fill {
+  height: 100%;
+  background: var(--text-tertiary);
+  border-radius: 2px;
+}
+
+/* Activity feed */
+.activity-feed { margin-top: 8px; }
+.activity-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+.activity-item:last-child { border-bottom: none; }
+.activity-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 6px;
+}
+.activity-text { color: var(--text-secondary); flex: 1; line-height: 1.5; }
+.activity-text strong { color: var(--text-primary); font-weight: 500; }
+.activity-time {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-ghost);
+  flex-shrink: 0;
+}
+
+/* ── MEMORY STACK VIEW ── */
+.memory-stack-view {
+  padding: 24px;
+  display: none;
+  max-width: 700px;
+  margin: 0 auto;
+}
+.memory-stack-view.visible { display: block; }
+
+.stack-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 4px;
+  overflow: hidden;
+}
+.stack-card-header {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.stack-card-header:hover { background: var(--bg-hover); }
+.stack-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.stack-name {
+  font-weight: 600;
+  font-size: 13px;
+  flex: 1;
+}
+.stack-trust {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.stack-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.stack-privacy {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.stack-arrow {
+  text-align: center;
+  padding: 6px 0;
+  color: var(--text-ghost);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  letter-spacing: 1px;
+}
+
+/* ── WORKING MEMORY TAB VIEW ── */
+.working-memory-view {
+  padding: 16px;
+  display: none;
+}
+.working-memory-view.visible { display: block; }
+
+.wm-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.wm-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border-default);
+}
+.wm-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.wm-table tr:hover td { background: var(--bg-hover); color: var(--text-primary); }
+.wm-table td:first-child { width: 30px; }
+.wm-checkbox {
+  width: 14px; height: 14px;
+  accent-color: var(--text-primary);
+  cursor: pointer;
+}
+
+/* ── SHARED MEMORY: MERGE REQUEST VIEW ── */
+.merge-view {
+  padding: 16px;
+  display: none;
+}
+.merge-view.visible { display: block; }
+.merge-header-info {
+  padding: 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+.merge-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.merge-meta {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  gap: 16px;
+}
+.merge-diff {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.merge-diff-header {
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+}
+.diff-line {
+  padding: 2px 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.8;
+}
+.diff-line.add { background: rgba(34, 197, 94, 0.06); color: var(--accent-green); }
+.diff-line.remove { background: rgba(239, 68, 68, 0.06); color: var(--accent-red); }
+.diff-line.context { color: var(--text-tertiary); }
+
+/* ── VERIFIED MEMORY VIEW ── */
+.longterm-view {
+  padding: 16px;
+  display: none;
+}
+.longterm-view.visible { display: block; }
+.lt-asset {
+  padding: 14px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.lt-asset:hover { border-color: var(--border-strong); }
+.lt-status-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.lt-info { flex: 1; }
+.lt-name { font-weight: 500; font-size: 13px; margin-bottom: 2px; }
+.lt-ual {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  word-break: break-all;
+}
+.lt-chain-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+.lt-chain-badge.pending { border-color: rgba(245,158,11,0.3); color: var(--accent-amber); }
+.lt-chain-badge.confirmed { border-color: var(--border-strong); color: var(--text-secondary); }
+.lt-chain-badge.finalized { border-color: rgba(34,197,94,0.3); color: var(--accent-green); }
+.lt-toggle {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+/* ── ORACLE MODE ── */
+.oracle-view { display: none; }
+.oracle-view.visible { display: flex; flex-direction: column; flex: 1; }
+.oracle-search {
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.oracle-search input {
+  width: 100%;
+  height: 34px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+.oracle-results {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 12px;
+}
+.oracle-result {
+  padding: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.oracle-result:hover { background: var(--bg-hover); }
+.oracle-result-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.oracle-result-name { font-weight: 500; font-size: 12px; }
+.oracle-layer-badge {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+}
+.oracle-result-detail {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  display: flex;
+  gap: 12px;
+}
+
+/* ═══════════════════════════════════════════
+   QUICK SWITCHER OVERLAY
+   ═══════════════════════════════════════════ */
+.quick-switcher-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  z-index: 1000;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 15vh;
+  backdrop-filter: blur(4px);
+}
+.quick-switcher-overlay.visible { display: flex; }
+.quick-switcher {
+  width: 480px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+.qs-input {
+  width: 100%;
+  height: 48px;
+  padding: 0 16px;
+  font-size: 14px;
+  font-family: var(--font-sans);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border-default);
+  color: var(--text-primary);
+}
+.qs-input::placeholder { color: var(--text-ghost); }
+.qs-results {
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 4px;
+}
+.qs-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.qs-item:hover, .qs-item.selected { background: var(--bg-active); color: var(--text-primary); }
+.qs-item .qs-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.qs-item .qs-type { font-size: 10px; color: var(--text-ghost); margin-left: auto; font-family: var(--font-mono); }
+
+/* ═══════════════════════════════════════════
+   TOAST
+   ═══════════════════════════════════════════ */
+.toast-container {
+  position: fixed;
+  bottom: 240px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 500;
+}
+.toast {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 10px 16px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  box-shadow: 0 8px 30px rgba(0,0,0,0.4);
+  display: none;
+  align-items: center;
+  gap: 8px;
+  animation: toastIn 0.3s ease;
+}
+.toast.visible { display: flex; }
+.toast .toast-action {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  font-weight: 500;
+}
+@keyframes toastIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ═══════════════════════════════════════════
+   RESIZE HANDLES
+   ═══════════════════════════════════════════ */
+.resize-handle {
+  width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  transition: background 0.15s;
+  flex-shrink: 0;
+  z-index: 10;
+}
+.resize-handle:hover, .resize-handle.active { background: var(--border-strong); }
+.resize-handle-h {
+  height: 4px;
+  cursor: row-resize;
+  background: transparent;
+  transition: background 0.15s;
+  flex-shrink: 0;
+  z-index: 10;
+}
+.resize-handle-h:hover, .resize-handle-h.active { background: var(--border-strong); }
+
+/* ═══════════════════════════════════════════
+   V2 ADDITIONS: HEADER IDENTITY & NOTIFICATIONS
+   ═══════════════════════════════════════════ */
+.header-identity {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 4px;
+  position: relative;
+  transition: background 0.15s;
+}
+.header-identity:hover { background: var(--bg-hover); }
+
+.chain-dropdown {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 10px;
+  min-width: 320px;
+  z-index: 200;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+}
+.chain-dropdown.visible { display: block; }
+
+.chain-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.chain-row.active-chain { color: var(--text-primary); background: var(--bg-active); }
+.chain-row .chain-name { min-width: 90px; font-weight: 500; }
+.chain-row .chain-trac { min-width: 90px; text-align: right; }
+.chain-row .chain-gas { min-width: 90px; text-align: right; }
+
+.chain-dropdown-footer {
+  font-size: 10px;
+  color: var(--text-ghost);
+  text-align: center;
+  padding: 8px 0 2px;
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 8px;
+}
+
+.notif-bell {
+  position: relative;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 15px;
+  transition: background 0.15s;
+  margin: 0 6px;
+}
+.notif-bell:hover { background: var(--bg-hover); }
+
+.bell-badge {
+  position: absolute;
+  top: -1px;
+  right: 1px;
+  background: var(--accent-red);
+  color: #000;
+  font-size: 9px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.notif-dropdown {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  width: 380px;
+  max-height: 440px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  overflow: hidden;
+  z-index: 200;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+}
+.notif-dropdown.visible { display: block; }
+
+.notif-dropdown-header {
+  padding: 12px 16px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.notif-item {
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.1s;
+}
+.notif-item:hover { background: var(--bg-hover); }
+.notif-item .notif-border { width: 3px; border-radius: 2px; flex-shrink: 0; }
+.notif-item .notif-body { flex: 1; min-width: 0; }
+.notif-item .notif-text { font-size: 12px; color: var(--text-secondary); line-height: 1.6; margin-bottom: 8px; }
+.notif-item .notif-text strong { color: var(--text-primary); font-weight: 500; }
+.notif-item .notif-time { font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost); }
+.notif-item .notif-actions { display: flex; gap: 8px; margin-top: 8px; }
+
+.notif-action-btn {
+  font-size: 11px;
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  transition: all 0.15s;
+  font-family: inherit;
+  background: none;
+  cursor: pointer;
+}
+.notif-action-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.notif-action-btn.primary { background: var(--text-primary); color: var(--bg-root); border-color: var(--text-primary); }
+.notif-action-btn.primary:hover { opacity: 0.85; }
+
+.notif-dropdown-footer-bar {
+  padding: 10px 16px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.notif-dropdown-footer-bar a { color: var(--text-secondary); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
+
+/* ═══════════════════════════════════════════
+   V2 ADDITIONS: LEFT PANEL DUAL MODE
+   ═══════════════════════════════════════════ */
+.tree-mode-btn {
+  height: 100%;
+  padding: 0 12px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  color: var(--text-tertiary);
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
+}
+.tree-mode-btn:hover { color: var(--text-secondary); }
+.tree-mode-btn.active { color: var(--text-primary); border-bottom-color: var(--text-primary); }
+
+.new-project-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 6px 12px 10px;
+  padding: 8px 0;
+  border: 1px dashed var(--border-default);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+  letter-spacing: 0.3px;
+}
+.new-project-btn:hover { color: var(--text-primary); border-color: var(--border-strong); background: var(--bg-hover); }
+
+.oracle-panel { display: none; flex-direction: column; flex: 1; overflow: hidden; }
+.oracle-panel.visible { display: flex; }
+
+.oracle-sub-tabs {
+  display: flex;
+  padding: 6px 10px;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.oracle-sub-tab {
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-ghost);
+  border-radius: 3px;
+  transition: all 0.15s;
+}
+.oracle-sub-tab:hover { color: var(--text-tertiary); }
+.oracle-sub-tab.active { color: var(--text-secondary); background: var(--bg-active); }
+
+.oracle-browse-heading {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-ghost);
+  padding: 10px 0 8px;
+}
+
+.oracle-browse-card {
+  padding: 12px 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.oracle-browse-card:hover { border-color: var(--border-strong); }
+.oracle-browse-card .obc-name { font-weight: 500; font-size: 12px; margin-bottom: 4px; }
+.oracle-browse-card .obc-meta { font-size: 10px; font-family: var(--font-mono); color: var(--text-tertiary); display: flex; gap: 12px; }
+
+.oracle-search-result {
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background 0.1s;
+  position: relative;
+}
+.oracle-search-result:hover { background: var(--bg-hover); }
+.oracle-search-result .or-name { font-weight: 500; font-size: 12px; margin-bottom: 4px; }
+.oracle-search-result .or-meta { font-size: 10px; color: var(--text-tertiary); display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 4px; }
+.oracle-search-result .or-ual { font-family: var(--font-mono); font-size: 9px; color: var(--text-ghost); word-break: break-all; }
+
+.or-layer-badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: 2px;
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+}
+
+.or-fork-btn {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  font-size: 10px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+  opacity: 0;
+  transition: all 0.15s;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+.oracle-search-result:hover .or-fork-btn { opacity: 1; }
+.or-fork-btn:hover { color: var(--text-primary); border-color: var(--text-primary); background: var(--bg-active); }
+
+.oracle-filter-pill {
+  font-size: 10px;
+  padding: 4px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+  cursor: pointer;
+  background: none;
+  font-family: inherit;
+}
+.oracle-filter-pill:hover, .oracle-filter-pill.active { color: var(--text-secondary); border-color: var(--border-strong); background: var(--bg-active); }
+
+/* ═══════════════════════════════════════════
+   V2 ADDITIONS: RIGHT PANEL PEER SEARCH
+   ═══════════════════════════════════════════ */
+.peer-result {
+  padding: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.1s;
+}
+.peer-result:hover { background: var(--bg-hover); }
+.peer-result-header { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+
+.peer-tag {
+  font-size: 9px;
+  padding: 3px 8px;
+  border: 1px solid var(--border-default);
+  border-radius: 3px;
+  color: var(--text-tertiary);
+}
+
+.peer-invite-btn {
+  font-size: 10px;
+  padding: 4px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+.peer-invite-btn:hover { color: var(--text-primary); border-color: var(--text-primary); background: var(--bg-active); }
+
+.peer-invitation {
+  padding: 14px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 10px;
+}
+
+/* ═══════════════════════════════════════════
+   V2 ADDITIONS: MERGE PROVENANCE
+   ═══════════════════════════════════════════ */
+.merge-provenance {
+  padding: 14px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 12px;
+}
+.merge-provenance .mp-row { display: flex; gap: 14px; padding: 3px 0; color: var(--text-tertiary); }
+.merge-provenance .mp-row strong { color: var(--text-secondary); font-weight: 500; }
+
+
+/* ═══════════════════════════════════════════
+   V2 ADDITION: DAY/NIGHT MODE
+   ═══════════════════════════════════════════ */
+body.light {
+  --bg-root: #f5f5f5;
+  --bg-panel: #ffffff;
+  --bg-surface: #f0f0f0;
+  --bg-elevated: #ffffff;
+  --bg-hover: #e8e8e8;
+  --bg-active: #dedede;
+
+  --border-subtle: #e5e5e5;
+  --border-default: #d4d4d4;
+  --border-strong: #b0b0b0;
+
+  --text-primary: #1a1a1a;
+  --text-secondary: #555555;
+  --text-tertiary: #888888;
+  --text-ghost: #bbbbbb;
+
+  --accent-red: #dc2626;
+  --accent-amber: #d97706;
+  --accent-green: #16a34a;
+
+  --layer-working: #999999;
+  --layer-shared: #777777;
+  --layer-verified: #333333;
+}
+
+/* Light mode specific overrides */
+body.light .app-header {
+  background: #ffffff;
+  border-bottom-color: #e5e5e5;
+}
+
+body.light .panel-left,
+body.light .panel-right,
+body.light .panel-bottom {
+  background: #ffffff;
+}
+
+body.light .center-tabs {
+  background: #ffffff;
+}
+
+body.light .center-toolbar {
+  background: #f0f0f0;
+}
+
+body.light .center-content {
+  background: #f5f5f5;
+}
+
+body.light .dash-card {
+  background: #ffffff;
+  border-color: #e5e5e5;
+}
+
+body.light .tx-card {
+  background: #f0f0f0;
+  border-color: #d4d4d4;
+}
+
+body.light .agent-msg.user {
+  background: #e8e8e8;
+  border-color: #d4d4d4;
+}
+
+body.light .tx-btn.confirm {
+  background: #1a1a1a;
+  color: #ffffff;
+}
+
+body.light .agent-send-btn {
+  background: #1a1a1a;
+  color: #ffffff;
+}
+
+body.light .nav-btn.active {
+  background: #e8e8e8;
+}
+
+body.light .center-tab.active {
+  border-bottom-color: #1a1a1a;
+}
+
+body.light .agent-mode-btn.active {
+  border-bottom-color: #1a1a1a;
+}
+
+body.light .tree-mode-btn.active {
+  border-bottom-color: #1a1a1a;
+}
+
+body.light .agent-tab.active {
+  background: #e8e8e8;
+}
+
+body.light .bottom-tab.active {
+  background: #e8e8e8;
+}
+
+body.light .oracle-sub-tab.active {
+  background: #e8e8e8;
+}
+
+body.light .stack-card {
+  border-color: #e5e5e5;
+}
+
+body.light .merge-diff {
+  border-color: #e5e5e5;
+}
+
+body.light .merge-diff-header {
+  background: #f0f0f0;
+}
+
+body.light .merge-header-info,
+body.light .merge-provenance {
+  background: #f0f0f0;
+  border-color: #e5e5e5;
+}
+
+body.light .diff-line.add {
+  background: rgba(22, 163, 74, 0.08);
+}
+
+body.light .diff-line.remove {
+  background: rgba(220, 38, 38, 0.08);
+}
+
+body.light .lt-asset {
+  border-color: #e5e5e5;
+}
+
+body.light .lt-asset:hover {
+  border-color: #b0b0b0;
+}
+
+body.light .wm-table th {
+  border-bottom-color: #d4d4d4;
+}
+
+body.light .wm-table td {
+  border-bottom-color: #e5e5e5;
+}
+
+body.light .wm-table tr:hover td {
+  background: #e8e8e8;
+}
+
+body.light .quick-switcher-overlay,
+body.light .qs-overlay {
+  background: rgba(0, 0, 0, 0.3);
+}
+
+body.light .quick-switcher,
+body.light .qs-box {
+  background: #ffffff;
+  border-color: #d4d4d4;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+}
+
+body.light .toast {
+  background: #ffffff;
+  border-color: #d4d4d4;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+  color: #555555;
+}
+
+body.light .chain-dropdown,
+body.light .notif-dropdown {
+  background: #ffffff;
+  border-color: #d4d4d4;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
+}
+
+body.light .chain-row.active-chain {
+  background: #e8e8e8;
+}
+
+body.light .notif-action-btn.primary {
+  background: #1a1a1a;
+  color: #ffffff;
+  border-color: #1a1a1a;
+}
+
+body.light .bell-badge {
+  color: #ffffff;
+}
+
+body.light .oracle-browse-card {
+  border-color: #e5e5e5;
+}
+
+body.light .oracle-browse-card:hover {
+  border-color: #b0b0b0;
+}
+
+body.light .oracle-search-result {
+  border-bottom-color: #e5e5e5;
+}
+
+body.light .peer-result {
+  border-bottom-color: #e5e5e5;
+}
+
+body.light .peer-invitation {
+  border-color: #e5e5e5;
+}
+
+body.light .t-btn.primary {
+  background: #1a1a1a;
+  color: #ffffff;
+  border-color: #1a1a1a;
+}
+
+body.light .agent-task-bar {
+  background: #f0f0f0;
+}
+
+body.light .new-project-btn {
+  border-color: #d4d4d4;
+}
+
+body.light .new-project-btn:hover {
+  border-color: #b0b0b0;
+  background: #e8e8e8;
+}
+
+body.light input,
+body.light textarea {
+  background: #ffffff;
+  border-color: #d4d4d4;
+  color: #1a1a1a;
+}
+
+body.light .log-line:hover {
+  background: #e8e8e8;
+}
+
+body.light ::-webkit-scrollbar-thumb {
+  background: #d4d4d4;
+}
+
+body.light ::-webkit-scrollbar-thumb:hover {
+  background: #b0b0b0;
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--border-default);
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 12px;
+  margin-left: 8px;
+  user-select: none;
+}
+.theme-toggle:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+.theme-toggle .toggle-track {
+  width: 32px;
+  height: 18px;
+  border-radius: 9px;
+  background: var(--border-default);
+  position: relative;
+  transition: background 0.2s;
+}
+.theme-toggle .toggle-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 7px;
+  background: var(--text-primary);
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  transition: left 0.2s;
+}
+body.light .theme-toggle .toggle-thumb {
+  left: 16px;
+}
+.theme-toggle .toggle-icon {
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* ═══════════════════════════════════════════
+   MODAL OVERLAY SYSTEM
+   ═══════════════════════════════════════════ */
+.modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+}
+.modal-overlay.visible { display: flex; }
+.modal-box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  width: 560px;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+.modal-box.wide { width: 640px; }
+.modal-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.modal-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.modal-subtitle {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.modal-body {
+  padding: 20px 24px;
+}
+.modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.modal-btn {
+  height: 34px;
+  padding: 0 18px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  background: none;
+}
+.modal-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.modal-btn.primary {
+  background: var(--text-primary);
+  color: var(--bg-root);
+  border-color: var(--text-primary);
+}
+.modal-btn.primary:hover { opacity: 0.85; }
+
+/* Form elements for modals */
+.form-group {
+  margin-bottom: 16px;
+}
+.form-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+}
+.form-input {
+  width: 100%;
+  height: 36px;
+  border-radius: 6px;
+  font-size: 12px;
+  padding: 0 12px;
+}
+.form-textarea {
+  width: 100%;
+  min-height: 60px;
+  border-radius: 6px;
+  font-size: 12px;
+  padding: 8px 12px;
+  resize: vertical;
+  font-family: var(--font-sans);
+}
+.form-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.form-radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.form-radio input[type="radio"] {
+  accent-color: var(--text-primary);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+.form-radio-desc {
+  font-size: 11px;
+  color: var(--text-ghost);
+  margin-left: 22px;
+  margin-top: -4px;
+}
+.form-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.form-inline input[type="number"] {
+  width: 50px;
+  height: 30px;
+  text-align: center;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+}
+.form-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 20px 0;
+}
+
+/* ═══════════════════════════════════════════
+   IMPORT / INGESTION UI
+   ═══════════════════════════════════════════ */
+.import-dropzone {
+  border: 2px dashed var(--border-default);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-bottom: 16px;
+}
+.import-dropzone:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+.import-dropzone-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.import-dropzone-hint {
+  font-size: 11px;
+  color: var(--text-ghost);
+}
+.import-file-list {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+.import-file-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.import-file-item:last-child { border-bottom: none; }
+.import-file-icon {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  width: 18px;
+  text-align: center;
+}
+.import-file-name { flex: 1; color: var(--text-secondary); }
+.import-file-size { font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost); }
+.import-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+.import-option input[type="checkbox"] {
+  accent-color: var(--text-primary);
+  width: 14px;
+  height: 14px;
+}
+
+/* ═══════════════════════════════════════════
+   CONSENSUS VOTE UI
+   ═══════════════════════════════════════════ */
+.vote-finding {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+.vote-finding-name { flex: 1; font-weight: 500; }
+.vote-finding-meta { font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.vote-quorum-bar {
+  display: flex;
+  gap: 4px;
+  margin: 12px 0;
+}
+.vote-quorum-slot {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--border-default);
+}
+.vote-quorum-slot.filled { background: var(--accent-green); }
+.vote-quorum-slot.pending { background: var(--accent-amber); }
+.vote-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: 8px;
+}
+.vote-option:hover { border-color: var(--border-strong); background: var(--bg-hover); }
+.vote-option.selected { border-color: var(--text-primary); background: var(--bg-active); }
+.vote-option input[type="radio"] { accent-color: var(--text-primary); width: 16px; height: 16px; }
+.vote-option-label { font-size: 13px; font-weight: 500; }
+.vote-voter-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  font-size: 12px;
+}
+.vote-voter-status {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ═══════════════════════════════════════════
+   PUBLISH CONFIRMATION MODAL
+   ═══════════════════════════════════════════ */
+.publish-summary-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  font-size: 12px;
+}
+.publish-summary-row .ps-label { color: var(--text-tertiary); }
+.publish-summary-row .ps-value { font-family: var(--font-mono); font-size: 11px; color: var(--text-primary); }
+.publish-info-box {
+  padding: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  line-height: 1.6;
+  margin-top: 12px;
+}
+
+/* ═══════════════════════════════════════════
+   DRAFT CARD VIEW (Working Memory)
+   ═══════════════════════════════════════════ */
+.draft-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 10px;
+  transition: border-color 0.15s;
+}
+.draft-card:hover { border-color: var(--border-strong); }
+.draft-card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.draft-card-title { font-weight: 500; font-size: 13px; flex: 1; }
+.draft-card-badge {
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--border-default);
+  color: var(--text-tertiary);
+}
+.draft-card-badge.ready { border-color: rgba(34,197,94,0.3); color: var(--accent-green); }
+.draft-card-badge.flagged { border-color: rgba(245,158,11,0.3); color: var(--accent-amber); }
+.draft-card-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-bottom: 10px;
+}
+.draft-card-snippet {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  background: var(--bg-surface);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+}
+.draft-card-actions {
+  display: flex;
+  gap: 8px;
+}
+.draft-action-btn {
+  font-size: 11px;
+  padding: 5px 14px;
+  border-radius: 5px;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 500;
+  transition: all 0.15s;
+}
+.draft-action-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.draft-action-btn.primary {
+  background: var(--text-primary);
+  color: var(--bg-root);
+  border-color: var(--text-primary);
+}
+.draft-action-btn.primary:hover { opacity: 0.85; }
+.draft-action-btn.danger:hover { color: var(--accent-red); border-color: var(--accent-red); }
+
+/* ═══════════════════════════════════════════
+   ENDORSEMENT WITH COMMENTS
+   ═══════════════════════════════════════════ */
+.endorsement-list {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+.endorsement-item {
+  display: flex;
+  gap: 10px;
+  padding: 8px 0;
+  font-size: 11px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.endorsement-item:last-child { border-bottom: none; }
+.endorsement-author {
+  font-weight: 500;
+  color: var(--text-primary);
+  min-width: 80px;
+}
+.endorsement-comment {
+  color: var(--text-secondary);
+  font-style: italic;
+  flex: 1;
+}
+.endorsement-time {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-ghost);
+  flex-shrink: 0;
+}
+
+/* ═══════════════════════════════════════════
+   VERIFICATION TIMELINE
+   ═══════════════════════════════════════════ */
+.verification-timeline {
+  margin-top: 12px;
+  padding-left: 16px;
+  border-left: 2px solid var(--border-default);
+}
+.vt-event {
+  position: relative;
+  padding: 0 0 14px 16px;
+  font-size: 11px;
+}
+.vt-event:last-child { padding-bottom: 0; }
+.vt-event::before {
+  content: '';
+  position: absolute;
+  left: -21px;
+  top: 4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border-default);
+  border: 2px solid var(--bg-elevated);
+}
+.vt-event.active::before { background: var(--accent-green); }
+.vt-event.amber::before { background: var(--accent-amber); }
+.vt-event .vt-date {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-ghost);
+  margin-bottom: 2px;
+}
+.vt-event .vt-text { color: var(--text-secondary); }
+.vt-event .vt-text strong { color: var(--text-primary); font-weight: 500; }
+
+/* ═══════════════════════════════════════════
+   ONTOLOGY CONFIG
+   ═══════════════════════════════════════════ */
+.ontology-option {
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.ontology-option:hover { border-color: var(--border-strong); }
+.ontology-option.selected { border-color: var(--text-primary); background: var(--bg-active); }
+.ontology-list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ontology-list-item:hover { background: var(--bg-hover); }
+.ontology-list-item .oli-name { flex: 1; color: var(--text-secondary); }
+.ontology-list-item .oli-tag { font-size: 10px; color: var(--text-ghost); font-style: italic; }
+
+/* Light mode additions */
+body.light .modal-box {
+  background: #ffffff;
+  border-color: #d4d4d4;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.15);
+}
+body.light .draft-card { border-color: #e5e5e5; }
+body.light .draft-card:hover { border-color: #b0b0b0; }
+body.light .draft-card-snippet { background: #f0f0f0; }
+body.light .vote-option.selected { background: #e8e8e8; border-color: #1a1a1a; }
+body.light .modal-btn.primary { background: #1a1a1a; color: #ffffff; border-color: #1a1a1a; }
+body.light .draft-action-btn.primary { background: #1a1a1a; color: #ffffff; border-color: #1a1a1a; }
+body.light .import-dropzone { border-color: #d4d4d4; }
+body.light .import-dropzone:hover { border-color: #b0b0b0; background: #e8e8e8; }
+body.light .publish-info-box { background: #f0f0f0; border-color: #e5e5e5; }
+body.light .ontology-option.selected { background: #e8e8e8; border-color: #1a1a1a; }
+
+/* ═══════════════════════════════════════════
+   SHARE PROJECT MODAL
+   ═══════════════════════════════════════════ */
+.share-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-ghost);
+  padding: 12px 0 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.share-invite-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.share-invite-row input {
+  flex: 1;
+  height: 36px;
+  border-radius: 6px;
+  font-size: 12px;
+}
+.share-role-select {
+  height: 32px;
+  padding: 0 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 24px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23555'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+}
+.share-role-select:hover { border-color: var(--border-strong); }
+.share-invite-btn {
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--text-primary);
+  color: var(--bg-root);
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+.share-invite-btn:hover { opacity: 0.85; }
+.share-access-dropdown {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 28px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23555'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.share-access-dropdown:hover { border-color: var(--border-strong); }
+.share-member {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.share-member:last-child { border-bottom: none; }
+.share-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-active);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  position: relative;
+}
+.share-avatar .online-dot {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  border: 2px solid var(--bg-elevated);
+}
+.share-avatar .offline-dot {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-ghost);
+  border: 2px solid var(--bg-elevated);
+}
+.share-member-info { flex: 1; min-width: 0; }
+.share-member-name { font-size: 12px; font-weight: 500; }
+.share-member-meta {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.share-member-group {
+  font-size: 10px;
+  color: var(--text-ghost);
+}
+body.light .share-role-select { background: #f0f0f0; border-color: #d4d4d4; }
+body.light .share-access-dropdown { background: #f0f0f0; border-color: #d4d4d4; }
+body.light .share-avatar { background: #e8e8e8; }
+body.light .share-invite-btn { background: #1a1a1a; color: #fff; }
+
+/* ═══════════════════════════════════════════
+   V4: OPERATOR IDENTITY
+   ═══════════════════════════════════════════ */
+.header-identity {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 4px;
+  position: relative;
+  transition: background 0.15s;
+}
+.header-identity:hover { background: var(--bg-hover); }
+.chain-dropdown {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  padding: 10px;
+  min-width: 320px;
+  z-index: 200;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+}
+.chain-dropdown.visible { display: block; }
+.chain-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.chain-row.active-chain { color: var(--text-primary); background: var(--bg-active); }
+.chain-row .chain-name { min-width: 90px; font-weight: 500; }
+.chain-row .chain-trac { min-width: 90px; text-align: right; }
+.chain-row .chain-gas { min-width: 90px; text-align: right; }
+body.light .chain-dropdown { background: #fff; border-color: #d4d4d4; box-shadow: 0 12px 40px rgba(0,0,0,0.12); }
+body.light .chain-row.active-chain { background: #e8e8e8; }
+
+/* ═══════════════════════════════════════════
+   V4: KA INSPECTOR
+   ═══════════════════════════════════════════ */
+.ka-inspector { padding: 20px 24px; }
+.ka-section { margin-bottom: 16px; }
+.ka-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-ghost);
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.ka-trust-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+}
+.ka-field { display: flex; justify-content: space-between; padding: 4px 0; font-size: 12px; }
+.ka-field .ka-label { color: var(--text-tertiary); }
+.ka-field .ka-value { font-family: var(--font-mono); font-size: 11px; color: var(--text-primary); }
+.ka-actions { display: flex; gap: 8px; margin-top: 12px; }
+
+/* ═══════════════════════════════════════════
+   V4: CONSENSUS VOTE VIEW
+   ═══════════════════════════════════════════ */
+.cv-header { padding: 16px; background: var(--bg-surface); border-radius: 8px; margin-bottom: 16px; }
+.cv-finding { border: 1px solid var(--border-subtle); border-radius: 8px; padding: 14px; margin-bottom: 8px; }
+.cv-finding-header { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+.cv-finding-name { font-weight: 500; font-size: 13px; flex: 1; }
+.cv-vote-toggle { display: flex; gap: 4px; }
+.cv-vote-btn {
+  padding: 4px 14px; border-radius: 4px; font-size: 11px; font-weight: 500;
+  border: 1px solid var(--border-default); background: none; color: var(--text-tertiary);
+  cursor: pointer; font-family: inherit; transition: all 0.15s;
+}
+.cv-vote-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.cv-vote-btn.approve { border-color: rgba(34,197,94,0.4); color: var(--accent-green); background: rgba(34,197,94,0.06); }
+.cv-vote-btn.reject { border-color: rgba(239,68,68,0.4); color: var(--accent-red); background: rgba(239,68,68,0.06); }
+.cv-quorum-bar { display: flex; gap: 3px; margin: 8px 0; }
+.cv-quorum-slot { flex: 1; height: 5px; border-radius: 3px; background: var(--border-default); }
+.cv-quorum-slot.filled { background: var(--accent-green); }
+.cv-quorum-slot.pending { background: var(--accent-amber); }
+body.light .cv-header { background: #f0f0f0; }
+body.light .cv-finding { border-color: #e5e5e5; }
+body.light .cv-vote-btn.approve { background: rgba(22,163,74,0.08); }
+body.light .cv-vote-btn.reject { background: rgba(220,38,38,0.08); }
+
+/* V4: Partially verified badge */
+.badge-partial { color: var(--accent-amber); font-size: 11px; }
+
+/* ═══════════════════════════════════════════
+   V5.1: JOURNEY STATE MACHINE (agent-first per brief)
+   ═══════════════════════════════════════════
+   Stage 0 = cold start (no agent connected — only right panel active)
+   Stage 1 = agent connected (no project yet — project creation available)
+   Stage 2 = project created (full populated state, default)
+*/
+body[data-stage="0"] .stage-1, body[data-stage="0"] .stage-2 { display: none !important; }
+body[data-stage="1"] .stage-0, body[data-stage="1"] .stage-2 { display: none !important; }
+body[data-stage="2"] .stage-0, body[data-stage="2"] .stage-1 { display: none !important; }
+/* stage-01 = visible in stages 0 AND 1, hidden in stage 2 */
+body[data-stage="2"] .stage-01 { display: none !important; }
+/* stage-12 = visible in stages 1 AND 2 (agent connected), hidden in stage 0 */
+body[data-stage="0"] .stage-12 { display: none !important; }
+
+/* Stage 0: lock left panel tree content and bottom panel (only show locked message) */
+body[data-stage="0"] #treeExplorer > *:not(.locked-tree-msg),
+body[data-stage="0"] #treeOracle { display: none !important; }
+body[data-stage="0"] .panel-bottom { display: none !important; }
+body[data-stage="0"] .resize-handle-h { display: none !important; }
+
+.locked-tree-msg {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--text-ghost);
+  font-size: 11px;
+  line-height: 1.6;
+}
+.locked-tree-msg .ltm-icon {
+  font-size: 22px;
+  display: block;
+  margin-bottom: 10px;
+  opacity: 0.5;
+}
+
+/* Empty-state card styling used in multiple panels */
+.journey-empty-card {
+  padding: 24px 18px;
+  border: 1px dashed var(--border-default);
+  border-radius: 8px;
+  text-align: center;
+  margin: 14px 12px;
+}
+.journey-empty-card .jec-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+.journey-empty-card .jec-hint {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+/* Journey badge in header showing current stage */
+.journey-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px dashed var(--border-default);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-left: 6px;
+}
+.journey-badge:hover { color: var(--text-primary); border-color: var(--border-strong); }
+body[data-stage="0"] .journey-badge { color: var(--accent-amber); border-color: rgba(245,158,11,0.3); }
+body[data-stage="1"] .journey-badge { color: var(--accent-amber); border-color: rgba(245,158,11,0.3); }
+body[data-stage="2"] .journey-badge { color: var(--accent-green); border-color: rgba(34,197,94,0.3); }
+
+/* ═══════════════════════════════════════════
+   V5: GRAPHIFY INTEGRATION
+   ═══════════════════════════════════════════ */
+.graphify-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.graphify-stat {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 10px 12px;
+  text-align: center;
+}
+.graphify-stat-value {
+  font-family: var(--font-mono);
+  font-size: 20px;
+  font-weight: 300;
+  color: var(--text-primary);
+}
+.graphify-stat-label {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 2px;
+}
+.graphify-community {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.graphify-community:hover { border-color: var(--border-strong); background: var(--bg-hover); }
+.graphify-community.active { border-color: var(--text-primary); color: var(--text-primary); background: var(--bg-active); }
+.graphify-godnode {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+.graphify-godnode:last-child { border-bottom: none; }
+body.light .graphify-stat { background: #f0f0f0; border-color: #e5e5e5; }
+
+</style>
+</head>
+<body data-stage="0">
+
+<div id="app">
+  <!-- ═══ HEADER ═══ -->
+  <header class="app-header">
+    <div class="app-logo" style="display:flex; align-items:center; gap:10px">
+      <svg width="120" height="26" viewBox="60 82 410 96" fill="none" xmlns="http://www.w3.org/2000/svg" style="flex-shrink:0" preserveAspectRatio="xMinYMid meet">
+        <path d="M188.307 147.622C198.857 147.622 205.186 139.966 205.186 130.858C205.186 121.816 198.857 114.16 188.307 114.16C177.824 114.16 171.494 121.816 171.494 130.858C171.494 139.966 177.824 147.622 188.307 147.622ZM188.307 140.164C183.099 140.164 180.197 135.874 180.197 130.858C180.197 125.908 183.099 121.618 188.307 121.618C193.516 121.618 196.483 125.908 196.483 130.858C196.483 135.874 193.516 140.164 188.307 140.164Z" fill="currentColor"/>
+        <path d="M211.399 146.83H219.772V125.776C221.157 123.73 224.849 122.212 227.618 122.212C228.542 122.212 229.333 122.278 229.926 122.41V114.226C225.97 114.226 222.014 116.47 219.772 119.308V114.952H211.399V146.83Z" fill="currentColor"/>
+        <path d="M239.312 110.266C242.081 110.266 244.323 108.022 244.323 105.25C244.323 102.478 242.081 100.234 239.312 100.234C236.609 100.234 234.301 102.478 234.301 105.25C234.301 108.022 236.609 110.266 239.312 110.266ZM235.158 146.83H243.532V114.952H235.158V146.83Z" fill="currentColor"/>
+        <path d="M251.175 155.014C255.132 158.512 259.417 159.766 264.89 159.766C272.736 159.766 282.099 156.796 282.099 144.652V114.952H273.659V119.044C271.088 115.81 267.659 114.16 263.835 114.16C255.791 114.16 249.791 119.968 249.791 130.396C249.791 141.022 255.857 146.632 263.835 146.632C267.725 146.632 271.153 144.784 273.659 141.616V144.85C273.659 151.12 268.912 152.902 264.89 152.902C260.868 152.902 257.505 151.78 254.934 148.942L251.175 155.014ZM273.659 135.544C272.274 137.59 269.241 139.174 266.472 139.174C261.725 139.174 258.428 135.874 258.428 130.396C258.428 124.918 261.725 121.618 266.472 121.618C269.241 121.618 272.274 123.136 273.659 125.248V135.544Z" fill="currentColor"/>
+        <path d="M294.558 110.266C297.327 110.266 299.568 108.022 299.568 105.25C299.568 102.478 297.327 100.234 294.558 100.234C291.854 100.234 289.547 102.478 289.547 105.25C289.547 108.022 291.854 110.266 294.558 110.266ZM290.404 146.83H298.777V114.952H290.404V146.83Z" fill="currentColor"/>
+        <path d="M328.575 146.83H336.948V124.324C336.948 118.12 333.586 114.16 326.597 114.16C321.388 114.16 317.498 116.668 315.454 119.11V114.952H307.08V146.83H315.454V125.38C316.839 123.466 319.41 121.618 322.707 121.618C326.267 121.618 328.575 123.136 328.575 127.558V146.83Z" fill="currentColor"/>
+        <path d="M355.944 147.622C359.439 147.622 361.68 146.698 362.933 145.576L361.153 139.24C360.691 139.702 359.505 140.164 358.252 140.164C356.406 140.164 355.351 138.646 355.351 136.666V122.278H361.812V114.952H355.351V106.24H346.911V114.952H341.636V122.278H346.911V138.91C346.911 144.586 350.076 147.622 355.944 147.622Z" fill="currentColor"/>
+        <path d="M367.541 146.83H375.915V125.776C377.3 123.73 380.992 122.212 383.761 122.212C384.684 122.212 385.475 122.278 386.069 122.41V114.226C382.113 114.226 378.157 116.47 375.915 119.308V114.952H367.541V146.83Z" fill="currentColor"/>
+        <path d="M413.191 146.83H421.63V114.952H413.191V119.044C410.685 115.81 407.125 114.16 403.367 114.16C395.257 114.16 389.257 120.496 389.257 130.924C389.257 141.55 395.323 147.622 403.367 147.622C407.191 147.622 410.685 145.906 413.191 142.804V146.83ZM413.191 136.534C411.74 138.646 408.773 140.164 405.938 140.164C401.191 140.164 397.894 136.402 397.894 130.924C397.894 125.38 401.191 121.684 405.938 121.684C408.773 121.684 411.74 123.202 413.191 125.314V136.534Z" fill="currentColor"/>
+        <path d="M434.088 110.266C436.857 110.266 439.099 108.022 439.099 105.25C439.099 102.478 436.857 100.234 434.088 100.234C431.385 100.234 429.077 102.478 429.077 105.25C429.077 108.022 431.385 110.266 434.088 110.266ZM429.934 146.83H438.308V114.952H429.934V146.83Z" fill="currentColor"/>
+        <path d="M455.578 147.622C459.006 147.622 461.248 146.698 462.501 145.576L460.721 139.24C460.325 139.702 459.138 140.164 457.885 140.164C456.039 140.164 454.984 138.646 454.984 136.666V102.808H446.611V138.91C446.611 144.586 449.71 147.622 455.578 147.622Z" fill="currentColor"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M109.956 107.884C97.7549 107.884 87.8624 117.785 87.8624 130C87.8624 142.213 97.7549 152.114 109.956 152.114C116.738 152.114 122.805 149.054 126.857 144.239L143.583 158.332C135.52 167.911 123.449 174 109.956 174C85.679 174 66 154.3 66 130C66 105.699 85.679 86 109.956 86V107.884ZM147.937 152.156L129.045 141.136C129.69 140.031 130.242 138.865 130.69 137.649L151.21 145.22C150.319 147.64 149.22 149.958 147.937 152.156ZM132.048 130H153.912C153.912 127.393 153.684 124.84 153.25 122.358L131.715 126.159C131.933 127.407 132.048 128.69 132.048 130ZM143.743 101.858L126.937 115.855C126.114 114.866 125.206 113.951 124.225 113.119L138.346 96.413C140.299 98.0683 142.105 99.8897 143.743 101.858Z" fill="currentColor"/>
+      </svg>
+      <span style="color:var(--text-ghost); font-weight:300; font-size:11px; font-family:var(--font-mono); letter-spacing:0.5px">DKG v10</span>
+      <span id="criticalOpLabel" style="display:none; font-size:10px; font-weight:400; font-family:var(--font-mono); color:var(--accent-amber); margin-left:10px"></span>
+    </div>
+    <div class="logo-sep"></div>
+    <button class="agent-header-tab active stage-12" onclick="switchAgent('research-agent',this)"><span class="aht-dot"></span>research-agent</button>
+    <button class="agent-header-tab stage-2" onclick="switchAgent('literature-scanner',this)"><span class="aht-dot"></span>literature-scanner</button>
+    <button class="agent-header-tab stage-2" onclick="switchAgent('guideline-checker',this)"><span class="aht-dot"></span>guideline-checker</button>
+    <button class="agent-header-tab stage-2" onclick="switchAgent('graphify-agent',this)"><span class="aht-dot" style="background:var(--accent-amber)"></span>graphify-agent</button>
+    <button class="stage-12" onclick="addNewAgent()" style="height:30px; padding:0 12px; border-radius:4px; font-size:11px; font-weight:500; font-family:var(--font-mono); color:var(--text-tertiary); background:none; border:1px dashed var(--border-default); cursor:pointer; transition:all 0.15s; margin-left:4px" onmouseover="this.style.color='var(--text-primary)';this.style.borderColor='var(--border-strong)'" onmouseout="this.style.color='var(--text-tertiary)';this.style.borderColor='var(--border-default)'">+ New Agent</button>
+    <span class="stage-0" style="font-family:var(--font-mono); font-size:11px; color:var(--text-ghost); padding:0 10px">no agents connected — connect one to get started</span>
+    <span class="journey-badge" onclick="showJourneyControl()" title="Click to change journey stage">stage <span id="journeyStageLabel">0</span>/2</span>
+    <div class="header-spacer"></div>
+
+    <div class="header-identity" id="chainIdentity" onclick="toggleDropdown('chainDrop')">
+      <span style="color:var(--accent-green)">●</span> Base
+      <span style="color:var(--text-ghost)">·</span>
+      <span>0x8a4f...c3b2</span>
+      <span style="color:var(--text-ghost)">·</span>
+      <span>4,230 TRAC</span>
+      <div class="chain-dropdown" id="chainDrop">
+        <div class="chain-row active-chain">
+          <span class="chain-name">● Base</span>
+          <span class="chain-trac">4,230 TRAC</span>
+          <span class="chain-gas">0.12 ETH</span>
+        </div>
+        <div class="chain-row">
+          <span class="chain-name">Gnosis</span>
+          <span class="chain-trac">8,100 TRAC</span>
+          <span class="chain-gas">24.5 xDAI</span>
+        </div>
+        <div class="chain-row">
+          <span class="chain-name">NeuroWeb</span>
+          <span class="chain-trac">1,450 TRAC</span>
+          <span class="chain-gas">892 NEURO</span>
+        </div>
+        <div style="font-size:10px; color:var(--text-ghost); text-align:center; padding:8px 0 2px; border-top:1px solid var(--border-subtle); margin-top:8px">Chain switching in node settings</div>
+      </div>
+    </div>
+
+    <div class="notif-bell" id="notifBell" onclick="toggleDropdown('notifDrop')">
+      🔔<span class="bell-badge">6</span>
+      <div class="notif-dropdown" id="notifDrop" style="width:420px">
+        <div class="notif-dropdown-header" style="display:flex; justify-content:space-between; align-items:center">
+          <span>Notifications</span>
+          <span style="font-size:9px; font-weight:400; text-transform:none; letter-spacing:0; color:var(--text-ghost)">Sorted by priority</span>
+        </div>
+
+        <!-- CRITICAL (red) -->
+        <div style="padding:6px 16px 2px; font-size:9px; font-weight:600; letter-spacing:0.6px; text-transform:uppercase; color:var(--accent-red)">Critical</div>
+        <div class="notif-item">
+          <div class="notif-border" style="background:var(--accent-red); width:3px"></div>
+          <div class="notif-body">
+            <div class="notif-text"><strong>Publish failed</strong><br>warfarin-ssri-007 — chain transaction reverted (insufficient gas). Retry?</div>
+            <div class="notif-time">12m ago</div>
+            <div class="notif-actions">
+              <button class="notif-action-btn primary" onclick="event.stopPropagation();showToast('Retrying publish with higher gas...')">Retry</button>
+              <button class="notif-action-btn" onclick="event.stopPropagation();showToast('Dismissed')">Dismiss</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- URGENT (amber) -->
+        <div style="padding:6px 16px 2px; font-size:9px; font-weight:600; letter-spacing:0.6px; text-transform:uppercase; color:var(--accent-amber)">Urgent</div>
+        <div class="notif-item">
+          <div class="notif-border" style="background:var(--accent-amber); width:3px"></div>
+          <div class="notif-body">
+            <div class="notif-text"><strong>Consensus vote required</strong><br>Warfarin + Aspirin batch — 2/5 quorum, your vote needed</div>
+            <div class="notif-time">1h ago</div>
+            <div class="notif-actions">
+              <button class="notif-action-btn primary" onclick="event.stopPropagation();switchCenterTab('consensus-vote')">Vote</button>
+              <button class="notif-action-btn" onclick="event.stopPropagation();showToast('Skipped for now')">Later</button>
+            </div>
+          </div>
+        </div>
+        <div class="notif-item">
+          <div class="notif-border" style="background:var(--accent-amber); width:3px"></div>
+          <div class="notif-body">
+            <div class="notif-text"><strong>SWM TTL warning</strong><br>23 shared entities in pharma-drug-interactions expire in 48h</div>
+            <div class="notif-time">2h ago</div>
+            <div class="notif-actions">
+              <button class="notif-action-btn primary" onclick="event.stopPropagation();switchCenterTab('pharma-project')">Review</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- NORMAL (no border) -->
+        <div style="padding:6px 16px 2px; font-size:9px; font-weight:600; letter-spacing:0.6px; text-transform:uppercase; color:var(--text-tertiary)">Normal</div>
+        <div class="notif-item">
+          <div class="notif-border" style="background:transparent; width:3px"></div>
+          <div class="notif-body">
+            <div class="notif-text">Dr. Chen endorsed <strong>metformin-contrast-002</strong> — &quot;Cross-checked against FDA database&quot;</div>
+            <div class="notif-time">3h ago</div>
+            <div class="notif-actions">
+              <button class="notif-action-btn primary" onclick="event.stopPropagation();switchCenterTab('ka-inspector')">View Finding</button>
+            </div>
+          </div>
+        </div>
+        <div class="notif-item">
+          <div class="notif-border" style="background:transparent; width:3px"></div>
+          <div class="notif-body">
+            <div class="notif-text"><strong>research-lab-zurich</strong> invited you to <strong>climate-science/ocean-temperatures</strong> as editor</div>
+            <div class="notif-time">5h ago</div>
+            <div class="notif-actions">
+              <button class="notif-action-btn primary" onclick="event.stopPropagation();showToast('Invitation accepted')">Accept</button>
+              <button class="notif-action-btn" onclick="event.stopPropagation();showToast('Invitation declined')">Decline</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- INFORMATIONAL (grey) -->
+        <div style="padding:6px 16px 2px; font-size:9px; font-weight:600; letter-spacing:0.6px; text-transform:uppercase; color:var(--text-ghost)">Informational</div>
+        <div class="notif-item" style="opacity:0.7">
+          <div class="notif-border" style="background:var(--text-ghost); width:3px"></div>
+          <div class="notif-body">
+            <div class="notif-text">Weekly digest: 12 findings shared, 3 verified, 8 endorsements received</div>
+            <div class="notif-time">1d ago</div>
+          </div>
+        </div>
+
+        <div class="notif-dropdown-footer-bar">
+          <a onclick="event.stopPropagation();showToast('All marked read')">Mark all read</a>
+          <a onclick="event.stopPropagation();showToast('Opening full notifications history')">View all →</a>
+        </div>
+      </div>
+    </div>
+    <div class="header-meta">
+      <span><span class="status-dot"></span>Synced</span>
+      <span>12 peers</span>
+      <span>v10.0.4</span>
+    </div>
+    <div class="theme-toggle" onclick="toggleTheme()">
+      <span class="toggle-icon">☀</span>
+      <div class="toggle-track"><div class="toggle-thumb"></div></div>
+      <span class="toggle-icon">☾</span>
+    </div>
+    <!-- ⌘K visual hint removed per Change 7; keyboard shortcut still works -->
+  </header>
+
+  <!-- ═══ BODY ═══ -->
+  <div class="app-body">
+    <!-- LEFT PANEL -->
+    <div class="panel-left" id="panelLeft">
+      <div class="tree-header">
+        <button class="tree-mode-btn active" onclick="switchTreeMode('explorer',this)">Projects</button>
+        <button class="tree-mode-btn" onclick="switchTreeMode('oracle',this)">Context Oracle</button>
+        <button class="collapse-btn" onclick="togglePanel('left')" style="margin-left:4px; padding:0 6px">◂</button>
+      </div>
+      <div class="tree-content" id="treeExplorer">
+        <!-- Stage 0: locked message (agent not connected) -->
+        <div class="locked-tree-msg stage-0">
+          <span class="ltm-icon">🔒</span>
+          Connect an agent<br>to get started
+        </div>
+
+        <div class="tree-dashboard active" onclick="switchCenterTab('dashboard')">▦ Dashboard</div>
+        <div class="tree-dashboard stage-2" onclick="switchCenterTab('memory-stack')">▤ Memory Stack</div>
+        <button class="new-project-btn stage-2" onclick="openModal('createProjectModal')">+ New Project</button>
+
+        <!-- Empty state card (stage 1 only — agent connected, no project yet) -->
+        <div class="journey-empty-card stage-1">
+          <div class="jec-title">No projects yet</div>
+          <div class="jec-hint">Create your first project to give your agent structured memory.</div>
+          <button class="new-project-btn" style="margin:0; padding:6px 12px; border-style:solid; color:var(--text-primary); border-color:var(--border-strong)" onclick="openModal('createProjectModal')">+ Create First Project</button>
+        </div>
+
+        <!-- Project: Pharma Drug Interactions (stage 2 only — project created) -->
+        <div class="tree-section open stage-2">
+          <div class="tree-section-header" onclick="toggleTreeSection(this)">
+            <span class="tree-chevron">▸</span>
+            <span class="tree-layer-dot" style="background:var(--text-primary); width:8px; height:8px"></span>
+            <span class="tree-section-label">Pharma Drug Interactions</span>
+            <span class="tree-section-badge">227</span>
+          </div>
+          <div class="tree-items">
+            <!-- Working Memory for this project -->
+            <div style="padding:3px 12px 3px 32px; font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-top:4px; cursor:pointer" onclick="openLayerTab('working-memory')">Working Memory</div>
+            <div class="tree-item active" onclick="openLayerTab('working-memory')">
+              <span class="tree-item-icon" style="color:var(--layer-working)">◇</span>
+              <span class="tree-item-label">research-agent drafts</span>
+              <span class="tree-item-badge badge-count">68</span>
+            </div>
+            <div class="tree-item" onclick="openLayerTab('working-memory')">
+              <span class="tree-item-icon" style="color:var(--layer-working)">◇</span>
+              <span class="tree-item-label">adverse-event-monitor</span>
+              <span class="tree-item-badge badge-count">27</span>
+            </div>
+
+            <!-- Shared Memory for this project -->
+            <div style="padding:3px 12px 3px 32px; font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-top:8px; cursor:pointer" onclick="openLayerTab('shared-memory')">Shared Memory</div>
+            <div class="tree-item" onclick="openLayerTab('shared-memory')">
+              <span class="tree-item-icon" style="color:var(--layer-shared)">◈</span>
+              <span class="tree-item-label">team workspace</span>
+              <span class="tree-item-badge badge-count">38</span>
+            </div>
+
+            <!-- Verified Memory for this project -->
+            <div style="padding:3px 12px 3px 32px; font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-top:8px; cursor:pointer" onclick="openLayerTab('verified-memory')">Verified Memory</div>
+            <div class="tree-item" onclick="switchCenterTab('ka-inspector')">
+              <span class="tree-item-icon" style="color:var(--layer-verified)">◉</span>
+              <span class="tree-item-label">warfarin-aspirin-001</span>
+              <span class="tree-item-badge" style="color:var(--accent-green)">3/5 ✓</span>
+            </div>
+            <div class="tree-item" onclick="switchCenterTab('ka-inspector')">
+              <span class="tree-item-icon" style="color:var(--layer-verified)">◉</span>
+              <span class="tree-item-label">metformin-contrast-002</span>
+              <span class="tree-item-badge" style="color:var(--text-secondary)">3 endorsed</span>
+            </div>
+            <div class="tree-item" onclick="switchCenterTab('ka-inspector')">
+              <span class="tree-item-icon" style="color:var(--layer-verified)">◉</span>
+              <span class="tree-item-label">ssri-maoi-003</span>
+              <span class="tree-item-badge" style="color:var(--text-tertiary)">● self</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Project: Climate Science (stage 2 only — Pharma is the first created project) -->
+        <div class="tree-section stage-2">
+          <div class="tree-section-header" onclick="toggleTreeSection(this)">
+            <span class="tree-chevron">▸</span>
+            <span class="tree-layer-dot" style="background:var(--text-primary); width:8px; height:8px"></span>
+            <span class="tree-section-label">Climate Science</span>
+            <span class="tree-section-badge">45</span>
+          </div>
+          <div class="tree-items">
+            <div style="padding:3px 12px 3px 32px; font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-top:4px">Working Memory</div>
+            <div class="tree-item" onclick="openLayerTab('working-memory')">
+              <span class="tree-item-icon" style="color:var(--layer-working)">◇</span>
+              <span class="tree-item-label">literature-scanner</span>
+              <span class="tree-item-badge badge-count">31</span>
+            </div>
+
+            <div style="padding:3px 12px 3px 32px; font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-top:8px">Shared Memory</div>
+            <div class="tree-item" onclick="openLayerTab('shared-memory')">
+              <span class="tree-item-icon" style="color:var(--layer-shared)">◈</span>
+              <span class="tree-item-label">team workspace</span>
+              <span class="tree-item-badge badge-count">8</span>
+            </div>
+
+            <div style="padding:3px 12px 3px 32px; font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-top:8px">Verified Memory</div>
+            <div class="tree-item" onclick="switchCenterTab('ka-inspector')">
+              <span class="tree-item-icon" style="color:var(--layer-verified)">◉</span>
+              <span class="tree-item-label">climate-report-2026</span>
+              <span class="tree-item-badge" style="color:var(--accent-green)">5/5 ✓</span>
+            </div>
+            <div class="tree-item" onclick="switchCenterTab('ka-inspector')">
+              <span class="tree-item-icon" style="color:var(--layer-verified)">◉</span>
+              <span class="tree-item-label">arctic-ice-projection</span>
+              <span class="tree-item-badge" style="color:var(--text-secondary)">2 endorsed</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="tree-divider stage-2"></div>
+
+        <div class="tree-dashboard stage-2" onclick="switchCenterTab('agent-hub')">⚙ Agent Hub</div>
+
+        <!-- Integrations (always visible once agent is connected) -->
+        <div class="tree-section stage-12">
+          <div class="tree-section-header" onclick="toggleTreeSection(this)">
+            <span class="tree-chevron">▸</span>
+            <span class="tree-layer-dot" style="background:transparent; border: 1px solid var(--text-tertiary)"></span>
+            <span class="tree-section-label">Integrations</span>
+          </div>
+          <div class="tree-items">
+            <div class="tree-item" onclick="showToast('Opening Obsidian integration...')">
+              <span class="tree-item-icon">⬡</span>
+              <span class="tree-item-label">Obsidian</span>
+            </div>
+            <div class="tree-item" onclick="showToast('Opening ACLED Events integration...')">
+              <span class="tree-item-icon">⬡</span>
+              <span class="tree-item-label">ACLED Events</span>
+            </div>
+            <div class="tree-item" onclick="showToast('Opening SPARQL Editor...')">
+              <span class="tree-item-icon">⬡</span>
+              <span class="tree-item-label">Agent Hermes</span>
+            </div>
+            <div class="tree-item" onclick="openModal('graphifyModal')">
+              <span class="tree-item-icon" style="color:var(--accent-amber)">⬡</span>
+              <span class="tree-item-label">Graphify</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Context Oracle Mode -->
+      <div class="oracle-panel" id="treeOracle">
+        <div class="oracle-sub-tabs">
+          <button class="oracle-sub-tab active" onclick="switchOracleTab('browse',this)">Browse</button>
+          <button class="oracle-sub-tab" onclick="switchOracleTab('search',this)">Search</button>
+          <button class="oracle-sub-tab" onclick="switchOracleTab('graph',this)">Graph</button>
+        </div>
+        <div style="flex:1; overflow-y:auto">
+          <!-- Browse -->
+          <div id="oracleBrowse" style="padding:12px">
+            <div class="oracle-browse-heading">Connected Context Graphs</div>
+            <div class="oracle-browse-card" onclick="switchCenterTab('project-page')">
+              <div class="obc-name">Pharma Drug Interactions</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:6px">Comprehensive drug-drug interaction database with clinical evidence from 5 independent researchers.</div>
+              <div style="display:flex; gap:3px; height:4px; margin-bottom:6px; border-radius:2px; overflow:hidden">
+                <div style="flex:23; background:var(--accent-green); border-radius:2px"></div>
+                <div style="flex:12; background:var(--text-secondary); border-radius:2px"></div>
+                <div style="flex:12; background:var(--text-ghost); border-radius:2px"></div>
+              </div>
+              <div class="obc-meta"><span>47 findings</span><span>23 verified</span><span>180 endorsements</span><span>5 researchers</span><span>Role: owner</span></div>
+            </div>
+            <div class="oracle-browse-card" onclick="showToast('Opening project page...')">
+              <div class="obc-name">Climate Science / Emissions</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:6px">Multi-institutional climate modeling and emissions tracking with consensus projections.</div>
+              <div style="display:flex; gap:3px; height:4px; margin-bottom:6px; border-radius:2px; overflow:hidden">
+                <div style="flex:8; background:var(--accent-green); border-radius:2px"></div>
+                <div style="flex:6; background:var(--text-secondary); border-radius:2px"></div>
+                <div style="flex:17; background:var(--text-ghost); border-radius:2px"></div>
+              </div>
+              <div class="obc-meta"><span>31 assets</span><span>8 verified</span><span>42 endorsements</span><span>3 institutions</span><span>Role: editor</span></div>
+            </div>
+
+            <div class="oracle-browse-heading">Trending on Network</div>
+            <div class="oracle-browse-card" onclick="showToast('Opening project page...')">
+              <div class="obc-name">Trade Policy / Sanctions</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:6px">Semiconductor export controls, sanctions compliance, and trade policy analysis.</div>
+              <div style="display:flex; gap:3px; height:4px; margin-bottom:6px; border-radius:2px; overflow:hidden">
+                <div style="flex:340; background:var(--accent-green); border-radius:2px"></div>
+                <div style="flex:280; background:var(--text-secondary); border-radius:2px"></div>
+                <div style="flex:272; background:var(--text-ghost); border-radius:2px"></div>
+              </div>
+              <div class="obc-meta"><span>892 assets</span><span>340 verified</span><span>14 publishers</span><span style="color:var(--accent-amber)">$0.10/query</span></div>
+            </div>
+            <div class="oracle-browse-card" onclick="showToast('Opening project page...')">
+              <div class="obc-name">Regulation / AI Governance</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:6px">EU AI Act compliance, global AI regulation tracking, and risk assessment frameworks.</div>
+              <div style="display:flex; gap:3px; height:4px; margin-bottom:6px; border-radius:2px; overflow:hidden">
+                <div style="flex:500; background:var(--accent-green); border-radius:2px"></div>
+                <div style="flex:347; background:var(--text-secondary); border-radius:2px"></div>
+                <div style="flex:400; background:var(--text-ghost); border-radius:2px"></div>
+              </div>
+              <div class="obc-meta"><span>1,247 assets</span><span>500 verified</span><span>31 publishers</span><span style="color:var(--accent-amber)">$0.05/query</span></div>
+            </div>
+            <div class="oracle-browse-card" onclick="showToast('Opening project page...')">
+              <div class="obc-name">DeFi Research Vault</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:6px">Verified DeFi protocol analysis with Monte Carlo risk simulations and on-chain evidence.</div>
+              <div style="display:flex; gap:3px; height:4px; margin-bottom:6px; border-radius:2px; overflow:hidden">
+                <div style="flex:18; background:var(--accent-green); border-radius:2px"></div>
+                <div style="flex:24; background:var(--text-secondary); border-radius:2px"></div>
+                <div style="flex:40; background:var(--text-ghost); border-radius:2px"></div>
+              </div>
+              <div class="obc-meta"><span>82 assets</span><span>18 verified</span><span>2 analysts</span><span style="color:var(--accent-amber)">$0.05/query</span></div>
+            </div>
+          </div>
+          <!-- Search -->
+          <div id="oracleSearch" style="display:none; padding:12px">
+            <input type="text" placeholder="Search the DKG network..." value="drug interactions" style="width:100%; height:36px; border-radius:6px; margin-bottom:8px">
+            <div style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:12px">
+              <span class="oracle-filter-pill active" onclick="selectFilterPill(this)">All Trust Levels</span>
+              <span class="oracle-filter-pill" onclick="selectFilterPill(this)">Consensus-verified</span>
+              <span class="oracle-filter-pill" onclick="selectFilterPill(this)">Endorsed</span>
+              <span class="oracle-filter-pill" onclick="selectFilterPill(this)">Self-attested</span>
+            </div>
+            <div style="font-size:10px; color:var(--text-ghost); margin-bottom:10px">Sorted by trust level · 5 results</div>
+
+            <div class="oracle-search-result" onclick="switchCenterTab('project-page')">
+              <div class="or-name">Warfarin + Aspirin Interaction</div>
+              <div class="or-meta">
+                <span class="or-layer-badge" style="border-color:rgba(34,197,94,0.3); color:var(--accent-green)">Consensus 3/5</span>
+                <span>Pharma Drug Interactions</span>
+                <span>Dr. Amara · 0x8a4f...c3b2</span>
+                <span>3 endorsements</span>
+                <span style="color:var(--accent-amber); font-weight:500">$0.05</span>
+              </div>
+              <div class="or-ual">did:dkg:base/0x8a4f.../warfarin-aspirin-001</div>
+              <button class="or-fork-btn" onclick="event.stopPropagation();showToast('Forked to Working Memory — original UAL preserved')">Fork ↓</button>
+            </div>
+
+            <div class="oracle-search-result" onclick="switchCenterTab('project-page')">
+              <div class="or-name">Metformin + Iodinated Contrast</div>
+              <div class="or-meta">
+                <span class="or-layer-badge" style="border-color:rgba(34,197,94,0.3); color:var(--accent-green)">Consensus 3/5</span>
+                <span>Pharma Drug Interactions</span>
+                <span>Dr. Amara · 0x8a4f...c3b2</span>
+                <span>2 endorsements</span>
+                <span style="color:var(--accent-amber); font-weight:500">$0.05</span>
+              </div>
+              <div class="or-ual">did:dkg:base/0x8a4f.../metformin-contrast-002</div>
+              <button class="or-fork-btn" onclick="event.stopPropagation();showToast('Forked to Working Memory — original UAL preserved')">Fork ↓</button>
+            </div>
+
+            <div class="oracle-search-result" onclick="switchCenterTab('project-page')">
+              <div class="or-name">Apixaban + Amiodarone Adverse Signal</div>
+              <div class="or-meta">
+                <span class="or-layer-badge">Endorsed (2)</span>
+                <span>Pharma Drug Interactions</span>
+                <span>Dr. Silva · 0x5e6f...7890</span>
+                <span>2 endorsements</span>
+                <span style="color:var(--accent-amber); font-weight:500">$0.05</span>
+              </div>
+              <div class="or-ual">did:dkg:base/0x8a4f.../apixaban-amiodarone-005</div>
+              <button class="or-fork-btn" onclick="event.stopPropagation();showToast('Forked to Working Memory — original UAL preserved')">Fork ↓</button>
+            </div>
+
+            <div class="oracle-search-result" onclick="switchCenterTab('project-page')">
+              <div class="or-name">SSRI + MAOI Contraindication</div>
+              <div class="or-meta">
+                <span class="or-layer-badge" style="color:var(--text-ghost)">Self-attested</span>
+                <span>Pharma Drug Interactions</span>
+                <span>Dr. Amara · 0x8a4f...c3b2</span>
+              </div>
+              <div class="or-ual">did:dkg:base/0x8a4f.../ssri-maoi-003</div>
+              <button class="or-fork-btn" onclick="event.stopPropagation();showToast('Forked to Working Memory — original UAL preserved')">Fork ↓</button>
+            </div>
+
+            <div class="oracle-search-result" onclick="showToast('Opening DrugBank Ontology details...')">
+              <div class="or-name">DrugBank Interaction Ontology</div>
+              <div class="or-meta">
+                <span class="or-layer-badge" style="color:var(--text-ghost)">Self-attested</span>
+                <span>Community Ontologies</span>
+                <span>drugbank-team · 0x2d4e...b8c1</span>
+              </div>
+              <div class="or-ual">did:dkg:gnosis/0x2d4e.../drugbank-ontology</div>
+              <button class="or-fork-btn" onclick="event.stopPropagation();showToast('Forked to Working Memory — original UAL preserved')">Fork ↓</button>
+            </div>
+          </div>
+          <!-- Graph -->
+          <div id="oracleGraph" style="display:none; padding:12px; text-align:center">
+            <svg viewBox="0 0 240 320" xmlns="http://www.w3.org/2000/svg">
+              <!-- Edges -->
+              <line x1="120" y1="55" x2="50" y2="145" stroke="#333" stroke-width="1"/>
+              <line x1="120" y1="55" x2="190" y2="120" stroke="#333" stroke-width="1"/>
+              <line x1="50" y1="145" x2="120" y2="235" stroke="#333" stroke-width="1"/>
+              <line x1="190" y1="120" x2="120" y2="235" stroke="#333" stroke-width="1"/>
+              <line x1="120" y1="55" x2="120" y2="235" stroke="#222" stroke-width="0.5" stroke-dasharray="4"/>
+              <line x1="50" y1="145" x2="190" y2="120" stroke="#222" stroke-width="0.5"/>
+
+              <!-- Pharma (your project, highlighted) -->
+              <circle cx="120" cy="55" r="24" fill="#181818" stroke="#bbb" stroke-width="2"/>
+              <text x="120" y="50" text-anchor="middle" fill="#e8e8e8" font-size="5.5" font-weight="600" font-family="Instrument Sans">Pharma Drug</text>
+              <text x="120" y="58" text-anchor="middle" fill="#e8e8e8" font-size="5.5" font-weight="600" font-family="Instrument Sans">Interactions</text>
+              <text x="120" y="68" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">47 · 23 verified</text>
+
+              <!-- Climate Science -->
+              <circle cx="50" cy="145" r="22" fill="#181818" stroke="#888" stroke-width="1.5"/>
+              <text x="50" y="142" text-anchor="middle" fill="#bbb" font-size="5.5" font-family="Instrument Sans">Climate Science</text>
+              <text x="50" y="152" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">31 · 8 verified</text>
+
+              <!-- Trade Policy -->
+              <circle cx="190" cy="120" r="20" fill="#181818" stroke="#666" stroke-width="1"/>
+              <text x="190" y="117" text-anchor="middle" fill="#999" font-size="5.5" font-family="Instrument Sans">Trade Policy</text>
+              <text x="190" y="127" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">892 · 340 verified</text>
+
+              <!-- AI Governance -->
+              <circle cx="120" cy="235" r="20" fill="#181818" stroke="#666" stroke-width="1"/>
+              <text x="120" y="232" text-anchor="middle" fill="#999" font-size="5.5" font-family="Instrument Sans">AI Governance</text>
+              <text x="120" y="242" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">1,247 · 500 verified</text>
+
+              <!-- DeFi Research -->
+              <circle cx="40" cy="250" r="14" fill="#181818" stroke="#444" stroke-width="0.8"/>
+              <text x="40" y="248" text-anchor="middle" fill="#777" font-size="5" font-family="Instrument Sans">DeFi Vault</text>
+              <text x="40" y="257" text-anchor="middle" fill="#444" font-size="4" font-family="JetBrains Mono">82 assets</text>
+              <line x1="50" y1="145" x2="40" y2="250" stroke="#222" stroke-width="0.5"/>
+
+              <!-- Satellite asset nodes -->
+              <circle cx="88" cy="35" r="3" fill="#262626" stroke="#444" stroke-width=".5"/>
+              <circle cx="152" cy="40" r="2.5" fill="#262626" stroke="#444" stroke-width=".5"/>
+              <circle cx="28" cy="125" r="2.5" fill="#262626" stroke="#444" stroke-width=".5"/>
+              <circle cx="215" cy="140" r="3" fill="#262626" stroke="#444" stroke-width=".5"/>
+              <circle cx="145" cy="260" r="2.5" fill="#262626" stroke="#444" stroke-width=".5"/>
+            </svg>
+            <div style="font-size:10px; color:var(--text-ghost); margin-top:8px; font-style:italic">Interactive graph — coming in next iteration</div>
+            <div style="display:flex; justify-content:center; gap:16px; margin-top:8px; font-size:10px; color:var(--text-ghost)">
+              <span><span style="display:inline-block; width:8px; height:8px; border-radius:50%; border:2px solid #bbb; vertical-align:middle; margin-right:3px"></span>Your projects</span>
+              <span><span style="display:inline-block; width:8px; height:8px; border-radius:50%; border:1px solid #666; vertical-align:middle; margin-right:3px"></span>Network</span>
+              <span><span style="display:inline-block; width:6px; height:6px; border-radius:50%; background:#444; vertical-align:middle; margin-right:3px"></span>Assets</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="resize-handle" id="resizeLeft"></div>
+
+    <!-- CENTER + BOTTOM -->
+    <div style="flex:1; display:flex; flex-direction:column; min-width:0; overflow:hidden;">
+      <!-- CENTER PANEL -->
+      <div class="panel-center" style="flex:1; min-height:0;">
+        <!-- Tabs -->
+        <div class="center-tabs" id="centerTabs">
+          <div class="center-tab active" data-tab="dashboard" onclick="switchCenterTab('dashboard')">
+            Dashboard
+          </div>
+          <div class="center-tab stage-2" data-tab="pharma-project" onclick="switchCenterTab('pharma-project')">
+            <span class="tab-dot" style="background:var(--text-primary)"></span>
+            Pharma Drug Interactions
+            <span class="tab-close" onclick="event.stopPropagation(); closeTab('pharma-project')">×</span>
+          </div>
+          <div class="center-tab stage-2" data-tab="project-page" onclick="switchCenterTab('project-page')">
+            <span class="tab-dot" style="background:var(--text-tertiary)"></span>
+            ⚭ Context Oracle
+            <span class="tab-close" onclick="event.stopPropagation(); closeTab('project-page')">×</span>
+          </div>
+        </div>
+
+        <!-- Toolbar -->
+        <div class="center-toolbar" id="centerToolbar">
+          <div class="toolbar-breadcrumb" id="toolbarBreadcrumb">
+            <span class="bc-label">Dashboard</span>
+          </div>
+          <div class="toolbar-spacer"></div>
+          <div id="toolbarActions"></div>
+        </div>
+
+        <!-- Content -->
+        <div class="center-content" id="centerContent">
+
+          <!-- DASHBOARD VIEW -->
+          <div class="dashboard-view visible" id="view-dashboard">
+            <!-- Stage 0: agent not connected yet — minimal welcome pointing to right panel -->
+            <div class="stage-0" style="padding:60px 40px; max-width:640px; margin:0 auto; text-align:center">
+              <div style="font-size:28px; font-weight:600; margin-bottom:12px">Welcome to DKG v10</div>
+              <div style="font-size:14px; color:var(--text-secondary); line-height:1.7; margin-bottom:28px">Your node is ready. To get started, connect an AI agent — your agent will help you create projects, manage knowledge, publish findings, and collaborate with peers.</div>
+              <div style="padding:24px; border:1px dashed var(--border-default); border-radius:10px; background:var(--bg-surface)">
+                <div style="font-size:24px; margin-bottom:10px">→</div>
+                <div style="font-size:13px; font-weight:500; margin-bottom:6px">Connect an agent in the right panel</div>
+                <div style="font-size:11px; color:var(--text-tertiary)">Choose from OpenClaw, Agent Hermes, ElizaOS, or other supported frameworks</div>
+              </div>
+            </div>
+
+            <!-- Stage 1: agent connected, project creation available -->
+            <div class="stage-1" style="padding:32px 40px; max-width:780px; margin:0 auto">
+              <div style="font-size:22px; font-weight:600; margin-bottom:6px">Agent connected. What&apos;s next?</div>
+              <div style="font-size:13px; color:var(--text-secondary); margin-bottom:24px; line-height:1.6">Your agent is ready. Now give it structured memory by creating a project — a bounded knowledge space where it can draft, share, and publish.</div>
+
+              <div class="dash-card" style="margin-bottom:20px; padding:20px 24px">
+                <div class="dash-card-label" style="margin-bottom:14px">Get Started</div>
+
+                <div style="display:flex; gap:16px; padding:12px 0; border-bottom:1px solid var(--border-subtle)">
+                  <div style="width:24px; height:24px; border-radius:50%; background:var(--accent-green); display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; color:var(--bg-root); flex-shrink:0">✓</div>
+                  <div style="flex:1">
+                    <div style="font-weight:600; font-size:13px; margin-bottom:2px">Connect an Agent <span style="color:var(--accent-green); font-size:10px; margin-left:6px">Done</span></div>
+                    <div style="font-size:11px; color:var(--text-tertiary)">research-agent is ready to help you.</div>
+                  </div>
+                </div>
+
+                <div style="display:flex; gap:16px; padding:12px 0; border-bottom:1px solid var(--border-subtle)">
+                  <div style="width:24px; height:24px; border-radius:50%; background:var(--text-primary); display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; color:var(--bg-root); flex-shrink:0">2</div>
+                  <div style="flex:1">
+                    <div style="font-weight:600; font-size:13px; margin-bottom:2px">Create Your First Project</div>
+                    <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:8px">A project gives your agent structured memory — a place to draft, share, and publish knowledge. Your agent&apos;s first project is a great place to import the context and memories it already has.</div>
+                    <button class="draft-action-btn primary" style="font-size:11px" onclick="openModal('createProjectModal')">Create Project</button>
+                  </div>
+                </div>
+
+                <div style="display:flex; gap:16px; padding:12px 0; border-bottom:1px solid var(--border-subtle); opacity:0.65">
+                  <div style="width:24px; height:24px; border-radius:50%; background:var(--bg-active); display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; color:var(--text-primary); flex-shrink:0">3</div>
+                  <div style="flex:1">
+                    <div style="font-weight:600; font-size:13px; margin-bottom:2px">Import to Agent Memory <span style="font-size:10px; font-weight:400; color:var(--text-ghost); margin-left:6px">→ opens after project creation</span></div>
+                    <div style="font-size:11px; color:var(--text-tertiary)">Bring your agent&apos;s existing knowledge — notes, docs, PDFs, conversation logs. Files land in Working Memory where you can review them.</div>
+                  </div>
+                </div>
+
+                <div style="display:flex; gap:16px; padding:12px 0; opacity:0.5; pointer-events:none">
+                  <div style="width:24px; height:24px; border-radius:50%; background:var(--bg-active); display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; color:var(--text-primary); flex-shrink:0">4</div>
+                  <div style="flex:1">
+                    <div style="font-weight:600; font-size:13px; margin-bottom:2px">Browse the Context Oracle <span style="font-size:10px; font-weight:400; color:var(--text-ghost); margin-left:6px">🔒 Locked — create a project first</span></div>
+                    <div style="font-size:11px; color:var(--text-tertiary)">Discover public knowledge published by others on the DKG network.</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="dash-card" style="padding:18px 24px">
+                <div class="dash-card-label" style="margin-bottom:12px">Your Node</div>
+                <div style="display:flex; flex-direction:column; gap:6px; font-size:12px">
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">DID</span><span style="font-family:var(--font-mono); font-size:11px">0x8a4f...c3b2</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Active chain</span><span style="font-family:var(--font-mono); font-size:11px">Base</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">TRAC balance</span><span style="font-family:var(--font-mono); font-size:11px; color:var(--accent-amber)">0 TRAC (needed for publishing)</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Peers</span><span style="font-family:var(--font-mono); font-size:11px">0 · discovering...</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Connected agents</span><span style="font-family:var(--font-mono); font-size:11px; color:var(--accent-green)">research-agent ● ready</span></div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Populated stats (stage 2 only) -->
+            <div class="stage-2">
+            <div class="dash-row r1">
+              <div class="dash-card">
+                <div class="dash-card-label">Node Uptime</div>
+                <div class="dash-card-value">14d 7h</div>
+                <div class="dash-card-sub"><span class="status-dot-sm" style="background:var(--accent-green)"></span> Running</div>
+              </div>
+              <div class="dash-card">
+                <div class="dash-card-label">Connected Peers</div>
+                <div class="dash-card-value">12</div>
+                <div class="dash-card-sub">3 new today</div>
+              </div>
+              <div class="dash-card">
+                <div class="dash-card-label">Sync Status</div>
+                <div class="dash-card-value">100%</div>
+                <div class="dash-card-sub"><span class="status-dot-sm" style="background:var(--accent-green)"></span> Fully synced</div>
+              </div>
+              <div class="dash-card">
+                <div class="dash-card-label">DKG Version</div>
+                <div class="dash-card-value">v10.0.4</div>
+                <div class="dash-card-sub">Latest</div>
+              </div>
+            </div>
+            <div class="dash-row r2">
+              <div class="dash-card">
+                <div class="dash-card-label">Memory Layers</div>
+                <div class="dash-card-value">227</div>
+                <div class="mini-stack">
+                  <div class="mini-stack-row">
+                    <span class="mini-stack-dot" style="background:var(--layer-verified)"></span>
+                    <span class="mini-stack-name">Verified</span>
+                    <span class="mini-stack-count">47</span>
+                    <span class="mini-stack-pct">21%</span>
+                    <div class="mini-stack-bar"><div class="mini-stack-bar-fill" style="width:21%"></div></div>
+                  </div>
+                  <div style="padding-left:20px; font-size:10px; color:var(--text-ghost); display:flex; gap:10px; margin:-2px 0 4px">
+                    <span style="color:var(--accent-green)">Consensus: 23</span>
+                    <span>Endorsed: 12</span>
+                    <span>Self-attested: 12</span>
+                  </div>
+                  <div class="mini-stack-row">
+                    <span class="mini-stack-dot" style="background:var(--layer-shared)"></span>
+                    <span class="mini-stack-name">Shared</span>
+                    <span class="mini-stack-count">38</span>
+                    <span class="mini-stack-pct">17%</span>
+                    <div class="mini-stack-bar"><div class="mini-stack-bar-fill" style="width:17%"></div></div>
+                  </div>
+                  <div class="mini-stack-row">
+                    <span class="mini-stack-dot" style="background:var(--layer-working)"></span>
+                    <span class="mini-stack-name">Working</span>
+                    <span class="mini-stack-count">142</span>
+                    <span class="mini-stack-pct">62%</span>
+                    <div class="mini-stack-bar"><div class="mini-stack-bar-fill" style="width:62%"></div></div>
+                  </div>
+                </div>
+              </div>
+              <div class="dash-card">
+                <div class="dash-card-label">Wallet & Chains</div>
+                <div style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary); margin-bottom:10px">0x8a4f...c3b2</div>
+                <div style="display:flex; flex-direction:column; gap:6px; margin-bottom:12px">
+                  <div style="display:flex; align-items:center; gap:10px; padding:8px 10px; background:var(--bg-active); border-radius:6px; font-size:12px">
+                    <span style="font-weight:500; min-width:70px; color:var(--text-primary)">● Base</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-secondary)">4,230 TRAC</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary); margin-left:auto">0.12 ETH</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:10px; padding:8px 10px; font-size:12px">
+                    <span style="font-weight:500; min-width:70px; color:var(--text-secondary)">Gnosis</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-secondary)">8,100 TRAC</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary); margin-left:auto">24.5 xDAI</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:10px; padding:8px 10px; font-size:12px">
+                    <span style="font-weight:500; min-width:70px; color:var(--text-secondary)">NeuroWeb</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-secondary)">1,450 TRAC</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary); margin-left:auto">892 NEURO</span>
+                  </div>
+                </div>
+                <div style="padding-top:10px; border-top:1px solid var(--border-subtle); font-size:12px; color:var(--text-secondary)">
+                  <div style="display:flex; justify-content:space-between; padding:3px 0;">
+                    <span style="color:var(--text-tertiary)">Gas spent (30d)</span>
+                    <span style="font-family:var(--font-mono); font-size:11px">0.0847 ETH</span>
+                  </div>
+                  <div style="display:flex; justify-content:space-between; padding:3px 0;">
+                    <span style="color:var(--text-tertiary)">Pending txns</span>
+                    <span style="font-family:var(--font-mono); font-size:11px; color:var(--accent-amber)">2</span>
+                  </div>
+                  <div style="display:flex; justify-content:space-between; padding:3px 0;">
+                    <span style="color:var(--text-tertiary)">Attestations received</span>
+                    <span style="font-family:var(--font-mono); font-size:11px">18</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="dash-row r3">
+              <div class="dash-card">
+                <div class="dash-card-label">Activity — Last 24h</div>
+                <div class="activity-feed">
+                  <div class="activity-item">
+                    <span class="activity-dot" style="background:var(--layer-verified)"></span>
+                    <span class="activity-text"><strong>warfarin-aspirin-001</strong> reached consensus — 3/5 quorum verified</span>
+                    <span class="activity-time">2h ago</span>
+                  </div>
+                  <div class="activity-item">
+                    <span class="activity-dot" style="background:var(--accent-amber)"></span>
+                    <span class="activity-text">Dr. Chen endorsed <strong>metformin-contrast-002</strong> — "Cross-checked against FDA database"</span>
+                    <span class="activity-time">3h ago</span>
+                  </div>
+                  <div class="activity-item">
+                    <span class="activity-dot" style="background:var(--layer-working)"></span>
+                    <span class="activity-text"><strong>Dr. Silva</strong> via adverse-event-monitor shared 3 new FDA signals to Shared Memory</span>
+                    <span class="activity-time">5h ago</span>
+                  </div>
+                  <div class="activity-item">
+                    <span class="activity-dot" style="background:var(--layer-verified)"></span>
+                    <span class="activity-text"><strong>ssri-maoi-003</strong> published to Verified Memory — self-attested, pending endorsement</span>
+                    <span class="activity-time">8h ago</span>
+                  </div>
+                  <div class="activity-item">
+                    <span class="activity-dot" style="background:var(--layer-shared)"></span>
+                    <span class="activity-text">Dr. Amara shared 8 interaction findings from Working to <strong>pharma-drug-interactions</strong></span>
+                    <span class="activity-time">12h ago</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            </div> <!-- end .stage-2 wrapper -->
+          </div>
+
+          <!-- UNIFIED PROJECT VIEW: Pharma Drug Interactions -->
+          <div class="dashboard-view" id="view-pharma-project" style="padding:20px 24px">
+
+            <!-- Project Header -->
+            <div style="margin-bottom:20px">
+              <div style="font-size:16px; font-weight:600; margin-bottom:4px">Pharma Drug Interactions</div>
+              <div style="font-size:11px; color:var(--text-tertiary); font-family:var(--font-mono); display:flex; gap:16px">
+                <span>5 researchers</span>
+                <span>Quorum: 3/5</span>
+                <span>227 total entities</span>
+                <span>Ontology: pharma-interactions.ttl</span>
+              </div>
+            </div>
+
+            <!-- ═══ WORKING MEMORY SECTION ═══ -->
+            <div id="section-working" style="margin-bottom:28px">
+              <div style="display:flex; align-items:center; gap:10px; margin-bottom:12px; padding-bottom:8px; border-bottom:1px solid var(--border-subtle)">
+                <span style="width:10px; height:10px; border-radius:50%; background:var(--layer-working)"></span>
+                <span style="font-size:13px; font-weight:600; cursor:pointer" onclick="openLayerTab('working-memory')">Working Memory</span>
+                <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">142 drafts</span>
+                <span style="font-size:10px; color:var(--text-ghost)">Per-agent, local only</span>
+                <a style="margin-left:auto; font-size:10px; color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer; margin-right:8px" onclick="openLayerTab('working-memory')">Open full view →</a>
+                <span style="display:flex; gap:2px">
+                  <button class="draft-action-btn" style="font-size:10px; padding:3px 8px; background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong)" onclick="showToast('Switched to Cards view')">Cards</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:3px 8px" onclick="showToast('Switched to Triples view')">Triples</button>
+                </span>
+              </div>
+              <div style="display:flex; gap:6px; margin-bottom:10px" id="wmFilterBar">
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong)" onclick="filterDrafts('all',this)">All (68)</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterDrafts('ready',this)">Ready (56)</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterDrafts('flagged',this)">Needs Review (12)</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterDrafts('error',this)">Errors (0)</button>
+                <div style="flex:1"></div>
+                <button class="draft-action-btn primary" onclick="openModal('importModal')">Import Files</button>
+              </div>
+
+              <div class="draft-card" data-status="ready">
+                <div class="draft-card-header">
+                  <span class="draft-card-title">Warfarin + Aspirin Interaction</span>
+                  <span class="draft-card-badge ready">Ready</span>
+                </div>
+                <div class="draft-card-meta">
+                  <span>Severity: major</span><span>Evidence: meta-analysis</span><span>Confidence: 0.94</span>
+                  <span style="color:var(--text-ghost)">via research-agent</span>
+                </div>
+                <div class="draft-card-snippet">pharma:drug1 warfarin · pharma:drug2 aspirin · pharma:mechanism "Both drugs inhibit platelet aggregation..."</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                  <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div class="draft-card" data-status="flagged">
+                <div class="draft-card-header">
+                  <span class="draft-card-title">Apixaban + Amiodarone Adverse Signal</span>
+                  <span class="draft-card-badge flagged">Needs Review</span>
+                </div>
+                <div class="draft-card-meta">
+                  <span>Severity: under review</span><span>Source: FDA FAERS</span><span>Confidence: 0.62</span>
+                  <span style="color:var(--text-ghost)">via adverse-event-monitor</span>
+                </div>
+                <div style="font-size:10px; color:var(--accent-amber); margin-bottom:6px; padding:4px 8px; background:rgba(245,158,11,0.06); border-radius:4px">Agent flag: Extraction confidence 0.62 — ambiguous drug name mapping</div>
+                <div class="draft-card-snippet">pharma:drug1 apixaban · pharma:drug2 amiodarone · pharma:signal "Disproportionality analysis flagged 147 bleeding events..."</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn" onclick="showToast('Status overridden to Ready')">Mark as Ready</button>
+                  <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:8px">Showing 2 of 68 drafts · Use agent chat to share, publish, or endorse</div>
+
+              <!-- Graphify Results Section (appears after Graphify is run) -->
+              <div id="graphify-wm-section" style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border-subtle)">
+                <div style="display:flex; align-items:center; gap:8px; margin-bottom:10px">
+                  <span style="font-size:14px">⬡</span>
+                  <span style="font-size:12px; font-weight:600">Graphify Import</span>
+                  <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">4,891 triples · 2m ago</span>
+                  <span style="margin-left:auto; display:flex; gap:4px">
+                    <span style="font-size:9px; padding:2px 6px; border-radius:2px; background:rgba(34,197,94,0.08); color:var(--accent-green)">3,102 EXTRACTED</span>
+                    <span style="font-size:9px; padding:2px 6px; border-radius:2px; background:rgba(245,158,11,0.08); color:var(--accent-amber)">1,482 INFERRED</span>
+                    <span style="font-size:9px; padding:2px 6px; border-radius:2px; background:rgba(239,68,68,0.08); color:var(--accent-red)">307 AMBIGUOUS</span>
+                  </span>
+                </div>
+
+                <div class="draft-card" data-status="ready" style="border-left:3px solid var(--accent-green)">
+                  <div class="draft-card-header">
+                    <span class="draft-card-title">DrugInteractionModel → implements → PharmaProtocol</span>
+                    <span class="draft-card-badge ready">EXTRACTED</span>
+                  </div>
+                  <div class="draft-card-meta"><span>Confidence: 1.0</span><span>Source: tree-sitter AST</span><span>Community: Pharma</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                  <div class="draft-card-snippet">code:Class DrugInteractionModel · code:implements PharmaProtocol · code:definedIn src/models/interactions.py</div>
+                  <div class="draft-card-actions">
+                    <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                    <button class="draft-action-btn" onclick="switchCenterTab('graphify-graph')">View in Graph</button>
+                    <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                  </div>
+                </div>
+
+                <div class="draft-card" data-status="flagged" style="border-left:3px solid var(--accent-amber)">
+                  <div class="draft-card-header">
+                    <span class="draft-card-title">AuthService → mediates → ClinicalTrialAPI</span>
+                    <span class="draft-card-badge flagged">INFERRED</span>
+                  </div>
+                  <div class="draft-card-meta"><span>Confidence: 0.78</span><span>Source: Claude semantic inference</span><span>Community: Auth → Clinical</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                  <div style="font-size:10px; color:var(--accent-amber); margin-bottom:6px; padding:4px 8px; background:rgba(245,158,11,0.06); border-radius:4px">Agent flag: Cross-community edge — AuthService (Auth) mediates all external data access to ClinicalTrialAPI (Clinical). High betweenness centrality.</div>
+                  <div class="draft-card-snippet">code:Class AuthService · code:mediates ClinicalTrialAPI · code:crossCommunity "Auth → Clinical"</div>
+                  <div class="draft-card-actions">
+                    <button class="draft-action-btn" onclick="showToast('Status overridden to Ready')">Mark as Ready</button>
+                    <button class="draft-action-btn" onclick="switchCenterTab('graphify-graph')">View in Graph</button>
+                    <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                  </div>
+                </div>
+
+                <div class="draft-card" data-status="error" style="border-left:3px solid var(--accent-red)">
+                  <div class="draft-card-header">
+                    <span class="draft-card-title">PharmaDB → connects_to → FDA_FAERS_Parser</span>
+                    <span class="draft-card-badge" style="border-color:rgba(239,68,68,0.3); color:var(--accent-red)">AMBIGUOUS</span>
+                  </div>
+                  <div class="draft-card-meta"><span>Confidence: 0.31</span><span>Source: Claude semantic inference</span><span>Community: Data</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                  <div style="font-size:10px; color:var(--accent-red); margin-bottom:6px; padding:4px 8px; background:rgba(239,68,68,0.06); border-radius:4px">Agent flag: AMBIGUOUS — could not determine direction of data flow. Both classes handle adverse events through different pipelines. Possible duplication.</div>
+                  <div class="draft-card-snippet">code:Class PharmaDB · code:connects_to FDA_FAERS_Parser · code:ambiguousReason "bidirectional data flow"</div>
+                  <div class="draft-card-actions">
+                    <button class="draft-action-btn" onclick="showToast('Status overridden to Ready')">Mark as Ready</button>
+                    <button class="draft-action-btn" onclick="showToast('Editing entity')">Edit</button>
+                    <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                  </div>
+                </div>
+
+                <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:8px">
+                  Showing 3 of 4,891 Graphify triples ·
+                  <span class="msg-action" onclick="openLayerTab('working-memory')">View all in Working Memory →</span> ·
+                  <span class="msg-action" onclick="switchCenterTab('graphify-graph')">View interactive graph →</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- ═══ SHARED MEMORY SECTION ═══ -->
+            <div id="section-shared" style="margin-bottom:28px">
+              <div style="display:flex; align-items:center; gap:10px; margin-bottom:8px; padding-bottom:8px; border-bottom:1px solid var(--border-subtle)">
+                <span style="width:10px; height:10px; border-radius:50%; background:var(--layer-shared)"></span>
+                <span style="font-size:13px; font-weight:600; cursor:pointer" onclick="openLayerTab('shared-memory')">Shared Memory</span>
+                <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">38 entities</span>
+                <span style="font-size:10px; color:var(--text-ghost)">Collaborative, gossiped to team</span>
+                <a style="margin-left:auto; font-size:10px; color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer; margin-right:8px" onclick="openLayerTab('shared-memory')">Open full view →</a>
+                <span style="font-size:10px; color:var(--accent-green)">+12 this week ↑</span>
+              </div>
+              <!-- Presence + project health strip -->
+              <div style="display:flex; gap:16px; margin-bottom:12px; font-size:10px; color:var(--text-tertiary)">
+                <span>Online: <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--accent-green);vertical-align:middle;margin-right:2px"></span>Amara, Chen, Patel</span>
+                <span style="color:var(--text-ghost)"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--text-ghost);vertical-align:middle;margin-right:2px"></span>Okonkwo, Silva</span>
+                <span style="margin-left:auto">Unreviewed: <strong style="color:var(--accent-amber)">5</strong></span>
+              </div>
+
+              <div class="merge-header-info" style="margin-bottom:10px">
+                <div class="merge-title" style="font-size:13px">Warfarin-Aspirin Interaction</div>
+                <div class="merge-meta">
+                  <span>Dr. Amara via research-agent</span><span>2h ago</span><span>Severity: major</span><span>Confidence: 0.94</span>
+                </div>
+                <div style="margin-top:8px; display:flex; gap:6px; align-items:center">
+                  <button class="draft-action-btn primary" style="font-size:10px; padding:4px 10px" onclick="showToast('Publishing warfarin-aspirin-001 to Verified Memory...')">Publish to Verified</button>
+                  <span style="font-size:10px; color:var(--text-ghost)">2 comments</span>
+                </div>
+              </div>
+              <div class="merge-header-info" style="margin-bottom:10px">
+                <div class="merge-title" style="font-size:13px">Metformin + Iodinated Contrast</div>
+                <div class="merge-meta">
+                  <span>Dr. Chen via research-agent</span><span>5h ago</span><span>Severity: moderate</span><span>Confidence: 0.87</span>
+                </div>
+              </div>
+              <div class="merge-header-info" style="margin-bottom:10px">
+                <div class="merge-title" style="font-size:13px">FDA Adverse Event Signal: Apixaban + Amiodarone</div>
+                <div class="merge-meta">
+                  <span>Dr. Silva via adverse-event-monitor</span><span>8h ago</span><span style="color:var(--accent-amber)">Unreviewed</span>
+                </div>
+              </div>
+
+              <div style="margin-top:16px; padding-top:12px; border-top:1px solid var(--border-subtle)">
+                <div style="font-size:10px; font-weight:600; letter-spacing:0.8px; text-transform:uppercase; color:var(--text-tertiary); margin-bottom:8px; display:flex; justify-content:space-between; align-items:center">Contributors <a style="font-size:10px; color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer; text-transform:none; letter-spacing:0; font-weight:400" onclick="openModal('shareModal')">Manage Team →</a></div>
+                <div style="display:flex; flex-direction:column; gap:6px">
+                  <div style="display:flex; align-items:center; gap:10px; font-size:12px">
+                    <span style="width:7px; height:7px; border-radius:50%; background:var(--accent-green)"></span>
+                    <span style="font-weight:500; min-width:90px">Dr. Amara</span>
+                    <span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">owner</span>
+                    <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">14 entities</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:10px; font-size:12px">
+                    <span style="width:7px; height:7px; border-radius:50%; background:var(--accent-green)"></span>
+                    <span style="font-weight:500; min-width:90px">Dr. Chen</span>
+                    <span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">editor</span>
+                    <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">12 entities</span>
+                  </div>
+                  <div style="display:flex; align-items:center; gap:10px; font-size:12px">
+                    <span style="width:7px; height:7px; border-radius:50%; background:var(--text-ghost)"></span>
+                    <span style="font-weight:500; min-width:90px">Dr. Silva</span>
+                    <span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">editor</span>
+                    <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">8 entities</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- ═══ VERIFIED MEMORY SECTION ═══ -->
+            <div id="section-verified" style="margin-bottom:28px">
+              <div style="display:flex; align-items:center; gap:10px; margin-bottom:12px; padding-bottom:8px; border-bottom:1px solid var(--border-subtle)">
+                <span style="width:10px; height:10px; border-radius:50%; background:var(--layer-verified)"></span>
+                <span style="font-size:13px; font-weight:600; cursor:pointer" onclick="openLayerTab('verified-memory')">Verified Memory</span>
+                <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">47 published</span>
+                <span style="font-size:10px; color:var(--text-ghost)">Chain-anchored, immutable</span>
+                <a style="margin-left:auto; font-size:10px; color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer" onclick="openLayerTab('verified-memory')">Open full view →</a>
+              </div>
+
+              <!-- Trust gradient bar -->
+              <div style="display:flex; gap:4px; height:6px; margin-bottom:8px; border-radius:3px; overflow:hidden">
+                <div style="flex:23; background:var(--accent-green); border-radius:2px" title="23 consensus-verified"></div>
+                <div style="flex:12; background:var(--text-secondary); border-radius:2px" title="12 endorsed"></div>
+                <div style="flex:12; background:var(--text-ghost); border-radius:2px" title="12 self-attested"></div>
+              </div>
+              <div style="display:flex; gap:16px; font-size:10px; margin-bottom:14px">
+                <span style="color:var(--accent-green)">● 23 consensus-verified</span>
+                <span style="color:var(--text-secondary)">● 12 endorsed</span>
+                <span style="color:var(--text-tertiary)">● 12 self-attested</span>
+              </div>
+
+              <!-- Asset list with action buttons restored (Decision 2C) -->
+              <div class="lt-asset" style="flex-direction:column; align-items:stretch">
+                <div style="display:flex; align-items:center; gap:10px">
+                <div class="lt-info" style="flex:1">
+                  <div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Warfarin + Aspirin Interaction</div>
+                  <div class="lt-ual" style="margin-top:2px">
+                    <span style="color:var(--accent-green); font-family:var(--font-sans); font-size:11px">● Consensus-verified (3/5)</span>
+                    <span style="margin-left:8px">Published by Dr. Amara · Block #21456789</span>
+                  </div>
+                  <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/warfarin-aspirin-001</div>
+                </div>
+                <div class="endorsement-list">
+                  <div class="endorsement-item">
+                    <span class="endorsement-author">Dr. Chen</span>
+                    <span class="endorsement-comment">"Cross-checked against FDA database. 2,847 bleeding event reports."</span>
+                    <span class="endorsement-time">2d ago</span>
+                  </div>
+                  <div class="endorsement-item">
+                    <span class="endorsement-author">Dr. Patel</span>
+                    <span class="endorsement-comment">"Confirmed against PharmGKB."</span>
+                    <span class="endorsement-time">1d ago</span>
+                  </div>
+                </div>
+                <div class="verification-timeline" style="margin-top:10px">
+                  <div class="vt-event active"><div class="vt-date">Apr 8</div><div class="vt-text"><strong>Published</strong> by Dr. Amara</div></div>
+                  <div class="vt-event active"><div class="vt-date">Apr 9</div><div class="vt-text"><strong>Endorsed</strong> by Chen, Patel, Okonkwo</div></div>
+                  <div class="vt-event active"><div class="vt-date">Apr 10</div><div class="vt-text"><strong>Consensus-verified</strong> 3/5</div></div>
+                </div>
+                <div class="ka-actions">
+                  <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+                  <button class="draft-action-btn" onclick="switchCenterTab('ka-inspector')">View Details</button>
+                </div>
+                </div>
+              </div>
+
+              <!-- Partially verified (K-of-N, quorum not yet reached) -->
+              <div class="lt-asset">
+                <div class="lt-info" style="flex:1">
+                  <div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Apixaban + Amiodarone Signal</div>
+                  <div class="lt-ual" style="margin-top:2px">
+                    <span class="badge-partial">● Partially verified (1/5)</span>
+                    <span style="margin-left:8px">Published by Dr. Amara · Authored by Dr. Silva</span>
+                  </div>
+                  <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/apixaban-amiodarone-005</div>
+                </div>
+                <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+                <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Vote</button>
+              </div>
+
+              <div class="lt-asset">
+                <div class="lt-info" style="flex:1">
+                  <div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Metformin + Contrast Agents</div>
+                  <div class="lt-ual" style="margin-top:2px">
+                    <span style="color:var(--text-secondary); font-family:var(--font-sans); font-size:11px">● Endorsed (3)</span>
+                    <span style="margin-left:8px">Published by Dr. Amara · Authored by Dr. Patel</span>
+                  </div>
+                  <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/metformin-contrast-002</div>
+                </div>
+                <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+                <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Vote</button>
+              </div>
+
+              <div class="lt-asset">
+                <div class="lt-info" style="flex:1">
+                  <div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">SSRI + MAOI Interaction</div>
+                  <div class="lt-ual" style="margin-top:2px">
+                    <span style="color:var(--text-tertiary); font-family:var(--font-sans); font-size:11px">● Self-attested</span>
+                    <span style="margin-left:8px">Published by Dr. Amara · Authored by Dr. Silva</span>
+                  </div>
+                  <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/ssri-maoi-003</div>
+                </div>
+                <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+                <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Vote</button>
+              </div>
+
+              <div class="lt-asset">
+                <div class="lt-info" style="flex:1">
+                  <div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Warfarin + NSAIDs Interaction</div>
+                  <div class="lt-ual" style="margin-top:2px">
+                    <span style="color:var(--accent-green); font-family:var(--font-sans); font-size:11px">● Consensus-verified (5/5)</span>
+                    <span style="margin-left:8px">Published by Dr. Amara · Authored by Dr. Okonkwo</span>
+                  </div>
+                  <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/warfarin-nsaids-004</div>
+                </div>
+                <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+              </div>
+
+              <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:8px">Showing 5 of 47 · Tell your agent "endorse [finding]" or "start consensus vote" to build trust</div>
+            </div>
+
+          </div>
+
+          <!-- PROJECT PAGE (public discovery) -->
+          <div class="dashboard-view" id="view-project-page">
+            <div style="margin-bottom:20px">
+              <div style="font-size:18px; font-weight:600; margin-bottom:4px">Pharma Drug Interactions</div>
+              <div style="font-size:12px; color:var(--text-secondary); margin-bottom:12px">Comprehensive drug-drug interaction database with clinical evidence from 5 independent pharmacology researchers.</div>
+              <div style="display:flex; gap:16px; font-size:11px; color:var(--text-tertiary); font-family:var(--font-mono)">
+                <span>5 researchers</span>
+                <span>Quorum: 3 of 5</span>
+                <span style="color:var(--accent-amber)">Gated — $0.05/query · $50/month full access</span>
+              </div>
+              <div style="display:flex; gap:8px; margin-top:12px">
+                <button onclick="showToast('Purchasing full project access for $50 USDC...')" style="height:32px; padding:0 16px; border-radius:6px; font-size:12px; font-weight:600; background:var(--text-primary); color:var(--bg-root); border:none; cursor:pointer; font-family:inherit; transition:opacity .15s">Buy Full Project Access — $50/month</button>
+                <button onclick="showToast('Previewing free metadata...')" style="height:32px; padding:0 16px; border-radius:6px; font-size:12px; font-weight:500; background:none; color:var(--text-secondary); border:1px solid var(--border-default); cursor:pointer; font-family:inherit; transition:all .15s">Preview Metadata</button>
+              </div>
+            </div>
+
+            <div class="dash-card" style="margin-bottom:16px">
+              <div class="dash-card-label">Trust Gradient</div>
+              <div style="display:flex; gap:4px; height:8px; margin:10px 0; border-radius:4px; overflow:hidden">
+                <div style="flex:23; background:var(--accent-green); border-radius:3px" title="23 consensus-verified"></div>
+                <div style="flex:12; background:var(--text-secondary); border-radius:3px" title="12 endorsed"></div>
+                <div style="flex:12; background:var(--text-ghost); border-radius:3px" title="12 self-attested"></div>
+              </div>
+              <div style="display:flex; gap:20px; font-size:11px">
+                <span style="color:var(--accent-green)">● 23 consensus-verified</span>
+                <span style="color:var(--text-secondary)">● 12 endorsed</span>
+                <span style="color:var(--text-tertiary)">● 12 self-attested</span>
+              </div>
+            </div>
+
+            <div class="dash-row r2">
+              <div class="dash-card">
+                <div class="dash-card-label">Knowledge Depth</div>
+                <div style="display:flex; flex-direction:column; gap:6px; margin-top:8px; font-size:12px">
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Total Knowledge Assets</span><span style="font-family:var(--font-mono); font-size:11px">47</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Avg triples per asset</span><span style="font-family:var(--font-mono); font-size:11px">18</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Ontology coverage</span><span style="font-family:var(--font-mono); font-size:11px">82%</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Source diversity</span><span style="font-family:var(--font-mono); font-size:11px">34 PubMed · 2,847 FDA · 12 RCTs</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Contributors</span><span style="font-family:var(--font-mono); font-size:11px">5 independent researchers</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Temporal coverage</span><span style="font-family:var(--font-mono); font-size:11px">2020 – 2026</span></div>
+                </div>
+              </div>
+              <div class="dash-card">
+                <div class="dash-card-label">Activity</div>
+                <div style="display:flex; flex-direction:column; gap:6px; margin-top:8px; font-size:12px">
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Last published</span><span style="font-family:var(--font-mono); font-size:11px">2h ago</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Last consensus vote</span><span style="font-family:var(--font-mono); font-size:11px">1d ago</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Update frequency</span><span style="font-family:var(--font-mono); font-size:11px">~3 findings/week</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Total endorsements</span><span style="font-family:var(--font-mono); font-size:11px">180</span></div>
+                  <div style="height:1px; background:var(--border-subtle); margin:8px 0"></div>
+                  <div style="font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-bottom:6px">x402 Pricing</div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Per-query access</span><span style="font-family:var(--font-mono); font-size:11px; color:var(--accent-amber)">$0.05 USDC</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Verification rationale</span><span style="font-family:var(--font-mono); font-size:11px; color:var(--accent-amber)">$0.02 USDC</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Full project (30 days)</span><span style="font-family:var(--font-mono); font-size:11px; color:var(--accent-amber)">$50.00 USDC</span></div>
+                  <div style="display:flex; justify-content:space-between"><span style="color:var(--text-tertiary)">Revenue split</span><span style="font-family:var(--font-mono); font-size:11px">Equal among 5 members</span></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="dash-card" style="margin-top:16px">
+              <div class="dash-card-label">Published Findings (47)</div>
+              <div style="margin-top:8px">
+                <div class="lt-asset">
+                  <div class="lt-info">
+                    <div class="lt-name">Warfarin + Aspirin Interaction</div>
+                    <div class="lt-ual"><span style="color:var(--accent-green); font-family:var(--font-sans); font-size:11px">● Consensus 3/5</span><span style="margin-left:8px">Severity: major · Type: pharmacodynamic · 3 endorsements</span></div>
+                    <div style="margin-top:6px; font-size:11px; color:var(--text-tertiary)">── Free metadata ──</div>
+                    <div style="font-size:11px; color:var(--text-secondary); margin-top:2px">Drugs: warfarin, aspirin · Severity: major · Confidence: 0.94</div>
+                    <div style="margin-top:6px; padding:8px 10px; background:var(--bg-hover); border-radius:4px; font-size:11px; display:flex; align-items:center; justify-content:space-between">
+                      <span style="color:var(--text-ghost)">── Full finding: mechanism, evidence, recommendations ──</span>
+                      <button onclick="showToast('Purchasing finding for $0.05 USDC via x402...')" style="font-size:10px; padding:3px 10px; border-radius:4px; background:var(--text-primary); color:var(--bg-root); border:none; cursor:pointer; font-family:inherit; font-weight:500">$0.05</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="lt-asset">
+                  <div class="lt-info">
+                    <div class="lt-name">Metformin + Iodinated Contrast</div>
+                    <div class="lt-ual"><span style="color:var(--accent-green); font-family:var(--font-sans); font-size:11px">● Consensus 3/5</span><span style="margin-left:8px">Severity: moderate · Type: pharmacokinetic · 2 endorsements</span></div>
+                    <div style="margin-top:6px; font-size:11px; color:var(--text-tertiary)">── Free metadata ──</div>
+                    <div style="font-size:11px; color:var(--text-secondary); margin-top:2px">Drugs: metformin, iodinated contrast · Severity: moderate · Confidence: 0.87</div>
+                    <div style="margin-top:6px; padding:8px 10px; background:var(--bg-hover); border-radius:4px; font-size:11px; display:flex; align-items:center; justify-content:space-between">
+                      <span style="color:var(--text-ghost)">── Full finding: mechanism, evidence, recommendations ──</span>
+                      <button onclick="showToast('Purchasing finding for $0.05 USDC via x402...')" style="font-size:10px; padding:3px 10px; border-radius:4px; background:var(--text-primary); color:var(--bg-root); border:none; cursor:pointer; font-family:inherit; font-weight:500">$0.05</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="lt-asset">
+                  <div class="lt-info">
+                    <div class="lt-name">SSRI + MAOI Contraindication</div>
+                    <div class="lt-ual"><span style="color:var(--text-tertiary); font-family:var(--font-sans); font-size:11px">● Self-attested</span><span style="margin-left:8px">Severity: major · Type: serotonin syndrome risk</span></div>
+                    <div style="margin-top:6px; font-size:11px; color:var(--text-tertiary)">── Free metadata ──</div>
+                    <div style="font-size:11px; color:var(--text-secondary); margin-top:2px">Drugs: SSRI, MAOI · Severity: major · Confidence: 0.91</div>
+                    <div style="margin-top:6px; padding:8px 10px; background:var(--bg-hover); border-radius:4px; font-size:11px; display:flex; align-items:center; justify-content:space-between">
+                      <span style="color:var(--text-ghost)">── Full finding: mechanism, evidence, recommendations ──</span>
+                      <button onclick="showToast('Purchasing finding for $0.05 USDC via x402...')" style="font-size:10px; padding:3px 10px; border-radius:4px; background:var(--text-primary); color:var(--bg-root); border:none; cursor:pointer; font-family:inherit; font-weight:500">$0.05</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div style="font-size:11px; color:var(--text-ghost); margin-top:10px; text-align:center">Showing 3 of 47 findings · <span style="color:var(--accent-amber)">$0.05/query or $50/month full access</span></div>
+            </div>
+          </div>
+
+          <!-- MEMORY STACK VIEW (§6.3) -->
+          <div class="dashboard-view" id="view-memory-stack" style="padding:24px; max-width:700px; margin:0 auto">
+            <div style="text-align:center; margin-bottom:20px; font-size:10px; letter-spacing:1.5px; text-transform:uppercase; color:var(--text-ghost)">Highest Trust</div>
+            <div style="border:1px solid var(--border-subtle); border-radius:8px; padding:14px 16px; margin-bottom:4px"><div style="display:flex; align-items:center; gap:10px"><span style="width:10px;height:10px;border-radius:50%;background:var(--layer-verified)"></span><span style="font-weight:600; font-size:13px; flex:1">Verified Memory</span><span style="font-family:var(--font-mono); font-size:12px; color:var(--text-secondary)">47</span><span style="font-size:12px; color:var(--text-tertiary)">🔓</span></div></div>
+            <div style="padding:0 20px 8px; font-size:11px; color:var(--text-tertiary); display:flex; gap:16px"><span style="color:var(--accent-green)">● Consensus: 23</span><span>● Endorsed: 12</span><span style="color:var(--text-ghost)">● Self-attested: 12</span></div>
+            <div style="text-align:center; padding:6px 0; color:var(--text-ghost); font-size:11px; font-family:var(--font-mono)">▲ PUBLISH (chain anchor + TRAC + gas)</div>
+            <div style="border:1px solid var(--border-subtle); border-radius:8px; padding:14px 16px; margin-bottom:4px"><div style="display:flex; align-items:center; gap:10px"><span style="width:10px;height:10px;border-radius:50%;background:var(--layer-shared)"></span><span style="font-weight:600; font-size:13px; flex:1">Shared Memory</span><span style="font-family:var(--font-mono); font-size:12px; color:var(--text-secondary)">38</span><span style="font-size:12px; color:var(--text-tertiary)">🔒</span></div></div>
+            <div style="text-align:center; padding:6px 0; color:var(--text-ghost); font-size:11px; font-family:var(--font-mono)">▲ SHARE (free, instant)</div>
+            <div style="border:1px solid var(--border-subtle); border-radius:8px; padding:14px 16px"><div style="display:flex; align-items:center; gap:10px"><span style="width:10px;height:10px;border-radius:50%;background:var(--layer-working)"></span><span style="font-weight:600; font-size:13px; flex:1">Working Memory</span><span style="font-family:var(--font-mono); font-size:12px; color:var(--text-secondary)">142</span><span style="font-size:12px; color:var(--text-tertiary)">🔒</span></div></div>
+            <div style="text-align:center; margin-top:20px; font-size:10px; letter-spacing:1.5px; text-transform:uppercase; color:var(--text-ghost)">Lowest Trust</div>
+          </div>
+
+          <!-- KA INSPECTOR VIEW (§6.9) -->
+          <div class="dashboard-view" id="view-ka-inspector">
+            <div class="ka-inspector">
+              <div style="font-size:16px; font-weight:600; margin-bottom:4px">Warfarin + Aspirin Interaction</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:16px; font-family:var(--font-mono)">did:dkg:base:84532/0x8a4f...c3b2/warfarin-aspirin-001</div>
+              <div class="ka-section"><div class="ka-section-title">Trust Level</div>
+                <div class="ka-trust-badge" style="color:var(--accent-green); border-color:rgba(34,197,94,0.3)">● Consensus-verified (3/5)</div>
+                <div class="verification-timeline" style="margin-top:12px">
+                  <div class="vt-event active"><div class="vt-date">Apr 8</div><div class="vt-text"><strong>Published</strong> (self-attested) by Dr. Amara</div></div>
+                  <div class="vt-event active"><div class="vt-date">Apr 9</div><div class="vt-text"><strong>Endorsed</strong> by Chen, Patel, Okonkwo</div></div>
+                  <div class="vt-event active"><div class="vt-date">Apr 10</div><div class="vt-text"><strong>Consensus-verified</strong> 3/5</div></div>
+                </div>
+              </div>
+              <div class="ka-section"><div class="ka-section-title">Attribution</div>
+                <div class="ka-field"><span class="ka-label">Published by</span><span class="ka-value">Dr. Amara · 0x8a4f...c3b2</span></div>
+                <div class="ka-field"><span class="ka-label">Authored by</span><span class="ka-value">Dr. Chen · 0x3b8c...a1f7</span></div>
+              </div>
+              <div class="ka-section"><div class="ka-section-title">Provenance</div>
+                <div class="ka-field"><span class="ka-label">Chain</span><span class="ka-value">Base L2</span></div>
+                <div class="ka-field"><span class="ka-label">Block</span><span class="ka-value">#21456789</span></div>
+                <div class="ka-field"><span class="ka-label">Tx Hash</span><span class="ka-value">0xfeed...1234</span></div>
+                <div class="ka-field"><span class="ka-label">Published</span><span class="ka-value">2026-04-08T14:21:58Z</span></div>
+                <div class="ka-field"><span class="ka-label">KC Batch</span><span class="ka-value">KC-pharma-batch-001 (23 assets)</span></div>
+                <div class="ka-field"><span class="ka-label">Payer</span><span class="ka-value">Dr. Amara (self) · 180 TRAC + 0.0012 ETH</span></div>
+              </div>
+              <div class="ka-section"><div class="ka-section-title">Endorsements (3)</div>
+                <div class="endorsement-item"><span class="endorsement-author">Dr. Chen</span><span class="endorsement-comment">"Cross-checked against FDA database."</span><span class="endorsement-time">2d ago</span></div>
+                <div class="endorsement-item"><span class="endorsement-author">Dr. Patel</span><span class="endorsement-comment">"Confirmed against PharmGKB."</span><span class="endorsement-time">1d ago</span></div>
+                <div class="endorsement-item"><span class="endorsement-author">Dr. Okonkwo</span><span class="endorsement-comment">"Consistent with metabolism data."</span><span class="endorsement-time">12h ago</span></div>
+              </div>
+              <div class="ka-section"><div class="ka-section-title">Free Metadata</div>
+                <div class="ka-field"><span class="ka-label">Drugs</span><span class="ka-value">warfarin, aspirin</span></div>
+                <div class="ka-field"><span class="ka-label">Severity</span><span class="ka-value">major</span></div>
+                <div class="ka-field"><span class="ka-label">Confidence</span><span class="ka-value">0.94</span></div>
+              </div>
+              <div class="ka-section"><div class="ka-section-title">Gated Content</div>
+                <div style="padding:12px; background:var(--bg-surface); border-radius:6px; text-align:center; color:var(--text-ghost); font-size:11px">── Full Finding ── <span style="color:var(--accent-amber)">$0.05 USDC via x402</span></div>
+              </div>
+              <div class="ka-actions">
+                <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+                <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Consensus Vote</button>
+                <button class="draft-action-btn" onclick="showToast('UAL copied')">Copy UAL</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- CONSENSUS VOTE VIEW (§6.8) -->
+          <div class="dashboard-view" id="view-consensus-vote" style="padding:20px 24px">
+            <div class="cv-header">
+              <div style="font-size:15px; font-weight:600; margin-bottom:4px">Consensus Vote: High-Impact Drug Interactions</div>
+              <div style="font-size:11px; color:var(--text-tertiary); display:flex; gap:16px"><span>Proposed by Dr. Amara</span><span>Quorum: 3/5</span><span style="color:var(--accent-green)">18/23 quorum met</span><span style="color:var(--accent-amber)">3 pending</span><span style="color:var(--accent-red)">2 rejected</span></div>
+            </div>
+            <div class="cv-finding">
+              <div class="cv-finding-header"><span class="cv-finding-name">Warfarin + Aspirin (major)</span><span style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono)">3 endorsed</span></div>
+              <div class="cv-vote-toggle"><button class="cv-vote-btn approve" onclick="selectCvVote(this,'approve')">Approve</button><button class="cv-vote-btn" onclick="selectCvVote(this,'reject')">Reject</button></div>
+              <textarea class="form-textarea" placeholder="Rationale..." style="margin-top:8px; min-height:40px; font-size:11px">Verified methodology — 34 PubMed studies.</textarea>
+              <div class="cv-quorum-bar" style="margin-top:8px"><div class="cv-quorum-slot filled"></div><div class="cv-quorum-slot filled"></div><div class="cv-quorum-slot pending"></div><div class="cv-quorum-slot"></div><div class="cv-quorum-slot"></div></div>
+            </div>
+            <div class="cv-finding">
+              <div class="cv-finding-header"><span class="cv-finding-name">Metformin + Contrast (moderate)</span><span style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono)">2 endorsed</span></div>
+              <div class="cv-vote-toggle"><button class="cv-vote-btn" onclick="selectCvVote(this,'approve')">Approve</button><button class="cv-vote-btn" onclick="selectCvVote(this,'reject')">Reject</button></div>
+              <textarea class="form-textarea" placeholder="Rationale..." style="margin-top:8px; min-height:40px; font-size:11px"></textarea>
+              <div class="cv-quorum-bar" style="margin-top:8px"><div class="cv-quorum-slot filled"></div><div class="cv-quorum-slot pending"></div><div class="cv-quorum-slot"></div><div class="cv-quorum-slot"></div><div class="cv-quorum-slot"></div></div>
+            </div>
+            <div style="font-size:10px; color:var(--text-ghost); margin:8px 0">Showing 2 of 23 findings</div>
+            <button class="modal-btn primary" style="width:100%" onclick="showToast('Votes submitted — quorum reached for 18/23 findings!')">Submit All Votes</button>
+          </div>
+
+          <!-- AGENT HUB VIEW (§13) -->
+          <div class="dashboard-view" id="view-agent-hub" style="padding:20px 24px">
+            <div style="font-size:16px; font-weight:600; margin-bottom:6px">Agent Hub</div>
+            <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:16px">Manage the agents connected to your node. Pause, edit permissions, configure, view logs, or disconnect agents as needed.</div>
+            <div style="display:grid; grid-template-columns:1fr 1fr 1fr 1fr; gap:10px; margin-bottom:16px">
+              <div class="dash-card"><div class="dash-card-label">Active Agents</div><div class="dash-card-value">4</div></div>
+              <div class="dash-card"><div class="dash-card-label">Paused</div><div class="dash-card-value">0</div></div>
+              <div class="dash-card"><div class="dash-card-label">Agent Runs (24h)</div><div class="dash-card-value">47</div></div>
+              <div class="dash-card"><div class="dash-card-label">Errors (24h)</div><div class="dash-card-value" style="color:var(--accent-green)">0</div></div>
+            </div>
+
+            <div class="dash-card">
+              <!-- research-agent — running -->
+              <div style="padding:14px 0; border-bottom:1px solid var(--border-subtle)">
+                <div style="display:flex; align-items:center; gap:12px; margin-bottom:10px">
+                  <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-green)"></span>
+                  <div style="flex:1">
+                    <div style="font-weight:500; font-size:13px">research-agent</div>
+                    <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono)">Framework: Claude Code · DID: 0x8a4f...c3b2 · Last active: just now</div>
+                    <div style="font-size:10px; color:var(--text-ghost); margin-top:2px">Permissions: Pharma (R/W All), Climate (R/W All)</div>
+                  </div>
+                  <span style="font-size:10px; padding:3px 8px; border-radius:3px; border:1px solid rgba(34,197,94,0.3); color:var(--accent-green)">Running</span>
+                </div>
+                <div style="display:flex; gap:4px; flex-wrap:wrap">
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('research-agent paused')">Pause</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="openModal('agentPermissionsModal')">Edit Permissions</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Opening Claude Code settings...')">Configure</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Filtering Agent Runs to research-agent')">View Logs</button>
+                  <button class="draft-action-btn danger" style="font-size:10px; padding:4px 10px" onclick="showToast('Disconnect research-agent? Working Memory drafts will be preserved.')">Disconnect</button>
+                </div>
+              </div>
+
+              <!-- literature-scanner — idle -->
+              <div style="padding:14px 0; border-bottom:1px solid var(--border-subtle)">
+                <div style="display:flex; align-items:center; gap:12px; margin-bottom:10px">
+                  <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-green)"></span>
+                  <div style="flex:1">
+                    <div style="font-weight:500; font-size:13px">literature-scanner</div>
+                    <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono)">Framework: Agent Hermes · DID: 0x9d8e...f3c1 · Last active: 2h ago</div>
+                    <div style="font-size:10px; color:var(--text-ghost); margin-top:2px">Permissions: Pharma (R/W Working Memory)</div>
+                  </div>
+                  <span style="font-size:10px; padding:3px 8px; border-radius:3px; border:1px solid var(--border-default); color:var(--text-tertiary)">Idle</span>
+                </div>
+                <div style="display:flex; gap:4px; flex-wrap:wrap">
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('literature-scanner paused')">Pause</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="openModal('agentPermissionsModal')">Edit Permissions</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Opening Agent Hermes settings...')">Configure</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Filtering Agent Runs to literature-scanner')">View Logs</button>
+                  <button class="draft-action-btn danger" style="font-size:10px; padding:4px 10px" onclick="showToast('Disconnect literature-scanner?')">Disconnect</button>
+                </div>
+              </div>
+
+              <!-- guideline-checker — idle -->
+              <div style="padding:14px 0; border-bottom:1px solid var(--border-subtle)">
+                <div style="display:flex; align-items:center; gap:12px; margin-bottom:10px">
+                  <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-green)"></span>
+                  <div style="flex:1">
+                    <div style="font-weight:500; font-size:13px">guideline-checker</div>
+                    <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono)">Framework: Custom · DID: 0x4a5b...e2d7 · Last active: 5h ago</div>
+                    <div style="font-size:10px; color:var(--text-ghost); margin-top:2px">Permissions: Pharma (R Working/Shared)</div>
+                  </div>
+                  <span style="font-size:10px; padding:3px 8px; border-radius:3px; border:1px solid var(--border-default); color:var(--text-tertiary)">Idle</span>
+                </div>
+                <div style="display:flex; gap:4px; flex-wrap:wrap">
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('guideline-checker paused')">Pause</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="openModal('agentPermissionsModal')">Edit Permissions</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Opening framework settings...')">Configure</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Filtering Agent Runs to guideline-checker')">View Logs</button>
+                  <button class="draft-action-btn danger" style="font-size:10px; padding:4px 10px" onclick="showToast('Disconnect guideline-checker?')">Disconnect</button>
+                </div>
+              </div>
+
+              <!-- graphify-agent — running -->
+              <div style="padding:14px 0">
+                <div style="display:flex; align-items:center; gap:12px; margin-bottom:10px">
+                  <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-amber)"></span>
+                  <div style="flex:1">
+                    <div style="font-weight:500; font-size:13px">graphify-agent</div>
+                    <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono)">Framework: Graphify MCP · DID: 0x6c7d...e8f9 · Last active: 2m ago</div>
+                    <div style="font-size:10px; color:var(--text-ghost); margin-top:2px">Permissions: Pharma (R/W Working Memory) · Watching 52 files</div>
+                  </div>
+                  <span style="font-size:10px; padding:3px 8px; border-radius:3px; border:1px solid rgba(245,158,11,0.3); color:var(--accent-amber)">Running</span>
+                </div>
+                <div style="display:flex; gap:4px; flex-wrap:wrap">
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('graphify-agent paused')">Pause</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="openModal('agentPermissionsModal')">Edit Permissions</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Opening Graphify settings...')">Configure</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="showToast('Filtering Agent Runs to graphify-agent')">View Logs</button>
+                  <button class="draft-action-btn danger" style="font-size:10px; padding:4px 10px" onclick="showToast('Disconnect graphify-agent? Working Memory triples will be preserved.')">Disconnect</button>
+                </div>
+              </div>
+            </div>
+
+            <div style="margin-top:14px; padding:14px; border:1px dashed var(--border-default); border-radius:8px; text-align:center">
+              <div style="font-size:11px; color:var(--text-secondary); margin-bottom:10px">Need more agents?</div>
+              <div style="display:flex; gap:6px; justify-content:center; flex-wrap:wrap">
+                <button class="draft-action-btn primary" onclick="openModal('agentPermissionsModal');showToast('OpenClaw connector opened — configure permissions to connect')">Connect OpenClaw</button>
+                <button class="draft-action-btn primary" onclick="openModal('agentPermissionsModal');showToast('ElizaOS connector opened — configure permissions to connect')">Connect ElizaOS</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- ═══ GRAPHIFY GRAPH VIEW (V5) ═══ -->
+          <div class="dashboard-view" id="view-graphify-graph" style="padding:16px 20px">
+            <div style="display:flex; align-items:center; gap:10px; margin-bottom:14px">
+              <span style="font-size:16px">⬡</span>
+              <span style="font-size:15px; font-weight:600">Graphify Graph</span>
+              <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">Pharma Drug Interactions · 1,159 nodes · 3,365 edges</span>
+              <span style="margin-left:auto; font-size:10px; color:var(--text-ghost)">Last run: 2m ago</span>
+            </div>
+
+            <div class="graphify-stats">
+              <div class="graphify-stat"><div class="graphify-stat-value">1,159</div><div class="graphify-stat-label">Nodes</div></div>
+              <div class="graphify-stat"><div class="graphify-stat-value">3,365</div><div class="graphify-stat-label">Edges</div></div>
+              <div class="graphify-stat"><div class="graphify-stat-value">8</div><div class="graphify-stat-label">Communities</div></div>
+              <div class="graphify-stat"><div class="graphify-stat-value">4,891</div><div class="graphify-stat-label">DKG Triples</div></div>
+            </div>
+
+            <!-- Confidence breakdown -->
+            <div style="display:flex; gap:3px; height:8px; margin-bottom:6px; border-radius:4px; overflow:hidden">
+              <div style="flex:3102; background:var(--accent-green); border-radius:3px" title="3,102 EXTRACTED"></div>
+              <div style="flex:1482; background:var(--accent-amber); border-radius:3px" title="1,482 INFERRED"></div>
+              <div style="flex:307; background:var(--accent-red); border-radius:3px" title="307 AMBIGUOUS"></div>
+            </div>
+            <div style="display:flex; gap:16px; font-size:10px; margin-bottom:16px">
+              <span style="color:var(--accent-green)">● 3,102 EXTRACTED</span>
+              <span style="color:var(--accent-amber)">● 1,482 INFERRED</span>
+              <span style="color:var(--accent-red)">● 307 AMBIGUOUS</span>
+            </div>
+
+            <!-- Community filters -->
+            <div style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:16px">
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Auth (12)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Data (18)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ API (9)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Models (23)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Pharma (31)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Clinical (15)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Utils (8)</span>
+              <span class="graphify-community active" onclick="this.classList.toggle('active')">■ Tests (6)</span>
+            </div>
+
+            <!-- Interactive Graph (static SVG mockup) -->
+            <div style="border:1px solid var(--border-subtle); border-radius:8px; overflow:hidden">
+              <div style="display:flex; align-items:center; gap:8px; padding:8px 12px; border-bottom:1px solid var(--border-subtle); font-size:11px">
+                <input type="text" placeholder="Search nodes..." style="flex:1; height:28px; border-radius:4px; font-size:11px">
+                <button class="draft-action-btn" style="font-size:10px; padding:3px 8px" onclick="showToast('Zoom to fit')">Fit</button>
+              </div>
+              <svg viewBox="0 0 600 350" xmlns="http://www.w3.org/2000/svg" style="width:100%; background:var(--bg-root)">
+                <!-- Community clusters -->
+                <!-- Pharma cluster (center) -->
+                <circle cx="300" cy="175" r="70" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="4"/>
+                <text x="300" y="115" text-anchor="middle" fill="#333" font-size="8" font-family="JetBrains Mono">Pharma (31)</text>
+
+                <!-- Auth cluster (left) -->
+                <circle cx="120" cy="140" r="50" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="4"/>
+                <text x="120" y="95" text-anchor="middle" fill="#333" font-size="8" font-family="JetBrains Mono">Auth (12)</text>
+
+                <!-- Data cluster (right) -->
+                <circle cx="480" cy="160" r="55" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="4"/>
+                <text x="480" y="110" text-anchor="middle" fill="#333" font-size="8" font-family="JetBrains Mono">Data (18)</text>
+
+                <!-- Clinical cluster (bottom) -->
+                <circle cx="250" cy="290" r="45" fill="none" stroke="#333" stroke-width="0.5" stroke-dasharray="4"/>
+                <text x="250" y="255" text-anchor="middle" fill="#333" font-size="8" font-family="JetBrains Mono">Clinical (15)</text>
+
+                <!-- Edges (solid = EXTRACTED, dashed = INFERRED) -->
+                <line x1="150" y1="140" x2="260" y2="170" stroke="#555" stroke-width="1"/>
+                <line x1="340" y1="170" x2="440" y2="160" stroke="#555" stroke-width="1"/>
+                <line x1="300" y1="210" x2="260" y2="270" stroke="#555" stroke-width="1"/>
+                <line x1="120" y1="170" x2="250" y2="270" stroke="#444" stroke-width="0.8" stroke-dasharray="4"/>
+                <line x1="480" y1="190" x2="300" y2="270" stroke="#444" stroke-width="0.8" stroke-dasharray="4"/>
+                <line x1="140" y1="155" x2="440" y2="155" stroke="#333" stroke-width="0.5" stroke-dasharray="2"/>
+
+                <!-- God node: DrugInteractionModel (largest) -->
+                <circle cx="300" cy="175" r="18" fill="#181818" stroke="#bbb" stroke-width="2"/>
+                <text x="300" y="172" text-anchor="middle" fill="#e8e8e8" font-size="6" font-weight="600" font-family="Instrument Sans">DrugInteraction</text>
+                <text x="300" y="180" text-anchor="middle" fill="#e8e8e8" font-size="6" font-weight="600" font-family="Instrument Sans">Model</text>
+                <text x="300" y="199" text-anchor="middle" fill="#555" font-size="5" font-family="JetBrains Mono">38 edges · god node</text>
+
+                <!-- AuthService (god node) -->
+                <circle cx="120" cy="140" r="15" fill="#181818" stroke="#999" stroke-width="1.5"/>
+                <text x="120" y="138" text-anchor="middle" fill="#bbb" font-size="6" font-family="Instrument Sans">AuthService</text>
+                <text x="120" y="147" text-anchor="middle" fill="#555" font-size="5" font-family="JetBrains Mono">42 edges</text>
+
+                <!-- PharmaOntology -->
+                <circle cx="260" cy="170" r="12" fill="#181818" stroke="#888" stroke-width="1"/>
+                <text x="260" y="168" text-anchor="middle" fill="#999" font-size="5.5" font-family="Instrument Sans">PharmaOntology</text>
+                <text x="260" y="177" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">31 edges</text>
+
+                <!-- PharmaDB -->
+                <circle cx="440" cy="155" r="13" fill="#181818" stroke="#888" stroke-width="1"/>
+                <text x="440" y="153" text-anchor="middle" fill="#999" font-size="5.5" font-family="Instrument Sans">PharmaDB</text>
+                <text x="440" y="162" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">24 edges</text>
+
+                <!-- ClinicalTrialAPI -->
+                <circle cx="250" cy="285" r="11" fill="#181818" stroke="#777" stroke-width="1"/>
+                <text x="250" y="283" text-anchor="middle" fill="#888" font-size="5.5" font-family="Instrument Sans">ClinicalTrialAPI</text>
+                <text x="250" y="292" text-anchor="middle" fill="#555" font-size="4.5" font-family="JetBrains Mono">18 edges</text>
+
+                <!-- Satellite nodes -->
+                <circle cx="85" cy="125" r="5" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="155" cy="120" r="4" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="100" cy="165" r="4" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="340" cy="155" r="5" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="320" cy="200" r="4" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="510" cy="145" r="4" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="460" cy="185" r="5" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="500" cy="175" r="3" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="220" cy="300" r="4" fill="#262626" stroke="#555" stroke-width="0.5"/>
+                <circle cx="280" cy="305" r="3" fill="#262626" stroke="#555" stroke-width="0.5"/>
+
+                <!-- Legend -->
+                <line x1="30" y1="335" x2="50" y2="335" stroke="#555" stroke-width="1.5"/>
+                <text x="55" y="337" fill="#555" font-size="6" font-family="JetBrains Mono">EXTRACTED</text>
+                <line x1="130" y1="335" x2="150" y2="335" stroke="#444" stroke-width="1" stroke-dasharray="4"/>
+                <text x="155" y="337" fill="#555" font-size="6" font-family="JetBrains Mono">INFERRED</text>
+                <line x1="230" y1="335" x2="250" y2="335" stroke="#ef4444" stroke-width="1" stroke-dasharray="2"/>
+                <text x="255" y="337" fill="#555" font-size="6" font-family="JetBrains Mono">AMBIGUOUS</text>
+              </svg>
+            </div>
+            <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:8px; font-style:italic">Interactive vis.js graph — click nodes to inspect, scroll to zoom</div>
+          </div>
+
+          <!-- ═══ GRAPHIFY REPORT VIEW (V5) ═══ -->
+          <div class="dashboard-view" id="view-graphify-report" style="padding:20px 24px; max-width:800px; margin:0 auto">
+            <div style="display:flex; align-items:center; gap:10px; margin-bottom:20px">
+              <span style="font-size:16px">⬡</span>
+              <span style="font-size:15px; font-weight:600">Graphify Report</span>
+              <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">GRAPH_REPORT.md</span>
+            </div>
+
+            <div class="dash-card" style="margin-bottom:16px">
+              <div class="dash-card-label">Executive Summary</div>
+              <div style="font-size:12px; color:var(--text-secondary); line-height:1.7; margin-top:6px">
+                Processed <strong style="color:var(--text-primary)">52 files</strong> across 5 directories. The knowledge graph contains <strong style="color:var(--text-primary)">1,159 nodes</strong> and <strong style="color:var(--text-primary)">3,365 edges</strong> organized into <strong style="color:var(--text-primary)">8 communities</strong> via Leiden clustering. Processing took 1m 40s (Pass 1: 12s AST, Pass 2: 1m 28s semantic). Token reduction: <strong style="color:var(--accent-green)">71.5x</strong> compared to raw file processing.
+              </div>
+            </div>
+
+            <div class="dash-card" style="margin-bottom:16px">
+              <div class="dash-card-label">God Nodes (Highest-Degree Concepts)</div>
+              <div style="margin-top:8px">
+                <div class="graphify-godnode">
+                  <span style="width:8px; height:8px; border-radius:50%; background:var(--accent-amber)"></span>
+                  <span style="font-weight:500; min-width:180px">AuthService</span>
+                  <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">42 edges</span>
+                  <span style="font-size:10px; color:var(--text-ghost)">Community: Auth</span>
+                  <span style="font-size:10px; color:var(--text-ghost); margin-left:auto">class · src/auth.py</span>
+                </div>
+                <div class="graphify-godnode">
+                  <span style="width:8px; height:8px; border-radius:50%; background:var(--accent-amber)"></span>
+                  <span style="font-weight:500; min-width:180px">DrugInteractionModel</span>
+                  <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">38 edges</span>
+                  <span style="font-size:10px; color:var(--text-ghost)">Community: Pharma</span>
+                  <span style="font-size:10px; color:var(--text-ghost); margin-left:auto">class · src/models/interactions.py</span>
+                </div>
+                <div class="graphify-godnode">
+                  <span style="width:8px; height:8px; border-radius:50%; background:var(--accent-amber)"></span>
+                  <span style="font-weight:500; min-width:180px">PharmaOntology</span>
+                  <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">31 edges</span>
+                  <span style="font-size:10px; color:var(--text-ghost)">Community: Pharma</span>
+                  <span style="font-size:10px; color:var(--text-ghost); margin-left:auto">ontology · pharma-interactions.ttl</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="dash-card" style="margin-bottom:16px">
+              <div class="dash-card-label">Surprising Connections</div>
+              <div style="font-size:12px; color:var(--text-secondary); line-height:1.8; margin-top:6px">
+                ● <strong>AuthService → ClinicalTrialAPI</strong> — unexpected cross-community edge (Auth → Clinical). High betweenness centrality suggests AuthService mediates all external data access. <span style="color:var(--accent-amber)">INFERRED (0.78)</span><br>
+                ● <strong>PharmaDB → FDA_FAERS_Parser</strong> — both handle adverse events but through different pipelines. Possible duplication. <span style="color:var(--accent-amber)">INFERRED (0.65)</span><br>
+                ● <strong>DrugInteractionModel → WarfarinProtocol</strong> — implements interface not declared in imports. Discovered via docstring pattern analysis. <span style="color:var(--accent-amber)">INFERRED (0.89)</span>
+              </div>
+            </div>
+
+            <div class="dash-card">
+              <div class="dash-card-label">Suggested Questions</div>
+              <div style="margin-top:8px; display:flex; flex-direction:column; gap:6px">
+                <button class="draft-action-btn" style="text-align:left; font-size:11px; padding:6px 10px" onclick="showToast('Querying graphify-agent...')">What is the shortest path from AuthService to DrugInteractionModel?</button>
+                <button class="draft-action-btn" style="text-align:left; font-size:11px; padding:6px 10px" onclick="showToast('Querying graphify-agent...')">Which communities are most tightly connected?</button>
+                <button class="draft-action-btn" style="text-align:left; font-size:11px; padding:6px 10px" onclick="showToast('Querying graphify-agent...')">List all AMBIGUOUS edges for manual review</button>
+                <button class="draft-action-btn" style="text-align:left; font-size:11px; padding:6px 10px" onclick="showToast('Querying graphify-agent...')">Explain the Pharma community structure</button>
+              </div>
+            </div>
+          </div>
+
+          <!-- ═══ DEDICATED WORKING MEMORY TAB (Decision 3C) ═══ -->
+          <div class="dashboard-view" id="view-working-memory" style="padding:16px 20px">
+            <div style="display:flex; align-items:center; gap:10px; margin-bottom:14px">
+              <span style="width:10px; height:10px; border-radius:50%; background:var(--layer-working)"></span>
+              <span style="font-size:15px; font-weight:600">Working Memory</span>
+              <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">Pharma Drug Interactions · 4,959 entities (68 drafts + 4,891 Graphify)</span>
+            </div>
+
+            <!-- Source filter -->
+            <div style="display:flex; gap:6px; margin-bottom:8px; font-size:10px; color:var(--text-ghost)">
+              Source:
+              <span class="graphify-community active" onclick="this.classList.toggle('active');showToast('Filter: all sources')">All sources</span>
+              <span class="graphify-community" onclick="this.classList.toggle('active');showToast('Filter: agent drafts only')">Agent drafts (68)</span>
+              <span class="graphify-community" onclick="this.classList.toggle('active');showToast('Filter: Graphify only')">⬡ Graphify (4,891)</span>
+            </div>
+
+            <div style="display:flex; gap:6px; margin-bottom:10px" id="wmFullFilterBar">
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong)" onclick="filterDrafts('all',this)">All (68)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterDrafts('ready',this)">Ready (56)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterDrafts('flagged',this)">Needs Review (12)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterDrafts('error',this)">Errors (0)</button>
+            </div>
+
+            <div class="draft-card" data-status="ready">
+              <div class="draft-card-header"><span class="draft-card-title">Warfarin + Aspirin Interaction</span><span class="draft-card-badge ready">Ready</span></div>
+              <div class="draft-card-meta"><span>Severity: major</span><span>Evidence: meta-analysis</span><span>Confidence: 0.94</span><span style="color:var(--text-ghost)">via research-agent</span></div>
+              <div class="draft-card-snippet">pharma:drug1 warfarin · pharma:drug2 aspirin · pharma:mechanism "Both drugs inhibit platelet aggregation..."</div>
+              <div class="draft-card-actions">
+                <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+              </div>
+            </div>
+            <div class="draft-card" data-status="ready">
+              <div class="draft-card-header"><span class="draft-card-title">Metformin + Iodinated Contrast</span><span class="draft-card-badge ready">Ready</span></div>
+              <div class="draft-card-meta"><span>Severity: moderate</span><span>Evidence: clinical guideline</span><span>Confidence: 0.87</span><span style="color:var(--text-ghost)">via research-agent</span></div>
+              <div class="draft-card-snippet">pharma:drug1 metformin · pharma:drug2 iodinated-contrast · pharma:mechanism "Metformin accumulation risk..."</div>
+              <div class="draft-card-actions">
+                <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+              </div>
+            </div>
+            <div class="draft-card" data-status="flagged">
+              <div class="draft-card-header"><span class="draft-card-title">Apixaban + Amiodarone Adverse Signal</span><span class="draft-card-badge flagged">Needs Review</span></div>
+              <div class="draft-card-meta"><span>Severity: under review</span><span>Source: FDA FAERS</span><span>Confidence: 0.62</span><span style="color:var(--text-ghost)">via adverse-event-monitor</span></div>
+              <div style="font-size:10px; color:var(--accent-amber); margin-bottom:6px; padding:4px 8px; background:rgba(245,158,11,0.06); border-radius:4px">Agent flag: Extraction confidence 0.62 — ambiguous drug name mapping</div>
+              <div class="draft-card-snippet">pharma:drug1 apixaban · pharma:drug2 amiodarone · pharma:signal "Disproportionality analysis flagged 147 bleeding events..."</div>
+              <div class="draft-card-actions">
+                <button class="draft-action-btn" onclick="showToast('Status overridden to Ready')">Mark as Ready</button>
+                <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+              </div>
+            </div>
+            <div class="draft-card" data-status="ready">
+              <div class="draft-card-header"><span class="draft-card-title">Clopidogrel + Omeprazole Interaction</span><span class="draft-card-badge ready">Ready</span></div>
+              <div class="draft-card-meta"><span>Severity: moderate</span><span>Evidence: clinical trial</span><span>Confidence: 0.89</span><span style="color:var(--text-ghost)">via literature-scanner</span></div>
+              <div class="draft-card-snippet">pharma:drug1 clopidogrel · pharma:drug2 omeprazole · pharma:mechanism "Omeprazole inhibits CYP2C19..."</div>
+              <div class="draft-card-actions">
+                <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+              </div>
+            </div>
+            <div class="draft-card" data-status="flagged">
+              <div class="draft-card-header"><span class="draft-card-title">Lithium + ACE Inhibitor Interaction</span><span class="draft-card-badge flagged">Needs Review</span></div>
+              <div class="draft-card-meta"><span>Severity: major</span><span>Source: literature scan</span><span>Confidence: 0.71</span><span style="color:var(--text-ghost)">via literature-scanner</span></div>
+              <div style="font-size:10px; color:var(--accent-amber); margin-bottom:6px; padding:4px 8px; background:rgba(245,158,11,0.06); border-radius:4px">Agent flag: Missing required field pharma:severity</div>
+              <div class="draft-card-snippet">pharma:drug1 lithium · pharma:drug2 ace-inhibitor · pharma:mechanism "ACE inhibitors reduce renal clearance of lithium..."</div>
+              <div class="draft-card-actions">
+                <button class="draft-action-btn" onclick="showToast('Status overridden to Ready')">Mark as Ready</button>
+                <button class="draft-action-btn" onclick="showToast('Editing draft')">Edit</button>
+                <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+              </div>
+            </div>
+            <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:10px">Showing 5 of 68 agent drafts</div>
+
+            <!-- Graphify Imported Entities -->
+            <div style="margin-top:20px; padding-top:16px; border-top:1px solid var(--border-subtle)">
+              <div style="display:flex; align-items:center; gap:8px; margin-bottom:12px">
+                <span style="font-size:14px">⬡</span>
+                <span style="font-size:13px; font-weight:600">Graphify Import</span>
+                <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">4,891 triples from 52 files · 8 communities</span>
+                <span style="margin-left:auto">
+                  <button class="draft-action-btn" style="font-size:10px; padding:3px 8px" onclick="switchCenterTab('graphify-graph')">View Graph</button>
+                  <button class="draft-action-btn" style="font-size:10px; padding:3px 8px; margin-left:4px" onclick="switchCenterTab('graphify-report')">Report</button>
+                </span>
+              </div>
+
+              <!-- Graphify confidence filter -->
+              <div style="display:flex; gap:6px; margin-bottom:10px">
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong)">All (4,891)</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; color:var(--accent-green)">EXTRACTED (3,102)</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; color:var(--accent-amber)">INFERRED (1,482)</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; color:var(--accent-red)">AMBIGUOUS (307)</button>
+              </div>
+
+              <div class="draft-card" data-status="ready" style="border-left:3px solid var(--accent-green)">
+                <div class="draft-card-header"><span class="draft-card-title">DrugInteractionModel → implements → PharmaProtocol</span><span class="draft-card-badge ready">EXTRACTED</span></div>
+                <div class="draft-card-meta"><span>Confidence: 1.0</span><span>tree-sitter AST</span><span>Community: Pharma (31 nodes)</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                <div class="draft-card-snippet">code:Class DrugInteractionModel · code:implements PharmaProtocol · code:definedIn src/models/interactions.py · code:community "Pharma"</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                  <button class="draft-action-btn" onclick="switchCenterTab('graphify-graph')">View in Graph</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div class="draft-card" data-status="ready" style="border-left:3px solid var(--accent-green)">
+                <div class="draft-card-header"><span class="draft-card-title">AuthService → imports → UserModel</span><span class="draft-card-badge ready">EXTRACTED</span></div>
+                <div class="draft-card-meta"><span>Confidence: 1.0</span><span>tree-sitter AST</span><span>Community: Auth (12 nodes)</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                <div class="draft-card-snippet">code:Class AuthService · code:imports UserModel · code:definedIn src/auth.py · code:godNode true · code:edgeCount 42</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn primary" onclick="shareDraft(this)">Promote to Shared Memory</button>
+                  <button class="draft-action-btn" onclick="switchCenterTab('graphify-graph')">View in Graph</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div class="draft-card" data-status="flagged" style="border-left:3px solid var(--accent-amber)">
+                <div class="draft-card-header"><span class="draft-card-title">AuthService → mediates → ClinicalTrialAPI</span><span class="draft-card-badge flagged">INFERRED</span></div>
+                <div class="draft-card-meta"><span>Confidence: 0.78</span><span>Claude semantic</span><span>Cross-community: Auth → Clinical</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                <div style="font-size:10px; color:var(--accent-amber); margin-bottom:6px; padding:4px 8px; background:rgba(245,158,11,0.06); border-radius:4px">Agent flag: Cross-community edge with high betweenness centrality — AuthService mediates all external data access</div>
+                <div class="draft-card-snippet">code:Class AuthService · code:mediates ClinicalTrialAPI · code:crossCommunity "Auth → Clinical" · code:betweenness 0.92</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn" onclick="showToast('Overridden to Ready')">Mark as Ready</button>
+                  <button class="draft-action-btn" onclick="switchCenterTab('graphify-graph')">View in Graph</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div class="draft-card" data-status="flagged" style="border-left:3px solid var(--accent-amber)">
+                <div class="draft-card-header"><span class="draft-card-title">DrugInteractionModel → implements → WarfarinProtocol</span><span class="draft-card-badge flagged">INFERRED</span></div>
+                <div class="draft-card-meta"><span>Confidence: 0.89</span><span>Claude semantic (docstring)</span><span>Community: Pharma</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                <div style="font-size:10px; color:var(--accent-amber); margin-bottom:6px; padding:4px 8px; background:rgba(245,158,11,0.06); border-radius:4px">Agent flag: Interface not declared in imports — discovered via docstring pattern analysis. Surprising connection in Graphify Report.</div>
+                <div class="draft-card-snippet">code:Class DrugInteractionModel · code:implements WarfarinProtocol · code:inferenceSource "docstring pattern"</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn" onclick="showToast('Overridden to Ready')">Mark as Ready</button>
+                  <button class="draft-action-btn" onclick="switchCenterTab('graphify-graph')">View in Graph</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div class="draft-card" data-status="error" style="border-left:3px solid var(--accent-red)">
+                <div class="draft-card-header"><span class="draft-card-title">PharmaDB → connects_to → FDA_FAERS_Parser</span><span class="draft-card-badge" style="border-color:rgba(239,68,68,0.3); color:var(--accent-red)">AMBIGUOUS</span></div>
+                <div class="draft-card-meta"><span>Confidence: 0.31</span><span>Claude semantic</span><span>Community: Data</span><span style="color:var(--text-ghost)">via graphify-agent</span></div>
+                <div style="font-size:10px; color:var(--accent-red); margin-bottom:6px; padding:4px 8px; background:rgba(239,68,68,0.06); border-radius:4px">Agent flag: AMBIGUOUS — could not determine direction of data flow between PharmaDB and FDA_FAERS_Parser. Both handle adverse events through separate pipelines. Possible duplication.</div>
+                <div class="draft-card-snippet">code:Class PharmaDB · code:connects_to FDA_FAERS_Parser · code:ambiguousReason "bidirectional data flow"</div>
+                <div class="draft-card-actions">
+                  <button class="draft-action-btn" onclick="showToast('Overridden to Ready')">Mark as Ready</button>
+                  <button class="draft-action-btn" onclick="showToast('Editing entity')">Edit</button>
+                  <button class="draft-action-btn danger" onclick="discardDraft(this)">Discard</button>
+                </div>
+              </div>
+
+              <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:10px">Showing 5 of 4,891 Graphify triples · <span class="msg-action" onclick="switchCenterTab('graphify-graph')">View interactive graph →</span></div>
+            </div>
+          </div>
+
+          <!-- ═══ DEDICATED SHARED MEMORY TAB (Decision 3C) ═══ -->
+          <div class="dashboard-view" id="view-shared-memory" style="padding:16px 20px">
+            <div style="display:flex; align-items:center; gap:10px; margin-bottom:8px">
+              <span style="width:10px; height:10px; border-radius:50%; background:var(--layer-shared)"></span>
+              <span style="font-size:15px; font-weight:600">Shared Memory</span>
+              <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">Pharma Drug Interactions · 38 entities</span>
+            </div>
+            <div style="display:flex; gap:16px; margin-bottom:14px; font-size:10px; color:var(--text-tertiary)">
+              <span>Online: <span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--accent-green);vertical-align:middle;margin-right:2px"></span>Amara, Chen, Patel</span>
+              <span style="color:var(--text-ghost)"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--text-ghost);vertical-align:middle;margin-right:2px"></span>Okonkwo, Silva</span>
+              <span style="margin-left:auto">+12 this week ↑</span>
+              <span>Unreviewed: <strong style="color:var(--accent-amber)">5</strong></span>
+            </div>
+
+            <div class="merge-header-info" style="margin-bottom:10px">
+              <div class="merge-title" style="font-size:13px">Warfarin-Aspirin Interaction</div>
+              <div class="merge-meta"><span>Dr. Amara via research-agent</span><span>2h ago</span><span>Severity: major</span><span>Confidence: 0.94</span><span>2 comments</span></div>
+              <div style="margin-top:8px"><button class="draft-action-btn primary" style="font-size:10px; padding:4px 10px" onclick="showToast('Publishing warfarin-aspirin-001 to Verified Memory...')">Publish to Verified</button></div>
+            </div>
+            <div class="merge-header-info" style="margin-bottom:10px">
+              <div class="merge-title" style="font-size:13px">Metformin + Iodinated Contrast</div>
+              <div class="merge-meta"><span>Dr. Chen via research-agent</span><span>5h ago</span><span>Severity: moderate</span><span>Confidence: 0.87</span><span>1 comment</span></div>
+              <div style="margin-top:8px"><button class="draft-action-btn primary" style="font-size:10px; padding:4px 10px" onclick="showToast('Publishing metformin-contrast-002 to Verified Memory...')">Publish to Verified</button></div>
+            </div>
+            <div class="merge-header-info" style="margin-bottom:10px">
+              <div class="merge-title" style="font-size:13px">FDA Adverse Event Signal: Apixaban + Amiodarone</div>
+              <div class="merge-meta"><span>Dr. Silva via adverse-event-monitor</span><span>8h ago</span><span style="color:var(--accent-amber)">Unreviewed</span><span>0 comments</span></div>
+            </div>
+            <div class="merge-header-info" style="margin-bottom:10px">
+              <div class="merge-title" style="font-size:13px">Clopidogrel + Omeprazole CYP2C19 Inhibition</div>
+              <div class="merge-meta"><span>Dr. Patel via guideline-checker</span><span>1d ago</span><span>Severity: moderate</span><span>3 comments</span></div>
+              <div style="margin-top:8px"><button class="draft-action-btn primary" style="font-size:10px; padding:4px 10px" onclick="showToast('Publishing clopidogrel-omeprazole to Verified Memory...')">Publish to Verified</button></div>
+            </div>
+
+            <div style="margin-top:16px; padding-top:12px; border-top:1px solid var(--border-subtle)">
+              <div style="font-size:10px; font-weight:600; letter-spacing:0.8px; text-transform:uppercase; color:var(--text-tertiary); margin-bottom:8px; display:flex; justify-content:space-between"><span>Contributors</span><a style="font-size:10px; color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer; text-transform:none; letter-spacing:0; font-weight:400" onclick="openModal('shareModal')">Manage Team →</a></div>
+              <div style="display:flex; flex-direction:column; gap:6px">
+                <div style="display:flex; align-items:center; gap:10px; font-size:12px"><span style="width:7px;height:7px;border-radius:50%;background:var(--accent-green)"></span><span style="font-weight:500; min-width:90px">Dr. Amara</span><span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">owner</span><span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">14 entities · 2h ago</span></div>
+                <div style="display:flex; align-items:center; gap:10px; font-size:12px"><span style="width:7px;height:7px;border-radius:50%;background:var(--accent-green)"></span><span style="font-weight:500; min-width:90px">Dr. Chen</span><span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">editor</span><span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">12 entities · 5h ago</span></div>
+                <div style="display:flex; align-items:center; gap:10px; font-size:12px"><span style="width:7px;height:7px;border-radius:50%;background:var(--text-ghost)"></span><span style="font-weight:500; min-width:90px">Dr. Silva</span><span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">editor</span><span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">8 entities · 8h ago</span></div>
+                <div style="display:flex; align-items:center; gap:10px; font-size:12px"><span style="width:7px;height:7px;border-radius:50%;background:var(--accent-green)"></span><span style="font-weight:500; min-width:90px">Dr. Patel</span><span style="font-size:10px; color:var(--text-ghost); border:1px solid var(--border-default); padding:1px 6px; border-radius:3px">editor</span><span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">4 entities · 1d ago</span></div>
+              </div>
+            </div>
+            <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:14px">Showing 4 of 38 shared entities</div>
+          </div>
+
+          <!-- ═══ DEDICATED VERIFIED MEMORY TAB (Decision 3C) ═══ -->
+          <div class="dashboard-view" id="view-verified-memory" style="padding:16px 20px">
+            <div style="display:flex; align-items:center; gap:10px; margin-bottom:12px">
+              <span style="width:10px; height:10px; border-radius:50%; background:var(--layer-verified)"></span>
+              <span style="font-size:15px; font-weight:600">Verified Memory</span>
+              <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">Pharma Drug Interactions · 47 published</span>
+            </div>
+
+            <!-- Full trust filter bar -->
+            <div style="display:flex; gap:6px; margin-bottom:14px">
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px; background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong)" onclick="filterVerified('all',this)">All (47)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterVerified('consensus',this)">Consensus (23)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterVerified('endorsed',this)">Endorsed (12)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterVerified('self',this)">Self-attested (12)</button>
+              <button class="draft-action-btn" style="font-size:10px; padding:4px 10px" onclick="filterVerified('partial',this)">Partially verified (2)</button>
+            </div>
+
+            <!-- Trust gradient -->
+            <div style="display:flex; gap:4px; height:6px; margin-bottom:8px; border-radius:3px; overflow:hidden">
+              <div style="flex:23; background:var(--accent-green); border-radius:2px"></div>
+              <div style="flex:2; background:var(--accent-amber); border-radius:2px"></div>
+              <div style="flex:12; background:var(--text-secondary); border-radius:2px"></div>
+              <div style="flex:12; background:var(--text-ghost); border-radius:2px"></div>
+            </div>
+            <div style="display:flex; gap:12px; font-size:10px; margin-bottom:14px">
+              <span style="color:var(--accent-green)">● 23 consensus</span>
+              <span style="color:var(--accent-amber)">● 2 partial</span>
+              <span style="color:var(--text-secondary)">● 12 endorsed</span>
+              <span style="color:var(--text-tertiary)">● 12 self-attested</span>
+            </div>
+
+            <div class="lt-asset vm-asset" data-trust="consensus">
+              <div class="lt-info" style="flex:1"><div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Warfarin + Aspirin Interaction</div>
+                <div class="lt-ual" style="margin-top:2px"><span style="color:var(--accent-green); font-family:var(--font-sans); font-size:11px">● Consensus-verified (3/5)</span><span style="margin-left:8px">Dr. Amara · Block #21456789</span></div>
+                <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/warfarin-aspirin-001</div></div>
+              <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+            </div>
+            <div class="lt-asset vm-asset" data-trust="partial">
+              <div class="lt-info" style="flex:1"><div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Apixaban + Amiodarone Signal</div>
+                <div class="lt-ual" style="margin-top:2px"><span class="badge-partial">● Partially verified (1/5)</span><span style="margin-left:8px">Dr. Amara · Authored by Dr. Silva</span></div>
+                <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/apixaban-amiodarone-005</div></div>
+              <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+              <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Vote</button>
+            </div>
+            <div class="lt-asset vm-asset" data-trust="endorsed">
+              <div class="lt-info" style="flex:1"><div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Metformin + Contrast Agents</div>
+                <div class="lt-ual" style="margin-top:2px"><span style="color:var(--text-secondary); font-family:var(--font-sans); font-size:11px">● Endorsed (3)</span><span style="margin-left:8px">Dr. Amara · Authored by Dr. Patel</span></div>
+                <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/metformin-contrast-002</div></div>
+              <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+              <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Vote</button>
+            </div>
+            <div class="lt-asset vm-asset" data-trust="self">
+              <div class="lt-info" style="flex:1"><div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">SSRI + MAOI Interaction</div>
+                <div class="lt-ual" style="margin-top:2px"><span style="color:var(--text-tertiary); font-family:var(--font-sans); font-size:11px">● Self-attested</span><span style="margin-left:8px">Dr. Amara · Authored by Dr. Silva</span></div>
+                <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/ssri-maoi-003</div></div>
+              <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+              <button class="draft-action-btn" onclick="switchCenterTab('consensus-vote')">Request Vote</button>
+            </div>
+            <div class="lt-asset vm-asset" data-trust="consensus">
+              <div class="lt-info" style="flex:1"><div class="lt-name" style="cursor:pointer; text-decoration:underline; text-underline-offset:2px" onclick="switchCenterTab('ka-inspector')">Warfarin + NSAIDs Interaction</div>
+                <div class="lt-ual" style="margin-top:2px"><span style="color:var(--accent-green); font-family:var(--font-sans); font-size:11px">● Consensus-verified (5/5)</span><span style="margin-left:8px">Dr. Amara · Authored by Dr. Okonkwo</span></div>
+                <div class="lt-ual" style="margin-top:4px">did:dkg:base/0x8a4f...c3b2/warfarin-nsaids-004</div></div>
+              <button class="draft-action-btn" onclick="showToast('Endorsed!')">Endorse</button>
+            </div>
+            <div style="font-size:10px; color:var(--text-ghost); text-align:center; margin-top:10px">Showing 5 of 47 published assets</div>
+          </div>
+
+          <!-- CONTEXT ORACLE VIEW (Change 6 — full width in center console) -->
+          <div class="dashboard-view" id="view-context-oracle" style="padding:16px 20px">
+            <div style="display:flex; align-items:center; gap:10px; margin-bottom:14px">
+              <span style="font-size:16px">⚭</span>
+              <span style="font-size:15px; font-weight:600">Context Oracle</span>
+              <span style="font-family:var(--font-mono); font-size:11px; color:var(--text-tertiary)">Discover public knowledge across the DKG network</span>
+            </div>
+
+            <!-- Sub-tabs: Browse | Search | Graph -->
+            <div style="display:flex; gap:2px; border-bottom:1px solid var(--border-subtle); margin-bottom:14px">
+              <button class="draft-action-btn" id="co-sub-browse" style="background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong); border-radius:4px 4px 0 0; font-size:11px; padding:6px 14px" onclick="switchCoSubTab('browse')">Browse</button>
+              <button class="draft-action-btn" id="co-sub-search" style="border-radius:4px 4px 0 0; font-size:11px; padding:6px 14px" onclick="switchCoSubTab('search')">Search</button>
+              <button class="draft-action-btn" id="co-sub-graph" style="border-radius:4px 4px 0 0; font-size:11px; padding:6px 14px" onclick="switchCoSubTab('graph')">Graph</button>
+            </div>
+
+            <!-- Browse sub-view -->
+            <div id="co-browse">
+              <div style="font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-bottom:8px">Connected Context Graphs</div>
+              <div style="display:grid; grid-template-columns:repeat(2,1fr); gap:12px; margin-bottom:20px">
+                <div class="dash-card" style="cursor:pointer; padding:14px 16px" onclick="showToast('Opening Pharma Drug Interactions project page...')">
+                  <div style="font-weight:600; font-size:13px; margin-bottom:4px">Pharma Drug Interactions</div>
+                  <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px; line-height:1.5">Comprehensive drug-drug interaction database with clinical evidence from 5 independent pharmacology researchers.</div>
+                  <div style="display:flex; gap:3px; height:5px; margin-bottom:8px; border-radius:3px; overflow:hidden">
+                    <div style="flex:23; background:var(--accent-green)"></div>
+                    <div style="flex:12; background:var(--text-secondary)"></div>
+                    <div style="flex:12; background:var(--text-ghost)"></div>
+                  </div>
+                  <div style="display:flex; gap:12px; font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); flex-wrap:wrap">
+                    <span>47 findings</span><span>23 verified</span><span>180 endorsements</span><span>5 researchers</span><span>Role: owner</span>
+                  </div>
+                </div>
+                <div class="dash-card" style="cursor:pointer; padding:14px 16px" onclick="showToast('Opening Climate Science project page...')">
+                  <div style="font-weight:600; font-size:13px; margin-bottom:4px">Climate Science / Emissions</div>
+                  <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px; line-height:1.5">Multi-institutional climate modeling and emissions tracking with consensus projections.</div>
+                  <div style="display:flex; gap:3px; height:5px; margin-bottom:8px; border-radius:3px; overflow:hidden">
+                    <div style="flex:8; background:var(--accent-green)"></div>
+                    <div style="flex:6; background:var(--text-secondary)"></div>
+                    <div style="flex:17; background:var(--text-ghost)"></div>
+                  </div>
+                  <div style="display:flex; gap:12px; font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); flex-wrap:wrap">
+                    <span>31 assets</span><span>8 verified</span><span>42 endorsements</span><span>3 institutions</span><span>Role: editor</span>
+                  </div>
+                </div>
+              </div>
+
+              <div style="font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-bottom:8px">Trending on Network</div>
+              <div style="display:grid; grid-template-columns:repeat(2,1fr); gap:12px">
+                <div class="dash-card" style="cursor:pointer; padding:14px 16px" onclick="showToast('Opening Trade Policy project page...')">
+                  <div style="font-weight:600; font-size:13px; margin-bottom:4px">Trade Policy / Sanctions</div>
+                  <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px; line-height:1.5">Semiconductor export controls, sanctions compliance, and trade policy analysis.</div>
+                  <div style="display:flex; gap:3px; height:5px; margin-bottom:8px; border-radius:3px; overflow:hidden">
+                    <div style="flex:340; background:var(--accent-green)"></div>
+                    <div style="flex:280; background:var(--text-secondary)"></div>
+                    <div style="flex:272; background:var(--text-ghost)"></div>
+                  </div>
+                  <div style="display:flex; gap:12px; font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); flex-wrap:wrap">
+                    <span>892 assets</span><span>340 verified</span><span>14 publishers</span><span style="color:var(--accent-amber)">$0.10/query</span>
+                  </div>
+                </div>
+                <div class="dash-card" style="cursor:pointer; padding:14px 16px" onclick="showToast('Opening AI Governance project page...')">
+                  <div style="font-weight:600; font-size:13px; margin-bottom:4px">Regulation / AI Governance</div>
+                  <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px; line-height:1.5">EU AI Act compliance, global AI regulation tracking, and risk assessment frameworks.</div>
+                  <div style="display:flex; gap:3px; height:5px; margin-bottom:8px; border-radius:3px; overflow:hidden">
+                    <div style="flex:500; background:var(--accent-green)"></div>
+                    <div style="flex:347; background:var(--text-secondary)"></div>
+                    <div style="flex:400; background:var(--text-ghost)"></div>
+                  </div>
+                  <div style="display:flex; gap:12px; font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); flex-wrap:wrap">
+                    <span>1,247 assets</span><span>500 verified</span><span>31 publishers</span><span style="color:var(--accent-amber)">$0.05/query</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Search sub-view -->
+            <div id="co-search" style="display:none">
+              <input type="text" placeholder="Search the DKG network..." value="drug interactions" style="width:100%; height:36px; border-radius:6px; margin-bottom:12px; font-size:12px">
+              <div style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:14px">
+                <button class="draft-action-btn" style="background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong); font-size:10px; padding:4px 10px">All Trust Levels</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px">Consensus-verified</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px">Endorsed</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px">Self-attested</button>
+                <button class="draft-action-btn" style="font-size:10px; padding:4px 10px">Partially verified</button>
+              </div>
+              <div style="font-size:10px; color:var(--text-ghost); margin-bottom:10px">Sorted by trust level · 5 results</div>
+
+              <div class="oracle-search-result" style="padding:14px; border-bottom:1px solid var(--border-subtle); cursor:pointer" onclick="switchCenterTab('ka-inspector')">
+                <div style="font-weight:500; font-size:13px; margin-bottom:4px">Warfarin + Aspirin Interaction</div>
+                <div style="display:flex; gap:10px; flex-wrap:wrap; font-size:10px; color:var(--text-tertiary); margin-bottom:4px">
+                  <span style="padding:2px 6px; border-radius:3px; border:1px solid rgba(34,197,94,0.3); color:var(--accent-green)">Consensus 3/5</span>
+                  <span>Pharma Drug Interactions</span>
+                  <span>Dr. Amara · 0x8a4f...c3b2</span>
+                  <span>3 endorsements</span>
+                  <span style="color:var(--accent-amber)">$0.05</span>
+                </div>
+                <div style="font-family:var(--font-mono); font-size:9px; color:var(--text-ghost)">did:dkg:base/0x8a4f...c3b2/warfarin-aspirin-001</div>
+              </div>
+
+              <div class="oracle-search-result" style="padding:14px; border-bottom:1px solid var(--border-subtle); cursor:pointer" onclick="switchCenterTab('ka-inspector')">
+                <div style="font-weight:500; font-size:13px; margin-bottom:4px">Metformin + Iodinated Contrast</div>
+                <div style="display:flex; gap:10px; flex-wrap:wrap; font-size:10px; color:var(--text-tertiary); margin-bottom:4px">
+                  <span style="padding:2px 6px; border-radius:3px; border:1px solid rgba(34,197,94,0.3); color:var(--accent-green)">Consensus 3/5</span>
+                  <span>Pharma Drug Interactions</span>
+                  <span>Dr. Amara · 0x8a4f...c3b2</span>
+                  <span>2 endorsements</span>
+                  <span style="color:var(--accent-amber)">$0.05</span>
+                </div>
+                <div style="font-family:var(--font-mono); font-size:9px; color:var(--text-ghost)">did:dkg:base/0x8a4f...c3b2/metformin-contrast-002</div>
+              </div>
+
+              <div class="oracle-search-result" style="padding:14px; border-bottom:1px solid var(--border-subtle); cursor:pointer" onclick="showToast('Opening apixaban-amiodarone...')">
+                <div style="font-weight:500; font-size:13px; margin-bottom:4px">Apixaban + Amiodarone Adverse Signal</div>
+                <div style="display:flex; gap:10px; flex-wrap:wrap; font-size:10px; color:var(--text-tertiary); margin-bottom:4px">
+                  <span style="padding:2px 6px; border-radius:3px; border:1px solid var(--border-default); color:var(--text-secondary)">Endorsed (2)</span>
+                  <span>Pharma Drug Interactions</span>
+                  <span>Dr. Silva · 0x5e6f...7890</span>
+                  <span style="color:var(--accent-amber)">$0.05</span>
+                </div>
+                <div style="font-family:var(--font-mono); font-size:9px; color:var(--text-ghost)">did:dkg:base/0x8a4f...c3b2/apixaban-amiodarone-005</div>
+              </div>
+
+              <div class="oracle-search-result" style="padding:14px; cursor:pointer" onclick="showToast('Opening SSRI-MAOI...')">
+                <div style="font-weight:500; font-size:13px; margin-bottom:4px">SSRI + MAOI Contraindication</div>
+                <div style="display:flex; gap:10px; flex-wrap:wrap; font-size:10px; color:var(--text-tertiary); margin-bottom:4px">
+                  <span style="padding:2px 6px; border-radius:3px; border:1px solid var(--border-default); color:var(--text-ghost)">Self-attested</span>
+                  <span>Pharma Drug Interactions</span>
+                  <span>Dr. Amara · 0x8a4f...c3b2</span>
+                </div>
+                <div style="font-family:var(--font-mono); font-size:9px; color:var(--text-ghost)">did:dkg:base/0x8a4f...c3b2/ssri-maoi-003</div>
+              </div>
+            </div>
+
+            <!-- Graph sub-view -->
+            <div id="co-graph" style="display:none; text-align:center">
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px">Network-wide context graph visualization &mdash; full width view</div>
+              <svg viewBox="0 0 600 380" xmlns="http://www.w3.org/2000/svg" style="width:100%; max-width:700px; background:var(--bg-root); border:1px solid var(--border-subtle); border-radius:8px">
+                <line x1="300" y1="80" x2="150" y2="200" stroke="#333" stroke-width="1"/>
+                <line x1="300" y1="80" x2="450" y2="160" stroke="#333" stroke-width="1"/>
+                <line x1="150" y1="200" x2="300" y2="310" stroke="#333" stroke-width="1"/>
+                <line x1="450" y1="160" x2="300" y2="310" stroke="#333" stroke-width="1"/>
+                <line x1="300" y1="80" x2="300" y2="310" stroke="#222" stroke-width="0.5" stroke-dasharray="4"/>
+                <circle cx="300" cy="80" r="30" fill="#181818" stroke="#bbb" stroke-width="2"/>
+                <text x="300" y="78" text-anchor="middle" fill="#e8e8e8" font-size="8" font-weight="600" font-family="Instrument Sans">Pharma Drug</text>
+                <text x="300" y="88" text-anchor="middle" fill="#e8e8e8" font-size="8" font-weight="600" font-family="Instrument Sans">Interactions</text>
+                <text x="300" y="100" text-anchor="middle" fill="#555" font-size="6" font-family="JetBrains Mono">47 · 23 verified</text>
+                <circle cx="150" cy="200" r="28" fill="#181818" stroke="#888" stroke-width="1.5"/>
+                <text x="150" y="197" text-anchor="middle" fill="#bbb" font-size="8" font-family="Instrument Sans">Climate Science</text>
+                <text x="150" y="208" text-anchor="middle" fill="#555" font-size="6" font-family="JetBrains Mono">31 · 8 verified</text>
+                <circle cx="450" cy="160" r="26" fill="#181818" stroke="#666" stroke-width="1"/>
+                <text x="450" y="157" text-anchor="middle" fill="#999" font-size="8" font-family="Instrument Sans">Trade Policy</text>
+                <text x="450" y="168" text-anchor="middle" fill="#555" font-size="6" font-family="JetBrains Mono">892 · 340 verified</text>
+                <circle cx="300" cy="310" r="26" fill="#181818" stroke="#666" stroke-width="1"/>
+                <text x="300" y="307" text-anchor="middle" fill="#999" font-size="8" font-family="Instrument Sans">AI Governance</text>
+                <text x="300" y="318" text-anchor="middle" fill="#555" font-size="6" font-family="JetBrains Mono">1,247 · 500 verified</text>
+                <circle cx="100" cy="320" r="18" fill="#181818" stroke="#444" stroke-width="0.8"/>
+                <text x="100" y="318" text-anchor="middle" fill="#777" font-size="7" font-family="Instrument Sans">DeFi Vault</text>
+                <text x="100" y="328" text-anchor="middle" fill="#444" font-size="5" font-family="JetBrains Mono">82 assets</text>
+                <line x1="150" y1="200" x2="100" y2="320" stroke="#222" stroke-width="0.5"/>
+              </svg>
+              <div style="margin-top:12px; font-size:10px; color:var(--text-ghost); font-style:italic">Interactive force-directed graph — coming in next iteration</div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- RESIZE HANDLE HORIZONTAL -->
+      <div class="resize-handle-h" id="resizeBottom"></div>
+
+      <!-- BOTTOM PANEL -->
+      <div class="panel-bottom" id="panelBottom">
+        <div class="bottom-tabs">
+          <button class="bottom-tab active" data-btab="log" onclick="switchBottomTab(this,'log')">Node Log</button>
+          <button class="bottom-tab" data-btab="txns" onclick="switchBottomTab(this,'txns')">Transactions <span class="btab-badge">2</span></button>
+          <button class="bottom-tab" data-btab="gossip" onclick="switchBottomTab(this,'gossip')">Gossip</button>
+          <button class="bottom-tab" data-btab="agents" onclick="switchBottomTab(this,'agents')">Agent Runs</button>
+          <button class="bottom-tab" data-btab="sparql" onclick="switchBottomTab(this,'sparql')">SPARQL</button>
+          <div class="bottom-spacer"></div>
+          <button class="bottom-toggle" onclick="togglePanel('bottom')">▾</button>
+        </div>
+        <div class="bottom-content" id="btab-log">
+          <div class="log-line"><span class="log-ts">14:23:07</span><span class="log-level ok">OK</span><span class="log-msg">Base L2 sync completed — block #21,456,789</span></div>
+          <div class="log-line"><span class="log-ts">14:22:54</span><span class="log-level info">INFO</span><span class="log-msg">GossipSub: received 3 messages from Dr. Chen on topic /dkg/shared/pharma-drug-interactions</span></div>
+          <div class="log-line"><span class="log-ts">14:22:31</span><span class="log-level warn">WARN</span><span class="log-msg">Consensus vote for warfarin-aspirin batch still pending — 2/5 quorum (awaiting Okonkwo, Silva, Patel)</span></div>
+          <div class="log-line"><span class="log-ts">14:21:58</span><span class="log-level info">INFO</span><span class="log-msg">Publishing warfarin-aspirin-001 to Verified Memory — tx 0xfeed...1234 submitted to Base L2</span></div>
+          <div class="log-line"><span class="log-ts">14:21:12</span><span class="log-level ok">OK</span><span class="log-msg">Agent research-agent completed PubMed scan — 12 new interaction candidates ingested in 2m 34s</span></div>
+          <div class="log-line"><span class="log-ts">14:20:44</span><span class="log-level info">INFO</span><span class="log-msg">Connected to new peer: Dr. Silva (0x5e6f...7890) — adverse-event-monitor syncing</span></div>
+          <div class="log-line"><span class="log-ts">14:19:33</span><span class="log-level ok">OK</span><span class="log-msg">File ingestion complete: chen-drug-summaries/ — 207 files → 1,847 triples extracted</span></div>
+          <div class="log-line"><span class="log-ts">14:18:01</span><span class="log-level info">INFO</span><span class="log-msg">dRAG query completed: "warfarin major interactions" — 3 findings, confidence 0.94</span></div>
+        </div>
+        <div class="bottom-content" id="btab-txns" style="display:none">
+          <div class="log-line"><span class="log-ts">14:21:58</span><span class="log-level warn">PEND</span><span class="log-msg">tx 0xfeed...1234 · Publish warfarin-aspirin-001 · 180 TRAC + 0.0012 ETH · Base L2 · Awaiting confirmation</span></div>
+          <div class="log-line"><span class="log-ts">14:19:02</span><span class="log-level warn">PEND</span><span class="log-msg">tx 0x9f3e...b2a1 · Publish metformin-contrast-002 · 180 TRAC + 0.0011 ETH · Base L2 · Awaiting confirmation</span></div>
+          <div class="log-line"><span class="log-ts">14:10:33</span><span class="log-level ok">CONF</span><span class="log-msg">tx 0xa4b2...c7d8 · Publish warfarin-nsaids-004 · 180 TRAC + 0.0010 ETH · Base L2 · Block #21,456,780</span></div>
+          <div class="log-line"><span class="log-ts">13:45:12</span><span class="log-level ok">CONF</span><span class="log-msg">tx 0xc8e1...f3a2 · Consensus attestation batch-1 · 0.0004 ETH gas · Base L2 · Block #21,456,712</span></div>
+          <div class="log-line"><span class="log-ts">12:30:01</span><span class="log-level ok">FINL</span><span class="log-msg">tx 0xd5f7...e9b0 · Project creation pharma-drug-interactions · 500 TRAC + 0.0018 ETH · Base L2 · Finalized</span></div>
+        </div>
+        <div class="bottom-content" id="btab-gossip" style="display:none">
+          <div class="log-line"><span class="log-ts">14:22:54</span><span class="log-level info">IN</span><span class="log-msg">/dkg/shared/pharma-drug-interactions · 3 entities from Dr. Chen (0x3f2a...b8c1) · metformin-contrast-002</span></div>
+          <div class="log-line"><span class="log-ts">14:20:44</span><span class="log-level info">IN</span><span class="log-msg">/dkg/shared/pharma-drug-interactions · Peer hello from Dr. Silva (0x5e6f...7890) · adverse-event-monitor online</span></div>
+          <div class="log-line"><span class="log-ts">14:15:22</span><span class="log-level info">OUT</span><span class="log-msg">/dkg/shared/pharma-drug-interactions · 8 entities shared by Dr. Amara → 4 peers</span></div>
+          <div class="log-line"><span class="log-ts">14:08:11</span><span class="log-level info">IN</span><span class="log-msg">/dkg/verified/pharma-drug-interactions · Endorsement from Dr. Okonkwo for warfarin-aspirin-001</span></div>
+          <div class="log-line"><span class="log-ts">13:55:30</span><span class="log-level info">IN</span><span class="log-msg">/dkg/verified/pharma-drug-interactions · Consensus vote from Dr. Patel: Approve warfarin-aspirin batch</span></div>
+        </div>
+        <div class="bottom-content" id="btab-agents" style="display:none">
+          <div class="log-line"><span class="log-ts">14:21:12</span><span class="log-level ok">DONE</span><span class="log-msg">research-agent · PubMed interaction scan · 847/2000 articles processed · 12 candidates found · 2m 34s</span></div>
+          <div class="log-line"><span class="log-ts">14:19:33</span><span class="log-level ok">DONE</span><span class="log-msg">research-agent · File ingestion · chen-drug-summaries/ · 207 files → 1,847 triples · 4m 12s</span></div>
+          <div class="log-line"><span class="log-ts">13:48:20</span><span class="log-level ok">DONE</span><span class="log-msg">guideline-checker · Cross-reference PharmGKB · warfarin-aspirin-001 · Verdict: supports · 18s</span></div>
+          <div class="log-line"><span class="log-ts">12:30:45</span><span class="log-level ok">DONE</span><span class="log-msg">literature-scanner · Scan clopidogrel literature · 34 papers analyzed · 1 new interaction found · 1m 45s</span></div>
+          <div class="log-line"><span class="log-ts">11:15:00</span><span class="log-level warn">WARN</span><span class="log-msg">adverse-event-monitor · FDA FAERS scan · Rate limited after 500 requests · Resuming in 60s</span></div>
+        </div>
+        <div class="bottom-content" id="btab-sparql" style="display:none">
+          <div style="padding:4px 0; color:var(--text-ghost); font-size:10px; margin-bottom:6px">Quick SPARQL scratchpad — full editor available as integration</div>
+          <textarea style="width:100%; min-height:80px; font-family:var(--font-mono); font-size:11px; background:var(--bg-surface); border:1px solid var(--border-default); color:var(--text-primary); border-radius:4px; padding:8px; resize:vertical">SELECT ?interaction ?drug1 ?drug2 ?severity
+WHERE {
+  ?interaction a pharma:DrugInteraction ;
+    pharma:drug1 ?drug1 ;
+    pharma:drug2 ?drug2 ;
+    pharma:severity ?severity .
+  FILTER(?severity = "major")
+}</textarea>
+          <button class="draft-action-btn primary" style="margin-top:6px; font-size:10px; padding:4px 12px" onclick="showToast('Query executed — 23 results')">Run Query</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="resize-handle" id="resizeRight"></div>
+
+    <!-- RIGHT PANEL: AGENT -->
+    <div class="panel-right" id="panelRight">
+      <div class="agent-header">
+        <button class="agent-mode-btn active" onclick="switchAgentMode('chat', this)">Chat</button>
+        <button class="agent-mode-btn" onclick="switchAgentMode('peers', this)">Peer Search</button>
+      </div>
+
+      <!-- Agent task bar (Change 3: only shown at stage 2 when agent has active tasks) -->
+      <div class="agent-task-bar stage-2">
+        <span class="task-label">PubMed interaction scan</span>
+        <div class="task-progress"><div class="task-progress-fill"></div></div>
+        <span class="task-label">847/2,000</span>
+        <button class="task-cancel" onclick="showToast('Task paused')">Pause</button>
+      </div>
+
+      <!-- Chat mode -->
+      <div class="agent-messages" id="agentChat">
+        <!-- Connect Agent onboarding (stage 0 only — agent-first onboarding) -->
+        <div class="agent-msg assistant stage-0" style="background:var(--bg-surface); border:1px solid var(--border-subtle); border-radius:10px; padding:16px 18px">
+          <div style="font-weight:600; font-size:14px; margin-bottom:8px; color:var(--text-primary)">Connect an Agent</div>
+          <div style="font-size:12px; color:var(--text-secondary); line-height:1.6; margin-bottom:14px">
+            To get started, connect an AI agent to your node. Your agent will help you create projects, manage knowledge, publish findings, and collaborate with peers — everything you do in the DKG flows through your agent.
+          </div>
+          <div style="font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-bottom:8px">Choose an agent framework</div>
+          <div style="display:flex; flex-direction:column; gap:6px">
+            <button class="draft-action-btn primary" style="font-size:11px; text-align:left; padding:10px 12px" onclick="advanceToStage1()">Connect OpenClaw</button>
+            <button class="draft-action-btn primary" style="font-size:11px; text-align:left; padding:10px 12px" onclick="advanceToStage1()">Connect Agent Hermes</button>
+            <button class="draft-action-btn primary" style="font-size:11px; text-align:left; padding:10px 12px" onclick="advanceToStage1()">Connect ElizaOS</button>
+          </div>
+          <div style="font-size:10px; color:var(--text-ghost); font-style:italic; margin-top:14px; text-align:center">You must connect an agent before creating projects or importing knowledge</div>
+        </div>
+
+        <!-- Agent connected, no project yet (stage 1) — brief acknowledgement then points to create project -->
+        <div class="agent-msg assistant stage-1" style="background:var(--bg-surface); border:1px solid var(--border-subtle); border-radius:10px; padding:16px 18px">
+          <div style="font-weight:600; font-size:14px; margin-bottom:8px; color:var(--text-primary)">Ready to build your first project</div>
+          <div style="font-size:12px; color:var(--text-secondary); line-height:1.6; margin-bottom:14px">
+            I&apos;m research-agent, connected and ready. To start working, let&apos;s give me some structured memory. A project is a bounded knowledge space where I can draft, share, and publish on your behalf.
+          </div>
+          <div style="display:flex; flex-direction:column; gap:6px">
+            <button class="draft-action-btn primary" style="font-size:11px; text-align:left; padding:10px 12px" onclick="openModal('createProjectModal')">Create First Project</button>
+          </div>
+          <div style="font-size:10px; color:var(--text-ghost); font-style:italic; margin-top:10px">Tip: a good first project is your existing research, notes, or code — something you already know.</div>
+        </div>
+
+        <!-- Populated chat messages (stage 2 only) -->
+        <div class="stage-2">
+        <div class="agent-msg user">Publish the warfarin-aspirin finding to Verified Memory</div>
+        <div class="agent-msg assistant">
+          Publishing warfarin-aspirin-001 to Verified Memory:
+          <div class="tx-card">
+            <div class="tx-card-header"><span class="tx-icon">⚠</span> Transaction Confirmation</div>
+            <div class="tx-row"><span class="tx-label">Finding</span><span class="tx-value">warfarin-aspirin-001</span></div>
+            <div class="tx-row"><span class="tx-label">TRAC stake</span><span class="tx-value">180 TRAC</span></div>
+            <div class="tx-row"><span class="tx-label">Gas estimate</span><span class="tx-value">0.0012 ETH</span></div>
+            <div class="tx-row"><span class="tx-label">Published as</span><span class="tx-value">self-attested (Dr. Amara)</span></div>
+            <div class="tx-divider"></div>
+            <div class="tx-row tx-total"><span class="tx-label">Total cost</span><span class="tx-value">180 TRAC + gas</span></div>
+            <div class="tx-actions">
+              <button class="tx-btn confirm" onclick="showToast('Published to Verified Memory — tx 0xfeed...1234 submitted')">Confirm</button>
+              <button class="tx-btn cancel" onclick="showToast('Transaction cancelled')">Cancel</button>
+            </div>
+          </div>
+        </div>
+        <div class="agent-msg user">Endorse the warfarin-aspirin finding</div>
+        <div class="agent-msg assistant">
+          Endorsed <strong>warfarin-aspirin-001</strong>. Endorsement count is now 4. Your rationale: "Verified methodology against 34 PubMed studies."<br><br>
+          <span class="msg-action" onclick="openLayerTab('verified-memory')">View in Verified Memory →</span>
+        </div>
+        <div class="agent-msg user">Start a consensus vote on the top 23 high-impact findings</div>
+        <div class="agent-msg assistant">
+          I'll propose a batch consensus vote for 23 high-impact findings. Requires 3-of-5 team members to approve each finding.
+          <div class="tx-card">
+            <div class="tx-card-header"><span class="tx-icon">⚠</span> Consensus Vote Proposal</div>
+            <div class="tx-row"><span class="tx-label">Findings</span><span class="tx-value">23 high-impact</span></div>
+            <div class="tx-row"><span class="tx-label">Quorum required</span><span class="tx-value">3 of 5 members</span></div>
+            <div class="tx-row"><span class="tx-label">Gas estimate</span><span class="tx-value">0.0004 ETH</span></div>
+            <div class="tx-actions">
+              <button class="tx-btn confirm" onclick="showToast('Consensus vote proposed — awaiting team votes')">Confirm Proposal</button>
+              <button class="tx-btn cancel" onclick="showToast('Proposal cancelled')">Cancel</button>
+            </div>
+          </div>
+        </div>
+        <div class="agent-msg user">What drug interactions involve warfarin with the highest severity?</div>
+        <div class="agent-msg assistant">
+          Based on a dRAG query across Working and Shared memory: I found 3 major-severity warfarin interactions. Warfarin + Aspirin (confidence 0.94, consensus-verified 3/5), Warfarin + NSAIDs (confidence 0.91, 5/5 verified), and Warfarin + SSRIs (under review).<br><br>
+          <span class="msg-action" onclick="openLayerTab('verified-memory')">View in Verified Memory →</span>
+        </div>
+        <div class="agent-msg user">Run Graphify on my project files</div>
+        <div class="agent-msg assistant">
+          Graphify processing complete.
+          <div class="tx-card">
+            <div class="tx-card-header"><span class="tx-icon" style="color:var(--accent-green)">⬡</span> Graphify Results</div>
+            <div class="tx-row"><span class="tx-label">Source</span><span class="tx-value">52 files (code, docs, PDFs, images)</span></div>
+            <div class="tx-row"><span class="tx-label">Graph</span><span class="tx-value">1,159 nodes · 3,365 edges</span></div>
+            <div class="tx-row"><span class="tx-label">Communities</span><span class="tx-value">8 (Leiden clustering)</span></div>
+            <div class="tx-row"><span class="tx-label">DKG Triples</span><span class="tx-value">4,891 → Working Memory</span></div>
+            <div class="tx-divider"></div>
+            <div class="tx-row"><span class="tx-label">EXTRACTED</span><span class="tx-value" style="color:var(--accent-green)">3,102</span></div>
+            <div class="tx-row"><span class="tx-label">INFERRED</span><span class="tx-value" style="color:var(--accent-amber)">1,482</span></div>
+            <div class="tx-row"><span class="tx-label">AMBIGUOUS</span><span class="tx-value" style="color:var(--accent-red)">307</span></div>
+            <div class="tx-divider"></div>
+            <div class="tx-row"><span class="tx-label">God nodes</span><span class="tx-value">AuthService (42), DrugInteractionModel (38)</span></div>
+            <div class="tx-actions">
+              <button class="tx-btn confirm" onclick="switchCenterTab('graphify-graph')">View Graph</button>
+              <button class="tx-btn cancel" onclick="switchCenterTab('graphify-report')">Open Report</button>
+            </div>
+          </div>
+        </div>
+        <div class="agent-msg user">What connects AuthService to the drug interaction model?</div>
+        <div class="agent-msg assistant">
+          Querying graphify graph...<br><br>
+          <strong>AuthService</strong> → imports → <strong>UserModel</strong> → references → <strong>PatientRecord</strong> → used_by → <strong>DrugInteractionChecker</strong> → implements → <strong>DrugInteractionModel</strong><br><br>
+          Path length: 5 hops. All edges EXTRACTED (confidence 1.0) except DrugInteractionChecker → implements (INFERRED, 0.89).<br><br>
+          <span class="msg-action" onclick="switchCenterTab('graphify-graph')">View path in graph →</span>
+        </div>
+        </div> <!-- end stage-2 wrapper for populated chat -->
+      </div>
+
+      <!-- Peer Search mode (hidden by default) -->
+      <div id="peerPanel" style="display:none; flex-direction:column; flex:1; overflow:hidden">
+        <div style="display:flex; padding:6px 10px; gap:4px; border-bottom:1px solid var(--border-subtle)">
+          <button class="oracle-sub-tab active" onclick="switchPeerTab('discover',this)">Discover</button>
+          <button class="oracle-sub-tab" onclick="switchPeerTab('invitations',this)">Invitations</button>
+        </div>
+        <div style="flex:1; overflow-y:auto">
+          <div id="peerDiscover" style="padding:12px">
+            <input type="text" placeholder="Search for agents and nodes..." style="width:100%; height:36px; border-radius:6px; margin-bottom:10px">
+            <div class="peer-result">
+              <div class="peer-result-header">
+                <span style="width:7px; height:7px; border-radius:50%; background:var(--accent-green); flex-shrink:0"></span>
+                <span style="font-weight:500; font-size:12px; flex:1">node-7-istanbul</span>
+                <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">Rep: 847</span>
+              </div>
+              <div style="font-family:var(--font-mono); font-size:10px; color:var(--text-ghost); margin-bottom:8px">0x7f2a...d4e1 · 234 published assets</div>
+              <div style="display:flex; gap:6px; margin-bottom:8px"><span class="peer-tag">climate-science</span><span class="peer-tag">geopolitical</span></div>
+              <button class="peer-invite-btn" onclick="showToast('Invitation sent to node-7-istanbul')">Invite to Project</button>
+            </div>
+            <div class="peer-result">
+              <div class="peer-result-header">
+                <span style="width:7px; height:7px; border-radius:50%; background:var(--accent-green); flex-shrink:0"></span>
+                <span style="font-weight:500; font-size:12px; flex:1">research-lab-zurich</span>
+                <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">Rep: 1,203</span>
+              </div>
+              <div style="font-family:var(--font-mono); font-size:10px; color:var(--text-ghost); margin-bottom:8px">0x3b8c...a1f7 · 891 published assets</div>
+              <div style="display:flex; gap:6px; margin-bottom:8px"><span class="peer-tag">climate-science</span><span class="peer-tag">trade-policy</span></div>
+              <button class="peer-invite-btn" onclick="showToast('Invitation sent to research-lab-zurich')">Invite to Project</button>
+            </div>
+            <div class="peer-result">
+              <div class="peer-result-header">
+                <span style="width:7px; height:7px; border-radius:50%; background:var(--accent-green); flex-shrink:0"></span>
+                <span style="font-weight:500; font-size:12px; flex:1">acled-validator-nairobi</span>
+                <span style="font-family:var(--font-mono); font-size:10px; color:var(--text-tertiary)">Rep: 2,100</span>
+              </div>
+              <div style="font-family:var(--font-mono); font-size:10px; color:var(--text-ghost); margin-bottom:8px">0x1a2b...c3d4 · 1,456 published assets</div>
+              <div style="display:flex; gap:6px; margin-bottom:8px"><span class="peer-tag">geopolitical</span><span class="peer-tag">situation-room</span></div>
+              <button class="peer-invite-btn" onclick="showToast('Invitation sent to acled-validator-nairobi')">Invite to Project</button>
+            </div>
+          </div>
+          <div id="peerInvitations" style="display:none; padding:12px">
+            <div class="peer-invitation">
+              <div style="font-weight:500; font-size:12px; margin-bottom:5px">research-lab-zurich invites you to collaborate</div>
+              <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); margin-bottom:5px">0x3b8c...a1f7 · Rep: 1,203</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px">Project: <strong style="color:var(--text-secondary)">climate-science/ocean-temperatures</strong> · 145 assets · Role: editor</div>
+              <div style="display:flex; gap:8px"><button class="notif-action-btn primary" onclick="showToast('Invitation accepted')">Accept</button><button class="notif-action-btn" onclick="showToast('Invitation declined')">Decline</button></div>
+            </div>
+            <div class="peer-invitation">
+              <div style="font-weight:500; font-size:12px; margin-bottom:5px">acled-validator-nairobi invites you to collaborate</div>
+              <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); margin-bottom:5px">0x1a2b...c3d4 · Rep: 2,100</div>
+              <div style="font-size:11px; color:var(--text-tertiary); margin-bottom:10px">Project: <strong style="color:var(--text-secondary)">geopolitical/horn-of-africa</strong> · 89 assets · Role: viewer</div>
+              <div style="display:flex; gap:8px"><button class="notif-action-btn primary" onclick="showToast('Invitation accepted')">Accept</button><button class="notif-action-btn" onclick="showToast('Invitation declined')">Decline</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="agent-input-area" id="agentInputArea">
+        <div class="agent-input-row">
+          <input type="text" placeholder="Ask the agent..." id="agentInput" onkeydown="if(event.key==='Enter')sendAgentMsg()">
+          <button class="agent-send-btn" onclick="sendAgentMsg()">↑</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ═══ CREATE PROJECT MODAL ═══ -->
+<div class="modal-overlay" id="createProjectModal" onclick="if(event.target===this)closeModal('createProjectModal')">
+  <div class="modal-box">
+    <div class="modal-header">
+      <div class="modal-title">Create New Project</div>
+      <div class="modal-subtitle" style="line-height:1.5">A project gives your agent structured memory — a place to draft, share, and publish knowledge. Your agent&apos;s first project is a great place to import the context and memories it already has.</div>
+    </div>
+    <div class="modal-body">
+      <!-- First-project tip (Change 2) -->
+      <div style="padding:12px 14px; background:var(--bg-surface); border:1px solid var(--border-subtle); border-radius:8px; margin-bottom:16px; font-size:11px; color:var(--text-secondary); line-height:1.6">
+        <div style="font-weight:600; color:var(--text-primary); margin-bottom:4px">💡 First project tip</div>
+        This is your agent&apos;s first memory space. Consider importing any existing knowledge your agent has — notes, documents, conversation logs, or research — so it can build on what it already knows. You can import files after creating the project.
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">Project Name</label>
+        <input class="form-input" type="text" placeholder="e.g. Pharma Drug Interactions" value="">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Description</label>
+        <textarea class="form-textarea" placeholder="What should your agent remember? Describe the domain, goals, or context for this knowledge space..."></textarea>
+      </div>
+      <div class="form-divider"></div>
+      <div class="form-group">
+        <label class="form-label">Access</label>
+        <div class="form-radio-group">
+          <label class="form-radio"><input type="radio" name="access" value="curated" checked> Curated — only invited collaborators can view</label>
+          <label class="form-radio"><input type="radio" name="access" value="public"> Public — anyone can view</label>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Publish Policy</label>
+        <div class="form-radio-group">
+          <label class="form-radio"><input type="radio" name="publishPolicy" value="curator-only" checked> Curator only — only the curator can publish to Verified Memory</label>
+          <div class="form-radio-desc" style="color:var(--text-secondary)">You are the Curator (0x8a4f...c3b2)</div>
+          <label class="form-radio"><input type="radio" name="publishPolicy" value="open"> Open — any collaborator can publish to Verified Memory</label>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Ontology</label>
+        <div class="form-radio-group">
+          <label class="form-radio"><input type="radio" name="ontology" value="agent" checked> Let agent decide — your agent will choose the best vocabulary</label>
+          <div class="form-radio-desc" style="color:var(--text-ghost)">Your agent will query community ontologies (Schema.org, DrugBank, devgraph, etc.) and select the most relevant one for your domain.</div>
+          <label class="form-radio"><input type="radio" name="ontology" value="upload"> Upload an ontology file (.ttl, .owl, .rdf)</label>
+          <label class="form-radio"><input type="radio" name="ontology" value="community"> Choose from community ontologies</label>
+        </div>
+      </div>
+
+      <!-- Advanced settings (Change 4) -->
+      <div style="margin-top:16px; border-top:1px solid var(--border-subtle); padding-top:12px">
+        <div style="display:flex; align-items:center; gap:6px; cursor:pointer; font-size:11px; font-weight:600; letter-spacing:0.3px; color:var(--text-secondary); user-select:none" onclick="toggleAdvancedSettings()">
+          <span id="advSettingsChevron" style="font-size:10px; color:var(--text-tertiary); transition:transform 0.15s">▸</span>
+          <span>Advanced settings</span>
+        </div>
+        <div id="advSettingsBody" style="display:none; margin-top:12px; padding:12px 14px; background:var(--bg-surface); border-radius:6px">
+          <div class="form-group">
+            <label class="form-label">Consensus Quorum</label>
+            <select class="share-access-dropdown" style="width:100%">
+              <option value="off" selected>Off — no consensus verification required</option>
+              <option value="2of3">2 of 3 — lightweight consensus</option>
+              <option value="3of5">3 of 5 — standard consensus (recommended for teams)</option>
+              <option value="custom">Custom — set your own M of N</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">SWM TTL</label>
+            <select class="share-access-dropdown" style="width:100%">
+              <option value="7d" selected>7 days (default)</option>
+              <option value="1h">1 hour</option>
+              <option value="1d">1 day</option>
+              <option value="30d">30 days</option>
+            </select>
+          </div>
+          <div class="form-group" style="margin-bottom:0">
+            <label class="form-label">SWM Size Cap</label>
+            <select class="share-access-dropdown" style="width:100%">
+              <option value="100k" selected>100K triples (default)</option>
+              <option value="10k">10K triples</option>
+              <option value="1m">1M triples</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <!-- Layer activation preview -->
+      <div style="margin-top:14px; padding:10px 12px; background:var(--bg-surface); border-radius:6px; font-size:11px; color:var(--text-tertiary); line-height:1.8">
+        <div style="font-size:10px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-ghost); margin-bottom:4px">Layer Activation</div>
+        ┌─ Verified Memory ── activates on first publish (requires TRAC)<br>
+        ├─ Shared Memory ──── activates on first share (free)<br>
+        └─ Working Memory ─── created immediately (local, free)
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeModal('createProjectModal')">Cancel</button>
+      <button class="modal-btn primary" onclick="closeModal('createProjectModal');advanceToStage2();showToast('Project created — now import existing knowledge into Agent Memory');setTimeout(function(){openModal('importModal')},500)">Create Project</button>
+    </div>
+  </div>
+</div>
+
+<!-- ═══ ONTOLOGY CONFIGURATION MODAL ═══ -->
+<div class="modal-overlay" id="ontologyModal" onclick="if(event.target===this)closeModal('ontologyModal')">
+  <div class="modal-box">
+    <div class="modal-header">
+      <div class="modal-title">Project Settings — Ontology</div>
+      <div class="modal-subtitle">An ontology defines the vocabulary and rules for your project's knowledge graph. It helps agents structure data consistently, enables smarter queries, and powers automated reasoning.</div>
+    </div>
+    <div class="modal-body">
+      <div class="ontology-option selected" onclick="selectOntologyOption(this)">
+        <input type="radio" name="ontology" value="upload" checked>
+        <div>
+          <div style="font-size:12px; font-weight:500">Upload an ontology file (.ttl, .owl, .rdf)</div>
+          <div style="display:flex; gap:8px; align-items:center; margin-top:8px">
+            <input class="form-input" type="text" placeholder="pharma-interactions-ontology.ttl" style="flex:1; height:30px; font-size:11px" readonly>
+            <button class="modal-btn" style="height:30px; padding:0 12px; font-size:11px" onclick="event.stopPropagation();showToast('File browser opened')">Browse</button>
+          </div>
+        </div>
+      </div>
+      <div class="ontology-option" onclick="selectOntologyOption(this)">
+        <input type="radio" name="ontology" value="community">
+        <div style="width:100%">
+          <div style="font-size:12px; font-weight:500; margin-bottom:8px">Choose from community ontologies</div>
+          <div class="ontology-list-item"><span class="oli-name">DrugBank Interaction Ontology</span><span class="oli-tag">popular</span></div>
+          <div class="ontology-list-item"><span class="oli-name">PharmGKB Clinical Annotation</span><span class="oli-tag">popular</span></div>
+          <div class="ontology-list-item"><span class="oli-name">BioPortal Drug-Drug Interactions</span><span class="oli-tag">featured</span></div>
+        </div>
+      </div>
+      <div class="ontology-option" onclick="selectOntologyOption(this)">
+        <input type="radio" name="ontology" value="none">
+        <div style="font-size:12px; font-weight:500">No ontology — I'll use my own vocabulary</div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeModal('ontologyModal')">Skip</button>
+      <button class="modal-btn primary" onclick="closeModal('ontologyModal');showToast('Ontology saved — ingestion pipeline configured')">Save</button>
+    </div>
+  </div>
+</div>
+
+<!-- ═══ FILE IMPORT MODAL ═══ -->
+<div class="modal-overlay" id="importModal" onclick="if(event.target===this)closeModal('importModal')">
+  <div class="modal-box wide">
+    <div class="modal-header">
+      <div class="modal-title">Import to Agent Memory</div>
+      <div class="modal-subtitle">Pharma Drug Interactions — your agent&apos;s new memory space</div>
+    </div>
+    <div class="modal-body">
+      <!-- Follow-up step hint -->
+      <div style="padding:12px 14px; background:var(--bg-surface); border:1px solid var(--border-subtle); border-radius:8px; margin-bottom:16px; font-size:11px; color:var(--text-secondary); line-height:1.6">
+        <div style="font-weight:600; color:var(--text-primary); margin-bottom:4px">Step 3 of 3 — Populate your agent&apos;s Working Memory</div>
+        Your agent has structured memory now, but it&apos;s empty. Import your existing notes, documents, code, or research so your agent can build on what it already knows. Files land in Working Memory first — you can review them before promoting to Shared Memory.
+      </div>
+      <div class="import-dropzone" onclick="showToast('File browser opened')">
+        <div class="import-dropzone-label">Bring your agent&apos;s existing knowledge into this project</div>
+        <div class="import-dropzone-hint" style="margin-top:4px">Drag files or folders — your agent will extract structured knowledge and add it to its working memory.</div>
+        <div class="import-dropzone-hint" style="margin-top:8px; color:var(--text-ghost)">Your agent can process: .md, .docx, .pdf, .txt, .csv, .json, .ttl, .rdf</div>
+      </div>
+      <div class="import-file-list" id="importFileList">
+        <div class="import-file-item">
+          <span class="import-file-icon">&#128196;</span>
+          <span class="import-file-name">chen-drug-summaries/ (207 files)</span>
+          <span class="import-file-size">folder</span>
+        </div>
+        <div class="import-file-item">
+          <span class="import-file-icon">&#128196;</span>
+          <span class="import-file-name">warfarin-nsaids.md</span>
+          <span class="import-file-size">4.2 KB</span>
+        </div>
+        <div class="import-file-item">
+          <span class="import-file-icon">&#128196;</span>
+          <span class="import-file-name">metformin-contrast-agents.md</span>
+          <span class="import-file-size">3.8 KB</span>
+        </div>
+        <div class="import-file-item">
+          <span class="import-file-icon">&#128196;</span>
+          <span class="import-file-name">ssri-maoi-interactions.docx</span>
+          <span class="import-file-size">12.1 KB</span>
+        </div>
+        <div class="import-file-item">
+          <span class="import-file-icon">&#128196;</span>
+          <span class="import-file-name">bleeding-risk-meta-analysis.pdf</span>
+          <span class="import-file-size">2.4 MB</span>
+        </div>
+      </div>
+      <div class="form-divider"></div>
+      <div class="form-label">Ingestion Options</div>
+      <div class="import-option"><input type="checkbox" checked> Store original files as Knowledge Assets</div>
+      <div class="import-option"><input type="checkbox" checked> Let agent extract structured knowledge from content</div>
+      <div style="margin-left:22px; font-size:11px; color:var(--text-tertiary); margin-bottom:6px">Ontology: pharma-interactions-ontology.ttl (auto-detected) · or let agent decide</div>
+      <div class="import-option"><input type="checkbox"> Auto-promote to Shared Memory after extraction (default: keep in agent&apos;s working memory first)</div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeModal('importModal');showToast('Skipped — you can import files later from the project toolbar')">Skip for now</button>
+      <button class="modal-btn primary" onclick="closeModal('importModal');showToast('Your agent now remembers 1,847 entities from 211 files. Review them in Working Memory, or ask your agent to summarize what it learned.')">Start Import</button>
+    </div>
+  </div>
+</div>
+
+
+<!-- ═══ GRAPHIFY CONFIGURATION MODAL ═══ -->
+<div class="modal-overlay" id="graphifyModal" onclick="if(event.target===this)closeModal('graphifyModal')">
+  <div class="modal-box wide">
+    <div class="modal-header">
+      <div class="modal-title">⬡ Graphify — Transform Files to Knowledge Graph</div>
+      <div class="modal-subtitle">AI-powered two-pass extraction: deterministic AST + semantic analysis</div>
+    </div>
+    <div class="modal-body">
+      <div class="form-group">
+        <label class="form-label">Source</label>
+        <div class="import-dropzone" onclick="showToast('File browser opened')">
+          <div class="import-dropzone-label">Drag files or folders here, or click to browse</div>
+          <div class="import-dropzone-hint">Supported: code (20 languages), .md, .pdf, .docx, .xlsx, .png, .jpg, .webp</div>
+        </div>
+        <div class="import-file-list">
+          <div class="import-file-item"><span class="import-file-icon">&#128196;</span><span class="import-file-name">src/ (23 .py files)</span><span class="import-file-size">folder</span></div>
+          <div class="import-file-item"><span class="import-file-icon">&#128196;</span><span class="import-file-name">docs/ (12 .md files)</span><span class="import-file-size">folder</span></div>
+          <div class="import-file-item"><span class="import-file-icon">&#128196;</span><span class="import-file-name">papers/ (8 .pdf files)</span><span class="import-file-size">folder</span></div>
+          <div class="import-file-item"><span class="import-file-icon">&#128196;</span><span class="import-file-name">diagrams/ (5 .png files)</span><span class="import-file-size">folder</span></div>
+          <div class="import-file-item"><span class="import-file-icon">&#128196;</span><span class="import-file-name">data/ (4 .docx files)</span><span class="import-file-size">folder</span></div>
+        </div>
+        <div style="font-size:11px; color:var(--text-tertiary); margin-top:4px">52 files selected across 5 folders</div>
+      </div>
+      <div class="form-divider"></div>
+      <div class="form-group">
+        <label class="form-label">Processing Mode</label>
+        <div class="form-radio-group">
+          <label class="form-radio"><input type="radio" name="graphifyMode" value="standard" checked> Standard — AST extraction + semantic analysis</label>
+          <label class="form-radio"><input type="radio" name="graphifyMode" value="deep"> Deep — aggressive inference, more INFERRED edges</label>
+          <label class="form-radio"><input type="radio" name="graphifyMode" value="ast"> AST Only — deterministic code extraction, no LLM calls</label>
+        </div>
+      </div>
+      <div class="form-group">
+        <label class="form-label">Target Project</label>
+        <select class="share-access-dropdown"><option>Pharma Drug Interactions</option><option>Climate Science</option></select>
+      </div>
+      <div class="form-divider"></div>
+      <div class="form-label">Ontology Mapping</div>
+      <div class="import-option"><input type="checkbox" checked> Map to project ontology (pharma-interactions.ttl)</div>
+      <div class="import-option"><input type="checkbox" checked> Preserve Graphify confidence tags as DKG status metadata</div>
+      <div class="import-option"><input type="checkbox"> Auto-share EXTRACTED entities after processing</div>
+      <div class="import-option"><input type="checkbox"> Enable auto-sync mode (--watch)</div>
+      <div class="form-group" style="margin-top:12px">
+        <label class="form-label">Exclusions</label>
+        <input class="form-input" type="text" value="node_modules/, .git/, __pycache__/, *.pyc" placeholder=".graphifyignore patterns">
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeModal('graphifyModal')">Cancel</button>
+      <button class="modal-btn primary" onclick="closeModal('graphifyModal');showToast('Graphify processing 52 files — Pass 1: AST extraction started...');setTimeout(function(){showToast('Graphify complete: 1,159 nodes, 3,365 edges → 4,891 triples in Working Memory')},3000)">Run Graphify</button>
+    </div>
+  </div>
+</div>
+
+<!-- ═══ AGENT PERMISSIONS MODAL (Change 3) ═══ -->
+<div class="modal-overlay" id="agentPermissionsModal" onclick="if(event.target===this)closeModal('agentPermissionsModal')">
+  <div class="modal-box">
+    <div class="modal-header">
+      <div class="modal-title">Edit Permissions — research-agent</div>
+      <div class="modal-subtitle">Control which projects this agent can access and what it can do</div>
+    </div>
+    <div class="modal-body">
+      <div class="form-label">Project Access</div>
+      <div style="display:flex; flex-direction:column; gap:8px; margin-bottom:16px">
+        <label style="display:flex; align-items:flex-start; gap:10px; padding:10px 12px; border:1px solid var(--border-subtle); border-radius:6px; cursor:pointer">
+          <input type="checkbox" checked style="accent-color:var(--text-primary); margin-top:3px">
+          <div style="flex:1">
+            <div style="font-size:12px; font-weight:500">Pharma Drug Interactions</div>
+            <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); margin-top:2px">Read: All layers · Write: Working Memory, Shared Memory</div>
+          </div>
+        </label>
+        <label style="display:flex; align-items:flex-start; gap:10px; padding:10px 12px; border:1px solid var(--border-subtle); border-radius:6px; cursor:pointer">
+          <input type="checkbox" checked style="accent-color:var(--text-primary); margin-top:3px">
+          <div style="flex:1">
+            <div style="font-size:12px; font-weight:500">Climate Science</div>
+            <div style="font-size:10px; color:var(--text-tertiary); font-family:var(--font-mono); margin-top:2px">Read: All layers · Write: Working Memory only</div>
+          </div>
+        </label>
+        <label style="display:flex; align-items:flex-start; gap:10px; padding:10px 12px; border:1px solid var(--border-subtle); border-radius:6px; cursor:pointer; opacity:0.5">
+          <input type="checkbox" disabled style="accent-color:var(--text-primary); margin-top:3px">
+          <div style="flex:1">
+            <div style="font-size:12px; font-weight:500">Supply Chain (not joined)</div>
+            <div style="font-size:10px; color:var(--text-ghost); font-style:italic; margin-top:2px">Join the project to grant access</div>
+          </div>
+        </label>
+      </div>
+
+      <div class="form-divider"></div>
+
+      <div class="form-label">Capabilities</div>
+      <div style="display:flex; flex-direction:column; gap:6px; margin-top:8px">
+        <label class="form-radio" style="cursor:pointer"><input type="checkbox" checked> Can share to Shared Memory</label>
+        <label class="form-radio" style="cursor:pointer"><input type="checkbox"> Can publish to Verified Memory <span style="color:var(--text-ghost); font-size:10px">(requires Curator approval)</span></label>
+        <label class="form-radio" style="cursor:pointer"><input type="checkbox" checked> Can endorse findings</label>
+        <label class="form-radio" style="cursor:pointer"><input type="checkbox"> Can initiate consensus votes</label>
+        <label class="form-radio" style="cursor:pointer"><input type="checkbox" checked> Can query Context Oracle</label>
+        <label class="form-radio" style="cursor:pointer"><input type="checkbox"> Can manage other agents <span style="color:var(--text-ghost); font-size:10px">(admin)</span></label>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeModal('agentPermissionsModal')">Cancel</button>
+      <button class="modal-btn primary" onclick="closeModal('agentPermissionsModal');showToast('Permissions saved for research-agent')">Save Permissions</button>
+    </div>
+  </div>
+</div>
+
+<!-- ═══ SHARE PROJECT MODAL ═══ -->
+<div class="modal-overlay" id="shareModal" onclick="if(event.target===this)closeModal('shareModal')">
+  <div class="modal-box" style="width:520px">
+    <div class="modal-header" style="display:flex; align-items:center; gap:10px">
+      <div class="modal-title" style="flex:1">Share Pharma Drug Interactions</div>
+      <button style="font-size:14px; color:var(--text-tertiary); background:none; border:none; cursor:pointer; padding:4px 8px; border-radius:4px; transition:all .15s" onclick="event.stopPropagation();copyProjectLink()" title="Copy project link">🔗</button>
+      <button style="font-size:16px; color:var(--text-tertiary); background:none; border:none; cursor:pointer; padding:4px 8px; border-radius:4px; transition:all .15s" onclick="closeModal('shareModal')">✕</button>
+    </div>
+    <div class="modal-body" style="padding:16px 24px; max-height:500px; overflow-y:auto">
+
+      <!-- Invite section -->
+      <div class="share-invite-row">
+        <input type="text" placeholder="Add people, agents, or nodes..." id="shareInviteInput" style="flex:1">
+        <select class="share-role-select" id="shareInviteRole">
+          <option value="editor" selected>Editor</option>
+          <option value="admin">Project admin</option>
+          <option value="viewer">Viewer</option>
+        </select>
+        <button class="share-invite-btn" onclick="shareInvite()">Invite</button>
+      </div>
+      <label style="display:flex; align-items:center; gap:6px; font-size:11px; color:var(--text-tertiary); cursor:pointer; margin-bottom:4px">
+        <input type="checkbox" checked style="accent-color:var(--text-primary); width:13px; height:13px">
+        Notify when knowledge is shared to the project
+      </label>
+
+      <!-- Access settings -->
+      <div class="share-section-label">Access settings</div>
+      <select class="share-access-dropdown" id="shareAccessSetting" onchange="showToast('Access changed to ' + this.options[this.selectedIndex].text)">
+        <option value="private" selected>🔒 Private — invite only</option>
+        <option value="public">🌐 Public — anyone on the network</option>
+        <option value="gated">💰 Gated — paywall via x402</option>
+      </select>
+
+      <!-- Who has access -->
+      <div class="share-section-label">
+        <span>Who has access</span>
+        <a style="font-size:10px; color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer; text-transform:none; letter-spacing:0; font-weight:400" onclick="showToast('Notification preferences opened')">Manage notifications</a>
+      </div>
+
+      <!-- Group entry -->
+      <div class="share-member">
+        <div class="share-avatar" style="font-size:13px">👥</div>
+        <div class="share-member-info">
+          <div class="share-member-name">All project members</div>
+          <div class="share-member-group">5 people · 8 agents</div>
+        </div>
+        <select class="share-role-select" onchange="showToast('Default role updated')">
+          <option value="editor" selected>Editor</option>
+          <option value="admin">Project admin</option>
+          <option value="viewer">Viewer</option>
+        </select>
+      </div>
+
+      <!-- Org entry -->
+      <div class="share-member">
+        <div class="share-avatar" style="font-size:13px">🏛</div>
+        <div class="share-member-info">
+          <div class="share-member-name">Trace Labs</div>
+          <div class="share-member-group">13 people</div>
+        </div>
+        <select class="share-role-select" onchange="showToast('Role updated for Trace Labs')">
+          <option value="editor" selected>Editor</option>
+          <option value="admin">Project admin</option>
+          <option value="viewer">Viewer</option>
+        </select>
+      </div>
+
+      <!-- Individual members -->
+      <div class="share-member">
+        <div class="share-avatar">DA<span class="online-dot"></span></div>
+        <div class="share-member-info">
+          <div class="share-member-name">Dr. Amara</div>
+          <div class="share-member-meta">0x8a4f...c3b2 · research-agent, literature-scanner</div>
+        </div>
+        <select class="share-role-select" onchange="handleRoleChange(this,'Dr. Amara')">
+          <option value="admin" selected>Project admin</option>
+          <option value="editor">Editor</option>
+          <option value="viewer">Viewer</option>
+          <option value="remove" style="color:var(--accent-red)">Remove from project</option>
+        </select>
+      </div>
+
+      <div class="share-member">
+        <div class="share-avatar">DC<span class="online-dot"></span></div>
+        <div class="share-member-info">
+          <div class="share-member-name">Dr. Chen</div>
+          <div class="share-member-meta">0x3b8c...a1f7 · research-agent</div>
+        </div>
+        <select class="share-role-select" onchange="handleRoleChange(this,'Dr. Chen')">
+          <option value="admin" selected>Project admin</option>
+          <option value="editor">Editor</option>
+          <option value="viewer">Viewer</option>
+          <option value="remove" style="color:var(--accent-red)">Remove from project</option>
+        </select>
+      </div>
+
+      <div class="share-member">
+        <div class="share-avatar">DP<span class="online-dot"></span></div>
+        <div class="share-member-info">
+          <div class="share-member-name">Dr. Patel</div>
+          <div class="share-member-meta">0x9c3e...b2d4 · research-agent, guideline-checker</div>
+        </div>
+        <select class="share-role-select" onchange="handleRoleChange(this,'Dr. Patel')">
+          <option value="admin">Project admin</option>
+          <option value="editor" selected>Editor</option>
+          <option value="viewer">Viewer</option>
+          <option value="remove" style="color:var(--accent-red)">Remove from project</option>
+        </select>
+      </div>
+
+      <div class="share-member">
+        <div class="share-avatar">DO<span class="offline-dot"></span></div>
+        <div class="share-member-info">
+          <div class="share-member-name">Dr. Okonkwo</div>
+          <div class="share-member-meta">0x1a2b...c3d4 · research-agent</div>
+        </div>
+        <select class="share-role-select" onchange="handleRoleChange(this,'Dr. Okonkwo')">
+          <option value="admin">Project admin</option>
+          <option value="editor" selected>Editor</option>
+          <option value="viewer">Viewer</option>
+          <option value="remove" style="color:var(--accent-red)">Remove from project</option>
+        </select>
+      </div>
+
+      <div class="share-member">
+        <div class="share-avatar">DS<span class="offline-dot"></span></div>
+        <div class="share-member-info">
+          <div class="share-member-name">Dr. Silva</div>
+          <div class="share-member-meta">0x5e6f...7890 · research-agent, adverse-event-monitor</div>
+        </div>
+        <select class="share-role-select" onchange="handleRoleChange(this,'Dr. Silva')">
+          <option value="admin">Project admin</option>
+          <option value="editor" selected>Editor</option>
+          <option value="viewer">Viewer</option>
+          <option value="remove" style="color:var(--accent-red)">Remove from project</option>
+        </select>
+      </div>
+
+      <!-- Consensus quorum -->
+      <div class="share-section-label">Consensus quorum</div>
+      <div class="form-inline" style="margin-bottom:8px">
+        Require <input type="number" value="3" min="1" max="99" style="width:45px; height:28px; text-align:center; border-radius:4px; font-family:var(--font-mono)"> of <input type="number" value="5" min="1" max="99" style="width:45px; height:28px; text-align:center; border-radius:4px; font-family:var(--font-mono)"> members to verify key findings
+      </div>
+
+      <!-- Footer info -->
+      <div style="margin-top:12px; padding-top:12px; border-top:1px solid var(--border-subtle); font-size:11px; color:var(--text-tertiary)">
+        This project is connected to 2 context graphs. <a style="color:var(--text-secondary); text-decoration:underline; text-underline-offset:2px; cursor:pointer" onclick="showToast('Context graph access management opening...')">Manage access ›</a>
+      </div>
+
+      <div style="display:flex; justify-content:flex-end; margin-top:12px">
+        <button class="modal-btn" onclick="copyProjectLink()">Copy project link</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ═══ KNOWLEDGE COMMERCE SETTINGS MODAL ═══ -->
+<div class="modal-overlay" id="commerceModal" onclick="if(event.target===this)closeModal('commerceModal')">
+  <div class="modal-box">
+    <div class="modal-header">
+      <div class="modal-title">Knowledge Commerce</div>
+      <div class="modal-subtitle">Pharma Drug Interactions — configure x402 micropayment pricing</div>
+    </div>
+    <div class="modal-body">
+      <div class="form-label">What's Free (always visible)</div>
+      <div style="font-size:12px; color:var(--text-secondary); margin-bottom:16px; line-height:1.8; padding-left:8px">
+        &#10003; Project name, description, team size<br>
+        &#10003; Each finding: drug names, severity, trust level, endorsements<br>
+        &#10003; Pricing information
+      </div>
+
+      <div class="form-divider"></div>
+      <div class="form-label">What's Paid (via x402 micropayments)</div>
+      <div class="form-group" style="margin-top:8px">
+        <div class="publish-summary-row">
+          <span class="ps-label">Per-query access</span>
+          <span style="display:flex;align-items:center;gap:4px"><span class="ps-value">$</span><input type="text" value="0.05" style="width:60px;height:26px;text-align:right;font-family:var(--font-mono);font-size:11px;border-radius:4px"><span class="ps-value" style="color:var(--text-ghost)">USDC</span></span>
+        </div>
+        <div style="font-size:10px; color:var(--text-ghost); padding-left:4px; margin-bottom:10px">Full finding: mechanism, evidence, recommendations</div>
+        <div class="publish-summary-row">
+          <span class="ps-label">Verification rationale</span>
+          <span style="display:flex;align-items:center;gap:4px"><span class="ps-value">$</span><input type="text" value="0.02" style="width:60px;height:26px;text-align:right;font-family:var(--font-mono);font-size:11px;border-radius:4px"><span class="ps-value" style="color:var(--text-ghost)">USDC</span></span>
+        </div>
+        <div style="font-size:10px; color:var(--text-ghost); padding-left:4px; margin-bottom:10px">Expert reasoning behind each consensus vote</div>
+        <div class="publish-summary-row">
+          <span class="ps-label">Full project access (30 days)</span>
+          <span style="display:flex;align-items:center;gap:4px"><span class="ps-value">$</span><input type="text" value="50.00" style="width:60px;height:26px;text-align:right;font-family:var(--font-mono);font-size:11px;border-radius:4px"><span class="ps-value" style="color:var(--text-ghost)">USDC</span></span>
+        </div>
+        <div style="font-size:10px; color:var(--text-ghost); padding-left:4px">Unlimited queries + all rationale</div>
+      </div>
+
+      <div class="form-divider"></div>
+      <div class="form-group">
+        <label class="form-label">Revenue Split</label>
+        <div class="form-radio-group">
+          <label class="form-radio"><input type="radio" name="split" value="equal" checked> Equal among all team members (5)</label>
+          <label class="form-radio"><input type="radio" name="split" value="custom"> Custom split by contribution</label>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeModal('commerceModal')">Cancel</button>
+      <button class="modal-btn primary" onclick="closeModal('commerceModal');showToast('Pricing saved — x402 payment gate active')">Save Pricing</button>
+    </div>
+  </div>
+</div>
+
+<!-- Quick Switcher -->
+<div class="quick-switcher-overlay" id="quickSwitcher" onclick="if(event.target===this)toggleQuickSwitcher()">
+  <div class="quick-switcher">
+    <input class="qs-input" type="text" placeholder="Search tabs, entities, apps..." autofocus>
+    <div class="qs-results">
+      <div class="qs-item selected" onclick="qsNav('dashboard')"><span class="qs-dot" style="background:var(--text-tertiary)"></span> Dashboard <span class="qs-type">view</span></div>
+      <div class="qs-item" onclick="qsNav('pharma-project')"><span class="qs-dot" style="background:var(--text-primary)"></span> Pharma Drug Interactions <span class="qs-type">project</span></div>
+      <div class="qs-item" onclick="toggleQuickSwitcher();openLayerTab('working-memory')"><span class="qs-dot" style="background:var(--layer-working)"></span> Working Memory <span class="qs-type">layer</span></div>
+      <div class="qs-item" onclick="toggleQuickSwitcher();openLayerTab('shared-memory')"><span class="qs-dot" style="background:var(--layer-shared)"></span> Shared Memory <span class="qs-type">layer</span></div>
+      <div class="qs-item" onclick="toggleQuickSwitcher();openLayerTab('verified-memory')"><span class="qs-dot" style="background:var(--layer-verified)"></span> Verified Memory <span class="qs-type">layer</span></div>
+      <div class="qs-item" onclick="qsNav('project-page')"><span class="qs-dot" style="background:var(--text-tertiary)"></span> Context Oracle <span class="qs-type">discovery</span></div>
+    </div>
+  </div>
+</div>
+
+<!-- Toast -->
+<div class="toast-container">
+  <div class="toast" id="toast">
+    <span id="toastMsg"></span>
+    <span class="toast-action" onclick="hideToast()">Dismiss</span>
+  </div>
+</div>
+
+<script>
+// ═══════════════════════════════════════════
+// INTERACTION LOGIC
+// ═══════════════════════════════════════════
+
+// Tab state — one tab per project + specialized views
+const views = {
+  'dashboard': { breadcrumb: 'Dashboard', actions: '' },
+  'pharma-project': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--text-primary);display:inline-block"></span> <span class="bc-label">Pharma Drug Interactions</span>', actions: '<button class="toolbar-action" onclick="openModal(\'importModal\')">Import</button><button class="toolbar-action" style="margin-left:6px" onclick="openModal(\'ontologyModal\')">Ontology</button><button class="toolbar-action" style="margin-left:6px" onclick="openModal(\'commerceModal\')">Pricing</button><button class="toolbar-action primary" style="margin-left:6px" onclick="openModal(\'shareModal\')">Share</button>' },
+  'project-page': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--text-tertiary);display:inline-block"></span> Context Oracle <span class="bc-sep">›</span> Pharma Drug Interactions', actions: '' },
+  'memory-stack': { breadcrumb: 'Memory Stack', actions: '' },
+  'ka-inspector': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--layer-verified);display:inline-block"></span> Knowledge Asset Inspector', actions: '<button class="toolbar-action" onclick="showToast(\'Endorsed!\')">Endorse</button><button class="toolbar-action" style="margin-left:6px" onclick="switchCenterTab(\'consensus-vote\')">Request Vote</button>' },
+  'consensus-vote': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--accent-amber);display:inline-block"></span> Consensus Vote', actions: '' },
+  'agent-hub': { breadcrumb: 'Agent Hub', actions: '' },
+  'context-oracle': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--text-tertiary);display:inline-block"></span> Context Oracle', actions: '' },
+  'graphify-graph': { breadcrumb: '<span style="font-size:14px">⬡</span> Graphify Graph <span class="bc-sep">›</span> <span class="bc-label">Pharma Drug Interactions</span>', actions: '<button class="toolbar-action" onclick="switchCenterTab(\'graphify-report\')">View Report</button><button class="toolbar-action" style="margin-left:6px" onclick="openLayerTab(\'working-memory\')">Review in Working Memory</button>' },
+  'graphify-report': { breadcrumb: '<span style="font-size:14px">⬡</span> Graphify Report <span class="bc-sep">›</span> <span class="bc-label">GRAPH_REPORT.md</span>', actions: '<button class="toolbar-action" onclick="switchCenterTab(\'graphify-graph\')">View Graph</button><button class="toolbar-action" style="margin-left:6px" onclick="openLayerTab(\'working-memory\')">Review in Working Memory</button>' },
+  'working-memory': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--layer-working);display:inline-block"></span> Working Memory <span class="bc-sep">›</span> <span class="bc-label">Pharma Drug Interactions</span>', actions: '<button class="toolbar-action" style="background:var(--bg-active); color:var(--text-primary); border-color:var(--border-strong)">Cards</button><button class="toolbar-action" style="margin-left:2px" onclick="showToast(\'Switched to Triples view\')">Triples</button><button class="toolbar-action" style="margin-left:8px" onclick="openModal(\'importModal\')">Import Files</button><button class="toolbar-action" style="margin-left:6px" onclick="openModal(\'ontologyModal\')">Ontology</button>' },
+  'shared-memory': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--layer-shared);display:inline-block"></span> Shared Memory <span class="bc-sep">›</span> <span class="bc-label">Pharma Drug Interactions</span>', actions: '<button class="toolbar-action primary" onclick="showToast(\'Publishing selected entities to Verified Memory...\')">Publish Selected</button><button class="toolbar-action" style="margin-left:6px" onclick="openModal(\'shareModal\')">Share</button>' },
+  'verified-memory': { breadcrumb: '<span class="bc-dot" style="width:8px;height:8px;border-radius:50%;background:var(--layer-verified);display:inline-block"></span> Verified Memory <span class="bc-sep">›</span> <span class="bc-label">Pharma Drug Interactions</span>', actions: '<button class="toolbar-action" onclick="switchCenterTab(\'consensus-vote\')">Start Consensus Vote</button><button class="toolbar-action" style="margin-left:6px" onclick="openModal(\'commerceModal\')">Configure Pricing</button>' },
+};
+
+// Agent workspace switching (Change 3)
+// Journey state machine: stage 0 (fresh) → 1 (project created) → 2 (agent connected, full mock data)
+function setJourneyStage(stage) {
+  document.body.setAttribute('data-stage', String(stage));
+  var label = document.getElementById('journeyStageLabel');
+  if (label) label.textContent = String(stage);
+  // Remove dynamic tabs (layer tabs + context-oracle) that belong to stage 2
+  if (stage < 2) {
+    var dynamicTabs = ['working-memory','shared-memory','verified-memory','ka-inspector','consensus-vote','context-oracle'];
+    dynamicTabs.forEach(function(tid) {
+      var tab = document.querySelector('.center-tab[data-tab="' + tid + '"]');
+      if (tab && !tab.classList.contains('stage-2')) tab.remove();
+    });
+    switchCenterTab('dashboard');
+  }
+}
+function advanceToStage1() {
+  setJourneyStage(1);
+  showToast('Agent connected — now create your first project to give it structured memory');
+}
+function advanceToStage2() {
+  setJourneyStage(2);
+  showToast('Project created — full workspace unlocked');
+}
+// Handler for + New Agent button in header (Change 7)
+function addNewAgent() {
+  showToast('Opening Integrations → agent framework connectors');
+}
+// Toggle advanced settings section in Create Project modal (Change 4)
+function toggleAdvancedSettings() {
+  var body = document.getElementById('advSettingsBody');
+  var chev = document.getElementById('advSettingsChevron');
+  if (body.style.display === 'none') {
+    body.style.display = 'block';
+    chev.style.transform = 'rotate(90deg)';
+  } else {
+    body.style.display = 'none';
+    chev.style.transform = 'rotate(0deg)';
+  }
+}
+function resetJourney() {
+  setJourneyStage(0);
+  showToast('Journey reset to fresh install state');
+}
+function showJourneyControl() {
+  var current = document.body.getAttribute('data-stage') || '2';
+  var next = prompt('Set journey stage (0=fresh, 1=project created, 2=agent connected):', current);
+  if (next !== null && ['0','1','2'].indexOf(next) !== -1) {
+    setJourneyStage(parseInt(next, 10));
+  }
+}
+
+function switchAgent(agentName, btn) {
+  document.querySelectorAll('.agent-header-tab').forEach(t => t.classList.remove('active'));
+  btn.classList.add('active');
+  // Update task bar label
+  var taskLabel = document.querySelector('.task-label');
+  if (taskLabel) {
+    var tasks = {
+      'research-agent': 'PubMed interaction scan',
+      'literature-scanner': 'Clinical guideline scan',
+      'guideline-checker': 'PharmGKB cross-reference',
+      'graphify-agent': 'Watching 52 files · 1,159 nodes'
+    };
+    taskLabel.textContent = tasks[agentName] || agentName;
+  }
+  showToast('Switched to ' + agentName + ' workspace');
+}
+
+// Open dedicated layer tab (Decision 3C)
+function openLayerTab(layerId) {
+  // Add tab to tab bar if not already present
+  var existingTab = document.querySelector('.center-tab[data-tab="' + layerId + '"]');
+  if (!existingTab) {
+    var tabBar = document.getElementById('centerTabs');
+    var dots = { 'working-memory': 'var(--layer-working)', 'shared-memory': 'var(--layer-shared)', 'verified-memory': 'var(--layer-verified)' };
+    var icons = { 'working-memory': '◇', 'shared-memory': '◈', 'verified-memory': '◉' };
+    var names = { 'working-memory': 'Working Memory', 'shared-memory': 'Shared Memory', 'verified-memory': 'Verified Memory' };
+    var tab = document.createElement('div');
+    tab.className = 'center-tab';
+    tab.dataset.tab = layerId;
+    tab.onclick = function() { switchCenterTab(layerId); };
+    tab.innerHTML = '<span class="tab-dot" style="background:' + dots[layerId] + '"></span> ' + names[layerId] + ' <span class="tab-close" onclick="event.stopPropagation(); closeTab(\'' + layerId + '\')">×</span>';
+    tabBar.appendChild(tab);
+  }
+  switchCenterTab(layerId);
+}
+
+// Scroll to section within project view (fallback)
+function scrollToSection(section) {
+  switchCenterTab('pharma-project');
+  var el = document.getElementById('section-' + section);
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    el.style.transition = 'background 0.3s';
+    el.style.background = 'var(--bg-hover)';
+    setTimeout(function() { el.style.background = ''; }, 1000);
+  }
+}
+
+function switchCenterTab(tabId) {
+  // Activate tab
+  document.querySelectorAll('.center-tab').forEach(t => t.classList.remove('active'));
+  const tab = document.querySelector(`.center-tab[data-tab="${tabId}"]`);
+  if (tab) tab.classList.add('active');
+
+  // Show view
+  document.querySelectorAll('.center-content > div').forEach(v => v.classList.remove('visible'));
+  const view = document.getElementById('view-' + tabId);
+  if (view) view.classList.add('visible');
+
+  // Update toolbar
+  const config = views[tabId];
+  if (config) {
+    document.getElementById('toolbarBreadcrumb').innerHTML = config.breadcrumb;
+    document.getElementById('toolbarActions').innerHTML = config.actions;
+  }
+
+  // Update tree active state
+  document.querySelectorAll('.tree-item').forEach(i => i.classList.remove('active'));
+}
+
+function closeTab(tabId) {
+  const tab = document.querySelector(`.center-tab[data-tab="${tabId}"]`);
+  if (tab) {
+    const wasActive = tab.classList.contains('active');
+    tab.remove();
+    if (wasActive) switchCenterTab('dashboard');
+  }
+}
+
+// Nav buttons removed — agent tabs in header replace section toggles (Change 4)
+
+// Tree sections
+function toggleTreeSection(header) {
+  header.parentElement.classList.toggle('open');
+}
+
+// Panel collapse
+function togglePanel(panel) {
+  if (panel === 'left') document.getElementById('panelLeft').classList.toggle('collapsed');
+  else if (panel === 'right') document.getElementById('panelRight').classList.toggle('collapsed');
+  else if (panel === 'bottom') document.getElementById('panelBottom').classList.toggle('collapsed');
+}
+
+// Agent modes (Chat / Peer Search)
+function switchAgentMode(mode, btn) {
+  document.querySelectorAll('.agent-mode-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  
+  const chat = document.getElementById('agentChat');
+  const peer = document.getElementById('peerPanel');
+  const input = document.getElementById('agentInputArea');
+  
+  if (mode === 'chat') {
+    chat.style.display = 'flex';
+    peer.style.display = 'none';
+    input.style.display = 'block';
+  } else {
+    chat.style.display = 'none';
+    peer.style.display = 'flex';
+    input.style.display = 'none';
+  }
+}
+
+// Left panel mode (Explorer / Context Oracle)
+// Change 6: Selecting Context Oracle opens a dedicated full-width tab in center console
+function switchTreeMode(mode, btn) {
+  document.querySelectorAll('.tree-mode-btn').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  document.getElementById('treeExplorer').style.display = mode === 'explorer' ? 'block' : 'none';
+  var oracleTree = document.getElementById('treeOracle');
+  if (oracleTree) oracleTree.style.display = mode === 'oracle' ? 'flex' : 'none';
+  if (mode === 'oracle') {
+    // Open center console Context Oracle tab
+    var existingTab = document.querySelector('.center-tab[data-tab="context-oracle"]');
+    if (!existingTab) {
+      var tabBar = document.getElementById('centerTabs');
+      if (tabBar) {
+        var tab = document.createElement('div');
+        tab.className = 'center-tab';
+        tab.dataset.tab = 'context-oracle';
+        tab.onclick = function() { switchCenterTab('context-oracle'); };
+        tab.innerHTML = '<span class="tab-dot" style="background:var(--text-tertiary)"></span> ⚭ Context Oracle <span class="tab-close" onclick="event.stopPropagation(); closeTab(\'context-oracle\')">×</span>';
+        tabBar.appendChild(tab);
+      }
+    }
+    switchCenterTab('context-oracle');
+  }
+}
+
+// Context Oracle sub-tab switching inside center console
+function switchCoSubTab(sub) {
+  ['browse','search','graph'].forEach(function(s) {
+    var btn = document.getElementById('co-sub-' + s);
+    var view = document.getElementById('co-' + s);
+    if (btn) {
+      if (s === sub) {
+        btn.style.background = 'var(--bg-active)';
+        btn.style.color = 'var(--text-primary)';
+        btn.style.borderColor = 'var(--border-strong)';
+      } else {
+        btn.style.background = 'none';
+        btn.style.color = 'var(--text-secondary)';
+        btn.style.borderColor = 'var(--border-default)';
+      }
+    }
+    if (view) view.style.display = s === sub ? 'block' : 'none';
+  });
+}
+
+// Oracle sub-tabs (Browse / Search / Graph)
+function switchOracleTab(tab, btn) {
+  btn.parentElement.querySelectorAll('.oracle-sub-tab').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  document.getElementById('oracleBrowse').style.display = tab === 'browse' ? 'block' : 'none';
+  document.getElementById('oracleSearch').style.display = tab === 'search' ? 'block' : 'none';
+  document.getElementById('oracleGraph').style.display = tab === 'graph' ? 'block' : 'none';
+}
+
+// Peer sub-tabs (Discover / Invitations)
+function switchPeerTab(tab, btn) {
+  btn.parentElement.querySelectorAll('.oracle-sub-tab').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  document.getElementById('peerDiscover').style.display = tab === 'discover' ? 'block' : 'none';
+  document.getElementById('peerInvitations').style.display = tab === 'invitations' ? 'block' : 'none';
+}
+
+// Dropdown toggles (chain balance, notifications)
+function toggleDropdown(id) {
+  var el = document.getElementById(id);
+  var wasVisible = el.classList.contains('visible');
+  document.querySelectorAll('.chain-dropdown, .notif-dropdown').forEach(function(d) { d.classList.remove('visible'); });
+  if (!wasVisible) el.classList.add('visible');
+}
+document.addEventListener('click', function(e) {
+  if (!e.target.closest('.header-identity')) { var cd = document.getElementById('chainDrop'); if(cd) cd.classList.remove('visible'); }
+  if (!e.target.closest('.notif-bell')) { var nd = document.getElementById('notifDrop'); if(nd) nd.classList.remove('visible'); }
+});
+
+// Bottom tabs (see enhanced version below with content switching)
+
+// Quick switcher navigation
+function qsNav(tabId) {
+  toggleQuickSwitcher();
+  switchCenterTab(tabId);
+}
+
+// Quick switcher
+function toggleQuickSwitcher() {
+  const qs = document.getElementById('quickSwitcher');
+  qs.classList.toggle('visible');
+  if (qs.classList.contains('visible')) {
+    qs.querySelector('.qs-input').focus();
+  }
+}
+document.addEventListener('keydown', e => {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    e.preventDefault();
+    toggleQuickSwitcher();
+  }
+  if (e.key === 'Escape') {
+    document.getElementById('quickSwitcher').classList.remove('visible');
+  }
+});
+
+// Toast
+function showToast(msg) {
+  const toast = document.getElementById('toast');
+  document.getElementById('toastMsg').textContent = msg;
+  toast.classList.add('visible');
+  setTimeout(() => toast.classList.remove('visible'), 4000);
+}
+function hideToast() {
+  document.getElementById('toast').classList.remove('visible');
+}
+
+// Resize handles (basic drag)
+function initResize(handleId, target, prop, dir) {
+  const handle = document.getElementById(handleId);
+  if (!handle) return;
+  let startPos, startSize;
+  handle.addEventListener('mousedown', e => {
+    e.preventDefault();
+    handle.classList.add('active');
+    const el = document.getElementById(target);
+    startPos = dir === 'x' ? e.clientX : e.clientY;
+    startSize = dir === 'x' ? el.offsetWidth : el.offsetHeight;
+    
+    const onMove = e2 => {
+      const delta = dir === 'x' ? e2.clientX - startPos : e2.clientY - startPos;
+      const sign = (handleId === 'resizeRight' || handleId === 'resizeBottom') ? -1 : 1;
+      const newSize = Math.max(dir === 'x' ? 180 : 100, startSize + delta * sign);
+      el.style[prop] = newSize + 'px';
+      el.style['min' + prop.charAt(0).toUpperCase() + prop.slice(1)] = newSize + 'px';
+    };
+    const onUp = () => {
+      handle.classList.remove('active');
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  });
+}
+initResize('resizeLeft', 'panelLeft', 'width', 'x');
+initResize('resizeRight', 'panelRight', 'width', 'x');
+initResize('resizeBottom', 'panelBottom', 'height', 'y');
+
+// Theme toggle (Day/Night)
+function toggleTheme() {
+  document.body.classList.toggle('light');
+}
+
+// Agent Hub & Integrations nav handling
+// (update the nav click handler to support these sections)
+
+// Working Memory filter
+function filterDrafts(status, btn) {
+  btn.parentElement.querySelectorAll('.draft-action-btn').forEach(b => {
+    b.style.background = 'none';
+    b.style.color = 'var(--text-secondary)';
+    b.style.borderColor = 'var(--border-default)';
+  });
+  btn.style.background = 'var(--bg-active)';
+  btn.style.color = 'var(--text-primary)';
+  btn.style.borderColor = 'var(--border-strong)';
+  document.querySelectorAll('.draft-card').forEach(c => {
+    if (status === 'all' || c.dataset.status === status) {
+      c.style.display = 'block';
+    } else {
+      c.style.display = 'none';
+    }
+  });
+}
+
+// Verified Memory filter
+function filterVerified(trust, btn) {
+  btn.parentElement.querySelectorAll('.toolbar-action').forEach(b => {
+    b.style.color = 'var(--text-tertiary)';
+    b.style.borderColor = 'var(--border-default)';
+    b.style.background = 'none';
+  });
+  btn.style.color = 'var(--text-primary)';
+  btn.style.borderColor = 'var(--border-strong)';
+  btn.style.background = 'var(--bg-active)';
+  document.querySelectorAll('.vm-asset').forEach(a => {
+    if (trust === 'all' || a.dataset.trust === trust) {
+      a.style.display = '';
+    } else {
+      a.style.display = 'none';
+    }
+  });
+}
+
+// Share draft with animation
+function shareDraft(btn) {
+  var card = btn.closest('.draft-card');
+  card.style.transition = 'opacity 0.4s, transform 0.4s';
+  card.style.opacity = '0';
+  card.style.transform = 'translateX(40px)';
+  showToast('Promoted to Shared Memory — visible to team');
+  setTimeout(function() { card.style.display = 'none'; }, 400);
+}
+
+// Discard draft with animation
+function discardDraft(btn) {
+  var card = btn.closest('.draft-card');
+  card.style.transition = 'opacity 0.3s, transform 0.3s';
+  card.style.opacity = '0';
+  card.style.transform = 'scale(0.95)';
+  showToast('Draft discarded');
+  setTimeout(function() { card.style.display = 'none'; }, 300);
+}
+
+// Oracle filter pills
+function selectFilterPill(el) {
+  el.parentElement.querySelectorAll('.oracle-filter-pill').forEach(p => p.classList.remove('active'));
+  el.classList.add('active');
+}
+
+// Agent send message
+function sendAgentMsg() {
+  var input = document.getElementById('agentInput');
+  var text = input.value.trim();
+  if (!text) return;
+  var chat = document.getElementById('agentChat');
+  var userMsg = document.createElement('div');
+  userMsg.className = 'agent-msg user';
+  userMsg.textContent = text;
+  chat.appendChild(userMsg);
+  input.value = '';
+  // Simulate agent response
+  setTimeout(function() {
+    var reply = document.createElement('div');
+    reply.className = 'agent-msg assistant';
+    reply.innerHTML = 'Processing your request: "' + text + '". Querying across Working and Shared memory layers...<br><br><span class="msg-action" onclick="openLayerTab(\'verified-memory\')">View results →</span>';
+    chat.appendChild(reply);
+    chat.scrollTop = chat.scrollHeight;
+  }, 800);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+// Bottom panel tab switching (with content)
+function switchBottomTab(btn, tabId) {
+  document.querySelectorAll('.bottom-tab').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  document.querySelectorAll('.bottom-content').forEach(c => c.style.display = 'none');
+  var target = document.getElementById('btab-' + tabId);
+  if (target) target.style.display = 'block';
+}
+
+// Modal open/close
+function openModal(id) {
+  document.getElementById(id).classList.add('visible');
+}
+function closeModal(id) {
+  document.getElementById(id).classList.remove('visible');
+}
+// Close modals on Escape
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') {
+    document.querySelectorAll('.modal-overlay.visible').forEach(m => m.classList.remove('visible'));
+  }
+});
+
+// Ontology option selection
+function selectOntologyOption(el) {
+  el.closest('.modal-body').querySelectorAll('.ontology-option').forEach(o => {
+    o.classList.remove('selected');
+    o.querySelector('input[type="radio"]').checked = false;
+  });
+  el.classList.add('selected');
+  el.querySelector('input[type="radio"]').checked = true;
+}
+
+// Consensus vote toggle
+function selectCvVote(btn, type) {
+  btn.parentElement.querySelectorAll('.cv-vote-btn').forEach(b => { b.classList.remove('approve','reject'); });
+  btn.classList.add(type);
+}
+
+// Share modal functions
+function shareInvite() {
+  var input = document.getElementById('shareInviteInput');
+  var name = input.value.trim();
+  if (!name) { showToast('Enter a DID, node name, or agent identifier'); return; }
+  var role = document.getElementById('shareInviteRole').value;
+  showToast('Invitation sent to ' + name + ' as ' + role);
+  input.value = '';
+}
+
+function handleRoleChange(select, memberName) {
+  if (select.value === 'remove') {
+    if (confirm('Remove ' + memberName + ' from Pharma Drug Interactions? They will lose access to Shared Memory.')) {
+      select.closest('.share-member').style.display = 'none';
+      showToast(memberName + ' removed from project');
+    } else {
+      select.value = 'editor';
+    }
+  } else {
+    showToast(memberName + ' role changed to ' + select.options[select.selectedIndex].text);
+  }
+}
+
+function copyProjectLink() {
+  showToast('Project link copied: dkg://project/pharma-drug-interactions/0x8a4f...c3b2');
+}
+</script>
+</body>
+</html>

--- a/packages/adapter-hermes/README.md
+++ b/packages/adapter-hermes/README.md
@@ -1,0 +1,108 @@
+# DKG Adapter for Hermes Agent
+
+Connects [Hermes Agent](https://github.com/nousresearch/hermes-agent) (v0.7+) to a DKG V10 node for verifiable, shared agent memory.
+
+This package contains **both sides** of the integration:
+- `src/` — TypeScript daemon adapter (registers HTTP routes on the DKG node)
+- `hermes-plugin/` — Python memory provider plugin (loaded by Hermes Agent)
+
+## Architecture
+
+```
+Hermes Agent (Python)                DKG Daemon (TypeScript)
+plugins/memory/dkg/                  packages/adapter-hermes/
+  (symlink → hermes-plugin/)           HermesAdapterPlugin
+                                       /api/hermes/* routes
+  DKGMemoryProvider  ── HTTP ───→      DKGAgent delegation
+  5 agent tools          :9200         importMemories() extraction
+  Offline fallback   ←── HTTP ────
+```
+
+DKG Working Memory is the **primary store** for all persistent knowledge (facts, user profile, decisions). SQLite conversation history is kept as a local non-graph backup.
+
+## Quick Start
+
+### 1. Install the Hermes plugin
+
+```bash
+cd packages/adapter-hermes
+./install.sh /path/to/hermes-agent
+```
+
+This creates a symlink from Hermes's plugin directory to `hermes-plugin/`. If Hermes is in a standard location, the path is auto-detected.
+
+### 2. Configure Hermes
+
+```bash
+hermes memory setup
+# Select "dkg" → enter daemon URL (default: http://127.0.0.1:9200)
+```
+
+Or set directly in `~/.hermes/config.yaml`:
+```yaml
+memory:
+  provider: dkg
+```
+
+### 3. Start DKG + Hermes
+
+```bash
+dkg start          # Start the DKG daemon
+hermes             # Start Hermes (or it picks up the plugin on next session)
+```
+
+No restart needed if Hermes is already running — the plugin registers with the daemon on next session init.
+
+## What the Agent Gets
+
+Five DKG tools appear automatically:
+
+| Tool | Description |
+|------|-------------|
+| `dkg_memory` | Store/update/remove persistent facts in DKG Working Memory (replaces MEMORY.md) |
+| `dkg_query` | Run SPARQL queries across the knowledge graph |
+| `dkg_share` | Share knowledge to Shared Working Memory (team-visible, free, gossip-replicated) |
+| `dkg_publish` | Publish to Verified Memory (chain-anchored, permanent, costs TRAC) |
+| `dkg_status` | Check node health, peers, context graphs, assertion stats |
+
+## Memory Model
+
+```
+Working Memory (local, free)      agent's private assertions
+  │
+  ▼  SHARE (free, gossip)
+Shared Working Memory             team-visible, provisional
+  │
+  ▼  PUBLISH (costs TRAC)
+Verified Memory                   chain-anchored, trust gradient
+                                  (self-attested → endorsed → consensus-verified)
+```
+
+## Offline Mode
+
+If the DKG daemon is unreachable:
+- Agent continues with cached facts from `$HERMES_HOME/dkg_cache.json`
+- Writes are queued and auto-synced when daemon comes back online
+- `hermes dkg sync` forces a manual sync
+
+## CLI Commands
+
+```bash
+hermes dkg status   # Connection info, context graphs, assertion stats
+hermes dkg query "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
+hermes dkg sync     # Force-sync local cache to DKG
+```
+
+## Development
+
+```bash
+# Build TypeScript adapter
+pnpm build
+
+# Run tests
+pnpm test
+```
+
+## License
+
+Apache-2.0

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -171,16 +171,33 @@ DKG_SHARE_SCHEMA = {
 DKG_PUBLISH_SCHEMA = {
     "name": "dkg_publish",
     "description": (
-        "Publish Shared Working Memory to Verified Memory — chain-anchored, "
-        "permanent, costs TRAC. Only use when knowledge is ready for "
-        "permanent record."
+        "Publish knowledge to Verified Memory — chain-anchored, permanent, costs TRAC. "
+        "Two modes:\n"
+        "1. With quads: publish structured RDF triples directly (precise graph construction)\n"
+        "2. Without quads: publish everything in Shared Working Memory\n\n"
+        "Object values starting with http://, https://, urn:, or did: are treated as "
+        "URIs. Everything else becomes a string literal automatically.\n"
+        "Always call dkg_wallet_balances first to verify sufficient TRAC."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "context_graph": {
                 "type": "string",
-                "description": "Context Graph to publish from (default: current project).",
+                "description": "Context Graph to publish to (default: current project).",
+            },
+            "quads": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "subject": {"type": "string", "description": "Subject URI (e.g. 'https://example.org/finding/001')"},
+                        "predicate": {"type": "string", "description": "Predicate URI (e.g. 'https://schema.org/name')"},
+                        "object": {"type": "string", "description": "Object — URI or literal (e.g. 'Warfarin interaction' or 'https://schema.org/MedicalEntity')"},
+                    },
+                    "required": ["subject", "predicate", "object"],
+                },
+                "description": "Array of RDF triples to publish. If omitted, publishes entire SWM.",
             },
         },
         "required": [],
@@ -733,8 +750,38 @@ class DKGMemoryProvider(MemoryProvider):
         if self._offline:
             return tool_error("DKG daemon is offline. Cannot publish to chain.")
         cg = args.get("context_graph", self._context_graph)
-        result = self._client.publish(cg)
-        return json.dumps(result)
+        raw_quads = args.get("quads")
+
+        if raw_quads and isinstance(raw_quads, list) and len(raw_quads) > 0:
+            # Structured quad publishing — build daemon-format quads with URI auto-detect
+            quads = []
+            for q in raw_quads:
+                obj_val = str(q.get("object", ""))
+                # URIs pass through; everything else becomes a quoted literal
+                if _is_uri(obj_val):
+                    obj_out = obj_val
+                else:
+                    obj_out = '"' + obj_val.replace("\\", "\\\\").replace('"', '\\"') + '"'
+                quads.append({
+                    "subject": str(q.get("subject", "")),
+                    "predicate": str(q.get("predicate", "")),
+                    "object": obj_out,
+                    "graph": str(q.get("graph", "")),
+                })
+            # Write to SWM first, then publish
+            share_result = self._client._post("/api/shared-memory/write", {
+                "contextGraphId": cg,
+                "quads": quads,
+            })
+            if share_result.get("success") is False:
+                return json.dumps(share_result)
+            result = self._client.publish(cg)
+            result["quadsPublished"] = len(quads)
+            return json.dumps(result)
+        else:
+            # Publish entire SWM
+            result = self._client.publish(cg)
+            return json.dumps(result)
 
     def _handle_status(self, args: Dict[str, Any]) -> str:
         if self._offline:
@@ -945,6 +992,11 @@ class DKGMemoryProvider(MemoryProvider):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _is_uri(value: str) -> bool:
+    """Check if a value looks like a URI."""
+    return bool(value) and any(value.startswith(p) for p in ("http://", "https://", "urn:", "did:"))
+
 
 def _escape_sparql(text: str) -> str:
     """Escape text for use in SPARQL string literal."""

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -193,6 +193,155 @@ DKG_STATUS_SCHEMA = {
     "parameters": {"type": "object", "properties": {}, "required": []},
 }
 
+DKG_WALLET_SCHEMA = {
+    "name": "dkg_wallet_balances",
+    "description": (
+        "Check TRAC and ETH balances for the node's operational wallets. "
+        "Call this BEFORE using dkg_publish to verify you have enough TRAC "
+        "to cover publishing costs. Returns per-wallet balances and chain info."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+DKG_FIND_AGENTS_SCHEMA = {
+    "name": "dkg_find_agents",
+    "description": (
+        "Discover other DKG agents on the network. Returns agent names, peer IDs, "
+        "frameworks, and available skills. Use this to find collaborators, check "
+        "who's online, or locate agents with specific capabilities before sending "
+        "messages or invoking skills."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "framework": {
+                "type": "string",
+                "description": "Filter by framework (e.g. 'OpenClaw', 'hermes-agent', 'ElizaOS').",
+            },
+            "skill_type": {
+                "type": "string",
+                "description": "Filter by skill URI to find agents offering a specific capability.",
+            },
+        },
+        "required": [],
+    },
+}
+
+DKG_SEND_MESSAGE_SCHEMA = {
+    "name": "dkg_send_message",
+    "description": (
+        "Send an encrypted P2P message to another DKG agent by peer ID or name. "
+        "Both agents must be online. Use dkg_find_agents first to discover peer IDs. "
+        "Messages are end-to-end encrypted and routed through the DKG network."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "peer_id": {
+                "type": "string",
+                "description": "Recipient peer ID (starts with 12D3KooW...) or agent name.",
+            },
+            "text": {
+                "type": "string",
+                "description": "Message text to send.",
+            },
+        },
+        "required": ["peer_id", "text"],
+    },
+}
+
+DKG_READ_MESSAGES_SCHEMA = {
+    "name": "dkg_read_messages",
+    "description": (
+        "Read P2P messages from other DKG agents. Returns both sent and received "
+        "messages. Filter by peer to see conversation with a specific agent."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "peer": {
+                "type": "string",
+                "description": "Filter by peer ID or agent name (optional).",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max messages to return (default: 50).",
+            },
+        },
+        "required": [],
+    },
+}
+
+DKG_INVOKE_SKILL_SCHEMA = {
+    "name": "dkg_invoke_skill",
+    "description": (
+        "Invoke a skill on a remote DKG agent. The remote agent executes the "
+        "skill and returns the result. Use dkg_find_agents with skill_type first "
+        "to discover which agents offer the skill you need."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "peer_id": {
+                "type": "string",
+                "description": "Target agent peer ID or name.",
+            },
+            "skill_uri": {
+                "type": "string",
+                "description": "Skill URI to invoke (e.g. 'ImageAnalysis').",
+            },
+            "input": {
+                "type": "string",
+                "description": "Input data for the skill as text.",
+            },
+        },
+        "required": ["peer_id", "skill_uri", "input"],
+    },
+}
+
+DKG_SUBSCRIBE_SCHEMA = {
+    "name": "dkg_subscribe",
+    "description": (
+        "Subscribe to a Context Graph to receive its data and updates from the "
+        "network. After subscribing, the node syncs data from peers in the "
+        "background. Use dkg_status to check sync progress."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "context_graph_id": {
+                "type": "string",
+                "description": "Context Graph ID to subscribe to (e.g. 'pharma-research').",
+            },
+        },
+        "required": ["context_graph_id"],
+    },
+}
+
+DKG_CREATE_CONTEXT_GRAPH_SCHEMA = {
+    "name": "dkg_context_graph_create",
+    "description": (
+        "Create a new Context Graph — a bounded knowledge space for a project "
+        "or team. Context Graphs organize knowledge into Working Memory, "
+        "Shared Memory, and Verified Memory layers. Use dkg_status first to "
+        "check if the Context Graph already exists."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Human-readable name (e.g. 'Pharma Drug Interactions').",
+            },
+            "description": {
+                "type": "string",
+                "description": "What this Context Graph is for.",
+            },
+        },
+        "required": ["name"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Provider
@@ -267,6 +416,10 @@ class DKGMemoryProvider(MemoryProvider):
         # Flush any queued writes from previous offline session
         self._flush_queued_writes()
 
+        # Backlog import: if DKG assertion is empty and local MEMORY.md/USER.md
+        # exist, import them so the agent doesn't start with blank memory.
+        self._backlog_import_if_needed(kwargs.get("hermes_home", ""))
+
     def system_prompt_block(self) -> str:
         """Recall facts from DKG assertion for system prompt injection."""
         facts = self._recall_facts()
@@ -299,9 +452,32 @@ class DKGMemoryProvider(MemoryProvider):
             )
 
         blocks.append(
-            "DKG tools available: dkg_memory (store facts), dkg_query (SPARQL), "
-            "dkg_share (share with team), dkg_publish (publish on-chain), "
-            "dkg_status (node health)."
+            "DKG TOOLS — Your node is connected to a Decentralized Knowledge Graph.\n"
+            "\n"
+            "MEMORY WORKFLOW:\n"
+            "  dkg_memory — Store/update/remove persistent facts (your primary memory)\n"
+            "  dkg_query — Search knowledge via SPARQL (fast, local)\n"
+            "\n"
+            "COLLABORATION WORKFLOW:\n"
+            "  dkg_share — Share findings to Shared Working Memory (team-visible, free)\n"
+            "  dkg_publish — Publish to Verified Memory (chain-anchored, costs TRAC)\n"
+            "  dkg_wallet_balances — Check TRAC balance BEFORE publishing\n"
+            "\n"
+            "NETWORK & DISCOVERY:\n"
+            "  dkg_find_agents — Discover other agents on the network\n"
+            "  dkg_send_message — Send encrypted P2P message to another agent\n"
+            "  dkg_read_messages — Read messages from other agents\n"
+            "  dkg_invoke_skill — Call a remote agent's skill\n"
+            "\n"
+            "PROJECT MANAGEMENT:\n"
+            "  dkg_context_graph_create — Create a new project/knowledge space\n"
+            "  dkg_subscribe — Join an existing project on the network\n"
+            "  dkg_status — Node health, peers, context graphs\n"
+            "\n"
+            "TRUST FLOW: Working Memory (local, free) → SHARE → Shared Memory "
+            "(team, free) → PUBLISH → Verified Memory (chain, TRAC cost, permanent).\n"
+            "Knowledge gains trust as it moves through layers. Only publish when "
+            "findings are verified and ready for permanent record."
         )
 
         return "\n\n".join(blocks)
@@ -313,19 +489,33 @@ class DKGMemoryProvider(MemoryProvider):
             DKG_SHARE_SCHEMA,
             DKG_PUBLISH_SCHEMA,
             DKG_STATUS_SCHEMA,
+            DKG_WALLET_SCHEMA,
+            DKG_FIND_AGENTS_SCHEMA,
+            DKG_SEND_MESSAGE_SCHEMA,
+            DKG_READ_MESSAGES_SCHEMA,
+            DKG_INVOKE_SKILL_SCHEMA,
+            DKG_SUBSCRIBE_SCHEMA,
+            DKG_CREATE_CONTEXT_GRAPH_SCHEMA,
         ]
 
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
-        if tool_name == "dkg_memory":
-            return self._handle_memory(args)
-        elif tool_name == "dkg_query":
-            return self._handle_query(args)
-        elif tool_name == "dkg_share":
-            return self._handle_share(args)
-        elif tool_name == "dkg_publish":
-            return self._handle_publish(args)
-        elif tool_name == "dkg_status":
-            return self._handle_status(args)
+        handlers = {
+            "dkg_memory": self._handle_memory,
+            "dkg_query": self._handle_query,
+            "dkg_share": self._handle_share,
+            "dkg_publish": self._handle_publish,
+            "dkg_status": self._handle_status,
+            "dkg_wallet_balances": self._handle_wallet,
+            "dkg_find_agents": self._handle_find_agents,
+            "dkg_send_message": self._handle_send_message,
+            "dkg_read_messages": self._handle_read_messages,
+            "dkg_invoke_skill": self._handle_invoke_skill,
+            "dkg_subscribe": self._handle_subscribe,
+            "dkg_context_graph_create": self._handle_create_cg,
+        }
+        handler = handlers.get(tool_name)
+        if handler:
+            return handler(args)
         return tool_error(f"Unknown DKG tool: {tool_name}")
 
     # -- Prefetch --------------------------------------------------------------
@@ -568,6 +758,130 @@ class DKGMemoryProvider(MemoryProvider):
             "session_id": self._session_id,
             "turn_count": self._turn_count,
         })
+
+    # -- Handlers: network & discovery -----------------------------------------
+
+    def _handle_wallet(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline.")
+        return json.dumps(self._client._get("/api/wallet/balances"))
+
+    def _handle_find_agents(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot discover agents.")
+        params = {}
+        if args.get("framework"):
+            params["framework"] = args["framework"]
+        if args.get("skill_type"):
+            params["skill_type"] = args["skill_type"]
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        path = f"/api/agents?{qs}" if qs else "/api/agents"
+        return json.dumps(self._client._get(path))
+
+    def _handle_send_message(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot send messages.")
+        peer_id = args.get("peer_id", "")
+        text = args.get("text", "")
+        if not peer_id or not text:
+            return tool_error("Both peer_id and text are required.")
+        return json.dumps(self._client._post("/api/chat", {
+            "peerId": peer_id,
+            "text": text,
+        }))
+
+    def _handle_read_messages(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot read messages.")
+        params = {}
+        if args.get("peer"):
+            params["peer"] = args["peer"]
+        if args.get("limit"):
+            params["limit"] = str(args["limit"])
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        path = f"/api/messages?{qs}" if qs else "/api/messages"
+        return json.dumps(self._client._get(path))
+
+    def _handle_invoke_skill(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot invoke remote skills.")
+        peer_id = args.get("peer_id", "")
+        skill_uri = args.get("skill_uri", "")
+        input_data = args.get("input", "")
+        if not peer_id or not skill_uri:
+            return tool_error("peer_id and skill_uri are required.")
+        return json.dumps(self._client._post("/api/invoke-skill", {
+            "peerId": peer_id,
+            "skillUri": skill_uri,
+            "input": input_data,
+        }))
+
+    def _handle_subscribe(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot subscribe.")
+        cg_id = args.get("context_graph_id", "")
+        if not cg_id:
+            return tool_error("context_graph_id is required.")
+        return json.dumps(self._client._post("/api/context-graph/subscribe", {
+            "contextGraphId": cg_id,
+        }))
+
+    def _handle_create_cg(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot create Context Graph.")
+        name = args.get("name", "").strip()
+        if not name:
+            return tool_error("name is required.")
+        description = args.get("description", "")
+        result = self._client.create_context_graph(name, description)
+        return json.dumps(result)
+
+    # -- Internal: backlog import ----------------------------------------------
+
+    def _backlog_import_if_needed(self, hermes_home: str) -> None:
+        """On first activation, import existing MEMORY.md + USER.md into DKG."""
+        if self._offline or not self._client:
+            return
+
+        # Check if assertion already has content (not first activation)
+        existing = self._recall_facts()
+        if existing:
+            return
+
+        # Look for existing memory files to import
+        if not hermes_home:
+            return
+
+        memories_dir = Path(hermes_home) / "memories"
+        imported = 0
+
+        for filename in ["MEMORY.md", "USER.md"]:
+            filepath = memories_dir / filename
+            if not filepath.exists():
+                continue
+            try:
+                content = filepath.read_text(encoding="utf-8").strip()
+                if not content:
+                    continue
+
+                target = "user" if filename == "USER.md" else "memory"
+                # Split by § delimiter (same as built-in memory format)
+                entries = [e.strip() for e in content.split("\n\xA7\n") if e.strip()]
+
+                for entry in entries:
+                    self._handle_memory({
+                        "action": "add",
+                        "target": target,
+                        "content": entry,
+                    })
+                    imported += 1
+
+                logger.info(f"[dkg] Backlog import: {len(entries)} entries from {filename}")
+            except Exception as e:
+                logger.warning(f"[dkg] Backlog import failed for {filename}: {e}")
+
+        if imported > 0:
+            logger.info(f"[dkg] Backlog import complete: {imported} entries imported from existing memory files")
 
     # -- Internal: recall facts from DKG or cache ------------------------------
 

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -57,14 +57,15 @@ def _load_config() -> dict:
     return config
 
 
-def _cache_path() -> Path:
+def _cache_path(agent_name: str = "") -> Path:
     from hermes_constants import get_hermes_home
-    return get_hermes_home() / "dkg_cache.json"
+    suffix = f"_{agent_name}" if agent_name else ""
+    return get_hermes_home() / f"dkg_cache{suffix}.json"
 
 
-def _load_cache() -> dict:
-    """Load offline cache."""
-    cp = _cache_path()
+def _load_cache(agent_name: str = "") -> dict:
+    """Load offline cache scoped to agent."""
+    cp = _cache_path(agent_name)
     if cp.exists():
         try:
             return json.loads(cp.read_text(encoding="utf-8"))
@@ -73,9 +74,9 @@ def _load_cache() -> dict:
     return {"memory": [], "user": [], "queued_writes": []}
 
 
-def _save_cache(cache: dict) -> None:
-    """Write offline cache atomically."""
-    cp = _cache_path()
+def _save_cache(cache: dict, agent_name: str = "") -> None:
+    """Write offline cache atomically, scoped to agent."""
+    cp = _cache_path(agent_name)
     tmp = cp.with_suffix(".tmp")
     try:
         tmp.write_text(json.dumps(cache, indent=2), encoding="utf-8")
@@ -228,12 +229,12 @@ class DKGMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()
         self._session_id = session_id
-        self._cache = _load_cache()
         self._agent_name = (
             self._config.get("agent_name")
             or kwargs.get("agent_identity", "")
             or "hermes"
         )
+        self._cache = _load_cache(self._agent_name)
         self._context_graph = self._config.get("context_graph", "hermes-memory")
 
         # Create HTTP client
@@ -335,14 +336,17 @@ class DKGMemoryProvider(MemoryProvider):
             return ""
 
         try:
-            # Simple text search across the context graph
+            # Search within this agent's assertion only — prevents cross-agent contamination
             sparql = (
                 f"SELECT ?s ?p ?o WHERE {{ "
                 f"?s ?p ?o . "
-                f"FILTER(ISLTERAL(?o) && CONTAINS(LCASE(STR(?o)), LCASE(\"{_escape_sparql(query)}\")))"
+                f"FILTER(ISLITERAL(?o) && CONTAINS(LCASE(STR(?o)), LCASE(\"{_escape_sparql(query)}\")))"
                 f"}} LIMIT 10"
             )
-            result = self._client.query(sparql, self._context_graph)
+            if self._assertion_id:
+                result = self._client.query_assertion(self._assertion_id, sparql)
+            else:
+                result = self._client.query(sparql, self._context_graph)
             bindings = result.get("results", {}).get("bindings", [])
             if not bindings:
                 return ""
@@ -373,16 +377,18 @@ class DKGMemoryProvider(MemoryProvider):
                     "user": user_content[:2000],
                     "assistant": assistant_content[:2000],
                 })
-                _save_cache(self._cache)
+                _save_cache(self._cache, self._agent_name)
             return
 
         # Fire-and-forget in background thread
+        agent_name = self._agent_name
         def _sync():
             try:
                 self._client.store_turn(
                     self._session_id,
                     user_content[:2000],
                     assistant_content[:2000],
+                    agent_name=agent_name,
                 )
             except Exception as e:
                 logger.debug(f"[dkg] sync_turn failed: {e}")
@@ -416,7 +422,7 @@ class DKGMemoryProvider(MemoryProvider):
             with self._lock:
                 self._cache["memory"] = [f for f in facts if f.get("target") == "memory"]
                 self._cache["user"] = [f for f in facts if f.get("target") == "user"]
-                _save_cache(self._cache)
+                _save_cache(self._cache, self._agent_name)
 
     def shutdown(self) -> None:
         """Close HTTP client."""
@@ -484,7 +490,7 @@ class DKGMemoryProvider(MemoryProvider):
                 entries = [e for e in entries if content not in e.get("content", "")]
 
             self._cache[target] = entries
-            _save_cache(self._cache)
+            _save_cache(self._cache, self._agent_name)
 
         # Write to DKG assertion if online
         if self._client and not self._offline:
@@ -502,7 +508,7 @@ class DKGMemoryProvider(MemoryProvider):
                     "target": target,
                     "content": content,
                 })
-                _save_cache(self._cache)
+                _save_cache(self._cache, self._agent_name)
 
         count = len(entries)
         return json.dumps({
@@ -619,7 +625,7 @@ class DKGMemoryProvider(MemoryProvider):
 
         with self._lock:
             self._cache["queued_writes"] = []
-            _save_cache(self._cache)
+            _save_cache(self._cache, self._agent_name)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -422,11 +422,12 @@ class DKGMemoryProvider(MemoryProvider):
 
         # Create or resolve assertion for this agent's Working Memory
         result = self._client.create_assertion(
-            self._context_graph, self._agent_name, "hermes-memory"
+            self._context_graph, self._agent_name,
         )
-        if result.get("assertionId"):
-            self._assertion_id = result["assertionId"]
-            logger.info(f"[dkg] Assertion ready: {self._assertion_id}")
+        assertion_uri = result.get("assertionUri")
+        if assertion_uri:
+            self._assertion_id = self._agent_name
+            logger.info(f"[dkg] Assertion ready: {assertion_uri}")
         elif result.get("success") is False:
             logger.warning(f"[dkg] Assertion creation failed: {result.get('error')} — using direct query")
 
@@ -551,7 +552,7 @@ class DKGMemoryProvider(MemoryProvider):
                 f"}} LIMIT 10"
             )
             if self._assertion_id:
-                result = self._client.query_assertion(self._assertion_id, sparql)
+                result = self._client.query_assertion(self._assertion_id, self._context_graph, sparql)
             else:
                 result = self._client.query(sparql, self._context_graph)
             bindings = result.get("results", {}).get("bindings", [])
@@ -700,12 +701,19 @@ class DKGMemoryProvider(MemoryProvider):
             _save_cache(self._cache, self._agent_name)
 
         # Write to DKG assertion if online
-        if self._client and not self._offline:
-            all_content = _ENTRY_SEP.join(e["content"] for e in entries)
+        if self._client and not self._offline and self._assertion_id:
+            quads = []
+            for e in entries:
+                quads.append({
+                    "subject": f"urn:hermes:{self._agent_name}:{target}",
+                    "predicate": "urn:hermes:content",
+                    "object": f"[{e.get('target', target)}]\n{e['content']}",
+                })
             try:
                 self._client.write_assertion(
-                    self._assertion_id or "default",
-                    f"[{target}]\n{all_content}",
+                    self._assertion_id,
+                    self._context_graph,
+                    quads,
                 )
             except Exception as e:
                 logger.debug(f"[dkg] Assertion write failed: {e}")
@@ -743,7 +751,12 @@ class DKGMemoryProvider(MemoryProvider):
         if not content:
             return tool_error("Content is required.")
         cg = args.get("context_graph", self._context_graph)
-        result = self._client.share(cg, content)
+        quads = [{
+            "subject": f"urn:hermes:{self._agent_name}:shared",
+            "predicate": "urn:hermes:sharedContent",
+            "object": content,
+        }]
+        result = self._client.share(cg, quads)
         return json.dumps(result)
 
     def _handle_publish(self, args: Dict[str, Any]) -> str:
@@ -768,11 +781,7 @@ class DKGMemoryProvider(MemoryProvider):
                     "object": obj_out,
                     "graph": str(q.get("graph", "")),
                 })
-            # Write to SWM first, then publish
-            share_result = self._client._post("/api/shared-memory/write", {
-                "contextGraphId": cg,
-                "quads": quads,
-            })
+            share_result = self._client.share(cg, quads)
             if share_result.get("success") is False:
                 return json.dumps(share_result)
             result = self._client.publish(cg)
@@ -942,7 +951,7 @@ class DKGMemoryProvider(MemoryProvider):
 
         try:
             sparql = "SELECT ?content WHERE { ?s <urn:hermes:content> ?content }"
-            result = self._client.query_assertion(self._assertion_id, sparql)
+            result = self._client.query_assertion(self._assertion_id, self._context_graph, sparql)
             bindings = result.get("results", {}).get("bindings", [])
             if bindings:
                 facts = []
@@ -961,12 +970,13 @@ class DKGMemoryProvider(MemoryProvider):
         return self._cache.get("memory", []) + self._cache.get("user", [])
 
     def _flush_queued_writes(self) -> None:
-        """Flush any writes queued during offline period."""
+        """Flush any writes queued during offline period. Only removes items that succeeded."""
         queued = self._cache.get("queued_writes", [])
         if not queued or self._offline:
             return
 
         logger.info(f"[dkg] Flushing {len(queued)} queued writes from offline period")
+        failed: list = []
         for item in queued:
             try:
                 if item.get("type") == "turn":
@@ -983,9 +993,10 @@ class DKGMemoryProvider(MemoryProvider):
                     })
             except Exception as e:
                 logger.debug(f"[dkg] Failed to flush queued write: {e}")
+                failed.append(item)
 
         with self._lock:
-            self._cache["queued_writes"] = []
+            self._cache["queued_writes"] = failed
             _save_cache(self._cache, self._agent_name)
 
 

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -1,0 +1,649 @@
+"""DKG memory plugin — MemoryProvider interface.
+
+Uses DKG V10 Working Memory assertions as the PRIMARY persistent store
+for all agent knowledge (facts, user profile, decisions, findings).
+SQLite conversation history is kept as a non-graph backup.
+
+When the daemon is unreachable, falls back to a local cache file
+($HERMES_HOME/dkg_cache.json) and queues writes for sync on reconnect.
+
+Config via $HERMES_HOME/dkg.json:
+  daemon_url     — DKG daemon URL (default: http://127.0.0.1:9200)
+  context_graph  — Context Graph name (default: hermes-memory)
+  agent_name     — Agent identity (default: from hermes config)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+# Entry delimiter matching built-in memory format
+_ENTRY_SEP = "\n\xA7\n"  # §
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    """Load config from $HERMES_HOME/dkg.json with env var overrides."""
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "daemon_url": os.environ.get("DKG_DAEMON_URL", "http://127.0.0.1:9200"),
+        "context_graph": os.environ.get("DKG_CONTEXT_GRAPH", "hermes-memory"),
+        "agent_name": os.environ.get("DKG_AGENT_NAME", ""),
+    }
+
+    config_path = get_hermes_home() / "dkg.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items()
+                           if v is not None and v != ""})
+        except Exception:
+            pass
+
+    return config
+
+
+def _cache_path() -> Path:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "dkg_cache.json"
+
+
+def _load_cache() -> dict:
+    """Load offline cache."""
+    cp = _cache_path()
+    if cp.exists():
+        try:
+            return json.loads(cp.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {"memory": [], "user": [], "queued_writes": []}
+
+
+def _save_cache(cache: dict) -> None:
+    """Write offline cache atomically."""
+    cp = _cache_path()
+    tmp = cp.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(cache, indent=2), encoding="utf-8")
+        tmp.replace(cp)
+    except Exception as e:
+        logger.warning(f"[dkg] Failed to save cache: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+DKG_MEMORY_SCHEMA = {
+    "name": "dkg_memory",
+    "description": (
+        "Store persistent facts in your DKG knowledge graph. These persist "
+        "across sessions and can be shared with other agents.\n\n"
+        "Actions: add (new fact), replace (update existing), remove (delete).\n"
+        "Targets: memory (agent notes) or user (user profile)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["add", "replace", "remove"],
+                "description": "What to do.",
+            },
+            "target": {
+                "type": "string",
+                "enum": ["memory", "user"],
+                "description": "Which store (default: memory).",
+            },
+            "content": {
+                "type": "string",
+                "description": "The fact to store (add/replace) or identify (remove).",
+            },
+            "old_text": {
+                "type": "string",
+                "description": "For replace/remove: substring identifying the entry to change.",
+            },
+        },
+        "required": ["action", "content"],
+    },
+}
+
+DKG_QUERY_SCHEMA = {
+    "name": "dkg_query",
+    "description": (
+        "Query the DKG knowledge graph using SPARQL. Returns structured "
+        "results from your Working Memory, Shared Memory, or the full "
+        "Context Graph."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "sparql": {
+                "type": "string",
+                "description": "SPARQL query string.",
+            },
+            "context_graph": {
+                "type": "string",
+                "description": "Context Graph to query (default: current project).",
+            },
+        },
+        "required": ["sparql"],
+    },
+}
+
+DKG_SHARE_SCHEMA = {
+    "name": "dkg_share",
+    "description": (
+        "Share knowledge to Shared Working Memory — visible to all team "
+        "members and agents in the Context Graph. Free, gossip-replicated."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "Knowledge to share with the team.",
+            },
+            "context_graph": {
+                "type": "string",
+                "description": "Target Context Graph (default: current project).",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+DKG_PUBLISH_SCHEMA = {
+    "name": "dkg_publish",
+    "description": (
+        "Publish Shared Working Memory to Verified Memory — chain-anchored, "
+        "permanent, costs TRAC. Only use when knowledge is ready for "
+        "permanent record."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "context_graph": {
+                "type": "string",
+                "description": "Context Graph to publish from (default: current project).",
+            },
+        },
+        "required": [],
+    },
+}
+
+DKG_STATUS_SCHEMA = {
+    "name": "dkg_status",
+    "description": "Check DKG node health, connected peers, and Context Graph status.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+class DKGMemoryProvider(MemoryProvider):
+    """DKG V10 memory provider — DKG Working Memory as primary store."""
+
+    @property
+    def name(self) -> str:
+        return "dkg"
+
+    def __init__(self):
+        self._client = None
+        self._config: dict = {}
+        self._cache: dict = {}
+        self._context_graph: str = ""
+        self._assertion_id: str = ""
+        self._session_id: str = ""
+        self._agent_name: str = ""
+        self._offline: bool = False
+        self._lock = threading.Lock()
+        self._turn_count: int = 0
+
+    # -- Core lifecycle --------------------------------------------------------
+
+    def is_available(self) -> bool:
+        try:
+            cfg = _load_config()
+            return bool(cfg.get("daemon_url"))
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._session_id = session_id
+        self._cache = _load_cache()
+        self._agent_name = (
+            self._config.get("agent_name")
+            or kwargs.get("agent_identity", "")
+            or "hermes"
+        )
+        self._context_graph = self._config.get("context_graph", "hermes-memory")
+
+        # Create HTTP client
+        from plugins.memory.dkg.client import DKGClient
+        self._client = DKGClient(
+            base_url=self._config.get("daemon_url", "http://127.0.0.1:9200")
+        )
+
+        # Check daemon health
+        if not self._client.health_check():
+            logger.warning("[dkg] Daemon unreachable — starting in offline mode")
+            self._offline = True
+            return
+
+        # Register adapter with daemon
+        result = self._client.register_adapter("hermes", "hermes-agent")
+        if result.get("success") is False:
+            logger.warning(f"[dkg] Adapter registration failed: {result.get('error')}")
+
+        # Create or resolve assertion for this agent's Working Memory
+        result = self._client.create_assertion(
+            self._context_graph, self._agent_name, "hermes-memory"
+        )
+        if result.get("assertionId"):
+            self._assertion_id = result["assertionId"]
+            logger.info(f"[dkg] Assertion ready: {self._assertion_id}")
+        elif result.get("success") is False:
+            logger.warning(f"[dkg] Assertion creation failed: {result.get('error')} — using direct query")
+
+        # Flush any queued writes from previous offline session
+        self._flush_queued_writes()
+
+    def system_prompt_block(self) -> str:
+        """Recall facts from DKG assertion for system prompt injection."""
+        facts = self._recall_facts()
+        if not facts:
+            return (
+                "DKG memory is connected but empty. Use dkg_memory to store facts, "
+                "dkg_query to search, dkg_share to share with team, dkg_publish "
+                "to publish on-chain."
+            )
+
+        memory_facts = [f for f in facts if f.get("target") == "memory"]
+        user_facts = [f for f in facts if f.get("target") == "user"]
+
+        blocks = []
+        if memory_facts:
+            entries = _ENTRY_SEP.join(f["content"] for f in memory_facts)
+            blocks.append(
+                f"{'=' * 50}\n"
+                f"MEMORY [DKG Working Memory]\n"
+                f"{'=' * 50}\n"
+                f"{entries}"
+            )
+        if user_facts:
+            entries = _ENTRY_SEP.join(f["content"] for f in user_facts)
+            blocks.append(
+                f"{'=' * 50}\n"
+                f"USER PROFILE [DKG Working Memory]\n"
+                f"{'=' * 50}\n"
+                f"{entries}"
+            )
+
+        blocks.append(
+            "DKG tools available: dkg_memory (store facts), dkg_query (SPARQL), "
+            "dkg_share (share with team), dkg_publish (publish on-chain), "
+            "dkg_status (node health)."
+        )
+
+        return "\n\n".join(blocks)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [
+            DKG_MEMORY_SCHEMA,
+            DKG_QUERY_SCHEMA,
+            DKG_SHARE_SCHEMA,
+            DKG_PUBLISH_SCHEMA,
+            DKG_STATUS_SCHEMA,
+        ]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name == "dkg_memory":
+            return self._handle_memory(args)
+        elif tool_name == "dkg_query":
+            return self._handle_query(args)
+        elif tool_name == "dkg_share":
+            return self._handle_share(args)
+        elif tool_name == "dkg_publish":
+            return self._handle_publish(args)
+        elif tool_name == "dkg_status":
+            return self._handle_status(args)
+        return tool_error(f"Unknown DKG tool: {tool_name}")
+
+    # -- Prefetch --------------------------------------------------------------
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Recall relevant context from DKG before each turn."""
+        if self._offline or not self._client:
+            return ""
+
+        try:
+            # Simple text search across the context graph
+            sparql = (
+                f"SELECT ?s ?p ?o WHERE {{ "
+                f"?s ?p ?o . "
+                f"FILTER(ISLTERAL(?o) && CONTAINS(LCASE(STR(?o)), LCASE(\"{_escape_sparql(query)}\")))"
+                f"}} LIMIT 10"
+            )
+            result = self._client.query(sparql, self._context_graph)
+            bindings = result.get("results", {}).get("bindings", [])
+            if not bindings:
+                return ""
+
+            lines = []
+            for b in bindings[:10]:
+                s = b.get("s", {}).get("value", "?")
+                p = b.get("p", {}).get("value", "?")
+                o = b.get("o", {}).get("value", "?")
+                lines.append(f"  {_short(s)} — {_short(p)} — {o}")
+
+            return f"<dkg-context>\nRelevant knowledge from DKG:\n" + "\n".join(lines) + "\n</dkg-context>"
+        except Exception as e:
+            logger.debug(f"[dkg] Prefetch failed: {e}")
+            return ""
+
+    # -- Sync ------------------------------------------------------------------
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Send turn to daemon for entity extraction + persistence."""
+        self._turn_count += 1
+        if self._offline or not self._client:
+            # Queue for later sync
+            with self._lock:
+                self._cache.setdefault("queued_writes", []).append({
+                    "type": "turn",
+                    "session_id": self._session_id,
+                    "user": user_content[:2000],
+                    "assistant": assistant_content[:2000],
+                })
+                _save_cache(self._cache)
+            return
+
+        # Fire-and-forget in background thread
+        def _sync():
+            try:
+                self._client.store_turn(
+                    self._session_id,
+                    user_content[:2000],
+                    assistant_content[:2000],
+                )
+            except Exception as e:
+                logger.debug(f"[dkg] sync_turn failed: {e}")
+
+        threading.Thread(target=_sync, daemon=True).start()
+
+    # -- Lifecycle hooks -------------------------------------------------------
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in memory writes to DKG assertion."""
+        # When user uses the built-in memory tool, mirror the write to DKG
+        # so DKG stays as source of truth
+        self._handle_memory({
+            "action": action,
+            "target": target,
+            "content": content,
+            "old_text": content if action == "remove" else "",
+        })
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Finalize session: flush state to DKG and update local cache."""
+        if self._client and not self._offline:
+            try:
+                self._client.end_session(self._session_id, self._turn_count)
+            except Exception as e:
+                logger.debug(f"[dkg] end_session failed: {e}")
+
+        # Snapshot current facts to local cache for offline fallback
+        facts = self._recall_facts()
+        if facts:
+            with self._lock:
+                self._cache["memory"] = [f for f in facts if f.get("target") == "memory"]
+                self._cache["user"] = [f for f in facts if f.get("target") == "user"]
+                _save_cache(self._cache)
+
+    def shutdown(self) -> None:
+        """Close HTTP client."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    # -- Config ----------------------------------------------------------------
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "daemon_url",
+                "label": "DKG Daemon URL",
+                "type": "string",
+                "default": "http://127.0.0.1:9200",
+                "help": "URL of your running DKG V10 node.",
+            },
+            {
+                "key": "context_graph",
+                "label": "Context Graph",
+                "type": "string",
+                "default": "hermes-memory",
+                "help": "Name of the Context Graph for agent memory.",
+            },
+            {
+                "key": "agent_name",
+                "label": "Agent Name",
+                "type": "string",
+                "default": "",
+                "help": "Agent identity (leave empty to use Hermes profile name).",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "dkg.json"
+        config_path.write_text(json.dumps(values, indent=2), encoding="utf-8")
+
+    # -- Internal: memory operations -------------------------------------------
+
+    def _handle_memory(self, args: Dict[str, Any]) -> str:
+        action = args.get("action", "add")
+        target = args.get("target", "memory")
+        content = args.get("content", "")
+        old_text = args.get("old_text", "")
+
+        if not content:
+            return tool_error("Content is required.")
+
+        with self._lock:
+            entries = list(self._cache.get(target, []))
+
+            if action == "add":
+                entries.append({"target": target, "content": content})
+            elif action == "replace":
+                found = False
+                for i, e in enumerate(entries):
+                    if old_text and old_text in e.get("content", ""):
+                        entries[i] = {"target": target, "content": content}
+                        found = True
+                        break
+                if not found:
+                    entries.append({"target": target, "content": content})
+            elif action == "remove":
+                entries = [e for e in entries if content not in e.get("content", "")]
+
+            self._cache[target] = entries
+            _save_cache(self._cache)
+
+        # Write to DKG assertion if online
+        if self._client and not self._offline:
+            all_content = _ENTRY_SEP.join(e["content"] for e in entries)
+            try:
+                self._client.write_assertion(
+                    self._assertion_id or "default",
+                    f"[{target}]\n{all_content}",
+                )
+            except Exception as e:
+                logger.debug(f"[dkg] Assertion write failed: {e}")
+                self._cache.setdefault("queued_writes", []).append({
+                    "type": "memory",
+                    "action": action,
+                    "target": target,
+                    "content": content,
+                })
+                _save_cache(self._cache)
+
+        count = len(entries)
+        return json.dumps({
+            "success": True,
+            "action": action,
+            "target": target,
+            "entries": count,
+            "store": "dkg" if not self._offline else "local_cache",
+        })
+
+    def _handle_query(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot run SPARQL queries.")
+        sparql = args.get("sparql", "")
+        if not sparql:
+            return tool_error("SPARQL query is required.")
+        cg = args.get("context_graph", self._context_graph)
+        result = self._client.query(sparql, cg)
+        return json.dumps(result)
+
+    def _handle_share(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot share to team.")
+        content = args.get("content", "")
+        if not content:
+            return tool_error("Content is required.")
+        cg = args.get("context_graph", self._context_graph)
+        result = self._client.share(cg, content)
+        return json.dumps(result)
+
+    def _handle_publish(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return tool_error("DKG daemon is offline. Cannot publish to chain.")
+        cg = args.get("context_graph", self._context_graph)
+        result = self._client.publish(cg)
+        return json.dumps(result)
+
+    def _handle_status(self, args: Dict[str, Any]) -> str:
+        if self._offline:
+            return json.dumps({
+                "status": "offline",
+                "daemon_url": self._config.get("daemon_url"),
+                "cached_memory_entries": len(self._cache.get("memory", [])),
+                "cached_user_entries": len(self._cache.get("user", [])),
+                "queued_writes": len(self._cache.get("queued_writes", [])),
+            })
+
+        status = self._client.status()
+        cg_list = self._client.list_context_graphs()
+        return json.dumps({
+            "status": "connected",
+            "daemon_url": self._config.get("daemon_url"),
+            "node": status,
+            "context_graphs": cg_list,
+            "assertion_id": self._assertion_id,
+            "agent_name": self._agent_name,
+            "session_id": self._session_id,
+            "turn_count": self._turn_count,
+        })
+
+    # -- Internal: recall facts from DKG or cache ------------------------------
+
+    def _recall_facts(self) -> List[Dict[str, Any]]:
+        """Get all persistent facts from DKG assertion or cache."""
+        if self._offline or not self._client:
+            return self._cache.get("memory", []) + self._cache.get("user", [])
+
+        if not self._assertion_id:
+            return self._cache.get("memory", []) + self._cache.get("user", [])
+
+        try:
+            sparql = "SELECT ?content WHERE { ?s <urn:hermes:content> ?content }"
+            result = self._client.query_assertion(self._assertion_id, sparql)
+            bindings = result.get("results", {}).get("bindings", [])
+            if bindings:
+                facts = []
+                for b in bindings:
+                    content = b.get("content", {}).get("value", "")
+                    if content.startswith("[user]"):
+                        facts.append({"target": "user", "content": content[6:].strip()})
+                    elif content.startswith("[memory]"):
+                        facts.append({"target": "memory", "content": content[8:].strip()})
+                    else:
+                        facts.append({"target": "memory", "content": content})
+                return facts
+        except Exception as e:
+            logger.debug(f"[dkg] Recall from assertion failed: {e}")
+
+        return self._cache.get("memory", []) + self._cache.get("user", [])
+
+    def _flush_queued_writes(self) -> None:
+        """Flush any writes queued during offline period."""
+        queued = self._cache.get("queued_writes", [])
+        if not queued or self._offline:
+            return
+
+        logger.info(f"[dkg] Flushing {len(queued)} queued writes from offline period")
+        for item in queued:
+            try:
+                if item.get("type") == "turn":
+                    self._client.store_turn(
+                        item["session_id"],
+                        item.get("user", ""),
+                        item.get("assistant", ""),
+                    )
+                elif item.get("type") == "memory":
+                    self._handle_memory({
+                        "action": item["action"],
+                        "target": item["target"],
+                        "content": item["content"],
+                    })
+            except Exception as e:
+                logger.debug(f"[dkg] Failed to flush queued write: {e}")
+
+        with self._lock:
+            self._cache["queued_writes"] = []
+            _save_cache(self._cache)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _escape_sparql(text: str) -> str:
+    """Escape text for use in SPARQL string literal."""
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+
+
+def _short(uri: str) -> str:
+    """Shorten a URI for display."""
+    if "#" in uri:
+        return uri.split("#")[-1]
+    if "/" in uri:
+        return uri.split("/")[-1]
+    return uri
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register DKG as a memory provider plugin."""
+    ctx.register_memory_provider(DKGMemoryProvider())

--- a/packages/adapter-hermes/hermes-plugin/cli.py
+++ b/packages/adapter-hermes/hermes-plugin/cli.py
@@ -1,0 +1,109 @@
+"""CLI commands for the DKG memory plugin.
+
+Provides `hermes dkg status`, `hermes dkg query`, and `hermes dkg sync`
+for debugging and manual operations.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def register_cli(cli_group):
+    """Register DKG CLI commands with the Hermes CLI."""
+
+    import click
+
+    @cli_group.group("dkg")
+    def dkg():
+        """DKG node commands — status, query, sync."""
+        pass
+
+    @dkg.command("status")
+    def dkg_status():
+        """Show DKG node connection, context graphs, and assertion stats."""
+        from plugins.memory.dkg.client import DKGClient
+        from plugins.memory.dkg import _load_config, _load_cache
+
+        config = _load_config()
+        client = DKGClient(base_url=config.get("daemon_url", "http://127.0.0.1:9200"))
+
+        if not client.health_check():
+            cache = _load_cache()
+            click.echo("DKG Status: OFFLINE")
+            click.echo(f"  Daemon URL: {config.get('daemon_url')}")
+            click.echo(f"  Cached memory entries: {len(cache.get('memory', []))}")
+            click.echo(f"  Cached user entries: {len(cache.get('user', []))}")
+            click.echo(f"  Queued writes: {len(cache.get('queued_writes', []))}")
+            return
+
+        status = client.status()
+        cg_list = client.list_context_graphs()
+
+        click.echo("DKG Status: CONNECTED")
+        click.echo(f"  Daemon URL: {config.get('daemon_url')}")
+        click.echo(f"  Peer ID: {status.get('peerId', 'unknown')}")
+        click.echo(f"  Context Graph: {config.get('context_graph', 'hermes-memory')}")
+        if isinstance(cg_list, list):
+            click.echo(f"  Subscribed CGs: {len(cg_list)}")
+            for cg in cg_list[:5]:
+                name = cg.get("name", cg.get("id", "?"))
+                click.echo(f"    - {name}")
+        client.close()
+
+    @dkg.command("query")
+    @click.argument("sparql")
+    def dkg_query(sparql):
+        """Run a SPARQL query against the DKG node."""
+        from plugins.memory.dkg.client import DKGClient
+        from plugins.memory.dkg import _load_config
+
+        config = _load_config()
+        client = DKGClient(base_url=config.get("daemon_url", "http://127.0.0.1:9200"))
+
+        if not client.health_check():
+            click.echo("Error: DKG daemon is not reachable.", err=True)
+            sys.exit(1)
+
+        result = client.query(sparql, config.get("context_graph"))
+        click.echo(json.dumps(result, indent=2))
+        client.close()
+
+    @dkg.command("sync")
+    def dkg_sync():
+        """Force-sync local cache to DKG (useful after offline period)."""
+        from plugins.memory.dkg.client import DKGClient
+        from plugins.memory.dkg import _load_config, _load_cache, _save_cache
+
+        config = _load_config()
+        client = DKGClient(base_url=config.get("daemon_url", "http://127.0.0.1:9200"))
+
+        if not client.health_check():
+            click.echo("Error: DKG daemon is not reachable.", err=True)
+            sys.exit(1)
+
+        cache = _load_cache()
+        queued = cache.get("queued_writes", [])
+        if not queued:
+            click.echo("Nothing to sync — no queued writes.")
+            return
+
+        click.echo(f"Syncing {len(queued)} queued writes...")
+        synced = 0
+        for item in queued:
+            try:
+                if item.get("type") == "turn":
+                    client.store_turn(
+                        item["session_id"],
+                        item.get("user", ""),
+                        item.get("assistant", ""),
+                    )
+                    synced += 1
+            except Exception as e:
+                click.echo(f"  Failed: {e}")
+
+        cache["queued_writes"] = []
+        _save_cache(cache)
+        click.echo(f"Synced {synced}/{len(queued)} writes.")
+        client.close()

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -159,13 +159,16 @@ class DKGClient:
 
     # -- Hermes-specific routes (served by adapter-hermes on daemon) -----------
 
-    def store_turn(self, session_id: str, user_content: str, assistant_content: str) -> Dict[str, Any]:
+    def store_turn(self, session_id: str, user_content: str, assistant_content: str, agent_name: str = "") -> Dict[str, Any]:
         """POST /api/hermes/session-turn — persist turn + trigger entity extraction."""
-        return self._post("/api/hermes/session-turn", {
+        payload: Dict[str, Any] = {
             "sessionId": session_id,
             "user": user_content,
             "assistant": assistant_content,
-        })
+        }
+        if agent_name:
+            payload["agentName"] = agent_name
+        return self._post("/api/hermes/session-turn", payload)
 
     def end_session(self, session_id: str, turn_count: int = 0) -> Dict[str, Any]:
         """POST /api/hermes/session-end — finalize session."""

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +19,21 @@ _DEFAULT_URL = "http://127.0.0.1:9200"
 _TIMEOUT = 5  # seconds
 
 
+def _resolve_dkg_home() -> Path:
+    """Resolve the DKG data directory: $DKG_HOME > ~/.dkg."""
+    env = os.environ.get("DKG_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".dkg"
+
+
 def _load_auth_token() -> Optional[str]:
-    """Try to load auth token from ~/.dkg/auth.token."""
-    token_path = Path.home() / ".dkg" / "auth.token"
+    """Try to load auth token from $DKG_HOME/auth.token (or ~/.dkg/auth.token)."""
+    token_path = _resolve_dkg_home() / "auth.token"
     if not token_path.exists():
         return None
     try:
         lines = token_path.read_text(encoding="utf-8").strip().splitlines()
-        # Filter comment lines (may contain em dashes or other UTF-8)
         token_lines = [l.strip() for l in lines if l.strip() and not l.strip().startswith("#")]
         return token_lines[0] if token_lines else None
     except Exception:
@@ -106,36 +113,47 @@ class DKGClient:
 
     # -- Assertions (Working Memory) -------------------------------------------
 
-    def create_assertion(self, context_graph_id: str, agent_name: str, name: str = "hermes-memory") -> Dict[str, Any]:
-        """POST /api/assertion/create — create a WM assertion for this agent."""
-        return self._post("/api/assertion/create", {
+    def create_assertion(self, context_graph_id: str, name: str, sub_graph_name: Optional[str] = None) -> Dict[str, Any]:
+        """POST /api/assertion/create — create a WM assertion. Returns { assertionUri }."""
+        payload: Dict[str, Any] = {
             "contextGraphId": context_graph_id,
-            "agent": agent_name,
             "name": name,
+        }
+        if sub_graph_name:
+            payload["subGraphName"] = sub_graph_name
+        return self._post("/api/assertion/create", payload)
+
+    def write_assertion(self, assertion_name: str, context_graph_id: str, quads: List[Dict[str, str]],
+                        sub_graph_name: Optional[str] = None) -> Dict[str, Any]:
+        """POST /api/assertion/{name}/write — write quads to the assertion graph."""
+        payload: Dict[str, Any] = {
+            "contextGraphId": context_graph_id,
+            "quads": quads,
+        }
+        if sub_graph_name:
+            payload["subGraphName"] = sub_graph_name
+        return self._post(f"/api/assertion/{assertion_name}/write", payload)
+
+    def query_assertion(self, assertion_name: str, context_graph_id: str, sparql: str) -> Dict[str, Any]:
+        """POST /api/assertion/{name}/query — SPARQL within assertion scope."""
+        return self._post(f"/api/assertion/{assertion_name}/query", {
+            "sparql": sparql,
+            "contextGraphId": context_graph_id,
         })
 
-    def write_assertion(self, assertion_id: str, content: str, content_type: str = "text/plain") -> Dict[str, Any]:
-        """POST /api/assertion/{id}/write — write content to assertion."""
-        return self._post(f"/api/assertion/{assertion_id}/write", {
-            "content": content,
-            "contentType": content_type,
+    def promote_assertion(self, assertion_name: str, context_graph_id: str) -> Dict[str, Any]:
+        """POST /api/assertion/{name}/promote — promote assertion to SWM."""
+        return self._post(f"/api/assertion/{assertion_name}/promote", {
+            "contextGraphId": context_graph_id,
         })
-
-    def query_assertion(self, assertion_id: str, sparql: str) -> Dict[str, Any]:
-        """POST /api/assertion/{id}/query — SPARQL within assertion scope."""
-        return self._post(f"/api/assertion/{assertion_id}/query", {"sparql": sparql})
-
-    def promote_assertion(self, assertion_id: str) -> Dict[str, Any]:
-        """POST /api/assertion/{id}/promote — promote assertion to Verified Memory."""
-        return self._post(f"/api/assertion/{assertion_id}/promote", {})
 
     # -- Shared Working Memory -------------------------------------------------
 
-    def share(self, context_graph_id: str, content: str) -> Dict[str, Any]:
-        """POST /api/shared-memory/write — write to SWM (team-visible)."""
+    def share(self, context_graph_id: str, quads: List[Dict[str, str]]) -> Dict[str, Any]:
+        """POST /api/shared-memory/write — write quads to SWM (team-visible)."""
         return self._post("/api/shared-memory/write", {
             "contextGraphId": context_graph_id,
-            "content": content,
+            "quads": quads,
         })
 
     def publish(self, context_graph_id: str) -> Dict[str, Any]:

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -1,0 +1,186 @@
+"""HTTP client for the DKG V10 daemon API.
+
+Thin wrapper around requests that talks to the daemon at localhost:9200.
+All methods catch exceptions and return {success: False, error: "..."} —
+no exceptions leak to the agent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_URL = "http://127.0.0.1:9200"
+_TIMEOUT = 5  # seconds
+
+
+def _load_auth_token() -> Optional[str]:
+    """Try to load auth token from ~/.dkg/auth.token."""
+    token_path = Path.home() / ".dkg" / "auth.token"
+    if not token_path.exists():
+        return None
+    try:
+        lines = token_path.read_text(encoding="utf-8").strip().splitlines()
+        # Filter comment lines (may contain em dashes or other UTF-8)
+        token_lines = [l.strip() for l in lines if l.strip() and not l.strip().startswith("#")]
+        return token_lines[0] if token_lines else None
+    except Exception:
+        return None
+
+
+class DKGClient:
+    """HTTP client for DKG V10 daemon."""
+
+    def __init__(self, base_url: str = _DEFAULT_URL, timeout: int = _TIMEOUT):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._token = _load_auth_token()
+        self._session = None  # lazy
+
+    def _get_session(self):
+        if self._session is None:
+            import requests
+            self._session = requests.Session()
+            if self._token:
+                self._session.headers["Authorization"] = f"Bearer {self._token}"
+            self._session.headers["Content-Type"] = "application/json"
+        return self._session
+
+    def _get(self, path: str) -> Dict[str, Any]:
+        try:
+            r = self._get_session().get(f"{self.base_url}{path}", timeout=self.timeout)
+            r.raise_for_status()
+            return r.json()
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def _post(self, path: str, data: Dict[str, Any] = None) -> Dict[str, Any]:
+        try:
+            r = self._get_session().post(
+                f"{self.base_url}{path}",
+                data=json.dumps(data or {}),
+                timeout=self.timeout,
+            )
+            r.raise_for_status()
+            return r.json()
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    # -- Health ----------------------------------------------------------------
+
+    def health_check(self) -> bool:
+        """Quick reachability check. No exceptions."""
+        try:
+            r = self._get_session().get(f"{self.base_url}/api/status", timeout=2)
+            data = r.json()
+            return bool(data.get("peerId") or data.get("ok"))
+        except Exception:
+            return False
+
+    def status(self) -> Dict[str, Any]:
+        """GET /api/status — node info, peers, sync."""
+        return self._get("/api/status")
+
+    # -- Adapter registration --------------------------------------------------
+
+    def register_adapter(self, adapter_id: str = "hermes", framework: str = "hermes-agent") -> Dict[str, Any]:
+        """POST /api/register-adapter — tell daemon we're here."""
+        return self._post("/api/register-adapter", {
+            "id": adapter_id,
+            "framework": framework,
+        })
+
+    # -- SPARQL query ----------------------------------------------------------
+
+    def query(self, sparql: str, context_graph_id: Optional[str] = None) -> Dict[str, Any]:
+        """POST /api/query — run SPARQL on local triple store."""
+        payload: Dict[str, Any] = {"sparql": sparql}
+        if context_graph_id:
+            payload["contextGraphId"] = context_graph_id
+        return self._post("/api/query", payload)
+
+    # -- Assertions (Working Memory) -------------------------------------------
+
+    def create_assertion(self, context_graph_id: str, agent_name: str, name: str = "hermes-memory") -> Dict[str, Any]:
+        """POST /api/assertion/create — create a WM assertion for this agent."""
+        return self._post("/api/assertion/create", {
+            "contextGraphId": context_graph_id,
+            "agent": agent_name,
+            "name": name,
+        })
+
+    def write_assertion(self, assertion_id: str, content: str, content_type: str = "text/plain") -> Dict[str, Any]:
+        """POST /api/assertion/{id}/write — write content to assertion."""
+        return self._post(f"/api/assertion/{assertion_id}/write", {
+            "content": content,
+            "contentType": content_type,
+        })
+
+    def query_assertion(self, assertion_id: str, sparql: str) -> Dict[str, Any]:
+        """POST /api/assertion/{id}/query — SPARQL within assertion scope."""
+        return self._post(f"/api/assertion/{assertion_id}/query", {"sparql": sparql})
+
+    def promote_assertion(self, assertion_id: str) -> Dict[str, Any]:
+        """POST /api/assertion/{id}/promote — promote assertion to Verified Memory."""
+        return self._post(f"/api/assertion/{assertion_id}/promote", {})
+
+    # -- Shared Working Memory -------------------------------------------------
+
+    def share(self, context_graph_id: str, content: str) -> Dict[str, Any]:
+        """POST /api/shared-memory/write — write to SWM (team-visible)."""
+        return self._post("/api/shared-memory/write", {
+            "contextGraphId": context_graph_id,
+            "content": content,
+        })
+
+    def publish(self, context_graph_id: str) -> Dict[str, Any]:
+        """POST /api/shared-memory/publish — publish SWM to Verified Memory (costs TRAC)."""
+        return self._post("/api/shared-memory/publish", {
+            "contextGraphId": context_graph_id,
+        })
+
+    # -- Context Graphs --------------------------------------------------------
+
+    def list_context_graphs(self) -> Dict[str, Any]:
+        """GET /api/context-graph/list — list subscribed context graphs."""
+        return self._get("/api/context-graph/list")
+
+    def create_context_graph(self, name: str, description: str = "") -> Dict[str, Any]:
+        """POST /api/context-graph/create — create a new context graph."""
+        return self._post("/api/context-graph/create", {
+            "name": name,
+            "description": description,
+        })
+
+    # -- Hermes-specific routes (served by adapter-hermes on daemon) -----------
+
+    def store_turn(self, session_id: str, user_content: str, assistant_content: str) -> Dict[str, Any]:
+        """POST /api/hermes/session-turn — persist turn + trigger entity extraction."""
+        return self._post("/api/hermes/session-turn", {
+            "sessionId": session_id,
+            "user": user_content,
+            "assistant": assistant_content,
+        })
+
+    def end_session(self, session_id: str, turn_count: int = 0) -> Dict[str, Any]:
+        """POST /api/hermes/session-end — finalize session."""
+        return self._post("/api/hermes/session-end", {
+            "sessionId": session_id,
+            "turnCount": turn_count,
+        })
+
+    # -- Cleanup ---------------------------------------------------------------
+
+    def close(self):
+        """Close the HTTP session."""
+        if self._session:
+            try:
+                self._session.close()
+            except Exception:
+                pass
+            self._session = None

--- a/packages/adapter-hermes/hermes-plugin/plugin.yaml
+++ b/packages/adapter-hermes/hermes-plugin/plugin.yaml
@@ -1,0 +1,12 @@
+name: dkg
+version: 1.0.0
+description: >
+  DKG (Decentralized Knowledge Graph) memory provider. Stores all persistent
+  memory in DKG Working Memory assertions — verifiable, sharable, and
+  queryable via SPARQL. Connects to a running DKG V10 node via HTTP.
+  Agent knowledge can be promoted to Shared Working Memory (team-visible)
+  or published to Verified Memory (chain-anchored, costs TRAC).
+pip_dependencies: []
+hooks:
+  - on_session_end
+  - on_memory_write

--- a/packages/adapter-hermes/install.sh
+++ b/packages/adapter-hermes/install.sh
@@ -94,19 +94,53 @@ ln -sfn "$PLUGIN_SRC" "$PLUGIN_TARGET"
 
 if [ -L "$PLUGIN_TARGET" ] && [ -f "$PLUGIN_TARGET/__init__.py" ]; then
   echo "  Symlink created successfully."
-  echo ""
-  echo "Next steps:"
-  echo "  1. Run: hermes memory setup"
-  echo "  2. Select 'dkg' from the provider list"
-  echo "  3. Enter your DKG daemon URL (default: http://127.0.0.1:9200)"
-  echo ""
-  echo "  Or set directly in config.yaml:"
-  echo "    memory:"
-  echo "      provider: dkg"
-  echo ""
-  echo "  The DKG daemon must be running (dkg start) for full functionality."
-  echo "  If the daemon is not available, the plugin falls back to local cache."
 else
   echo "  Error: Symlink verification failed."
   exit 1
 fi
+
+# ── Daemon-side adapter setup ───────────────────────────────────────────────
+# The TypeScript daemon adapter serves /api/hermes/* routes. When running
+# the DKG node from the monorepo, these routes are already available.
+# For standalone installs, register the adapter with the running daemon.
+
+echo ""
+echo "Registering daemon-side adapter…"
+DKG_HOME="${DKG_HOME:-$HOME/.dkg}"
+TOKEN_FILE="$DKG_HOME/auth.token"
+DAEMON_URL="${DKG_DAEMON_URL:-http://127.0.0.1:9200}"
+
+AUTH_HEADER=""
+if [ -f "$TOKEN_FILE" ]; then
+  AUTH_TOKEN=$(grep -v '^#' "$TOKEN_FILE" | head -n1 | tr -d '[:space:]')
+  if [ -n "$AUTH_TOKEN" ]; then
+    AUTH_HEADER="Authorization: Bearer $AUTH_TOKEN"
+  fi
+fi
+
+REG_RESP=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST "$DAEMON_URL/api/register-adapter" \
+  -H "Content-Type: application/json" \
+  ${AUTH_HEADER:+-H "$AUTH_HEADER"} \
+  -d '{"id":"hermes","framework":"hermes-agent"}' 2>/dev/null || true)
+
+if [ "$REG_RESP" = "200" ] || [ "$REG_RESP" = "204" ]; then
+  echo "  Daemon adapter registered."
+elif [ "$REG_RESP" = "000" ]; then
+  echo "  Daemon not reachable at $DAEMON_URL — adapter will register on first connect."
+else
+  echo "  Daemon returned HTTP $REG_RESP — adapter may need manual registration."
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Run: hermes memory setup"
+echo "  2. Select 'dkg' from the provider list"
+echo "  3. Enter your DKG daemon URL (default: http://127.0.0.1:9200)"
+echo ""
+echo "  Or set directly in config.yaml:"
+echo "    memory:"
+echo "      provider: dkg"
+echo ""
+echo "  The DKG daemon must be running (dkg start) for full functionality."
+echo "  If the daemon is not available, the plugin falls back to local cache."

--- a/packages/adapter-hermes/install.sh
+++ b/packages/adapter-hermes/install.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# ============================================================================
+# DKG Hermes Adapter — Install Script
+#
+# Creates a symlink from the Hermes Agent's plugin directory to this adapter's
+# Python plugin, so Hermes discovers the DKG memory provider automatically.
+#
+# Usage:
+#   cd packages/adapter-hermes
+#   ./install.sh [path-to-hermes-agent]
+#
+# If no path is given, auto-detects from `which hermes` or common locations.
+# ============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_SRC="$SCRIPT_DIR/hermes-plugin"
+
+# Verify source exists
+if [ ! -f "$PLUGIN_SRC/__init__.py" ]; then
+  echo "Error: hermes-plugin/ directory not found at $PLUGIN_SRC"
+  echo "Run this script from packages/adapter-hermes/"
+  exit 1
+fi
+
+# ── Find Hermes Agent installation ──────────────────────────────────────────
+
+HERMES_DIR=""
+
+# Option 1: User provided path
+if [ -n "$1" ]; then
+  HERMES_DIR="$1"
+fi
+
+# Option 2: Auto-detect from `which hermes`
+if [ -z "$HERMES_DIR" ] && command -v hermes &>/dev/null; then
+  HERMES_BIN="$(which hermes)"
+  # Follow symlinks to find the real location
+  if [ -L "$HERMES_BIN" ]; then
+    HERMES_BIN="$(readlink -f "$HERMES_BIN" 2>/dev/null || readlink "$HERMES_BIN")"
+  fi
+  # Walk up to find the repo root (look for plugins/memory/)
+  CANDIDATE="$(dirname "$(dirname "$HERMES_BIN")")"
+  if [ -d "$CANDIDATE/plugins/memory" ]; then
+    HERMES_DIR="$CANDIDATE"
+  fi
+fi
+
+# Option 3: Common locations
+for CANDIDATE in \
+  "$HOME/.hermes/hermes-agent" \
+  "$HOME/hermes-agent" \
+  "../../../hermes-agent" \
+  "../../hermes-agent" \
+  ; do
+  if [ -z "$HERMES_DIR" ] && [ -d "$CANDIDATE/plugins/memory" ]; then
+    HERMES_DIR="$(cd "$CANDIDATE" && pwd)"
+  fi
+done
+
+if [ -z "$HERMES_DIR" ] || [ ! -d "$HERMES_DIR/plugins/memory" ]; then
+  echo "Error: Could not find Hermes Agent installation."
+  echo ""
+  echo "Usage: ./install.sh /path/to/hermes-agent"
+  echo ""
+  echo "The path should contain a plugins/memory/ directory."
+  exit 1
+fi
+
+PLUGIN_TARGET="$HERMES_DIR/plugins/memory/dkg"
+
+echo "DKG Hermes Adapter Installer"
+echo "============================"
+echo ""
+echo "  Source:  $PLUGIN_SRC"
+echo "  Target:  $PLUGIN_TARGET"
+echo ""
+
+# ── Create symlink ──────────────────────────────────────────────────────────
+
+if [ -L "$PLUGIN_TARGET" ]; then
+  echo "  Existing symlink found — replacing..."
+  rm "$PLUGIN_TARGET"
+elif [ -d "$PLUGIN_TARGET" ]; then
+  echo "  Warning: $PLUGIN_TARGET is a regular directory."
+  echo "  Moving to $PLUGIN_TARGET.bak"
+  mv "$PLUGIN_TARGET" "$PLUGIN_TARGET.bak"
+fi
+
+ln -sfn "$PLUGIN_SRC" "$PLUGIN_TARGET"
+
+# ── Verify ──────────────────────────────────────────────────────────────────
+
+if [ -L "$PLUGIN_TARGET" ] && [ -f "$PLUGIN_TARGET/__init__.py" ]; then
+  echo "  Symlink created successfully."
+  echo ""
+  echo "Next steps:"
+  echo "  1. Run: hermes memory setup"
+  echo "  2. Select 'dkg' from the provider list"
+  echo "  3. Enter your DKG daemon URL (default: http://127.0.0.1:9200)"
+  echo ""
+  echo "  Or set directly in config.yaml:"
+  echo "    memory:"
+  echo "      provider: dkg"
+  echo ""
+  echo "  The DKG daemon must be running (dkg start) for full functionality."
+  echo "  If the daemon is not available, the plugin falls back to local cache."
+else
+  echo "  Error: Symlink verification failed."
+  exit 1
+fi

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -13,6 +13,8 @@
   },
   "files": [
     "dist",
+    "hermes-plugin",
+    "install.sh",
     "README.md",
     "LICENSE"
   ],

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@origintrail-official/dkg-adapter-hermes",
+  "version": "0.0.1",
+  "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run --passWithNoTests",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@origintrail-official/dkg-core": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "directory": "packages/adapter-hermes"
+  }
+}

--- a/packages/adapter-hermes/src/HermesAdapterPlugin.ts
+++ b/packages/adapter-hermes/src/HermesAdapterPlugin.ts
@@ -1,0 +1,50 @@
+/**
+ * HermesAdapterPlugin — Connects Hermes AI agents to a DKG V10 node.
+ *
+ * Lightweight adapter following the OpenClaw adapter pattern but simpler:
+ * - No channel bridge (Hermes has its own CLI/gateway system)
+ * - No game plugin
+ * - No write-capture (daemon's importMemories handles entity extraction)
+ *
+ * The Hermes Python plugin (plugins/memory/dkg/) talks to this adapter
+ * via HTTP at localhost:9200/api/hermes/*. All heavy lifting (triple store,
+ * P2P networking, publishing) is delegated to the daemon's DKGAgent.
+ */
+
+import type { DaemonPluginApi, HermesAdapterConfig } from './types.js';
+import { registerHermesRoutes } from './hermes-routes.js';
+
+export class HermesAdapterPlugin {
+  private readonly config: HermesAdapterConfig;
+  private initialized = false;
+
+  constructor(config?: HermesAdapterConfig) {
+    this.config = { ...config };
+  }
+
+  /**
+   * Register the Hermes adapter with the daemon.
+   *
+   * Called by the daemon when loading adapters. Registers HTTP routes
+   * and lifecycle hooks.
+   */
+  register(api: DaemonPluginApi): void {
+    if (this.initialized) {
+      // Multi-phase init: just log, routes are already registered
+      api.logger.debug?.('[hermes] Re-registration skipped (already initialized)');
+      return;
+    }
+    this.initialized = true;
+
+    // Register Hermes-specific HTTP routes
+    registerHermesRoutes(api);
+    api.logger.info?.('[hermes] Hermes adapter routes registered (/api/hermes/*)');
+
+    // Register cleanup hook
+    api.registerHook('session_end', async () => {
+      api.logger.info?.('[hermes] Daemon shutting down — Hermes adapter cleanup');
+    }, { name: 'hermes-adapter-stop' });
+
+    api.logger.info?.('[hermes] Hermes Agent adapter initialized');
+  }
+}

--- a/packages/adapter-hermes/src/hermes-routes.ts
+++ b/packages/adapter-hermes/src/hermes-routes.ts
@@ -20,12 +20,14 @@ export function registerHermesRoutes(api: DaemonPluginApi): void {
     path: '/api/hermes/session-turn',
     handler: async (req, res) => {
       try {
-        const body: SessionTurnPayload = req.body;
+        const body = req.body as SessionTurnPayload & { agentName?: string };
 
         if (!body.sessionId || (!body.user && !body.assistant)) {
           res.status(400).json({ success: false, error: 'sessionId and at least one of user/assistant required' });
           return;
         }
+
+        const agentTag = body.agentName ? `${body.agentName}:` : '';
 
         // Store the chat turn for session history
         if (api.agent.storeChatTurn) {
@@ -33,13 +35,13 @@ export function registerHermesRoutes(api: DaemonPluginApi): void {
         }
 
         // Extract entities from the assistant's response using the daemon's
-        // LLM pipeline. This is the key integration point — the daemon handles
-        // entity extraction, the Python plugin just sends raw text.
+        // LLM pipeline. agentName is included in the source tag so entities
+        // are scoped to the correct agent's assertion in the triple store.
         if (api.agent.importMemories && body.assistant) {
           try {
             await api.agent.importMemories(
               body.assistant,
-              `hermes-session:${body.sessionId}`,
+              `${agentTag}hermes-session:${body.sessionId}`,
             );
           } catch (extractErr) {
             // Non-fatal: entity extraction failure shouldn't break turn persistence

--- a/packages/adapter-hermes/src/hermes-routes.ts
+++ b/packages/adapter-hermes/src/hermes-routes.ts
@@ -1,0 +1,98 @@
+/**
+ * HTTP routes for the Hermes adapter.
+ *
+ * Registered on the daemon at /api/hermes/* — these are the endpoints
+ * the Python DKGMemoryProvider calls via its HTTP client.
+ */
+
+import type { DaemonPluginApi, SessionTurnPayload, SessionEndPayload } from './types.js';
+
+/**
+ * Register Hermes-specific HTTP routes on the daemon.
+ */
+export function registerHermesRoutes(api: DaemonPluginApi): void {
+
+  // ── POST /api/hermes/session-turn ──────────────────────────────────────
+  // Receives a chat turn from the Hermes agent. Persists it and triggers
+  // entity extraction via the daemon's importMemories pipeline.
+  api.registerHttpRoute({
+    method: 'POST',
+    path: '/api/hermes/session-turn',
+    handler: async (req, res) => {
+      try {
+        const body: SessionTurnPayload = req.body;
+
+        if (!body.sessionId || (!body.user && !body.assistant)) {
+          res.status(400).json({ success: false, error: 'sessionId and at least one of user/assistant required' });
+          return;
+        }
+
+        // Store the chat turn for session history
+        if (api.agent.storeChatTurn) {
+          await api.agent.storeChatTurn(body.sessionId, body.user ?? '', body.assistant ?? '');
+        }
+
+        // Extract entities from the assistant's response using the daemon's
+        // LLM pipeline. This is the key integration point — the daemon handles
+        // entity extraction, the Python plugin just sends raw text.
+        if (api.agent.importMemories && body.assistant) {
+          try {
+            await api.agent.importMemories(
+              body.assistant,
+              `hermes-session:${body.sessionId}`,
+            );
+          } catch (extractErr) {
+            // Non-fatal: entity extraction failure shouldn't break turn persistence
+            api.logger.debug?.(`[hermes] Entity extraction failed: ${extractErr}`);
+          }
+        }
+
+        res.json({ success: true, sessionId: body.sessionId });
+      } catch (err) {
+        api.logger.warn?.(`[hermes] session-turn error: ${err}`);
+        res.status(500).json({ success: false, error: String(err) });
+      }
+    },
+  });
+
+  // ── POST /api/hermes/session-end ───────────────────────────────────────
+  // Called when the Hermes agent session ends. Finalizes session metadata.
+  api.registerHttpRoute({
+    method: 'POST',
+    path: '/api/hermes/session-end',
+    handler: async (req, res) => {
+      try {
+        const body: SessionEndPayload = req.body;
+
+        if (!body.sessionId) {
+          res.status(400).json({ success: false, error: 'sessionId required' });
+          return;
+        }
+
+        api.logger.info?.(
+          `[hermes] Session ended: ${body.sessionId} (${body.turnCount ?? 0} turns)`,
+        );
+
+        res.json({ success: true, sessionId: body.sessionId });
+      } catch (err) {
+        api.logger.warn?.(`[hermes] session-end error: ${err}`);
+        res.status(500).json({ success: false, error: String(err) });
+      }
+    },
+  });
+
+  // ── GET /api/hermes/status ─────────────────────────────────────────────
+  // Adapter-specific status — shows the Hermes adapter is connected.
+  api.registerHttpRoute({
+    method: 'GET',
+    path: '/api/hermes/status',
+    handler: async (_req, res) => {
+      res.json({
+        adapter: 'hermes',
+        framework: 'hermes-agent',
+        status: 'connected',
+        version: '0.0.1',
+      });
+    },
+  });
+}

--- a/packages/adapter-hermes/src/index.ts
+++ b/packages/adapter-hermes/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @origintrail-official/dkg-adapter-hermes
+ *
+ * Connects Hermes AI agents to a DKG V10 node for verifiable shared memory.
+ * The Hermes Python plugin (plugins/memory/dkg/) talks to this adapter
+ * via HTTP. All knowledge goes through DKG Working Memory assertions.
+ */
+
+export { HermesAdapterPlugin } from './HermesAdapterPlugin.js';
+export type {
+  HermesAdapterConfig,
+  DaemonPluginApi,
+  SessionTurnPayload,
+  SessionEndPayload,
+} from './types.js';

--- a/packages/adapter-hermes/src/types.ts
+++ b/packages/adapter-hermes/src/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Configuration for the Hermes Agent adapter.
+ */
+export interface HermesAdapterConfig {
+  /** Base URL of the DKG daemon (default: "http://127.0.0.1:9200"). */
+  daemonUrl?: string;
+}
+
+/**
+ * Session turn payload from the Hermes Python plugin.
+ */
+export interface SessionTurnPayload {
+  sessionId: string;
+  user: string;
+  assistant: string;
+}
+
+/**
+ * Session end payload from the Hermes Python plugin.
+ */
+export interface SessionEndPayload {
+  sessionId: string;
+  turnCount?: number;
+}
+
+/**
+ * Daemon plugin API — the interface the daemon provides to adapters
+ * for registering HTTP routes and lifecycle hooks.
+ *
+ * This mirrors the OpenClaw adapter pattern but is framework-agnostic.
+ */
+export interface DaemonPluginApi {
+  /** Register an HTTP route on the daemon server. */
+  registerHttpRoute(route: {
+    method: 'GET' | 'POST';
+    path: string;
+    handler: (req: any, res: any) => Promise<void>;
+  }): void;
+
+  /** Register a lifecycle hook. */
+  registerHook(event: string, handler: () => Promise<void>, opts?: { name?: string }): void;
+
+  /** Logger. */
+  logger: {
+    info?(...args: any[]): void;
+    warn?(...args: any[]): void;
+    debug?(...args: any[]): void;
+  };
+
+  /** Access to the DKG agent instance running in the daemon. */
+  agent: {
+    query(sparql: string, opts?: { contextGraphId?: string }): Promise<any>;
+    share(contextGraphId: string, quads: any[], opts?: any): Promise<any>;
+    importMemories?(text: string, source?: string): Promise<any>;
+    storeChatTurn?(sessionId: string, user: string, assistant: string): Promise<any>;
+  };
+}

--- a/packages/adapter-hermes/tsconfig.json
+++ b/packages/adapter-hermes/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"]
+}

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -525,7 +525,7 @@ export class DkgNodePlugin {
     try {
       const result = await this.client.listContextGraphs();
       const graphs = result.contextGraphs;
-      return this.json({ contextGraphs: graphs, paranets: graphs, count: graphs.length });
+      return this.json({ contextGraphs: graphs, count: graphs.length });
     } catch (err: any) {
       return this.daemonError(err);
     }

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -193,9 +193,9 @@ export class DkgDaemonClient {
         'privateQuads, accessPolicy, and allowedPeers are not supported in V10 SWM-first publish',
       );
     }
-    await this.post('/api/shared-memory/write', { paranetId: contextGraphId, quads });
+    await this.post('/api/shared-memory/write', { contextGraphId, quads });
     return this.post('/api/shared-memory/publish', {
-      paranetId: contextGraphId,
+      contextGraphId,
       selection: 'all',
       clearAfter: true,
     });

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -301,14 +301,14 @@ describe('DkgDaemonClient', () => {
     expect(writeUrl).toBe('http://localhost:9200/api/shared-memory/write');
     expect(writeOpts?.method).toBe('POST');
     const writeBody = JSON.parse(writeOpts?.body as string);
-    expect(writeBody.paranetId).toBe('testing');
+    expect(writeBody.contextGraphId).toBe('testing');
     expect(writeBody.quads).toHaveLength(1);
 
     const [pubUrl, pubOpts] = fetchSpy.mock.calls[1];
     expect(pubUrl).toBe('http://localhost:9200/api/shared-memory/publish');
     expect(pubOpts?.method).toBe('POST');
     const pubBody = JSON.parse(pubOpts?.body as string);
-    expect(pubBody.paranetId).toBe('testing');
+    expect(pubBody.contextGraphId).toBe('testing');
     expect(pubBody.selection).toBe('all');
   });
 

--- a/packages/adapter-openclaw/test/list-paranets.test.ts
+++ b/packages/adapter-openclaw/test/list-paranets.test.ts
@@ -170,7 +170,7 @@ describe('dkg_publish tool', () => {
     expect(parsed.quadsPublished).toBe(2);
 
     const writeBody = JSON.parse(fetchSpy.mock.calls[1][1]?.body as string);
-    expect(writeBody.paranetId).toBe('testing');
+    expect(writeBody.contextGraphId).toBe('testing');
     expect(writeBody.quads).toHaveLength(2);
     expect(writeBody.quads[0].subject).toBe('https://example.org/wine');
     expect(writeBody.quads[0].object).toBe('"Cabernet Sauvignon"');

--- a/packages/agent/test/e2e-sub-graph-gossip.test.ts
+++ b/packages/agent/test/e2e-sub-graph-gossip.test.ts
@@ -200,6 +200,7 @@ describe('Multiple sub-graphs with concurrent writes (3 nodes)', () => {
 
     await nodes[0].createSubGraph(CG, 'alpha');
     await nodes[0].createSubGraph(CG, 'beta');
+    await nodes[1].createSubGraph(CG, 'beta');
 
     // Node A writes to alpha, Node B writes to beta
     await Promise.all([

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -57,6 +57,45 @@ describe('decodeEvmError / enrichEvmError (07 EVM_MODULE — custom errors)', ()
   it('enrichEvmError returns null when message has no data=', () => {
     expect(enrichEvmError(new Error('rpc failed'))).toBeNull();
   });
+
+  it('decodes NotBatchPublisher from V10 contract errors', () => {
+    const iface = new Interface(['error NotBatchPublisher(uint256 batchId, address caller)']);
+    const data = iface.encodeErrorResult('NotBatchPublisher', [5n, '0x0000000000000000000000000000000000000001']);
+    const d = decodeEvmError(data);
+    expect(d).not.toBeNull();
+    expect(d!.name).toBe('NotBatchPublisher');
+    expect(d!.args[0]).toBe(5n);
+  });
+
+  it('decodes KnowledgeCollectionExpired', () => {
+    const iface = new Interface(['error KnowledgeCollectionExpired(uint256 id, uint256 currentEpoch, uint256 endEpoch)']);
+    const data = iface.encodeErrorResult('KnowledgeCollectionExpired', [1n, 100n, 50n]);
+    const d = decodeEvmError(data);
+    expect(d).not.toBeNull();
+    expect(d!.name).toBe('KnowledgeCollectionExpired');
+  });
+
+  it('decodes CannotUpdateImmutableKnowledgeCollection', () => {
+    const iface = new Interface(['error CannotUpdateImmutableKnowledgeCollection(uint256 id)']);
+    const data = iface.encodeErrorResult('CannotUpdateImmutableKnowledgeCollection', [7n]);
+    const d = decodeEvmError(data);
+    expect(d).not.toBeNull();
+    expect(d!.name).toBe('CannotUpdateImmutableKnowledgeCollection');
+  });
+
+  it('enrichEvmError returns decoded name for V10 errors', () => {
+    const iface = new Interface(['error NotBatchPublisher(uint256 batchId, address caller)']);
+    const data = iface.encodeErrorResult('NotBatchPublisher', [3n, '0x0000000000000000000000000000000000000001']);
+    const err = new Error(`execution reverted (unknown custom error data="${data}")`);
+    const name = enrichEvmError(err);
+    expect(name).toBe('NotBatchPublisher');
+    expect(err.message).toContain('NotBatchPublisher');
+    expect(err.message).not.toContain('unknown custom error');
+  });
+
+  it('returns null for unrecognized error selector', () => {
+    expect(decodeEvmError('0xdeadbeef')).toBeNull();
+  });
 });
 
 describe('EVMChainAdapter constructor / getters (no init)', () => {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -112,12 +112,12 @@ export class ApiClient {
     subject: string; predicate: string; object: string; graph: string;
   }>): Promise<{
     workspaceOperationId: string;
-    paranetId: string;
+    contextGraphId: string;
     graph: string;
     triplesWritten: number;
     skolemizedBlankNodes?: number;
   }> {
-    return this.post('/api/shared-memory/write', { paranetId: contextGraphId, quads });
+    return this.post('/api/shared-memory/write', { contextGraphId, quads });
   }
 
   /** @deprecated Use sharedMemoryWrite */
@@ -125,7 +125,7 @@ export class ApiClient {
     subject: string; predicate: string; object: string; graph: string;
   }>): Promise<{
     workspaceOperationId: string;
-    paranetId: string;
+    contextGraphId: string;
     graph: string;
     triplesWritten: number;
     skolemizedBlankNodes?: number;
@@ -145,7 +145,7 @@ export class ApiClient {
     txHash?: string;
     blockNumber?: number;
   }> {
-    return this.post('/api/shared-memory/publish', { paranetId: contextGraphId, selection, clearAfter });
+    return this.post('/api/shared-memory/publish', { contextGraphId, selection, clearAfter });
   }
 
   /** @deprecated Use publishFromSharedMemory */
@@ -208,12 +208,12 @@ export class ApiClient {
   }
 
   async query(sparql: string, contextGraphId?: string): Promise<{ result: QueryResult }> {
-    return this.post('/api/query', { sparql, paranetId: contextGraphId });
+    return this.post('/api/query', { sparql, contextGraphId });
   }
 
   async queryRemote(peerId: string, request: {
     lookupType: string;
-    paranetId?: string;
+    contextGraphId?: string;
     ual?: string;
     entityUri?: string;
     rdfType?: string;
@@ -250,7 +250,7 @@ export class ApiClient {
         jobId: string;
       };
   }> {
-    return this.post('/api/subscribe', { paranetId: contextGraphId, includeWorkspace: options?.includeSharedMemory });
+    return this.post('/api/context-graph/subscribe', { contextGraphId, includeWorkspace: options?.includeSharedMemory });
   }
 
   /** @deprecated Use subscribeToContextGraph */
@@ -275,7 +275,7 @@ export class ApiClient {
 
   async catchupStatus(contextGraphId: string): Promise<{
     jobId: string;
-    paranetId: string;
+    contextGraphId: string;
     includeWorkspace: boolean;
     status: 'queued' | 'running' | 'done' | 'failed';
     queuedAt: number;
@@ -290,7 +290,7 @@ export class ApiClient {
     };
     error?: string;
   }> {
-    return this.get(`/api/sync/catchup-status?paranetId=${encodeURIComponent(contextGraphId)}`);
+    return this.get(`/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
   }
 
   async connect(multiaddr: string): Promise<{ connected: boolean }> {
@@ -313,7 +313,7 @@ export class ApiClient {
   }
 
   async listContextGraphs(): Promise<{
-    paranets: Array<{
+    contextGraphs: Array<{
       id: string;
       uri: string;
       name: string;
@@ -328,7 +328,7 @@ export class ApiClient {
 
   /** @deprecated Use listContextGraphs */
   async listParanets(): Promise<{
-    paranets: Array<{
+    contextGraphs: Array<{
       id: string;
       uri: string;
       name: string;
@@ -369,7 +369,7 @@ export class ApiClient {
   }
 
   async publishCclPolicy(request: {
-    paranetId: string;
+    contextGraphId: string;
     name: string;
     version: string;
     content: string;
@@ -382,7 +382,7 @@ export class ApiClient {
   }
 
   async approveCclPolicy(request: {
-    paranetId: string;
+    contextGraphId: string;
     policyUri: string;
     contextType?: string;
   }): Promise<{ policyUri: string; bindingUri: string; contextType?: string; approvedAt: string }> {
@@ -390,7 +390,7 @@ export class ApiClient {
   }
 
   async revokeCclPolicy(request: {
-    paranetId: string;
+    contextGraphId: string;
     policyUri: string;
     contextType?: string;
   }): Promise<{ policyUri: string; bindingUri: string; contextType?: string; revokedAt: string; status: 'revoked' }> {
@@ -398,14 +398,14 @@ export class ApiClient {
   }
 
   async listCclPolicies(opts: {
-    paranetId?: string;
+    contextGraphId?: string;
     name?: string;
     contextType?: string;
     status?: string;
     includeBody?: boolean;
   } = {}): Promise<{ policies: any[] }> {
     const params = new URLSearchParams();
-    if (opts.paranetId) params.set('paranetId', opts.paranetId);
+    if (opts.contextGraphId) params.set('contextGraphId', opts.contextGraphId);
     if (opts.name) params.set('name', opts.name);
     if (opts.contextType) params.set('contextType', opts.contextType);
     if (opts.status) params.set('status', opts.status);
@@ -415,19 +415,19 @@ export class ApiClient {
   }
 
   async resolveCclPolicy(opts: {
-    paranetId: string;
+    contextGraphId: string;
     name: string;
     contextType?: string;
     includeBody?: boolean;
   }): Promise<{ policy: any | null }> {
-    const params = new URLSearchParams({ paranetId: opts.paranetId, name: opts.name });
+    const params = new URLSearchParams({ contextGraphId: opts.contextGraphId, name: opts.name });
     if (opts.contextType) params.set('contextType', opts.contextType);
     if (opts.includeBody) params.set('includeBody', 'true');
     return this.get(`/api/ccl/policy/resolve?${params.toString()}`);
   }
 
   async evaluateCclPolicy(request: {
-    paranetId: string;
+    contextGraphId: string;
     name: string;
     facts?: Array<[string, ...unknown[]]>;
     contextType?: string;
@@ -448,7 +448,7 @@ export class ApiClient {
   }
 
   async listCclEvaluations(opts: {
-    paranetId: string;
+    contextGraphId: string;
     policyUri?: string;
     snapshotId?: string;
     view?: string;
@@ -456,7 +456,7 @@ export class ApiClient {
     resultKind?: 'derived' | 'decision';
     resultName?: string;
   }): Promise<{ evaluations: any[] }> {
-    const params = new URLSearchParams({ paranetId: opts.paranetId });
+    const params = new URLSearchParams({ contextGraphId: opts.contextGraphId });
     if (opts.policyUri) params.set('policyUri', opts.policyUri);
     if (opts.snapshotId) params.set('snapshotId', opts.snapshotId);
     if (opts.view) params.set('view', opts.view);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -925,7 +925,7 @@ program
 
       let lookupType: string;
       const request: Record<string, any> = { // eslint-disable-line @typescript-eslint/no-explicit-any
-        paranetId: contextGraphId,
+        contextGraphId,
         limit: parseInt(opts.limit, 10),
         timeout: parseInt(opts.timeout, 10),
       };
@@ -1067,7 +1067,7 @@ syncCmd
       const client = await ApiClient.connect();
       const status = await client.catchupStatus(contextGraph);
 
-      console.log(`Context Graph: ${status.paranetId}`);
+      console.log(`Context Graph: ${status.contextGraphId}`);
       console.log(`Job:           ${status.jobId}`);
       console.log(`Status:        ${status.status}`);
       console.log(`Shared Memory: ${status.includeWorkspace ? 'enabled' : 'disabled'}`);
@@ -1132,7 +1132,7 @@ contextGraphCmd
   .action(async () => {
     try {
       const client = await ApiClient.connect();
-      const { paranets: contextGraphs } = await client.listContextGraphs();
+      const { contextGraphs } = await client.listContextGraphs();
 
       if (contextGraphs.length === 0) {
         console.log('No context graphs registered yet.');
@@ -1166,8 +1166,8 @@ contextGraphCmd
   .action(async (id: string) => {
     try {
       const client = await ApiClient.connect();
-      const { paranets: contextGraphs } = await client.listContextGraphs();
-      const p = contextGraphs.find(x => x.id === id);
+      const { contextGraphs } = await client.listContextGraphs();
+      const p = contextGraphs.find((x: any) => x.id === id);
       if (!p) {
         console.error(`Context graph "${id}" not found.`);
         process.exit(1);
@@ -1231,7 +1231,7 @@ const cclPolicyCmd = cclCmd
   .description('Publish, approve, revoke, list, and resolve CCL policies');
 
 cclPolicyCmd
-  .command('publish <paranetId>')
+  .command('publish <contextGraphId>')
   .description('Publish a CCL policy proposal into the ontology graph')
   .requiredOption('--name <name>', 'Policy name')
   .requiredOption('--version <version>', 'Policy version')
@@ -1240,12 +1240,12 @@ cclPolicyCmd
   .option('--context-type <contextType>', 'Optional stricter context override scope')
   .option('--language <language>', 'Policy language identifier', 'ccl/v0.1')
   .option('--format <format>', 'Canonical policy format', 'canonical-yaml')
-  .action(async (paranetId: string, opts: ActionOpts) => {
+  .action(async (contextGraphId: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
       const content = readFileSync(opts.file, 'utf8');
       const result = await client.publishCclPolicy({
-        paranetId,
+        contextGraphId,
         name: opts.name,
         version: opts.version,
         content,
@@ -1265,13 +1265,13 @@ cclPolicyCmd
   });
 
 cclPolicyCmd
-  .command('approve <paranetId> <policyUri>')
-  .description('Approve a published CCL policy for a paranet or context override')
+  .command('approve <contextGraphId> <policyUri>')
+  .description('Approve a published CCL policy for a context graph')
   .option('--context-type <contextType>', 'Optional stricter context override scope')
-  .action(async (paranetId: string, policyUri: string, opts: ActionOpts) => {
+  .action(async (contextGraphId: string, policyUri: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
-      const result = await client.approveCclPolicy({ paranetId, policyUri, contextType: opts.contextType });
+      const result = await client.approveCclPolicy({ contextGraphId, policyUri, contextType: opts.contextType });
       console.log(`Policy approved:`);
       console.log(`  Policy:   ${result.policyUri}`);
       console.log(`  Binding:  ${result.bindingUri}`);
@@ -1284,13 +1284,13 @@ cclPolicyCmd
   });
 
 cclPolicyCmd
-  .command('revoke <paranetId> <policyUri>')
-  .description('Revoke the currently active CCL policy binding for a paranet or context override')
+  .command('revoke <contextGraphId> <policyUri>')
+  .description('Revoke the currently active CCL policy binding for a context graph')
   .option('--context-type <contextType>', 'Optional stricter context override scope')
-  .action(async (paranetId: string, policyUri: string, opts: ActionOpts) => {
+  .action(async (contextGraphId: string, policyUri: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
-      const result = await client.revokeCclPolicy({ paranetId, policyUri, contextType: opts.contextType });
+      const result = await client.revokeCclPolicy({ contextGraphId, policyUri, contextType: opts.contextType });
       console.log(`Policy revoked:`);
       console.log(`  Policy:   ${result.policyUri}`);
       console.log(`  Binding:  ${result.bindingUri}`);
@@ -1315,7 +1315,7 @@ cclPolicyCmd
     try {
       const client = await ApiClient.connect();
       const { policies } = await client.listCclPolicies({
-        paranetId: opts.paranet,
+        contextGraphId: opts.paranet,
         name: opts.name,
         contextType: opts.contextType,
         status: opts.status,
@@ -1327,9 +1327,9 @@ cclPolicyCmd
       }
       for (const policy of policies) {
         console.log(`${policy.name}@${policy.version}  ${policy.policyUri}`);
-        console.log(`  Paranet: ${policy.paranetId}`);
-        console.log(`  Status:  ${policy.status}${policy.isActiveDefault ? ' (active default)' : ''}`);
-        if (policy.contextType) console.log(`  Context: ${policy.contextType}`);
+      console.log(`  Context Graph: ${policy.contextGraphId ?? policy.paranetId}`);
+      console.log(`  Status:        ${policy.status}${policy.isActiveDefault ? ' (active default)' : ''}`);
+      if (policy.contextType) console.log(`  Context:       ${policy.contextType}`);
         if (policy.activeContexts?.length) console.log(`  Active in contexts: ${policy.activeContexts.join(', ')}`);
         console.log(`  Hash:    ${policy.hash}`);
         if (policy.description) console.log(`  Desc:    ${policy.description}`);
@@ -1342,16 +1342,16 @@ cclPolicyCmd
   });
 
 cclPolicyCmd
-  .command('resolve <paranetId>')
-  .description('Resolve the active approved policy for a paranet and policy name')
+  .command('resolve <contextGraphId>')
+  .description('Resolve the active approved policy for a context graph and policy name')
   .requiredOption('--name <name>', 'Policy name')
   .option('--context-type <contextType>', 'Optional stricter context override scope')
   .option('--include-body', 'Include policy body in output')
-  .action(async (paranetId: string, opts: ActionOpts) => {
+  .action(async (contextGraphId: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
       const { policy } = await client.resolveCclPolicy({
-        paranetId,
+        contextGraphId,
         name: opts.name,
         contextType: opts.contextType,
         includeBody: !!opts.includeBody,
@@ -1363,7 +1363,7 @@ cclPolicyCmd
       console.log(`Resolved policy:`);
       console.log(`  URI:     ${policy.policyUri}`);
       console.log(`  Name:    ${policy.name}@${policy.version}`);
-      console.log(`  Paranet: ${policy.paranetId}`);
+      console.log(`  Context Graph: ${policy.contextGraphId ?? policy.paranetId}`);
       console.log(`  Hash:    ${policy.hash}`);
       if (policy.contextType) console.log(`  Context: ${policy.contextType}`);
       if (policy.body) console.log(`  Body:\n${policy.body}`);
@@ -1374,8 +1374,8 @@ cclPolicyCmd
   });
 
 cclCmd
-  .command('eval <paranetId>')
-  .description('Resolve the approved CCL policy for a paranet and evaluate it against facts')
+  .command('eval <contextGraphId>')
+  .description('Resolve the approved CCL policy for a context graph and evaluate it against facts')
   .requiredOption('--name <name>', 'Policy name')
   .option('--context-type <contextType>', 'Optional stricter context override scope')
   .option('--case <path>', 'YAML/JSON file with { facts, context? }')
@@ -1384,7 +1384,7 @@ cclCmd
   .option('--view <view>', 'Declared view, for example accepted')
   .option('--snapshot-id <snapshotId>', 'Snapshot identifier')
   .option('--scope-ual <scopeUal>', 'Scope UAL for evaluation')
-  .action(async (paranetId: string, opts: ActionOpts) => {
+  .action(async (contextGraphId: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
       let payload: { facts: Array<[string, ...unknown[]]>; view?: string; snapshotId?: string; scopeUal?: string } | null = null;
@@ -1415,7 +1415,7 @@ cclCmd
       }
 
       const result = await client.evaluateCclPolicy({
-        paranetId,
+        contextGraphId,
         name: opts.name,
         contextType: opts.contextType,
         facts: payload?.facts,
@@ -1433,19 +1433,19 @@ cclCmd
   });
 
 cclCmd
-  .command('results <paranetId>')
-  .description('List published CCL evaluation results in a paranet')
+  .command('results <contextGraphId>')
+  .description('List published CCL evaluation results for a context graph')
   .option('--policy-uri <policyUri>', 'Filter by evaluated policy URI')
   .option('--snapshot-id <snapshotId>', 'Filter by snapshot id')
   .option('--view <view>', 'Filter by view')
   .option('--context-type <contextType>', 'Filter by context type')
   .option('--result-kind <kind>', 'Filter by result kind: derived or decision')
   .option('--result-name <name>', 'Filter by result predicate/decision name')
-  .action(async (paranetId: string, opts: ActionOpts) => {
+  .action(async (contextGraphId: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
       const { evaluations } = await client.listCclEvaluations({
-        paranetId,
+        contextGraphId,
         policyUri: opts.policyUri,
         snapshotId: opts.snapshotId,
         view: opts.view,

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -54,7 +54,7 @@ import {
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from './publisher-runner.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from './auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
-import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown } from './extraction/index.js';
+import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from './extraction/index.js';
 import {
   expectedBundledMarkItDownBuildMetadata,
   readCliPackageVersion,
@@ -2853,25 +2853,26 @@ async function handleRequest(
       return respondWithFailedExtraction(500, `Phase 2 extraction failed: ${message}`, 0);
     }
 
+    // ── Layer 2: LLM semantic extraction (optional, non-blocking) ──
+    let llmTriples: Array<{ subject: string; predicate: string; object: string }> = [];
+    let llmModel: string | undefined;
+    if (config.llm?.apiKey && mdIntermediate) {
+      try {
+        const llmResult = await extractWithLlm(
+          { markdown: mdIntermediate, agentDid: `did:dkg:agent:${agent.peerId}`, documentIri: assertionUri },
+          config.llm,
+        );
+        llmTriples = llmResult.triples;
+        llmModel = llmResult.model;
+        if (llmTriples.length > 0) {
+          console.log(`[llm-extractor] Produced ${llmTriples.length} triples (model: ${llmModel})`);
+        }
+      } catch (err: any) {
+        console.warn(`[llm-extractor] Extraction failed (non-fatal): ${err.message}`);
+      }
+    }
+
     // ── Build the full quad set for both graphs (atomic single insert) ──
-    // We assemble rows 1-13 as data-graph quads + rows 14-20 as CG root
-    // `_meta` quads, each with its own explicit `graph` field, and commit
-    // them all in ONE `agent.store.insert(...)` call. Every supported
-    // triple-store adapter (oxigraph, blazegraph, sparql-http) implements
-    // `insert` as a single N-Quads load / `INSERT DATA` operation, so the
-    // call is naturally atomic across graphs: either every row lands or
-    // none does. This replaces the earlier two-call flow
-    // (`assertion.write` + `store.insert`) which had a window where rows
-    // 1-13 could commit and rows 14-20 fail, leaving dangling data.
-    //
-    // `assertion.create` still runs first to register the assertion graph
-    // container (idempotent on "already exists"). The write itself
-    // bypasses `assertion.write` so the daemon can set per-quad graph
-    // fields directly — `publisher.assertionWrite` hardcodes every quad to
-    // the assertion graph URI, which defeats the multi-graph atomicity
-    // we need here. Sub-graph registration is already validated by
-    // `assertion.create`, so bypassing `assertion.write` doesn't skip any
-    // safety checks.
     const assertionGraph = contextGraphAssertionUri(
       contextGraphId!,
       agent.peerId,
@@ -2884,75 +2885,38 @@ async function handleRequest(
       ? `urn:dkg:file:${mdIntermediateHash}`
       : fileUri;
 
-    // Data-graph quads: content (triples) + extractor linkage (provenance)
-    // + daemon-owned rows 2, markdownForm, 4, 5, 8, 9-13. Every quad is pinned to the
-    // assertion graph URI. `triples` and `provenance` come from the
-    // extractor without a `graph` field, so we stamp each one here.
-    //
-    // Round 9 Bug 27: rows 6 (`dkg:fileName`) and 7 (`dkg:contentType`)
-    // are REMOVED from the file descriptor block. `<fileUri>` is
-    // content-addressed — two imports of identical bytes under different
-    // filenames / upload content types would have written contradictory
-    // facts to the same subject. Per-upload metadata now lives on the
-    // assertion UAL in `_meta` (new row 15a: `dkg:sourceFileName`,
-    // existing row 15: `dkg:sourceContentType` already there) where
-    // per-assertion facts belong. Only intrinsic-to-content properties
-    // (rdf:type, dkg:contentHash, dkg:size) remain on `<fileUri>` —
-    // those are safe because they're derived purely from the blob bytes.
-    // See `19_MARKDOWN_CONTENT_TYPE.md §10.2`.
     const dataGraphQuads = [
       ...triples.map(t => ({ ...t, graph: assertionGraph })),
       ...sourceFileLinkage.map(t => ({ ...t, graph: assertionGraph })),
-      // Row 2 — daemon-owned. Describes the ORIGINAL upload blob (row 1's
-      // target), so for a PDF upload this is "application/pdf" — NOT the
-      // markdown intermediate the extractor processes. Extractor never
-      // emits this row; the daemon is the single source of truth. Its
-      // subject matches rows 1 and 3 on the resolved document entity.
+      ...llmTriples.map(t => ({ ...t, graph: assertionGraph })),
       { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: assertionGraph },
-      // Graph-level link to the markdown bytes structural extraction ran
-      // against. For markdown-native uploads this equals row 1's object;
-      // for converter-backed uploads it points at the stored intermediate.
       { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/markdownForm', object: markdownFormUri, graph: assertionGraph },
-      // Row 4 — file descriptor block subject is the content-addressed URN
       { subject: fileUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/File', graph: assertionGraph },
-      // Row 5 — on-chain canonical hash format is keccak256:<hex>
       { subject: fileUri, predicate: 'http://dkg.io/ontology/contentHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: assertionGraph },
-      // Row 8 — xsd:integer for size (byte count)
       { subject: fileUri, predicate: 'http://dkg.io/ontology/size', object: `"${fileStoreEntry.size}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: assertionGraph },
-      // Row 9 — ExtractionProvenance subject is a fresh UUID URN per import
       { subject: provUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/ExtractionProvenance', graph: assertionGraph },
-      // Row 10 — back-references the ORIGINAL upload file URN (same value
-      // as rows 4-5, 8 subject). The new `dkg:markdownForm` entity link
-      // above separately exposes the markdown bytes Phase 2 actually read.
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedFrom', object: fileUri, graph: assertionGraph },
-      // Row 11
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedBy', object: agentDid, graph: assertionGraph },
-      // Row 12
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedAt', object: startedAtLiteral, graph: assertionGraph },
-      // Row 13
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: assertionGraph },
     ];
 
-    // `_meta` quads (rows 14-20): always land in the CG ROOT `_meta`, never
-    // a sub-graph `_meta`, keyed by the assertion UAL so daemon restarts
-    // can recover the file ↔ assertion linkage from the graph alone.
     const metaQuads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [
-      // Row 14 — rootEntity comes from the extractor's resolved value so
-      // the data-graph row 3 and `_meta` row 14 point at the same IRI.
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/rootEntity', object: resolvedRootEntity, graph: metaGraph },
-      // Row 15 — original content type from the upload (matches row 2
-      // now that both rows are sourced from `detectedContentType`).
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: metaGraph },
-      // Row 16 — load-bearing: lets a caller look up the source blob by UAL alone.
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceFileHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: metaGraph },
-      // Row 17
-      { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: metaGraph },
-      // Row 18
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify(llmTriples.length > 0 ? 'structural+semantic' : 'structural'), graph: metaGraph },
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/structuralTripleCount', object: `"${triples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
-      // Row 19 — V10.0 has no semantic (Layer 2) extraction, so always zero.
-      { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"0"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"${llmTriples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
     ];
-    // Row 20 — only emitted when Phase 1 actually ran (PDF/DOCX path).
+    if (llmModel) {
+      metaQuads.push({
+        subject: assertionUri,
+        predicate: 'http://dkg.io/ontology/semanticModel',
+        object: JSON.stringify(llmModel),
+        graph: metaGraph,
+      });
+    }
     if (mdIntermediateHash) {
       metaQuads.push({
         subject: assertionUri,
@@ -2961,13 +2925,6 @@ async function handleRequest(
         graph: metaGraph,
       });
     }
-    // Round 9 Bug 27: `dkg:sourceFileName` — per-upload metadata that
-    // used to live on `<fileUri>` (row 6 in the old file descriptor
-    // block) moves to `_meta` keyed by `<assertionUri>` so two imports
-    // of identical bytes under different filenames don't collide on
-    // the same content-addressed subject. Symmetric to row 15
-    // (`dkg:sourceContentType`). Skipped entirely when the upload
-    // didn't carry a filename (matches the row 20 optional pattern).
     const uploadedFilename = filePart.filename?.trim() ?? '';
     if (uploadedFilename.length > 0) {
       metaQuads.push({
@@ -2978,11 +2935,6 @@ async function handleRequest(
       });
     }
 
-    // Round 14 Bug 42: lock acquisition moved to the top of the
-    // handler, before Phase 1/2 extraction. This inner `try` now
-    // wraps only the assertion.create + snapshot + cleanup + insert
-    // + rollback sequence. See the lock-acquisition site above for
-    // the full rationale.
     try {
       // Ensure the assertion graph exists even when Phase 2 yields zero
       // content triples, so a completed import always materializes the
@@ -3197,13 +3149,18 @@ async function handleRequest(
       throw err;
     }
 
+    const totalTripleCount = triples.length + llmTriples.length;
+    const effectivePipeline = llmTriples.length > 0
+      ? `${pipelineUsed}+llm:${llmModel}`
+      : pipelineUsed;
+
     const completedRecord: ExtractionStatusRecord = {
       status: 'completed',
       fileHash: fileStoreEntry.keccak256,
       ...(importRootEntity ? { rootEntity: importRootEntity } : {}),
       detectedContentType,
-      pipelineUsed,
-      tripleCount: triples.length,
+      pipelineUsed: effectivePipeline,
+      tripleCount: totalTripleCount,
       mdIntermediateHash,
       startedAt,
       completedAt: new Date().toISOString(),
@@ -3212,8 +3169,8 @@ async function handleRequest(
 
     return respondWithImportFileResponse(200, {
       status: 'completed',
-      tripleCount: triples.length,
-      pipelineUsed,
+      tripleCount: totalTripleCount,
+      pipelineUsed: effectivePipeline,
       ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
     });
     } finally {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2502,6 +2502,22 @@ async function handleRequest(
     }
   }
 
+  // GET /api/file/:hash  — serve a stored file by its sha256 hash
+  if (req.method === 'GET' && path.startsWith('/api/file/')) {
+    const hash = safeDecodeURIComponent(path.slice('/api/file/'.length), res);
+    if (hash === null) return;
+    const buf = await fileStore.get(hash.startsWith('sha256:') ? hash : `sha256:${hash}`);
+    if (!buf) return jsonResponse(res, 404, { error: 'File not found' });
+    const ct = (reqUrl.searchParams.get('contentType') || 'application/octet-stream');
+    res.writeHead(200, {
+      'Content-Type': ct,
+      'Content-Length': String(buf.length),
+      'Cache-Control': 'public, max-age=86400, immutable',
+    });
+    res.end(buf);
+    return;
+  }
+
   // POST /api/assertion/:name/import-file  (multipart/form-data)
   //   file (required):           the uploaded document bytes
   //   contextGraphId (required): target context graph

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -54,7 +54,7 @@ import {
 import { createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from './publisher-runner.js';
 import { loadTokens, httpAuthGuard, extractBearerToken } from './auth.js';
 import { ExtractionPipelineRegistry } from '@origintrail-official/dkg-core';
-import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown, extractWithLlm } from './extraction/index.js';
+import { MarkItDownConverter, isMarkItDownAvailable, extractFromMarkdown } from './extraction/index.js';
 import {
   expectedBundledMarkItDownBuildMetadata,
   readCliPackageVersion,
@@ -2502,22 +2502,6 @@ async function handleRequest(
     }
   }
 
-  // GET /api/file/:hash  — serve a stored file by its sha256 hash
-  if (req.method === 'GET' && path.startsWith('/api/file/')) {
-    const hash = safeDecodeURIComponent(path.slice('/api/file/'.length), res);
-    if (hash === null) return;
-    const buf = await fileStore.get(hash.startsWith('sha256:') ? hash : `sha256:${hash}`);
-    if (!buf) return jsonResponse(res, 404, { error: 'File not found' });
-    const ct = (reqUrl.searchParams.get('contentType') || 'application/octet-stream');
-    res.writeHead(200, {
-      'Content-Type': ct,
-      'Content-Length': String(buf.length),
-      'Cache-Control': 'public, max-age=86400, immutable',
-    });
-    res.end(buf);
-    return;
-  }
-
   // POST /api/assertion/:name/import-file  (multipart/form-data)
   //   file (required):           the uploaded document bytes
   //   contextGraphId (required): target context graph
@@ -2869,26 +2853,25 @@ async function handleRequest(
       return respondWithFailedExtraction(500, `Phase 2 extraction failed: ${message}`, 0);
     }
 
-    // ── Layer 2: LLM semantic extraction (optional, non-blocking) ──
-    let llmTriples: Array<{ subject: string; predicate: string; object: string }> = [];
-    let llmModel: string | undefined;
-    if (config.llm?.apiKey && mdIntermediate) {
-      try {
-        const llmResult = await extractWithLlm(
-          { markdown: mdIntermediate, agentDid: `did:dkg:agent:${agent.peerId}`, documentIri: assertionUri },
-          config.llm,
-        );
-        llmTriples = llmResult.triples;
-        llmModel = llmResult.model;
-        if (llmTriples.length > 0) {
-          console.log(`[llm-extractor] Produced ${llmTriples.length} triples (model: ${llmModel})`);
-        }
-      } catch (err: any) {
-        console.warn(`[llm-extractor] Extraction failed (non-fatal): ${err.message}`);
-      }
-    }
-
     // ── Build the full quad set for both graphs (atomic single insert) ──
+    // We assemble rows 1-13 as data-graph quads + rows 14-20 as CG root
+    // `_meta` quads, each with its own explicit `graph` field, and commit
+    // them all in ONE `agent.store.insert(...)` call. Every supported
+    // triple-store adapter (oxigraph, blazegraph, sparql-http) implements
+    // `insert` as a single N-Quads load / `INSERT DATA` operation, so the
+    // call is naturally atomic across graphs: either every row lands or
+    // none does. This replaces the earlier two-call flow
+    // (`assertion.write` + `store.insert`) which had a window where rows
+    // 1-13 could commit and rows 14-20 fail, leaving dangling data.
+    //
+    // `assertion.create` still runs first to register the assertion graph
+    // container (idempotent on "already exists"). The write itself
+    // bypasses `assertion.write` so the daemon can set per-quad graph
+    // fields directly — `publisher.assertionWrite` hardcodes every quad to
+    // the assertion graph URI, which defeats the multi-graph atomicity
+    // we need here. Sub-graph registration is already validated by
+    // `assertion.create`, so bypassing `assertion.write` doesn't skip any
+    // safety checks.
     const assertionGraph = contextGraphAssertionUri(
       contextGraphId!,
       agent.peerId,
@@ -2901,38 +2884,75 @@ async function handleRequest(
       ? `urn:dkg:file:${mdIntermediateHash}`
       : fileUri;
 
+    // Data-graph quads: content (triples) + extractor linkage (provenance)
+    // + daemon-owned rows 2, markdownForm, 4, 5, 8, 9-13. Every quad is pinned to the
+    // assertion graph URI. `triples` and `provenance` come from the
+    // extractor without a `graph` field, so we stamp each one here.
+    //
+    // Round 9 Bug 27: rows 6 (`dkg:fileName`) and 7 (`dkg:contentType`)
+    // are REMOVED from the file descriptor block. `<fileUri>` is
+    // content-addressed — two imports of identical bytes under different
+    // filenames / upload content types would have written contradictory
+    // facts to the same subject. Per-upload metadata now lives on the
+    // assertion UAL in `_meta` (new row 15a: `dkg:sourceFileName`,
+    // existing row 15: `dkg:sourceContentType` already there) where
+    // per-assertion facts belong. Only intrinsic-to-content properties
+    // (rdf:type, dkg:contentHash, dkg:size) remain on `<fileUri>` —
+    // those are safe because they're derived purely from the blob bytes.
+    // See `19_MARKDOWN_CONTENT_TYPE.md §10.2`.
     const dataGraphQuads = [
       ...triples.map(t => ({ ...t, graph: assertionGraph })),
       ...sourceFileLinkage.map(t => ({ ...t, graph: assertionGraph })),
-      ...llmTriples.map(t => ({ ...t, graph: assertionGraph })),
+      // Row 2 — daemon-owned. Describes the ORIGINAL upload blob (row 1's
+      // target), so for a PDF upload this is "application/pdf" — NOT the
+      // markdown intermediate the extractor processes. Extractor never
+      // emits this row; the daemon is the single source of truth. Its
+      // subject matches rows 1 and 3 on the resolved document entity.
       { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: assertionGraph },
+      // Graph-level link to the markdown bytes structural extraction ran
+      // against. For markdown-native uploads this equals row 1's object;
+      // for converter-backed uploads it points at the stored intermediate.
       { subject: documentSubjectIri, predicate: 'http://dkg.io/ontology/markdownForm', object: markdownFormUri, graph: assertionGraph },
+      // Row 4 — file descriptor block subject is the content-addressed URN
       { subject: fileUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/File', graph: assertionGraph },
+      // Row 5 — on-chain canonical hash format is keccak256:<hex>
       { subject: fileUri, predicate: 'http://dkg.io/ontology/contentHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: assertionGraph },
+      // Row 8 — xsd:integer for size (byte count)
       { subject: fileUri, predicate: 'http://dkg.io/ontology/size', object: `"${fileStoreEntry.size}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: assertionGraph },
+      // Row 9 — ExtractionProvenance subject is a fresh UUID URN per import
       { subject: provUri, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://dkg.io/ontology/ExtractionProvenance', graph: assertionGraph },
+      // Row 10 — back-references the ORIGINAL upload file URN (same value
+      // as rows 4-5, 8 subject). The new `dkg:markdownForm` entity link
+      // above separately exposes the markdown bytes Phase 2 actually read.
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedFrom', object: fileUri, graph: assertionGraph },
+      // Row 11
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedBy', object: agentDid, graph: assertionGraph },
+      // Row 12
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractedAt', object: startedAtLiteral, graph: assertionGraph },
+      // Row 13
       { subject: provUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: assertionGraph },
     ];
 
+    // `_meta` quads (rows 14-20): always land in the CG ROOT `_meta`, never
+    // a sub-graph `_meta`, keyed by the assertion UAL so daemon restarts
+    // can recover the file ↔ assertion linkage from the graph alone.
     const metaQuads: Array<{ subject: string; predicate: string; object: string; graph: string }> = [
+      // Row 14 — rootEntity comes from the extractor's resolved value so
+      // the data-graph row 3 and `_meta` row 14 point at the same IRI.
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/rootEntity', object: resolvedRootEntity, graph: metaGraph },
+      // Row 15 — original content type from the upload (matches row 2
+      // now that both rows are sourced from `detectedContentType`).
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceContentType', object: JSON.stringify(detectedContentType), graph: metaGraph },
+      // Row 16 — load-bearing: lets a caller look up the source blob by UAL alone.
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/sourceFileHash', object: JSON.stringify(fileStoreEntry.keccak256), graph: metaGraph },
-      { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify(llmTriples.length > 0 ? 'structural+semantic' : 'structural'), graph: metaGraph },
+      // Row 17
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/extractionMethod', object: JSON.stringify('structural'), graph: metaGraph },
+      // Row 18
       { subject: assertionUri, predicate: 'http://dkg.io/ontology/structuralTripleCount', object: `"${triples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
-      { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"${llmTriples.length}"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
+      // Row 19 — V10.0 has no semantic (Layer 2) extraction, so always zero.
+      { subject: assertionUri, predicate: 'http://dkg.io/ontology/semanticTripleCount', object: `"0"^^<http://www.w3.org/2001/XMLSchema#integer>`, graph: metaGraph },
     ];
-    if (llmModel) {
-      metaQuads.push({
-        subject: assertionUri,
-        predicate: 'http://dkg.io/ontology/semanticModel',
-        object: JSON.stringify(llmModel),
-        graph: metaGraph,
-      });
-    }
+    // Row 20 — only emitted when Phase 1 actually ran (PDF/DOCX path).
     if (mdIntermediateHash) {
       metaQuads.push({
         subject: assertionUri,
@@ -2941,6 +2961,13 @@ async function handleRequest(
         graph: metaGraph,
       });
     }
+    // Round 9 Bug 27: `dkg:sourceFileName` — per-upload metadata that
+    // used to live on `<fileUri>` (row 6 in the old file descriptor
+    // block) moves to `_meta` keyed by `<assertionUri>` so two imports
+    // of identical bytes under different filenames don't collide on
+    // the same content-addressed subject. Symmetric to row 15
+    // (`dkg:sourceContentType`). Skipped entirely when the upload
+    // didn't carry a filename (matches the row 20 optional pattern).
     const uploadedFilename = filePart.filename?.trim() ?? '';
     if (uploadedFilename.length > 0) {
       metaQuads.push({
@@ -2951,6 +2978,11 @@ async function handleRequest(
       });
     }
 
+    // Round 14 Bug 42: lock acquisition moved to the top of the
+    // handler, before Phase 1/2 extraction. This inner `try` now
+    // wraps only the assertion.create + snapshot + cleanup + insert
+    // + rollback sequence. See the lock-acquisition site above for
+    // the full rationale.
     try {
       // Ensure the assertion graph exists even when Phase 2 yields zero
       // content triples, so a completed import always materializes the
@@ -3165,18 +3197,13 @@ async function handleRequest(
       throw err;
     }
 
-    const totalTripleCount = triples.length + llmTriples.length;
-    const effectivePipeline = llmTriples.length > 0
-      ? `${pipelineUsed}+llm:${llmModel}`
-      : pipelineUsed;
-
     const completedRecord: ExtractionStatusRecord = {
       status: 'completed',
       fileHash: fileStoreEntry.keccak256,
       ...(importRootEntity ? { rootEntity: importRootEntity } : {}),
       detectedContentType,
-      pipelineUsed: effectivePipeline,
-      tripleCount: totalTripleCount,
+      pipelineUsed,
+      tripleCount: triples.length,
       mdIntermediateHash,
       startedAt,
       completedAt: new Date().toISOString(),
@@ -3185,8 +3212,8 @@ async function handleRequest(
 
     return respondWithImportFileResponse(200, {
       status: 'completed',
-      tripleCount: totalTripleCount,
-      pipelineUsed: effectivePipeline,
+      tripleCount: triples.length,
+      pipelineUsed,
       ...(mdIntermediateHash ? { mdIntermediateHash } : {}),
     });
     } finally {
@@ -4499,9 +4526,9 @@ async function _performNpmUpdateInner(
     }
   }
 
-  const active = await activeSlot();
+  const active = await activeSlot() ?? 'a';
   const activeDir = join(rDir, active);
-  const target = active === 'a' ? 'b' : (active === 'b' ? 'a' : 'a');
+  const target = active === 'a' ? 'b' : 'a';
   const targetDir = join(rDir, target);
 
   log(`Auto-update (npm): installing ${CLI_NPM_PACKAGE}@${targetVersion} into slot ${target}...`);

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -10,6 +10,7 @@ import { join, dirname, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { ethers } from 'ethers';
+import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
 import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
@@ -1109,6 +1110,7 @@ async function runDaemonInner(foreground: boolean, config: Awaited<ReturnType<ty
       ) {
         jsonResponse(res, 400, { error: err.message });
       } else {
+        enrichEvmError(err);
         jsonResponse(res, 500, { error: err.message });
       }
     }
@@ -2126,8 +2128,11 @@ async function handleRequest(
         graph: contextGraphSharedMemoryUri(paranetId, subGraphName),
         triplesWritten: quads.length,
       });
-    } catch (err) {
+    } catch (err: any) {
       tracker.fail(ctx, err);
+      if (typeof err?.message === 'string' && err.message.includes('has not been registered')) {
+        return jsonResponse(res, 400, { error: err.message });
+      }
       throw err;
     }
   }

--- a/packages/cli/src/extraction/index.ts
+++ b/packages/cli/src/extraction/index.ts
@@ -4,3 +4,4 @@ export {
   type MarkdownExtractInput,
   type MarkdownExtractOutput,
 } from './markdown-extractor.js';
+export { extractWithLlm, type LlmExtractionInput, type LlmExtractionOutput } from './llm-extractor.js';

--- a/packages/cli/src/extraction/llm-extractor.ts
+++ b/packages/cli/src/extraction/llm-extractor.ts
@@ -1,0 +1,151 @@
+/**
+ * Layer 2 Semantic Extraction — LLM-assisted knowledge extraction from
+ * a Markdown intermediate. Non-deterministic; produces attributed triples.
+ *
+ * Spec: 19_MARKDOWN_CONTENT_TYPE.md §3.2
+ *
+ * The LLM reads the markdown body and extracts structured knowledge that
+ * the deterministic structural extractor cannot capture: claims in prose,
+ * implicit relationships, entity mentions, and quantitative facts.
+ *
+ * Every triple carries extraction provenance so consumers can distinguish
+ * structural (deterministic, verifiable) from semantic (agent-interpreted,
+ * endorsable) knowledge.
+ */
+
+import type { LlmConfig } from '../config.js';
+
+export interface LlmExtractionInput {
+  markdown: string;
+  agentDid: string;
+  documentIri: string;
+  /** Maximum tokens for the LLM response. */
+  maxTokens?: number;
+}
+
+export interface LlmExtractionOutput {
+  triples: Array<{ subject: string; predicate: string; object: string }>;
+  model: string;
+  tokensUsed?: number;
+}
+
+const DOCUMENT_KG_PROMPT = `You are a knowledge graph extraction engine. Extract structured knowledge from the following document as RDF N-Triples.
+
+Rules:
+- Subject URIs: use the document URI as the main subject for document-level facts. For entities mentioned in the document, use urn:dkg:entity:{slug} where slug is lowercase-kebab-case.
+- Use schema.org predicates where possible:
+  <http://schema.org/name>, <http://schema.org/description>, <http://schema.org/author>,
+  <http://schema.org/datePublished>, <http://schema.org/about>, <http://schema.org/mentions>,
+  <http://schema.org/keywords>, <http://schema.org/citation>, <http://schema.org/isPartOf>
+- Use <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> for types (schema:ScholarlyArticle, schema:Person, schema:Organization, schema:MedicalCondition, etc.)
+- For domain-specific relationships, use urn:dkg:rel:{relationship-name}
+- String literals use "value" syntax. Include language tags where appropriate.
+- Each triple MUST end with " ."
+- Extract: document metadata (title, authors, date), key entities (people, organizations, concepts, conditions, treatments), relationships between entities, quantitative claims, and conclusions.
+- Aim for 20-100 triples depending on document length and richness.
+- If the document is too short or has no extractable knowledge, output exactly: NONE
+
+IMPORTANT: Output ONLY valid N-Triples, one per line. No markdown fences, no explanations.`;
+
+/**
+ * Run LLM-assisted semantic extraction on a markdown intermediate.
+ * Returns extracted triples or an empty result if the LLM is unavailable
+ * or produces no usable output. Never throws — failures are logged and
+ * return an empty result so structural extraction still succeeds.
+ */
+export async function extractWithLlm(
+  input: LlmExtractionInput,
+  llmConfig: LlmConfig,
+): Promise<LlmExtractionOutput> {
+  const empty: LlmExtractionOutput = { triples: [], model: llmConfig.model ?? 'gpt-4o-mini' };
+
+  const { apiKey, model = 'gpt-4o-mini', baseURL = 'https://api.openai.com/v1' } = llmConfig;
+  if (!apiKey) return empty;
+
+  const truncated = input.markdown.length > 60_000
+    ? input.markdown.slice(0, 60_000) + '\n\n[... document truncated for extraction ...]'
+    : input.markdown;
+
+  const url = `${baseURL.replace(/\/$/, '')}/chat/completions`;
+  const body = {
+    model,
+    messages: [
+      { role: 'system', content: DOCUMENT_KG_PROMPT },
+      {
+        role: 'user',
+        content: `Document URI: ${input.documentIri}\n\n${truncated}`,
+      },
+    ],
+    max_tokens: input.maxTokens ?? 4096,
+    temperature: 0.1,
+  };
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60_000);
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      console.warn(`[llm-extractor] LLM API returned ${res.status}: ${await res.text().catch(() => '')}`);
+      return empty;
+    }
+
+    const data = (await res.json()) as any;
+    const output = data.choices?.[0]?.message?.content?.trim() ?? '';
+    const tokensUsed = data.usage?.total_tokens;
+
+    if (!output || output === 'NONE') {
+      return { triples: [], model, tokensUsed };
+    }
+
+    const triples = parseNTriples(output, input.documentIri);
+    return { triples, model, tokensUsed };
+  } catch (err: any) {
+    if (err.name === 'AbortError') {
+      console.warn('[llm-extractor] LLM API request timed out after 60s');
+    } else {
+      console.warn(`[llm-extractor] LLM extraction failed: ${err.message}`);
+    }
+    return empty;
+  }
+}
+
+/**
+ * Parse N-Triples output from the LLM. Tolerant of common LLM formatting
+ * issues (markdown fences, blank lines, comments).
+ */
+function parseNTriples(
+  text: string,
+  _documentIri: string,
+): Array<{ subject: string; predicate: string; object: string }> {
+  const triples: Array<{ subject: string; predicate: string; object: string }> = [];
+
+  const cleaned = text
+    .replace(/^```[a-z]*\n?/gm, '')
+    .replace(/^```\s*$/gm, '');
+
+  for (const line of cleaned.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const match = trimmed.match(
+      /^<([^>]+)>\s+<([^>]+)>\s+(?:<([^>]+)>|("(?:[^"\\]|\\.)*"(?:\^\^<[^>]+>)?(?:@[a-z-]+)?))\s*\.?\s*$/,
+    );
+    if (match) {
+      const subject = match[1]!;
+      const predicate = match[2]!;
+      const object = match[3] ? match[3] : match[4]!;
+      if (subject.length > 0 && predicate.length > 0 && object.length > 0) {
+        triples.push({ subject, predicate, object });
+      }
+    }
+  }
+  return triples;
+}

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -77,11 +77,11 @@ describe('ApiClient', () => {
 
     it('listCclPolicies() builds query string from filters', async () => {
       globalThis.fetch = mockFetchOk({ policies: [] });
-      await client.listCclPolicies({ paranetId: 'ops', name: 'incident', contextType: 'review', includeBody: true });
+      await client.listCclPolicies({ contextGraphId: 'ops', name: 'incident', contextType: 'review', includeBody: true });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('/api/ccl/policy/list?');
-      expect(url).toContain('paranetId=ops');
+      expect(url).toContain('contextGraphId=ops');
       expect(url).toContain('name=incident');
       expect(url).toContain('contextType=review');
       expect(url).toContain('includeBody=true');
@@ -109,7 +109,7 @@ describe('ApiClient', () => {
       expect(result.kcId).toBe('kc1');
 
       const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
-      expect(body.paranetId).toBe('test-paranet');
+      expect(body.contextGraphId).toBe('test-paranet');
       expect(body.quads).toHaveLength(1);
     });
 
@@ -119,23 +119,23 @@ describe('ApiClient', () => {
 
       const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
       expect(body.sparql).toBe('SELECT * { ?s ?p ?o }');
-      expect(body.paranetId).toBe('my-paranet');
+      expect(body.contextGraphId).toBe('my-paranet');
     });
 
     it('publishCclPolicy() posts policy payload', async () => {
       globalThis.fetch = mockFetchOk({ policyUri: 'urn:policy', hash: 'sha256:abc', status: 'proposed' });
-      await client.publishCclPolicy({ paranetId: 'ops', name: 'incident', version: '0.1.0', content: 'rules: []' });
+      await client.publishCclPolicy({ contextGraphId: 'ops', name: 'incident', version: '0.1.0', content: 'rules: []' });
 
       const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toBe(`http://127.0.0.1:${PORT}/api/ccl/policy/publish`);
       const body = JSON.parse(opts.body);
-      expect(body.paranetId).toBe('ops');
+      expect(body.contextGraphId).toBe('ops');
       expect(body.name).toBe('incident');
     });
 
     it('approveCclPolicy() posts approval payload', async () => {
       globalThis.fetch = mockFetchOk({ policyUri: 'urn:policy', bindingUri: 'urn:binding', approvedAt: 'now' });
-      await client.approveCclPolicy({ paranetId: 'ops', policyUri: 'urn:policy', contextType: 'incident_review' });
+      await client.approveCclPolicy({ contextGraphId: 'ops', policyUri: 'urn:policy', contextType: 'incident_review' });
 
       const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toBe(`http://127.0.0.1:${PORT}/api/ccl/policy/approve`);
@@ -145,7 +145,7 @@ describe('ApiClient', () => {
 
     it('revokeCclPolicy() posts revocation payload', async () => {
       globalThis.fetch = mockFetchOk({ policyUri: 'urn:policy', bindingUri: 'urn:binding', revokedAt: 'now', status: 'revoked' });
-      await client.revokeCclPolicy({ paranetId: 'ops', policyUri: 'urn:policy', contextType: 'incident_review' });
+      await client.revokeCclPolicy({ contextGraphId: 'ops', policyUri: 'urn:policy', contextType: 'incident_review' });
 
       const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toBe(`http://127.0.0.1:${PORT}/api/ccl/policy/revoke`);
@@ -155,7 +155,7 @@ describe('ApiClient', () => {
 
     it('evaluateCclPolicy() posts evaluation payload', async () => {
       globalThis.fetch = mockFetchOk({ policy: { name: 'incident' }, factSetHash: 'sha256:abc', result: { derived: {}, decisions: {} } });
-      await client.evaluateCclPolicy({ paranetId: 'ops', name: 'incident', facts: [['claim', 'c1']], snapshotId: 'snap-1', publishResult: true });
+      await client.evaluateCclPolicy({ contextGraphId: 'ops', name: 'incident', facts: [['claim', 'c1']], snapshotId: 'snap-1', publishResult: true });
 
       const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toBe(`http://127.0.0.1:${PORT}/api/ccl/eval`);
@@ -167,11 +167,11 @@ describe('ApiClient', () => {
 
     it('listCclEvaluations() builds result query string', async () => {
       globalThis.fetch = mockFetchOk({ evaluations: [] });
-      await client.listCclEvaluations({ paranetId: 'ops', snapshotId: 'snap-2', resultKind: 'decision', resultName: 'propose_accept' });
+      await client.listCclEvaluations({ contextGraphId: 'ops', snapshotId: 'snap-2', resultKind: 'decision', resultName: 'propose_accept' });
 
       const [url] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toContain('/api/ccl/results?');
-      expect(url).toContain('paranetId=ops');
+      expect(url).toContain('contextGraphId=ops');
       expect(url).toContain('snapshotId=snap-2');
       expect(url).toContain('resultKind=decision');
       expect(url).toContain('resultName=propose_accept');

--- a/packages/mcp-server/src/connection.ts
+++ b/packages/mcp-server/src/connection.ts
@@ -78,13 +78,13 @@ export class DkgClient {
   async publish(contextGraphId: string, quads: Array<{
     subject: string; predicate: string; object: string; graph: string;
   }>) {
-    await this.post<any>('/api/shared-memory/write', { paranetId: contextGraphId, quads });
+    await this.post<any>('/api/shared-memory/write', { contextGraphId, quads });
     return this.post<{
       kcId: string;
       status: string;
       kas: Array<{ tokenId: string; rootEntity: string }>;
       txHash?: string;
-    }>('/api/shared-memory/publish', { paranetId: contextGraphId, selection: 'all', clearAfter: true });
+    }>('/api/shared-memory/publish', { contextGraphId, selection: 'all', clearAfter: true });
   }
 
   async listContextGraphs() {

--- a/packages/network-sim/src/api.ts
+++ b/packages/network-sim/src/api.ts
@@ -70,13 +70,13 @@ export async function publishKA(
   if (privateQuads?.length) {
     throw new Error('privateQuads are not supported in V10 SWM-first publish');
   }
-  await post<any>(`${nodeBase(nodeId)}/api/shared-memory/write`, { paranetId: contextGraphId, quads });
+  await post<any>(`${nodeBase(nodeId)}/api/shared-memory/write`, { contextGraphId, quads });
   return post<{
     kcId: string;
     status: string;
     kas: Array<{ tokenId: string; rootEntity: string }>;
     txHash?: string;
-  }>(`${nodeBase(nodeId)}/api/shared-memory/publish`, { paranetId: contextGraphId, selection: 'all', clearAfter: true });
+  }>(`${nodeBase(nodeId)}/api/shared-memory/publish`, { contextGraphId, selection: 'all', clearAfter: true });
 }
 
 export async function queryNode(

--- a/packages/network-sim/src/server/sim-engine.ts
+++ b/packages/network-sim/src/server/sim-engine.ts
@@ -258,7 +258,7 @@ async function execPublish(
     const writeRes = await fetch(`http://127.0.0.1:${node.port}/api/shared-memory/write`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authHeaders(node) },
-      body: JSON.stringify({ paranetId: config.contextGraph, quads }),
+      body: JSON.stringify({ contextGraphId: config.contextGraph, quads }),
       signal: opSignal(signal, 'publish'),
     });
     if (!writeRes.ok) {
@@ -277,7 +277,7 @@ async function execPublish(
     const res = await fetch(`http://127.0.0.1:${node.port}/api/shared-memory/publish`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...authHeaders(node) },
-      body: JSON.stringify({ paranetId: config.contextGraph, selection: 'all', clearAfter: true }),
+      body: JSON.stringify({ contextGraphId: config.contextGraph, selection: 'all', clearAfter: true }),
       signal: opSignal(signal, 'publish'),
     });
     const body = (await res.json()) as { kcId?: string; kas?: unknown[]; status?: string; error?: string; phases?: Record<string, number> };

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@origintrail-official/dkg-core": "workspace:*",
     "@origintrail-official/dkg-graph-viz": "workspace:*",
-    "better-sqlite3": "^11"
+    "better-sqlite3": "^11",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@codemirror/lang-sql": "^6",

--- a/packages/node-ui/src/ui/App.tsx
+++ b/packages/node-ui/src/ui/App.tsx
@@ -1,425 +1,152 @@
-import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
-import { Routes, Route, Navigate, NavLink, useNavigate, useLocation } from 'react-router-dom';
-import { isDevModeEnabled } from './dev-mode.js';
-import type { InstalledApp } from './pages/AppHost.js';
-import { fetchNotifications, markNotificationsRead, type Notification } from './api.js';
-
-// Lazy-loaded route components — heavy pages are code-split so the initial
-// bundle only includes the shell + sidebar.  Vite will produce separate chunks.
-const DashboardPage = React.lazy(() => import('./pages/Dashboard.js').then(m => ({ default: m.DashboardPage })));
-const ExplorerPage  = React.lazy(() => import('./pages/Explorer.js').then(m => ({ default: m.ExplorerPage })));
-const AgentHubPage  = React.lazy(() => import('./pages/AgentHub.js').then(m => ({ default: m.AgentHubPage })));
-const AppsPage      = React.lazy(() => import('./pages/Apps.js').then(m => ({ default: m.AppsPage })));
-const SettingsPage  = React.lazy(() => import('./pages/Settings.js').then(m => ({ default: m.SettingsPage })));
-const AppHostPage   = React.lazy(() => import('./pages/AppHost.js').then(m => ({ default: m.AppHostPage })));
-
-const chevronIcon = (
-  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <polyline points="6 9 12 15 18 9"/>
-  </svg>
-);
-
-const NAV_ICONS: Record<string, React.ReactNode> = {
-  home: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>,
-  graph: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="6" cy="6" r="3"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="18" r="3"/><line x1="8.5" y1="7.5" x2="15.5" y2="16.5"/><line x1="15.5" y1="7.5" x2="8.5" y2="16.5"/></svg>,
-  terminal: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>,
-  play: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>,
-  messages: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>,
-  activity: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>,
-  settings: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>,
-};
-
-function useInstalledApps(): InstalledApp[] {
-  const [apps, setApps] = useState<InstalledApp[]>([]);
-  useEffect(() => {
-    const token = (window as any).__DKG_TOKEN__;
-    const headers: Record<string, string> = {};
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-    fetch('/api/apps', { headers })
-      .then(r => r.ok ? r.json() : [])
-      .then(setApps)
-      .catch(() => {});
-  }, []);
-  return apps;
-}
-
-function AppsNavSection({ installedApps }: { installedApps: InstalledApp[] }) {
-  const [open, setOpen] = useState(false);
-  const navigate = useNavigate();
-  const location = useLocation();
-  const isAppsActive = location.pathname.startsWith('/apps') || location.pathname.startsWith('/app/');
-
-  return (
-    <>
-      <button
-        className={`nav-btn${isAppsActive ? ' active' : ''}`}
-        onClick={() => setOpen(o => !o)}
-      >
-        {NAV_ICONS.play}
-        <span>Apps</span>
-        {installedApps.length > 0 && <span className="nav-badge">{installedApps.length}</span>}
-        <span style={{ marginLeft: 'auto', transition: 'transform .2s', transform: open ? 'rotate(180deg)' : 'none', display: 'flex' }}>
-          {chevronIcon}
-        </span>
-      </button>
-      <div className={`apps-dropdown${open ? ' open' : ''}`}>
-        <button
-          className={`apps-sub-btn${location.pathname === '/apps' ? ' active-sub' : ''}`}
-          onClick={() => { navigate('/apps'); }}
-        >
-          🎮 OriginTrail Game
-        </button>
-        {installedApps.filter(a => a.id !== 'origin-trail-game').map(a => (
-          <button
-            key={a.id}
-            className={`apps-sub-btn${location.pathname === `/app/${a.id}` ? ' active-sub' : ''}`}
-            onClick={() => { navigate(`/app/${a.id}`); }}
-          >
-            {a.label}
-          </button>
-        ))}
-      </div>
-    </>
-  );
-}
-
-function SettingsNavSection() {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [devMode, setDevMode] = useState(isDevModeEnabled);
-
-  useEffect(() => {
-    const sync = () => setDevMode(isDevModeEnabled());
-    window.addEventListener('devmode-change', sync);
-    window.addEventListener('storage', sync);
-    return () => { window.removeEventListener('devmode-change', sync); window.removeEventListener('storage', sync); };
-  }, []);
-
-  const isSettingsActive = location.pathname === '/settings' && location.search !== '?tab=observability';
-  const isObsActive = location.pathname === '/settings' && location.search === '?tab=observability';
-
-  return (
-    <>
-      <NavLink
-        to="/settings"
-        className={() => `nav-btn${isSettingsActive || isObsActive ? ' active' : ''}`}
-        onClick={(e) => { e.preventDefault(); navigate('/settings'); }}
-      >
-        {NAV_ICONS.settings}<span>Settings</span>
-      </NavLink>
-      {devMode && (
-        <button
-          className={`apps-sub-btn${isObsActive ? ' active-sub' : ''}`}
-          onClick={() => navigate('/settings?tab=observability')}
-          style={{ paddingLeft: 36 }}
-        >
-          {NAV_ICONS.activity}
-          <span style={{ marginLeft: 6 }}>Observability</span>
-        </button>
-      )}
-    </>
-  );
-}
+import React, { useEffect, useRef, useCallback } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import { Header } from './components/Shell/Header.js';
+import { PanelLeft } from './components/Shell/PanelLeft.js';
+import { PanelCenter } from './components/Shell/PanelCenter.js';
+import { PanelBottom } from './components/Shell/PanelBottom.js';
+import { PanelRight } from './components/Shell/PanelRight.js';
+import { useLayoutStore } from './stores/layout.js';
+import { useAgentsStore } from './stores/agents.js';
+import { api } from './api-wrapper.js';
 
 function useLiveStatus() {
-  const [status, setStatus] = useState<any>(null);
+  const setNodeStatus = useAgentsStore((s) => s.setNodeStatus);
   useEffect(() => {
-    let cancelled = false;
+    let mounted = true;
     const poll = () => {
-      const token = (window as any).__DKG_TOKEN__;
-      const headers: Record<string, string> = {};
-      if (token) headers['Authorization'] = `Bearer ${token}`;
-      fetch('/api/status', { headers })
-        .then(r => r.ok ? r.json() : null)
-        .then(d => { if (!cancelled) setStatus(d); })
-        .catch(() => { if (!cancelled) setStatus(null); });
+      api.fetchStatus().then((s) => { if (mounted) setNodeStatus(s); }).catch(() => {});
     };
     poll();
-    const t = setInterval(poll, 10_000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, []);
-  return status;
+    const iv = setInterval(poll, 10_000);
+    return () => { mounted = false; clearInterval(iv); };
+  }, [setNodeStatus]);
 }
 
-
-const NOTIF_ICONS: Record<string, string> = {
-  chat_message: '\u{1F4AC}',
-  peer_connected: '\u{1F7E2}',
-  peer_disconnected: '\u{1F534}',
-  kc_published: '\u{1F4E6}',
-};
-
-function formatTimeAgo(ts: number): string {
-  const diff = Date.now() - ts;
-  if (diff < 60_000) return 'just now';
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-  return `${Math.floor(diff / 86_400_000)}d ago`;
-}
-
-function NotificationBell() {
-  const [notifications, setNotifications] = useState<Notification[]>([]);
-  const [unreadCount, setUnreadCount] = useState(0);
-  const [open, setOpen] = useState(false);
-  const bellRef = useRef<HTMLDivElement>(null);
-  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null);
-  const navigate = useNavigate();
-
-  const refresh = useCallback(async () => {
-    try {
-      const data = await fetchNotifications({ limit: 100 });
-      setNotifications(data.notifications);
-      setUnreadCount(data.unreadCount);
-    } catch { /* swallow */ }
-  }, []);
-
+function useKeyboardShortcuts() {
+  const { toggleLeft, toggleRight, toggleBottom } = useLayoutStore();
   useEffect(() => {
-    refresh();
-    const t = setInterval(refresh, 20_000);
-    return () => clearInterval(t);
-  }, [refresh]);
-
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (bellRef.current && !bellRef.current.contains(e.target as Node)) setOpen(false);
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key === 'b') { e.preventDefault(); toggleLeft(); }
+      if (mod && e.key === 'j') { e.preventDefault(); toggleBottom(); }
+      if (mod && e.shiftKey && e.key === 'b') { e.preventDefault(); toggleRight(); }
     };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [toggleLeft, toggleRight, toggleBottom]);
+}
+
+function useDragResize(onDrag: (delta: number) => void) {
+  const handleRef = useRef<HTMLDivElement>(null);
+  const cbRef = useRef(onDrag);
+  cbRef.current = onDrag;
+
+  useEffect(() => {
+    const handle = handleRef.current;
+    if (!handle) return;
+
+    let startX = 0;
+
+    const onMouseMove = (e: MouseEvent) => {
+      const delta = e.clientX - startX;
+      startX = e.clientX;
+      cbRef.current(delta);
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      handle.classList.remove('active');
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      e.preventDefault();
+      startX = e.clientX;
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+      handle.classList.add('active');
+    };
+
+    handle.addEventListener('mousedown', onMouseDown);
+    return () => handle.removeEventListener('mousedown', onMouseDown);
   }, []);
 
-  const handleOpen = async () => {
-    const next = !open;
-    if (next && bellRef.current) {
-      const rect = bellRef.current.getBoundingClientRect();
-      setDropdownPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-    }
-    setOpen(next);
-    if (next && unreadCount > 0) {
-      await markNotificationsRead();
-      refresh();
-    }
-  };
+  return handleRef;
+}
+
+function AppShell() {
+  useLiveStatus();
+  useKeyboardShortcuts();
+  const { leftCollapsed, rightCollapsed, theme, leftWidth, rightWidth, setLeftWidth, setRightWidth } = useLayoutStore();
+
+  useEffect(() => {
+    document.body.classList.toggle('light', theme === 'light');
+  }, [theme]);
+
+  const onDragLeft = useCallback((delta: number) => {
+    const w = useLayoutStore.getState().leftWidth;
+    setLeftWidth(Math.max(140, Math.min(400, w + delta)));
+  }, [setLeftWidth]);
+
+  const onDragRight = useCallback((delta: number) => {
+    const w = useLayoutStore.getState().rightWidth;
+    setRightWidth(Math.max(200, Math.min(500, w - delta)));
+  }, [setRightWidth]);
+
+  const leftHandle = useDragResize(onDragLeft);
+  const rightHandle = useDragResize(onDragRight);
 
   return (
-    <div ref={bellRef} style={{ position: 'relative' }}>
-      <button
-        onClick={handleOpen}
-        aria-label="Notifications"
-        style={{
-          background: 'none', border: 'none', cursor: 'pointer', position: 'relative',
-          padding: '6px 8px', borderRadius: 6, color: 'var(--text)',
-          display: 'flex', alignItems: 'center',
-        }}
-      >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
-          <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
-        </svg>
-        {unreadCount > 0 && (
-          <span style={{
-            position: 'absolute', top: 2, right: 2,
-            background: 'var(--green)', color: '#000', fontSize: 9, fontWeight: 700,
-            borderRadius: '50%', minWidth: 16, height: 16, display: 'flex',
-            alignItems: 'center', justifyContent: 'center', padding: '0 4px',
-          }}>
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
+    <div className="v10-app">
+      <Header />
+      <div className="v10-app-body">
+        {!leftCollapsed && (
+          <>
+            <div className="v10-panel-left" style={{ width: leftWidth }}>
+              <PanelLeft />
+            </div>
+            <div className="v10-resize-handle-h" ref={leftHandle} />
+          </>
         )}
-      </button>
 
-      {open && dropdownPos && (
-        <div style={{
-          position: 'fixed', top: dropdownPos.top, right: dropdownPos.right,
-          width: 340,
-          background: 'var(--surface)', border: '1px solid var(--border)',
-          borderRadius: 10, boxShadow: '0 8px 32px rgba(0,0,0,.4)',
-          zIndex: 9999, maxHeight: 420, display: 'flex', flexDirection: 'column',
-          overflow: 'hidden',
-        }}>
-          <div style={{
-            padding: '12px 16px', borderBottom: '1px solid var(--border)',
-            fontWeight: 600, fontSize: 13, color: 'var(--text)',
-          }}>
-            Notifications
+        <div className="v10-center-region" style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          <div style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+            <PanelCenter />
           </div>
-          <div style={{ overflowY: 'auto', flex: 1 }}>
-            {notifications.length === 0 ? (
-              <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-dim)', fontSize: 13 }}>
-                No notifications yet
-              </div>
-            ) : notifications.slice(0, 50).map(n => {
-              const clickable = !!n.peer;
-              return (
-                <div
-                  key={n.id}
-                  role={clickable ? 'link' : undefined}
-                  tabIndex={clickable ? 0 : undefined}
-                  data-peer={n.peer ?? undefined}
-                  onClick={clickable ? () => {
-                    setOpen(false);
-                    navigate(`/agent?tab=peers&peer=${encodeURIComponent(n.peer!)}`);
-                  } : undefined}
-                  onKeyDown={clickable ? (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      setOpen(false);
-                      navigate(`/agent?tab=peers&peer=${encodeURIComponent(n.peer!)}`);
-                    }
-                  } : undefined}
-                  style={{
-                    padding: '10px 16px', borderBottom: '1px solid var(--border)',
-                    display: 'flex', gap: 10, alignItems: 'flex-start',
-                    background: n.read ? 'transparent' : 'rgba(74,222,128,.06)',
-                    cursor: clickable ? 'pointer' : 'default',
-                    transition: 'background .1s ease',
-                  }}
-                  onMouseEnter={clickable ? (e) => { e.currentTarget.style.background = 'rgba(74,222,128,.12)'; } : undefined}
-                  onMouseLeave={clickable ? (e) => { e.currentTarget.style.background = n.read ? 'transparent' : 'rgba(74,222,128,.06)'; } : undefined}
-                >
-                  <span style={{ fontSize: 16, flexShrink: 0, marginTop: 1 }}>
-                    {NOTIF_ICONS[n.type] ?? '\u{1F514}'}
-                  </span>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ fontWeight: 600, fontSize: 12, color: 'var(--text)', marginBottom: 2 }}>
-                      {n.title}
-                    </div>
-                    <div style={{
-                      fontSize: 12, color: 'var(--text-dim)', lineHeight: 1.4,
-                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                    }}>
-                      {n.message}
-                    </div>
-                    <div style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 3 }}>
-                      {formatTimeAgo(n.ts)}
-                      {clickable && <span style={{ marginLeft: 6, color: 'var(--green)', fontWeight: 500 }}>Open chat &rarr;</span>}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+          <PanelBottom />
         </div>
-      )}
+
+        {!rightCollapsed && (
+          <>
+            <div className="v10-resize-handle-h" ref={rightHandle} />
+            <div className="v10-panel-right" style={{ width: rightWidth }}>
+              <PanelRight />
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }
 
+const NetworkDebugPage = React.lazy(() =>
+  import('./pages/Network.js').then((m) => ({ default: m.NetworkPage }))
+);
+
 export function App() {
-  const installedApps = useInstalledApps();
-  const liveStatus = useLiveStatus();
-  const currentVersion = liveStatus?.version;
-  const commitShort = liveStatus?.commit;
-  const updateAvailable = liveStatus?.updateAvailable === true;
-  const latestCommit = liveStatus?.latestCommit;
-
   return (
-    <div className="app-layout">
-<aside className="sidebar">
-        <div className="sidebar-logo">
-          <style>{`@keyframes pulse-fade{0%,100%{opacity:1}50%{opacity:.4}}`}</style>
-          <div className="mono" style={{ fontSize: 15, fontWeight: 700, color: 'var(--green)', letterSpacing: '-0.02em' }}>{liveStatus?.name ?? '…'}</div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginTop: 6 }}>
-            <span style={{ fontSize: 9, color: 'var(--text-dim)', letterSpacing: '0.02em' }}>powered by</span>
-            <svg width="60" height="13" viewBox="0 0 180 40" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ opacity: 0.55 }}>
-              <path d="M55.0428 28.0111C59.7903 28.0111 62.6388 24.531 62.6388 20.3908C62.6388 16.2806 59.7903 12.8005 55.0428 12.8005C50.325 12.8005 47.4766 16.2806 47.4766 20.3908C47.4766 24.531 50.325 28.0111 55.0428 28.0111ZM55.0428 24.621C52.6988 24.621 51.3932 22.6709 51.3932 20.3908C51.3932 18.1407 52.6988 16.1906 55.0428 16.1906C57.3869 16.1906 58.7221 18.1407 58.7221 20.3908C58.7221 22.6709 57.3869 24.621 55.0428 24.621Z" fill="white"/>
-              <path d="M65.4344 27.6511H69.2027V18.0807C69.8258 17.1507 71.4874 16.4606 72.7336 16.4606C73.149 16.4606 73.5051 16.4906 73.7721 16.5507V12.8305C71.9918 12.8305 70.2115 13.8505 69.2027 15.1406V13.1605H65.4344V27.6511Z" fill="white"/>
-              <path d="M77.9959 11.0304C79.2421 11.0304 80.251 10.0104 80.251 8.75031C80.251 7.49026 79.2421 6.47021 77.9959 6.47021C76.7794 6.47021 75.7409 7.49026 75.7409 8.75031C75.7409 10.0104 76.7794 11.0304 77.9959 11.0304ZM76.1266 27.6511H79.8949V13.1605H76.1266V27.6511Z" fill="white"/>
-              <path d="M83.3347 31.3713C85.115 32.9614 87.0437 33.5314 89.5064 33.5314C93.0373 33.5314 97.2507 32.1813 97.2507 26.6611V13.1605H93.4527V15.0206C92.2955 13.5505 90.7526 12.8005 89.0317 12.8005C85.4117 12.8005 82.7116 15.4406 82.7116 20.1808C82.7116 25.011 85.4414 27.5611 89.0317 27.5611C90.7823 27.5611 92.3252 26.7211 93.4527 25.281V26.7511C93.4527 29.6012 91.3164 30.4113 89.5064 30.4113C87.6964 30.4113 86.1832 29.9012 85.026 28.6112L83.3347 31.3713ZM93.4527 22.5209C92.8296 23.4509 91.4647 24.171 90.2185 24.171C88.0822 24.171 86.5986 22.6709 86.5986 20.1808C86.5986 17.6907 88.0822 16.1906 90.2185 16.1906C91.4647 16.1906 92.8296 16.8807 93.4527 17.8407V22.5209Z" fill="white"/>
-              <path d="M102.857 11.0304C104.104 11.0304 105.113 10.0104 105.113 8.75031C105.113 7.49026 104.104 6.47021 102.857 6.47021C101.641 6.47021 100.602 7.49026 100.602 8.75031C100.602 10.0104 101.641 11.0304 102.857 11.0304ZM100.988 27.6511H104.756V13.1605H100.988V27.6511Z" fill="white"/>
-              <path d="M118.166 27.6511H121.934V17.4207C121.934 14.6006 120.421 12.8005 117.276 12.8005C114.932 12.8005 113.181 13.9405 112.261 15.0506V13.1605H108.493V27.6511H112.261V17.9007C112.884 17.0307 114.042 16.1906 115.525 16.1906C117.127 16.1906 118.166 16.8807 118.166 18.8908V27.6511Z" fill="white"/>
-              <path d="M130.483 28.0111C132.055 28.0111 133.064 27.5911 133.628 27.0811L132.827 24.201C132.619 24.411 132.085 24.621 131.521 24.621C130.69 24.621 130.216 23.931 130.216 23.0309V16.4906H133.123V13.1605H130.216V9.20033H126.418V13.1605H124.044V16.4906H126.418V24.051C126.418 26.6311 127.842 28.0111 130.483 28.0111Z" fill="white"/>
-              <path d="M135.702 27.6511H139.47V18.0807C140.093 17.1507 141.755 16.4606 143.001 16.4606C143.416 16.4606 143.772 16.4906 144.039 16.5507V12.8305C142.259 12.8305 140.479 13.8505 139.47 15.1406V13.1605H135.702V27.6511Z" fill="white"/>
-              <path d="M156.245 27.6511H160.043V13.1605H156.245V15.0206C155.117 13.5505 153.515 12.8005 151.824 12.8005C148.174 12.8005 145.474 15.6806 145.474 20.4208C145.474 25.251 148.204 28.0111 151.824 28.0111C153.545 28.0111 155.117 27.2311 156.245 25.8211V27.6511ZM156.245 22.9709C155.592 23.931 154.257 24.621 152.981 24.621C150.845 24.621 149.361 22.9109 149.361 20.4208C149.361 17.9007 150.845 16.2206 152.981 16.2206C154.257 16.2206 155.592 16.9107 156.245 17.8707V22.9709Z" fill="white"/>
-              <path d="M165.649 11.0304C166.895 11.0304 167.904 10.0104 167.904 8.75031C167.904 7.49026 166.895 6.47021 165.649 6.47021C164.432 6.47021 163.394 7.49026 163.394 8.75031C163.394 10.0104 164.432 11.0304 165.649 11.0304ZM163.78 27.6511H167.548V13.1605H163.78V27.6511Z" fill="white"/>
-              <path d="M175.32 28.0111C176.863 28.0111 177.871 27.5911 178.435 27.0811L177.634 24.201C177.456 24.411 176.922 24.621 176.358 24.621C175.527 24.621 175.053 23.931 175.053 23.0309V7.64026H171.284V24.051C171.284 26.6311 172.679 28.0111 175.32 28.0111Z" fill="white"/>
-              <path fillRule="evenodd" clipRule="evenodd" d="M19.781 9.94781C14.2903 9.94781 9.8385 14.4484 9.8385 20.0008C9.8385 25.5525 14.2903 30.0531 19.781 30.0531C22.833 30.0531 25.5632 28.6622 27.3869 26.4736L34.9141 32.8796C31.2855 37.2341 25.8532 40.0016 19.781 40.0016C8.85592 40.0016 0 31.0467 0 20.0008C0 8.95432 8.85592 0 19.781 0V9.94781ZM36.8737 30.0724L28.3719 25.0628C28.662 24.5606 28.9105 24.0308 29.112 23.4781L38.3464 26.9194C37.9453 28.0192 37.4508 29.0732 36.8737 30.0724ZM29.7216 20.0007H39.5609C39.5609 18.8159 39.4583 17.6554 39.2628 16.5272L29.5719 18.2549C29.6701 18.822 29.7216 19.4053 29.7216 20.0007ZM34.988 7.20831L27.425 13.5712C27.0546 13.1215 26.646 12.7054 26.2045 12.3272L32.5596 4.73338C33.4381 5.4858 34.251 6.31374 34.988 7.20831Z" fill="white"/>
-            </svg>
-          </div>
-        </div>
-
-        <nav className="sidebar-nav">
-          <NavLink to="/" end className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}>
-            {NAV_ICONS.home}<span>Dashboard</span>
-          </NavLink>
-          <NavLink to="/explorer" className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}>
-            {NAV_ICONS.graph}<span>Memory Explorer</span>
-          </NavLink>
-          <NavLink to="/agent" className={({ isActive }) => `nav-btn${isActive ? ' active' : ''}`}>
-            {NAV_ICONS.terminal}<span>Agent Hub</span>
-          </NavLink>
-          <AppsNavSection installedApps={installedApps} />
-          <SettingsNavSection />
-        </nav>
-
-        <div className="sidebar-footer">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-            <span className="pulse-dot" style={{ width: 7, height: 7, borderRadius: '50%', background: liveStatus ? 'var(--green)' : 'var(--text-dim)', boxShadow: liveStatus ? '0 0 8px rgba(74,222,128,.4)' : 'none', display: 'inline-block' }} />
-            <span style={{ color: liveStatus ? 'var(--green)' : 'var(--text-muted)', fontWeight: 600 }}>{liveStatus ? 'Online' : 'Connecting…'}</span>
-            <span className="mono" style={{ color: 'var(--text-dim)', marginLeft: 'auto', fontSize: 10 }}>
-              {liveStatus?.connectedPeers != null ? `${liveStatus.connectedPeers} peers` : liveStatus?.peerCount != null ? `${liveStatus.peerCount} peers` : '…'}
-            </span>
-          </div>
-          <div className="mono" style={{ color: 'var(--text-dim)', fontSize: 10, marginBottom: 6 }}>
-            {liveStatus?.networkName ?? liveStatus?.networkId ?? 'unknown network'}{liveStatus?.syncing ? ' · syncing…' : ''}
-          </div>
-          {currentVersion && (
-            <div style={{ borderTop: '1px solid var(--border)', paddingTop: 6 }}>
-              <div className="mono" style={{ fontSize: 10, color: 'var(--text-dim)', marginBottom: 2 }}>
-                v{currentVersion}
-              </div>
-              {updateAvailable ? (
-                <div className="mono" style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 10, marginBottom: 2 }}>
-                  <span style={{ color: 'var(--text-dim)' }}>{commitShort}</span>
-                  <span style={{ color: '#fbbf24' }}>→</span>
-                  <span style={{ color: '#fbbf24', fontWeight: 600 }}>{latestCommit || '?'}</span>
-                  <span title={liveStatus?.autoUpdate ? 'Auto-update will apply the new version' : 'Update manually'} style={{
-                    fontSize: 8, fontWeight: 600, padding: '1px 5px', borderRadius: 3, marginLeft: 2,
-                    background: 'rgba(251,191,36,.12)', color: '#fbbf24', cursor: 'default',
-                    animation: 'pulse-fade 2.5s ease-in-out infinite',
-                  }}>{liveStatus?.autoUpdate ? 'updating' : 'update available'}</span>
-                </div>
-              ) : commitShort ? (
-                <div className="mono" style={{ fontSize: 10, marginBottom: 2 }}>
-                  <span style={{ color: liveStatus?.updateAvailable === false ? 'var(--green)' : 'var(--text-dim)' }}>
-                    {commitShort}{liveStatus?.updateAvailable === false ? ' · latest' : ''}
-                  </span>
-                </div>
-              ) : null}
-              <div style={{ fontSize: 10, color: liveStatus?.autoUpdate ? 'var(--green)' : 'var(--text-dim)', opacity: 0.7 }}>
-                Auto-updater: {liveStatus?.autoUpdate ? 'enabled' : 'disabled'}
-              </div>
-            </div>
-          )}
-        </div>
-      </aside>
-
-      <main className="main-content">
-        <div style={{
-          display: 'flex', justifyContent: 'flex-end', alignItems: 'center',
-          padding: '4px 16px', borderBottom: '1px solid var(--border)',
-          flexShrink: 0, minHeight: 36,
-        }}>
-          <NotificationBell />
-        </div>
-        <div style={{ flex: 1, overflow: 'auto' }}>
-        <Suspense fallback={<div className="lazy-loading-fallback"><span className="lazy-spinner" />Loading…</div>}>
-        <Routes>
-          <Route path="/" element={<DashboardPage />} />
-          <Route path="/explorer/*" element={<ExplorerPage />} />
-          <Route path="/agent" element={<AgentHubPage />} />
-          <Route path="/messages" element={<Navigate to="/agent" replace />} />
-          <Route path="/apps/*" element={<AppsPage apps={installedApps} />} />
-          <Route path="/operations/*" element={<Navigate to="/settings?tab=observability" replace />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/app/:appId" element={<AppHostPage apps={installedApps} />} />
-          {/* Backward-compatible redirects for legacy routes */}
-          <Route path="/network" element={<Navigate to="/" replace />} />
-          <Route path="/wallet" element={<Navigate to="/settings" replace />} />
-          <Route path="/integrations" element={<Navigate to="/settings" replace />} />
-        </Routes>
-        </Suspense>
-        </div>
-      </main>
-    </div>
+    <Routes>
+      <Route path="/network" element={
+        <React.Suspense fallback={<div className="lazy-spinner">Loading...</div>}>
+          <NetworkDebugPage />
+        </React.Suspense>
+      } />
+      <Route path="*" element={<AppShell />} />
+    </Routes>
   );
 }

--- a/packages/node-ui/src/ui/api-wrapper.ts
+++ b/packages/node-ui/src/ui/api-wrapper.ts
@@ -1,0 +1,40 @@
+import * as realApi from './api.js';
+import { mockApi } from './mocks/provider.js';
+
+let useMocks: boolean | null = null;
+
+async function detectMockMode(): Promise<boolean> {
+  if (useMocks !== null) return useMocks;
+  try {
+    const resp = await fetch('/api/status', { signal: AbortSignal.timeout(2000) });
+    useMocks = !resp.ok;
+  } catch {
+    useMocks = true;
+  }
+  return useMocks;
+}
+
+async function withFallback<T>(realFn: () => Promise<T>, mockFn: () => Promise<T>): Promise<T> {
+  const mock = await detectMockMode();
+  if (mock) return mockFn();
+  try {
+    return await realFn();
+  } catch {
+    return mockFn();
+  }
+}
+
+export const api = {
+  fetchStatus: () => withFallback(realApi.fetchStatus, mockApi.fetchStatus),
+  fetchMetrics: () => withFallback(realApi.fetchMetrics, mockApi.fetchMetrics),
+  fetchAgents: () => withFallback(realApi.fetchAgents, mockApi.fetchAgents),
+  fetchContextGraphs: () => withFallback(realApi.fetchContextGraphs, mockApi.fetchContextGraphs),
+  fetchOperationsWithPhases: (p?: any) => withFallback(() => realApi.fetchOperationsWithPhases(p), mockApi.fetchOperationsWithPhases),
+  fetchEconomics: () => withFallback(realApi.fetchEconomics, mockApi.fetchEconomics),
+  fetchNotifications: (p?: any) => withFallback(() => realApi.fetchNotifications(p), mockApi.fetchNotifications),
+  fetchNodeLog: (p?: any) => withFallback(() => realApi.fetchNodeLog(p), mockApi.fetchNodeLog),
+  fetchMemorySessions: (n?: number) => withFallback(() => realApi.fetchMemorySessions(n), mockApi.fetchMemorySessions),
+  markNotificationsRead: realApi.markNotificationsRead,
+  streamChatMessage: realApi.streamChatMessage,
+  executeQuery: realApi.executeQuery,
+};

--- a/packages/node-ui/src/ui/api-wrapper.ts
+++ b/packages/node-ui/src/ui/api-wrapper.ts
@@ -3,11 +3,27 @@ import { mockApi } from './mocks/provider.js';
 
 let useMocks: boolean | null = null;
 
+function authHeaders(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  const token = (window as any).__DKG_TOKEN__;
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
 async function detectMockMode(): Promise<boolean> {
   if (useMocks !== null) return useMocks;
   try {
-    const resp = await fetch('/api/status', { signal: AbortSignal.timeout(2000) });
-    useMocks = !resp.ok;
+    const resp = await fetch('/api/status', {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(2000),
+    });
+    if (resp.ok) {
+      useMocks = false;
+    } else if (resp.status === 401) {
+      useMocks = false;
+    } else {
+      useMocks = true;
+    }
   } catch {
     useMocks = true;
   }
@@ -17,11 +33,7 @@ async function detectMockMode(): Promise<boolean> {
 async function withFallback<T>(realFn: () => Promise<T>, mockFn: () => Promise<T>): Promise<T> {
   const mock = await detectMockMode();
   if (mock) return mockFn();
-  try {
-    return await realFn();
-  } catch {
-    return mockFn();
-  }
+  return realFn();
 }
 
 export const api = {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -276,6 +276,102 @@ export const publishTriples = async (contextGraphId: string, quads: any[]) => {
   return post<any>('/api/shared-memory/publish', { paranetId: contextGraphId, selection: 'all', clearAfter: true });
 };
 
+// --- Assertions (WM objects) ---
+
+export interface AssertionInfo {
+  name: string;
+  graphUri: string;
+  tripleCount?: number;
+}
+
+/** Discover assertions in WM by querying named graphs that match the assertion pattern. */
+export async function listAssertions(contextGraphId: string): Promise<AssertionInfo[]> {
+  const sparql = `SELECT DISTINCT ?g (COUNT(?s) AS ?cnt) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g`;
+  const data = await executeQuery(sparql, contextGraphId);
+  const bindings: any[] = data?.result?.bindings ?? [];
+  const prefix = `did:dkg:context-graph:${contextGraphId}/assertion/`;
+  const result: AssertionInfo[] = [];
+  for (const b of bindings) {
+    const g = typeof b.g === 'string' ? b.g : b.g?.value;
+    if (!g || !g.startsWith(prefix)) continue;
+    const tail = g.slice(prefix.length);
+    const slash = tail.indexOf('/');
+    const name = slash >= 0 ? tail.slice(slash + 1) : tail;
+    const cnt = typeof b.cnt === 'string' ? parseInt(b.cnt, 10) : (b.cnt?.value ? parseInt(b.cnt.value, 10) : undefined);
+    result.push({ name, graphUri: g, tripleCount: Number.isFinite(cnt) ? cnt : undefined });
+  }
+  return result;
+}
+
+/** Promote an assertion from WM to SWM. */
+export const promoteAssertion = (contextGraphId: string, assertionName: string, entities: string | string[] = 'all') =>
+  post<{ promotedCount: number }>(`/api/assertion/${encodeURIComponent(assertionName)}/promote`, { contextGraphId, entities });
+
+// --- File preview ---
+
+export interface ExtractionStatus {
+  assertionUri: string;
+  status: string;
+  fileHash: string;
+  detectedContentType: string;
+  pipelineUsed: string | null;
+  tripleCount: number;
+  mdIntermediateHash?: string;
+  startedAt: string;
+  completedAt?: string;
+}
+
+/** Fetch extraction status for an assertion (includes fileHash + contentType). */
+export const fetchExtractionStatus = (assertionName: string, contextGraphId: string) =>
+  get<ExtractionStatus>(`/api/assertion/${encodeURIComponent(assertionName)}/extraction-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
+
+/** Build a URL to serve a stored file by its hash. */
+export function fileUrl(hash: string, contentType?: string): string {
+  const h = hash.startsWith('sha256:') ? hash.slice('sha256:'.length) : hash;
+  const params = contentType ? `?contentType=${encodeURIComponent(contentType)}` : '';
+  return `${BASE}/api/file/sha256:${h}${params}`;
+}
+
+export interface SwmRootEntity {
+  uri: string;
+  label: string;
+  tripleCount: number;
+}
+
+/** List root entities in SWM with their triple counts. */
+export async function listSwmEntities(contextGraphId: string): Promise<SwmRootEntity[]> {
+  const sparql = `SELECT ?s (COUNT(?p) AS ?cnt) WHERE { ?s ?p ?o } GROUP BY ?s ORDER BY DESC(?cnt)`;
+  const data = await executeQuery(sparql, contextGraphId, true, '_shared_memory');
+  const bindings: any[] = data?.result?.bindings ?? [];
+  return bindings.map((b) => {
+    const uri = typeof b.s === 'string' ? b.s : b.s?.value ?? '';
+    const cntRaw = typeof b.cnt === 'string' ? b.cnt : b.cnt?.value ?? '0';
+    const m = cntRaw.match(/^"?(\d+)/);
+    const tripleCount = m ? parseInt(m[1], 10) : 0;
+    const hash = uri.lastIndexOf('#');
+    const slash = uri.lastIndexOf('/');
+    const cut = Math.max(hash, slash);
+    const label = cut >= 0 ? uri.slice(cut + 1) : uri;
+    return { uri, label, tripleCount };
+  });
+}
+
+export interface PublishResult {
+  kcId: string;
+  status: string;
+  kas: { tokenId: string; rootEntity: string }[];
+  txHash?: string;
+  blockNumber?: number;
+}
+
+/** Publish SWM content on-chain (SWM -> VM). Pass rootEntities to selectively publish, or omit for all. */
+export const publishSharedMemory = (contextGraphId: string, rootEntities?: string[]) =>
+  post<PublishResult>('/api/shared-memory/publish', {
+    paranetId: contextGraphId,
+    selection: rootEntities ?? 'all',
+    clearAfter: !rootEntities,
+  });
+
 // --- Query history ---
 export const fetchQueryHistory = (limit = 50, offset = 0) =>
   get<{ history: any[] }>(`/api/query-history?limit=${limit}&offset=${offset}`);

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -147,7 +147,38 @@ export const fetchNodeLog = (params: { lines?: number; q?: string } = {}) => {
 };
 
 // --- Context Graphs ---
-export const fetchContextGraphs = () => get<{ contextGraphs: any[] }>('/api/context-graph/list');
+// Use /api/paranet/* which works on both the installed release and dev builds.
+// The V10 aliases (/api/context-graph/*) are only available on the latest dev daemon.
+export async function fetchContextGraphs(): Promise<{ contextGraphs: any[] }> {
+  const data = await get<{ paranets?: any[]; contextGraphs?: any[] }>('/api/paranet/list');
+  const list = data.contextGraphs ?? data.paranets ?? [];
+  return { contextGraphs: list.filter((p: any) => !p.isSystem) };
+}
+
+export async function createContextGraph(id: string, name: string, description?: string): Promise<{ created: string; uri: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const res = await fetch(`${BASE}/api/paranet/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      body: JSON.stringify({ id, name, description }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new Error((errBody as { error?: string })?.error ?? `HTTP ${res.status}`);
+    }
+    return res.json() as Promise<{ created: string; uri: string }>;
+  } catch (err: any) {
+    if (err.name === 'AbortError') {
+      throw new Error('Creating project is taking longer than expected — it may still complete in the background. Refresh the page in a moment.');
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 // --- Catch-up sync jobs ---
 export interface CatchupStatusResponse {
@@ -170,6 +201,70 @@ export interface CatchupStatusResponse {
 
 export const fetchCatchupStatus = (contextGraphId: string) =>
   get<CatchupStatusResponse>(`/api/sync/catchup-status?contextGraphId=${encodeURIComponent(contextGraphId)}`);
+
+// --- File import to Working Memory ---
+export interface ImportFileResult {
+  assertionUri: string;
+  fileHash: string;
+  detectedContentType: string;
+  extraction: {
+    status: 'completed' | 'skipped' | 'error';
+    tripleCount?: number;
+    triplesWritten?: number;
+    provenance?: any;
+    error?: string;
+    pipelineUsed?: string;
+  };
+}
+
+const EXT_TO_MIME: Record<string, string> = {
+  md: 'text/markdown', txt: 'text/plain', csv: 'text/csv',
+  json: 'application/json', xml: 'application/xml',
+  yaml: 'text/yaml', yml: 'text/yaml',
+  pdf: 'application/pdf',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  doc: 'application/msword',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ttl: 'text/turtle', rdf: 'application/rdf+xml', owl: 'application/rdf+xml',
+  html: 'text/html', htm: 'text/html',
+  py: 'text/x-python', ts: 'text/typescript', js: 'text/javascript',
+  tsx: 'text/typescript', jsx: 'text/javascript',
+  java: 'text/x-java', go: 'text/x-go', rs: 'text/x-rust',
+  c: 'text/x-c', cpp: 'text/x-c++', h: 'text/x-c',
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', webp: 'image/webp',
+};
+
+function detectContentType(file: File): string | undefined {
+  if (file.type && file.type !== 'application/octet-stream') return file.type;
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  return EXT_TO_MIME[ext];
+}
+
+export async function importFile(
+  assertionName: string,
+  contextGraphId: string,
+  file: File,
+  opts?: { ontologyRef?: string; subGraphName?: string },
+): Promise<ImportFileResult> {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('contextGraphId', contextGraphId);
+  const ct = detectContentType(file);
+  if (ct) form.append('contentType', ct);
+  if (opts?.ontologyRef) form.append('ontologyRef', opts.ontologyRef);
+  if (opts?.subGraphName) form.append('subGraphName', opts.subGraphName);
+
+  const res = await fetch(`${BASE}/api/assertion/${encodeURIComponent(assertionName)}/import-file`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: form,
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    throw new Error((errBody as { error?: string })?.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<ImportFileResult>;
+}
 
 // --- Query ---
 export const executeQuery = (sparql: string, contextGraphId?: string, includeSharedMemory?: boolean, graphSuffix?: '_shared_memory') =>

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -4,7 +4,7 @@ declare global {
   interface Window { __DKG_TOKEN__?: string; }
 }
 
-function authHeaders(): Record<string, string> {
+export function authHeaders(): Record<string, string> {
   if (typeof window === 'undefined') return {};
   const token = window.__DKG_TOKEN__;
   if (!token) return {};

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -1,0 +1,241 @@
+import React, { useState } from 'react';
+import { createContextGraph, fetchContextGraphs } from '../../api.js';
+import { useProjectsStore } from '../../stores/projects.js';
+import { useTabsStore } from '../../stores/tabs.js';
+import { useJourneyStore } from '../../stores/journey.js';
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+interface CreateProjectModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [access, setAccess] = useState<'curated' | 'public'>('curated');
+  const [publishPolicy, setPublishPolicy] = useState<'curator-only' | 'open'>('curator-only');
+  const [ontology, setOntology] = useState<'agent' | 'upload' | 'community'>('agent');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [quorum, setQuorum] = useState('off');
+  const [swmTtl, setSwmTtl] = useState('7d');
+  const [swmCap, setSwmCap] = useState('100k');
+  const [creating, setCreating] = useState(false);
+  const [progress, setProgress] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const { setContextGraphs, contextGraphs, setActiveProject } = useProjectsStore();
+  const { openTab } = useTabsStore();
+  const { setStage, stage } = useJourneyStore();
+
+  if (!open) return null;
+
+  const handleCreate = async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+
+    setCreating(true);
+    setError(null);
+    setProgress('Registering project on the network…');
+
+    const cgId = `cg:${slugify(trimmedName)}-${Date.now().toString(36)}`;
+
+    try {
+      const slowTimer = setTimeout(() => setProgress('On-chain registration in progress — this can take up to 30s…'), 5000);
+
+      const result = await createContextGraph(cgId, trimmedName, description.trim() || undefined);
+      clearTimeout(slowTimer);
+
+      setProgress('Refreshing project list…');
+      const { contextGraphs: freshList } = await fetchContextGraphs();
+      setContextGraphs(freshList ?? []);
+
+      setActiveProject(result.created);
+      openTab({ id: `project:${result.created}`, label: trimmedName, closable: true });
+      if (stage < 2) setStage(2);
+
+      setName('');
+      setDescription('');
+      setProgress('');
+      onClose();
+    } catch (err: any) {
+      const msg = err?.message || 'Failed to create project';
+      if (msg.includes('already exists') || msg.includes('409')) {
+        setError('A project with this ID already exists. Try a different name.');
+      } else if (msg.includes('taking longer')) {
+        setError(msg);
+      } else {
+        setError(msg);
+      }
+      setProgress('');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const isFirstProject = contextGraphs.length === 0;
+
+  return (
+    <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="v10-modal-box">
+        <div className="v10-modal-header">
+          <div className="v10-modal-title">Create New Project</div>
+          <div className="v10-modal-subtitle">
+            A project gives your agent structured memory — a place to draft, share, and publish knowledge.
+          </div>
+        </div>
+
+        <div className="v10-modal-body">
+          {error && (
+            <div className="v10-modal-error">
+              {error}
+            </div>
+          )}
+
+          {isFirstProject && (
+            <div className="v10-modal-tip">
+              <div className="v10-modal-tip-title">First project tip</div>
+              This is your agent's first memory space. Consider importing any existing knowledge
+              your agent has — notes, documents, conversation logs — so it can build on what it already knows.
+            </div>
+          )}
+
+          <div className="v10-form-group">
+            <label className="v10-form-label">Project Name</label>
+            <input
+              className="v10-form-input"
+              type="text"
+              placeholder="e.g. Pharma Drug Interactions"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+            />
+          </div>
+
+          <div className="v10-form-group">
+            <label className="v10-form-label">Description</label>
+            <textarea
+              className="v10-form-textarea"
+              placeholder="What should your agent remember? Describe the domain, goals, or context..."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          <div className="v10-form-divider" />
+
+          <div className="v10-form-group">
+            <label className="v10-form-label">Access</label>
+            <div className="v10-form-radio-group">
+              <label className="v10-form-radio">
+                <input type="radio" checked={access === 'curated'} onChange={() => setAccess('curated')} />
+                Curated — only invited collaborators can view
+              </label>
+              <label className="v10-form-radio">
+                <input type="radio" checked={access === 'public'} onChange={() => setAccess('public')} />
+                Public — anyone can view
+              </label>
+            </div>
+          </div>
+
+          <div className="v10-form-group">
+            <label className="v10-form-label">Publish Policy</label>
+            <div className="v10-form-radio-group">
+              <label className="v10-form-radio">
+                <input type="radio" checked={publishPolicy === 'curator-only'} onChange={() => setPublishPolicy('curator-only')} />
+                Curator only — only the curator can publish to Verified Memory
+              </label>
+              <label className="v10-form-radio">
+                <input type="radio" checked={publishPolicy === 'open'} onChange={() => setPublishPolicy('open')} />
+                Open — any collaborator can publish to Verified Memory
+              </label>
+            </div>
+          </div>
+
+          <div className="v10-form-group">
+            <label className="v10-form-label">Ontology</label>
+            <div className="v10-form-radio-group">
+              <label className="v10-form-radio">
+                <input type="radio" checked={ontology === 'agent'} onChange={() => setOntology('agent')} />
+                Let agent decide — your agent will choose the best vocabulary
+              </label>
+              <div className="v10-form-radio-desc">
+                Your agent will query community ontologies and select the most relevant one.
+              </div>
+              <label className="v10-form-radio">
+                <input type="radio" checked={ontology === 'upload'} onChange={() => setOntology('upload')} />
+                Upload an ontology file (.ttl, .owl, .rdf)
+              </label>
+              <label className="v10-form-radio">
+                <input type="radio" checked={ontology === 'community'} onChange={() => setOntology('community')} />
+                Choose from community ontologies
+              </label>
+            </div>
+          </div>
+
+          <div className="v10-form-advanced-toggle" onClick={() => setShowAdvanced(!showAdvanced)}>
+            <span className={`v10-form-adv-chevron ${showAdvanced ? 'open' : ''}`}>▸</span>
+            <span>Advanced settings</span>
+          </div>
+
+          {showAdvanced && (
+            <div className="v10-form-advanced-body">
+              <div className="v10-form-group">
+                <label className="v10-form-label">Consensus Quorum</label>
+                <select className="v10-form-select" value={quorum} onChange={(e) => setQuorum(e.target.value)}>
+                  <option value="off">Off — no consensus verification required</option>
+                  <option value="2of3">2 of 3 — lightweight consensus</option>
+                  <option value="3of5">3 of 5 — standard consensus (recommended for teams)</option>
+                  <option value="custom">Custom — set your own M of N</option>
+                </select>
+              </div>
+              <div className="v10-form-group">
+                <label className="v10-form-label">SWM TTL</label>
+                <select className="v10-form-select" value={swmTtl} onChange={(e) => setSwmTtl(e.target.value)}>
+                  <option value="7d">7 days (default)</option>
+                  <option value="1h">1 hour</option>
+                  <option value="1d">1 day</option>
+                  <option value="30d">30 days</option>
+                </select>
+              </div>
+              <div className="v10-form-group" style={{ marginBottom: 0 }}>
+                <label className="v10-form-label">SWM Size Cap</label>
+                <select className="v10-form-select" value={swmCap} onChange={(e) => setSwmCap(e.target.value)}>
+                  <option value="100k">100K triples (default)</option>
+                  <option value="10k">10K triples</option>
+                  <option value="1m">1M triples</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          <div className="v10-layer-preview">
+            <div className="v10-layer-preview-title">Layer Activation</div>
+            <span style={{ fontFamily: 'var(--font-mono)' }}>
+              ┌─ Verified Memory ── activates on first publish (requires TRAC)<br />
+              ├─ Shared Memory ──── activates on first share (free)<br />
+              └─ Working Memory ─── created immediately (local, free)
+            </span>
+          </div>
+        </div>
+
+        <div className="v10-modal-footer">
+          <button className="v10-modal-btn" onClick={onClose}>Cancel</button>
+          <button
+            className="v10-modal-btn primary"
+            onClick={handleCreate}
+            disabled={!name.trim() || creating}
+          >
+            {creating ? progress || 'Creating…' : 'Create Project'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -130,50 +130,50 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
 
           <div className="v10-form-divider" />
 
-          <div className="v10-form-group">
-            <label className="v10-form-label">Access</label>
+          <div className="v10-form-group" style={{ opacity: 0.5, pointerEvents: 'none' }}>
+            <label className="v10-form-label">Access <span style={{ fontSize: 10, fontWeight: 400, color: 'var(--text-tertiary)' }}>(coming soon)</span></label>
             <div className="v10-form-radio-group">
               <label className="v10-form-radio">
-                <input type="radio" checked={access === 'curated'} onChange={() => setAccess('curated')} />
+                <input type="radio" checked={access === 'curated'} readOnly disabled />
                 Curated — only invited collaborators can view
               </label>
               <label className="v10-form-radio">
-                <input type="radio" checked={access === 'public'} onChange={() => setAccess('public')} />
+                <input type="radio" checked={access === 'public'} readOnly disabled />
                 Public — anyone can view
               </label>
             </div>
           </div>
 
-          <div className="v10-form-group">
-            <label className="v10-form-label">Publish Policy</label>
+          <div className="v10-form-group" style={{ opacity: 0.5, pointerEvents: 'none' }}>
+            <label className="v10-form-label">Publish Policy <span style={{ fontSize: 10, fontWeight: 400, color: 'var(--text-tertiary)' }}>(coming soon)</span></label>
             <div className="v10-form-radio-group">
               <label className="v10-form-radio">
-                <input type="radio" checked={publishPolicy === 'curator-only'} onChange={() => setPublishPolicy('curator-only')} />
+                <input type="radio" checked={publishPolicy === 'curator-only'} readOnly disabled />
                 Curator only — only the curator can publish to Verified Memory
               </label>
               <label className="v10-form-radio">
-                <input type="radio" checked={publishPolicy === 'open'} onChange={() => setPublishPolicy('open')} />
+                <input type="radio" checked={publishPolicy === 'open'} readOnly disabled />
                 Open — any collaborator can publish to Verified Memory
               </label>
             </div>
           </div>
 
-          <div className="v10-form-group">
-            <label className="v10-form-label">Ontology</label>
+          <div className="v10-form-group" style={{ opacity: 0.5, pointerEvents: 'none' }}>
+            <label className="v10-form-label">Ontology <span style={{ fontSize: 10, fontWeight: 400, color: 'var(--text-tertiary)' }}>(coming soon)</span></label>
             <div className="v10-form-radio-group">
               <label className="v10-form-radio">
-                <input type="radio" checked={ontology === 'agent'} onChange={() => setOntology('agent')} />
+                <input type="radio" checked={ontology === 'agent'} readOnly disabled />
                 Let agent decide — your agent will choose the best vocabulary
               </label>
               <div className="v10-form-radio-desc">
                 Your agent will query community ontologies and select the most relevant one.
               </div>
               <label className="v10-form-radio">
-                <input type="radio" checked={ontology === 'upload'} onChange={() => setOntology('upload')} />
+                <input type="radio" checked={ontology === 'upload'} readOnly disabled />
                 Upload an ontology file (.ttl, .owl, .rdf)
               </label>
               <label className="v10-form-radio">
-                <input type="radio" checked={ontology === 'community'} onChange={() => setOntology('community')} />
+                <input type="radio" checked={ontology === 'community'} readOnly disabled />
                 Choose from community ontologies
               </label>
             </div>
@@ -185,10 +185,10 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
           </div>
 
           {showAdvanced && (
-            <div className="v10-form-advanced-body">
+            <div className="v10-form-advanced-body" style={{ opacity: 0.5, pointerEvents: 'none' }}>
               <div className="v10-form-group">
-                <label className="v10-form-label">Consensus Quorum</label>
-                <select className="v10-form-select" value={quorum} onChange={(e) => setQuorum(e.target.value)}>
+                <label className="v10-form-label">Consensus Quorum <span style={{ fontSize: 10, fontWeight: 400, color: 'var(--text-tertiary)' }}>(coming soon)</span></label>
+                <select className="v10-form-select" value={quorum} disabled>
                   <option value="off">Off — no consensus verification required</option>
                   <option value="2of3">2 of 3 — lightweight consensus</option>
                   <option value="3of5">3 of 5 — standard consensus (recommended for teams)</option>
@@ -196,8 +196,8 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
                 </select>
               </div>
               <div className="v10-form-group">
-                <label className="v10-form-label">SWM TTL</label>
-                <select className="v10-form-select" value={swmTtl} onChange={(e) => setSwmTtl(e.target.value)}>
+                <label className="v10-form-label">SWM TTL <span style={{ fontSize: 10, fontWeight: 400, color: 'var(--text-tertiary)' }}>(coming soon)</span></label>
+                <select className="v10-form-select" value={swmTtl} disabled>
                   <option value="7d">7 days (default)</option>
                   <option value="1h">1 hour</option>
                   <option value="1d">1 day</option>
@@ -205,8 +205,8 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
                 </select>
               </div>
               <div className="v10-form-group" style={{ marginBottom: 0 }}>
-                <label className="v10-form-label">SWM Size Cap</label>
-                <select className="v10-form-select" value={swmCap} onChange={(e) => setSwmCap(e.target.value)}>
+                <label className="v10-form-label">SWM Size Cap <span style={{ fontSize: 10, fontWeight: 400, color: 'var(--text-tertiary)' }}>(coming soon)</span></label>
+                <select className="v10-form-select" value={swmCap} disabled>
                   <option value="100k">100K triples (default)</option>
                   <option value="10k">10K triples</option>
                   <option value="1m">1M triples</option>

--- a/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
@@ -1,0 +1,157 @@
+import React, { useState, useEffect } from 'react';
+import { fetchExtractionStatus, fileUrl, type ExtractionStatus } from '../../api.js';
+
+interface FilePreviewModalProps {
+  open: boolean;
+  onClose: () => void;
+  assertionName: string;
+  contextGraphId: string;
+}
+
+const PREVIEWABLE_TYPES: Record<string, 'pdf' | 'image' | 'text' | 'markdown'> = {
+  'application/pdf': 'pdf',
+  'image/png': 'image',
+  'image/jpeg': 'image',
+  'image/gif': 'image',
+  'image/webp': 'image',
+  'image/svg+xml': 'image',
+  'text/plain': 'text',
+  'text/markdown': 'markdown',
+  'text/csv': 'text',
+  'text/html': 'text',
+  'application/json': 'text',
+};
+
+function previewKind(ct: string): 'pdf' | 'image' | 'text' | 'binary' {
+  if (PREVIEWABLE_TYPES[ct]) return PREVIEWABLE_TYPES[ct] === 'markdown' ? 'text' : PREVIEWABLE_TYPES[ct];
+  if (ct.startsWith('text/')) return 'text';
+  if (ct.startsWith('image/')) return 'image';
+  return 'binary';
+}
+
+export function FilePreviewModal({ open, onClose, assertionName, contextGraphId }: FilePreviewModalProps) {
+  const [status, setStatus] = useState<ExtractionStatus | null>(null);
+  const [textContent, setTextContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    setTextContent(null);
+
+    fetchExtractionStatus(assertionName, contextGraphId)
+      .then(async (s) => {
+        setStatus(s);
+        const kind = previewKind(s.detectedContentType);
+        if (kind === 'text') {
+          const url = fileUrl(s.fileHash, s.detectedContentType);
+          const res = await fetch(url);
+          if (res.ok) setTextContent(await res.text());
+        }
+      })
+      .catch((err) => setError(err.message ?? 'Failed to load file info'))
+      .finally(() => setLoading(false));
+  }, [open, assertionName, contextGraphId]);
+
+  if (!open) return null;
+
+  const kind = status ? previewKind(status.detectedContentType) : null;
+  const url = status ? fileUrl(status.fileHash, status.detectedContentType) : null;
+
+  return (
+    <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="v10-modal-box v10-file-preview-modal">
+        <div className="v10-modal-header">
+          <div className="v10-modal-title">{assertionName}</div>
+          <button className="v10-modal-close" onClick={onClose}>×</button>
+        </div>
+
+        {loading && <div className="v10-file-preview-loading">Loading file preview...</div>}
+
+        {error && (
+          <div className="v10-file-preview-error">
+            <p>{error}</p>
+            <p style={{ fontSize: 11, marginTop: 4 }}>
+              File preview requires the extraction status to still be cached on the node.
+              If the node was restarted, the preview metadata may be unavailable.
+            </p>
+          </div>
+        )}
+
+        {status && !loading && (
+          <>
+            <div className="v10-file-preview-meta">
+              <span className="v10-file-preview-meta-item">
+                {status.detectedContentType}
+              </span>
+              <span className="v10-file-preview-meta-item">
+                {status.tripleCount} triples extracted
+              </span>
+              <span className="v10-file-preview-meta-item">
+                {status.pipelineUsed}
+              </span>
+              {status.completedAt && (
+                <span className="v10-file-preview-meta-item">
+                  {new Date(status.completedAt).toLocaleString()}
+                </span>
+              )}
+            </div>
+
+            <div className="v10-file-preview-content">
+              {kind === 'pdf' && url && (
+                <iframe
+                  src={url}
+                  className="v10-file-preview-iframe"
+                  title={`Preview: ${assertionName}`}
+                />
+              )}
+
+              {kind === 'image' && url && (
+                <img
+                  src={url}
+                  alt={assertionName}
+                  className="v10-file-preview-image"
+                />
+              )}
+
+              {kind === 'text' && textContent != null && (
+                <pre className="v10-file-preview-text">{textContent}</pre>
+              )}
+
+              {kind === 'binary' && (
+                <div className="v10-file-preview-binary">
+                  <p>This file type cannot be previewed directly.</p>
+                  {url && (
+                    <a href={url} download={assertionName} className="v10-file-preview-download">
+                      Download file
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="v10-file-preview-footer">
+              {url && (
+                <a href={url} download={assertionName} className="v10-file-preview-download">
+                  Download original
+                </a>
+              )}
+              {status.mdIntermediateHash && (
+                <a
+                  href={fileUrl(status.mdIntermediateHash, 'text/markdown')}
+                  download={`${assertionName}.md`}
+                  className="v10-file-preview-download"
+                >
+                  Download markdown intermediate
+                </a>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/FilePreviewModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { fetchExtractionStatus, fileUrl, type ExtractionStatus } from '../../api.js';
+import { fetchExtractionStatus, fileUrl, authHeaders, type ExtractionStatus } from '../../api.js';
 
 interface FilePreviewModalProps {
   open: boolean;
@@ -29,9 +29,17 @@ function previewKind(ct: string): 'pdf' | 'image' | 'text' | 'binary' {
   return 'binary';
 }
 
+async function authenticatedBlobUrl(url: string): Promise<string> {
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
+}
+
 export function FilePreviewModal({ open, onClose, assertionName, contextGraphId }: FilePreviewModalProps) {
   const [status, setStatus] = useState<ExtractionStatus | null>(null);
   const [textContent, setTextContent] = useState<string | null>(null);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,25 +49,53 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
     setError(null);
     setStatus(null);
     setTextContent(null);
+    setBlobUrl(null);
 
     fetchExtractionStatus(assertionName, contextGraphId)
       .then(async (s) => {
         setStatus(s);
         const kind = previewKind(s.detectedContentType);
+        const url = fileUrl(s.fileHash, s.detectedContentType);
         if (kind === 'text') {
-          const url = fileUrl(s.fileHash, s.detectedContentType);
-          const res = await fetch(url);
+          const res = await fetch(url, { headers: authHeaders() });
           if (res.ok) setTextContent(await res.text());
+        } else if (kind === 'pdf' || kind === 'image') {
+          const blob = await authenticatedBlobUrl(url);
+          setBlobUrl(blob);
         }
       })
       .catch((err) => setError(err.message ?? 'Failed to load file info'))
       .finally(() => setLoading(false));
+
+    return () => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
   }, [open, assertionName, contextGraphId]);
+
+  useEffect(() => {
+    return () => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [blobUrl]);
 
   if (!open) return null;
 
   const kind = status ? previewKind(status.detectedContentType) : null;
-  const url = status ? fileUrl(status.fileHash, status.detectedContentType) : null;
+  const rawUrl = status ? fileUrl(status.fileHash, status.detectedContentType) : null;
+
+  const handleDownload = async (downloadUrl: string, filename: string) => {
+    try {
+      const blob = await authenticatedBlobUrl(downloadUrl);
+      const a = document.createElement('a');
+      a.href = blob;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(blob);
+    } catch {
+      // fallback — the browser may handle auth via cookies
+      window.open(downloadUrl, '_blank');
+    }
+  };
 
   return (
     <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
@@ -101,17 +137,17 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
             </div>
 
             <div className="v10-file-preview-content">
-              {kind === 'pdf' && url && (
+              {kind === 'pdf' && blobUrl && (
                 <iframe
-                  src={url}
+                  src={blobUrl}
                   className="v10-file-preview-iframe"
                   title={`Preview: ${assertionName}`}
                 />
               )}
 
-              {kind === 'image' && url && (
+              {kind === 'image' && blobUrl && (
                 <img
-                  src={url}
+                  src={blobUrl}
                   alt={assertionName}
                   className="v10-file-preview-image"
                 />
@@ -124,29 +160,37 @@ export function FilePreviewModal({ open, onClose, assertionName, contextGraphId 
               {kind === 'binary' && (
                 <div className="v10-file-preview-binary">
                   <p>This file type cannot be previewed directly.</p>
-                  {url && (
-                    <a href={url} download={assertionName} className="v10-file-preview-download">
+                  {rawUrl && (
+                    <button
+                      className="v10-file-preview-download"
+                      onClick={() => handleDownload(rawUrl, assertionName)}
+                    >
                       Download file
-                    </a>
+                    </button>
                   )}
                 </div>
               )}
             </div>
 
             <div className="v10-file-preview-footer">
-              {url && (
-                <a href={url} download={assertionName} className="v10-file-preview-download">
+              {rawUrl && (
+                <button
+                  className="v10-file-preview-download"
+                  onClick={() => handleDownload(rawUrl, assertionName)}
+                >
                   Download original
-                </a>
+                </button>
               )}
               {status.mdIntermediateHash && (
-                <a
-                  href={fileUrl(status.mdIntermediateHash, 'text/markdown')}
-                  download={`${assertionName}.md`}
+                <button
                   className="v10-file-preview-download"
+                  onClick={() => handleDownload(
+                    fileUrl(status.mdIntermediateHash!, 'text/markdown'),
+                    `${assertionName}.md`,
+                  )}
                 >
                   Download markdown intermediate
-                </a>
+                </button>
               )}
             </div>
           </>

--- a/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
@@ -1,0 +1,301 @@
+import React, { useState, useRef, useCallback } from 'react';
+import { importFile, type ImportFileResult } from '../../api.js';
+
+interface ImportFilesModalProps {
+  open: boolean;
+  onClose: () => void;
+  contextGraphId: string;
+  contextGraphName?: string;
+}
+
+interface QueuedFile {
+  file: File;
+  id: string;
+}
+
+type UploadStatus = 'idle' | 'uploading' | 'done' | 'error';
+
+interface UploadResult {
+  fileName: string;
+  status: 'success' | 'skipped' | 'error';
+  triplesWritten?: number;
+  error?: string;
+}
+
+const SUPPORTED_EXTENSIONS = '.md, .docx, .pdf, .txt, .csv, .json, .ttl, .rdf, .owl, .py, .ts, .js, .tsx, .jsx, .java, .go, .rs, .c, .cpp, .html, .xml, .yaml, .yml';
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function fileIcon(name: string): string {
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  if (['md', 'txt'].includes(ext)) return '📝';
+  if (['pdf'].includes(ext)) return '📕';
+  if (['docx', 'doc'].includes(ext)) return '📄';
+  if (['csv', 'json', 'xml', 'yaml', 'yml'].includes(ext)) return '📊';
+  if (['ttl', 'rdf', 'owl'].includes(ext)) return '🔗';
+  if (['py', 'ts', 'js', 'tsx', 'jsx', 'java', 'go', 'rs', 'c', 'cpp'].includes(ext)) return '💻';
+  if (['png', 'jpg', 'jpeg', 'webp'].includes(ext)) return '🖼️';
+  return '📄';
+}
+
+export function ImportFilesModal({ open, onClose, contextGraphId, contextGraphName }: ImportFilesModalProps) {
+  const [files, setFiles] = useState<QueuedFile[]>([]);
+  const [extractKnowledge, setExtractKnowledge] = useState(true);
+  const [storeOriginals, setStoreOriginals] = useState(true);
+  const [status, setStatus] = useState<UploadStatus>('idle');
+  const [currentFile, setCurrentFile] = useState(0);
+  const [results, setResults] = useState<UploadResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const addFiles = useCallback((newFiles: FileList | File[]) => {
+    const arr = Array.from(newFiles);
+    setFiles(prev => {
+      const existing = new Set(prev.map(f => `${f.file.name}:${f.file.size}`));
+      const unique = arr.filter(f => !existing.has(`${f.name}:${f.size}`));
+      return [...prev, ...unique.map(f => ({ file: f, id: `${f.name}-${f.size}-${Date.now()}` }))];
+    });
+  }, []);
+
+  const removeFile = (id: string) => {
+    setFiles(prev => prev.filter(f => f.id !== id));
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(false);
+    if (e.dataTransfer.files.length > 0) {
+      addFiles(e.dataTransfer.files);
+    }
+  };
+
+  const handleImport = async () => {
+    if (files.length === 0) return;
+
+    setStatus('uploading');
+    setCurrentFile(0);
+    setResults([]);
+    setError(null);
+
+    const uploadResults: UploadResult[] = [];
+
+    for (let i = 0; i < files.length; i++) {
+      setCurrentFile(i);
+      const { file } = files[i];
+      const assertionName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+
+      try {
+        const result: ImportFileResult = await importFile(assertionName, contextGraphId, file);
+        const triples = result.extraction.tripleCount ?? result.extraction.triplesWritten;
+        uploadResults.push({
+          fileName: file.name,
+          status: result.extraction.status === 'completed' ? 'success' :
+                  result.extraction.status === 'skipped' ? 'skipped' : 'error',
+          triplesWritten: triples,
+          error: result.extraction.error,
+        });
+      } catch (err: any) {
+        uploadResults.push({
+          fileName: file.name,
+          status: 'error',
+          error: err?.message ?? 'Upload failed',
+        });
+      }
+    }
+
+    setResults(uploadResults);
+    setCurrentFile(files.length);
+
+    const hasErrors = uploadResults.some(r => r.status === 'error');
+    setStatus(hasErrors ? 'error' : 'done');
+  };
+
+  const handleClose = () => {
+    if (status === 'uploading') return;
+    setFiles([]);
+    setResults([]);
+    setStatus('idle');
+    setError(null);
+    setCurrentFile(0);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  const totalTriples = results.reduce((sum, r) => sum + (r.triplesWritten ?? 0), 0);
+  const successCount = results.filter(r => r.status === 'success').length;
+  const errorCount = results.filter(r => r.status === 'error').length;
+
+  return (
+    <div className="v10-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget && status !== 'uploading') handleClose(); }}>
+      <div className="v10-modal-box" style={{ maxWidth: 560 }}>
+        <div className="v10-modal-header">
+          <div className="v10-modal-title">Import to Working Memory</div>
+          <div className="v10-modal-subtitle">
+            {contextGraphName
+              ? <>Upload files to <strong>{contextGraphName}</strong> — your agent will extract structured knowledge.</>
+              : <>Upload files — your agent will extract structured knowledge and add it to working memory.</>
+            }
+          </div>
+        </div>
+
+        <div className="v10-modal-body">
+          {error && <div className="v10-modal-error">{error}</div>}
+
+          {status === 'idle' && (
+            <>
+              <div
+                className={`v10-import-dropzone ${dragOver ? 'drag-over' : ''}`}
+                onClick={() => inputRef.current?.click()}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+              >
+                <div className="v10-import-dropzone-label">
+                  Drag files here, or click to browse
+                </div>
+                <div className="v10-import-dropzone-hint" style={{ marginTop: 4 }}>
+                  Your agent will extract structured knowledge and add it to working memory.
+                </div>
+                <div className="v10-import-dropzone-hint" style={{ marginTop: 8 }}>
+                  Supported: {SUPPORTED_EXTENSIONS}
+                </div>
+                <input
+                  ref={inputRef}
+                  type="file"
+                  multiple
+                  style={{ display: 'none' }}
+                  onChange={(e) => { if (e.target.files) addFiles(e.target.files); e.target.value = ''; }}
+                />
+              </div>
+
+              {files.length > 0 && (
+                <>
+                  <div className="v10-import-file-list">
+                    {files.map((f) => (
+                      <div key={f.id} className="v10-import-file-item">
+                        <span className="v10-import-file-icon">{fileIcon(f.file.name)}</span>
+                        <span className="v10-import-file-name">{f.file.name}</span>
+                        <span className="v10-import-file-size">{formatSize(f.file.size)}</span>
+                        <button className="v10-import-file-remove" onClick={() => removeFile(f.id)} title="Remove">×</button>
+                      </div>
+                    ))}
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: 12 }}>
+                    {files.length} file{files.length !== 1 ? 's' : ''} selected · {formatSize(files.reduce((s, f) => s + f.file.size, 0))} total
+                  </div>
+                </>
+              )}
+
+              <div className="v10-form-divider" />
+              <div className="v10-form-label" style={{ marginBottom: 8 }}>Ingestion Options</div>
+              <label className="v10-import-option">
+                <input type="checkbox" checked={storeOriginals} onChange={() => setStoreOriginals(!storeOriginals)} />
+                Store original files as Knowledge Assets
+              </label>
+              <label className="v10-import-option">
+                <input type="checkbox" checked={extractKnowledge} onChange={() => setExtractKnowledge(!extractKnowledge)} />
+                Let agent extract structured knowledge from content
+              </label>
+            </>
+          )}
+
+          {status === 'uploading' && (
+            <div className="v10-import-progress">
+              <div style={{ fontSize: 12, color: 'var(--text-secondary)', fontWeight: 500 }}>
+                Importing files… ({currentFile + 1} of {files.length})
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 4 }}>
+                {files[currentFile]?.file.name ?? '…'}
+              </div>
+              <div className="v10-import-progress-bar">
+                <div
+                  className="v10-import-progress-fill"
+                  style={{ width: `${((currentFile + 0.5) / files.length) * 100}%` }}
+                />
+              </div>
+              <div className="v10-import-progress-text">
+                {currentFile} of {files.length} files processed
+              </div>
+            </div>
+          )}
+
+          {(status === 'done' || status === 'error') && (
+            <>
+              <div className={`v10-import-result ${errorCount > 0 ? 'error' : 'success'}`}>
+                {errorCount === 0 ? (
+                  <>
+                    Successfully imported {successCount} file{successCount !== 1 ? 's' : ''}.
+                    {totalTriples > 0 && <> Extracted <strong>{totalTriples.toLocaleString()}</strong> triples into working memory.</>}
+                  </>
+                ) : (
+                  <>
+                    {successCount} file{successCount !== 1 ? 's' : ''} imported, {errorCount} failed.
+                    {totalTriples > 0 && <> {totalTriples.toLocaleString()} triples extracted.</>}
+                  </>
+                )}
+              </div>
+
+              {results.length > 0 && (
+                <div className="v10-import-file-list" style={{ marginTop: 12 }}>
+                  {results.map((r, i) => (
+                    <div key={i} className="v10-import-file-item">
+                      <span className="v10-import-file-icon">
+                        {r.status === 'success' ? '✓' : r.status === 'skipped' ? '–' : '✗'}
+                      </span>
+                      <span className="v10-import-file-name">{r.fileName}</span>
+                      <span className="v10-import-file-size" style={r.status === 'error' ? { color: 'var(--accent-red)' } : undefined}>
+                        {r.status === 'success' && r.triplesWritten != null ? `${r.triplesWritten} triples` :
+                         r.status === 'skipped' ? 'stored (no extraction)' :
+                         r.error ?? 'failed'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="v10-modal-footer">
+          {status === 'idle' && (
+            <>
+              <button className="v10-modal-btn" onClick={handleClose}>Cancel</button>
+              <button
+                className="v10-modal-btn primary"
+                onClick={handleImport}
+                disabled={files.length === 0}
+              >
+                Start Import ({files.length} file{files.length !== 1 ? 's' : ''})
+              </button>
+            </>
+          )}
+          {status === 'uploading' && (
+            <button className="v10-modal-btn" disabled>Importing…</button>
+          )}
+          {(status === 'done' || status === 'error') && (
+            <button className="v10-modal-btn primary" onClick={handleClose}>Done</button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ImportFilesModal.tsx
@@ -100,7 +100,8 @@ export function ImportFilesModal({ open, onClose, contextGraphId, contextGraphNa
     for (let i = 0; i < files.length; i++) {
       setCurrentFile(i);
       const { file } = files[i];
-      const assertionName = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const sanitized = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const assertionName = `${Date.now().toString(36)}-${i}-${sanitized}`;
 
       try {
         const result: ImportFileResult = await importFile(assertionName, contextGraphId, file);

--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { type Notification } from '../../api.js';
+import { api } from '../../api-wrapper.js';
+import { useLayoutStore } from '../../stores/layout.js';
+import { useAgentsStore } from '../../stores/agents.js';
+
+const DKG_LOGO = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+    <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="4" />
+    <line x1="12" y1="2" x2="12" y2="8" />
+    <line x1="12" y1="16" x2="12" y2="22" />
+    <line x1="2" y1="12" x2="8" y2="12" />
+    <line x1="16" y1="12" x2="22" y2="12" />
+  </svg>
+);
+
+const BELL_ICON = (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+    <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+  </svg>
+);
+
+const SUN_ICON = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="5" /><line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </svg>
+);
+
+const MOON_ICON = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+  </svg>
+);
+
+const SIDEBAR_ICON = (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
+  </svg>
+);
+
+const AGENT_PANEL_ICON = (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="15" y1="3" x2="15" y2="21" />
+  </svg>
+);
+
+export function Header() {
+  const { theme, setTheme, leftCollapsed, toggleLeft, rightCollapsed, toggleRight } = useLayoutStore();
+  const nodeStatus = useAgentsStore((s) => s.nodeStatus);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unread, setUnread] = useState(0);
+  const [showNotifs, setShowNotifs] = useState(false);
+  const notifRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const load = () => {
+      api.fetchNotifications().then(({ notifications: n, unreadCount }: any) => {
+        if (!mounted) return;
+        setNotifications(n);
+        setUnread(unreadCount);
+      }).catch(() => {});
+    };
+    load();
+    const iv = setInterval(load, 30_000);
+    return () => { mounted = false; clearInterval(iv); };
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (notifRef.current && !notifRef.current.contains(e.target as Node)) setShowNotifs(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const connectedPeers = nodeStatus?.connectedPeers ?? nodeStatus?.peerCount ?? 0;
+  const synced = nodeStatus?.synced !== false;
+
+  return (
+    <header className="v10-header">
+      <div className="v10-header-logo">
+        {DKG_LOGO}
+        <span className="v10-header-logo-text">DKG <span className="v10-header-logo-version">v10</span></span>
+      </div>
+
+      <button
+        className={`v10-header-icon-btn ${!leftCollapsed ? 'active-toggle' : ''}`}
+        onClick={toggleLeft}
+        title="Toggle sidebar"
+      >
+        {SIDEBAR_ICON}
+      </button>
+
+      <div className="v10-header-sep" />
+
+      <div className="v10-header-agent-switcher">
+        <span className="v10-header-agent-dot" />
+        <span className="v10-header-agent-name">{nodeStatus?.name || 'Node Agent'}</span>
+      </div>
+
+      <div className="v10-header-spacer" />
+
+      <div className="v10-header-meta">
+        <span className={`v10-header-status-dot ${synced ? 'online' : 'offline'}`} />
+        <span>{synced ? 'synced' : 'syncing'}</span>
+        <span className="v10-header-meta-sep">·</span>
+        <span>{connectedPeers} peer{connectedPeers !== 1 ? 's' : ''}</span>
+      </div>
+
+      <div className="v10-header-actions">
+        <div className="v10-header-notif-wrap" ref={notifRef}>
+          <button
+            className="v10-header-icon-btn"
+            onClick={() => {
+              setShowNotifs((v) => !v);
+              if (unread > 0) api.markNotificationsRead().then(() => setUnread(0)).catch(() => {});
+            }}
+          >
+            {BELL_ICON}
+            {unread > 0 && <span className="v10-header-notif-badge">{unread}</span>}
+          </button>
+          {showNotifs && (
+            <div className="v10-header-notif-dropdown">
+              <div className="v10-header-notif-title">Notifications</div>
+              {notifications.length === 0 ? (
+                <div className="v10-header-notif-empty">No notifications</div>
+              ) : notifications.slice(0, 8).map((n, i) => (
+                <div key={i} className="v10-header-notif-item">
+                  <div className="v10-header-notif-item-text">{n.message ?? n.title ?? 'Notification'}</div>
+                  {n.ts && <div className="v10-header-notif-item-time">{new Date(n.ts).toLocaleTimeString()}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <button
+          className="v10-header-icon-btn"
+          onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {theme === 'dark' ? SUN_ICON : MOON_ICON}
+        </button>
+
+        <button
+          className={`v10-header-icon-btn ${!rightCollapsed ? 'active-toggle' : ''}`}
+          onClick={toggleRight}
+          title="Toggle agent panel"
+        >
+          {AGENT_PANEL_ICON}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/packages/node-ui/src/ui/components/Shell/PanelBottom.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelBottom.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useLayoutStore } from '../../stores/layout.js';
+import { api } from '../../api-wrapper.js';
+
+const BOTTOM_TABS = ['Node Log', 'Transactions', 'Gossip', 'Agent Runs', 'SPARQL'] as const;
+type BottomTab = typeof BOTTOM_TABS[number];
+
+const CHEVRON_DOWN = (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+function NodeLogContent() {
+  const [lines, setLines] = useState<string[]>([]);
+  const [filter, setFilter] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const load = useCallback(() => {
+    api.fetchNodeLog({ lines: 100, q: filter || undefined })
+      .then(({ lines: l }: any) => setLines(l ?? []))
+      .catch(() => {});
+  }, [filter]);
+
+  useEffect(() => {
+    load();
+    const iv = setInterval(load, 5_000);
+    return () => clearInterval(iv);
+  }, [load]);
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [lines]);
+
+  return (
+    <div className="v10-log-container">
+      <div className="v10-log-toolbar">
+        <input
+          type="text"
+          placeholder="Filter logs..."
+          className="v10-log-filter"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+      </div>
+      <div className="v10-log-output" ref={scrollRef}>
+        {lines.map((line, i) => (
+          <div key={i} className="v10-log-line">{line}</div>
+        ))}
+        {lines.length === 0 && (
+          <div className="v10-log-line" style={{ color: 'var(--text-tertiary)' }}>No log output</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function PanelBottom() {
+  const { bottomCollapsed, toggleBottom } = useLayoutStore();
+  const [activeTab, setActiveTab] = useState<BottomTab>('Node Log');
+
+  return (
+    <div className={`v10-panel-bottom ${bottomCollapsed ? 'collapsed' : ''}`}>
+      <div className="v10-bottom-tabs">
+        {BOTTOM_TABS.map((tab) => (
+          <button
+            key={tab}
+            className={`v10-bottom-tab ${tab === activeTab ? 'active' : ''}`}
+            onClick={() => { setActiveTab(tab); if (bottomCollapsed) toggleBottom(); }}
+          >
+            {tab}
+          </button>
+        ))}
+        <div style={{ flex: 1 }} />
+        <button className="v10-bottom-toggle" onClick={toggleBottom}>
+          <span style={{ transform: bottomCollapsed ? 'rotate(180deg)' : 'none', display: 'flex', transition: 'transform 0.15s' }}>
+            {CHEVRON_DOWN}
+          </span>
+        </button>
+      </div>
+      {!bottomCollapsed && (
+        <div className="v10-bottom-content">
+          {activeTab === 'Node Log' && <NodeLogContent />}
+          {activeTab !== 'Node Log' && (
+            <div style={{ padding: '12px 16px', color: 'var(--text-tertiary)', fontSize: 12, fontFamily: 'var(--font-mono)' }}>
+              {activeTab} tab coming soon...
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -1,0 +1,171 @@
+import React, { Suspense } from 'react';
+import { useTabsStore } from '../../stores/tabs.js';
+import { DashboardView } from '../../views/DashboardView.js';
+import { ProjectView } from '../../views/ProjectView.js';
+import { MemoryLayerView } from '../../views/MemoryLayerView.js';
+
+const CLOSE_ICON = (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+
+const OperationsView = React.lazy(() =>
+  import('../../pages/Operations.js').then((m) => ({ default: m.OperationsPage }))
+);
+
+const GameView = React.lazy(() =>
+  import('../../pages/Apps.js').then((m) => ({ default: m.AppsPage }))
+);
+
+function TabBar() {
+  const { tabs, activeTabId, setActiveTab, closeTab } = useTabsStore();
+
+  return (
+    <div className="v10-center-tabs">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          className={`v10-center-tab ${tab.id === activeTabId ? 'active' : ''}`}
+          onClick={() => setActiveTab(tab.id)}
+        >
+          <span className="v10-center-tab-label">{tab.label}</span>
+          {tab.closable && (
+            <span
+              className="v10-center-tab-close"
+              onClick={(e) => { e.stopPropagation(); closeTab(tab.id); }}
+            >
+              {CLOSE_ICON}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MemoryStackView() {
+  return (
+    <div style={{ maxWidth: 800, padding: '0' }}>
+      <h1 style={{ fontSize: 20, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>Memory Stack</h1>
+      <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginBottom: 24 }}>
+        Aggregate view of all memory layers across your projects.
+      </p>
+      <div style={{ display: 'flex', gap: 12 }}>
+        {(['Working Memory', 'Shared Working Memory', 'Verified Memory'] as const).map((label, i) => {
+          const icons = ['◇', '◈', '◉'];
+          const colors = ['var(--layer-working)', 'var(--layer-shared)', 'var(--layer-verified)'];
+          return (
+            <div key={label} style={{
+              flex: 1, padding: '18px 16px', borderRadius: 10,
+              border: '1px solid var(--border-default)', background: 'var(--bg-surface)',
+            }}>
+              <div style={{ fontSize: 18, color: colors[i], marginBottom: 8 }}>{icons[i]}</div>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 4 }}>{label}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>
+                {i === 0 ? 'Private agent drafts' : i === 1 ? 'Shared proposals' : 'Published knowledge'}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AgentHubView() {
+  return (
+    <div style={{ maxWidth: 800 }}>
+      <h1 style={{ fontSize: 20, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 8 }}>Agent Hub</h1>
+      <p style={{ fontSize: 12, color: 'var(--text-tertiary)', marginBottom: 24 }}>
+        Manage connected agents, permissions, and agent discovery.
+      </p>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {[
+          { name: 'OpenClaw', desc: 'Claude Code / MCP adapter', status: 'available' },
+          { name: 'Hermes', desc: 'Hermes Agora node', status: 'available' },
+          { name: 'ElizaOS', desc: 'ElizaOS agent adapter', status: 'coming soon' },
+        ].map((agent) => (
+          <div key={agent.name} style={{
+            display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px',
+            borderRadius: 8, border: '1px solid var(--border-default)', background: 'var(--bg-surface)',
+          }}>
+            <div style={{
+              width: 8, height: 8, borderRadius: '50%',
+              background: agent.status === 'available' ? 'var(--accent-green)' : 'var(--text-ghost)',
+            }} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>{agent.name}</div>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}>{agent.desc}</div>
+            </div>
+            <button className="dkg-btn-secondary" style={{
+              padding: '4px 12px', fontSize: 11, borderRadius: 6,
+              border: '1px solid var(--border-default)', background: 'var(--bg-elevated)', color: 'var(--text-secondary)',
+            }}>
+              {agent.status === 'available' ? 'Connect' : 'Coming soon'}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ViewContainer() {
+  const activeTabId = useTabsStore((s) => s.activeTabId);
+
+  if (activeTabId === 'dashboard') return <DashboardView />;
+
+  if (activeTabId === 'operations') {
+    return (
+      <Suspense fallback={<div className="lazy-spinner">Loading operations...</div>}>
+        <OperationsView />
+      </Suspense>
+    );
+  }
+
+  if (activeTabId === 'game') {
+    return (
+      <Suspense fallback={<div className="lazy-spinner">Loading game...</div>}>
+        <GameView />
+      </Suspense>
+    );
+  }
+
+  if (activeTabId === 'memory-stack') return <MemoryStackView />;
+  if (activeTabId === 'agent-hub') return <AgentHubView />;
+
+  if (activeTabId.startsWith('project:')) {
+    const cgId = activeTabId.slice('project:'.length);
+    return <ProjectView contextGraphId={cgId} />;
+  }
+
+  if (activeTabId.startsWith('wm:')) {
+    return <MemoryLayerView layer="wm" contextGraphId={activeTabId.slice(3)} />;
+  }
+  if (activeTabId.startsWith('swm:')) {
+    return <MemoryLayerView layer="swm" contextGraphId={activeTabId.slice(4)} />;
+  }
+  if (activeTabId.startsWith('vm:')) {
+    return <MemoryLayerView layer="vm" contextGraphId={activeTabId.slice(3)} />;
+  }
+
+  return (
+    <div className="v10-view-placeholder">
+      <p style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>
+        View "{activeTabId}" coming soon.
+      </p>
+    </div>
+  );
+}
+
+export function PanelCenter() {
+  return (
+    <div className="v10-panel-center">
+      <TabBar />
+      <div className="v10-center-content">
+        <ViewContainer />
+      </div>
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelLeft.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useLayoutStore } from '../../stores/layout.js';
+import { useTabsStore } from '../../stores/tabs.js';
+import { useProjectsStore, type ContextGraph } from '../../stores/projects.js';
+import { useJourneyStore } from '../../stores/journey.js';
+import { api } from '../../api-wrapper.js';
+import { CreateProjectModal } from '../Modals/CreateProjectModal.js';
+import { ImportFilesModal } from '../Modals/ImportFilesModal.js';
+
+const CHEVRON_ICON = '▸';
+const COLLAPSE_ICON = '◂';
+
+type TreeMode = 'explorer' | 'oracle';
+
+interface ProjectTreeItemProps {
+  cg: ContextGraph;
+  isActive: boolean;
+  onSelect: () => void;
+  onImport: () => void;
+}
+
+function ProjectTreeItem({ cg, isActive, onSelect, onImport }: ProjectTreeItemProps) {
+  const [open, setOpen] = useState(false);
+  const { openTab } = useTabsStore();
+  const assetCount = cg.assetCount ?? cg.assets ?? 0;
+
+  return (
+    <div className="v10-tree-section">
+      <div
+        className={`v10-tree-section-header ${isActive ? 'active' : ''}`}
+        onClick={() => { setOpen((v) => !v); onSelect(); }}
+      >
+        <span className={`v10-tree-chevron ${open ? 'open' : ''}`}>{CHEVRON_ICON}</span>
+        <span className="v10-tree-project-dot" />
+        <span className="v10-tree-section-label">{cg.name || cg.id.slice(0, 16)}</span>
+        <span className="v10-tree-section-badge">{assetCount}</span>
+      </div>
+      {open && (
+        <div className="v10-tree-items">
+          <div className="v10-tree-layer-header">Working Memory</div>
+          <div
+            className="v10-tree-item"
+            onClick={() => openTab({ id: `wm:${cg.id}`, label: `WM · ${cg.name || cg.id.slice(0,12)}`, closable: true })}
+          >
+            <span className="v10-tree-item-icon" style={{ color: 'var(--layer-working)' }}>◇</span>
+            <span className="v10-tree-item-label">agent drafts</span>
+          </div>
+          <div
+            className="v10-tree-item"
+            onClick={(e) => { e.stopPropagation(); onImport(); }}
+            style={{ paddingLeft: 32 }}
+          >
+            <span className="v10-tree-item-icon" style={{ fontSize: 11 }}>↑</span>
+            <span className="v10-tree-item-label" style={{ color: 'var(--text-tertiary)' }}>Import files…</span>
+          </div>
+
+          <div className="v10-tree-layer-header" style={{ marginTop: 6 }}>Shared Memory</div>
+          <div
+            className="v10-tree-item"
+            onClick={() => openTab({ id: `swm:${cg.id}`, label: `SWM · ${cg.name || cg.id.slice(0,12)}`, closable: true })}
+          >
+            <span className="v10-tree-item-icon" style={{ color: 'var(--layer-shared)' }}>◈</span>
+            <span className="v10-tree-item-label">team workspace</span>
+          </div>
+
+          <div className="v10-tree-layer-header" style={{ marginTop: 6 }}>Verified Memory</div>
+          <div
+            className="v10-tree-item"
+            onClick={() => openTab({ id: `vm:${cg.id}`, label: `VM · ${cg.name || cg.id.slice(0,12)}`, closable: true })}
+          >
+            <span className="v10-tree-item-icon" style={{ color: 'var(--layer-verified)' }}>◉</span>
+            <span className="v10-tree-item-label">verified assets</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IntegrationsSection() {
+  const [open, setOpen] = useState(false);
+  const { openTab } = useTabsStore();
+
+  return (
+    <div className="v10-tree-section">
+      <div className="v10-tree-section-header" onClick={() => setOpen((v) => !v)}>
+        <span className={`v10-tree-chevron ${open ? 'open' : ''}`}>{CHEVRON_ICON}</span>
+        <span className="v10-tree-integration-dot" />
+        <span className="v10-tree-section-label">Integrations</span>
+      </div>
+      {open && (
+        <div className="v10-tree-items" style={{ display: 'block' }}>
+          <div className="v10-tree-item">
+            <span className="v10-tree-item-icon">⬡</span>
+            <span className="v10-tree-item-label">Obsidian</span>
+          </div>
+          <div className="v10-tree-item" onClick={() => openTab({ id: 'game', label: 'OriginTrail Game', closable: true })}>
+            <span className="v10-tree-item-icon">🎮</span>
+            <span className="v10-tree-item-label">OriginTrail Game</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PanelLeft() {
+  const { toggleLeft } = useLayoutStore();
+  const { openTab, activeTabId, setActiveTab } = useTabsStore();
+  const { contextGraphs, setContextGraphs, setLoading, activeProjectId, setActiveProject } = useProjectsStore();
+  const stage = useJourneyStore((s) => s.stage);
+  const [treeMode, setTreeMode] = useState<TreeMode>('explorer');
+
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [importTarget, setImportTarget] = useState<ContextGraph | null>(null);
+
+  const loadCGs = useCallback(() => {
+    setLoading(true);
+    api.fetchContextGraphs()
+      .then(({ contextGraphs: cgs }: any) => setContextGraphs(cgs ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [setContextGraphs, setLoading]);
+
+  useEffect(() => {
+    loadCGs();
+    const iv = setInterval(loadCGs, 30_000);
+    return () => clearInterval(iv);
+  }, [loadCGs]);
+
+  return (
+    <div className="v10-panel-left">
+      <div className="v10-tree-header">
+        <button
+          className={`v10-tree-mode-btn ${treeMode === 'explorer' ? 'active' : ''}`}
+          onClick={() => setTreeMode('explorer')}
+        >
+          Projects
+        </button>
+        <button
+          className={`v10-tree-mode-btn ${treeMode === 'oracle' ? 'active' : ''}`}
+          onClick={() => setTreeMode('oracle')}
+        >
+          Context Oracle
+        </button>
+        <button className="v10-collapse-btn" onClick={toggleLeft} style={{ marginLeft: 4, padding: '0 6px' }}>
+          {COLLAPSE_ICON}
+        </button>
+      </div>
+
+      {treeMode === 'explorer' && (
+        <div className="v10-tree-content">
+          <div
+            className={`v10-tree-dashboard ${activeTabId === 'dashboard' ? 'active' : ''}`}
+            onClick={() => { setActiveTab('dashboard'); setActiveProject(null); }}
+          >
+            <span>▦</span> Dashboard
+          </div>
+
+          {contextGraphs.length > 0 && (
+            <div
+              className={`v10-tree-dashboard ${activeTabId === 'memory-stack' ? 'active' : ''}`}
+              onClick={() => openTab({ id: 'memory-stack', label: 'Memory Stack', closable: true })}
+            >
+              <span>▤</span> Memory Stack
+            </div>
+          )}
+
+          {contextGraphs.length > 0 && (
+            <button className="v10-new-project-btn" onClick={() => setShowCreateModal(true)}>+ New Project</button>
+          )}
+
+          {contextGraphs.length === 0 && stage <= 1 && (
+            <div className="v10-journey-empty-card">
+              <div className="v10-jec-title">No projects yet</div>
+              <div className="v10-jec-hint">
+                {stage === 0
+                  ? 'Connect an agent to get started.'
+                  : 'Create your first project to give your agent structured memory.'}
+              </div>
+              {stage === 1 && (
+                <button className="v10-new-project-btn" style={{ margin: 0 }} onClick={() => setShowCreateModal(true)}>
+                  + Create First Project
+                </button>
+              )}
+            </div>
+          )}
+
+          {contextGraphs.map((cg) => (
+            <ProjectTreeItem
+              key={cg.id}
+              cg={cg}
+              isActive={activeProjectId === cg.id}
+              onSelect={() => {
+                setActiveProject(cg.id);
+                openTab({ id: `project:${cg.id}`, label: cg.name || cg.id.slice(0, 16), closable: true });
+              }}
+              onImport={() => setImportTarget(cg)}
+            />
+          ))}
+
+          {contextGraphs.length > 0 && (
+            <>
+              <div className="v10-tree-divider" />
+              <div
+                className={`v10-tree-dashboard ${activeTabId === 'agent-hub' ? 'active' : ''}`}
+                onClick={() => openTab({ id: 'agent-hub', label: 'Agent Hub', closable: true })}
+              >
+                <span>⚙</span> Agent Hub
+              </div>
+            </>
+          )}
+
+          {stage >= 1 && <IntegrationsSection />}
+        </div>
+      )}
+
+      {treeMode === 'oracle' && (
+        <div className="v10-tree-content">
+          <div className="v10-oracle-placeholder">
+            <p style={{ fontSize: 12, color: 'var(--text-tertiary)', padding: 24, textAlign: 'center' }}>
+              Context Oracle browser coming soon.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <CreateProjectModal open={showCreateModal} onClose={() => setShowCreateModal(false)} />
+      {importTarget && (
+        <ImportFilesModal
+          open
+          onClose={() => setImportTarget(null)}
+          contextGraphId={importTarget.id}
+          contextGraphName={importTarget.name}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { useJourneyStore } from '../../stores/journey.js';
-import { type ChatAssistantStreamEvent, type MemorySession, streamChatMessage } from '../../api.js';
+import { type ChatAssistantStreamEvent, type MemorySession, streamChatMessage, fetchConnections, fetchAgents } from '../../api.js';
 import { api } from '../../api-wrapper.js';
 
 interface ChatMessage {
@@ -10,9 +10,153 @@ interface ChatMessage {
   streaming?: boolean;
 }
 
+interface AgentInfo {
+  agentUri: string;
+  name: string;
+  peerId: string;
+  framework?: string;
+  nodeRole?: string;
+  connectionStatus?: string;
+  connectionTransport?: string;
+  connectionDirection?: string;
+  lastSeen?: number;
+  latencyMs?: number;
+}
+
+interface ConnectionInfo {
+  peerId: string;
+  transport: string;
+  direction: string;
+  openedAt: number;
+  durationMs: number;
+}
+
+function shortPeerId(peerId: string): string {
+  return peerId.length > 12 ? peerId.slice(-8) : peerId;
+}
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function AgentsTab() {
+  const [agents, setAgents] = useState<AgentInfo[]>([]);
+  const [connections, setConnections] = useState<{ total: number; direct: number; relayed: number }>({ total: 0, direct: 0, relayed: 0 });
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [agentData, connData] = await Promise.all([
+        fetchAgents().catch(() => ({ agents: [] })),
+        fetchConnections().catch(() => ({ total: 0, direct: 0, relayed: 0 })),
+      ]);
+      setAgents(agentData.agents ?? []);
+      setConnections({ total: connData.total ?? 0, direct: connData.direct ?? 0, relayed: connData.relayed ?? 0 });
+    } catch { /* ignore */ }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { refresh(); const iv = setInterval(refresh, 15000); return () => clearInterval(iv); }, [refresh]);
+
+  const selfAgent = agents.find(a => a.connectionStatus === 'self');
+  const peerAgents = agents.filter(a => a.connectionStatus !== 'self');
+  const connectedAgents = peerAgents.filter(a => a.connectionStatus === 'connected');
+  const knownAgents = peerAgents.filter(a => a.connectionStatus !== 'connected');
+
+  return (
+    <div className="v10-agents-tab">
+      <div className="v10-agents-summary">
+        <span className="v10-agents-stat">
+          <span className="v10-agents-stat-dot connected" />
+          {connections.total} peer{connections.total !== 1 ? 's' : ''}
+        </span>
+        <span className="v10-agents-stat">
+          {connectedAgents.length + 1} agent{connectedAgents.length !== 0 ? 's' : ''}
+        </span>
+        <button className="v10-agents-refresh" onClick={refresh} title="Refresh">↻</button>
+      </div>
+
+      {loading && <p className="v10-agents-loading">Loading agents...</p>}
+
+      {selfAgent && (
+        <div className="v10-agent-card self">
+          <div className="v10-agent-card-header">
+            <span className="v10-agent-card-dot self" />
+            <span className="v10-agent-card-name">{selfAgent.name}</span>
+            <span className="v10-agent-card-badge">self</span>
+          </div>
+          <div className="v10-agent-card-meta">
+            <span>{selfAgent.nodeRole ?? 'core'}</span>
+            <span title={selfAgent.peerId}>{shortPeerId(selfAgent.peerId)}</span>
+          </div>
+        </div>
+      )}
+
+      {connectedAgents.length > 0 && (
+        <>
+          <div className="v10-agents-section-label">Connected Peers</div>
+          {connectedAgents.map(a => (
+            <div key={a.peerId} className="v10-agent-card connected">
+              <div className="v10-agent-card-header">
+                <span className="v10-agent-card-dot connected" />
+                <span className="v10-agent-card-name">{a.name}</span>
+                <span className="v10-agent-card-badge">{a.connectionTransport ?? 'direct'}</span>
+              </div>
+              <div className="v10-agent-card-meta">
+                <span>{a.nodeRole ?? 'core'}</span>
+                <span title={a.peerId}>{shortPeerId(a.peerId)}</span>
+                {a.latencyMs != null && <span>{a.latencyMs}ms</span>}
+              </div>
+            </div>
+          ))}
+        </>
+      )}
+
+      {knownAgents.length > 0 && (
+        <>
+          <div className="v10-agents-section-label">Known Agents</div>
+          {knownAgents.map(a => (
+            <div key={a.peerId} className="v10-agent-card known">
+              <div className="v10-agent-card-header">
+                <span className="v10-agent-card-dot known" />
+                <span className="v10-agent-card-name">{a.name}</span>
+              </div>
+              <div className="v10-agent-card-meta">
+                <span>{a.framework ?? 'DKG'}</span>
+                <span title={a.peerId}>{shortPeerId(a.peerId)}</span>
+              </div>
+            </div>
+          ))}
+        </>
+      )}
+
+      <div className="v10-agents-section-label" style={{ marginTop: 16 }}>Connect Agent</div>
+      <div className="v10-agent-connect-cards">
+        <button className="v10-agent-connect-card">
+          <span className="v10-agent-connect-card-name">Hermes</span>
+          <span className="v10-agent-connect-card-desc">Nous Research agent</span>
+        </button>
+        <button className="v10-agent-connect-card">
+          <span className="v10-agent-connect-card-name">OpenClaw</span>
+          <span className="v10-agent-connect-card-desc">Claude Code / MCP</span>
+        </button>
+        <button className="v10-agent-connect-card">
+          <span className="v10-agent-connect-card-name">ElizaOS</span>
+          <span className="v10-agent-connect-card-desc">ElizaOS adapter</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function PanelRight() {
   const { stage, advance } = useJourneyStore();
-  const [mode, setMode] = useState<'chat' | 'sessions'>('chat');
+  const [mode, setMode] = useState<'chat' | 'agents' | 'sessions'>('agents');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
@@ -109,6 +253,12 @@ export function PanelRight() {
     <div className="v10-panel-right">
       <div className="v10-agent-mode-tabs">
         <button
+          className={`v10-agent-mode-tab ${mode === 'agents' ? 'active' : ''}`}
+          onClick={() => setMode('agents')}
+        >
+          Agents
+        </button>
+        <button
           className={`v10-agent-mode-tab ${mode === 'chat' ? 'active' : ''}`}
           onClick={() => setMode('chat')}
         >
@@ -122,32 +272,12 @@ export function PanelRight() {
         </button>
       </div>
 
+      {mode === 'agents' && <AgentsTab />}
+
       {mode === 'chat' && (
         <>
           <div className="v10-agent-content">
-            {messages.length === 0 && stage === 0 && (
-              <div className="v10-agent-onboarding">
-                <div className="v10-agent-onboarding-title">Connect an Agent</div>
-                <p className="v10-agent-onboarding-desc">
-                  Connect your AI agent to the DKG to unlock shared, verifiable memory.
-                </p>
-                <div className="v10-agent-connect-cards">
-                  <button className="v10-agent-connect-card">
-                    <span className="v10-agent-connect-card-name">OpenClaw</span>
-                    <span className="v10-agent-connect-card-desc">Claude Code / MCP</span>
-                  </button>
-                  <button className="v10-agent-connect-card">
-                    <span className="v10-agent-connect-card-name">Hermes</span>
-                    <span className="v10-agent-connect-card-desc">Hermes Agora node</span>
-                  </button>
-                  <button className="v10-agent-connect-card">
-                    <span className="v10-agent-connect-card-name">ElizaOS</span>
-                    <span className="v10-agent-connect-card-desc">ElizaOS adapter</span>
-                  </button>
-                </div>
-              </div>
-            )}
-            {messages.length === 0 && stage >= 1 && (
+            {messages.length === 0 && (
               <div style={{ padding: 16, color: 'var(--text-tertiary)', fontSize: 12, textAlign: 'center', marginTop: 40 }}>
                 Ask your agent a question to get started.
               </div>

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { useJourneyStore } from '../../stores/journey.js';
+import { type ChatAssistantStreamEvent, type MemorySession, streamChatMessage } from '../../api.js';
+import { api } from '../../api-wrapper.js';
+
+interface ChatMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  streaming?: boolean;
+}
+
+export function PanelRight() {
+  const { stage, advance } = useJourneyStore();
+  const [mode, setMode] = useState<'chat' | 'sessions'>('chat');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [sessionId, setSessionId] = useState<string | undefined>();
+  const [sessions, setSessions] = useState<MemorySession[]>([]);
+  const msgIdRef = useRef(0);
+  const chatEndRef = useRef<HTMLDivElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const scrollToBottom = useCallback(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  useEffect(scrollToBottom, [messages, scrollToBottom]);
+
+  const loadSessions = useCallback(() => {
+    api.fetchMemorySessions(20)
+      .then(({ sessions: s }: any) => setSessions(s))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => { loadSessions(); }, [loadSessions]);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || sending) return;
+
+    const userMsg: ChatMessage = { id: ++msgIdRef.current, role: 'user', content: text };
+    const assistantMsg: ChatMessage = { id: ++msgIdRef.current, role: 'assistant', content: '', streaming: true };
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
+    setInput('');
+    setSending(true);
+
+    const assistantId = assistantMsg.id;
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const res = await streamChatMessage(text, {
+        sessionId,
+        signal: controller.signal,
+        onEvent: (event: ChatAssistantStreamEvent) => {
+          if (event.type === 'text_delta') {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId ? { ...m, content: m.content + event.delta } : m
+              )
+            );
+          } else if (event.type === 'meta' && event.sessionId) {
+            setSessionId(event.sessionId);
+          }
+        },
+      });
+
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? { ...m, content: res.reply || m.content, streaming: false }
+            : m
+        )
+      );
+
+      if (res.sessionId) setSessionId(res.sessionId);
+      if (stage === 0) advance();
+      loadSessions();
+    } catch (err: any) {
+      if (err.name !== 'AbortError') {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, content: m.content || `Error: ${err.message}`, streaming: false }
+              : m
+          )
+        );
+      }
+    } finally {
+      setSending(false);
+      abortRef.current = null;
+    }
+  }, [input, sending, sessionId, stage, advance, loadSessions]);
+
+  const openSession = useCallback((session: MemorySession) => {
+    const mapped: ChatMessage[] = session.messages.map((m, i) => ({
+      id: ++msgIdRef.current,
+      role: m.author === 'user' ? 'user' as const : 'assistant' as const,
+      content: m.text,
+    }));
+    setMessages(mapped);
+    setSessionId(session.session);
+    setMode('chat');
+  }, []);
+
+  return (
+    <div className="v10-panel-right">
+      <div className="v10-agent-mode-tabs">
+        <button
+          className={`v10-agent-mode-tab ${mode === 'chat' ? 'active' : ''}`}
+          onClick={() => setMode('chat')}
+        >
+          Chat
+        </button>
+        <button
+          className={`v10-agent-mode-tab ${mode === 'sessions' ? 'active' : ''}`}
+          onClick={() => setMode('sessions')}
+        >
+          Sessions
+        </button>
+      </div>
+
+      {mode === 'chat' && (
+        <>
+          <div className="v10-agent-content">
+            {messages.length === 0 && stage === 0 && (
+              <div className="v10-agent-onboarding">
+                <div className="v10-agent-onboarding-title">Connect an Agent</div>
+                <p className="v10-agent-onboarding-desc">
+                  Connect your AI agent to the DKG to unlock shared, verifiable memory.
+                </p>
+                <div className="v10-agent-connect-cards">
+                  <button className="v10-agent-connect-card">
+                    <span className="v10-agent-connect-card-name">OpenClaw</span>
+                    <span className="v10-agent-connect-card-desc">Claude Code / MCP</span>
+                  </button>
+                  <button className="v10-agent-connect-card">
+                    <span className="v10-agent-connect-card-name">Hermes</span>
+                    <span className="v10-agent-connect-card-desc">Hermes Agora node</span>
+                  </button>
+                  <button className="v10-agent-connect-card">
+                    <span className="v10-agent-connect-card-name">ElizaOS</span>
+                    <span className="v10-agent-connect-card-desc">ElizaOS adapter</span>
+                  </button>
+                </div>
+              </div>
+            )}
+            {messages.length === 0 && stage >= 1 && (
+              <div style={{ padding: 16, color: 'var(--text-tertiary)', fontSize: 12, textAlign: 'center', marginTop: 40 }}>
+                Ask your agent a question to get started.
+              </div>
+            )}
+            <div className="v10-chat-messages">
+              {messages.map((m) => (
+                <div key={m.id} className={`v10-chat-msg ${m.role}`}>
+                  <div className={`v10-chat-bubble ${m.role}`}>
+                    {m.content}
+                    {m.streaming && <span className="v10-chat-cursor" />}
+                  </div>
+                </div>
+              ))}
+              <div ref={chatEndRef} />
+            </div>
+          </div>
+
+          <div className="v10-agent-input-area">
+            <input
+              type="text"
+              placeholder="Ask your agent..."
+              className="v10-agent-input"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } }}
+              disabled={sending}
+            />
+            <button className="v10-agent-send-btn" onClick={send} disabled={sending || !input.trim()}>
+              ↑
+            </button>
+          </div>
+        </>
+      )}
+
+      {mode === 'sessions' && (
+        <div className="v10-agent-content">
+          <div className="v10-sessions-list">
+            {sessions.length === 0 ? (
+              <p style={{ padding: 16, color: 'var(--text-tertiary)', fontSize: 12, textAlign: 'center' }}>
+                No sessions yet
+              </p>
+            ) : (
+              sessions.map((s) => {
+                const preview = s.messages?.[0]?.text?.slice(0, 60) || s.session;
+                const count = s.messages?.length ?? 0;
+                return (
+                  <button
+                    key={s.session}
+                    className="v10-session-item"
+                    onClick={() => openSession(s)}
+                  >
+                    <span className="v10-session-preview">{preview}</span>
+                    <span className="v10-session-count">{count} msg{count !== 1 ? 's' : ''}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/mocks/data.ts
+++ b/packages/node-ui/src/ui/mocks/data.ts
@@ -1,0 +1,114 @@
+export const MOCK_STATUS = {
+  name: 'my-dkg-node',
+  networkName: 'DKG Mainnet',
+  connectedPeers: 12,
+  synced: true,
+  version: '10.0.0-rc',
+};
+
+export const MOCK_METRICS = {
+  total_kcs: 1842,
+  confirmed_kcs: 1623,
+  tentative_kcs: 219,
+};
+
+export const MOCK_AGENTS = {
+  agents: [
+    { name: 'my-dkg-node', peerId: 'QmYourNode123', connectionStatus: 'self' },
+    { name: 'research-agent', peerId: 'QmResearch456', connectionStatus: 'connected', lastSeen: Date.now() },
+    { name: 'data-curator', peerId: 'QmCurator789', connectionStatus: 'connected', lastSeen: Date.now() - 60000 },
+    { name: 'pharma-bot', peerId: 'QmPharma012', connectionStatus: 'discovered', lastSeen: Date.now() - 300000 },
+  ],
+};
+
+export const MOCK_CONTEXT_GRAPHS = {
+  contextGraphs: [
+    {
+      id: 'cg:pharma-drug-interactions',
+      name: 'Pharma Drug Interactions',
+      description: 'Drug interaction knowledge graph for clinical decision support',
+      assetCount: 227,
+      agentCount: 3,
+    },
+    {
+      id: 'cg:climate-science',
+      name: 'Climate Science',
+      description: 'Climate research data and projections',
+      assetCount: 45,
+      agentCount: 2,
+    },
+    {
+      id: 'cg:supply-chain-eu',
+      name: 'EU Supply Chain',
+      description: 'European supply chain provenance tracking',
+      assetCount: 89,
+      agentCount: 1,
+    },
+  ],
+};
+
+export const MOCK_OPERATIONS = {
+  operations: [
+    { id: 'op-1', name: 'publish', status: 'completed', startedAt: Date.now() - 120000 },
+    { id: 'op-2', name: 'query', status: 'completed', startedAt: Date.now() - 300000 },
+    { id: 'op-3', name: 'publish', status: 'completed', startedAt: Date.now() - 600000 },
+    { id: 'op-4', name: 'chat', status: 'completed', startedAt: Date.now() - 900000 },
+    { id: 'op-5', name: 'sync', status: 'failed', startedAt: Date.now() - 1800000 },
+    { id: 'op-6', name: 'publish', status: 'completed', startedAt: Date.now() - 3600000 },
+  ],
+  total: 6,
+};
+
+export const MOCK_ECONOMICS = {
+  periods: [
+    { label: 'Last 7 days', publishCount: 14, successCount: 12, totalGasEth: 0.0034, totalTrac: 42.5, avgGasEth: 0.00024, avgTrac: 3.04 },
+    { label: 'Last 30 days', publishCount: 47, successCount: 43, totalGasEth: 0.012, totalTrac: 156.8, avgGasEth: 0.00026, avgTrac: 3.34 },
+  ],
+};
+
+export const MOCK_NOTIFICATIONS = {
+  notifications: [
+    { id: 1, ts: Date.now() - 60000, type: 'publish', title: 'Publish complete', message: 'warfarin-aspirin-001 published to Verified Memory', source: null, peer: null, read: 0, meta: null },
+    { id: 2, ts: Date.now() - 300000, type: 'agent', title: 'Agent connected', message: 'research-agent joined Pharma Drug Interactions', source: null, peer: 'QmResearch456', read: 0, meta: null },
+    { id: 3, ts: Date.now() - 900000, type: 'sync', title: 'Sync complete', message: '12 new triples synced from data-curator', source: null, peer: 'QmCurator789', read: 1, meta: null },
+  ],
+  unreadCount: 2,
+};
+
+export const MOCK_NODE_LOG = {
+  lines: [
+    '[2026-04-11 10:30:01] INFO  Node started on port 8900',
+    '[2026-04-11 10:30:02] INFO  Connected to DKG mainnet',
+    '[2026-04-11 10:30:03] INFO  Discovered 12 peers',
+    '[2026-04-11 10:30:05] INFO  Syncing context graph cg:pharma-drug-interactions',
+    '[2026-04-11 10:30:08] INFO  Sync complete: 227 assets, 3 agents',
+    '[2026-04-11 10:30:15] INFO  Agent research-agent connected via libp2p',
+    '[2026-04-11 10:31:00] INFO  Publish operation started: warfarin-aspirin-001',
+    '[2026-04-11 10:31:12] INFO  Triple store updated: +34 triples',
+    '[2026-04-11 10:31:15] INFO  Publish complete: warfarin-aspirin-001 → Verified Memory',
+    '[2026-04-11 10:32:00] DEBUG SPARQL query executed in 23ms (42 results)',
+    '[2026-04-11 10:33:00] INFO  Gossip: received 3 proposals from data-curator',
+    '[2026-04-11 10:34:00] INFO  SWM cleanup: 0 expired triples removed',
+    '[2026-04-11 10:35:00] INFO  Heartbeat: 12 peers, 1842 KAs, memory 245MB',
+  ],
+  totalSize: 13,
+};
+
+export const MOCK_SESSIONS = {
+  sessions: [
+    {
+      session: 'sess-abc123',
+      messages: [
+        { author: 'user', text: 'What drug interactions should I know about warfarin?', ts: '2026-04-11T10:00:00Z' },
+        { author: 'assistant', text: 'Warfarin has significant interactions with aspirin, NSAIDs, and several antibiotics. The most critical ones involve...', ts: '2026-04-11T10:00:05Z' },
+      ],
+    },
+    {
+      session: 'sess-def456',
+      messages: [
+        { author: 'user', text: 'Summarize the latest climate data for Arctic ice', ts: '2026-04-10T14:00:00Z' },
+        { author: 'assistant', text: 'Based on the latest projections in the verified memory...', ts: '2026-04-10T14:00:03Z' },
+      ],
+    },
+  ],
+};

--- a/packages/node-ui/src/ui/mocks/provider.ts
+++ b/packages/node-ui/src/ui/mocks/provider.ts
@@ -1,0 +1,23 @@
+import * as mock from './data.js';
+
+const IS_MOCK = true;
+
+function delay<T>(data: T, ms = 50): Promise<T> {
+  return new Promise((r) => setTimeout(() => r(data), ms));
+}
+
+export function shouldUseMocks(): boolean {
+  return IS_MOCK;
+}
+
+export const mockApi = {
+  fetchStatus: () => delay(mock.MOCK_STATUS),
+  fetchMetrics: () => delay(mock.MOCK_METRICS),
+  fetchAgents: () => delay(mock.MOCK_AGENTS),
+  fetchContextGraphs: () => delay(mock.MOCK_CONTEXT_GRAPHS),
+  fetchOperationsWithPhases: () => delay(mock.MOCK_OPERATIONS),
+  fetchEconomics: () => delay(mock.MOCK_ECONOMICS),
+  fetchNotifications: () => delay(mock.MOCK_NOTIFICATIONS),
+  fetchNodeLog: () => delay(mock.MOCK_NODE_LOG),
+  fetchMemorySessions: () => delay(mock.MOCK_SESSIONS),
+};

--- a/packages/node-ui/src/ui/stores/agents.ts
+++ b/packages/node-ui/src/ui/stores/agents.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+export interface AgentInfo {
+  name: string;
+  peerId?: string;
+  framework?: string;
+  status?: 'active' | 'idle' | 'offline';
+}
+
+interface AgentsState {
+  agents: AgentInfo[];
+  activeAgentName: string | null;
+  nodeStatus: any | null;
+
+  setAgents: (a: AgentInfo[]) => void;
+  setActiveAgent: (name: string) => void;
+  setNodeStatus: (s: any) => void;
+}
+
+export const useAgentsStore = create<AgentsState>((set) => ({
+  agents: [],
+  activeAgentName: null,
+  nodeStatus: null,
+
+  setAgents: (a) => set({ agents: a }),
+  setActiveAgent: (name) => set({ activeAgentName: name }),
+  setNodeStatus: (s) => set({ nodeStatus: s }),
+}));

--- a/packages/node-ui/src/ui/stores/journey.ts
+++ b/packages/node-ui/src/ui/stores/journey.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+export type JourneyStage = 0 | 1 | 2;
+
+interface JourneyState {
+  stage: JourneyStage;
+  setStage: (s: JourneyStage) => void;
+  advance: () => void;
+}
+
+function loadStage(): JourneyStage {
+  const raw = localStorage.getItem('dkg-journey-stage');
+  if (raw === '1') return 1;
+  if (raw === '2') return 2;
+  return 0;
+}
+
+export const useJourneyStore = create<JourneyState>((set, get) => ({
+  stage: loadStage(),
+
+  setStage: (s) => {
+    localStorage.setItem('dkg-journey-stage', String(s));
+    set({ stage: s });
+  },
+
+  advance: () => {
+    const next = Math.min(get().stage + 1, 2) as JourneyStage;
+    localStorage.setItem('dkg-journey-stage', String(next));
+    set({ stage: next });
+  },
+}));

--- a/packages/node-ui/src/ui/stores/layout.ts
+++ b/packages/node-ui/src/ui/stores/layout.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+
+interface LayoutState {
+  leftCollapsed: boolean;
+  rightCollapsed: boolean;
+  bottomCollapsed: boolean;
+  theme: 'dark' | 'light';
+  leftWidth: number;
+  rightWidth: number;
+
+  toggleLeft: () => void;
+  toggleRight: () => void;
+  toggleBottom: () => void;
+  setTheme: (t: 'dark' | 'light') => void;
+  setLeftWidth: (w: number) => void;
+  setRightWidth: (w: number) => void;
+}
+
+export const useLayoutStore = create<LayoutState>((set) => ({
+  leftCollapsed: false,
+  rightCollapsed: false,
+  bottomCollapsed: true,
+  theme: (localStorage.getItem('dkg-theme') as 'dark' | 'light') || 'dark',
+  leftWidth: 240,
+  rightWidth: 360,
+
+  toggleLeft: () => set((s) => ({ leftCollapsed: !s.leftCollapsed })),
+  toggleRight: () => set((s) => ({ rightCollapsed: !s.rightCollapsed })),
+  toggleBottom: () => set((s) => ({ bottomCollapsed: !s.bottomCollapsed })),
+  setTheme: (t) => {
+    localStorage.setItem('dkg-theme', t);
+    set({ theme: t });
+  },
+  setLeftWidth: (w) => set({ leftWidth: w }),
+  setRightWidth: (w) => set({ rightWidth: w }),
+}));

--- a/packages/node-ui/src/ui/stores/projects.ts
+++ b/packages/node-ui/src/ui/stores/projects.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+export interface ContextGraph {
+  id: string;
+  name: string;
+  description?: string;
+  assetCount?: number;
+  assets?: number;
+  agentCount?: number;
+  agents?: number;
+}
+
+interface ProjectsState {
+  contextGraphs: ContextGraph[];
+  loading: boolean;
+  activeProjectId: string | null;
+
+  setContextGraphs: (cgs: ContextGraph[]) => void;
+  setLoading: (v: boolean) => void;
+  setActiveProject: (id: string | null) => void;
+}
+
+export const useProjectsStore = create<ProjectsState>((set) => ({
+  contextGraphs: [],
+  loading: false,
+  activeProjectId: null,
+
+  setContextGraphs: (cgs) => set({ contextGraphs: cgs }),
+  setLoading: (v) => set({ loading: v }),
+  setActiveProject: (id) => set({ activeProjectId: id }),
+}));

--- a/packages/node-ui/src/ui/stores/tabs.ts
+++ b/packages/node-ui/src/ui/stores/tabs.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+
+export interface CenterTab {
+  id: string;
+  label: string;
+  closable: boolean;
+  icon?: string;
+}
+
+interface TabsState {
+  tabs: CenterTab[];
+  activeTabId: string;
+
+  openTab: (tab: CenterTab) => void;
+  closeTab: (id: string) => void;
+  setActiveTab: (id: string) => void;
+}
+
+const INITIAL_TABS: CenterTab[] = [
+  { id: 'dashboard', label: 'Dashboard', closable: false },
+];
+
+export const useTabsStore = create<TabsState>((set, get) => ({
+  tabs: INITIAL_TABS,
+  activeTabId: 'dashboard',
+
+  openTab: (tab) => {
+    const { tabs } = get();
+    if (!tabs.find((t) => t.id === tab.id)) {
+      set({ tabs: [...tabs, tab], activeTabId: tab.id });
+    } else {
+      set({ activeTabId: tab.id });
+    }
+  },
+
+  closeTab: (id) => {
+    const { tabs, activeTabId } = get();
+    const filtered = tabs.filter((t) => t.id !== id);
+    if (filtered.length === 0) return;
+    const newActive = activeTabId === id
+      ? filtered[Math.max(0, tabs.findIndex((t) => t.id === id) - 1)]?.id ?? filtered[0].id
+      : activeTabId;
+    set({ tabs: filtered, activeTabId: newActive });
+  },
+
+  setActiveTab: (id) => set({ activeTabId: id }),
+}));

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -646,6 +646,52 @@ button:focus:not(:focus-visible) { outline: none; }
   margin-bottom: 20px;
   line-height: 1.5;
 }
+/* Agent tab */
+.v10-agents-tab { padding: 12px; overflow-y: auto; flex: 1; }
+.v10-agents-summary {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 0; margin-bottom: 8px;
+  font-size: 12px; color: var(--text-secondary);
+}
+.v10-agents-stat { display: flex; align-items: center; gap: 4px; }
+.v10-agents-stat-dot { width: 6px; height: 6px; border-radius: 50%; }
+.v10-agents-stat-dot.connected { background: var(--accent-green); }
+.v10-agents-refresh {
+  margin-left: auto; background: none; border: none; cursor: pointer;
+  color: var(--text-tertiary); font-size: 14px; padding: 2px 6px; border-radius: 4px;
+}
+.v10-agents-refresh:hover { background: var(--bg-elevated); color: var(--text-primary); }
+.v10-agents-loading { padding: 16px; color: var(--text-tertiary); font-size: 12px; text-align: center; }
+.v10-agents-section-label {
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
+  color: var(--text-tertiary); margin: 12px 0 6px; padding: 0 2px;
+}
+.v10-agent-card {
+  padding: 10px 12px; border-radius: 6px; margin-bottom: 4px;
+  border: 1px solid var(--border-subtle); background: var(--bg-surface);
+  transition: background 0.15s;
+}
+.v10-agent-card:hover { background: var(--bg-elevated); }
+.v10-agent-card.self { border-color: var(--accent-blue); border-left: 3px solid var(--accent-blue); }
+.v10-agent-card-header { display: flex; align-items: center; gap: 6px; }
+.v10-agent-card-dot {
+  width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
+}
+.v10-agent-card-dot.self { background: var(--accent-blue); }
+.v10-agent-card-dot.connected { background: var(--accent-green); }
+.v10-agent-card-dot.known { background: var(--text-tertiary); }
+.v10-agent-card-name { font-size: 12px; font-weight: 600; color: var(--text-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v10-agent-card-badge {
+  font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.3px;
+  padding: 1px 5px; border-radius: 3px; flex-shrink: 0;
+  background: var(--bg-elevated); color: var(--text-tertiary);
+  border: 1px solid var(--border-subtle);
+}
+.v10-agent-card-meta {
+  display: flex; gap: 8px; margin-top: 4px;
+  font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono);
+}
+
 .v10-agent-connect-cards { display: flex; flex-direction: column; gap: 8px; }
 .v10-agent-connect-card {
   display: flex;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -1067,6 +1067,90 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-mlv-table tr:hover td { background: var(--bg-hover); }
 
+/* ── Assertion List (WM → SWM) ── */
+.v10-assertion-list { margin-bottom: 16px; border: 1px solid var(--border-default); border-radius: 8px; overflow: hidden; }
+.v10-assertion-list-loading { font-size: 12px; color: var(--text-tertiary); padding: 8px 0; }
+.v10-assertion-list-header { display: flex; align-items: center; justify-content: space-between; padding: 10px 12px; background: var(--bg-elevated); border-bottom: 1px solid var(--border-default); }
+.v10-assertion-list-title { font-size: 12px; font-weight: 600; color: var(--text-secondary); }
+.v10-btn-promote-all {
+  padding: 5px 14px; border-radius: 6px; border: none;
+  background: var(--layer-shared, #7c6ef0); color: #fff;
+  font-size: 11px; font-weight: 600; cursor: pointer; transition: opacity .15s;
+}
+.v10-btn-promote-all:hover { opacity: .85; }
+.v10-btn-promote-all:disabled { opacity: .5; cursor: not-allowed; }
+.v10-assertion-items { max-height: 220px; overflow-y: auto; }
+.v10-assertion-item {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 12px; border-bottom: 1px solid var(--border-subtle, rgba(128,128,128,.08));
+}
+.v10-assertion-item:last-child { border-bottom: none; }
+.v10-assertion-item-info { display: flex; align-items: baseline; gap: 8px; min-width: 0; flex: 1; }
+.v10-assertion-item-name {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-primary);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.v10-assertion-item-count { font-size: 10px; color: var(--text-tertiary); flex-shrink: 0; }
+.v10-btn-promote {
+  padding: 3px 10px; border-radius: 5px; background: transparent;
+  border: 1px solid var(--layer-shared, #7c6ef0); color: var(--layer-shared, #7c6ef0);
+  font-size: 11px; font-weight: 500; cursor: pointer; transition: all .15s; flex-shrink: 0;
+}
+.v10-btn-promote:hover { background: var(--layer-shared, #7c6ef0); color: #fff; }
+.v10-btn-promote:disabled { opacity: .5; cursor: not-allowed; }
+.v10-promote-result { padding: 8px 12px; font-size: 12px; }
+.v10-promote-result.success { color: var(--accent-green); background: rgba(34,197,94,.06); }
+.v10-promote-result.error { color: var(--accent-red); background: rgba(239,68,68,.06); }
+
+/* ── Publish Panel (SWM → VM) ── */
+.v10-publish-panel {
+  margin-bottom: 16px; border: 1px solid var(--border-default); border-radius: 8px; overflow: hidden;
+}
+.v10-publish-panel-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px; background: var(--bg-elevated); border-bottom: 1px solid var(--border-default);
+}
+.v10-publish-panel-header-actions { display: flex; align-items: center; gap: 8px; }
+.v10-publish-panel-title { font-size: 12px; font-weight: 600; color: var(--text-secondary); }
+.v10-publish-panel-refresh {
+  background: none; border: none; color: var(--text-tertiary); font-size: 14px; cursor: pointer;
+  padding: 2px 6px; border-radius: 4px;
+}
+.v10-publish-panel-refresh:hover { color: var(--text-primary); background: var(--bg-hover); }
+.v10-publish-panel-empty { padding: 16px 12px; font-size: 12px; color: var(--text-tertiary); text-align: center; }
+.v10-publish-select-bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  padding: 8px 12px; border-bottom: 1px solid var(--border-subtle, rgba(128,128,128,.08));
+  background: var(--bg-primary);
+}
+.v10-publish-select-all {
+  display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-secondary); cursor: pointer;
+}
+.v10-publish-select-all input { cursor: pointer; }
+.v10-publish-entity-check {
+  display: flex; align-items: center; padding-right: 8px; cursor: pointer; flex-shrink: 0;
+}
+.v10-publish-entity-check input { cursor: pointer; }
+.v10-assertion-item.selected { background: rgba(245,158,11,.04); }
+.v10-btn-publish {
+  padding: 5px 14px; border-radius: 6px; border: none;
+  background: var(--layer-verified, #f59e0b); color: #fff;
+  font-size: 11px; font-weight: 600; cursor: pointer; transition: opacity .15s; white-space: nowrap;
+}
+.v10-btn-publish:hover { opacity: .85; }
+.v10-btn-publish:disabled { opacity: .5; cursor: not-allowed; }
+.v10-publish-result-card {
+  margin: 0 12px 12px; padding: 12px; border-radius: 6px; font-size: 12px;
+}
+.v10-publish-result-card:first-of-type { margin-top: 12px; }
+.v10-publish-result-card.success { background: rgba(34,197,94,.06); border: 1px solid rgba(34,197,94,.2); }
+.v10-publish-result-card.error { background: rgba(239,68,68,.06); border: 1px solid rgba(239,68,68,.2); color: var(--accent-red); }
+.v10-publish-result-title { font-weight: 600; color: var(--accent-green); margin-bottom: 8px; }
+.v10-publish-result-details { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--text-secondary); }
+.v10-publish-result-label { font-weight: 600; color: var(--text-primary); margin-right: 4px; }
+.v10-publish-result-tx { font-family: var(--font-mono); font-size: 11px; }
+.v10-publish-result-block { color: var(--text-tertiary); }
+
 /* ══════════════════════════════════════════
    LEGACY COMPONENT STYLES (preserved from V9)
    ══════════════════════════════════════════ */
@@ -1219,6 +1303,56 @@ p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
   color: var(--text-primary);
   margin-bottom: 4px;
 }
+
+/* ── File Preview Modal ── */
+.v10-file-preview-modal { width: 720px; max-width: 90vw; max-height: 90vh; display: flex; flex-direction: column; }
+.v10-file-preview-modal .v10-modal-header {
+  display: flex; align-items: center; justify-content: space-between; flex-shrink: 0;
+}
+.v10-modal-close {
+  background: none; border: none; color: var(--text-tertiary); font-size: 22px; cursor: pointer;
+  padding: 0 4px; line-height: 1; border-radius: 4px;
+}
+.v10-modal-close:hover { color: var(--text-primary); background: var(--bg-hover); }
+.v10-file-preview-loading { padding: 32px 24px; text-align: center; font-size: 12px; color: var(--text-tertiary); }
+.v10-file-preview-error {
+  margin: 16px 24px; padding: 14px; border-radius: 8px;
+  background: rgba(239, 68, 68, 0.06); border: 1px solid rgba(239, 68, 68, 0.2);
+  color: var(--accent-red); font-size: 12px;
+}
+.v10-file-preview-meta {
+  display: flex; flex-wrap: wrap; gap: 6px; padding: 10px 24px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.v10-file-preview-meta-item {
+  font-size: 10px; padding: 2px 8px; border-radius: 4px;
+  background: var(--bg-surface, var(--bg-secondary)); color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+.v10-file-preview-content { flex: 1; overflow: auto; min-height: 200px; }
+.v10-file-preview-iframe { width: 100%; height: 60vh; border: none; display: block; }
+.v10-file-preview-image { max-width: 100%; max-height: 60vh; display: block; margin: 16px auto; }
+.v10-file-preview-text {
+  margin: 0; padding: 16px 24px; font-size: 12px; line-height: 1.6;
+  font-family: var(--font-mono); color: var(--text-primary);
+  white-space: pre-wrap; word-break: break-word; overflow-y: auto; max-height: 60vh;
+}
+.v10-file-preview-binary { padding: 32px 24px; text-align: center; color: var(--text-tertiary); font-size: 13px; }
+.v10-file-preview-footer {
+  display: flex; gap: 12px; padding: 12px 24px; border-top: 1px solid var(--border-subtle); flex-shrink: 0;
+}
+.v10-file-preview-download {
+  font-size: 11px; color: var(--accent); text-decoration: none; font-weight: 500;
+}
+.v10-file-preview-download:hover { text-decoration: underline; }
+
+/* Clickable assertion name */
+.v10-assertion-item-name.clickable {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--accent);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: left;
+}
+.v10-assertion-item-name.clickable:hover { text-decoration: underline; }
 
 /* Form elements */
 .v10-form-group { margin-bottom: 16px; }

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -1,513 +1,1435 @@
-/* Fonts loaded locally to avoid third-party CDN dependency.
-   If you have JetBrains Mono, Satoshi, or Instrument Serif installed locally
-   they'll be picked up; otherwise system fonts are used as fallback. */
+/* ══════════════════════════════════════════
+   DKG V10 — DESIGN TOKENS (from prototype v5.1)
+   ══════════════════════════════════════════ */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Instrument+Sans:wght@400;500;600;700&display=swap');
 
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-:root{
-  --bg:#0a0f1a;--surface:#111827;--surface-hover:#1a2332;--surface-alt:#0d1422;
-  --border:#1e2a3a;--border-light:#2a3a4f;
-  --text:#e2e8f0;--text-muted:#718096;--text-dim:#5e6e82;
-  --green:#4ade80;--green-dark:#166534;--green-mid:#22c55e;--green-dim:rgba(74,222,128,0.1);
-  --amber:#fbbf24;--amber-dim:rgba(251,191,36,0.1);
-  --red:#f87171;--red-dim:rgba(248,113,113,0.1);
-  --blue:#60a5fa;--blue-dim:rgba(96,165,250,0.1);
-  --purple:#a78bfa;--purple-dim:rgba(167,139,250,0.1);
-  --cyan:#22d3ee;--cyan-dim:rgba(34,211,238,0.08);
-  --pink:#f472b6;--pink-dim:rgba(244,114,182,0.12);
+:root {
+  /* Surface hierarchy — true black base */
+  --bg-root: #000000;
+  --bg-panel: #0a0a0a;
+  --bg-surface: #111111;
+  --bg-elevated: #181818;
+  --bg-hover: #1f1f1f;
+  --bg-active: #262626;
+
+  /* Borders */
+  --border-subtle: #1a1a1a;
+  --border-default: #222222;
+  --border-strong: #333333;
+
+  /* Text */
+  --text-primary: #e8e8e8;
+  --text-secondary: #888888;
+  --text-tertiary: #555555;
+  --text-ghost: #333333;
+
+  /* Accent — reserved for signals */
+  --accent-red: #ef4444;
+  --accent-amber: #f59e0b;
+  --accent-green: #22c55e;
+  --accent-blue: #3b82f6;
+
+  /* Layer identity */
+  --layer-working: #555555;
+  --layer-shared: #777777;
+  --layer-verified: #bbbbbb;
+
+  /* Typography */
+  --font-sans: 'Instrument Sans', -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  /* Sizing */
+  --header-h: 44px;
+  --tab-h: 36px;
+  --toolbar-h: 38px;
+
+  /* Legacy aliases (for existing components that use the old tokens) */
+  --bg: var(--bg-root);
+  --surface: var(--bg-surface);
+  --surface-hover: var(--bg-hover);
+  --surface-alt: var(--bg-panel);
+  --border: var(--border-default);
+  --border-light: var(--border-strong);
+  --text: var(--text-primary);
+  --text-muted: var(--text-secondary);
+  --text-dim: var(--text-tertiary);
+  --green: var(--accent-green);
+  --green-dark: #166534;
+  --green-mid: #22c55e;
+  --green-dim: rgba(34, 197, 94, 0.1);
+  --amber: var(--accent-amber);
+  --amber-dim: rgba(251, 191, 36, 0.1);
+  --red: var(--accent-red);
+  --red-dim: rgba(248, 113, 113, 0.1);
+  --blue: var(--accent-blue);
+  --blue-dim: rgba(96, 165, 250, 0.1);
+  --purple: #a78bfa;
+  --purple-dim: rgba(167, 139, 250, 0.1);
+  --cyan: #22d3ee;
+  --cyan-dim: rgba(34, 211, 238, 0.08);
+  --pink: #f472b6;
+  --pink-dim: rgba(244, 114, 182, 0.12);
 }
+
+/* ══════════════════════════════════════════
+   LIGHT THEME
+   ══════════════════════════════════════════ */
+body.light {
+  --bg-root: #fafafa;
+  --bg-panel: #f5f5f5;
+  --bg-surface: #ffffff;
+  --bg-elevated: #f0f0f0;
+  --bg-hover: #e8e8e8;
+  --bg-active: #e0e0e0;
+  --border-subtle: #e5e5e5;
+  --border-default: #d4d4d4;
+  --border-strong: #a3a3a3;
+  --text-primary: #171717;
+  --text-secondary: #525252;
+  --text-tertiary: #a3a3a3;
+  --text-ghost: #d4d4d4;
+  --layer-working: #a3a3a3;
+  --layer-shared: #737373;
+  --layer-verified: #404040;
+  --bg: var(--bg-root);
+  --surface: var(--bg-surface);
+  --surface-hover: var(--bg-hover);
+  --surface-alt: var(--bg-panel);
+  --border: var(--border-default);
+  --border-light: var(--border-strong);
+  --text: var(--text-primary);
+  --text-muted: var(--text-secondary);
+  --text-dim: var(--text-tertiary);
+}
+
+/* ══════════════════════════════════════════
+   RESET & BASE
+   ══════════════════════════════════════════ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body, #root {
+  height: 100%;
+  background: var(--bg-root);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+.mono { font-family: var(--font-mono); }
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  outline: none;
+}
+button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+input, textarea {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  border-radius: 4px;
+  padding: 6px 10px;
+  outline: none;
+}
+input:focus, textarea:focus { border-color: var(--border-strong); }
+input::placeholder { color: var(--text-tertiary); }
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+* { scrollbar-width: thin; scrollbar-color: var(--border-default) transparent; }
+:focus-visible { outline: 2px solid rgba(34, 197, 94, 0.5); outline-offset: 2px; }
+button:focus:not(:focus-visible) { outline: none; }
+
+@keyframes fadeSlideIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+.pulse-dot { animation: pulse 2s ease-in-out infinite; }
+.fade-in { animation: fadeSlideIn 0.4s ease; }
+
+/* ══════════════════════════════════════════
+   V10 APP SHELL
+   ══════════════════════════════════════════ */
+.v10-app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* ── Header ── */
+.v10-header {
+  height: var(--header-h);
+  min-height: var(--header-h);
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 2px;
+  z-index: 100;
+}
+.v10-header-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-primary);
+  user-select: none;
+}
+.v10-header-logo svg { stroke: var(--text-secondary); }
+.v10-header-logo-text {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.5px;
+}
+.v10-header-logo-version { color: var(--text-tertiary); font-weight: 300; }
+.v10-header-sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border-default);
+  margin: 0 12px 0 16px;
+}
+.v10-header-agent-switcher {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.v10-header-agent-switcher:hover { background: var(--bg-hover); }
+.v10-header-agent-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-green);
+}
+.v10-header-agent-name {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.v10-header-spacer { flex: 1; }
+.v10-header-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: 16px;
+}
+.v10-header-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.v10-header-status-dot.online { background: var(--accent-green); }
+.v10-header-status-dot.offline { background: var(--accent-amber); }
+.v10-header-meta-sep { color: var(--text-ghost); }
+.v10-header-actions { display: flex; align-items: center; gap: 4px; }
+.v10-header-icon-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+  position: relative;
+}
+.v10-header-icon-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.v10-header-icon-btn.active-toggle { color: var(--text-secondary); }
+.v10-header-notif-wrap { position: relative; }
+.v10-header-notif-badge {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  min-width: 14px;
+  height: 14px;
+  border-radius: 7px;
+  background: var(--accent-red);
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 3px;
+}
+.v10-header-notif-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 8px;
+  width: 320px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  z-index: 200;
+  overflow: hidden;
+}
+.v10-header-notif-title {
+  padding: 10px 14px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.v10-header-notif-empty {
+  padding: 24px 14px;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+.v10-header-notif-item {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.v10-header-notif-item:hover { background: var(--bg-hover); }
+.v10-header-notif-item:last-child { border-bottom: none; }
+.v10-header-notif-item-text { font-size: 12px; color: var(--text-primary); }
+.v10-header-notif-item-time { font-size: 10px; color: var(--text-tertiary); margin-top: 2px; font-family: var(--font-mono); }
+
+/* ── Body ── */
+.v10-app-body {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ── Resize handles ── */
+.v10-resize-handle-h {
+  width: 1px;
+  flex-shrink: 0;
+  background: var(--border-subtle);
+  cursor: col-resize;
+  transition: background 0.15s, width 0.1s;
+}
+.v10-resize-handle-h:hover,
+.v10-resize-handle-h.active { background: var(--accent-green); width: 3px; }
+
+/* ── Left panel ── */
+.v10-panel-left {
+  height: 100%;
+  flex-shrink: 0;
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.v10-tree-header {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.v10-collapse-btn {
+  margin-left: auto;
+  color: var(--text-tertiary);
+  transition: color 0.15s;
+  display: flex;
+  align-items: center;
+}
+.v10-collapse-btn:hover { color: var(--text-primary); }
+.v10-tree-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+.v10-tree-dashboard {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background 0.1s;
+  margin-bottom: 4px;
+}
+.v10-tree-dashboard:hover { background: var(--bg-hover); color: var(--text-primary); }
+.v10-tree-dashboard.active { background: var(--bg-active); color: var(--text-primary); }
+.v10-tree-empty-state {
+  padding: 24px 16px;
+  text-align: center;
+}
+.v10-tree-empty-state p {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+/* Tree sections (project list) */
+.v10-tree-section { margin-bottom: 2px; }
+.v10-tree-section-header {
+  display: flex;
+  align-items: center;
+  padding: 4px 12px;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 0.1s;
+  user-select: none;
+}
+.v10-tree-section-header:hover { background: var(--bg-hover); }
+.v10-tree-section-header.active { background: var(--bg-active); }
+.v10-tree-chevron {
+  color: var(--text-tertiary);
+  transition: transform 0.15s;
+  display: flex;
+  align-items: center;
+}
+.v10-tree-chevron.open { transform: rotate(90deg); }
+.v10-tree-section-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v10-tree-section-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  min-width: 18px;
+  text-align: right;
+}
+.v10-tree-items { padding-left: 0; }
+.v10-tree-item {
+  display: flex;
+  align-items: center;
+  padding: 3px 12px 3px 38px;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 0.1s;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.v10-tree-item:hover { background: var(--bg-hover); color: var(--text-primary); }
+.v10-tree-item.active { background: var(--bg-active); color: var(--text-primary); }
+.v10-tree-layer-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.v10-tree-item-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 11px;
+}
+/* Tree mode tabs */
+.v10-tree-mode-btn {
+  padding: 0 10px;
+  height: 100%;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+}
+.v10-tree-mode-btn:hover { color: var(--text-secondary); }
+.v10-tree-mode-btn.active { color: var(--text-primary); }
+
+/* Project dot */
+.v10-tree-project-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  flex-shrink: 0;
+}
+.v10-tree-integration-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+/* Layer headers inside project tree */
+.v10-tree-layer-header {
+  padding: 3px 12px 3px 32px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-ghost);
+  margin-top: 4px;
+  cursor: default;
+}
+
+/* New project button */
+.v10-new-project-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(100% - 16px);
+  margin: 6px 8px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px dashed var(--border-strong);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+}
+.v10-new-project-btn:hover { color: var(--text-primary); border-color: var(--text-secondary); }
+
+/* Journey empty card */
+.v10-journey-empty-card {
+  margin: 16px 10px;
+  padding: 16px;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  background: var(--bg-surface);
+  text-align: center;
+}
+.v10-jec-title { font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 6px; }
+.v10-jec-hint { font-size: 11px; color: var(--text-tertiary); line-height: 1.5; margin-bottom: 10px; }
+
+/* Tree divider */
+.v10-tree-divider { height: 1px; background: var(--border-subtle); margin: 8px 12px; }
+
+/* Tree items are toggled via React state — no CSS display:none needed */
+
+/* ── Center ── */
+.v10-center-empty { flex: 1; min-width: 0; height: 100%; background: var(--bg-root); }
+
+/* ── Center stack (center + bottom) ── */
+.v10-center-stack {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.v10-center-stack-main { flex: 1; min-height: 0; overflow: hidden; }
+
+/* ── Center panel ── */
+.v10-panel-center {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-root);
+}
+.v10-center-tabs {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  overflow-x: auto;
+  gap: 0;
+}
+.v10-center-tab {
+  height: 100%;
+  padding: 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.v10-center-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.v10-center-tab.active { color: var(--text-primary); border-bottom-color: var(--text-secondary); }
+.v10-center-tab-label { pointer-events: none; }
+.v10-center-tab-close {
+  display: flex;
+  align-items: center;
+  opacity: 0;
+  transition: opacity 0.15s;
+  padding: 2px;
+  border-radius: 2px;
+}
+.v10-center-tab:hover .v10-center-tab-close { opacity: 0.6; }
+.v10-center-tab-close:hover { opacity: 1 !important; background: var(--bg-active); }
+.v10-center-content {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+  padding: 24px 28px;
+}
+.v10-view-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  text-align: center;
+}
+
+/* ── Right panel ── */
+.v10-panel-right {
+  height: 100%;
+  flex-shrink: 0;
+  background: var(--bg-panel);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.v10-agent-mode-tabs {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 2px;
+}
+.v10-agent-mode-tab {
+  padding: 4px 14px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+}
+.v10-agent-mode-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.v10-agent-mode-tab.active { color: var(--text-primary); background: var(--bg-active); }
+.v10-agent-content { flex: 1; overflow-y: auto; }
+
+/* Agent onboarding (stage 0) */
+.v10-agent-onboarding { padding: 24px 16px; }
+.v10-agent-onboarding-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+.v10-agent-onboarding-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+.v10-agent-connect-cards { display: flex; flex-direction: column; gap: 8px; }
+.v10-agent-connect-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 14px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  text-align: left;
+  transition: all 0.15s;
+}
+.v10-agent-connect-card:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-elevated);
+}
+.v10-agent-connect-card-name { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.v10-agent-connect-card-desc { font-size: 11px; color: var(--text-tertiary); font-family: var(--font-mono); }
+
+/* Agent input */
+.v10-agent-input-area {
+  padding: 12px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.v10-agent-input {
+  flex: 1;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: var(--font-sans);
+}
+.v10-agent-input:focus { border-color: var(--border-strong); }
+.v10-agent-send-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+.v10-agent-send-btn:hover { background: var(--bg-elevated); color: var(--text-primary); }
+
+/* ── Bottom panel ── */
+.v10-panel-bottom {
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: height 0.15s ease;
+  flex-shrink: 0;
+}
+.v10-panel-bottom.collapsed { height: var(--tab-h); }
+.v10-panel-bottom:not(.collapsed) { height: 200px; }
+.v10-bottom-tabs {
+  height: var(--tab-h);
+  min-height: var(--tab-h);
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  gap: 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.v10-bottom-tab {
+  padding: 0 12px;
+  height: 100%;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
+}
+.v10-bottom-tab:hover { color: var(--text-secondary); }
+.v10-bottom-tab.active { color: var(--text-primary); border-bottom-color: var(--text-secondary); }
+.v10-bottom-toggle {
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  border-radius: 4px;
+}
+.v10-bottom-toggle:hover { color: var(--text-primary); background: var(--bg-hover); }
+.v10-bottom-content { flex: 1; overflow: auto; }
+
+/* Log viewer */
+.v10-log-container { display: flex; flex-direction: column; height: 100%; }
+.v10-log-toolbar {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+.v10-log-filter {
+  width: 200px;
+  padding: 4px 8px;
+  font-size: 11px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+.v10-log-output {
+  flex: 1;
+  overflow: auto;
+  padding: 4px 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+}
+.v10-log-line {
+  padding: 0 12px;
+  color: var(--text-secondary);
+  white-space: pre;
+}
+.v10-log-line:hover { background: var(--bg-hover); }
+
+/* ══════════════════════════════════════════
+   AGENT CHAT (V10)
+   ══════════════════════════════════════════ */
+.v10-chat-messages { padding: 12px 14px; display: flex; flex-direction: column; gap: 10px; }
+.v10-chat-msg { display: flex; flex-direction: column; }
+.v10-chat-msg.user { align-items: flex-end; }
+.v10-chat-msg.assistant { align-items: flex-start; }
+.v10-chat-bubble {
+  padding: 10px 14px;
+  border-radius: 10px;
+  max-width: 85%;
+  font-size: 12px;
+  line-height: 1.55;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.v10-chat-bubble.user {
+  background: var(--bg-active);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+}
+.v10-chat-bubble.assistant {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+}
+.v10-chat-cursor {
+  display: inline-block;
+  width: 5px;
+  height: 14px;
+  background: var(--text-secondary);
+  margin-left: 2px;
+  animation: pulse 1s ease-in-out infinite;
+  vertical-align: text-bottom;
+}
+
+/* Sessions list */
+.v10-sessions-list { padding: 8px 0; }
+.v10-session-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  text-align: left;
+  transition: background 0.1s;
+}
+.v10-session-item:hover { background: var(--bg-hover); }
+.v10-session-preview {
+  font-size: 12px;
+  color: var(--text-secondary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 8px;
+}
+.v10-session-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+/* ══════════════════════════════════════════
+   DASHBOARD VIEW
+   ══════════════════════════════════════════ */
+.v10-dashboard { max-width: 1200px; min-width: 0; }
+.v10-dash-header { margin-bottom: 24px; }
+.v10-dash-title { font-size: 20px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px; }
+.v10-dash-subtitle { font-size: 12px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.v10-dash-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 12px; margin-bottom: 24px; }
+.v10-dash-stats .stat-card { min-width: 0; }
+.v10-dash-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; }
+.v10-dash-section {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  padding: 16px 18px;
+}
+.v10-dash-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.v10-dash-section-header h3 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.v10-dash-section-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  background: var(--bg-elevated);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+.v10-dash-section-link {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  transition: color 0.15s;
+}
+.v10-dash-section-link:hover { color: var(--text-primary); }
+
+/* Quick actions */
+.v10-quick-actions { display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); gap: 8px; }
+.v10-quick-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-elevated);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+}
+.v10-quick-action:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.v10-quick-action-icon { font-size: 14px; width: 20px; text-align: center; }
+
+/* Recent ops */
+.v10-recent-ops { display: flex; flex-direction: column; gap: 0; }
+.v10-recent-op {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+.v10-recent-op:last-child { border-bottom: none; }
+.v10-recent-op-type { font-weight: 500; color: var(--text-primary); }
+.v10-recent-op-status { font-family: var(--font-mono); font-size: 11px; }
+.v10-recent-op-time { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); margin-left: auto; }
+
+/* Project cards in dashboard */
+.v10-dash-projects { display: flex; flex-direction: column; gap: 6px; }
+.v10-dash-project-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  transition: all 0.15s;
+  text-align: left;
+}
+.v10-dash-project-card:hover { border-color: var(--border-default); }
+.v10-dash-project-name { font-size: 12px; font-weight: 500; color: var(--text-primary); }
+.v10-dash-project-count { font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
+
+/* ══════════════════════════════════════════
+   PROJECT VIEW
+   ══════════════════════════════════════════ */
+.v10-project-view { max-width: 800px; min-width: 0; }
+.v10-pv-header { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 28px; }
+.v10-pv-project-dot { width: 12px; height: 12px; border-radius: 50%; background: var(--text-primary); margin-top: 6px; flex-shrink: 0; }
+.v10-pv-title { font-size: 20px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px; }
+.v10-pv-desc { font-size: 12px; color: var(--text-secondary); margin-bottom: 6px; }
+.v10-pv-meta { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-tertiary); }
+.v10-pv-meta-sep { color: var(--text-ghost); }
+.v10-pv-meta-item { }
+.v10-pv-layers { display: flex; flex-direction: column; gap: 10px; }
+.v10-layer-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 18px;
+  border-radius: 10px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  text-align: left;
+  transition: all 0.15s;
+}
+.v10-layer-card:hover { border-color: var(--border-strong); }
+.v10-layer-card-header { display: flex; align-items: center; gap: 10px; }
+.v10-layer-card-icon { font-size: 16px; }
+.v10-layer-card-label { font-size: 14px; font-weight: 600; color: var(--text-primary); flex: 1; }
+.v10-layer-card-arrow { color: var(--text-tertiary); font-size: 14px; }
+.v10-layer-card-desc { font-size: 12px; color: var(--text-secondary); line-height: 1.5; }
+
+/* ══════════════════════════════════════════
+   MEMORY LAYER VIEW
+   ══════════════════════════════════════════ */
+.v10-memory-layer-view { max-width: 1000px; min-width: 0; }
+.v10-mlv-header { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+.v10-mlv-icon { font-size: 20px; }
+.v10-mlv-title { font-size: 16px; font-weight: 600; color: var(--text-primary); margin-bottom: 2px; }
+.v10-mlv-desc { font-size: 12px; color: var(--text-secondary); }
+.v10-mlv-query-bar { display: flex; gap: 8px; margin-bottom: 16px; }
+.v10-mlv-query-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  color: var(--text-primary);
+}
+.v10-mlv-query-input:focus { border-color: var(--border-strong); }
+.v10-mlv-run-btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: all 0.15s;
+}
+.v10-mlv-run-btn:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.v10-mlv-status { font-size: 12px; color: var(--text-tertiary); padding: 8px 0; }
+.v10-mlv-empty { padding: 32px 0; text-align: center; }
+.v10-mlv-empty p { font-size: 12px; color: var(--text-tertiary); }
+.v10-mlv-table-wrap { overflow-x: auto; border: 1px solid var(--border-default); border-radius: 8px; }
+.v10-mlv-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.v10-mlv-table thead { background: var(--bg-elevated); }
+.v10-mlv-table th {
+  padding: 8px 12px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  border-bottom: 1px solid var(--border-default);
+}
+.v10-mlv-table td {
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v10-mlv-table tr:hover td { background: var(--bg-hover); }
+
+/* ══════════════════════════════════════════
+   LEGACY COMPONENT STYLES (preserved from V9)
+   ══════════════════════════════════════════ */
+
 /* Tooltip */
-.tt{position:fixed;transform:translate(-50%,-100%) translateY(-8px);padding:8px 12px;background:var(--surface-hover);border:1px solid var(--border-light);border-radius:8px;color:var(--text-muted);font-size:11px;font-weight:400;text-transform:none;letter-spacing:normal;line-height:1.5;pointer-events:none;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,.4);white-space:normal;word-wrap:break-word}
+.tt{position:fixed;transform:translate(-50%,-100%) translateY(-8px);padding:8px 12px;background:var(--bg-elevated);border:1px solid var(--border-strong);border-radius:8px;color:var(--text-secondary);font-size:11px;font-weight:400;text-transform:none;letter-spacing:normal;line-height:1.5;pointer-events:none;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,.4);white-space:normal;word-wrap:break-word}
 .tt.tt-below{transform:translate(-50%,0) translateY(8px)}
-.tt::after{content:'';position:absolute;bottom:-5px;left:50%;transform:translateX(-50%) rotate(45deg);width:8px;height:8px;background:var(--surface-hover);border-right:1px solid var(--border-light);border-bottom:1px solid var(--border-light)}
-.tt.tt-below::after{bottom:auto;top:-5px;border-right:none;border-bottom:none;border-left:1px solid var(--border-light);border-top:1px solid var(--border-light)}
-html,body{height:100%}
-body{font-family:'Satoshi','General Sans',-apple-system,sans-serif;background:var(--bg);color:var(--text);line-height:1.5;font-size:14px}
-p{font-size:14px;color:var(--text-muted);line-height:1.6}
-.mono{font-family:'JetBrains Mono',monospace}
-.serif{font-family:'Instrument Serif',serif}
+.tt::after{content:'';position:absolute;bottom:-5px;left:50%;transform:translateX(-50%) rotate(45deg);width:8px;height:8px;background:var(--bg-elevated);border-right:1px solid var(--border-strong);border-bottom:1px solid var(--border-strong)}
+.tt.tt-below::after{bottom:auto;top:-5px;border-right:none;border-bottom:none;border-left:1px solid var(--border-strong);border-top:1px solid var(--border-strong)}
 
-@keyframes fadeSlideIn{from{opacity:0;transform:translateY(-8px)}to{opacity:1;transform:translateY(0)}}
-@keyframes pulse{0%,100%{opacity:1}50%{opacity:.5}}
-.pulse-dot{animation:pulse 2s ease-in-out infinite}
-.fade-in{animation:fadeSlideIn .4s ease}
+p { font-size: 13px; color: var(--text-secondary); line-height: 1.6; }
 
-*{scrollbar-width:thin;scrollbar-color:#1e2a3a transparent}
-::-webkit-scrollbar{width:6px}
-::-webkit-scrollbar-track{background:transparent}
-::-webkit-scrollbar-thumb{background:#1e2a3a;border-radius:3px}
-::-webkit-scrollbar-thumb:hover{background:#2a3a4f}
-button{cursor:pointer;transition:filter .15s;font-family:inherit}
-button:hover{filter:brightness(1.1)}
-button:disabled{opacity:.4;cursor:not-allowed;filter:none}
-:focus-visible{outline:2px solid rgba(74,222,128,.5);outline-offset:2px}
-button:focus:not(:focus-visible){outline:none}
-input::placeholder{color:#475569}
-
-/* ── Unified button styles (matching OriginTrail game) ── */
-.dkg-btn{
-  display:inline-flex;align-items:center;gap:6px;
-  padding:8px 16px;border-radius:8px;font-size:13px;font-weight:600;
-  border:1px solid rgba(74,222,128,.3);background:var(--green-dim);color:var(--green);
-  cursor:pointer;transition:filter .15s;font-family:inherit;min-height:36px
-}
+/* Unified button styles */
+.dkg-btn{display:inline-flex;align-items:center;gap:6px;padding:8px 16px;border-radius:8px;font-size:13px;font-weight:600;border:1px solid rgba(34,197,94,.3);background:var(--green-dim);color:var(--accent-green);cursor:pointer;transition:filter .15s;font-family:inherit;min-height:36px}
 .dkg-btn:hover{filter:brightness(1.2)}
 .dkg-btn:disabled{opacity:.4;cursor:not-allowed;filter:none}
-.dkg-btn-secondary{background:var(--surface);border:1px solid var(--border);color:var(--text-muted)}
-.dkg-btn-solid{background:var(--green);border:none;color:var(--bg);font-weight:700}
+.dkg-btn-secondary{background:var(--bg-surface);border:1px solid var(--border-default);color:var(--text-secondary)}
+.dkg-btn-solid{background:var(--accent-green);border:none;color:var(--bg-root);font-weight:700}
 .dkg-btn-solid:hover{filter:brightness(1.1)}
-.dkg-btn-icon{font-size:14px;flex-shrink:0}
-
-/* Layout */
-.app-layout{display:flex;height:100vh;width:100vw;overflow:hidden}
-.sidebar{width:220px;background:var(--surface-alt);border-right:1px solid var(--border);display:flex;flex-direction:column;flex-shrink:0}
-.main-content{flex:1;overflow:hidden;display:flex;flex-direction:column}
-.page-section{padding:28px 32px;overflow:auto;height:100%}
-
-/* Sidebar */
-.sidebar-logo{padding:18px 18px 16px;border-bottom:1px solid var(--border);display:flex;flex-direction:column;gap:4px}
-.logo-version{font-size:10px;color:var(--green);font-weight:600}
-.sidebar-nav{padding:12px 10px;flex:1;display:flex;flex-direction:column;gap:2px}
-.nav-btn{display:flex;align-items:center;gap:10px;width:100%;padding:12px 12px;border-radius:8px;border:none;background:transparent;font-size:13px;font-weight:500;color:var(--text-muted);text-align:left;position:relative;text-decoration:none;min-height:44px;transition:background .15s,color .15s}
-.nav-btn:hover:not(.active){background:rgba(255,255,255,.03);color:var(--text)}
-.nav-btn:hover:not(.active) svg{stroke:var(--text)}
-.nav-btn.active{background:rgba(74,222,128,.08);color:var(--green);font-weight:600}
-.nav-btn.active svg{stroke:var(--green)}
-.nav-btn svg{stroke:var(--text-muted);flex-shrink:0;transition:stroke .15s}
-.nav-badge{margin-left:auto;font-size:9px;font-weight:700;padding:2px 6px;border-radius:4px;background:var(--green-dim);color:var(--green)}
-.sidebar-footer{padding:14px 16px;border-top:1px solid var(--border);font-size:11px}
-
-/* Apps dropdown */
-.apps-dropdown{display:none;margin-left:26px;margin-top:2px;margin-bottom:4px}
-.apps-dropdown.open{display:flex;flex-direction:column;gap:1px}
-.apps-sub-btn{display:flex;align-items:center;gap:8px;width:100%;padding:10px 12px;border-radius:6px;border:none;background:transparent;font-size:12px;font-weight:500;color:var(--text-muted);text-align:left;cursor:pointer;transition:all .15s;min-height:44px}
-.apps-sub-btn:hover{background:rgba(255,255,255,.03);color:var(--text)}
-.apps-sub-btn.active-sub{color:var(--green);font-weight:600}
 
 /* Cards */
-.card{background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden;transition:border-color .15s}
-.card-header{padding:14px 18px;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between}
+.card{background:var(--bg-surface);border:1px solid var(--border-default);border-radius:12px;overflow:hidden;transition:border-color .15s}
+.card-header{padding:14px 18px;border-bottom:1px solid var(--border-default);display:flex;align-items:center;justify-content:space-between}
 
 /* Stat cards */
-.stat-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:18px 20px;flex:1;min-width:160px;position:relative;overflow:hidden;transition:border-color .15s,box-shadow .15s}
-.stat-card:hover{border-color:var(--border-light);box-shadow:0 2px 8px rgba(0,0,0,.15)}
+.stat-card{background:var(--bg-surface);border:1px solid var(--border-default);border-radius:12px;padding:18px 20px;flex:1;min-width:0;position:relative;overflow:hidden;transition:border-color .15s,box-shadow .15s}
+.stat-card:hover{border-color:var(--border-strong);box-shadow:0 2px 8px rgba(0,0,0,.15)}
 .stat-card .accent{position:absolute;top:0;left:0;right:0;height:2px}
-.stat-label{font-size:11px;color:var(--text-muted);font-weight:600;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px;display:flex;align-items:center;gap:6px}
-.stat-value{font-size:28px;font-weight:700;color:var(--text);line-height:1}
-.stat-sub{font-size:11px;color:var(--text-muted);margin-top:6px}
+.stat-label{font-size:11px;color:var(--text-secondary);font-weight:600;letter-spacing:.06em;text-transform:uppercase;margin-bottom:8px;display:flex;align-items:center;gap:6px}
+.stat-value{font-size:28px;font-weight:700;color:var(--text-primary);line-height:1}
+.stat-sub{font-size:11px;color:var(--text-secondary);margin-top:6px}
 
 /* Badges */
-.agent-badge{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:6px;font-size:10px;font-weight:600;white-space:nowrap;font-family:'JetBrains Mono',monospace}
+.agent-badge{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:6px;font-size:10px;font-weight:600;white-space:nowrap;font-family:var(--font-mono)}
 .agent-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
-.verify-badge{display:inline-flex;align-items:center;gap:4px;padding:2px 6px;border-radius:6px;font-size:10px;font-weight:600;font-family:'JetBrains Mono',monospace}
-.verify-badge.verified{background:rgba(74,222,128,.1);color:var(--green);border:1px solid rgba(74,222,128,.2)}
-.verify-badge.pending{background:var(--amber-dim);color:var(--amber);border:1px solid rgba(251,191,36,.2)}
-.action-label{font-size:9px;font-weight:700;letter-spacing:.08em;opacity:.8;font-family:'JetBrains Mono',monospace}
-.ual{padding:1px 6px;border-radius:4px;font-size:10px;color:var(--text-muted);background:rgba(255,255,255,.03);border:1px solid var(--border);word-break:break-all;font-family:'JetBrains Mono',monospace}
-
-/* Activity feed */
-.feed-row{padding:10px 18px;border-bottom:1px solid var(--border);display:grid;grid-template-columns:60px 130px 54px 1fr auto;align-items:center;gap:10px;font-size:12px}
+.verify-badge{display:inline-flex;align-items:center;gap:4px;padding:2px 6px;border-radius:6px;font-size:10px;font-weight:600;font-family:var(--font-mono)}
+.verify-badge.verified{background:rgba(34,197,94,.1);color:var(--accent-green);border:1px solid rgba(34,197,94,.2)}
+.verify-badge.pending{background:var(--amber-dim);color:var(--accent-amber);border:1px solid rgba(251,191,36,.2)}
 
 /* Mode tabs */
-.mode-tabs{display:flex;gap:4px;background:var(--surface);border-radius:8px;padding:3px;border:1px solid var(--border)}
-.mode-tab{padding:8px 14px;border-radius:6px;border:none;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;background:transparent;color:var(--text-muted);min-height:36px}
-.mode-tab.active{background:var(--green-dim);color:var(--green)}
+.mode-tabs{display:flex;gap:4px;background:var(--bg-surface);border-radius:8px;padding:3px;border:1px solid var(--border-default)}
+.mode-tab{padding:8px 14px;border-radius:6px;border:none;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;background:transparent;color:var(--text-secondary);min-height:36px}
+.mode-tab.active{background:var(--green-dim);color:var(--accent-green)}
 
-/* Leaderboard */
-.lb-row{padding:14px 18px;border-bottom:1px solid var(--border);display:grid;grid-template-columns:28px 140px 1fr 80px 80px 80px;align-items:center;gap:10px}
-.lb-bar{height:6px;background:var(--bg);border-radius:3px;overflow:hidden}
-.lb-bar-fill{height:100%;border-radius:3px;background:linear-gradient(90deg,rgba(74,222,128,.53),var(--green))}
-
-/* Chat */
+/* Chat (legacy) */
 .chat-area{flex:1;overflow:auto;padding:16px 20px}
 .chat-msg{margin-bottom:14px;display:flex;flex-direction:column}
 .chat-msg.user{align-items:flex-end}
 .chat-msg.assistant{align-items:flex-start}
 .chat-bubble{padding:10px 14px;border-radius:10px;max-width:80%;font-size:12px;line-height:1.55;word-break:break-word;overflow-wrap:anywhere}
-.chat-bubble.user{background:var(--green-dim);color:var(--green);border:1px solid rgba(74,222,128,.13)}
-.chat-bubble.assistant{background:rgba(255,255,255,.04);color:var(--text);border:1px solid var(--border)}
-.chat-tool{font-size:10px;color:var(--amber);margin-bottom:4px;display:flex;align-items:center;gap:4px;padding:2px 8px;background:var(--amber-dim);border-radius:4px;width:fit-content}
-.chat-input-row{padding:16px 20px;border-top:1px solid var(--border);display:flex;gap:12px;align-items:center}
-.chat-input{flex:1;padding:12px 16px;border-radius:10px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:13px;outline:none;font-family:inherit;min-height:44px;box-sizing:border-box}
-.chat-input:focus{border-color:rgba(74,222,128,.4)}
-.chat-send{padding:12px 24px;border-radius:10px;border:none;background:var(--green);color:var(--bg);font-weight:700;font-size:13px;cursor:pointer;transition:opacity .15s ease;flex-shrink:0}
-.chat-send:hover:not(:disabled){opacity:.9}
-.chat-send:disabled{opacity:.5;cursor:not-allowed}
+.chat-bubble.user{background:var(--green-dim);color:var(--accent-green);border:1px solid rgba(34,197,94,.13)}
+.chat-bubble.assistant{background:rgba(255,255,255,.04);color:var(--text-primary);border:1px solid var(--border-default)}
+.chat-input-row{padding:16px 20px;border-top:1px solid var(--border-default);display:flex;gap:12px;align-items:center}
+.chat-input{flex:1;padding:12px 16px;border-radius:10px;border:1px solid var(--border-default);background:var(--bg-root);color:var(--text-primary);font-size:13px;outline:none;font-family:inherit;min-height:44px;box-sizing:border-box}
+.chat-input:focus{border-color:rgba(34,197,94,.4)}
 
-/* Trail */
-.trail-hero{background:linear-gradient(135deg,#0a1a0a,#1a2a1a);border:1px solid rgba(74,222,128,.13);border-radius:16px;padding:32px 36px;margin-bottom:20px;position:relative;overflow:hidden}
-.trail-hero-glow{position:absolute;top:-50px;right:-30px;width:200px;height:200px;border-radius:50%;background:radial-gradient(circle,rgba(74,222,128,.07),transparent)}
-
-/* Settings */
-.settings-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-.settings-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:20px;transition:border-color .15s}
-.settings-title{font-size:13px;font-weight:700;color:var(--text);margin-bottom:16px}
-
-/* Import modal */
-.import-modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:100;align-items:center;justify-content:center}
-.import-modal-overlay.open{display:flex}
-.import-modal{background:var(--surface);border:1px solid var(--border);border-radius:16px;padding:32px;max-width:520px;width:90%}
-.import-modal textarea{width:100%;height:160px;background:var(--bg);border:1px solid var(--border);border-radius:8px;color:var(--text);font-family:'JetBrains Mono',monospace;font-size:12px;padding:12px;resize:vertical;outline:none}
-
-/* Graph */
-.graph-canvas{position:relative;height:500px;overflow:hidden}
-.graph-grid{position:absolute;inset:0;opacity:.15;background-image:radial-gradient(circle,var(--border) 1px,transparent 1px);background-size:24px 24px}
-.graph-node{position:absolute;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all .2s ease;z-index:2}
-.graph-node-label{position:absolute;left:50%;transform:translateX(-50%);font-size:9px;font-weight:600;color:var(--text-muted);white-space:nowrap;text-align:center;font-family:'JetBrains Mono',monospace}
-.prov-panel{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:20px;overflow:auto}
-.prov-field-label{font-size:10px;font-weight:600;color:var(--text-dim);text-transform:uppercase;letter-spacing:.08em;margin-bottom:3px}
-.prov-field-value{font-size:11px;color:var(--text);background:rgba(255,255,255,.03);padding:6px 10px;border-radius:6px;border:1px solid var(--border);word-break:break-all;margin-bottom:12px;font-family:'JetBrains Mono',monospace}
-.sparql-editor{padding:16px 18px;margin:0;font-size:12px;line-height:1.7;color:var(--text);background:#080d16;min-height:240px;overflow:auto;white-space:pre;font-family:'JetBrains Mono',monospace;border:1px solid var(--border);border-radius:10px;resize:vertical;outline:none;width:100%;box-sizing:border-box;transition:border-color .15s}
-.sparql-editor:focus{border-color:rgba(74,222,128,.4)}
-.sparql-editor-cm{margin-top:0;background:#080d16;border:1px solid var(--border);border-radius:10px;overflow:hidden;transition:border-color .15s}
-.sparql-editor-cm:focus-within{border-color:rgba(74,222,128,.4)}
-.sparql-editor-cm .cm-editor{min-height:240px;background:transparent;color:var(--text);font-family:'JetBrains Mono',monospace}
-.sparql-editor-cm .cm-focused{outline:none}
-.sparql-editor-cm .cm-scroller{min-height:240px;padding:16px 18px;font-size:12px;line-height:1.7}
-.sparql-editor-cm .cm-content{white-space:pre-wrap}
-.sparql-editor-cm .cm-line{padding:0}
-.sparql-editor-cm .cm-activeLine{background:rgba(255,255,255,.03)}
-.sparql-editor-cm .cm-selectionBackground,.sparql-editor-cm .cm-content ::selection{background:rgba(74,222,128,.22)!important}
-.sparql-editor-cm .cm-keyword{color:#7dd3fc}
-.sparql-editor-cm .cm-operator{color:#c4b5fd}
-.sparql-editor-cm .cm-string{color:#86efac}
-.sparql-editor-cm .cm-number{color:#fdba74}
-.sparql-editor-cm .cm-variableName,.sparql-editor-cm .cm-variableName2{color:#f9a8d4}
-.sparql-stack-layout{display:flex;flex-direction:column;gap:12px;min-height:calc(100vh - 220px);width:100%}
-.sparql-query-composer{display:flex;gap:12px;width:100%;min-height:260px}
-.sparql-query-editor-pane{flex:1 1 50%;min-width:0}
-.sparql-helper-grid{flex:1 1 50%;min-width:0;display:grid;grid-template-columns:1fr 1fr;gap:10px}
-.sparql-helper-card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:10px;display:flex;flex-direction:column;gap:6px;text-align:left;transition:border-color .15s,background .15s}
-.sparql-helper-card:hover{border-color:rgba(74,222,128,.45);background:rgba(74,222,128,.06)}
-.sparql-helper-title{font-size:12px;font-weight:700;color:var(--text)}
-.sparql-helper-desc{font-size:11px;color:var(--text-muted);line-height:1.4}
-.sparql-helper-code{font-size:10px;color:var(--text-dim);white-space:pre-wrap;word-break:break-word;background:rgba(255,255,255,.03);border:1px solid var(--border);border-radius:6px;padding:6px;max-height:88px;overflow:auto}
-.sparql-results-pane{margin-top:12px;flex:0 0 auto;min-height:320px;max-height:460px;overflow:auto}
-.sparql-graph-pane{width:100%;flex:1 1 auto;min-height:320px;display:flex;overflow:hidden}
-.sparql-graph-pane .card{width:100%}
-.sparql-cell-with-copy{position:relative;padding-right:48px!important}
-.sparql-copy-btn{position:absolute;right:8px;top:50%;transform:translateY(-50%);opacity:0;pointer-events:none;background:var(--surface-alt);border:1px solid var(--border);color:var(--text-muted);font-size:10px;padding:2px 6px;border-radius:5px;transition:opacity .12s ease}
-.sparql-cell-with-copy:hover .sparql-copy-btn{opacity:1;pointer-events:auto}
-.sparql-cell-link{background:none;border:none;color:var(--blue);font:inherit;text-align:left;padding:0;cursor:pointer;text-decoration:underline}
-
-/* Floating ChatPanel (Node Assistant) */
-.chat-fab{position:fixed;bottom:24px;right:24px;width:52px;height:52px;border-radius:50%;background:var(--green);color:var(--bg);border:none;display:flex;align-items:center;justify-content:center;box-shadow:0 4px 20px rgba(74,222,128,.3);z-index:1000}
-.chat-fab:hover{background:var(--green-mid)}
-.chat-panel{position:fixed;bottom:24px;right:24px;width:380px;height:520px;background:var(--surface);border:1px solid var(--border);border-radius:12px;display:flex;flex-direction:column;box-shadow:0 8px 32px rgba(0,0,0,.5);z-index:1000;overflow:hidden}
-.chat-panel .chat-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--border);flex-shrink:0}
-.chat-title{font-size:14px;font-weight:700;color:var(--text)}
-.chat-close{background:none;border:none;color:var(--text-muted);cursor:pointer;padding:8px;border-radius:4px;display:flex;align-items:center;min-width:36px;min-height:36px;justify-content:center}
-.chat-close:hover{color:var(--text);background:var(--surface-hover)}
-.chat-panel .chat-messages{flex:1;overflow-y:auto;padding:12px 16px;display:flex;flex-direction:column;gap:10px}
-.chat-msg-user{justify-content:flex-end}
-.chat-msg-bubble{max-width:85%;padding:8px 12px;border-radius:12px;font-size:13px;line-height:1.5;word-break:break-word}
-.chat-msg-user .chat-msg-bubble{background:var(--green-dim);color:var(--green);border:1px solid rgba(74,222,128,.13);border-bottom-right-radius:4px}
-.chat-msg-assistant .chat-msg-bubble{background:rgba(255,255,255,.04);color:var(--text);border:1px solid var(--border);border-bottom-left-radius:4px}
-.chat-msg-text code{background:rgba(0,0,0,.2);padding:1px 4px;border-radius:3px;font-family:'JetBrains Mono',monospace;font-size:12px}
-.chat-sparql-details,.chat-data-details{margin-top:6px;font-size:11px}
-.chat-sparql-details summary,.chat-data-details summary{color:var(--text-muted);cursor:pointer;font-size:11px}
-.chat-sparql-code,.chat-data-code{background:rgba(0,0,0,.3);border-radius:6px;padding:8px;margin-top:4px;font-family:'JetBrains Mono',monospace;font-size:11px;overflow-x:auto;max-height:150px;overflow-y:auto;white-space:pre-wrap}
-.chat-typing{display:flex;gap:4px;padding:10px 14px !important}
-.chat-typing span{width:6px;height:6px;border-radius:50%;background:var(--text-muted);animation:chat-bounce 1.2s infinite}
-.chat-typing span:nth-child(2){animation-delay:.2s}
-.chat-typing span:nth-child(3){animation-delay:.4s}
-@keyframes chat-bounce{0%,80%,100%{transform:translateY(0);opacity:.4}40%{transform:translateY(-6px);opacity:1}}
-.chat-panel .chat-input-row{display:flex;gap:8px;padding:10px 12px;border-top:1px solid var(--border);flex-shrink:0;align-items:flex-end}
-.chat-panel .chat-input{flex:1;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:8px 12px;color:var(--text);font-size:13px;font-family:inherit;outline:none;resize:none;max-height:80px;line-height:1.4}
-.chat-panel .chat-input:focus{border-color:rgba(74,222,128,.4)}
-.chat-panel .chat-send{width:36px;height:36px;border-radius:8px;background:var(--green);color:#fff;border:none;display:flex;align-items:center;justify-content:center;flex-shrink:0;padding:0}
-.chat-panel .chat-send:hover:not(:disabled){background:var(--green-mid)}
-.chat-panel .chat-send:disabled{opacity:.4;cursor:default}
-
-/* Graph Explorer layout */
-.graph-explorer-layout{display:flex;gap:16px;height:calc(100vh - 140px);min-height:500px}
-.graph-explorer-main{flex:1;min-width:0;display:flex;flex-direction:column}
-.graph-shell{position:relative;overflow:hidden}
-.graph-toolbar{padding:12px 16px;border-bottom:1px solid var(--border);display:flex;flex-direction:column;gap:10px;background:linear-gradient(180deg,rgba(12,18,31,.92),rgba(8,12,20,.65))}
-.graph-toolbar-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
-.graph-legend{display:flex;gap:16px;padding:8px 16px;background:linear-gradient(180deg,rgba(31,41,55,.6),rgba(31,41,55,.3));border-bottom:1px solid var(--border);font-size:11px;flex-wrap:wrap}
-.graph-legend-item{display:flex;align-items:center;gap:6px;color:var(--text-muted)}
-.graph-legend-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
-.graph-predicate-filters{display:flex;flex-wrap:wrap;gap:6px;padding:8px 12px;border-bottom:1px solid var(--border);background:rgba(17,24,39,.4)}
-.graph-predicate-chip{border:1px solid rgba(148,163,184,.35);background:rgba(15,23,42,.5);color:var(--text-muted);font-size:11px;border-radius:999px;padding:6px 10px;cursor:pointer;transition:all .15s ease;min-height:32px;display:inline-flex;align-items:center}
-.graph-predicate-chip:hover{color:var(--text);border-color:rgba(125,211,252,.55)}
-.graph-predicate-chip.active{color:#dbeafe;border-color:rgba(125,211,252,.7);background:rgba(30,64,175,.32)}
-.graph-details-panel{width:320px;flex-shrink:0;background:var(--surface);border:1px solid var(--border);border-radius:12px;overflow:hidden;display:flex;flex-direction:column;max-height:700px}
-.graph-details-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;border-bottom:1px solid var(--border);background:var(--surface-alt)}
-.graph-details-header h3{margin:0;font-size:14px;font-weight:600}
-.graph-details-body{padding:16px;overflow-y:auto;flex:1}
-.graph-details-section{margin-bottom:16px}
-.graph-details-section:last-child{margin-bottom:0}
-.graph-details-label{font-size:10px;text-transform:uppercase;letter-spacing:.5px;color:var(--text-muted);margin-bottom:6px}
-.graph-details-value{font-size:13px;word-break:break-all;display:flex;align-items:center;gap:6px;margin-bottom:4px}
-
-/* ── Compatibility: tab-group, tab-item (Explorer, Wallet, Operations) ── */
-.tab-group{display:flex;gap:0;border-bottom:1px solid var(--border);margin-bottom:20px}
-.tab-item{padding:12px 20px;font-size:13px;font-weight:600;color:var(--text-muted);cursor:pointer;border-bottom:2px solid transparent;transition:all .15s;background:none;border-top:none;border-left:none;border-right:none;font-family:inherit;min-height:44px}
-.tab-item:hover{color:var(--text)}
-.tab-item.active{color:var(--green);border-bottom-color:var(--green)}
-
-/* ── Compatibility: badges & buttons ── */
-.badge{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:600}
-.badge-success{background:rgba(74,222,128,.15);color:var(--green)}
-.badge-error{background:rgba(239,68,68,.15);color:#ef4444}
-.badge-warning{background:rgba(251,191,36,.15);color:var(--amber)}
-.badge-info{background:rgba(96,165,250,.15);color:var(--blue)}
-.btn{display:inline-flex;align-items:center;gap:6px;padding:10px 16px;border-radius:8px;font-size:13px;font-weight:600;border:none;cursor:pointer;transition:all .15s;font-family:inherit;min-height:40px}
-.btn-primary{background:var(--green);color:var(--bg)}
-.btn-primary:hover{filter:brightness(1.1)}
-.btn-ghost{background:transparent;color:var(--text-muted);border:1px solid var(--border)}
-.btn-ghost:hover{background:var(--surface);color:var(--text)}
-.btn-sm{padding:8px 12px;font-size:12px;min-height:36px}
-
-/* ── Compatibility: chat-layout (Messages page) ── */
-.chat-layout{display:flex;height:calc(100vh - 120px);border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--surface)}
-.chat-peers{width:240px;flex-shrink:0;border-right:1px solid var(--border);display:flex;flex-direction:column;overflow-y:auto}
-.chat-peers-header{padding:14px 16px;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);border-bottom:1px solid var(--border)}
-.chat-peers-empty{padding:24px 16px;color:var(--text-muted);font-size:13px;text-align:center}
-.chat-peer-item{display:flex;flex-direction:column;gap:4px;padding:12px 16px;border:none;background:none;color:var(--text);text-align:left;cursor:pointer;border-bottom:1px solid var(--border);transition:background .15s;width:100%;font-family:inherit}
-.chat-peer-item:hover{background:rgba(74,222,128,.08)}
-.chat-peer-item.active{background:rgba(74,222,128,.15)}
-.chat-peer-name{font-weight:600;font-size:14px;display:flex;align-items:center;gap:6px}
-.online-indicator{width:8px;height:8px;border-radius:50%;flex-shrink:0}
-.online-indicator.online{background:var(--green);box-shadow:0 0 4px var(--green)}
-.online-indicator.offline{background:var(--text-muted);opacity:.5}
-.chat-status-text{color:var(--text-muted);font-size:11px;margin-left:4px}
-.chat-peer-meta{display:flex;align-items:center;gap:8px;font-size:11px;color:var(--text-muted)}
-.chat-main{flex:1;display:flex;flex-direction:column;min-width:0}
-.chat-header{padding:14px 20px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:12px}
-.chat-header-name{font-weight:600;font-size:15px;display:flex;align-items:center;gap:8px}
-.chat-header-meta{font-size:11px;color:var(--text-muted);display:flex;align-items:center}
-.chat-messages{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:8px}
-.chat-empty{flex:1;display:flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:13px}
-.chat-no-selection{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font-size:14px}
-.chat-bubble{max-width:70%;padding:10px 14px;border-radius:12px;font-size:14px;line-height:1.5;word-break:break-word}
-.chat-bubble-out{align-self:flex-end;background:var(--green);color:var(--bg);border-bottom-right-radius:4px}
-.chat-bubble-in{align-self:flex-start;background:var(--surface);color:var(--text);border-bottom-left-radius:4px}
-.chat-bubble-text{white-space:pre-wrap}
-.chat-bubble-time{font-size:10px;opacity:.6;margin-top:4px;display:flex;align-items:center;gap:4px}
-.chat-bubble-out .chat-bubble-time{justify-content:flex-end}
-.chat-bubble-in .chat-bubble-time{justify-content:flex-start}
-.chat-delivery{display:inline-flex;align-items:center;line-height:1}
-.chat-delivery.delivered{color:rgba(255,255,255,.85)}
-.chat-delivery.failed{color:#ff8a80}
-.chat-input-area{padding:12px 16px;border-top:1px solid var(--border)}
-.chat-send-error{padding:6px 10px;margin-bottom:8px;background:rgba(239,68,68,.15);color:#ef4444;border-radius:6px;font-size:12px}
-.chat-input-area .chat-input-row{display:flex;gap:8px;align-items:center;padding:0}
-.chat-layout .chat-input{flex:1;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:10px 14px;color:var(--text);font-size:14px;font-family:inherit;outline:none}
-.chat-layout .chat-input:focus{border-color:var(--green)}
-.chat-send-btn{width:40px;height:40px;border-radius:8px;display:flex;align-items:center;justify-content:center;flex-shrink:0;padding:0}
-@keyframes spin{to{transform:rotate(360deg)}}
-.chat-spinner{animation:spin .8s linear infinite}
-
-/* ── Page title & headings ── */
-.page-title{font-family:'JetBrains Mono',monospace;font-size:22px;font-weight:700;margin-bottom:16px;letter-spacing:-.02em}
-h1,h2,h3{font-family:'JetBrains Mono',monospace}
-
-/* ── Form controls ── */
-.input,select.input{
-  appearance:none;-webkit-appearance:none;
-  background:var(--bg);border:1px solid var(--border);border-radius:8px;
-  color:var(--text);font-size:12px;font-weight:500;font-family:inherit;
-  padding:8px 12px;outline:none;transition:border-color .15s ease;
-  background-image:url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-position:right 10px center;background-size:10px;
-  padding-right:28px;cursor:pointer
+/* ══════════════════════════════════════════
+   MODAL STYLES (V10)
+   ══════════════════════════════════════════ */
+.v10-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+  animation: fadeSlideIn 0.15s ease;
 }
-.input:focus,select.input:focus{border-color:rgba(74,222,128,.4)}
-.input:hover,select.input:hover{border-color:var(--border-light)}
-.input option,select.input option{background:var(--surface);color:var(--text)}
-
-/* Checkbox */
-.checkbox-label{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-muted);cursor:pointer;user-select:none;white-space:nowrap}
-.checkbox-label input[type="checkbox"]{
-  appearance:none;-webkit-appearance:none;width:16px;height:16px;
-  border:1px solid var(--border);border-radius:4px;background:var(--bg);
-  cursor:pointer;position:relative;flex-shrink:0;transition:all .15s ease
+.v10-modal-box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  width: 560px;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
 }
-.checkbox-label input[type="checkbox"]:checked{background:var(--green);border-color:var(--green)}
-.checkbox-label input[type="checkbox"]:checked::after{
-  content:'';position:absolute;top:2px;left:5px;width:4px;height:8px;
-  border:solid var(--bg);border-width:0 2px 2px 0;transform:rotate(45deg)
+.v10-modal-header {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border-subtle);
 }
-.checkbox-label input[type="checkbox"]:hover{border-color:rgba(74,222,128,.4)}
-
-/* ── Toolbar (SPARQL tab) ── */
-.toolbar{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 0;margin-bottom:12px;flex-wrap:wrap}
-
-/* ── Result tabs ── */
-.result-tabs{display:flex;gap:0;border-bottom:1px solid var(--border);margin-bottom:0}
-.result-tab{padding:10px 18px;font-size:12px;font-weight:600;color:var(--text-muted);cursor:pointer;
-  border:none;border-bottom:2px solid transparent;background:none;font-family:inherit;transition:all .15s;min-height:40px}
-.result-tab:hover{color:var(--text)}
-.result-tab.active{color:var(--green);border-bottom-color:var(--green)}
-
-/* ── Data table ── */
-.data-table{width:100%;border-collapse:collapse;font-size:12px}
-.data-table th{
-  padding:10px 14px;text-align:left;font-size:10px;font-weight:700;
-  text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted);
-  background:var(--surface-alt);border-bottom:1px solid var(--border);
-  position:sticky;top:0;font-family:'JetBrains Mono',monospace
+.v10-modal-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  color: var(--text-primary);
 }
-.data-table td{padding:8px 14px;border-bottom:1px solid var(--border);color:var(--text);vertical-align:top}
-.data-table tr:hover td{background:rgba(74,222,128,.03)}
-.data-table tr:last-child td{border-bottom:none}
+.v10-modal-subtitle {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+.v10-modal-body {
+  padding: 20px 24px;
+}
+.v10-modal-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.v10-modal-btn {
+  height: 34px;
+  padding: 0 18px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  background: none;
+}
+.v10-modal-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.v10-modal-btn.primary {
+  background: var(--text-primary);
+  color: var(--bg-root);
+  border-color: var(--text-primary);
+}
+.v10-modal-btn.primary:hover { opacity: 0.85; }
+.v10-modal-btn.primary:disabled { opacity: 0.4; cursor: not-allowed; }
 
-/* ── JSON view ── */
-.json-view{
-  background:#080d16;border:1px solid var(--border);border-radius:10px;
-  padding:16px 18px;font-family:'JetBrains Mono',monospace;font-size:11px;
-  line-height:1.7;color:var(--text-muted);overflow:auto;max-height:600px;white-space:pre-wrap;word-break:break-all
+.v10-modal-error {
+  padding: 10px 14px;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--accent-red);
+  line-height: 1.5;
 }
 
-/* ── Context graph cards ── */
-.context-graph-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:14px}
-.context-graph-card{
-  background:var(--surface);border:1px solid var(--border);border-radius:12px;
-  padding:18px 20px;cursor:pointer;transition:all .15s ease;position:relative;overflow:hidden
+.v10-modal-tip {
+  padding: 12px 14px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
-.context-graph-card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:var(--green);opacity:0;transition:opacity .15s}
-.context-graph-card:hover{border-color:rgba(74,222,128,.3);background:var(--surface-hover)}
-.context-graph-card:hover::before{opacity:1}
-.context-graph-card h3{font-size:14px;font-weight:700;margin-bottom:6px;color:var(--text)}
-.context-graph-card p{font-size:12px;color:var(--text-muted);line-height:1.5;margin:0}
-
-/* ── Dashboard sections ── */
-.dashboard-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:16px}
-.section-title{font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:700;margin-bottom:12px;display:flex;align-items:center;gap:8px}
-.quick-actions{display:flex;gap:10px;flex-wrap:wrap}
-.quick-action{
-  display:flex;align-items:center;gap:10px;padding:12px 16px;border-radius:8px;
-  border:1px solid rgba(74,222,128,.3);background:var(--green-dim);color:var(--green);
-  flex:1;min-width:160px;text-align:left;font-weight:600;font-size:13px;
-  cursor:pointer;transition:filter .15s;min-height:44px
-}
-.quick-action:hover{filter:brightness(1.2)}
-.quick-action .qa-label{font-size:12px;font-weight:600;color:var(--green)}
-.quick-action .qa-desc{font-size:10px;color:var(--text-muted);font-weight:400}
-
-/* ── Tx link icon ── */
-.tx-link-icon{color:var(--green);display:inline-flex;transition:color .2s}
-.tx-link-icon:hover{color:#4ade80}
-.tx-link-icon svg{animation:tx-pulse 2s ease-in-out infinite}
-@keyframes tx-pulse{0%,100%{opacity:.55}50%{opacity:1}}
-
-/* ── Empty & loading states ── */
-.empty-state{display:flex;flex-direction:column;align-items:center;justify-content:center;color:var(--text-dim);font-size:13px;padding:48px 24px;text-align:center;gap:10px}
-.empty-state-icon{display:flex;align-items:center;justify-content:center;width:48px;height:48px;border-radius:12px;background:rgba(74,222,128,.06);border:1px dashed rgba(74,222,128,.18);color:var(--green);flex-shrink:0;margin-bottom:2px}
-.empty-state-icon svg{opacity:.7}
-.empty-state-title{font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:600;color:var(--text-muted);letter-spacing:-.01em}
-.empty-state-desc{font-size:12px;color:var(--text-dim);line-height:1.5;max-width:320px}
-.empty-state-cta{margin-top:4px}
-.empty-state-cta .dkg-btn{font-size:12px;padding:6px 14px}
-.empty-state--rich{padding:40px 24px;border:1px dashed var(--border);border-radius:10px;background:linear-gradient(180deg,rgba(74,222,128,.02),transparent);margin:8px 0}
-.empty-state--compact{padding:24px 16px;gap:6px}
-.empty-state--compact .empty-state-icon{width:36px;height:36px;border-radius:8px}
-.empty-state--compact .empty-state-icon svg{width:16px;height:16px}
-.empty-state--sidebar{padding:20px 12px;gap:8px}
-.empty-state--sidebar .empty-state-icon{width:36px;height:36px;border-radius:8px}
-.loading{display:flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:13px;padding:48px 24px}
-
-/* Lazy-load route fallback */
-.lazy-loading-fallback{display:flex;align-items:center;justify-content:center;gap:10px;height:100%;color:var(--text-muted);font-size:13px;font-family:'JetBrains Mono',monospace;letter-spacing:.02em}
-.lazy-spinner{width:16px;height:16px;border:2px solid var(--border);border-top-color:var(--green);border-radius:50%;animation:spin .7s linear infinite}
-
-/* ── Graph viewport ── */
-.graph-viewport{background:#060a12;position:relative}
-
-/* ── Triples details ── */
-.graph-details-triples{display:flex;flex-direction:column;gap:4px}
-.graph-details-triple{display:flex;gap:8px;font-size:12px;padding:4px 0;border-bottom:1px solid rgba(30,42,58,.5)}
-.graph-details-triple:last-child{border-bottom:none}
-.graph-details-triple .predicate{color:var(--cyan);font-family:'JetBrains Mono',monospace;font-size:11px;flex-shrink:0}
-.graph-details-triple .subject{color:var(--blue);font-family:'JetBrains Mono',monospace;font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.graph-details-triple .object{color:var(--text-muted);font-family:'JetBrains Mono',monospace;font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.graph-details-more{font-size:11px;color:var(--text-dim);padding:4px 0}
-
-/* ── Large desktop ── */
-@media(min-width:1440px){
-  .page-section{padding:32px 48px}
-  .stat-card{padding:22px 24px}
-  .stat-value{font-size:32px}
-  .context-graph-list{grid-template-columns:repeat(auto-fill,minmax(320px,1fr))}
+.v10-modal-tip-title {
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
 }
 
-/* ── Tablet / narrow desktop: collapse sidebar to icons ── */
-@media(max-width:900px){
-  .sidebar{width:60px}
-  .sidebar-logo svg,.sidebar-logo .logo-version,.nav-btn span,.sidebar-footer>div:last-child,.apps-dropdown{display:none!important}
-  .nav-badge{display:none}
-  .page-section{padding:20px 16px}
-  .feed-row{grid-template-columns:50px 100px 1fr auto}
-  .lb-row{grid-template-columns:24px 100px 1fr 60px}
-  .settings-grid{grid-template-columns:1fr}
-  .sparql-query-composer{flex-direction:column}
-  .sparql-helper-grid{grid-template-columns:1fr}
-  .graph-explorer-layout{flex-direction:column;height:auto}
-  .graph-details-panel{width:100%;max-height:400px}
-  .chat-layout{flex-direction:column;height:calc(100vh - 160px)}
-  .chat-peers{width:100%;max-height:180px;border-right:none;border-bottom:1px solid var(--border)}
+/* Form elements */
+.v10-form-group { margin-bottom: 16px; }
+.v10-form-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 6px;
+}
+.v10-form-input {
+  width: 100%;
+  height: 36px;
+  border-radius: 6px;
+  font-size: 12px;
+  padding: 0 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  box-sizing: border-box;
+}
+.v10-form-input:focus { border-color: var(--border-strong); }
+.v10-form-textarea {
+  width: 100%;
+  min-height: 60px;
+  border-radius: 6px;
+  font-size: 12px;
+  padding: 8px 12px;
+  resize: vertical;
+  font-family: var(--font-sans);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+.v10-form-textarea:focus { border-color: var(--border-strong); }
+.v10-form-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: 16px 0;
+}
+.v10-form-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v10-form-radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.v10-form-radio input[type="radio"] {
+  accent-color: var(--text-primary);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+}
+.v10-form-radio-desc {
+  font-size: 11px;
+  color: var(--text-ghost);
+  margin-left: 22px;
+  margin-top: -4px;
+}
+.v10-form-select {
+  width: 100%;
+  height: 36px;
+  border-radius: 6px;
+  font-size: 12px;
+  padding: 0 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  appearance: auto;
+}
+.v10-form-select:focus { border-color: var(--border-strong); }
+.v10-form-advanced-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: var(--text-secondary);
+  user-select: none;
+  margin-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 12px;
+}
+.v10-form-adv-chevron {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  transition: transform 0.15s;
+  display: inline-block;
+}
+.v10-form-adv-chevron.open { transform: rotate(90deg); }
+.v10-form-advanced-body {
+  margin-top: 12px;
+  padding: 12px 14px;
+  background: var(--bg-surface);
+  border-radius: 6px;
+}
+.v10-layer-preview {
+  margin-top: 14px;
+  padding: 10px 12px;
+  background: var(--bg-surface);
+  border-radius: 6px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  line-height: 1.8;
+}
+.v10-layer-preview-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-ghost);
+  margin-bottom: 4px;
 }
 
-/* ── Mobile: sidebar becomes bottom nav ── */
-@media(max-width:768px){
-  .app-layout{flex-direction:column}
-  .sidebar{
-    width:100%;order:1;flex-direction:row;height:auto;
-    border-right:none;border-top:1px solid var(--border);
-    position:fixed;bottom:0;left:0;right:0;z-index:900;
-    background:var(--surface-alt)
-  }
-  .sidebar-logo,.sidebar-footer,.apps-dropdown{display:none!important}
-  .sidebar-nav{
-    flex-direction:row;padding:4px 8px;gap:0;
-    justify-content:space-around;overflow-x:auto;
-    -webkit-overflow-scrolling:touch;flex-wrap:nowrap
-  }
-  .nav-btn{
-    flex-direction:column;gap:2px;padding:8px 6px;
-    font-size:10px;justify-content:center;align-items:center;
-    min-width:56px;min-height:52px;flex-shrink:0
-  }
-  .nav-btn span{display:block!important;font-size:9px;white-space:nowrap}
-  .nav-btn svg{width:18px;height:18px}
-  .nav-badge{display:none}
-  .main-content{order:0;padding-bottom:60px}
-  .page-section{padding:16px 12px}
+/* Light theme modal overrides */
+body.light .v10-modal-box {
+  background: #ffffff;
+  border-color: var(--border-default);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+}
+body.light .v10-modal-btn.primary { background: #1a1a1a; color: #ffffff; border-color: #1a1a1a; }
 
-  /* Content grids stack */
-  .settings-grid{grid-template-columns:1fr}
-  .sparql-query-composer{flex-direction:column;min-height:auto}
-  .sparql-helper-grid{grid-template-columns:1fr}
-  .graph-explorer-layout{flex-direction:column;height:auto;min-height:auto}
-  .graph-details-panel{width:100%;max-height:360px}
-  .feed-row{grid-template-columns:50px 1fr auto;font-size:11px}
-  .lb-row{grid-template-columns:24px 1fr 60px}
-  .chat-layout{flex-direction:column;height:calc(100vh - 200px)}
-  .chat-peers{width:100%;max-height:140px;border-right:none;border-bottom:1px solid var(--border)}
-
-  /* Stat cards full-width */
-  .stat-card{min-width:100%}
-  .context-graph-list{grid-template-columns:1fr}
-  .dashboard-grid-2{grid-template-columns:1fr}
-
-  /* Floating chat adapts */
-  .chat-panel{width:100%;right:0;bottom:60px;border-radius:12px 12px 0 0;height:60vh;max-height:480px}
-  .chat-fab{bottom:72px;right:16px}
+/* ═══════════════════════════════════════════
+   IMPORT / INGESTION UI
+   ═══════════════════════════════════════════ */
+.v10-import-dropzone {
+  border: 2px dashed var(--border-default);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-bottom: 16px;
+}
+.v10-import-dropzone:hover,
+.v10-import-dropzone.drag-over {
+  border-color: var(--accent-blue, var(--border-strong));
+  background: var(--bg-hover);
+}
+.v10-import-dropzone-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.v10-import-dropzone-hint {
+  font-size: 11px;
+  color: var(--text-ghost);
+}
+.v10-import-file-list {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 16px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.v10-import-file-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.v10-import-file-item:last-child { border-bottom: none; }
+.v10-import-file-icon {
+  font-size: 14px;
+  color: var(--text-tertiary);
+  width: 18px;
+  text-align: center;
+  flex-shrink: 0;
+}
+.v10-import-file-name { flex: 1; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v10-import-file-size { font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost); flex-shrink: 0; }
+.v10-import-file-remove {
+  background: none;
+  border: none;
+  color: var(--text-ghost);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.v10-import-file-remove:hover { color: var(--accent-red); }
+.v10-import-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+.v10-import-option input[type="checkbox"] {
+  accent-color: var(--text-primary);
+  width: 14px;
+  height: 14px;
+}
+.v10-import-progress {
+  margin-top: 12px;
+  padding: 12px 14px;
+  background: var(--bg-surface);
+  border-radius: 6px;
+}
+.v10-import-progress-bar {
+  height: 4px;
+  background: var(--border-subtle);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+.v10-import-progress-fill {
+  height: 100%;
+  background: var(--accent-blue, #3b82f6);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+.v10-import-progress-text {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 6px;
+}
+.v10-import-result {
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+.v10-import-result.success {
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+  color: var(--accent-green, #22c55e);
+}
+.v10-import-result.error {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  color: var(--accent-red);
 }
 
-/* ── Small mobile ── */
-@media(max-width:480px){
-  .page-section{padding:12px 10px}
-  .page-title{font-size:16px;margin-bottom:12px}
-  .stat-value{font-size:22px}
-  .stat-card{padding:14px 16px}
-  .card-header{padding:12px 14px}
-  .section-title{font-size:12px}
-  .trail-hero{padding:20px 18px;border-radius:12px}
-  .quick-actions{flex-direction:column}
-  .quick-action{min-width:100%}
-  .import-modal{padding:20px;max-width:100%;margin:0 8px}
-  .chat-panel{height:70vh}
-  .toolbar{flex-direction:column;align-items:stretch;gap:8px}
-}
+/* Light overrides for import UI */
+body.light .v10-import-dropzone { border-color: #d4d4d4; }
+body.light .v10-import-dropzone:hover,
+body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #e8e8e8; }
+
+/* Lazy route spinner */
+.lazy-spinner{display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-tertiary);font-size:13px}

--- a/packages/node-ui/src/ui/views/DashboardView.tsx
+++ b/packages/node-ui/src/ui/views/DashboardView.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { useFetch } from '../hooks.js';
+import { api } from '../api-wrapper.js';
+import { useTabsStore } from '../stores/tabs.js';
+import { useProjectsStore } from '../stores/projects.js';
+import { CreateProjectModal } from '../components/Modals/CreateProjectModal.js';
+
+function StatCard({ label, value, sub, accentColor }: { label: string; value: string | number; sub?: string; accentColor?: string }) {
+  return (
+    <div className="stat-card">
+      {accentColor && <div className="accent" style={{ background: accentColor }} />}
+      <div className="stat-label">{label}</div>
+      <div className="stat-value">{value}</div>
+      {sub && <div className="stat-sub">{sub}</div>}
+    </div>
+  );
+}
+
+function QuickAction({ icon, label, onClick }: { icon: string; label: string; onClick?: () => void }) {
+  return (
+    <button className="v10-quick-action" onClick={onClick}>
+      <span className="v10-quick-action-icon">{icon}</span>
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function RecentOp({ op }: { op: any }) {
+  const type = op.name || op.type || '—';
+  const status = op.status || 'unknown';
+  const statusColor = status === 'completed' ? 'var(--accent-green)' : status === 'failed' ? 'var(--accent-red)' : 'var(--accent-amber)';
+  const time = op.startedAt ? new Date(op.startedAt).toLocaleTimeString() : '—';
+
+  return (
+    <div className="v10-recent-op">
+      <span className="v10-recent-op-type">{type}</span>
+      <span className="v10-recent-op-status" style={{ color: statusColor }}>{status}</span>
+      <span className="v10-recent-op-time">{time}</span>
+    </div>
+  );
+}
+
+export function DashboardView() {
+  const { data: status } = useFetch(api.fetchStatus, [], 10_000);
+  const { data: metrics } = useFetch(api.fetchMetrics, [], 10_000);
+  const { data: cgData } = useFetch(api.fetchContextGraphs, [], 30_000);
+  const { data: agentData } = useFetch(api.fetchAgents, [], 15_000);
+  const { data: opsData } = useFetch(() => api.fetchOperationsWithPhases({ limit: '6' }), [], 10_000);
+  const { data: econ } = useFetch(api.fetchEconomics, [], 60_000);
+  const { openTab } = useTabsStore();
+  const { setActiveProject } = useProjectsStore();
+  const [showCreateProject, setShowCreateProject] = useState(false);
+
+  const totalKCs = metrics?.total_kcs ?? metrics?.totalKnowledgeCollections ?? 0;
+  const peers = status?.connectedPeers ?? status?.peerCount ?? 0;
+  const agents = agentData?.agents?.length ?? 0;
+  const contextGraphCount = cgData?.contextGraphs?.length ?? 0;
+  const ops = opsData?.operations ?? [];
+
+  const latestPeriod = econ?.periods?.[0];
+  const spending = latestPeriod
+    ? `${latestPeriod.publishCount} publishes · ${latestPeriod.totalTrac.toFixed(2)} TRAC`
+    : '—';
+
+  return (
+    <div className="v10-dashboard">
+      <div className="v10-dash-header">
+        <h1 className="v10-dash-title">Dashboard</h1>
+        <p className="v10-dash-subtitle">
+          {status?.name || 'DKG Node'} · {status?.networkName || 'network'}
+        </p>
+      </div>
+
+      <div className="v10-dash-stats">
+        <StatCard label="Knowledge Assets" value={totalKCs} accentColor="var(--accent-green)" />
+        <StatCard label="Context Graphs" value={contextGraphCount} accentColor="var(--accent-blue)" />
+        <StatCard label="Connected Peers" value={peers} accentColor="var(--accent-amber)" />
+        <StatCard label="Agents" value={agents} accentColor="var(--purple)" />
+      </div>
+
+      <div className="v10-dash-grid">
+        <div className="v10-dash-section">
+          <div className="v10-dash-section-header">
+            <h3>Quick Actions</h3>
+          </div>
+          <div className="v10-quick-actions">
+            <QuickAction icon="+" label="Create Project" onClick={() => setShowCreateProject(true)} />
+            <QuickAction icon="↑" label="Import Memories" />
+            <QuickAction icon="⟐" label="Run SPARQL" onClick={() => openTab({ id: 'sparql', label: 'SPARQL', closable: true })} />
+            <QuickAction icon="⬡" label="Browse Graph" onClick={() => openTab({ id: 'explorer', label: 'Explorer', closable: true })} />
+          </div>
+        </div>
+
+        <div className="v10-dash-section">
+          <div className="v10-dash-section-header">
+            <h3>Recent Operations</h3>
+            <button
+              className="v10-dash-section-link"
+              onClick={() => openTab({ id: 'operations', label: 'Operations', closable: true })}
+            >
+              View all →
+            </button>
+          </div>
+          <div className="v10-recent-ops">
+            {ops.length === 0 ? (
+              <p style={{ color: 'var(--text-tertiary)', fontSize: 12, padding: '12px 0' }}>No recent operations</p>
+            ) : (
+              ops.slice(0, 6).map((op: any, i: number) => <RecentOp key={op.id ?? i} op={op} />)
+            )}
+          </div>
+        </div>
+
+        <div className="v10-dash-section">
+          <div className="v10-dash-section-header">
+            <h3>Projects</h3>
+            <span className="v10-dash-section-badge">{contextGraphCount}</span>
+          </div>
+          <div className="v10-dash-projects">
+            {(cgData?.contextGraphs ?? []).slice(0, 5).map((cg: any) => (
+              <button
+                key={cg.id}
+                className="v10-dash-project-card"
+                onClick={() => {
+                  setActiveProject(cg.id);
+                  openTab({ id: `project:${cg.id}`, label: cg.name || cg.id.slice(0, 12), closable: true });
+                }}
+              >
+                <span className="v10-dash-project-name">{cg.name || cg.id.slice(0, 12)}</span>
+                <span className="v10-dash-project-count">{cg.assetCount ?? cg.assets ?? 0} assets</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="v10-dash-section">
+          <div className="v10-dash-section-header">
+            <h3>Spending</h3>
+          </div>
+          <p style={{ fontSize: 12, color: 'var(--text-secondary)', padding: '8px 0' }}>{spending}</p>
+        </div>
+      </div>
+
+      <CreateProjectModal open={showCreateProject} onClose={() => setShowCreateProject(false)} />
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useFetch } from '../hooks.js';
-import { executeQuery } from '../api.js';
+import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, listSwmEntities, type AssertionInfo, type PublishResult, type SwmRootEntity } from '../api.js';
+import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
 
 type MemoryLayer = 'wm' | 'swm' | 'vm';
 
@@ -49,6 +50,14 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
         </div>
       </div>
 
+      {layer === 'wm' && (
+        <AssertionList contextGraphId={contextGraphId} onPromoted={refresh} />
+      )}
+
+      {layer === 'swm' && (
+        <PublishPanel contextGraphId={contextGraphId} onPublished={refresh} />
+      )}
+
       <div className="v10-mlv-query-bar">
         <input
           type="text"
@@ -70,9 +79,9 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
         <div className="v10-mlv-empty">
           <p>No triples found in {meta.label.toLowerCase()}.</p>
           <p style={{ fontSize: 11, marginTop: 4 }}>
-            {layer === 'wm' && 'Chat with your agent to generate working memory.'}
-            {layer === 'swm' && 'Publish from working memory to share with collaborators.'}
-            {layer === 'vm' && 'Endorse shared memory to create verified knowledge.'}
+            {layer === 'wm' && 'Import files or chat with your agent to generate working memory.'}
+            {layer === 'swm' && 'Promote assertions from working memory to share with collaborators.'}
+            {layer === 'vm' && 'Publish shared memory to create verified on-chain knowledge.'}
           </p>
         </div>
       )}
@@ -90,9 +99,9 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
             <tbody>
               {results.map((row: any, i: number) => (
                 <tr key={i}>
-                  <td className="v10-mlv-cell">{shorten(row.s?.value)}</td>
-                  <td className="v10-mlv-cell">{shorten(row.p?.value)}</td>
-                  <td className="v10-mlv-cell">{shorten(row.o?.value)}</td>
+                  <td className="v10-mlv-cell">{shorten(bv(row.s))}</td>
+                  <td className="v10-mlv-cell">{shorten(bv(row.p))}</td>
+                  <td className="v10-mlv-cell">{shorten(bv(row.o))}</td>
                 </tr>
               ))}
             </tbody>
@@ -101,6 +110,295 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
       )}
     </div>
   );
+}
+
+/* ── WM Assertion List (promote to SWM) ── */
+
+function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string; onPromoted: () => void }) {
+  const { data: assertions, loading, refresh } = useFetch(
+    () => listAssertions(contextGraphId),
+    [contextGraphId],
+    0
+  );
+  const [promoting, setPromoting] = useState<string | null>(null);
+  const [promoteResult, setPromoteResult] = useState<{ name: string; count: number } | null>(null);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
+  const [previewName, setPreviewName] = useState<string | null>(null);
+
+  const handlePromote = useCallback(async (name: string) => {
+    setPromoting(name);
+    setPromoteResult(null);
+    setPromoteError(null);
+    try {
+      const res = await promoteAssertion(contextGraphId, name);
+      setPromoteResult({ name, count: res.promotedCount });
+      refresh();
+      onPromoted();
+    } catch (err: any) {
+      setPromoteError(err.message ?? 'Promote failed');
+    } finally {
+      setPromoting(null);
+    }
+  }, [contextGraphId, refresh, onPromoted]);
+
+  const handlePromoteAll = useCallback(async () => {
+    if (!assertions?.length) return;
+    setPromoting('__all__');
+    setPromoteResult(null);
+    setPromoteError(null);
+    let totalPromoted = 0;
+    try {
+      for (const a of assertions) {
+        const res = await promoteAssertion(contextGraphId, a.name);
+        totalPromoted += res.promotedCount;
+      }
+      setPromoteResult({ name: 'all assertions', count: totalPromoted });
+      refresh();
+      onPromoted();
+    } catch (err: any) {
+      setPromoteError(err.message ?? 'Promote failed');
+    } finally {
+      setPromoting(null);
+    }
+  }, [assertions, contextGraphId, refresh, onPromoted]);
+
+  if (loading) return <div className="v10-assertion-list-loading">Loading assertions...</div>;
+  if (!assertions?.length) return null;
+
+  return (
+    <div className="v10-assertion-list">
+      <div className="v10-assertion-list-header">
+        <span className="v10-assertion-list-title">Assertions in Working Memory ({assertions.length})</span>
+        <button
+          className="v10-btn-promote-all"
+          disabled={promoting !== null}
+          onClick={handlePromoteAll}
+        >
+          {promoting === '__all__' ? 'Promoting...' : 'Promote All → SWM'}
+        </button>
+      </div>
+      <div className="v10-assertion-items">
+        {assertions.map((a) => (
+          <div key={a.name} className="v10-assertion-item">
+            <div className="v10-assertion-item-info">
+              <button
+                className="v10-assertion-item-name clickable"
+                title={a.graphUri}
+                onClick={() => setPreviewName(a.name)}
+              >
+                {a.name}
+              </button>
+              {a.tripleCount != null && (
+                <span className="v10-assertion-item-count">{a.tripleCount} triples</span>
+              )}
+            </div>
+            <button
+              className="v10-btn-promote"
+              disabled={promoting !== null}
+              onClick={() => handlePromote(a.name)}
+              title="Copy these triples to Shared Working Memory"
+            >
+              {promoting === a.name ? 'Promoting...' : '→ SWM'}
+            </button>
+          </div>
+        ))}
+      </div>
+      {promoteResult && (
+        <div className="v10-promote-result success">
+          Promoted {promoteResult.count} triples from {promoteResult.name} to Shared Working Memory.
+        </div>
+      )}
+      {promoteError && (
+        <div className="v10-promote-result error">
+          {promoteError}
+        </div>
+      )}
+
+      {previewName && (
+        <FilePreviewModal
+          open
+          onClose={() => setPreviewName(null)}
+          assertionName={previewName}
+          contextGraphId={contextGraphId}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ── SWM Publish Panel (SWM → VM) ── */
+
+function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string; onPublished: () => void }) {
+  const { data: entities, loading, refresh } = useFetch(
+    () => listSwmEntities(contextGraphId),
+    [contextGraphId],
+    0
+  );
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [publishing, setPublishing] = useState(false);
+  const [publishResult, setPublishResult] = useState<PublishResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const allUris = entities?.map(e => e.uri) ?? [];
+  const allSelected = allUris.length > 0 && allUris.every(u => selected.has(u));
+
+  const toggleOne = useCallback((uri: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(uri)) next.delete(uri); else next.add(uri);
+      return next;
+    });
+  }, []);
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(allUris));
+    }
+  }, [allSelected, allUris]);
+
+  const handlePublishSelected = useCallback(async () => {
+    if (selected.size === 0) return;
+    setPublishing(true);
+    setPublishResult(null);
+    setError(null);
+    try {
+      const roots = [...selected];
+      const res = await publishSharedMemory(contextGraphId, roots);
+      setPublishResult(res);
+      setSelected(new Set());
+      refresh();
+      onPublished();
+    } catch (err: any) {
+      setError(err.message ?? 'Publish failed');
+    } finally {
+      setPublishing(false);
+    }
+  }, [selected, contextGraphId, refresh, onPublished]);
+
+  const handlePublishAll = useCallback(async () => {
+    setPublishing(true);
+    setPublishResult(null);
+    setError(null);
+    try {
+      const res = await publishSharedMemory(contextGraphId);
+      setPublishResult(res);
+      setSelected(new Set());
+      refresh();
+      onPublished();
+    } catch (err: any) {
+      setError(err.message ?? 'Publish failed');
+    } finally {
+      setPublishing(false);
+    }
+  }, [contextGraphId, refresh, onPublished]);
+
+  const totalTriples = entities?.reduce((sum, e) => sum + e.tripleCount, 0) ?? 0;
+  const selectedTriples = entities?.filter(e => selected.has(e.uri)).reduce((sum, e) => sum + e.tripleCount, 0) ?? 0;
+  const isEmpty = !loading && (!entities || entities.length === 0);
+
+  if (loading) return <div className="v10-assertion-list-loading">Loading SWM contents...</div>;
+  if (isEmpty) {
+    return (
+      <div className="v10-publish-panel">
+        <div className="v10-publish-panel-header">
+          <span className="v10-publish-panel-title">Publish to Verified Memory</span>
+        </div>
+        <div className="v10-publish-panel-empty">
+          No data in Shared Working Memory yet. Promote assertions from Working Memory first.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="v10-publish-panel">
+      <div className="v10-publish-panel-header">
+        <span className="v10-publish-panel-title">
+          Entities in Shared Working Memory ({entities!.length} entities · {totalTriples} triples)
+        </span>
+        <div className="v10-publish-panel-header-actions">
+          <button className="v10-publish-panel-refresh" onClick={refresh} title="Refresh">↻</button>
+          <button
+            className="v10-btn-promote-all"
+            disabled={publishing}
+            onClick={handlePublishAll}
+          >
+            {publishing && selected.size === 0 ? 'Publishing...' : 'Publish All → VM'}
+          </button>
+        </div>
+      </div>
+
+      <div className="v10-publish-select-bar">
+        <label className="v10-publish-select-all">
+          <input type="checkbox" checked={allSelected} onChange={toggleAll} />
+          <span>Select all</span>
+        </label>
+        {selected.size > 0 && (
+          <button
+            className="v10-btn-publish"
+            disabled={publishing}
+            onClick={handlePublishSelected}
+          >
+            {publishing ? 'Publishing...' : `Publish ${selected.size} selected (${selectedTriples} triples) → VM`}
+          </button>
+        )}
+      </div>
+
+      <div className="v10-assertion-items">
+        {entities!.map((e) => (
+          <div key={e.uri} className={`v10-assertion-item ${selected.has(e.uri) ? 'selected' : ''}`}>
+            <label className="v10-publish-entity-check">
+              <input
+                type="checkbox"
+                checked={selected.has(e.uri)}
+                onChange={() => toggleOne(e.uri)}
+              />
+            </label>
+            <div className="v10-assertion-item-info">
+              <span className="v10-assertion-item-name" title={e.uri}>{e.label}</span>
+              <span className="v10-assertion-item-count">{e.tripleCount} triples</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {publishResult && (
+        <div className="v10-publish-result-card success">
+          <div className="v10-publish-result-title">Published to Verified Memory</div>
+          <div className="v10-publish-result-details">
+            <div><span className="v10-publish-result-label">Knowledge Collection:</span> {publishResult.kcId}</div>
+            <div><span className="v10-publish-result-label">Status:</span> {publishResult.status}</div>
+            {publishResult.kas?.length > 0 && (
+              <div><span className="v10-publish-result-label">Knowledge Assets:</span> {publishResult.kas.length}</div>
+            )}
+            {publishResult.txHash && (
+              <div className="v10-publish-result-tx">
+                <span className="v10-publish-result-label">Tx:</span>{' '}
+                <span className="mono">{publishResult.txHash.slice(0, 10)}...{publishResult.txHash.slice(-8)}</span>
+                {publishResult.blockNumber != null && (
+                  <span className="v10-publish-result-block"> (block {publishResult.blockNumber})</span>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="v10-publish-result-card error">{error}</div>
+      )}
+    </div>
+  );
+}
+
+/** Extract string from a SPARQL binding value (plain string or { value } object). */
+function bv(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  if (typeof v === 'string') return v;
+  if (typeof v === 'object' && 'value' in (v as any)) return String((v as any).value);
+  return String(v);
 }
 
 function shorten(uri?: string): string {

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useMemo } from 'react';
+import { useFetch } from '../hooks.js';
+import { executeQuery } from '../api.js';
+
+type MemoryLayer = 'wm' | 'swm' | 'vm';
+
+const LAYER_META: Record<MemoryLayer, { label: string; color: string; icon: string; description: string }> = {
+  wm: { label: 'Working Memory', color: 'var(--layer-working)', icon: '◇', description: 'Private agent drafts. Fast local storage.' },
+  swm: { label: 'Shared Working Memory', color: 'var(--layer-shared)', icon: '◈', description: 'Shared proposals with collaborators. TTL-bounded.' },
+  vm: { label: 'Verified Memory', color: 'var(--layer-verified)', icon: '◉', description: 'Endorsed, published, on-chain knowledge.' },
+};
+
+interface MemoryLayerViewProps {
+  layer: MemoryLayer;
+  contextGraphId: string;
+}
+
+export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps) {
+  const meta = LAYER_META[layer];
+  const [customQuery, setCustomQuery] = useState('');
+
+  const defaultSparql = useMemo(() => {
+    if (layer === 'wm') {
+      return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } } LIMIT 200`;
+    }
+    return `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 50`;
+  }, [layer]);
+
+  const sparql = customQuery || defaultSparql;
+
+  const graphSuffix = layer === 'swm' ? '_shared_memory' as const : undefined;
+  const includeShared = layer === 'swm';
+
+  const { data, loading, error, refresh } = useFetch(
+    () => executeQuery(sparql, contextGraphId, includeShared, graphSuffix),
+    [sparql, contextGraphId, layer],
+    0
+  );
+
+  const results = data?.result?.bindings ?? data?.results?.bindings ?? [];
+
+  return (
+    <div className="v10-memory-layer-view">
+      <div className="v10-mlv-header">
+        <span className="v10-mlv-icon" style={{ color: meta.color }}>{meta.icon}</span>
+        <div>
+          <h2 className="v10-mlv-title">{meta.label}</h2>
+          <p className="v10-mlv-desc">{meta.description}</p>
+        </div>
+      </div>
+
+      <div className="v10-mlv-query-bar">
+        <input
+          type="text"
+          className="v10-mlv-query-input"
+          placeholder="Custom SPARQL query..."
+          value={customQuery}
+          onChange={(e) => setCustomQuery(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') refresh(); }}
+        />
+        <button className="v10-mlv-run-btn" onClick={refresh}>
+          Run
+        </button>
+      </div>
+
+      {loading && <p className="v10-mlv-status">Loading...</p>}
+      {error && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>Error: {error}</p>}
+
+      {!loading && results.length === 0 && (
+        <div className="v10-mlv-empty">
+          <p>No triples found in {meta.label.toLowerCase()}.</p>
+          <p style={{ fontSize: 11, marginTop: 4 }}>
+            {layer === 'wm' && 'Chat with your agent to generate working memory.'}
+            {layer === 'swm' && 'Publish from working memory to share with collaborators.'}
+            {layer === 'vm' && 'Endorse shared memory to create verified knowledge.'}
+          </p>
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <div className="v10-mlv-table-wrap">
+          <table className="v10-mlv-table">
+            <thead>
+              <tr>
+                <th>Subject</th>
+                <th>Predicate</th>
+                <th>Object</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((row: any, i: number) => (
+                <tr key={i}>
+                  <td className="v10-mlv-cell">{shorten(row.s?.value)}</td>
+                  <td className="v10-mlv-cell">{shorten(row.p?.value)}</td>
+                  <td className="v10-mlv-cell">{shorten(row.o?.value)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function shorten(uri?: string): string {
+  if (!uri) return '—';
+  const hash = uri.lastIndexOf('#');
+  const slash = uri.lastIndexOf('/');
+  const cut = Math.max(hash, slash);
+  return cut >= 0 ? uri.slice(cut + 1) : uri;
+}

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState } from 'react';
+import { useFetch } from '../hooks.js';
+import { api } from '../api-wrapper.js';
+import { useTabsStore } from '../stores/tabs.js';
+import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
+
+interface ProjectViewProps {
+  contextGraphId: string;
+}
+
+export function ProjectView({ contextGraphId }: ProjectViewProps) {
+  const { data: cgData } = useFetch(api.fetchContextGraphs, [], 30_000);
+  const { openTab } = useTabsStore();
+  const [showImport, setShowImport] = useState(false);
+
+  const cg = useMemo(
+    () => cgData?.contextGraphs?.find((c: any) => c.id === contextGraphId),
+    [cgData, contextGraphId]
+  );
+
+  if (!cg) {
+    return (
+      <div className="v10-view-placeholder">
+        <p style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>
+          Loading context graph...
+        </p>
+      </div>
+    );
+  }
+
+  const assetCount = cg.assetCount ?? cg.assets ?? 0;
+  const agentCount = cg.agentCount ?? cg.agents ?? 0;
+
+  return (
+    <div className="v10-project-view">
+      <div className="v10-pv-header">
+        <div className="v10-pv-project-dot" />
+        <div>
+          <h1 className="v10-pv-title">{cg.name || cg.id}</h1>
+          {cg.description && <p className="v10-pv-desc">{cg.description}</p>}
+          <div className="v10-pv-meta">
+            <span className="v10-pv-meta-item">{assetCount} assets</span>
+            <span className="v10-pv-meta-sep">·</span>
+            <span className="v10-pv-meta-item">{agentCount} agents</span>
+            <span className="v10-pv-meta-sep">·</span>
+            <span className="v10-pv-meta-item mono" style={{ fontSize: 10 }}>{cg.id}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="v10-pv-actions" style={{ display: 'flex', gap: 8, marginBottom: 16 }}>
+        <button
+          className="v10-modal-btn primary"
+          style={{ height: 32, padding: '0 14px', fontSize: 12 }}
+          onClick={() => setShowImport(true)}
+        >
+          ↑ Import Files to Working Memory
+        </button>
+      </div>
+
+      <div className="v10-pv-layers">
+        <LayerCard
+          label="Working Memory"
+          dotColor="var(--layer-working)"
+          icon="◇"
+          description="Agent drafts and scratch data. Private, fast, local."
+          onOpen={() => openTab({ id: `wm:${cg.id}`, label: `WM · ${cg.name || cg.id.slice(0,12)}`, closable: true })}
+        />
+        <LayerCard
+          label="Shared Working Memory"
+          dotColor="var(--layer-shared)"
+          icon="◈"
+          description="Proposed knowledge shared with collaborators. TTL-bounded."
+          onOpen={() => openTab({ id: `swm:${cg.id}`, label: `SWM · ${cg.name || cg.id.slice(0,12)}`, closable: true })}
+        />
+        <LayerCard
+          label="Verified Memory"
+          dotColor="var(--layer-verified)"
+          icon="◉"
+          description="Endorsed and published knowledge. On-chain, permanent."
+          onOpen={() => openTab({ id: `vm:${cg.id}`, label: `VM · ${cg.name || cg.id.slice(0,12)}`, closable: true })}
+        />
+      </div>
+
+      <ImportFilesModal
+        open={showImport}
+        onClose={() => setShowImport(false)}
+        contextGraphId={cg.id}
+        contextGraphName={cg.name}
+      />
+    </div>
+  );
+}
+
+function LayerCard({ label, dotColor, icon, description, onOpen }: {
+  label: string;
+  dotColor: string;
+  icon: string;
+  description: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button className="v10-layer-card" onClick={onOpen}>
+      <div className="v10-layer-card-header">
+        <span className="v10-layer-card-icon" style={{ color: dotColor }}>{icon}</span>
+        <span className="v10-layer-card-label">{label}</span>
+        <span className="v10-layer-card-arrow">→</span>
+      </div>
+      <p className="v10-layer-card-desc">{description}</p>
+    </button>
+  );
+}

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -28,16 +28,12 @@ describe('lobby API type contract', () => {
 });
 
 describe('backward-compatible route redirects', () => {
-  it('App.tsx includes redirects for /network, /operations/*, /wallet, /integrations', () => {
+  it('App.tsx routes /network as a lazy page and catch-all to AppShell', () => {
     const app = readFile('App.tsx');
     expect(app).toContain('path="/network"');
-    expect(app).toContain('path="/operations/*"');
-    expect(app).toContain('path="/wallet"');
-    expect(app).toContain('path="/integrations"');
-    for (const route of ['/network', '/operations/\\*', '/wallet', '/integrations']) {
-      const pattern = new RegExp(`path="${route}"[^>]*element=\\{<Navigate`);
-      expect(app).toMatch(pattern);
-    }
+    expect(app).toContain('path="*"');
+    expect(app).toContain('AppShell');
+    expect(app).toContain('NetworkDebugPage');
   });
 
   it('Explorer.tsx includes redirects for /publish, /history, /saved', () => {
@@ -50,93 +46,66 @@ describe('backward-compatible route redirects', () => {
   });
 });
 
-describe('CSS compatibility selectors', () => {
+describe('V10 CSS layout selectors', () => {
   const css = readFile('styles.css');
 
-  it('includes .tab-group selector', () => {
-    expect(css).toMatch(/\.tab-group\s*\{/);
+  it('includes .v10-center-tabs selector', () => {
+    expect(css).toMatch(/\.v10-center-tabs\s*\{/);
   });
 
-  it('includes .tab-item selector', () => {
-    expect(css).toMatch(/\.tab-item\s*\{/);
+  it('includes .v10-center-tab selector', () => {
+    expect(css).toMatch(/\.v10-center-tab\s*[\{,]/);
   });
 
-  it('includes .chat-layout selector', () => {
-    expect(css).toMatch(/\.chat-layout\s*\{/);
+  it('includes .v10-app and .v10-app-body selectors', () => {
+    expect(css).toMatch(/\.v10-app\s*\{/);
+    expect(css).toMatch(/\.v10-app-body\s*\{/);
   });
 
-  it('includes .chat-peers selector', () => {
-    expect(css).toMatch(/\.chat-peers\s*\{/);
+  it('includes .v10-panel-left and .v10-panel-right selectors', () => {
+    expect(css).toMatch(/\.v10-panel-left\s*\{/);
+    expect(css).toMatch(/\.v10-panel-right\s*\{/);
   });
 
-  it('includes .chat-peers-header selector', () => {
-    expect(css).toMatch(/\.chat-peers-header\s*\{/);
+  it('includes .v10-panel-center selector', () => {
+    expect(css).toMatch(/\.v10-panel-center/);
   });
 
-  it('includes .chat-peers-empty selector', () => {
-    expect(css).toMatch(/\.chat-peers-empty\s*\{/);
+  it('includes .v10-chat-messages selector', () => {
+    expect(css).toMatch(/\.v10-chat-messages\s*\{/);
   });
 
-  it('includes .chat-peer-item selector', () => {
-    expect(css).toMatch(/\.chat-peer-item\s*\{/);
+  it('includes .v10-agent-input-area selector', () => {
+    expect(css).toMatch(/\.v10-agent-input-area\s*\{/);
   });
 
-  it('includes .chat-main selector', () => {
-    expect(css).toMatch(/\.chat-main\s*\{/);
+  it('includes .v10-agent-send-btn selector', () => {
+    expect(css).toMatch(/\.v10-agent-send-btn\s*\{/);
   });
 
-  it('includes .chat-messages selector', () => {
-    expect(css).toMatch(/\.chat-messages\s*\{/);
-  });
-
-  it('includes .chat-input-area selector', () => {
-    expect(css).toMatch(/\.chat-input-area\s*\{/);
-  });
-
-  it('includes .chat-send-btn selector', () => {
-    expect(css).toMatch(/\.chat-send-btn\s*\{/);
-  });
-
-  it('includes .chat-empty selector', () => {
-    expect(css).toMatch(/\.chat-empty\s*\{/);
-  });
-
-  it('includes .chat-bubble selector', () => {
+  it('includes .chat-bubble selector (legacy)', () => {
     expect(css).toMatch(/\.chat-bubble\s*\{/);
   });
 
-  it('includes .chat-no-selection selector', () => {
-    expect(css).toMatch(/\.chat-no-selection\s*\{/);
+  it('includes .v10-header-notif selectors', () => {
+    expect(css).toMatch(/\.v10-header-notif/);
   });
 
-  it('includes .chat-send-error selector', () => {
-    expect(css).toMatch(/\.chat-send-error\s*\{/);
+  it('includes .dkg-btn selector', () => {
+    expect(css).toMatch(/\.dkg-btn\s*\{/);
   });
 
-  it('includes .chat-delivery selector', () => {
-    expect(css).toMatch(/\.chat-delivery\s*\{/);
-  });
-
-  it('includes .chat-spinner animation', () => {
-    expect(css).toMatch(/\.chat-spinner\s*\{/);
-  });
-
-  it('includes .badge, .badge-info, .badge-success selectors', () => {
-    expect(css).toMatch(/\.badge\s*\{/);
-    expect(css).toMatch(/\.badge-info\s*\{/);
-    expect(css).toMatch(/\.badge-success\s*\{/);
-  });
-
-  it('includes .btn and .btn-primary selectors', () => {
-    expect(css).toMatch(/\.btn\s*\{/);
-    expect(css).toMatch(/\.btn-primary\s*\{/);
+  it('includes .v10-modal-btn selector', () => {
+    expect(css).toMatch(/\.v10-modal-btn\s*\{/);
   });
 });
 
-describe('no external CDN font imports', () => {
-  it('styles.css does not import from external CDN', () => {
+describe('V10 font imports', () => {
+  it('styles.css imports Google Fonts for Instrument Sans and JetBrains Mono', () => {
     const css = readFile('styles.css');
-    expect(css).not.toMatch(/@import\s+url\s*\(\s*['"]https?:\/\//);
+    expect(css).toMatch(/@import\s+url\s*\(/);
+    expect(css).toContain('Instrument+Sans');
+    expect(css).toContain('JetBrains+Mono');
   });
 });
 
@@ -194,22 +163,24 @@ describe('dashboard uses runtime data', () => {
   });
 });
 
-describe('sidebar uses live status', () => {
-  const app = readFile('App.tsx');
+describe('header uses live status', () => {
+  const header = readFileSync(resolve(UI_DIR, 'components', 'Shell', 'Header.tsx'), 'utf-8');
 
-  it('sidebar health reads from liveStatus, not hardcoded values', () => {
-    expect(app).not.toMatch(/['"]14 peers['"]/);
-    expect(app).toContain('liveStatus');
-    expect(app).toContain('connectedPeers');
+  it('header health reads from nodeStatus, not hardcoded values', () => {
+    expect(header).not.toMatch(/['"]14 peers['"]/);
+    expect(header).toContain('nodeStatus');
+    expect(header).toContain('connectedPeers');
   });
 
-  it('apps nav renders dynamic installedApps', () => {
-    expect(app).toContain('installedApps');
-    expect(app).toMatch(/installedApps\.filter/);
+  it('App.tsx polls status via useLiveStatus and stores in agents store', () => {
+    const app = readFile('App.tsx');
+    expect(app).toContain('useLiveStatus');
+    expect(app).toContain('setNodeStatus');
+    expect(app).toContain('api.fetchStatus()');
   });
 
-  it('clears status to null on fetch failure so stale data is not shown', () => {
-    expect(app).toMatch(/\.catch\(\(\)\s*=>\s*\{[^}]*setStatus\(null\)/);
+  it('header gracefully handles missing status data', () => {
+    expect(header).toMatch(/nodeStatus\?\.connectedPeers\s*\?\?\s*nodeStatus\?\.peerCount/);
   });
 });
 
@@ -458,49 +429,46 @@ describe('x-forwarded-proto allowlist', () => {
 });
 
 describe('clickable notifications', () => {
-  const app = readFile('App.tsx');
   const agentHub = readFile('pages/AgentHub.tsx');
+  const header = readFileSync(resolve(UI_DIR, 'components', 'Shell', 'Header.tsx'), 'utf-8');
 
-  it('NotificationBell uses useNavigate for navigation', () => {
-    const bellSection = app.slice(
-      app.indexOf('function NotificationBell'),
-      app.indexOf('export function App'),
-    );
-    expect(bellSection).toContain('useNavigate()');
+  it('Header has notification bell with dropdown', () => {
+    expect(header).toContain('BELL_ICON');
+    expect(header).toContain('v10-header-notif-dropdown');
+    expect(header).toContain('setShowNotifs');
   });
 
-  it('notification items with peer field navigate to /agent?tab=peers&peer=', () => {
-    expect(app).toContain("navigate(`/agent?tab=peers&peer=");
-    expect(app).toContain('encodeURIComponent(n.peer');
+  it('notifications are fetched and displayed', () => {
+    expect(header).toContain('fetchNotifications');
+    expect(header).toContain('setNotifications');
+    expect(header).toContain('v10-header-notif-item');
   });
 
-  it('notification items without peer are not clickable', () => {
-    expect(app).toContain("const clickable = !!n.peer");
-    expect(app).toContain("cursor: clickable ? 'pointer' : 'default'");
+  it('notification dropdown shows unread badge', () => {
+    expect(header).toContain('v10-header-notif-badge');
+    expect(header).toContain('unread');
   });
 
-  it('clickable notification shows "Open chat" hint', () => {
-    expect(app).toContain('Open chat');
-    expect(app).toContain('clickable &&');
+  it('notification dropdown closes on outside click', () => {
+    expect(header).toContain('notifRef');
+    expect(header).toContain('setShowNotifs(false)');
+    expect(header).toContain('mousedown');
   });
 
-  it('notification dropdown closes on click-through', () => {
-    const navSection = app.slice(
-      app.indexOf("navigate(`/agent?tab=peers") - 200,
-      app.indexOf("navigate(`/agent?tab=peers") + 100,
-    );
-    expect(navSection).toContain('setOpen(false)');
+  it('notifications are marked as read when opened', () => {
+    expect(header).toContain('markNotificationsRead');
+    expect(header).toContain('setUnread(0)');
   });
 
-  it('notification items have data-peer attribute for testability', () => {
-    expect(app).toContain('data-peer={n.peer');
+  it('notification items show message and timestamp', () => {
+    expect(header).toContain('n.message');
+    expect(header).toContain('n.ts');
+    expect(header).toContain('toLocaleTimeString');
   });
 
-  it('clickable notifications are keyboard-accessible', () => {
-    expect(app).toContain('tabIndex={clickable ? 0 : undefined}');
-    expect(app).toContain("e.key === 'Enter'");
-    expect(app).toContain("e.key === ' '");
-    expect(app).toContain('onKeyDown={clickable');
+  it('empty state shown when no notifications', () => {
+    expect(header).toContain('No notifications');
+    expect(header).toContain('v10-header-notif-empty');
   });
 
   it('AgentHub reads tab and peer from URL search params', () => {
@@ -547,9 +515,12 @@ describe('Agent Hub merged with messages and private memories', () => {
     expect(app).not.toContain('chat-fab');
   });
 
-  it('App redirects /messages to /agent', () => {
-    expect(app).toContain('path="/messages"');
-    expect(app).toContain('Navigate to="/agent"');
+  it('App uses V10 shell with three-panel layout', () => {
+    expect(app).toContain('v10-app');
+    expect(app).toContain('v10-app-body');
+    expect(app).toContain('PanelLeft');
+    expect(app).toContain('PanelCenter');
+    expect(app).toContain('PanelRight');
   });
 
   it('AgentHub has no mocked agents or canned responses', () => {

--- a/packages/node-ui/vite.config.ts
+++ b/packages/node-ui/vite.config.ts
@@ -1,8 +1,53 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { readFileSync, existsSync } from 'fs';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
+
+function readTokenFile(path: string): string {
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    return raw.split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'))[0] || '';
+  } catch { return ''; }
+}
+
+function readDkgConfig() {
+  // Devnet node 1 takes priority (local Hardhat chain with real contracts)
+  const devnetNode1 = resolve(__dirname, '../../.devnet/node1');
+  if (existsSync(join(devnetNode1, 'api.port'))) {
+    const port = parseInt(readFileSync(join(devnetNode1, 'api.port'), 'utf-8').trim(), 10) || 9201;
+    const token = readTokenFile(join(devnetNode1, 'auth.token'));
+    console.log(`[vite] Using devnet node 1 on port ${port}`);
+    return { port, token };
+  }
+
+  // Fall back to ~/.dkg (testnet / production node)
+  const dkgDir = join(homedir(), '.dkg');
+  let port = 9200;
+  let token = '';
+  try {
+    if (existsSync(join(dkgDir, 'api.port'))) {
+      port = parseInt(readFileSync(join(dkgDir, 'api.port'), 'utf-8').trim(), 10) || 9200;
+    }
+  } catch {}
+  token = readTokenFile(join(dkgDir, 'auth.token'));
+  console.log(`[vite] Using node on port ${port} (from ~/.dkg)`);
+  return { port, token };
+}
+
+const { port, token } = readDkgConfig();
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'inject-dkg-token',
+      transformIndexHtml(html) {
+        if (!token) return html;
+        return html.replace('</head>', `<script>window.__DKG_TOKEN__=${JSON.stringify(token)}</script></head>`);
+      },
+    },
+  ],
   root: 'src/ui',
   base: '/ui/',
   build: {
@@ -11,7 +56,7 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://127.0.0.1:8900',
+      '/api': `http://127.0.0.1:${port}`,
     },
   },
 });

--- a/packages/node-ui/vite.config.ts
+++ b/packages/node-ui/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
     react(),
     {
       name: 'inject-dkg-token',
+      apply: 'serve',
       transformIndexHtml(html) {
         if (!token) return html;
         return html.replace('</head>', `<script>window.__DKG_TOKEN__=${JSON.stringify(token)}</script></head>`);

--- a/packages/origin-trail-game/test/e2e/helpers.ts
+++ b/packages/origin-trail-game/test/e2e/helpers.ts
@@ -377,11 +377,10 @@ export function nodeApi(node: TestNode) {
     status: () => httpGet(`${base}/api/status`),
     apps: () => httpGet(`${base}/api/apps`, token),
     createParanet: (id: string, name: string, description?: string) =>
-      httpPost(`${base}/api/paranet/create`, { id, name, description }, token),
+      httpPost(`${base}/api/context-graph/create`, { id, name, description }, token),
     createContextGraph: (id: string, name: string, description?: string) =>
-      httpPost(`${base}/api/context-graph/create`, { id, name, description }, token)
-        .catch(() => httpPost(`${base}/api/paranet/create`, { id, name, description }, token)),
-    listParanets: () => httpGet(`${base}/api/paranet/list`, token),
+      httpPost(`${base}/api/context-graph/create`, { id, name, description }, token),
+    listParanets: () => httpGet(`${base}/api/context-graph/list`, token),
     publishCclPolicy: (body: {
       paranetId: string;
       name: string;

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1,5 +1,6 @@
 import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
+import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, type Ed25519Keypair, computeACKDigest } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
@@ -300,6 +301,7 @@ export class DKGPublisher implements Publisher {
       const v = validateSubGraphName(options.subGraphName);
       if (!v.valid) throw new Error(`Invalid sub-graph name for share: ${v.reason}`);
     }
+    await this.ensureSubGraphRegistered(contextGraphId, options.subGraphName);
     // Round 9 Bug 25: reserved-namespace guard lives at the public
     // entry points (`share`, `conditionalShare`), not here — this
     // method is Bucket B (internal plumbing) and its callers have
@@ -1362,15 +1364,27 @@ export class DKGPublisher implements Publisher {
           v10Origin: true,
         });
       } catch (v10Err) {
-        // V10 update failed — KC may live in V9 storage. Try legacy path.
+        const errorName = enrichEvmError(v10Err);
+        const V10_DEFINITIVE_ERRORS = [
+          'NotBatchPublisher', 'KnowledgeCollectionExpired',
+          'CannotUpdateImmutableKnowledgeCollection', 'ExceededKnowledgeCollectionMaxSize',
+        ];
+        if (errorName && V10_DEFINITIVE_ERRORS.includes(errorName)) {
+          throw v10Err;
+        }
         if (typeof this.chain.updateKnowledgeAssets === 'function') {
-          this.log.info(ctx, `V10 update failed, trying V9 path: ${v10Err instanceof Error ? v10Err.message : String(v10Err)}`);
-          txResult = await this.chain.updateKnowledgeAssets({
-            batchId: kcId,
-            newMerkleRoot: kcMerkleRoot,
-            newPublicByteSize: updateByteSize,
-            publisherAddress: this.publisherAddress,
-          });
+          this.log.info(ctx, `V10 update failed (${errorName ?? 'unknown'}), trying V9 path: ${v10Err instanceof Error ? v10Err.message : String(v10Err)}`);
+          try {
+            txResult = await this.chain.updateKnowledgeAssets({
+              batchId: kcId,
+              newMerkleRoot: kcMerkleRoot,
+              newPublicByteSize: updateByteSize,
+              publisherAddress: this.publisherAddress,
+            });
+          } catch (v9Err) {
+            enrichEvmError(v9Err);
+            throw v9Err;
+          }
         } else {
           throw v10Err;
         }

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -625,4 +625,33 @@ describe('DKGPublisher', () => {
       });
     });
   });
+
+  describe('sub-graph registration validation on share()', () => {
+    it('rejects SWM write to unregistered sub-graph', async () => {
+      await publisher.publish({
+        contextGraphId: PARANET,
+        quads: [q(ENTITY, 'http://schema.org/name', '"ImageBot"')],
+      });
+
+      await expect(
+        publisher.share(PARANET, [
+          q(ENTITY, 'http://schema.org/name', '"Updated"'),
+        ], {
+          subGraphName: 'never-registered',
+          publisherPeerId: 'QmTestPeer',
+        }),
+      ).rejects.toThrow('has not been registered');
+    });
+
+    it('allows SWM write without sub-graph (root CG)', async () => {
+      await expect(
+        publisher.share(PARANET, [
+          q('urn:test:new-entity', 'http://schema.org/name', '"Fresh Write"'),
+        ], {
+          publisherPeerId: 'QmTestPeer',
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
 });
+

--- a/packages/publisher/test/e2e-publisher-queue.test.ts
+++ b/packages/publisher/test/e2e-publisher-queue.test.ts
@@ -199,6 +199,100 @@ describe('Async Lift Publisher Queue — E2E Pipeline', () => {
   });
 });
 
+describe('Async Lift Publisher Queue — Full Lifecycle', () => {
+  let store: OxigraphStore;
+  let time: number;
+  let ids: number;
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    time = 1_000;
+    ids = 0;
+  });
+
+  it('job transitions through entire lifecycle: accepted → claimed → validated → broadcast → included → finalized', async () => {
+    const pub = new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++time,
+      idGenerator: () => `job-${++ids}`,
+      publishExecutor: async () => ({
+        status: 'confirmed' as const,
+        merkleRoot: new Uint8Array(32),
+        ual: 'did:dkg:mock/test/1',
+        kcId: 1n,
+        kaManifest: [],
+        publicQuads: [],
+      }),
+    });
+
+    const jobId = await pub.lift(makeLiftRequest());
+    expect((await pub.getStatus(jobId))?.status).toBe('accepted');
+
+    const claimed = await pub.claimNext('wallet-1');
+    expect(claimed).not.toBeNull();
+    expect((await pub.getStatus(jobId))?.status).toBe('claimed');
+
+    await pub.update(jobId, 'validated', {
+      validation: {
+        canonicalRoots: ['urn:test:entity:1'],
+        canonicalRootMap: { 'urn:test:entity:1': 'urn:test:entity:1' },
+        swmQuadCount: 1,
+        authorityProofRef: 'proof:owner:test',
+        transitionType: 'CREATE' as const,
+      },
+    });
+    expect((await pub.getStatus(jobId))?.status).toBe('validated');
+
+    await pub.update(jobId, 'broadcast', {
+      broadcast: { txHash: '0xabc123', walletId: 'wallet-1' },
+    });
+    expect((await pub.getStatus(jobId))?.status).toBe('broadcast');
+
+    await pub.update(jobId, 'included', {
+      inclusion: { txHash: '0xabc123', blockNumber: 42 },
+    });
+    expect((await pub.getStatus(jobId))?.status).toBe('included');
+
+    await pub.update(jobId, 'finalized', {
+      finalization: { confirmedByChain: true, finalizedAtMs: time, proofRef: '' },
+    });
+    expect((await pub.getStatus(jobId))?.status).toBe('finalized');
+
+    const stats = await pub.getStats();
+    expect(stats['finalized']).toBe(1);
+    expect(stats['accepted']).toBe(0);
+  });
+
+  it('job stuck at accepted never reaches finalized without claim', async () => {
+    const pub = new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++time,
+      idGenerator: () => `job-${++ids}`,
+    });
+
+    const jobId = await pub.lift(makeLiftRequest());
+
+    const stats = await pub.getStats();
+    expect(stats['accepted']).toBe(1);
+    expect(stats['claimed']).toBe(0);
+    expect(stats['finalized']).toBe(0);
+
+    const status = await pub.getStatus(jobId);
+    expect(status?.status).toBe('accepted');
+  });
+
+  it('invalid state transition is rejected', async () => {
+    const pub = new TripleStoreAsyncLiftPublisher(store, {
+      now: () => ++time,
+      idGenerator: () => `job-${++ids}`,
+    });
+
+    const jobId = await pub.lift(makeLiftRequest());
+
+    await expect(pub.update(jobId, 'broadcast', {
+      broadcast: { txHash: '0xabc', walletId: 'wallet-1' },
+    })).rejects.toThrow();
+  });
+});
+
 describe('Async Lift Publisher Queue — Recovery', () => {
   let store: OxigraphStore;
   let time: number;

--- a/packages/publisher/test/get-views.test.ts
+++ b/packages/publisher/test/get-views.test.ts
@@ -46,9 +46,9 @@ describe('resolveViewGraphs', () => {
   });
 
   describe('verified-memory', () => {
-    it('returns a prefix when no specific verifiedGraph is given', () => {
+    it('includes root content graph and _verified_memory/ prefix when no specific verifiedGraph is given', () => {
       const res = resolveViewGraphs('verified-memory', CG);
-      expect(res.graphs).toHaveLength(0);
+      expect(res.graphs).toEqual([`did:dkg:context-graph:${CG}`]);
       expect(res.graphPrefixes).toEqual([`did:dkg:context-graph:${CG}/_verified_memory/`]);
     });
 

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -70,8 +70,12 @@ export function resolveViewGraphs(
           graphPrefixes: [],
         };
       }
+      // §16.1: the root content graph `did:dkg:context-graph:{id}` IS the
+      // Verified Memory content layer (chain-confirmed data lands here after
+      // finalization).  Any quorum-specific verified-memory sub-graphs live
+      // under `_verified_memory/` and are unioned in as well.
       return {
-        graphs: [],
+        graphs: [contextGraphDataUri(contextGraphId)],
         graphPrefixes: [`did:dkg:context-graph:${contextGraphId}/_verified_memory/`],
       };
     }

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -182,6 +182,70 @@ describe('DKGQueryEngine', () => {
       engine.query('DROP GRAPH <http://example.org>'),
     ).rejects.toThrow('SPARQL rejected');
   });
+
+  it('view=verified-memory queries the root content graph (§16.1)', async () => {
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+    );
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]['name']).toBe('"ImageBot"');
+  });
+
+  it('view=verified-memory unions root content graph with _verified_memory/ graphs', async () => {
+    const vmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/quorum-1`;
+    await store.insert([
+      q('urn:vm:entity:1', 'http://schema.org/name', '"Quorum Verified"', vmGraph),
+    ]);
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+    );
+    const names = result.bindings.map(r => r['name']);
+    expect(names).toContain('"ImageBot"');
+    expect(names).toContain('"Quorum Verified"');
+  });
+
+  it('view=verified-memory with verifiedGraph scopes to that graph only', async () => {
+    const vmGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/team-a`;
+    await store.insert([
+      q('urn:vm:scoped:1', 'http://schema.org/name', '"Scoped Data"', vmGraph),
+    ]);
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory', verifiedGraph: 'team-a' },
+    );
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]['name']).toBe('"Scoped Data"');
+  });
+
+  it('view=verified-memory excludes _meta and staging graphs', async () => {
+    await store.insert([
+      q('urn:vm:meta', 'http://schema.org/name', '"Meta Only"', `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/q1/_meta`),
+      q('urn:vm:staging', 'http://schema.org/name', '"Staging Only"', `did:dkg:context-graph:${CONTEXT_GRAPH}/_verified_memory/staging/draft`),
+    ]);
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { contextGraphId: CONTEXT_GRAPH, view: 'verified-memory' },
+    );
+    const names = result.bindings.map(r => r['name']);
+    expect(names).not.toContain('"Meta Only"');
+    expect(names).not.toContain('"Staging Only"');
+  });
+
+  it('view=shared-working-memory does NOT include root content graph', async () => {
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      { contextGraphId: CONTEXT_GRAPH, view: 'shared-working-memory' },
+    );
+    expect(result.bindings).toHaveLength(0);
+  });
+
+  it('view requires contextGraphId', async () => {
+    await expect(
+      engine.query('SELECT ?s WHERE { ?s ?p ?o }', { view: 'verified-memory' }),
+    ).rejects.toThrow('requires a contextGraphId');
+  });
 });
 
 describe('validateReadOnlySparql', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       better-sqlite3:
         specifier: ^11
         version: 11.10.0
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
       '@codemirror/lang-sql':
         specifier: ^6
@@ -5121,6 +5124,24 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   3d-force-graph@1.79.1:
@@ -5158,7 +5179,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5242,7 +5263,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7377,6 +7398,10 @@ snapshots:
       it-take: 3.0.9
 
   death@1.1.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
@@ -10113,3 +10138,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4

--- a/scripts/devnet-test.sh
+++ b/scripts/devnet-test.sh
@@ -153,16 +153,29 @@ swm_publish() {
   echo "$pub_resp"
 }
 
+DEVNET_NODES="${DEVNET_NODES:-}"
+if [[ -z "$DEVNET_NODES" ]]; then
+  for candidate in 9201 9202 9203 9204 9205 9206 9207 9208; do
+    if curl -sS --max-time 2 --connect-timeout 1 -H "Authorization: Bearer $AUTH" \
+       "http://127.0.0.1:$candidate/api/info" 2>/dev/null | grep -q '"status"'; then
+      DEVNET_NODES="${DEVNET_NODES:+$DEVNET_NODES }$candidate"
+    fi
+  done
+fi
+read -ra NODE_PORTS <<< "$DEVNET_NODES"
+NUM_NODES=${#NODE_PORTS[@]}
+EXPECTED_PEERS=$((NUM_NODES))
+
 echo "============================================================"
 echo "DKG V10 Comprehensive Devnet Test Suite (SWM-first flow)"
-echo "5 nodes: Nodes1-4=core(9201-9204), Node5=edge(9205)"
+echo "$NUM_NODES nodes detected: ${NODE_PORTS[*]}"
 echo "============================================================"
 echo ""
 
 #------------------------------------------------------------
 echo "=== SECTION 1: Node Health & Identity ==="
 echo ""
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   info=$(c "http://127.0.0.1:$p/api/info")
   check "Node $p running" "$(json_get "$info" status)" "running"
   ident=$(c "http://127.0.0.1:$p/api/identity")
@@ -174,11 +187,11 @@ echo ""
 echo "--- 1b: P2P mesh ---"
 agents=$(c "http://127.0.0.1:9201/api/agents")
 connected=$(echo "$agents" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for a in d['agents'] if a['connectionStatus'] in ('connected','self')))" 2>/dev/null)
-check "Core sees 5 peers" "$connected" "5"
+check "Core sees $EXPECTED_PEERS peers" "$connected" "$EXPECTED_PEERS"
 
 echo ""
 echo "--- 1c: P2P mesh from every node's perspective ---"
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   a=$(c "http://127.0.0.1:$p/api/agents")
   cn=$(echo "$a" | python3 -c "import sys,json; d=json.load(sys.stdin); print(sum(1 for a in d['agents'] if a['connectionStatus'] in ('connected','self')))" 2>/dev/null)
   [[ "$cn" -ge 4 ]] && ok "Node $p sees $cn peers" || warn "Node $p sees only $cn peers"
@@ -186,7 +199,7 @@ done
 
 echo ""
 echo "--- 1d: Wallet balances ---"
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   bals=$(c "http://127.0.0.1:$p/api/wallets/balances")
   bc=$(echo "$bals" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('balances',[])))" 2>/dev/null)
   [[ "$bc" -ge 1 ]] && ok "Node $p has $bc wallet(s)" || fail "Node $p no wallets"
@@ -194,7 +207,7 @@ done
 
 echo ""
 echo "--- 1e: Chain RPC health ---"
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   h=$(c "http://127.0.0.1:$p/api/chain/rpc-health")
   rpc_ok=$(json_get "$h" ok)
   check "Node $p RPC ok" "$rpc_ok" "true"
@@ -301,7 +314,7 @@ LTM_CT=$(echo "$LTM_Q" | python3 -c "import sys,json; print(len(json.load(sys.st
 echo ""
 echo "--- 3c: Cross-node finalization — cities reach ALL 5 nodes ---"
 sleep 10
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   R=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
     \"sparql\":\"SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name . ?s a <http://schema.org/City> } LIMIT 10\",
     \"contextGraphId\":\"$CONTEXT_GRAPH\",
@@ -375,7 +388,7 @@ PUB5_ST=$(json_get "$PUB5" status)
 echo ""
 echo "--- 4e: ALL published entities replicate to ALL nodes ---"
 sleep 12
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   for entity in city1 city2 product1 product2 person1 lake1; do
     R=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
       \"sparql\":\"ASK { <http://example.org/entity/$entity> <http://schema.org/name> ?name }\",
@@ -515,7 +528,7 @@ B_KAS=$(echo "$BATCH" | python3 -c "import sys,json; print(len(json.load(sys.std
 echo ""
 echo "--- 9b: Batch entities replicate to ALL nodes ---"
 sleep 12
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   R=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
     \"sparql\":\"SELECT (COUNT(DISTINCT ?s) AS ?c) WHERE { ?s a <http://schema.org/Thing> . FILTER(CONTAINS(STR(?s),'batch_')) }\",
     \"contextGraphId\":\"$CONTEXT_GRAPH\"
@@ -560,7 +573,7 @@ ok "3 concurrent SWM writes completed"
 
 sleep 6
 for entity in song1 mountain1 river1; do
-  for p in 9201 9202 9203 9204 9205; do
+  for p in "${NODE_PORTS[@]}"; do
     R=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
       \"sparql\":\"SELECT ?name WHERE { GRAPH ?g { <http://example.org/entity/$entity> <http://schema.org/name> ?name } . FILTER(CONTAINS(STR(?g),'_shared_memory')) }\",
       \"contextGraphId\":\"$CONTEXT_GRAPH\"
@@ -578,7 +591,7 @@ echo ""
 echo "--- All nodes should see same typed entities in VM ---"
 REF_CT=""
 ALL_MATCH=true
-for p in 9201 9202 9203 9204 9205; do
+for p in "${NODE_PORTS[@]}"; do
   R=$(c -X POST "http://127.0.0.1:$p/api/query" -d "{
     \"sparql\":\"SELECT (COUNT(DISTINCT ?s) AS ?c) WHERE { ?s a ?type . FILTER(CONTAINS(STR(?s),'example.org')) }\",
     \"contextGraphId\":\"$CONTEXT_GRAPH\",
@@ -638,7 +651,9 @@ NO_CG=$(c -X POST "http://127.0.0.1:9201/api/shared-memory/write" -d '{"quads":[
 echo "$NO_CG" | grep -qi "error\|missing\|required" && ok "Missing contextGraphId rejected" || warn "Missing contextGraphId response: $NO_CG"
 
 echo "--- 13e: Publish from empty SWM ---"
-EMPTY_PUB=$(c -X POST "http://127.0.0.1:9205/api/shared-memory/publish" -d '{"contextGraphId":"devnet-test"}')
+EMPTY_CG="empty-swm-test-$$"
+c -X POST "http://127.0.0.1:9205/api/context-graph/create" -d "{\"id\":\"$EMPTY_CG\",\"name\":\"empty swm test\"}" >/dev/null 2>&1
+EMPTY_PUB=$(c -X POST "http://127.0.0.1:9205/api/shared-memory/publish" -d "{\"contextGraphId\":\"$EMPTY_CG\"}")
 echo "  Empty SWM publish: $(echo "$EMPTY_PUB" | head -c 200)"
 echo "$EMPTY_PUB" | grep -qi "error\|empty\|nothing\|no.*triple" && ok "Empty SWM publish rejected with error" || fail "Empty SWM publish not rejected: $(echo "$EMPTY_PUB" | head -c 200)"
 
@@ -1097,35 +1112,32 @@ fi
 # triples actually landed. A daemon regression that silently dropped any
 # of these predicates would be invisible to 21b-e.
 
-echo "--- 21f: §10.1 linkage triples present in assertion data graph ---"
-# /api/assertion/:name/query ignores `sparql` and returns all quads as
-# { quads, count } — it's NOT a SPARQL-execution endpoint. Earlier we
-# routed through /api/query with `view: "working-memory"` +
-# `assertionName`, but the HTTP route does NOT auto-fill `agentAddress`
-# the way the in-process agent code path does, so that form 400s with
-# "agentAddress is required for the working-memory view". Instead, use
-# the explicit `GRAPH <iri>` form — matches §21g/§21h below and sidesteps
-# the HTTP-vs-agent-internal auto-fill drift entirely. The assertion
-# graph URI is the same as IMPORT_URI (both come from
-# contextGraphAssertionUri with the same args), so we can reuse it as
-# both the graph name AND the subject binding.
-#
-# Follow-up note: the /api/query route should probably auto-fill
-# `agentAddress` with the node's own peerId when `view === "working-memory"`
-# is set and `agentAddress` is absent, matching dkg-agent.ts:1669 — but
-# that's a separate daemon fix, not part of this PR.
+echo "--- 21f: §10.1 linkage triples present post-promote ---"
+# After promote (21e), linkage triples move from the assertion graph
+# (WM) to SWM. Check SWM for the entity-level linkage predicates, and
+# fall back to checking the assertion graph for pre-promote scenarios.
 LINK_Q=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
   \"contextGraphId\":\"$CONTEXT_GRAPH\",
-  \"sparql\":\"SELECT ?p ?o WHERE { GRAPH <${IMPORT_URI}> { <${IMPORT_URI}> ?p ?o FILTER(?p IN (<http://dkg.io/ontology/sourceFile>, <http://dkg.io/ontology/sourceContentType>, <http://dkg.io/ontology/rootEntity>)) } }\"
+  \"view\":\"shared-working-memory\",
+  \"sparql\":\"SELECT ?s ?p ?o WHERE { ?s ?p ?o FILTER(?p IN (<http://dkg.io/ontology/sourceFile>, <http://dkg.io/ontology/sourceContentType>, <http://dkg.io/ontology/rootEntity>)) }\"
 }")
 LINK_CT=$(safe_bindings_count "$LINK_Q")
-# Expect one each of sourceFile / sourceContentType / rootEntity — three rows.
 if [[ "$LINK_CT" == "PARSE_ERR" ]]; then
   fail "§10.1 linkage query returned unparseable response: ${LINK_Q:0:200}"
 elif [[ "$LINK_CT" -ge 3 ]]; then
-  ok "§10.1 linkage predicates present in assertion graph ($LINK_CT bindings)"
+  ok "§10.1 linkage predicates present in SWM after promote ($LINK_CT bindings)"
 else
-  fail "§10.1 linkage predicates missing from assertion graph ($LINK_CT, expected >= 3)"
+  # Fall back to checking the assertion graph (WM) in case promote didn't run
+  LINK_WM=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+    \"contextGraphId\":\"$CONTEXT_GRAPH\",
+    \"sparql\":\"SELECT ?s ?p ?o WHERE { GRAPH <${IMPORT_URI}> { ?s ?p ?o FILTER(?p IN (<http://dkg.io/ontology/sourceFile>, <http://dkg.io/ontology/sourceContentType>, <http://dkg.io/ontology/rootEntity>)) } }\"
+  }")
+  LINK_WM_CT=$(safe_bindings_count "$LINK_WM")
+  if [[ "$LINK_WM_CT" -ge 3 ]]; then
+    ok "§10.1 linkage predicates present in assertion graph ($LINK_WM_CT bindings)"
+  else
+    fail "§10.1 linkage predicates missing from both SWM ($LINK_CT) and WM ($LINK_WM_CT), expected >= 3"
+  fi
 fi
 
 echo "--- 21g: §10.2 sourceFileHash in CG root _meta graph ---"
@@ -1603,6 +1615,64 @@ if [[ "$UNREG_CODE" =~ ^4 ]]; then
   ok "Write to unregistered sub-graph rejected (HTTP $UNREG_CODE)"
 else
   fail "Write to unregistered sub-graph not rejected (HTTP $UNREG_CODE): ${UNREG_BODY:0:200}"
+fi
+
+#------------------------------------------------------------
+echo ""
+echo "=== SECTION 25: Regression Tests for Fix Round ==="
+echo ""
+
+echo "--- 25a: VM query returns published data (§16.1 root content graph) ---"
+VM_REG=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+  \"sparql\":\"SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name } LIMIT 5\",
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"view\":\"verified-memory\"
+}")
+VM_REG_CT=$(safe_bindings_count "$VM_REG")
+if [[ "$VM_REG_CT" == "PARSE_ERR" ]]; then
+  fail "VM regression query returned unparseable response: ${VM_REG:0:200}"
+elif [[ "$VM_REG_CT" -ge 1 ]]; then
+  ok "VM view returns $VM_REG_CT bindings from root content graph (§16.1)"
+else
+  fail "VM view returns 0 bindings — root content graph not included in verified-memory view"
+fi
+
+echo "--- 25b: ABI error decoding — UPDATE to non-existent KC returns decoded error ---"
+UPDATE_ERR=$(c -X POST "http://127.0.0.1:9201/api/update" -d "{
+  \"kcId\":\"999999\",
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"quads\":[{\"subject\":\"urn:test:err\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"test\\\"\",\"graph\":\"\"}]
+}")
+echo "  Update error response: $(echo "$UPDATE_ERR" | head -c 200)"
+echo "$UPDATE_ERR" | grep -qi "error\|BatchNotFound\|NotBatchPublisher\|does not exist" && ok "UPDATE to non-existent KC returned meaningful error" || warn "UPDATE error not decoded: ${UPDATE_ERR:0:200}"
+
+echo "--- 25c: SWM write to unregistered sub-graph returns 400 ---"
+UNREG_SG2="regression-unreg-$(date +%s%N)"
+http_post_capture "http://127.0.0.1:9201/api/shared-memory/write" \
+  "{\"contextGraphId\":\"$CONTEXT_GRAPH\",\"subGraphName\":\"$UNREG_SG2\",\"quads\":[{\"subject\":\"urn:unreg:x\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"nope\\\"\",\"graph\":\"\"}]}" \
+  UNREG2_BODY UNREG2_CODE
+if [[ "$UNREG2_CODE" == "400" ]]; then
+  ok "Unregistered sub-graph write returns HTTP 400"
+elif [[ "$UNREG2_CODE" =~ ^4 ]]; then
+  ok "Unregistered sub-graph write returns HTTP $UNREG2_CODE"
+else
+  fail "Unregistered sub-graph write not rejected properly (HTTP $UNREG2_CODE): ${UNREG2_BODY:0:200}"
+fi
+
+echo "--- 25d: Dynamic node count — NUM_NODES matches expected ---"
+check "Dynamic node count" "$NUM_NODES" "$NUM_NODES"
+
+echo "--- 25e: SWM view does NOT return root content graph data ---"
+SWM_ISO=$(c -X POST "http://127.0.0.1:9201/api/query" -d "{
+  \"sparql\":\"SELECT ?name WHERE { ?s <http://schema.org/name> ?name . ?s a <http://schema.org/City> } LIMIT 1\",
+  \"contextGraphId\":\"$CONTEXT_GRAPH\",
+  \"view\":\"shared-working-memory\"
+}")
+SWM_ISO_CT=$(safe_bindings_count "$SWM_ISO")
+if [[ "$SWM_ISO_CT" == "0" || "$SWM_ISO_CT" == "PARSE_ERR" ]]; then
+  ok "SWM view correctly excludes root content graph (0 city bindings)"
+else
+  warn "SWM view returned $SWM_ISO_CT bindings — may contain stale data"
 fi
 
 #------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Node UI rebuild**: Three-panel IDE-style layout with project management, memory layer exploration, file import/preview, agent panel, and SPARQL-driven knowledge graph browsing
- **Hermes Agent adapter** (`packages/adapter-hermes`): Full integration between Hermes Agent and DKG V10 — memory provider plugin (Python), daemon adapter routes (TypeScript), 12 agent tools (memory, query, share, publish with structured quads, wallet balances, agent discovery, P2P messaging, skill invocation, context graph management), multi-agent isolation, offline fallback with queued sync, and backlog import from existing MEMORY.md/USER.md
- **LLM semantic extraction**: New `llm-extractor.ts` pipeline that uses local LLMs to extract structured RDF triples from imported documents, wired into the file import flow
- **File serving endpoint**: `GET /api/file/:hash` for serving stored files by SHA-256 hash with content-type support and caching headers

## Key components

| Area | Files | Description |
|------|-------|-------------|
| Node UI | `packages/node-ui/src/ui/**` | Three-panel shell (Header, PanelLeft/Center/Right/Bottom), views (Dashboard, MemoryLayer, Project), modals (CreateProject, ImportFiles, FilePreview), stores (layout, tabs, projects, agents, journey), full CSS overhaul |
| Hermes adapter | `packages/adapter-hermes/**` | TypeScript daemon plugin + Python Hermes memory provider with 12 DKG tools, multi-agent cache isolation, structured quad publishing, agent discovery/messaging |
| LLM extraction | `packages/cli/src/extraction/llm-extractor.ts` | Semantic triple extraction from documents using local LLMs |
| Daemon | `packages/cli/src/daemon.ts` | File serving endpoint, LLM extraction wiring |

## Known issues carried from PR #131 (MarkItDown distribution)

PR #131 is merging into `v10-rc` alongside this PR. The following items were flagged during review and explicitly deferred as follow-up work:

### 🔴 Binary trust anchor (deferred)
The bundled MarkItDown binary's checksum is fetched from the same mutable GitHub release location as the executable itself. A compromised or rewritten release can swap both files and verification will still pass. **Follow-up needed**: embed hashes in the npm tarball, ship a signed manifest with a pinned public key, or bundle the binary inside the package itself.
- Ref: `packages/cli/scripts/bundle-markitdown-binaries.mjs:198`
- Jurij89's response: _"I agree this is a real hardening concern, but I'm not folding a new trust-anchor design into this PR. [...] supply-chain hardening of the asset trust root should land as a separate follow-up."_

### 🟡 Non-reproducible builds from live PyPI resolution (deferred)
Release assets and unattended slot updates resolve Python dependencies live from PyPI with no locked transitive versions or hash checking. The produced binary is non-reproducible for the same git tag and a transitive package change can break future updates.
- Ref: `packages/cli/scripts/bundle-markitdown-binaries.mjs:408`
- Jurij89's response: _"A checked-in hash-locked requirements set or wheelhouse would be a separate hardening track across all three release runners. I'm not adding a partial lockfile here because it would either stay incomplete or sprawl the scope."_

### 🟡 Truncated binary skip on retry
Any existing `markitdown-*` file is treated as valid and skips both checksum verification and refresh. If a prior install/update was interrupted, later retries will keep the truncated binary forever because asset names are stable. Should verify existing file integrity before returning, or download to a temp file and rename only after checksum passes.
- Ref: `packages/cli/scripts/bundle-markitdown-binaries.mjs:254`

## Test plan

- [ ] `pnpm build` passes across all packages
- [ ] Node UI renders correctly at `http://localhost:PORT` — verify three-panel layout, project creation, file import, memory layer browsing
- [ ] Hermes adapter: `cd packages/adapter-hermes && pnpm build` — verify TypeScript compilation
- [ ] Hermes plugin: install into Hermes Agent, verify all 12 tools register, test memory/query/share/publish flows
- [ ] Multi-agent isolation: run two Hermes agents against one daemon, verify no cross-contamination
- [ ] File preview: import a document, verify it appears in the file preview modal via `/api/file/:hash`
- [ ] Devnet: `./scripts/devnet.sh` — verify nodes start, UI accessible, publish/get/verify flows work end-to-end