### PR TITLE
feat(v10): Phase 11 — reward TRAC source wiring + effective-stake denominator fix

### DIFF
--- a/packages/chain/abi/DKGStakingConvictionNFT.json
+++ b/packages/chain/abi/DKGStakingConvictionNFT.json
@@ -135,77 +135,13 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint96",
-        "name": "requested",
-        "type": "uint96"
-      },
-      {
-        "internalType": "uint96",
-        "name": "available",
-        "type": "uint96"
-      }
-    ],
-    "name": "InsufficientStake",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidAmount",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "InvalidLockEpochs",
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint40",
-        "name": "expiresAtEpoch",
-        "type": "uint40"
-      }
-    ],
-    "name": "LockNotExpired",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
-      }
-    ],
+    "inputs": [],
     "name": "NotPositionOwner",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      }
-    ],
-    "name": "PositionNotFound",
     "type": "error"
   },
   {
@@ -222,6 +158,11 @@
   {
     "inputs": [],
     "name": "ZeroAddressHub",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAmount",
     "type": "error"
   },
   {
@@ -279,10 +220,35 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
         "internalType": "uint256",
-        "name": "positionId",
+        "name": "tokenId",
         "type": "uint256"
       },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "lockEpochs",
+        "type": "uint8"
+      }
+    ],
+    "name": "ConvertedFromV8",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
       {
         "indexed": true,
         "internalType": "address",
@@ -290,7 +256,13 @@
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
         "internalType": "uint72",
         "name": "identityId",
         "type": "uint72"
@@ -303,9 +275,9 @@
       },
       {
         "indexed": false,
-        "internalType": "uint40",
+        "internalType": "uint8",
         "name": "lockEpochs",
-        "type": "uint40"
+        "type": "uint8"
       }
     ],
     "name": "PositionCreated",
@@ -317,17 +289,42 @@
       {
         "indexed": true,
         "internalType": "uint256",
-        "name": "positionId",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "oldIdentityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "newIdentityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "PositionRedelegated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
         "type": "uint256"
       },
       {
         "indexed": false,
-        "internalType": "uint96",
-        "name": "amount",
-        "type": "uint96"
+        "internalType": "uint8",
+        "name": "newLockEpochs",
+        "type": "uint8"
       }
     ],
-    "name": "PositionUnstaked",
+    "name": "PositionRelocked",
     "type": "event"
   },
   {
@@ -356,8 +353,66 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      }
+    ],
+    "name": "WithdrawalCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalFinalized",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "SCALE18",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WITHDRAWAL_DELAY",
     "outputs": [
       {
         "internalType": "uint256",
@@ -387,6 +442,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "askContract",
+    "outputs": [
+      {
+        "internalType": "contract Ask",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -406,16 +474,152 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
-    "name": "chronosAddress",
+    "name": "chronos",
     "outputs": [
       {
-        "internalType": "address",
+        "internalType": "contract Chronos",
         "name": "",
         "type": "address"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint8",
+        "name": "lockEpochs",
+        "type": "uint8"
+      }
+    ],
+    "name": "convertToNFT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "convictionStakingStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint8",
+        "name": "lockEpochs",
+        "type": "uint8"
+      }
+    ],
+    "name": "createConviction",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      }
+    ],
+    "name": "createWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "delegatorsInfo",
+    "outputs": [
+      {
+        "internalType": "contract DelegatorsInfo",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "finalizeWithdrawal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -432,93 +636,6 @@
         "internalType": "address",
         "name": "",
         "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      }
-    ],
-    "name": "getConviction",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      }
-    ],
-    "name": "getMultiplier",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      }
-    ],
-    "name": "getPosition",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "owner_",
-        "type": "address"
-      },
-      {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint96",
-        "name": "stakedAmount",
-        "type": "uint96"
-      },
-      {
-        "internalType": "uint40",
-        "name": "lockEpochs",
-        "type": "uint40"
-      },
-      {
-        "internalType": "uint40",
-        "name": "createdAtEpoch",
-        "type": "uint40"
-      },
-      {
-        "internalType": "uint256",
-        "name": "conviction",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "multiplier",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -569,25 +686,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      }
-    ],
-    "name": "isLockExpired",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "name",
     "outputs": [
@@ -598,6 +696,19 @@
       }
     ],
     "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextTokenId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -620,37 +731,78 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "positions",
+    "inputs": [],
+    "name": "parametersStorage",
     "outputs": [
       {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint96",
-        "name": "stakedAmount",
-        "type": "uint96"
-      },
-      {
-        "internalType": "uint40",
-        "name": "lockEpochs",
-        "type": "uint40"
-      },
-      {
-        "internalType": "uint40",
-        "name": "createdAtEpoch",
-        "type": "uint40"
+        "internalType": "contract ParametersStorage",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "profileStorage",
+    "outputs": [
+      {
+        "internalType": "contract ProfileStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "randomSamplingStorage",
+    "outputs": [
+      {
+        "internalType": "contract RandomSamplingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "newIdentityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "redelegate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "newLockEpochs",
+        "type": "uint8"
+      }
+    ],
+    "name": "relock",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -736,40 +888,63 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint96",
-        "name": "amount",
-        "type": "uint96"
-      },
-      {
-        "internalType": "uint40",
-        "name": "lockEpochs",
-        "type": "uint40"
-      }
-    ],
-    "name": "stake",
+    "inputs": [],
+    "name": "shardingTableContract",
     "outputs": [
       {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
+        "internalType": "contract ShardingTable",
+        "name": "",
+        "type": "address"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "stakingStorageAddress",
+    "name": "shardingTableStorage",
     "outputs": [
       {
-        "internalType": "address",
+        "internalType": "contract ShardingTableStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingContract",
+    "outputs": [
+      {
+        "internalType": "contract IStaking",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingStorage",
+    "outputs": [
+      {
+        "internalType": "contract StakingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingV10",
+    "outputs": [
+      {
+        "internalType": "contract StakingV10",
         "name": "",
         "type": "address"
       }
@@ -929,24 +1104,6 @@
       }
     ],
     "name": "transferFrom",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "positionId",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint96",
-        "name": "amount",
-        "type": "uint96"
-      }
-    ],
-    "name": "unstake",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/chain/abi/RandomSampling.json
+++ b/packages/chain/abi/RandomSampling.json
@@ -27,6 +27,16 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "NoEligibleContextGraph",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoEligibleKnowledgeCollection",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint72",
@@ -52,6 +62,62 @@
     "inputs": [],
     "name": "ZeroAddressHub",
     "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "knowledgeCollectionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "chunkId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "activeProofPeriodStartBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "ChallengeGenerated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_KC_RETRIES",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [],
@@ -104,6 +170,45 @@
     "outputs": [
       {
         "internalType": "contract Chronos",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "contextGraphStorage",
+    "outputs": [
+      {
+        "internalType": "contract ContextGraphStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "contextGraphValueStorage",
+    "outputs": [
+      {
+        "internalType": "contract ContextGraphValueStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "convictionStakingStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakingStorage",
         "name": "",
         "type": "address"
       }
@@ -286,6 +391,40 @@
         "internalType": "contract ParametersStorage",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "seed",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "targetEpoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewChallengeForSeed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "cgId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "kcId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chunkId",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/packages/chain/abi/Staking.json
+++ b/packages/chain/abi/Staking.json
@@ -29,33 +29,17 @@
   {
     "inputs": [
       {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint40",
-        "name": "expiresAtEpoch",
-        "type": "uint40"
-      }
-    ],
-    "name": "ConvictionLockActive",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidLockEpochs",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "amount",
         "type": "uint256"
       }
     ],
     "name": "MaximumStakeExceeded",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyConvictionNFT",
     "type": "error"
   },
   {
@@ -83,6 +67,22 @@
   {
     "inputs": [],
     "name": "ShardingTableIsFull",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "TokenIdAlreadyRecorded",
     "type": "error"
   },
   {
@@ -186,6 +186,43 @@
     "type": "error"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint40",
+        "name": "lockEpochs",
+        "type": "uint40"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "StakeRecorded",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "SCALE18",
     "outputs": [
@@ -196,6 +233,34 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      },
+      {
+        "internalType": "uint40",
+        "name": "lockEpochs",
+        "type": "uint40"
+      }
+    ],
+    "name": "_recordStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -297,25 +362,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint40",
-        "name": "lockEpochs",
-        "type": "uint40"
-      }
-    ],
-    "name": "convictionMultiplier",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "multiplier18",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "delegatorsInfo",
     "outputs": [
@@ -365,30 +411,6 @@
     "name": "finalizeWithdrawal",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "address",
-        "name": "delegator",
-        "type": "address"
-      }
-    ],
-    "name": "getDelegatorConvictionMultiplier",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "multiplier18",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -635,29 +657,6 @@
       }
     ],
     "name": "stake",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint96",
-        "name": "addedStake",
-        "type": "uint96"
-      },
-      {
-        "internalType": "uint40",
-        "name": "lockEpochs",
-        "type": "uint40"
-      }
-    ],
-    "name": "stakeWithLock",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -1460,11 +1460,11 @@ export class EVMChainAdapter implements ChainAdapter {
     };
   }
 
-  async getDelegatorConvictionMultiplier(identityId: bigint, delegator: string): Promise<{ multiplier: number }> {
-    await this.init();
-    const staking = this.contracts.staking!;
-    const multiplier18: bigint = await staking.getDelegatorConvictionMultiplier(identityId, delegator);
-    return { multiplier: Number(multiplier18) / 1e18 };
+  async getDelegatorConvictionMultiplier(_identityId: bigint, _delegator: string): Promise<{ multiplier: number }> {
+    // V8 address-keyed stakers have no conviction multiplier (always 1x).
+    // V10 per-position multipliers are queried by tokenId via
+    // ConvictionStakingStorage.getPosition(), not this address-keyed function.
+    return { multiplier: 1 };
   }
 
   // =====================================================================

--- a/packages/evm-module/abi/ConvictionStakingStorage.json
+++ b/packages/evm-module/abi/ConvictionStakingStorage.json
@@ -622,6 +622,25 @@
   {
     "inputs": [
       {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "getNodeV10BaseStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"
@@ -888,6 +907,25 @@
       }
     ],
     "name": "nodeLastFinalizedEpoch",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "",
+        "type": "uint72"
+      }
+    ],
+    "name": "nodeV10BaseStake",
     "outputs": [
       {
         "internalType": "uint256",

--- a/packages/evm-module/abi/RandomSampling.json
+++ b/packages/evm-module/abi/RandomSampling.json
@@ -205,6 +205,19 @@
   },
   {
     "inputs": [],
+    "name": "convictionStakingStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "createChallenge",
     "outputs": [],
     "stateMutability": "nonpayable",

--- a/packages/evm-module/abi/Staking.json
+++ b/packages/evm-module/abi/Staking.json
@@ -362,25 +362,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint40",
-        "name": "lockEpochs",
-        "type": "uint40"
-      }
-    ],
-    "name": "convictionMultiplier",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "multiplier18",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "delegatorsInfo",
     "outputs": [
@@ -430,30 +411,6 @@
     "name": "finalizeWithdrawal",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint72",
-        "name": "",
-        "type": "uint72"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "getDelegatorConvictionMultiplier",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "multiplier18",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "pure",
     "type": "function"
   },
   {

--- a/packages/evm-module/abi/StakingV10.json
+++ b/packages/evm-module/abi/StakingV10.json
@@ -482,6 +482,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "epochStorage",
+    "outputs": [
+      {
+        "internalType": "contract EpochStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -67,9 +67,8 @@ contract DKGStakingConvictionNFT is INamed, IVersioned, ContractStatus, IInitial
     // Constants
     // ========================================================================
 
-    /// @notice 1e18 fixed-point scale shared with `ConvictionStakingStorage`
-    ///         and `Staking.convictionMultiplier`. Tier table and reward
-    ///         math all use this scale.
+    /// @notice 1e18 fixed-point scale shared with `ConvictionStakingStorage`.
+    ///         Tier table and reward math all use this scale.
     uint256 public constant SCALE18 = 1e18;
 
     /// @notice Time between `requestWithdrawal` and `processWithdrawal`.
@@ -225,14 +224,12 @@ contract DKGStakingConvictionNFT is INamed, IVersioned, ContractStatus, IInitial
     // tier on both sides.
     //
     // Discrete, exact-match tier table — no snap-down semantics. Values
-    // that don't land on one of the tiers revert. This is stricter than
-    // `Staking.convictionMultiplier` (which uses snap-down `>=` branches):
-    // `createConviction` / `convertToNFT` are the only entry points that
-    // invoke this function with a user-supplied `lockEpochs`, and any
-    // value outside the valid set is an API error that must not round
-    // down silently to a lower tier (a user passing 4 silently snapping
-    // to tier 3 would commit the user to a different lock than they
-    // intended).
+    // that don't land on one of the tiers revert. `createConviction` /
+    // `convertToNFT` are the only entry points that invoke this function
+    // with a user-supplied `lockEpochs`, and any value outside the valid
+    // set is an API error that must not round down silently to a lower
+    // tier (a user passing 4 silently snapping to tier 3 would commit
+    // the user to a different lock than they intended).
     //
     // Why `0 → SCALE18` rather than a revert at the helper level:
     //   The post-expiry rest state in `ConvictionStakingStorage` is

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -21,6 +21,7 @@ import {ParametersStorage} from "./storage/ParametersStorage.sol";
 import {ShardingTableStorage} from "./storage/ShardingTableStorage.sol";
 import {ContextGraphStorage} from "./storage/ContextGraphStorage.sol";
 import {ContextGraphValueStorage} from "./storage/ContextGraphValueStorage.sol";
+import {ConvictionStakingStorage} from "./storage/ConvictionStakingStorage.sol";
 import {ICustodian} from "./interfaces/ICustodian.sol";
 import {HubLib} from "./libraries/HubLib.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
@@ -50,6 +51,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     ShardingTableStorage public shardingTableStorage;
     ContextGraphStorage public contextGraphStorage;
     ContextGraphValueStorage public contextGraphValueStorage;
+    ConvictionStakingStorage public convictionStakingStorage;
 
     error MerkleRootMismatchError(bytes32 computedMerkleRoot, bytes32 expectedMerkleRoot);
     /// @notice Thrown by `_generateChallenge` when no public, active CG holds
@@ -129,6 +131,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         // regular hub contract.
         contextGraphStorage = ContextGraphStorage(hub.getAssetStorageAddress("ContextGraphStorage"));
         contextGraphValueStorage = ContextGraphValueStorage(hub.getContractAddress("ContextGraphValueStorage"));
+        convictionStakingStorage = ConvictionStakingStorage(hub.getContractAddress("ConvictionStakingStorage"));
     }
 
     /**
@@ -268,9 +271,16 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
             randomSamplingStorage.addToAllNodesEpochScore(epoch, score18);
 
             // Calculate and add to nodeEpochScorePerStake
-            uint96 totalNodeStake = stakingStorage.getNodeStake(identityId);
-            if (totalNodeStake > 0) {
-                uint256 nodeScorePerStake36 = (score18 * SCALE18) / totalNodeStake;
+            // Phase 11: use effective node stake = V8_raw + V10_effective
+            // = nodeStake + (nodeEffective_V10 - nodeV10BaseStake)
+            uint256 rawNodeStake = uint256(stakingStorage.getNodeStake(identityId));
+            uint256 nodeEffV10 = convictionStakingStorage.getNodeEffectiveStakeAtEpoch(
+                identityId, epoch
+            );
+            uint256 nodeV10Base = convictionStakingStorage.getNodeV10BaseStake(identityId);
+            uint256 effectiveNodeStake = rawNodeStake + nodeEffV10 - nodeV10Base;
+            if (effectiveNodeStake > 0) {
+                uint256 nodeScorePerStake36 = (score18 * SCALE18) / effectiveNodeStake;
                 randomSamplingStorage.addToNodeEpochScorePerStake(epoch, identityId, nodeScorePerStake36);
             }
         } else {

--- a/packages/evm-module/contracts/Staking.sol
+++ b/packages/evm-module/contracts/Staking.sol
@@ -907,42 +907,6 @@ contract Staking is INamed, IVersioned, ContractStatus, IInitializable {
     }
 
     // ========================================================================
-    // V10 Conviction Multiplier — Discrete Tiers
-    // ========================================================================
-
-    /**
-     * @notice Compute the conviction multiplier for a delegator's lock duration.
-     * Discrete tiers (lockEpochs → multiplier):
-     *   0 = invalid (returns 0), 1 = 1.0x, ≥2 = 1.5x, ≥3 = 2.0x,
-     *   ≥6 = 3.5x, ≥12 = 6.0x.
-     * Values between tiers snap DOWN to the nearest tier.
-     * @param lockEpochs Lock duration in epochs (1 epoch ≈ 30 days)
-     * @return multiplier18 Multiplier scaled by 1e18 (e.g. 6e18 = 6x)
-     */
-    function convictionMultiplier(uint40 lockEpochs) public pure returns (uint256 multiplier18) {
-        if (lockEpochs == 0) return 0;
-        if (lockEpochs >= 12) return 6 * SCALE18;
-        if (lockEpochs >= 6) return 35 * SCALE18 / 10; // 3.5x
-        if (lockEpochs >= 3) return 2 * SCALE18;
-        if (lockEpochs >= 2) return 15 * SCALE18 / 10; // 1.5x
-        return SCALE18; // lockEpochs == 1 → 1.0x base
-    }
-
-    /**
-     * @notice Get the conviction multiplier for a specific delegator on a node.
-     * @dev Returns SCALE18 (1x) for all delegators. No per-delegator lock state
-     *      is currently tracked in `Staking`; callers requiring multiplier data
-     *      should read from the appropriate staking-position contract instead.
-     * @return multiplier18 SCALE18 (1x).
-     */
-    function getDelegatorConvictionMultiplier(
-        uint72 /* identityId */,
-        address /* delegator */
-    ) external pure returns (uint256 multiplier18) {
-        return SCALE18;
-    }
-
-    // ========================================================================
     // V10 Two-Layer Staking Wire — NFT-backed stake recording
     // ========================================================================
 

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -58,9 +58,8 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
     // Constants
     // ========================================================================
 
-    /// @notice 1e18 fixed-point scale shared with `ConvictionStakingStorage`,
-    ///         `Staking.convictionMultiplier`, and
-    ///         `DKGStakingConvictionNFT._convictionMultiplier`. Tier math
+    /// @notice 1e18 fixed-point scale shared with `ConvictionStakingStorage`
+    ///         and `DKGStakingConvictionNFT._convictionMultiplier`. Tier math
     ///         and reward accounting all use this scale.
     uint256 public constant SCALE18 = 1e18;
 
@@ -384,7 +383,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //    to first-time address-keyed delegators, and the Phase 4
         //    `_recordStake` path applies to NFT-keyed ones.
         bytes32 delegatorKey = bytes32(tokenId);
-        staking.prepareForStakeChange(chronos.getCurrentEpoch(), identityId, delegatorKey);
+        _prepareForStakeChangeV10(chronos.getCurrentEpoch(), tokenId);
 
         // 6. Pull TRAC straight from `staker` into `StakingStorage`.
         //    The NFT wrapper never holds funds (Phase 5 decision Q4):
@@ -518,8 +517,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //    re-collect score the delegator has already effectively earned
         //    under the old (post-expiry, 1x) contribution profile. Mirrors
         //    the Phase 4 `Staking._recordStake` settlement step.
-        bytes32 delegatorKey = bytes32(tokenId);
-        staking.prepareForStakeChange(currentEpoch, pos.identityId, delegatorKey);
+        _prepareForStakeChangeV10(currentEpoch, tokenId);
 
         // 4. Resolve the new tier multiplier. Reverts `"Invalid lock"` for
         //    any lock outside {0,1,3,6,12}. Tier==0 is the rest state at 1x
@@ -681,8 +679,8 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //        score the new node earned before the NFT ever arrived.
         uint256 currentEpoch = chronos.getCurrentEpoch();
         bytes32 delegatorKey = bytes32(tokenId);
-        staking.prepareForStakeChange(currentEpoch, oldIdentityId, delegatorKey);
-        staking.prepareForStakeChange(currentEpoch, newIdentityId, delegatorKey);
+        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, newIdentityId);
 
         // 7. Move the StakingStorage delegator stake base. Writing 0 on
         //    the old (identity, key) bucket triggers
@@ -840,10 +838,10 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         if (uint256(amount) > withdrawable) revert InsufficientWithdrawable();
 
         // Settle delegator score indices BEFORE mutating any effective stake.
-        // `prepareForStakeChange` is `onlyContracts` on the V8 `Staking`
-        // contract — StakingV10 is Hub-registered so the call is authorized.
+        // `_prepareForStakeChangeV10` uses effective stake (via
+        // `_getEffectiveStakeAtEpoch`) instead of V8's raw base.
         bytes32 delegatorKey = bytes32(tokenId);
-        staking.prepareForStakeChange(currentEpoch, pos.identityId, delegatorKey);
+        _prepareForStakeChangeV10(currentEpoch, tokenId);
 
         // Compute split: drain rewards first, raw for the remainder. The
         // earlier `withdrawable` check guarantees `rawDraw <= pos.raw`.
@@ -937,7 +935,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // Settle delegator score indices BEFORE mutating effective stake.
         uint256 currentEpoch = chronos.getCurrentEpoch();
         bytes32 delegatorKey = bytes32(tokenId);
-        staking.prepareForStakeChange(currentEpoch, pos.identityId, delegatorKey);
+        _prepareForStakeChangeV10(currentEpoch, tokenId);
 
         // Restore the conviction-side buckets to their pre-create state.
         // Re-use the rewardsPortion split captured at create time so a
@@ -1128,11 +1126,11 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // style reward claim at the same (identityId, delegatorKey) would
         // read `lastSettledScorePerStake` against a stale base and collect
         // score that belongs to the pre-compound delegation. Matches the
-        // stake / relock / redelegate / finalizeWithdrawal pattern in this
-        // contract — `prepareForStakeChange` is `external onlyContracts`
-        // on the V8 `Staking` contract and StakingV10 is Hub-registered.
+        // stake / relock / redelegate / createWithdrawal / cancelWithdrawal
+        // pattern in this contract — `_prepareForStakeChangeV10` uses
+        // effective stake instead of V8's raw base.
         bytes32 delegatorKey = bytes32(tokenId);
-        staking.prepareForStakeChange(currentEpoch, pos.identityId, delegatorKey);
+        _prepareForStakeChangeV10(currentEpoch, tokenId);
 
         // Local cache to avoid repeated SLOAD in the walk loop.
         uint256 raw = uint256(pos.raw);
@@ -1425,7 +1423,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //    don't want to commit to a lock tier but still want the
         //    NFT-backed model.
         bytes32 v10Key = bytes32(tokenId);
-        staking.prepareForStakeChange(currentEpoch, identityId, v10Key);
+        _prepareForStakeChangeV10(currentEpoch, tokenId);
 
         ss.setDelegatorStakeBase(identityId, v10Key, amount);
         ss.increaseNodeStake(identityId, amount);
@@ -1449,5 +1447,179 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         ask.recalculateActiveSet();
 
         emit ConvertedFromV8(staker, tokenId, identityId, amount, lockEpochs);
+    }
+
+    // ========================================================================
+    // Internal helpers â V10 score-per-stake settlement
+    // ========================================================================
+
+    /**
+     * @dev Return the effective stake a position contributes at `epoch`.
+     *      Pre-expiry: `raw * multiplier18 / SCALE18 + rewards`.
+     *      Post-expiry (or lock-0 rest state where `expiryEpoch == 0`):
+     *      `raw + rewards`.
+     *
+     *      Used by `_prepareForStakeChangeV10` as the per-delegator base for
+     *      settlement (replaces V8's `stakingStorage.getDelegatorStakeBase`).
+     */
+    function _getEffectiveStakeAtEpoch(
+        ConvictionStakingStorage.Position memory pos,
+        uint256 epoch
+    ) internal pure returns (uint256) {
+        uint256 raw = uint256(pos.raw);
+        uint256 rewards = uint256(pos.rewards);
+        uint256 expiryEpoch = uint256(pos.expiryEpoch);
+        if (expiryEpoch != 0 && epoch < expiryEpoch) {
+            return (raw * uint256(pos.multiplier18)) / SCALE18 + rewards;
+        }
+        return raw + rewards;
+    }
+
+    /**
+     * @dev V10 analog of V8's `Staking._prepareForStakeChange` (Staking.sol:739-791).
+     *      Settles the delegator's score-per-stake index at `epoch` using the
+     *      position's **effective stake** (via `_getEffectiveStakeAtEpoch`)
+     *      instead of V8's raw `stakingStorage.getDelegatorStakeBase`.
+     *
+     *      This is the KEY difference from V8: the denominator in
+     *      `nodeEpochScorePerStake36` will use effective node stake (after M3),
+     *      so the per-delegator settlement must also use effective stake.
+     *      Otherwise `sum(delegatorScores) != nodeScore`.
+     *
+     *      V10's `UnclaimedEpochs` guard ensures effective stake is constant
+     *      throughout the claim window (no V10 mutations while unclaimed
+     *      epochs exist), making the effective-stake lookup safe at any epoch.
+     *
+     * @param epoch    The epoch to settle at (typically `currentEpoch`).
+     * @param tokenId  The V10 NFT position. `identityId` is read from the
+     *                 position itself.
+     * @return delegatorScore  The delegator's total score at `epoch` after
+     *                         settlement (existing + newly earned).
+     */
+    function _prepareForStakeChangeV10(
+        uint256 epoch,
+        uint256 tokenId
+    ) internal returns (uint256 delegatorScore) {
+        bytes32 delegatorKey = bytes32(tokenId);
+        ConvictionStakingStorage.Position memory pos = convictionStorage.getPosition(tokenId);
+        uint72 identityId = pos.identityId;
+
+        // 1. Current score-per-stake index for the node.
+        uint256 nodeScorePerStake36 = randomSamplingStorage.getNodeEpochScorePerStake(epoch, identityId);
+
+        uint256 currentDelegatorScore18 = randomSamplingStorage.getEpochNodeDelegatorScore(
+            epoch,
+            identityId,
+            delegatorKey
+        );
+
+        // 2. Last index at which this delegator was settled.
+        uint256 lastSettled = randomSamplingStorage
+            .getDelegatorLastSettledNodeEpochScorePerStake(epoch, identityId, delegatorKey);
+
+        // Nothing new to settle.
+        if (nodeScorePerStake36 == lastSettled) {
+            return currentDelegatorScore18;
+        }
+
+        // 3. Effective stake â the KEY difference from V8.
+        uint256 effectiveStake = _getEffectiveStakeAtEpoch(pos, epoch);
+
+        // If the delegator has no effective stake, just bump the index and exit.
+        if (effectiveStake == 0) {
+            randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
+                epoch,
+                identityId,
+                delegatorKey,
+                nodeScorePerStake36
+            );
+            return currentDelegatorScore18;
+        }
+
+        // 4. Newly earned score for this delegator in the epoch.
+        uint256 scorePerStakeDiff36 = nodeScorePerStake36 - lastSettled;
+        uint256 scoreEarned18 = (effectiveStake * scorePerStakeDiff36) / SCALE18;
+
+        // 5. Persist results.
+        if (scoreEarned18 > 0) {
+            randomSamplingStorage.addToEpochNodeDelegatorScore(epoch, identityId, delegatorKey, scoreEarned18);
+        }
+
+        randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
+            epoch,
+            identityId,
+            delegatorKey,
+            nodeScorePerStake36
+        );
+
+        return currentDelegatorScore18 + scoreEarned18;
+    }
+
+    /**
+     * @dev Overload for the redelegate new-node baseline case. Uses
+     *      `overrideIdentityId` instead of `pos.identityId` â needed when
+     *      settling on a node the position hasn't moved to yet (the position
+     *      still points at the OLD node at the time of the call).
+     *
+     *      Otherwise identical to the single-arg overload above.
+     */
+    function _prepareForStakeChangeV10(
+        uint256 epoch,
+        uint256 tokenId,
+        uint72 overrideIdentityId
+    ) internal returns (uint256 delegatorScore) {
+        bytes32 delegatorKey = bytes32(tokenId);
+        ConvictionStakingStorage.Position memory pos = convictionStorage.getPosition(tokenId);
+        uint72 identityId = overrideIdentityId;
+
+        // 1. Current score-per-stake index for the node.
+        uint256 nodeScorePerStake36 = randomSamplingStorage.getNodeEpochScorePerStake(epoch, identityId);
+
+        uint256 currentDelegatorScore18 = randomSamplingStorage.getEpochNodeDelegatorScore(
+            epoch,
+            identityId,
+            delegatorKey
+        );
+
+        // 2. Last index at which this delegator was settled.
+        uint256 lastSettled = randomSamplingStorage
+            .getDelegatorLastSettledNodeEpochScorePerStake(epoch, identityId, delegatorKey);
+
+        // Nothing new to settle.
+        if (nodeScorePerStake36 == lastSettled) {
+            return currentDelegatorScore18;
+        }
+
+        // 3. Effective stake â the KEY difference from V8.
+        uint256 effectiveStake = _getEffectiveStakeAtEpoch(pos, epoch);
+
+        // If the delegator has no effective stake, just bump the index and exit.
+        if (effectiveStake == 0) {
+            randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
+                epoch,
+                identityId,
+                delegatorKey,
+                nodeScorePerStake36
+            );
+            return currentDelegatorScore18;
+        }
+
+        // 4. Newly earned score for this delegator in the epoch.
+        uint256 scorePerStakeDiff36 = nodeScorePerStake36 - lastSettled;
+        uint256 scoreEarned18 = (effectiveStake * scorePerStakeDiff36) / SCALE18;
+
+        // 5. Persist results.
+        if (scoreEarned18 > 0) {
+            randomSamplingStorage.addToEpochNodeDelegatorScore(epoch, identityId, delegatorKey, scoreEarned18);
+        }
+
+        randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
+            epoch,
+            identityId,
+            delegatorKey,
+            nodeScorePerStake36
+        );
+
+        return currentDelegatorScore18 + scoreEarned18;
     }
 }

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -1166,38 +1166,41 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
 
             // Step 1: delegator's score for this epoch
             uint256 delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
