### PR TITLE
refactor(v10): Phase 3 — DelegatorsInfo revert to V8

### DIFF
--- a/packages/evm-module/contracts/Staking.sol
+++ b/packages/evm-module/contracts/Staking.sol
@@ -102,10 +102,10 @@ contract Staking is INamed, IVersioned, ContractStatus, IInitializable {
      * @param addedStake Amount of tokens to stake (must be > 0)
      */
     function stake(uint72 identityId, uint96 addedStake) external profileExists(identityId) {
-        _stakeWithLock(identityId, addedStake, 1);
+        _stake(identityId, addedStake);
     }
 
-    function _stakeWithLock(uint72 identityId, uint96 addedStake, uint40 lockEpochs) internal {
+    function _stake(uint72 identityId, uint96 addedStake) internal {
         IERC20 token = tokenContract;
         StakingStorage ss = stakingStorage;
 
@@ -123,15 +123,9 @@ contract Staking is INamed, IVersioned, ContractStatus, IInitializable {
         _validateDelegatorEpochClaims(identityId, msg.sender);
 
         bytes32 delegatorKey = _getDelegatorKey(msg.sender);
-        uint40 currentEpoch = uint40(chronos.getCurrentEpoch());
+        uint256 currentEpoch = chronos.getCurrentEpoch();
         // settle all pending score changes for the node's delegator
         _prepareForStakeChange(currentEpoch, identityId, delegatorKey);
-
-        // Update conviction lock: can only extend, never shorten
-        (uint40 existingLock, ) = delegatorsInfo.getDelegatorLock(identityId, msg.sender);
-        if (lockEpochs > existingLock) {
-            delegatorsInfo.setDelegatorLock(identityId, msg.sender, lockEpochs, currentEpoch);
-        }
 
         uint96 delegatorStakeBase = stakingStorage.getDelegatorStakeBase(identityId, delegatorKey);
 
@@ -251,15 +245,6 @@ contract Staking is INamed, IVersioned, ContractStatus, IInitializable {
 
         if (removedStake == 0) {
             revert TokenLib.ZeroTokenAmount();
-        }
-
-        // Check conviction lock: cannot withdraw while lock is active
-        (uint40 lockEpochs, uint40 lockStartEpoch) = delegatorsInfo.getDelegatorLock(identityId, msg.sender);
-        if (lockEpochs > 0) {
-            uint40 currentEpochU40 = uint40(chronos.getCurrentEpoch());
-            if (currentEpochU40 < lockStartEpoch + lockEpochs) {
-                revert StakingLib.ConvictionLockActive(identityId, lockStartEpoch + lockEpochs);
-            }
         }
 
         // Validate that all claims have been settled for the node before changing stake
@@ -945,16 +930,15 @@ contract Staking is INamed, IVersioned, ContractStatus, IInitializable {
 
     /**
      * @notice Get the conviction multiplier for a specific delegator on a node.
-     * @param identityId Node identity
-     * @param delegator Delegator address
-     * @return multiplier18 Multiplier scaled by 1e18
+     * @dev Returns SCALE18 (1x) for all delegators. No per-delegator lock state
+     *      is currently tracked in `Staking`; callers requiring multiplier data
+     *      should read from the appropriate staking-position contract instead.
+     * @return multiplier18 SCALE18 (1x).
      */
     function getDelegatorConvictionMultiplier(
-        uint72 identityId,
-        address delegator
-    ) external view returns (uint256 multiplier18) {
-        (uint40 lockEpochs, ) = delegatorsInfo.getDelegatorLock(identityId, delegator);
-        if (lockEpochs == 0) return SCALE18; // Default: V8-compatible 1x for unset locks
-        return convictionMultiplier(lockEpochs);
+        uint72 /* identityId */,
+        address /* delegator */
+    ) external pure returns (uint256 multiplier18) {
+        return SCALE18;
     }
 }

--- a/packages/evm-module/contracts/libraries/StakingLib.sol
+++ b/packages/evm-module/contracts/libraries/StakingLib.sol
@@ -33,6 +33,4 @@ library StakingLib {
     error MaximumStakeExceeded(uint256 amount);
     error WithdrawalExceedsStake(uint96 stake, uint96 amount);
     error AmountExceedsOperatorFeeBalance(uint96 feeBalance, uint96 amount);
-    error InvalidLockEpochs();
-    error ConvictionLockActive(uint72 identityId, uint40 expiresAtEpoch);
 }

--- a/packages/evm-module/contracts/storage/DelegatorsInfo.sol
+++ b/packages/evm-module/contracts/storage/DelegatorsInfo.sol
@@ -35,10 +35,6 @@ contract DelegatorsInfo is INamed, IVersioned, ContractStatus, IInitializable {
     // IdentityId => Delegator => LastStakeHeldEpoch (the last epoch when delegator held stake, 0 if fully claimed)
     mapping(uint72 => mapping(address => uint256)) public lastStakeHeldEpoch;
 
-    // V9 Staking Conviction: lock tracking per delegator per node
-    mapping(uint72 => mapping(address => uint40)) public delegatorLockEpochs;
-    mapping(uint72 => mapping(address => uint40)) public delegatorLockStartEpoch;
-
     event DelegatorAdded(uint72 indexed identityId, address indexed delegator);
     event DelegatorRemoved(uint72 indexed identityId, address indexed delegator);
     event DelegatorLastClaimedEpochUpdated(
@@ -163,10 +159,6 @@ contract DelegatorsInfo is INamed, IVersioned, ContractStatus, IInitializable {
         return netNodeEpochRewards[identityId][epoch];
     }
 
-    function setLastClaimedDelegatorsRewardsEpoch(uint72 identityId, uint256 epoch) external onlyContracts {
-        lastClaimedDelegatorsRewardsEpoch[identityId] = epoch;
-    }
-
     function setHasDelegatorClaimedEpochRewards(
         uint256 epoch,
         uint72 identityId,
@@ -222,27 +214,5 @@ contract DelegatorsInfo is INamed, IVersioned, ContractStatus, IInitializable {
                 i++;
             }
         }
-    }
-
-    // V9 Conviction lock setters/getters
-
-    function setDelegatorLock(
-        uint72 identityId,
-        address delegator,
-        uint40 lockEpochs,
-        uint40 lockStartEpoch
-    ) external onlyContracts {
-        delegatorLockEpochs[identityId][delegator] = lockEpochs;
-        delegatorLockStartEpoch[identityId][delegator] = lockStartEpoch;
-    }
-
-    function getDelegatorLock(
-        uint72 identityId,
-        address delegator
-    ) external view returns (uint40 lockEpochs, uint40 lockStartEpoch) {
-        return (
-            delegatorLockEpochs[identityId][delegator],
-            delegatorLockStartEpoch[identityId][delegator]
-        );
     }
 }

--- a/packages/evm-module/test/integration/Staking.test.ts
+++ b/packages/evm-module/test/integration/Staking.test.ts
@@ -3122,7 +3122,6 @@ describe(`Delegator Scoring`, function () {
 
       // Partial withdrawal of 25 TRAC
       const withdrawalAmount = toTRAC(25);
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, withdrawalAmount);
@@ -3533,7 +3532,6 @@ describe(`Delegator Scoring`, function () {
 
       // Step 3: withdraw(10) - triggers first settlement
       const withdrawAmount = toTRAC(10);
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, withdrawAmount);
@@ -3664,7 +3662,6 @@ describe(`Delegator Scoring`, function () {
         node1Id,
         d1Key,
       );
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, totalStake);
@@ -3722,7 +3719,6 @@ describe(`Delegator Scoring`, function () {
         .stake(node1Id, stakeAmount);
 
       // Step 2: requestWithdrawal(all) - NO proof yet
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, stakeAmount);
@@ -3984,7 +3980,6 @@ describe(`Delegator Scoring`, function () {
         .stake(node1Id, stakeAmount);
 
       // Step 2: withdrawAll
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, stakeAmount);
@@ -4214,7 +4209,6 @@ describe(`Delegator Scoring`, function () {
         .stake(node1Id, initialStake);
 
       const withdrawAmount = toTRAC(70);
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, withdrawAmount);
@@ -4737,7 +4731,6 @@ describe(`Delegator Scoring`, function () {
       );
 
       // Step 2: One withdraws all
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, stake1);
@@ -5170,7 +5163,6 @@ describe(`Delegator Scoring`, function () {
         .stake(node1Id, initialStake);
 
       // Step 2: Withdraw all stake
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, initialStake);
@@ -5303,7 +5295,6 @@ describe(`Delegator Scoring`, function () {
         .submitProof(chunks[chunkId], proof);
 
       // Step 2: Withdraw all stake
-      await contracts.delegatorsInfo.setDelegatorLock(node1Id, accounts.delegator1.address, 0, 0);
       await contracts.staking
         .connect(accounts.delegator1)
         .requestWithdrawal(node1Id, initialStake);

--- a/packages/evm-module/test/unit/Ask.test.ts
+++ b/packages/evm-module/test/unit/Ask.test.ts
@@ -122,7 +122,6 @@ describe('@unit Ask', () => {
     expect(weightedSum).to.equal(expectedWeighted);
 
     const partialWithdraw = hre.ethers.parseUnits('10000', 18);
-    await DelegatorsInfo.setDelegatorLock(identityId, accounts[2].address, 0, 0);
     await Staking.connect(accounts[2]).requestWithdrawal(
       identityId,
       partialWithdraw,


### PR DESCRIPTION
## Summary
- `DelegatorsInfo.sol` reverted to V8 surface area (byte-for-byte). Drops `delegatorLockEpochs`, `delegatorLockStartEpoch`, the `setDelegatorLock` / `getDelegatorLock` helpers, and the orphaned `setLastClaimedDelegatorsRewardsEpoch` setter. Lock data now lives exclusively in `ConvictionStakingStorage` (Phase 2, merged).
- `Staking.sol` callers of the removed helpers are neutralized, not rerouted. Phase 11 owns the rewards rewire; Phase 3 just deletes the V10-era lock surface area and keeps the V8 legacy paths compiling.
- Integration Staking tests and the Ask unit test drop the pre-withdrawal `setDelegatorLock(id, addr, 0, 0)` workaround — with the lock guard gone, it no longer serves a purpose.

## Plan reference
`~/.claude/dkg-v9/.ai/v10-implementation-plan.md` Phase 3 (lines 336–361)

## Deletions
- `DelegatorsInfo.delegatorLockEpochs`
- `DelegatorsInfo.delegatorLockStartEpoch`
- `DelegatorsInfo.setDelegatorLock(...)`
- `DelegatorsInfo.getDelegatorLock(...)`
- `DelegatorsInfo.setLastClaimedDelegatorsRewardsEpoch(...)` (orphaned — zero callers in the entire repo)
- `StakingLib.ConvictionLockActive` and `StakingLib.InvalidLockEpochs` errors (dead after the revert; the NFT and PCA contracts each declare their own `InvalidLockEpochs` locally)
- `_stakeWithLock(..., uint40 lockEpochs)` → renamed to `_stake(uint72, uint96)`, lock extend-or-write block dropped
- `requestWithdrawal` conviction-lock guard (V8-era withdrawals never observed it)
- 9 `setDelegatorLock(node1Id, ..., 0, 0)` calls in `test/integration/Staking.test.ts` and 1 in `test/unit/Ask.test.ts`

## Stubbed, not deleted
- `Staking.getDelegatorConvictionMultiplier(uint72, address)` — now `pure`, returns `SCALE18` (1x) for every delegator. Matches the prior V8-compatible default for unset locks and keeps the external ABI stable. The pure tier function `Staking.convictionMultiplier(uint40)` is untouched — it has no `DelegatorsInfo` dependency and is still consumed by the V10 unit tests and V10 E2E Flow 1 assertions.

## Preserved (not touched)
- V10 Hub wiring / constructor
- V8 legacy `stake()`, `claim()`, `requestWithdrawal()`, `finalizeWithdrawal()` paths
- Phase 2 `ConvictionStakingStorage` (frozen)
- `DKGStakingConvictionNFT`, `PublishingConvictionAccount` (Phase 5 owns the NFT rewrite)
- `test/unit/DelegatorsInfo.test.ts` — already V8-equivalent (only delta is a test-fixture `resetDeploymentsJson` helper, not lock-related)

## Verification
- `grep -rn delegatorLockEpochs contracts/ test/` → 0 matches
- `grep -rn delegatorLockStartEpoch contracts/ test/` → 0 matches
- `diff contracts/storage/DelegatorsInfo.sol ../../protocol/dkg-evm-module/contracts/storage/DelegatorsInfo.sol` → **0 delta** (byte-for-byte V8 match)
- `hardhat compile` → clean (one unrelated pre-existing warning in `KnowledgeAssetsStorage.sol`)
- `hardhat test --grep 'DelegatorsInfo'` → **35 passing**
- `hardhat test --grep 'ConvictionStakingStorage'` → **40 passing** (Phase 2 regression)
- `hardhat test --grep 'Staking'` → **150 passing** (V8 legacy stake / claim / withdraw intact)
- `hardhat test --grep '@integration'` → **60 passing**
- `hardhat test --grep 'V10 E2E'` → **9 passing** (Flow 1 staker + Flow 2 publisher + Flow 3 publish-via-NFT all green)

## Out of scope (per plan)
- No rewiring of lock reads to `ConvictionStakingStorage` → Phase 11
- No `DKGStakingConvictionNFT` changes → Phase 5
- No new `_recordStake` entry → Phase 4

## Commits
1. `refactor(evm): V10 Phase 3 — revert DelegatorsInfo.sol to V8`
2. `refactor(evm): V10 Phase 3 — neutralize Staking.sol callers of removed DelegatorsInfo helpers`
3. `test(evm): V10 Phase 3 — remove lock-guard workarounds from Staking/Ask tests`

🤖 Phase 3 of V10 contracts redesign