### PR TITLE
fix: address PR 137 carry-forward follow-ups

### DIFF
--- a/packages/adapter-openclaw/setup-entry.mjs
+++ b/packages/adapter-openclaw/setup-entry.mjs
@@ -1,7 +1,7 @@
 import runtimeEntry from './openclaw-entry.mjs';
 
 export default function setupEntry(api = {}) {
-  const mode = api.registrationMode ?? 'setup-only';
+  const mode = api.registrationMode ?? 'full';
   const log = api.logger ?? console;
 
   if (mode === 'setup-only' || mode === 'cli-metadata') {

--- a/packages/adapter-openclaw/setup-entry.mjs
+++ b/packages/adapter-openclaw/setup-entry.mjs
@@ -1,1 +1,13 @@
-export { default } from './openclaw-entry.mjs';
+import runtimeEntry from './openclaw-entry.mjs';
+
+export default function setupEntry(api = {}) {
+  const mode = api.registrationMode ?? 'setup-only';
+  const log = api.logger ?? console;
+
+  if (mode === 'setup-only' || mode === 'cli-metadata') {
+    log.info?.(`[dkg-setup-entry] Setup-safe load for registrationMode=${mode}; skipping runtime registration`);
+    return;
+  }
+
+  return runtimeEntry(api);
+}

--- a/packages/adapter-openclaw/setup-entry.mjs
+++ b/packages/adapter-openclaw/setup-entry.mjs
@@ -1,5 +1,3 @@
-import runtimeEntry from './openclaw-entry.mjs';
-
 export default function setupEntry(api = {}) {
   const mode = api.registrationMode ?? 'full';
   const log = api.logger ?? console;
@@ -9,5 +7,5 @@ export default function setupEntry(api = {}) {
     return;
   }
 
-  return runtimeEntry(api);
+  return import('./openclaw-entry.mjs').then(({ default: runtimeEntry }) => runtimeEntry(api));
 }

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -75,7 +75,11 @@ export class DkgChannelPlugin {
   private server: Server | null = null;
   private serverStart: Promise<void> | null = null;
   private readonly pendingRequests = new Map<string, PendingRequest>();
-  private readonly pendingTurnPersistence = new Map<string, { attempt: number; timer: ReturnType<typeof setTimeout> | null }>();
+  private readonly pendingTurnPersistence = new Map<string, {
+    attempt: number;
+    timer: ReturnType<typeof setTimeout> | null;
+    allowDuringShutdown: boolean;
+  }>();
   private readonly port: number;
   private useGatewayRoute = false;
   private channelRegistered = false;
@@ -223,6 +227,7 @@ export class DkgChannelPlugin {
     }
 
     for (const [id, job] of this.pendingTurnPersistence) {
+      if (job.allowDuringShutdown) continue;
       if (!job.timer) continue;
       clearTimeout(job.timer);
       this.deletePendingTurnPersistence(id);
@@ -970,7 +975,7 @@ export class DkgChannelPlugin {
 
     const attemptPersist = (attempt: number): void => {
       if (!this.canContinuePersistenceAttempt(allowDuringShutdown)) return;
-      this.pendingTurnPersistence.set(correlationId, { attempt, timer: null });
+      this.pendingTurnPersistence.set(correlationId, { attempt, timer: null, allowDuringShutdown });
       void this.persistTurn(userMessage, assistantReply, correlationId, identity, opts)
         .then(() => {
           this.deletePendingTurnPersistence(correlationId);
@@ -1004,10 +1009,10 @@ export class DkgChannelPlugin {
             }
             const job = this.pendingTurnPersistence.get(correlationId);
             if (!job) return;
-            this.pendingTurnPersistence.set(correlationId, { attempt: attempt + 1, timer: null });
+            this.pendingTurnPersistence.set(correlationId, { attempt: attempt + 1, timer: null, allowDuringShutdown });
             attemptPersist(attempt + 1);
           }, retryDelayMs);
-          this.pendingTurnPersistence.set(correlationId, { attempt, timer });
+          this.pendingTurnPersistence.set(correlationId, { attempt, timer, allowDuringShutdown });
         });
     };
 

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -33,6 +33,7 @@ export const CHANNEL_NAME = 'dkg-ui';
 const DEFAULT_CHANNEL_ACCOUNT_ID = 'default';
 const TURN_PERSIST_RETRY_DELAYS_MS = [250, 1_000] as const;
 const CHANNEL_RESPONSE_TIMEOUT_MS = 180_000;
+const STOP_DRAIN_TIMEOUT_MS = 1_500;
 const NO_TEXT_RESPONSE_ERROR = 'Agent returned no text response';
 const CANCELLED_TURN_MESSAGE = '[OpenClaw reply cancelled before completion]';
 const FAILED_TURN_MESSAGE_PREFIX = '[OpenClaw reply failed before completion';
@@ -235,7 +236,12 @@ export class DkgChannelPlugin {
       this.server = null;
     }
 
-    await this.waitForStopDrain();
+    const drained = await this.waitForStopDrain(STOP_DRAIN_TIMEOUT_MS);
+    if (!drained) {
+      this.api?.logger.warn?.(
+        `[dkg-channel] Channel stop timed out after ${STOP_DRAIN_TIMEOUT_MS}ms waiting for turn persistence to drain; continuing shutdown`,
+      );
+    }
   }
 
   private deletePendingTurnPersistence(correlationId: string): void {
@@ -252,12 +258,26 @@ export class DkgChannelPlugin {
     }
   }
 
-  private waitForStopDrain(): Promise<void> {
+  private waitForStopDrain(timeoutMs: number): Promise<boolean> {
     if (this.inFlight === 0 && this.pendingTurnPersistence.size === 0) {
-      return Promise.resolve();
+      return Promise.resolve(true);
     }
     return new Promise((resolve) => {
-      this.stopWaiters.push(resolve);
+      let settled = false;
+      const waiter = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(true);
+      };
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        const index = this.stopWaiters.indexOf(waiter);
+        if (index >= 0) this.stopWaiters.splice(index, 1);
+        resolve(false);
+      }, timeoutMs);
+      this.stopWaiters.push(waiter);
       this.notifyStopIdle();
     });
   }

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -34,6 +34,8 @@ const DEFAULT_CHANNEL_ACCOUNT_ID = 'default';
 const TURN_PERSIST_RETRY_DELAYS_MS = [250, 1_000] as const;
 const CHANNEL_RESPONSE_TIMEOUT_MS = 180_000;
 const NO_TEXT_RESPONSE_ERROR = 'Agent returned no text response';