-            if (delegatorScore18 == 0) continue;
 
             uint256 nodeScore18 = randomSamplingStorage.getNodeEpochScore(e, identityId);
-            if (nodeScore18 == 0) continue;
 
             // Step 2: convert score → TRAC (V8 pattern from Staking.sol:568-593)
-            uint256 netNodeRewards;
-            if (!delegatorsInfo.isOperatorFeeClaimedForEpoch(identityId, e)) {
-                uint256 allNodesScore18 = randomSamplingStorage.getAllNodesEpochScore(e);
-                if (allNodesScore18 > 0) {
-                    uint256 grossNodeRewards = (epochStorage.getEpochPool(EPOCH_POOL_INDEX, e)
-                        * nodeScore18) / allNodesScore18;
-                    uint96 operatorFeeAmount = uint96(
-                        (grossNodeRewards
-                            * profileStorage.getLatestOperatorFeePercentage(identityId))
-                            / parametersStorage.maxOperatorFee()
-                    );
-                    netNodeRewards = grossNodeRewards - operatorFeeAmount;
-                    delegatorsInfo.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
-                    delegatorsInfo.setNetNodeEpochRewards(identityId, e, netNodeRewards);
-                    stakingStorage.increaseOperatorFeeBalance(identityId, operatorFeeAmount);
+            uint256 epochReward = 0;
+            if (delegatorScore18 > 0 && nodeScore18 > 0) {
+                uint256 netNodeRewards;
+                if (!delegatorsInfo.isOperatorFeeClaimedForEpoch(identityId, e)) {
+                    uint256 allNodesScore18 = randomSamplingStorage.getAllNodesEpochScore(e);
+                    if (allNodesScore18 > 0) {
+                        uint256 grossNodeRewards = (epochStorage.getEpochPool(EPOCH_POOL_INDEX, e)
+                            * nodeScore18) / allNodesScore18;
+                        uint96 operatorFeeAmount = uint96(
+                            (grossNodeRewards
+                                * profileStorage.getLatestOperatorFeePercentage(identityId))
+                                / parametersStorage.maxOperatorFee()
+                        );
+                        netNodeRewards = grossNodeRewards - operatorFeeAmount;
+                        delegatorsInfo.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
+                        delegatorsInfo.setNetNodeEpochRewards(identityId, e, netNodeRewards);
+                        stakingStorage.increaseOperatorFeeBalance(identityId, operatorFeeAmount);
+                    }
+                } else {
+                    netNodeRewards = delegatorsInfo.getNetNodeEpochRewards(identityId, e);
                 }
-            } else {
-                netNodeRewards = delegatorsInfo.getNetNodeEpochRewards(identityId, e);
+                epochReward = (delegatorScore18 * netNodeRewards) / nodeScore18;
             }
 
-            // Set operator fee flag for scoreless epochs to not block Profile.updateOperatorFee
+            // Unconditional fee-flag write — mirrors V8 Staking.sol:596-600.
+            // Ensures Profile.updateOperatorFee is never blocked by rewardless epochs.
             if (!delegatorsInfo.isOperatorFeeClaimedForEpoch(identityId, e)) {
                 delegatorsInfo.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
             }
 
-            rewardTotal += (delegatorScore18 * netNodeRewards) / nodeScore18;
+            rewardTotal += epochReward;
         }
 
         if (rewardTotal == 0) {

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -391,7 +391,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //    to first-time address-keyed delegators, and the Phase 4
         //    `_recordStake` path applies to NFT-keyed ones.
         bytes32 delegatorKey = bytes32(tokenId);
-        _prepareForStakeChangeV10(chronos.getCurrentEpoch(), tokenId);
+        _prepareForStakeChangeV10(chronos.getCurrentEpoch(), tokenId, identityId);
 
         // 6. Pull TRAC straight from `staker` into `StakingStorage`.
         //    The NFT wrapper never holds funds (Phase 5 decision Q4):
@@ -525,7 +525,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //    re-collect score the delegator has already effectively earned
         //    under the old (post-expiry, 1x) contribution profile. Mirrors
         //    the Phase 4 `Staking._recordStake` settlement step.
-        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, pos.identityId);
 
         // 4. Resolve the new tier multiplier. Reverts `"Invalid lock"` for
         //    any lock outside {0,1,3,6,12}. Tier==0 is the rest state at 1x
@@ -687,7 +687,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //        score the new node earned before the NFT ever arrived.
         uint256 currentEpoch = chronos.getCurrentEpoch();
         bytes32 delegatorKey = bytes32(tokenId);
-        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, oldIdentityId);
         _prepareForStakeChangeV10(currentEpoch, tokenId, newIdentityId);
 
         // 7. Move the StakingStorage delegator stake base. Writing 0 on
@@ -849,7 +849,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // `_prepareForStakeChangeV10` uses effective stake (via
         // `_getEffectiveStakeAtEpoch`) instead of V8's raw base.
         bytes32 delegatorKey = bytes32(tokenId);
-        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, pos.identityId);
 
         // Compute split: drain rewards first, raw for the remainder. The
         // earlier `withdrawable` check guarantees `rawDraw <= pos.raw`.
@@ -943,7 +943,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // Settle delegator score indices BEFORE mutating effective stake.
         uint256 currentEpoch = chronos.getCurrentEpoch();
         bytes32 delegatorKey = bytes32(tokenId);
-        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, pos.identityId);
 
         // Restore the conviction-side buckets to their pre-create state.
         // Re-use the rewardsPortion split captured at create time so a
@@ -1133,7 +1133,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // pattern in this contract — `_prepareForStakeChangeV10` uses
         // effective stake instead of V8's raw base.
         bytes32 delegatorKey = bytes32(tokenId);
-        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, pos.identityId);
 
         // Local cache to avoid repeated SLOAD in the walk loop.
         uint256 raw = uint256(pos.raw);
@@ -1169,9 +1169,17 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
 
             uint256 nodeScore18 = randomSamplingStorage.getNodeEpochScore(e, identityId);
 
-            // Step 2: convert score → TRAC (V8 pattern from Staking.sol:568-593)
+            // Step 2: convert score → TRAC (V8 pattern from Staking.sol:567-600).
+            // Fee computation gates on `nodeScore18 > 0` ONLY — any epoch
+            // with a nonzero node score must cache netNodeRewards so later
+            // claimants on the same (identityId, epoch) can read the cached
+            // value. Gating on `delegatorScore18` as well would let a dust
+            // claimant mark the fee as claimed without writing the cache,
+            // zeroing out all subsequent claimants.
             uint256 epochReward = 0;
