### PR TITLE
fix(evm): drop wall-clock mining interval to kill proof-period race

### DIFF
--- a/packages/evm-module/hardhat.node.config.ts
+++ b/packages/evm-module/hardhat.node.config.ts
@@ -39,7 +39,7 @@ const config: HardhatUserConfig = {
       saveDeployments: false,
       mining: {
         auto: true,
-        interval: [3000, 5000],
+        interval: 0,
       },
     },
     base_sepolia_dev: {


### PR DESCRIPTION
## Summary
- Hardhat's `mining.interval: [3000, 5000]` advances `block.number` on a wall-clock timer. Under `solidity-coverage` on slow CI runners, the gap between `createChallenge()` and `submitProof()` in `submitProofAndLogScore` (StakingRewards/Profile fixtures — dynamic `assertion-tools` import + `splitIntoChunks` + `calculateMerkleProof`) exceeds `proofingPeriodDurationInBlocks` (100 blocks). The background miner rolls the proof period forward, `submitProof` then re-checks the active period via `updateAndGetActiveProofPeriodStartBlock()`, the stored challenge start no longer matches, and the tx reverts `"This challenge is no longer active"`.
- Five integration tests blew up in CI on PR #178 (and the same race had already produced one failure on PR #149). Locally the merkle proof computes in <1s so the race never fires — that's why it only manifests on CI.
- Setting `interval: 0` makes blocks advance only on explicit `evm_mine` or tx submission. `time.increase()` semantics are unaffected. No test logic changed.

## Test plan
- [x] Targeted: `StakingRewards.test.ts` under coverage → 29/29 passing in 36s (4 of these were the CI failures)
- [x] Targeted: `Profile.test.ts` under coverage → 12/12 passing in 25s (1 of these was the 5th CI failure)
- [x] Full coverage suite (`pnpm test:coverage`) → **765 passing, 0 failing** in 6m on local. CI was 731 passing + 5 failing of this exact class.
- [ ] CI Solidity job green on this branch

## Failing tests (all 5 share the same revert)
1. `Profile Contract > Operator Fee Management > should REVERT fee update if previous epoch rewards are not claimed` (`"before each"` hook)
2. `rewards tests > D1 cannot claim the newest finalised epoch while older remain unclaimed` (`"before all"` hook)
3. `Claim order enforcement tests > D1, D3 attempt to claim epoch 3 rewards - should revert (must claim epoch 2 first)` (`"before all"` hook)
4. `Proportional rewards tests - Double stake = Double rewards > D1, D2, D3, D4 claim epoch 2 rewards - D2 and D4 should get double rewards (double stakes)` (`"before all"` hook)
5. `Operator fee withdrawal tests > Both nodes request operator fee withdrawal - amounts should be equal` (`"before all"` hook)

All trace through `submitProofAndLogScore` → `RandomSampling.submitProof` (contracts/RandomSampling.sol:326) → `Error: VM Exception while processing transaction: reverted with reason string 'This challenge is no longer active'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)