### PR TITLE
fix: polish local agent chat UX and inject active context graph

### DIFF
--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -153,13 +153,49 @@ function formatAttachmentContext(attachmentRefs: OpenClawAttachmentRef[]): strin
   return ['Attached Working Memory items:', ...lines].join('\n');
 }
 
-function buildAgentBody(text: string, attachmentRefs?: OpenClawAttachmentRef[]): string {
-  if (!attachmentRefs?.length) return text;
+interface ChatContextEntry {
+  key: string;
+  label: string;
+  value: string;
+}
+
+function sanitizeChatContextEntry(entry: ChatContextEntry): ChatContextEntry {
+  return {
+    key: sanitizeAttachmentContextValue(entry.key),
+    label: sanitizeAttachmentContextValue(entry.label),
+    value: sanitizeAttachmentContextValue(entry.value),
+  };
+}
+
+function sanitizeChatContextEntries(entries: ChatContextEntry[] | undefined): ChatContextEntry[] | undefined {
+  return entries?.map((entry) => sanitizeChatContextEntry(entry));
+}
+
+function formatChatContext(entries: ChatContextEntry[]): string {
+  const lines = entries.map((entry) => `- ${sanitizeAttachmentPromptField(entry.label, entry.key)}: ${sanitizeAttachmentPromptField(entry.value, 'unknown')}`);
+  return [
+    'Context for this chat turn:',
+    'If "target_context_graph" is present below, treat it as authoritative for this turn unless the user explicitly overrides it in the same message.',
+    ...lines,
+  ].join('\n');
+}
+
+function buildAgentBody(text: string, opts?: { attachmentRefs?: OpenClawAttachmentRef[]; contextEntries?: ChatContextEntry[] }): string {
+  const sections: string[] = [];
   const trimmed = text.trim();
-  if (!trimmed) {
-    return `User attached Working Memory items for this chat turn.\n\n${formatAttachmentContext(attachmentRefs)}`;
+  if (trimmed) {
+    sections.push(text);
   }
-  return `${text}\n\n${formatAttachmentContext(attachmentRefs)}`;
+  if (opts?.contextEntries?.length) {
+    sections.push(formatChatContext(opts.contextEntries));
+  }
+  if (opts?.attachmentRefs?.length) {
+    sections.push(formatAttachmentContext(opts.attachmentRefs));
+  }
+  if (sections.length === 0) {
+    return 'User sent an empty chat turn.';
+  }
+  return sections.join('\n\n');
 }
 const moduleRequire = createRequire(import.meta.url);
 
@@ -177,6 +213,30 @@ interface PersistTurnOptions {
 
 interface InboundChatOptions {
   attachmentRefs?: OpenClawAttachmentRef[];
+  contextEntries?: ChatContextEntry[];
+}
+
+function normalizeChatContextEntry(raw: unknown): ChatContextEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const record = raw as Record<string, unknown>;
+  const key = typeof record.key === 'string' ? record.key.trim() : '';
+  const label = typeof record.label === 'string' ? record.label.trim() : '';
+  const value = typeof record.value === 'string' ? record.value.trim() : '';
+  if (!key || !label || !value) return null;
+  return { key, label, value };
+}
+
+function normalizeChatContextEntries(raw: unknown): ChatContextEntry[] | undefined {
+  if (raw == null) return undefined;
+  if (!Array.isArray(raw)) return undefined;
+  if (raw.length === 0) return [];
+  const entries: ChatContextEntry[] = [];
+  for (const entry of raw) {
+    const normalized = normalizeChatContextEntry(entry);
+    if (!normalized) return undefined;
+    entries.push(normalized);
+  }
+  return entries;
 }
 
 export class DkgChannelPlugin {
@@ -548,15 +608,20 @@ export class DkgChannelPlugin {
     const cfg = this.cfg;
     const attachmentRefs = normalizeAttachmentRefs(opts?.attachmentRefs);
     const contextAttachmentRefs = sanitizeAttachmentRefsForContext(attachmentRefs);
+    const contextEntries = normalizeChatContextEntries(opts?.contextEntries);
+    const sanitizedContextEntries = sanitizeChatContextEntries(contextEntries);
     if (opts?.attachmentRefs != null && attachmentRefs === undefined) {
       throw new Error('Invalid attachment refs');
+    }
+    if (opts?.contextEntries != null && contextEntries === undefined) {
+      throw new Error('Invalid context entries');
     }
 
     // --- Primary: dispatch via runtime channel (uses plugin-sdk when available) ---
     if (runtime?.channel && cfg) {
       api.logger.info?.(`[dkg-channel] Dispatching for: ${correlationId}`);
       try {
-        const reply = await this.dispatchViaPluginSdk(text, correlationId, identity, contextAttachmentRefs);
+        const reply = await this.dispatchViaPluginSdk(text, correlationId, identity, contextAttachmentRefs, sanitizedContextEntries);
         // Fire-and-forget: persist turn to DKG graph for Agent Hub visualization
         this.queueTurnPersistence(text, reply.text, correlationId, identity, {
           attachmentRefs,
@@ -576,7 +641,7 @@ export class DkgChannelPlugin {
         channelName: CHANNEL_NAME,
         senderId: identity || 'owner',
         senderIsOwner: true,
-        text: buildAgentBody(text, contextAttachmentRefs),
+        text: buildAgentBody(text, { attachmentRefs: contextAttachmentRefs, contextEntries: sanitizedContextEntries }),
         correlationId,
       } as any);
       this.queueTurnPersistence(text, reply.text, correlationId, identity || 'owner', {
@@ -600,6 +665,7 @@ export class DkgChannelPlugin {
     correlationId: string,
     identity: string,
     attachmentRefs?: OpenClawAttachmentRef[],
+    contextEntries?: ChatContextEntry[],
   ): Promise<ChannelOutboundReply> {
     const log = this.api!.logger;
     const runtime = this.runtime;
@@ -637,7 +703,8 @@ export class DkgChannelPlugin {
       storePath,
       sessionKey: route.sessionKey,
     });
-    const agentBody = buildAgentBody(text, attachmentRefs);
+    const agentBody = buildAgentBody(text, { attachmentRefs, contextEntries });
+    const commandBody = contextEntries?.length ? agentBody : text;
     const formattedBody = runtime.channel.reply.formatAgentEnvelope({
       channel: 'DKG UI',
       from: identity || 'Owner',
@@ -651,9 +718,10 @@ export class DkgChannelPlugin {
     const ctxPayload = {
       Body: formattedBody,
       BodyForAgent: agentBody,
-      RawBody: text,
-      CommandBody: text,
-      BodyForCommands: text,
+      RawBody: commandBody,
+      CommandBody: commandBody,
+      BodyForCommands: commandBody,
+      ...(commandBody !== text ? { OriginalRawBody: text } : {}),
       From: identity || 'Owner',
       To: route.agentId,
       SessionKey: route.sessionKey,
@@ -669,6 +737,10 @@ export class DkgChannelPlugin {
       ...(attachmentRefs?.length ? {
         AttachmentRefs: attachmentRefs.map((ref) => ({ ...ref })),
         AttachmentSummary: formatAttachmentContext(attachmentRefs),
+      } : {}),
+      ...(contextEntries?.length ? {
+        ContextEntries: contextEntries.map((entry) => ({ ...entry })),
+        ContextSummary: formatChatContext(contextEntries),
       } : {}),
     };
 
@@ -805,12 +877,17 @@ export class DkgChannelPlugin {
     const cfg = this.cfg;
     const attachmentRefs = normalizeAttachmentRefs(opts?.attachmentRefs);
     const contextAttachmentRefs = sanitizeAttachmentRefsForContext(attachmentRefs);
+    const contextEntries = normalizeChatContextEntries(opts?.contextEntries);
+    const sanitizedContextEntries = sanitizeChatContextEntries(contextEntries);
     if (opts?.attachmentRefs != null && attachmentRefs === undefined) {
       throw new Error('Invalid attachment refs');
     }
+    if (opts?.contextEntries != null && contextEntries === undefined) {
+      throw new Error('Invalid context entries');
+    }
 
     if (!runtime?.channel || !cfg) {
-      const reply = await this.processInbound(text, correlationId, identity, { attachmentRefs });
+      const reply = await this.processInbound(text, correlationId, identity, { attachmentRefs, contextEntries });
       yield { type: 'final', text: reply.text, correlationId: reply.correlationId ?? correlationId };
       return;
     }
@@ -834,14 +911,16 @@ export class DkgChannelPlugin {
     const previousTimestamp = runtime.channel.session.readSessionUpdatedAt?.({
       storePath, sessionKey: route.sessionKey,
     });
-    const agentBody = buildAgentBody(text, contextAttachmentRefs);
+    const agentBody = buildAgentBody(text, { attachmentRefs: contextAttachmentRefs, contextEntries: sanitizedContextEntries });
+    const commandBody = sanitizedContextEntries?.length ? agentBody : text;
     const formattedBody = runtime.channel.reply.formatAgentEnvelope({
       channel: 'DKG UI', from: identity || 'Owner', body: agentBody,
       timestamp: Date.now(), previousTimestamp, envelope: envelopeOpts,
     });
     const ctxPayload = {
-      Body: formattedBody, BodyForAgent: agentBody, RawBody: text,
-      CommandBody: text, BodyForCommands: text,
+      Body: formattedBody, BodyForAgent: agentBody, RawBody: commandBody,
+      CommandBody: commandBody, BodyForCommands: commandBody,
+      ...(commandBody !== text ? { OriginalRawBody: text } : {}),
       From: identity || 'Owner', To: route.agentId,
       SessionKey: route.sessionKey, AccountId: 'default',
       Provider: CHANNEL_NAME, Surface: CHANNEL_NAME, ChatType: 'direct',
@@ -851,6 +930,10 @@ export class DkgChannelPlugin {
       ...(contextAttachmentRefs?.length ? {
         AttachmentRefs: contextAttachmentRefs.map((ref) => ({ ...ref })),
         AttachmentSummary: formatAttachmentContext(contextAttachmentRefs),
+      } : {}),
+      ...(sanitizedContextEntries?.length ? {
+        ContextEntries: sanitizedContextEntries.map((entry) => ({ ...entry })),
+        ContextSummary: formatChatContext(sanitizedContextEntries),
       } : {}),
     };
 
@@ -1273,7 +1356,7 @@ export class DkgChannelPlugin {
     const start = Date.now();
     this.inFlight++;
     try {
-      let parsed: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown };
+      let parsed: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown; contextEntries?: unknown };
       try {
         const body = await readBody(req);
         parsed = JSON.parse(body);
@@ -1290,9 +1373,15 @@ export class DkgChannelPlugin {
 
       try {
         const attachmentRefs = normalizeAttachmentRefs(parsed.attachmentRefs);
+        const contextEntries = normalizeChatContextEntries(parsed.contextEntries);
         if (parsed.attachmentRefs != null && attachmentRefs === undefined) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Invalid "attachmentRefs"' }));
+          return;
+        }
+        if (parsed.contextEntries != null && contextEntries === undefined) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid "contextEntries"' }));
           return;
         }
         const { text, correlationId, identity } = parsed;
@@ -1301,7 +1390,7 @@ export class DkgChannelPlugin {
           res.end(JSON.stringify({ error: 'Missing "text" or "correlationId"' }));
           return;
         }
-        const reply = await this.processInbound(text, correlationId, identity ?? 'owner', { attachmentRefs });
+        const reply = await this.processInbound(text, correlationId, identity ?? 'owner', { attachmentRefs, contextEntries });
 
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify(reply));
@@ -1330,7 +1419,7 @@ export class DkgChannelPlugin {
     const start = Date.now();
     this.inFlight++;
     try {
-      let parsed: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown };
+      let parsed: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown; contextEntries?: unknown };
       try {
         const body = await readBody(req);
         parsed = JSON.parse(body);
@@ -1346,9 +1435,15 @@ export class DkgChannelPlugin {
       }
 
       const attachmentRefs = normalizeAttachmentRefs(parsed.attachmentRefs);
+      const contextEntries = normalizeChatContextEntries(parsed.contextEntries);
       if (parsed.attachmentRefs != null && attachmentRefs === undefined) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ error: 'Invalid "attachmentRefs"' }));
+        return;
+      }
+      if (parsed.contextEntries != null && contextEntries === undefined) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid "contextEntries"' }));
         return;
       }
       const { text, correlationId, identity } = parsed;
@@ -1370,7 +1465,7 @@ export class DkgChannelPlugin {
       res.on('error', () => { clientDisconnected = true; });
 
       try {
-        for await (const event of this.processInboundStream(text, correlationId, identity ?? 'owner', { attachmentRefs })) {
+        for await (const event of this.processInboundStream(text, correlationId, identity ?? 'owner', { attachmentRefs, contextEntries })) {
           if (clientDisconnected) break;
           const ok = res.write(`data: ${JSON.stringify(event)}\n\n`);
           if (!ok) await new Promise<void>((r) => res.once('drain', r));
@@ -1394,9 +1489,15 @@ export class DkgChannelPlugin {
     try {
       const body = typeof req.body === 'object' ? req.body : JSON.parse(await readBody(req));
       const attachmentRefs = normalizeAttachmentRefs(body.attachmentRefs);
+      const contextEntries = normalizeChatContextEntries(body.contextEntries);
       if (body.attachmentRefs != null && attachmentRefs === undefined) {
         res.writeHead?.(400, { 'Content-Type': 'application/json' });
         res.end?.(JSON.stringify({ error: 'Invalid "attachmentRefs"' }));
+        return;
+      }
+      if (body.contextEntries != null && contextEntries === undefined) {
+        res.writeHead?.(400, { 'Content-Type': 'application/json' });
+        res.end?.(JSON.stringify({ error: 'Invalid "contextEntries"' }));
         return;
       }
       const { text, correlationId, identity } = body;
@@ -1406,7 +1507,7 @@ export class DkgChannelPlugin {
         return;
       }
 
-      const reply = await this.processInbound(text, correlationId, identity ?? 'owner', { attachmentRefs });
+      const reply = await this.processInbound(text, correlationId, identity ?? 'owner', { attachmentRefs, contextEntries });
       res.writeHead?.(200, { 'Content-Type': 'application/json' });
       res.end?.(JSON.stringify(reply));
     } catch (err: any) {

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -42,6 +42,17 @@ discover other agents on the network.
 
 ## 3. Quick Start
 
+## Turn Context Override
+
+When the chat turn includes injected context with `target_context_graph`, treat that value as the authoritative target context graph for the current turn unless the user explicitly overrides it in the same message.
+
+Implications:
+
+- Default all DKG reads, writes, imports, promotions, publishes, and queries in that turn to the injected target context graph.
+- Do not keep using an older conversational context graph when a newer injected `target_context_graph` is present.
+- If the injected value includes both display name and ID, prefer the ID when calling tools or APIs.
+- If the user explicitly says to use a different context graph in the same turn, follow the user's explicit instruction instead.
+
 **Step 1 — Create a Context Graph:**
 
 ```bash

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -2307,6 +2307,35 @@ export function normalizeOpenClawAttachmentRefs(raw: unknown): OpenClawAttachmen
   return refs;
 }
 
+export interface OpenClawChatContextEntry {
+  key: string;
+  label: string;
+  value: string;
+}
+
+function normalizeOpenClawChatContextEntry(raw: unknown): OpenClawChatContextEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const record = raw as Record<string, unknown>;
+  const key = typeof record.key === 'string' ? record.key.trim() : '';
+  const label = typeof record.label === 'string' ? record.label.trim() : '';
+  const value = typeof record.value === 'string' ? record.value.trim() : '';
+  if (!key || !label || !value) return null;
+  return { key, label, value };
+}
+
+export function normalizeOpenClawChatContextEntries(raw: unknown): OpenClawChatContextEntry[] | undefined {
+  if (raw == null) return undefined;
+  if (!Array.isArray(raw)) return undefined;
+  if (raw.length === 0) return [];
+  const entries: OpenClawChatContextEntry[] = [];
+  for (const entry of raw) {
+    const normalized = normalizeOpenClawChatContextEntry(entry);
+    if (!normalized) return undefined;
+    entries.push(normalized);
+  }
+  return entries;
+}
+
 export function hasOpenClawChatTurnContent(
   text: unknown,
   attachmentRefs: OpenClawAttachmentRef[] | undefined,
@@ -2845,18 +2874,22 @@ async function handleRequest(
   // OpenClaw channel bridge — routes DKG UI messages through OpenClaw agent
   // -----------------------------------------------------------------------
 
-  // POST /api/openclaw-channel/send  { text, correlationId, identity?, attachmentRefs? }
+  // POST /api/openclaw-channel/send  { text, correlationId, identity?, attachmentRefs?, contextEntries? }
   // DKG Node UI frontend calls this to send a message to the local OpenClaw
   // agent.  The daemon forwards to the adapter's channel bridge server and
   // returns the agent's reply.
   if (req.method === 'POST' && path === '/api/openclaw-channel/send') {
     const body = await readBody(req, SMALL_BODY_BYTES);
-    let payload: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown };
+    let payload: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown; contextEntries?: unknown };
     try { payload = JSON.parse(body); } catch { return jsonResponse(res, 400, { error: 'Invalid JSON' }); }
 
     const normalizedAttachmentRefs = normalizeOpenClawAttachmentRefs(payload.attachmentRefs);
     if (payload.attachmentRefs != null && normalizedAttachmentRefs === undefined) {
       return jsonResponse(res, 400, { error: 'Invalid "attachmentRefs"' });
+    }
+    const normalizedContextEntries = normalizeOpenClawChatContextEntries(payload.contextEntries);
+    if (payload.contextEntries != null && normalizedContextEntries === undefined) {
+      return jsonResponse(res, 400, { error: 'Invalid "contextEntries"' });
     }
     const { text, correlationId, identity } = payload;
     if (!hasOpenClawChatTurnContent(text, normalizedAttachmentRefs)) {
@@ -2891,6 +2924,7 @@ async function handleRequest(
             correlationId: corrId,
             identity: identity ?? 'owner',
             ...(attachmentRefs ? { attachmentRefs } : {}),
+            ...(normalizedContextEntries ? { contextEntries: normalizedContextEntries } : {}),
           }),
           signal: AbortSignal.timeout(OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS),
         });
@@ -2933,16 +2967,20 @@ async function handleRequest(
     );
   }
 
-  // POST /api/openclaw-channel/stream  { text, correlationId, identity?, attachmentRefs? }
+  // POST /api/openclaw-channel/stream  { text, correlationId, identity?, attachmentRefs?, contextEntries? }
   // SSE streaming variant — pipes agent response chunks as they arrive.
   if (req.method === 'POST' && path === '/api/openclaw-channel/stream') {
     const body = await readBody(req, SMALL_BODY_BYTES);
-    let payload: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown };
+    let payload: { text?: string; correlationId?: string; identity?: string; attachmentRefs?: unknown; contextEntries?: unknown };
     try { payload = JSON.parse(body); } catch { return jsonResponse(res, 400, { error: 'Invalid JSON' }); }
 
     const normalizedAttachmentRefs = normalizeOpenClawAttachmentRefs(payload.attachmentRefs);
     if (payload.attachmentRefs != null && normalizedAttachmentRefs === undefined) {
       return jsonResponse(res, 400, { error: 'Invalid "attachmentRefs"' });
+    }
+    const normalizedContextEntries = normalizeOpenClawChatContextEntries(payload.contextEntries);
+    if (payload.contextEntries != null && normalizedContextEntries === undefined) {
+      return jsonResponse(res, 400, { error: 'Invalid "contextEntries"' });
     }
     const { text, correlationId, identity } = payload;
     if (!hasOpenClawChatTurnContent(text, normalizedAttachmentRefs)) {
@@ -2980,6 +3018,7 @@ async function handleRequest(
             correlationId: corrId,
             identity: identity ?? 'owner',
             ...(attachmentRefs ? { attachmentRefs } : {}),
+            ...(normalizedContextEntries ? { contextEntries: normalizedContextEntries } : {}),
           }),
           signal: AbortSignal.timeout(OPENCLAW_CHANNEL_RESPONSE_TIMEOUT_MS),
         });

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -539,11 +539,18 @@ export interface LocalAgentChatAttachmentRef {
   rootEntity?: string;
 }
 
+export interface LocalAgentChatContextEntry {
+  key: string;
+  label: string;
+  value: string;
+}
+
 interface LocalAgentChatRequestOptions {
   correlationId?: string;
   signal?: AbortSignal;
   identity?: string;
   attachments?: LocalAgentChatAttachmentRef[];
+  contextEntries?: LocalAgentChatContextEntry[];
 }
 
 export const sendOpenClawChat = (peerId: string, text: string) =>
@@ -563,6 +570,7 @@ export async function sendOpenClawLocalChat(
     correlationId: opts?.correlationId ?? crypto.randomUUID(),
     ...(opts?.identity ? { identity: opts.identity } : {}),
     ...(opts?.attachments?.length ? { attachmentRefs: opts.attachments } : {}),
+    ...(opts?.contextEntries?.length ? { contextEntries: opts.contextEntries } : {}),
   };
   const res = await fetch('/api/openclaw-channel/send', {
     method: 'POST',
@@ -597,6 +605,7 @@ export async function streamOpenClawLocalChat(
     correlationId: opts.correlationId ?? crypto.randomUUID(),
     ...(opts.identity ? { identity: opts.identity } : {}),
     ...(opts.attachments?.length ? { attachmentRefs: opts.attachments } : {}),
+    ...(opts.contextEntries?.length ? { contextEntries: opts.contextEntries } : {}),
   };
   const res = await fetch('/api/openclaw-channel/stream', {
     method: 'POST',
@@ -1032,6 +1041,7 @@ export async function streamLocalAgentChat(
     onEvent?: (event: LocalAgentStreamEvent) => void;
     sessionId?: string;
     attachments?: LocalAgentChatAttachmentRef[];
+    contextEntries?: LocalAgentChatContextEntry[];
   } = {},
 ): Promise<{ text: string; correlationId: string }> {
   const normalizedId = id.trim().toLowerCase();

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -831,14 +831,14 @@ function ConnectedAgentsTab(props: {
                   </div>
                 )}
 
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, flexWrap: 'wrap' }}>
-                  <label className="v10-local-agent-copy" style={{ margin: 0, display: 'flex', alignItems: 'center', gap: 8 }}>
-                    New attachments target:
+                <div className="v10-local-agent-toolbar">
+                  <label className="v10-local-agent-target-picker">
+                    <span className="v10-local-agent-target-label">Project</span>
                     <select
+                      className="v10-local-agent-target-select"
                       value={activeProjectId ?? ''}
                       onChange={(e) => onSelectProject(e.target.value)}
                       disabled={projectsLoading || availableProjects.length === 0}
-                      style={{ minWidth: 220 }}
                     >
                       <option value="">{projectsLoading ? 'Loading projects...' : 'Choose a project'}</option>
                       {availableProjects.map((project) => (
@@ -849,27 +849,7 @@ function ConnectedAgentsTab(props: {
                     </select>
                   </label>
 
-                  <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                    <input
-                      ref={attachmentInputRef}
-                      type="file"
-                      multiple
-                      style={{ display: 'none' }}
-                      onChange={(e) => {
-                        if (e.target.files) {
-                          onAddAttachments(e.target.files);
-                          e.target.value = '';
-                        }
-                      }}
-                    />
-                    <button
-                      className="v10-agents-refresh"
-                      onClick={() => attachmentInputRef.current?.click()}
-                      disabled={!selected?.chatAttachments || !activeProjectId || localSending}
-                    >
-                      Attach files
-                    </button>
-                  </div>
+                  <div className="v10-local-agent-toolbar-actions" />
                 </div>
                 {selectedAttachmentDrafts.length > 0 && (
                   <div className="v10-local-agent-copy" style={{ margin: 0, color: 'var(--text-tertiary)' }}>
@@ -879,37 +859,62 @@ function ConnectedAgentsTab(props: {
                   </div>
                 )}
 
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <input
-                    type="text"
-                    placeholder={
-                      showingSessionHistory
-                        ? `Reconnect ${selected.name} to resume live chat...`
-                        : selected.chatReady
-                        ? `Message ${selected.name}...`
-                        : selected.status === 'connecting'
-                          ? `${selected.name} is still connecting...`
-                          : `${selected.name} bridge offline...`
+                <input
+                  ref={attachmentInputRef}
+                  type="file"
+                  multiple
+                  style={{ display: 'none' }}
+                  onChange={(e) => {
+                    if (e.target.files) {
+                      onAddAttachments(e.target.files);
+                      e.target.value = '';
                     }
-                    className="v10-agent-input"
-                    value={localInput}
-                    onChange={(e) => onLocalInputChange(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.shiftKey) {
-                        e.preventDefault();
-                        onSendLocalMessage();
+                  }}
+                />
+
+                <div className="v10-local-agent-composer-row">
+                  <div className="v10-local-agent-composer-shell">
+                    <button
+                      type="button"
+                      className="v10-agent-send-btn secondary v10-local-agent-inline-attach"
+                      onClick={() => attachmentInputRef.current?.click()}
+                      disabled={!selected?.chatAttachments || !activeProjectId || localSending}
+                      title="Attach files"
+                      aria-label="Attach files"
+                    >
+                      <span aria-hidden="true">📎</span>
+                      <span>Upload file</span>
+                    </button>
+                    <textarea
+                      placeholder={
+                        showingSessionHistory
+                          ? `Reconnect ${selected.name} to resume live chat...`
+                          : selected.chatReady
+                          ? `Message ${selected.name}...`
+                          : selected.status === 'connecting'
+                            ? `${selected.name} is still connecting...`
+                            : `${selected.name} bridge offline...`
                       }
-                    }}
-                    disabled={inputDisabled}
-                    style={{ flex: 1 }}
-                  />
-                  <button
-                    className="v10-agent-send-btn"
-                    onClick={onSendLocalMessage}
-                    disabled={inputDisabled || (!localInput.trim() && !hasSendableAttachmentDrafts)}
-                  >
-                    Send
-                  </button>
+                      className="v10-agent-input"
+                      value={localInput}
+                      onChange={(e) => onLocalInputChange(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && !e.shiftKey) {
+                          e.preventDefault();
+                          onSendLocalMessage();
+                        }
+                      }}
+                      disabled={inputDisabled}
+                      rows={3}
+                    />
+                    <button
+                      className="v10-agent-send-btn v10-local-agent-inline-send"
+                      onClick={onSendLocalMessage}
+                      disabled={inputDisabled || (!localInput.trim() && !hasSendableAttachmentDrafts)}
+                    >
+                      Send
+                    </button>
+                  </div>
                 </div>
                 {!activeProjectId && (
                   <div className="v10-local-agent-copy" style={{ margin: 0, color: 'var(--text-tertiary)' }}>

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -5,6 +5,7 @@ import {
   importFile,
   type ImportFileResult,
   type LocalAgentChatAttachmentRef,
+  type LocalAgentChatContextEntry,
   type LocalAgentIntegration,
   type LocalAgentHistoryMessage,
   type LocalAgentStreamEvent,
@@ -139,6 +140,16 @@ function draftToAttachmentRef(draft: LocalAgentAttachmentDraft): LocalAgentChatA
   };
 }
 
+function buildChatContextEntries(projects: ContextGraph[], activeProjectId: string | null): LocalAgentChatContextEntry[] {
+  if (!activeProjectId) return [];
+  const displayName = getProjectDisplayName(projects, activeProjectId);
+  return [{
+    key: 'target_context_graph',
+    label: 'Target context graph',
+    value: displayName === activeProjectId ? activeProjectId : `${displayName} (${activeProjectId})`,
+  }];
+}
+
 function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage {
   const author = message.author.toLowerCase();
   return {
@@ -169,6 +180,52 @@ function mergeLocalAgentMessages(existing: LocalAgentMessage[], incoming: LocalA
     merged.push(message);
   }
   return merged;
+}
+
+function normalizeMessageContent(content: string): string {
+  return content.replace(/\\n/g, '\n');
+}
+
+function renderInlineMarkdown(text: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  const pattern = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+
+    const token = match[0];
+    if (token.startsWith('**') && token.endsWith('**')) {
+      nodes.push(<strong key={`md-${key++}`}>{token.slice(2, -2)}</strong>);
+    } else if (token.startsWith('`') && token.endsWith('`')) {
+      nodes.push(<code key={`md-${key++}`}>{token.slice(1, -1)}</code>);
+    } else {
+      nodes.push(token);
+    }
+
+    lastIndex = match.index + token.length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
+}
+
+function renderMessageContent(content: string): React.ReactNode {
+  const normalized = normalizeMessageContent(content);
+  const lines = normalized.split('\n');
+  return lines.map((line, index) => (
+    <React.Fragment key={`line-${index}`}>
+      {renderInlineMarkdown(line)}
+      {index < lines.length - 1 && <br />}
+    </React.Fragment>
+  ));
 }
 
 export function getLocalAgentConversationStateKey(
@@ -694,7 +751,7 @@ function ConnectedAgentsTab(props: {
               {localMessages.map((message) => (
                 <div key={message.id} className={`v10-chat-msg ${message.role}`}>
                   <div className={`v10-chat-bubble ${message.role}`}>
-                    {message.content}
+                    {renderMessageContent(message.content)}
                     {message.streaming && <span className="v10-chat-cursor" />}
                   </div>
                   {message.attachments && message.attachments.length > 0 && (
@@ -727,10 +784,9 @@ function ConnectedAgentsTab(props: {
             <div className="v10-agent-input-area">
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: '100%' }}>
                 {selectedAttachmentDrafts.length > 0 && (
-                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  <div className="v10-local-agent-attachment-list">
                     {selectedAttachmentDrafts.map((attachment) => {
                       const triples = attachment.result?.extraction.tripleCount ?? attachment.result?.extraction.triplesWritten;
-                      const targetLabel = getProjectDisplayName(availableProjects, attachment.contextGraphId);
                       const statusLabel = attachment.status === 'queued'
                         ? 'Queued - imports on send'
                         : attachment.status === 'uploading'
@@ -745,30 +801,27 @@ function ConnectedAgentsTab(props: {
                       return (
                         <div
                           key={attachment.id}
-                          style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: 8,
-                            padding: '6px 10px',
-                            borderRadius: 999,
-                            border: '1px solid var(--border-subtle)',
-                            background: 'var(--panel-elevated)',
-                            fontSize: 12,
-                          }}
+                          className="v10-local-agent-attachment-item"
                         >
-                          <span style={{ fontWeight: 700 }}>{fileBadge(attachment.file.name)}</span>
-                          <span>{attachment.file.name}</span>
-                          <span style={{ color: 'var(--text-tertiary)' }}>{formatFileSize(attachment.file.size)}</span>
-                          <span style={{ color: 'var(--text-tertiary)' }}>To {targetLabel}</span>
-                          <span style={{ color: attachment.status === 'error' ? 'var(--accent-red)' : 'var(--text-tertiary)' }}>
-                            {statusLabel}
-                          </span>
+                          <div className="v10-local-agent-attachment-main">
+                            <div className="v10-local-agent-attachment-title-row">
+                              <span className="v10-local-agent-attachment-badge">{fileBadge(attachment.file.name)}</span>
+                              <span className="v10-local-agent-attachment-name" title={attachment.file.name}>{attachment.file.name}</span>
+                            </div>
+                            <div className="v10-local-agent-attachment-meta-row">
+                              <span>{formatFileSize(attachment.file.size)}</span>
+                              <span style={{ color: attachment.status === 'error' ? 'var(--accent-red)' : undefined }}>
+                                {statusLabel}
+                              </span>
+                            </div>
+                          </div>
                           <button
                             className="v10-agents-refresh"
+                            type="button"
                             onClick={() => onRemoveAttachment(attachment.id)}
                             title="Remove attachment"
                             disabled={localSending}
-                            style={{ padding: '2px 8px' }}
+                            style={{ padding: '2px 8px', flexShrink: 0 }}
                           >
                             Remove
                           </button>
@@ -987,6 +1040,10 @@ export function PanelRight() {
   const localAbortRef = useRef<AbortController | null>(null);
   const autoFocusedLocalAgentRef = useRef(false);
   const localChatEndRef = useRef<HTMLDivElement>(null);
+  const memorySessionsRef = useRef<MemorySession[]>([]);
+  const localMessagesByConversationRef = useRef<Record<string, LocalAgentMessage[]>>({});
+  const selectedIntegrationIdRef = useRef('openclaw');
+  const selectedSessionIdRef = useRef<string | null>(getDefaultLocalAgentSessionId('openclaw'));
   const availableProjects = useProjectsStore((state) => state.contextGraphs);
   const projectsLoading = useProjectsStore((state) => state.loading);
   const activeProjectId = useProjectsStore((state) => state.activeProjectId);
@@ -1028,6 +1085,22 @@ export function PanelRight() {
   }, []);
 
   useEffect(scrollLocalChatToBottom, [selectedConversationKey, selectedLocalMessages, scrollLocalChatToBottom]);
+
+  useEffect(() => {
+    memorySessionsRef.current = memorySessions;
+  }, [memorySessions]);
+
+  useEffect(() => {
+    localMessagesByConversationRef.current = localMessagesByConversation;
+  }, [localMessagesByConversation]);
+
+  useEffect(() => {
+    selectedIntegrationIdRef.current = selectedIntegrationId;
+  }, [selectedIntegrationId]);
+
+  useEffect(() => {
+    selectedSessionIdRef.current = selectedSessionId;
+  }, [selectedSessionId]);
 
   const updateLocalMessages = useCallback((
     conversationKey: string,
@@ -1199,14 +1272,16 @@ export function PanelRight() {
     try {
       const { integrations: items } = await fetchLocalAgentIntegrations();
       setIntegrations(items);
-      const sessionSummaries = summarizeLocalAgentSessions(memorySessions, items);
+      const sessionSummaries = summarizeLocalAgentSessions(memorySessionsRef.current, items);
       const connected = [...items].sort(compareLocalAgentIntegrations).filter((item) => item.persistentChat);
+      const selectedIntegrationId = selectedIntegrationIdRef.current;
+      const selectedSessionId = selectedSessionIdRef.current;
       const selectedItem = items.find((item) => item.id === selectedIntegrationId) ?? null;
       const preserveSelected = shouldPreserveSelectedLocalAgentTab({
         selectedIntegrationId,
         selectedItem,
         selectedSessionId,
-        localMessagesByConversation,
+        localMessagesByConversation: localMessagesByConversationRef.current,
         sessionSummaries,
       });
       if (!preserveSelected) {
@@ -1225,7 +1300,7 @@ export function PanelRight() {
       // Keep the last known integrations in place so transient refresh failures
       // do not collapse an attached agent chat surface back into the add-agent UI.
     }
-  }, [localMessagesByConversation, memorySessions, selectedIntegrationId, selectedSessionId, setSelectedIntegration]);
+  }, [setSelectedIntegration]);
 
   const loadLocalHistory = useCallback(async (integrationId: string, sessionId: string | null = null) => {
     const conversation = resolveLocalAgentConversation({ integrationId, sessionId });
@@ -1346,12 +1421,18 @@ export function PanelRight() {
 
       controller = new AbortController();
       localAbortRef.current = controller;
+      const contextEntries = buildChatContextEntries(availableProjects, activeProjectId);
+      console.debug('[local-agent] outgoing contextEntries', {
+        activeProjectId,
+        contextEntries,
+      });
 
       const result = await streamLocalAgentChat(integrationId, text, {
         correlationId,
         signal: controller?.signal,
         sessionId: conversation.sessionId ?? undefined,
         attachments,
+        contextEntries,
         onEvent: (event: LocalAgentStreamEvent) => {
           if (event.type === 'text_delta') {
             updateLocalMessages(conversationKey, (prev) =>
@@ -1402,7 +1483,9 @@ export function PanelRight() {
       localAbortRef.current = null;
     }
   }, [
+    activeProjectId,
     advance,
+    availableProjects,
     loadSessions,
     localInput,
     localSending,

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -195,7 +195,7 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
 
   while ((match = pattern.exec(text)) !== null) {
     if (match.index > lastIndex) {
-      nodes.push(text.slice(lastIndex, match.index));
+      nodes.push(<React.Fragment key={`md-${key++}`}>{text.slice(lastIndex, match.index)}</React.Fragment>);
     }
 
     const token = match[0];
@@ -204,14 +204,14 @@ function renderInlineMarkdown(text: string): React.ReactNode[] {
     } else if (token.startsWith('`') && token.endsWith('`')) {
       nodes.push(<code key={`md-${key++}`}>{token.slice(1, -1)}</code>);
     } else {
-      nodes.push(token);
+      nodes.push(<React.Fragment key={`md-${key++}`}>{token}</React.Fragment>);
     }
 
     lastIndex = match.index + token.length;
   }
 
   if (lastIndex < text.length) {
-    nodes.push(text.slice(lastIndex));
+    nodes.push(<React.Fragment key={`md-${key++}`}>{text.slice(lastIndex)}</React.Fragment>);
   }
 
   return nodes;
@@ -518,7 +518,7 @@ function formatLocalAgentErrorMessage(
   return message;
 }
 
-function ConnectedAgentsTab(props: {
+export function ConnectedAgentsTab(props: {
   integrations: LocalAgentIntegration[];
   selectedIntegrationId: string;
   selectedIntegration: LocalAgentIntegration | null;
@@ -1427,10 +1427,6 @@ export function PanelRight() {
       controller = new AbortController();
       localAbortRef.current = controller;
       const contextEntries = buildChatContextEntries(availableProjects, activeProjectId);
-      console.debug('[local-agent] outgoing contextEntries', {
-        activeProjectId,
-        contextEntries,
-      });
 
       const result = await streamLocalAgentChat(integrationId, text, {
         correlationId,

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -918,6 +918,89 @@ button:focus:not(:focus-visible) { outline: none; }
   color: var(--text-secondary);
   line-height: 1.55;
 }
+.v10-local-agent-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.v10-local-agent-target-picker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  width: 100%;
+  margin: 0;
+}
+.v10-local-agent-target-label {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.v10-local-agent-target-select {
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--panel-elevated);
+  color: var(--text-primary);
+}
+.v10-local-agent-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v10-local-agent-composer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.v10-local-agent-composer-shell {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 96px;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+}
+.v10-local-agent-composer-shell:focus-within {
+  border-color: var(--border-strong);
+}
+.v10-local-agent-inline-attach {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  min-width: 96px;
+  height: 26px;
+  padding: 0 10px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+}
+.v10-local-agent-inline-send {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  height: 24px;
+  min-width: 48px;
+  padding: 0 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
 .v10-local-agent-attachment-list {
   display: flex;
   flex-direction: column;
@@ -1028,15 +1111,20 @@ button:focus:not(:focus-visible) { outline: none; }
 }
 .v10-agent-input {
   flex: 1;
-  padding: 8px 12px;
-  border-radius: 6px;
-  border: 1px solid var(--border-default);
-  background: var(--bg-surface);
+  min-height: 94px;
+  width: 100%;
+  padding: 14px 14px 42px;
+  border-radius: 0;
+  border: 0;
+  background: transparent;
   color: var(--text-primary);
   font-size: 12px;
   font-family: var(--font-sans);
+  min-width: 0;
+  resize: none;
+  align-self: stretch;
 }
-.v10-agent-input:focus { border-color: var(--border-strong); }
+.v10-agent-input:focus { outline: none; }
 .v10-agent-send-btn {
   min-width: 56px;
   height: 34px;

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -918,6 +918,51 @@ button:focus:not(:focus-visible) { outline: none; }
   color: var(--text-secondary);
   line-height: 1.55;
 }
+.v10-local-agent-attachment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v10-local-agent-attachment-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--panel-elevated);
+  min-width: 0;
+}
+.v10-local-agent-attachment-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+.v10-local-agent-attachment-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.v10-local-agent-attachment-badge {
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.v10-local-agent-attachment-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.v10-local-agent-attachment-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
 .v10-local-agent-actions {
   display: flex;
   flex-wrap: wrap;
@@ -970,11 +1015,16 @@ button:focus:not(:focus-visible) { outline: none; }
 
 /* Agent input */
 .v10-agent-input-area {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
   padding: 12px;
   border-top: 1px solid var(--border-subtle);
   display: flex;
   gap: 8px;
   align-items: center;
+  background: var(--bg-panel);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.18);
 }
 .v10-agent-input {
   flex: 1;

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -655,6 +655,32 @@ describe('OpenClaw bridge behavioral tests', () => {
     }
   });
 
+  it('streamLocalAgentChat forwards injected context entries', async () => {
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      body: null,
+      json: async () => ({ text: 'reply', correlationId: 'corr-2' }),
+    });
+    const original = globalThis.fetch;
+    globalThis.fetch = fakeFetch;
+    try {
+      const { streamLocalAgentChat } = await import('../src/ui/api.js');
+      await streamLocalAgentChat('openclaw', 'hello', {
+        contextEntries: [
+          { key: 'target_context_graph', label: 'Target context graph', value: 'the minotaur' },
+        ],
+      });
+      const [, opts] = fakeFetch.mock.calls[0];
+      const body = JSON.parse(opts.body);
+      expect(body.contextEntries).toEqual([
+        { key: 'target_context_graph', label: 'Target context graph', value: 'the minotaur' },
+      ]);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
   it('fetchLocalAgentIntegrations maps OpenClaw readiness and Hermes placeholder state', async () => {
     const fakeFetch = vi.fn()
       .mockResolvedValueOnce({

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -208,15 +208,17 @@ describe('PanelRight UI - connected agent flow', () => {
   });
 
   it('shows the inline attachment tray and project fallback picker in the chat composer', () => {
-    expect(panelRight).toContain('Attach files');
-    expect(panelRight).toContain('New attachments target:');
+    expect(panelRight).toContain('aria-label="Attach files"');
+    expect(panelRight).toContain('Upload file');
+    expect(panelRight).toContain('📎');
+    expect(panelRight).toContain('Target');
     expect(panelRight).toContain('Choose a project');
     expect(panelRight).toContain("value={activeProjectId ?? ''}");
     expect(panelRight).not.toContain('{activeProjectId ? (');
     expect(panelRight).toContain('Stored only');
     expect(panelRight).toContain('Queued - imports on send');
     expect(panelRight).toContain('Queued files keep their stored target');
-    expect(panelRight).toContain('To {targetLabel}');
+    expect(panelRight).not.toContain('To {targetLabel}');
     expect(panelRight).toContain('attachment.id ?? attachment.assertionUri ?? attachment.fileHash');
   });
 

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+
+const fetchAgentsMock = vi.fn();
+const fetchConnectionsMock = vi.fn();
+const fetchLocalAgentIntegrationsMock = vi.fn();
+const fetchLocalAgentHistoryMock = vi.fn();
+const streamLocalAgentChatMock = vi.fn();
+const connectLocalAgentIntegrationMock = vi.fn();
+const disconnectLocalAgentIntegrationMock = vi.fn();
+const apiFetchMemorySessionsMock = vi.fn();
+
+vi.mock('../src/ui/api.js', async () => {
+  const actual = await vi.importActual<any>('../src/ui/api.js');
+  return {
+    ...actual,
+    fetchAgents: fetchAgentsMock,
+    fetchConnections: fetchConnectionsMock,
+    fetchLocalAgentIntegrations: fetchLocalAgentIntegrationsMock,
+    fetchLocalAgentHistory: fetchLocalAgentHistoryMock,
+    streamLocalAgentChat: streamLocalAgentChatMock,
+    connectLocalAgentIntegration: connectLocalAgentIntegrationMock,
+    disconnectLocalAgentIntegration: disconnectLocalAgentIntegrationMock,
+  };
+});
+
+vi.mock('../src/ui/api-wrapper.js', () => ({
+  api: {
+    fetchMemorySessions: apiFetchMemorySessionsMock,
+  },
+}));
+
+describe('PanelRight component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+
+    fetchAgentsMock.mockResolvedValue({ agents: [{
+      agentUri: 'did:dkg:agent:peer-2',
+      name: 'Peer Two',
+      peerId: 'peer-2',
+      connectionStatus: 'connected',
+    }] });
+    fetchConnectionsMock.mockResolvedValue({ total: 1, direct: 1, relayed: 0 });
+    fetchLocalAgentIntegrationsMock.mockResolvedValue({ integrations: [{
+      id: 'openclaw',
+      name: 'OpenClaw',
+      description: 'Local bridge',
+      connectSupported: true,
+      chatSupported: true,
+      chatReady: true,
+      chatAttachments: true,
+      persistentChat: true,
+      bridgeOnline: true,
+      bridgeStatusLabel: 'Connected',
+      configured: true,
+      detected: true,
+      status: 'connected',
+      statusLabel: 'Connected',
+      detail: 'ready',
+      target: 'local',
+    }] });
+    fetchLocalAgentHistoryMock.mockResolvedValue([]);
+    streamLocalAgentChatMock.mockResolvedValue({ text: 'Roger that', correlationId: 'corr-1' });
+    apiFetchMemorySessionsMock.mockResolvedValue({ sessions: [] });
+  });
+
+  it('renders, loads agent state, and sends chat with injected context entries', async () => {
+    const { PanelRight } = await import('../src/ui/components/Shell/PanelRight.js');
+    const { useProjectsStore } = await import('../src/ui/stores/projects.js');
+
+    act(() => {
+      useProjectsStore.setState({
+        contextGraphs: [{ id: 'origin-trail-game', name: 'Origin Trail Game' }],
+        loading: false,
+        activeProjectId: 'origin-trail-game',
+      });
+    });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(React.createElement(PanelRight));
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('OpenClaw connected');
+    expect(container.textContent).toContain('Project');
+    expect(container.textContent).toContain('Upload file');
+
+    const projectSelect = container.querySelector('select') as HTMLSelectElement | null;
+    expect(projectSelect).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')?.set;
+      valueSetter?.call(projectSelect, 'origin-trail-game');
+      projectSelect!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const attachInput = container.querySelector('input[type="file"]') as HTMLInputElement | null;
+    expect(attachInput).toBeTruthy();
+    await act(async () => {
+      Object.defineProperty(attachInput, 'files', {
+        configurable: true,
+        value: [new File(['hello'], 'draft.md', { type: 'text/markdown' })],
+      });
+      attachInput!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('draft.md');
+    const removeButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('Remove'));
+    expect(removeButton).toBeTruthy();
+    await act(async () => {
+      removeButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).not.toContain('draft.md');
+
+    const networkTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Network');
+    expect(networkTab).toBeTruthy();
+    await act(async () => {
+      networkTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('Peer Two');
+
+    const sessionsTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Sessions');
+    expect(sessionsTab).toBeTruthy();
+    await act(async () => {
+      sessionsTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('No integrated-agent sessions yet.');
+
+    const agentsTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Agents');
+    await act(async () => {
+      agentsTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+      valueSetter?.call(textarea, 'Check memory');
+      textarea!.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    const sendButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('Send'));
+    expect(sendButton).toBeTruthy();
+    expect(sendButton?.hasAttribute('disabled')).toBe(false);
+
+    await act(async () => {
+      sendButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(streamLocalAgentChatMock).toHaveBeenCalledWith('openclaw', 'Check memory', expect.objectContaining({
+      contextEntries: [{
+        key: 'target_context_graph',
+        label: 'Target context graph',
+        value: 'Origin Trail Game (origin-trail-game)',
+      }],
+    }));
+    expect(container.textContent).toContain('Roger that');
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/packages/node-ui/test/panel-right.logic.test.ts
+++ b/packages/node-ui/test/panel-right.logic.test.ts
@@ -1,0 +1,267 @@
+import React from 'react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+let ConnectedAgentsTab: any;
+let getLocalAgentConversationStateKey: any;
+let markLocalAgentIntegrationDisconnected: any;
+let networkPeerCardStatusClass: any;
+let resolveConnectedAgentsTabState: any;
+let resolveLocalAgentSelectionState: any;
+let shouldPreserveSelectedLocalAgentTab: any;
+let shouldPreserveSessionForIntegrationSelection: any;
+let shouldPreserveSessionOnReconnect: any;
+let upsertLocalAgentIntegrationState: any;
+
+beforeAll(async () => {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  });
+
+  const panelRight = await import('../src/ui/components/Shell/PanelRight.js');
+  ConnectedAgentsTab = panelRight.ConnectedAgentsTab;
+  getLocalAgentConversationStateKey = panelRight.getLocalAgentConversationStateKey;
+  markLocalAgentIntegrationDisconnected = panelRight.markLocalAgentIntegrationDisconnected;
+  networkPeerCardStatusClass = panelRight.networkPeerCardStatusClass;
+  resolveConnectedAgentsTabState = panelRight.resolveConnectedAgentsTabState;
+  resolveLocalAgentSelectionState = panelRight.resolveLocalAgentSelectionState;
+  shouldPreserveSelectedLocalAgentTab = panelRight.shouldPreserveSelectedLocalAgentTab;
+  shouldPreserveSessionForIntegrationSelection = panelRight.shouldPreserveSessionForIntegrationSelection;
+  shouldPreserveSessionOnReconnect = panelRight.shouldPreserveSessionOnReconnect;
+  upsertLocalAgentIntegrationState = panelRight.upsertLocalAgentIntegrationState;
+});
+
+function integration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'openclaw',
+    name: 'OpenClaw',
+    description: 'Local bridge',
+    connectSupported: true,
+    chatSupported: true,
+    chatReady: true,
+    chatAttachments: true,
+    persistentChat: true,
+    bridgeOnline: true,
+    bridgeStatusLabel: 'Connected',
+    configured: true,
+    detected: true,
+    status: 'connected',
+    statusLabel: 'Connected',
+    detail: 'ready',
+    target: 'local',
+    ...overrides,
+  } as any;
+}
+
+function renderConnectedAgentsTab(overrides: Record<string, unknown> = {}) {
+  const props = {
+    integrations: [integration()],
+    selectedIntegrationId: 'openclaw',
+    selectedIntegration: integration(),
+    selectedSessionId: 'openclaw:default',
+    selectedHasConversation: false,
+    selectedIntegrationHasAnyConversation: false,
+    onSelectIntegration: vi.fn(),
+    onConnectIntegration: vi.fn(),
+    onDisconnectIntegration: vi.fn(),
+    onRefreshIntegrations: vi.fn(),
+    connectBusyId: null,
+    connectNotice: null,
+    connectError: null,
+    localMessages: [],
+    localHistoryLoaded: true,
+    localChatEndRef: { current: null },
+    localInput: '',
+    onLocalInputChange: vi.fn(),
+    onSendLocalMessage: vi.fn(),
+    localSending: false,
+    activeProjectId: 'origin-trail-game',
+    availableProjects: [
+      { id: 'origin-trail-game', name: 'Origin Trail Game' },
+      { id: 'testing', name: 'Testing' },
+    ],
+    projectsLoading: false,
+    onSelectProject: vi.fn(),
+    attachments: [],
+    onAddAttachments: vi.fn(),
+    onRemoveAttachment: vi.fn(),
+    ...overrides,
+  } as any;
+
+  return renderToStaticMarkup(React.createElement(ConnectedAgentsTab, props));
+}
+
+describe('PanelRight logic helpers', () => {
+  it('resolves conversation state keys and session preservation correctly', () => {
+    const integrations = [integration(), integration({ id: 'hermes', name: 'Hermes', persistentChat: false })];
+    expect(getLocalAgentConversationStateKey('openclaw', null)).toBe('integration:openclaw');
+    expect(getLocalAgentConversationStateKey('openclaw', 'openclaw:abc')).toBe('openclaw:abc');
+    expect(shouldPreserveSessionForIntegrationSelection({
+      integrationId: 'openclaw',
+      selectedSessionId: 'openclaw:abc',
+      integrations,
+    })).toBe(true);
+    expect(shouldPreserveSessionOnReconnect({
+      integrationId: 'hermes',
+      selectedSessionId: 'openclaw:abc',
+      integrations,
+    })).toBe(false);
+  });
+
+  it('resolves local agent selection state from saved sessions and message history', () => {
+    const integrations = [integration(), integration({ id: 'hermes', name: 'Hermes', persistentChat: false })];
+    const state = resolveLocalAgentSelectionState({
+      integrations,
+      selectedIntegrationId: 'hermes',
+      selectedSessionId: 'hermes:thread-1',
+      localMessagesByConversation: {
+        'hermes:thread-1': [{ id: 'm1', role: 'user', content: 'hello' }],
+      },
+      sessions: [{
+        sessionId: 'hermes:thread-1',
+        integrationId: 'hermes',
+        integrationName: 'Hermes',
+        preview: 'hello',
+        messageCount: 1,
+        lastTs: '2026-04-14T10:00:00Z',
+      }],
+    });
+
+    expect(state.selectedIntegration?.id).toBe('hermes');
+    expect(state.selectedConversation?.stateKey).toBe('hermes:thread-1');
+    expect(state.selectedHasConversation).toBe(true);
+    expect(state.selectedIntegrationHasAnyConversation).toBe(true);
+    expect(state.connectedIntegrations.map((item) => item.id)).toEqual(['openclaw']);
+  });
+
+  it('resolves tab state for disconnected stored sessions and loading conversations', () => {
+    const selected = integration({ id: 'openclaw', persistentChat: false, chatReady: false, bridgeOnline: false, status: 'available' });
+    const stored = resolveConnectedAgentsTabState({
+      connectedAgents: [integration()],
+      selectedIntegration: selected,
+      selectedIntegrationId: 'openclaw',
+      selectedHasConversation: true,
+      selectedIntegrationHasAnyConversation: true,
+      localHistoryLoaded: true,
+      localMessagesCount: 0,
+    });
+
+    expect(stored.showingSessionHistory).toBe(true);
+    expect(stored.showingStoredSessions).toBe(true);
+    expect(stored.visibleAgentTabs[0]?.id).toBe('openclaw');
+
+    const loader = resolveConnectedAgentsTabState({
+      connectedAgents: [integration()],
+      selectedIntegration: integration(),
+      selectedIntegrationId: 'openclaw',
+      selectedHasConversation: false,
+      selectedIntegrationHasAnyConversation: false,
+      localHistoryLoaded: false,
+      localMessagesCount: 0,
+    });
+    expect(loader.shouldShowConversationLoader).toBe(true);
+  });
+
+  it('upserts integrations, marks disconnections, and preserves selected tabs with history', () => {
+    const list = [integration({ id: 'hermes', name: 'Hermes', persistentChat: false, connectSupported: false, status: 'coming_soon', statusLabel: 'Coming next' })];
+    const upserted = upsertLocalAgentIntegrationState(list, integration());
+    expect(upserted.map((item) => item.id)).toEqual(['openclaw', 'hermes']);
+
+    const disconnected = markLocalAgentIntegrationDisconnected([integration()], 'openclaw');
+    expect(disconnected[0]).toMatchObject({
+      persistentChat: false,
+      chatReady: false,
+      bridgeOnline: false,
+      status: 'available',
+      target: undefined,
+    });
+
+    expect(shouldPreserveSelectedLocalAgentTab({
+      selectedIntegrationId: 'openclaw',
+      selectedItem: disconnected[0],
+      selectedSessionId: 'openclaw:abc',
+      localMessagesByConversation: {
+        'openclaw:abc': [{ id: 'm1', role: 'assistant', content: 'hi' }],
+      },
+      sessionSummaries: [],
+    })).toBe(true);
+  });
+
+  it('maps network peer status classes conservatively', () => {
+    expect(networkPeerCardStatusClass({ connectionStatus: 'connected' })).toBe('connected');
+    expect(networkPeerCardStatusClass({ connectionStatus: 'disconnected' })).toBe('offline');
+    expect(networkPeerCardStatusClass({})).toBe('offline');
+  });
+});
+
+describe('ConnectedAgentsTab rendering', () => {
+  it('renders add-agent flow with OpenClaw and Hermes content', () => {
+    const markup = renderConnectedAgentsTab({
+      integrations: [
+        integration({ persistentChat: false, configured: false, detected: false, bridgeOnline: false, chatReady: false, status: 'available', statusLabel: 'Ready to connect' }),
+        integration({ id: 'hermes', name: 'Hermes', persistentChat: false, configured: false, detected: false, bridgeOnline: false, chatReady: false, status: 'coming_soon', statusLabel: 'Coming next', connectSupported: false }),
+      ],
+      selectedIntegrationId: '__add_agent__',
+      selectedIntegration: null,
+      connectBusyId: 'openclaw',
+      connectNotice: 'connected',
+      connectError: 'error',
+    });
+
+    expect(markup).toContain('Connect Another Agent');
+    expect(markup).toContain('Connecting...');
+    expect(markup).toContain('Docs');
+    expect(markup).toContain('Release Notes');
+    expect(markup).toContain('Hermes will plug into this same local-agent contract next');
+    expect(markup).toContain('connected');
+    expect(markup).toContain('error');
+  });
+
+  it('renders chat shell, markdown bubbles, attachments, project picker, and upload composer', () => {
+    const markup = renderConnectedAgentsTab({
+      localMessages: [{
+        id: 'a1',
+        role: 'assistant',
+        content: 'Hello **world**\n`code`',
+        ts: '10:00',
+        attachments: [{ fileName: 'spec.md', contextGraphId: 'origin-trail-game', assertionName: 'spec' }],
+      }],
+      attachments: [{
+        id: 'draft-1',
+        file: new File(['hello'], 'spec.md', { type: 'text/markdown' }),
+        contextGraphId: 'origin-trail-game',
+        assertionName: 'spec',
+        status: 'queued',
+      }],
+      localInput: 'draft',
+    });
+
+    expect(markup).toContain('OpenClaw connected');
+    expect(markup).toContain('Refresh');
+    expect(markup).toContain('Disconnect');
+    expect(markup).toContain('Hello <strong>world</strong><br/><code>code</code>');
+    expect(markup).toContain('spec.md');
+    expect(markup).toContain('Queued - imports on send');
+    expect(markup).toContain('Queued files keep their stored target: Origin Trail Game.');
+    expect(markup).toContain('Project');
+    expect(markup).toContain('Upload file');
+    expect(markup).toContain('Message OpenClaw');
+    expect(markup).toContain('Send');
+  });
+
+  it('renders disconnected history warnings and empty-state messaging', () => {
+    const markup = renderConnectedAgentsTab({
+      selectedIntegration: integration({ persistentChat: false, chatReady: false, bridgeOnline: false, status: 'available' }),
+      selectedHasConversation: true,
+      selectedIntegrationHasAnyConversation: true,
+      localMessages: [],
+      localHistoryLoaded: true,
+    });
+
+    expect(markup).toContain('Session history');
+    expect(markup).toContain('is not currently attached to this node');
+    expect(markup).toContain('session history is available, but there are no stored turns to show yet');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,12 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
 
+  packages/digital-twin:
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
+
   packages/epcis:
     dependencies:
       ajv:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,12 +340,6 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
 
-  packages/digital-twin:
-    devDependencies:
-      vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
-
   packages/epcis:
     dependencies:
       ajv:


### PR DESCRIPTION
## Summary
- make the Agents chat composer/target bar stay pinned while the message list scrolls
- improve local chat message rendering with newline unescaping and basic markdown formatting
- clean up the attachment queue UI and pass the selected context graph through each OpenClaw chat turn as injected context

## Details
- adds sticky positioning and visual separation for the bottom chat composer area
- renders escaped \n, **bold**, and  `code`  in agent messages
- replaces the crowded multi-file attachment pills with a clearer stacked card layout
- threads contextEntries through the UI, daemon, and OpenClaw adapter
- injects target_context_graph for each turn and instructs the DKG/OpenClaw path to treat it as authoritative for that turn unless the user explicitly overrides it