-            if (delegatorScore18 > 0 && nodeScore18 > 0) {
+            if (nodeScore18 > 0) {
+                // Compute/cache operator fee and netNodeRewards — runs for
+                // ANY epoch with node score, regardless of delegator score.
                 uint256 netNodeRewards;
                 if (!delegatorsInfo.isOperatorFeeClaimedForEpoch(identityId, e)) {
                     uint256 allNodesScore18 = randomSamplingStorage.getAllNodesEpochScore(e);
@@ -1191,7 +1199,11 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
                 } else {
                     netNodeRewards = delegatorsInfo.getNetNodeEpochRewards(identityId, e);
                 }
-                epochReward = (delegatorScore18 * netNodeRewards) / nodeScore18;
+
+                // Only compute the delegator's share if they have nonzero score.
+                if (delegatorScore18 > 0) {
+                    epochReward = (delegatorScore18 * netNodeRewards) / nodeScore18;
+                }
             }
 
             // Unconditional fee-flag write — mirrors V8 Staking.sol:596-600.
@@ -1428,7 +1440,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         //    don't want to commit to a lock tier but still want the
         //    NFT-backed model.
         bytes32 v10Key = bytes32(tokenId);
-        _prepareForStakeChangeV10(currentEpoch, tokenId);
+        _prepareForStakeChangeV10(currentEpoch, tokenId, identityId);
 
         ss.setDelegatorStakeBase(identityId, v10Key, amount);
         ss.increaseNodeStake(identityId, amount);
@@ -1482,100 +1494,55 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
 
     /**
      * @dev V10 analog of V8's `Staking._prepareForStakeChange` (Staking.sol:739-791).
-     *      Settles the delegator's score-per-stake index at `epoch` using the
-     *      position's **effective stake** (via `_getEffectiveStakeAtEpoch`)
-     *      instead of V8's raw `stakingStorage.getDelegatorStakeBase`.
+     *      Settles the delegator's score-per-stake index at `epoch` using
+     *      **effective stake** (via `_getEffectiveStakeAtEpoch`) instead of
+     *      V8's raw `stakingStorage.getDelegatorStakeBase`.
      *
-     *      This is the KEY difference from V8: the denominator in
-     *      `nodeEpochScorePerStake36` will use effective node stake (after M3),
-     *      so the per-delegator settlement must also use effective stake.
-     *      Otherwise `sum(delegatorScores) != nodeScore`.
+     *      Settlement vs baseline logic:
+     *        - If `pos.identityId == identityId` the position lives on this
+     *          node, so we settle with the real effective stake.
+     *        - Otherwise (position is on a different node, or doesn't exist
+     *          yet -- e.g. `stake()` / `convertToNFT()` before
+     *          `createPosition`) we baseline only: bump the index with zero
+     *          effective stake so a later claim doesn't collect score the
+     *          node earned before the position arrived.
+     *
+     *      Every call site passes the target node's `identityId` explicitly.
+     *      This eliminates the two-overload bug where the 2-arg version read
+     *      `identityId` from a non-existent position (node 0 baseline)
+     *      and the 3-arg version used the old position's effective stake on
+     *      the new node (free score on redelegate).
      *
      *      V10's `UnclaimedEpochs` guard ensures effective stake is constant
      *      throughout the claim window (no V10 mutations while unclaimed
      *      epochs exist), making the effective-stake lookup safe at any epoch.
      *
-     * @param epoch    The epoch to settle at (typically `currentEpoch`).
-     * @param tokenId  The V10 NFT position. `identityId` is read from the
-     *                 position itself.
+     * @param epoch       The epoch to settle at (typically `currentEpoch`).
+     * @param tokenId     The V10 NFT position.
+     * @param identityId  The target node. Must be passed explicitly by every
+     *                    call site -- never derived from the position.
      * @return delegatorScore  The delegator's total score at `epoch` after
      *                         settlement (existing + newly earned).
      */
     function _prepareForStakeChangeV10(
         uint256 epoch,
-        uint256 tokenId
-    ) internal returns (uint256 delegatorScore) {
-        bytes32 delegatorKey = bytes32(tokenId);
-        ConvictionStakingStorage.Position memory pos = convictionStorage.getPosition(tokenId);
-        uint72 identityId = pos.identityId;
-
-        // 1. Current score-per-stake index for the node.
-        uint256 nodeScorePerStake36 = randomSamplingStorage.getNodeEpochScorePerStake(epoch, identityId);
-
-        uint256 currentDelegatorScore18 = randomSamplingStorage.getEpochNodeDelegatorScore(
-            epoch,
-            identityId,
-            delegatorKey
-        );
-
-        // 2. Last index at which this delegator was settled.
-        uint256 lastSettled = randomSamplingStorage
-            .getDelegatorLastSettledNodeEpochScorePerStake(epoch, identityId, delegatorKey);
-
-        // Nothing new to settle.
-        if (nodeScorePerStake36 == lastSettled) {
-            return currentDelegatorScore18;
-        }
-
-        // 3. Effective stake â the KEY difference from V8.
-        uint256 effectiveStake = _getEffectiveStakeAtEpoch(pos, epoch);
-
-        // If the delegator has no effective stake, just bump the index and exit.
-        if (effectiveStake == 0) {
-            randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
-                epoch,
-                identityId,
-                delegatorKey,
-                nodeScorePerStake36
-            );
-            return currentDelegatorScore18;
-        }
-
-        // 4. Newly earned score for this delegator in the epoch.
-        uint256 scorePerStakeDiff36 = nodeScorePerStake36 - lastSettled;
-        uint256 scoreEarned18 = (effectiveStake * scorePerStakeDiff36) / SCALE18;
-
-        // 5. Persist results.
-        if (scoreEarned18 > 0) {
-            randomSamplingStorage.addToEpochNodeDelegatorScore(epoch, identityId, delegatorKey, scoreEarned18);
-        }
-
-        randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
-            epoch,
-            identityId,
-            delegatorKey,
-            nodeScorePerStake36
-        );
-
-        return currentDelegatorScore18 + scoreEarned18;
-    }
-
-    /**
-     * @dev Overload for the redelegate new-node baseline case. Uses
-     *      `overrideIdentityId` instead of `pos.identityId` â needed when
-     *      settling on a node the position hasn't moved to yet (the position
-     *      still points at the OLD node at the time of the call).
-     *
-     *      Otherwise identical to the single-arg overload above.
-     */
-    function _prepareForStakeChangeV10(
-        uint256 epoch,
         uint256 tokenId,
-        uint72 overrideIdentityId
+        uint72 identityId
     ) internal returns (uint256 delegatorScore) {
         bytes32 delegatorKey = bytes32(tokenId);
+
+        // Determine settlement vs baseline: if the position lives on this
+        // node, settle with real effective stake. Otherwise baseline only
+        // (zero effective).
         ConvictionStakingStorage.Position memory pos = convictionStorage.getPosition(tokenId);
-        uint72 identityId = overrideIdentityId;
+
+        uint256 effectiveStake;
+        if (pos.identityId == identityId) {
+            effectiveStake = _getEffectiveStakeAtEpoch(pos, epoch);
+        } else {
+            // Position is on a different node or doesn't exist -- baseline only.
+            effectiveStake = 0;
+        }
 
         // 1. Current score-per-stake index for the node.
         uint256 nodeScorePerStake36 = randomSamplingStorage.getNodeEpochScorePerStake(epoch, identityId);
@@ -1595,10 +1562,8 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
             return currentDelegatorScore18;
         }
 
-        // 3. Effective stake â the KEY difference from V8.
-        uint256 effectiveStake = _getEffectiveStakeAtEpoch(pos, epoch);
-
-        // If the delegator has no effective stake, just bump the index and exit.
+        // If effective stake is zero (baseline or empty position), just bump
+        // the index.
         if (effectiveStake == 0) {
             randomSamplingStorage.setDelegatorLastSettledNodeEpochScorePerStake(
                 epoch,
@@ -1609,11 +1574,11 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
             return currentDelegatorScore18;
         }
 
-        // 4. Newly earned score for this delegator in the epoch.
+        // 3. Newly earned score for this delegator in the epoch.
         uint256 scorePerStakeDiff36 = nodeScorePerStake36 - lastSettled;
         uint256 scoreEarned18 = (effectiveStake * scorePerStakeDiff36) / SCALE18;
 
-        // 5. Persist results.
+        // 4. Persist results.
         if (scoreEarned18 > 0) {
             randomSamplingStorage.addToEpochNodeDelegatorScore(epoch, identityId, delegatorKey, scoreEarned18);
         }

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -12,6 +12,7 @@ import {StakingStorage} from "./storage/StakingStorage.sol";
 import {ConvictionStakingStorage} from "./storage/ConvictionStakingStorage.sol";
 import {DelegatorsInfo} from "./storage/DelegatorsInfo.sol";
 import {RandomSamplingStorage} from "./storage/RandomSamplingStorage.sol";
+import {EpochStorage} from "./storage/EpochStorage.sol";
 import {Chronos} from "./storage/Chronos.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
@@ -69,6 +70,11 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
     ///         governs the V8 legacy address-keyed path only).
     uint256 public constant WITHDRAWAL_DELAY = 15 days;
 
+    /// @notice EpochStorage shard ID for the reward pool. Matches V8
+    ///         `Staking.EPOCH_POOL_INDEX` — the two contracts read the same
+    ///         reward pool.
+    uint256 private constant EPOCH_POOL_INDEX = 1;
+
     // NOTE: `EPOCHS_PER_MONTH` is not defined here. The relock math works in
     // raw epoch counts — Chronos exposes an absolute epoch number, and lock
     // tiers {0, 1, 3, 6, 12} are the authoritative lock set per
@@ -91,6 +97,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
     ProfileStorage public profileStorage;
     Staking public staking;
     IERC20 public token;
+    EpochStorage public epochStorage;
 
     // ========================================================================
     // Events
@@ -226,6 +233,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         profileStorage = ProfileStorage(hub.getContractAddress("ProfileStorage"));
         staking = Staking(hub.getContractAddress("Staking"));
         token = IERC20(hub.getContractAddress("Token"));
+        epochStorage = EpochStorage(hub.getContractAddress("EpochStorageV8"));
     }
 
     function name() external pure virtual override returns (string memory) {
@@ -1067,16 +1075,14 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
      *           `rewardsSnapshot` is `pos.rewards` captured once before
      *           the walk — matching the spec's semantics of "the
      *           compounded rewards value at the time of claim".
-     *        5. Per-epoch reward:
-     *              reward_e = effStake_e * nodeEpochScorePerStake[e] / 1e18
-     *           scale matches V8 `_prepareForStakeChange`
-     *           (`scoreEarned18 = stakeBase * scorePerStakeDiff36 / SCALE18`).
-     *           In the V8 address-keyed path the score is further converted
-     *           to TRAC via `reward = delegatorScore18 * netNodeRewards /
-     *           nodeScore18` — that conversion lives in Phase 11, which will
-     *           replace this formula with the actual Paymaster flow. Phase 5
-     *           treats the score-weighted effective stake as the reward TRAC
-     *           stub so the claim bookkeeping path can be unit-tested end-to-end.
+     *        5. Per-epoch reward (two-step, mirrors V8 Staking.sol:568-593):
+     *           a. `delegatorScore18 = effStake * scorePerStake36 / 1e18`
+     *           b. `netNodeRewards = epochPool * nodeScore / allNodesScore
+     *              - operatorFee` (first claimer per (node, epoch) computes
+     *              and caches via `delegatorsInfo`; subsequent claimers read
+     *              the cached value).
+     *           c. `trac_reward = delegatorScore18 * netNodeRewards /
+     *              nodeScore18`
      *        6. If the window produced zero reward (all scores were zero or
      *           the Paymaster was empty), advance `lastClaimedEpoch` to
      *           skip the walk on the next call but emit nothing and skip
@@ -1088,16 +1094,13 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
      *           and global `increaseNodeStake` / `increaseTotalStake` +
      *           `setLastClaimedEpoch` + emit `RewardsClaimed`.
      *
-     *      **TRAC source — Phase 11.** Phase 5 `claim` does NOT pull TRAC
-     *      from any external source. The StakingStorage vault must be
-     *      pre-funded with the reward TRAC by Phase 11's Paymaster /
-     *      EpochStorage integration; unit tests simulate this by calling
-     *      `Token.mint(stakingStorage, rewardTotal)` before `claim`. If
-     *      the vault is under-funded, `increaseNodeStake` +
-     *      `increaseTotalStake` still succeed (they are pure accounting
-     *      mutations), but a later `finalizeWithdrawal` would revert on
-     *      the `transferStake` underflow. It is Phase 11's responsibility
-     *      to keep the vault funded in step with reward accrual.
+     *      **TRAC source.** TRAC is already in StakingStorage at claim time
+     *      — publishers deposit it during publishing via `Paymaster.coverCost`,
+     *      which distributes tokens across the epoch range into EpochStorage.
+     *      `claim()` reads `epochStorage.getEpochPool(1, e)` to compute each
+     *      epoch's gross reward but does not transfer any TRAC itself. The
+     *      vault balance invariant holds because the TRAC deposited by
+     *      publishers covers all claims.
      */
     function claim(
         address staker,
@@ -1153,32 +1156,48 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
                 effStake = raw + rewardsSnapshot;
             }
 
-            // Per-epoch score-per-stake from RandomSamplingStorage.
-            // `nodeEpochScorePerStake[e][identityId]` is stored at 1e36
-            // scale (score18 * SCALE18 / totalNodeStake_wei — see
-            // `RandomSampling.submitProof` at `:273`). Dividing by 1e18
-            // gives a 1e18-scaled score value matching V8's
-            // `_prepareForStakeChange` dimensional output:
-            //   scoreEarned18 = stakeBase * scorePerStakeDiff36 / SCALE18
-            // In the V8 reward path this `scoreEarned18` is further
-            // converted to TRAC via `reward = delegatorScore18 *
-            // netNodeRewards / nodeScore18`, where netNodeRewards comes
-            // from `epochStorage.getEpochPool(...) * nodeScore18 /
-            // allNodesScore18 - operatorFee`. That conversion is Phase 11's
-            // responsibility; Phase 5 treats the 1e18-scaled score as the
-            // reward TRAC stub so the claim bookkeeping can be exercised
-            // end-to-end under unit test.
-            //
-            // NOTE: Unlike a "cumulative index" design, V8's
-            // `nodeEpochScorePerStake` is PER-EPOCH — each epoch's value
-            // is the score-per-stake accrued within that epoch alone. No
-            // `[e] - [e-1]` subtraction is needed (or correct).
+            // Score computation (unchanged from Phase 5) — then score→TRAC
+            // conversion added by Phase 11.  `scorePerStake36` is PER-EPOCH,
+            // not cumulative — no `[e] - [e-1]` subtraction needed.
             uint256 scorePerStake36 = randomSamplingStorage.getNodeEpochScorePerStake(
                 e,
                 identityId
             );
 
-            rewardTotal += (effStake * scorePerStake36) / SCALE18;
+            // Step 1: delegator's score for this epoch
+            uint256 delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
+            if (delegatorScore18 == 0) continue;
+
+            uint256 nodeScore18 = randomSamplingStorage.getNodeEpochScore(e, identityId);
+            if (nodeScore18 == 0) continue;
+
+            // Step 2: convert score → TRAC (V8 pattern from Staking.sol:568-593)
+            uint256 netNodeRewards;
+            if (!delegatorsInfo.isOperatorFeeClaimedForEpoch(identityId, e)) {
+                uint256 allNodesScore18 = randomSamplingStorage.getAllNodesEpochScore(e);
+                if (allNodesScore18 > 0) {
+                    uint256 grossNodeRewards = (epochStorage.getEpochPool(EPOCH_POOL_INDEX, e)
+                        * nodeScore18) / allNodesScore18;
+                    uint96 operatorFeeAmount = uint96(
+                        (grossNodeRewards
+                            * profileStorage.getLatestOperatorFeePercentage(identityId))
+                            / parametersStorage.maxOperatorFee()
+                    );
+                    netNodeRewards = grossNodeRewards - operatorFeeAmount;
+                    delegatorsInfo.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
+                    delegatorsInfo.setNetNodeEpochRewards(identityId, e, netNodeRewards);
+                    stakingStorage.increaseOperatorFeeBalance(identityId, operatorFeeAmount);
+                }
+            } else {
+                netNodeRewards = delegatorsInfo.getNetNodeEpochRewards(identityId, e);
+            }
+
+            // Set operator fee flag for scoreless epochs to not block Profile.updateOperatorFee
+            if (!delegatorsInfo.isOperatorFeeClaimedForEpoch(identityId, e)) {
+                delegatorsInfo.setIsOperatorFeeClaimedForEpoch(identityId, e, true);
+            }
+
+            rewardTotal += (delegatorScore18 * netNodeRewards) / nodeScore18;
         }
 
         if (rewardTotal == 0) {
@@ -1226,23 +1245,6 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
         // 4. Advance the position's claim cursor to the walked boundary so
         //    subsequent calls in the same epoch are pure no-ops.
         convictionStorage.setLastClaimedEpoch(tokenId, uint64(claimToEpoch));
-
-        // WARNING: claim() increases StakingStorage accounting (nodeStake /
-        // totalStake / delegatorStakeBase) by `rewardTotal` ahead of the
-        // actual TRAC arriving in the StakingStorage vault. Phase 11 MUST
-        // land before ANY testnet/mainnet deployment — otherwise
-        // finalizeWithdrawal will underflow the vault and leave the
-        // totalStake invariant broken.
-        //
-        // Phase 11 wires Paymaster/EpochStorage to push reward TRAC into
-        // StakingStorage in the same transaction as this accounting update,
-        // restoring the invariant.
-        //
-        // For Phase 5 unit tests, the fixture pre-funds the vault via
-        // Token.mint(stakingStorage, amount).
-        //
-        // TODO(Phase 11): pull `rewardTotal` TRAC from Paymaster/EpochStorage
-        // into StakingStorage.
 
         emit RewardsClaimed(tokenId, uint96(rewardTotal));
     }

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -19,9 +19,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
     //     used by `StakingV10.cancelWithdrawal`.
     string private constant _VERSION = "1.2.0";
 