+const CANCELLED_TURN_MESSAGE = '[OpenClaw reply cancelled before completion]';
+const FAILED_TURN_MESSAGE_PREFIX = '[OpenClaw reply failed before completion';
 
 /** Strip identity to safe characters and cap length to prevent injection into session keys / URIs. */
 function sanitizeIdentity(raw: string): string {
@@ -52,6 +54,11 @@ interface PendingRequest {
   resolve: (reply: ChannelOutboundReply) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+}
+
+interface PersistTurnOptions {
+  persistenceState?: 'stored' | 'failed' | 'pending';
+  failureReason?: string | null;
 }
 
 export class DkgChannelPlugin {
@@ -74,6 +81,7 @@ export class DkgChannelPlugin {
   private gatewayRoutesRegistered = false;
   private inFlight = 0;
   private readonly maxInFlight = 3;
+  private stopping = false;
 
   constructor(
     private readonly config: NonNullable<DkgOpenClawConfig['channel']>,
@@ -87,6 +95,7 @@ export class DkgChannelPlugin {
   // ---------------------------------------------------------------------------
 
   register(api: OpenClawPluginApi): void {
+    this.stopping = false;
     this.api = api;
     const log = api.logger;
 
@@ -199,6 +208,8 @@ export class DkgChannelPlugin {
   }
 
   async stop(): Promise<void> {
+    this.stopping = true;
+
     // Reject all pending requests
     for (const [id, pending] of this.pendingRequests) {
       clearTimeout(pending.timer);
@@ -680,6 +691,9 @@ export class DkgChannelPlugin {
       .catch((err: any) => push({ type: 'error', error: err instanceof Error ? err : new Error(String(err)) }));
 
     // Yield events as they arrive
+    let terminalState: 'cancelled' | 'completed' | 'failed' = 'cancelled';
+    let finalText: string | null = null;
+    let failureReason: string | null = null;
     let completed = false;
     try {
       while (true) {
@@ -688,9 +702,19 @@ export class DkgChannelPlugin {
         if (item.type === 'text_delta') {
           yield item;
         } else if (item.type === 'done') {
+          try {
+            finalText = finalizeAgentReplyText(replyText);
+            terminalState = 'completed';
+          } catch (err) {
+            terminalState = 'failed';
+            failureReason = getErrorMessage(err);
+            throw err;
+          }
           completed = true;
           break;
         } else if (item.type === 'error') {
+          terminalState = 'failed';
+          failureReason = item.error.message;
           clearTimeout(timer);
           throw item.error;
         }
@@ -698,12 +722,32 @@ export class DkgChannelPlugin {
     } finally {
       clearTimeout(timer);
       aborted = true; // Stop dangling deliver() callbacks from queuing
+
+      if (!this.stopping) {
+        if (terminalState === 'completed' && finalText) {
+          this.queueTurnPersistence(text, finalText, correlationId, identity);
+        } else if (terminalState === 'failed') {
+          this.queueTurnPersistence(
+            text,
+            this.buildFailedAssistantReply(failureReason),
+            correlationId,
+            identity,
+            { persistenceState: 'failed', failureReason },
+          );
+        } else {
+          this.queueTurnPersistence(
+            text,
+            CANCELLED_TURN_MESSAGE,
+            correlationId,
+            identity,
+            { persistenceState: 'failed', failureReason: 'cancelled' },
+          );
+        }
+      }
     }
 
     // Only yield final if the stream completed normally (not cancelled)
-    if (completed) {
-      const finalText = finalizeAgentReplyText(replyText);
-      this.queueTurnPersistence(text, finalText, correlationId, identity);
+    if (completed && finalText) {
       yield { type: 'final', text: finalText, correlationId };
     }
   }
@@ -837,6 +881,7 @@ export class DkgChannelPlugin {
     assistantReply: string,
     correlationId: string,
     identity: string,
+    opts?: PersistTurnOptions,
   ): Promise<void> {
     // Non-owner identities (e.g. background workers) get their own session
     // so they don't pollute the user's DKG UI chat history.
@@ -847,7 +892,11 @@ export class DkgChannelPlugin {
       sessionId,
       userMessage,
       assistantReply,
-      { turnId: correlationId },
+      {
+        turnId: correlationId,
+        ...(opts?.persistenceState ? { persistenceState: opts.persistenceState } : {}),
+        ...(opts?.failureReason != null ? { failureReason: opts.failureReason } : {}),
+      },
     );
     this.api?.logger.info?.(`[dkg-channel] Turn persisted to DKG graph: ${correlationId}`);
   }
@@ -857,16 +906,24 @@ export class DkgChannelPlugin {
     assistantReply: string,
     correlationId: string,
     identity: string,
+    opts?: PersistTurnOptions,
   ): void {
-    if (this.pendingTurnPersistence.has(correlationId)) return;
+    if (this.stopping || this.pendingTurnPersistence.has(correlationId)) return;
 
     const attemptPersist = (attempt: number): void => {
+      if (this.stopping) return;
       this.pendingTurnPersistence.set(correlationId, { attempt, timer: null });
-      void this.persistTurn(userMessage, assistantReply, correlationId, identity)
+      void this.persistTurn(userMessage, assistantReply, correlationId, identity, opts)
         .then(() => {
           this.pendingTurnPersistence.delete(correlationId);
         })
         .catch((err: any) => {
+          const currentJob = this.pendingTurnPersistence.get(correlationId);
+          if (this.stopping || !currentJob) {
+            this.pendingTurnPersistence.delete(correlationId);
+            return;
+          }
+
           const retryDelayMs = TURN_PERSIST_RETRY_DELAYS_MS[attempt - 1];
           if (retryDelayMs == null) {
             this.pendingTurnPersistence.delete(correlationId);
@@ -880,6 +937,10 @@ export class DkgChannelPlugin {
             `[dkg-channel] Turn persistence failed (attempt ${attempt}); retrying in ${retryDelayMs}ms: ${err.message}`,
           );
           const timer = setTimeout(() => {
+            if (this.stopping) {
+              this.pendingTurnPersistence.delete(correlationId);
+              return;
+            }
             const job = this.pendingTurnPersistence.get(correlationId);
             if (!job) return;
             this.pendingTurnPersistence.set(correlationId, { attempt: attempt + 1, timer: null });
@@ -890,6 +951,14 @@ export class DkgChannelPlugin {
     };
 
     attemptPersist(1);
+  }
+
+  private buildFailedAssistantReply(reason?: string | null): string {
+    const normalizedReason = reason?.trim();
+    if (!normalizedReason || normalizedReason === 'cancelled') {
+      return CANCELLED_TURN_MESSAGE;
+    }
+    return `${FAILED_TURN_MESSAGE_PREFIX}: ${normalizedReason}]`;
   }
 
   // ---------------------------------------------------------------------------
@@ -1124,6 +1193,13 @@ function readBody(req: IncomingMessage, maxBytes = 1_048_576): Promise<string> {
 function formatError(err: unknown): string {
   if (err instanceof Error) {
     return err.stack ?? err.message;
+  }
+  return String(err);
+}
+
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
   }
   return String(err);
 }

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -760,7 +760,7 @@ export class DkgChannelPlugin {
           ),
         );
 
-    dispatchFn()
+    const dispatchCompletion = dispatchFn()
       .then(() => {
         dispatchTerminal = 'done';
         push({ type: 'done' });
@@ -771,6 +771,55 @@ export class DkgChannelPlugin {
         dispatchFailureMessage = dispatchFailure.message;
         push({ type: 'error', error: dispatchFailure });
       });
+
+    const persistResolvedTerminalState = (): void => {
+      let resolvedTerminalState = terminalState;
+      let resolvedFinalText = finalText;
+      let resolvedFailureReason = failureReason;
+
+      if (resolvedTerminalState === 'cancelled') {
+        const queuedTerminal = [...queue].reverse().find(
+          (item): item is { type: 'done' } | { type: 'error'; error: Error } =>
+            item.type === 'done' || item.type === 'error',
+        );
+        if (queuedTerminal?.type === 'done' || dispatchTerminal === 'done') {
+          try {
+            resolvedFinalText = finalizeAgentReplyText(replyText);
+            resolvedTerminalState = 'completed';
+          } catch (err) {
+            resolvedTerminalState = 'failed';
+            resolvedFailureReason = getErrorMessage(err);
+          }
+        } else if (queuedTerminal?.type === 'error' || dispatchTerminal === 'error') {
+          const queuedTerminalError: Error | null =
+            queuedTerminal && queuedTerminal.type === 'error' ? queuedTerminal.error : null;
+          resolvedTerminalState = 'failed';
+          resolvedFailureReason = queuedTerminalError?.message ?? dispatchFailureMessage ?? resolvedFailureReason;
+        }
+      }
+
+      if (resolvedTerminalState === 'completed' && resolvedFinalText) {
+        this.queueTurnPersistence(text, resolvedFinalText, correlationId, identity, undefined, true);
+      } else if (resolvedTerminalState === 'failed') {
+        this.queueTurnPersistence(
+          text,
+          this.buildFailedAssistantReply(resolvedFailureReason),
+          correlationId,
+          identity,
+          { persistenceState: 'failed', failureReason: resolvedFailureReason },
+          true,
+        );
+      } else {
+        this.queueTurnPersistence(
+          text,
+          CANCELLED_TURN_MESSAGE,
+          correlationId,
+          identity,
+          { persistenceState: 'failed', failureReason: 'cancelled' },
+          true,
+        );
+      }
+    };
 
     // Yield events as they arrive
     let terminalState: 'cancelled' | 'completed' | 'failed' = 'cancelled';
@@ -805,48 +854,14 @@ export class DkgChannelPlugin {
       clearTimeout(timer);
       aborted = true; // Stop dangling deliver() callbacks from queuing
 
-      if (terminalState === 'cancelled') {
-        const queuedTerminal = [...queue].reverse().find(
-          (item): item is { type: 'done' } | { type: 'error'; error: Error } =>
-            item.type === 'done' || item.type === 'error',
-        );
-        if (queuedTerminal?.type === 'done' || dispatchTerminal === 'done') {
-          try {
-            finalText = finalizeAgentReplyText(replyText);
-            terminalState = 'completed';
-          } catch (err) {
-            terminalState = 'failed';
-            failureReason = getErrorMessage(err);
-          }
-        } else if (queuedTerminal?.type === 'error' || dispatchTerminal === 'error') {
-          const queuedTerminalError: Error | null =
-            queuedTerminal && queuedTerminal.type === 'error' ? queuedTerminal.error : null;
-          terminalState = 'failed';
-          failureReason = queuedTerminalError?.message ?? dispatchFailureMessage ?? failureReason;
-        }
+      if (terminalState === 'cancelled' && dispatchTerminal == null) {
+        void dispatchCompletion.finally(() => {
+          persistResolvedTerminalState();
+        });
+        return;
       }
 
-      if (terminalState === 'completed' && finalText) {
-        this.queueTurnPersistence(text, finalText, correlationId, identity, undefined, true);
-      } else if (terminalState === 'failed') {
-        this.queueTurnPersistence(
-          text,
-          this.buildFailedAssistantReply(failureReason),
-          correlationId,
-          identity,
-          { persistenceState: 'failed', failureReason },
-          true,
-        );
-      } else {
-        this.queueTurnPersistence(
-          text,
-          CANCELLED_TURN_MESSAGE,
-          correlationId,
-          identity,
-          { persistenceState: 'failed', failureReason: 'cancelled' },
-          true,
-        );
-      }
+      persistResolvedTerminalState();
     }
 
     // Only yield final if the stream completed normally (not cancelled)

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -725,6 +725,8 @@ export class DkgChannelPlugin {
     const timer = setTimeout(() => push({ type: 'error', error: new Error('Agent response timeout') }), TIMEOUT_MS);
 
     let replyText = '';
+    let dispatchTerminal: 'done' | 'error' | null = null;
+    let dispatchFailureMessage: string | null = null;
     const deliver = async (payload: any) => {
       const t = payload?.text;
       if (t) {
@@ -759,8 +761,16 @@ export class DkgChannelPlugin {
         );
 
     dispatchFn()
-      .then(() => push({ type: 'done' }))
-      .catch((err: any) => push({ type: 'error', error: err instanceof Error ? err : new Error(String(err)) }));
+      .then(() => {
+        dispatchTerminal = 'done';
+        push({ type: 'done' });
+      })
+      .catch((err: any) => {
+        dispatchTerminal = 'error';
+        const dispatchFailure = err instanceof Error ? err : new Error(String(err));
+        dispatchFailureMessage = dispatchFailure.message;
+        push({ type: 'error', error: dispatchFailure });
+      });
 
     // Yield events as they arrive
     let terminalState: 'cancelled' | 'completed' | 'failed' = 'cancelled';
@@ -794,6 +804,27 @@ export class DkgChannelPlugin {
     } finally {
       clearTimeout(timer);
       aborted = true; // Stop dangling deliver() callbacks from queuing
+
+      if (terminalState === 'cancelled') {
+        const queuedTerminal = [...queue].reverse().find(
+          (item): item is { type: 'done' } | { type: 'error'; error: Error } =>
+            item.type === 'done' || item.type === 'error',
+        );
+        if (queuedTerminal?.type === 'done' || dispatchTerminal === 'done') {
+          try {
+            finalText = finalizeAgentReplyText(replyText);
+            terminalState = 'completed';
+          } catch (err) {
+            terminalState = 'failed';
+            failureReason = getErrorMessage(err);
+          }
+        } else if (queuedTerminal?.type === 'error' || dispatchTerminal === 'error') {
+          const queuedTerminalError: Error | null =
+            queuedTerminal && queuedTerminal.type === 'error' ? queuedTerminal.error : null;
+          terminalState = 'failed';
+          failureReason = queuedTerminalError?.message ?? dispatchFailureMessage ?? failureReason;
+        }
+      }
 
       if (terminalState === 'completed' && finalText) {
         this.queueTurnPersistence(text, finalText, correlationId, identity, undefined, true);

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -84,6 +84,7 @@ export class DkgChannelPlugin {
   private readonly maxInFlight = 3;
   private stopping = false;
   private readonly stopWaiters: Array<() => void> = [];
+  private stopDrainDeadlineAt: number | null = null;
 
   constructor(
     private readonly config: NonNullable<DkgOpenClawConfig['channel']>,
@@ -98,6 +99,7 @@ export class DkgChannelPlugin {
 
   register(api: OpenClawPluginApi): void {
     this.stopping = false;
+    this.stopDrainDeadlineAt = null;
     this.api = api;
     const log = api.logger;
 
@@ -211,6 +213,7 @@ export class DkgChannelPlugin {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    this.stopDrainDeadlineAt = Date.now() + STOP_DRAIN_TIMEOUT_MS;
 
     // Reject all pending requests
     for (const [id, pending] of this.pendingRequests) {
@@ -280,6 +283,12 @@ export class DkgChannelPlugin {
       this.stopWaiters.push(waiter);
       this.notifyStopIdle();
     });
+  }
+
+  private canContinuePersistenceAttempt(allowDuringShutdown: boolean): boolean {
+    if (!this.stopping) return true;
+    if (!allowDuringShutdown) return false;
+    return (this.stopDrainDeadlineAt ?? 0) > Date.now();
   }
 
   // ---------------------------------------------------------------------------
@@ -957,10 +966,10 @@ export class DkgChannelPlugin {
     opts?: PersistTurnOptions,
     allowDuringShutdown = false,
   ): void {
-    if ((this.stopping && !allowDuringShutdown) || this.pendingTurnPersistence.has(correlationId)) return;
+    if (!this.canContinuePersistenceAttempt(allowDuringShutdown) || this.pendingTurnPersistence.has(correlationId)) return;
 
     const attemptPersist = (attempt: number): void => {
-      if (this.stopping && !allowDuringShutdown) return;
+      if (!this.canContinuePersistenceAttempt(allowDuringShutdown)) return;
       this.pendingTurnPersistence.set(correlationId, { attempt, timer: null });
       void this.persistTurn(userMessage, assistantReply, correlationId, identity, opts)
         .then(() => {
@@ -971,7 +980,7 @@ export class DkgChannelPlugin {
           if (!currentJob) {
             return;
           }
-          if (this.stopping) {
+          if (!this.canContinuePersistenceAttempt(allowDuringShutdown)) {
             this.deletePendingTurnPersistence(correlationId);
             return;
           }
@@ -989,7 +998,7 @@ export class DkgChannelPlugin {
             `[dkg-channel] Turn persistence failed (attempt ${attempt}); retrying in ${retryDelayMs}ms: ${err.message}`,
           );
           const timer = setTimeout(() => {
-            if (this.stopping) {
+            if (!this.canContinuePersistenceAttempt(allowDuringShutdown)) {
               this.deletePendingTurnPersistence(correlationId);
               return;
             }

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -249,13 +249,23 @@ export class DkgChannelPlugin {
       this.api?.logger.warn?.(
         `[dkg-channel] Channel stop timed out after ${STOP_DRAIN_TIMEOUT_MS}ms waiting for turn persistence to drain; continuing shutdown`,
       );
+      this.clearPendingTurnPersistence();
     }
+    this.stopDrainDeadlineAt = null;
   }
 
   private deletePendingTurnPersistence(correlationId: string): void {
     const job = this.pendingTurnPersistence.get(correlationId);
     if (job?.timer) clearTimeout(job.timer);
     this.pendingTurnPersistence.delete(correlationId);
+    this.notifyStopIdle();
+  }
+
+  private clearPendingTurnPersistence(): void {
+    for (const job of this.pendingTurnPersistence.values()) {
+      if (job.timer) clearTimeout(job.timer);
+    }
+    this.pendingTurnPersistence.clear();
     this.notifyStopIdle();
   }
 

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -420,7 +420,7 @@ export class DkgChannelPlugin {
       try {
         const reply = await this.dispatchViaPluginSdk(text, correlationId, identity);
         // Fire-and-forget: persist turn to DKG graph for Agent Hub visualization
-        this.queueTurnPersistence(text, reply.text, correlationId, identity);
+        this.queueTurnPersistence(text, reply.text, correlationId, identity, undefined, true);
         return reply;
       } catch (err: any) {
         api.logger.warn?.(`[dkg-channel] dispatchViaPluginSdk failed: ${err.message}`);
@@ -439,7 +439,7 @@ export class DkgChannelPlugin {
         text,
         correlationId,
       });
-      this.queueTurnPersistence(text, reply.text, correlationId, identity || 'owner');
+      this.queueTurnPersistence(text, reply.text, correlationId, identity || 'owner', undefined, true);
       return reply;
     }
 

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -82,6 +82,7 @@ export class DkgChannelPlugin {
   private inFlight = 0;
   private readonly maxInFlight = 3;
   private stopping = false;
+  private readonly stopWaiters: Array<() => void> = [];
 
   constructor(
     private readonly config: NonNullable<DkgOpenClawConfig['channel']>,
@@ -218,8 +219,9 @@ export class DkgChannelPlugin {
     }
 
     for (const [id, job] of this.pendingTurnPersistence) {
-      if (job.timer) clearTimeout(job.timer);
-      this.pendingTurnPersistence.delete(id);
+      if (!job.timer) continue;
+      clearTimeout(job.timer);
+      this.deletePendingTurnPersistence(id);
     }
 
     if (this.serverStart) {
@@ -232,6 +234,32 @@ export class DkgChannelPlugin {
       });
       this.server = null;
     }
+
+    await this.waitForStopDrain();
+  }
+
+  private deletePendingTurnPersistence(correlationId: string): void {
+    const job = this.pendingTurnPersistence.get(correlationId);
+    if (job?.timer) clearTimeout(job.timer);
+    this.pendingTurnPersistence.delete(correlationId);
+    this.notifyStopIdle();
+  }
+
+  private notifyStopIdle(): void {
+    if (!this.stopping || this.inFlight > 0 || this.pendingTurnPersistence.size > 0) return;
+    while (this.stopWaiters.length > 0) {
+      this.stopWaiters.shift()?.();
+    }
+  }
+
+  private waitForStopDrain(): Promise<void> {
+    if (this.inFlight === 0 && this.pendingTurnPersistence.size === 0) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.stopWaiters.push(resolve);
+      this.notifyStopIdle();
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -723,26 +751,26 @@ export class DkgChannelPlugin {
       clearTimeout(timer);
       aborted = true; // Stop dangling deliver() callbacks from queuing
 
-      if (!this.stopping) {
-        if (terminalState === 'completed' && finalText) {
-          this.queueTurnPersistence(text, finalText, correlationId, identity);
-        } else if (terminalState === 'failed') {
-          this.queueTurnPersistence(
-            text,
-            this.buildFailedAssistantReply(failureReason),
-            correlationId,
-            identity,
-            { persistenceState: 'failed', failureReason },
-          );
-        } else {
-          this.queueTurnPersistence(
-            text,
-            CANCELLED_TURN_MESSAGE,
-            correlationId,
-            identity,
-            { persistenceState: 'failed', failureReason: 'cancelled' },
-          );
-        }
+      if (terminalState === 'completed' && finalText) {
+        this.queueTurnPersistence(text, finalText, correlationId, identity, undefined, true);
+      } else if (terminalState === 'failed') {
+        this.queueTurnPersistence(
+          text,
+          this.buildFailedAssistantReply(failureReason),
+          correlationId,
+          identity,
+          { persistenceState: 'failed', failureReason },
+          true,
+        );
+      } else {
+        this.queueTurnPersistence(
+          text,
+          CANCELLED_TURN_MESSAGE,
+          correlationId,
+          identity,
+          { persistenceState: 'failed', failureReason: 'cancelled' },
+          true,
+        );
       }
     }
 
@@ -907,26 +935,30 @@ export class DkgChannelPlugin {
     correlationId: string,
     identity: string,
     opts?: PersistTurnOptions,
+    allowDuringShutdown = false,
   ): void {
-    if (this.stopping || this.pendingTurnPersistence.has(correlationId)) return;
+    if ((this.stopping && !allowDuringShutdown) || this.pendingTurnPersistence.has(correlationId)) return;
 
     const attemptPersist = (attempt: number): void => {
-      if (this.stopping) return;
+      if (this.stopping && !allowDuringShutdown) return;
       this.pendingTurnPersistence.set(correlationId, { attempt, timer: null });
       void this.persistTurn(userMessage, assistantReply, correlationId, identity, opts)
         .then(() => {
-          this.pendingTurnPersistence.delete(correlationId);
+          this.deletePendingTurnPersistence(correlationId);
         })
         .catch((err: any) => {
           const currentJob = this.pendingTurnPersistence.get(correlationId);
-          if (this.stopping || !currentJob) {
-            this.pendingTurnPersistence.delete(correlationId);
+          if (!currentJob) {
+            return;
+          }
+          if (this.stopping) {
+            this.deletePendingTurnPersistence(correlationId);
             return;
           }
 
           const retryDelayMs = TURN_PERSIST_RETRY_DELAYS_MS[attempt - 1];
           if (retryDelayMs == null) {
-            this.pendingTurnPersistence.delete(correlationId);
+            this.deletePendingTurnPersistence(correlationId);
             this.api?.logger.warn?.(
               `[dkg-channel] Turn persistence failed permanently after ${attempt} attempt(s): ${err.message}`,
             );
@@ -938,7 +970,7 @@ export class DkgChannelPlugin {
           );
           const timer = setTimeout(() => {
             if (this.stopping) {
-              this.pendingTurnPersistence.delete(correlationId);
+              this.deletePendingTurnPersistence(correlationId);
               return;
             }
             const job = this.pendingTurnPersistence.get(correlationId);
@@ -1038,6 +1070,7 @@ export class DkgChannelPlugin {
       }
     } finally {
       this.inFlight--;
+      this.notifyStopIdle();
       const durationMs = Date.now() - start;
       this.api?.logger.info?.(`[dkg-channel] handleInboundHttp completed in ${durationMs}ms`);
     }
@@ -1102,6 +1135,7 @@ export class DkgChannelPlugin {
       if (!res.writableEnded) res.end();
     } finally {
       this.inFlight--;
+      this.notifyStopIdle();
       const durationMs = Date.now() - start;
       this.api?.logger.info?.(`[dkg-channel] handleInboundStreamHttp completed in ${durationMs}ms`);
     }

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -190,8 +190,8 @@ export class DkgNodePlugin {
 
   private async syncLocalAgentIntegrationState(api: OpenClawPluginApi, registrationMode: string): Promise<void> {
     const existing = await this.loadStoredOpenClawIntegration(api);
-    if (existing?.enabled === false || existing?.runtime?.status === 'disconnected') {
-      api.logger.info?.('[dkg] Stored OpenClaw integration is disconnected; skipping startup re-registration');
+    if (this.wasOpenClawExplicitlyUserDisconnected(existing)) {
+      api.logger.info?.('[dkg] Stored OpenClaw integration was explicitly disconnected by the user; skipping startup re-registration');
       return;
     }
 
@@ -267,14 +267,17 @@ export class DkgNodePlugin {
     }
   }
 
+  private wasOpenClawExplicitlyUserDisconnected(existing: LocalAgentIntegrationRecord | null): boolean {
+    if (!existing) return false;
+    if (existing.metadata?.userDisabled === true) return true;
+    return Boolean(existing.connectedAt && existing.enabled === false && existing.runtime?.status === 'disconnected');
+  }
+
   private buildOpenClawTransport(
     existing?: LocalAgentIntegrationTransport,
     api?: OpenClawPluginApi,
   ): LocalAgentIntegrationTransport {
-    const transport: LocalAgentIntegrationTransport = {
-      ...(existing ?? {}),
-      kind: 'openclaw-channel',
-    };
+    const transport: LocalAgentIntegrationTransport = { kind: 'openclaw-channel' };
     if (!this.channelPlugin) return transport;
 
     const gatewayBaseUrl = this.resolveGatewayBaseUrl(api, existing?.gatewayUrl);

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -42,6 +42,7 @@ const OPENCLAW_LOCAL_AGENT_MANIFEST = {
   packageName: '@origintrail-official/dkg-adapter-openclaw',
   setupEntry: './setup-entry.mjs',
 } as const;
+const LOCAL_AGENT_STATE_RETRY_DELAY_MS = 1_000;
 
 export class DkgNodePlugin {
   private readonly config: DkgOpenClawConfig;
@@ -56,6 +57,7 @@ export class DkgNodePlugin {
   /** Guard: backlog import runs at most once per plugin lifecycle. */
   private backlogImportDone: Promise<void> | null = null;
   private warnedLegacyGameConfig = false;
+  private localAgentIntegrationRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config?: DkgOpenClawConfig) {
     this.config = { ...config };
@@ -174,7 +176,22 @@ export class DkgNodePlugin {
       return;
     }
 
+    this.clearLocalAgentIntegrationRetry();
     void this.syncLocalAgentIntegrationState(api, registrationMode);
+  }
+
+  private clearLocalAgentIntegrationRetry(): void {
+    if (!this.localAgentIntegrationRetryTimer) return;
+    clearTimeout(this.localAgentIntegrationRetryTimer);
+    this.localAgentIntegrationRetryTimer = null;
+  }
+
+  private scheduleLocalAgentIntegrationRetry(api: OpenClawPluginApi, registrationMode: string): void {
+    if (this.localAgentIntegrationRetryTimer) return;
+    this.localAgentIntegrationRetryTimer = setTimeout(() => {
+      this.localAgentIntegrationRetryTimer = null;
+      void this.syncLocalAgentIntegrationState(api, registrationMode);
+    }, LOCAL_AGENT_STATE_RETRY_DELAY_MS);
   }
 
   private warnOnLegacyGameConfig(api: OpenClawPluginApi): void {
@@ -192,8 +209,10 @@ export class DkgNodePlugin {
     const existing = await this.loadStoredOpenClawIntegration(api);
     if (existing === undefined) {
       api.logger.warn?.('[dkg] Stored OpenClaw integration state could not be loaded; aborting startup re-registration to preserve any persisted disconnect state');
+      this.scheduleLocalAgentIntegrationRetry(api, registrationMode);
       return;
     }
+    this.clearLocalAgentIntegrationRetry();
     if (this.wasOpenClawExplicitlyUserDisconnected(existing)) {
       api.logger.info?.('[dkg] Stored OpenClaw integration was explicitly disconnected by the user; skipping startup re-registration');
       return;
@@ -382,6 +401,7 @@ export class DkgNodePlugin {
 
   async stop(): Promise<void> {
     // Stop integration modules
+    this.clearLocalAgentIntegrationRetry();
     this.writeCapture?.stop();
     await this.channelPlugin?.stop();
   }

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -14,7 +14,11 @@
 import { readFile } from 'node:fs/promises';
 import { existsSync, readdirSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
-import { DkgDaemonClient } from './dkg-client.js';
+import {
+  DkgDaemonClient,
+  type LocalAgentIntegrationRecord,
+  type LocalAgentIntegrationTransport,
+} from './dkg-client.js';
 import { DkgChannelPlugin } from './DkgChannelPlugin.js';
 import { DkgMemoryPlugin } from './DkgMemoryPlugin.js';
 import { WriteCapture } from './write-capture.js';
@@ -170,64 +174,7 @@ export class DkgNodePlugin {
       return;
     }
 
-    const metadata = {
-      channelId: 'dkg-ui',
-      registrationMode,
-      transportMode: this.channelPlugin.isUsingGatewayRoute ? 'gateway+bridge' : 'bridge',
-    };
-    const bridgeAlreadyReady = this.channelPlugin.isListening;
-    const basePayload = {
-      id: 'openclaw',
-      enabled: true,
-      description: 'Connect a local OpenClaw agent through the DKG node.',
-      transport: this.buildOpenClawTransport(),
-      capabilities: OPENCLAW_LOCAL_AGENT_CAPABILITIES,
-      manifest: OPENCLAW_LOCAL_AGENT_MANIFEST,
-      setupEntry: OPENCLAW_LOCAL_AGENT_MANIFEST.setupEntry,
-      metadata,
-    };
-
-    this.client.connectLocalAgentIntegration({
-      ...basePayload,
-      runtime: {
-        status: bridgeAlreadyReady ? 'ready' : 'connecting',
-        ready: bridgeAlreadyReady,
-        lastError: null,
-      },
-    }).catch(err => {
-      api.logger.warn?.(`[dkg] Local agent registration failed (will retry on next gateway start): ${err.message}`);
-    });
-
-    if (bridgeAlreadyReady) {
-      return;
-    }
-
-    void this.channelPlugin.start()
-      .then(() => this.client.updateLocalAgentIntegration('openclaw', {
-        ...basePayload,
-        transport: this.buildOpenClawTransport(),
-        runtime: {
-          status: 'ready',
-          ready: true,
-          lastError: null,
-        },
-      }))
-      .catch(async (err: any) => {
-        api.logger.warn?.(`[dkg] OpenClaw channel startup did not reach ready state: ${err.message}`);
-        try {
-          await this.client.updateLocalAgentIntegration('openclaw', {
-            ...basePayload,
-            transport: this.buildOpenClawTransport(),
-            runtime: {
-              status: 'error',
-              ready: false,
-              lastError: err.message ?? String(err),
-            },
-          });
-        } catch (updateErr: any) {
-          api.logger.warn?.(`[dkg] Failed to persist OpenClaw channel error state: ${updateErr.message}`);
-        }
-      });
+    void this.syncLocalAgentIntegrationState(api, registrationMode);
   }
 
   private warnOnLegacyGameConfig(api: OpenClawPluginApi): void {
@@ -241,11 +188,99 @@ export class DkgNodePlugin {
     }
   }
 
-  private buildOpenClawTransport(): { kind: string; bridgeUrl?: string; healthUrl?: string } {
-    const transport: { kind: string; bridgeUrl?: string; healthUrl?: string } = {
+  private async syncLocalAgentIntegrationState(api: OpenClawPluginApi, registrationMode: string): Promise<void> {
+    const existing = await this.loadStoredOpenClawIntegration(api);
+    if (existing?.enabled === false || existing?.runtime?.status === 'disconnected') {
+      api.logger.info?.('[dkg] Stored OpenClaw integration is disconnected; skipping startup re-registration');
+      return;
+    }
+
+    const metadata = {
+      channelId: 'dkg-ui',
+      registrationMode,
+      transportMode: this.channelPlugin?.isUsingGatewayRoute ? 'gateway+bridge' : 'bridge',
+    };
+    const bridgeAlreadyReady = this.channelPlugin?.isListening === true;
+    const basePayload = {
+      id: 'openclaw',
+      enabled: true,
+      description: 'Connect a local OpenClaw agent through the DKG node.',
+      transport: this.buildOpenClawTransport(existing?.transport, api),
+      capabilities: OPENCLAW_LOCAL_AGENT_CAPABILITIES,
+      manifest: OPENCLAW_LOCAL_AGENT_MANIFEST,
+      setupEntry: OPENCLAW_LOCAL_AGENT_MANIFEST.setupEntry,
+      metadata,
+    };
+
+    try {
+      await this.client.connectLocalAgentIntegration({
+        ...basePayload,
+        runtime: {
+          status: bridgeAlreadyReady ? 'ready' : 'connecting',
+          ready: bridgeAlreadyReady,
+          lastError: null,
+        },
+      });
+    } catch (err: any) {
+      api.logger.warn?.(`[dkg] Local agent registration failed (will retry on next gateway start): ${err.message}`);
+      return;
+    }
+
+    if (bridgeAlreadyReady || !this.channelPlugin) {
+      return;
+    }
+
+    void this.channelPlugin.start()
+      .then(() => this.client.updateLocalAgentIntegration('openclaw', {
+        ...basePayload,
+        transport: this.buildOpenClawTransport(existing?.transport, api),
+        runtime: {
+          status: 'ready',
+          ready: true,
+          lastError: null,
+        },
+      }))
+      .catch(async (err: any) => {
+        api.logger.warn?.(`[dkg] OpenClaw channel startup did not reach ready state: ${err.message}`);
+        try {
+          await this.client.updateLocalAgentIntegration('openclaw', {
+            ...basePayload,
+            transport: this.buildOpenClawTransport(existing?.transport, api),
+            runtime: {
+              status: 'error',
+              ready: false,
+              lastError: err.message ?? String(err),
+            },
+          });
+        } catch (updateErr: any) {
+          api.logger.warn?.(`[dkg] Failed to persist OpenClaw channel error state: ${updateErr.message}`);
+        }
+      });
+  }
+
+  private async loadStoredOpenClawIntegration(api: OpenClawPluginApi): Promise<LocalAgentIntegrationRecord | null> {
+    try {
+      return await this.client.getLocalAgentIntegration('openclaw');
+    } catch (err: any) {
+      api.logger.warn?.(`[dkg] Failed to load stored OpenClaw integration state: ${err.message}`);
+      return null;
+    }
+  }
+
+  private buildOpenClawTransport(
+    existing?: LocalAgentIntegrationTransport,
+    api?: OpenClawPluginApi,
+  ): LocalAgentIntegrationTransport {
+    const transport: LocalAgentIntegrationTransport = {
+      ...(existing ?? {}),
       kind: 'openclaw-channel',
     };
     if (!this.channelPlugin) return transport;
+
+    const gatewayBaseUrl = this.resolveGatewayBaseUrl(api, existing?.gatewayUrl);
+    if (this.channelPlugin.isUsingGatewayRoute && gatewayBaseUrl) {
+      transport.gatewayUrl = gatewayBaseUrl;
+    }
 
     const bridgePort = this.channelPlugin.bridgePort;
     if (bridgePort > 0) {
@@ -254,6 +289,49 @@ export class DkgNodePlugin {
     }
 
     return transport;
+  }
+
+  private resolveGatewayBaseUrl(api?: OpenClawPluginApi, existingGatewayUrl?: string): string | undefined {
+    const rawGateway = api?.config && typeof api.config === 'object'
+      ? (api.config as Record<string, unknown>).gateway
+      : undefined;
+    const gateway = rawGateway && typeof rawGateway === 'object'
+      ? rawGateway as Record<string, unknown>
+      : undefined;
+    const rawPort = gateway?.port ?? process.env.OPENCLAW_GATEWAY_PORT;
+    const hasExplicitPort = rawPort !== undefined && rawPort !== null && String(rawPort).trim() !== '';
+    if (!hasExplicitPort && existingGatewayUrl?.trim()) {
+      return existingGatewayUrl.trim();
+    }
+
+    const port = this.normalizePort(rawPort) ?? 18789;
+    const rawCustomHost = typeof gateway?.customBindHost === 'string' ? gateway.customBindHost.trim() : '';
+    const configuredHost = rawCustomHost || '127.0.0.1';
+    const host = this.normalizeGatewayHost(configuredHost);
+    const tls = gateway?.tls && typeof gateway.tls === 'object'
+      ? gateway.tls as Record<string, unknown>
+      : undefined;
+    const protocol = tls?.enabled === true ? 'https' : 'http';
+    return `${protocol}://${host}:${port}`;
+  }
+
+  private normalizePort(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+      return value;
+    }
+    if (typeof value === 'string' && value.trim()) {
+      const parsed = Number.parseInt(value, 10);
+      return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    }
+    return null;
+  }
+
+  private normalizeGatewayHost(value: string): string {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === '0.0.0.0' || trimmed === '::' || trimmed === '[::]') {
+      return '127.0.0.1';
+    }
+    return trimmed;
   }
 
   async stop(): Promise<void> {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -299,8 +299,11 @@ export class DkgNodePlugin {
       ? rawGateway as Record<string, unknown>
       : undefined;
     const rawPort = gateway?.port ?? process.env.OPENCLAW_GATEWAY_PORT;
-    const hasExplicitPort = rawPort !== undefined && rawPort !== null && String(rawPort).trim() !== '';
-    if (!hasExplicitPort && existingGatewayUrl?.trim()) {
+    const tls = gateway?.tls && typeof gateway.tls === 'object'
+      ? gateway.tls as Record<string, unknown>
+      : undefined;
+    const hasCurrentGatewayConfig = this.hasGatewayConfig(gateway, rawPort, tls);
+    if (!hasCurrentGatewayConfig && existingGatewayUrl?.trim()) {
       return existingGatewayUrl.trim();
     }
 
@@ -308,11 +311,31 @@ export class DkgNodePlugin {
     const rawCustomHost = typeof gateway?.customBindHost === 'string' ? gateway.customBindHost.trim() : '';
     const configuredHost = rawCustomHost || '127.0.0.1';
     const host = this.normalizeGatewayHost(configuredHost);
-    const tls = gateway?.tls && typeof gateway.tls === 'object'
-      ? gateway.tls as Record<string, unknown>
-      : undefined;
     const protocol = tls?.enabled === true ? 'https' : 'http';
-    return `${protocol}://${host}:${port}`;
+    return this.formatGatewayBaseUrl(protocol, host, port);
+  }
+
+  private hasGatewayConfig(
+    gateway: Record<string, unknown> | undefined,
+    rawPort: unknown,
+    tls: Record<string, unknown> | undefined,
+  ): boolean {
+    if (rawPort !== undefined && rawPort !== null && String(rawPort).trim() !== '') {
+      return true;
+    }
+    if (!gateway) return false;
+    const hasCustomBindHost = typeof gateway.customBindHost === 'string' && gateway.customBindHost.trim() !== '';
+    if (hasCustomBindHost) return true;
+    return Boolean(tls && Object.keys(tls).length > 0);
+  }
+
+  private formatGatewayBaseUrl(protocol: 'http' | 'https', host: string, port: number): string {
+    const formattedHost = host.includes(':') && !host.startsWith('[')
+      ? `[${host}]`
+      : host;
+    const url = new URL(`${protocol}://${formattedHost}`);
+    url.port = String(port);
+    return url.toString().replace(/\/$/, '');
   }
 
   private normalizePort(value: unknown): number | null {
@@ -330,6 +353,9 @@ export class DkgNodePlugin {
     const trimmed = value.trim();
     if (!trimmed || trimmed === '0.0.0.0' || trimmed === '::' || trimmed === '[::]') {
       return '127.0.0.1';
+    }
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      return trimmed.slice(1, -1);
     }
     return trimmed;
   }

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -303,7 +303,10 @@ export class DkgNodePlugin {
     const transport: LocalAgentIntegrationTransport = { kind: 'openclaw-channel' };
     if (!this.channelPlugin) return transport;
 
-    const gatewayBaseUrl = this.resolveGatewayBaseUrl(api, existing?.gatewayUrl);
+    const gatewayBaseUrl = this.resolveGatewayBaseUrl(
+      api,
+      this.channelPlugin.isUsingGatewayRoute ? undefined : existing?.gatewayUrl,
+    );
     if (this.channelPlugin.isUsingGatewayRoute && gatewayBaseUrl) {
       transport.gatewayUrl = gatewayBaseUrl;
     }

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -289,6 +289,15 @@ export class DkgNodePlugin {
     if (bridgePort > 0) {
       transport.bridgeUrl = `http://127.0.0.1:${bridgePort}`;
       transport.healthUrl = `${transport.bridgeUrl}/health`;
+    } else {
+      const existingBridgeUrl = existing?.bridgeUrl?.trim();
+      const existingHealthUrl = existing?.healthUrl?.trim();
+      if (existingBridgeUrl) {
+        transport.bridgeUrl = existingBridgeUrl;
+      }
+      if (existingHealthUrl) {
+        transport.healthUrl = existingHealthUrl;
+      }
     }
 
     return transport;

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -342,7 +342,11 @@ export class DkgNodePlugin {
     if (!gateway) return false;
     const hasCustomBindHost = typeof gateway.customBindHost === 'string' && gateway.customBindHost.trim() !== '';
     if (hasCustomBindHost) return true;
-    return Boolean(tls && Object.keys(tls).length > 0);
+    if (!tls) return false;
+    const tlsKeys = Object.keys(tls);
+    if (tlsKeys.length === 0) return false;
+    if (tlsKeys.length === 1 && tls.enabled === false) return false;
+    return true;
   }
 
   private formatGatewayBaseUrl(protocol: 'http' | 'https', host: string, port: number): string {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -190,6 +190,10 @@ export class DkgNodePlugin {
 
   private async syncLocalAgentIntegrationState(api: OpenClawPluginApi, registrationMode: string): Promise<void> {
     const existing = await this.loadStoredOpenClawIntegration(api);
+    if (existing === undefined) {
+      api.logger.warn?.('[dkg] Stored OpenClaw integration state could not be loaded; aborting startup re-registration to preserve any persisted disconnect state');
+      return;
+    }
     if (this.wasOpenClawExplicitlyUserDisconnected(existing)) {
       api.logger.info?.('[dkg] Stored OpenClaw integration was explicitly disconnected by the user; skipping startup re-registration');
       return;
@@ -258,12 +262,12 @@ export class DkgNodePlugin {
       });
   }
 
-  private async loadStoredOpenClawIntegration(api: OpenClawPluginApi): Promise<LocalAgentIntegrationRecord | null> {
+  private async loadStoredOpenClawIntegration(api: OpenClawPluginApi): Promise<LocalAgentIntegrationRecord | null | undefined> {
     try {
       return await this.client.getLocalAgentIntegration('openclaw');
     } catch (err: any) {
       api.logger.warn?.(`[dkg] Failed to load stored OpenClaw integration state: ${err.message}`);
-      return null;
+      return undefined;
     }
   }
 

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -59,6 +59,10 @@ export interface LocalAgentIntegrationPayload {
   runtime?: LocalAgentIntegrationRuntime;
 }
 
+export interface LocalAgentIntegrationRecord extends LocalAgentIntegrationPayload {
+  status?: string;
+}
+
 export class DkgDaemonClient {
   readonly baseUrl: string;
   private readonly timeoutMs: number;
@@ -149,7 +153,12 @@ export class DkgDaemonClient {
     sessionId: string,
     userMessage: string,
     assistantReply: string,
-    opts?: { turnId?: string; toolCalls?: Array<{ name: string; args: Record<string, unknown>; result: unknown }> },
+    opts?: {
+      turnId?: string;
+      toolCalls?: Array<{ name: string; args: Record<string, unknown>; result: unknown }>;
+      persistenceState?: 'stored' | 'failed' | 'pending';
+      failureReason?: string | null;
+    },
   ): Promise<void> {
     await this.post('/api/openclaw-channel/persist-turn', {
       sessionId,
@@ -157,6 +166,8 @@ export class DkgDaemonClient {
       assistantReply,
       turnId: opts?.turnId,
       toolCalls: opts?.toolCalls,
+      persistenceState: opts?.persistenceState,
+      failureReason: opts?.failureReason,
     });
   }
 
@@ -186,6 +197,20 @@ export class DkgDaemonClient {
 
   async connectLocalAgentIntegration(payload: LocalAgentIntegrationPayload): Promise<Record<string, unknown>> {
     return this.post('/api/local-agent-integrations/connect', payload);
+  }
+
+  async getLocalAgentIntegration(id: string): Promise<LocalAgentIntegrationRecord | null> {
+    try {
+      const response = await this.get<{ integration?: LocalAgentIntegrationRecord }>(
+        `/api/local-agent-integrations/${encodeURIComponent(id)}`,
+      );
+      return response.integration ?? null;
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('responded 404')) {
+        return null;
+      }
+      throw err;
+    }
   }
 
   async updateLocalAgentIntegration(

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -61,6 +61,8 @@ export interface LocalAgentIntegrationPayload {
 
 export interface LocalAgentIntegrationRecord extends LocalAgentIntegrationPayload {
   status?: string;
+  connectedAt?: string;
+  updatedAt?: string;
 }
 
 export class DkgDaemonClient {

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -268,6 +268,40 @@ export interface DkgConfigOverrides {
   portExplicit?: boolean;
 }
 
+function migrateLegacyOpenClawTransport(existing: Record<string, any>): void {
+  const legacyTransport = existing.openclawChannel;
+  if (!legacyTransport || typeof legacyTransport !== 'object') return;
+
+  const bridgeUrl = typeof legacyTransport.bridgeUrl === 'string' && legacyTransport.bridgeUrl.trim()
+    ? legacyTransport.bridgeUrl.trim()
+    : undefined;
+  const gatewayUrl = typeof legacyTransport.gatewayUrl === 'string' && legacyTransport.gatewayUrl.trim()
+    ? legacyTransport.gatewayUrl.trim()
+    : undefined;
+  if (!bridgeUrl && !gatewayUrl) return;
+
+  if (!existing.localAgentIntegrations || typeof existing.localAgentIntegrations !== 'object') {
+    existing.localAgentIntegrations = {};
+  }
+
+  const currentOpenClaw = existing.localAgentIntegrations.openclaw && typeof existing.localAgentIntegrations.openclaw === 'object'
+    ? existing.localAgentIntegrations.openclaw
+    : {};
+  const currentTransport = currentOpenClaw.transport && typeof currentOpenClaw.transport === 'object'
+    ? currentOpenClaw.transport
+    : {};
+
+  existing.localAgentIntegrations.openclaw = {
+    ...currentOpenClaw,
+    transport: {
+      kind: currentTransport.kind ?? 'openclaw-channel',
+      ...(bridgeUrl ? { bridgeUrl } : {}),
+      ...(gatewayUrl ? { gatewayUrl } : {}),
+      ...currentTransport,
+    },
+  };
+}
+
 export function writeDkgConfig(
   agentName: string,
   network: NetworkConfig,
@@ -289,6 +323,7 @@ export function writeDkgConfig(
       warn(`Could not parse existing ${configPath} — will overwrite`);
     }
   }
+  migrateLegacyOpenClawTransport(existing);
   delete existing.openclawAdapter;
   delete existing.openclawChannel;
 

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -603,7 +603,7 @@ describe('DkgChannelPlugin', () => {
     );
   });
 
-  it('processInboundStream should not persist a partial reply when the consumer cancels early', async () => {
+  it('processInboundStream should persist a cancelled turn without storing the partial reply text', async () => {
     let resumeDispatch!: () => void;
     const mockRuntime = {
       channel: {
@@ -646,7 +646,16 @@ describe('DkgChannelPlugin', () => {
     resumeDispatch();
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    expect(storeSpy).not.toHaveBeenCalled();
+    expect(storeSpy).toHaveBeenCalledWith(
+      'openclaw:dkg-ui',
+      'Hello',
+      '[OpenClaw reply cancelled before completion]',
+      {
+        turnId: 'corr-stream-cancel',
+        persistenceState: 'failed',
+        failureReason: 'cancelled',
+      },
+    );
   });
 
   it('processInboundStream should surface a real error when the agent returns no text', async () => {
@@ -679,7 +688,17 @@ describe('DkgChannelPlugin', () => {
 
     const stream = plugin.processInboundStream('Hello', 'corr-stream-empty', 'owner');
     await expect(stream.next()).rejects.toThrow('Agent returned no text response');
-    expect(storeSpy).not.toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(storeSpy).toHaveBeenCalledWith(
+      'openclaw:dkg-ui',
+      'Hello',
+      '[OpenClaw reply failed before completion: Agent returned no text response]',
+      {
+        turnId: 'corr-stream-empty',
+        persistenceState: 'failed',
+        failureReason: 'Agent returned no text response',
+      },
+    );
   });
 
   it('processInboundStream should request block streaming when plugin-sdk helpers are available', async () => {
@@ -757,5 +776,54 @@ describe('DkgChannelPlugin', () => {
 
     await plugin.stop();
     await plugin.stop();
+  });
+
+  it('stop should prevent a late persistence failure from scheduling retries after shutdown', async () => {
+    vi.useFakeTimers();
+    try {
+      let rejectPersist!: (err: Error) => void;
+      const mockRuntime = {
+        channel: {
+          routing: {
+            resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+          },
+          session: {
+            resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+            readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+            recordInboundSession: vi.fn(),
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+            formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+            async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+              await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
+            },
+          },
+        },
+      };
+      const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+
+      const api = makeApi() as any;
+      api.runtime = mockRuntime;
+      api.cfg = mockCfg;
+      const storeSpy = vi.spyOn(client, 'storeChatTurn').mockImplementationOnce(() =>
+        new Promise<void>((_resolve, reject) => {
+          rejectPersist = reject;
+        }),
+      );
+      plugin.register(api);
+
+      await plugin.processInbound('Hello', 'corr-stop-retry', 'owner');
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+
+      await plugin.stop();
+      rejectPersist(new Error('late persistence failure'));
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -828,65 +828,76 @@ describe('DkgChannelPlugin', () => {
     }
   });
 
-  it('stop should still allow one final turn persistence attempt for a reply that finished during shutdown', async () => {
-    let resumeDispatch!: () => void;
-    const mockRuntime = {
-      channel: {
-        routing: {
-          resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
-        },
-        session: {
-          resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
-          readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
-          recordInboundSession: vi.fn(),
-        },
-        reply: {
-          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
-          formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
-          async dispatchReplyWithBufferedBlockDispatcher(params: any) {
-            await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
-            await new Promise<void>((resolve) => { resumeDispatch = resolve; });
+  it('stop should only wait a bounded time for a final turn persistence attempt that hangs during shutdown', async () => {
+    vi.useFakeTimers();
+    try {
+      let resumeDispatch!: () => void;
+      const mockRuntime = {
+        channel: {
+          routing: {
+            resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+          },
+          session: {
+            resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+            readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+            recordInboundSession: vi.fn(),
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+            formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+            async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+              await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
+              await new Promise<void>((resolve) => { resumeDispatch = resolve; });
+            },
           },
         },
-      },
-    };
-    const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+      };
+      const mockCfg = { session: { dmScope: 'main' }, agents: {} };
 
-    const api = makeApi() as any;
-    api.runtime = mockRuntime;
-    api.cfg = mockCfg;
-    let resolveStore!: () => void;
-    const storePromise = new Promise<void>((resolve) => { resolveStore = resolve; });
-    const storeSpy = vi.spyOn(client, 'storeChatTurn').mockImplementation(() => storePromise);
-    plugin.register(api);
+      const api = makeApi() as any;
+      api.runtime = mockRuntime;
+      api.cfg = mockCfg;
+      let resolveStore!: () => void;
+      const storePromise = new Promise<void>((resolve) => { resolveStore = resolve; });
+      const storeSpy = vi.spyOn(client, 'storeChatTurn').mockImplementation(() => storePromise);
+      plugin.register(api);
 
-    const stream = plugin.processInboundStream('Hello', 'corr-stream-stop-store', 'owner');
-    await expect(stream.next()).resolves.toEqual({
-      done: false,
-      value: { type: 'text_delta', delta: 'Reply before shutdown' },
-    });
+      const stream = plugin.processInboundStream('Hello', 'corr-stream-stop-store', 'owner');
+      await expect(stream.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'text_delta', delta: 'Reply before shutdown' },
+      });
 
-    const nextItem = stream.next();
-    const stopPromise = plugin.stop();
-    resumeDispatch();
-    await expect(nextItem).resolves.toEqual({
-      done: false,
-      value: { type: 'final', text: 'Reply before shutdown', correlationId: 'corr-stream-stop-store' },
-    });
-    await expect(stream.next()).resolves.toEqual({ done: true, value: undefined });
-    let stopSettled = false;
-    void stopPromise.then(() => { stopSettled = true; });
-    await Promise.resolve();
-    expect(stopSettled).toBe(false);
-    resolveStore();
-    await stopPromise;
+      const nextItem = stream.next();
+      const stopPromise = plugin.stop();
+      resumeDispatch();
+      await expect(nextItem).resolves.toEqual({
+        done: false,
+        value: { type: 'final', text: 'Reply before shutdown', correlationId: 'corr-stream-stop-store' },
+      });
+      await expect(stream.next()).resolves.toEqual({ done: true, value: undefined });
 
-    expect(storeSpy).toHaveBeenCalledTimes(1);
-    expect(storeSpy).toHaveBeenCalledWith(
-      'openclaw:dkg-ui',
-      'Hello',
-      'Reply before shutdown',
-      { turnId: 'corr-stream-stop-store' },
-    );
+      let stopSettled = false;
+      void stopPromise.then(() => { stopSettled = true; });
+      await Promise.resolve();
+      expect(stopSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1_500);
+      await stopPromise;
+      expect(stopSettled).toBe(true);
+
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+      expect(storeSpy).toHaveBeenCalledWith(
+        'openclaw:dkg-ui',
+        'Hello',
+        'Reply before shutdown',
+        { turnId: 'corr-stream-stop-store' },
+      );
+
+      resolveStore();
+      await Promise.resolve();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -832,6 +832,62 @@ describe('DkgChannelPlugin', () => {
     }
   });
 
+  it('stop should preserve an already-scheduled shutdown-allowed persistence retry within the bounded drain window', async () => {
+    vi.useFakeTimers();
+    try {
+      const mockRuntime = {
+        channel: {
+          routing: {
+            resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+          },
+          session: {
+            resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+            readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+            recordInboundSession: vi.fn(),
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+            formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+            async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+              await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
+            },
+          },
+        },
+      };
+      const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+
+      const api = makeApi() as any;
+      api.runtime = mockRuntime;
+      api.cfg = mockCfg;
+      const storeSpy = vi.spyOn(client, 'storeChatTurn')
+        .mockRejectedValueOnce(new Error('temporary daemon outage'))
+        .mockResolvedValueOnce(undefined);
+      plugin.register(api);
+
+      await plugin.processInbound('Hello', 'corr-stop-preserve-retry', 'owner');
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+
+      await Promise.resolve();
+      const stopPromise = plugin.stop();
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+
+      expect(storeSpy).toHaveBeenCalledTimes(2);
+      expect(storeSpy).toHaveBeenLastCalledWith(
+        'openclaw:dkg-ui',
+        'Hello',
+        'Reply before shutdown',
+        { turnId: 'corr-stop-preserve-retry' },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('processInbound should still persist a completed non-stream reply when shutdown has already begun', async () => {
     let resumeDispatch!: () => void;
     let markDispatchReady!: () => void;

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -603,7 +603,7 @@ describe('DkgChannelPlugin', () => {
     );
   });
 
-  it('processInboundStream should persist a cancelled turn without storing the partial reply text', async () => {
+  it('processInboundStream should wait for a still-running dispatch to settle before persisting a closed stream', async () => {
     let resumeDispatch!: () => void;
     const mockRuntime = {
       channel: {
@@ -643,18 +643,15 @@ describe('DkgChannelPlugin', () => {
       done: true,
       value: undefined,
     });
+    expect(storeSpy).not.toHaveBeenCalled();
     resumeDispatch();
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(storeSpy).toHaveBeenCalledWith(
       'openclaw:dkg-ui',
       'Hello',
-      '[OpenClaw reply cancelled before completion]',
-      {
-        turnId: 'corr-stream-cancel',
-        persistenceState: 'failed',
-        failureReason: 'cancelled',
-      },
+      'Partial reply',
+      { turnId: 'corr-stream-cancel' },
     );
   });
 

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -816,14 +816,77 @@ describe('DkgChannelPlugin', () => {
       await plugin.processInbound('Hello', 'corr-stop-retry', 'owner');
       expect(storeSpy).toHaveBeenCalledTimes(1);
 
-      await plugin.stop();
+      const stopPromise = plugin.stop();
       rejectPersist(new Error('late persistence failure'));
       await Promise.resolve();
+      await stopPromise;
       await vi.advanceTimersByTimeAsync(2_000);
 
       expect(storeSpy).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('stop should still allow one final turn persistence attempt for a reply that finished during shutdown', async () => {
+    let resumeDispatch!: () => void;
+    const mockRuntime = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+          recordInboundSession: vi.fn(),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+          async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+            await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
+            await new Promise<void>((resolve) => { resumeDispatch = resolve; });
+          },
+        },
+      },
+    };
+    const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+
+    const api = makeApi() as any;
+    api.runtime = mockRuntime;
+    api.cfg = mockCfg;
+    let resolveStore!: () => void;
+    const storePromise = new Promise<void>((resolve) => { resolveStore = resolve; });
+    const storeSpy = vi.spyOn(client, 'storeChatTurn').mockImplementation(() => storePromise);
+    plugin.register(api);
+
+    const stream = plugin.processInboundStream('Hello', 'corr-stream-stop-store', 'owner');
+    await expect(stream.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'text_delta', delta: 'Reply before shutdown' },
+    });
+
+    const nextItem = stream.next();
+    const stopPromise = plugin.stop();
+    resumeDispatch();
+    await expect(nextItem).resolves.toEqual({
+      done: false,
+      value: { type: 'final', text: 'Reply before shutdown', correlationId: 'corr-stream-stop-store' },
+    });
+    await expect(stream.next()).resolves.toEqual({ done: true, value: undefined });
+    let stopSettled = false;
+    void stopPromise.then(() => { stopSettled = true; });
+    await Promise.resolve();
+    expect(stopSettled).toBe(false);
+    resolveStore();
+    await stopPromise;
+
+    expect(storeSpy).toHaveBeenCalledTimes(1);
+    expect(storeSpy).toHaveBeenCalledWith(
+      'openclaw:dkg-ui',
+      'Hello',
+      'Reply before shutdown',
+      { turnId: 'corr-stream-stop-store' },
+    );
   });
 });

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -658,6 +658,53 @@ describe('DkgChannelPlugin', () => {
     );
   });
 
+  it('processInboundStream should persist the completed reply when final completion was already queued before the consumer stopped iterating', async () => {
+    const mockRuntime = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+          recordInboundSession: vi.fn(),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+          async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+            await params.dispatcherOptions.deliver({ text: 'Complete reply' });
+          },
+        },
+      },
+    };
+    const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+
+    const api = makeApi() as any;
+    api.runtime = mockRuntime;
+    api.cfg = mockCfg;
+    const storeSpy = vi.spyOn(client, 'storeChatTurn').mockResolvedValue(undefined);
+    plugin.register(api);
+
+    const stream = plugin.processInboundStream('Hello', 'corr-stream-finished-before-return', 'owner');
+    await expect(stream.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'text_delta', delta: 'Complete reply' },
+    });
+    await expect(stream.return(undefined)).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(storeSpy).toHaveBeenCalledWith(
+      'openclaw:dkg-ui',
+      'Hello',
+      'Complete reply',
+      { turnId: 'corr-stream-finished-before-return' },
+    );
+  });
+
   it('processInboundStream should surface a real error when the agent returns no text', async () => {
     const mockRuntime = {
       channel: {

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -778,7 +778,7 @@ describe('DkgChannelPlugin', () => {
     await plugin.stop();
   });
 
-  it('stop should prevent a late persistence failure from scheduling retries after shutdown', async () => {
+  it('stop should allow a late non-stream persistence failure to retry within the bounded shutdown window', async () => {
     vi.useFakeTimers();
     try {
       let rejectPersist!: (err: Error) => void;
@@ -806,11 +806,13 @@ describe('DkgChannelPlugin', () => {
       const api = makeApi() as any;
       api.runtime = mockRuntime;
       api.cfg = mockCfg;
-      const storeSpy = vi.spyOn(client, 'storeChatTurn').mockImplementationOnce(() =>
-        new Promise<void>((_resolve, reject) => {
-          rejectPersist = reject;
-        }),
-      );
+      const storeSpy = vi.spyOn(client, 'storeChatTurn')
+        .mockImplementationOnce(() =>
+          new Promise<void>((_resolve, reject) => {
+            rejectPersist = reject;
+          }),
+        )
+        .mockResolvedValueOnce(undefined);
       plugin.register(api);
 
       await plugin.processInbound('Hello', 'corr-stop-retry', 'owner');
@@ -819,13 +821,77 @@ describe('DkgChannelPlugin', () => {
       const stopPromise = plugin.stop();
       rejectPersist(new Error('late persistence failure'));
       await Promise.resolve();
-      await stopPromise;
-      await vi.advanceTimersByTimeAsync(2_000);
-
+      await vi.advanceTimersByTimeAsync(249);
       expect(storeSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+
+      expect(storeSpy).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('processInbound should still persist a completed non-stream reply when shutdown has already begun', async () => {
+    let resumeDispatch!: () => void;
+    let markDispatchReady!: () => void;
+    const dispatchReady = new Promise<void>((resolve) => { markDispatchReady = resolve; });
+    const mockRuntime = {
+      channel: {
+        routing: {
+          resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+        },
+        session: {
+          resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+          readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+          recordInboundSession: vi.fn(),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+          formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+          async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+            markDispatchReady();
+            await new Promise<void>((resolve) => { resumeDispatch = resolve; });
+            await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
+          },
+        },
+      },
+    };
+    const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+
+    const api = makeApi() as any;
+    api.runtime = mockRuntime;
+    api.cfg = mockCfg;
+    let resolveStore!: () => void;
+    const storePromise = new Promise<void>((resolve) => { resolveStore = resolve; });
+    const storeSpy = vi.spyOn(client, 'storeChatTurn').mockImplementation(() => storePromise);
+    plugin.register(api);
+
+    const replyPromise = plugin.processInbound('Hello', 'corr-stop-nonstream', 'owner');
+    await dispatchReady;
+    const stopPromise = plugin.stop();
+    resumeDispatch();
+
+    await expect(replyPromise).resolves.toEqual({
+      text: 'Reply before shutdown',
+      correlationId: 'corr-stop-nonstream',
+    });
+
+    let stopSettled = false;
+    void stopPromise.then(() => { stopSettled = true; });
+    await Promise.resolve();
+    expect(storeSpy).toHaveBeenCalledTimes(1);
+    expect(stopSettled).toBe(false);
+
+    resolveStore();
+    await stopPromise;
+    expect(stopSettled).toBe(true);
+    expect(storeSpy).toHaveBeenCalledWith(
+      'openclaw:dkg-ui',
+      'Hello',
+      'Reply before shutdown',
+      { turnId: 'corr-stop-nonstream' },
+    );
   });
 
   it('stop should only wait a bounded time for a final turn persistence attempt that hangs during shutdown', async () => {

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -900,4 +900,78 @@ describe('DkgChannelPlugin', () => {
       vi.useRealTimers();
     }
   });
+
+  it('stop should retry a shutdown-allowed final turn persistence attempt within the bounded drain window', async () => {
+    vi.useFakeTimers();
+    try {
+      let resumeDispatch!: () => void;
+      const mockRuntime = {
+        channel: {
+          routing: {
+            resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'agent-1', sessionKey: 'session-1' }),
+          },
+          session: {
+            resolveStorePath: vi.fn().mockReturnValue('/tmp/store'),
+            readSessionUpdatedAt: vi.fn().mockReturnValue(undefined),
+            recordInboundSession: vi.fn(),
+          },
+          reply: {
+            resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+            formatAgentEnvelope: vi.fn().mockReturnValue('[DKG UI Owner] Hello'),
+            async dispatchReplyWithBufferedBlockDispatcher(params: any) {
+              await params.dispatcherOptions.deliver({ text: 'Reply before shutdown' });
+              await new Promise<void>((resolve) => { resumeDispatch = resolve; });
+            },
+          },
+        },
+      };
+      const mockCfg = { session: { dmScope: 'main' }, agents: {} };
+
+      const api = makeApi() as any;
+      api.runtime = mockRuntime;
+      api.cfg = mockCfg;
+      const storeSpy = vi.spyOn(client, 'storeChatTurn')
+        .mockRejectedValueOnce(new Error('temporary daemon outage'))
+        .mockResolvedValueOnce(undefined);
+      plugin.register(api);
+
+      const stream = plugin.processInboundStream('Hello', 'corr-stream-stop-retry', 'owner');
+      await expect(stream.next()).resolves.toEqual({
+        done: false,
+        value: { type: 'text_delta', delta: 'Reply before shutdown' },
+      });
+
+      const nextItem = stream.next();
+      const stopPromise = plugin.stop();
+      resumeDispatch();
+      await expect(nextItem).resolves.toEqual({
+        done: false,
+        value: { type: 'final', text: 'Reply before shutdown', correlationId: 'corr-stream-stop-retry' },
+      });
+      await expect(stream.next()).resolves.toEqual({ done: true, value: undefined });
+
+      let stopSettled = false;
+      void stopPromise.then(() => { stopSettled = true; });
+      await Promise.resolve();
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+      expect(stopSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(249);
+      expect(storeSpy).toHaveBeenCalledTimes(1);
+      expect(stopSettled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(storeSpy).toHaveBeenCalledTimes(2);
+      expect(stopSettled).toBe(true);
+      expect(storeSpy).toHaveBeenLastCalledWith(
+        'openclaw:dkg-ui',
+        'Hello',
+        'Reply before shutdown',
+        { turnId: 'corr-stream-stop-retry' },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -1007,6 +1007,7 @@ describe('DkgChannelPlugin', () => {
       await vi.advanceTimersByTimeAsync(1_500);
       await stopPromise;
       expect(stopSettled).toBe(true);
+      expect((plugin as any).pendingTurnPersistence.size).toBe(0);
 
       expect(storeSpy).toHaveBeenCalledTimes(1);
       expect(storeSpy).toHaveBeenCalledWith(

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -169,6 +169,204 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('persists gatewayUrl on first registration when gateway routing is available', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {
+          gateway: {
+            port: 19789,
+          },
+        },
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+      const readyCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/openclaw')
+        && call[1]?.method === 'PUT',
+      );
+
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://127.0.0.1:19789',
+        },
+        metadata: {
+          transportMode: 'gateway+bridge',
+        },
+      });
+      expect(readyCall).toBeTruthy();
+      expect(JSON.parse(String(readyCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://127.0.0.1:19789',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('preserves a stored gatewayUrl when OpenClaw re-registers its transport', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              enabled: true,
+              transport: {
+                kind: 'openclaw-channel',
+                gatewayUrl: 'http://127.0.0.1:9200',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+      const readyCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/openclaw')
+        && call[1]?.method === 'PUT',
+      );
+
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://127.0.0.1:9200',
+        },
+      });
+      expect(readyCall).toBeTruthy();
+      expect(JSON.parse(String(readyCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://127.0.0.1:9200',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not re-enable a stored disconnected OpenClaw integration on startup', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              enabled: false,
+              runtime: { status: 'disconnected', ready: false },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const info = vi.fn();
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info },
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(fakeFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/local-agent-integrations/openclaw'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      )).toBe(false);
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/openclaw')
+        && call[1]?.method === 'PUT',
+      )).toBe(false);
+      expect(info).toHaveBeenCalledWith(expect.stringContaining('skipping startup re-registration'));
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('setup-only registration skips tool registration but keeps the plugin bootable', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -874,6 +874,74 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('retries startup re-registration in-process after a transient stored-state load failure', async () => {
+    vi.useFakeTimers();
+    const originalFetch = globalThis.fetch;
+    const warn = vi.fn();
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        if (fakeFetch.mock.calls.filter((call) =>
+          String(call[0]).includes('/api/local-agent-integrations/openclaw') && call[1]?.method === 'GET',
+        ).length === 1) {
+          throw new Error('temporary daemon outage');
+        }
+        return {
+          ok: true,
+          json: async () => ({ integration: null }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { warn },
+      };
+
+      plugin.register(mockApi);
+      await Promise.resolve();
+
+      expect(fakeFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/local-agent-integrations/openclaw'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      )).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(fakeFetch.mock.calls.filter((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/openclaw') && call[1]?.method === 'GET',
+      )).toHaveLength(2);
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      )).toBe(true);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to load stored OpenClaw integration state'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('aborting startup re-registration'));
+    } finally {
+      vi.useRealTimers();
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('setup-only registration skips tool registration but keeps the plugin bootable', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -232,7 +232,7 @@ describe('DkgNodePlugin', () => {
     }
   });
 
-  it('preserves a stored gatewayUrl when OpenClaw re-registers its transport', async () => {
+  it('drops a stale stored gatewayUrl when the current runtime is bridge-only', async () => {
     const originalFetch = globalThis.fetch;
     const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -270,7 +270,6 @@ describe('DkgNodePlugin', () => {
         registrationMode: 'full',
         registerTool: () => {},
         registerHook: () => {},
-        registerHttpRoute: () => {},
         on: () => {},
         logger: {},
       };
@@ -287,19 +286,45 @@ describe('DkgNodePlugin', () => {
       );
 
       expect(connectCall).toBeTruthy();
-      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toEqual({
+        id: 'openclaw',
+        enabled: true,
+        description: 'Connect a local OpenClaw agent through the DKG node.',
         transport: {
           kind: 'openclaw-channel',
-          gatewayUrl: 'http://127.0.0.1:9200',
         },
+        capabilities: expect.objectContaining({
+          localChat: true,
+          connectFromUi: true,
+          dkgPrimaryMemory: true,
+          wmImportPipeline: true,
+          nodeServedSkill: true,
+        }),
+        manifest: {
+          packageName: '@origintrail-official/dkg-adapter-openclaw',
+          setupEntry: './setup-entry.mjs',
+        },
+        setupEntry: './setup-entry.mjs',
+        metadata: expect.objectContaining({
+          channelId: 'dkg-ui',
+          registrationMode: 'full',
+          transportMode: 'bridge',
+        }),
+        runtime: expect.objectContaining({
+          status: 'connecting',
+          ready: false,
+          lastError: null,
+        }),
       });
       expect(readyCall).toBeTruthy();
       expect(JSON.parse(String(readyCall?.[1]?.body))).toMatchObject({
         transport: {
           kind: 'openclaw-channel',
-          gatewayUrl: 'http://127.0.0.1:9200',
+          bridgeUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/),
+          healthUrl: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/health$/),
         },
       });
+      expect(JSON.parse(String(readyCall?.[1]?.body)).transport.gatewayUrl).toBeUndefined();
     } finally {
       await plugin?.stop();
       globalThis.fetch = originalFetch;
@@ -491,7 +516,7 @@ describe('DkgNodePlugin', () => {
     }
   });
 
-  it('does not re-enable a stored disconnected OpenClaw integration on startup', async () => {
+  it('does not re-enable a stored OpenClaw integration when the user explicitly disconnected it', async () => {
     const originalFetch = globalThis.fetch;
     const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -503,6 +528,7 @@ describe('DkgNodePlugin', () => {
               id: 'openclaw',
               enabled: false,
               runtime: { status: 'disconnected', ready: false },
+              metadata: { userDisabled: true },
             },
           }),
         };
@@ -545,7 +571,122 @@ describe('DkgNodePlugin', () => {
         String(call[0]).includes('/api/local-agent-integrations/openclaw')
         && call[1]?.method === 'PUT',
       )).toBe(false);
-      expect(info).toHaveBeenCalledWith(expect.stringContaining('skipping startup re-registration'));
+      expect(info).toHaveBeenCalledWith(expect.stringContaining('explicitly disconnected by the user'));
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('does not re-enable a legacy pre-flag disconnected OpenClaw integration on startup', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              enabled: false,
+              connectedAt: '2026-04-13T09:00:00.000Z',
+              runtime: { status: 'disconnected', ready: false },
+              transport: {
+                kind: 'openclaw-channel',
+                bridgeUrl: 'http://127.0.0.1:9201',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const info = vi.fn();
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info },
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      )).toBe(false);
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/openclaw')
+        && call[1]?.method === 'PUT',
+      )).toBe(false);
+      expect(info).toHaveBeenCalledWith(expect.stringContaining('explicitly disconnected by the user'));
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('re-registers a transport-only OpenClaw record on startup', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              transport: {
+                kind: 'openclaw-channel',
+                bridgeUrl: 'http://127.0.0.1:9201',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      )).toBe(true);
     } finally {
       await plugin?.stop();
       globalThis.fetch = originalFetch;

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -306,6 +306,191 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('recomputes gatewayUrl from current gateway config even when the port stays at the default', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              enabled: true,
+              transport: {
+                kind: 'openclaw-channel',
+                gatewayUrl: 'http://127.0.0.1:18789',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {
+          gateway: {
+            customBindHost: 'localhost',
+            tls: { enabled: true },
+          },
+        },
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'https://localhost:18789',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('keeps a stored gatewayUrl when the current gateway object has no URL-affecting settings', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              enabled: true,
+              transport: {
+                kind: 'openclaw-channel',
+                gatewayUrl: 'http://10.0.0.5:18789',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {
+          gateway: {
+            announceBonjour: true,
+          },
+        } as any,
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://10.0.0.5:18789',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('formats IPv6 gateway hosts as valid URLs', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {
+          gateway: {
+            customBindHost: '::1',
+            port: 18789,
+          },
+        },
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://[::1]:18789',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('does not re-enable a stored disconnected OpenClaw integration on startup', async () => {
     const originalFetch = globalThis.fetch;
     const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -756,6 +756,59 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('aborts startup re-registration when stored OpenClaw integration state cannot be loaded', async () => {
+    const originalFetch = globalThis.fetch;
+    const warn = vi.fn();
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        throw new Error('temporary daemon outage');
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { warn },
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(fakeFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/local-agent-integrations/openclaw'),
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      )).toBe(false);
+      expect(fakeFetch.mock.calls.some((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/openclaw')
+        && call[1]?.method === 'PUT',
+      )).toBe(false);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Failed to load stored OpenClaw integration state'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('aborting startup re-registration'));
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('setup-only registration skips tool registration but keeps the plugin bootable', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -399,7 +399,7 @@ describe('DkgNodePlugin', () => {
     }
   });
 
-  it('keeps a stored gatewayUrl when the current gateway object has no URL-affecting settings', async () => {
+  it('derives the current local gatewayUrl when gateway routing is active and the current gateway object has no URL-affecting settings', async () => {
     const originalFetch = globalThis.fetch;
     const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -457,7 +457,7 @@ describe('DkgNodePlugin', () => {
       expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
         transport: {
           kind: 'openclaw-channel',
-          gatewayUrl: 'http://10.0.0.5:18789',
+          gatewayUrl: 'http://127.0.0.1:18789',
         },
       });
     } finally {
@@ -466,7 +466,7 @@ describe('DkgNodePlugin', () => {
     }
   });
 
-  it('keeps a stored gatewayUrl when gateway tls config only sets enabled=false', async () => {
+  it('derives the current local gatewayUrl when gateway tls config only sets enabled=false', async () => {
     const originalFetch = globalThis.fetch;
     const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -522,7 +522,7 @@ describe('DkgNodePlugin', () => {
       expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
         transport: {
           kind: 'openclaw-channel',
-          gatewayUrl: 'http://10.0.0.5:18789',
+          gatewayUrl: 'http://127.0.0.1:18789',
         },
       });
     } finally {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -466,6 +466,71 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('keeps a stored gatewayUrl when gateway tls config only sets enabled=false', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              transport: {
+                kind: 'openclaw-channel',
+                gatewayUrl: 'http://10.0.0.5:18789',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {
+          gateway: {
+            tls: { enabled: false },
+          },
+        },
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        registerHttpRoute: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          gatewayUrl: 'http://10.0.0.5:18789',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('formats IPv6 gateway hosts as valid URLs', async () => {
     const originalFetch = globalThis.fetch;
     const fakeFetch = vi.fn().mockResolvedValue({

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -693,6 +693,69 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('preserves a stored bridgeUrl and healthUrl when the current bridge has not bound a port yet', async () => {
+    const originalFetch = globalThis.fetch;
+    const fakeFetch = vi.fn().mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/api/local-agent-integrations/openclaw') && init?.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            integration: {
+              id: 'openclaw',
+              transport: {
+                kind: 'openclaw-channel',
+                bridgeUrl: 'http://127.0.0.1:9201',
+                healthUrl: 'http://127.0.0.1:9201/health',
+              },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({ ok: true, integration: { id: 'openclaw' } }),
+      };
+    });
+    globalThis.fetch = fakeFetch;
+    let plugin: DkgNodePlugin | null = null;
+
+    try {
+      plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: true, port: 0 },
+        memory: { enabled: false },
+      });
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: {},
+      };
+
+      plugin.register(mockApi);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      const connectCall = fakeFetch.mock.calls.find((call) =>
+        String(call[0]).includes('/api/local-agent-integrations/connect'),
+      );
+
+      expect(connectCall).toBeTruthy();
+      expect(JSON.parse(String(connectCall?.[1]?.body))).toMatchObject({
+        transport: {
+          kind: 'openclaw-channel',
+          bridgeUrl: 'http://127.0.0.1:9201',
+          healthUrl: 'http://127.0.0.1:9201/health',
+        },
+      });
+    } finally {
+      await plugin?.stop();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('setup-only registration skips tool registration but keeps the plugin bootable', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',

--- a/packages/adapter-openclaw/test/setup-entry.test.ts
+++ b/packages/adapter-openclaw/test/setup-entry.test.ts
@@ -50,4 +50,16 @@ describe('setup-entry', () => {
 
     expect(runtimeEntry).toHaveBeenCalledWith(api);
   });
+
+  it('defaults missing registrationMode to the runtime entry', async () => {
+    const { default: setupEntry } = await import('../setup-entry.mjs');
+    const api = {
+      config: {},
+      logger: { info: vi.fn() },
+    } as any;
+
+    setupEntry(api);
+
+    expect(runtimeEntry).toHaveBeenCalledWith(api);
+  });
 });

--- a/packages/adapter-openclaw/test/setup-entry.test.ts
+++ b/packages/adapter-openclaw/test/setup-entry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import setupEntry from '../setup-entry.mjs';
+
+describe('setup-entry', () => {
+  it('skips runtime registration during setup-only phases', () => {
+    const registerTool = vi.fn();
+    const registerHook = vi.fn();
+    const registerChannel = vi.fn();
+    const registerHttpRoute = vi.fn();
+    const info = vi.fn();
+
+    setupEntry({
+      config: {},
+      registrationMode: 'setup-only',
+      registerTool,
+      registerHook,
+      registerChannel,
+      registerHttpRoute,
+      on: vi.fn(),
+      logger: { info },
+    } as any);
+
+    expect(registerTool).not.toHaveBeenCalled();
+    expect(registerHook).not.toHaveBeenCalled();
+    expect(registerChannel).not.toHaveBeenCalled();
+    expect(registerHttpRoute).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('skipping runtime registration'));
+  });
+});

--- a/packages/adapter-openclaw/test/setup-entry.test.ts
+++ b/packages/adapter-openclaw/test/setup-entry.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
-import setupEntry from '../setup-entry.mjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtimeEntry = vi.fn();
+
+vi.mock('../openclaw-entry.mjs', () => ({
+  default: runtimeEntry,
+}));
 
 describe('setup-entry', () => {
-  it('skips runtime registration during setup-only phases', () => {
+  beforeEach(() => {
+    runtimeEntry.mockReset();
+  });
+
+  it('skips runtime registration during setup-only phases', async () => {
+    const { default: setupEntry } = await import('../setup-entry.mjs');
     const registerTool = vi.fn();
     const registerHook = vi.fn();
     const registerChannel = vi.fn();
@@ -24,6 +34,20 @@ describe('setup-entry', () => {
     expect(registerHook).not.toHaveBeenCalled();
     expect(registerChannel).not.toHaveBeenCalled();
     expect(registerHttpRoute).not.toHaveBeenCalled();
+    expect(runtimeEntry).not.toHaveBeenCalled();
     expect(info).toHaveBeenCalledWith(expect.stringContaining('skipping runtime registration'));
+  });
+
+  it('delegates to the runtime entry outside setup-only modes', async () => {
+    const { default: setupEntry } = await import('../setup-entry.mjs');
+    const api = {
+      config: {},
+      registrationMode: 'full',
+      logger: { info: vi.fn() },
+    } as any;
+
+    setupEntry(api);
+
+    expect(runtimeEntry).toHaveBeenCalledWith(api);
   });
 });

--- a/packages/adapter-openclaw/test/setup-entry.test.ts
+++ b/packages/adapter-openclaw/test/setup-entry.test.ts
@@ -2,9 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const runtimeEntry = vi.fn();
 
-vi.mock('../openclaw-entry.mjs', () => ({
-  default: runtimeEntry,
-}));
+async function importSetupEntry(
+  runtimeFactory: () => { default: typeof runtimeEntry },
+) {
+  vi.resetModules();
+  vi.doMock('../openclaw-entry.mjs', runtimeFactory);
+  return import('../setup-entry.mjs');
+}
 
 describe('setup-entry', () => {
   beforeEach(() => {
@@ -12,14 +16,16 @@ describe('setup-entry', () => {
   });
 
   it('skips runtime registration during setup-only phases', async () => {
-    const { default: setupEntry } = await import('../setup-entry.mjs');
+    const { default: setupEntry } = await importSetupEntry(() => ({
+      default: runtimeEntry,
+    }));
     const registerTool = vi.fn();
     const registerHook = vi.fn();
     const registerChannel = vi.fn();
     const registerHttpRoute = vi.fn();
     const info = vi.fn();
 
-    setupEntry({
+    await setupEntry({
       config: {},
       registrationMode: 'setup-only',
       registerTool,
@@ -39,27 +45,43 @@ describe('setup-entry', () => {
   });
 
   it('delegates to the runtime entry outside setup-only modes', async () => {
-    const { default: setupEntry } = await import('../setup-entry.mjs');
+    const { default: setupEntry } = await importSetupEntry(() => ({
+      default: runtimeEntry,
+    }));
     const api = {
       config: {},
       registrationMode: 'full',
       logger: { info: vi.fn() },
     } as any;
 
-    setupEntry(api);
+    await setupEntry(api);
 
     expect(runtimeEntry).toHaveBeenCalledWith(api);
   });
 
   it('defaults missing registrationMode to the runtime entry', async () => {
-    const { default: setupEntry } = await import('../setup-entry.mjs');
+    const { default: setupEntry } = await importSetupEntry(() => ({
+      default: runtimeEntry,
+    }));
     const api = {
       config: {},
       logger: { info: vi.fn() },
     } as any;
 
-    setupEntry(api);
+    await setupEntry(api);
 
     expect(runtimeEntry).toHaveBeenCalledWith(api);
+  });
+
+  it('does not import the runtime entry during setup-only loads', async () => {
+    const { default: setupEntry } = await importSetupEntry(() => {
+      throw new Error('runtime entry should stay lazy during setup-only loads');
+    });
+
+    expect(setupEntry({
+      config: {},
+      registrationMode: 'setup-only',
+      logger: { info: vi.fn() },
+    } as any)).toBeUndefined();
   });
 });

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -165,6 +165,44 @@ describe('writeDkgConfig', () => {
       process.env.DKG_HOME = original;
     }
   });
+
+  it('migrates legacy OpenClaw transport hints into localAgentIntegrations before removing the old key', () => {
+    const dkgHome = join(testDir, '.dkg');
+    mkdirSync(dkgHome, { recursive: true });
+    writeFileSync(join(dkgHome, 'config.json'), JSON.stringify({
+      name: 'existing-node',
+      apiPort: 9300,
+      openclawChannel: {
+        bridgeUrl: 'http://127.0.0.1:9301',
+        gatewayUrl: 'http://127.0.0.1:9300',
+      },
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+          },
+        },
+      },
+    }));
+
+    const original = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+
+    try {
+      writeDkgConfig('existing-node', fakeNetwork, 9200);
+
+      const config = JSON.parse(readFileSync(join(dkgHome, 'config.json'), 'utf-8'));
+      expect(config.openclawChannel).toBeUndefined();
+      expect(config.localAgentIntegrations.openclaw.transport).toMatchObject({
+        kind: 'openclaw-channel',
+        bridgeUrl: 'http://127.0.0.1:9301',
+        gatewayUrl: 'http://127.0.0.1:9300',
+      });
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { join, dirname, resolve } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { ethers } from 'ethers';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
@@ -76,8 +76,6 @@ import { FileStore } from './file-store.js';
 import { VectorStore, OpenAIEmbeddingProvider, type EmbeddingProvider } from './vector-store.js';
 import { parseBoundary, parseMultipart, MultipartParseError } from './http/multipart.js';
 import { handleCapture, EpcisValidationError, handleEventsQuery, EpcisQueryError, type Publisher as EpcisPublisher } from '@origintrail-official/dkg-epcis';
-import { readFileSync } from 'node:fs';
-
 type MarkItDownTarget = {
   platform: string;
   arch: string;
@@ -1716,27 +1714,88 @@ type OpenClawUiSetupCommand = {
   source: 'workspace' | 'npx';
 };
 
+type WorkspacePackageLookupDeps = {
+  fileExists?: (path: string) => boolean;
+  readFileText?: (path: string) => string;
+  readDirNames?: (path: string) => string[];
+};
+
+function resolveWorkspacePackageBinCommand(
+  packageName: string,
+  runtimeModuleUrl = import.meta.url,
+  deps: WorkspacePackageLookupDeps = {},
+): OpenClawUiSetupCommand | null {
+  const fileExists = deps.fileExists ?? existsSync;
+  const readFileText = deps.readFileText ?? ((path: string) => readFileSync(path, 'utf8'));
+  const readDirNames = deps.readDirNames ?? ((path: string) => readdirSync(path, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name));
+
+  const repoRoot = fileURLToPath(new URL('../../../', runtimeModuleUrl));
+  const packagesDir = join(repoRoot, 'packages');
+  let packageDirs: string[];
+  try {
+    packageDirs = readDirNames(packagesDir);
+  } catch {
+    return null;
+  }
+
+  for (const dirName of packageDirs) {
+    const packageJsonPath = join(packagesDir, dirName, 'package.json');
+    if (!fileExists(packageJsonPath)) continue;
+
+    try {
+      const raw = readFileText(packageJsonPath);
+      const parsed = JSON.parse(raw) as { name?: unknown; bin?: unknown };
+      if (parsed.name !== packageName || !parsed.bin) continue;
+
+      const binEntry = typeof parsed.bin === 'string'
+        ? parsed.bin
+        : typeof parsed.bin === 'object' && parsed.bin !== null
+          ? Object.values(parsed.bin as Record<string, unknown>).find((value): value is string => typeof value === 'string')
+          : undefined;
+      if (!binEntry) continue;
+
+      const binPath = resolve(packagesDir, dirName, binEntry);
+      if (!fileExists(binPath)) continue;
+
+      return {
+        command: process.execPath,
+        args: [binPath, 'setup', '--no-fund', '--no-start', '--no-verify'],
+        source: 'workspace',
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
 export function getOpenClawUiSetupCommand(
   packageName: string,
   runtimeModuleUrl = import.meta.url,
   fileExists: (path: string) => boolean = existsSync,
 ): OpenClawUiSetupCommand {
-  const setupArgs = ['setup', '--no-fund', '--no-start', '--no-verify'];
-
   if (packageName === '@origintrail-official/dkg-adapter-openclaw') {
     const localSetupCliPath = fileURLToPath(new URL('../../adapter-openclaw/dist/setup-cli.js', runtimeModuleUrl));
     if (fileExists(localSetupCliPath)) {
       return {
         command: process.execPath,
-        args: [localSetupCliPath, ...setupArgs],
+        args: [localSetupCliPath, 'setup', '--no-fund', '--no-start', '--no-verify'],
         source: 'workspace',
       };
     }
   }
 
+  const workspaceCommand = resolveWorkspacePackageBinCommand(packageName, runtimeModuleUrl, { fileExists });
+  if (workspaceCommand) {
+    return workspaceCommand;
+  }
+
   return {
     command: 'npx',
-    args: ['--yes', packageName, ...setupArgs],
+    args: ['--yes', packageName, 'setup', '--no-fund', '--no-start', '--no-verify'],
     source: 'npx',
   };
 }
@@ -1892,7 +1951,7 @@ export async function connectLocalAgentIntegrationFromUi(
   const saveConfigState = deps.saveConfig;
 
   let health = await probeHealth(config, bridgeAuthToken, { ignoreBridgeCache: true });
-  if (health.ok) {
+  if (health.ok && hadAttachedBridgeBeforeConnect) {
     const integration = updateLocalAgentIntegration(config, requested.id, {
       transport: transportPatchFromOpenClawTarget(config, health.target),
       runtime: {
@@ -2127,17 +2186,25 @@ export function isValidOpenClawPersistTurnPayload(payload: {
   sessionId?: unknown;
   userMessage?: unknown;
   assistantReply?: unknown;
+  persistenceState?: unknown;
 }): payload is {
   sessionId: string;
   userMessage: string;
   assistantReply: string;
   turnId?: unknown;
   toolCalls?: unknown;
+  persistenceState?: unknown;
 } {
   return typeof payload.sessionId === 'string'
     && payload.sessionId.trim().length > 0
     && typeof payload.userMessage === 'string'
-    && typeof payload.assistantReply === 'string';
+    && typeof payload.assistantReply === 'string'
+    && (
+      payload.persistenceState === undefined
+      || payload.persistenceState === 'stored'
+      || payload.persistenceState === 'failed'
+      || payload.persistenceState === 'pending'
+    );
 }
 
 let _standaloneCache: boolean | null = null;
@@ -2699,18 +2766,21 @@ async function handleRequest(
     if (!isValidOpenClawPersistTurnPayload(payload)) {
       return jsonResponse(res, 400, { error: 'Missing required fields: sessionId, userMessage, assistantReply' });
     }
-    const { sessionId, userMessage, assistantReply, turnId, toolCalls } = payload;
+    const { sessionId, userMessage, assistantReply, turnId, toolCalls, persistenceState } = payload;
     const normalizedToolCalls = Array.isArray(toolCalls)
       ? toolCalls as Array<{ name: string; args: Record<string, unknown>; result: unknown }>
       : undefined;
     const normalizedTurnId = typeof turnId === 'string' ? turnId : crypto.randomUUID();
+    const normalizedPersistenceState = persistenceState === 'failed' || persistenceState === 'pending'
+      ? persistenceState
+      : 'stored';
     try {
       await memoryManager.storeChatExchange(
         sessionId,
         userMessage,
         assistantReply,
         normalizedToolCalls,
-        { turnId: normalizedTurnId, persistenceState: 'stored' },
+        { turnId: normalizedTurnId, persistenceState: normalizedPersistenceState },
       );
       return jsonResponse(res, 200, { ok: true });
     } catch (err: any) {
@@ -4254,7 +4324,7 @@ async function handleRequest(
 
   // GET /api/integrations — aggregated view for Integrations panel
   if (req.method === 'GET' && path === '/api/integrations') {
-    const [skills, paranets] = await Promise.all([agent.findSkills(), agent.listContextGraphs()]);
+    const [skills, contextGraphs] = await Promise.all([agent.findSkills(), agent.listContextGraphs()]);
     const localAgentIntegrations = listLocalAgentIntegrations(config);
     const adapters = localAgentIntegrations.map((integration) => ({
       id: integration.id,
@@ -4264,7 +4334,7 @@ async function handleRequest(
       status: integration.status,
       capabilities: integration.capabilities,
     }));
-    return jsonResponse(res, 200, { adapters, localAgentIntegrations, skills, paranets });
+    return jsonResponse(res, 200, { adapters, localAgentIntegrations, skills, contextGraphs, paranets: contextGraphs });
   }
 
   // POST /api/register-adapter — legacy OpenClaw alias for /api/local-agent-integrations/connect

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1358,7 +1358,22 @@ function isLocalAgentExplicitlyUserDisabled(
 }
 
 function isExplicitLocalAgentDisconnectPatch(patch: Pick<LocalAgentIntegrationConfig, 'enabled' | 'runtime'>): boolean {
-  return patch.enabled === false || patch.runtime?.status === 'disconnected';
+  return patch.runtime?.status === 'disconnected';
+}
+
+export function normalizeExplicitLocalAgentDisconnectBody(body: Record<string, unknown>): Record<string, unknown> {
+  if (body.enabled !== false) return body;
+  const runtime = isPlainRecord(body.runtime) ? body.runtime : undefined;
+  if (runtime?.status === 'disconnected') return body;
+  return {
+    ...body,
+    runtime: {
+      ...(runtime ?? {}),
+      status: 'disconnected',
+      ready: typeof runtime?.ready === 'boolean' ? runtime.ready : false,
+      lastError: runtime?.lastError ?? null,
+    },
+  };
 }
 
 function mergeLocalAgentIntegrationConfig(
@@ -4326,13 +4341,14 @@ async function handleRequest(
     let parsed: Record<string, unknown>;
     try { parsed = JSON.parse(body); } catch { return jsonResponse(res, 400, { error: 'Invalid JSON body' }); }
     try {
+      const normalizedParsed = normalizeExplicitLocalAgentDisconnectBody(parsed);
       const normalizedId = normalizeIntegrationId(id);
-      const disconnectRequested = parsed.enabled === false
-        || (isPlainRecord(parsed.runtime) && parsed.runtime.status === 'disconnected');
+      const disconnectRequested = normalizedParsed.enabled === false
+        || (isPlainRecord(normalizedParsed.runtime) && normalizedParsed.runtime.status === 'disconnected');
       if (disconnectRequested && normalizedId) {
         cancelPendingLocalAgentAttachJob(normalizedId);
       }
-      const integration = updateLocalAgentIntegration(config, id, parsed);
+      const integration = updateLocalAgentIntegration(config, id, normalizedParsed);
       await saveConfig(config);
       return jsonResponse(res, 200, { ok: true, integration });
     } catch (err: any) {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2221,6 +2221,7 @@ export function isValidOpenClawPersistTurnPayload(payload: {
   userMessage?: unknown;
   assistantReply?: unknown;
   persistenceState?: unknown;
+  failureReason?: unknown;
 }): payload is {
   sessionId: string;
   userMessage: string;
@@ -2228,11 +2229,17 @@ export function isValidOpenClawPersistTurnPayload(payload: {
   turnId?: unknown;
   toolCalls?: unknown;
   persistenceState?: unknown;
+  failureReason?: unknown;
 } {
   return typeof payload.sessionId === 'string'
     && payload.sessionId.trim().length > 0
     && typeof payload.userMessage === 'string'
     && typeof payload.assistantReply === 'string'
+    && (
+      payload.failureReason === undefined
+      || payload.failureReason === null
+      || typeof payload.failureReason === 'string'
+    )
     && (
       payload.persistenceState === undefined
       || payload.persistenceState === 'stored'
@@ -2800,7 +2807,7 @@ async function handleRequest(
     if (!isValidOpenClawPersistTurnPayload(payload)) {
       return jsonResponse(res, 400, { error: 'Missing required fields: sessionId, userMessage, assistantReply' });
     }
-    const { sessionId, userMessage, assistantReply, turnId, toolCalls, persistenceState } = payload;
+    const { sessionId, userMessage, assistantReply, turnId, toolCalls, persistenceState, failureReason } = payload;
     const normalizedToolCalls = Array.isArray(toolCalls)
       ? toolCalls as Array<{ name: string; args: Record<string, unknown>; result: unknown }>
       : undefined;
@@ -2808,13 +2815,20 @@ async function handleRequest(
     const normalizedPersistenceState = persistenceState === 'failed' || persistenceState === 'pending'
       ? persistenceState
       : 'stored';
+    const normalizedFailureReason = typeof failureReason === 'string'
+      ? failureReason
+      : (failureReason === null ? null : undefined);
     try {
       await memoryManager.storeChatExchange(
         sessionId,
         userMessage,
         assistantReply,
         normalizedToolCalls,
-        { turnId: normalizedTurnId, persistenceState: normalizedPersistenceState },
+        {
+          turnId: normalizedTurnId,
+          persistenceState: normalizedPersistenceState,
+          failureReason: normalizedFailureReason,
+        },
       );
       return jsonResponse(res, 200, { ok: true });
     } catch (err: any) {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1351,6 +1351,16 @@ function normalizeLocalAgentRuntime(input: unknown): LocalAgentIntegrationRuntim
   return Object.keys(runtime).length > 0 ? runtime : undefined;
 }
 
+function isLocalAgentExplicitlyUserDisabled(
+  integration: Pick<LocalAgentIntegrationConfig, 'metadata'> | null | undefined,
+): boolean {
+  return integration?.metadata?.userDisabled === true;
+}
+
+function isExplicitLocalAgentDisconnectPatch(patch: Pick<LocalAgentIntegrationConfig, 'enabled' | 'runtime'>): boolean {
+  return patch.enabled === false || patch.runtime?.status === 'disconnected';
+}
+
 function mergeLocalAgentIntegrationConfig(
   base: LocalAgentIntegrationConfig | undefined,
   patch: LocalAgentIntegrationConfig,
@@ -1485,6 +1495,9 @@ export function connectLocalAgentIntegration(
     runtime: patch.runtime ?? { status: patch.enabled === false ? 'disconnected' : 'configured', updatedAt: now.toISOString() },
   };
   const next = mergeLocalAgentIntegrationConfig(mergeLocalAgentIntegrationConfig(existing, base), patch);
+  if (next.enabled === true && isLocalAgentExplicitlyUserDisabled(next)) {
+    next.metadata = { ...(next.metadata ?? {}), userDisabled: false };
+  }
   next.runtime = { ...(next.runtime ?? {}), updatedAt: now.toISOString() };
   config.localAgentIntegrations = { ...getStoredLocalAgentIntegrations(config), [id]: next };
   if (id === 'openclaw') pruneLegacyOpenClawConfig(config);
@@ -1502,6 +1515,11 @@ export function updateLocalAgentIntegration(
   const existing = getStoredLocalAgentIntegrations(config)[normalizedId] ?? { id: normalizedId };
   const patch = extractLocalAgentIntegrationPatch(body);
   const next = mergeLocalAgentIntegrationConfig(existing, patch);
+  if (isExplicitLocalAgentDisconnectPatch(patch)) {
+    next.metadata = { ...(next.metadata ?? {}), userDisabled: true };
+  } else if (patch.enabled === true && isLocalAgentExplicitlyUserDisabled(next)) {
+    next.metadata = { ...(next.metadata ?? {}), userDisabled: false };
+  }
   next.id = normalizedId;
   next.updatedAt = now.toISOString();
   next.runtime = { ...(next.runtime ?? {}), updatedAt: now.toISOString() };
@@ -1517,10 +1535,10 @@ export function hasConfiguredLocalAgentChat(config: DkgConfig, id: string): bool
     && integration.capabilities.localChat === true;
 }
 
-function hasLocalAgentTransportConfig(
-  integration: Pick<LocalAgentIntegrationConfig, 'transport' | 'runtime' | 'enabled'> | null | undefined,
+function hasStoredLocalAgentTransportConfig(
+  integration: Pick<LocalAgentIntegrationConfig, 'transport' | 'runtime'> | null | undefined,
 ): boolean {
-  if (!integration || integration.enabled !== true) return false;
+  if (!integration) return false;
   return Boolean(
     integration.transport?.bridgeUrl
     || integration.transport?.gatewayUrl
@@ -1927,7 +1945,7 @@ export async function connectLocalAgentIntegrationFromUi(
 ): Promise<{ integration: LocalAgentIntegrationRecord; notice?: string }> {
   const requestedId = typeof body.id === 'string' ? normalizeIntegrationId(body.id) : '';
   const existingBeforeConnect = requestedId ? getLocalAgentIntegration(config, requestedId) : null;
-  const hadAttachedBridgeBeforeConnect = hasLocalAgentTransportConfig(existingBeforeConnect);
+  const hadStoredTransportBeforeConnect = hasStoredLocalAgentTransportConfig(existingBeforeConnect);
   const requested = connectLocalAgentIntegration(config, {
     ...body,
     runtime: {
@@ -1951,7 +1969,7 @@ export async function connectLocalAgentIntegrationFromUi(
   const saveConfigState = deps.saveConfig;
 
   let health = await probeHealth(config, bridgeAuthToken, { ignoreBridgeCache: true });
-  if (health.ok && hadAttachedBridgeBeforeConnect) {
+  if (health.ok && hadStoredTransportBeforeConnect) {
     const integration = updateLocalAgentIntegration(config, requested.id, {
       transport: transportPatchFromOpenClawTarget(config, health.target),
       runtime: {
@@ -2031,8 +2049,8 @@ export async function connectLocalAgentIntegrationFromUi(
         return;
       }
       await persistIntegrationState({
-        enabled: hadAttachedBridgeBeforeConnect ? true : false,
-        ...(hadAttachedBridgeBeforeConnect && existingBeforeConnect?.transport
+        enabled: hadStoredTransportBeforeConnect ? true : false,
+        ...(hadStoredTransportBeforeConnect && existingBeforeConnect?.transport
           ? { transport: existingBeforeConnect.transport }
           : {}),
         runtime: {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1809,6 +1809,7 @@ export function getOpenClawUiSetupCommand(
   packageName: string,
   runtimeModuleUrl = import.meta.url,
   fileExists: (path: string) => boolean = existsSync,
+  deps: Omit<WorkspacePackageLookupDeps, 'fileExists'> = {},
 ): OpenClawUiSetupCommand {
   if (packageName === '@origintrail-official/dkg-adapter-openclaw') {
     const localSetupCliPath = fileURLToPath(new URL('../../adapter-openclaw/dist/setup-cli.js', runtimeModuleUrl));
@@ -1821,7 +1822,7 @@ export function getOpenClawUiSetupCommand(
     }
   }
 
-  const workspaceCommand = resolveWorkspacePackageBinCommand(packageName, runtimeModuleUrl, { fileExists });
+  const workspaceCommand = resolveWorkspacePackageBinCommand(packageName, runtimeModuleUrl, { fileExists, ...deps });
   if (workspaceCommand) {
     return workspaceCommand;
   }

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1362,15 +1362,15 @@ function isExplicitLocalAgentDisconnectPatch(patch: Pick<LocalAgentIntegrationCo
 }
 
 export function normalizeExplicitLocalAgentDisconnectBody(body: Record<string, unknown>): Record<string, unknown> {
-  if (body.enabled !== false) return body;
   const runtime = isPlainRecord(body.runtime) ? body.runtime : undefined;
-  if (runtime?.status === 'disconnected') return body;
+  if (body.enabled !== false && runtime?.status !== 'disconnected') return body;
   return {
     ...body,
+    enabled: false,
     runtime: {
       ...(runtime ?? {}),
       status: 'disconnected',
-      ready: typeof runtime?.ready === 'boolean' ? runtime.ready : false,
+      ready: false,
       lastError: runtime?.lastError ?? null,
     },
   };
@@ -1531,6 +1531,8 @@ export function updateLocalAgentIntegration(
   const patch = extractLocalAgentIntegrationPatch(body);
   const next = mergeLocalAgentIntegrationConfig(existing, patch);
   if (isExplicitLocalAgentDisconnectPatch(patch)) {
+    next.enabled = false;
+    next.runtime = { ...(next.runtime ?? {}), status: 'disconnected', ready: false, lastError: null };
     next.metadata = { ...(next.metadata ?? {}), userDisabled: true };
   } else if (patch.enabled === true && isLocalAgentExplicitlyUserDisabled(next)) {
     next.metadata = { ...(next.metadata ?? {}), userDisabled: false };

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -410,6 +410,45 @@ describe('local agent integration registry helpers', () => {
     expect((config as Record<string, unknown>).openclawChannel).toBeUndefined();
   });
 
+  it('marks explicit OpenClaw disconnects as user-disabled and clears that flag on reconnect', () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          metadata: {
+            source: 'node-ui',
+          },
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9201',
+          },
+        },
+      },
+    });
+
+    const disconnected = updateLocalAgentIntegration(config, 'openclaw', {
+      enabled: false,
+      runtime: {
+        status: 'disconnected',
+        ready: false,
+        lastError: null,
+      },
+    });
+
+    expect(disconnected.enabled).toBe(false);
+    expect(disconnected.metadata?.userDisabled).toBe(true);
+
+    const reconnected = connectLocalAgentIntegration(config, {
+      id: 'openclaw',
+      metadata: {
+        source: 'node-ui',
+      },
+    });
+
+    expect(reconnected.enabled).toBe(true);
+    expect(reconnected.metadata?.userDisabled).toBe(false);
+  });
+
   it('UI connect marks OpenClaw ready immediately when the local bridge is already healthy for an already attached integration', async () => {
     const config = makeConfig({
       localAgentIntegrations: {
@@ -446,6 +485,53 @@ describe('local agent integration registry helpers', () => {
     expect(result.integration.status).toBe('ready');
     expect(result.integration.runtime.ready).toBe(true);
     expect(result.integration.transport.bridgeUrl).toBe('http://127.0.0.1:9201');
+    expect(result.notice).toBe('OpenClaw is connected and chat-ready.');
+  });
+
+  it('UI reconnect keeps the healthy-bridge fast path after a manual OpenClaw disconnect', async () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: false,
+          metadata: {
+            source: 'node-ui',
+            userDisabled: true,
+          },
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9201',
+          },
+          runtime: {
+            status: 'disconnected',
+            ready: false,
+          },
+        },
+      },
+    });
+    const runSetup = vi.fn();
+    const restartGateway = vi.fn();
+    const waitForReady = vi.fn();
+    const probeHealth = vi.fn().mockResolvedValue({
+      ok: true,
+      target: 'bridge',
+    });
+
+    const result = await connectLocalAgentIntegrationFromUi(
+      config,
+      {
+        id: 'openclaw',
+        metadata: { source: 'node-ui' },
+      },
+      'bridge-token',
+      { runSetup, restartGateway, waitForReady, probeHealth },
+    );
+
+    expect(runSetup).not.toHaveBeenCalled();
+    expect(restartGateway).not.toHaveBeenCalled();
+    expect(waitForReady).not.toHaveBeenCalled();
+    expect(result.integration.status).toBe('ready');
+    expect(result.integration.runtime.ready).toBe(true);
+    expect(result.integration.metadata?.userDisabled).toBe(false);
     expect(result.notice).toBe('OpenClaw is connected and chat-ready.');
   });
 

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -15,6 +15,7 @@ import {
   parseRequiredSignatures,
   pipeOpenClawStream,
   probeOpenClawChannelHealth,
+  normalizeExplicitLocalAgentDisconnectBody,
   shouldBypassRateLimitForLoopbackTraffic,
   updateLocalAgentIntegration,
 } from '../src/daemon.js';
@@ -357,6 +358,23 @@ describe('daemon loopback request handling', () => {
 });
 
 describe('local agent integration registry helpers', () => {
+  it('normalizes plain enabled:false local-agent updates into explicit disconnect patches', () => {
+    const normalized = normalizeExplicitLocalAgentDisconnectBody({
+      enabled: false,
+      metadata: { source: 'node-ui' },
+    });
+
+    expect(normalized).toEqual({
+      enabled: false,
+      metadata: { source: 'node-ui' },
+      runtime: {
+        status: 'disconnected',
+        ready: false,
+        lastError: null,
+      },
+    });
+  });
+
   it('lists built-in local integrations even before they are connected', () => {
     const integrations = listLocalAgentIntegrations(makeConfig());
 
@@ -620,6 +638,7 @@ describe('local agent integration registry helpers', () => {
     expect(integration?.status).toBe('error');
     expect(integration?.runtime.ready).toBe(false);
     expect(integration?.runtime.lastError).toBe('setup failed');
+    expect(integration?.metadata?.userDisabled).not.toBe(true);
     expect(saveConfig).toHaveBeenCalled();
   });
 

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -303,6 +303,30 @@ describe('OpenClaw persist-turn validation', () => {
       assistantReply: '',
     })).toBe(false);
   });
+
+  it('accepts explicit failed and pending persistence states', () => {
+    expect(isValidOpenClawPersistTurnPayload({
+      sessionId: 'openclaw:dkg-ui',
+      userMessage: 'hi',
+      assistantReply: '',
+      persistenceState: 'failed',
+    })).toBe(true);
+    expect(isValidOpenClawPersistTurnPayload({
+      sessionId: 'openclaw:dkg-ui',
+      userMessage: 'hi',
+      assistantReply: '',
+      persistenceState: 'pending',
+    })).toBe(true);
+  });
+
+  it('rejects unknown persistence states', () => {
+    expect(isValidOpenClawPersistTurnPayload({
+      sessionId: 'openclaw:dkg-ui',
+      userMessage: 'hi',
+      assistantReply: '',
+      persistenceState: 'cancelled',
+    })).toBe(false);
+  });
 });
 
 describe('daemon loopback request handling', () => {
@@ -386,8 +410,18 @@ describe('local agent integration registry helpers', () => {
     expect((config as Record<string, unknown>).openclawChannel).toBeUndefined();
   });
 
-  it('UI connect marks OpenClaw ready immediately when the local bridge is already healthy', async () => {
-    const config = makeConfig();
+  it('UI connect marks OpenClaw ready immediately when the local bridge is already healthy for an already attached integration', async () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9201',
+          },
+        },
+      },
+    });
     const runSetup = vi.fn();
     const restartGateway = vi.fn();
     const waitForReady = vi.fn();
@@ -413,6 +447,53 @@ describe('local agent integration registry helpers', () => {
     expect(result.integration.runtime.ready).toBe(true);
     expect(result.integration.transport.bridgeUrl).toBe('http://127.0.0.1:9201');
     expect(result.notice).toBe('OpenClaw is connected and chat-ready.');
+  });
+
+  it('UI connect does not trust a healthy bridge fast-path for a first-time attach', async () => {
+    const config = makeConfig();
+    const runSetup = vi.fn().mockResolvedValue(undefined);
+    const restartGateway = vi.fn().mockResolvedValue(undefined);
+    const waitForReady = vi.fn().mockResolvedValue({
+      ok: true,
+      target: 'bridge',
+    });
+    const probeHealth = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        target: 'bridge',
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        error: 'bridge still starting',
+      });
+    const saveConfig = vi.fn().mockResolvedValue(undefined);
+    let attachJob: Promise<void> | null = null;
+
+    const result = await connectLocalAgentIntegrationFromUi(
+      config,
+      {
+        id: 'openclaw',
+        metadata: { source: 'node-ui' },
+      },
+      'bridge-token',
+      {
+        runSetup,
+        restartGateway,
+        waitForReady,
+        probeHealth,
+        saveConfig,
+        onAttachScheduled: (_id, job) => { attachJob = job; },
+      },
+    );
+
+    expect(result.integration.status).toBe('connecting');
+    expect(runSetup).toHaveBeenCalledTimes(1);
+    if (!attachJob) throw new Error('Expected OpenClaw attach job to be scheduled');
+    await attachJob;
+    expect(restartGateway).toHaveBeenCalledTimes(1);
+    const integration = getLocalAgentIntegration(config, 'openclaw');
+    expect(integration?.status).toBe('ready');
+    expect(integration?.runtime.ready).toBe(true);
   });
 
   it('does not leave a failed first-time OpenClaw attach marked as connected', async () => {

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -353,6 +353,30 @@ describe('OpenClaw persist-turn validation', () => {
       persistenceState: 'cancelled',
     })).toBe(false);
   });
+
+  it('accepts string/null failure reasons and rejects invalid ones', () => {
+    expect(isValidOpenClawPersistTurnPayload({
+      sessionId: 'openclaw:dkg-ui',
+      userMessage: 'hi',
+      assistantReply: '',
+      persistenceState: 'failed',
+      failureReason: 'timeout',
+    })).toBe(true);
+    expect(isValidOpenClawPersistTurnPayload({
+      sessionId: 'openclaw:dkg-ui',
+      userMessage: 'hi',
+      assistantReply: '',
+      persistenceState: 'failed',
+      failureReason: null,
+    })).toBe(true);
+    expect(isValidOpenClawPersistTurnPayload({
+      sessionId: 'openclaw:dkg-ui',
+      userMessage: 'hi',
+      assistantReply: '',
+      persistenceState: 'failed',
+      failureReason: { code: 'timeout' },
+    })).toBe(false);
+  });
 });
 
 describe('daemon loopback request handling', () => {

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -424,6 +424,27 @@ describe('local agent integration registry helpers', () => {
     });
   });
 
+  it('normalizes runtime-only disconnect patches into disabled local-agent updates', () => {
+    const normalized = normalizeExplicitLocalAgentDisconnectBody({
+      runtime: {
+        status: 'disconnected',
+        ready: true,
+        lastError: 'stale error',
+      },
+      metadata: { source: 'node-ui' },
+    });
+
+    expect(normalized).toEqual({
+      enabled: false,
+      metadata: { source: 'node-ui' },
+      runtime: {
+        status: 'disconnected',
+        ready: false,
+        lastError: 'stale error',
+      },
+    });
+  });
+
   it('lists built-in local integrations even before they are connected', () => {
     const integrations = listLocalAgentIntegrations(makeConfig());
 
@@ -514,6 +535,44 @@ describe('local agent integration registry helpers', () => {
 
     expect(reconnected.enabled).toBe(true);
     expect(reconnected.metadata?.userDisabled).toBe(false);
+  });
+
+  it('forces runtime-status disconnect updates into a disabled stored integration', () => {
+    const config = makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          capabilities: {
+            localChat: true,
+          },
+          metadata: {
+            source: 'node-ui',
+          },
+          runtime: {
+            status: 'ready',
+            ready: true,
+          },
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9201',
+          },
+        },
+      },
+    });
+
+    const disconnected = updateLocalAgentIntegration(config, 'openclaw', {
+      runtime: {
+        status: 'disconnected',
+        ready: true,
+      },
+    });
+
+    expect(disconnected.enabled).toBe(false);
+    expect(disconnected.status).toBe('disconnected');
+    expect(disconnected.runtime.ready).toBe(false);
+    expect(disconnected.metadata?.userDisabled).toBe(true);
+    expect(hasConfiguredLocalAgentChat(config, 'openclaw')).toBe(false);
+    expect(getOpenClawChannelTargets(config)).toEqual([]);
   });
 
   it('UI connect marks OpenClaw ready immediately when the local bridge is already healthy for an already attached integration', async () => {

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -282,6 +282,31 @@ describe('OpenClaw UI setup command resolution', () => {
       source: 'npx',
     });
   });
+
+  it('resolves workspace package bins from the repo root instead of packages/packages', () => {
+    const command = getOpenClawUiSetupCommand(
+      '@origintrail-official/dkg-adapter-hermes',
+      runtimeModuleUrl,
+      () => true,
+      {
+        readDirNames: (path) => {
+          expect(path).toMatch(/dkg-v9[\\/]packages$/);
+          return ['adapter-hermes'];
+        },
+        readFileText: (path) => {
+          expect(path).toMatch(/packages[\\/]adapter-hermes[\\/]package\.json$/);
+          return JSON.stringify({
+            name: '@origintrail-official/dkg-adapter-hermes',
+            bin: 'dist/setup-cli.js',
+          });
+        },
+      },
+    );
+
+    expect(command.source).toBe('workspace');
+    expect(command.command).toBe(process.execPath);
+    expect(command.args[0]).toMatch(/packages[\\/]adapter-hermes[\\/]dist[\\/]setup-cli\.js$/);
+  });
 });
 
 describe('OpenClaw persist-turn validation', () => {

--- a/packages/node-ui/src/api.ts
+++ b/packages/node-ui/src/api.ts
@@ -425,8 +425,22 @@ export async function handleNodeUIRequest(
   ) {
     const sessionId = normalizeSessionId(decodeURIComponent(path.slice('/api/memory/sessions/'.length)));
     if (!sessionId) return json(res, 400, { error: 'Invalid session ID' });
+    const rawLimit = url.searchParams.get('limit');
+    const parsedLimit = rawLimit && /^\d+$/.test(rawLimit)
+      ? Number.parseInt(rawLimit, 10)
+      : undefined;
+    if (rawLimit && (!/^\d+$/.test(rawLimit) || (parsedLimit ?? 0) <= 0)) {
+      return json(res, 400, { error: 'Invalid "limit" query parameter' });
+    }
+    const rawOrder = (url.searchParams.get('order') ?? 'asc').toLowerCase();
+    if (rawOrder !== 'asc' && rawOrder !== 'desc') {
+      return json(res, 400, { error: 'Invalid "order" query parameter' });
+    }
     try {
-      const session = await memoryManager.getSession(sessionId);
+      const session = await memoryManager.getSession(sessionId, {
+        ...(parsedLimit != null ? { limit: parsedLimit } : {}),
+        order: rawOrder,
+      });
       if (!session) return json(res, 404, { error: 'Session not found' });
       return json(res, 200, session);
     } catch (err: any) {

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -616,6 +616,10 @@ export class ChatMemoryManager {
 
   async getSession(
     sessionId: string,
+    opts: {
+      limit?: number;
+      order?: 'asc' | 'desc';
+    } = {},
   ): Promise<{
     session: string;
     messages: Array<{
@@ -628,6 +632,13 @@ export class ChatMemoryManager {
   } | null> {
     await this.ensureInitialized();
     try {
+      const requestedLimit = typeof opts.limit === 'number' && Number.isInteger(opts.limit) && opts.limit > 0
+        ? opts.limit
+        : null;
+      const limit = requestedLimit != null
+        ? Math.min(requestedLimit, 500)
+        : 500;
+      const order = opts.order === 'desc' ? 'DESC' : 'ASC';
       const sessionUri = `${CHAT_NS}session:${sessionId}`;
       const msgsResult = await this.tools.query(
         `SELECT ?author ?text ?ts ?turnId ?persistenceState WHERE {
@@ -642,14 +653,15 @@ export class ChatMemoryManager {
             ?turn <${DKG_ONT}turnId> ?turnId .
             ?turn <${DKG_ONT}persistenceState> ?persistenceState .
           }
-        } ORDER BY ?ts LIMIT 500`,
+        } ORDER BY ${order}(?ts) LIMIT ${limit}`,
         { contextGraphId: MEMORY_CONTEXT_GRAPH, includeSharedMemory: true },
       );
       const bindings = msgsResult.bindings ?? [];
       if (bindings.length === 0) return null;
+      const orderedBindings = order === 'DESC' ? [...bindings].reverse() : bindings;
       return {
         session: sessionId,
-        messages: bindings.map((mb: any) => ({
+        messages: orderedBindings.map((mb: any) => ({
           author: mb.author?.includes('user') ? 'user' : 'agent',
           text: stripRdfLiteral(mb.text ?? ''),
           ts: stripRdfLiteral(mb.ts ?? ''),

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -623,6 +623,7 @@ export class ChatMemoryManager {
   ): Promise<{
     session: string;
     messages: Array<{
+      uri: string;
       author: string;
       text: string;
       ts: string;
@@ -641,7 +642,7 @@ export class ChatMemoryManager {
       const order = opts.order === 'desc' ? 'DESC' : 'ASC';
       const sessionUri = `${CHAT_NS}session:${sessionId}`;
       const msgsResult = await this.tools.query(
-        `SELECT ?author ?text ?ts ?turnId ?persistenceState WHERE {
+        `SELECT ?m ?author ?text ?ts ?turnId ?persistenceState WHERE {
           ?m <${SCHEMA}isPartOf> <${sessionUri}> .
           ?m <${SCHEMA}author> ?author .
           ?m <${SCHEMA}text> ?text .
@@ -662,6 +663,7 @@ export class ChatMemoryManager {
       return {
         session: sessionId,
         messages: orderedBindings.map((mb: any) => ({
+          uri: String(mb.m ?? '').replace(/[<>]/g, ''),
           author: mb.author?.includes('user') ? 'user' : 'agent',
           text: stripRdfLiteral(mb.text ?? ''),
           ts: stripRdfLiteral(mb.ts ?? ''),

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -300,7 +300,7 @@ export class ChatMemoryManager {
     userMessage: string,
     assistantReply: string,
     toolCalls?: Array<{ name: string; args: Record<string, unknown>; result: unknown }>,
-    opts?: { turnId?: string; persistenceState?: 'stored' | 'failed' | 'pending' },
+    opts?: { turnId?: string; persistenceState?: 'stored' | 'failed' | 'pending'; failureReason?: string | null },
   ): Promise<void> {
     await this.ensureInitialized();
     const userTs = new Date();
@@ -312,6 +312,9 @@ export class ChatMemoryManager {
     const assistantMsgUri = `${CHAT_NS}msg:${assistantMsgId}`;
     const turnId = opts?.turnId?.trim();
     const persistenceState = opts?.persistenceState ?? 'stored';
+    const failureReason = typeof opts?.failureReason === 'string'
+      ? opts.failureReason.trim()
+      : (opts?.failureReason === null ? null : undefined);
     const turnUri = turnId ? `${CHAT_NS}turn:${turnId}` : undefined;
 
     const isNewSession = !this.knownSessions.has(sessionId);
@@ -350,6 +353,9 @@ export class ChatMemoryManager {
         { subject: turnUri, predicate: `${DKG_ONT}hasUserMessage`, object: userMsgUri, graph: '' },
         { subject: turnUri, predicate: `${DKG_ONT}hasAssistantMessage`, object: assistantMsgUri, graph: '' },
         { subject: turnUri, predicate: `${DKG_ONT}persistenceState`, object: JSON.stringify(persistenceState), graph: '' },
+        ...(persistenceState === 'failed' && failureReason
+          ? [{ subject: turnUri, predicate: `${DKG_ONT}failureReason`, object: JSON.stringify(failureReason), graph: '' }]
+          : []),
         { subject: userMsgUri, predicate: `${DKG_ONT}turnId`, object: JSON.stringify(turnId), graph: '' },
         { subject: assistantMsgUri, predicate: `${DKG_ONT}turnId`, object: JSON.stringify(turnId), graph: '' },
       );
@@ -629,6 +635,7 @@ export class ChatMemoryManager {
       ts: string;
       turnId?: string;
       persistStatus?: 'pending' | 'in_progress' | 'stored' | 'failed' | 'skipped';
+      failureReason?: string | null;
     }>;
   } | null> {
     await this.ensureInitialized();
@@ -642,7 +649,7 @@ export class ChatMemoryManager {
       const order = opts.order === 'desc' ? 'DESC' : 'ASC';
       const sessionUri = `${CHAT_NS}session:${sessionId}`;
       const msgsResult = await this.tools.query(
-        `SELECT ?m ?author ?text ?ts ?turnId ?persistenceState WHERE {
+        `SELECT ?m ?author ?text ?ts ?turnId ?persistenceState ?failureReason WHERE {
           ?m <${SCHEMA}isPartOf> <${sessionUri}> .
           ?m <${SCHEMA}author> ?author .
           ?m <${SCHEMA}text> ?text .
@@ -653,6 +660,7 @@ export class ChatMemoryManager {
             ?turn <${SCHEMA}isPartOf> <${sessionUri}> .
             ?turn <${DKG_ONT}turnId> ?turnId .
             ?turn <${DKG_ONT}persistenceState> ?persistenceState .
+            OPTIONAL { ?turn <${DKG_ONT}failureReason> ?failureReason }
           }
         } ORDER BY ${order}(?ts) LIMIT ${limit}`,
         { contextGraphId: MEMORY_CONTEXT_GRAPH, includeSharedMemory: true },
@@ -674,6 +682,10 @@ export class ChatMemoryManager {
               return status;
             }
             return undefined;
+          })(),
+          failureReason: (() => {
+            const reason = stripRdfLiteral(mb.failureReason ?? '').trim();
+            return reason.length > 0 ? reason : undefined;
           })(),
         })),
       };

--- a/packages/node-ui/src/chat-memory.ts
+++ b/packages/node-ui/src/chat-memory.ts
@@ -667,10 +667,9 @@ export class ChatMemoryManager {
       );
       const bindings = msgsResult.bindings ?? [];
       if (bindings.length === 0) return null;
-      const orderedBindings = order === 'DESC' ? [...bindings].reverse() : bindings;
       return {
         session: sessionId,
-        messages: orderedBindings.map((mb: any) => ({
+        messages: bindings.map((mb: any) => ({
           uri: String(mb.m ?? '').replace(/[<>]/g, ''),
           author: mb.author?.includes('user') ? 'user' : 'agent',
           text: stripRdfLiteral(mb.text ?? ''),

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -397,6 +397,7 @@ export interface MemorySession {
     ts: string;
     turnId?: string;
     persistStatus?: 'pending' | 'in_progress' | 'stored' | 'failed' | 'skipped';
+    failureReason?: string | null;
   }>;
 }
 export interface MemorySessionPublicationStatus {
@@ -741,6 +742,7 @@ export interface LocalAgentHistoryMessage {
   author: string;
   ts: string;
   turnId?: string;
+  failureReason?: string | null;
 }
 
 interface LocalAgentSurface {
@@ -815,6 +817,7 @@ async function fetchLocalAgentHistoryBySessionId(
         author: message.author,
         ts: message.ts,
         turnId: message.turnId,
+        failureReason: message.failureReason,
       }));
   } catch (err) {
     if (err instanceof HttpError && err.status === 404) {

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -431,8 +431,25 @@ export interface MemorySessionGraphDelta {
 }
 export const fetchMemorySessions = (limit = 20) =>
   get<{ sessions: MemorySession[] }>(`/api/memory/sessions?limit=${limit}`);
-export const fetchMemorySession = (sessionId: string) =>
-  get<MemorySession>(`/api/memory/sessions/${encodeURIComponent(sessionId)}`);
+export const fetchMemorySession = (
+  sessionId: string,
+  opts: {
+    limit?: number;
+    order?: 'asc' | 'desc';
+  } = {},
+) => {
+  const params = new URLSearchParams();
+  if (opts.limit && Number.isInteger(opts.limit) && opts.limit > 0) {
+    params.set('limit', String(opts.limit));
+  }
+  if (opts.order === 'desc' || opts.order === 'asc') {
+    params.set('order', opts.order);
+  }
+  const query = params.toString();
+  return get<MemorySession>(
+    `/api/memory/sessions/${encodeURIComponent(sessionId)}${query ? `?${query}` : ''}`,
+  );
+};
 export const fetchMemorySessionGraphDelta = (
   sessionId: string,
   turnId: string,
@@ -773,9 +790,11 @@ async function fetchLocalAgentHistoryBySessionId(
   limit = 50,
 ): Promise<LocalAgentHistoryMessage[]> {
   try {
-    const session = await fetchMemorySession(sessionId);
+    const session = await fetchMemorySession(sessionId, {
+      limit,
+      order: 'desc',
+    });
     return session.messages
-      .slice(-limit)
       .map((message, index) => ({
         uri: `urn:dkg:chat:session:${sessionId}:message:${index}`,
         text: message.text,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -516,9 +516,13 @@ export const sendOpenClawChat = (peerId: string, text: string) =>
 
 export async function sendOpenClawLocalChat(
   text: string,
-  opts?: { correlationId?: string; signal?: AbortSignal },
+  opts?: { correlationId?: string; signal?: AbortSignal; identity?: string },
 ): Promise<{ text: string; correlationId: string }> {
-  const body = { text, correlationId: opts?.correlationId ?? crypto.randomUUID() };
+  const body = {
+    text,
+    correlationId: opts?.correlationId ?? crypto.randomUUID(),
+    ...(opts?.identity ? { identity: opts.identity } : {}),
+  };
   const res = await fetch('/api/openclaw-channel/send', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders() },
@@ -547,9 +551,14 @@ export async function streamOpenClawLocalChat(
     correlationId?: string;
     signal?: AbortSignal;
     onEvent?: (event: OpenClawStreamEvent) => void;
+    identity?: string;
   } = {},
 ): Promise<{ text: string; correlationId: string }> {
-  const body = { text, correlationId: opts.correlationId ?? crypto.randomUUID() };
+  const body = {
+    text,
+    correlationId: opts.correlationId ?? crypto.randomUUID(),
+    ...(opts.identity ? { identity: opts.identity } : {}),
+  };
   const res = await fetch('/api/openclaw-channel/stream', {
     method: 'POST',
     headers: {
@@ -719,6 +728,11 @@ export interface LocalAgentHistoryMessage {
 interface LocalAgentSurface {
   connectSupported: boolean;
   chatSupported: boolean;
+  defaultSessionId?: (integrationId: string) => string;
+  resolveChatContext?: (args: {
+    integrationId: string;
+    sessionId?: string;
+  }) => Record<string, unknown>;
   fetchHealth?: () => Promise<{
     ok: boolean;
     target?: 'bridge' | 'gateway';
@@ -731,38 +745,50 @@ const LOCAL_AGENT_SURFACES: Record<string, LocalAgentSurface> = {
   openclaw: {
     connectSupported: true,
     chatSupported: true,
+    defaultSessionId: (integrationId: string) => `${integrationId}:dkg-ui`,
+    resolveChatContext: ({ integrationId, sessionId }) => {
+      if (!sessionId) return {};
+      const prefix = `${integrationId}:dkg-ui:`;
+      if (!sessionId.startsWith(prefix)) return {};
+      const identity = sessionId.slice(prefix.length).trim();
+      return identity ? { identity } : {};
+    },
     fetchHealth: fetchOpenClawLocalHealth,
     streamChat: streamOpenClawLocalChat,
   },
 };
 
-function buildLocalAgentSessionUri(id: string): string {
-  return `urn:dkg:chat:session:${id}:dkg-ui`;
+export function getDefaultLocalAgentSessionId(integrationId: string): string | null {
+  const normalizedId = integrationId.trim().toLowerCase();
+  return LOCAL_AGENT_SURFACES[normalizedId]?.defaultSessionId?.(normalizedId) ?? null;
 }
 
-async function fetchNamedLocalAgentHistory(id: string, limit = 50): Promise<LocalAgentHistoryMessage[]> {
-  const sessionUri = buildLocalAgentSessionUri(id);
-  const sparql = `SELECT ?uri ?text ?author ?ts ?turnId WHERE {
-      ?uri a <http://schema.org/Message> ;
-           <http://schema.org/isPartOf> <${sessionUri}> ;
-           <http://schema.org/text> ?text ;
-           <http://schema.org/author> ?author ;
-           <http://schema.org/dateCreated> ?ts .
-      OPTIONAL { ?uri <http://dkg.io/ontology/turnId> ?turnId }
+function resolveLocalAgentHistorySessionId(integrationId: string, sessionId?: string): string | null {
+  if (sessionId?.trim()) return sessionId.trim();
+  return getDefaultLocalAgentSessionId(integrationId);
+}
+
+async function fetchLocalAgentHistoryBySessionId(
+  sessionId: string,
+  limit = 50,
+): Promise<LocalAgentHistoryMessage[]> {
+  try {
+    const session = await fetchMemorySession(sessionId);
+    return session.messages
+      .slice(-limit)
+      .map((message, index) => ({
+        uri: `urn:dkg:chat:session:${sessionId}:message:${index}`,
+        text: message.text,
+        author: message.author,
+        ts: message.ts,
+        turnId: message.turnId,
+      }));
+  } catch (err) {
+    if (err instanceof HttpError && err.status === 404) {
+      return [];
     }
-    ORDER BY DESC(?ts)
-    LIMIT ${limit}`;
-  const res = await executeQuery(sparql, 'agent-memory', true);
-  const bindings: any[] = res?.result?.bindings ?? (res as any)?.results?.bindings ?? [];
-  const history = bindings.map((b: any) => ({
-    uri: bv(b.uri) ?? '',
-    text: bv(b.text) ?? '',
-    author: bv(b.author) ?? '',
-    ts: bv(b.ts) ?? '',
-    turnId: bv(b.turnId) ?? undefined,
-  }));
-  history.reverse();
-  return history;
+    throw err;
+  }
 }
 
 /**
@@ -770,7 +796,7 @@ async function fetchNamedLocalAgentHistory(id: string, limit = 50): Promise<Loca
  * Queries schema:Message items linked to the openclaw:dkg-ui session.
  */
 export async function fetchOpenClawLocalHistory(limit = 50): Promise<LocalAgentHistoryMessage[]> {
-  return fetchNamedLocalAgentHistory('openclaw', limit);
+  return fetchLocalAgentHistory('openclaw', limit);
 }
 
 export type LocalAgentStreamEvent = OpenClawStreamEvent;
@@ -924,8 +950,14 @@ export async function fetchLocalAgentHealth(id: string) {
   throw new Error(`${id} local health is not available yet.`);
 }
 
-export async function fetchLocalAgentHistory(id: string, limit = 50): Promise<LocalAgentHistoryMessage[]> {
-  return fetchNamedLocalAgentHistory(id, limit);
+export async function fetchLocalAgentHistory(
+  id: string,
+  limit = 50,
+  opts: { sessionId?: string } = {},
+): Promise<LocalAgentHistoryMessage[]> {
+  const sessionId = resolveLocalAgentHistorySessionId(id, opts.sessionId);
+  if (!sessionId) return [];
+  return fetchLocalAgentHistoryBySessionId(sessionId, limit);
 }
 
 export async function streamLocalAgentChat(
@@ -935,11 +967,19 @@ export async function streamLocalAgentChat(
     correlationId?: string;
     signal?: AbortSignal;
     onEvent?: (event: LocalAgentStreamEvent) => void;
+    sessionId?: string;
   } = {},
 ): Promise<{ text: string; correlationId: string }> {
-  const surface = LOCAL_AGENT_SURFACES[id];
+  const normalizedId = id.trim().toLowerCase();
+  const surface = LOCAL_AGENT_SURFACES[normalizedId];
   if (surface?.streamChat) {
-    return surface.streamChat(text, opts);
+    return surface.streamChat(text, {
+      ...opts,
+      ...surface.resolveChatContext?.({
+        integrationId: normalizedId,
+        sessionId: opts.sessionId,
+      }),
+    });
   }
   throw new Error(`${id} local chat is not available yet.`);
 }

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -391,6 +391,7 @@ export const deleteSavedQuery = (id: number) =>
 export interface MemorySession {
   session: string;
   messages: Array<{
+    uri: string;
     author: string;
     text: string;
     ts: string;
@@ -789,14 +790,27 @@ async function fetchLocalAgentHistoryBySessionId(
   sessionId: string,
   limit = 50,
 ): Promise<LocalAgentHistoryMessage[]> {
+  const buildFallbackHistoryMessageUri = (message: Pick<MemorySession['messages'][number], 'author' | 'text' | 'ts' | 'turnId'>): string => {
+    if (message.turnId) {
+      return `urn:dkg:chat:turn:${encodeURIComponent(message.turnId)}:${encodeURIComponent(message.author)}`;
+    }
+    const source = `${sessionId}\n${message.author}\n${message.ts}\n${message.text}`;
+    let hash = 2166136261;
+    for (let index = 0; index < source.length; index += 1) {
+      hash ^= source.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return `urn:dkg:chat:session:${encodeURIComponent(sessionId)}:message:${(hash >>> 0).toString(16)}`;
+  };
+
   try {
     const session = await fetchMemorySession(sessionId, {
       limit,
       order: 'desc',
     });
     return session.messages
-      .map((message, index) => ({
-        uri: `urn:dkg:chat:session:${sessionId}:message:${index}`,
+      .map((message) => ({
+        uri: message.uri || buildFallbackHistoryMessageUri(message),
         text: message.text,
         author: message.author,
         ts: message.ts,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -810,7 +810,8 @@ async function fetchLocalAgentHistoryBySessionId(
       limit,
       order: 'desc',
     });
-    return session.messages
+    return [...session.messages]
+      .reverse()
       .map((message) => ({
         uri: message.uri || buildFallbackHistoryMessageUri(message),
         text: message.text,

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -9,6 +9,7 @@ import {
   disconnectLocalAgentIntegration,
   fetchAgents,
   fetchConnections,
+  getDefaultLocalAgentSessionId,
   fetchLocalAgentHistory,
   fetchLocalAgentIntegrations,
   streamLocalAgentChat,
@@ -104,6 +105,25 @@ function mergeLocalAgentMessages(existing: LocalAgentMessage[], incoming: LocalA
   return merged;
 }
 
+export function getLocalAgentConversationStateKey(
+  integrationId: string,
+  sessionId: string | null,
+): string {
+  return sessionId?.trim() || `integration:${integrationId}`;
+}
+
+function resolveLocalAgentConversation(args: {
+  integrationId: string;
+  sessionId: string | null;
+}): { integrationId: string; sessionId: string | null; stateKey: string } {
+  const resolvedSessionId = args.sessionId ?? getDefaultLocalAgentSessionId(args.integrationId);
+  return {
+    integrationId: args.integrationId,
+    sessionId: resolvedSessionId,
+    stateKey: getLocalAgentConversationStateKey(args.integrationId, resolvedSessionId),
+  };
+}
+
 function integrationIdFromSessionId(
   sessionId: string,
   integrations: LocalAgentIntegration[],
@@ -146,20 +166,26 @@ function summarizeLocalAgentSessions(
 
 function hasLocalAgentConversation(
   integrationId: string,
-  localMessagesByIntegration: Record<string, LocalAgentMessage[]>,
-  localHistoryLoadedByIntegration: Record<string, boolean>,
+  selectedSessionId: string | null,
+  localMessagesByConversation: Record<string, LocalAgentMessage[]>,
   sessions: LocalAgentSessionSummary[],
 ): boolean {
-  return (localMessagesByIntegration[integrationId]?.length ?? 0) > 0
-    || localHistoryLoadedByIntegration[integrationId] === true
+  const conversation = resolveLocalAgentConversation({
+    integrationId,
+    sessionId: selectedSessionId,
+  });
+  return (localMessagesByConversation[conversation.stateKey]?.length ?? 0) > 0
+    || (conversation.sessionId
+      ? sessions.some((session) => session.sessionId === conversation.sessionId)
+      : false)
     || sessions.some((session) => session.integrationId === integrationId);
 }
 
 export function resolveLocalAgentSelectionState(args: {
   integrations: LocalAgentIntegration[];
   selectedIntegrationId: string;
-  localMessagesByIntegration: Record<string, LocalAgentMessage[]>;
-  localHistoryLoadedByIntegration: Record<string, boolean>;
+  selectedSessionId: string | null;
+  localMessagesByConversation: Record<string, LocalAgentMessage[]>;
   sessions: LocalAgentSessionSummary[];
 }) {
   const sortedIntegrations = [...args.integrations].sort(compareLocalAgentIntegrations);
@@ -167,11 +193,17 @@ export function resolveLocalAgentSelectionState(args: {
   const selectedIntegration = sortedIntegrations.find((item) => item.id === args.selectedIntegrationId)
     ?? connectedIntegrations[0]
     ?? null;
+  const selectedConversation = selectedIntegration
+    ? resolveLocalAgentConversation({
+      integrationId: selectedIntegration.id,
+      sessionId: args.selectedSessionId,
+    })
+    : null;
   const selectedHasConversation = selectedIntegration
     ? hasLocalAgentConversation(
       selectedIntegration.id,
-      args.localMessagesByIntegration,
-      args.localHistoryLoadedByIntegration,
+      args.selectedSessionId,
+      args.localMessagesByConversation,
       args.sessions,
     )
     : false;
@@ -180,6 +212,7 @@ export function resolveLocalAgentSelectionState(args: {
     sortedIntegrations,
     connectedIntegrations,
     selectedIntegration,
+    selectedConversation,
     selectedHasConversation,
   };
 }
@@ -231,6 +264,10 @@ function bridgeStatusDotClass(integration: LocalAgentIntegration): string {
   if (integration.bridgeOnline) return 'connected';
   if (integration.status === 'connecting') return 'known';
   return 'offline';
+}
+
+export function networkPeerCardStatusClass(agent: Pick<AgentInfo, 'connectionStatus'>): 'connected' | 'offline' {
+  return agent.connectionStatus === 'connected' ? 'connected' : 'offline';
 }
 
 function localAgentToolbarLabel(
@@ -528,12 +565,18 @@ function NetworkTab(props: {
       {peerAgents.length === 0 && !loading && (
         <div className="v10-agent-empty-state">No connected peers yet.</div>
       )}
-      {peerAgents.map((agent) => (
-        <div key={agent.peerId} className="v10-agent-card connected">
+      {peerAgents.map((agent) => {
+        const statusClass = networkPeerCardStatusClass(agent);
+        return (
+        <div key={agent.peerId} className={`v10-agent-card ${statusClass}`}>
           <div className="v10-agent-card-header">
-            <span className="v10-agent-card-dot connected" />
+            <span className={`v10-agent-card-dot ${statusClass}`} />
             <span className="v10-agent-card-name">{agent.name}</span>
-            <span className="v10-agent-card-badge">{agent.connectionTransport ?? 'direct'}</span>
+            <span className="v10-agent-card-badge">
+              {agent.connectionStatus === 'connected'
+                ? (agent.connectionTransport ?? 'direct')
+                : 'Disconnected'}
+            </span>
           </div>
           <div className="v10-agent-card-meta">
             <span>{agent.nodeRole ?? 'core'}</span>
@@ -542,7 +585,8 @@ function NetworkTab(props: {
             {agent.lastSeen != null && <span>{formatDuration(Date.now() - agent.lastSeen)} ago</span>}
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -594,14 +638,17 @@ export function PanelRight() {
 
   const [integrations, setIntegrations] = useState<LocalAgentIntegration[]>([]);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState('openclaw');
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    () => getDefaultLocalAgentSessionId('openclaw'),
+  );
   const [connectBusyId, setConnectBusyId] = useState<string | null>(null);
   const [connectNotice, setConnectNotice] = useState<string | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
 
-  const [localMessagesByIntegration, setLocalMessagesByIntegration] = useState<Record<string, LocalAgentMessage[]>>({});
-  const [localInput, setLocalInput] = useState('');
-  const [localSending, setLocalSending] = useState(false);
-  const [localHistoryLoadedByIntegration, setLocalHistoryLoadedByIntegration] = useState<Record<string, boolean>>({});
+  const [localMessagesByConversation, setLocalMessagesByConversation] = useState<Record<string, LocalAgentMessage[]>>({});
+  const [localInputByConversation, setLocalInputByConversation] = useState<Record<string, string>>({});
+  const [localSendingByConversation, setLocalSendingByConversation] = useState<Record<string, boolean>>({});
+  const [localHistoryLoadedByConversation, setLocalHistoryLoadedByConversation] = useState<Record<string, boolean>>({});
 
   const localAbortRef = useRef<AbortController | null>(null);
   const autoFocusedLocalAgentRef = useRef(false);
@@ -612,35 +659,73 @@ export function PanelRight() {
     sortedIntegrations,
     connectedIntegrations,
     selectedIntegration,
+    selectedConversation,
     selectedHasConversation,
   } = resolveLocalAgentSelectionState({
     integrations,
     selectedIntegrationId,
-    localMessagesByIntegration,
-    localHistoryLoadedByIntegration,
+    selectedSessionId,
+    localMessagesByConversation,
     sessions: localSessions,
   });
-  const selectedLocalMessages = selectedIntegration
-    ? (localMessagesByIntegration[selectedIntegration.id] ?? [])
+  const selectedConversationKey = selectedConversation?.stateKey ?? null;
+  const selectedLocalMessages = selectedConversationKey
+    ? (localMessagesByConversation[selectedConversationKey] ?? [])
     : [];
-  const selectedLocalHistoryLoaded = selectedIntegration
-    ? (localHistoryLoadedByIntegration[selectedIntegration.id] ?? false)
+  const selectedLocalHistoryLoaded = selectedConversationKey
+    ? (localHistoryLoadedByConversation[selectedConversationKey] ?? false)
+    : false;
+  const localInput = selectedConversationKey
+    ? (localInputByConversation[selectedConversationKey] ?? '')
+    : '';
+  const localSending = selectedConversationKey
+    ? (localSendingByConversation[selectedConversationKey] ?? false)
     : false;
 
   const scrollLocalChatToBottom = useCallback(() => {
     localChatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, []);
 
-  useEffect(scrollLocalChatToBottom, [selectedIntegration?.id, selectedLocalMessages, scrollLocalChatToBottom]);
+  useEffect(scrollLocalChatToBottom, [selectedConversationKey, selectedLocalMessages, scrollLocalChatToBottom]);
 
   const updateLocalMessages = useCallback((
-    integrationId: string,
+    conversationKey: string,
     updater: (messages: LocalAgentMessage[]) => LocalAgentMessage[],
   ) => {
-    setLocalMessagesByIntegration((prev) => ({
+    setLocalMessagesByConversation((prev) => ({
       ...prev,
-      [integrationId]: updater(prev[integrationId] ?? []),
+      [conversationKey]: updater(prev[conversationKey] ?? []),
     }));
+  }, []);
+
+  const setLocalInputForConversation = useCallback((conversationKey: string | null, value: string) => {
+    if (!conversationKey) return;
+    setLocalInputByConversation((prev) => ({
+      ...prev,
+      [conversationKey]: value,
+    }));
+  }, []);
+
+  const setLocalSendingForConversation = useCallback((conversationKey: string, value: boolean) => {
+    setLocalSendingByConversation((prev) => ({
+      ...prev,
+      [conversationKey]: value,
+    }));
+  }, []);
+
+  const setSelectedIntegration = useCallback((
+    integrationId: string,
+    opts: { preserveSession?: boolean; sessionId?: string | null } = {},
+  ) => {
+    setSelectedIntegrationId(integrationId);
+    if (integrationId === ADD_AGENT_TAB_ID) {
+      setSelectedSessionId(null);
+      return;
+    }
+    if (opts.preserveSession) {
+      return;
+    }
+    setSelectedSessionId(opts.sessionId ?? getDefaultLocalAgentSessionId(integrationId));
   }, []);
 
   const loadSessions = useCallback(() => {
@@ -679,43 +764,46 @@ export function PanelRight() {
         || (Boolean(selectedItem)
           && (selectedItem.persistentChat || hasLocalAgentConversation(
             selectedIntegrationId,
-            localMessagesByIntegration,
-            localHistoryLoadedByIntegration,
+            selectedSessionId,
+            localMessagesByConversation,
             sessionSummaries,
           )));
       if (!preserveSelected) {
-        setSelectedIntegrationId(connected[0]?.id ?? ADD_AGENT_TAB_ID);
+        setSelectedIntegration(connected[0]?.id ?? ADD_AGENT_TAB_ID);
       }
       const preferred = connected[0];
       if (preferred && !autoFocusedLocalAgentRef.current && selectedIntegrationId !== ADD_AGENT_TAB_ID) {
         autoFocusedLocalAgentRef.current = true;
-        setSelectedIntegrationId(preferred.id);
+        setSelectedIntegration(preferred.id);
         setMode('agents');
       } else if (!preferred && !preserveSelected) {
         autoFocusedLocalAgentRef.current = false;
-        setSelectedIntegrationId(ADD_AGENT_TAB_ID);
+        setSelectedIntegration(ADD_AGENT_TAB_ID);
       }
     } catch {
       // Keep the last known integrations in place so transient refresh failures
       // do not collapse an attached agent chat surface back into the add-agent UI.
     }
-  }, [localHistoryLoadedByIntegration, localMessagesByIntegration, memorySessions, selectedIntegrationId]);
+  }, [localMessagesByConversation, memorySessions, selectedIntegrationId, selectedSessionId, setSelectedIntegration]);
 
-  const loadLocalHistory = useCallback(async (integrationId: string) => {
-    setLocalHistoryLoadedByIntegration((prev) => ({
+  const loadLocalHistory = useCallback(async (integrationId: string, sessionId: string | null = null) => {
+    const conversation = resolveLocalAgentConversation({ integrationId, sessionId });
+    setLocalHistoryLoadedByConversation((prev) => ({
       ...prev,
-      [integrationId]: false,
+      [conversation.stateKey]: false,
     }));
     try {
-      const history = await fetchLocalAgentHistory(integrationId, 100);
+      const history = await fetchLocalAgentHistory(integrationId, 100, {
+        sessionId: conversation.sessionId ?? undefined,
+      });
       const loaded = history.map(mapHistoryMessage);
-      updateLocalMessages(integrationId, (prev) => mergeLocalAgentMessages(prev, loaded));
+      updateLocalMessages(conversation.stateKey, (prev) => mergeLocalAgentMessages(prev, loaded));
     } catch {
-      updateLocalMessages(integrationId, (prev) => prev);
+      updateLocalMessages(conversation.stateKey, (prev) => prev);
     } finally {
-      setLocalHistoryLoadedByIntegration((prev) => ({
+      setLocalHistoryLoadedByConversation((prev) => ({
         ...prev,
-        [integrationId]: true,
+        [conversation.stateKey]: true,
       }));
       loadSessions();
     }
@@ -750,41 +838,51 @@ export function PanelRight() {
 
   useEffect(() => {
     if (!selectedIntegration?.chatSupported || (!selectedIntegration.persistentChat && !selectedHasConversation)) {
-      if (selectedIntegration) {
-        setLocalHistoryLoadedByIntegration((prev) => ({
+      if (selectedConversationKey) {
+        setLocalHistoryLoadedByConversation((prev) => ({
           ...prev,
-          [selectedIntegration.id]: false,
+          [selectedConversationKey]: false,
         }));
       }
       return;
     }
     let cancelled = false;
     (async () => {
-      await loadLocalHistory(selectedIntegration.id);
+      await loadLocalHistory(selectedIntegration.id, selectedConversation?.sessionId ?? null);
       if (cancelled) return;
     })();
     return () => {
       cancelled = true;
     };
-  }, [selectedHasConversation, selectedIntegration?.chatSupported, selectedIntegration?.id, selectedIntegration?.persistentChat, loadLocalHistory]);
+  }, [
+    loadLocalHistory,
+    selectedConversation?.sessionId,
+    selectedConversationKey,
+    selectedHasConversation,
+    selectedIntegration?.chatSupported,
+    selectedIntegration?.id,
+    selectedIntegration?.persistentChat,
+  ]);
 
   const sendLocalMessage = useCallback(async () => {
     const integration = selectedIntegration;
+    const conversation = selectedConversation;
     const text = localInput.trim();
-    if (!integration?.chatSupported || !integration.chatReady || !text || localSending) return;
+    if (!integration?.chatSupported || !integration.chatReady || !text || localSending || !conversation) return;
     const integrationId = integration.id;
+    const conversationKey = conversation.stateKey;
     const correlationId = crypto.randomUUID();
 
-    const userId = `local:${integrationId}:${correlationId}:user`;
-    const assistantId = `local:${integrationId}:${correlationId}:assistant`;
+    const userId = `local:${conversationKey}:${correlationId}:user`;
+    const assistantId = `local:${conversationKey}:${correlationId}:assistant`;
     const now = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    updateLocalMessages(integrationId, (prev) => [
+    updateLocalMessages(conversationKey, (prev) => [
       ...prev,
       { id: userId, turnId: correlationId, role: 'user', content: text, ts: now },
       { id: assistantId, turnId: correlationId, role: 'assistant', content: '', ts: now, streaming: true },
     ]);
-    setLocalInput('');
-    setLocalSending(true);
+    setLocalInputForConversation(conversationKey, '');
+    setLocalSendingForConversation(conversationKey, true);
     setConnectError(null);
 
     const controller = new AbortController();
@@ -794,9 +892,10 @@ export function PanelRight() {
       const result = await streamLocalAgentChat(integrationId, text, {
         correlationId,
         signal: controller.signal,
+        sessionId: conversation.sessionId ?? undefined,
         onEvent: (event: LocalAgentStreamEvent) => {
           if (event.type === 'text_delta') {
-            updateLocalMessages(integrationId, (prev) =>
+            updateLocalMessages(conversationKey, (prev) =>
               prev.map((message) =>
                 message.id === assistantId ? { ...message, content: message.content + event.delta } : message,
               ),
@@ -805,7 +904,7 @@ export function PanelRight() {
         },
       });
 
-      updateLocalMessages(integrationId, (prev) =>
+      updateLocalMessages(conversationKey, (prev) =>
         prev.map((message) =>
           message.id === assistantId
             ? {
@@ -820,7 +919,7 @@ export function PanelRight() {
       loadSessions();
       if (stage === 0) advance();
     } catch (err: any) {
-      updateLocalMessages(integrationId, (prev) =>
+      updateLocalMessages(conversationKey, (prev) =>
         prev.map((message) =>
           message.id === assistantId
             ? {
@@ -835,10 +934,22 @@ export function PanelRight() {
       );
       void refreshLocalIntegrations();
     } finally {
-      setLocalSending(false);
+      setLocalSendingForConversation(conversationKey, false);
       localAbortRef.current = null;
     }
-  }, [advance, loadSessions, localInput, localSending, refreshLocalIntegrations, selectedIntegration, stage, updateLocalMessages]);
+  }, [
+    advance,
+    loadSessions,
+    localInput,
+    localSending,
+    refreshLocalIntegrations,
+    selectedConversation,
+    selectedIntegration,
+    setLocalInputForConversation,
+    setLocalSendingForConversation,
+    stage,
+    updateLocalMessages,
+  ]);
 
   const connectIntegration = useCallback(async (integrationId: string) => {
     setConnectBusyId(integrationId);
@@ -848,7 +959,7 @@ export function PanelRight() {
       const result = await connectLocalAgentIntegration(integrationId);
       setIntegrations((prev) => upsertLocalAgentIntegrationState(prev, result.integration));
       await refreshLocalIntegrations();
-      setSelectedIntegrationId(integrationId);
+      setSelectedIntegration(integrationId);
       autoFocusedLocalAgentRef.current = true;
       setConnectNotice(
         result.notice
@@ -863,7 +974,7 @@ export function PanelRight() {
     } finally {
       setConnectBusyId(null);
     }
-  }, [refreshLocalIntegrations]);
+  }, [refreshLocalIntegrations, setSelectedIntegration]);
 
   const disconnectIntegration = useCallback(async (integrationId: string) => {
     setConnectError(null);
@@ -872,20 +983,19 @@ export function PanelRight() {
       await disconnectLocalAgentIntegration(integrationId);
       setIntegrations((prev) => markLocalAgentIntegrationDisconnected(prev, integrationId));
       autoFocusedLocalAgentRef.current = false;
-      setSelectedIntegrationId(integrationId);
+      setSelectedIntegration(integrationId, { preserveSession: selectedIntegrationId === integrationId });
       setConnectNotice('The local agent was disconnected from this node. Session history remains available here.');
       setMode('agents');
       await refreshLocalIntegrations();
     } catch (err: any) {
       setConnectError(err.message);
     }
-  }, [refreshLocalIntegrations]);
+  }, [refreshLocalIntegrations, selectedIntegrationId, setSelectedIntegration]);
 
-  const openSession = useCallback(async (session: LocalAgentSessionSummary) => {
-    setSelectedIntegrationId(session.integrationId);
+  const openSession = useCallback((session: LocalAgentSessionSummary) => {
+    setSelectedIntegration(session.integrationId, { sessionId: session.sessionId });
     setMode('agents');
-    await loadLocalHistory(session.integrationId);
-  }, [loadLocalHistory]);
+  }, [setSelectedIntegration]);
 
   return (
     <div className="v10-panel-right">
@@ -916,7 +1026,7 @@ export function PanelRight() {
           selectedIntegrationId={selectedIntegrationId}
           selectedIntegration={selectedIntegration}
           selectedHasConversation={selectedHasConversation}
-          onSelectIntegration={setSelectedIntegrationId}
+          onSelectIntegration={setSelectedIntegration}
           onConnectIntegration={connectIntegration}
           onDisconnectIntegration={disconnectIntegration}
           onRefreshIntegrations={refreshLocalIntegrations}
@@ -927,7 +1037,7 @@ export function PanelRight() {
           localHistoryLoaded={selectedLocalHistoryLoaded}
           localChatEndRef={localChatEndRef}
           localInput={localInput}
-          onLocalInputChange={setLocalInput}
+          onLocalInputChange={(value) => setLocalInputForConversation(selectedConversationKey, value)}
           onSendLocalMessage={sendLocalMessage}
           localSending={localSending}
         />

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -177,7 +177,18 @@ function hasLocalAgentConversation(
   return (localMessagesByConversation[conversation.stateKey]?.length ?? 0) > 0
     || (conversation.sessionId
       ? sessions.some((session) => session.sessionId === conversation.sessionId)
-      : false)
+      : false);
+}
+
+function hasAnyLocalAgentConversation(
+  integrationId: string,
+  localMessagesByConversation: Record<string, LocalAgentMessage[]>,
+  sessions: LocalAgentSessionSummary[],
+): boolean {
+  const integrationStateKey = getLocalAgentConversationStateKey(integrationId, null);
+  return Object.entries(localMessagesByConversation).some(([stateKey, messages]) =>
+    messages.length > 0
+      && (stateKey === integrationStateKey || stateKey.startsWith(`${integrationId}:`)))
     || sessions.some((session) => session.integrationId === integrationId);
 }
 
@@ -207,6 +218,13 @@ export function resolveLocalAgentSelectionState(args: {
       args.sessions,
     )
     : false;
+  const selectedIntegrationHasAnyConversation = selectedIntegration
+    ? hasAnyLocalAgentConversation(
+      selectedIntegration.id,
+      args.localMessagesByConversation,
+      args.sessions,
+    )
+    : false;
 
   return {
     sortedIntegrations,
@@ -214,6 +232,40 @@ export function resolveLocalAgentSelectionState(args: {
     selectedIntegration,
     selectedConversation,
     selectedHasConversation,
+    selectedIntegrationHasAnyConversation,
+  };
+}
+
+export function resolveConnectedAgentsTabState(args: {
+  connectedAgents: LocalAgentIntegration[];
+  selectedIntegration: LocalAgentIntegration | null;
+  selectedIntegrationId: string;
+  selectedHasConversation: boolean;
+  selectedIntegrationHasAnyConversation: boolean;
+  localHistoryLoaded: boolean;
+  localMessagesCount: number;
+}) {
+  const selected = args.selectedIntegration;
+  const showingSessionHistory = Boolean(selected && !selected.persistentChat && args.selectedHasConversation);
+  const showingStoredSessions = Boolean(
+    selected && !selected.persistentChat && args.selectedIntegrationHasAnyConversation,
+  );
+  const visibleAgentTabs = showingStoredSessions
+    ? [selected!, ...args.connectedAgents.filter((item) => item.id !== selected!.id)]
+    : args.connectedAgents;
+  const showAddFlow = args.selectedIntegrationId === ADD_AGENT_TAB_ID
+    || (!selected && args.connectedAgents.length === 0)
+    || Boolean(selected && !selected.persistentChat && !args.selectedIntegrationHasAnyConversation);
+  const shouldShowConversationLoader = !args.localHistoryLoaded
+    && args.localMessagesCount === 0
+    && Boolean(selected?.persistentChat || args.selectedHasConversation);
+
+  return {
+    showingSessionHistory,
+    showingStoredSessions,
+    visibleAgentTabs,
+    showAddFlow,
+    shouldShowConversationLoader,
   };
 }
 
@@ -258,6 +310,29 @@ export function markLocalAgentIntegrationDisconnected(
     error: undefined,
     target: undefined,
   });
+}
+
+export function shouldPreserveSelectedLocalAgentTab(args: {
+  selectedIntegrationId: string;
+  selectedItem: LocalAgentIntegration | null;
+  selectedSessionId: string | null;
+  localMessagesByConversation: Record<string, LocalAgentMessage[]>;
+  sessionSummaries: LocalAgentSessionSummary[];
+}): boolean {
+  return args.selectedIntegrationId === ADD_AGENT_TAB_ID
+    || (Boolean(args.selectedItem)
+      && (args.selectedItem.persistentChat
+        || hasLocalAgentConversation(
+          args.selectedIntegrationId,
+          args.selectedSessionId,
+          args.localMessagesByConversation,
+          args.sessionSummaries,
+        )
+        || hasAnyLocalAgentConversation(
+          args.selectedIntegrationId,
+          args.localMessagesByConversation,
+          args.sessionSummaries,
+        )));
 }
 
 function bridgeStatusDotClass(integration: LocalAgentIntegration): string {
@@ -308,6 +383,7 @@ function ConnectedAgentsTab(props: {
   selectedIntegrationId: string;
   selectedIntegration: LocalAgentIntegration | null;
   selectedHasConversation: boolean;
+  selectedIntegrationHasAnyConversation: boolean;
   onSelectIntegration: (id: string) => void;
   onConnectIntegration: (id: string) => void;
   onDisconnectIntegration: (id: string) => void;
@@ -328,6 +404,7 @@ function ConnectedAgentsTab(props: {
     selectedIntegrationId,
     selectedIntegration,
     selectedHasConversation,
+    selectedIntegrationHasAnyConversation,
     onSelectIntegration,
     onConnectIntegration,
     onDisconnectIntegration,
@@ -348,13 +425,21 @@ function ConnectedAgentsTab(props: {
   const connectedAgents = sortedIntegrations.filter((item) => item.persistentChat);
   const addableIntegrations = sortedIntegrations.filter((item) => !item.persistentChat);
   const selected = selectedIntegration;
-  const showingSessionHistory = Boolean(selected && !selected.persistentChat && selectedHasConversation);
-  const visibleAgentTabs = showingSessionHistory
-    ? [selected!, ...connectedAgents.filter((item) => item.id !== selected!.id)]
-    : connectedAgents;
-  const showAddFlow = selectedIntegrationId === ADD_AGENT_TAB_ID
-    || (!selected && connectedAgents.length === 0)
-    || Boolean(selected && !selected.persistentChat && !selectedHasConversation);
+  const {
+    showingSessionHistory,
+    showingStoredSessions,
+    visibleAgentTabs,
+    showAddFlow,
+    shouldShowConversationLoader,
+  } = resolveConnectedAgentsTabState({
+    connectedAgents,
+    selectedIntegration,
+    selectedIntegrationId,
+    selectedHasConversation,
+    selectedIntegrationHasAnyConversation,
+    localHistoryLoaded,
+    localMessagesCount: localMessages.length,
+  });
   const inputDisabled = localSending || !selected?.chatReady;
 
   return (
@@ -471,20 +556,24 @@ function ConnectedAgentsTab(props: {
                   ? `${selected.name} is not currently attached to this node. Session history remains available here; reconnect from the + tab when you want live chat again.`
                   : selected.status === 'connecting'
                   ? `${selected.name} is still finishing setup. This chat tab stays in place and will go live automatically when the connection is ready.`
+                  : showingStoredSessions
+                  ? `${selected.name} has saved sessions on this node. Open one from Sessions or reconnect from the + tab to resume live chat here.`
                   : `${selected.name} is temporarily unavailable. Refresh after it recovers to resume chatting here.`}
               </div>
             )}
 
             <div className="v10-chat-messages v10-local-agent-messages">
-              {!localHistoryLoaded && localMessages.length === 0 && (
+              {shouldShowConversationLoader && (
                 <div className="v10-agent-empty-state">
                   Loading the latest conversation from DKG memory...
                 </div>
               )}
-              {localHistoryLoaded && localMessages.length === 0 && (
+              {(!shouldShowConversationLoader && localMessages.length === 0) && (
                 <div className="v10-agent-empty-state">
                   {showingSessionHistory
                     ? `${selected.name} session history is available, but there are no stored turns to show yet.`
+                    : showingStoredSessions
+                    ? `${selected.name} has saved sessions on this node. Open one from Sessions or reconnect from the + tab to start a fresh live thread.`
                     : selected.chatReady
                     ? `Send a message to start chatting with ${selected.name}.`
                     : `${selected.name} is attached to this node. Your conversation history will stay here even while the bridge reconnects.`}
@@ -661,6 +750,7 @@ export function PanelRight() {
     selectedIntegration,
     selectedConversation,
     selectedHasConversation,
+    selectedIntegrationHasAnyConversation,
   } = resolveLocalAgentSelectionState({
     integrations,
     selectedIntegrationId,
@@ -760,14 +850,13 @@ export function PanelRight() {
       const sessionSummaries = summarizeLocalAgentSessions(memorySessions, items);
       const connected = [...items].sort(compareLocalAgentIntegrations).filter((item) => item.persistentChat);
       const selectedItem = items.find((item) => item.id === selectedIntegrationId) ?? null;
-      const preserveSelected = selectedIntegrationId === ADD_AGENT_TAB_ID
-        || (Boolean(selectedItem)
-          && (selectedItem.persistentChat || hasLocalAgentConversation(
-            selectedIntegrationId,
-            selectedSessionId,
-            localMessagesByConversation,
-            sessionSummaries,
-          )));
+      const preserveSelected = shouldPreserveSelectedLocalAgentTab({
+        selectedIntegrationId,
+        selectedItem,
+        selectedSessionId,
+        localMessagesByConversation,
+        sessionSummaries,
+      });
       if (!preserveSelected) {
         setSelectedIntegration(connected[0]?.id ?? ADD_AGENT_TAB_ID);
       }
@@ -1026,6 +1115,7 @@ export function PanelRight() {
           selectedIntegrationId={selectedIntegrationId}
           selectedIntegration={selectedIntegration}
           selectedHasConversation={selectedHasConversation}
+          selectedIntegrationHasAnyConversation={selectedIntegrationHasAnyConversation}
           onSelectIntegration={setSelectedIntegration}
           onConnectIntegration={connectIntegration}
           onDisconnectIntegration={disconnectIntegration}

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -136,6 +136,15 @@ function integrationIdFromSessionId(
   return null;
 }
 
+export function shouldPreserveSessionOnReconnect(args: {
+  integrationId: string;
+  selectedSessionId: string | null;
+  integrations: LocalAgentIntegration[];
+}): boolean {
+  return args.selectedSessionId != null
+    && integrationIdFromSessionId(args.selectedSessionId, args.integrations)?.id === args.integrationId;
+}
+
 function summarizeLocalAgentSessions(
   sessions: MemorySession[],
   integrations: LocalAgentIntegration[],
@@ -809,7 +818,6 @@ export function PanelRight() {
   ) => {
     setSelectedIntegrationId(integrationId);
     if (integrationId === ADD_AGENT_TAB_ID) {
-      setSelectedSessionId(null);
       return;
     }
     if (opts.preserveSession) {
@@ -1048,7 +1056,12 @@ export function PanelRight() {
       const result = await connectLocalAgentIntegration(integrationId);
       setIntegrations((prev) => upsertLocalAgentIntegrationState(prev, result.integration));
       await refreshLocalIntegrations();
-      setSelectedIntegration(integrationId);
+      const preserveSession = shouldPreserveSessionOnReconnect({
+        integrationId,
+        selectedSessionId,
+        integrations,
+      });
+      setSelectedIntegration(integrationId, { preserveSession });
       autoFocusedLocalAgentRef.current = true;
       setConnectNotice(
         result.notice
@@ -1063,7 +1076,7 @@ export function PanelRight() {
     } finally {
       setConnectBusyId(null);
     }
-  }, [refreshLocalIntegrations, setSelectedIntegration]);
+  }, [integrations, refreshLocalIntegrations, selectedSessionId, setSelectedIntegration]);
 
   const disconnectIntegration = useCallback(async (integrationId: string) => {
     setConnectError(null);

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -136,13 +136,21 @@ function integrationIdFromSessionId(
   return null;
 }
 
-export function shouldPreserveSessionOnReconnect(args: {
+export function shouldPreserveSessionForIntegrationSelection(args: {
   integrationId: string;
   selectedSessionId: string | null;
   integrations: LocalAgentIntegration[];
 }): boolean {
   return args.selectedSessionId != null
     && integrationIdFromSessionId(args.selectedSessionId, args.integrations)?.id === args.integrationId;
+}
+
+export function shouldPreserveSessionOnReconnect(args: {
+  integrationId: string;
+  selectedSessionId: string | null;
+  integrations: LocalAgentIntegration[];
+}): boolean {
+  return shouldPreserveSessionForIntegrationSelection(args);
 }
 
 function summarizeLocalAgentSessions(
@@ -391,9 +399,10 @@ function ConnectedAgentsTab(props: {
   integrations: LocalAgentIntegration[];
   selectedIntegrationId: string;
   selectedIntegration: LocalAgentIntegration | null;
+  selectedSessionId: string | null;
   selectedHasConversation: boolean;
   selectedIntegrationHasAnyConversation: boolean;
-  onSelectIntegration: (id: string) => void;
+  onSelectIntegration: (id: string, opts?: { preserveSession?: boolean; sessionId?: string | null }) => void;
   onConnectIntegration: (id: string) => void;
   onDisconnectIntegration: (id: string) => void;
   onRefreshIntegrations: () => void;
@@ -412,6 +421,7 @@ function ConnectedAgentsTab(props: {
     integrations,
     selectedIntegrationId,
     selectedIntegration,
+    selectedSessionId,
     selectedHasConversation,
     selectedIntegrationHasAnyConversation,
     onSelectIntegration,
@@ -458,7 +468,13 @@ function ConnectedAgentsTab(props: {
           <button
             key={integration.id}
             className={`v10-agent-subtab ${selected?.id === integration.id && !showAddFlow ? 'active' : ''}`}
-            onClick={() => onSelectIntegration(integration.id)}
+            onClick={() => onSelectIntegration(integration.id, {
+              preserveSession: shouldPreserveSessionForIntegrationSelection({
+                integrationId: integration.id,
+                selectedSessionId,
+                integrations,
+              }),
+            })}
             role="tab"
             aria-selected={selected?.id === integration.id && !showAddFlow}
           >
@@ -1127,6 +1143,7 @@ export function PanelRight() {
           integrations={integrations}
           selectedIntegrationId={selectedIntegrationId}
           selectedIntegration={selectedIntegration}
+          selectedSessionId={selectedSessionId}
           selectedHasConversation={selectedHasConversation}
           selectedIntegrationHasAnyConversation={selectedIntegrationHasAnyConversation}
           onSelectIntegration={setSelectedIntegration}

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -193,7 +193,7 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
       getSession: vi.fn().mockResolvedValue({
         session: 'session-1',
         messages: [
-          { author: 'user', text: 'latest', ts: '2026-04-14T08:00:00Z' },
+          { uri: 'urn:dkg:chat:msg:user-1', author: 'user', text: 'latest', ts: '2026-04-14T08:00:00Z' },
         ],
       }),
     } as any;
@@ -220,7 +220,10 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
     expect(handled).toBe(true);
     expect(state.statusCode).toBe(200);
     expect(memoryManager.getSession).toHaveBeenCalledWith('session-1', { limit: 25, order: 'desc' });
-    expect(parseJsonBody(state.body)).toMatchObject({ session: 'session-1' });
+    expect(parseJsonBody(state.body)).toMatchObject({
+      session: 'session-1',
+      messages: [{ uri: 'urn:dkg:chat:msg:user-1' }],
+    });
   });
 
   it('returns 400 for invalid session query parameters', async () => {

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -193,7 +193,13 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
       getSession: vi.fn().mockResolvedValue({
         session: 'session-1',
         messages: [
-          { uri: 'urn:dkg:chat:msg:user-1', author: 'user', text: 'latest', ts: '2026-04-14T08:00:00Z' },
+          {
+            uri: 'urn:dkg:chat:msg:user-1',
+            author: 'user',
+            text: 'latest',
+            ts: '2026-04-14T08:00:00Z',
+            failureReason: 'timeout',
+          },
         ],
       }),
     } as any;
@@ -222,7 +228,7 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
     expect(memoryManager.getSession).toHaveBeenCalledWith('session-1', { limit: 25, order: 'desc' });
     expect(parseJsonBody(state.body)).toMatchObject({
       session: 'session-1',
-      messages: [{ uri: 'urn:dkg:chat:msg:user-1' }],
+      messages: [{ uri: 'urn:dkg:chat:msg:user-1', failureReason: 'timeout' }],
     });
   });
 

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -188,6 +188,76 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
     expect(memoryManager.getSessionGraphDelta).not.toHaveBeenCalled();
   });
 
+  it('passes session history limit and descending ordering through to memoryManager.getSession()', async () => {
+    const memoryManager = {
+      getSession: vi.fn().mockResolvedValue({
+        session: 'session-1',
+        messages: [
+          { author: 'user', text: 'latest', ts: '2026-04-14T08:00:00Z' },
+        ],
+      }),
+    } as any;
+
+    const { req, url } = createMockReq({
+      method: 'GET',
+      path: '/api/memory/sessions/session-1?limit=25&order=desc',
+    });
+    const { res, state } = createMockRes();
+
+    const handled = await handleNodeUIRequest(
+      req,
+      res,
+      url,
+      {} as any,
+      '.',
+      undefined,
+      undefined,
+      undefined,
+      memoryManager,
+      undefined,
+    );
+
+    expect(handled).toBe(true);
+    expect(state.statusCode).toBe(200);
+    expect(memoryManager.getSession).toHaveBeenCalledWith('session-1', { limit: 25, order: 'desc' });
+    expect(parseJsonBody(state.body)).toMatchObject({ session: 'session-1' });
+  });
+
+  it('returns 400 for invalid session query parameters', async () => {
+    const memoryManager = {
+      getSession: vi.fn(),
+    } as any;
+
+    const invalidCases = [
+      '/api/memory/sessions/session-1?limit=0',
+      '/api/memory/sessions/session-1?limit=25xyz',
+      '/api/memory/sessions/session-1?order=sideways',
+    ];
+
+    for (const path of invalidCases) {
+      const { req, url } = createMockReq({ method: 'GET', path });
+      const { res, state } = createMockRes();
+
+      const handled = await handleNodeUIRequest(
+        req,
+        res,
+        url,
+        {} as any,
+        '.',
+        undefined,
+        undefined,
+        undefined,
+        memoryManager,
+        undefined,
+      );
+
+      expect(handled).toBe(true);
+      expect(state.statusCode).toBe(400);
+    }
+
+    expect(memoryManager.getSession).not.toHaveBeenCalled();
+  });
+
   it('returns publication status for a valid session id', async () => {
     const memoryManager = {
       getSessionPublicationStatus: vi.fn().mockResolvedValue({

--- a/packages/node-ui/test/api-routes.test.ts
+++ b/packages/node-ui/test/api-routes.test.ts
@@ -188,15 +188,21 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
     expect(memoryManager.getSessionGraphDelta).not.toHaveBeenCalled();
   });
 
-  it('passes session history limit and descending ordering through to memoryManager.getSession()', async () => {
+  it('passes session history limit and descending ordering through to memoryManager.getSession() without reordering the backend result', async () => {
     const memoryManager = {
       getSession: vi.fn().mockResolvedValue({
         session: 'session-1',
         messages: [
           {
+            uri: 'urn:dkg:chat:msg:agent-2',
+            author: 'agent',
+            text: 'newest',
+            ts: '2026-04-14T08:00:01Z',
+          },
+          {
             uri: 'urn:dkg:chat:msg:user-1',
             author: 'user',
-            text: 'latest',
+            text: 'older',
             ts: '2026-04-14T08:00:00Z',
             failureReason: 'timeout',
           },
@@ -228,7 +234,10 @@ describe('handleNodeUIRequest Stage 5 memory/publication routes', () => {
     expect(memoryManager.getSession).toHaveBeenCalledWith('session-1', { limit: 25, order: 'desc' });
     expect(parseJsonBody(state.body)).toMatchObject({
       session: 'session-1',
-      messages: [{ uri: 'urn:dkg:chat:msg:user-1', failureReason: 'timeout' }],
+      messages: [
+        { uri: 'urn:dkg:chat:msg:agent-2', text: 'newest' },
+        { uri: 'urn:dkg:chat:msg:user-1', failureReason: 'timeout' },
+      ],
     });
   });
 

--- a/packages/node-ui/test/chat-memory.test.ts
+++ b/packages/node-ui/test/chat-memory.test.ts
@@ -167,6 +167,25 @@ describe('ChatMemoryManager', () => {
     expect(session!.messages[1].author).toBe('agent');
   });
 
+  it('getSession can request the latest session window and returns it in chronological order', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ bindings: [] })
+      .mockResolvedValueOnce({
+        bindings: [
+          { author: 'urn:dkg:chat:actor:agent', text: '"Newest"', ts: '"2026-01-01T12:00:02Z"', turnId: '"turn-3"' },
+          { author: 'urn:dkg:chat:actor:user', text: '"Middle"', ts: '"2026-01-01T12:00:01Z"', turnId: '"turn-2"' },
+          { author: 'urn:dkg:chat:actor:user', text: '"Oldest"', ts: '"2026-01-01T12:00:00Z"', turnId: '"turn-1"' },
+        ],
+      });
+
+    const session = await manager.getSession('test-session-latest', { limit: 3, order: 'desc' });
+
+    expect(session).not.toBeNull();
+    expect(session!.messages.map((message) => message.text)).toEqual(['Oldest', 'Middle', 'Newest']);
+    const queryText = String(mockQuery.mock.calls[1][0]);
+    expect(queryText).toContain('ORDER BY DESC(?ts) LIMIT 3');
+  });
+
   it('getSession returns null when session has no messages', async () => {
     mockQuery
       .mockResolvedValueOnce({ bindings: [] })

--- a/packages/node-ui/test/chat-memory.test.ts
+++ b/packages/node-ui/test/chat-memory.test.ts
@@ -153,8 +153,8 @@ describe('ChatMemoryManager', () => {
       .mockResolvedValueOnce({ bindings: [] })
       .mockResolvedValueOnce({
         bindings: [
-          { author: 'urn:dkg:chat:actor:user', text: '"What is DKG?"', ts: '"2026-01-01T12:00:00Z"' },
-          { author: 'urn:dkg:chat:actor:agent', text: '"DKG is the Decentralized Knowledge Graph"', ts: '"2026-01-01T12:00:01Z"' },
+          { m: 'urn:dkg:chat:msg:user-1', author: 'urn:dkg:chat:actor:user', text: '"What is DKG?"', ts: '"2026-01-01T12:00:00Z"' },
+          { m: 'urn:dkg:chat:msg:agent-1', author: 'urn:dkg:chat:actor:agent', text: '"DKG is the Decentralized Knowledge Graph"', ts: '"2026-01-01T12:00:01Z"' },
         ],
       });
 
@@ -162,6 +162,7 @@ describe('ChatMemoryManager', () => {
     expect(session).not.toBeNull();
     expect(session!.session).toBe('test-session-1');
     expect(session!.messages).toHaveLength(2);
+    expect(session!.messages[0].uri).toBe('urn:dkg:chat:msg:user-1');
     expect(session!.messages[0].author).toBe('user');
     expect(session!.messages[0].text).toBe('What is DKG?');
     expect(session!.messages[1].author).toBe('agent');
@@ -172,9 +173,9 @@ describe('ChatMemoryManager', () => {
       .mockResolvedValueOnce({ bindings: [] })
       .mockResolvedValueOnce({
         bindings: [
-          { author: 'urn:dkg:chat:actor:agent', text: '"Newest"', ts: '"2026-01-01T12:00:02Z"', turnId: '"turn-3"' },
-          { author: 'urn:dkg:chat:actor:user', text: '"Middle"', ts: '"2026-01-01T12:00:01Z"', turnId: '"turn-2"' },
-          { author: 'urn:dkg:chat:actor:user', text: '"Oldest"', ts: '"2026-01-01T12:00:00Z"', turnId: '"turn-1"' },
+          { m: 'urn:dkg:chat:msg:agent-3', author: 'urn:dkg:chat:actor:agent', text: '"Newest"', ts: '"2026-01-01T12:00:02Z"', turnId: '"turn-3"' },
+          { m: 'urn:dkg:chat:msg:user-2', author: 'urn:dkg:chat:actor:user', text: '"Middle"', ts: '"2026-01-01T12:00:01Z"', turnId: '"turn-2"' },
+          { m: 'urn:dkg:chat:msg:user-1', author: 'urn:dkg:chat:actor:user', text: '"Oldest"', ts: '"2026-01-01T12:00:00Z"', turnId: '"turn-1"' },
         ],
       });
 
@@ -182,7 +183,13 @@ describe('ChatMemoryManager', () => {
 
     expect(session).not.toBeNull();
     expect(session!.messages.map((message) => message.text)).toEqual(['Oldest', 'Middle', 'Newest']);
+    expect(session!.messages.map((message) => message.uri)).toEqual([
+      'urn:dkg:chat:msg:user-1',
+      'urn:dkg:chat:msg:user-2',
+      'urn:dkg:chat:msg:agent-3',
+    ]);
     const queryText = String(mockQuery.mock.calls[1][0]);
+    expect(queryText).toContain('SELECT ?m ?author ?text ?ts ?turnId ?persistenceState');
     expect(queryText).toContain('ORDER BY DESC(?ts) LIMIT 3');
   });
 
@@ -200,6 +207,7 @@ describe('ChatMemoryManager', () => {
       .mockResolvedValueOnce({
         bindings: [
           {
+            m: 'urn:dkg:chat:msg:agent-1',
             author: 'urn:dkg:chat:actor:agent',
             text: '"Answer"',
             ts: '"2026-01-01T12:00:01Z"',
@@ -211,6 +219,7 @@ describe('ChatMemoryManager', () => {
 
     const session = await manager.getSession('test-session-2');
     expect(session).not.toBeNull();
+    expect(session!.messages[0].uri).toBe('urn:dkg:chat:msg:agent-1');
     expect(session!.messages[0].turnId).toBe('turn-1');
     expect(session!.messages[0].persistStatus).toBe('stored');
   });

--- a/packages/node-ui/test/chat-memory.test.ts
+++ b/packages/node-ui/test/chat-memory.test.ts
@@ -38,6 +38,20 @@ describe('ChatMemoryManager', () => {
     expect(sessionTriple.object).toContain('session-1');
   });
 
+  it('persists failureReason on failed chat turns', async () => {
+    mockQuery.mockResolvedValueOnce({ bindings: [] });
+    await manager.storeChatExchange('session-1', 'Hello', 'Hi there!', undefined, {
+      turnId: 'turn-1',
+      persistenceState: 'failed',
+      failureReason: 'timeout',
+    });
+
+    const quads = mockShare.mock.calls[0][1];
+    const failureReasonQuad = quads.find((q: any) => q.predicate?.includes('failureReason'));
+    expect(failureReasonQuad).toBeDefined();
+    expect(failureReasonQuad.object).toBe('"timeout"');
+  });
+
   it('includes session triples only on first write for a session', async () => {
     mockQuery.mockResolvedValueOnce({ bindings: [] });
     await manager.storeChatExchange('session-1', 'First message', 'First reply');
@@ -189,7 +203,7 @@ describe('ChatMemoryManager', () => {
       'urn:dkg:chat:msg:agent-3',
     ]);
     const queryText = String(mockQuery.mock.calls[1][0]);
-    expect(queryText).toContain('SELECT ?m ?author ?text ?ts ?turnId ?persistenceState');
+    expect(queryText).toContain('SELECT ?m ?author ?text ?ts ?turnId ?persistenceState ?failureReason');
     expect(queryText).toContain('ORDER BY DESC(?ts) LIMIT 3');
   });
 
@@ -222,6 +236,29 @@ describe('ChatMemoryManager', () => {
     expect(session!.messages[0].uri).toBe('urn:dkg:chat:msg:agent-1');
     expect(session!.messages[0].turnId).toBe('turn-1');
     expect(session!.messages[0].persistStatus).toBe('stored');
+  });
+
+  it('getSession includes failureReason for failed turns when present', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ bindings: [] })
+      .mockResolvedValueOnce({
+        bindings: [
+          {
+            m: 'urn:dkg:chat:msg:agent-1',
+            author: 'urn:dkg:chat:actor:agent',
+            text: '"Answer"',
+            ts: '"2026-01-01T12:00:01Z"',
+            turnId: '"turn-1"',
+            persistenceState: '"failed"',
+            failureReason: '"timeout"',
+          },
+        ],
+      });
+
+    const session = await manager.getSession('test-session-3');
+    expect(session).not.toBeNull();
+    expect(session!.messages[0].persistStatus).toBe('failed');
+    expect(session!.messages[0].failureReason).toBe('timeout');
   });
 
   it('getStats returns session and triple counts', async () => {

--- a/packages/node-ui/test/chat-memory.test.ts
+++ b/packages/node-ui/test/chat-memory.test.ts
@@ -182,7 +182,7 @@ describe('ChatMemoryManager', () => {
     expect(session!.messages[1].author).toBe('agent');
   });
 
-  it('getSession can request the latest session window and returns it in chronological order', async () => {
+  it('getSession can request the latest session window in descending backend order', async () => {
     mockQuery
       .mockResolvedValueOnce({ bindings: [] })
       .mockResolvedValueOnce({
@@ -196,11 +196,11 @@ describe('ChatMemoryManager', () => {
     const session = await manager.getSession('test-session-latest', { limit: 3, order: 'desc' });
 
     expect(session).not.toBeNull();
-    expect(session!.messages.map((message) => message.text)).toEqual(['Oldest', 'Middle', 'Newest']);
+    expect(session!.messages.map((message) => message.text)).toEqual(['Newest', 'Middle', 'Oldest']);
     expect(session!.messages.map((message) => message.uri)).toEqual([
-      'urn:dkg:chat:msg:user-1',
-      'urn:dkg:chat:msg:user-2',
       'urn:dkg:chat:msg:agent-3',
+      'urn:dkg:chat:msg:user-2',
+      'urn:dkg:chat:msg:user-1',
     ]);
     const queryText = String(mockQuery.mock.calls[1][0]);
     expect(queryText).toContain('SELECT ?m ?author ?text ?ts ?turnId ?persistenceState ?failureReason');

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -53,7 +53,8 @@ describe('OpenClaw bridge API contract', () => {
   it('exports fetchOpenClawLocalHistory', () => {
     expect(apiSrc).toContain('fetchOpenClawLocalHistory');
     expect(apiSrc).toContain('getDefaultLocalAgentSessionId');
-    expect(apiSrc).toContain('fetchMemorySession(sessionId)');
+    expect(apiSrc).toContain('fetchMemorySession(sessionId, {');
+    expect(apiSrc).toContain("order: 'desc'");
   });
 
   it('exports the future-friendly local agent integration contract', () => {
@@ -377,7 +378,7 @@ describe('OpenClaw bridge behavioral tests', () => {
     expect(panelRight).toContain('Connect OpenClaw');
   });
 
-  it('fetchOpenClawLocalHistory loads the default OpenClaw session from /api/memory/sessions/:sessionId', async () => {
+  it('fetchOpenClawLocalHistory requests the newest turns from /api/memory/sessions/:sessionId and returns chronological order', async () => {
     const fakeFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -396,6 +397,8 @@ describe('OpenClaw bridge behavioral tests', () => {
       const history = await fetchOpenClawLocalHistory(3);
       const [url] = fakeFetch.mock.calls[0];
       expect(String(url)).toContain('/api/memory/sessions/openclaw%3Adkg-ui');
+      expect(String(url)).toContain('limit=3');
+      expect(String(url)).toContain('order=desc');
       expect(history.map((row: any) => row.text)).toEqual(['first', 'second', 'third']);
       expect(history[0].turnId).toBe('turn-1');
     } finally {
@@ -403,13 +406,14 @@ describe('OpenClaw bridge behavioral tests', () => {
     }
   });
 
-  it('fetchLocalAgentHistory uses the selected sessionId when reopening a non-default OpenClaw thread', async () => {
+  it('fetchLocalAgentHistory uses the selected sessionId and latest-first session query when reopening a non-default OpenClaw thread', async () => {
     const fakeFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         session: 'openclaw:dkg-ui:worker-1',
         messages: [
           { text: 'worker hello', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
+          { text: 'worker reply', author: 'agent', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
         ],
       }),
     });
@@ -422,8 +426,11 @@ describe('OpenClaw bridge behavioral tests', () => {
       });
       const [url] = fakeFetch.mock.calls[0];
       expect(String(url)).toContain('/api/memory/sessions/openclaw%3Adkg-ui%3Aworker-1');
-      expect(history).toHaveLength(1);
+      expect(String(url)).toContain('limit=10');
+      expect(String(url)).toContain('order=desc');
+      expect(history).toHaveLength(2);
       expect(history[0].text).toBe('worker hello');
+      expect(history[1].text).toBe('worker reply');
     } finally {
       globalThis.fetch = original;
     }

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -387,9 +387,9 @@ describe('OpenClaw bridge behavioral tests', () => {
       json: async () => ({
         session: 'openclaw:dkg-ui',
         messages: [
-          { text: 'first', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
-          { text: 'second', author: 'user', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
-          { text: 'third', author: 'agent', ts: '2026-03-11T10:02:00Z', turnId: 'turn-3' },
+          { uri: 'urn:dkg:chat:msg:user-1', text: 'first', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
+          { uri: 'urn:dkg:chat:msg:user-2', text: 'second', author: 'user', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
+          { uri: 'urn:dkg:chat:msg:agent-3', text: 'third', author: 'agent', ts: '2026-03-11T10:02:00Z', turnId: 'turn-3' },
         ],
       }),
     });
@@ -415,8 +415,8 @@ describe('OpenClaw bridge behavioral tests', () => {
       json: async () => ({
         session: 'openclaw:dkg-ui:worker-1',
         messages: [
-          { text: 'worker hello', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
-          { text: 'worker reply', author: 'agent', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
+          { uri: 'urn:dkg:chat:msg:worker-user-1', text: 'worker hello', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
+          { uri: 'urn:dkg:chat:msg:worker-agent-2', text: 'worker reply', author: 'agent', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
         ],
       }),
     });
@@ -434,6 +434,46 @@ describe('OpenClaw bridge behavioral tests', () => {
       expect(history).toHaveLength(2);
       expect(history[0].text).toBe('worker hello');
       expect(history[1].text).toBe('worker reply');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('fetchLocalAgentHistory uses stable backend message URIs when the loaded history window shifts', async () => {
+    const firstWindow = {
+      session: 'openclaw:dkg-ui',
+      messages: [
+        { uri: 'urn:dkg:chat:msg:user-hello', text: 'hello there', author: 'user', ts: '2026-03-11T10:00:00Z' },
+        { uri: 'urn:dkg:chat:msg:agent-reply', text: 'reply here', author: 'agent', ts: '2026-03-11T10:01:00Z' },
+      ],
+    };
+    const shiftedWindow = {
+      session: 'openclaw:dkg-ui',
+      messages: [
+        { uri: 'urn:dkg:chat:msg:user-older', text: 'older context', author: 'user', ts: '2026-03-11T09:59:00Z' },
+        { uri: 'urn:dkg:chat:msg:user-hello', text: 'hello there', author: 'user', ts: '2026-03-11T10:00:00Z' },
+        { uri: 'urn:dkg:chat:msg:agent-reply', text: 'reply here', author: 'agent', ts: '2026-03-11T10:01:00Z' },
+      ],
+    };
+    const fakeFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => firstWindow,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => shiftedWindow,
+      });
+    const original = globalThis.fetch;
+    globalThis.fetch = fakeFetch;
+    try {
+      const { fetchLocalAgentHistory } = await import('../src/ui/api.js');
+      const firstHistory = await fetchLocalAgentHistory('openclaw', 2);
+      const secondHistory = await fetchLocalAgentHistory('openclaw', 3);
+      expect(firstHistory[0].uri).toBe('urn:dkg:chat:msg:user-hello');
+      expect(firstHistory[1].uri).toBe('urn:dkg:chat:msg:agent-reply');
+      expect(firstHistory[0].uri).toBe(secondHistory[1].uri);
+      expect(firstHistory[1].uri).toBe(secondHistory[2].uri);
     } finally {
       globalThis.fetch = original;
     }

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -52,8 +52,8 @@ describe('OpenClaw bridge API contract', () => {
 
   it('exports fetchOpenClawLocalHistory', () => {
     expect(apiSrc).toContain('fetchOpenClawLocalHistory');
-    expect(apiSrc).toContain('openclaw:dkg-ui');
-    expect(apiSrc).toContain('ORDER BY DESC(?ts)');
+    expect(apiSrc).toContain('getDefaultLocalAgentSessionId');
+    expect(apiSrc).toContain('fetchMemorySession(sessionId)');
   });
 
   it('exports the future-friendly local agent integration contract', () => {
@@ -149,6 +149,19 @@ describe('PanelRight UI - connected agent flow', () => {
   it('keeps the + add-agent tab selected during background refreshes', () => {
     expect(panelRight).toContain('const preserveSelected = selectedIntegrationId === ADD_AGENT_TAB_ID');
     expect(panelRight).toContain("preferred && !autoFocusedLocalAgentRef.current && selectedIntegrationId !== ADD_AGENT_TAB_ID");
+  });
+
+  it('keeps local agent state keyed by session so non-default threads do not collapse to the default conversation', () => {
+    expect(panelRight).toContain('selectedSessionId');
+    expect(panelRight).toContain('localMessagesByConversation');
+    expect(panelRight).toContain('getLocalAgentConversationStateKey');
+    expect(panelRight).toContain('sessionId: conversation.sessionId ?? undefined');
+    expect(panelRight).not.toContain('localHistoryLoadedByIntegration[integrationId] === true');
+  });
+
+  it('preserves the selected session when disconnecting or reopening a specific local-agent thread', () => {
+    expect(panelRight).toContain('setSelectedIntegration(integrationId, { preserveSession: selectedIntegrationId === integrationId })');
+    expect(panelRight).toContain('setSelectedIntegration(session.integrationId, { sessionId: session.sessionId })');
   });
 
   it('keeps the interface future-friendly for Hermes', () => {
@@ -364,17 +377,16 @@ describe('OpenClaw bridge behavioral tests', () => {
     expect(panelRight).toContain('Connect OpenClaw');
   });
 
-  it('fetchOpenClawLocalHistory requests newest rows first and returns chronological order', async () => {
+  it('fetchOpenClawLocalHistory loads the default OpenClaw session from /api/memory/sessions/:sessionId', async () => {
     const fakeFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
-        result: {
-          bindings: [
-            { uri: { value: 'urn:3' }, text: { value: 'third' }, author: { value: 'agent' }, ts: { value: '2026-03-11T10:02:00Z' }, turnId: { value: 'turn-3' } },
-            { uri: { value: 'urn:2' }, text: { value: 'second' }, author: { value: 'user' }, ts: { value: '2026-03-11T10:01:00Z' }, turnId: { value: 'turn-2' } },
-            { uri: { value: 'urn:1' }, text: { value: 'first' }, author: { value: 'user' }, ts: { value: '2026-03-11T10:00:00Z' }, turnId: { value: 'turn-1' } },
-          ],
-        },
+        session: 'openclaw:dkg-ui',
+        messages: [
+          { text: 'first', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
+          { text: 'second', author: 'user', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
+          { text: 'third', author: 'agent', ts: '2026-03-11T10:02:00Z', turnId: 'turn-3' },
+        ],
       }),
     });
     const original = globalThis.fetch;
@@ -382,12 +394,59 @@ describe('OpenClaw bridge behavioral tests', () => {
     try {
       const { fetchOpenClawLocalHistory } = await import('../src/ui/api.js');
       const history = await fetchOpenClawLocalHistory(3);
-      const [, opts] = fakeFetch.mock.calls[0];
-      const body = JSON.parse(opts.body);
-      expect(body.sparql).toContain('ORDER BY DESC(?ts)');
-      expect(body.sparql).toContain('?turnId');
+      const [url] = fakeFetch.mock.calls[0];
+      expect(String(url)).toContain('/api/memory/sessions/openclaw%3Adkg-ui');
       expect(history.map((row: any) => row.text)).toEqual(['first', 'second', 'third']);
       expect(history[0].turnId).toBe('turn-1');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('fetchLocalAgentHistory uses the selected sessionId when reopening a non-default OpenClaw thread', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        session: 'openclaw:dkg-ui:worker-1',
+        messages: [
+          { text: 'worker hello', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
+        ],
+      }),
+    });
+    const original = globalThis.fetch;
+    globalThis.fetch = fakeFetch;
+    try {
+      const { fetchLocalAgentHistory } = await import('../src/ui/api.js');
+      const history = await fetchLocalAgentHistory('openclaw', 10, {
+        sessionId: 'openclaw:dkg-ui:worker-1',
+      });
+      const [url] = fakeFetch.mock.calls[0];
+      expect(String(url)).toContain('/api/memory/sessions/openclaw%3Adkg-ui%3Aworker-1');
+      expect(history).toHaveLength(1);
+      expect(history[0].text).toBe('worker hello');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('streamLocalAgentChat forwards the non-default OpenClaw identity so follow-up sends stay on the selected session', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      body: null,
+      json: async () => ({ text: 'reply', correlationId: 'corr-1' }),
+    });
+    const original = globalThis.fetch;
+    globalThis.fetch = fakeFetch;
+    try {
+      const { streamLocalAgentChat } = await import('../src/ui/api.js');
+      await streamLocalAgentChat('openclaw', 'hello', {
+        sessionId: 'openclaw:dkg-ui:background-worker',
+      });
+      const [, opts] = fakeFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.identity).toBe('background-worker');
+      expect(body.correlationId).toBeTruthy();
     } finally {
       globalThis.fetch = original;
     }
@@ -546,23 +605,86 @@ describe('OpenClaw bridge behavioral tests', () => {
           },
         ],
         selectedIntegrationId: 'openclaw',
-        localMessagesByIntegration: {},
-        localHistoryLoadedByIntegration: {},
+        selectedSessionId: 'openclaw:dkg-ui:session-1',
+        localMessagesByConversation: {},
         sessions: [
           {
-            id: 'session-1',
+            sessionId: 'openclaw:dkg-ui:session-1',
             integrationId: 'openclaw',
             integrationName: 'OpenClaw',
-            title: 'OpenClaw - session-1',
-            lastUpdatedAt: '2026-04-13 20:00',
-            lastMessagePreview: 'Hey there',
+            preview: 'Hey there',
+            messageCount: 1,
+            lastTs: '2026-04-13T20:00:00Z',
           },
         ],
       });
 
       expect(state.selectedIntegration?.id).toBe('openclaw');
       expect(state.selectedHasConversation).toBe(true);
+      expect(state.selectedConversation?.sessionId).toBe('openclaw:dkg-ui:session-1');
       expect(state.connectedIntegrations).toHaveLength(0);
+    } finally {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
+  });
+
+  it('resolveLocalAgentSelectionState does not treat an empty history load as an existing conversation', async () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    try {
+      const { getLocalAgentConversationStateKey, resolveLocalAgentSelectionState } = await import('../src/ui/components/Shell/PanelRight.tsx');
+      const state = resolveLocalAgentSelectionState({
+        integrations: [
+          {
+            id: 'openclaw',
+            name: 'OpenClaw',
+            framework: 'OpenClaw',
+            description: 'OpenClaw framework adapter',
+            chatSupported: true,
+            connectSupported: true,
+            configured: true,
+            detected: true,
+            persistentChat: true,
+            chatReady: true,
+            bridgeOnline: true,
+            bridgeStatusLabel: 'Connected',
+            status: 'chat_ready',
+            statusLabel: 'Chat ready',
+            detail: 'Connected through the bridge.',
+            source: 'live',
+          },
+        ],
+        selectedIntegrationId: 'openclaw',
+        selectedSessionId: 'openclaw:dkg-ui',
+        localMessagesByConversation: {
+          [getLocalAgentConversationStateKey('openclaw', 'openclaw:dkg-ui')]: [],
+        },
+        sessions: [],
+      });
+
+      expect(state.selectedHasConversation).toBe(false);
+      expect(state.selectedConversation?.sessionId).toBe('openclaw:dkg-ui');
+    } finally {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
+  });
+
+  it('networkPeerCardStatusClass keeps disconnected known peers out of the connected styling', async () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    try {
+      const { networkPeerCardStatusClass } = await import('../src/ui/components/Shell/PanelRight.tsx');
+      expect(networkPeerCardStatusClass({ connectionStatus: 'connected' } as any)).toBe('connected');
+      expect(networkPeerCardStatusClass({ connectionStatus: 'disconnected' } as any)).toBe('offline');
+      expect(networkPeerCardStatusClass({ connectionStatus: 'known' } as any)).toBe('offline');
     } finally {
       (globalThis as any).localStorage = originalLocalStorage;
     }

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -166,6 +166,7 @@ describe('PanelRight UI - connected agent flow', () => {
   it('preserves the selected session when disconnecting or reopening a specific local-agent thread', () => {
     expect(panelRight).toContain('setSelectedIntegration(integrationId, { preserveSession: selectedIntegrationId === integrationId })');
     expect(panelRight).toContain('setSelectedIntegration(session.integrationId, { sessionId: session.sessionId })');
+    expect(panelRight).toContain('shouldPreserveSessionOnReconnect');
   });
 
   it('keeps the interface future-friendly for Hermes', () => {
@@ -214,11 +215,17 @@ describe('Agent hub shell surfaces', () => {
 describe('OpenClaw bridge behavioral tests', () => {
   beforeEach(() => {
     (globalThis as any).window = { __DKG_TOKEN__: undefined };
+    (globalThis as any).localStorage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
     vi.resetModules();
   });
 
   afterEach(() => {
     delete (globalThis as any).window;
+    delete (globalThis as any).localStorage;
   });
 
   it('fetchOpenClawAgents calls GET /api/openclaw-agents', async () => {
@@ -407,6 +414,46 @@ describe('OpenClaw bridge behavioral tests', () => {
     } finally {
       globalThis.fetch = original;
     }
+  });
+
+  it('preserves a reopened non-default session when reconnecting the same integration', async () => {
+    const { shouldPreserveSessionOnReconnect } = await import('../src/ui/components/Shell/PanelRight.tsx');
+    const integrations = [
+      {
+        id: 'openclaw',
+        name: 'OpenClaw',
+        framework: 'OpenClaw',
+        connected: false,
+        chatReady: false,
+        persistentChat: true,
+        connectSupported: true,
+      },
+      {
+        id: 'hermes',
+        name: 'Hermes',
+        framework: 'Hermes',
+        connected: false,
+        chatReady: false,
+        persistentChat: true,
+        connectSupported: true,
+      },
+    ];
+
+    expect(shouldPreserveSessionOnReconnect({
+      integrationId: 'openclaw',
+      selectedSessionId: 'openclaw:dkg-ui:worker-1',
+      integrations,
+    })).toBe(true);
+    expect(shouldPreserveSessionOnReconnect({
+      integrationId: 'openclaw',
+      selectedSessionId: 'hermes:dkg-ui',
+      integrations,
+    })).toBe(false);
+    expect(shouldPreserveSessionOnReconnect({
+      integrationId: 'openclaw',
+      selectedSessionId: null,
+      integrations,
+    })).toBe(false);
   });
 
   it('fetchLocalAgentHistory uses the selected sessionId and latest-first session query when reopening a non-default OpenClaw thread', async () => {

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -388,15 +388,15 @@ describe('OpenClaw bridge behavioral tests', () => {
     expect(panelRight).toContain('Connect OpenClaw');
   });
 
-  it('fetchOpenClawLocalHistory requests the newest turns from /api/memory/sessions/:sessionId and returns chronological order', async () => {
+  it('fetchOpenClawLocalHistory requests the newest turns from /api/memory/sessions/:sessionId and normalizes them back to chronological order for chat display', async () => {
     const fakeFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         session: 'openclaw:dkg-ui',
         messages: [
-          { uri: 'urn:dkg:chat:msg:user-1', text: 'first', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
-          { uri: 'urn:dkg:chat:msg:user-2', text: 'second', author: 'user', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
           { uri: 'urn:dkg:chat:msg:agent-3', text: 'third', author: 'agent', ts: '2026-03-11T10:02:00Z', turnId: 'turn-3' },
+          { uri: 'urn:dkg:chat:msg:user-2', text: 'second', author: 'user', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
+          { uri: 'urn:dkg:chat:msg:user-1', text: 'first', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
         ],
       }),
     });
@@ -456,14 +456,14 @@ describe('OpenClaw bridge behavioral tests', () => {
     })).toBe(false);
   });
 
-  it('fetchLocalAgentHistory uses the selected sessionId and latest-first session query when reopening a non-default OpenClaw thread', async () => {
+  it('fetchLocalAgentHistory uses the selected sessionId and latest-first session query when reopening a non-default OpenClaw thread, while returning chronological rows', async () => {
     const fakeFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         session: 'openclaw:dkg-ui:worker-1',
         messages: [
-          { uri: 'urn:dkg:chat:msg:worker-user-1', text: 'worker hello', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
           { uri: 'urn:dkg:chat:msg:worker-agent-2', text: 'worker reply', author: 'agent', ts: '2026-03-11T10:01:00Z', turnId: 'turn-2' },
+          { uri: 'urn:dkg:chat:msg:worker-user-1', text: 'worker hello', author: 'user', ts: '2026-03-11T10:00:00Z', turnId: 'turn-1' },
         ],
       }),
     });
@@ -490,16 +490,16 @@ describe('OpenClaw bridge behavioral tests', () => {
     const firstWindow = {
       session: 'openclaw:dkg-ui',
       messages: [
-        { uri: 'urn:dkg:chat:msg:user-hello', text: 'hello there', author: 'user', ts: '2026-03-11T10:00:00Z' },
         { uri: 'urn:dkg:chat:msg:agent-reply', text: 'reply here', author: 'agent', ts: '2026-03-11T10:01:00Z' },
+        { uri: 'urn:dkg:chat:msg:user-hello', text: 'hello there', author: 'user', ts: '2026-03-11T10:00:00Z' },
       ],
     };
     const shiftedWindow = {
       session: 'openclaw:dkg-ui',
       messages: [
-        { uri: 'urn:dkg:chat:msg:user-older', text: 'older context', author: 'user', ts: '2026-03-11T09:59:00Z' },
-        { uri: 'urn:dkg:chat:msg:user-hello', text: 'hello there', author: 'user', ts: '2026-03-11T10:00:00Z' },
         { uri: 'urn:dkg:chat:msg:agent-reply', text: 'reply here', author: 'agent', ts: '2026-03-11T10:01:00Z' },
+        { uri: 'urn:dkg:chat:msg:user-hello', text: 'hello there', author: 'user', ts: '2026-03-11T10:00:00Z' },
+        { uri: 'urn:dkg:chat:msg:user-older', text: 'older context', author: 'user', ts: '2026-03-11T09:59:00Z' },
       ],
     };
     const fakeFetch = vi.fn()

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -163,7 +163,9 @@ describe('PanelRight UI - connected agent flow', () => {
     expect(panelRight).not.toContain('localHistoryLoadedByIntegration[integrationId] === true');
   });
 
-  it('preserves the selected session when disconnecting or reopening a specific local-agent thread', () => {
+  it('preserves the selected session when reselecting, disconnecting, or reopening a specific local-agent thread', () => {
+    expect(panelRight).toContain('shouldPreserveSessionForIntegrationSelection');
+    expect(panelRight).toContain('onClick={() => onSelectIntegration(integration.id, {');
     expect(panelRight).toContain('setSelectedIntegration(integrationId, { preserveSession: selectedIntegrationId === integrationId })');
     expect(panelRight).toContain('setSelectedIntegration(session.integrationId, { sessionId: session.sessionId })');
     expect(panelRight).toContain('shouldPreserveSessionOnReconnect');
@@ -416,8 +418,11 @@ describe('OpenClaw bridge behavioral tests', () => {
     }
   });
 
-  it('preserves a reopened non-default session when reconnecting the same integration', async () => {
-    const { shouldPreserveSessionOnReconnect } = await import('../src/ui/components/Shell/PanelRight.tsx');
+  it('preserves a reopened non-default session when reselecting or reconnecting the same integration', async () => {
+    const {
+      shouldPreserveSessionForIntegrationSelection,
+      shouldPreserveSessionOnReconnect,
+    } = await import('../src/ui/components/Shell/PanelRight.tsx');
     const integrations = [
       {
         id: 'openclaw',
@@ -439,6 +444,21 @@ describe('OpenClaw bridge behavioral tests', () => {
       },
     ];
 
+    expect(shouldPreserveSessionForIntegrationSelection({
+      integrationId: 'openclaw',
+      selectedSessionId: 'openclaw:dkg-ui:worker-1',
+      integrations,
+    })).toBe(true);
+    expect(shouldPreserveSessionForIntegrationSelection({
+      integrationId: 'openclaw',
+      selectedSessionId: 'hermes:dkg-ui',
+      integrations,
+    })).toBe(false);
+    expect(shouldPreserveSessionForIntegrationSelection({
+      integrationId: 'openclaw',
+      selectedSessionId: null,
+      integrations,
+    })).toBe(false);
     expect(shouldPreserveSessionOnReconnect({
       integrationId: 'openclaw',
       selectedSessionId: 'openclaw:dkg-ui:worker-1',

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -148,7 +148,7 @@ describe('PanelRight UI - connected agent flow', () => {
   });
 
   it('keeps the + add-agent tab selected during background refreshes', () => {
-    expect(panelRight).toContain('const preserveSelected = selectedIntegrationId === ADD_AGENT_TAB_ID');
+    expect(panelRight).toContain('const preserveSelected = shouldPreserveSelectedLocalAgentTab({');
     expect(panelRight).toContain("preferred && !autoFocusedLocalAgentRef.current && selectedIntegrationId !== ADD_AGENT_TAB_ID");
   });
 
@@ -157,6 +157,9 @@ describe('PanelRight UI - connected agent flow', () => {
     expect(panelRight).toContain('localMessagesByConversation');
     expect(panelRight).toContain('getLocalAgentConversationStateKey');
     expect(panelRight).toContain('sessionId: conversation.sessionId ?? undefined');
+    expect(panelRight).toContain('selectedIntegrationHasAnyConversation');
+    expect(panelRight).toContain('resolveConnectedAgentsTabState');
+    expect(panelRight).toContain('shouldPreserveSelectedLocalAgentTab');
     expect(panelRight).not.toContain('localHistoryLoadedByIntegration[integrationId] === true');
   });
 
@@ -675,6 +678,176 @@ describe('OpenClaw bridge behavioral tests', () => {
 
       expect(state.selectedHasConversation).toBe(false);
       expect(state.selectedConversation?.sessionId).toBe('openclaw:dkg-ui');
+    } finally {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
+  });
+
+  it('resolveLocalAgentSelectionState keeps integration-wide stored sessions separate from the selected default thread', async () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    try {
+      const { resolveLocalAgentSelectionState } = await import('../src/ui/components/Shell/PanelRight.tsx');
+      const state = resolveLocalAgentSelectionState({
+        integrations: [
+          {
+            id: 'openclaw',
+            name: 'OpenClaw',
+            framework: 'OpenClaw',
+            description: 'OpenClaw framework adapter',
+            chatSupported: true,
+            connectSupported: true,
+            configured: false,
+            detected: false,
+            persistentChat: false,
+            chatReady: false,
+            bridgeOnline: false,
+            bridgeStatusLabel: 'Ready to connect',
+            status: 'available',
+            statusLabel: 'Ready to connect',
+            detail: 'Use the node-served skill plus OpenClaw onboarding to attach an existing local agent.',
+            source: 'live',
+          },
+        ],
+        selectedIntegrationId: 'openclaw',
+        selectedSessionId: 'openclaw:dkg-ui',
+        localMessagesByConversation: {},
+        sessions: [
+          {
+            sessionId: 'openclaw:dkg-ui:worker-1',
+            integrationId: 'openclaw',
+            integrationName: 'OpenClaw',
+            preview: 'Worker thread',
+            messageCount: 2,
+            lastTs: '2026-04-13T21:00:00Z',
+          },
+        ],
+      });
+
+      expect(state.selectedConversation?.sessionId).toBe('openclaw:dkg-ui');
+      expect(state.selectedHasConversation).toBe(false);
+      expect(state.selectedIntegrationHasAnyConversation).toBe(true);
+    } finally {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
+  });
+
+  it('resolveConnectedAgentsTabState keeps a disconnected integration visible when it has saved sessions elsewhere', async () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    try {
+      const { resolveConnectedAgentsTabState } = await import('../src/ui/components/Shell/PanelRight.tsx');
+      const openclaw = {
+        id: 'openclaw',
+        name: 'OpenClaw',
+        framework: 'OpenClaw',
+        description: 'OpenClaw framework adapter',
+        chatSupported: true,
+        connectSupported: true,
+        configured: false,
+        detected: false,
+        persistentChat: false,
+        chatReady: false,
+        bridgeOnline: false,
+        bridgeStatusLabel: 'Ready to connect',
+        status: 'available',
+        statusLabel: 'Ready to connect',
+        detail: 'Use the node-served skill plus OpenClaw onboarding to attach an existing local agent.',
+        source: 'live',
+      };
+      const connectedHermes = {
+        id: 'hermes',
+        name: 'Hermes',
+        framework: 'Hermes',
+        description: 'Hermes framework adapter',
+        chatSupported: true,
+        connectSupported: false,
+        configured: true,
+        detected: true,
+        persistentChat: true,
+        chatReady: true,
+        bridgeOnline: true,
+        bridgeStatusLabel: 'Connected',
+        status: 'chat_ready',
+        statusLabel: 'Chat ready',
+        detail: 'Connected through the bridge.',
+        source: 'live',
+      };
+
+      const state = resolveConnectedAgentsTabState({
+        connectedAgents: [connectedHermes],
+        selectedIntegration: openclaw,
+        selectedIntegrationId: 'openclaw',
+        selectedHasConversation: false,
+        selectedIntegrationHasAnyConversation: true,
+        localHistoryLoaded: false,
+        localMessagesCount: 0,
+      });
+
+      expect(state.showingSessionHistory).toBe(false);
+      expect(state.showingStoredSessions).toBe(true);
+      expect(state.showAddFlow).toBe(false);
+      expect(state.visibleAgentTabs.map((item: any) => item.id)).toEqual(['openclaw', 'hermes']);
+      expect(state.shouldShowConversationLoader).toBe(false);
+    } finally {
+      (globalThis as any).localStorage = originalLocalStorage;
+    }
+  });
+
+  it('shouldPreserveSelectedLocalAgentTab keeps a disconnected integration selected when other saved sessions exist', async () => {
+    const originalLocalStorage = (globalThis as any).localStorage;
+    (globalThis as any).localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    try {
+      const { shouldPreserveSelectedLocalAgentTab } = await import('../src/ui/components/Shell/PanelRight.tsx');
+      const openclaw = {
+        id: 'openclaw',
+        name: 'OpenClaw',
+        framework: 'OpenClaw',
+        description: 'OpenClaw framework adapter',
+        chatSupported: true,
+        connectSupported: true,
+        configured: false,
+        detected: false,
+        persistentChat: false,
+        chatReady: false,
+        bridgeOnline: false,
+        bridgeStatusLabel: 'Ready to connect',
+        status: 'available',
+        statusLabel: 'Ready to connect',
+        detail: 'Use the node-served skill plus OpenClaw onboarding to attach an existing local agent.',
+        source: 'live',
+      };
+
+      const preserve = shouldPreserveSelectedLocalAgentTab({
+        selectedIntegrationId: 'openclaw',
+        selectedItem: openclaw,
+        selectedSessionId: 'openclaw:dkg-ui',
+        localMessagesByConversation: {},
+        sessionSummaries: [
+          {
+            sessionId: 'openclaw:dkg-ui:worker-1',
+            integrationId: 'openclaw',
+            integrationName: 'OpenClaw',
+            preview: 'Worker thread',
+            messageCount: 2,
+            lastTs: '2026-04-13T21:00:00Z',
+          },
+        ],
+      });
+
+      expect(preserve).toBe(true);
     } finally {
       (globalThis as any).localStorage = originalLocalStorage;
     }


### PR DESCRIPTION
## Summary
- address the still-valid carry-forward review items from PR #137 against the merged `v10-rc` baseline
- harden the OpenClaw adapter/daemon contract around setup-safe registration, gateway fallback transport, disconnect persistence, and cancellation-safe turn persistence
- make the right-rail local-agent state session-aware so Sessions reopen the correct transcript and disconnected peers render accurately

## What changed
- `packages/adapter-openclaw`
  - split `setup-entry.mjs` into a setup-safe wrapper
  - preserve or derive `gatewayUrl` on OpenClaw registration payloads so gateway fallback is usable on first registration and reruns
  - skip startup re-registration when OpenClaw is stored as disconnected
  - migrate legacy transport hints into `localAgentIntegrations.openclaw.transport` during setup reruns
  - persist cancelled/failed streaming turns truthfully and prevent retry resurrection after `stop()`
- `packages/cli`
  - stop trusting an arbitrary healthy bridge as proof of first-time attach readiness
  - prefer local workspace package setup resolution before `npx`
  - accept/forward structured `persistenceState` on `/api/openclaw-channel/persist-turn`
  - restore `contextGraphs` in `/api/integrations` for UI compatibility
- `packages/node-ui`
  - reopen Sessions by concrete `sessionId`
  - key local-agent history, draft input, and send state by conversation/session instead of integration only
  - separate empty-history load state from conversation existence
  - render disconnected peers as offline and preserve the selected session on disconnect

## Verification
- `packages/adapter-openclaw`: `pnpm exec vitest run test/setup-entry.test.ts test/plugin.test.ts test/setup.test.ts test/dkg-channel.test.ts`
- `packages/cli`: `pnpm exec vitest run test/daemon-openclaw.test.ts`
- `packages/node-ui`: `pnpm exec vitest run test/openclaw-bridge.test.ts`
- repo root: `pnpm build`

## Notes
- This PR intentionally focuses on the valid PR #137 carry-forward items first.
- The requested right-rail UI polish will be added on top of this branch in the same PR after the initial review loop.
- Agent-chat attachment support will ship in a chained follow-up PR once the carry-forward baseline is merged.
