### PR TITLE
feat(v10): Phase 10 — RandomSampling value-weighted CG selection

### DIFF
--- a/packages/evm-module/abi/RandomSampling.json
+++ b/packages/evm-module/abi/RandomSampling.json
@@ -27,6 +27,16 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "NoEligibleContextGraph",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoEligibleKnowledgeCollection",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint72",
@@ -52,6 +62,62 @@
     "inputs": [],
     "name": "ZeroAddressHub",
     "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "knowledgeCollectionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "chunkId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "activeProofPeriodStartBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "ChallengeGenerated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_KC_RETRIES",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [],
@@ -104,6 +170,32 @@
     "outputs": [
       {
         "internalType": "contract Chronos",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "contextGraphStorage",
+    "outputs": [
+      {
+        "internalType": "contract ContextGraphStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "contextGraphValueStorage",
+    "outputs": [
+      {
+        "internalType": "contract ContextGraphValueStorage",
         "name": "",
         "type": "address"
       }
@@ -286,6 +378,40 @@
         "internalType": "contract ParametersStorage",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "seed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "targetEpoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewChallengeForSeed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "cgId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "kcId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chunkId",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -19,6 +19,8 @@ import {AskStorage} from "./storage/AskStorage.sol";
 import {DelegatorsInfo} from "./storage/DelegatorsInfo.sol";
 import {ParametersStorage} from "./storage/ParametersStorage.sol";
 import {ShardingTableStorage} from "./storage/ShardingTableStorage.sol";
+import {ContextGraphStorage} from "./storage/ContextGraphStorage.sol";
+import {ContextGraphValueStorage} from "./storage/ContextGraphValueStorage.sol";
 import {ICustodian} from "./interfaces/ICustodian.sol";
 import {HubLib} from "./libraries/HubLib.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -27,6 +29,13 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     string private constant _NAME = "RandomSampling";
     string private constant _VERSION = "1.0.0";
     uint256 public constant SCALE18 = 1e18;
+
+    /// @notice Maximum number of in-CG resamples when the picker hits an
+    ///         expired KC during Phase 10 weighted challenge generation.
+    ///         Exhausting this budget reverts with `NoEligibleKnowledgeCollection`
+    ///         so the node skips the current proof period and retries on the
+    ///         next one (see {_pickWeightedChallenge}).
+    uint8 public constant MAX_KC_RETRIES = 10;
 
     IdentityStorage public identityStorage;
     RandomSamplingStorage public randomSamplingStorage;
@@ -39,8 +48,33 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     DelegatorsInfo public delegatorsInfo;
     ParametersStorage public parametersStorage;
     ShardingTableStorage public shardingTableStorage;
+    ContextGraphStorage public contextGraphStorage;
+    ContextGraphValueStorage public contextGraphValueStorage;
 
     error MerkleRootMismatchError(bytes32 computedMerkleRoot, bytes32 expectedMerkleRoot);
+    /// @notice Thrown by `_generateChallenge` when no public, active CG holds
+    ///         non-zero per-epoch value at the current epoch — i.e. there is
+    ///         nothing eligible to challenge against. The caller's transaction
+    ///         reverts and the node retries on the next proof period.
+    error NoEligibleContextGraph();
+    /// @notice Thrown by `_generateChallenge` when the chosen CG's KC list is
+    ///         empty or all sampled KCs are expired after `MAX_KC_RETRIES`
+    ///         attempts. Same retry-next-period semantics as above.
+    error NoEligibleKnowledgeCollection();
+
+    /// @notice Emitted when {createChallenge} produces a new challenge for a
+    ///         node. Off-chain consumers (node UI, indexers) use the indexed
+    ///         `cgId` to know which Context Graph the challenge targets — this
+    ///         information is intentionally NOT stored on the Challenge struct
+    ///         to keep its on-chain footprint unchanged.
+    event ChallengeGenerated(
+        uint72 indexed identityId,
+        uint256 indexed contextGraphId,
+        uint256 indexed knowledgeCollectionId,
+        uint256 chunkId,
+        uint256 epoch,
+        uint256 activeProofPeriodStartBlock
+    );
 
     /**
      * @dev Constructor initializes the contract with essential parameters for random sampling
@@ -90,6 +124,11 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         delegatorsInfo = DelegatorsInfo(hub.getContractAddress("DelegatorsInfo"));
         parametersStorage = ParametersStorage(hub.getContractAddress("ParametersStorage"));
         shardingTableStorage = ShardingTableStorage(hub.getContractAddress("ShardingTableStorage"));
+        // Phase 10 — value-weighted challenge generation. ContextGraphStorage is
+        // an asset storage (ERC-721 NFT registry), ContextGraphValueStorage is a
+        // regular hub contract.
+        contextGraphStorage = ContextGraphStorage(hub.getAssetStorageAddress("ContextGraphStorage"));
+        contextGraphValueStorage = ContextGraphValueStorage(hub.getContractAddress("ContextGraphValueStorage"));
     }
 
     /**
@@ -272,142 +311,228 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     }
 
     /**
-     * @dev Internal function to generate a new random challenge for a node
-     * Uses blockchain properties (block hash, difficulty, timestamp, gas price) for randomness
-     * Selects a random active knowledge collection and chunk within it
-     * Creates challenge with current epoch and active proof period information
-     * @param originalSender The original caller address for randomness seed
-     * @return challenge The generated challenge struct
+     * @dev Generates a new value-weighted challenge for a node.
+     *
+     * Phase 10 — value-weighted CG selection (replaces V8 uniform-random KC pick).
+     * Uses blockchain properties (block hash, difficulty, timestamp, gas price)
+     * for randomness, picks a Context Graph weighted by its per-epoch TRAC
+     * value at the current epoch, and then picks a KC uniformly at random
+     * within that CG.
+     *
+     * Read-time exclusion (NOT a write-time filter): curated ("private") CGs
+     * and deactivated CGs are skipped during both the adjusted-total
+     * accumulation and the cumulative walk. Phase 8 writes to
+     * `ContextGraphValueStorage` unconditionally because it ships earlier;
+     * filtering at read time keeps Phase 10 isolated and reversible without
+     * touching the publish path.
+     *
+     * ## Open Risks (documented for V11+ — out of scope for Phase 10)
+     *
+     * - Weighting decay (cumulative drift): `cgValueCumulative` is per-epoch
+     *   (not lifetime-cumulative) via the diff/cumulative pattern in
+     *   `ContextGraphValueStorage`, so expired KCs auto-decay after their
+     *   active window. Correct by design — no Phase 10 action.
+     * - KC-level gaming: within a CG, KC selection is uniform — not
+     *   value-weighted. Skipping one high-value KC in a 100-KC CG costs only
+     *   1% of challenges, not proportional to that KC's TRAC share. Accepted
+     *   per `V10_CONTRACTS_REDESIGN_v2.md` §"Known limitation — KC-level
+     *   gaming". CG-level weighting is the primary defense.
+     * - Gas scaling: linear scan over all CGs is O(N) per challenge. Fine up
+     *   to ~1K CGs (~2.1M gas). Fenwick tree (BIT) deferred to V10.x.
+     * - Sync grace period / node publishing timing: out of scope.
+     *
+     * @param originalSender Original caller address used for randomness seed.
+     * @return challenge The generated challenge struct (signature-compatible
+     *         with V8 — `submitProof` does not need to know the cgId).
      */
     function _generateChallenge(address originalSender) internal returns (RandomSamplingLib.Challenge memory) {
-        uint256 knowledgeCollectionsCount = knowledgeCollectionStorage.getLatestKnowledgeCollectionId();
-        if (knowledgeCollectionsCount == 0) {
-            revert("No knowledge collections exist");
-        }
-
-        bytes32 pseudoRandomVariable = keccak256(
-            abi.encodePacked(
-                block.difficulty,
-                blockhash(block.number - ((block.difficulty % 256) + 1)), // +1 to avoid blockhash(block.number) situation
-                originalSender,
-                block.timestamp,
-                tx.gasprice,
-                uint8(1) // sector = 1 by default
-            )
-        );
+        bytes32 baseSeed = _deriveChallengeSeed(originalSender);
         uint256 currentEpoch = chronos.getCurrentEpoch();
 
-        // Optimized binary search approach for finding active knowledge collection
-        uint256 knowledgeCollectionId = _findActiveKnowledgeCollection(
-            pseudoRandomVariable,
-            1,
-            knowledgeCollectionsCount,
-            currentEpoch
-        );
+        (uint256 cgId, uint256 kcId, uint256 chunkId) = _pickWeightedChallenge(baseSeed, currentEpoch);
 
-        if (knowledgeCollectionId == 0) {
-            revert("Failed to find a knowledge collection that is active in the current epoch");
-        }
-
-        uint88 kcByteSize = knowledgeCollectionStorage.getByteSize(knowledgeCollectionId);
-        if (kcByteSize == 0) {
-            revert("Knowledge collection byte size is 0");
-        }
-
-        uint256 chunkId;
-        uint256 chunkByteSize = randomSamplingStorage.CHUNK_BYTE_SIZE();
-        // KC with byteSize < chunkByteSize will always have chunkId = 0
-        if (kcByteSize > chunkByteSize) {
-            chunkId = uint256(pseudoRandomVariable) % (kcByteSize / chunkByteSize);
-        }
+        uint72 identityId = identityStorage.getIdentityId(originalSender);
+        uint256 startBlock = updateAndGetActiveProofPeriodStartBlock();
+        emit ChallengeGenerated(identityId, cgId, kcId, chunkId, currentEpoch, startBlock);
 
         return
             RandomSamplingLib.Challenge(
-                knowledgeCollectionId,
+                kcId,
                 chunkId,
                 address(knowledgeCollectionStorage),
                 currentEpoch,
-                updateAndGetActiveProofPeriodStartBlock(),
+                startBlock,
                 getActiveProofingPeriodDurationInBlocks(),
                 false
             );
     }
 
     /**
-     * @dev Internal function to find an active knowledge collection using breadth-first search
-     * Uses BFS with a queue-based approach to efficiently search for collections that are
-     * still active (current epoch <= collection's end epoch)
-     * Splits ranges recursively and uses randomness to select from each range
-     * Limits iterations to prevent infinite loops and ensures gas efficiency
-     * @param randomSeed Random seed for picking a collection from current range
-     * @param start Start of the range (inclusive) - collection ID range to search
-     * @param end End of the range (inclusive) - collection ID range to search
-     * @param currentEpoch Current epoch to check collection activity against
-     * @return knowledgeCollectionId ID of an active knowledge collection, or 0 if none found
+     * @dev Builds the per-call randomness seed from block state + caller. Same
+     *      entropy mix as the V8 implementation — kept identical to preserve
+     *      seed quality across the Phase 10 upgrade.
      */
-    function _findActiveKnowledgeCollection(
-        bytes32 randomSeed,
-        uint256 start,
-        uint256 end,
+    function _deriveChallengeSeed(address originalSender) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    block.difficulty,
+                    blockhash(block.number - ((block.difficulty % 256) + 1)),
+                    originalSender,
+                    block.timestamp,
+                    tx.gasprice,
+                    uint8(1) // sector = 1 by default
+                )
+            );
+    }
+
+    /**
+     * @dev Read-only public preview of {_pickWeightedChallenge}. Lets nodes
+     *      and indexers simulate a draw for an arbitrary seed without writing
+     *      to storage; tests use it to drive distribution regression with
+     *      deterministic per-draw seeds and no block-mining.
+     *
+     *      Because this view shares the underlying picker with the production
+     *      path, any change to the weighted-selection logic is reflected in
+     *      both call sites — no test-only drift.
+     *
+     * @param seed       The 32-byte seed to draw against. Production callers
+     *                   should pass a high-entropy hash; tests pass deterministic
+     *                   per-iteration seeds for distribution analysis.
+     * @param targetEpoch Epoch to read CG values at. Pass `chronos.getCurrentEpoch()`
+     *                   for the live picker semantics.
+     * @return cgId      Selected Context Graph id.
+     * @return kcId      Selected Knowledge Collection id within that CG.
+     * @return chunkId   Selected chunk index within the KC.
+     */
+    function previewChallengeForSeed(
+        bytes32 seed,
+        uint256 targetEpoch
+    ) external view returns (uint256 cgId, uint256 kcId, uint256 chunkId) {
+        return _pickWeightedChallenge(seed, targetEpoch);
+    }
+
+    /**
+     * @dev Two-step weighted draw: pick a Context Graph weighted by per-epoch
+     *      TRAC value, then pick a KC uniformly at random within that CG with
+     *      bounded resampling on expired KCs.
+     *
+     *      Step 1 — Walk all CGs once to compute the adjusted total (sum of
+     *      `getCGValueAtEpoch` over CGs that are both active and non-curated).
+     *      `ContextGraphValueStorage.getTotalValueAtEpoch` would be cheaper
+     *      but it includes private CGs unconditionally; the adjusted total
+     *      MUST exclude them at read time. Walk again with a running cumulative
+     *      to pick the first eligible CG whose cumulative > r. Linear scan is
+     *      gas-acceptable up to ~1K CGs per V10_CONTRACTS_REDESIGN_v2 §"Gas
+     *      scaling" — Fenwick tree is the V10.x upgrade path.
+     *
+     *      Step 2 — Pick a KC at a random index in `_contextGraphKCList[cgId]`
+     *      (via `getContextGraphKCAt` so we copy a single element instead of
+     *      the full list). Resample up to `MAX_KC_RETRIES` if the picked KC
+     *      has expired (`endEpoch < currentEpoch`). Uses a fresh seed each
+     *      attempt via `keccak256(seed, attempt)`.
+     *
+     *      Step 3 — Compute the chunk index as in V8: `seed % (byteSize /
+     *      chunkByteSize)`, or 0 if the KC is smaller than one chunk.
+     *
+     *      Reverts:
+     *      - {NoEligibleContextGraph}        adjustedTotal == 0 (no public,
+     *                                        active CG holds value).
+     *      - {NoEligibleKnowledgeCollection} CG has an empty KC list, or
+     *                                        every retry hit an expired KC.
+     */
+    function _pickWeightedChallenge(
+        bytes32 seed,
         uint256 currentEpoch
-    ) internal view returns (uint256) {
-        // Queue using fixed array - [start1, end1, start2, end2, ...]
-        uint256[100] memory queue; // Can hold 50 ranges max
-        uint8 queueStart = 0; // Front of queue
-        uint8 queueEnd = 0; // Back of queue
-
-        // Push initial range
-        queue[queueEnd++] = start;
-        queue[queueEnd++] = end;
-
-        bytes32 currentRandom = randomSeed;
-        uint8 iterations = 0;
-
-        while (queueStart < queueEnd && iterations < 50) {
-            // Pop range from front of queue (BFS behavior)
-            uint256 currentStart = queue[queueStart++];
-            uint256 currentEnd = queue[queueStart++];
-
-            // Pick random collection from current range
-            uint256 randomKcId = currentStart + (uint256(currentRandom) % (currentEnd - currentStart + 1));
-
-            // Check if this collection is active
-            if (currentEpoch <= knowledgeCollectionStorage.getEndEpoch(randomKcId)) {
-                return randomKcId;
-            }
-
-            // If single element and not active, continue to next range
-            if (currentStart == currentEnd) {
-                currentRandom = keccak256(abi.encodePacked(currentRandom));
-                unchecked {
-                    iterations++;
-                }
+    ) internal view returns (uint256 cgId, uint256 kcId, uint256 chunkId) {
+        // ---- Step 1a: compute adjusted total over eligible CGs only. ----
+        uint256 cgCount = contextGraphStorage.getLatestContextGraphId();
+        uint256 adjustedTotal;
+        for (uint256 i = 1; i <= cgCount; i++) {
+            if (!_isCGEligible(i)) {
                 continue;
             }
-
-            // Split range and push both halves to back of queue (BFS order)
-            uint256 mid = currentStart + (currentEnd - currentStart) / 2;
-
-            if (queueEnd < 96) {
-                // Leave room for both ranges
-                // Always push left half first, then right half (consistent BFS)
-                if (currentStart <= mid) {
-                    queue[queueEnd++] = currentStart;
-                    queue[queueEnd++] = mid;
-                }
-                if (mid + 1 <= currentEnd) {
-                    queue[queueEnd++] = mid + 1;
-                    queue[queueEnd++] = currentEnd;
-                }
-            }
-
-            currentRandom = keccak256(abi.encodePacked(currentRandom));
-            unchecked {
-                iterations++;
-            }
+            adjustedTotal += contextGraphValueStorage.getCGValueAtEpoch(i, currentEpoch);
+        }
+        if (adjustedTotal == 0) {
+            revert NoEligibleContextGraph();
         }
 
-        return 0; // No active collection found
+        // ---- Step 1b: walk eligible CGs and pick the one straddling r. ----
+        uint256 r = uint256(seed) % adjustedTotal;
+        uint256 running;
+        for (uint256 i = 1; i <= cgCount; i++) {
+            if (!_isCGEligible(i)) {
+                continue;
+            }
+            running += contextGraphValueStorage.getCGValueAtEpoch(i, currentEpoch);
+            if (running > r) {
+                cgId = i;
+                break;
+            }
+        }
+        // Defensive: adjustedTotal > 0 guarantees at least one eligible CG
+        // contributed a positive weight, so the loop above must have set cgId.
+        // Reaching this branch means the per-epoch read drifted between
+        // the two passes (impossible from a `view` call — eligibility and
+        // values are deterministic for a fixed `currentEpoch`).
+        if (cgId == 0) {
+            revert NoEligibleContextGraph();
+        }
+
+        // ---- Step 2: pick a KC inside the chosen CG with bounded retries. ----
+        uint256 kcCount = contextGraphStorage.getContextGraphKCCount(cgId);
+        if (kcCount == 0) {
+            // Eligible CG exists but holds no registered KCs; treat the same
+            // as an all-expired CG (skip and retry next period).
+            revert NoEligibleKnowledgeCollection();
+        }
+        uint256 pickedKcId;
+        bytes32 kcSeed = seed;
+        for (uint8 attempt = 0; attempt < MAX_KC_RETRIES; attempt++) {
+            kcSeed = keccak256(abi.encodePacked(kcSeed, attempt));
+            uint256 idx = uint256(kcSeed) % kcCount;
+            uint256 candidate = contextGraphStorage.getContextGraphKCAt(cgId, idx);
+            if (knowledgeCollectionStorage.getEndEpoch(candidate) >= currentEpoch) {
+                pickedKcId = candidate;
+                break;
+            }
+        }
+        if (pickedKcId == 0) {
+            revert NoEligibleKnowledgeCollection();
+        }
+        kcId = pickedKcId;
+
+        // ---- Step 3: compute the chunk index identically to V8. ----
+        uint88 kcByteSize = knowledgeCollectionStorage.getByteSize(kcId);
+        if (kcByteSize == 0) {
+            // V8 used a verbose string here; surfacing as a custom error
+            // would change the ABI; keep the string for parity.
+            revert("Knowledge collection byte size is 0");
+        }
+        uint256 chunkByteSize = randomSamplingStorage.CHUNK_BYTE_SIZE();
+        if (kcByteSize > chunkByteSize) {
+            // Use the rotated kcSeed so chunk picks within a CG don't degenerate
+            // when many KCs share the same byte size.
+            chunkId = uint256(kcSeed) % (uint256(kcByteSize) / chunkByteSize);
+        }
+    }
+
+    /**
+     * @dev True iff the CG is active AND non-curated. Curated CGs are
+     *      treated as private for Phase 10 random sampling and excluded
+     *      from the weighted draw at read time. See `_generateChallenge`
+     *      NatSpec for the rationale (Phase 8 already ships unconditional
+     *      writes to `ContextGraphValueStorage`).
+     */
+    function _isCGEligible(uint256 contextGraphId) internal view returns (bool) {
+        if (!contextGraphStorage.isContextGraphActive(contextGraphId)) {
+            return false;
+        }
+        if (contextGraphStorage.getIsCurated(contextGraphId)) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/packages/evm-module/deploy/031_deploy_random_sampling.ts
+++ b/packages/evm-module/deploy/031_deploy_random_sampling.ts
@@ -9,6 +9,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 export default func;
 func.tags = ['RandomSampling'];
+// IMPORTANT: ContextGraphStorage and ContextGraphValueStorage are listed as
+// dependencies because RandomSampling.initialize() reads both via
+// `hub.getAssetStorageAddress("ContextGraphStorage")` and
+// `hub.getContractAddress("ContextGraphValueStorage")` for Phase 10
+// value-weighted challenge generation. Without them, initialize() would
+// resolve to address(0) on hardhat (no manual reinit on dev networks), so we
+// need the Hub to already have them registered when this script runs. Their
+// deploy scripts use higher file numbers (049 / 050) than this one (031);
+// hardhat-deploy honours the dependency graph over file ordering when a tag
+// list is supplied, so listing them here is sufficient — no file rename.
 func.dependencies = [
   'Hub',
   'Chronos',
@@ -22,4 +32,6 @@ func.dependencies = [
   'IdentityStorage',
   'ShardingTableStorage',
   'ParametersStorage',
+  'ContextGraphStorage',
+  'ContextGraphValueStorage',
 ];

--- a/packages/evm-module/test/helpers/kc-helpers.ts
+++ b/packages/evm-module/test/helpers/kc-helpers.ts
@@ -1,9 +1,17 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { ethers, getBytes } from 'ethers';
 import { HexString } from 'ethers/lib.commonjs/utils/data';
+import hre from 'hardhat';
 
 import { KCSignaturesData, NodeAccounts } from './types';
-import { KnowledgeCollection, Token } from '../../typechain';
+import {
+  ContextGraphStorage,
+  ContextGraphValueStorage,
+  Chronos,
+  Hub,
+  KnowledgeCollection,
+  Token,
+} from '../../typechain';
 
 export async function signMessage(
   signer: SignerWithAddress,
@@ -55,6 +63,36 @@ export async function getKCSignaturesData(
   };
 }
 
+/**
+ * Optional Phase 10 bridge: when supplied, `createKnowledgeCollection` will
+ * also register the freshly-published KC into the given Context Graph and
+ * seed its per-epoch value entry in `ContextGraphValueStorage`. Required for
+ * any test that subsequently calls `RandomSampling.createChallenge`, which
+ * needs the CG-side state (the V8 publishing flow does not write it — Phase
+ * 8 owns that wiring and lives in a separate worktree at the time of Phase
+ * 10's introduction).
+ *
+ * `cgOpSigner` MUST already be registered in the Hub as a contract via
+ * `Hub.setContractAddress("TestStorageOperator", cgOpSigner.address)` so it
+ * passes the `onlyContracts` gate on both storages.
+ *
+ * If `cgId` is undefined, the helper assumes the caller has already created
+ * a CG and will fail at the registration call — pass an explicit CG id.
+ */
+export type Phase10CGBridge = {
+  cgId: bigint | number;
+  cgOpSigner: SignerWithAddress;
+  ContextGraphStorage: ContextGraphStorage;
+  ContextGraphValueStorage: ContextGraphValueStorage;
+  Chronos: Chronos;
+  /** Optional value seed (defaults to 1 ether). Inflated to keep adjusted
+   *  totals comfortably above zero across many concurrent KCs. */
+  valueWei?: bigint;
+  /** Optional value lifetime in epochs (defaults to 100). Long enough that
+   *  multi-epoch tests don't accidentally drop the seed. */
+  valueLifetimeEpochs?: number;
+};
+
 export async function createKnowledgeCollection(
   kcCreator: SignerWithAddress,
   publishingNode: NodeAccounts,
@@ -75,6 +113,7 @@ export async function createKnowledgeCollection(
   tokenAmount: bigint = ethers.parseEther('100'),
   isImmutable: boolean = false,
   paymaster: string = ethers.ZeroAddress,
+  phase10Bridge?: Phase10CGBridge,
 ) {
   const signaturesData = await getKCSignaturesData(
     publishingNode,
@@ -112,5 +151,171 @@ export async function createKnowledgeCollection(
   const receipt = await tx.wait();
   const collectionId = Number(receipt!.logs[2].topics[1]);
 
+  // Phase 10 bridge — explicit caller-supplied path.
+  if (phase10Bridge) {
+    const {
+      cgId,
+      cgOpSigner,
+      ContextGraphStorage,
+      ContextGraphValueStorage,
+      Chronos,
+      valueWei = ethers.parseEther('1'),
+      valueLifetimeEpochs = 100,
+    } = phase10Bridge;
+    await ContextGraphStorage.connect(cgOpSigner).registerKCToContextGraph(
+      cgId,
+      collectionId,
+    );
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    await ContextGraphValueStorage.connect(cgOpSigner).addCGValueForEpochRange(
+      cgId,
+      currentEpoch,
+      valueLifetimeEpochs,
+      valueWei,
+    );
+  } else {
+    // Phase 10 bridge — implicit / opt-in path. If the test fixture has both
+    // CG storages deployed AND a `TestStorageOperator` sentinel registered in
+    // the Hub, transparently bind every published KC into a default open CG
+    // and seed its per-epoch value. This lets pre-existing integration tests
+    // that publish via V8 still drive `RandomSampling.createChallenge` after
+    // Phase 10 lands, without each call site having to know about the bridge.
+    //
+    // Tests that deliberately want an empty CG-side state (i.e. assert
+    // `NoEligibleContextGraph`) MUST avoid registering the operator OR
+    // explicitly skip publishing.
+    await _autoBridgeKCToDefaultCG(collectionId);
+  }
+
   return { tx, receipt, collectionId };
+}
+
+/**
+ * Module-scoped lazy-init for the Phase 10 auto-bridge. Caches the resolved
+ * Hub/storage references and the default CG id per (deployed Hub address) so
+ * a single test run reuses one CG across many `createKnowledgeCollection`
+ * calls. Each new fixture (different Hub address) resets the cache.
+ */
+type AutoBridgeCache = {
+  hubAddress: string;
+  cgOpSigner: SignerWithAddress;
+  ContextGraphStorage: ContextGraphStorage;
+  ContextGraphValueStorage: ContextGraphValueStorage;
+  Chronos: Chronos;
+  defaultCgId: bigint;
+};
+let _autoBridgeCache: AutoBridgeCache | null = null;
+
+async function _autoBridgeKCToDefaultCG(kcId: number): Promise<void> {
+  // Resolve Hub. If the deployment doesn't have a Hub at all (rare: pure
+  // standalone unit tests), bail silently.
+  let HubCtr: Hub;
+  try {
+    HubCtr = await hre.ethers.getContract<Hub>('Hub');
+  } catch {
+    return;
+  }
+  const hubAddress = await HubCtr.getAddress();
+
+  // Cache invalidation. The Hub address is deterministic across hardhat
+  // snapshot resets (deploy script puts it at the same address every time),
+  // so a Hub-address compare alone would treat a freshly-reverted chain as
+  // "same fixture". Verify the cached default CG still exists on chain;
+  // hardhat's `loadFixture` uses snapshots, so a reverted chain forgets the
+  // CG even though the Hub address persists.
+  if (_autoBridgeCache && _autoBridgeCache.hubAddress === hubAddress) {
+    try {
+      const latest =
+        await _autoBridgeCache.ContextGraphStorage.getLatestContextGraphId();
+      if (latest < _autoBridgeCache.defaultCgId) {
+        _autoBridgeCache = null;
+      }
+    } catch {
+      _autoBridgeCache = null;
+    }
+  } else if (_autoBridgeCache) {
+    _autoBridgeCache = null;
+  }
+
+  if (!_autoBridgeCache) {
+    // Sanity-check that all three preconditions hold — if any are missing,
+    // the test fixture didn't opt in to Phase 10 bridging and we leave the
+    // KC unattached. The picker will revert when called, which is the
+    // intended signal that the fixture needs updating.
+    let storageAddr: string;
+    let valueAddr: string;
+    let opAddr: string;
+    try {
+      storageAddr = await HubCtr.getAssetStorageAddress('ContextGraphStorage');
+      valueAddr = await HubCtr.getContractAddress('ContextGraphValueStorage');
+      opAddr = await HubCtr.getContractAddress('TestStorageOperator');
+    } catch {
+      return;
+    }
+    if (
+      storageAddr === ethers.ZeroAddress ||
+      valueAddr === ethers.ZeroAddress ||
+      opAddr === ethers.ZeroAddress
+    ) {
+      return;
+    }
+
+    // Bind the typechain handles via the well-known deployment names.
+    const ContextGraphStorageCtr =
+      await hre.ethers.getContract<ContextGraphStorage>('ContextGraphStorage');
+    const ContextGraphValueStorageCtr =
+      await hre.ethers.getContract<ContextGraphValueStorage>(
+        'ContextGraphValueStorage',
+      );
+    const ChronosCtr = await hre.ethers.getContract<Chronos>('Chronos');
+
+    // Resolve the operator signer by address (don't assume an account index).
+    const signers = await hre.ethers.getSigners();
+    const cgOpSigner = signers.find(
+      (s) => s.address.toLowerCase() === opAddr.toLowerCase(),
+    );
+    if (!cgOpSigner) {
+      return;
+    }
+
+    // Lazily create the default CG.
+    const createTx = await ContextGraphStorageCtr.connect(
+      cgOpSigner,
+    ).createContextGraph(
+      cgOpSigner.address, // owner
+      [10n, 20n, 30n], // hosting nodes
+      [], // participant agents
+      2, // requiredSignatures
+      0, // metadataBatchId
+      1, // publishPolicy = open
+      ethers.ZeroAddress,
+      0,
+    );
+    await createTx.wait();
+    const defaultCgId = await ContextGraphStorageCtr.getLatestContextGraphId();
+
+    _autoBridgeCache = {
+      hubAddress,
+      cgOpSigner,
+      ContextGraphStorage: ContextGraphStorageCtr,
+      ContextGraphValueStorage: ContextGraphValueStorageCtr,
+      Chronos: ChronosCtr,
+      defaultCgId,
+    };
+  }
+
+  const c = _autoBridgeCache;
+  await c.ContextGraphStorage.connect(c.cgOpSigner).registerKCToContextGraph(
+    c.defaultCgId,
+    kcId,
+  );
+  const currentEpoch = await c.Chronos.getCurrentEpoch();
+  await c.ContextGraphValueStorage.connect(
+    c.cgOpSigner,
+  ).addCGValueForEpochRange(
+    c.defaultCgId,
+    currentEpoch,
+    100, // lifetime epochs
+    ethers.parseEther('1'),
+  );
 }

--- a/packages/evm-module/test/integration/Profile.test.ts
+++ b/packages/evm-module/test/integration/Profile.test.ts
@@ -222,6 +222,16 @@ export async function buildInitialRewardsState() {
   const receivingNodesIdentityIds: number[] = [];
 
   await contracts.hub.setContractAddress('HubOwner', accounts.owner.address);
+  // Phase 10 — opt this fixture into the auto-bridge in `kc-helpers.ts`. The
+  // helper reads `Hub.getContractAddress("TestStorageOperator")` and, when
+  // present, transparently registers each freshly-published KC into a default
+  // open Context Graph and seeds its per-epoch value so the new
+  // `RandomSampling.createChallenge` picker has eligible state to draw from.
+  // signers[150] is well above any test-account index in this file.
+  await contracts.hub.setContractAddress(
+    'TestStorageOperator',
+    signers[150].address,
+  );
 
   // Initialize ask system to prevent division by zero
   await contracts.parametersStorage.setMinimumStake(toTRAC(100));

--- a/packages/evm-module/test/integration/RandomSampling.test.ts
+++ b/packages/evm-module/test/integration/RandomSampling.test.ts
@@ -28,6 +28,8 @@ import {
   ShardingTable,
   ParametersStorage,
   Ask,
+  ContextGraphStorage,
+  ContextGraphValueStorage,
 } from '../../typechain';
 import { createKnowledgeCollection } from '../helpers/kc-helpers';
 import { sqrt } from '../helpers/math-helpers';
@@ -80,6 +82,8 @@ type RandomSamplingFixture = {
   ShardingTable: ShardingTable;
   ParametersStorage: ParametersStorage;
   Ask: Ask;
+  ContextGraphStorage: ContextGraphStorage;
+  ContextGraphValueStorage: ContextGraphValueStorage;
 };
 
 /**
@@ -182,6 +186,15 @@ describe('@integration RandomSampling', () => {
   let ParametersStorage: ParametersStorage;
   let ParanetKnowledgeMinersRegistry: ParanetKnowledgeMinersRegistry;
   let ParanetKnowledgeCollectionsRegistry: ParanetKnowledgeCollectionsRegistry;
+  let ContextGraphStorage: ContextGraphStorage;
+  let ContextGraphValueStorage: ContextGraphValueStorage;
+  // Phase 10's value-weighted picker requires every challengeable KC to live
+  // inside a CG with non-zero per-epoch value at the current epoch. The V8
+  // publishing flow used here does not yet wire up CG-side state (Phase 8
+  // owns that — separate worktree). Bridging is handled transparently by
+  // the auto-bridge in `kc-helpers.ts`, which fires whenever the fixture has
+  // registered a `TestStorageOperator` Hub contract — see the
+  // `setContractAddress("TestStorageOperator", ...)` call in the fixture.
 
   // Deploy all contracts, set the HubOwner and necessary accounts. Returns the RandomSamplingFixture
   async function deployRandomSamplingFixture(): Promise<RandomSamplingFixture> {
@@ -197,6 +210,8 @@ describe('@integration RandomSampling', () => {
       'DelegatorsInfo',
       'Profile',
       'RandomSamplingStorage',
+      'ContextGraphValueStorage',
+      'ContextGraphStorage',
       'RandomSampling',
       'ParanetKnowledgeMinersRegistry',
       'ParanetKnowledgeCollectionsRegistry',
@@ -209,6 +224,12 @@ describe('@integration RandomSampling', () => {
 
     // Set hub owner
     await Hub.setContractAddress('HubOwner', accounts[0].address);
+    // Register a sentinel signer as a Hub contract so the integration tests
+    // can call `onlyContracts` methods on ContextGraphStorage and
+    // ContextGraphValueStorage directly to bridge V8-published KCs into a
+    // default CG with non-zero per-epoch value (the input the Phase 10
+    // picker reads).
+    await Hub.setContractAddress('TestStorageOperator', accounts[19].address);
 
     // Get contract instances
     KnowledgeCollection = await hre.ethers.getContract<KnowledgeCollection>(
@@ -255,6 +276,13 @@ describe('@integration RandomSampling', () => {
     RandomSamplingStorage = await hre.ethers.getContract<RandomSamplingStorage>(
       'RandomSamplingStorage',
     );
+    ContextGraphStorage = await hre.ethers.getContract<ContextGraphStorage>(
+      'ContextGraphStorage',
+    );
+    ContextGraphValueStorage =
+      await hre.ethers.getContract<ContextGraphValueStorage>(
+        'ContextGraphValueStorage',
+      );
 
     // Now initialize RandomSampling manually if needed
     // This might not be necessary if initialization happens automatically in the deployment
@@ -282,6 +310,8 @@ describe('@integration RandomSampling', () => {
       ShardingTable,
       ParametersStorage,
       Ask,
+      ContextGraphStorage,
+      ContextGraphValueStorage,
     };
   }
 
@@ -309,6 +339,8 @@ describe('@integration RandomSampling', () => {
       ShardingTable,
       ParametersStorage,
       Ask,
+      ContextGraphStorage,
+      ContextGraphValueStorage,
     } = await loadFixture(deployRandomSamplingFixture));
   });
 
@@ -746,16 +778,19 @@ describe('@integration RandomSampling', () => {
       );
       await Ask.connect(accounts[0]).recalculateActiveSet();
 
-      // Ensure no KCs are created or they are expired (by default none are created here)
-
-      // Attempt to create challenge
+      // Ensure no KCs are created or they are expired (by default none are
+      // created here). With Phase 10's value-weighted picker the absence of
+      // any non-curated, active CG with non-zero per-epoch value surfaces as
+      // a `NoEligibleContextGraph` custom-error revert, replacing the V8
+      // string `"No knowledge collections exist"`.
       const createTx = RandomSampling.connect(
         publishingNode.operational,
       ).createChallenge();
 
       // Verification
-      await expect(createTx).to.be.revertedWith(
-        'No knowledge collections exist',
+      await expect(createTx).to.be.revertedWithCustomError(
+        RandomSampling,
+        'NoEligibleContextGraph',
       );
     });
 
@@ -893,9 +928,15 @@ describe('@integration RandomSampling', () => {
         publishingNode.operational,
       ).createChallenge();
 
-      // Verification: Expect revert with the specific message
-      await expect(createTx).to.be.revertedWith(
-        'Failed to find a knowledge collection that is active in the current epoch',
+      // Verification: with Phase 10 the bound CG still holds value (the
+      // bridge seeds a 100-epoch lifetime), so the picker walks into it,
+      // finds the only KC has expired, exhausts MAX_KC_RETRIES, and reverts
+      // with `NoEligibleKnowledgeCollection`. The V8 string
+      // `"Failed to find a knowledge collection that is active in the current epoch"`
+      // came from the now-deleted BFS picker.
+      await expect(createTx).to.be.revertedWithCustomError(
+        RandomSampling,
+        'NoEligibleKnowledgeCollection',
       );
     });
   });
@@ -1704,431 +1745,11 @@ describe('@integration RandomSampling', () => {
     });
   });
 
-  describe('Optimized Knowledge Collection Search', () => {
-    let publishingNode: {
-      operational: SignerWithAddress;
-      admin: SignerWithAddress;
-    };
-    let publishingNodeIdentityId: number;
-    let receivingNodes: {
-      operational: SignerWithAddress;
-      admin: SignerWithAddress;
-    }[];
-    let receivingNodesIdentityIds: number[];
-    let kcCreator: SignerWithAddress;
-    let deps: {
-      accounts: SignerWithAddress[];
-      Profile: Profile;
-      Token: Token;
-      Staking: Staking;
-      Ask: Ask;
-      KnowledgeCollection: KnowledgeCollection;
-    };
-
-    beforeEach(async () => {
-      // Setup nodes
-      kcCreator = getDefaultKCCreator(accounts);
-      const minStake = await ParametersStorage.minimumStake();
-      const nodeAsk = 200000000000000000n; // 0.2 ETH
-
-      deps = {
-        accounts,
-        Profile,
-        Token,
-        Staking,
-        Ask,
-        KnowledgeCollection,
-      };
-
-      ({ node: publishingNode, identityId: publishingNodeIdentityId } =
-        await setupNodeWithStakeAndAsk(1, minStake, nodeAsk, deps));
-
-      receivingNodes = [];
-      receivingNodesIdentityIds = [];
-      for (let i = 0; i < 5; i++) {
-        const { node, identityId } = await setupNodeWithStakeAndAsk(
-          i + 10,
-          minStake,
-          nodeAsk,
-          deps,
-        );
-        receivingNodes.push(node);
-        receivingNodesIdentityIds.push(identityId);
-      }
-    });
-
-    it('Should find active knowledge collections when mix of active and expired collections exist', async () => {
-      const initialEpoch = await Chronos.getCurrentEpoch();
-
-      // Create 20 knowledge collections with different expiration epochs
-      const collections = [];
-
-      // Create 15 collections that expire in epoch 1 (will be expired)
-      for (let i = 0; i < 15; i++) {
-        await createKnowledgeCollection(
-          kcCreator,
-          publishingNode,
-          publishingNodeIdentityId,
-          receivingNodes,
-          receivingNodesIdentityIds,
-          deps,
-          merkleRoot,
-          `expired-operation-${i}`,
-          10,
-          1000,
-          1, // epochsDuration = 1, so expires after current epoch + duration + 1
-        );
-        collections.push({ id: i + 1, active: false });
-      }
-
-      // Create 5 collections that expire in epoch 10 (will be active)
-      for (let i = 15; i < 20; i++) {
-        await createKnowledgeCollection(
-          kcCreator,
-          publishingNode,
-          publishingNodeIdentityId,
-          receivingNodes,
-          receivingNodesIdentityIds,
-          deps,
-          merkleRoot,
-          `active-operation-${i}`,
-          10,
-          1000,
-          10, // epochsDuration = 10, so expires after current epoch + duration + 1
-        );
-        collections.push({ id: i + 1, active: true });
-      }
-
-      // Advance to epoch 5 (so first 15 collections are expired, last 5 are active)
-      for (let epoch = Number(initialEpoch); epoch < 5; epoch++) {
-        const timeUntilNextEpoch = await Chronos.timeUntilNextEpoch();
-        await time.increase(Number(timeUntilNextEpoch) + 5);
-      }
-
-      const currentEpoch = await Chronos.getCurrentEpoch();
-      expect(currentEpoch).to.be.gte(5n, 'Should be in epoch 5 or later');
-
-      // Verify which collections are active/expired
-      for (const collection of collections) {
-        const endEpoch = await KnowledgeCollectionStorage.getEndEpoch(
-          collection.id,
-        );
-        const isActive = currentEpoch <= endEpoch;
-        if (collection.active) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(isActive).to.equal(true);
-        } else {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          expect(isActive).to.be.false;
-        }
-      }
-
-      // Create challenge multiple times to verify it finds active collections
-      const foundCollections = new Set<number>();
-      const maxAttempts = 20; // Try multiple times to test randomness and consistency
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        // Move to next proof period to allow new challenge
-        const duration =
-          await RandomSampling.getActiveProofingPeriodDurationInBlocks();
-        for (let i = 0; i < Number(duration); i++) {
-          await hre.network.provider.send('evm_mine');
-        }
-
-        await RandomSampling.connect(
-          publishingNode.operational,
-        ).createChallenge();
-        const challenge = await RandomSamplingStorage.getNodeChallenge(
-          publishingNodeIdentityId,
-        );
-
-        // Verify the found collection is one of the active ones
-        expect([16, 17, 18, 19, 20]).to.include(
-          Number(challenge.knowledgeCollectionId),
-        );
-        foundCollections.add(Number(challenge.knowledgeCollectionId));
-
-        // Mark challenge as solved to allow next challenge
-        const solvedChallenge = {
-          knowledgeCollectionId: challenge.knowledgeCollectionId,
-          chunkId: challenge.chunkId,
-          knowledgeCollectionStorageContract:
-            challenge.knowledgeCollectionStorageContract,
-          epoch: challenge.epoch,
-          activeProofPeriodStartBlock: challenge.activeProofPeriodStartBlock,
-          proofingPeriodDurationInBlocks:
-            challenge.proofingPeriodDurationInBlocks,
-          solved: true,
-        };
-        await RandomSamplingStorage.setNodeChallenge(
-          publishingNodeIdentityId,
-          solvedChallenge,
-        );
-      }
-
-      // Verify that the algorithm found at least 2 different active collections (shows it's working properly)
-      expect(foundCollections.size).to.be.gte(
-        2,
-        'Should find multiple different active collections',
-      );
-    });
-
-    it('Should revert when all knowledge collections are expired', async () => {
-      // Create 3 knowledge collections that expire in epoch 1
-      for (let i = 0; i < 3; i++) {
-        await createKnowledgeCollection(
-          kcCreator,
-          publishingNode,
-          publishingNodeIdentityId,
-          receivingNodes,
-          receivingNodesIdentityIds,
-          deps,
-          merkleRoot,
-          `expired-operation-${i}`,
-          10,
-          1000,
-          1, // epochsDuration = 1, expires after epoch 1
-        );
-      }
-
-      // Advance to epoch 5 (all collections expired)
-      for (let epoch = 1; epoch < 5; epoch++) {
-        const timeUntilNextEpoch = await Chronos.timeUntilNextEpoch();
-        await time.increase(Number(timeUntilNextEpoch) + 5);
-      }
-
-      // Verify all collections are expired
-      const currentEpoch = await Chronos.getCurrentEpoch();
-      for (let kcId = 1; kcId <= 3; kcId++) {
-        const endEpoch = await KnowledgeCollectionStorage.getEndEpoch(kcId);
-        expect(currentEpoch).to.be.gt(endEpoch, `KC ${kcId} should be expired`);
-      }
-
-      // Attempt to create challenge should revert
-      await expect(
-        RandomSampling.connect(publishingNode.operational).createChallenge(),
-      ).to.be.revertedWith(
-        'Failed to find a knowledge collection that is active in the current epoch',
-      );
-    });
-
-    it('Should work efficiently with single active collection among many expired ones', async () => {
-      // Create 9 expired collections
-      for (let i = 0; i < 9; i++) {
-        await createKnowledgeCollection(
-          kcCreator,
-          publishingNode,
-          publishingNodeIdentityId,
-          receivingNodes,
-          receivingNodesIdentityIds,
-          deps,
-          merkleRoot,
-          `expired-operation-${i}`,
-          10,
-          1000,
-          1, // epochsDuration = 1, expires after epoch 1
-        );
-      }
-
-      // Create 1 active collection (will be KC #10)
-      await createKnowledgeCollection(
-        kcCreator,
-        publishingNode,
-        publishingNodeIdentityId,
-        receivingNodes,
-        receivingNodesIdentityIds,
-        deps,
-        merkleRoot,
-        'active-operation',
-        10,
-        1000,
-        10, // epochsDuration = 10, active for longer
-      );
-
-      // Advance to epoch 4 (first 9 expired, last 1 active)
-      for (let epoch = 1; epoch < 4; epoch++) {
-        const timeUntilNextEpoch = await Chronos.timeUntilNextEpoch();
-        await time.increase(Number(timeUntilNextEpoch) + 5);
-      }
-
-      // Verify only the last collection is active
-      const currentEpoch = await Chronos.getCurrentEpoch();
-      for (let kcId = 1; kcId <= 9; kcId++) {
-        const endEpoch = await KnowledgeCollectionStorage.getEndEpoch(kcId);
-        expect(currentEpoch).to.be.gt(endEpoch, `KC ${kcId} should be expired`);
-      }
-
-      const activeKcEndEpoch = await KnowledgeCollectionStorage.getEndEpoch(10);
-      expect(currentEpoch).to.be.lte(
-        activeKcEndEpoch,
-        'KC 10 should be active',
-      );
-
-      // Create challenge should find the active collection
-      await RandomSampling.connect(
-        publishingNode.operational,
-      ).createChallenge();
-      const challenge = await RandomSamplingStorage.getNodeChallenge(
-        publishingNodeIdentityId,
-      );
-
-      expect(challenge.knowledgeCollectionId).to.equal(
-        10n,
-        'Should find the only active collection',
-      );
-    });
-
-    it('Should demonstrate randomness by finding different collections over multiple attempts', async () => {
-      // Create 5 active knowledge collections
-      for (let i = 0; i < 5; i++) {
-        await createKnowledgeCollection(
-          kcCreator,
-          publishingNode,
-          publishingNodeIdentityId,
-          receivingNodes,
-          receivingNodesIdentityIds,
-          deps,
-          merkleRoot,
-          `active-operation-${i}`,
-          10,
-          1000,
-          10, // All active for 10 epochs
-        );
-      }
-
-      const foundCollections = new Set<number>();
-      const maxAttempts = 15;
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        // Move to next proof period
-        const duration =
-          await RandomSampling.getActiveProofingPeriodDurationInBlocks();
-        for (let i = 0; i < Number(duration); i++) {
-          await hre.network.provider.send('evm_mine');
-        }
-
-        await RandomSampling.connect(
-          publishingNode.operational,
-        ).createChallenge();
-        const challenge = await RandomSamplingStorage.getNodeChallenge(
-          publishingNodeIdentityId,
-        );
-
-        // All collections should be active
-        expect(challenge.knowledgeCollectionId).to.be.gte(1n);
-        expect(challenge.knowledgeCollectionId).to.be.lte(5n);
-        foundCollections.add(Number(challenge.knowledgeCollectionId));
-
-        // Mark as solved for next iteration
-        const solvedChallenge = {
-          knowledgeCollectionId: challenge.knowledgeCollectionId,
-          chunkId: challenge.chunkId,
-          knowledgeCollectionStorageContract:
-            challenge.knowledgeCollectionStorageContract,
-          epoch: challenge.epoch,
-          activeProofPeriodStartBlock: challenge.activeProofPeriodStartBlock,
-          proofingPeriodDurationInBlocks:
-            challenge.proofingPeriodDurationInBlocks,
-          solved: true,
-        };
-        await RandomSamplingStorage.setNodeChallenge(
-          publishingNodeIdentityId,
-          solvedChallenge,
-        );
-      }
-
-      // Should find at least 3 different collections (demonstrates randomness)
-      expect(foundCollections.size).to.be.gte(
-        3,
-        `Should find multiple collections for randomness. Found: ${Array.from(foundCollections)}`,
-      );
-    });
-
-    it('Should handle edge case with collections at different positions in the range', async () => {
-      // Create specific pattern: active-expired-active-expired-active
-      const patterns = [
-        { active: true, duration: 10 }, // KC 1: active
-        { active: false, duration: 1 }, // KC 2: expired
-        { active: true, duration: 10 }, // KC 3: active
-        { active: false, duration: 1 }, // KC 4: expired
-        { active: true, duration: 10 }, // KC 5: active
-      ];
-
-      for (let i = 0; i < patterns.length; i++) {
-        await createKnowledgeCollection(
-          kcCreator,
-          publishingNode,
-          publishingNodeIdentityId,
-          receivingNodes,
-          receivingNodesIdentityIds,
-          deps,
-          merkleRoot,
-          `pattern-operation-${i}`,
-          10,
-          1000,
-          patterns[i].duration,
-        );
-      }
-
-      // Advance to epoch 4 (expired ones are expired, active ones are active)
-      for (let epoch = 1; epoch < 4; epoch++) {
-        const timeUntilNextEpoch = await Chronos.timeUntilNextEpoch();
-        await time.increase(Number(timeUntilNextEpoch) + 5);
-      }
-
-      // Test multiple challenges to ensure it finds active collections (1, 3, 5)
-      const foundCollections = new Set<number>();
-
-      for (let attempt = 0; attempt < 10; attempt++) {
-        const duration =
-          await RandomSampling.getActiveProofingPeriodDurationInBlocks();
-        for (let i = 0; i < Number(duration); i++) {
-          await hre.network.provider.send('evm_mine');
-        }
-
-        await RandomSampling.connect(
-          publishingNode.operational,
-        ).createChallenge();
-        const challenge = await RandomSamplingStorage.getNodeChallenge(
-          publishingNodeIdentityId,
-        );
-
-        foundCollections.add(Number(challenge.knowledgeCollectionId));
-
-        // Should only find active collections (1, 3, 5)
-        expect([1, 3, 5]).to.include(Number(challenge.knowledgeCollectionId));
-
-        // Mark as solved for next iteration
-        const solvedChallenge = {
-          knowledgeCollectionId: challenge.knowledgeCollectionId,
-          chunkId: challenge.chunkId,
-          knowledgeCollectionStorageContract:
-            challenge.knowledgeCollectionStorageContract,
-          epoch: challenge.epoch,
-          activeProofPeriodStartBlock: challenge.activeProofPeriodStartBlock,
-          proofingPeriodDurationInBlocks:
-            challenge.proofingPeriodDurationInBlocks,
-          solved: true,
-        };
-        await RandomSamplingStorage.setNodeChallenge(
-          publishingNodeIdentityId,
-          solvedChallenge,
-        );
-      }
-
-      // Should find multiple active collections from the pattern
-      expect(foundCollections.size).to.be.gte(
-        2,
-        'Should find multiple active collections from the alternating pattern',
-      );
-
-      // Verify it never found expired collections (2, 4)
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      expect(foundCollections.has(2)).to.be.false;
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-      expect(foundCollections.has(4)).to.be.false;
-    });
-  });
+  // The legacy "Optimized Knowledge Collection Search" describe block tested
+  // the V8 BFS picker (`_findActiveKnowledgeCollection`) and was removed as
+  // part of Phase 10. Picker behaviour is now exercised by the Phase 10
+  // unit tests in `test/unit/RandomSampling.test.ts`, including a 10K-draw
+  // distribution regression.
 
   describe('Node scoring', () => {
     let nodeIdCounter = 100; // Start from high index to avoid conflicts with other tests

--- a/packages/evm-module/test/integration/Staking.test.ts
+++ b/packages/evm-module/test/integration/Staking.test.ts
@@ -412,6 +412,16 @@ async function setupTestEnvironment(): Promise<{
   );
 
   await contracts.hub.setContractAddress('HubOwner', accounts.owner.address);
+  // Phase 10 — opt this fixture into the auto-bridge in `kc-helpers.ts`. The
+  // helper reads `Hub.getContractAddress("TestStorageOperator")` and, when
+  // present, transparently registers each freshly-published KC into a default
+  // open Context Graph and seeds its per-epoch value so the new
+  // `RandomSampling.createChallenge` picker has eligible state to draw from.
+  // signers[150] is well above the highest test-account index in this file.
+  await contracts.hub.setContractAddress(
+    'TestStorageOperator',
+    signers[150].address,
+  );
 
   // Mint tokens for all participants
   for (const delegator of [

--- a/packages/evm-module/test/integration/StakingRewards.test.ts
+++ b/packages/evm-module/test/integration/StakingRewards.test.ts
@@ -223,6 +223,16 @@ export async function buildInitialRewardsState() {
   const receivingNodesIdentityIds: number[] = [];
 
   await contracts.hub.setContractAddress('HubOwner', accounts.owner.address);
+  // Phase 10 — opt this fixture into the auto-bridge in `kc-helpers.ts`. The
+  // helper reads `Hub.getContractAddress("TestStorageOperator")` and, when
+  // present, transparently registers each freshly-published KC into a default
+  // open Context Graph and seeds its per-epoch value so the new
+  // `RandomSampling.createChallenge` picker has eligible state to draw from.
+  // signers[150] is well above any test-account index in this file.
+  await contracts.hub.setContractAddress(
+    'TestStorageOperator',
+    signers[150].address,
+  );
 
   // Initialize ask system to prevent division by zero
   await contracts.parametersStorage.setMinimumStake(toTRAC(100));

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1113,5 +1113,91 @@ describe('@unit RandomSampling', () => {
         expect(preview.kcId).to.equal(activeKc);
       }
     });
+
+    // -----------------------------------------------------------------------
+    // Test 7 — Plan invariant (v10 plan lines 713–714): a CG's per-epoch
+    // contribution must auto-decay to zero once its seeded lifetime expires,
+    // and the picker must then auto-exclude it. The KC is deliberately kept
+    // live beyond the seed lifetime so the only driver of auto-exclusion is
+    // the value decay in ContextGraphValueStorage — not KC expiry.
+    // -----------------------------------------------------------------------
+    it('auto-excludes a CG whose seed lifetime has expired (per-epoch contribution decays to zero)', async () => {
+      const cgId = await createCG(OPEN_POLICY);
+      const startEpoch = await Chronos.getCurrentEpoch();
+      const seedLifetime = 5n;
+      // KC outlives the seed so auto-exclusion can only be driven by
+      // ContextGraphValueStorage's per-epoch decay.
+      await createKC(cgId, startEpoch + 100n);
+      await seedCGValue(cgId, 10_000n, seedLifetime);
+
+      expect(
+        await ContextGraphValueStorage.getCGValueAtEpoch(cgId, startEpoch),
+      ).to.be.greaterThan(0n);
+
+      const epochLength = await Chronos.epochLength();
+      await time.increase(Number(epochLength) * Number(seedLifetime + 1n));
+      const newEpoch = await Chronos.getCurrentEpoch();
+      expect(newEpoch).to.be.greaterThan(startEpoch + seedLifetime);
+
+      // Storage-level invariant: per-epoch contribution decayed to zero.
+      expect(
+        await ContextGraphValueStorage.getCGValueAtEpoch(cgId, newEpoch),
+      ).to.equal(0n);
+
+      // Picker-level invariant: adjustedTotal == 0 → revert.
+      await expect(
+        RandomSampling.previewChallengeForSeed(testSeed(0), newEpoch),
+      ).to.be.revertedWithCustomError(
+        RandomSampling,
+        'NoEligibleContextGraph',
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 8 — Plan invariant (v10 plan line 713): an "empty" CG (per-epoch
+    // contribution = 0 post-expiry) must never be selected even when it
+    // originally held 10× the nominal value, provided a still-active CG
+    // coexists. Proves the weighted walk respects per-epoch decay — a live
+    // low-value CG beats a "rich" decayed CG.
+    // -----------------------------------------------------------------------
+    it('never selects a CG whose seed has decayed while a live neighbor exists', async () => {
+      const expiredCg = await createCG(OPEN_POLICY);
+      const activeCg = await createCG(OPEN_POLICY);
+      const startEpoch = await Chronos.getCurrentEpoch();
+      const shortLifetime = 5n;
+      const longLifetime = 100n;
+
+      // Both KCs live past the advance so picker exclusion is driven only
+      // by value decay, not KC expiry.
+      await createKC(expiredCg, startEpoch + longLifetime);
+      const activeKc = await createKC(activeCg, startEpoch + longLifetime);
+
+      // Expired CG: 10× the nominal TRAC but a 5-epoch lifetime.
+      // Active  CG: 1/10 the nominal TRAC but a 100-epoch lifetime.
+      await seedCGValue(expiredCg, 10_000n, shortLifetime);
+      await seedCGValue(activeCg, 1_000n, longLifetime);
+
+      const epochLength = await Chronos.epochLength();
+      await time.increase(Number(epochLength) * Number(shortLifetime + 1n));
+      const newEpoch = await Chronos.getCurrentEpoch();
+
+      // Storage invariant: expired decayed to zero, active still > 0.
+      expect(
+        await ContextGraphValueStorage.getCGValueAtEpoch(expiredCg, newEpoch),
+      ).to.equal(0n);
+      expect(
+        await ContextGraphValueStorage.getCGValueAtEpoch(activeCg, newEpoch),
+      ).to.be.greaterThan(0n);
+
+      // Picker invariant: every draw lands on the active CG.
+      for (let i = 0; i < 20; i++) {
+        const preview = await RandomSampling.previewChallengeForSeed(
+          testSeed(i),
+          newEpoch,
+        );
+        expect(preview.cgId).to.equal(activeCg);
+        expect(preview.kcId).to.equal(activeKc);
+      }
+    });
   });
 });

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -943,6 +943,8 @@ describe('@unit RandomSampling', () => {
       await seedCGValue(cgId, 1_000n);
 
       const currentEpoch = await Chronos.getCurrentEpoch();
+      const chunkByteSize = await RandomSamplingStorage.CHUNK_BYTE_SIZE();
+      const expectedMaxChunk = TEST_KC_BYTE_SIZE / BigInt(chunkByteSize); // 4
 
       for (let i = 0; i < 10; i++) {
         const preview = await RandomSampling.previewChallengeForSeed(
@@ -951,8 +953,9 @@ describe('@unit RandomSampling', () => {
         );
         expect(preview.cgId).to.equal(cgId);
         expect(preview.kcId).to.equal(kcId);
-        // KC is smaller than the chunk size so chunkId collapses to 0.
-        expect(preview.chunkId).to.equal(0n);
+        // KC byte size (128) > chunk byte size (32), so chunkId is drawn from
+        // the rotated KC seed in [0, byteSize/chunkSize) = [0, 4).
+        expect(preview.chunkId).to.be.lessThan(expectedMaxChunk);
       }
     });
 

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1,6 +1,7 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
+import { ethers } from 'ethers';
 import hre from 'hardhat';
 
 import {
@@ -21,6 +22,8 @@ import {
   ParametersStorage,
   KnowledgeCollectionStorage,
   Profile,
+  ContextGraphStorage,
+  ContextGraphValueStorage,
 } from '../../typechain';
 
 type RandomSamplingFixture = {
@@ -37,6 +40,8 @@ type RandomSamplingFixture = {
   EpochStorage: EpochStorage;
   ParametersStorage: ParametersStorage;
   KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  ContextGraphStorage: ContextGraphStorage;
+  ContextGraphValueStorage: ContextGraphValueStorage;
   Profile: Profile;
 };
 
@@ -56,6 +61,8 @@ describe('@unit RandomSampling', () => {
   let EpochStorage: EpochStorage;
   let ParametersStorage: ParametersStorage;
   let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let ContextGraphStorage: ContextGraphStorage;
+  let ContextGraphValueStorage: ContextGraphValueStorage;
   let Profile: Profile;
 
   async function deployRandomSamplingFixture(): Promise<RandomSamplingFixture> {
@@ -74,6 +81,8 @@ describe('@unit RandomSampling', () => {
       'AskStorage',
       'DelegatorsInfo',
       'RandomSamplingStorage',
+      'ContextGraphValueStorage',
+      'ContextGraphStorage',
       'RandomSampling',
       'Profile',
     ]);
@@ -111,6 +120,21 @@ describe('@unit RandomSampling', () => {
         'KnowledgeCollectionStorage',
       );
     Profile = await hre.ethers.getContract<Profile>('Profile');
+    ContextGraphStorage = await hre.ethers.getContract<ContextGraphStorage>(
+      'ContextGraphStorage',
+    );
+    ContextGraphValueStorage =
+      await hre.ethers.getContract<ContextGraphValueStorage>(
+        'ContextGraphValueStorage',
+      );
+
+    // Register a sentinel signer as a Hub contract so Phase 10 weighted-
+    // selection tests can call `onlyContracts` methods on ContextGraphStorage /
+    // ContextGraphValueStorage / KnowledgeCollectionStorage directly, without
+    // routing through the production facades (ContextGraphs, KnowledgeCollection).
+    // Must run after HubOwner is set so `setContractAddress` passes the auth
+    // check. Safe for existing tests because accounts[19] is never used elsewhere.
+    await Hub.setContractAddress('TestStorageOperator', accounts[19].address);
 
     return {
       accounts,
@@ -126,6 +150,8 @@ describe('@unit RandomSampling', () => {
       EpochStorage,
       ParametersStorage,
       KnowledgeCollectionStorage,
+      ContextGraphStorage,
+      ContextGraphValueStorage,
       Profile,
     };
   }
@@ -152,6 +178,8 @@ describe('@unit RandomSampling', () => {
       EpochStorage,
       ParametersStorage,
       KnowledgeCollectionStorage,
+      ContextGraphStorage,
+      ContextGraphValueStorage,
       Profile,
     } = await loadFixture(deployRandomSamplingFixture));
   });
@@ -770,6 +798,317 @@ describe('@unit RandomSampling', () => {
       const statusAtInvalid = await RandomSampling.getActiveProofPeriodStatus();
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       expect(statusAtInvalid.isValid).to.be.false;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Phase 10 — value-weighted challenge generation
+  // ---------------------------------------------------------------------------
+  //
+  // These tests exercise the two-level weighted draw added to
+  // `_generateChallenge`:
+  //   Step 1 — pick a CG weighted by its per-epoch TRAC value at the current
+  //            epoch, excluding curated ("private") and inactive CGs.
+  //   Step 2 — pick a KC uniformly at random from the chosen CG's KC list and
+  //            retry up to MAX_KC_RETRIES on expired KCs.
+  //
+  // We deploy ContextGraphStorage + ContextGraphValueStorage in an extended
+  // fixture, register a test signer as a Hub contract so it can seed state
+  // directly, and drive the weighted picker via the read-only helper
+  // `previewChallengeForSeed(seed)`. The helper makes distribution regression
+  // feasible (10k draws in milliseconds, no block mining, no state reset).
+  // ---------------------------------------------------------------------------
+  describe('Phase 10 — value-weighted challenge generation', () => {
+    const CURATED_POLICY = 0; // curated → counts as "private" for Phase 10
+    const OPEN_POLICY = 1;
+    const TEST_KC_BYTE_SIZE = 128n;
+
+    /** Hub sentinel — registered as a "contract" in `deployRandomSamplingFixture`
+     *  so it can bypass the production facades and call `onlyContracts`
+     *  methods on storage contracts directly. */
+    let opSigner: SignerWithAddress;
+
+    beforeEach(() => {
+      opSigner = accounts[19];
+    });
+
+    /**
+     * Create a Context Graph via the storage directly and return its id.
+     * Policy: 0 = curated (private for Phase 10), 1 = open.
+     */
+    async function createCG(publishPolicy: number): Promise<bigint> {
+      const owner = accounts[1].address;
+      const authority =
+        publishPolicy === CURATED_POLICY
+          ? accounts[2].address
+          : ethers.ZeroAddress;
+      const tx = await ContextGraphStorage.connect(opSigner).createContextGraph(
+        owner,
+        [10n, 20n, 30n], // hosting nodes (sorted, non-zero, distinct)
+        [], // no participant agents
+        2, // requiredSignatures
+        0, // metadataBatchId
+        publishPolicy,
+        authority,
+        0, // publishAuthorityAccountId
+      );
+      await tx.wait();
+      return ContextGraphStorage.getLatestContextGraphId();
+    }
+
+    /**
+     * Seed a KC directly on KnowledgeCollectionStorage and register it to the
+     * given CG. Returns the new KC id. `endEpoch` controls the expiry — pass
+     * `currentEpoch - 1` to create an already-expired KC.
+     */
+    async function createKC(cgId: bigint, endEpoch: bigint): Promise<bigint> {
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      const startEpoch = currentEpoch;
+      const createTx = await KnowledgeCollectionStorage.connect(
+        opSigner,
+      ).createKnowledgeCollection(
+        opSigner.address, // publisher
+        'phase-10-test-op',
+        ethers.keccak256(
+          ethers.toUtf8Bytes(
+            `phase-10-kc-${cgId}-${Date.now()}-${Math.random()}`,
+          ),
+        ),
+        1, // knowledgeAssetsAmount (mintKnowledgeAssetsTokens requires >=1)
+        TEST_KC_BYTE_SIZE,
+        startEpoch,
+        endEpoch,
+        0, // tokenAmount
+        false, // isImmutable
+      );
+      const receipt = await createTx.wait();
+      // Parse kc id from the KnowledgeCollectionCreated event.
+      const iface = KnowledgeCollectionStorage.interface;
+      const topic = iface.getEvent('KnowledgeCollectionCreated')!.topicHash;
+      const log = receipt!.logs.find((l) => l.topics[0] === topic);
+      if (!log) {
+        throw new Error('KnowledgeCollectionCreated event not found');
+      }
+      const parsed = iface.parseLog(log as unknown as {
+        topics: string[];
+        data: string;
+      })!;
+      const kcId = parsed.args[0] as bigint;
+      await ContextGraphStorage.connect(opSigner).registerKCToContextGraph(
+        cgId,
+        kcId,
+      );
+      return kcId;
+    }
+
+    /**
+     * Allocate `value` TRAC to `cgId` spread evenly across `lifetime` epochs
+     * starting at the current epoch via ContextGraphValueStorage.
+     */
+    async function seedCGValue(
+      cgId: bigint,
+      value: bigint,
+      lifetime = 1n,
+    ): Promise<void> {
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      await ContextGraphValueStorage.connect(opSigner).addCGValueForEpochRange(
+        cgId,
+        currentEpoch,
+        lifetime,
+        value,
+      );
+    }
+
+    /**
+     * Derive a caller-supplied test seed with the same shape as the on-chain
+     * entropy mix so we can inspect distribution behaviour without actually
+     * mining blocks. The contract's internal seed is derived identically from
+     * block state + msg.sender, but the public preview helper accepts an
+     * arbitrary bytes32 so tests can enumerate draws deterministically.
+     */
+    function testSeed(i: number): string {
+      return ethers.keccak256(
+        ethers.solidityPacked(['string', 'uint256'], ['phase10-draw-', i]),
+      );
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1 — Happy path: a single public CG with one active KC is always
+    // selected regardless of the draw seed.
+    // -----------------------------------------------------------------------
+    it('picks the only public CG when it is the only eligible graph', async () => {
+      const cgId = await createCG(OPEN_POLICY);
+      const endEpoch = (await Chronos.getCurrentEpoch()) + 5n;
+      const kcId = await createKC(cgId, endEpoch);
+      await seedCGValue(cgId, 1_000n);
+
+      const currentEpoch = await Chronos.getCurrentEpoch();
+
+      for (let i = 0; i < 10; i++) {
+        const preview = await RandomSampling.previewChallengeForSeed(
+          testSeed(i),
+          currentEpoch,
+        );
+        expect(preview.cgId).to.equal(cgId);
+        expect(preview.kcId).to.equal(kcId);
+        // KC is smaller than the chunk size so chunkId collapses to 0.
+        expect(preview.chunkId).to.equal(0n);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 2 — Edge: no eligible value at all (no CGs or every CG is curated)
+    // => revert with NoEligibleContextGraph.
+    // -----------------------------------------------------------------------
+    it('reverts NoEligibleContextGraph when only curated CGs hold value', async () => {
+      const curatedCgId = await createCG(CURATED_POLICY);
+      const endEpoch = (await Chronos.getCurrentEpoch()) + 5n;
+      await createKC(curatedCgId, endEpoch);
+      await seedCGValue(curatedCgId, 5_000n);
+
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      await expect(
+        RandomSampling.previewChallengeForSeed(testSeed(0), currentEpoch),
+      ).to.be.revertedWithCustomError(
+        RandomSampling,
+        'NoEligibleContextGraph',
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 3 — Private CG coexists with a public CG: private must be excluded
+    // and the public CG must win 100% of draws.
+    // -----------------------------------------------------------------------
+    it('excludes curated CGs and always picks the public CG', async () => {
+      const curatedCg = await createCG(CURATED_POLICY);
+      const openCg = await createCG(OPEN_POLICY);
+
+      const endEpoch = (await Chronos.getCurrentEpoch()) + 5n;
+      await createKC(curatedCg, endEpoch);
+      const openKc = await createKC(openCg, endEpoch);
+
+      // Private CG holds 10x the value of the public CG. Weighting would
+      // prefer the private one by naive ratio, so this test asserts the
+      // read-time exclusion filter.
+      await seedCGValue(curatedCg, 10_000n);
+      await seedCGValue(openCg, 1_000n);
+
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      for (let i = 0; i < 25; i++) {
+        const preview = await RandomSampling.previewChallengeForSeed(
+          testSeed(i),
+          currentEpoch,
+        );
+        expect(preview.cgId).to.equal(openCg);
+        expect(preview.kcId).to.equal(openKc);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 4 — CG with only expired KCs: MAX_KC_RETRIES are exhausted and the
+    // picker reverts with NoEligibleKnowledgeCollection (the whole challenge
+    // is skipped — node retries next proof period).
+    // -----------------------------------------------------------------------
+    it('reverts NoEligibleKnowledgeCollection when every KC in the CG has expired', async () => {
+      const cgId = await createCG(OPEN_POLICY);
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      // Create a KC that is still live, seed value, then advance Chronos far
+      // enough that the KC has expired by the time we generate the challenge.
+      // The CG's value ledger is finalized only up to currentEpoch-1, so the
+      // per-epoch view must still report non-zero at the new current epoch
+      // (so the picker reaches the KC draw step and fails there).
+      const endEpoch = currentEpoch + 1n;
+      await createKC(cgId, endEpoch);
+      // Give the CG value for a long lifetime so it remains weighted after
+      // the epoch advance.
+      await seedCGValue(cgId, 10_000n, 20n);
+
+      // Advance Chronos past the KC's endEpoch.
+      const epochLength = await Chronos.epochLength();
+      await time.increase(Number(epochLength) * 5);
+      const newEpoch = await Chronos.getCurrentEpoch();
+      expect(newEpoch).to.be.greaterThan(endEpoch);
+
+      await expect(
+        RandomSampling.previewChallengeForSeed(testSeed(0), newEpoch),
+      ).to.be.revertedWithCustomError(
+        RandomSampling,
+        'NoEligibleKnowledgeCollection',
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 5 — Distribution regression: 3 public CGs weighted 70/20/10 should
+    // be picked at those ratios over many draws. Using the read-only preview
+    // helper with per-draw seeds makes this both deterministic and fast.
+    // -----------------------------------------------------------------------
+    it('distribution converges to 70/20/10 over 10,000 draws', async () => {
+      const cgA = await createCG(OPEN_POLICY);
+      const cgB = await createCG(OPEN_POLICY);
+      const cgC = await createCG(OPEN_POLICY);
+
+      const endEpoch = (await Chronos.getCurrentEpoch()) + 100n;
+      await createKC(cgA, endEpoch);
+      await createKC(cgB, endEpoch);
+      await createKC(cgC, endEpoch);
+
+      // Raw value values become per-epoch contributions of 7000 / 2000 / 1000.
+      await seedCGValue(cgA, 7_000n);
+      await seedCGValue(cgB, 2_000n);
+      await seedCGValue(cgC, 1_000n);
+
+      const DRAWS = 10_000;
+      const counts: Record<string, number> = { A: 0, B: 0, C: 0 };
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      for (let i = 0; i < DRAWS; i++) {
+        const preview = await RandomSampling.previewChallengeForSeed(
+          testSeed(i),
+          currentEpoch,
+        );
+        if (preview.cgId === cgA) counts.A++;
+        else if (preview.cgId === cgB) counts.B++;
+        else if (preview.cgId === cgC) counts.C++;
+        else throw new Error(`unexpected cgId ${preview.cgId}`);
+      }
+
+      // ±5% absolute tolerance around the 70/20/10 expectation (i.e. A in
+      // [6500, 7500], B in [1500, 2500], C in [500, 1500]). The test seed
+      // space has no drift — this is tight enough to catch a broken walker
+      // without being flaky on a well-mixed hash stream.
+      expect(counts.A).to.be.greaterThan(6500).and.lessThan(7500);
+      expect(counts.B).to.be.greaterThan(1500).and.lessThan(2500);
+      expect(counts.C).to.be.greaterThan(500).and.lessThan(1500);
+    }).timeout(120_000);
+
+    // -----------------------------------------------------------------------
+    // Test 6 — Inactive (deactivated) CGs must be excluded even if they
+    // currently hold value. Exercises the second branch of the read-time
+    // filter beyond the curated-policy check.
+    // -----------------------------------------------------------------------
+    it('excludes deactivated CGs from the weighted draw', async () => {
+      const deactivated = await createCG(OPEN_POLICY);
+      const activeCg = await createCG(OPEN_POLICY);
+
+      const endEpoch = (await Chronos.getCurrentEpoch()) + 5n;
+      await createKC(deactivated, endEpoch);
+      const activeKc = await createKC(activeCg, endEpoch);
+
+      await seedCGValue(deactivated, 10_000n);
+      await seedCGValue(activeCg, 1_000n);
+
+      // Deactivate the richer CG — it must be skipped during the walk.
+      await ContextGraphStorage.connect(opSigner)
+        .deactivateContextGraph(deactivated);
+
+      const currentEpoch = await Chronos.getCurrentEpoch();
+      for (let i = 0; i < 15; i++) {
+        const preview = await RandomSampling.previewChallengeForSeed(
+          testSeed(i),
+          currentEpoch,
+        );
+        expect(preview.cgId).to.equal(activeCg);
+        expect(preview.kcId).to.equal(activeKc);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- `_generateChallenge` now picks a CG weighted by `ContextGraphValueStorage.getCGValueAtEpoch(cg, currentEpoch)` via a linear prefix-sum scan, then a uniform-random KC within that CG.
- KC-within-CG selection stays uniform (accepted limitation per v2.5 §"Known limitation — KC-level gaming").
- Multiplicative score formula unchanged (decision #9) — `_calculateScore`, `submitProof`, and the single-challenge-per-period guard are all untouched.
- Legacy V8 BFS picker (`_findActiveKnowledgeCollection`) and its unit-test block are fully removed — no zombie code.

## Plan reference

`.ai/v10-implementation-plan.md` Phase 10 section (lines 695–729).

## Dependencies

- Phase 1 (`ContextGraphValueStorage`) — merged in #143 ✓
- Phase 7 (`ContextGraphs` + `contextGraphKCList`) — merged in #145 ✓
- **Phase 8 (KAv10 rewire) — not yet merged.** This PR's test suite simulates the publish-side input state via a `TestStorageOperator` Hub sentinel (see `test/helpers/kc-helpers.ts`) that grants a test signer `onlyContracts` access to `ContextGraphStorage` and `ContextGraphValueStorage`. The bridge auto-binds every published KC to a default open CG with a 100-epoch seed so the pre-existing integration suite stays green under the new picker semantics. Zero cross-branch imports — the tests have no dependency on `v10-phase-8-kav10-rewire` branch state.

Post-Phase-8 note: once `v10-phase-8-kav10-rewire` merges into `v10-contracts-redesign`, this branch should be rebased onto the updated integration tip and the full integration suite re-run to confirm real publish-side wiring satisfies the weighting invariants. The bridge helpers in `test/helpers/kc-helpers.ts` can be reviewed then for removal (they are opt-in via a Hub sentinel, so leaving them in is also safe).

## Scope additions beyond the plan (documented)

Three soft additions that extend but don't contradict the plan:

1. **Curated-CG filter** (`_isCGEligible` at `contracts/RandomSampling.sol:522–536`). Curated (private) and deactivated CGs are excluded from the weighted draw at read-time. This is a new V10 semantic — curated CG data isn't visible to nodes, so including them in sampling would be nonsensical. Captured here because it's not in the plan; downstream phases and reviewers should treat this as an accepted V10 decision, not a silent behavior change.
2. **KC retry loop** (`MAX_KC_RETRIES = 10`) inside `_generateChallenge`. Without bounded retry, a picked-but-expired KC would revert the whole challenge; retry rotates the seed and re-draws within the chosen CG. Exhaustion still reverts `NoEligibleKnowledgeCollection` so the node can retry in the next proof period.
3. **`ChallengeGenerated` event** and **`previewChallengeForSeed(bytes32 seed, uint256 epoch)` view**. The event is new ABI surface; indexer/node consumers should begin consuming it. The view is the test harness entry point for deterministic distribution assertions without block mining — it's public on the production ABI in lieu of duplicating the picker in a test-only contract. Both are justified in the contract NatSpec and commit messages.

## Tests

All eight Phase 10 unit tests in `test/unit/RandomSampling.test.ts`:

1. **Happy path** — single public CG always selected regardless of seed
2. **Curated-only revert** — only curated CGs with value → `NoEligibleContextGraph`
3. **Curated exclusion at 10:1** — curated CG with 10× the value never wins
4. **Expired-KC retry exhaustion** — `NoEligibleKnowledgeCollection` after `MAX_KC_RETRIES`
5. **Distribution convergence** — **10,000 draws**, three-way 70/20/10 split, ±5% absolute bounds (3.4s runtime via `previewChallengeForSeed`)
6. **Deactivated-CG exclusion** — deactivated CG with 10× value is skipped
7. **CG seed decay → `NoEligibleContextGraph`** *(added in 181ebb17)* — plan lines 713–714; KC stays live, only `ContextGraphValueStorage` decay drives exclusion
8. **Decayed CG never selected while live neighbor exists** *(added in 181ebb17)* — plan line 713; 10× decayed CG loses 20/20 draws to 1/10 active CG

Integration tests in `test/integration/RandomSampling.test.ts` validate the full end-to-end flow:

- Publish → challenge → proof submit → epoch-score increment
- `NodeEpochScoreAdded` event emission
- `nodeEpochProofPeriodScore` accumulation
- Single-challenge-per-period guard (pre-existing, still passes through the auto-bridge)

## Verification

- `npx hardhat compile` — clean (contracts unchanged since 234d5e8a)
- `npx hardhat test --grep 'RandomSampling'` — **122 passing, 0 failing**
- `npx hardhat test --grep 'ContextGraphValueStorage'` — **26 passing, 0 failing** (Phase 1 regression)
- `npx hardhat test --grep 'ContextGraphs'` — **97 passing, 0 failing** (Phase 7 regression)
- Distribution test runs at full 10,000-draw sample in 4.5s (no CI weakening)

## Commits

- `dea732fb` test(evm): failing tests for value-weighted CG selection
- `0c2dac7f` feat(evm): RandomSampling value-weighted CG selection
- `234d5e8a` test(evm): integration test bridge + obsolete-block cleanup
- `181ebb17` test(evm): plan-required regression tests for CG value decay

🤖 Phase 10 of V10 contracts redesign