### PR TITLE
fix: use on-chain context graph authority in publish flows

### DIFF
--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -170,6 +170,33 @@ export class EVMChainAdapter implements ChainAdapter {
     return s;
   }
 
+  /**
+   * Pick the next signer in the pool that the on-chain ContextGraphs contract
+   * authorizes for the target context graph. Falls back to round-robin only
+   * when the auth surface is unavailable.
+   */
+  private async nextAuthorizedSigner(contextGraphId: bigint): Promise<Wallet> {
+    if (!this.contracts.contextGraphs) {
+      return this.nextSigner();
+    }
+
+    const start = this.signerIndex % this.signerPool.length;
+    for (let i = 0; i < this.signerPool.length; i += 1) {
+      const idx = (start + i) % this.signerPool.length;
+      const signer = this.signerPool[idx];
+      const authorized = await this.contracts.contextGraphs.isAuthorizedPublisher(contextGraphId, signer.address);
+      if (authorized) {
+        this.signerIndex = idx + 1;
+        return signer;
+      }
+    }
+
+    throw new Error(
+      `No authorized publisher wallet found in signer pool for context graph ${contextGraphId.toString()}. ` +
+      'Ensure at least one configured wallet is permitted by on-chain publish authority.',
+    );
+  }
+
   /** All operational wallet addresses (for display / funding). */
   getSignerAddresses(): string[] {
     return this.signerPool.map((s) => s.address);
@@ -1033,7 +1060,7 @@ export class EVMChainAdapter implements ChainAdapter {
       throw new Error('KnowledgeAssetsStorage contract not deployed (required for log parsing).');
     }
 
-    const signer = await this.nextSigner();
+    const signer = await this.nextAuthorizedSigner(params.contextGraphId);
     const receiverIdentityIds = params.receiverSignatures.map((s) => s.identityId);
     const receiverRs = params.receiverSignatures.map((s) => ethers.hexlify(s.r));
     const receiverVSs = params.receiverSignatures.map((s) => ethers.hexlify(s.vs));
@@ -1176,7 +1203,7 @@ export class EVMChainAdapter implements ChainAdapter {
       );
     }
 
-    const txSigner = this.nextSigner();
+    const txSigner = await this.nextAuthorizedSigner(params.contextGraphId);
     const ka = this.contracts.knowledgeAssetsV10.connect(txSigner) as Contract;
     const kaAddress = await ka.getAddress();
 

--- a/packages/publisher/src/async-lift-publish-options.ts
+++ b/packages/publisher/src/async-lift-publish-options.ts
@@ -34,6 +34,7 @@ export interface LiftResolvedPublishSlice {
   readonly operationCtx?: OperationContext;
   readonly onPhase?: PhaseCallback;
   readonly receiverSignatureProvider?: ReceiverSignatureProvider;
+  readonly publishContextGraphId?: string;
 }
 
 export interface LiftPublishMappingInput {
@@ -118,6 +119,7 @@ export function mapLiftRequestToPublishOptions(input: LiftPublishMappingInput): 
     operationCtx: input.resolved.operationCtx,
     onPhase: input.resolved.onPhase,
     receiverSignatureProvider: input.resolved.receiverSignatureProvider,
+    publishContextGraphId: input.resolved.publishContextGraphId,
   };
 }
 

--- a/packages/publisher/src/workspace-resolution.ts
+++ b/packages/publisher/src/workspace-resolution.ts
@@ -103,10 +103,30 @@ export async function resolveLiftWorkspaceSlice(params: {
     selection: { rootEntities: requestedRoots },
   });
 
+  const publishContextGraphId = await resolveOnChainContextGraphId({
+    store: params.store,
+    contextGraphId: request.contextGraphId,
+  });
+
   return {
     quads,
     publisherPeerId: operation.publisherPeerId,
+    publishContextGraphId,
   };
+}
+
+async function resolveOnChainContextGraphId(params: {
+  store: TripleStore;
+  contextGraphId: string;
+}): Promise<string | undefined> {
+  const ontologyGraph = 'did:dkg:context-graph:ontology';
+  const contextGraphUri = `did:dkg:context-graph:${params.contextGraphId}`;
+  const result = await params.store.query(
+    `SELECT ?id WHERE { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <https://dkg.network/ontology#ParanetOnChainId> ?id } } LIMIT 1`,
+  );
+  if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+  const value = stripLiteral(result.bindings[0]?.['id']);
+  return value ? value.trim() : undefined;
 }
 
 function buildWorkspaceSelectionQuery(

--- a/packages/publisher/test/access-protocol.test.ts
+++ b/packages/publisher/test/access-protocol.test.ts
@@ -95,7 +95,7 @@ describe('Access Protocol', () => {
     const storeA = new OxigraphStore();
     const { result, bus } = await publishWithPrivate(storeA, { publisherPeerId: nodeA.peerId });
 
-    expect(result.status).toBe('tentative');
+    expect(result.status).toBe('confirmed');
     expect(result.kaManifest[0].privateTripleCount).toBe(2);
 
     const accessHandler = new AccessHandler(storeA, bus);
@@ -121,7 +121,7 @@ describe('Access Protocol', () => {
     const storeA = new OxigraphStore();
     const { result, bus } = await publishWithPrivate(storeA, { publisherPeerId: nodeB.peerId });
 
-    expect(result.status).toBe('tentative');
+    expect(result.status).toBe('confirmed');
     expect(result.kaManifest[0].privateTripleCount).toBe(2);
 
     const publicResult = await storeA.query(`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,12 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
 
+  packages/digital-twin:
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
+
   packages/epcis:
     dependencies:
       ajv:


### PR DESCRIPTION
Summary
- fix private context-graph create/register flows so participant-based graphs can be registered correctly and published to Verified Memory
- make direct and async publish resolve the correct on-chain context-graph id and use an authorized publisher wallet
- add CLI/manual coverage for private late-join sync and local context-graph testing