### PR TITLE
chore(v10): rip selectiveDisclosureMerkleRoot, restore V8 shape (phase 0c)

### DIFF
--- a/packages/evm-module/contracts/libraries/KnowledgeCollectionLib.sol
+++ b/packages/evm-module/contracts/libraries/KnowledgeCollectionLib.sol
@@ -18,10 +18,6 @@ library KnowledgeCollectionLib {
         uint40 endEpoch;
         uint96 tokenAmount;
         bool isImmutable;
-        // Optional triple-level merkle root for selective disclosure proofs.
-        // bytes32(0) means not set. When populated, allows proving individual
-        // triples belong to this KC without revealing the full dataset.
-        bytes32 selectiveDisclosureMerkleRoot;
     }
 
     error ExceededKnowledgeCollectionMaxSize(uint256 id, uint256 minted, uint256 requested, uint256 maxSize);

--- a/packages/evm-module/contracts/storage/KnowledgeCollectionStorage.sol
+++ b/packages/evm-module/contracts/storage/KnowledgeCollectionStorage.sol
@@ -98,42 +98,6 @@ contract KnowledgeCollectionStorage is
         uint96 tokenAmount,
         bool isImmutable
     ) external onlyContracts returns (uint256) {
-        return _createKnowledgeCollection(
-            publisher, publishOperationId, merkleRoot, knowledgeAssetsAmount,
-            byteSize, startEpoch, endEpoch, tokenAmount, isImmutable, bytes32(0)
-        );
-    }
-
-    function createKnowledgeCollectionWithDisclosureRoot(
-        address publisher,
-        string calldata publishOperationId,
-        bytes32 merkleRoot,
-        uint256 knowledgeAssetsAmount,
-        uint88 byteSize,
-        uint40 startEpoch,
-        uint40 endEpoch,
-        uint96 tokenAmount,
-        bool isImmutable,
-        bytes32 selectiveDisclosureMerkleRoot
-    ) external onlyContracts returns (uint256) {
-        return _createKnowledgeCollection(
-            publisher, publishOperationId, merkleRoot, knowledgeAssetsAmount,
-            byteSize, startEpoch, endEpoch, tokenAmount, isImmutable, selectiveDisclosureMerkleRoot
-        );
-    }
-
-    function _createKnowledgeCollection(
-        address publisher,
-        string calldata publishOperationId,
-        bytes32 merkleRoot,
-        uint256 knowledgeAssetsAmount,
-        uint88 byteSize,
-        uint40 startEpoch,
-        uint40 endEpoch,
-        uint96 tokenAmount,
-        bool isImmutable,
-        bytes32 selectiveDisclosureMerkleRoot
-    ) internal returns (uint256) {
         uint256 knowledgeCollectionId = ++_knowledgeCollectionsCounter;
 
         KnowledgeCollectionLib.KnowledgeCollection storage kc = knowledgeCollections[knowledgeCollectionId];
@@ -144,9 +108,6 @@ contract KnowledgeCollectionStorage is
         kc.endEpoch = endEpoch;
         kc.tokenAmount = tokenAmount;
         kc.isImmutable = isImmutable;
-        if (selectiveDisclosureMerkleRoot != bytes32(0)) {
-            kc.selectiveDisclosureMerkleRoot = selectiveDisclosureMerkleRoot;
-        }
 
         unchecked {
             _totalTokenAmount += tokenAmount;
@@ -321,14 +282,6 @@ contract KnowledgeCollectionStorage is
         knowledgeCollections[id].merkleRoots.pop();
 
         emit KnowledgeCollectionMerkleRootRemoved(id, latestMerkleRoot);
-    }
-
-    function getSelectiveDisclosureMerkleRoot(uint256 id) external view returns (bytes32) {
-        return knowledgeCollections[id].selectiveDisclosureMerkleRoot;
-    }
-
-    function setSelectiveDisclosureMerkleRoot(uint256 id, bytes32 root) external onlyContracts {
-        knowledgeCollections[id].selectiveDisclosureMerkleRoot = root;
     }
 
     function getMinted(uint256 id) external view returns (uint256) {


### PR DESCRIPTION
## Summary
- Removes the dead `selectiveDisclosureMerkleRoot` field per decision #24 so KCL + KCS become byte-identical to V8. No redeployment needed.

Part of V10 Phase 0 (dead code cleanup, CLAUDE.md Step 0 rule). Base: `v10-rc`.

## What changed (2 files, −51 LOC)
- `packages/evm-module/contracts/libraries/KnowledgeCollectionLib.sol` — removed `selectiveDisclosureMerkleRoot` field
- `packages/evm-module/contracts/storage/KnowledgeCollectionStorage.sol` — collapsed 3-function overload family (`createKnowledgeCollection`, `createKnowledgeCollectionWithDisclosureRoot`, `_createKnowledgeCollection`) into the single V8 public signature; deleted `getSelectiveDisclosureMerkleRoot`/`setSelectiveDisclosureMerkleRoot`

## Scope note
Plan listed 5 files. Actual count is 2 — the other 3 spec-listed files turned out to be no-ops in this codebase:
- `KnowledgeAssets.sol` (V9) calls `createKnowledgeBatch` on `KnowledgeAssetsStorage`, not `createKnowledgeCollection` — no change needed.
- `KnowledgeAssetsV10.sol` + `KnowledgeCollection.sol` (the actual V10 entry point) both call the 9-param public overload whose external signature is unchanged.
- `test/unit/KnowledgeCollection.test.ts` has zero references to the removed symbols.

## Byte-identical vs V8
- \`diff KnowledgeCollectionLib.sol vs protocol/dkg-evm-module V8 reference\` → 0 delta
- \`diff KnowledgeCollectionStorage.sol vs V8 reference\` → 0 delta

## Test plan
- [x] \`pnpm compile\` clean
- [x] \`hardhat test --grep 'KnowledgeCollection'\` → 10/10 pass
- [x] Full \`@integration\` → 65/65 pass (publish flow — critical)
- [x] Full \`@unit\` → 398 pass / 1 pre-existing failure (see below)
- [x] \`grep -rn 'selectiveDisclosureMerkleRoot|SelectiveDisclosure|WithDisclosureRoot' packages/evm-module/contracts/\` → 0

## Pre-existing failure (NOT introduced by this PR)
\`test/unit/ContextGraphs.test.ts:65\` reverts on base \`v10-rc\` with \`ContractDoesNotExist("KnowledgeCollectionStorage")\` from \`deploy/051_deploy_context_graphs.ts\` → \`ContextGraphs.initialize\` → \`Hub.getAssetStorageAddress\`. Verified on untouched base. Separate triage needed (deploy ordering bug, pre-existing).

## Follow-up
- Stale ABI JSON artifacts (\`packages/evm-module/abi/KnowledgeCollectionStorage.json\`, \`packages/chain/abi/KnowledgeCollectionStorage.json\`) will need a separate ABI-sync commit.