-    // Multiplier scale, matches Staking.convictionMultiplier /
-    // DKGStakingConvictionNFT._convictionMultiplier (both return 1e18-scaled
-    // values so fractional tiers like 1.5x and 3.5x are representable).
+    // Multiplier scale, matches DKGStakingConvictionNFT._convictionMultiplier
+    // (returns 1e18-scaled values so fractional tiers like 1.5x and 3.5x
+    // are representable).
     uint256 internal constant SCALE18 = 1e18;
 
     // Position layout (two storage slots — Phase 5 split-bucket model):
@@ -141,6 +141,14 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
     mapping(uint72 => uint256) public nodeLastFinalizedEpoch;
     mapping(uint72 => uint256) public nodeFirstDirtyEpoch;
 
+    // Phase 11 — per-node sum of V10 delegator bases (raw + rewards).
+    // Updated at transaction time only (stake/claim/withdraw/redelegate/convert),
+    // never at epoch boundaries. Used by RandomSampling.submitProof to compute
+    //   effectiveNodeStake = nodeStake + (nodeEffective - nodeV10BaseStake)
+    // so the denominator for score-per-stake separates the multiplier boost
+    // from the underlying base commitment.
+    mapping(uint72 => uint256) public nodeV10BaseStake;
+
     constructor(address hubAddress) HubDependent(hubAddress) {}
 
     function initialize() public onlyHub {
@@ -165,11 +173,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
     // 1x rest state (post-expiry positions and V8-compat defaults both land
     // here). `lockEpochs == 1` is the 1-month bootstrap tier at 1.5x.
     //
-    // NOTE: `Staking.convictionMultiplier` and
-    // `DKGStakingConvictionNFT._convictionMultiplier` still carry the legacy
-    // snap-down tier tables. Updating them is out of scope for this Phase 5
-    // storage hotfix; downstream subagents must align all three in a single
-    // symmetric change before mainnet.
+    // NOTE: `DKGStakingConvictionNFT._convictionMultiplier` uses exact-match
+    // semantics aligned with this table. The legacy snap-down
+    // `Staking.convictionMultiplier` has been deleted (Phase 11).
     function expectedMultiplier18(uint40 lockEpochs) public pure returns (uint64) {
         if (lockEpochs == 0) return uint64(SCALE18);              // rest state: 1.0x
         if (lockEpochs == 1) return uint64((15 * SCALE18) / 10);  // 1.5x
@@ -213,6 +219,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
             multiplier18: multiplier18,
             lastClaimedEpoch: uint64(currentEpoch - 1)
         });
+
+        // Phase 11: track the raw base for this node (rewards starts at 0).
+        nodeV10BaseStake[identityId] += uint256(raw);
 
         // Apply diff: full effective stake (raw * multiplier18 / 1e18) enters at currentEpoch
         int256 initialEffective = (int256(uint256(raw)) * int256(uint256(multiplier18))) / int256(SCALE18);
@@ -336,6 +345,11 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
 
         pos.identityId = newIdentityId;
 
+        // Phase 11: move the base (raw + rewards) between nodes.
+        uint256 base = uint256(raw) + uint256(rewardsBucket);
+        nodeV10BaseStake[oldIdentityId] -= base;
+        nodeV10BaseStake[newIdentityId] += base;
+
         if (currentEpoch > 1) {
             _finalizeNodeEffectiveStakeUpTo(oldIdentityId, currentEpoch - 1);
             _finalizeNodeEffectiveStakeUpTo(newIdentityId, currentEpoch - 1);
@@ -382,6 +396,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
             effectiveStakeDiff[expiryEpoch] += expiryDelta;
             nodeEffectiveStakeDiff[identityId][expiryEpoch] += expiryDelta;
         }
+
+        // Phase 11: subtract the full base before zeroing the struct.
+        nodeV10BaseStake[identityId] -= uint256(raw) + uint256(rewardsBucket);
 
         delete positions[tokenId];
 
@@ -444,6 +461,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
 
         pos.rewards = pos.rewards + amount;
 
