### PR TITLE
chore: point testnet Hub to base_sepolia_test deployment

### DIFF
--- a/network/testnet.json
+++ b/network/testnet.json
@@ -19,7 +19,7 @@
   "chain": {
     "type": "evm",
     "rpcUrl": "https://sepolia.base.org",
-    "hubAddress": "0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6",
+    "hubAddress": "0xf21CE8f8b01548D97DCFb36869f1ccB0814a4e05",
     "chainId": "base:84532"
   },
   "faucet": {


### PR DESCRIPTION
## Summary

- Updates `network/testnet.json` hubAddress from `0xC056e67...` (base_sepolia_v9) to `0xf21CE8f8b01548D97DCFb36869f1ccB0814a4e05` (base_sepolia_test)
- The V10 contracts (ContextGraphs, KnowledgeAssetsV10, DKGPublishingConvictionNFT, etc.) are only registered on the base_sepolia_test Hub — the previous Hub had no V10 wiring

## Context

PR #188 deployed all 15 PR #149 contracts to `base_sepolia_test`. Nodes using `network/testnet.json` were pointing at the old `base_sepolia_v9` Hub which doesn't have V10 contracts, causing ContextGraphs/KnowledgeAssetsV10 lookups to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)