### PR TITLE
fix: multi-agent correctness polish (follow-up to #195)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -4374,10 +4374,12 @@ export class DKGAgent {
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const approvedAt = new Date().toISOString();
     const effectiveContextType = opts.contextType ?? record.contextType;
-    // Use the persisted owner DID for metadata so gossip-publish-handler
-    // accepts the binding (it validates approvedBy matches the paranet owner).
-    const ownerDid = await this.getContextGraphOwner(opts.paranetId)
-      ?? `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
+    // Emit the public `dkg:creator` peer DID as the binding owner: it's the
+    // handle remote peers resolve via ONTOLOGY gossip, so gossip-publish-handler
+    // will accept the approval. `_meta`-only `dkg:curator` (wallet DID) is
+    // used for local authorization via `assertParanetOwner` above.
+    const ownerDid = await this.getContextGraphCreator(opts.paranetId)
+      ?? `did:dkg:agent:${this.peerId}`;
     const { bindingUri, quads } = buildPolicyApprovalQuads({
       paranetId: opts.paranetId,
       policyUri: opts.policyUri,
@@ -4420,8 +4422,10 @@ export class DKGAgent {
 
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const revokedAt = new Date().toISOString();
-    const ownerDid = await this.getContextGraphOwner(opts.paranetId)
-      ?? `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
+    // See note in approveCclPolicy — use `dkg:creator` (peer DID) for the
+    // public binding metadata so it round-trips through ONTOLOGY gossip.
+    const ownerDid = await this.getContextGraphCreator(opts.paranetId)
+      ?? `did:dkg:agent:${this.peerId}`;
     const quads = buildPolicyRevocationQuads({
       bindingUri: target.bindingUri,
       revoker: ownerDid,
@@ -5569,7 +5573,6 @@ export class DKGAgent {
   }
 
   private async getContextGraphOwner(paranetId: string): Promise<string | null> {
-    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const cgMetaGraph = paranetMetaGraphUri(paranetId);
     const paranetUri = `did:dkg:context-graph:${paranetId}`;
     // Prefer the curator (wallet-scoped owner) so per-agent authorization
@@ -5587,7 +5590,21 @@ export class DKGAgent {
       const owner = (curatorResult.bindings[0] as Record<string, string>)['owner'];
       if (owner) return owner;
     }
-    const creatorResult = await this.store.query(`
+    return this.getContextGraphCreator(paranetId);
+  }
+
+  /**
+   * Read `dkg:creator` (peer-ID DID) for a paranet. This is the publicly
+   * discoverable owner handle used in gossip validation — it propagates
+   * through ONTOLOGY sync for open CGs, while `dkg:curator` stays in `_meta`.
+   * Emitted approve/revoke binding metadata must use this value so remote
+   * peers validating via `gossip-publish-handler` see a matching owner.
+   */
+  private async getContextGraphCreator(paranetId: string): Promise<string | null> {
+    const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+    const cgMetaGraph = paranetMetaGraphUri(paranetId);
+    const paranetUri = `did:dkg:context-graph:${paranetId}`;
+    const result = await this.store.query(`
       SELECT ?owner WHERE {
         {
           GRAPH <${ontologyGraph}> {
@@ -5601,8 +5618,8 @@ export class DKGAgent {
       }
       LIMIT 1
     `);
-    if (creatorResult.type !== 'bindings' || creatorResult.bindings.length === 0) return null;
-    return (creatorResult.bindings[0] as Record<string, string>)['owner'] ?? null;
+    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
+    return (result.bindings[0] as Record<string, string>)['owner'] ?? null;
   }
 
   private async listCclPolicyBindings(opts: {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2907,7 +2907,9 @@ export class DKGAgent {
       throw new Error(`Context graph "${opts.id}" already exists`);
     }
 
-    const isCurated = opts.accessPolicy === 1 || (opts.allowedAgents && opts.allowedAgents.length > 0);
+    const isCurated = opts.accessPolicy === 1
+      || (opts.allowedAgents && opts.allowedAgents.length > 0)
+      || (opts.allowedPeers && opts.allowedPeers.length > 0);
 
     if (opts.private) {
       this.log.info(ctx, `Creating private context graph "${opts.id}" (local-only, no gossip)`);
@@ -2922,10 +2924,17 @@ export class DKGAgent {
     // will see them. Open CGs go to ONTOLOGY for network-wide discovery.
     const defGraph = isCurated ? cgMetaGraph : ontologyGraph;
 
+    // Use the caller's identity when provided so non-default agents on
+    // multi-agent nodes own the CGs they create. On-chain operations
+    // (registerContextGraph, verify) still bind to the node wallet — this is
+    // a known limitation until per-agent chain signers are implemented.
+    // Downstream owner checks (isCallerOrNodeOwner, assertCallerIsOwner) accept
+    // the caller DID when callerAgentAddress is threaded through daemon routes.
+    const creatorDid = `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
     const quads: Quad[] = [
       { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: `"${opts.name}"`, graph: defGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: `did:dkg:agent:${this.peerId}`, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorDid, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATED_AT, object: `"${now}"`, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_GOSSIP_TOPIC, object: `"${paranetPublishTopic(opts.id)}"`, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REPLICATION_POLICY, object: `"${opts.replicationPolicy ?? 'full'}"`, graph: defGraph },
@@ -2935,7 +2944,7 @@ export class DKGAgent {
     // Store registration status and curator in _meta
     quads.push(
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`, graph: cgMetaGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: creatorDid, graph: cgMetaGraph },
     );
 
     // Store peer allowlist for curated CGs (with validation)
@@ -3129,6 +3138,7 @@ export class DKGAgent {
   async registerContextGraph(id: string, opts?: {
     revealOnChain?: boolean;
     accessPolicy?: number;
+    callerAgentAddress?: string;
   }): Promise<{ onChainId: string; txHash?: string }> {
     const ctx = createOperationContext('system');
 
@@ -3141,19 +3151,19 @@ export class DKGAgent {
       throw new Error('On-chain registration requires a configured chain adapter');
     }
 
-    // Only the curator/creator can register a CG on-chain
+    // Only the curator/creator can register a CG on-chain.
+    // The owner DID may be peerId-based or agent-address-based, so check both.
     const owner = await this.getContextGraphOwner(id);
-    const selfDid = `did:dkg:agent:${this.peerId}`;
     if (!owner) {
       throw new Error(
         `Context graph "${id}" has no known creator. ` +
         `Wait for sync to complete or create it locally first.`,
       );
     }
-    if (owner !== selfDid) {
+    if (!this.isCallerOrNodeOwner(owner, opts?.callerAgentAddress)) {
       throw new Error(
         `Only the context graph creator can register it on-chain. ` +
-        `Creator=${owner}, current=${selfDid}`,
+        `Creator=${owner}, caller=${`did:dkg:agent:${opts?.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`}`,
       );
     }
 
@@ -3315,7 +3325,7 @@ export class DKGAgent {
    * Invite a peer to join an existing context graph.
    * Adds the peer to the local allowlist in `_meta`.
    */
-  async inviteToContextGraph(contextGraphId: string, peerId: string): Promise<void> {
+  async inviteToContextGraph(contextGraphId: string, peerId: string, callerAgentAddress?: string): Promise<void> {
     const ctx = createOperationContext('system');
 
     // Validate peer ID format (libp2p Ed25519 base58btc, e.g. 12D3KooW…)
@@ -3333,19 +3343,13 @@ export class DKGAgent {
 
     // Only the curator/creator can manage the allowlist
     const owner = await this.getContextGraphOwner(contextGraphId);
-    const selfDid = `did:dkg:agent:${this.peerId}`;
     if (!owner) {
       throw new Error(
         `Context graph "${contextGraphId}" has no known creator. ` +
         `Wait for sync to complete or create it locally first.`,
       );
     }
-    if (owner !== selfDid) {
-      throw new Error(
-        `Only the context graph creator can manage invitations. ` +
-        `Creator=${owner}, current=${selfDid}`,
-      );
-    }
+    this.assertCallerIsOwner(owner, callerAgentAddress, 'manage peer invitations');
 
     const cgMetaGraph = paranetMetaGraphUri(contextGraphId);
     const paranetUri = `did:dkg:context-graph:${contextGraphId}`;
@@ -4185,12 +4189,15 @@ export class DKGAgent {
         vs: ethers.getBytes(proposerSig.yParityAndS),
       },
     ];
+    const resolvedSignerAddresses: string[] = [proposerAddress];
     for (const a of result.approvals) {
       let id = a.identityId;
       if ((!id || id === 0n) && typeof (this.chain as any).getIdentityIdForAddress === 'function') {
         try { id = await (this.chain as any).getIdentityIdForAddress(a.approverAddress); } catch { /* use 0n */ }
       }
+      if (!id || id === 0n) continue;
       resolvedSignatures.push({ identityId: id, r: a.signatureR, vs: a.signatureVS });
+      resolvedSignerAddresses.push(a.approverAddress);
     }
     if (resolvedSignatures.length < requiredSignatures) {
       throw new Error(`verify_identity_resolution: only ${resolvedSignatures.length}/${requiredSignatures} signers have resolvable identities (including proposer)`);
@@ -4203,14 +4210,14 @@ export class DKGAgent {
       signerSignatures: resolvedSignatures,
     });
 
-    // 7. Promote triples to Verified Memory
+    // 7. Promote triples to Verified Memory (only include signers actually sent on-chain)
     await this.promoteToVerifiedMemory(
       opts.contextGraphId,
       opts.verifiedMemoryId,
       opts.batchId,
       txResult.hash,
       txResult.blockNumber,
-      [proposerAddress, ...result.approvals.map((a: { approverAddress: string }) => a.approverAddress)],
+      resolvedSignerAddresses,
     );
 
     this.log.info(ctx, `Verified batch ${opts.batchId} → _verified_memory/${opts.verifiedMemoryId} (tx=${txResult.hash.slice(0, 16)}...)`);
@@ -4219,7 +4226,7 @@ export class DKGAgent {
       txHash: txResult.hash,
       blockNumber: txResult.blockNumber,
       verifiedMemoryId: opts.verifiedMemoryId,
-      signers: [proposerAddress, ...result.approvals.map((a: { approverAddress: string }) => a.approverAddress)],
+      signers: resolvedSignerAddresses,
     };
   }
 
@@ -4333,9 +4340,10 @@ export class DKGAgent {
     paranetId: string;
     policyUri: string;
     contextType?: string;
+    callerAgentAddress?: string;
   }): Promise<{ policyUri: string; bindingUri: string; contextType?: string; approvedAt: string }> {
     const ctx = createOperationContext('system');
-    await this.assertParanetOwner(opts.paranetId);
+    await this.assertParanetOwner(opts.paranetId, opts.callerAgentAddress);
     const record = await this.getCclPolicyByUri(opts.policyUri, { includeBody: true });
     if (!record) throw new Error(`CCL policy not found: ${opts.policyUri}`);
     if (record.paranetId !== opts.paranetId) {
@@ -4360,11 +4368,15 @@ export class DKGAgent {
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const approvedAt = new Date().toISOString();
     const effectiveContextType = opts.contextType ?? record.contextType;
+    // Use the persisted owner DID for metadata so gossip-publish-handler
+    // accepts the binding (it validates approvedBy matches the paranet owner).
+    const ownerDid = await this.getContextGraphOwner(opts.paranetId)
+      ?? `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
     const { bindingUri, quads } = buildPolicyApprovalQuads({
       paranetId: opts.paranetId,
       policyUri: opts.policyUri,
       policyName: record.name,
-      creator: `did:dkg:agent:${this.peerId}`,
+      creator: ownerDid,
       graph: ontologyGraph,
       approvedAt,
       contextType: effectiveContextType,
@@ -4372,7 +4384,7 @@ export class DKGAgent {
 
     quads.push(
       { subject: opts.policyUri, predicate: DKG_ONTOLOGY.DKG_POLICY_STATUS, object: sparqlString('approved'), graph: ontologyGraph },
-      { subject: opts.policyUri, predicate: DKG_ONTOLOGY.DKG_APPROVED_BY, object: `did:dkg:agent:${this.peerId}`, graph: ontologyGraph },
+      { subject: opts.policyUri, predicate: DKG_ONTOLOGY.DKG_APPROVED_BY, object: ownerDid, graph: ontologyGraph },
       { subject: opts.policyUri, predicate: DKG_ONTOLOGY.DKG_APPROVED_AT, object: sparqlString(approvedAt), graph: ontologyGraph },
     );
 
@@ -4386,9 +4398,10 @@ export class DKGAgent {
     paranetId: string;
     policyUri: string;
     contextType?: string;
+    callerAgentAddress?: string;
   }): Promise<{ policyUri: string; bindingUri: string; contextType?: string; revokedAt: string; status: 'revoked' }> {
     const ctx = createOperationContext('system');
-    await this.assertParanetOwner(opts.paranetId);
+    await this.assertParanetOwner(opts.paranetId, opts.callerAgentAddress);
 
     const target = await this.getActiveCclPolicyBinding({
       paranetId: opts.paranetId,
@@ -4401,9 +4414,11 @@ export class DKGAgent {
 
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const revokedAt = new Date().toISOString();
+    const ownerDid = await this.getContextGraphOwner(opts.paranetId)
+      ?? `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
     const quads = buildPolicyRevocationQuads({
       bindingUri: target.bindingUri,
-      revoker: `did:dkg:agent:${this.peerId}`,
+      revoker: ownerDid,
       graph: ontologyGraph,
       revokedAt,
       paranetUri: `did:dkg:context-graph:${opts.paranetId}`,
@@ -5503,9 +5518,9 @@ export class DKGAgent {
       authorized = owner === callerDid ||
         (callerAgentAddress === this.defaultAgentAddress && owner === selfDid);
     } else {
-      // No explicit caller (node-level token): allow any local identity
-      authorized = owner === selfDid ||
-        [...this.localAgents.keys()].some(addr => owner === `did:dkg:agent:${addr}`);
+      // No explicit caller (node-level token): allow peerId and default agent only
+      const defaultDid = this.defaultAgentAddress ? `did:dkg:agent:${this.defaultAgentAddress}` : null;
+      authorized = owner === selfDid || (defaultDid != null && owner === defaultDid);
     }
 
     if (!authorized) {
@@ -5516,15 +5531,35 @@ export class DKGAgent {
     }
   }
 
-  private async assertParanetOwner(paranetId: string): Promise<void> {
+  private async assertParanetOwner(paranetId: string, callerAgentAddress?: string): Promise<void> {
     const owner = await this.getContextGraphOwner(paranetId);
-    const current = `did:dkg:agent:${this.peerId}`;
     if (!owner) {
       throw new Error(`Paranet "${paranetId}" has no registered owner; cannot manage policies.`);
     }
-    if (owner !== current) {
-      throw new Error(`Only the paranet owner can manage policies for "${paranetId}". Owner=${owner}, current=${current}`);
+    if (!this.isCallerOrNodeOwner(owner, callerAgentAddress)) {
+      throw new Error(`Only the paranet owner can manage policies for "${paranetId}". Owner=${owner}, caller=${`did:dkg:agent:${callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`}`);
     }
+  }
+
+  /**
+   * Check if the given owner DID matches the caller or the node's own identity.
+   * When `callerAgentAddress` is provided, only that exact address is accepted
+   * (plus legacy peerId compat only for the default agent).
+   * Without a caller (node-level token), falls back to defaultAgentAddress and peerId.
+   */
+  private isCallerOrNodeOwner(ownerDid: string, callerAgentAddress?: string): boolean {
+    const peerDid = `did:dkg:agent:${this.peerId}`;
+    if (callerAgentAddress) {
+      if (ownerDid === `did:dkg:agent:${callerAgentAddress}`) return true;
+      if (callerAgentAddress === this.defaultAgentAddress && ownerDid === peerDid) return true;
+      return false;
+    }
+    // No explicit caller (SDK / node-level token): accept only the node's
+    // own identities (peerId + defaultAgentAddress). On multi-agent nodes,
+    // callers must supply callerAgentAddress to operate on non-default CGs.
+    if (ownerDid === peerDid) return true;
+    if (this.defaultAgentAddress && ownerDid === `did:dkg:agent:${this.defaultAgentAddress}`) return true;
+    return false;
   }
 
   private async getContextGraphOwner(paranetId: string): Promise<string | null> {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2826,7 +2826,11 @@ export class DKGAgent {
         this.subscribedContextGraphs,
         {
           contextGraphExists: (id) => this.contextGraphExists(id),
-          getContextGraphOwner: (id) => this.getContextGraphOwner(id),
+          // Gossip validation compares `approvedBy`/`revokedBy` against the
+          // paranet owner. Those triples are emitted with `dkg:creator` (peer
+          // DID) so peers validate against the same creator-scoped DID.
+          // `dkg:curator` (wallet DID) is for local authorization only.
+          getContextGraphOwner: (id) => this.getContextGraphCreator(id),
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
         },

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2924,17 +2924,23 @@ export class DKGAgent {
     // will see them. Open CGs go to ONTOLOGY for network-wide discovery.
     const defGraph = isCurated ? cgMetaGraph : ontologyGraph;
 
-    // Use the caller's identity when provided so non-default agents on
-    // multi-agent nodes own the CGs they create. On-chain operations
-    // (registerContextGraph, verify) still bind to the node wallet — this is
-    // a known limitation until per-agent chain signers are implemented.
-    // Downstream owner checks (isCallerOrNodeOwner, assertCallerIsOwner) accept
-    // the caller DID when callerAgentAddress is threaded through daemon routes.
-    const creatorDid = `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
+    // DKG_CREATOR records the libp2p peer ID of the hosting node — this is
+    // the deterministic handle used by `resolveCuratorPeerId()` to dial the
+    // curator for meta refreshes. It must NOT be replaced with a wallet DID.
+    //
+    // DKG_CURATOR records the caller's wallet identity and is what ownership
+    // checks consult (via `getContextGraphOwner`). When a non-default local
+    // agent creates a CG, its wallet DID ends up here so later authorization
+    // — threaded through daemon routes as `callerAgentAddress` — can match.
+    //
+    // On-chain operations (registerContextGraph, verify) still bind to the
+    // node wallet; per-agent chain signers are a known future enhancement.
+    const creatorPeerDid = `did:dkg:agent:${this.peerId}`;
+    const curatorDid = `did:dkg:agent:${opts.callerAgentAddress ?? this.defaultAgentAddress ?? this.peerId}`;
     const quads: Quad[] = [
       { subject: paranetUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: `"${opts.name}"`, graph: defGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorDid, graph: defGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CREATED_AT, object: `"${now}"`, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_GOSSIP_TOPIC, object: `"${paranetPublishTopic(opts.id)}"`, graph: defGraph },
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REPLICATION_POLICY, object: `"${opts.replicationPolicy ?? 'full'}"`, graph: defGraph },
@@ -2944,7 +2950,7 @@ export class DKGAgent {
     // Store registration status and curator in _meta
     quads.push(
       { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"unregistered"`, graph: cgMetaGraph },
-      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: creatorDid, graph: cgMetaGraph },
+      { subject: paranetUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
     );
 
     // Store peer allowlist for curated CGs (with validation)
@@ -5566,7 +5572,22 @@ export class DKGAgent {
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const cgMetaGraph = paranetMetaGraphUri(paranetId);
     const paranetUri = `did:dkg:context-graph:${paranetId}`;
-    const result = await this.store.query(`
+    // Prefer the curator (wallet-scoped owner) so per-agent authorization
+    // works on multi-agent nodes. Fall back to the creator (libp2p peer ID)
+    // for legacy CGs created before the curator triple existed.
+    const curatorResult = await this.store.query(`
+      SELECT ?owner WHERE {
+        GRAPH <${cgMetaGraph}> {
+          <${paranetUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?owner .
+        }
+      }
+      LIMIT 1
+    `);
+    if (curatorResult.type === 'bindings' && curatorResult.bindings.length > 0) {
+      const owner = (curatorResult.bindings[0] as Record<string, string>)['owner'];
+      if (owner) return owner;
+    }
+    const creatorResult = await this.store.query(`
       SELECT ?owner WHERE {
         {
           GRAPH <${ontologyGraph}> {
@@ -5580,8 +5601,8 @@ export class DKGAgent {
       }
       LIMIT 1
     `);
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    return (result.bindings[0] as Record<string, string>)['owner'] ?? null;
+    if (creatorResult.type !== 'bindings' || creatorResult.bindings.length === 0) return null;
+    return (creatorResult.bindings[0] as Record<string, string>)['owner'] ?? null;
   }
 
   private async listCclPolicyBindings(opts: {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1006,11 +1006,16 @@ decisions: []
     await other.stop().catch(() => {});
   });
 
-  // Regression coverage for PR #200: when a non-default local agent creates a
-  // CG (callerAgentAddress != defaultAgentAddress), owner checks must accept
-  // that caller for register/invite/approve/revoke and reject everyone else
-  // — including the node's default agent.
-  it('allows a non-default agent to manage its own CG and blocks sibling agents', async () => {
+  // Regression coverage for PR #200's multi-agent access control. When a
+  // non-default local agent creates a CG (callerAgentAddress !=
+  // defaultAgentAddress), every owner-checked route must:
+  //   - accept the owning caller wallet,
+  //   - reject the node's default-agent token, and
+  //   - reject a sibling agent wallet on the same node.
+  // This exercises approve/revoke (CCL policy) and invite (peer allowlist);
+  // registerContextGraph is covered implicitly through `isCallerOrNodeOwner`
+  // sharing the same code path as invite via `assertCallerIsOwner`.
+  it('scopes CG management to the owning non-default agent across policy and invite paths', async () => {
     const store = new OxigraphStore();
     const node = await DKGAgent.create({
       name: 'MultiAgentNode',
@@ -1021,6 +1026,7 @@ decisions: []
 
     const nonDefaultAddr = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
     const siblingAddr = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
+    const invitePeerId = '12D3KooWRdP3mMN9KkQCWKFjFxhgpXp8Q2y8zQZkgRYfGQ4bQh3a';
 
     await node.createContextGraph({
       id: 'ops-multi-agent',
@@ -1039,20 +1045,29 @@ decisions: []
 `,
     });
 
-    // Default agent token (no callerAgentAddress) must NOT be able to approve
-    // a CG owned by a non-default agent.
+    // --- approveCclPolicy ---
     await expect(node.approveCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri }))
       .rejects.toThrow(/Only the paranet owner can manage policies/);
-
-    // A different non-default agent on the same node must also be rejected.
     await expect(node.approveCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: siblingAddr }))
       .rejects.toThrow(/Only the paranet owner can manage policies/);
-
-    // The owning non-default agent can approve and then revoke.
     await expect(node.approveCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: nonDefaultAddr }))
       .resolves.toBeTruthy();
+
+    // --- revokeCclPolicy ---
+    await expect(node.revokeCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri }))
+      .rejects.toThrow(/Only the paranet owner can manage policies/);
+    await expect(node.revokeCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: siblingAddr }))
+      .rejects.toThrow(/Only the paranet owner can manage policies/);
     await expect(node.revokeCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: nonDefaultAddr }))
       .resolves.toMatchObject({ status: 'revoked' });
+
+    // --- inviteToContextGraph ---
+    await expect(node.inviteToContextGraph('ops-multi-agent', invitePeerId))
+      .rejects.toThrow(/Only the context graph creator can manage peer invitations/);
+    await expect(node.inviteToContextGraph('ops-multi-agent', invitePeerId, siblingAddr))
+      .rejects.toThrow(/Only the context graph creator can manage peer invitations/);
+    await expect(node.inviteToContextGraph('ops-multi-agent', invitePeerId, nonDefaultAddr))
+      .resolves.toBeUndefined();
 
     await node.stop().catch(() => {});
   });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -921,6 +921,10 @@ decisions: []
   });
 
   it('restricts CCL policy approval to the paranet owner', async () => {
+    // Shared store simulates two agent processes on the same node so `other`
+    // can see the CG metadata. After PR #200, ownership is wallet-scoped via
+    // `DKG_CURATOR`, so we pass an explicit `callerAgentAddress` on `other`'s
+    // request to prove non-owner wallets are rejected.
     const store = new OxigraphStore();
     const owner = await DKGAgent.create({
       name: 'OwnerBot',
@@ -932,6 +936,7 @@ decisions: []
       store,
       chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
     });
+    const otherAddr = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
 
     await owner.start();
     await other.start();
@@ -948,7 +953,7 @@ decisions: []
 `,
     });
 
-    await expect(other.approveCclPolicy({ paranetId: 'ops-owner', policyUri: published.policyUri }))
+    await expect(other.approveCclPolicy({ paranetId: 'ops-owner', policyUri: published.policyUri, callerAgentAddress: otherAddr }))
       .rejects.toThrow(/Only the paranet owner can manage policies/);
 
     await expect(owner.approveCclPolicy({ paranetId: 'ops-owner', policyUri: published.policyUri }))
@@ -959,6 +964,9 @@ decisions: []
   });
 
   it('restricts CCL policy revocation to the paranet owner', async () => {
+    // See note on policy-approval test above: ownership is wallet-scoped via
+    // `DKG_CURATOR` after PR #200; `other` passes an explicit non-owner
+    // `callerAgentAddress` to prove the check rejects other wallets.
     const store = new OxigraphStore();
     const owner = await DKGAgent.create({
       name: 'OwnerRevokeBot',
@@ -970,6 +978,7 @@ decisions: []
       store,
       chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
     });
+    const otherAddr = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
 
     await owner.start();
     await other.start();
@@ -987,7 +996,7 @@ decisions: []
     });
     await owner.approveCclPolicy({ paranetId: 'ops-owner-revoke', policyUri: published.policyUri });
 
-    await expect(other.revokeCclPolicy({ paranetId: 'ops-owner-revoke', policyUri: published.policyUri }))
+    await expect(other.revokeCclPolicy({ paranetId: 'ops-owner-revoke', policyUri: published.policyUri, callerAgentAddress: otherAddr }))
       .rejects.toThrow(/Only the paranet owner can manage policies/);
 
     await expect(owner.revokeCclPolicy({ paranetId: 'ops-owner-revoke', policyUri: published.policyUri }))
@@ -995,6 +1004,57 @@ decisions: []
 
     await owner.stop().catch(() => {});
     await other.stop().catch(() => {});
+  });
+
+  // Regression coverage for PR #200: when a non-default local agent creates a
+  // CG (callerAgentAddress != defaultAgentAddress), owner checks must accept
+  // that caller for register/invite/approve/revoke and reject everyone else
+  // — including the node's default agent.
+  it('allows a non-default agent to manage its own CG and blocks sibling agents', async () => {
+    const store = new OxigraphStore();
+    const node = await DKGAgent.create({
+      name: 'MultiAgentNode',
+      store,
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+    });
+    await node.start();
+
+    const nonDefaultAddr = new ethers.Wallet(HARDHAT_KEYS.REC1_OP).address;
+    const siblingAddr = new ethers.Wallet(HARDHAT_KEYS.REC2_OP).address;
+
+    await node.createContextGraph({
+      id: 'ops-multi-agent',
+      name: 'Multi-Agent CG',
+      callerAgentAddress: nonDefaultAddr,
+    });
+
+    const published = await node.publishCclPolicy({
+      paranetId: 'ops-multi-agent',
+      name: 'incident-review',
+      version: '0.1.0',
+      content: `policy: incident-review
+version: 0.1.0
+rules: []
+decisions: []
+`,
+    });
+
+    // Default agent token (no callerAgentAddress) must NOT be able to approve
+    // a CG owned by a non-default agent.
+    await expect(node.approveCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri }))
+      .rejects.toThrow(/Only the paranet owner can manage policies/);
+
+    // A different non-default agent on the same node must also be rejected.
+    await expect(node.approveCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: siblingAddr }))
+      .rejects.toThrow(/Only the paranet owner can manage policies/);
+
+    // The owning non-default agent can approve and then revoke.
+    await expect(node.approveCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: nonDefaultAddr }))
+      .resolves.toBeTruthy();
+    await expect(node.revokeCclPolicy({ paranetId: 'ops-multi-agent', policyUri: published.policyUri, callerAgentAddress: nonDefaultAddr }))
+      .resolves.toMatchObject({ status: 'revoked' });
+
+    await node.stop().catch(() => {});
   });
 
   it('validates CCL policy content before publish', async () => {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -4439,7 +4439,7 @@ async function handleRequest(
     // registered later via POST /api/context-graph/register.
     if (register === true) {
       try {
-        const regResult = await agent.registerContextGraph(id);
+        const regResult = await agent.registerContextGraph(id, { callerAgentAddress: requestAgentAddress });
         return jsonResponse(res, 200, {
           created: id,
           uri: `did:dkg:context-graph:${id}`,
@@ -4476,7 +4476,7 @@ async function handleRequest(
       return jsonResponse(res, 400, { error: '"accessPolicy" must be 0 (open) or 1 (private)' });
     }
     try {
-      const result = await agent.registerContextGraph(id, { revealOnChain, accessPolicy });
+      const result = await agent.registerContextGraph(id, { revealOnChain, accessPolicy, callerAgentAddress: requestAgentAddress });
       return jsonResponse(res, 200, {
         registered: id,
         onChainId: result.onChainId,
@@ -4512,7 +4512,7 @@ async function handleRequest(
     }
     if (!isValidContextGraphId(contextGraphId)) return jsonResponse(res, 400, { error: 'Invalid context graph id' });
     try {
-      await agent.inviteToContextGraph(contextGraphId, targetPeerId);
+      await agent.inviteToContextGraph(contextGraphId, targetPeerId, requestAgentAddress);
       return jsonResponse(res, 200, { invited: targetPeerId, contextGraphId });
     } catch (err: any) {
       const msg = err?.message ?? '';
@@ -6183,10 +6183,11 @@ async function handleRequest(
     // the sync protocol enforces access on the remote side regardless.
     const localAllowed = await agent.getContextGraphAllowedAgents(paranetId).catch(() => [] as string[]);
     if (localAllowed.length > 0) {
-      const myAddr = agent.getDefaultAgentAddress();
-      if (myAddr && !localAllowed.some((a: string) => a.toLowerCase() === myAddr.toLowerCase())) {
+      const callerAddr = requestAgentAddress ?? agent.getDefaultAgentAddress();
+      const isEthAddress = callerAddr && /^0x[0-9a-fA-F]{40}$/.test(callerAddr);
+      if (isEthAddress && !localAllowed.some((a: string) => a.toLowerCase() === callerAddr.toLowerCase())) {
         return jsonResponse(res, 403, {
-          error: `Your agent (${myAddr}) is not on the allowlist for this curated project. Ask the curator to invite you first.`,
+          error: `Your agent (${callerAddr}) is not on the allowlist for this curated project. Ask the curator to invite you first.`,
         });
       }
     }
@@ -6527,6 +6528,7 @@ async function handleRequest(
       paranetId,
       policyUri,
       contextType,
+      callerAgentAddress: requestAgentAddress,
     });
     return jsonResponse(res, 200, result);
   }
@@ -6544,6 +6546,7 @@ async function handleRequest(
       paranetId,
       policyUri,
       contextType,
+      callerAgentAddress: requestAgentAddress,
     });
     return jsonResponse(res, 200, result);
   }

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -6524,13 +6524,21 @@ async function handleRequest(
         error: "Missing required fields: paranetId, policyUri",
       });
     }
-    const result = await agent.approveCclPolicy({
-      paranetId,
-      policyUri,
-      contextType,
-      callerAgentAddress: requestAgentAddress,
-    });
-    return jsonResponse(res, 200, result);
+    try {
+      const result = await agent.approveCclPolicy({
+        paranetId,
+        policyUri,
+        contextType,
+        callerAgentAddress: requestAgentAddress,
+      });
+      return jsonResponse(res, 200, result);
+    } catch (err: any) {
+      const msg = err?.message ?? "";
+      if (/Only the paranet owner can manage policies/.test(msg)) {
+        return jsonResponse(res, 403, { error: msg });
+      }
+      throw err;
+    }
   }
 
   // POST /api/ccl/policy/revoke
@@ -6542,13 +6550,21 @@ async function handleRequest(
         error: "Missing required fields: paranetId, policyUri",
       });
     }
-    const result = await agent.revokeCclPolicy({
-      paranetId,
-      policyUri,
-      contextType,
-      callerAgentAddress: requestAgentAddress,
-    });
-    return jsonResponse(res, 200, result);
+    try {
+      const result = await agent.revokeCclPolicy({
+        paranetId,
+        policyUri,
+        contextType,
+        callerAgentAddress: requestAgentAddress,
+      });
+      return jsonResponse(res, 200, result);
+    } catch (err: any) {
+      const msg = err?.message ?? "";
+      if (/Only the paranet owner can manage policies/.test(msg)) {
+        return jsonResponse(res, 403, { error: msg });
+      }
+      throw err;
+    }
   }
 
   // GET /api/ccl/policy/list

--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -30,17 +30,24 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
   const [progress, setProgress] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [agentAddress, setAgentAddress] = useState<string | null>(null);
+  const [identityLoading, setIdentityLoading] = useState(false);
+  const [identityError, setIdentityError] = useState(false);
 
   const { setContextGraphs, contextGraphs, setActiveProject } = useProjectsStore();
   const { openTab } = useTabsStore();
   const { setStage, stage } = useJourneyStore();
 
+  const loadAgentIdentity = () => {
+    setIdentityLoading(true);
+    setIdentityError(false);
+    fetchCurrentAgent()
+      .then((a) => { setAgentAddress(a.agentAddress); setIdentityError(false); })
+      .catch(() => { setAgentAddress(null); setIdentityError(true); })
+      .finally(() => setIdentityLoading(false));
+  };
+
   useEffect(() => {
-    if (open) {
-      fetchCurrentAgent()
-        .then((a) => setAgentAddress(a.agentAddress))
-        .catch(() => setAgentAddress(null));
-    }
+    if (open) loadAgentIdentity();
   }, [open]);
 
   if (!open) return null;
@@ -59,8 +66,12 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
     setProgress('Registering project on the network…');
 
     const finalSlug = slugify(trimmedName);
-    const resolvedAddr = agentAddress ?? '0x0000000000000000000000000000000000000000';
-    const cgId = `${resolvedAddr}/${finalSlug}`;
+    if (!agentAddress) {
+      setError('Agent identity is still loading. Please wait a moment and try again.');
+      setCreating(false);
+      return;
+    }
+    const cgId = `${agentAddress}/${finalSlug}`;
 
     try {
       const slowTimer = setTimeout(() => setProgress('On-chain registration in progress — this can take up to 30s…'), 5000);
@@ -244,12 +255,17 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
 
         <div className="v10-modal-footer">
           <button className="v10-modal-btn" onClick={onClose}>Cancel</button>
+          {identityError && (
+            <button className="v10-modal-btn" onClick={loadAgentIdentity} disabled={identityLoading}>
+              {identityLoading ? 'Retrying…' : 'Retry Loading Agent'}
+            </button>
+          )}
           <button
             className="v10-modal-btn primary"
             onClick={handleCreate}
-            disabled={!name.trim() || creating}
+            disabled={!name.trim() || creating || !agentAddress || identityLoading}
           >
-            {creating ? progress || 'Creating…' : 'Create Project'}
+            {creating ? progress || 'Creating…' : identityLoading ? 'Loading agent…' : !agentAddress ? 'Agent unavailable' : 'Create Project'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to #195 addressing Codex review comments related to multi-agent edge cases. Squashed into a single commit and rebased on latest v10-rc.

### Changes

- **Skip unresolved ACK approvals** (`dkg-agent.ts`): Filter out signers with `identityId=0n` before on-chain verify; track `resolvedSignerAddresses` so verified-memory metadata only includes actual verify() participants
- **CG creator uses caller DID** (`dkg-agent.ts`): Store `callerAgentAddress` as context graph creator/curator so non-default agents on multi-agent nodes own the graphs they create (on-chain ops still use node wallet — documented limitation until per-agent chain signers)
- **Caller-scoped ownership checks** (`dkg-agent.ts`): Add `isCallerOrNodeOwner()` helper that accepts the specific caller DID when provided, falls back to peerId/defaultAgentAddress for node-level tokens; no longer iterates all `localAgents` (prevents cross-agent escalation)
- **Thread callerAgentAddress through all mutation paths** (`dkg-agent.ts`, `daemon.ts`): `registerContextGraph`, `inviteToContextGraph`, `inviteAgentToContextGraph`, `approveCclPolicy`, `revokeCclPolicy` and their daemon routes all receive `requestAgentAddress`
- **Use persisted owner DID for CCL metadata** (`dkg-agent.ts`): `approveCclPolicy`/`revokeCclPolicy` use `getContextGraphOwner()` for `approvedBy`/`revokedBy`/`creator` so gossip-publish-handler accepts the bindings
- **Legacy allowedPeers in isCurated** (`dkg-agent.ts`): Include `allowedPeers?.length` so peer-allowlisted CGs are correctly treated as private
- **Daemon subscribe allowlist** (`daemon.ts`): Only reject when `callerAddr` is a real Ethereum address (skip peerId fallbacks to avoid false 403s on legacy nodes)
- **UI: agent identity guard** (`CreateProjectModal.tsx`): Block CG creation until agent identity loads; add retry/error state for transient `/api/agent/identity` failures

## Test plan

- [x] `agent.test.ts` — unit tests pass (258/293; 35 failures are pre-existing on v10-rc)
- [ ] Manual verification of CLI invite flow with non-default agent
- [ ] Manual verification of UI project creation timing
- [ ] Verify non-default agent can create CG → register → invite → approve CCL