+        // Phase 11: rewards are part of the base.
+        nodeV10BaseStake[identityId] += uint256(amount);
+
         if (currentEpoch > 1) {
             _finalizeEffectiveStakeUpTo(currentEpoch - 1);
             _finalizeNodeEffectiveStakeUpTo(identityId, currentEpoch - 1);
@@ -471,6 +491,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
         _markNodeDirty(identityId, currentEpoch);
 
         pos.rewards = pos.rewards - amount;
+
+        // Phase 11: rewards are part of the base.
+        nodeV10BaseStake[identityId] -= uint256(amount);
 
         if (currentEpoch > 1) {
             _finalizeEffectiveStakeUpTo(currentEpoch - 1);
@@ -523,6 +546,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
         }
 
         pos.raw = pos.raw - amount;
+
+        // Phase 11: raw is part of the base.
+        nodeV10BaseStake[identityId] -= uint256(amount);
 
         if (currentEpoch > 1) {
             _finalizeEffectiveStakeUpTo(currentEpoch - 1);
@@ -580,6 +606,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
         }
 
         pos.raw = pos.raw + amount;
+
+        // Phase 11: raw is part of the base.
+        nodeV10BaseStake[identityId] += uint256(amount);
 
         if (currentEpoch > 1) {
             _finalizeEffectiveStakeUpTo(currentEpoch - 1);
@@ -672,6 +701,10 @@ contract ConvictionStakingStorage is INamed, IVersioned, HubDependent {
 
     function getNodeLastFinalizedEpoch(uint72 identityId) external view returns (uint256) {
         return nodeLastFinalizedEpoch[identityId];
+    }
+
+    function getNodeV10BaseStake(uint72 identityId) external view returns (uint256) {
+        return nodeV10BaseStake[identityId];
     }
 
     // ============================================================

--- a/packages/evm-module/deploy/031_deploy_random_sampling.ts
+++ b/packages/evm-module/deploy/031_deploy_random_sampling.ts
@@ -34,4 +34,5 @@ func.dependencies = [
   'ParametersStorage',
   'ContextGraphStorage',
   'ContextGraphValueStorage',
+  'ConvictionStakingStorage',
 ];

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -15,9 +15,9 @@ const ALICE_ID = 100n;
 const BOB_ID = 200n;
 const OTHER_ID = 999n;
 
-// Multiplier scale: matches Staking.convictionMultiplier and
-// DKGStakingConvictionNFT._convictionMultiplier (both 1e18-scaled). Fractional
-// tiers 1.5x and 3.5x are representable as 1.5e18 / 3.5e18.
+// Multiplier scale: matches DKGStakingConvictionNFT._convictionMultiplier
+// (1e18-scaled). Fractional tiers 1.5x and 3.5x are representable as
+// 1.5e18 / 3.5e18.
 const SCALE18 = 10n ** 18n;
 const ONE_X = SCALE18;
 const ONE_AND_HALF_X = (15n * SCALE18) / 10n;
@@ -72,7 +72,7 @@ describe('@unit ConvictionStakingStorage', () => {
   });
 
   // ------------------------------------------------------------
-  // Tier ladder (mirrors Staking.convictionMultiplier)
+  // Tier ladder (mirrors DKGStakingConvictionNFT._convictionMultiplier)
   // ------------------------------------------------------------
 
   describe('expectedMultiplier18 tier ladder', () => {

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -10,6 +10,7 @@ import {
   ConvictionStakingStorage,
   DelegatorsInfo,
   DKGStakingConvictionNFT,
+  EpochStorage,
   Hub,
   ParametersStorage,
   Profile,
@@ -1657,25 +1658,25 @@ describe('@unit DKGStakingConvictionNFT', () => {
   });
 
   // =====================================================================
-  // claim (→ StakingV10.claim) — Phase 5 auto-compound
+  // claim (→ StakingV10.claim) — Phase 11 TRAC-denominated rewards
   // =====================================================================
   //
   // StakingV10.claim walks `[pos.lastClaimedEpoch + 1 .. currentEpoch - 1]`,
   // computes per-epoch effective stake (multiplier pre-expiry, flat post-
-  // expiry, plus rewardsSnapshot always at 1x), multiplies by the
-  // per-epoch `nodeEpochScorePerStake` (stored by `RandomSamplingStorage`
-  // at 1e36 scale), divides by 1e18 to match the V8 `_prepareForStakeChange`
-  // dimensional output (`scoreEarned18 = stakeBase * scorePerStakeDiff36 /
-  // SCALE18`), and banks the sum into `pos.rewards` via
-  // `ConvictionStakingStorage.increaseRewards`.
+  // expiry, plus rewardsSnapshot always at 1x), then converts the
+  // delegator's score fraction into TRAC via the epoch reward pool:
   //
-  // **Stub semantics:** Phase 5 treats the score-weighted stake product as
-  // the reward TRAC amount. Phase 11 replaces the formula with the actual
-  // Paymaster-sourced `epochPool * nodeScore18 / allNodesScore18` flow.
-  // Tests inject `nodeEpochScorePerStake` via the hub-owner-privileged
-  // setter (`onlyContracts` admits `hub.owner()`) and pre-fund the
-  // StakingStorage vault with TRAC matching the expected reward so the
-  // node-stake bookkeeping stays sound across a downstream withdrawal.
+  //   delegatorScore18 = effStake * scorePerStake36 / 1e18
+  //   grossNodeRewards = epochPool * nodeScore18 / allNodesScore18
+  //   operatorFee = grossNodeRewards * opFeePercentage / maxOperatorFee
+  //   netNodeRewards = grossNodeRewards - operatorFee
+  //   reward = delegatorScore18 * netNodeRewards / nodeScore18
+  //
+  // Tests inject per-epoch state via hub-owner-privileged setters on
+  // RandomSamplingStorage (scorePerStake, nodeScore, allNodesScore) and
+  // EpochStorage (epoch pool), then pre-fund the StakingStorage vault with
+  // TRAC matching the expected reward so the node-stake bookkeeping stays
+  // sound across a downstream withdrawal.
   //
   // No-op contract: a fresh position has `lastClaimedEpoch = currentEpoch
   // - 1`, so claim on the same epoch returns without emitting. A claim
@@ -1692,14 +1693,90 @@ describe('@unit DKGStakingConvictionNFT', () => {
       identityId: number,
       scorePerStake36: bigint,
     ) => {
-      const RandomSamplingStorageContract = await hre.ethers.getContract<RandomSamplingStorage>(
-        'RandomSamplingStorage',
-      );
-      await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScorePerStake(
-        epoch,
-        identityId,
-        scorePerStake36,
-      );
+      const rss = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+      await rss.connect(accounts[0]).setNodeEpochScorePerStake(epoch, identityId, scorePerStake36);
+    };
+
+    // Helper — inject nodeEpochScore for a node at a specific epoch.
+    const injectNodeEpochScore = async (
+      epoch: number | bigint,
+      identityId: number,
+      score18: bigint,
+    ) => {
+      const rss = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+      await rss.connect(accounts[0]).setNodeEpochScore(epoch, identityId, score18);
+    };
+
+    // Helper — inject allNodesEpochScore for a specific epoch.
+    const injectAllNodesEpochScore = async (epoch: number | bigint, score18: bigint) => {
+      const rss = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+      await rss.connect(accounts[0]).setAllNodesEpochScore(epoch, score18);
+    };
+
+    // Helper — fund a contiguous range of epoch pools via EpochStorage.
+    // Each epoch in [startEpoch .. endEpoch] receives `amountPerEpoch`.
+    // IMPORTANT: EpochStorage.addTokensToEpochRange triggers epoch
+    // finalization on every call, which locks in the cumulative sums from
+    // diffs set up so far. Calling it multiple times for overlapping
+    // epoch windows would finalize partial state. Always fund the full
+    // epoch range in a single call when possible.
+    const fundEpochPoolRange = async (
+      startEpoch: number | bigint,
+      endEpoch: number | bigint,
+      amountPerEpoch: bigint,
+    ) => {
+      const es = await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
+      const numEpochs = BigInt(endEpoch) - BigInt(startEpoch) + 1n;
+      const totalAmount = amountPerEpoch * numEpochs;
+      await es.connect(accounts[0]).addTokensToEpochRange(1, startEpoch, endEpoch, totalAmount);
+    };
+
+    // Helper — fund a single epoch pool (convenience wrapper).
+    const fundEpochPool = async (epoch: number | bigint, amount: bigint) => {
+      await fundEpochPoolRange(epoch, epoch, amount);
+    };
+
+    // Helper — inject all epoch-level reward state in one call (single epoch).
+    // Sets scorePerStake, nodeScore, allNodesScore, and epoch pool for
+    // a single (epoch, identityId) tuple.
+    const injectEpochRewardState = async (
+      epoch: number | bigint,
+      identityId: number,
+      scorePerStake36: bigint,
+      nodeScore18: bigint,
+      allNodesScore18: bigint,
+      epochPool: bigint,
+    ) => {
+      await injectScorePerStake(epoch, identityId, scorePerStake36);
+      await injectNodeEpochScore(epoch, identityId, nodeScore18);
+      await injectAllNodesEpochScore(epoch, allNodesScore18);
+      await fundEpochPool(epoch, epochPool);
+    };
+
+    // Helper — inject score/epoch state for multiple epochs with a UNIFORM
+    // epoch pool. Uses a single `addTokensToEpochRange` call to avoid the
+    // finalization-ordering issue where subsequent calls lock in partial
+    // cumulative sums from earlier diffs.
+    const injectMultiEpochRewardState = async (
+      startEpoch: bigint,
+      epochCount: number,
+      identityId: number,
+      scorePerStakes: bigint[],
+      nodeScore18: bigint,
+      allNodesScore18: bigint,
+      epochPool: bigint,
+    ) => {
+      // Fund the full epoch range in ONE call.
+      const endEpoch = startEpoch + BigInt(epochCount) - 1n;
+      await fundEpochPoolRange(startEpoch, endEpoch, epochPool);
+
+      // Then inject per-epoch scores (these don't trigger finalization).
+      for (let i = 0; i < epochCount; i++) {
+        const e = startEpoch + BigInt(i);
+        await injectScorePerStake(e, identityId, scorePerStakes[i]);
+        await injectNodeEpochScore(e, identityId, nodeScore18);
+        await injectAllNodesEpochScore(e, allNodesScore18);
+      }
     };
 
     // Helper — pre-fund the StakingStorage vault with `amount` TRAC so the
@@ -1710,11 +1787,36 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await Token.mint(stakingStorageAddr, amount);
     };
 
-    // Helper — compute expected reward for a single epoch using the
-    // Phase 5 stub formula. Matches `StakingV10.claim`'s inner loop
-    // exactly: `reward = effStake * scorePerStake36 / 1e18`.
-    const computeReward = (effStake: bigint, scorePerStake36: bigint): bigint => {
-      return (effStake * scorePerStake36) / SCALE18;
+    // Helper — compute expected TRAC reward for a single epoch using the
+    // Phase 11 formula. Matches `StakingV10.claim`'s inner loop exactly:
+    //   delegatorScore18 = effStake * scorePerStake36 / 1e18
+    //   grossNodeRewards = epochPool * nodeScore18 / allNodesScore18
+    //   operatorFee = grossNodeRewards * operatorFeePercentage / maxOperatorFee
+    //   netNodeRewards = grossNodeRewards - operatorFee
+    //   reward = delegatorScore18 * netNodeRewards / nodeScore18
+    const computeReward = (
+      effStake: bigint,
+      scorePerStake36: bigint,
+      epochPool: bigint,
+      nodeScore18: bigint,
+      allNodesScore18: bigint,
+      operatorFeePercentage: bigint = 0n,
+      maxOperatorFee: bigint = 10_000n,
+    ): bigint => {
+      const delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
+      if (delegatorScore18 === 0n || nodeScore18 === 0n) return 0n;
+      const grossNodeRewards = (epochPool * nodeScore18) / allNodesScore18;
+      const operatorFee = (grossNodeRewards * operatorFeePercentage) / maxOperatorFee;
+      const netNodeRewards = grossNodeRewards - operatorFee;
+      return (delegatorScore18 * netNodeRewards) / nodeScore18;
+    };
+
+    // Helper — assert the vault balance invariant after every claim.
+    const assertVaultInvariant = async () => {
+      const stakingStorageAddr = await StakingStorage.getAddress();
+      const vaultBalance = await Token.balanceOf(stakingStorageAddr);
+      const totalStake = await StakingStorage.getTotalStake();
+      expect(vaultBalance).to.be.gte(totalStake);
     };
 
     // -----------------------------------------------------------------
@@ -1819,12 +1921,30 @@ describe('@unit DKGStakingConvictionNFT', () => {
 
       // Pre-expiry, 12-epoch lock, multiplier = 6x.
       //   effStake = raw * 6 (rewardsSnapshot = 0)
-      //   reward = effStake * scorePerStake36 / 1e18
-      const scorePerStake36 = hre.ethers.parseEther('0.001'); // 1e15 (a modest score rate)
-      await injectScorePerStake(walkEpoch, identityId, scorePerStake36);
-
+      // Single node (nodeScore = allNodesScore), operator fee = 0.
+      // So reward = delegatorScore18 * epochPool / nodeScore18.
       const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, scorePerStake36);
+      const scorePerStake36 = hre.ethers.parseEther('0.001'); // 1e15 (a modest score rate)
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18; // only node
+      const epochPool = hre.ethers.parseEther('1000');
+
+      await injectEpochRewardState(
+        walkEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
+
+      const expectedReward = computeReward(
+        effStake,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
       await fundVault(expectedReward);
 
       const nodeStakeBefore = await StakingStorage.getNodeStake(identityId);
@@ -1854,6 +1974,9 @@ describe('@unit DKGStakingConvictionNFT', () => {
       // TRAC-zero invariant: neither the NFT wrapper nor StakingV10 hold funds.
       expect(await Token.balanceOf(await NFT.getAddress())).to.equal(0n);
       expect(await Token.balanceOf(await StakingV10Contract.getAddress())).to.equal(0n);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
     });
 
     it('multi-epoch happy path: three epochs of distinct scores, claim sums cumulatively', async () => {
@@ -1867,15 +1990,33 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await advanceEpochs(3);
 
       // Pre-expiry throughout (12-epoch lock), so effStake = raw*6 for all three.
+      // Single node, operator fee = 0. Uniform epoch pool across all 3 epochs.
+      const effStake = (amount * SIX_X) / SCALE18;
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('1000');
+
       const s0 = hre.ethers.parseEther('0.001'); // 1e15
       const s1 = hre.ethers.parseEther('0.002'); // 2e15
       const s2 = hre.ethers.parseEther('0.003'); // 3e15
-      await injectScorePerStake(creationEpoch, identityId, s0);
-      await injectScorePerStake(creationEpoch + 1n, identityId, s1);
-      await injectScorePerStake(creationEpoch + 2n, identityId, s2);
 
-      const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, s0 + s1 + s2);
+      // Fund all 3 epochs in a single call to avoid EpochStorage finalization
+      // ordering issues, then inject per-epoch scores.
+      await injectMultiEpochRewardState(
+        creationEpoch,
+        3,
+        identityId,
+        [s0, s1, s2],
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
+
+      // Sum rewards per-epoch.
+      const expectedReward =
+        computeReward(effStake, s0, epochPool, nodeScore18, allNodesScore18) +
+        computeReward(effStake, s1, epochPool, nodeScore18, allNodesScore18) +
+        computeReward(effStake, s2, epochPool, nodeScore18, allNodesScore18);
       await fundVault(expectedReward);
 
       const tx = await NFT.connect(accounts[0]).claim(0);
@@ -1885,6 +2026,9 @@ describe('@unit DKGStakingConvictionNFT', () => {
 
       const pos = await ConvictionStakingStorageContract.getPosition(0);
       expect(pos.rewards).to.equal(expectedReward);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
     });
 
     it('pre-expiry multiplier applied: 6x multiplier on a 12-epoch lock', async () => {
@@ -1896,23 +2040,47 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const creationEpoch = await ChronosContract.getCurrentEpoch();
       await advanceEpochs(1);
       const scorePerStake36 = hre.ethers.parseEther('0.01'); // 1e16
-      await injectScorePerStake(creationEpoch, identityId, scorePerStake36);
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('1000');
+      await injectEpochRewardState(
+        creationEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
 
       // effStake = raw * 6x (still pre-expiry since expiryEpoch = creation+12)
       const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, scorePerStake36);
+      const expectedReward = computeReward(
+        effStake,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
       await fundVault(expectedReward);
 
-      // Compare against a hypothetical 1x position: same scorePerStake should
-      // produce 6x the reward of a rest-tier position. Rather than deploy two
-      // positions, we verify the computeReward shape directly: expectedReward
-      // should equal 6 * (raw * score / 1e18).
-      const baselineReward = computeReward(amount, scorePerStake36); // 1x effective
+      // Compare against a hypothetical 1x position: same epoch pool means the
+      // 6x effective should produce 6x the delegator-score fraction and thus
+      // 6x the reward of a 1x position.
+      const baselineReward = computeReward(
+        amount,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
       expect(expectedReward).to.equal(baselineReward * 6n);
 
       await NFT.connect(accounts[0]).claim(0);
       const pos = await ConvictionStakingStorageContract.getPosition(0);
       expect(pos.rewards).to.equal(expectedReward);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
     });
 
     it('post-expiry 1x downgrade: claim across an epoch where lock has already expired', async () => {
@@ -1922,7 +2090,7 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 1);
 
       const creationEpoch = await ChronosContract.getCurrentEpoch();
-      // 1-epoch lock → expiryEpoch = creationEpoch + 1. Advance 3 epochs so the
+      // 1-epoch lock -> expiryEpoch = creationEpoch + 1. Advance 3 epochs so the
       // claim window covers creationEpoch (pre-expiry) AND creationEpoch+1,+2
       // (post-expiry). Inject distinct scores to verify per-epoch math.
       await advanceEpochs(3);
@@ -1931,15 +2099,34 @@ describe('@unit DKGStakingConvictionNFT', () => {
       // unambiguously the 1x rate.
       const postExpiryEpoch = creationEpoch + 2n; // strictly > expiryEpoch=creation+1
       const scorePerStake36 = hre.ethers.parseEther('0.01');
-      await injectScorePerStake(postExpiryEpoch, identityId, scorePerStake36);
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('1000');
+      await injectEpochRewardState(
+        postExpiryEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
 
       // effStake_post = raw (no multiplier after expiry)
-      const expectedReward = computeReward(amount, scorePerStake36);
+      const expectedReward = computeReward(
+        amount,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
       await fundVault(expectedReward);
 
       await NFT.connect(accounts[0]).claim(0);
       const pos = await ConvictionStakingStorageContract.getPosition(0);
       expect(pos.rewards).to.equal(expectedReward);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
     });
 
     it('multiplier + post-expiry split: two epochs, first boosted, second flat', async () => {
@@ -1949,21 +2136,32 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 1);
 
       const creationEpoch = await ChronosContract.getCurrentEpoch();
-      // 1-epoch lock → expiryEpoch = creationEpoch + 1. With advanceEpochs(3):
+      // 1-epoch lock -> expiryEpoch = creationEpoch + 1. With advanceEpochs(3):
       //   - claim window = [creationEpoch .. creationEpoch + 2]
       //   - pre-expiry: epoch == creationEpoch (strict < expiryEpoch)
       //   - post-expiry: creationEpoch + 1, creationEpoch + 2 (>= expiryEpoch)
       await advanceEpochs(3);
       const scorePre = hre.ethers.parseEther('0.01');
       const scorePost = hre.ethers.parseEther('0.02');
-      await injectScorePerStake(creationEpoch, identityId, scorePre); // pre-expiry
-      await injectScorePerStake(creationEpoch + 2n, identityId, scorePost); // post-expiry
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('1000');
+
+      // Fund all 3 epochs in one call, then inject per-epoch scores.
+      await fundEpochPoolRange(creationEpoch, creationEpoch + 2n, epochPool);
+      await injectScorePerStake(creationEpoch, identityId, scorePre);
+      await injectNodeEpochScore(creationEpoch, identityId, nodeScore18);
+      await injectAllNodesEpochScore(creationEpoch, allNodesScore18);
+      await injectScorePerStake(creationEpoch + 2n, identityId, scorePost);
+      await injectNodeEpochScore(creationEpoch + 2n, identityId, nodeScore18);
+      await injectAllNodesEpochScore(creationEpoch + 2n, allNodesScore18);
 
       // Pre-expiry epoch earns at 1.5x; post-expiry epoch at 1x.
       const effStakePre = (amount * ONE_AND_HALF_X) / SCALE18;
       const effStakePost = amount;
       const expectedReward =
-        computeReward(effStakePre, scorePre) + computeReward(effStakePost, scorePost);
+        computeReward(effStakePre, scorePre, epochPool, nodeScore18, allNodesScore18) +
+        computeReward(effStakePost, scorePost, epochPool, nodeScore18, allNodesScore18);
       await fundVault(expectedReward);
 
       const tx = await NFT.connect(accounts[0]).claim(0);
@@ -1973,6 +2171,9 @@ describe('@unit DKGStakingConvictionNFT', () => {
 
       const pos = await ConvictionStakingStorageContract.getPosition(0);
       expect(pos.rewards).to.equal(expectedReward);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
     });
 
     // -----------------------------------------------------------------
@@ -1988,10 +2189,26 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const creationEpoch = await ChronosContract.getCurrentEpoch();
       await advanceEpochs(1);
       const scorePerStake36 = hre.ethers.parseEther('0.001');
-      await injectScorePerStake(creationEpoch, identityId, scorePerStake36);
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('1000');
+      await injectEpochRewardState(
+        creationEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
 
       const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, scorePerStake36);
+      const expectedReward = computeReward(
+        effStake,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
       await fundVault(expectedReward);
 
       // First claim — pays out expected reward.
@@ -2014,15 +2231,18 @@ describe('@unit DKGStakingConvictionNFT', () => {
     it('reverts RewardOverflow when accumulated reward exceeds uint96 max', async () => {
       const { identityId } = await createProfile();
       // We need to push `rewardTotal` past `type(uint96).max` (~7.92e28)
-      // through the Phase 5 stub formula:
-      //    rewardTotal = effStake * scorePerStake36 / 1e18
-      // Pre-expiry effStake at 6x for `amount` raw is `amount * 6`. To
-      // hit ~8e28, set amount large and crank scorePerStake36.
-      // amount * 6 * scorePerStake36 / 1e18 > 2^96
-      //   amount = 1e22 (10000 TRAC)
-      //   effStake = 6e22
-      //   need scorePerStake36 > 2^96 * 1e18 / 6e22 ≈ 1.32e15
-      // Round up generously to make the overshoot unambiguous: 1e21.
+      // through the TRAC formula. With a massive epoch pool and the
+      // delegator being the only staker on the only node, the full pool
+      // flows to the delegator. We need epochPool > 2^96.
+      //
+      // amount = 1e22 (10000 TRAC), effStake = 6e22 at 6x
+      // nodeScore = allNodesScore = 100e18
+      // scorePerStake36 chosen so delegatorScore18 = nodeScore18
+      //   => delegatorScore18 = effStake * scorePerStake36 / 1e18 = 100e18
+      //   => scorePerStake36 = 100e18 * 1e18 / 6e22 = 1e18 * 100 / 6e4
+      //      = 1e18 / 600 ~ 1.666e15 (but doesn't need to be exact)
+      // With delegatorScore = nodeScore, reward = netNodeRewards = epochPool.
+      // Set epochPool = 1e29 > 2^96 (~7.92e28) — overflow.
       const amount = hre.ethers.parseEther('10000'); // 1e22
       await mintAndApprove(accounts[0], amount);
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
@@ -2030,12 +2250,26 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const creationEpoch = await ChronosContract.getCurrentEpoch();
       await advanceEpochs(1);
 
-      // Inject a huge per-epoch score-per-stake. The Phase 5 stub formula
-      // yields rewardTotal = 6e22 * 1e21 / 1e18 = 6e25. Still under 2^96
-      // (~7.92e28), so nudge it higher.
-      // 6e22 * 1e25 / 1e18 = 6e29 > 2^96 — that overflows.
+      const nodeScore18 = hre.ethers.parseEther('100'); // 1e20
+      const allNodesScore18 = nodeScore18;
+      // Make delegatorScore18 = nodeScore18 so reward = epochPool exactly.
+      // delegatorScore18 = effStake * scorePerStake36 / 1e18
+      // effStake = 6e22. We need scorePerStake36 = nodeScore18 * 1e18 / effStake
+      //   = 1e20 * 1e18 / 6e22 = 1e38 / 6e22 = 1e16 / 6 ~ 1.666e15
+      // Use a round value that gets close enough to overflow.
       const scorePerStake36 = 10n ** 25n;
-      await injectScorePerStake(creationEpoch, identityId, scorePerStake36);
+      // epochPool must be huge to force overflow. The epoch pool is uint96,
+      // but addTokensToEpochRange takes uint96. So we need to set it near
+      // the uint96 max. 2^96 - 1 ~ 7.92e28.
+      const hugePool = (1n << 96n) - 1n; // max uint96
+      await injectEpochRewardState(
+        creationEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        hugePool,
+      );
 
       await expect(
         NFT.connect(accounts[0]).claim(0),
@@ -2055,10 +2289,26 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const creationEpoch = await ChronosContract.getCurrentEpoch();
       await advanceEpochs(1);
       const scorePerStake36 = hre.ethers.parseEther('0.001');
-      await injectScorePerStake(creationEpoch, identityId, scorePerStake36);
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('1000');
+      await injectEpochRewardState(
+        creationEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
 
       const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, scorePerStake36);
+      const expectedReward = computeReward(
+        effStake,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
       await fundVault(expectedReward);
 
       // 1. Claim — banks reward into pos.rewards + delegator/node/total.
@@ -2097,6 +2347,192 @@ describe('@unit DKGStakingConvictionNFT', () => {
       expect(posFinal.raw).to.equal(amount);
       expect(posFinal.rewards).to.equal(0n);
       expect(await NFT.ownerOf(0)).to.equal(accounts[0].address);
+    });
+
+    // -----------------------------------------------------------------
+    // Reward distribution proportionality
+    // -----------------------------------------------------------------
+
+    it('6x staker gets 6/7, 1x staker gets 1/7 of net node rewards', async () => {
+      const { identityId } = await createProfile();
+      const aliceAmount = hre.ethers.parseEther('1000');
+      const bobAmount = hre.ethers.parseEther('1000');
+
+      // Alice: 12-epoch lock (6x), Bob: 0 lock via post-expiry (1x).
+      // We create both at different tiers on the same node.
+      // Alice — 12-epoch lock, 6x
+      await mintAndApprove(accounts[0], aliceAmount);
+      await NFT.connect(accounts[0]).createConviction(identityId, aliceAmount, 12);
+
+      // Bob — 1-epoch lock, 1.5x pre-expiry but we'll claim only post-expiry.
+      // Actually, to get a clean 1x we use the same epoch for both but
+      // let Bob use 1-epoch lock and claim the creation epoch (pre-expiry
+      // at 1.5x). To get a true 6:1 ratio we need Bob to be at 1x.
+      //
+      // Simplification: advance past Bob's expiry so Bob is at 1x.
+      await mintAndApprove(accounts[2], bobAmount);
+      await Token.connect(accounts[2]).approve(await StakingV10Contract.getAddress(), bobAmount);
+      await NFT.connect(accounts[2]).createConviction(identityId, bobAmount, 1);
+
+      const creationEpoch = await ChronosContract.getCurrentEpoch();
+      // Advance 2 epochs so Bob's 1-epoch lock is expired on the claim epoch.
+      // Bob's expiryEpoch = creationEpoch + 1, so epoch creationEpoch+1 is
+      // post-expiry for Bob but still pre-expiry for Alice (expiry at +12).
+      await advanceEpochs(2);
+      const claimEpoch = creationEpoch + 1n;
+
+      // Effective stakes: Alice = 1000 * 6 = 6000, Bob = 1000 * 1 = 1000
+      // Total effective = 7000
+      const aliceEff = (aliceAmount * SIX_X) / SCALE18; // 6000e18
+      const bobEff = bobAmount; // 1000e18 (post-expiry, 1x)
+
+      // nodeScore = sum of proofs. We set it directly.
+      // scorePerStake36 = nodeScore18 * 1e18 / effectiveNodeStake is the
+      // relationship from proof submission. We pick clean round numbers:
+      const nodeScore18 = hre.ethers.parseEther('700'); // 700e18
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('7000'); // 7000 TRAC
+
+      // scorePerStake36 such that the sum of delegator scores = nodeScore.
+      // delegatorScore_alice = aliceEff * sps / 1e18, bob same.
+      // sum = (aliceEff + bobEff) * sps / 1e18 = nodeScore
+      // sps = nodeScore * 1e18 / (aliceEff + bobEff)
+      //     = 700e18 * 1e18 / 7000e18 = 1e17
+      const totalEffective = aliceEff + bobEff;
+      const scorePerStake36 = (nodeScore18 * SCALE18) / totalEffective;
+
+      await injectEpochRewardState(
+        claimEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        allNodesScore18,
+        epochPool,
+      );
+
+      // Also inject creation epoch with 0 score (already default, but
+      // we inject the first-epoch score for both). Both positions walk
+      // [creationEpoch .. creationEpoch+1]; only claimEpoch has score.
+
+      // netNodeRewards = epochPool (single node, opFee=0) = 7000 TRAC
+      // Alice reward = aliceEff * sps / 1e18 * 7000e18 / nodeScore18
+      //              = 6000e18 * 1e17 / 1e18 * 7000e18 / 700e18
+      //              = 600e18 * 10 = 6000e18
+      // Bob reward   = 1000e18 * 1e17 / 1e18 * 7000e18 / 700e18
+      //              = 100e18 * 10 = 1000e18
+      const aliceExpected = computeReward(
+        aliceEff,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
+      const bobExpected = computeReward(
+        bobEff,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
+
+      // Fund vault with total rewards.
+      await fundVault(aliceExpected + bobExpected);
+
+      // Alice claims first (tokenId 0).
+      await NFT.connect(accounts[0]).claim(0);
+      const alicePos = await ConvictionStakingStorageContract.getPosition(0);
+      expect(alicePos.rewards).to.equal(aliceExpected);
+
+      // Bob claims second (tokenId 1).
+      await NFT.connect(accounts[2]).claim(1);
+      const bobPos = await ConvictionStakingStorageContract.getPosition(1);
+      expect(bobPos.rewards).to.equal(bobExpected);
+
+      // Proportionality: Alice gets 6/7, Bob gets 1/7 of netNodeRewards.
+      const netNodeRewards = epochPool; // single node, no op fee
+      expect(aliceExpected).to.equal((netNodeRewards * 6n) / 7n);
+      expect(bobExpected).to.equal(netNodeRewards / 7n);
+      // Total within 1 wei of netNodeRewards (integer division rounding).
+      expect(netNodeRewards - (aliceExpected + bobExpected)).to.be.lte(1n);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
+    });
+
+    // -----------------------------------------------------------------
+    // Expiry boundary — multiplier transitions at expiryEpoch
+    // -----------------------------------------------------------------
+
+    it('expiry boundary: pre-expiry epochs use 6x, expiryEpoch onward uses 1x', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseEther('1000');
+      await mintAndApprove(accounts[0], amount);
+      await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
+
+      const creationEpoch = await ChronosContract.getCurrentEpoch();
+      // expiryEpoch = creationEpoch + 12. Advance 14 epochs to cover
+      // [creationEpoch .. creationEpoch+13]. Epochs 0..11 are pre-expiry
+      // (6x), epoch 12+ are post-expiry (1x).
+      await advanceEpochs(14);
+
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const epochPool = hre.ethers.parseEther('100');
+      const scorePerStake36 = hre.ethers.parseEther('0.001'); // 1e15
+
+      // Inject score for exactly two epochs: one pre-expiry and one
+      // post-expiry (the boundary epoch). This isolates the multiplier
+      // transition.
+      const lastPreExpiryEpoch = creationEpoch + 11n; // epoch index 11, still < expiryEpoch=creation+12
+      const firstPostExpiryEpoch = creationEpoch + 12n; // expiryEpoch itself
+
+      // Fund the full 14-epoch range in one call to avoid finalization issues.
+      await fundEpochPoolRange(creationEpoch, creationEpoch + 13n, epochPool);
+
+      // Inject per-epoch score data for just the two epochs we care about.
+      await injectScorePerStake(lastPreExpiryEpoch, identityId, scorePerStake36);
+      await injectNodeEpochScore(lastPreExpiryEpoch, identityId, nodeScore18);
+      await injectAllNodesEpochScore(lastPreExpiryEpoch, allNodesScore18);
+      await injectScorePerStake(firstPostExpiryEpoch, identityId, scorePerStake36);
+      await injectNodeEpochScore(firstPostExpiryEpoch, identityId, nodeScore18);
+      await injectAllNodesEpochScore(firstPostExpiryEpoch, allNodesScore18);
+
+      // Pre-expiry: effStake = 1000 * 6 = 6000
+      const effStakePre = (amount * SIX_X) / SCALE18;
+      // Post-expiry: effStake = 1000 (1x)
+      const effStakePost = amount;
+
+      const rewardPre = computeReward(
+        effStakePre,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
+      const rewardPost = computeReward(
+        effStakePost,
+        scorePerStake36,
+        epochPool,
+        nodeScore18,
+        allNodesScore18,
+      );
+
+      // Verify the multiplier difference is exactly 6:1.
+      expect(rewardPre).to.equal(rewardPost * 6n);
+
+      const expectedTotal = rewardPre + rewardPost;
+      await fundVault(expectedTotal);
+
+      const tx = await NFT.connect(accounts[0]).claim(0);
+      await expect(tx)
+        .to.emit(StakingV10Contract, 'RewardsClaimed')
+        .withArgs(0n, expectedTotal);
+
+      const pos = await ConvictionStakingStorageContract.getPosition(0);
+      expect(pos.rewards).to.equal(expectedTotal);
+
+      // Vault balance invariant.
+      await assertVaultInvariant();
     });
   });
 
@@ -2464,21 +2900,82 @@ describe('@unit DKGStakingConvictionNFT', () => {
   describe('transfer (accrued-interest model)', () => {
     // Helper — inject `nodeEpochScorePerStake36` at a specific epoch via the
     // hub-owner-privileged setter. Mirrors the helper in the claim describe
-    // block — duplicated locally so this block stays self-contained. The
-    // `claim` helper cannot be referenced across describe boundaries.
+    // block — duplicated locally so this block stays self-contained.
     const injectScorePerStake = async (
       epoch: number | bigint,
       identityId: number,
       scorePerStake36: bigint,
     ) => {
-      const RandomSamplingStorageContract = await hre.ethers.getContract<RandomSamplingStorage>(
-        'RandomSamplingStorage',
-      );
-      await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScorePerStake(
-        epoch,
-        identityId,
-        scorePerStake36,
-      );
+      const rss = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+      await rss.connect(accounts[0]).setNodeEpochScorePerStake(epoch, identityId, scorePerStake36);
+    };
+
+    // Helper — inject nodeEpochScore for a node at a specific epoch.
+    const injectNodeEpochScore = async (
+      epoch: number | bigint,
+      identityId: number,
+      score18: bigint,
+    ) => {
+      const rss = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+      await rss.connect(accounts[0]).setNodeEpochScore(epoch, identityId, score18);
+    };
+
+    // Helper — inject allNodesEpochScore for a specific epoch.
+    const injectAllNodesEpochScore = async (epoch: number | bigint, score18: bigint) => {
+      const rss = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+      await rss.connect(accounts[0]).setAllNodesEpochScore(epoch, score18);
+    };
+
+    // Helper — fund a contiguous range of epoch pools via EpochStorage.
+    const fundEpochPoolRange = async (
+      startEpoch: number | bigint,
+      endEpoch: number | bigint,
+      amountPerEpoch: bigint,
+    ) => {
+      const es = await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
+      const numEpochs = BigInt(endEpoch) - BigInt(startEpoch) + 1n;
+      const totalAmount = amountPerEpoch * numEpochs;
+      await es.connect(accounts[0]).addTokensToEpochRange(1, startEpoch, endEpoch, totalAmount);
+    };
+
+    // Helper — fund a single epoch pool (convenience wrapper).
+    const fundEpochPool = async (epoch: number | bigint, amount: bigint) => {
+      await fundEpochPoolRange(epoch, epoch, amount);
+    };
+
+    // Helper — inject all epoch-level reward state in one call (single epoch).
+    const injectEpochRewardState = async (
+      epoch: number | bigint,
+      identityId: number,
+      scorePerStake36: bigint,
+      nodeScore18: bigint,
+      allNodesScore18: bigint,
+      epochPool: bigint,
+    ) => {
+      await injectScorePerStake(epoch, identityId, scorePerStake36);
+      await injectNodeEpochScore(epoch, identityId, nodeScore18);
+      await injectAllNodesEpochScore(epoch, allNodesScore18);
+      await fundEpochPool(epoch, epochPool);
+    };
+
+    // Helper — inject score/epoch state for multiple epochs with a UNIFORM pool.
+    const injectMultiEpochRewardState = async (
+      startEpoch: bigint,
+      epochCount: number,
+      identityId: number,
+      scorePerStakes: bigint[],
+      nodeScore18: bigint,
+      allNodesScore18: bigint,
+      epochPool: bigint,
+    ) => {
+      const endEpoch = startEpoch + BigInt(epochCount) - 1n;
+      await fundEpochPoolRange(startEpoch, endEpoch, epochPool);
+      for (let i = 0; i < epochCount; i++) {
+        const e = startEpoch + BigInt(i);
+        await injectScorePerStake(e, identityId, scorePerStakes[i]);
+        await injectNodeEpochScore(e, identityId, nodeScore18);
+        await injectAllNodesEpochScore(e, allNodesScore18);
+      }
     };
 
     // Helper — pre-fund the StakingStorage vault so the claim's
@@ -2488,10 +2985,22 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await Token.mint(stakingStorageAddr, amount);
     };
 
-    // Single-epoch reward formula — mirrors StakingV10.claim's inner loop
-    // exactly: `reward = effStake * scorePerStake36 / 1e18`.
-    const computeReward = (effStake: bigint, scorePerStake36: bigint): bigint => {
-      return (effStake * scorePerStake36) / SCALE18;
+    // TRAC reward formula — mirrors StakingV10.claim's inner loop.
+    const computeReward = (
+      effStake: bigint,
+      scorePerStake36: bigint,
+      epochPool: bigint,
+      nodeScore18: bigint,
+      allNodesScore18: bigint,
+      operatorFeePercentage: bigint = 0n,
+      maxOperatorFee: bigint = 10_000n,
+    ): bigint => {
+      const delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
+      if (delegatorScore18 === 0n || nodeScore18 === 0n) return 0n;
+      const grossNodeRewards = (epochPool * nodeScore18) / allNodesScore18;
+      const operatorFee = (grossNodeRewards * operatorFeePercentage) / maxOperatorFee;
+      const netNodeRewards = grossNodeRewards - operatorFee;
+      return (delegatorScore18 * netNodeRewards) / nodeScore18;
     };
 
     it('ERC-721 transfer does not mutate Position state', async () => {
@@ -2543,16 +3052,30 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await advanceEpochs(3);
 
       // Inject score for 3 epochs — pre-expiry throughout (12-epoch lock),
-      // so effStake = raw * 6x for all three.
+      // so effStake = raw * 6x for all three. Single node, opFee=0.
+      const effStake = (amount * SIX_X) / SCALE18;
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+
       const s0 = hre.ethers.parseEther('0.001'); // 1e15
       const s1 = hre.ethers.parseEther('0.002'); // 2e15
       const s2 = hre.ethers.parseEther('0.003'); // 3e15
-      await injectScorePerStake(creationEpoch, identityId, s0);
-      await injectScorePerStake(creationEpoch + 1n, identityId, s1);
-      await injectScorePerStake(creationEpoch + 2n, identityId, s2);
+      const pool = hre.ethers.parseEther('1000');
 
-      const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, s0 + s1 + s2);
+      await injectMultiEpochRewardState(
+        creationEpoch,
+        3,
+        identityId,
+        [s0, s1, s2],
+        nodeScore18,
+        allNodesScore18,
+        pool,
+      );
+
+      const expectedReward =
+        computeReward(effStake, s0, pool, nodeScore18, allNodesScore18) +
+        computeReward(effStake, s1, pool, nodeScore18, allNodesScore18) +
+        computeReward(effStake, s2, pool, nodeScore18, allNodesScore18);
       await fundVault(expectedReward);
 
       // Alice transfers to Bob WITHOUT claiming first. The accrued coupon
@@ -2590,7 +3113,15 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const creationEpoch = await ChronosContract.getCurrentEpoch();
       await advanceEpochs(1);
       const scorePerStake36 = hre.ethers.parseEther('0.001');
-      await injectScorePerStake(creationEpoch, identityId, scorePerStake36);
+      const nodeScore18 = hre.ethers.parseEther('100');
+      await injectEpochRewardState(
+        creationEpoch,
+        identityId,
+        scorePerStake36,
+        nodeScore18,
+        nodeScore18,
+        hre.ethers.parseEther('1000'),
+      );
 
       await NFT.connect(accounts[0]).transferFrom(
         accounts[0].address,
@@ -2650,11 +3181,24 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await advanceEpochs(2);
       const s0 = hre.ethers.parseEther('0.001');
       const s1 = hre.ethers.parseEther('0.002');
-      await injectScorePerStake(creationEpoch, identityId, s0);
-      await injectScorePerStake(creationEpoch + 1n, identityId, s1);
+      const nodeScore18 = hre.ethers.parseEther('100');
+      const allNodesScore18 = nodeScore18;
+      const pool = hre.ethers.parseEther('1000');
+
+      await injectMultiEpochRewardState(
+        creationEpoch,
+        2,
+        identityId,
+        [s0, s1],
+        nodeScore18,
+        allNodesScore18,
+        pool,
+      );
 
       const effStake = (amount * SIX_X) / SCALE18;
-      const expectedReward = computeReward(effStake, s0 + s1);
+      const expectedReward =
+        computeReward(effStake, s0, pool, nodeScore18, allNodesScore18) +
+        computeReward(effStake, s1, pool, nodeScore18, allNodesScore18);
       await fundVault(expectedReward);
 
       await NFT.connect(accounts[0]).transferFrom(

--- a/packages/evm-module/test/v10-conviction.test.ts
+++ b/packages/evm-module/test/v10-conviction.test.ts
@@ -29,6 +29,7 @@ import {
   ConvictionStakingStorage,
   DelegatorsInfo,
   DKGStakingConvictionNFT,
+  EpochStorage,
   Hub,
   ParametersStorage,
   Profile,
@@ -264,11 +265,13 @@ describe('@integration V10 Phase 5 — NFT-backed staking', function () {
   // Test 3 — claim after time advance banks rewards
   // --------------------------------------------------------------------------
   //
-  // Inject a per-epoch `nodeEpochScorePerStake` via the hub-owner-privileged
-  // `RandomSamplingStorage.setNodeEpochScorePerStake`, advance one epoch,
-  // and call `NFT.claim`. The Phase 5 stub formula is:
-  //     reward = effStake * scorePerStake36 / 1e18
-  // where `effStake = raw * multiplier18 / 1e18` pre-expiry. We verify the
+  // Inject per-epoch `nodeEpochScorePerStake`, `nodeEpochScore`,
+  // `allNodesEpochScore`, and `epochPool` via hub-owner-privileged setters,
+  // advance one epoch, and call `NFT.claim`. The Phase 11 TRAC formula is:
+  //     delegatorScore18 = effStake * scorePerStake36 / 1e18
+  //     grossNodeRewards = epochPool * nodeScore18 / allNodesScore18
+  //     reward = delegatorScore18 * grossNodeRewards / nodeScore18
+  // (with operatorFee = 0 for a fresh profile). We verify the
   // `RewardsClaimed` event fires and the position's `rewards` bucket
   // matches.
   it('claim: reward accrues after one-epoch advance and banks into position.rewards', async () => {
@@ -283,14 +286,33 @@ describe('@integration V10 Phase 5 — NFT-backed staking', function () {
     await time.increase(Number(epochLength));
 
     // Inject score for the single walkable epoch (creationEpoch).
-    // Pre-expiry, 12-epoch lock → multiplier 6x.
+    // Pre-expiry, 12-epoch lock -> multiplier 6x. Single node, opFee=0.
     const scorePerStake36 = hre.ethers.parseEther('0.001'); // 1e15
+    const nodeScore18 = hre.ethers.parseEther('100');
+    const allNodesScore18 = nodeScore18;
+    const epochPool = hre.ethers.parseEther('1000');
+
     await RandomSamplingStorageContract.connect(
       accounts[0],
     ).setNodeEpochScorePerStake(creationEpoch, identityId, scorePerStake36);
+    await RandomSamplingStorageContract.connect(
+      accounts[0],
+    ).setNodeEpochScore(creationEpoch, identityId, nodeScore18);
+    await RandomSamplingStorageContract.connect(
+      accounts[0],
+    ).setAllNodesEpochScore(creationEpoch, allNodesScore18);
+    const EpochStorageContract = await hre.ethers.getContract<EpochStorage>('EpochStorageV8');
+    await EpochStorageContract.connect(accounts[0]).addTokensToEpochRange(
+      1,
+      creationEpoch,
+      creationEpoch,
+      epochPool,
+    );
 
     const effStake = (amount * SIX_X) / SCALE18;
-    const expectedReward = (effStake * scorePerStake36) / SCALE18;
+    const delegatorScore18 = (effStake * scorePerStake36) / SCALE18;
+    const grossNodeRewards = (epochPool * nodeScore18) / allNodesScore18;
+    const expectedReward = (delegatorScore18 * grossNodeRewards) / nodeScore18;
 
     // Pre-fund the StakingStorage vault with the anticipated reward so the
     // post-claim node-stake bookkeeping stays tied to on-chain TRAC.

--- a/packages/evm-module/test/v10-conviction.test.ts
+++ b/packages/evm-module/test/v10-conviction.test.ts
@@ -10,15 +10,12 @@
 // this file is deliberately short.
 //
 // Legacy note: previous revisions tested `Staking.convictionMultiplier`
-// (V8 pure math) and `PublishingConvictionAccount` basic flows. Both are
-// covered elsewhere:
-//   - V8 `convictionMultiplier` snap-down math is checked in
-//     `test/v10-e2e-conviction.test.ts::Flow 1::verifies all conviction
-//     multiplier tiers`.
-//   - `PublishingConvictionAccount` flows are the `Flow 2` suite in the
-//     same e2e file.
-// The previous scope is removed here to avoid duplication and keep this
-// file focused on the Phase 5 NFT + StakingV10 stack.
+// (V8 pure math, now deleted in Phase 11) and `PublishingConvictionAccount`
+// basic flows. The canonical tier table now lives in
+// `DKGStakingConvictionNFT._convictionMultiplier` (exact-match semantics),
+// tested in `test/unit/DKGStakingConvictionNFT.test.ts`.
+// `PublishingConvictionAccount` flows are the `Flow 2` suite in the e2e file.
+// This file is focused on the Phase 5 NFT + StakingV10 stack.
 
 import { randomBytes } from 'crypto';
 

--- a/packages/evm-module/test/v10-e2e-conviction.test.ts
+++ b/packages/evm-module/test/v10-e2e-conviction.test.ts
@@ -162,22 +162,11 @@ describe('V10 E2E Conviction System', function () {
       await Token.connect(staker).approve(await Staking.getAddress(), STAKE_AMOUNT * 2n);
     });
 
-    it('stakes with no lock (1x multiplier, lockEpochs=1 default)', async () => {
+    it('stakes with no lock (1x multiplier)', async () => {
       await Staking.connect(staker).stake(identityId, STAKE_AMOUNT);
 
       const nodeStake = await StakingStorage.getNodeStake(identityId);
       expect(nodeStake).to.equal(STAKE_AMOUNT);
-
-      const multiplier = await Staking.getDelegatorConvictionMultiplier(identityId, staker.address);
-      expect(multiplier).to.equal(SCALE18);
-    });
-
-    it('verifies all conviction multiplier tiers', async () => {
-      expect(await Staking.convictionMultiplier(1)).to.equal(SCALE18);
-      expect(await Staking.convictionMultiplier(2)).to.equal(15n * SCALE18 / 10n);
-      expect(await Staking.convictionMultiplier(3)).to.equal(2n * SCALE18);
-      expect(await Staking.convictionMultiplier(6)).to.equal(35n * SCALE18 / 10n);
-      expect(await Staking.convictionMultiplier(12)).to.equal(6n * SCALE18);
     });
   });
 

--- a/packages/evm-module/test/v10-reward-flywheel.test.ts
+++ b/packages/evm-module/test/v10-reward-flywheel.test.ts
@@ -1,0 +1,512 @@
+// =============================================================================
+// V10 Phase 11 — @integration full reward flywheel test
+// =============================================================================
+//
+// Proves the complete V10 reward cycle works end-to-end:
+//
+//   1. One node with a V10 staker (1000 TRAC, 12-epoch lock = 6x) and
+//      a V8 staker (1000 TRAC, 1x).
+//   2. Epoch pool funded + scores injected (simulating publish + proof).
+//   3. One epoch advance.
+//   4. V10 staker claims via DKGStakingConvictionNFT.claim(tokenId).
+//   5. V8 staker claims via Staking.claimDelegatorRewards(identityId, epoch, delegator).
+//   6. Assert 6/7 + 1/7 conservation with rounding-dust tolerance.
+//   7. Assert vault balance invariant: Token.balanceOf(StakingStorage) >= totalStake.
+//
+// Scores are injected directly into RandomSamplingStorage + EpochStorage
+// rather than going through the publish + proof pipeline. This isolates
+// the reward-claim logic from the publish pipeline, which has its own
+// integration tests in StakingRewards.test.ts.
+
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import hre from 'hardhat';
+
+import {
+  Chronos,
+  ConvictionStakingStorage,
+  DelegatorsInfo,
+  DKGStakingConvictionNFT,
+  EpochStorage,
+  Hub,
+  ParametersStorage,
+  Profile,
+  ProfileStorage,
+  RandomSamplingStorage,
+  Staking,
+  StakingStorage,
+  StakingV10,
+  Token,
+} from '../typechain';
+import { createProfile } from './helpers/profile-helpers';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SCALE18 = 10n ** 18n;
+const toTRAC = (n: number) => hre.ethers.parseEther(n.toString());
+
+// V10 tier 12 = 6x multiplier
+const SIX_X = 6n * SCALE18;
+const LOCK_EPOCHS = 12;
+
+// Staking amounts
+const V10_RAW = toTRAC(1_000);
+const V8_RAW = toTRAC(1_000);
+
+// Effective stakes:  V10 = 1000 * 6 = 6000,  V8 = 1000
+// Total effective = 7000
+const V10_EFFECTIVE = (V10_RAW * SIX_X) / SCALE18; // 6000e18
+const V8_EFFECTIVE = V8_RAW;                         // 1000e18
+const TOTAL_EFFECTIVE = V10_EFFECTIVE + V8_EFFECTIVE; // 7000e18
+
+// EpochStorage shard index used by both Staking.sol and StakingV10.sol
+const EPOCH_POOL_INDEX = 1n;
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+type FlywheelFixture = {
+  accounts: SignerWithAddress[];
+  Hub: Hub;
+  Token: Token;
+  Chronos: Chronos;
+  Profile: Profile;
+  ProfileStorage: ProfileStorage;
+  Staking: Staking;
+  StakingV10: StakingV10;
+  StakingStorage: StakingStorage;
+  ConvictionStakingStorage: ConvictionStakingStorage;
+  DelegatorsInfo: DelegatorsInfo;
+  RandomSamplingStorage: RandomSamplingStorage;
+  EpochStorage: EpochStorage;
+  ParametersStorage: ParametersStorage;
+  NFT: DKGStakingConvictionNFT;
+};
+
+async function deployFlywheelFixture(): Promise<FlywheelFixture> {
+  // Pull the full V10 deploy graph — DKGStakingConvictionNFT transitively
+  // brings Hub, StakingV10, Staking, ConvictionStakingStorage, storages,
+  // Profile, Token, EpochStorage, RandomSamplingStorage, etc.
+  await hre.deployments.fixture([
+    'DKGStakingConvictionNFT',
+    'StakingV10',
+    'Profile',
+    'Staking',
+    'EpochStorage',
+    'RandomSamplingStorage',
+    'DelegatorsInfo',
+  ]);
+
+  const accounts = await hre.ethers.getSigners();
+  const Hub = await hre.ethers.getContract<Hub>('Hub');
+
+  // Grant HubOwner to accounts[0] so we can poke privileged setters.
+  await Hub.setContractAddress('HubOwner', accounts[0].address);
+
+  return {
+    accounts,
+    Hub,
+    Token: await hre.ethers.getContract<Token>('Token'),
+    Chronos: await hre.ethers.getContract<Chronos>('Chronos'),
+    Profile: await hre.ethers.getContract<Profile>('Profile'),
+    ProfileStorage: await hre.ethers.getContract<ProfileStorage>('ProfileStorage'),
+    Staking: await hre.ethers.getContract<Staking>('Staking'),
+    StakingV10: await hre.ethers.getContract<StakingV10>('StakingV10'),
+    StakingStorage: await hre.ethers.getContract<StakingStorage>('StakingStorage'),
+    ConvictionStakingStorage: await hre.ethers.getContract<ConvictionStakingStorage>(
+      'ConvictionStakingStorage',
+    ),
+    DelegatorsInfo: await hre.ethers.getContract<DelegatorsInfo>('DelegatorsInfo'),
+    RandomSamplingStorage: await hre.ethers.getContract<RandomSamplingStorage>(
+      'RandomSamplingStorage',
+    ),
+    EpochStorage: await hre.ethers.getContract<EpochStorage>('EpochStorageV8'),
+    ParametersStorage: await hre.ethers.getContract<ParametersStorage>('ParametersStorage'),
+    NFT: await hre.ethers.getContract<DKGStakingConvictionNFT>('DKGStakingConvictionNFT'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('@integration V10 Phase 11 — full reward flywheel', function () {
+  let accounts: SignerWithAddress[];
+  let Token: Token;
+  let Chronos: Chronos;
+  let ProfileContract: Profile;
+  let ProfileStorageContract: ProfileStorage;
+  let StakingContract: Staking;
+  let StakingV10Contract: StakingV10;
+  let StakingStorageContract: StakingStorage;
+  let ConvictionStorageContract: ConvictionStakingStorage;
+  let RandomSamplingStorageContract: RandomSamplingStorage;
+  let EpochStorageContract: EpochStorage;
+  let ParametersStorageContract: ParametersStorage;
+  let NFT: DKGStakingConvictionNFT;
+
+  beforeEach(async function () {
+    hre.helpers.resetDeploymentsJson();
+    const fx = await loadFixture(deployFlywheelFixture);
+    ({
+      accounts,
+      Token,
+      Chronos,
+      ParametersStorage: ParametersStorageContract,
+      RandomSamplingStorage: RandomSamplingStorageContract,
+      EpochStorage: EpochStorageContract,
+      NFT,
+    } = fx);
+    ProfileContract = fx.Profile;
+    ProfileStorageContract = fx.ProfileStorage;
+    StakingContract = fx.Staking;
+    StakingV10Contract = fx.StakingV10;
+    StakingStorageContract = fx.StakingStorage;
+    ConvictionStorageContract = fx.ConvictionStakingStorage;
+  });
+
+  // -----------------------------------------------------------------------
+  // The single main test
+  // -----------------------------------------------------------------------
+
+  it('V10 (6x) + V8 (1x) stakers share rewards in 6:1 ratio with conservation', async function () {
+    // ------------------------------------------------------------------
+    // Actors
+    // ------------------------------------------------------------------
+    const nodeOp = accounts[1];   // node operational wallet
+    const nodeAdmin = accounts[2]; // node admin wallet
+    const v10Staker = accounts[3];
+    const v8Staker = accounts[4];
+
+    // ------------------------------------------------------------------
+    // Step 0: Set operator fee update delay to 0 so we can set it immediately
+    // ------------------------------------------------------------------
+    await ParametersStorageContract.connect(accounts[0]).setOperatorFeeUpdateDelay(0);
+
+    // ------------------------------------------------------------------
+    // Step 1: Create a node profile
+    // ------------------------------------------------------------------
+    const { identityId } = await createProfile(ProfileContract, {
+      operational: nodeOp,
+      admin: nodeAdmin,
+    });
+
+    // Set operator fee to 10% (1000 / 10000)
+    await ProfileContract.connect(nodeAdmin).updateOperatorFee(identityId, 1000);
+
+    // ------------------------------------------------------------------
+    // Step 2: V10 staker — create conviction (12-epoch lock = 6x)
+    // ------------------------------------------------------------------
+    await Token.mint(v10Staker.address, V10_RAW);
+    await Token.connect(v10Staker).approve(await StakingV10Contract.getAddress(), V10_RAW);
+    await NFT.connect(v10Staker).createConviction(identityId, V10_RAW, LOCK_EPOCHS);
+    const tokenId = 0n; // first NFT minted
+
+    // Sanity: position exists with correct tier
+    const pos = await ConvictionStorageContract.getPosition(tokenId);
+    expect(pos.identityId).to.equal(identityId);
+    expect(pos.raw).to.equal(V10_RAW);
+    expect(pos.multiplier18).to.equal(SIX_X);
+
+    // ------------------------------------------------------------------
+    // Step 3: V8 staker — classic stake (1x)
+    // ------------------------------------------------------------------
+    await Token.mint(v8Staker.address, V8_RAW);
+    await Token.connect(v8Staker).approve(await StakingContract.getAddress(), V8_RAW);
+    await StakingContract.connect(v8Staker).stake(identityId, V8_RAW);
+
+    // Sanity: combined raw node stake = V10_RAW + V8_RAW = 2000 TRAC
+    const nodeStake = await StakingStorageContract.getNodeStake(identityId);
+    expect(nodeStake).to.equal(V10_RAW + V8_RAW);
+
+    // Record the staking epoch for later
+    const stakingEpoch = await Chronos.getCurrentEpoch();
+
+    // ------------------------------------------------------------------
+    // Step 4: Simulate publish — fund epoch pool + mint backing TRAC
+    // ------------------------------------------------------------------
+    // We will fund `stakingEpoch` with EPOCH_POOL_AMOUNT, which is
+    // the total TRAC that all nodes (just ours) share in this epoch.
+    const EPOCH_POOL_AMOUNT = toTRAC(700); // 700 TRAC in the pool
+
+    // Fund epoch pool: addTokensToEpochRange is `onlyContracts`-gated.
+    // accounts[0] is HubOwner, which is trusted by the Hub access control.
+    await EpochStorageContract.connect(accounts[0]).addTokensToEpochRange(
+      EPOCH_POOL_INDEX,
+      stakingEpoch,
+      stakingEpoch,
+      EPOCH_POOL_AMOUNT,
+    );
+
+    // Mint matching TRAC to StakingStorage so the vault backs the rewards.
+    const ssAddr = await StakingStorageContract.getAddress();
+    await Token.mint(ssAddr, EPOCH_POOL_AMOUNT);
+
+    // ------------------------------------------------------------------
+    // Step 5: Simulate proof — inject scores into RandomSamplingStorage
+    // ------------------------------------------------------------------
+    // nodeScore = some arbitrary value — the ratio matters, not magnitude.
+    // We pick nodeScore = 1000e18 for clarity.
+    const nodeScore = toTRAC(1000);
+
+    // allNodesScore = nodeScore (single node in the network)
+    await RandomSamplingStorageContract.connect(accounts[0]).setAllNodesEpochScore(
+      stakingEpoch,
+      nodeScore,
+    );
+    await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScore(
+      stakingEpoch,
+      identityId,
+      nodeScore,
+    );
+
+    // scorePerStake36 = nodeScore * 1e18 / effectiveNodeStake
+    // effectiveNodeStake = 6000 + 1000 = 7000 TRAC
+    // scorePerStake36 = 1000e18 * 1e18 / 7000e18 = 1e18 / 7
+    const scorePerStake36 = (nodeScore * SCALE18) / TOTAL_EFFECTIVE;
+    await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScorePerStake(
+      stakingEpoch,
+      identityId,
+      scorePerStake36,
+    );
+
+    // ------------------------------------------------------------------
+    // Step 6: Advance one epoch so stakingEpoch is finalised
+    // ------------------------------------------------------------------
+    const timeUntilNext = await Chronos.timeUntilNextEpoch();
+    await time.increase(timeUntilNext + 1n);
+
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    expect(currentEpoch).to.be.gt(stakingEpoch);
+
+    // ------------------------------------------------------------------
+    // Step 7: V10 staker claims via NFT.claim(tokenId)
+    // ------------------------------------------------------------------
+    const v10BalBefore = await Token.balanceOf(v10Staker.address);
+    await NFT.connect(v10Staker).claim(tokenId);
+
+    // V10 claim auto-compounds into the position — rewards go into
+    // pos.rewards, and the StakingStorage delegator base increases.
+    // The staker's wallet balance should NOT change (rewards are staked).
+    const v10BalAfter = await Token.balanceOf(v10Staker.address);
+    expect(v10BalAfter).to.equal(v10BalBefore); // auto-compound, no transfer out
+
+    const posAfterClaim = await ConvictionStorageContract.getPosition(tokenId);
+    const v10Reward = posAfterClaim.rewards;
+
+    // ------------------------------------------------------------------
+    // Step 8: V8 staker claims via Staking.claimDelegatorRewards
+    // ------------------------------------------------------------------
+    // Track cumulative earned rewards before claim
+    const v8DelegatorKey = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [v8Staker.address]),
+    );
+    const v8CumBefore = await StakingStorageContract.getDelegatorCumulativeEarnedRewards(
+      identityId,
+      v8DelegatorKey,
+    );
+
+    await StakingContract.connect(v8Staker).claimDelegatorRewards(
+      identityId,
+      stakingEpoch,
+      v8Staker.address,
+    );
+
+    const v8CumAfter = await StakingStorageContract.getDelegatorCumulativeEarnedRewards(
+      identityId,
+      v8DelegatorKey,
+    );
+    const v8Reward = v8CumAfter - v8CumBefore;
+
+    // ------------------------------------------------------------------
+    // Step 9: Compute expected values
+    // ------------------------------------------------------------------
+    // grossNodeRewards = epochPool * nodeScore / allNodesScore
+    //                  = 700 * 1 = 700 TRAC (single node)
+    const grossNodeRewards = (EPOCH_POOL_AMOUNT * nodeScore) / nodeScore;
+    expect(grossNodeRewards).to.equal(EPOCH_POOL_AMOUNT);
+
+    // operatorFee = grossNodeRewards * 1000 / 10000 = 10%
+    const maxOperatorFee = await ParametersStorageContract.maxOperatorFee();
+    const operatorFeePercentage = await ProfileStorageContract.getLatestOperatorFeePercentage(
+      identityId,
+    );
+    const operatorFeeAmount = (grossNodeRewards * BigInt(operatorFeePercentage)) / BigInt(maxOperatorFee);
+    const netNodeRewards = grossNodeRewards - operatorFeeAmount;
+
+    // V10 expected: effStake * scorePerStake36 / 1e18 gives delegator's
+    // score; then (delegatorScore * netNodeRewards) / nodeScore.
+    //
+    // V10 delegator score = V10_EFFECTIVE * scorePerStake36 / 1e18
+    //                     = 6000 * (1e18/7) / 1e18 = 6000/7
+    //
+    // V10 reward = (6000/7) * netNodeRewards / 1000 = 6/7 * netNodeRewards
+    //
+    // But due to integer division, we check with tolerance.
+    const expectedV10Reward = (netNodeRewards * V10_EFFECTIVE) / TOTAL_EFFECTIVE;
+    const expectedV8Reward = (netNodeRewards * V8_EFFECTIVE) / TOTAL_EFFECTIVE;
+
+    // ------------------------------------------------------------------
+    // Assertion A: 6/7 + 1/7 conservation (rounding dust only)
+    // ------------------------------------------------------------------
+    // The total claimed rewards must not exceed netNodeRewards.
+    const totalClaimed = v10Reward + v8Reward;
+    expect(totalClaimed).to.be.lte(netNodeRewards);
+
+    // Rounding dust tolerance: scorePerStake36 = nodeScore * 1e18 / 7000e18
+    // truncates, then each claim path does
+    //   (effStake * scorePerStake36) / 1e18          — truncation 1
+    //   (delegatorScore * netNodeRewards) / nodeScore — truncation 2
+    // Two cascading integer divisions per staker. The total dust across
+    // both stakers is bounded by ~5000 wei for these magnitudes (observed
+    // 630 wei at 700 TRAC pool, but scales with divisor precision).
+    const dust = netNodeRewards - totalClaimed;
+    expect(dust).to.be.lte(10_000n);
+
+    // Each individual reward should be close to the expected value.
+    expect(v10Reward).to.be.closeTo(expectedV10Reward, 10_000);
+    expect(v8Reward).to.be.closeTo(expectedV8Reward, 10_000);
+
+    // Sanity: V10 reward should be ~6x V8 reward
+    // (6000/7000) / (1000/7000) = 6
+    // Allow a wider tolerance (1 TRAC) for the ratio check due to rounding
+    if (v8Reward > 0n) {
+      // v10Reward / v8Reward should be approximately 6
+      // Instead of division, check: v10Reward * 1 ~= v8Reward * 6
+      expect(v10Reward).to.be.closeTo(v8Reward * 6n, toTRAC(1));
+    }
+
+    // ------------------------------------------------------------------
+    // Assertion B: vault balance invariant
+    // ------------------------------------------------------------------
+    // Token.balanceOf(StakingStorage) >= totalStake after all claims.
+    // totalStake grew by the auto-compounded rewards (both V10 and V8
+    // restake via delegator base increase).
+    const totalStake = await StakingStorageContract.getTotalStake();
+    const vaultBalance = await Token.balanceOf(ssAddr);
+    expect(vaultBalance).to.be.gte(totalStake);
+
+    // ------------------------------------------------------------------
+    // Assertion C: operator fee was banked
+    // ------------------------------------------------------------------
+    const operatorFeeBalance = await StakingStorageContract.getOperatorFeeBalance(identityId);
+    expect(operatorFeeBalance).to.equal(operatorFeeAmount);
+
+    // ------------------------------------------------------------------
+    // Log summary (informational)
+    // ------------------------------------------------------------------
+    console.log('\n  Reward Flywheel Summary:');
+    console.log(`    Epoch pool:          ${hre.ethers.formatEther(EPOCH_POOL_AMOUNT)} TRAC`);
+    console.log(`    Operator fee (10%):  ${hre.ethers.formatEther(operatorFeeAmount)} TRAC`);
+    console.log(`    Net node rewards:    ${hre.ethers.formatEther(netNodeRewards)} TRAC`);
+    console.log(`    V10 reward (6/7):    ${hre.ethers.formatEther(v10Reward)} TRAC`);
+    console.log(`    V8 reward (1/7):     ${hre.ethers.formatEther(v8Reward)} TRAC`);
+    console.log(`    Total claimed:       ${hre.ethers.formatEther(totalClaimed)} TRAC`);
+    console.log(`    Rounding dust:       ${dust.toString()} wei`);
+    console.log(`    Vault balance:       ${hre.ethers.formatEther(vaultBalance)} TRAC`);
+    console.log(`    Total stake:         ${hre.ethers.formatEther(totalStake)} TRAC`);
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge case: zero operator fee
+  // -----------------------------------------------------------------------
+
+  it('V10 + V8 conservation holds with 0% operator fee', async function () {
+    const nodeOp = accounts[1];
+    const nodeAdmin = accounts[2];
+    const v10Staker = accounts[3];
+    const v8Staker = accounts[4];
+
+    // No operator fee set — default is 0%
+    const { identityId } = await createProfile(ProfileContract, {
+      operational: nodeOp,
+      admin: nodeAdmin,
+    });
+
+    // V10 stake
+    await Token.mint(v10Staker.address, V10_RAW);
+    await Token.connect(v10Staker).approve(await StakingV10Contract.getAddress(), V10_RAW);
+    await NFT.connect(v10Staker).createConviction(identityId, V10_RAW, LOCK_EPOCHS);
+    const tokenId = 0n;
+
+    // V8 stake
+    await Token.mint(v8Staker.address, V8_RAW);
+    await Token.connect(v8Staker).approve(await StakingContract.getAddress(), V8_RAW);
+    await StakingContract.connect(v8Staker).stake(identityId, V8_RAW);
+
+    const stakingEpoch = await Chronos.getCurrentEpoch();
+
+    // Fund epoch pool + backing TRAC
+    const POOL = toTRAC(350);
+    await EpochStorageContract.connect(accounts[0]).addTokensToEpochRange(
+      EPOCH_POOL_INDEX,
+      stakingEpoch,
+      stakingEpoch,
+      POOL,
+    );
+    const ssAddr = await StakingStorageContract.getAddress();
+    await Token.mint(ssAddr, POOL);
+
+    // Inject scores
+    const nodeScore = toTRAC(500);
+    await RandomSamplingStorageContract.connect(accounts[0]).setAllNodesEpochScore(
+      stakingEpoch,
+      nodeScore,
+    );
+    await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScore(
+      stakingEpoch,
+      identityId,
+      nodeScore,
+    );
+    const scorePerStake36 = (nodeScore * SCALE18) / TOTAL_EFFECTIVE;
+    await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScorePerStake(
+      stakingEpoch,
+      identityId,
+      scorePerStake36,
+    );
+
+    // Advance epoch
+    await time.increase((await Chronos.timeUntilNextEpoch()) + 1n);
+
+    // Claims
+    await NFT.connect(v10Staker).claim(tokenId);
+    const posAfter = await ConvictionStorageContract.getPosition(tokenId);
+    const v10Reward = posAfter.rewards;
+
+    const v8Key = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [v8Staker.address]),
+    );
+    const v8CumBefore = await StakingStorageContract.getDelegatorCumulativeEarnedRewards(
+      identityId,
+      v8Key,
+    );
+    await StakingContract.connect(v8Staker).claimDelegatorRewards(
+      identityId,
+      stakingEpoch,
+      v8Staker.address,
+    );
+    const v8CumAfter = await StakingStorageContract.getDelegatorCumulativeEarnedRewards(
+      identityId,
+      v8Key,
+    );
+    const v8Reward = v8CumAfter - v8CumBefore;
+
+    // 0% operator fee → netNodeRewards = grossNodeRewards = POOL
+    const totalClaimed = v10Reward + v8Reward;
+    expect(totalClaimed).to.be.lte(POOL);
+    expect(POOL - totalClaimed).to.be.lte(10_000n); // rounding dust from scorePerStake36 truncation
+
+    // Vault invariant
+    const totalStake = await StakingStorageContract.getTotalStake();
+    const vaultBalance = await Token.balanceOf(ssAddr);
+    expect(vaultBalance).to.be.gte(totalStake);
+
+    // Operator fee balance should be 0
+    const opFee = await StakingStorageContract.getOperatorFeeBalance(identityId);
+    expect(opFee).to.equal(0n);
+  });
+});

--- a/packages/evm-module/test/v10-reward-flywheel.test.ts
+++ b/packages/evm-module/test/v10-reward-flywheel.test.ts
@@ -509,4 +509,228 @@ describe('@integration V10 Phase 11 — full reward flywheel', function () {
     const opFee = await StakingStorageContract.getOperatorFeeBalance(identityId);
     expect(opFee).to.equal(0n);
   });
+
+  // -----------------------------------------------------------------------
+  // 3-way mixed V8 + multiple V10 positions on the same node
+  // -----------------------------------------------------------------------
+
+  it('3-way same-node: Carol(V8 1000) + Alice(V10 6x 1000) + Bob(V10 2x 1000) share rewards correctly', async function () {
+    // Actors
+    const nodeOp = accounts[1];
+    const nodeAdmin = accounts[2];
+    const alice = accounts[3];   // V10, 12-epoch lock = 6x
+    const bob = accounts[4];     // V10, 3-epoch lock = 2x
+    const carol = accounts[5];   // V8, 1x
+
+    // No operator fee — 0% for clean math
+    const { identityId } = await createProfile(ProfileContract, {
+      operational: nodeOp,
+      admin: nodeAdmin,
+    });
+
+    // ------------------------------------------------------------------
+    // Stake: Alice V10 1000 TRAC @ 12 epochs (6x) → effective 6000
+    // ------------------------------------------------------------------
+    const ALICE_RAW = toTRAC(1_000);
+    const ALICE_LOCK = 12;
+    const ALICE_MULT = 6n * SCALE18;
+    const ALICE_EFF = (ALICE_RAW * ALICE_MULT) / SCALE18; // 6000e18
+
+    await Token.mint(alice.address, ALICE_RAW);
+    await Token.connect(alice).approve(await StakingV10Contract.getAddress(), ALICE_RAW);
+    await NFT.connect(alice).createConviction(identityId, ALICE_RAW, ALICE_LOCK);
+    const aliceTokenId = 0n;
+
+    const alicePos = await ConvictionStorageContract.getPosition(aliceTokenId);
+    expect(alicePos.identityId).to.equal(identityId);
+    expect(alicePos.raw).to.equal(ALICE_RAW);
+    expect(alicePos.multiplier18).to.equal(ALICE_MULT);
+
+    // ------------------------------------------------------------------
+    // Stake: Bob V10 1000 TRAC @ 3 epochs (2x) → effective 2000
+    // ------------------------------------------------------------------
+    const BOB_RAW = toTRAC(1_000);
+    const BOB_LOCK = 3;
+    const BOB_MULT = 2n * SCALE18;
+    const BOB_EFF = (BOB_RAW * BOB_MULT) / SCALE18; // 2000e18
+
+    await Token.mint(bob.address, BOB_RAW);
+    await Token.connect(bob).approve(await StakingV10Contract.getAddress(), BOB_RAW);
+    await NFT.connect(bob).createConviction(identityId, BOB_RAW, BOB_LOCK);
+    const bobTokenId = 1n;
+
+    const bobPos = await ConvictionStorageContract.getPosition(bobTokenId);
+    expect(bobPos.identityId).to.equal(identityId);
+    expect(bobPos.raw).to.equal(BOB_RAW);
+    expect(bobPos.multiplier18).to.equal(BOB_MULT);
+
+    // ------------------------------------------------------------------
+    // Stake: Carol V8 1000 TRAC (1x) → effective 1000
+    // ------------------------------------------------------------------
+    const CAROL_RAW = toTRAC(1_000);
+    const CAROL_EFF = CAROL_RAW; // 1000e18
+
+    await Token.mint(carol.address, CAROL_RAW);
+    await Token.connect(carol).approve(await StakingContract.getAddress(), CAROL_RAW);
+    await StakingContract.connect(carol).stake(identityId, CAROL_RAW);
+
+    // ------------------------------------------------------------------
+    // Effective stake calculations:
+    //   nodeStake (StakingStorage) = Alice 1000 + Bob 1000 + Carol 1000 = 3000
+    //   nodeEffV10 (ConvictionStakingStorage) = Alice 6000 + Bob 2000 = 8000
+    //   nodeV10BaseStake = Alice 1000 + Bob 1000 = 2000
+    //   effectiveNodeStake = 3000 + (8000 - 2000) = 9000
+    //
+    //   Carol share = 1000/9000 = 1/9
+    //   Alice share = 6000/9000 = 2/3
+    //   Bob share   = 2000/9000 = 2/9
+    //   Total       = 1/9 + 6/9 + 2/9 = 9/9 ✓
+    // ------------------------------------------------------------------
+    const TOTAL_EFF_3WAY = ALICE_EFF + BOB_EFF + CAROL_EFF; // 9000e18
+
+    // Sanity: combined raw node stake = 3000 TRAC
+    const nodeStake = await StakingStorageContract.getNodeStake(identityId);
+    expect(nodeStake).to.equal(ALICE_RAW + BOB_RAW + CAROL_RAW);
+
+    const stakingEpoch = await Chronos.getCurrentEpoch();
+
+    // ------------------------------------------------------------------
+    // Fund epoch pool with 9000 TRAC for clean math
+    // ------------------------------------------------------------------
+    const EPOCH_POOL = toTRAC(9_000);
+    await EpochStorageContract.connect(accounts[0]).addTokensToEpochRange(
+      EPOCH_POOL_INDEX,
+      stakingEpoch,
+      stakingEpoch,
+      EPOCH_POOL,
+    );
+    const ssAddr = await StakingStorageContract.getAddress();
+    await Token.mint(ssAddr, EPOCH_POOL);
+
+    // ------------------------------------------------------------------
+    // Inject scores (single node in the network)
+    // ------------------------------------------------------------------
+    const nodeScore = toTRAC(1_000);
+    await RandomSamplingStorageContract.connect(accounts[0]).setAllNodesEpochScore(
+      stakingEpoch,
+      nodeScore,
+    );
+    await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScore(
+      stakingEpoch,
+      identityId,
+      nodeScore,
+    );
+
+    // scorePerStake36 = nodeScore * 1e18 / effectiveNodeStake
+    //                 = 1000e18 * 1e18 / 9000e18
+    const scorePerStake36 = (nodeScore * SCALE18) / TOTAL_EFF_3WAY;
+    await RandomSamplingStorageContract.connect(accounts[0]).setNodeEpochScorePerStake(
+      stakingEpoch,
+      identityId,
+      scorePerStake36,
+    );
+
+    // ------------------------------------------------------------------
+    // Advance one epoch
+    // ------------------------------------------------------------------
+    await time.increase((await Chronos.timeUntilNextEpoch()) + 1n);
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    expect(currentEpoch).to.be.gt(stakingEpoch);
+
+    // ------------------------------------------------------------------
+    // Alice claims (V10)
+    // ------------------------------------------------------------------
+    await NFT.connect(alice).claim(aliceTokenId);
+    const alicePosAfter = await ConvictionStorageContract.getPosition(aliceTokenId);
+    const aliceReward = alicePosAfter.rewards;
+
+    // ------------------------------------------------------------------
+    // Bob claims (V10)
+    // ------------------------------------------------------------------
+    await NFT.connect(bob).claim(bobTokenId);
+    const bobPosAfter = await ConvictionStorageContract.getPosition(bobTokenId);
+    const bobReward = bobPosAfter.rewards;
+
+    // ------------------------------------------------------------------
+    // Carol claims (V8)
+    // ------------------------------------------------------------------
+    const carolKey = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [carol.address]),
+    );
+    const carolCumBefore = await StakingStorageContract.getDelegatorCumulativeEarnedRewards(
+      identityId,
+      carolKey,
+    );
+    await StakingContract.connect(carol).claimDelegatorRewards(
+      identityId,
+      stakingEpoch,
+      carol.address,
+    );
+    const carolCumAfter = await StakingStorageContract.getDelegatorCumulativeEarnedRewards(
+      identityId,
+      carolKey,
+    );
+    const carolReward = carolCumAfter - carolCumBefore;
+
+    // ------------------------------------------------------------------
+    // Expected values (0% operator fee → net = gross = 9000 TRAC)
+    // ------------------------------------------------------------------
+    const netNodeRewards = EPOCH_POOL; // single node, allNodesScore = nodeScore
+
+    const expectedAlice = (netNodeRewards * ALICE_EFF) / TOTAL_EFF_3WAY; // 6000/9000 = 2/3
+    const expectedBob = (netNodeRewards * BOB_EFF) / TOTAL_EFF_3WAY;     // 2000/9000 = 2/9
+    const expectedCarol = (netNodeRewards * CAROL_EFF) / TOTAL_EFF_3WAY; // 1000/9000 = 1/9
+
+    // ------------------------------------------------------------------
+    // Assertion A: individual reward shares
+    // ------------------------------------------------------------------
+    expect(aliceReward).to.be.closeTo(expectedAlice, 10_000);
+    expect(bobReward).to.be.closeTo(expectedBob, 10_000);
+    expect(carolReward).to.be.closeTo(expectedCarol, 10_000);
+
+    // Sanity: Alice ~= 6x Carol, Bob ~= 2x Carol
+    if (carolReward > 0n) {
+      expect(aliceReward).to.be.closeTo(carolReward * 6n, toTRAC(1));
+      expect(bobReward).to.be.closeTo(carolReward * 2n, toTRAC(1));
+    }
+
+    // Sanity: Alice ~= 3x Bob
+    if (bobReward > 0n) {
+      expect(aliceReward).to.be.closeTo(bobReward * 3n, toTRAC(1));
+    }
+
+    // ------------------------------------------------------------------
+    // Assertion B: conservation — total claimed <= netNodeRewards, dust small
+    // ------------------------------------------------------------------
+    const totalClaimed = aliceReward + bobReward + carolReward;
+    expect(totalClaimed).to.be.lte(netNodeRewards);
+    const dust = netNodeRewards - totalClaimed;
+    expect(dust).to.be.lte(10_000n);
+
+    // ------------------------------------------------------------------
+    // Assertion C: vault balance invariant
+    // ------------------------------------------------------------------
+    const totalStake = await StakingStorageContract.getTotalStake();
+    const vaultBalance = await Token.balanceOf(ssAddr);
+    expect(vaultBalance).to.be.gte(totalStake);
+
+    // ------------------------------------------------------------------
+    // Assertion D: operator fee = 0
+    // ------------------------------------------------------------------
+    const opFee = await StakingStorageContract.getOperatorFeeBalance(identityId);
+    expect(opFee).to.equal(0n);
+
+    // ------------------------------------------------------------------
+    // Log summary
+    // ------------------------------------------------------------------
+    console.log('\n  3-Way Mixed Reward Summary:');
+    console.log(`    Epoch pool:          ${hre.ethers.formatEther(EPOCH_POOL)} TRAC`);
+    console.log(`    Alice (V10 6x):      ${hre.ethers.formatEther(aliceReward)} TRAC  (expected ${hre.ethers.formatEther(expectedAlice)})`);
+    console.log(`    Bob   (V10 2x):      ${hre.ethers.formatEther(bobReward)} TRAC  (expected ${hre.ethers.formatEther(expectedBob)})`);
+    console.log(`    Carol (V8  1x):      ${hre.ethers.formatEther(carolReward)} TRAC  (expected ${hre.ethers.formatEther(expectedCarol)})`);
+    console.log(`    Total claimed:       ${hre.ethers.formatEther(totalClaimed)} TRAC`);
+    console.log(`    Rounding dust:       ${dust.toString()} wei`);
+    console.log(`    Vault balance:       ${hre.ethers.formatEther(vaultBalance)} TRAC`);
+    console.log(`    Total stake:         ${hre.ethers.formatEther(totalStake)} TRAC`);
+  });
 });


### PR DESCRIPTION
## Summary
- `StakingV10.claim()` now produces real TRAC-denominated rewards via `delegatorScore × netNodeRewards / nodeScore` — closes the Phase 5 TODO at StakingV10.sol:1246. No TRAC transfer needed at claim time (TRAC already in StakingStorage from `Paymaster.coverCost` at publish time).
- `RandomSampling.submitProof` denominator fixed: uses `effectiveNodeStake = nodeStake + (nodeEffV10 - nodeV10BaseStake)` instead of raw `nodeStake`. V10 multipliers now correctly weight score distribution.
- `_prepareForStakeChangeV10` in StakingV10 replaces all 7 V8 settlement calls — uses effective delegator stake (respecting multiplier + expiry), not raw base.
- `nodeV10BaseStake` per-node counter added to ConvictionStakingStorage, updated by 7 mutators.
- `Staking.convictionMultiplier` + `getDelegatorConvictionMultiplier` (dead code with off-by-one bug) deleted. NatSpec refs updated.
- Integration test proves full reward flywheel: V10 6x staker gets 6/7, V8 1x staker gets 1/7 of net node rewards.

## Plan reference
`~/.claude/dkg-v9/.ai/plans/2026-04-16-v10-phase-11-reward-wiring.md`
`~/.claude/dkg-v9/.ai/v10-implementation-plan.md` Phase 11 section.

## The TRAC reward flow
Publishers pay TRAC → `Paymaster.coverCost(amount)` → `token.transfer(StakingStorage, amount)` at publish time. `EpochStorage.addTokensToEpochRange` records per-epoch accounting. At claim time, V8 and V10 only increase accounting entries (delegatorBase, nodeStake, totalStake) — no token movement. The vault is already funded.

## Effective-stake denominator
`submitProof` now computes `scorePerStake36 = score18 × 1e18 / effectiveNodeStake` where `effectiveNodeStake = V8_raw + V10_effective`. This ensures proportional score distribution weighted by conviction multiplier. `calculateNodeScore` stake factor S(t) stays raw — conviction multiplier affects intra-node distribution only, not inter-node scoring.

## Key invariant restored
After `StakingV10.claim()`: `tokenContract.balanceOf(stakingStorage) >= sum(all delegator bases)`. Phase 5's score stub broke this (accounting raced ahead of reality). Phase 11 produces correct TRAC amounts from the existing funded vault.

## Tests
- 6x/1x split: 6000/1000 of 7000 effective → 6/7 and 1/7 of net rewards
- Expiry boundary: epochs 1-12 use 6x, epoch 13+ uses 1x
- Vault balance invariant after every claim
- V8 legacy `claimDelegatorRewards` unchanged (276 staking tests green)
- Full flywheel: inject epoch pool + scores → V10 claim + V8 claim → conservation holds (630 wei dust on 700 TRAC pool)
- 99 DKGStakingConvictionNFT tests, 71 ConvictionStakingStorage, 122 RandomSampling, 8 V10 E2E

## Deletions
- `Staking.convictionMultiplier` (dead since Phase 5 moved V10 logic to StakingV10.sol, had Phase 12c off-by-one)
- `Staking.getDelegatorConvictionMultiplier` (always returned 1x regardless of input)

## Files changed
- `contracts/StakingV10.sol` — `_prepareForStakeChangeV10`, `_getEffectiveStakeAtEpoch`, score→TRAC in claim, EpochStorage dep
- `contracts/storage/ConvictionStakingStorage.sol` — `nodeV10BaseStake` mapping + 7 mutator updates
- `contracts/RandomSampling.sol` — `submitProof` effective denominator + ConvictionStakingStorage dep
- `contracts/Staking.sol` — delete 2 dead functions
- `contracts/DKGStakingConvictionNFT.sol` — NatSpec updates
- `deploy/031_deploy_random_sampling.ts` — added ConvictionStakingStorage dependency
- `test/unit/DKGStakingConvictionNFT.test.ts` — TRAC-denominated claim tests + vault invariant
- `test/v10-reward-flywheel.test.ts` — new integration test
- `test/v10-e2e-conviction.test.ts` — removed dead function test cases
- `test/v10-conviction.test.ts` — updated comments
- `test/unit/ConvictionStakingStorage.test.ts` — updated comments

## Out of scope
- No changes to `KnowledgeAssetsV10` (Phase 8 frozen)
- No changes to `Paymaster` beyond calling its existing interface
- `calculateNodeScore` stake factor stays raw (by design)

## Verification
- `npx hardhat compile` — clean
- `grep 'TODO(Phase 11)' contracts/` → 0 matches
- `grep 'convictionMultiplier' contracts/Staking.sol` → 0 matches
- All test suites green (99 + 71 + 122 + 276 + 8 + 2)
- Deploy smoke clean
- Working tree clean

🤖 Phase 11 of V10 contracts redesign