### PR TITLE
feat(node-ui): project overview redesign with layer-centric UI and split-pane canvas

### DIFF
--- a/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/CreateProjectModal.tsx
@@ -240,14 +240,6 @@ export function CreateProjectModal({ open, onClose }: CreateProjectModalProps) {
             </div>
           )}
 
-          <div className="v10-layer-preview">
-            <div className="v10-layer-preview-title">Layer Activation</div>
-            <span style={{ fontFamily: 'var(--font-mono)' }}>
-              ┌─ Verified Memory ── activates on first publish (requires TRAC)<br />
-              ├─ Shared Memory ──── activates on first share (free)<br />
-              └─ Working Memory ─── created immediately (local, free)
-            </span>
-          </div>
         </div>
 
         <div className="v10-modal-footer">

--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -78,10 +78,15 @@ function MemoryStackView() {
   );
 }
 
+const TEXT_CONTENT_TYPES = ['text/', 'application/json', 'application/xml', 'application/javascript', 'application/x-yaml'];
+function isTextContentType(ct: string) { return TEXT_CONTENT_TYPES.some(t => ct.startsWith(t)); }
+
 function DocumentViewer({ docRef }: { docRef: string }) {
   const { tabs, activeTabId, closeTab } = useTabsStore();
   const setActiveTab = useTabsStore(s => s.setActiveTab);
   const [content, setContent] = useState<string | null>(null);
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [contentType, setContentType] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,17 +102,52 @@ function DocumentViewer({ docRef }: { docRef: string }) {
   };
 
   useEffect(() => {
+    let cancelled = false;
     setLoading(true);
     setError(null);
+    setContent(null);
+    setBlobUrl(null);
+    setContentType('');
+
     const fileHash = docRef.replace('urn:dkg:file:', '');
-    fetch(`/api/file/${encodeURIComponent(fileHash)}`, { headers: authHeaders() })
-      .then(res => {
+    const controller = new AbortController();
+
+    fetch(`/api/file/${encodeURIComponent(fileHash)}`, { headers: authHeaders(), signal: controller.signal })
+      .then(async res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.text();
+        const ct = res.headers.get('content-type') ?? 'application/octet-stream';
+        if (cancelled) return;
+        setContentType(ct);
+
+        if (isTextContentType(ct)) {
+          const text = await res.text();
+          if (!cancelled) { setContent(text); setLoading(false); }
+        } else if (ct.startsWith('image/')) {
+          const blob = await res.blob();
+          if (!cancelled) { setBlobUrl(URL.createObjectURL(blob)); setLoading(false); }
+        } else if (ct === 'application/pdf') {
+          const blob = await res.blob();
+          if (!cancelled) { setBlobUrl(URL.createObjectURL(blob)); setLoading(false); }
+        } else {
+          const text = await res.text();
+          if (!cancelled) { setContent(text); setLoading(false); }
+        }
       })
-      .then(text => { setContent(text); setLoading(false); })
-      .catch(err => { setError(err.message); setLoading(false); });
+      .catch(err => { if (!cancelled) { setError(err.message); setLoading(false); } });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
   }, [docRef]);
+
+  useEffect(() => {
+    const url = blobUrl;
+    return () => { if (url) URL.revokeObjectURL(url); };
+  }, [blobUrl]);
+
+  const isImage = contentType.startsWith('image/');
+  const isPdf = contentType === 'application/pdf';
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
@@ -130,7 +170,13 @@ function DocumentViewer({ docRef }: { docRef: string }) {
       <div style={{ flex: 1, overflow: 'auto', padding: '20px 24px' }}>
         {loading && <div style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>Loading document...</div>}
         {error && <div style={{ color: 'var(--accent-red)', fontSize: 12 }}>Failed to load: {error}</div>}
-        {content && (
+        {!loading && isImage && blobUrl && (
+          <img src={blobUrl} alt={docLabel} style={{ maxWidth: '100%', borderRadius: 8 }} />
+        )}
+        {!loading && isPdf && blobUrl && (
+          <iframe src={blobUrl} title={docLabel} style={{ width: '100%', height: '100%', border: 'none', borderRadius: 8 }} />
+        )}
+        {content && !isImage && !isPdf && (
           <pre style={{
             fontFamily: 'var(--font-mono)', fontSize: 12, lineHeight: 1.7,
             color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
@@ -182,7 +228,9 @@ function ViewContainer() {
   }
 
   if (activeTabId.startsWith('doc:')) {
-    const docRef = activeTabId.slice(4);
+    const raw = activeTabId.slice(4);
+    const lastColon = raw.lastIndexOf(':');
+    const docRef = lastColon > 0 ? raw.slice(lastColon + 1) : raw;
     return <DocumentViewer docRef={docRef} />;
   }
 

--- a/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelCenter.tsx
@@ -1,8 +1,9 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useState, useEffect } from 'react';
 import { useTabsStore } from '../../stores/tabs.js';
 import { DashboardView } from '../../views/DashboardView.js';
 import { ProjectView } from '../../views/ProjectView.js';
 import { MemoryLayerView } from '../../views/MemoryLayerView.js';
+import { authHeaders } from '../../api.js';
 
 const CLOSE_ICON = (
   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -77,6 +78,73 @@ function MemoryStackView() {
   );
 }
 
+function DocumentViewer({ docRef }: { docRef: string }) {
+  const { tabs, activeTabId, closeTab } = useTabsStore();
+  const setActiveTab = useTabsStore(s => s.setActiveTab);
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentTab = tabs.find(t => t.id === activeTabId);
+  const docLabel = currentTab?.label ?? 'Document';
+
+  const handleBack = () => {
+    const projectTab = tabs.find(t => t.id.startsWith('project:'));
+    if (projectTab) {
+      setActiveTab(projectTab.id);
+    }
+    closeTab(activeTabId);
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    const fileHash = docRef.replace('urn:dkg:file:', '');
+    fetch(`/api/file/${encodeURIComponent(fileHash)}`, { headers: authHeaders() })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.text();
+      })
+      .then(text => { setContent(text); setLoading(false); })
+      .catch(err => { setError(err.message); setLoading(false); });
+  }, [docRef]);
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <div style={{
+        flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10,
+        padding: '8px 16px', borderBottom: '1px solid var(--border-subtle)', background: 'var(--bg-panel)',
+      }}>
+        <button
+          onClick={handleBack}
+          style={{
+            border: '1px solid var(--border-default)', borderRadius: 5, background: 'none',
+            color: 'var(--text-secondary)', fontSize: 11, fontWeight: 600, padding: '4px 10px',
+            cursor: 'pointer', fontFamily: 'var(--font-sans)',
+          }}
+        >
+          ← Back to Project
+        </button>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>📄 {docLabel}</span>
+      </div>
+      <div style={{ flex: 1, overflow: 'auto', padding: '20px 24px' }}>
+        {loading && <div style={{ color: 'var(--text-tertiary)', fontSize: 12 }}>Loading document...</div>}
+        {error && <div style={{ color: 'var(--accent-red)', fontSize: 12 }}>Failed to load: {error}</div>}
+        {content && (
+          <pre style={{
+            fontFamily: 'var(--font-mono)', fontSize: 12, lineHeight: 1.7,
+            color: 'var(--text-primary)', whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+            background: 'var(--bg-surface)', borderRadius: 8, padding: 16,
+            border: '1px solid var(--border-default)', margin: 0,
+          }}>
+            {content}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function ViewContainer() {
   const activeTabId = useTabsStore((s) => s.activeTabId);
 
@@ -111,6 +179,11 @@ function ViewContainer() {
   if (activeTabId.startsWith('project:')) {
     const cgId = activeTabId.slice('project:'.length);
     return <ProjectView contextGraphId={cgId} />;
+  }
+
+  if (activeTabId.startsWith('doc:')) {
+    const docRef = activeTabId.slice(4);
+    return <DocumentViewer docRef={docRef} />;
   }
 
   if (activeTabId.startsWith('wm:')) {

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -30,9 +30,9 @@
   --accent-blue: #3b82f6;
 
   /* Layer identity */
-  --layer-working: #555555;
-  --layer-shared: #777777;
-  --layer-verified: #bbbbbb;
+  --layer-working: #64748b;
+  --layer-shared: #f59e0b;
+  --layer-verified: #22c55e;
 
   /* Typography */
   --font-sans: 'Instrument Sans', -apple-system, sans-serif;
@@ -2293,23 +2293,6 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
   max-width: none; margin: -24px -28px; overflow: hidden;
 }
 
-/* ── Header ── */
-.v10-me-header {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 12px 16px; border-bottom: 1px solid var(--border-subtle); flex-shrink: 0;
-}
-.v10-me-header-left { display: flex; align-items: center; gap: 12px; }
-.v10-me-project-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--text-primary); flex-shrink: 0; }
-.v10-me-title { font-size: 15px; font-weight: 600; color: var(--text-primary); margin: 0; }
-.v10-me-meta { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-tertiary); font-family: var(--font-mono); margin-top: 2px; }
-.v10-me-meta-sep { color: var(--text-ghost); }
-.v10-me-header-actions { display: flex; gap: 4px; }
-.v10-me-action-btn {
-  padding: 4px 10px; border-radius: 5px; font-size: 11px; font-weight: 500;
-  color: var(--text-tertiary); border: 1px solid var(--border-default); background: none; transition: all 0.15s;
-}
-.v10-me-action-btn:hover { color: var(--text-secondary); border-color: var(--border-strong); }
-
 /* ── Trust Summary ── */
 .v10-trust-summary { padding: 8px 16px; border-bottom: 1px solid var(--border-subtle); flex-shrink: 0; }
 .v10-trust-summary-bar { display: flex; height: 4px; border-radius: 2px; overflow: hidden; background: var(--bg-elevated); margin-bottom: 6px; }
@@ -2335,33 +2318,10 @@ body.light .v10-import-dropzone.drag-over { border-color: #b0b0b0; background: #
 .v10-trust-ring.trust-shared { color: #f59e0b; }
 .v10-trust-ring.trust-working { color: #64748b; }
 
-/* ── Toolbar (tabs + search) ── */
-.v10-me-toolbar {
-  display: flex; align-items: center; gap: 8px;
-  padding: 6px 16px; border-bottom: 1px solid var(--border-subtle); flex-shrink: 0;
-}
-.v10-me-tabs { display: flex; gap: 2px; }
-.v10-me-tab {
-  padding: 4px 12px; border-radius: 5px; font-size: 11px; font-weight: 500;
-  color: var(--text-tertiary); background: none; border: none; transition: all 0.15s; cursor: pointer;
-}
-.v10-me-tab:hover { color: var(--text-secondary); background: var(--bg-hover); }
-.v10-me-tab.active { color: var(--text-primary); background: var(--bg-active); }
-.v10-me-search {
-  margin-left: auto; width: 200px; height: 28px; padding: 0 10px;
-  font-size: 11px; border-radius: 5px; background: var(--bg-surface);
-  border: 1px solid var(--border-default); color: var(--text-primary); font-family: var(--font-sans);
-}
-.v10-me-search:focus { border-color: var(--border-strong); width: 280px; transition: width 0.2s; }
-
 /* ── Loading / Error / Empty ── */
 .v10-me-loading { display: flex; align-items: center; justify-content: center; flex: 1; }
 .v10-me-loading-text { font-size: 12px; color: var(--text-tertiary); }
 .v10-me-error { padding: 12px 16px; font-size: 12px; color: var(--accent-red); background: rgba(239,68,68,0.06); }
-.v10-me-empty { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 48px 24px; }
-.v10-me-empty-icon { font-size: 48px; color: var(--text-ghost); margin-bottom: 16px; }
-.v10-me-empty-title { font-size: 16px; font-weight: 600; color: var(--text-secondary); margin: 0 0 8px; }
-.v10-me-empty-desc { font-size: 12px; color: var(--text-tertiary); max-width: 360px; line-height: 1.6; margin-bottom: 20px; }
 
 /* ── Graph View (full graph tab) ── */
 .v10-gv-container { flex: 1; position: relative; min-height: 0; background: var(--bg-surface); }
@@ -2379,121 +2339,6 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 /* ══════════════════════════════════════════
    TIMELINE VIEW
    ══════════════════════════════════════════ */
-
-.v10-tl-scroll { flex: 1; overflow-y: auto; padding: 16px; }
-.v10-tl-empty { padding: 32px; text-align: center; font-size: 12px; color: var(--text-tertiary); }
-
-.v10-tl-date-group { margin-bottom: 24px; }
-.v10-tl-date-label {
-  font-size: 12px; font-weight: 700; color: var(--text-primary);
-  padding: 4px 0 8px; border-bottom: 1px solid var(--border-subtle); margin-bottom: 8px;
-  font-family: var(--font-mono); letter-spacing: 0.5px;
-}
-.v10-tl-type-group { margin-bottom: 24px; }
-.v10-tl-type-label {
-  font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
-  color: var(--text-ghost); padding: 4px 0 8px; margin-bottom: 8px;
-}
-.v10-tl-date-items { display: flex; flex-direction: column; gap: 6px; }
-
-/* ── Narrative Card ── */
-.v10-nc {
-  display: flex; align-items: flex-start; gap: 12px;
-  padding: 12px 14px; border-radius: 8px; text-align: left; width: 100%;
-  background: var(--bg-surface); border: 1px solid var(--border-default);
-  border-left: 4px solid var(--border-default);
-  transition: all 0.15s; cursor: pointer;
-}
-.v10-nc:hover { border-color: var(--border-strong); background: var(--bg-hover); }
-.v10-nc-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
-.v10-nc-header { display: flex; align-items: center; gap: 8px; }
-.v10-nc-icon { font-size: 16px; flex-shrink: 0; }
-.v10-nc-label { font-size: 13px; font-weight: 600; color: var(--text-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v10-nc-desc { font-size: 11px; color: var(--text-secondary); line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-/* contributor byline */
-.v10-nc-contributors { display: flex; align-items: center; flex-wrap: wrap; gap: 2px; }
-.v10-nc-contributor { display: inline-flex; align-items: center; gap: 3px; cursor: pointer; padding: 1px 4px; border-radius: 4px; transition: background 0.1s; }
-.v10-nc-contributor:hover { background: rgba(99, 102, 241, 0.12); }
-.v10-nc-contrib-name { font-size: 11px; font-weight: 600; color: var(--text-primary); }
-.v10-nc-contrib-tool { font-size: 9px; font-weight: 500; color: var(--text-ghost); background: var(--bg-elevated); padding: 0 5px; border-radius: 3px; margin-left: 2px; }
-.v10-nc-contrib-sep { color: var(--text-ghost); font-size: 10px; margin: 0 2px; }
-/* relationships */
-.v10-nc-rels { display: flex; flex-wrap: wrap; gap: 4px 10px; }
-.v10-nc-rel { font-size: 10px; color: var(--text-tertiary); display: flex; align-items: center; gap: 3px; }
-.v10-nc-rel-pred { font-weight: 600; color: var(--text-ghost); }
-.v10-nc-rel-target { color: var(--text-secondary); }
-.v10-nc-rel-clickable { cursor: pointer; padding: 0 2px; border-radius: 2px; transition: background 0.1s; }
-.v10-nc-rel-clickable:hover { background: rgba(99, 102, 241, 0.12); color: var(--text-primary); }
-/* footer */
-.v10-nc-footer { display: flex; align-items: center; gap: 8px; margin-top: 2px; }
-.v10-nc-type { font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); }
-.v10-nc-date { font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); }
-.v10-nc-stats { font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); margin-left: auto; }
-
-/* ══════════════════════════════════════════
-   CONVERSATION VIEW (read-only transcript)
-   ══════════════════════════════════════════ */
-
-.v10-conv-scroll { flex: 1; overflow-y: auto; padding: 8px 12px; }
-.v10-conv-date-divider {
-  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
-  color: var(--text-ghost); text-align: center; padding: 12px 0 6px;
-  border-bottom: 1px solid var(--border-subtle); margin-bottom: 8px;
-}
-.v10-conv-turn {
-  display: flex; align-items: flex-start; gap: 12px; width: 100%;
-  padding: 12px 14px; margin-bottom: 6px; border-radius: 8px;
-  background: var(--bg-surface); border: 1px solid var(--border-subtle);
-  border-left: 4px solid var(--border-default);
-  text-align: left; cursor: pointer; transition: all 0.15s;
-}
-.v10-conv-turn:hover { border-color: var(--border-strong); background: var(--bg-hover); }
-.v10-conv-turn-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
-.v10-conv-turn-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.v10-conv-speaker { font-size: 13px; font-weight: 700; color: var(--text-primary); }
-.v10-conv-tool {
-  font-size: 9px; font-weight: 500; color: var(--text-ghost);
-  background: var(--bg-elevated); padding: 1px 6px; border-radius: 3px;
-}
-.v10-conv-time { font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); margin-left: auto; }
-.v10-conv-title { font-size: 13px; font-weight: 600; color: var(--text-primary); }
-.v10-conv-body {
-  font-size: 11px; color: var(--text-tertiary); line-height: 1.6;
-  white-space: pre-wrap; word-break: break-word;
-  display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden;
-}
-.v10-conv-mentions { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
-.v10-conv-mention {
-  font-size: 10px; font-weight: 600; color: #6366f1;
-  background: rgba(99, 102, 241, 0.08); padding: 2px 8px; border-radius: 4px;
-  cursor: pointer; transition: background 0.1s;
-}
-.v10-conv-mention:hover { background: rgba(99, 102, 241, 0.18); }
-.v10-conv-turn-footer { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
-.v10-conv-turn-uri { font-size: 8px; font-family: var(--font-mono); color: var(--text-ghost); opacity: 0.6; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-
-/* ══════════════════════════════════════════
-   ENTITIES VIEW (grouped list)
-   ══════════════════════════════════════════ */
-
-.v10-ev-scroll { flex: 1; overflow-y: auto; padding: 8px 0; }
-.v10-ev-group { margin-bottom: 8px; }
-.v10-ev-group-label {
-  font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;
-  color: var(--text-ghost); padding: 8px 16px 4px;
-}
-.v10-ev-item {
-  display: flex; align-items: flex-start; gap: 8px; width: 100%;
-  padding: 8px 16px; text-align: left; transition: background 0.1s;
-  background: none; border: none; border-left: 3px solid transparent; color: inherit; cursor: pointer;
-}
-.v10-ev-item:hover { background: var(--bg-hover); }
-.v10-ev-item.selected { background: var(--bg-active); }
-.v10-ev-item-icon { font-size: 14px; width: 20px; text-align: center; flex-shrink: 0; margin-top: 1px; }
-.v10-ev-item-content { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
-.v10-ev-item-label { font-size: 12px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v10-ev-item-desc { font-size: 10px; color: var(--text-tertiary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v10-ev-item-links { font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); flex-shrink: 0; margin-top: 2px; }
 
 /* ══════════════════════════════════════════
    DRILLDOWN PANEL (focused 2-hop graph + rich card)
@@ -2613,3 +2458,388 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 
 /* Lazy route spinner */
 .lazy-spinner{display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-tertiary);font-size:13px}
+
+/* ══════════════════════════════════════════
+   PROJECT OVERVIEW REDESIGN — Layer-centric UI
+   ══════════════════════════════════════════ */
+
+/* ── Layer Switcher Bar ── */
+.v10-layer-switcher {
+  flex-shrink: 0; display: flex; align-items: center;
+  border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel);
+  padding: 0 4px; height: 36px; min-height: 36px; gap: 0;
+}
+.v10-layer-switch-btn {
+  height: 100%; padding: 0 14px; display: flex; align-items: center; gap: 6px;
+  font-size: 12px; font-weight: 500; color: var(--text-tertiary);
+  border: none; background: none; cursor: pointer;
+  border-bottom: 2px solid transparent; transition: all 0.15s; white-space: nowrap;
+  font-family: var(--font-sans);
+}
+.v10-layer-switch-btn:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.v10-layer-switch-btn.active { color: var(--text-primary); }
+.v10-layer-switch-btn.active[data-layer="overview"] { border-bottom-color: var(--text-secondary); }
+.v10-layer-switch-btn.active[data-layer="wm"] { border-bottom-color: #64748b; }
+.v10-layer-switch-btn.active[data-layer="swm"] { border-bottom-color: #f59e0b; }
+.v10-layer-switch-btn.active[data-layer="vm"] { border-bottom-color: #22c55e; }
+.v10-layer-switch-icon { font-size: 11px; }
+.v10-layer-switch-count {
+  font-family: var(--font-mono); font-size: 9px; padding: 1px 5px;
+  border-radius: 3px; background: var(--bg-elevated); color: var(--text-ghost);
+}
+.v10-layer-switch-btn.active .v10-layer-switch-count { color: var(--text-tertiary); }
+.v10-layer-switcher-spacer { flex: 1; }
+.v10-layer-switcher-actions { display: flex; align-items: center; gap: 4px; padding-right: 4px; }
+
+/* ── Project Overview Card ── */
+.v10-po { flex-shrink: 0; padding: 14px 16px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
+.v10-po-top { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 12px; }
+.v10-po-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--text-primary); flex-shrink: 0; margin-top: 4px; }
+.v10-po-title { font-size: 15px; font-weight: 600; color: var(--text-primary); }
+.v10-po-desc { font-size: 11px; color: var(--text-tertiary); margin-top: 2px; line-height: 1.5; }
+.v10-po-stats { display: flex; gap: 20px; margin-bottom: 12px; flex-wrap: wrap; }
+.v10-po-stat { display: flex; flex-direction: column; align-items: center; gap: 1px; min-width: 50px; }
+.v10-po-stat-val { font-size: 20px; font-weight: 700; color: var(--text-primary); font-family: var(--font-mono); }
+.v10-po-stat-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-ghost); font-weight: 600; }
+.v10-po-participants { margin-bottom: 12px; }
+.v10-po-participants-label { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: var(--text-ghost); margin-bottom: 6px; }
+.v10-po-participants-list { display: flex; flex-wrap: wrap; gap: 6px; }
+.v10-po-participant {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 10px; border-radius: 12px; font-size: 11px; font-weight: 600;
+  background: var(--bg-surface); border: 1px solid var(--border-default); color: var(--text-primary);
+}
+.v10-po-participant-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.v10-po-progress { margin-bottom: 0; }
+.v10-po-progress-label { display: flex; justify-content: space-between; font-size: 10px; color: var(--text-tertiary); margin-bottom: 4px; }
+.v10-po-progress-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden; background: var(--bg-elevated); }
+.v10-po-progress-seg { min-width: 3px; transition: width 0.3s ease; }
+.v10-po-progress-seg.wm { background: #64748b; }
+.v10-po-progress-seg.swm { background: #f59e0b; }
+.v10-po-progress-seg.vm { background: #22c55e; }
+.v10-po-progress-legend { display: flex; gap: 14px; margin-top: 6px; font-size: 9px; font-family: var(--font-mono); color: var(--text-ghost); }
+.v10-po-legend-item { display: flex; align-items: center; gap: 4px; }
+.v10-po-legend-dot { width: 6px; height: 6px; border-radius: 50%; }
+
+/* ── Memory Strip ── */
+.v10-memory-strip { flex-shrink: 0; border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel); }
+.v10-memory-layer {
+  display: flex; align-items: stretch; border-bottom: 1px solid var(--border-subtle); min-height: 0; cursor: pointer;
+}
+.v10-memory-layer:last-child { border-bottom: none; }
+.v10-layer-label {
+  width: 160px; flex-shrink: 0; display: flex; align-items: center;
+  gap: 8px; padding: 8px 12px;
+  border-right: 1px solid var(--border-subtle); cursor: pointer;
+  transition: background 0.15s;
+}
+.v10-layer-label:hover { background: var(--bg-hover); }
+.v10-layer-abbr { font-family: var(--font-sans); font-size: 12px; font-weight: 600; white-space: nowrap; }
+.v10-layer-count { font-family: var(--font-mono); font-size: 10px; color: var(--text-ghost); margin-left: auto; }
+.v10-layer-items {
+  flex: 1; display: flex; align-items: center; gap: 6px;
+  padding: 5px 10px; overflow-x: auto; min-width: 0;
+}
+.v10-layer-chip {
+  flex-shrink: 0; display: flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border-radius: 6px; font-size: 11px;
+  border: 1px solid var(--border-default); background: var(--bg-surface);
+  cursor: pointer; transition: all 0.15s; max-width: 260px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.v10-layer-chip:hover { border-color: var(--border-strong); background: var(--bg-elevated); }
+.v10-chip-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.v10-chip-text { color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; }
+.v10-chip-meta { font-family: var(--font-mono); font-size: 9px; color: var(--text-ghost); flex-shrink: 0; }
+@keyframes v10-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+.v10-chip-activity { animation: v10-pulse 2s ease-in-out infinite; }
+.v10-memory-layer.wm { background: rgba(100,116,139,0.03); }
+.v10-memory-layer.wm .v10-layer-chip { border-style: dashed; opacity: 0.8; }
+.v10-memory-layer.wm .v10-layer-chip:hover { opacity: 1; }
+.v10-memory-layer.swm { background: rgba(245,158,11,0.02); }
+.v10-memory-layer.vm { background: rgba(34,197,94,0.02); }
+.v10-memory-layer.vm .v10-layer-chip { border-color: rgba(34,197,94,0.2); }
+.v10-layer-chevron {
+  font-size: 10px; color: var(--text-ghost); transition: transform 0.2s; margin-right: 2px;
+  flex-shrink: 0; width: 14px; text-align: center;
+}
+.v10-memory-layer.expanded .v10-layer-chevron { transform: rotate(90deg); }
+
+/* ── Expandable layer in overview ── */
+.v10-layer-expand-content {
+  max-height: 0; overflow: hidden; transition: max-height 0.3s ease;
+  background: var(--bg-root); border-bottom: 1px solid var(--border-subtle);
+}
+.v10-layer-expand-content.open { max-height: 700px; overflow: hidden; }
+.v10-layer-expand-content > .v10-split-pane { flex: 1; height: 100%; }
+.v10-layer-expand-content > .v10-split-pane > .v10-split-canvas { padding: 12px; overflow-y: auto; }
+.v10-layer-expand-content > .v10-split-pane > .v10-split-content { overflow-y: auto; }
+.v10-layer-expand-tabs {
+  display: flex; align-items: center; gap: 2px;
+  padding: 0 10px; border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel); height: 28px; min-height: 28px;
+}
+.v10-layer-expand-tab {
+  height: 100%; padding: 0 10px; font-size: 10px; font-weight: 500;
+  color: var(--text-tertiary); border: none; background: none; cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s; display: flex; align-items: center; gap: 4px;
+  font-family: var(--font-sans);
+}
+.v10-layer-expand-tab:hover { color: var(--text-secondary); }
+.v10-layer-expand-tab.active { color: var(--text-primary); border-bottom-color: var(--text-secondary); }
+.v10-layer-expand-items { padding: 0; }
+.v10-layer-expand-items .v10-item-row { padding: 6px 16px; }
+.v10-layer-expand-items .v10-item-row:last-child { border-bottom: none; }
+.v10-layer-expand-footer {
+  padding: 6px 16px 8px; display: flex; gap: 8px;
+}
+.v10-layer-expand-footer-btn {
+  font-size: 10px; font-weight: 600; color: var(--text-tertiary);
+  padding: 4px 10px; border-radius: 5px; border: 1px solid var(--border-default);
+  transition: all 0.15s; background: none; cursor: pointer; font-family: var(--font-sans);
+}
+.v10-layer-expand-footer-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.v10-layer-expand-footer-btn.promote { color: #f59e0b; border-color: rgba(245,158,11,0.25); }
+.v10-layer-expand-footer-btn.promote:hover { background: rgba(245,158,11,0.08); }
+.v10-layer-expand-footer-btn.publish { color: #22c55e; border-color: rgba(34,197,94,0.25); }
+.v10-layer-expand-footer-btn.publish:hover { background: rgba(34,197,94,0.08); }
+
+/* ── Item rows (shared by strip and layer views) ── */
+.v10-item-row {
+  display: flex; align-items: center; gap: 10px; padding: 8px 16px;
+  border-bottom: 1px solid var(--border-subtle); cursor: pointer; transition: background 0.1s;
+}
+.v10-item-row:hover { background: var(--bg-hover); }
+.v10-item-row.selected { background: var(--bg-active); }
+.v10-item-icon { font-size: 14px; width: 22px; text-align: center; flex-shrink: 0; color: var(--text-tertiary); }
+.v10-item-info { flex: 1; min-width: 0; }
+.v10-item-name { font-size: 12px; font-weight: 600; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v10-item-ual { font-size: 9px; color: var(--text-ghost); font-family: var(--font-mono); margin-top: 1px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v10-item-meta-row { display: flex; gap: 8px; margin-top: 1px; }
+.v10-item-type { font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.v10-item-count { font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono); }
+.v10-item-owner { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono); flex-shrink: 0; margin-right: 6px; }
+.v10-item-owner-dot { width: 5px; height: 5px; border-radius: 50%; }
+.v10-trust-badge {
+  display: inline-flex; align-items: center; gap: 3px; padding: 2px 7px;
+  border-radius: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.3px; flex-shrink: 0;
+}
+.v10-trust-badge.vm { background: rgba(34,197,94,0.12); color: #22c55e; }
+.v10-trust-badge.swm { background: rgba(245,158,11,0.12); color: #f59e0b; }
+.v10-trust-badge.wm { background: rgba(100,116,139,0.12); color: #94a3b8; }
+.v10-item-promote-btn {
+  padding: 3px 10px; border-radius: 5px; font-size: 10px; font-weight: 600;
+  border: 1px solid var(--border-default); color: var(--text-tertiary);
+  flex-shrink: 0; transition: all 0.15s; background: none; cursor: pointer;
+  font-family: var(--font-sans);
+}
+.v10-item-promote-btn:hover { border-color: var(--border-strong); color: var(--text-primary); }
+
+/* ── Layer Detail View (full WM/SWM/VM) ── */
+.v10-layer-detail { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+.v10-layer-detail-header {
+  padding: 12px 16px; border-bottom: 1px solid var(--border-subtle);
+  display: flex; align-items: center; gap: 10px;
+}
+.v10-layer-detail-icon { font-size: 18px; }
+.v10-layer-detail-title { font-size: 15px; font-weight: 600; color: var(--text-primary); }
+.v10-layer-detail-desc { font-size: 11px; color: var(--text-tertiary); margin-top: 1px; }
+.v10-layer-detail-actions { margin-left: auto; display: flex; gap: 6px; }
+.v10-layer-action-btn {
+  padding: 5px 12px; border-radius: 6px; font-size: 11px; font-weight: 600;
+  border: 1px solid var(--border-default); color: var(--text-secondary); transition: all 0.15s;
+  background: none; cursor: pointer; font-family: var(--font-sans);
+}
+.v10-layer-action-btn:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.v10-layer-action-btn.primary { background: rgba(34,197,94,0.08); color: #22c55e; border-color: rgba(34,197,94,0.3); }
+.v10-layer-action-btn.primary:hover { background: rgba(34,197,94,0.15); }
+.v10-layer-action-btn.promote { background: rgba(245,158,11,0.08); color: #f59e0b; border-color: rgba(245,158,11,0.25); }
+.v10-layer-action-btn.promote:hover { background: rgba(245,158,11,0.15); }
+.v10-layer-detail-content { flex: 1; overflow: auto; }
+
+/* ── Content tabs (inside layer views) ── */
+.v10-content-tabs {
+  flex-shrink: 0; display: flex; align-items: center;
+  border-bottom: 1px solid var(--border-subtle); background: var(--bg-panel);
+  padding: 0 12px; height: 32px; min-height: 32px; gap: 2px;
+}
+.v10-content-tab {
+  height: 100%; padding: 0 12px; font-size: 11px; font-weight: 500;
+  color: var(--text-tertiary); border: none; background: none; cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s; display: flex; align-items: center; gap: 5px;
+  font-family: var(--font-sans);
+}
+.v10-content-tab:hover { color: var(--text-secondary); }
+.v10-content-tab.active { color: var(--text-primary); border-bottom-color: var(--text-secondary); }
+.v10-content-tab-icon { font-size: 12px; }
+
+/* ── Split-Pane Layout (canvas left | content right) ── */
+.v10-split-pane {
+  display: flex; flex: 1; min-height: 0; overflow: hidden;
+}
+.v10-split-canvas {
+  flex: 1; min-width: 0; overflow-y: auto; padding: 16px;
+  border-right: 1px solid var(--border-subtle);
+  display: flex; flex-direction: column; gap: 12px;
+}
+.v10-split-content {
+  flex: 1; min-width: 0; display: flex; flex-direction: column; overflow: hidden;
+}
+
+/* ── Generative Widgets ── */
+.v10-gen-widget {
+  width: 100%; border: 1px solid var(--border-default);
+  border-radius: 10px; background: var(--bg-surface); overflow: hidden;
+  animation: v10SlideUp 0.3s ease;
+}
+@keyframes v10SlideUp { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+.v10-gen-widget-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px; border-bottom: 1px solid var(--border-subtle); background: var(--bg-elevated);
+}
+.v10-gen-widget-title { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.v10-gen-widget-right { display: flex; align-items: center; gap: 10px; }
+.v10-gen-widget-agent { display: flex; align-items: center; gap: 4px; font-size: 10px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.v10-gen-widget-agent-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent-blue); }
+.v10-gen-widget-dismiss {
+  font-size: 14px; color: var(--text-ghost); padding: 2px 4px; border-radius: 3px;
+  transition: all 0.15s; cursor: pointer; border: none; background: none;
+}
+.v10-gen-widget-dismiss:hover { color: var(--text-secondary); background: var(--bg-hover); }
+.v10-gen-widget-body { padding: 14px; }
+.v10-gen-widget-footnote { padding: 10px 14px; border-top: 1px solid var(--border-subtle); font-size: 10px; color: var(--text-ghost); line-height: 1.5; }
+.v10-gen-widget.dissolved { opacity: 0.3; filter: blur(1px); pointer-events: none; max-height: 40px; overflow: hidden; transition: all 0.5s; }
+
+/* Layer summary widget */
+.v10-layer-summary { display: flex; flex-direction: column; gap: 10px; }
+.v10-layer-summary-stat {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 6px 0; border-bottom: 1px solid var(--border-subtle);
+}
+.v10-layer-summary-stat:last-child { border-bottom: none; }
+.v10-layer-summary-label { font-size: 11px; color: var(--text-tertiary); }
+.v10-layer-summary-value { font-size: 12px; font-weight: 600; font-family: var(--font-mono); color: var(--text-primary); }
+.v10-layer-summary-bar { height: 4px; border-radius: 2px; background: var(--bg-hover); overflow: hidden; }
+.v10-layer-summary-bar-fill { height: 100%; border-radius: 2px; transition: width 0.4s ease; }
+
+/* Decision card widget */
+.v10-decision-question { font-size: 14px; font-weight: 600; color: var(--text-primary); margin-bottom: 10px; line-height: 1.4; }
+.v10-decision-context { font-size: 12px; color: var(--text-secondary); line-height: 1.6; margin-bottom: 14px; }
+.v10-decision-evidence {
+  padding: 10px 12px; border-radius: 6px; background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle); margin-bottom: 14px;
+}
+.v10-evidence-title { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-ghost); margin-bottom: 6px; }
+.v10-evidence-item { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-tertiary); padding: 2px 0; }
+.v10-evidence-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--text-ghost); flex-shrink: 0; }
+.v10-decision-actions { display: flex; gap: 8px; }
+.v10-decision-btn {
+  flex: 1; height: 32px; border-radius: 6px; font-size: 11px; font-weight: 600;
+  display: flex; align-items: center; justify-content: center; transition: all 0.15s; cursor: pointer;
+}
+.v10-decision-btn.approve { background: rgba(34,197,94,0.1); color: var(--accent-green); border: 1px solid rgba(34,197,94,0.3); }
+.v10-decision-btn.approve:hover { background: rgba(34,197,94,0.2); }
+.v10-decision-btn.revise { background: rgba(245,158,11,0.08); color: var(--accent-amber); border: 1px solid rgba(245,158,11,0.25); }
+.v10-decision-btn.revise:hover { background: rgba(245,158,11,0.15); }
+.v10-decision-btn.discuss { background: var(--bg-elevated); color: var(--text-secondary); border: 1px solid var(--border-default); }
+.v10-decision-btn.discuss:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* Canvas empty state */
+.v10-canvas-empty {
+  flex: 1; display: flex; flex-direction: column; align-items: center;
+  justify-content: center; text-align: center; color: var(--text-ghost); gap: 8px;
+  min-height: 120px;
+}
+.v10-canvas-empty-icon { font-size: 28px; opacity: 0.3; }
+.v10-canvas-empty-text { font-size: 11px; max-width: 240px; line-height: 1.6; }
+
+/* ── Provenance Bar ── */
+.v10-provenance-bar {
+  flex-shrink: 0; padding: 6px 14px; border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel); display: flex; align-items: center; gap: 8px;
+  font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono);
+}
+.v10-provenance-bar-dot { width: 4px; height: 4px; border-radius: 50%; background: #22c55e; }
+
+/* ── Graph view inside layer detail ── */
+.v10-graph-view {
+  flex: 1; position: relative; background: var(--bg-surface);
+  display: flex; align-items: center; justify-content: center; min-height: 300px;
+}
+.v10-graph-placeholder {
+  color: var(--text-ghost); font-size: 12px; font-family: var(--font-mono);
+}
+.v10-docs-placeholder {
+  flex: 1; display: flex; align-items: center; justify-content: center;
+  color: var(--text-ghost); font-size: 12px;
+}
+.v10-items-list { padding: 0; }
+
+/* ── KA Detail View ── */
+.v10-ka-detail { flex: 1; display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.v10-ka-header {
+  padding: 12px 20px; border-bottom: 1px solid var(--border-subtle);
+  display: flex; flex-direction: column; gap: 8px; flex-shrink: 0;
+}
+.v10-ka-back {
+  align-self: flex-start; border: 1px solid var(--border-default); border-radius: 5px;
+  background: none; color: var(--text-secondary); font-size: 11px; font-weight: 600;
+  padding: 4px 10px; cursor: pointer; font-family: var(--font-sans); transition: all 0.15s;
+}
+.v10-ka-back:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.v10-ka-header-left { display: flex; flex-direction: column; gap: 2px; }
+.v10-ka-label { font-size: 10px; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.5px; }
+.v10-ka-name { font-size: 15px; font-weight: 600; color: var(--text-primary); display: flex; align-items: center; gap: 8px; }
+.v10-ka-ual { font-size: 10px; color: var(--text-ghost); font-family: var(--font-mono); margin-top: 2px; }
+.v10-ka-split { display: flex; flex: 1; min-height: 0; overflow: hidden; }
+.v10-ka-left { flex: 1; min-width: 0; overflow-y: auto; padding: 16px 20px; border-right: 1px solid var(--border-subtle); }
+.v10-ka-right { width: 300px; flex-shrink: 0; overflow-y: auto; padding: 16px; }
+.v10-ka-section { margin-bottom: 16px; }
+.v10-ka-section-title {
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
+  color: var(--text-ghost); margin-bottom: 8px;
+}
+.v10-ka-desc { font-size: 12px; color: var(--text-secondary); line-height: 1.7; }
+.v10-ka-desc p { margin-bottom: 8px; }
+.v10-ka-meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; font-size: 10px; font-family: var(--font-mono); color: var(--text-ghost); }
+.v10-ka-meta-item { display: flex; align-items: center; gap: 4px; }
+.v10-ka-prop { display: flex; gap: 8px; padding: 4px 0; font-size: 11px; border-bottom: 1px solid var(--border-subtle); }
+.v10-ka-prop:last-child { border-bottom: none; }
+.v10-ka-prop-key { color: var(--text-tertiary); font-weight: 600; min-width: 120px; flex-shrink: 0; font-family: var(--font-mono); font-size: 10px; }
+.v10-ka-prop-val { color: var(--text-secondary); word-break: break-all; }
+.v10-ka-conn {
+  display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; padding: 5px 8px;
+  border-radius: 4px; cursor: pointer; border: none; background: none; color: inherit;
+  font-family: var(--font-sans); font-size: 11px; transition: background 0.1s;
+}
+.v10-ka-conn:hover { background: var(--bg-hover); }
+.v10-ka-conn-pred { color: var(--text-ghost); font-family: var(--font-mono); font-size: 10px; min-width: 80px; }
+.v10-ka-conn-arrow { color: var(--text-ghost); }
+.v10-ka-conn-target { color: var(--text-secondary); font-weight: 500; }
+.v10-ka-triples-table { width: 100%; border-collapse: collapse; font-size: 10px; font-family: var(--font-mono); }
+.v10-ka-triples-table th {
+  padding: 6px 8px; text-align: left; font-size: 9px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-ghost);
+  border-bottom: 1px solid var(--border-default); background: var(--bg-elevated);
+}
+.v10-ka-triples-table td {
+  padding: 5px 8px; border-bottom: 1px solid var(--border-subtle); color: var(--text-secondary);
+  max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.v10-ka-timeline { position: relative; padding-left: 24px; }
+.v10-ka-timeline::before { content: ''; position: absolute; left: 7px; top: 0; bottom: 0; width: 1px; background: var(--border-default); }
+.v10-ka-event { position: relative; padding: 0 0 16px 0; }
+.v10-ka-event:last-child { padding-bottom: 0; }
+.v10-ka-event-dot {
+  position: absolute; left: -21px; top: 2px; width: 10px; height: 10px;
+  border-radius: 50%; border: 2px solid var(--border-strong); background: var(--bg-elevated);
+}
+.v10-ka-event-dot.created { border-color: var(--layer-working); background: rgba(100,116,139,0.15); }
+.v10-ka-event-dot.shared { border-color: var(--layer-shared); background: rgba(245,158,11,0.15); }
+.v10-ka-event-dot.verified { border-color: var(--layer-verified); background: rgba(34,197,94,0.15); }
+.v10-ka-event-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 2px; }
+.v10-ka-event-title { font-size: 11px; font-weight: 600; color: var(--text-primary); }
+.v10-ka-event-time { font-family: var(--font-mono); font-size: 9px; color: var(--text-ghost); }
+.v10-ka-event-desc { font-size: 10px; color: var(--text-tertiary); line-height: 1.5; }

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useFetch } from '../hooks.js';
 import { api } from '../api-wrapper.js';
-import { listJoinRequests, approveJoinRequest, rejectJoinRequest, listParticipants, type PendingJoinRequest } from '../api.js';
+import { listJoinRequests, approveJoinRequest, rejectJoinRequest, listParticipants, listAssertions, promoteAssertion, publishSharedMemory, type PendingJoinRequest } from '../api.js';
 import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import { useMemoryEntities, type TrustLevel, type MemoryEntity, type Triple } from '../hooks/useMemoryEntities.js';
@@ -16,7 +16,7 @@ interface ProjectViewProps {
 }
 
 type LayerView = 'overview' | 'wm' | 'swm' | 'vm';
-type LayerContentTab = 'items' | 'graph' | 'docs';
+type LayerContentTab = 'items' | 'assertions' | 'graph' | 'docs';
 
 const TRUST_COLORS: Record<TrustLevel, string> = {
   verified: '#22c55e',
@@ -170,10 +170,11 @@ function ProjectOverviewCard({ cg, memory, participants }: {
   memory: ReturnType<typeof useMemoryEntities>;
   participants: string[];
 }) {
-  const { wm: working, swm: shared, vm: verified, total } = memory.counts;
-  const pctVm = total > 0 ? Math.round((verified / total) * 100) : 0;
-  const pctSwm = total > 0 ? Math.round((shared / total) * 100) : 0;
-  const pctWm = total > 0 ? 100 - pctVm - pctSwm : 0;
+  const { wm: working, swm: shared, vm: verified } = memory.counts;
+  const layerSum = working + shared + verified;
+  const pctVm = layerSum > 0 ? Math.round((verified / layerSum) * 100) : 0;
+  const pctSwm = layerSum > 0 ? Math.round((shared / layerSum) * 100) : 0;
+  const pctWm = layerSum > 0 ? Math.max(0, 100 - pctVm - pctSwm) : 0;
 
   return (
     <div className="v10-po">
@@ -185,7 +186,7 @@ function ProjectOverviewCard({ cg, memory, participants }: {
         </div>
       </div>
       <div className="v10-po-stats">
-        <div className="v10-po-stat"><span className="v10-po-stat-val">{total}</span><span className="v10-po-stat-label">KAs total</span></div>
+        <div className="v10-po-stat"><span className="v10-po-stat-val">{layerSum}</span><span className="v10-po-stat-label">Entities total</span></div>
         <div className="v10-po-stat"><span className="v10-po-stat-val">{working}</span><span className="v10-po-stat-label">in Working</span></div>
         <div className="v10-po-stat"><span className="v10-po-stat-val">{shared}</span><span className="v10-po-stat-label">in Shared</span></div>
         <div className="v10-po-stat"><span className="v10-po-stat-val">{verified}</span><span className="v10-po-stat-label">in Verified</span></div>
@@ -204,7 +205,7 @@ function ProjectOverviewCard({ cg, memory, participants }: {
           </div>
         </div>
       )}
-      {total > 0 && (
+      {layerSum > 0 && (
         <div className="v10-po-progress">
           <div className="v10-po-progress-label">
             <span>Knowledge Progress</span>
@@ -228,7 +229,7 @@ function ProjectOverviewCard({ cg, memory, participants }: {
 
 // ─── Pending Join Requests ───────────────────────────────────
 
-function PendingJoinRequestsBar({ contextGraphId }: { contextGraphId: string }) {
+function PendingJoinRequestsBar({ contextGraphId, onParticipantsChanged }: { contextGraphId: string; onParticipantsChanged?: () => void }) {
   const [requests, setRequests] = useState<PendingJoinRequest[]>([]);
   const [processing, setProcessing] = useState<string | null>(null);
 
@@ -245,6 +246,7 @@ function PendingJoinRequestsBar({ contextGraphId }: { contextGraphId: string }) 
     try {
       await approveJoinRequest(contextGraphId, addr);
       setRequests(prev => prev.filter(r => r.agentAddress !== addr));
+      onParticipantsChanged?.();
     } catch { /* noop */ } finally { setProcessing(null); }
   };
 
@@ -253,6 +255,7 @@ function PendingJoinRequestsBar({ contextGraphId }: { contextGraphId: string }) 
     try {
       await rejectJoinRequest(contextGraphId, addr);
       setRequests(prev => prev.filter(r => r.agentAddress !== addr));
+      onParticipantsChanged?.();
     } catch { /* noop */ } finally { setProcessing(null); }
   };
 
@@ -345,10 +348,11 @@ function MemoryStripGraph({ layerKey, memory }: {
 
 // ─── Memory Strip (expandable layer rows) ────────────────────
 
-function MemoryStrip({ memory, onSwitchLayer, onSelectEntity }: {
+function MemoryStrip({ memory, onSwitchLayer, onSelectEntity, contextGraphId }: {
   memory: ReturnType<typeof useMemoryEntities>;
   onSwitchLayer: (layer: LayerView) => void;
   onSelectEntity: (uri: string) => void;
+  contextGraphId: string;
 }) {
   const [expanded, setExpanded] = useState<string | null>(null);
   const [expandTab, setExpandTab] = useState<Record<string, string>>({ wm: 'items', swm: 'items', vm: 'items' });
@@ -443,7 +447,13 @@ function MemoryStrip({ memory, onSwitchLayer, onSelectEntity }: {
                     <button
                       className={`v10-layer-expand-tab ${activeTab === 'items' ? 'active' : ''}`}
                       onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'items' })); }}
-                    >Knowledge Assets</button>
+                    >{layer.key === 'vm' ? 'Knowledge Assets' : 'Entities'}</button>
+                    {layer.key !== 'vm' && (
+                      <button
+                        className={`v10-layer-expand-tab ${activeTab === 'assertions' ? 'active' : ''}`}
+                        onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'assertions' })); }}
+                      >Assertions</button>
+                    )}
                     <button
                       className={`v10-layer-expand-tab ${activeTab === 'graph' ? 'active' : ''}`}
                       onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'graph' })); }}
@@ -453,6 +463,9 @@ function MemoryStrip({ memory, onSwitchLayer, onSelectEntity }: {
                       onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'docs' })); }}
                     >Documents</button>
                   </div>
+                  {activeTab === 'assertions' && layer.key !== 'vm' && (
+                    <AssertionsList contextGraphId={contextGraphId} layer={layer.key as 'wm' | 'swm'} onComplete={memory.refresh} />
+                  )}
                   {activeTab === 'items' && (
                     <>
                       <div className="v10-layer-expand-items">
@@ -476,11 +489,6 @@ function MemoryStrip({ memory, onSwitchLayer, onSelectEntity }: {
                         })}
                       </div>
                       <div className="v10-layer-expand-footer">
-                        {layer.promoteLabel && (
-                          <button className={`v10-layer-expand-footer-btn ${layer.key === 'swm' ? 'publish' : 'promote'}`} onClick={e => e.stopPropagation()}>
-                            {layer.promoteLabel}
-                          </button>
-                        )}
                         <button className="v10-layer-expand-footer-btn" onClick={e => { e.stopPropagation(); onSwitchLayer(layer.viewLayer); }}>
                           View full layer →
                         </button>
@@ -492,7 +500,7 @@ function MemoryStrip({ memory, onSwitchLayer, onSelectEntity }: {
                   )}
                   {activeTab === 'docs' && (
                     <div style={{ maxHeight: 300, overflow: 'auto' }}>
-                      <DocumentsList entities={layer.entities} />
+                      <DocumentsList entities={layer.entities} contextGraphId={contextGraphId} />
                     </div>
                   )}
                 </div>
@@ -618,38 +626,79 @@ function LayerStatsWidget({ entities, triples, layer }: {
   );
 }
 
-function LayerActionsWidget({ layer, count }: { layer: 'wm' | 'swm'; count: number }) {
+function LayerActionsWidget({ layer, count, contextGraphId, onComplete }: {
+  layer: 'wm' | 'swm';
+  count: number;
+  contextGraphId: string;
+  onComplete: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
   if (count === 0) return null;
   const isWm = layer === 'wm';
   const color = isWm ? '#f59e0b' : '#22c55e';
   const target = isWm ? 'Shared Memory' : 'Verified Memory';
 
+  const handleAction = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      if (isWm) {
+        const assertions = await listAssertions(contextGraphId);
+        let promoted = 0;
+        for (const a of assertions) {
+          const res = await promoteAssertion(contextGraphId, a.name);
+          promoted += res.promotedCount;
+        }
+        setResult(`Promoted ${promoted} triple${promoted !== 1 ? 's' : ''} to Shared Memory`);
+      } else {
+        await publishSharedMemory(contextGraphId);
+        setResult('Published to Verified Memory');
+      }
+      onComplete();
+    } catch (err: any) {
+      setError(err.message ?? 'Action failed');
+    } finally {
+      setBusy(false);
+    }
+  }, [isWm, contextGraphId, onComplete]);
+
   return (
-    <GenWidget title={isWm ? 'Promote' : 'Publish'} footnote={`Moves ${count} asset${count !== 1 ? 's' : ''} to ${target}.`}>
+    <GenWidget title={isWm ? 'Promote' : 'Publish'} footnote={`Moves assets from this layer to ${target}.`}>
       <div className="v10-decision-context" style={{ marginBottom: 10 }}>
         {count} asset{count !== 1 ? 's' : ''} in this layer can be {isWm ? 'promoted to Shared Memory for collaborative review' : 'published to Verified Memory on-chain'}.
       </div>
+      {result && <div style={{ fontSize: 11, color: 'var(--accent-green)', marginBottom: 8 }}>✓ {result}</div>}
+      {error && <div style={{ fontSize: 11, color: 'var(--accent-red)', marginBottom: 8 }}>✕ {error}</div>}
       <div className="v10-decision-actions">
-        <button className="v10-decision-btn approve" style={{ borderColor: `${color}50`, color, background: `${color}15` }}>
-          ✓ {isWm ? 'Promote All → Shared' : 'Publish All → VM'}
+        <button
+          className="v10-decision-btn approve"
+          style={{ borderColor: `${color}50`, color, background: `${color}15`, opacity: busy ? 0.5 : 1 }}
+          disabled={busy}
+          onClick={handleAction}
+        >
+          {busy ? '...' : `✓ ${isWm ? 'Promote All → Shared' : 'Publish All → VM'}`}
         </button>
-        <button className="v10-decision-btn discuss">Review First</button>
       </div>
     </GenWidget>
   );
 }
 
-function CanvasPanel({ layer, entities, tripleCount }: {
+function CanvasPanel({ layer, entities, tripleCount, contextGraphId, onComplete }: {
   layer: 'wm' | 'swm' | 'vm';
   entities: MemoryEntity[];
   tripleCount: number;
+  contextGraphId: string;
+  onComplete: () => void;
 }) {
   return (
     <div className="v10-split-canvas">
       <LayerStatsWidget entities={entities} triples={tripleCount} layer={layer} />
       <TypeBreakdownWidget entities={entities} />
       {(layer === 'wm' || layer === 'swm') && (
-        <LayerActionsWidget layer={layer} count={entities.length} />
+        <LayerActionsWidget layer={layer} count={entities.length} contextGraphId={contextGraphId} onComplete={onComplete} />
       )}
       {entities.length === 0 && (
         <div className="v10-canvas-empty">
@@ -663,14 +712,127 @@ function CanvasPanel({ layer, entities, tripleCount }: {
   );
 }
 
+// ─── Assertions List (WM/SWM named graphs) ──────────────────
+
+function AssertionsList({ contextGraphId, layer, onComplete }: {
+  contextGraphId: string;
+  layer: 'wm' | 'swm';
+  onComplete: () => void;
+}) {
+  const { data: assertions, loading, refresh } = useFetch(
+    () => listAssertions(contextGraphId),
+    [contextGraphId],
+    0
+  );
+  const [busy, setBusy] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePromote = useCallback(async (name: string) => {
+    setBusy(name);
+    setResult(null);
+    setError(null);
+    try {
+      if (layer === 'wm') {
+        const res = await promoteAssertion(contextGraphId, name);
+        setResult(`Promoted ${res.promotedCount} triples to Shared Memory`);
+      } else {
+        await publishSharedMemory(contextGraphId);
+        setResult('Published to Verified Memory');
+      }
+      refresh();
+      onComplete();
+    } catch (err: any) {
+      setError(err.message ?? 'Action failed');
+    } finally {
+      setBusy(null);
+    }
+  }, [contextGraphId, layer, refresh, onComplete]);
+
+  const handlePromoteAll = useCallback(async () => {
+    if (!assertions?.length) return;
+    setBusy('__all__');
+    setResult(null);
+    setError(null);
+    try {
+      if (layer === 'wm') {
+        let total = 0;
+        for (const a of assertions) {
+          const res = await promoteAssertion(contextGraphId, a.name);
+          total += res.promotedCount;
+        }
+        setResult(`Promoted ${total} triples across ${assertions.length} assertion${assertions.length !== 1 ? 's' : ''}`);
+      } else {
+        await publishSharedMemory(contextGraphId);
+        setResult('Published all to Verified Memory');
+      }
+      refresh();
+      onComplete();
+    } catch (err: any) {
+      setError(err.message ?? 'Action failed');
+    } finally {
+      setBusy(null);
+    }
+  }, [assertions, contextGraphId, layer, refresh, onComplete]);
+
+  if (loading) {
+    return <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-ghost)', fontSize: 12 }}>Loading assertions...</div>;
+  }
+
+  if (!assertions?.length) {
+    return <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-ghost)', fontSize: 12 }}>No assertions in this layer</div>;
+  }
+
+  const actionLabel = layer === 'wm' ? 'Promote → Shared' : 'Publish → VM';
+  const actionAllLabel = layer === 'wm' ? 'Promote All → Shared' : 'Publish All → VM';
+
+  return (
+    <div style={{ flex: 1, overflow: 'auto' }}>
+      <div style={{ padding: '8px 16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--border-subtle)' }}>
+        <span style={{ fontSize: 11, color: 'var(--text-tertiary)' }}>{assertions.length} assertion{assertions.length !== 1 ? 's' : ''}</span>
+        <button
+          className={`v10-layer-expand-footer-btn ${layer === 'wm' ? 'promote' : 'publish'}`}
+          disabled={busy !== null}
+          onClick={handlePromoteAll}
+          style={{ opacity: busy === '__all__' ? 0.5 : 1 }}
+        >
+          {busy === '__all__' ? '...' : actionAllLabel}
+        </button>
+      </div>
+      {result && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--accent-green)' }}>✓ {result}</div>}
+      {error && <div style={{ padding: '6px 16px', fontSize: 11, color: 'var(--accent-red)' }}>✕ {error}</div>}
+      {assertions.map(a => (
+        <div key={a.name} className="v10-item-row">
+          <span className="v10-item-icon">▤</span>
+          <div className="v10-item-info">
+            <div className="v10-item-name" style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>{a.name}</div>
+            <div className="v10-item-meta-row">
+              {a.tripleCount != null && <span className="v10-item-count">{a.tripleCount} triples</span>}
+            </div>
+          </div>
+          <button
+            className={`v10-layer-expand-footer-btn ${layer === 'wm' ? 'promote' : 'publish'}`}
+            disabled={busy !== null}
+            onClick={ev => { ev.stopPropagation(); handlePromote(a.name); }}
+            style={{ opacity: busy === a.name ? 0.5 : 1, flexShrink: 0 }}
+          >
+            {busy === a.name ? '...' : actionLabel}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // ─── Full Layer Detail View (WM / SWM / VM) ─────────────────
 
-function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntity }: {
+function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntity, contextGraphId }: {
   layer: 'wm' | 'swm' | 'vm';
   memory: ReturnType<typeof useMemoryEntities>;
   nodeColors: Record<string, string>;
   onNodeClick: (node: any) => void;
   onSelectEntity: (uri: string) => void;
+  contextGraphId: string;
 }) {
   const [contentTab, setContentTab] = useState<LayerContentTab>('items');
 
@@ -724,14 +886,19 @@ function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntit
     <div className="v10-layer-detail">
       <div className="v10-split-pane">
         {/* Left: Generative Canvas */}
-        <CanvasPanel layer={layer} entities={entities} tripleCount={layerTriples.length} />
+        <CanvasPanel layer={layer} entities={entities} tripleCount={layerTriples.length} contextGraphId={contextGraphId} onComplete={memory.refresh} />
 
         {/* Right: Content Tabs */}
         <div className="v10-split-content">
           <div className="v10-content-tabs">
             <button className={`v10-content-tab ${contentTab === 'items' ? 'active' : ''}`} onClick={() => setContentTab('items')}>
-              <span className="v10-content-tab-icon">◈</span> Knowledge Assets
+              <span className="v10-content-tab-icon">◈</span> {layer === 'vm' ? 'Knowledge Assets' : 'Entities'}
             </button>
+            {layer !== 'vm' && (
+              <button className={`v10-content-tab ${contentTab === 'assertions' ? 'active' : ''}`} onClick={() => setContentTab('assertions')}>
+                <span className="v10-content-tab-icon">▤</span> Assertions
+              </button>
+            )}
             <button className={`v10-content-tab ${contentTab === 'graph' ? 'active' : ''}`} onClick={() => setContentTab('graph')}>
               <span className="v10-content-tab-icon">⬡</span> Graph
             </button>
@@ -748,11 +915,7 @@ function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntit
                   <div className="v10-layer-detail-title">{config.title}</div>
                   <div className="v10-layer-detail-desc">{config.desc}</div>
                 </div>
-                <div className="v10-layer-detail-actions">
-                  {config.actionLabel && (
-                    <button className={`v10-layer-action-btn ${config.actionClass}`}>{config.actionLabel}</button>
-                  )}
-                </div>
+                <div className="v10-layer-detail-actions" />
               </div>
               <div className="v10-layer-detail-content">
                 <div className="v10-items-list">
@@ -772,8 +935,6 @@ function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntit
                         <span className={`v10-trust-badge ${layer}`}>
                           {config.icon} {layer === 'vm' ? 'Verified' : layer === 'swm' ? 'Shared' : 'Working'}
                         </span>
-                        {layer === 'wm' && <button className="v10-item-promote-btn" onClick={ev => ev.stopPropagation()}>→ Shared</button>}
-                        {layer === 'swm' && <button className="v10-item-promote-btn" onClick={ev => ev.stopPropagation()}>→ VM</button>}
                       </div>
                     );
                   })}
@@ -785,6 +946,10 @@ function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntit
                 </div>
               </div>
             </>
+          )}
+
+          {contentTab === 'assertions' && layer !== 'vm' && (
+            <AssertionsList contextGraphId={contextGraphId} layer={layer} onComplete={memory.refresh} />
           )}
 
           {contentTab === 'graph' && (
@@ -807,7 +972,7 @@ function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntit
           )}
 
           {contentTab === 'docs' && (
-            <DocumentsList entities={entities} />
+            <DocumentsList entities={entities} contextGraphId={contextGraphId} />
           )}
         </div>
       </div>
@@ -822,7 +987,7 @@ const MARKDOWN_FORM = 'http://dkg.io/ontology/markdownForm';
 const SOURCE_FILE = 'http://dkg.io/ontology/sourceFile';
 const DKG_SIZE = 'http://dkg.io/ontology/size';
 
-function DocumentsList({ entities }: { entities: MemoryEntity[] }) {
+function DocumentsList({ entities, contextGraphId }: { entities: MemoryEntity[]; contextGraphId?: string }) {
   const openTab = useTabsStore(s => s.openTab);
 
   const docs = useMemo(() => {
@@ -832,8 +997,9 @@ function DocumentsList({ entities }: { entities: MemoryEntity[] }) {
   const handleOpenDoc = (e: MemoryEntity) => {
     const fileRef = e.connections.find(c => c.predicate === MARKDOWN_FORM || c.predicate === SOURCE_FILE)?.targetUri;
     const fileHash = fileRef?.replace('urn:dkg:file:', '') ?? '';
+    const scope = contextGraphId ? `${contextGraphId}:` : '';
     openTab({
-      id: `doc:${fileHash || e.uri}`,
+      id: `doc:${scope}${fileHash || e.uri}`,
       label: e.label,
       closable: true,
       icon: '📄',
@@ -1146,13 +1312,15 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
 
   const memory = useMemoryEntities(contextGraphId);
 
-  useEffect(() => {
+  const refreshParticipants = useCallback(() => {
     if (cg?.id) {
       listParticipants(cg.id)
         .then(data => setParticipants(data.allowedAgents))
         .catch(() => setParticipants([]));
     }
   }, [cg?.id]);
+
+  useEffect(() => { refreshParticipants(); }, [refreshParticipants]);
 
   const selectedEntity = useMemo(
     () => selectedUri ? memory.entities.get(selectedUri) ?? null : null,
@@ -1205,14 +1373,14 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
       {activeLayer === 'overview' && !selectedEntity && (
         <>
           <ProjectOverviewCard cg={cg} memory={memory} participants={participants} />
-          <PendingJoinRequestsBar contextGraphId={contextGraphId} />
+          <PendingJoinRequestsBar contextGraphId={contextGraphId} onParticipantsChanged={refreshParticipants} />
           {memory.loading && (
             <div className="v10-me-loading"><div className="v10-me-loading-text">Loading memory...</div></div>
           )}
           {memory.error && (
             <div className="v10-me-error">Error: {memory.error}</div>
           )}
-          <MemoryStrip memory={memory} onSwitchLayer={setActiveLayer} onSelectEntity={handleNavigate} />
+          <MemoryStrip memory={memory} onSwitchLayer={setActiveLayer} onSelectEntity={handleNavigate} contextGraphId={contextGraphId} />
         </>
       )}
 
@@ -1224,6 +1392,7 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           nodeColors={nodeColors}
           onNodeClick={handleNodeClick}
           onSelectEntity={handleNavigate}
+          contextGraphId={contextGraphId}
         />
       )}
 

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -1,11 +1,11 @@
 import React, { useMemo, useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import { useFetch } from '../hooks.js';
 import { api } from '../api-wrapper.js';
-import { listJoinRequests, approveJoinRequest, rejectJoinRequest, type PendingJoinRequest } from '../api.js';
+import { listJoinRequests, approveJoinRequest, rejectJoinRequest, listParticipants, type PendingJoinRequest } from '../api.js';
 import { ImportFilesModal } from '../components/Modals/ImportFilesModal.js';
 import { ShareProjectModal } from '../components/Modals/ShareProjectModal.js';
 import { useMemoryEntities, type TrustLevel, type MemoryEntity, type Triple } from '../hooks/useMemoryEntities.js';
-import { TrustSummaryBar, TrustBadge } from '../components/MemoryExplorer/TrustIndicator.js';
+import { useTabsStore } from '../stores/tabs.js';
 
 const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))
@@ -15,18 +15,13 @@ interface ProjectViewProps {
   contextGraphId: string;
 }
 
-type ViewTab = 'timeline' | 'graph' | 'knowledge';
+type LayerView = 'overview' | 'wm' | 'swm' | 'vm';
+type LayerContentTab = 'items' | 'graph' | 'docs';
 
 const TRUST_COLORS: Record<TrustLevel, string> = {
   verified: '#22c55e',
   shared: '#f59e0b',
   working: '#64748b',
-};
-
-const TRUST_LABELS: Record<TrustLevel, string> = {
-  verified: 'Verified',
-  shared: 'Shared',
-  working: 'Private',
 };
 
 const TYPE_LABELS: Record<string, { icon: string; group: string }> = {
@@ -64,19 +59,6 @@ function entityMeta(e: MemoryEntity) {
   return { ...info, type: primaryType };
 }
 
-function isConversationTurn(e: MemoryEntity): boolean {
-  return e.types.some(t => t.includes('ConversationTurn'));
-}
-
-function getDate(e: MemoryEntity): string | null {
-  const datePreds = ['http://schema.org/startDate', 'http://schema.org/dateCreated', 'http://schema.org/datePublished'];
-  for (const p of datePreds) {
-    const v = e.properties.get(p);
-    if (v?.[0]) return v[0];
-  }
-  return null;
-}
-
 function getDescription(e: MemoryEntity): string | null {
   const descPreds = ['http://schema.org/description', 'http://schema.org/text'];
   for (const p of descPreds) {
@@ -85,26 +67,6 @@ function getDescription(e: MemoryEntity): string | null {
   }
   return null;
 }
-
-function getAgentTool(e: MemoryEntity): string | null {
-  const v = e.properties.get('http://schema.org/additionalType');
-  return v?.[0] ?? null;
-}
-
-function humanizeLabel(entity: MemoryEntity | undefined, uri: string): string {
-  if (entity) return entity.label;
-  const slash = uri.lastIndexOf('/');
-  const hash = uri.lastIndexOf('#');
-  const cut = Math.max(slash, hash);
-  return cut >= 0 ? uri.slice(cut + 1) : uri;
-}
-
-const CONTRIBUTOR_PREDS = new Set([
-  'http://schema.org/contributor',
-  'http://schema.org/author',
-  'http://schema.org/agent',
-  'http://schema.org/creator',
-]);
 
 function neighborhoodTriples(entityUri: string, allTriples: Triple[], hops: number = 2): Triple[] {
   const visited = new Set<string>([entityUri]);
@@ -128,558 +90,825 @@ function neighborhoodTriples(entityUri: string, allTriples: Triple[], hops: numb
   return allTriples.filter(t => visited.has(t.subject) || visited.has(t.object));
 }
 
-// ─── Trust Status Box ────────────────────────────────────────
+function matchesSearch(e: MemoryEntity, q: string): boolean {
+  const lower = q.toLowerCase();
+  if (e.label.toLowerCase().includes(lower)) return true;
+  if (e.uri.toLowerCase().includes(lower)) return true;
+  for (const t of e.types) if (shortType(t).toLowerCase().includes(lower)) return true;
+  for (const [, vals] of e.properties) {
+    for (const v of vals) if (v.toLowerCase().includes(lower)) return true;
+  }
+  for (const c of e.connections) if (c.targetLabel.toLowerCase().includes(lower)) return true;
+  return false;
+}
 
-function TrustStatusBox({ level }: { level: TrustLevel }) {
-  const color = TRUST_COLORS[level];
-  const label = TRUST_LABELS[level];
+function humanizeLabel(entity: MemoryEntity | undefined, uri: string): string {
+  if (entity) return entity.label;
+  const slash = uri.lastIndexOf('/');
+  const hash = uri.lastIndexOf('#');
+  const cut = Math.max(slash, hash);
+  return cut >= 0 ? uri.slice(cut + 1) : uri;
+}
+
+// ─── Layer Switcher Bar ──────────────────────────────────────
+
+function LayerSwitcher({ active, counts, onSwitch, onShare, onImport, onRefresh }: {
+  active: LayerView;
+  counts: { wm: number; swm: number; vm: number; total: number };
+  onSwitch: (v: LayerView) => void;
+  onShare: () => void;
+  onImport: () => void;
+  onRefresh: () => void;
+}) {
   return (
-    <span className="v10-trust-status-box" style={{ borderColor: color, color }}>
-      {label}
-    </span>
+    <div className="v10-layer-switcher">
+      <button
+        className={`v10-layer-switch-btn ${active === 'overview' ? 'active' : ''}`}
+        data-layer="overview"
+        onClick={() => onSwitch('overview')}
+      >
+        <span className="v10-layer-switch-icon">◎</span> Overview
+      </button>
+      <button
+        className={`v10-layer-switch-btn ${active === 'wm' ? 'active' : ''}`}
+        data-layer="wm"
+        onClick={() => onSwitch('wm')}
+      >
+        <span className="v10-layer-switch-icon" style={{ color: '#64748b' }}>◇</span> Working Memory
+        {counts.wm > 0 && <span className="v10-layer-switch-count">{counts.wm}</span>}
+      </button>
+      <button
+        className={`v10-layer-switch-btn ${active === 'swm' ? 'active' : ''}`}
+        data-layer="swm"
+        onClick={() => onSwitch('swm')}
+      >
+        <span className="v10-layer-switch-icon" style={{ color: '#f59e0b' }}>◈</span> Shared Memory
+        {counts.swm > 0 && <span className="v10-layer-switch-count">{counts.swm}</span>}
+      </button>
+      <button
+        className={`v10-layer-switch-btn ${active === 'vm' ? 'active' : ''}`}
+        data-layer="vm"
+        onClick={() => onSwitch('vm')}
+      >
+        <span className="v10-layer-switch-icon" style={{ color: '#22c55e' }}>◉</span> Verified Memory
+        {counts.vm > 0 && <span className="v10-layer-switch-count">{counts.vm}</span>}
+      </button>
+      <div className="v10-layer-switcher-spacer" />
+      <div className="v10-layer-switcher-actions">
+        <button className="v10-layer-action-btn" onClick={onShare}>⤴ Share</button>
+        <button className="v10-layer-action-btn" onClick={onImport}>↑ Import</button>
+        <button className="v10-layer-action-btn" onClick={onRefresh}>↻</button>
+      </div>
+    </div>
   );
 }
 
-// ─── Project Home Header ─────────────────────────────────────
+// ─── Project Overview Card ───────────────────────────────────
 
-function ProjectHome({ cg, memory }: {
+function ProjectOverviewCard({ cg, memory, participants }: {
   cg: any;
   memory: ReturnType<typeof useMemoryEntities>;
+  participants: string[];
 }) {
-  const [allowedAgents, setAllowedAgents] = useState<string[]>([]);
-  const [pendingRequests, setPendingRequests] = useState<PendingJoinRequest[]>([]);
-  const [processingRequest, setProcessingRequest] = useState<string | null>(null);
+  const { wm: working, swm: shared, vm: verified, total } = memory.counts;
+  const pctVm = total > 0 ? Math.round((verified / total) * 100) : 0;
+  const pctSwm = total > 0 ? Math.round((shared / total) * 100) : 0;
+  const pctWm = total > 0 ? 100 - pctVm - pctSwm : 0;
+
+  return (
+    <div className="v10-po">
+      <div className="v10-po-top">
+        <span className="v10-po-dot" />
+        <div>
+          <div className="v10-po-title">{cg.name || cg.id}</div>
+          {cg.description && <div className="v10-po-desc">{cg.description}</div>}
+        </div>
+      </div>
+      <div className="v10-po-stats">
+        <div className="v10-po-stat"><span className="v10-po-stat-val">{total}</span><span className="v10-po-stat-label">KAs total</span></div>
+        <div className="v10-po-stat"><span className="v10-po-stat-val">{working}</span><span className="v10-po-stat-label">in Working</span></div>
+        <div className="v10-po-stat"><span className="v10-po-stat-val">{shared}</span><span className="v10-po-stat-label">in Shared</span></div>
+        <div className="v10-po-stat"><span className="v10-po-stat-val">{verified}</span><span className="v10-po-stat-label">in Verified</span></div>
+        <div className="v10-po-stat"><span className="v10-po-stat-val">{participants.length}</span><span className="v10-po-stat-label">participants</span></div>
+      </div>
+      {participants.length > 0 && (
+        <div className="v10-po-participants">
+          <div className="v10-po-participants-label">Participants</div>
+          <div className="v10-po-participants-list">
+            {participants.map(addr => (
+              <span key={addr} className="v10-po-participant" title={addr}>
+                <span className="v10-po-participant-dot" style={{ background: '#3b82f6' }} />
+                {addr.slice(0, 6)}…{addr.slice(-4)}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      {total > 0 && (
+        <div className="v10-po-progress">
+          <div className="v10-po-progress-label">
+            <span>Knowledge Progress</span>
+            <span style={{ color: '#22c55e', fontWeight: 600 }}>{pctVm}% verified</span>
+          </div>
+          <div className="v10-po-progress-bar">
+            {pctVm > 0 && <div className="v10-po-progress-seg vm" style={{ width: `${pctVm}%` }} />}
+            {pctSwm > 0 && <div className="v10-po-progress-seg swm" style={{ width: `${pctSwm}%` }} />}
+            {pctWm > 0 && <div className="v10-po-progress-seg wm" style={{ width: `${pctWm}%` }} />}
+          </div>
+          <div className="v10-po-progress-legend">
+            <span className="v10-po-legend-item"><span className="v10-po-legend-dot" style={{ background: '#22c55e' }} />Verified ({verified})</span>
+            <span className="v10-po-legend-item"><span className="v10-po-legend-dot" style={{ background: '#f59e0b' }} />Shared ({shared})</span>
+            <span className="v10-po-legend-item"><span className="v10-po-legend-dot" style={{ background: '#64748b' }} />Working ({working})</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Pending Join Requests ───────────────────────────────────
+
+function PendingJoinRequestsBar({ contextGraphId }: { contextGraphId: string }) {
+  const [requests, setRequests] = useState<PendingJoinRequest[]>([]);
+  const [processing, setProcessing] = useState<string | null>(null);
 
   useEffect(() => {
-    if (cg?.id) {
-      import('../api.js').then(({ listParticipants }) =>
-        listParticipants(cg.id)
-          .then((data) => setAllowedAgents(data.allowedAgents))
-          .catch(() => setAllowedAgents([]))
-      );
-      listJoinRequests(cg.id)
-        .then((data) => setPendingRequests(data.requests.filter(r => r.status === 'pending')))
-        .catch(() => setPendingRequests([]));
-    }
-  }, [cg?.id]);
+    listJoinRequests(contextGraphId)
+      .then(data => setRequests(data.requests.filter(r => r.status === 'pending')))
+      .catch(() => setRequests([]));
+  }, [contextGraphId]);
 
-  const handleApproveRequest = async (addr: string) => {
-    setProcessingRequest(addr);
+  if (requests.length === 0) return null;
+
+  const handleApprove = async (addr: string) => {
+    setProcessing(addr);
     try {
-      await approveJoinRequest(cg.id, addr);
-      setPendingRequests(prev => prev.filter(r => r.agentAddress !== addr));
-      setAllowedAgents(prev => [...prev, addr]);
-    } catch {
-      // silently fail
-    } finally {
-      setProcessingRequest(null);
-    }
+      await approveJoinRequest(contextGraphId, addr);
+      setRequests(prev => prev.filter(r => r.agentAddress !== addr));
+    } catch { /* noop */ } finally { setProcessing(null); }
   };
 
-  const handleRejectRequest = async (addr: string) => {
-    setProcessingRequest(addr);
+  const handleReject = async (addr: string) => {
+    setProcessing(addr);
     try {
-      await rejectJoinRequest(cg.id, addr);
-      setPendingRequests(prev => prev.filter(r => r.agentAddress !== addr));
-    } catch {
-      // silently fail
-    } finally {
-      setProcessingRequest(null);
-    }
-  };
-
-  const knowledgeAgents = useMemo(() => {
-    const found: Array<{ uri: string; label: string; tool: string | null }> = [];
-    const seen = new Set<string>();
-    for (const [, e] of memory.entities) {
-      const isPerson = e.types.some(t => t.includes('Person'));
-      const isAgent = e.types.some(t => t.includes('SoftwareApplication'));
-      if (!isPerson && !isAgent) continue;
-      const tool = getAgentTool(e);
-      if ((tool || isPerson) && !seen.has(e.uri)) {
-        seen.add(e.uri);
-        found.push({ uri: e.uri, label: e.label, tool });
-      }
-    }
-    return found;
-  }, [memory.entities]);
-
-  const participantCount = allowedAgents.length || knowledgeAgents.length;
-
-  const turnCount = useMemo(() => {
-    let c = 0;
-    for (const e of memory.entityList) {
-      if (isConversationTurn(e)) c++;
-    }
-    return c;
-  }, [memory.entityList]);
-
-  return (
-    <div className="v10-ph">
-      {cg.description && <p className="v10-ph-desc">{cg.description}</p>}
-      <div className="v10-ph-stats">
-        <div className="v10-ph-stat">
-          <span className="v10-ph-stat-val">{memory.counts.total}</span>
-          <span className="v10-ph-stat-label">entities</span>
-        </div>
-        <div className="v10-ph-stat">
-          <span className="v10-ph-stat-val">{memory.graphTriples.length}</span>
-          <span className="v10-ph-stat-label">facts</span>
-        </div>
-        <div className="v10-ph-stat">
-          <span className="v10-ph-stat-val">{turnCount}</span>
-          <span className="v10-ph-stat-label">turns</span>
-        </div>
-        <div className="v10-ph-stat">
-          <span className="v10-ph-stat-val">{participantCount}</span>
-          <span className="v10-ph-stat-label">participants</span>
-        </div>
-      </div>
-      {(allowedAgents.length > 0 || knowledgeAgents.length > 0) && (
-        <div className="v10-ph-agents">
-          <span className="v10-ph-agents-label">Participants</span>
-          <div className="v10-ph-agents-list">
-            {allowedAgents.length > 0
-              ? allowedAgents.map(addr => (
-                  <span key={addr} className="v10-ph-agent-chip" title={`did:dkg:agent:${addr}`}>
-                    {addr.slice(0, 6)}…{addr.slice(-4)}
-                  </span>
-                ))
-              : knowledgeAgents.map(a => (
-                  <span key={a.uri} className="v10-ph-agent-chip">
-                    {a.label}
-                    {a.tool && <span className="v10-ph-agent-tool">{a.tool}</span>}
-                  </span>
-                ))
-            }
-          </div>
-        </div>
-      )}
-
-      {pendingRequests.length > 0 && (
-        <div className="v10-ph-join-requests">
-          <span className="v10-ph-agents-label">
-            Pending Join Requests
-            <span className="v10-ph-join-badge">{pendingRequests.length}</span>
-          </span>
-          <div className="v10-ph-join-list">
-            {pendingRequests.map(req => (
-              <div key={req.agentAddress} className="v10-ph-join-item">
-                <div className="v10-ph-join-info">
-                  <span className="v10-ph-join-name">{req.name || `${req.agentAddress.slice(0, 6)}…${req.agentAddress.slice(-4)}`}</span>
-                  <span className="v10-ph-join-addr" title={req.agentAddress}>{req.agentAddress.slice(0, 10)}…</span>
-                </div>
-                <div className="v10-ph-join-actions">
-                  <button
-                    className="v10-ph-join-btn approve"
-                    onClick={() => handleApproveRequest(req.agentAddress)}
-                    disabled={processingRequest === req.agentAddress}
-                  >
-                    {processingRequest === req.agentAddress ? '…' : '✓ Approve'}
-                  </button>
-                  <button
-                    className="v10-ph-join-btn reject"
-                    onClick={() => handleRejectRequest(req.agentAddress)}
-                    disabled={processingRequest === req.agentAddress}
-                  >
-                    ✕
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ─── Timeline (only dated items — conversation turns + dated entities) ─────
-
-function TimelineView({ memory, search, onSelect }: {
-  memory: ReturnType<typeof useMemoryEntities>;
-  search: string;
-  onSelect: (uri: string) => void;
-}) {
-  const items = useMemo(() => {
-    const dated: Array<{ date: string; time: string | null; entity: MemoryEntity; isConvTurn: boolean }> = [];
-
-    for (const e of memory.entityList) {
-      if (search && !matchesSearch(e, search)) continue;
-      const d = getDate(e);
-      if (!d) continue;
-      const isTurn = isConversationTurn(e);
-      const dateStr = d.split('T')[0] ?? d;
-      const timeStr = d.includes('T') ? d.split('T')[1]?.slice(0, 5) ?? null : null;
-      dated.push({ date: dateStr, time: timeStr, entity: e, isConvTurn: isTurn });
-    }
-
-    dated.sort((a, b) => {
-      const cmp = b.date.localeCompare(a.date);
-      if (cmp !== 0) return cmp;
-      return (b.time ?? '').localeCompare(a.time ?? '');
-    });
-
-    const dateGroups = new Map<string, typeof dated>();
-    for (const item of dated) {
-      const list = dateGroups.get(item.date) ?? [];
-      list.push(item);
-      dateGroups.set(item.date, list);
-    }
-
-    return [...dateGroups.entries()];
-  }, [memory.entityList, search]);
-
-  if (items.length === 0) {
-    return <div className="v10-tl-empty">No dated entries found.</div>;
-  }
-
-  return (
-    <div className="v10-tl-scroll">
-      {items.map(([date, entries]) => (
-        <div key={date} className="v10-tl-date-group">
-          <div className="v10-tl-date-label">{date}</div>
-          <div className="v10-tl-date-items">
-            {entries.map(({ entity, isConvTurn, time }) =>
-              isConvTurn
-                ? <ConversationTurnCard key={entity.uri} entity={entity} allEntities={memory.entities} onSelect={onSelect} time={time} />
-                : <NarrativeCard key={entity.uri} entity={entity} allEntities={memory.entities} onSelect={onSelect} />
-            )}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ─── Conversation Turn Card ──────────────────────────────────
-
-function ConversationTurnCard({ entity, allEntities, onSelect, time }: {
-  entity: MemoryEntity;
-  allEntities: Map<string, MemoryEntity>;
-  onSelect: (uri: string) => void;
-  time: string | null;
-}) {
-  const speaker = entity.connections.find(c =>
-    c.predicate === 'http://schema.org/agent' || c.predicate === 'http://schema.org/author'
-  );
-  const speakerEntity = speaker ? allEntities.get(speaker.targetUri) : undefined;
-  const speakerName = humanizeLabel(speakerEntity, speaker?.targetUri ?? '');
-  const speakerTool = entity.properties.get('http://dkg.io/ontology/speakerTool')?.[0]
-    ?? (speakerEntity ? getAgentTool(speakerEntity) : null);
-
-  const desc = getDescription(entity);
-
-  const mentions = useMemo(() => {
-    const result: Array<{ uri: string; label: string }> = [];
-    for (const conn of entity.connections) {
-      if (conn.predicate === 'http://schema.org/mentions') {
-        result.push({ uri: conn.targetUri, label: conn.targetLabel });
-      }
-    }
-    return result;
-  }, [entity.connections]);
-
-  const trustColor = TRUST_COLORS[entity.trustLevel];
-
-  return (
-    <div className="v10-conv-turn" style={{ borderLeftColor: trustColor }} onClick={() => onSelect(entity.uri)} role="button" tabIndex={0}>
-      <div className="v10-conv-turn-main">
-        <div className="v10-conv-turn-header">
-          <span className="v10-conv-speaker">{speakerName}</span>
-          {speakerTool && <span className="v10-conv-tool">{speakerTool}</span>}
-          {time && <span className="v10-conv-time">{time}</span>}
-        </div>
-
-        <div className="v10-conv-title">{entity.label}</div>
-
-        {desc && (
-          <div className="v10-conv-body">
-            {desc.length > 400 ? desc.slice(0, 400) + '...' : desc}
-          </div>
-        )}
-
-        {mentions.length > 0 && (
-          <div className="v10-conv-mentions">
-            {mentions.map(m => (
-              <span
-                key={m.uri}
-                className="v10-conv-mention"
-                onClick={(e) => { e.stopPropagation(); onSelect(m.uri); }}
-                role="link"
-                tabIndex={0}
-              >
-                {m.label}
-              </span>
-            ))}
-          </div>
-        )}
-
-        <div className="v10-conv-turn-footer">
-          <span className="v10-conv-turn-uri">{entity.uri.split('/').pop()}</span>
-        </div>
-      </div>
-
-      <TrustStatusBox level={entity.trustLevel} />
-    </div>
-  );
-}
-
-// ─── Narrative Card (non-turn entities) ──────────────────────
-
-function NarrativeCard({ entity, allEntities, onSelect }: {
-  entity: MemoryEntity;
-  allEntities: Map<string, MemoryEntity>;
-  onSelect: (uri: string) => void;
-}) {
-  const { icon, type } = entityMeta(entity);
-  const desc = getDescription(entity);
-  const trustColor = TRUST_COLORS[entity.trustLevel];
-
-  const { contributors, otherOut, incoming } = useMemo(() => {
-    const contribs: Array<{ uri: string; label: string; agentTool: string | null }> = [];
-    const other = new Map<string, Array<{ uri: string; label: string }>>();
-
-    for (const conn of entity.connections) {
-      if (CONTRIBUTOR_PREDS.has(conn.predicate)) {
-        const target = allEntities.get(conn.targetUri);
-        contribs.push({
-          uri: conn.targetUri,
-          label: conn.targetLabel,
-          agentTool: target ? getAgentTool(target) : null,
-        });
-      } else {
-        const pred = shortPred(conn.predicate);
-        const list = other.get(pred) ?? [];
-        list.push({ uri: conn.targetUri, label: conn.targetLabel });
-        other.set(pred, list);
-      }
-    }
-
-    const inc: Array<{ pred: string; uri: string; label: string; agentTool: string | null }> = [];
-    for (const [, o] of allEntities) {
-      for (const conn of o.connections) {
-        if (conn.targetUri === entity.uri) {
-          if (CONTRIBUTOR_PREDS.has(conn.predicate)) {
-            contribs.push({ uri: o.uri, label: o.label, agentTool: getAgentTool(o) });
-          } else {
-            inc.push({ pred: shortPred(conn.predicate), uri: o.uri, label: o.label, agentTool: null });
-          }
-        }
-      }
-    }
-
-    const seen = new Set<string>();
-    const deduped = contribs.filter(c => { if (seen.has(c.uri)) return false; seen.add(c.uri); return true; });
-
-    return { contributors: deduped, otherOut: [...other.entries()], incoming: inc };
-  }, [entity, allEntities]);
-
-  const clickEntity = (e: React.MouseEvent, uri: string) => {
-    e.stopPropagation();
-    onSelect(uri);
+      await rejectJoinRequest(contextGraphId, addr);
+      setRequests(prev => prev.filter(r => r.agentAddress !== addr));
+    } catch { /* noop */ } finally { setProcessing(null); }
   };
 
   return (
-    <div className="v10-nc" style={{ borderLeftColor: trustColor }} onClick={() => onSelect(entity.uri)} role="button" tabIndex={0}>
-      <div className="v10-nc-main">
-        <div className="v10-nc-header">
-          <span className="v10-nc-icon">{icon}</span>
-          <span className="v10-nc-label">{entity.label}</span>
-        </div>
-
-        {contributors.length > 0 && (
-          <div className="v10-nc-contributors">
-            {contributors.map((c, i) => (
-              <span key={c.uri} className="v10-nc-contributor" onClick={(e) => clickEntity(e, c.uri)} role="link" tabIndex={0}>
-                {i > 0 && <span className="v10-nc-contrib-sep">·</span>}
-                <span className="v10-nc-contrib-name">{c.label}</span>
-                {c.agentTool && <span className="v10-nc-contrib-tool">{c.agentTool}</span>}
-              </span>
-            ))}
+    <div className="v10-ph-join-requests" style={{ margin: '0 16px 8px', padding: '8px 12px', borderRadius: 8, background: 'var(--bg-surface)', border: '1px solid #f59e0b44' }}>
+      <span style={{ fontSize: 9, fontWeight: 700, textTransform: 'uppercase' as const, letterSpacing: '0.8px', color: 'var(--text-ghost)', marginBottom: 6, display: 'block' }}>
+        Pending Join Requests <span className="v10-ph-join-badge">{requests.length}</span>
+      </span>
+      <div className="v10-ph-join-list">
+        {requests.map(req => (
+          <div key={req.agentAddress} className="v10-ph-join-item">
+            <div className="v10-ph-join-info">
+              <span className="v10-ph-join-name">{req.name || `${req.agentAddress.slice(0, 6)}…${req.agentAddress.slice(-4)}`}</span>
+              <span className="v10-ph-join-addr" title={req.agentAddress}>{req.agentAddress.slice(0, 10)}…</span>
+            </div>
+            <div className="v10-ph-join-actions">
+              <button className="v10-ph-join-btn approve" onClick={() => handleApprove(req.agentAddress)} disabled={processing === req.agentAddress}>
+                {processing === req.agentAddress ? '…' : '✓ Approve'}
+              </button>
+              <button className="v10-ph-join-btn reject" onClick={() => handleReject(req.agentAddress)} disabled={processing === req.agentAddress}>✕</button>
+            </div>
           </div>
-        )}
-
-        {desc && <p className="v10-nc-desc">{desc}</p>}
-
-        {(otherOut.length > 0 || incoming.length > 0) && (
-          <div className="v10-nc-rels">
-            {otherOut.map(([pred, targets]) => (
-              <span key={pred} className="v10-nc-rel">
-                <span className="v10-nc-rel-pred">{pred}</span>
-                {targets.map((t, i) => (
-                  <span key={t.uri} className="v10-nc-rel-target v10-nc-rel-clickable" onClick={(e) => clickEntity(e, t.uri)} role="link" tabIndex={0}>
-                    {i > 0 && ', '}{t.label}
-                  </span>
-                ))}
-              </span>
-            ))}
-            {incoming.map((inc, i) => (
-              <span key={`in-${i}`} className="v10-nc-rel">
-                <span className="v10-nc-rel-pred">← {inc.pred}</span>
-                <span className="v10-nc-rel-target v10-nc-rel-clickable" onClick={(e) => clickEntity(e, inc.uri)} role="link" tabIndex={0}>
-                  {inc.label}
-                </span>
-              </span>
-            ))}
-          </div>
-        )}
-
-        <div className="v10-nc-footer">
-          <span className="v10-nc-type">{type}</span>
-          <span className="v10-nc-stats">
-            {entity.connections.length} links · {entity.properties.size} props
-          </span>
-        </div>
+        ))}
       </div>
-
-      <TrustStatusBox level={entity.trustLevel} />
     </div>
   );
 }
 
-// ─── Knowledge Assets View (all non-turn entities, rich cards) ─────
+// ─── Memory Strip Graph (inline graph for expanded layer) ────
 
-function KnowledgeAssetsView({ memory, search, onSelect }: {
+function MemoryStripGraph({ layerKey, memory }: {
+  layerKey: 'wm' | 'swm' | 'vm';
   memory: ReturnType<typeof useMemoryEntities>;
-  search: string;
-  onSelect: (uri: string) => void;
 }) {
-  const typeGroups = useMemo(() => {
-    const groups = new Map<string, MemoryEntity[]>();
-    for (const e of memory.entityList) {
-      if (isConversationTurn(e)) continue;
-      if (search && !matchesSearch(e, search)) continue;
-      const { group } = entityMeta(e);
-      const list = groups.get(group) ?? [];
-      list.push(e);
-      groups.set(group, list);
-    }
-    const entries = [...groups.entries()].sort((a, b) => b[1].length - a[1].length);
-    for (const [, entities] of entries) {
-      entities.sort((a, b) => {
-        const connDiff = b.connections.length - a.connections.length;
-        if (connDiff !== 0) return connDiff;
-        return a.label.localeCompare(b.label);
-      });
-    }
-    return entries;
-  }, [memory.entityList, search]);
+  const targetLayer: TrustLevel = layerKey === 'vm' ? 'verified' : layerKey === 'swm' ? 'shared' : 'working';
+  const color = layerKey === 'vm' ? '#22c55e' : layerKey === 'swm' ? '#f59e0b' : '#64748b';
 
-  if (typeGroups.length === 0) {
-    return <div className="v10-tl-empty">No knowledge assets found.</div>;
-  }
+  const triples = useMemo(() => {
+    const seen = new Set<string>();
+    return memory.allTriples
+      .filter(t => t.layer === targetLayer)
+      .filter(t => {
+        const key = `${t.subject}|${t.predicate}|${t.object}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .map(({ subject, predicate, object }) => ({ subject, predicate, object }));
+  }, [memory.allTriples, targetLayer]);
 
-  return (
-    <div className="v10-tl-scroll">
-      {typeGroups.map(([group, entities]) => (
-        <div key={group} className="v10-tl-type-group">
-          <div className="v10-tl-type-label">{group} ({entities.length})</div>
-          <div className="v10-tl-date-items">
-            {entities.map(e => (
-              <NarrativeCard key={e.uri} entity={e} allEntities={memory.entities} onSelect={onSelect} />
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// ─── Graph View (full graph, preserved from before) ──────────
-
-function GraphView({ memory, nodeColors, onNodeClick }: {
-  memory: ReturnType<typeof useMemoryEntities>;
-  nodeColors: Record<string, string>;
-  onNodeClick: (node: any) => void;
-}) {
   const graphOptions = useMemo(() => ({
     labelMode: 'humanized' as const,
     renderer: '2d' as const,
     labels: {
-      predicates: [
-        'http://schema.org/name',
-        'http://www.w3.org/2000/01/rdf-schema#label',
-        'http://purl.org/dc/terms/title',
-        'http://schema.org/text',
-      ],
+      predicates: ['http://schema.org/name', 'http://www.w3.org/2000/01/rdf-schema#label', 'http://purl.org/dc/terms/title'],
+      minZoomForLabels: 0.3,
+    },
+    style: {
+      defaultNodeColor: color,
+      defaultEdgeColor: '#334155',
+      edgeWidth: 0.7,
+      fontSize: 16,
+    },
+    hexagon: { baseSize: 7, minSize: 5, maxSize: 10, scaleWithDegree: true },
+    focus: { maxNodes: 2000, hops: 999 },
+  }), [color]);
+
+  if (triples.length === 0) {
+    return (
+      <div className="v10-graph-view" style={{ height: 300 }}>
+        <span className="v10-graph-placeholder">No triples in this layer</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="v10-graph-view" style={{ height: 300, position: 'relative' }}>
+      <Suspense fallback={<span className="v10-graph-placeholder">Loading graph...</span>}>
+        <RdfGraph
+          data={triples}
+          format="triples"
+          options={graphOptions}
+          style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+          initialFit
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+// ─── Memory Strip (expandable layer rows) ────────────────────
+
+function MemoryStrip({ memory, onSwitchLayer, onSelectEntity }: {
+  memory: ReturnType<typeof useMemoryEntities>;
+  onSwitchLayer: (layer: LayerView) => void;
+  onSelectEntity: (uri: string) => void;
+}) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [expandTab, setExpandTab] = useState<Record<string, string>>({ wm: 'items', swm: 'items', vm: 'items' });
+
+  const layerEntities = useMemo(() => {
+    const wm: MemoryEntity[] = [];
+    const swm: MemoryEntity[] = [];
+    const vm: MemoryEntity[] = [];
+    for (const e of memory.entityList) {
+      if (e.trustLevel === 'verified') vm.push(e);
+      else if (e.trustLevel === 'shared') swm.push(e);
+      else wm.push(e);
+    }
+    return { wm, swm, vm };
+  }, [memory.entityList]);
+
+  const layerTripleCounts = useMemo(() => {
+    let wm = 0, swm = 0, vm = 0;
+    for (const t of memory.allTriples) {
+      if (t.layer === 'verified') vm++;
+      else if (t.layer === 'shared') swm++;
+      else wm++;
+    }
+    return { wm, swm, vm };
+  }, [memory.allTriples]);
+
+  const toggleExpand = (layer: string) => {
+    setExpanded(prev => prev === layer ? null : layer);
+  };
+
+  const layers: Array<{
+    key: string;
+    label: string;
+    color: string;
+    icon: string;
+    entities: MemoryEntity[];
+    promoteLabel: string | null;
+    viewLayer: LayerView;
+  }> = [
+    { key: 'wm', label: 'Working Memory', color: '#64748b', icon: '◇', entities: layerEntities.wm, promoteLabel: 'Promote All → Shared', viewLayer: 'wm' },
+    { key: 'swm', label: 'Shared Working Memory', color: '#f59e0b', icon: '◈', entities: layerEntities.swm, promoteLabel: 'Publish All → VM', viewLayer: 'swm' },
+    { key: 'vm', label: 'Verified Memory', color: '#22c55e', icon: '◉', entities: layerEntities.vm, promoteLabel: null, viewLayer: 'vm' },
+  ];
+
+  return (
+    <div className="v10-memory-strip">
+      {layers.map(layer => {
+        const isExpanded = expanded === layer.key;
+        const activeTab = expandTab[layer.key] ?? 'items';
+        return (
+          <React.Fragment key={layer.key}>
+            <div
+              className={`v10-memory-layer ${layer.key} ${isExpanded ? 'expanded' : ''}`}
+              onClick={() => toggleExpand(layer.key)}
+            >
+              <div className="v10-layer-label" style={{ color: layer.color }}>
+                <span className="v10-layer-abbr">{layer.label}</span>
+                <span className="v10-layer-count">{layer.entities.length}</span>
+              </div>
+              <div className="v10-layer-items">
+                <span className="v10-layer-chevron">▸</span>
+                {layer.entities.length === 0 && (
+                  <span style={{ fontSize: 11, color: 'var(--text-ghost)', fontStyle: 'italic' }}>No assets yet</span>
+                )}
+                {layer.entities.slice(0, 6).map(e => {
+                  const { icon } = entityMeta(e);
+                  return (
+                    <div key={e.uri} className="v10-layer-chip" style={{ borderColor: `${layer.color}40` }}>
+                      <span className="v10-chip-dot" style={{ background: layer.color }} />
+                      <span className="v10-chip-text">{e.label}</span>
+                      <span className="v10-chip-meta">{icon}</span>
+                    </div>
+                  );
+                })}
+                {layer.entities.length > 6 && (
+                  <span className="v10-chip-meta">+{layer.entities.length - 6} more</span>
+                )}
+              </div>
+            </div>
+            <div className={`v10-layer-expand-content ${isExpanded ? 'open' : ''}`}>
+              <div className="v10-split-pane" style={{ minHeight: 0 }}>
+                {/* Left: Canvas widgets */}
+                <CanvasPanel
+                  layer={layer.key as 'wm' | 'swm' | 'vm'}
+                  entities={layer.entities}
+                  tripleCount={layerTripleCounts[layer.key as 'wm' | 'swm' | 'vm']}
+                />
+
+                {/* Right: Content tabs */}
+                <div className="v10-split-content">
+                  <div className="v10-layer-expand-tabs">
+                    <button
+                      className={`v10-layer-expand-tab ${activeTab === 'items' ? 'active' : ''}`}
+                      onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'items' })); }}
+                    >Knowledge Assets</button>
+                    <button
+                      className={`v10-layer-expand-tab ${activeTab === 'graph' ? 'active' : ''}`}
+                      onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'graph' })); }}
+                    >Graph</button>
+                    <button
+                      className={`v10-layer-expand-tab ${activeTab === 'docs' ? 'active' : ''}`}
+                      onClick={e => { e.stopPropagation(); setExpandTab(prev => ({ ...prev, [layer.key]: 'docs' })); }}
+                    >Documents</button>
+                  </div>
+                  {activeTab === 'items' && (
+                    <>
+                      <div className="v10-layer-expand-items">
+                        {layer.entities.slice(0, 10).map(e => {
+                          const { icon, type } = entityMeta(e);
+                          return (
+                            <div key={e.uri} className="v10-item-row" style={{ cursor: 'pointer' }} onClick={(ev) => { ev.stopPropagation(); onSelectEntity(e.uri); }}>
+                              <span className="v10-item-icon">{icon}</span>
+                              <div className="v10-item-info">
+                                <div className="v10-item-name">{e.label}</div>
+                                <div className="v10-item-meta-row">
+                                  <span className="v10-item-type">{type}</span>
+                                  <span className="v10-item-count">· {e.connections.length + e.properties.size} triples</span>
+                                </div>
+                              </div>
+                              <span className={`v10-trust-badge ${layer.key}`}>
+                                {layer.icon} {layer.key === 'vm' ? 'Verified' : layer.key === 'swm' ? 'Shared' : 'Working'}
+                              </span>
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <div className="v10-layer-expand-footer">
+                        {layer.promoteLabel && (
+                          <button className={`v10-layer-expand-footer-btn ${layer.key === 'swm' ? 'publish' : 'promote'}`} onClick={e => e.stopPropagation()}>
+                            {layer.promoteLabel}
+                          </button>
+                        )}
+                        <button className="v10-layer-expand-footer-btn" onClick={e => { e.stopPropagation(); onSwitchLayer(layer.viewLayer); }}>
+                          View full layer →
+                        </button>
+                      </div>
+                    </>
+                  )}
+                  {activeTab === 'graph' && (
+                    <MemoryStripGraph layerKey={layer.key as 'wm' | 'swm' | 'vm'} memory={memory} />
+                  )}
+                  {activeTab === 'docs' && (
+                    <div style={{ maxHeight: 300, overflow: 'auto' }}>
+                      <DocumentsList entities={layer.entities} />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Generative Widget Components ─────────────────────────────
+
+function GenWidget({ title, agent, footnote, dismissed, onDismiss, children }: {
+  title: string;
+  agent?: string;
+  footnote?: string;
+  dismissed?: boolean;
+  onDismiss?: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`v10-gen-widget ${dismissed ? 'dissolved' : ''}`}>
+      <div className="v10-gen-widget-header">
+        <span className="v10-gen-widget-title">{title}</span>
+        <div className="v10-gen-widget-right">
+          {agent && (
+            <span className="v10-gen-widget-agent">
+              <span className="v10-gen-widget-agent-dot" />
+              {agent}
+            </span>
+          )}
+          {onDismiss && (
+            <button className="v10-gen-widget-dismiss" onClick={onDismiss}>✕</button>
+          )}
+        </div>
+      </div>
+      <div className="v10-gen-widget-body">{children}</div>
+      {footnote && <div className="v10-gen-widget-footnote">{footnote}</div>}
+    </div>
+  );
+}
+
+function TypeBreakdownWidget({ entities }: { entities: MemoryEntity[] }) {
+  const breakdown = useMemo(() => {
+    const counts = new Map<string, { icon: string; count: number }>();
+    for (const e of entities) {
+      const { icon, type } = entityMeta(e);
+      const existing = counts.get(type);
+      if (existing) existing.count++;
+      else counts.set(type, { icon, count: 1 });
+    }
+    return [...counts.entries()].sort((a, b) => b[1].count - a[1].count);
+  }, [entities]);
+
+  if (breakdown.length === 0) return null;
+
+  return (
+    <GenWidget title="Entity Types">
+      <div className="v10-layer-summary">
+        {breakdown.map(([type, { icon, count }]) => (
+          <div key={type} className="v10-layer-summary-stat">
+            <span className="v10-layer-summary-label">{icon} {type}</span>
+            <span className="v10-layer-summary-value">{count}</span>
+          </div>
+        ))}
+      </div>
+    </GenWidget>
+  );
+}
+
+function LayerStatsWidget({ entities, triples, layer }: {
+  entities: MemoryEntity[];
+  triples: number;
+  layer: 'wm' | 'swm' | 'vm';
+}) {
+  const docCount = useMemo(
+    () => entities.filter(e => e.properties.has('http://dkg.io/ontology/sourceContentType')).length,
+    [entities]
+  );
+  const totalConns = useMemo(
+    () => entities.reduce((sum, e) => sum + e.connections.length, 0),
+    [entities]
+  );
+  const avgConns = entities.length > 0 ? (totalConns / entities.length).toFixed(1) : '0';
+  const layerConfig = {
+    wm: { icon: '◇', color: '#64748b' },
+    swm: { icon: '◈', color: '#f59e0b' },
+    vm: { icon: '◉', color: '#22c55e' },
+  }[layer];
+
+  return (
+    <GenWidget title="Layer Stats">
+      <div className="v10-layer-summary">
+        <div className="v10-layer-summary-stat">
+          <span className="v10-layer-summary-label">Knowledge Assets</span>
+          <span className="v10-layer-summary-value">{entities.length}</span>
+        </div>
+        <div className="v10-layer-summary-stat">
+          <span className="v10-layer-summary-label">Triples</span>
+          <span className="v10-layer-summary-value">{triples}</span>
+        </div>
+        <div className="v10-layer-summary-stat">
+          <span className="v10-layer-summary-label">Connections</span>
+          <span className="v10-layer-summary-value">{totalConns}</span>
+        </div>
+        <div className="v10-layer-summary-stat">
+          <span className="v10-layer-summary-label">Avg. connections / entity</span>
+          <span className="v10-layer-summary-value">{avgConns}</span>
+        </div>
+        {docCount > 0 && (
+          <div className="v10-layer-summary-stat">
+            <span className="v10-layer-summary-label">📄 Documents</span>
+            <span className="v10-layer-summary-value">{docCount}</span>
+          </div>
+        )}
+        <div className="v10-layer-summary-bar">
+          <div className="v10-layer-summary-bar-fill" style={{ width: '100%', background: layerConfig.color }} />
+        </div>
+      </div>
+    </GenWidget>
+  );
+}
+
+function LayerActionsWidget({ layer, count }: { layer: 'wm' | 'swm'; count: number }) {
+  if (count === 0) return null;
+  const isWm = layer === 'wm';
+  const color = isWm ? '#f59e0b' : '#22c55e';
+  const target = isWm ? 'Shared Memory' : 'Verified Memory';
+
+  return (
+    <GenWidget title={isWm ? 'Promote' : 'Publish'} footnote={`Moves ${count} asset${count !== 1 ? 's' : ''} to ${target}.`}>
+      <div className="v10-decision-context" style={{ marginBottom: 10 }}>
+        {count} asset{count !== 1 ? 's' : ''} in this layer can be {isWm ? 'promoted to Shared Memory for collaborative review' : 'published to Verified Memory on-chain'}.
+      </div>
+      <div className="v10-decision-actions">
+        <button className="v10-decision-btn approve" style={{ borderColor: `${color}50`, color, background: `${color}15` }}>
+          ✓ {isWm ? 'Promote All → Shared' : 'Publish All → VM'}
+        </button>
+        <button className="v10-decision-btn discuss">Review First</button>
+      </div>
+    </GenWidget>
+  );
+}
+
+function CanvasPanel({ layer, entities, tripleCount }: {
+  layer: 'wm' | 'swm' | 'vm';
+  entities: MemoryEntity[];
+  tripleCount: number;
+}) {
+  return (
+    <div className="v10-split-canvas">
+      <LayerStatsWidget entities={entities} triples={tripleCount} layer={layer} />
+      <TypeBreakdownWidget entities={entities} />
+      {(layer === 'wm' || layer === 'swm') && (
+        <LayerActionsWidget layer={layer} count={entities.length} />
+      )}
+      {entities.length === 0 && (
+        <div className="v10-canvas-empty">
+          <div className="v10-canvas-empty-icon">⬡</div>
+          <div className="v10-canvas-empty-text">
+            Import data or chat with agents to populate this layer.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Full Layer Detail View (WM / SWM / VM) ─────────────────
+
+function LayerDetailView({ layer, memory, nodeColors, onNodeClick, onSelectEntity }: {
+  layer: 'wm' | 'swm' | 'vm';
+  memory: ReturnType<typeof useMemoryEntities>;
+  nodeColors: Record<string, string>;
+  onNodeClick: (node: any) => void;
+  onSelectEntity: (uri: string) => void;
+}) {
+  const [contentTab, setContentTab] = useState<LayerContentTab>('items');
+
+  const config = {
+    wm: { icon: '◇', title: 'Working Memory', desc: 'Private agent scratchpad — ephemeral, fast local storage', color: '#64748b', actionLabel: 'Promote All → Shared', actionClass: 'promote' },
+    swm: { icon: '◈', title: 'Shared Working Memory', desc: 'Team workspace — shared proposals, TTL-bounded', color: '#f59e0b', actionLabel: 'Publish All → VM', actionClass: 'primary' },
+    vm: { icon: '◉', title: 'Verified Memory', desc: 'Endorsed, published, on-chain knowledge', color: '#22c55e', actionLabel: null, actionClass: '' },
+  }[layer];
+
+  const entities = useMemo(() => {
+    return memory.entityList.filter(e => {
+      if (layer === 'vm') return e.trustLevel === 'verified';
+      if (layer === 'swm') return e.trustLevel === 'shared';
+      return e.trustLevel === 'working';
+    });
+  }, [memory.entityList, layer]);
+
+  const layerTriples = useMemo(() => {
+    const targetLayer: TrustLevel = layer === 'vm' ? 'verified' : layer === 'swm' ? 'shared' : 'working';
+    const seen = new Set<string>();
+    return memory.allTriples
+      .filter(t => t.layer === targetLayer)
+      .filter(t => {
+        const key = `${t.subject}|${t.predicate}|${t.object}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .map(({ subject, predicate, object }) => ({ subject, predicate, object }));
+  }, [memory.allTriples, layer]);
+
+  const graphOptions = useMemo(() => ({
+    labelMode: 'humanized' as const,
+    renderer: '2d' as const,
+    labels: {
+      predicates: ['http://schema.org/name', 'http://www.w3.org/2000/01/rdf-schema#label', 'http://purl.org/dc/terms/title'],
       minZoomForLabels: 0.3,
     },
     style: {
       nodeColors,
-      defaultNodeColor: TRUST_COLORS.working,
+      defaultNodeColor: config.color,
       defaultEdgeColor: '#334155',
       edgeWidth: 0.7,
       fontSize: 16,
     },
     hexagon: { baseSize: 7, minSize: 5, maxSize: 10, scaleWithDegree: true },
     focus: { maxNodes: 3000, hops: 999 },
-  }), [nodeColors]);
+  }), [nodeColors, config.color]);
 
   return (
-    <div className="v10-gv-container">
-      <Suspense fallback={<div className="v10-me-graph-loading">Loading graph...</div>}>
-        <RdfGraph
-          data={memory.graphTriples}
-          format="triples"
-          options={graphOptions}
-          style={{ width: '100%', height: '100%' }}
-          onNodeClick={onNodeClick}
-          initialFit
-        />
-      </Suspense>
-      <div className="v10-me-graph-legend">
-        <span className="v10-me-legend-item">
-          <span className="v10-me-legend-dot" style={{ background: TRUST_COLORS.verified }} /> Verified
-        </span>
-        <span className="v10-me-legend-item">
-          <span className="v10-me-legend-dot" style={{ background: TRUST_COLORS.shared }} /> Shared
-        </span>
-        <span className="v10-me-legend-item">
-          <span className="v10-me-legend-dot" style={{ background: TRUST_COLORS.working }} /> Draft
-        </span>
+    <div className="v10-layer-detail">
+      <div className="v10-split-pane">
+        {/* Left: Generative Canvas */}
+        <CanvasPanel layer={layer} entities={entities} tripleCount={layerTriples.length} />
+
+        {/* Right: Content Tabs */}
+        <div className="v10-split-content">
+          <div className="v10-content-tabs">
+            <button className={`v10-content-tab ${contentTab === 'items' ? 'active' : ''}`} onClick={() => setContentTab('items')}>
+              <span className="v10-content-tab-icon">◈</span> Knowledge Assets
+            </button>
+            <button className={`v10-content-tab ${contentTab === 'graph' ? 'active' : ''}`} onClick={() => setContentTab('graph')}>
+              <span className="v10-content-tab-icon">⬡</span> Graph
+            </button>
+            <button className={`v10-content-tab ${contentTab === 'docs' ? 'active' : ''}`} onClick={() => setContentTab('docs')}>
+              <span className="v10-content-tab-icon">📄</span> Documents
+            </button>
+          </div>
+
+          {contentTab === 'items' && (
+            <>
+              <div className="v10-layer-detail-header">
+                <span className="v10-layer-detail-icon" style={{ color: config.color }}>{config.icon}</span>
+                <div>
+                  <div className="v10-layer-detail-title">{config.title}</div>
+                  <div className="v10-layer-detail-desc">{config.desc}</div>
+                </div>
+                <div className="v10-layer-detail-actions">
+                  {config.actionLabel && (
+                    <button className={`v10-layer-action-btn ${config.actionClass}`}>{config.actionLabel}</button>
+                  )}
+                </div>
+              </div>
+              <div className="v10-layer-detail-content">
+                <div className="v10-items-list">
+                  {entities.map(e => {
+                    const { icon, type } = entityMeta(e);
+                    return (
+                      <div key={e.uri} className="v10-item-row" style={{ cursor: 'pointer' }} onClick={() => onSelectEntity(e.uri)}>
+                        <span className="v10-item-icon">{icon}</span>
+                        <div className="v10-item-info">
+                          <div className="v10-item-name">{e.label}</div>
+                          <div className="v10-item-ual">{e.uri}</div>
+                          <div className="v10-item-meta-row">
+                            <span className="v10-item-type">{type}</span>
+                            <span className="v10-item-count">· {e.connections.length + e.properties.size} triples</span>
+                          </div>
+                        </div>
+                        <span className={`v10-trust-badge ${layer}`}>
+                          {config.icon} {layer === 'vm' ? 'Verified' : layer === 'swm' ? 'Shared' : 'Working'}
+                        </span>
+                        {layer === 'wm' && <button className="v10-item-promote-btn" onClick={ev => ev.stopPropagation()}>→ Shared</button>}
+                        {layer === 'swm' && <button className="v10-item-promote-btn" onClick={ev => ev.stopPropagation()}>→ VM</button>}
+                      </div>
+                    );
+                  })}
+                  {entities.length === 0 && (
+                    <div style={{ padding: 24, textAlign: 'center', color: 'var(--text-ghost)', fontSize: 12 }}>
+                      No entities in {config.title}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
+          {contentTab === 'graph' && (
+            <div className="v10-graph-view" style={{ flex: 1, position: 'relative' }}>
+              {layerTriples.length > 0 ? (
+                <Suspense fallback={<span className="v10-graph-placeholder">Loading graph...</span>}>
+                  <RdfGraph
+                    data={layerTriples}
+                    format="triples"
+                    options={graphOptions}
+                    style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+                    onNodeClick={onNodeClick}
+                    initialFit
+                  />
+                </Suspense>
+              ) : (
+                <span className="v10-graph-placeholder">No data to graph in {config.title}</span>
+              )}
+            </div>
+          )}
+
+          {contentTab === 'docs' && (
+            <DocumentsList entities={entities} />
+          )}
+        </div>
       </div>
     </div>
   );
 }
 
-// ─── Drill-down panel (2-hop focused graph + rich card) ──────
+// ─── Documents List ──────────────────────────────────────────
 
-function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigate, onClose, contextGraphId }: {
+const SOURCE_CONTENT_TYPE = 'http://dkg.io/ontology/sourceContentType';
+const MARKDOWN_FORM = 'http://dkg.io/ontology/markdownForm';
+const SOURCE_FILE = 'http://dkg.io/ontology/sourceFile';
+const DKG_SIZE = 'http://dkg.io/ontology/size';
+
+function DocumentsList({ entities }: { entities: MemoryEntity[] }) {
+  const openTab = useTabsStore(s => s.openTab);
+
+  const docs = useMemo(() => {
+    return entities.filter(e => e.properties.has(SOURCE_CONTENT_TYPE));
+  }, [entities]);
+
+  const handleOpenDoc = (e: MemoryEntity) => {
+    const fileRef = e.connections.find(c => c.predicate === MARKDOWN_FORM || c.predicate === SOURCE_FILE)?.targetUri;
+    const fileHash = fileRef?.replace('urn:dkg:file:', '') ?? '';
+    openTab({
+      id: `doc:${fileHash || e.uri}`,
+      label: e.label,
+      closable: true,
+      icon: '📄',
+    });
+  };
+
+  if (docs.length === 0) {
+    return (
+      <div className="v10-docs-placeholder" style={{ flex: 1 }}>
+        No documents in this layer. Import a file to get started.
+      </div>
+    );
+  }
+
+  return (
+    <div className="v10-layer-detail-content">
+      <div className="v10-items-list">
+        {docs.map(e => {
+          const contentType = e.properties.get(SOURCE_CONTENT_TYPE)?.[0] ?? '';
+          const fileRef = e.connections.find(c => c.predicate === MARKDOWN_FORM || c.predicate === SOURCE_FILE)?.targetUri;
+          const fileEntity = fileRef ? entities.find(f => f.uri === fileRef) : undefined;
+          const size = fileEntity?.properties.get(DKG_SIZE)?.[0] ?? e.properties.get(DKG_SIZE)?.[0];
+          return (
+            <div key={e.uri} className="v10-item-row" onClick={() => handleOpenDoc(e)}>
+              <span className="v10-item-icon">📄</span>
+              <div className="v10-item-info">
+                <div className="v10-item-name">{e.label}</div>
+                <div className="v10-item-meta-row">
+                  {contentType && <span className="v10-item-type">{contentType}</span>}
+                  {size && <span className="v10-item-count">· {Math.round(parseInt(size) / 1024)}KB</span>}
+                </div>
+              </div>
+              <button className="v10-item-promote-btn" onClick={ev => { ev.stopPropagation(); handleOpenDoc(e); }}>Open →</button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Provenance Bar ──────────────────────────────────────────
+
+function ProvenanceBar({ memory }: { memory: ReturnType<typeof useMemoryEntities> }) {
+  const latestEvent = useMemo(() => {
+    if (memory.counts.vm > 0) return `${memory.counts.vm} knowledge assets verified on-chain`;
+    if (memory.counts.swm > 0) return `${memory.counts.swm} assets in shared memory`;
+    if (memory.counts.wm > 0) return `${memory.counts.wm} drafts in working memory`;
+    return 'No activity yet';
+  }, [memory.counts]);
+
+  return (
+    <div className="v10-provenance-bar">
+      <span className="v10-provenance-bar-dot" />
+      <span>{latestEvent}</span>
+    </div>
+  );
+}
+
+// ─── KA Detail View (split-pane: content+triples+graph | provenance) ─────
+
+type KAPane = 'content' | 'triples' | 'graph';
+
+function KADetailView({ entity, allEntities, allTriples, onNavigate, onClose }: {
   entity: MemoryEntity;
   allEntities: Map<string, MemoryEntity>;
   allTriples: Triple[];
-  nodeColors: Record<string, string>;
   onNavigate: (uri: string) => void;
   onClose: () => void;
-  contextGraphId: string;
 }) {
+  const [pane, setPane] = useState<KAPane>('content');
   const { icon, type } = entityMeta(entity);
   const desc = getDescription(entity);
-
-  const hoodTriples = useMemo(
-    () => neighborhoodTriples(entity.uri, allTriples, 2),
-    [entity.uri, allTriples]
-  );
-
-  const hoodOptions = useMemo(() => ({
-    labelMode: 'humanized' as const,
-    renderer: '2d' as const,
-    labels: {
-      predicates: ['http://schema.org/name', 'http://www.w3.org/2000/01/rdf-schema#label'],
-      minZoomForLabels: 0.2,
-    },
-    style: {
-      nodeColors,
-      defaultNodeColor: TRUST_COLORS.working,
-      defaultEdgeColor: '#475569',
-      edgeWidth: 1.0,
-      fontSize: 16,
-    },
-    hexagon: { baseSize: 7, minSize: 4, maxSize: 10, scaleWithDegree: true },
-    focus: { maxNodes: 500, hops: 999 },
-    autoFitDisabled: true,
-  }), [nodeColors]);
+  const layerBadge = entity.trustLevel === 'verified' ? 'vm' : entity.trustLevel === 'shared' ? 'swm' : 'wm';
+  const layerLabel = entity.trustLevel === 'verified' ? 'Verified Memory' : entity.trustLevel === 'shared' ? 'Shared Working Memory' : 'Working Memory';
 
   const incoming = useMemo(() => {
     const result: Array<{ pred: string; entity: MemoryEntity }> = [];
@@ -693,183 +922,211 @@ function DrilldownPanel({ entity, allEntities, allTriples, nodeColors, onNavigat
     return result;
   }, [entity.uri, allEntities]);
 
-  const mentionedIn = useMemo(() => {
-    const turns: Array<{ entity: MemoryEntity; date: string | null }> = [];
-    for (const [, other] of allEntities) {
-      if (!isConversationTurn(other)) continue;
-      const mentions = other.connections.some(c =>
-        c.targetUri === entity.uri && c.predicate === 'http://schema.org/mentions'
-      );
-      if (mentions) {
-        turns.push({ entity: other, date: getDate(other) });
-      }
-    }
-    turns.sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
-    return turns;
-  }, [entity.uri, allEntities]);
+  const entityTriples = useMemo(
+    () => allTriples.filter(t => t.subject === entity.uri || t.object === entity.uri),
+    [entity.uri, allTriples]
+  );
 
-  const sourceFile = useMemo(() => {
-    const conn = entity.connections.find(c => c.predicate === 'http://dkg.io/ontology/sourceFile');
-    return conn?.targetUri ?? null;
-  }, [entity]);
+  const hoodTriples = useMemo(
+    () => neighborhoodTriples(entity.uri, allTriples, 2),
+    [entity.uri, allTriples]
+  );
 
-  const [similar, setSimilar] = useState<Array<{ entityUri: string; label: string | null; similarity: number }>>([]);
-  useEffect(() => {
-    const label = entity.label;
-    if (!label || !contextGraphId) return;
-    let cancelled = false;
-    const token = typeof window !== 'undefined' ? (window as any).__DKG_TOKEN__ : null;
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-    fetch('/api/memory/search', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ query: label, contextGraphId, limit: 5, memoryLayers: ['swm', 'vm'] }),
-    })
-      .then(r => r.json())
-      .then(data => {
-        if (cancelled || !data.results) return;
-        setSimilar(
-          data.results
-            .filter((r: any) => r.entityUri !== entity.uri)
-            .slice(0, 5)
-            .map((r: any) => ({ entityUri: r.entityUri, label: r.label, similarity: r.similarity }))
-        );
-      })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [entity.uri, entity.label, contextGraphId]);
+  const graphOptions = useMemo(() => ({
+    labelMode: 'humanized' as const,
+    renderer: '2d' as const,
+    labels: {
+      predicates: ['http://schema.org/name', 'http://www.w3.org/2000/01/rdf-schema#label'],
+      minZoomForLabels: 0.2,
+    },
+    style: {
+      defaultNodeColor: TRUST_COLORS[entity.trustLevel],
+      defaultEdgeColor: '#475569',
+      edgeWidth: 1.0,
+      fontSize: 16,
+    },
+    hexagon: { baseSize: 7, minSize: 4, maxSize: 10, scaleWithDegree: true },
+    focus: { maxNodes: 500, hops: 999 },
+  }), [entity.trustLevel]);
+
+  const tripleCount = entity.connections.length + entity.properties.size;
 
   return (
-    <div className="v10-dd-panel">
-      <div className="v10-dd-header">
-        <button className="v10-dd-back" onClick={onClose}>← Back</button>
-      </div>
-
-      <div className="v10-dd-graph">
-        <Suspense fallback={<div className="v10-me-graph-loading">Loading...</div>}>
-          <RdfGraph
-            data={hoodTriples}
-            format="triples"
-            options={hoodOptions}
-            style={{ width: '100%', height: '100%' }}
-            onNodeClick={(n: any) => n?.id && n.id !== entity.uri && onNavigate(n.id)}
-            initialFit
-          />
-        </Suspense>
-        <div className="v10-dd-graph-info">
-          {hoodTriples.length} facts in neighborhood
+    <div className="v10-ka-detail">
+      <div className="v10-ka-header">
+        <button className="v10-ka-back" onClick={onClose}>← Back to Project</button>
+        <div className="v10-ka-header-left">
+          <div className="v10-ka-label">Knowledge Asset</div>
+          <div className="v10-ka-name">
+            {icon} {entity.label}
+            <span className={`v10-trust-badge ${layerBadge}`}>{layerLabel}</span>
+          </div>
+          <div className="v10-ka-ual">{entity.uri} · {type} · {tripleCount} triples</div>
         </div>
       </div>
 
-      <div className="v10-dd-card">
-        <div className="v10-dd-card-header">
-          <span className="v10-dd-icon">{icon}</span>
-          <div>
-            <h2 className="v10-dd-title">{entity.label}</h2>
-            <div className="v10-dd-type-row">
-              <span className="v10-dd-type">{type}</span>
-              <TrustStatusBox level={entity.trustLevel} />
+      <div className="v10-ka-split">
+        {/* Left pane: Content / Triples / Graph */}
+        <div className="v10-ka-left">
+          <div className="v10-content-tabs" style={{ margin: '0 -20px', padding: '0 20px', background: 'transparent' }}>
+            <button className={`v10-content-tab ${pane === 'content' ? 'active' : ''}`} onClick={() => setPane('content')}>Content</button>
+            <button className={`v10-content-tab ${pane === 'triples' ? 'active' : ''}`} onClick={() => setPane('triples')}>Triples</button>
+            <button className={`v10-content-tab ${pane === 'graph' ? 'active' : ''}`} onClick={() => setPane('graph')}>Graph</button>
+          </div>
+
+          {pane === 'content' && (
+            <>
+              {desc && (
+                <div className="v10-ka-section">
+                  <div className="v10-ka-desc"><p>{desc}</p></div>
+                </div>
+              )}
+
+              {entity.properties.size > 0 && (
+                <div className="v10-ka-section">
+                  <div className="v10-ka-section-title">Properties</div>
+                  {[...entity.properties].map(([pred, vals]) => (
+                    <div key={pred} className="v10-ka-prop">
+                      <span className="v10-ka-prop-key">{shortPred(pred)}</span>
+                      <span className="v10-ka-prop-val">{vals.join(', ')}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {entity.connections.length > 0 && (
+                <div className="v10-ka-section">
+                  <div className="v10-ka-section-title">Links to ({entity.connections.length})</div>
+                  {entity.connections.map((conn, i) => (
+                    <button key={i} className="v10-ka-conn" onClick={() => onNavigate(conn.targetUri)}>
+                      <span className="v10-ka-conn-pred">{shortPred(conn.predicate)}</span>
+                      <span className="v10-ka-conn-arrow">→</span>
+                      <span className="v10-ka-conn-target">{conn.targetLabel}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {incoming.length > 0 && (
+                <div className="v10-ka-section">
+                  <div className="v10-ka-section-title">Referenced by ({incoming.length})</div>
+                  {incoming.map((inc, i) => (
+                    <button key={i} className="v10-ka-conn" onClick={() => onNavigate(inc.entity.uri)}>
+                      <span className="v10-ka-conn-target">{inc.entity.label}</span>
+                      <span className="v10-ka-conn-arrow">→</span>
+                      <span className="v10-ka-conn-pred">{inc.pred}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              <div className="v10-ka-meta">
+                <span className="v10-ka-meta-item">{icon} {type}</span>
+                <span className="v10-ka-meta-item">{tripleCount} triples</span>
+                <span className="v10-ka-meta-item">{entity.connections.length} links</span>
+              </div>
+            </>
+          )}
+
+          {pane === 'triples' && (
+            <div style={{ marginTop: 8, overflowX: 'auto', border: '1px solid var(--border-default)', borderRadius: 6 }}>
+              <table className="v10-ka-triples-table">
+                <thead>
+                  <tr><th>Subject</th><th>Predicate</th><th>Object</th></tr>
+                </thead>
+                <tbody>
+                  {entityTriples.slice(0, 50).map((t, i) => (
+                    <tr key={i}>
+                      <td title={t.subject}>{shortPred(t.subject)}</td>
+                      <td title={t.predicate}>{shortPred(t.predicate)}</td>
+                      <td title={t.object}>{t.object.startsWith('"') ? t.object.replace(/^"|"$/g, '').slice(0, 60) : shortPred(t.object)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div style={{ fontSize: 10, color: 'var(--text-ghost)', fontFamily: 'var(--font-mono)', padding: '6px 8px' }}>
+                {Math.min(entityTriples.length, 50)} of {entityTriples.length} triples shown
+              </div>
+            </div>
+          )}
+
+          {pane === 'graph' && (
+            <div style={{ height: 300, position: 'relative', marginTop: 8, borderRadius: 6, overflow: 'hidden', border: '1px solid var(--border-default)' }}>
+              {hoodTriples.length > 0 ? (
+                <Suspense fallback={<span className="v10-graph-placeholder">Loading graph...</span>}>
+                  <RdfGraph
+                    data={hoodTriples}
+                    format="triples"
+                    options={graphOptions}
+                    style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
+                    onNodeClick={(n: any) => n?.id && n.id !== entity.uri && onNavigate(n.id)}
+                    initialFit
+                  />
+                </Suspense>
+              ) : (
+                <div className="v10-graph-placeholder">No neighborhood data</div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Right pane: Provenance Trail */}
+        <div className="v10-ka-right">
+          <div className="v10-ka-section-title">Provenance Trail</div>
+          <div className="v10-ka-timeline">
+            {entity.trustLevel === 'verified' && (
+              <div className="v10-ka-event">
+                <div className="v10-ka-event-dot verified" />
+                <div className="v10-ka-event-header">
+                  <span className="v10-ka-event-title">Published to Verified Memory</span>
+                </div>
+                <div className="v10-ka-event-desc">Knowledge asset endorsed and published on-chain</div>
+              </div>
+            )}
+            {(entity.trustLevel === 'shared' || entity.trustLevel === 'verified') && (
+              <div className="v10-ka-event">
+                <div className="v10-ka-event-dot shared" />
+                <div className="v10-ka-event-header">
+                  <span className="v10-ka-event-title">Promoted to Shared Working Memory</span>
+                </div>
+                <div className="v10-ka-event-desc">Shared with project participants for review</div>
+              </div>
+            )}
+            <div className="v10-ka-event">
+              <div className="v10-ka-event-dot created" />
+              <div className="v10-ka-event-header">
+                <span className="v10-ka-event-title">Created in Working Memory</span>
+              </div>
+              <div className="v10-ka-event-desc">Extracted from imported data or agent conversation</div>
+            </div>
+          </div>
+
+          {/* Trust Summary */}
+          <div style={{ marginTop: 16, padding: '10px 12px', borderRadius: 6, background: 'var(--bg-surface)', border: '1px solid var(--border-subtle)' }}>
+            <div className="v10-ka-section-title" style={{ marginBottom: 6 }}>Entity Summary</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 4, fontSize: 10 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--text-tertiary)' }}>Type</span>
+                <span style={{ color: 'var(--text-primary)', fontWeight: 600, fontFamily: 'var(--font-mono)' }}>{type}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--text-tertiary)' }}>Triples</span>
+                <span style={{ color: 'var(--text-primary)', fontWeight: 600, fontFamily: 'var(--font-mono)' }}>{tripleCount}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--text-tertiary)' }}>Links</span>
+                <span style={{ color: 'var(--text-primary)', fontWeight: 600, fontFamily: 'var(--font-mono)' }}>{entity.connections.length}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span style={{ color: 'var(--text-tertiary)' }}>Layer</span>
+                <span style={{ color: 'var(--text-primary)', fontWeight: 600, fontFamily: 'var(--font-mono)' }}>{layerLabel.split(' ')[0]}</span>
+              </div>
             </div>
           </div>
         </div>
-
-        {desc && <p className="v10-dd-desc">{desc}</p>}
-
-        <div className="v10-dd-uri mono">{entity.uri}</div>
-
-        {sourceFile && (
-          <div className="v10-dd-section">
-            <h4 className="v10-dd-section-title">Source</h4>
-            <a className="v10-dd-source-link" href={`/api/file/${encodeURIComponent(sourceFile.replace('urn:dkg:file:', ''))}`} target="_blank" rel="noreferrer">
-              View source file
-            </a>
-          </div>
-        )}
-
-        {entity.properties.size > 0 && (
-          <div className="v10-dd-section">
-            <h4 className="v10-dd-section-title">Properties</h4>
-            {[...entity.properties].map(([pred, vals]) => (
-              <div key={pred} className="v10-dd-prop">
-                <span className="v10-dd-prop-key">{shortPred(pred)}</span>
-                <span className="v10-dd-prop-val">{vals.join(', ')}</span>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {entity.connections.length > 0 && (
-          <div className="v10-dd-section">
-            <h4 className="v10-dd-section-title">Links to ({entity.connections.length})</h4>
-            {entity.connections.map((conn, i) => (
-              <button key={i} className="v10-dd-conn" onClick={() => onNavigate(conn.targetUri)}>
-                <span className="v10-dd-conn-pred">{shortPred(conn.predicate)}</span>
-                <span className="v10-dd-conn-arrow">→</span>
-                <span className="v10-dd-conn-target">{conn.targetLabel}</span>
-              </button>
-            ))}
-          </div>
-        )}
-
-        {incoming.length > 0 && (
-          <div className="v10-dd-section">
-            <h4 className="v10-dd-section-title">Referenced by ({incoming.length})</h4>
-            {incoming.map((inc, i) => (
-              <button key={i} className="v10-dd-conn" onClick={() => onNavigate(inc.entity.uri)}>
-                <span className="v10-dd-conn-target">{inc.entity.label}</span>
-                <span className="v10-dd-conn-arrow">→</span>
-                <span className="v10-dd-conn-pred">{inc.pred}</span>
-              </button>
-            ))}
-          </div>
-        )}
-
-        {mentionedIn.length > 0 && (
-          <div className="v10-dd-section">
-            <h4 className="v10-dd-section-title">Mentioned in ({mentionedIn.length} turns)</h4>
-            {mentionedIn.map((m, i) => (
-              <button key={i} className="v10-dd-conn" onClick={() => onNavigate(m.entity.uri)}>
-                <span className="v10-dd-conn-target">{m.entity.label}</span>
-                {m.date && <span className="v10-dd-conn-date">{m.date}</span>}
-              </button>
-            ))}
-          </div>
-        )}
-
-        {similar.length > 0 && (
-          <div className="v10-dd-section">
-            <h4 className="v10-dd-section-title">Similar</h4>
-            {similar.map((s, i) => {
-              const target = allEntities.get(s.entityUri);
-              return (
-                <button key={i} className="v10-dd-conn" onClick={() => onNavigate(s.entityUri)}>
-                  <span className="v10-dd-conn-target">{target?.label ?? s.label ?? s.entityUri}</span>
-                  {s.similarity != null && (
-                    <span className="v10-dd-conn-sim">{Math.round(s.similarity * 100)}%</span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        )}
       </div>
     </div>
   );
-}
-
-// ─── Search helper ───────────────────────────────────────────
-
-function matchesSearch(e: MemoryEntity, q: string): boolean {
-  const lower = q.toLowerCase();
-  if (e.label.toLowerCase().includes(lower)) return true;
-  if (e.uri.toLowerCase().includes(lower)) return true;
-  for (const t of e.types) if (shortType(t).toLowerCase().includes(lower)) return true;
-  for (const [, vals] of e.properties) {
-    for (const v of vals) if (v.toLowerCase().includes(lower)) return true;
-  }
-  for (const c of e.connections) if (c.targetLabel.toLowerCase().includes(lower)) return true;
-  return false;
 }
 
 // ─── Main ProjectView ────────────────────────────────────────
@@ -878,9 +1135,9 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   const { data: cgData } = useFetch(api.fetchContextGraphs, [], 30_000);
   const [showImport, setShowImport] = useState(false);
   const [showShare, setShowShare] = useState(false);
-  const [activeTab, setActiveTab] = useState<ViewTab>('timeline');
+  const [activeLayer, setActiveLayer] = useState<LayerView>('overview');
   const [selectedUri, setSelectedUri] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
+  const [participants, setParticipants] = useState<string[]>([]);
 
   const cg = useMemo(
     () => cgData?.contextGraphs?.find((c: any) => c.id === contextGraphId),
@@ -888,6 +1145,14 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
   );
 
   const memory = useMemoryEntities(contextGraphId);
+
+  useEffect(() => {
+    if (cg?.id) {
+      listParticipants(cg.id)
+        .then(data => setParticipants(data.allowedAgents))
+        .catch(() => setParticipants([]));
+    }
+  }, [cg?.id]);
 
   const selectedEntity = useMemo(
     () => selectedUri ? memory.entities.get(selectedUri) ?? null : null,
@@ -902,17 +1167,8 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     return colors;
   }, [memory.entities]);
 
-  const handleSelect = useCallback((uri: string) => {
-    setSelectedUri(uri);
-  }, []);
-
-  const handleNavigate = useCallback((uri: string) => {
-    setSelectedUri(uri);
-  }, []);
-
-  const handleNodeClick = useCallback((node: any) => {
-    if (node?.id) setSelectedUri(node.id);
-  }, []);
+  const handleNavigate = useCallback((uri: string) => { setSelectedUri(uri); }, []);
+  const handleNodeClick = useCallback((node: any) => { if (node?.id) setSelectedUri(node.id); }, []);
 
   if (!cg) {
     return (
@@ -922,99 +1178,57 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
     );
   }
 
-  const hasData = memory.entityList.length > 0;
-
   return (
     <div className="v10-memory-explorer">
-      {/* ── Header ── */}
-      <div className="v10-me-header">
-        <div className="v10-me-header-left">
-          <div className="v10-me-project-dot" />
-          <div>
-            <h1 className="v10-me-title">{cg.name || cg.id}</h1>
-          </div>
-        </div>
-        <div className="v10-me-header-actions">
-          <button className="v10-me-action-btn" onClick={() => setShowShare(true)}>⤴ Share</button>
-          <button className="v10-me-action-btn" onClick={() => setShowImport(true)}>↑ Import</button>
-          <button className="v10-me-action-btn" onClick={memory.refresh}>↻</button>
-        </div>
-      </div>
+      {/* Layer Switcher */}
+      <LayerSwitcher
+        active={activeLayer}
+        counts={memory.counts}
+        onSwitch={v => { setActiveLayer(v); setSelectedUri(null); }}
+        onShare={() => setShowShare(true)}
+        onImport={() => setShowImport(true)}
+        onRefresh={memory.refresh}
+      />
 
-      {hasData && <ProjectHome cg={cg} memory={memory} />}
-
-      <TrustSummaryBar counts={memory.counts} />
-
-      {/* ── Search + Tab bar ── */}
-      {hasData && (
-        <div className="v10-me-toolbar">
-          <div className="v10-me-tabs">
-            {(['timeline', 'graph', 'knowledge'] as ViewTab[]).map(tab => (
-              <button
-                key={tab}
-                className={`v10-me-tab ${activeTab === tab ? 'active' : ''}`}
-                onClick={() => { setActiveTab(tab); setSelectedUri(null); }}
-              >
-                {tab === 'timeline' ? '◷ Timeline' : tab === 'graph' ? '⬡ Graph' : '◈ Knowledge Assets'}
-              </button>
-            ))}
-          </div>
-          <input
-            className="v10-me-search"
-            type="text"
-            placeholder="Search memory..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-          />
-        </div>
-      )}
-
-      {memory.loading && (
-        <div className="v10-me-loading"><div className="v10-me-loading-text">Loading memory...</div></div>
-      )}
-      {memory.error && (
-        <div className="v10-me-error">Error: {memory.error}</div>
-      )}
-
-      {/* ── Drilldown overlay ── */}
-      {!memory.loading && hasData && selectedEntity && (
-        <DrilldownPanel
+      {/* Drilldown overlay */}
+      {selectedEntity && (
+        <KADetailView
           entity={selectedEntity}
           allEntities={memory.entities}
           allTriples={memory.graphTriples}
-          nodeColors={nodeColors}
           onNavigate={handleNavigate}
           onClose={() => setSelectedUri(null)}
-          contextGraphId={contextGraphId}
         />
       )}
 
-      {/* ── Tab content ── */}
-      {!memory.loading && hasData && !selectedEntity && (
+      {/* Overview View */}
+      {activeLayer === 'overview' && !selectedEntity && (
         <>
-          {activeTab === 'timeline' && (
-            <TimelineView memory={memory} search={search} onSelect={handleSelect} />
+          <ProjectOverviewCard cg={cg} memory={memory} participants={participants} />
+          <PendingJoinRequestsBar contextGraphId={contextGraphId} />
+          {memory.loading && (
+            <div className="v10-me-loading"><div className="v10-me-loading-text">Loading memory...</div></div>
           )}
-          {activeTab === 'graph' && (
-            <GraphView memory={memory} nodeColors={nodeColors} onNodeClick={handleNodeClick} />
+          {memory.error && (
+            <div className="v10-me-error">Error: {memory.error}</div>
           )}
-          {activeTab === 'knowledge' && (
-            <KnowledgeAssetsView memory={memory} search={search} onSelect={handleSelect} />
-          )}
+          <MemoryStrip memory={memory} onSwitchLayer={setActiveLayer} onSelectEntity={handleNavigate} />
         </>
       )}
 
-      {/* ── Empty state ── */}
-      {!memory.loading && !hasData && (
-        <div className="v10-me-empty">
-          <div className="v10-me-empty-icon">⬡</div>
-          <h2 className="v10-me-empty-title">No knowledge yet</h2>
-          <p className="v10-me-empty-desc">
-            Import files, chat with your agent, or connect an integration to start building this project's memory.
-          </p>
-          <button className="v10-modal-btn primary" onClick={() => setShowImport(true)}>↑ Import Files</button>
-        </div>
+      {/* Layer Detail Views */}
+      {(activeLayer === 'wm' || activeLayer === 'swm' || activeLayer === 'vm') && !selectedEntity && (
+        <LayerDetailView
+          layer={activeLayer}
+          memory={memory}
+          nodeColors={nodeColors}
+          onNodeClick={handleNodeClick}
+          onSelectEntity={handleNavigate}
+        />
       )}
+
+      {/* Provenance Bar */}
+      <ProvenanceBar memory={memory} />
 
       <ImportFilesModal
         open={showImport}


### PR DESCRIPTION
## Summary

- Replaces the old timeline/graph/knowledge-assets tabs with a **Layer Switcher** bar (Overview / WM / SWM / VM) and redesigns the project view to match the collaborative memory workspace mockup
- Adds a **split-pane layout** inside each layer view: left half shows data-driven generative widgets (entity type breakdown, layer stats, promote/publish actions derived from actual KG data), right half shows content tabs
- **Renames "Knowledge Assets" → "Entities"** in WM/SWM tabs (only VM entities are true Knowledge Assets)
- Adds an **Assertions tab** in WM/SWM listing named graphs from `listAssertions` API, with per-assertion and bulk promote/publish actions
- **Wires promote/publish** canvas widget to real API calls (`listAssertions`, `promoteAssertion`, `publishSharedMemory`) with loading/error/success states
- Introduces a **KA Detail View** with Content/Triples/Graph tabs on the left and a provenance trail on the right, plus a back button for navigation
- Adds **Document Viewer** with back navigation, proper content-type handling (text, images, PDFs), and stale-request cancellation
- Removes the "Layer Activation" block from the create project modal

### Bug fixes (from Codex review)
- **Fix progress bar overflow**: Use per-layer sum as denominator instead of deduped `total`, preventing negative/overflow percentages when entities span multiple layers
- **Fix stale document requests**: Cancel in-flight fetch via AbortController when `docRef` changes; clear previous content immediately
- **Fix binary document rendering**: Detect response content-type and render images inline, PDFs in iframe, instead of dumping binary as text
- **Fix stale participants**: Bubble `onParticipantsChanged` callback from `PendingJoinRequestsBar` to re-fetch participant list after approve/reject
- **Fix cross-project doc tab collision**: Scope document tab IDs with `contextGraphId` so the same file opened from different projects gets separate tabs

## Test plan

- [ ] Create a new project and import a markdown document
- [ ] Verify the Overview tab shows the Memory Strip with expandable layer rows
- [ ] Expand a layer row and confirm the split-pane: canvas widgets on left, content tabs on right
- [ ] Check WM/SWM tabs show "Entities" (not "Knowledge Assets") and VM shows "Knowledge Assets"
- [ ] Click the "Assertions" tab in WM — verify it lists named graphs with promote buttons
- [ ] Click "Promote → Shared" on an individual assertion — verify it calls the API
- [ ] Click into WM/SWM/VM detail views and verify same split-pane layout
- [ ] Click a knowledge asset to open the KA Detail view, verify back button works
- [ ] Check the Graph tab renders the visualization
- [ ] Check the Documents tab shows imported files; open a document and verify content loads
- [ ] Verify progress bar percentages sum correctly and don't exceed 100%
- [ ] Approve a join request and verify the participants list updates without page refresh