### PR TITLE
fix(v10): Paymaster routes TRAC to StakingStorage (H1, phase 9)

### DIFF
--- a/packages/evm-module/contracts/Paymaster.sol
+++ b/packages/evm-module/contracts/Paymaster.sol
@@ -60,7 +60,7 @@ contract Paymaster is Ownable(msg.sender) {
     }
 
     function coverCost(uint256 amount) external onlyAllowed {
-        _transferTokens(hub.getContractAddress("KnowledgeCollection"), amount);
+        _transferTokens(hub.getContractAddress("StakingStorage"), amount);
     }
 
     function _transferTokens(address to, uint256 amount) internal {

--- a/packages/evm-module/test/unit/Paymaster.test.ts
+++ b/packages/evm-module/test/unit/Paymaster.test.ts
@@ -13,7 +13,7 @@ describe('@unit Paymaster', () => {
   let Paymaster: Paymaster;
   let owner: SignerWithAddress;
   let user: SignerWithAddress;
-  let knowledgeCollectionAddress: string;
+  let stakingStorageAddress: string;
 
   async function deployPaymasterFixture() {
     await hre.deployments.fixture(['Hub', 'Token']);
@@ -28,12 +28,10 @@ describe('@unit Paymaster', () => {
     const PaymasterFactory = await hre.ethers.getContractFactory('Paymaster');
     Paymaster = await PaymasterFactory.deploy(Hub.getAddress());
 
-    // Set mock KnowledgeCollection address in Hub
-    knowledgeCollectionAddress = accounts[3].address;
-    await Hub.setContractAddress(
-      'KnowledgeCollection',
-      knowledgeCollectionAddress,
-    );
+    // Set mock StakingStorage address in Hub — V10 publishing fees flow
+    // to stakers via StakingStorage, so coverCost() must route TRAC there.
+    stakingStorageAddress = accounts[3].address;
+    await Hub.setContractAddress('StakingStorage', stakingStorageAddress);
 
     // Reset user's balance to zero first
     const initialBalance = await Token.balanceOf(user.address);
@@ -184,9 +182,53 @@ describe('@unit Paymaster', () => {
         .to.emit(Token, 'Transfer')
         .withArgs(
           await Paymaster.getAddress(),
-          knowledgeCollectionAddress,
+          stakingStorageAddress,
           coverAmount,
         );
+    });
+
+    it('Should send TRAC to StakingStorage, not KnowledgeCollection (H1 regression)', async () => {
+      // Register a DIFFERENT mock address under "KnowledgeCollection" so we
+      // can prove the Transfer destination is StakingStorage and explicitly
+      // NOT KnowledgeCollection. If a future change ever flips the Hub
+      // lookup string back to "KnowledgeCollection", this test fires.
+      const knowledgeCollectionMock = accounts[5].address;
+      await Hub.setContractAddress(
+        'KnowledgeCollection',
+        knowledgeCollectionMock,
+      );
+
+      // Sanity: the two mocks are distinct addresses.
+      expect(stakingStorageAddress).to.not.equal(knowledgeCollectionMock);
+
+      const tx = await Paymaster.connect(user).coverCost(coverAmount);
+      const receipt = await tx.wait();
+      if (!receipt) {
+        throw new Error('coverCost transaction had no receipt');
+      }
+
+      const tokenAddress = await Token.getAddress();
+      const paymasterAddress = await Paymaster.getAddress();
+      const transferTopic = Token.interface.getEvent('Transfer').topicHash;
+
+      const transfers = receipt.logs
+        .filter(
+          (log) => log.address === tokenAddress && log.topics[0] === transferTopic,
+        )
+        .map((log) => Token.interface.parseLog(log)!);
+
+      const coverTransfer = transfers.find(
+        (parsed) => parsed.args.from === paymasterAddress,
+      );
+      expect(
+        coverTransfer,
+        'expected a Transfer emitted from Paymaster',
+      ).to.not.equal(undefined);
+
+      // Anti-regression: must land at StakingStorage, NOT KnowledgeCollection.
+      expect(coverTransfer!.args.to).to.equal(stakingStorageAddress);
+      expect(coverTransfer!.args.to).to.not.equal(knowledgeCollectionMock);
+      expect(coverTransfer!.args.value).to.equal(coverAmount);
     });
 
     it('Should revert when non-allowed address tries to cover cost', async () => {


### PR DESCRIPTION
## Summary

- PR #100 audit finding **H1**: `Paymaster.coverCost()` was transferring sponsored TRAC to the `KnowledgeCollection` contract, silently diverting publishing fees away from stakers. Per V10 economics (`04_TOKEN_ECONOMICS.md`) sponsored publishing fees must land at `StakingStorage` so they accrue to delegators.
- One-line production fix: `Paymaster.sol:63` — Hub lookup string `"KnowledgeCollection"` → `"StakingStorage"`. No other contracts or interfaces touched.
- Adds a bidirectional regression test: `'Should send TRAC to StakingStorage, not KnowledgeCollection (H1 regression)'` registers two distinct mocks under each Hub name, parses the `Transfer` event from the receipt, and asserts the destination equals the `StakingStorage` mock AND explicitly **not** the `KnowledgeCollection` mock. If a future change ever flips the string back, the test fires.

Spec ref: `~/.claude/dkg-v9/.ai/v10-implementation-plan.md` Phase 9.
Audit ref: `~/.claude/dkg-v9/.ai/pr100-audit-findings.md` H1.

## Files

- `packages/evm-module/contracts/Paymaster.sol` (+1 / -1)
- `packages/evm-module/test/unit/Paymaster.test.ts` (+50 / -8)

## Test plan

- [x] Red first: with the old `Paymaster.sol`, 4 tests in the `Cover Cost` block fail as expected (updated + new regression)
- [x] Green after fix: all 19 Paymaster tests pass
- [x] Full evm-module suite green (766 / 766 passing)
- [x] `hardhat compile` clean (no new warnings)
- [x] No scope creep: `git show --stat HEAD` lists only the two files above
- [x] Single commit on branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)