### PR TITLE
fix: address PR #146 review feedback (round 2)

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2856,11 +2856,11 @@ async function handleRequest(
       }
       tracker.complete(ctx, { tripleCount: result.kaManifest?.length ?? 0 });
 
-      // Re-tag vector store embeddings from swm → vm for published entities
-      if (vectorStore && result.kaManifest?.length) {
+      // Re-tag vector store embeddings from swm → vm only after confirmed publish
+      if (vectorStore && result.kaManifest?.length && result.status !== 'tentative') {
         for (const ka of result.kaManifest) {
           try {
-            await vectorStore.updateLayer({ sourceUri: ka.rootEntity, contextGraphId: paranetId, newLayer: 'vm' });
+            await vectorStore.updateLayer({ entityUri: ka.rootEntity, contextGraphId: paranetId, newLayer: 'vm' });
           } catch { /* best-effort */ }
         }
       }
@@ -4732,8 +4732,11 @@ async function handleRequest(
       graph: targetGraph,
     });
 
-    // Session linking (if session URI provided and is a valid IRI)
-    if (sessionUri && typeof sessionUri === 'string' && isSafeIri(sessionUri)) {
+    // Session linking (if session URI provided)
+    if (sessionUri && typeof sessionUri === 'string') {
+      if (!isSafeIri(sessionUri)) {
+        return jsonResponse(res, 400, { error: `Invalid sessionUri: contains characters unsafe for RDF IRIs` });
+      }
       quads.push({
         subject: turnUri,
         predicate: 'http://schema.org/isPartOf',

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'node:url';
 import { ethers } from 'ethers';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, escapeSparqlLiteral, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -4869,7 +4869,7 @@ async function handleRequest(
     }
 
     // Fan-out 2: SPARQL text search (scoped to the requested CG + layers)
-    const escapedQuery = query.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t').toLowerCase();
+    const escapedQuery = escapeSparqlLiteral(query.toLowerCase());
     const cgUri = `did:dkg:context-graph:${contextGraphId}`;
     const graphFilters = memoryLayers.map((l: string) => {
       if (l === 'swm') return `STRSTARTS(STR(?g), "${cgUri}/_shared_memory")`;

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2857,10 +2857,10 @@ async function handleRequest(
       tracker.complete(ctx, { tripleCount: result.kaManifest?.length ?? 0 });
 
       // Re-tag vector store embeddings from swm → vm only after confirmed publish
-      if (vectorStore && result.kaManifest?.length && result.status !== 'tentative') {
+      if (vectorStore && result.kaManifest?.length && result.status === 'confirmed') {
         for (const ka of result.kaManifest) {
           try {
-            await vectorStore.updateLayer({ entityUri: ka.rootEntity, contextGraphId: paranetId, newLayer: 'vm' });
+            await vectorStore.updateLayer({ entityUri: ka.rootEntity, contextGraphId: paranetId, fromLayer: 'swm', newLayer: 'vm' });
           } catch { /* best-effort */ }
         }
       }

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2855,6 +2855,16 @@ async function handleRequest(
         tracker.setTxHash(ctx, chain.txHash, chainId ? Number(chainId) : undefined);
       }
       tracker.complete(ctx, { tripleCount: result.kaManifest?.length ?? 0 });
+
+      // Re-tag vector store embeddings from swm → vm for published entities
+      if (vectorStore && result.kaManifest?.length) {
+        for (const ka of result.kaManifest) {
+          try {
+            await vectorStore.updateLayer({ sourceUri: ka.rootEntity, contextGraphId: paranetId, newLayer: 'vm' });
+          } catch { /* best-effort */ }
+        }
+      }
+
       const httpStatus = result.contextGraphError ? 207 : 200;
       return jsonResponse(res, httpStatus, {
         kcId: String(result.kcId),
@@ -4722,8 +4732,8 @@ async function handleRequest(
       graph: targetGraph,
     });
 
-    // Session linking (if session URI provided)
-    if (sessionUri && typeof sessionUri === 'string') {
+    // Session linking (if session URI provided and is a valid IRI)
+    if (sessionUri && typeof sessionUri === 'string' && isSafeIri(sessionUri)) {
       quads.push({
         subject: turnUri,
         predicate: 'http://schema.org/isPartOf',
@@ -4795,10 +4805,11 @@ async function handleRequest(
     });
   }
 
-  // POST /api/memory/search — tri-modal search across text, graph, and vector stores.
+  // POST /api/memory/search — search across graph and vector stores.
   //
-  // Fans out the query to SPARQL (triple store), text search (file store),
-  // and vector similarity (vector store), then merges and deduplicates results.
+  // Currently fans out to: (1) vector similarity, (2) SPARQL text match.
+  // File-store full-text search leg is NOT yet implemented; callers should
+  // use GET /api/file/:hash directly for source file content retrieval.
   //
   // Spec: 21_TRI_MODAL_MEMORY.md §7
   if (req.method === 'POST' && path === '/api/memory/search') {
@@ -4855,7 +4866,7 @@ async function handleRequest(
     }
 
     // Fan-out 2: SPARQL text search (scoped to the requested CG + layers)
-    const escapedQuery = query.replace(/"/g, '\\"').toLowerCase();
+    const escapedQuery = query.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t').toLowerCase();
     const cgUri = `did:dkg:context-graph:${contextGraphId}`;
     const graphFilters = memoryLayers.map((l: string) => {
       if (l === 'swm') return `STRSTARTS(STR(?g), "${cgUri}/_shared_memory")`;

--- a/packages/cli/src/vector-store.ts
+++ b/packages/cli/src/vector-store.ts
@@ -156,10 +156,10 @@ export class VectorStore {
     return scored.slice(0, opts.limit);
   }
 
-  async updateLayer(opts: { entityUri: string; contextGraphId: string; newLayer: 'wm' | 'swm' | 'vm' }): Promise<number> {
+  async updateLayer(opts: { entityUri: string; contextGraphId: string; fromLayer: 'wm' | 'swm' | 'vm'; newLayer: 'wm' | 'swm' | 'vm' }): Promise<number> {
     const info = this.db.prepare(
-      'UPDATE embeddings SET memory_layer = ? WHERE entity_uri = ? AND context_graph_id = ?'
-    ).run(opts.newLayer, opts.entityUri, opts.contextGraphId);
+      'UPDATE embeddings SET memory_layer = ? WHERE entity_uri = ? AND context_graph_id = ? AND memory_layer = ?'
+    ).run(opts.newLayer, opts.entityUri, opts.contextGraphId, opts.fromLayer);
     return info.changes;
   }
 

--- a/packages/cli/src/vector-store.ts
+++ b/packages/cli/src/vector-store.ts
@@ -156,10 +156,10 @@ export class VectorStore {
     return scored.slice(0, opts.limit);
   }
 
-  async updateLayer(opts: { sourceUri: string; contextGraphId: string; newLayer: 'wm' | 'swm' | 'vm' }): Promise<number> {
+  async updateLayer(opts: { entityUri: string; contextGraphId: string; newLayer: 'wm' | 'swm' | 'vm' }): Promise<number> {
     const info = this.db.prepare(
-      'UPDATE embeddings SET memory_layer = ? WHERE source_uri = ? AND context_graph_id = ?'
-    ).run(opts.newLayer, opts.sourceUri, opts.contextGraphId);
+      'UPDATE embeddings SET memory_layer = ? WHERE entity_uri = ? AND context_graph_id = ?'
+    ).run(opts.newLayer, opts.entityUri, opts.contextGraphId);
     return info.changes;
   }
 

--- a/packages/cli/src/vector-store.ts
+++ b/packages/cli/src/vector-store.ts
@@ -156,6 +156,13 @@ export class VectorStore {
     return scored.slice(0, opts.limit);
   }
 
+  async updateLayer(opts: { sourceUri: string; contextGraphId: string; newLayer: 'wm' | 'swm' | 'vm' }): Promise<number> {
+    const info = this.db.prepare(
+      'UPDATE embeddings SET memory_layer = ? WHERE source_uri = ? AND context_graph_id = ?'
+    ).run(opts.newLayer, opts.sourceUri, opts.contextGraphId);
+    return info.changes;
+  }
+
   async delete(opts: { sourceUri?: string; entityUri?: string }): Promise<number> {
     if (opts.sourceUri) {
       const info = this.db.prepare('DELETE FROM embeddings WHERE source_uri = ?').run(opts.sourceUri);

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -65,7 +65,7 @@ function shortPredicate(uri: string): string {
 
 function wmSparql(cgId: string) {
   const cgUri = `did:dkg:context-graph:${cgId}`;
-  return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } } LIMIT 1500`;
+  return `SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } LIMIT 1500`;
 }
 const SPARQL_SWM = `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;
 const SPARQL_VM = `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -64,7 +64,7 @@ function shortPredicate(uri: string): string {
 }
 
 function wmSparql(cgId: string) {
-  const cgUri = `did:dkg:context-graph:${cgId}`;
+  const cgUri = `did:dkg:context-graph:${cgId}/`;
   return `SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } LIMIT 1500`;
 }
 const SPARQL_SWM = `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -65,7 +65,7 @@ function shortPredicate(uri: string): string {
 
 function wmSparql(cgId: string) {
   const cgUri = `did:dkg:context-graph:${cgId}`;
-  return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}")) } } LIMIT 1500`;
+  return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } } LIMIT 1500`;
 }
 const SPARQL_SWM = `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;
 const SPARQL_VM = `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -81,7 +81,7 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
 
   const defaultSparql = useMemo(() => {
     if (layer === 'wm') {
-      const cgUri = `did:dkg:context-graph:${contextGraphId}`;
+      const cgUri = `did:dkg:context-graph:${contextGraphId}/`;
       return `SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } LIMIT 1000`;
     }
     return `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -82,7 +82,7 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
   const defaultSparql = useMemo(() => {
     if (layer === 'wm') {
       const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-      return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } } LIMIT 1000`;
+      return `SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } LIMIT 1000`;
     }
     return `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;
   }, [layer, contextGraphId]);

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -82,7 +82,7 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
   const defaultSparql = useMemo(() => {
     if (layer === 'wm') {
       const cgUri = `did:dkg:context-graph:${contextGraphId}`;
-      return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}")) } } LIMIT 1000`;
+      return `SELECT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } FILTER(STRSTARTS(STR(?g), "${cgUri}") && !CONTAINS(STR(?g), "/_shared_memory") && !CONTAINS(STR(?g), "/_verified_memory")) } } LIMIT 1000`;
     }
     return `SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 500`;
   }, [layer, contextGraphId]);

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -625,11 +625,21 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
     return conn?.targetUri ?? null;
   }, [entity]);
 
-  // Fetch full body from source file if description is truncated
+  // Fetch full body from source file only for text-based content
+  const sourceContentType = useMemo(() => {
+    const vals = entity.properties.get('http://dkg.io/ontology/sourceContentType');
+    return vals?.[0] ?? null;
+  }, [entity]);
+
+  const isTruncated = desc != null && desc.length >= 1990;
+  const isTextSource = sourceContentType != null && (
+    sourceContentType.startsWith('text/') || sourceContentType === 'application/json'
+  );
+
   const [fullBody, setFullBody] = useState<string | null>(null);
   useEffect(() => {
     setFullBody(null);
-    if (!sourceFile || !desc || desc.length < 1990) return;
+    if (!sourceFile || !isTruncated || !isTextSource) return;
     let cancelled = false;
     const hash = sourceFile.replace('urn:dkg:file:', '');
     const token = typeof window !== 'undefined' ? (window as any).__DKG_TOKEN__ : null;
@@ -640,7 +650,7 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
       .then(text => { if (!cancelled) setFullBody(text ?? null); })
       .catch(() => { if (!cancelled) setFullBody(null); });
     return () => { cancelled = true; };
-  }, [sourceFile, desc]);
+  }, [sourceFile, isTruncated, isTextSource]);
 
   const [similar, setSimilar] = useState<Array<{ entityUri: string; label: string | null; similarity: number }>>([]);
   useEffect(() => {

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -628,7 +628,8 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
   // Fetch full body from source file if description is truncated
   const [fullBody, setFullBody] = useState<string | null>(null);
   useEffect(() => {
-    if (!sourceFile || !desc || desc.length < 1990) { setFullBody(null); return; }
+    setFullBody(null);
+    if (!sourceFile || !desc || desc.length < 1990) return;
     let cancelled = false;
     const hash = sourceFile.replace('urn:dkg:file:', '');
     const token = typeof window !== 'undefined' ? (window as any).__DKG_TOKEN__ : null;
@@ -636,8 +637,8 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
     if (token) headers['Authorization'] = `Bearer ${token}`;
     fetch(`/api/file/${encodeURIComponent(hash)}`, { headers })
       .then(r => r.ok ? r.text() : null)
-      .then(text => { if (!cancelled && text) setFullBody(text); })
-      .catch(() => {});
+      .then(text => { if (!cancelled) setFullBody(text ?? null); })
+      .catch(() => { if (!cancelled) setFullBody(null); });
     return () => { cancelled = true; };
   }, [sourceFile, desc]);
 

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -625,6 +625,22 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
     return conn?.targetUri ?? null;
   }, [entity]);
 
+  // Fetch full body from source file if description is truncated
+  const [fullBody, setFullBody] = useState<string | null>(null);
+  useEffect(() => {
+    if (!sourceFile || !desc || desc.length < 1990) { setFullBody(null); return; }
+    let cancelled = false;
+    const hash = sourceFile.replace('urn:dkg:file:', '');
+    const token = typeof window !== 'undefined' ? (window as any).__DKG_TOKEN__ : null;
+    const headers: Record<string, string> = {};
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    fetch(`/api/file/${encodeURIComponent(hash)}`, { headers })
+      .then(r => r.ok ? r.text() : null)
+      .then(text => { if (!cancelled && text) setFullBody(text); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [sourceFile, desc]);
+
   const [similar, setSimilar] = useState<Array<{ entityUri: string; label: string | null; similarity: number }>>([]);
   useEffect(() => {
     const label = entity.label;
@@ -686,7 +702,7 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
           </div>
         </div>
 
-        {desc && <p className="v10-dd-desc">{desc}</p>}
+        {(fullBody || desc) && <p className="v10-dd-desc" style={{ whiteSpace: 'pre-wrap' }}>{fullBody ?? desc}</p>}
 
         <div className="v10-dd-uri mono">{entity.uri}</div>
 


### PR DESCRIPTION
## Summary

Follow-up to PR #146 — addresses the second round of review comments:

- **SPARQL injection hardening**: `/api/memory/search` now properly escapes backslash, newline, CR, and tab characters in query input (previously only escaped double-quotes)
- **WM query scoping**: `useMemoryEntities` and `MemoryLayerView` WM SPARQL filters now exclude `_shared_memory` and `_verified_memory` graph URIs, preventing double-counting of SWM/VM triples in the Working Memory layer
- **sessionUri validation**: `/api/memory/turn` now gates `sessionUri` on `isSafeIri()` before inserting into quads, preventing invalid RDF from untrusted input
- **Vector store layer promotion**: New `VectorStore.updateLayer()` method, called after `publishFromSharedMemory`, re-tags embeddings from `swm` → `vm` so vector search respects memory layer boundaries
- **Drilldown full body**: When `schema:description` is truncated (>1990 chars), the `DrilldownPanel` now fetches the source file via `/api/file/:hash` to display the full conversation turn
- **Search contract clarification**: Updated endpoint comment to document that `/api/memory/search` currently covers vector + SPARQL only (file-store search leg is deferred)

## Test plan

- [ ] Build CLI and node-ui packages (`pnpm build`)
- [ ] Verify WM entities page no longer shows SWM/VM duplicates
- [ ] Test `/api/memory/search` with special characters in query
- [ ] Verify drilldown of a long conversation turn shows full body
- [ ] Test publish flow and confirm vector store layer updates to `vm`


Made with [Cursor](https://cursor.com)