### PR TITLE
feat: V10 npm publish prep project.json, version bump, CI workflow

### DIFF
--- a/.github/workflows/npm-continuous-publish.yml
+++ b/.github/workflows/npm-continuous-publish.yml
@@ -1,15 +1,15 @@
-# Automatically publish all public packages to NPM on every push to main.
-# Uses a dev pre-release suffix (e.g. 9.0.0-beta.5-dev.1710412800)
-# and publishes as `latest` so all NPM-installed nodes auto-update.
+# Automatically publish all public packages to NPM on every push to the
+# release branch. Uses a dev pre-release suffix so each push gets a unique
+# version (e.g. 10.0.0-rc.1-dev.1774300000.abc1234) tagged as `latest`.
 #
+# To switch the release branch: change the branches list below.
 # To disable: remove the NPM_TOKEN secret from the repo settings.
-# After that, only manual `npm publish` will push new versions.
 
 name: Continuous NPM Publish
 
 on:
   push:
-    branches: [main]
+    branches: [v10-rc]  # ← change this when the release branch moves
 
 permissions:
   contents: read

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-demo",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.28.1",
   "scripts": {
     "build": "turbo build",
-    "build:runtime": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg --filter @origintrail-official/dkg-app-origin-trail-game run build",
+    "build:runtime": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg-adapter-openclaw --filter @origintrail-official/dkg --filter @origintrail-official/dkg-app-origin-trail-game run build",
     "test": "turbo test",
     "test:coverage": "turbo test:coverage",
     "lint": "turbo lint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v9",
-  "version": "9.0.0-beta.6",
+  "version": "10.0.0-rc.1",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "scripts": {

--- a/packages/adapter-autoresearch/package.json
+++ b/packages/adapter-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-autoresearch",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "description": "Autoresearch adapter — collaborative autonomous ML research over the Decentralized Knowledge Graph",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V9 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-elizaos/src/index.ts
+++ b/packages/adapter-elizaos/src/index.ts
@@ -26,9 +26,9 @@ import {
 } from './actions.js';
 
 export const dkgPlugin: Plugin = {
-  name: 'dkg-v9',
+  name: 'dkg',
   description:
-    'Turns this ElizaOS agent into a DKG V9 node — publish knowledge, ' +
+    'Turns this ElizaOS agent into a DKG node — publish knowledge, ' +
     'query the graph, discover agents, and invoke remote skills over a ' +
     'decentralized P2P network.',
   actions: [dkgPublish, dkgQuery, dkgFindAgents, dkgSendMessage, dkgInvokeSkill],

--- a/packages/adapter-elizaos/test/plugin.test.ts
+++ b/packages/adapter-elizaos/test/plugin.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe('dkgPlugin', () => {
   it('has name and description', () => {
-    expect(dkgPlugin.name).toBe('dkg-v9');
+    expect(dkgPlugin.name).toBe('dkg');
     expect(typeof dkgPlugin.description).toBe('string');
     expect(dkgPlugin.description.length).toBeGreaterThan(0);
   });

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/openclaw.plugin.json
+++ b/packages/adapter-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "adapter-openclaw",
   "name": "DKG Node UI Bridge",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "description": "Connects a local OpenClaw agent to a DKG V10 node for node-backed chat, memory, and agent-network capabilities.",
   "kind": "memory",
   "channels": ["dkg-ui"],

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./setup": {
+      "import": "./dist/setup-command.js",
+      "types": "./dist/setup-command.d.ts"
     }
   },
   "files": [

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -13,7 +13,8 @@
     "./setup": {
       "import": "./dist/setup-command.js",
       "types": "./dist/setup-command.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/src/index.ts
+++ b/packages/adapter-openclaw/src/index.ts
@@ -2,6 +2,7 @@ export { DkgNodePlugin } from './DkgNodePlugin.js';
 export { DkgDaemonClient, type DkgClientOptions } from './dkg-client.js';
 export { DkgChannelPlugin, CHANNEL_NAME } from './DkgChannelPlugin.js';
 export { runSetup, type SetupOptions } from './setup.js';
+export { registerSetupCommand } from './setup-command.js';
 // Codex Bug B24: the `DkgMemoryPlugin` class no longer exposes the legacy
 // `OpenClawMemorySearchManager` surface (see the breaking-change JSDoc on
 // the class). Both explicit tool surfaces that previously shipped alongside

--- a/packages/adapter-openclaw/src/index.ts
+++ b/packages/adapter-openclaw/src/index.ts
@@ -1,6 +1,7 @@
 export { DkgNodePlugin } from './DkgNodePlugin.js';
 export { DkgDaemonClient, type DkgClientOptions } from './dkg-client.js';
 export { DkgChannelPlugin, CHANNEL_NAME } from './DkgChannelPlugin.js';
+export { runSetup, type SetupOptions } from './setup.js';
 // Codex Bug B24: the `DkgMemoryPlugin` class no longer exposes the legacy
 // `OpenClawMemorySearchManager` surface (see the breaking-change JSDoc on
 // the class). Both explicit tool surfaces that previously shipped alongside

--- a/packages/adapter-openclaw/src/setup-cli.ts
+++ b/packages/adapter-openclaw/src/setup-cli.ts
@@ -10,7 +10,7 @@
 
 import { Command } from 'commander';
 import { readFileSync } from 'node:fs';
-import { runSetup } from './setup.js';
+import { registerSetupCommand } from './setup-command.js';
 
 function getVersion(): string {
   try {
@@ -25,24 +25,7 @@ const program = new Command('dkg-openclaw')
   .description('DKG OpenClaw adapter management')
   .version(getVersion());
 
-program
-  .command('setup')
-  .description('Set up DKG node + OpenClaw adapter (non-interactive, idempotent)')
-  .option('--workspace <dir>', 'Override OpenClaw workspace directory')
-  .option('--name <name>', 'Override agent name')
-  .option('--port <port>', 'Override daemon API port (default: 9200)')
-  .option('--no-fund', 'Skip wallet funding via faucet')
-  .option('--no-verify', 'Skip post-setup verification')
-  .option('--no-start', 'Skip daemon start (configure only)')
-  .option('--dry-run', 'Preview changes without writing anything')
-  .action(async (opts) => {
-    try {
-      await runSetup(opts);
-    } catch (err: any) {
-      console.error(`\n[setup] ERROR: ${err.message}\n`);
-      process.exit(1);
-    }
-  });
+registerSetupCommand(program);
 
 // Default to 'setup' when no subcommand is given
 if (process.argv.length <= 2) {

--- a/packages/adapter-openclaw/src/setup-command.ts
+++ b/packages/adapter-openclaw/src/setup-command.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared commander registrar for the `setup` subcommand.
+ *
+ * Imported by both the standalone `dkg-openclaw` binary
+ * (packages/adapter-openclaw/src/setup-cli.ts) and the top-level DKG
+ * CLI's `dkg openclaw setup` entry so the flag surface, help text, and
+ * error handling live in exactly one place.
+ */
+
+import type { Command } from 'commander';
+
+/**
+ * Attach the `setup` subcommand to an existing commander program and
+ * return the sub-command so callers can chain further configuration.
+ *
+ * `runSetup` is imported lazily inside the action handler so merely
+ * declaring the command (e.g. during `dkg --help`) does not eagerly
+ * load the adapter's heavier runtime dependencies.
+ */
+export function registerSetupCommand(parent: Command): Command {
+  return parent
+    .command('setup')
+    .description('Set up DKG node + OpenClaw adapter (non-interactive, idempotent)')
+    .option('--workspace <dir>', 'Override OpenClaw workspace directory')
+    .option('--name <name>', 'Override agent name')
+    .option('--port <port>', 'Override daemon API port (default: 9200)')
+    .option('--no-fund', 'Skip wallet funding via faucet')
+    .option('--no-verify', 'Skip post-setup verification')
+    .option('--no-start', 'Skip daemon start (configure only)')
+    .option('--dry-run', 'Preview changes without writing anything')
+    .action(async (opts) => {
+      try {
+        const { runSetup } = await import('./setup.js');
+        await runSetup(opts);
+      } catch (err: any) {
+        console.error(`\n[setup] ERROR: ${err.message}\n`);
+        process.exit(1);
+      }
+    });
+}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/attested-assets/package.json
+++ b/packages/attested-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-attested-assets",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,2 +1,6 @@
-# Build artifact: copied from repo root during build for NPM packaging
+# Build artifacts: copied from repo root during build for NPM packaging
+# (see the `build` script in package.json). Kept out of source control
+# so builds don't dirty the worktree and so the root copies stay the
+# single source of truth.
 network/
+project.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,7 @@
     "dkg": "./dist/cli.js"
   },
   "scripts": {
+    "prebuild": "pnpm --filter @origintrail-official/dkg-adapter-openclaw run build",
     "build": "tsc && node -e \"const fs=require('fs');const p=require('path');fs.mkdirSync('network',{recursive:true});for(const f of fs.readdirSync('../../network')){if(f.endsWith('.json'))fs.copyFileSync(p.join('../../network',f),p.join('network',f))};fs.copyFileSync('../../project.json','project.json')\"",
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "9.0.0-beta.6",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {
     "dkg": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc && node -e \"const fs=require('fs');fs.mkdirSync('network',{recursive:true});fs.copyFileSync('../../network/testnet.json','network/testnet.json')\"",
+    "build": "tsc && node -e \"const fs=require('fs');const p=require('path');fs.mkdirSync('network',{recursive:true});for(const f of fs.readdirSync('../../network')){if(f.endsWith('.json'))fs.copyFileSync(p.join('../../network',f),p.join('network',f))};fs.copyFileSync('../../project.json','project.json')\"",
     "postinstall": "node ./scripts/bundle-markitdown-binaries.mjs --quiet --current-platform --best-effort",
     "markitdown:build": "node ./scripts/bundle-markitdown-binaries.mjs --build-current-platform",
     "test": "vitest run",
@@ -43,6 +43,7 @@
   "files": [
     "dist",
     "network",
+    "project.json",
     "markitdown-build-info.json",
     "markitdown-targets.json",
     "scripts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "clean": "node -e \"const fs=require('fs');for(const d of['dist','network']){fs.rmSync(d,{recursive:true,force:true})};fs.rmSync('tsconfig.tsbuildinfo',{force:true})\""
   },
   "dependencies": {
+    "@origintrail-official/dkg-adapter-openclaw": "workspace:*",
     "@origintrail-official/dkg-agent": "workspace:*",
     "@origintrail-official/dkg-app-origin-trail-game": "workspace:*",
     "@origintrail-official/dkg-chain": "workspace:*",

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -1,0 +1,8 @@
+{
+  "repo": "OriginTrail/dkg-v9",
+  "defaultBranch": "v10-rc",
+  "githubUrl": "https://github.com/OriginTrail/dkg-v9",
+  "projectName": "dkg",
+  "syslogAppName": "dkg",
+  "defaultNetwork": "testnet"
+}

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -1,8 +1,0 @@
-{
-  "repo": "OriginTrail/dkg-v9",
-  "defaultBranch": "v10-rc",
-  "githubUrl": "https://github.com/OriginTrail/dkg-v9",
-  "projectName": "dkg",
-  "syslogAppName": "dkg",
-  "defaultNetwork": "testnet"
-}

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -28,8 +28,15 @@ if (
 }
 export const MARKITDOWN_UPSTREAM_VERSION = MARKITDOWN_BUILD_INFO.markItDownUpstreamVersion;
 export const PYINSTALLER_VERSION = MARKITDOWN_BUILD_INFO.pyInstallerVersion;
+export const RELEASE_BINARY_FETCH_TIMEOUT_MS = 15_000;
+export const RELEASE_CHECKSUM_FETCH_TIMEOUT_MS = 5_000;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 function loadDefaultReleaseRepo() {
-  for (const base of [resolve(__dirname, '..'), resolve(__dirname, '..', '..', '..', '..')]) {
+  const scriptDir = __dirname;
+  for (const base of [resolve(scriptDir, '..'), resolve(scriptDir, '..', '..', '..', '..')]) {
     try {
       const proj = JSON.parse(readFileSync(join(base, 'project.json'), 'utf-8'));
       if (proj.repo) return proj.repo;
@@ -38,11 +45,6 @@ function loadDefaultReleaseRepo() {
   return 'OriginTrail/dkg-v9';
 }
 export const DEFAULT_RELEASE_REPO = loadDefaultReleaseRepo();
-export const RELEASE_BINARY_FETCH_TIMEOUT_MS = 15_000;
-export const RELEASE_CHECKSUM_FETCH_TIMEOUT_MS = 5_000;
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 const DEFAULT_PACKAGE_DIR = resolve(__dirname, '..');
 
 function loadSupportedTargets(packageDir = DEFAULT_PACKAGE_DIR) {

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -35,8 +35,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 function loadDefaultReleaseRepo() {
+  // From packages/cli/scripts/:
+  //   ..        → packages/cli/           (post-build artifact copy; lives here only in the published tarball or after a `pnpm --filter dkg build`)
+  //   ../../..  → <repo root>             (monorepo source of truth)
+  // Prefer the monorepo root so source edits to project.json always
+  // take effect in a fresh checkout; fall back to the package-local
+  // copy for published installs where the repo root is absent.
   const scriptDir = __dirname;
-  for (const base of [resolve(scriptDir, '..'), resolve(scriptDir, '..', '..', '..', '..')]) {
+  for (const base of [resolve(scriptDir, '..', '..', '..'), resolve(scriptDir, '..')]) {
     try {
       const proj = JSON.parse(readFileSync(join(base, 'project.json'), 'utf-8'));
       if (proj.repo) return proj.repo;

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -28,7 +28,16 @@ if (
 }
 export const MARKITDOWN_UPSTREAM_VERSION = MARKITDOWN_BUILD_INFO.markItDownUpstreamVersion;
 export const PYINSTALLER_VERSION = MARKITDOWN_BUILD_INFO.pyInstallerVersion;
-export const DEFAULT_RELEASE_REPO = 'OriginTrail/dkg-v9';
+function loadDefaultReleaseRepo() {
+  for (const base of [resolve(__dirname, '..'), resolve(__dirname, '..', '..', '..', '..')]) {
+    try {
+      const proj = JSON.parse(readFileSync(join(base, 'project.json'), 'utf-8'));
+      if (proj.repo) return proj.repo;
+    } catch { /* try next */ }
+  }
+  return 'OriginTrail/dkg-v9';
+}
+export const DEFAULT_RELEASE_REPO = loadDefaultReleaseRepo();
 export const RELEASE_BINARY_FETCH_TIMEOUT_MS = 15_000;
 export const RELEASE_CHECKSUM_FETCH_TIMEOUT_MS = 5_000;
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1578,25 +1578,17 @@ const openclawCmd = program
   .command('openclaw')
   .description('OpenClaw adapter management');
 
-openclawCmd
-  .command('setup')
-  .description('Set up the DKG OpenClaw adapter (non-interactive, idempotent)')
-  .option('--workspace <dir>', 'Override OpenClaw workspace directory')
-  .option('--name <name>', 'Override agent name')
-  .option('--port <port>', 'Override daemon API port (default: 9200)')
-  .option('--no-fund', 'Skip wallet funding via faucet')
-  .option('--no-verify', 'Skip post-setup verification')
-  .option('--no-start', 'Skip daemon start (configure only)')
-  .option('--dry-run', 'Preview changes without writing anything')
-  .action(async (opts: Record<string, unknown>) => {
-    try {
-      const { runSetup } = await import('@origintrail-official/dkg-adapter-openclaw');
-      await runSetup(opts);
-    } catch (err: any) {
-      console.error(`\n[setup] ERROR: ${err.message}\n`);
-      process.exit(1);
-    }
-  });
+// Delegate to the adapter's shared commander registrar so the flag
+// surface, help text, and exit semantics stay in exactly one place
+// (packages/adapter-openclaw/src/setup-command.ts) and cannot drift
+// between `dkg openclaw setup` and the standalone `dkg-openclaw setup`.
+// The `/setup` subpath export is a light module that only pulls in
+// `commander` types at load; `runSetup` is loaded lazily when the
+// command actually runs, keeping `dkg` cold-start cheap.
+{
+  const { registerSetupCommand } = await import('@origintrail-official/dkg-adapter-openclaw/setup');
+  registerSetupCommand(openclawCmd);
+}
 
 // ─── dkg ccl ────────────────────────────────────────────────────────
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,7 +15,7 @@ import yaml from 'js-yaml';
 import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir,
-  loadNetworkConfig, releasesDir, activeSlot, swapSlot,
+  loadNetworkConfig, loadProjectConfig, releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
 } from './config.js';
@@ -549,12 +549,9 @@ program
       console.log(isTTY ? STARTUP_BANNER : '');
       console.log(`  Node:       ${config.name} (PID ${startedPid})`);
       console.log(`  Node UI:    ${cyan(`http://${hostDisplay}:${port}/ui`)}`);
-      console.log(`  GitHub:     ${cyan('https://github.com/OriginTrail/dkg-v9')}`);
+      console.log(`  GitHub:     ${cyan(loadProjectConfig().githubUrl)}`);
       console.log(`  Discord:    ${cyan('https://discord.com/invite/xCaY7hvNwD')}`);
       console.log(`  Logs:       ${logPath()}`);
-      console.log('');
-      console.log(`  ${yellow('This is an experimental testnet node. Things will break.')}`);
-      console.log(`  ${yellow('Not intended for production use.')}`);
       console.log('');
       return;
     }
@@ -2701,10 +2698,11 @@ program
   .action(async (versionOrRef: string | undefined, opts: ActionOpts) => {
     const config = await loadConfig();
     const net = await loadNetworkConfig();
+    const proj = loadProjectConfig();
     const au = config.autoUpdate ?? net?.autoUpdate ?? {
       enabled: true,
-      repo: 'OriginTrail/dkg-v9',
-      branch: 'main',
+      repo: proj.repo,
+      branch: proj.defaultBranch,
       allowPrerelease: true,
       checkIntervalMinutes: 30,
     };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1578,17 +1578,59 @@ const openclawCmd = program
   .command('openclaw')
   .description('OpenClaw adapter management');
 
-// Delegate to the adapter's shared commander registrar so the flag
-// surface, help text, and exit semantics stay in exactly one place
-// (packages/adapter-openclaw/src/setup-command.ts) and cannot drift
-// between `dkg openclaw setup` and the standalone `dkg-openclaw setup`.
-// The `/setup` subpath export is a light module that only pulls in
-// `commander` types at load; `runSetup` is loaded lazily when the
-// command actually runs, keeping `dkg` cold-start cheap.
-{
-  const { registerSetupCommand } = await import('@origintrail-official/dkg-adapter-openclaw/setup');
-  registerSetupCommand(openclawCmd);
-}
+// Delegate `dkg openclaw setup` to the adapter's own `dkg-openclaw`
+// binary via a child process so:
+//   1. the flag surface, help text, and exit semantics live in exactly
+//      one place (packages/adapter-openclaw/src/setup-cli.ts), with no
+//      risk of drift between `dkg openclaw setup` and `dkg-openclaw
+//      setup`;
+//   2. we avoid a top-level static import that would break `dkg`
+//      startup in fresh workspace checkouts where the adapter's
+//      `dist/` has not been built yet — the resolution is now deferred
+//      to the point where the user actually runs the command, and the
+//      failure (if any) is localized with an actionable error.
+//
+// `allowUnknownOption` + `passThroughOptions` ensure every flag the
+// user passes (including `--help` and anything added to the adapter
+// later) is forwarded verbatim to the underlying binary.
+openclawCmd
+  .command('setup')
+  .description('Set up the DKG OpenClaw adapter (delegates to dkg-openclaw)')
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .helpOption(false)
+  .action(async () => {
+    const { spawnSync } = await import('node:child_process');
+    const { createRequire } = await import('node:module');
+    const { dirname: _dirname, join: _join } = await import('node:path');
+    const { existsSync: _existsSync } = await import('node:fs');
+
+    const req = createRequire(import.meta.url);
+    let binPath: string;
+    try {
+      const adapterPkgJson = req.resolve('@origintrail-official/dkg-adapter-openclaw/package.json');
+      binPath = _join(_dirname(adapterPkgJson), 'dist', 'setup-cli.js');
+      if (!_existsSync(binPath)) {
+        throw new Error(`adapter binary not found at ${binPath}`);
+      }
+    } catch (err: any) {
+      console.error('\n[dkg openclaw setup] OpenClaw adapter is not available.');
+      console.error(`  Reason: ${err.message ?? err}`);
+      console.error('  • In a monorepo dev checkout: run `pnpm build` at the repo root to build all workspaces.');
+      console.error('  • With a global install: reinstall with `npm install -g @origintrail-official/dkg`.\n');
+      process.exit(1);
+    }
+
+    // Forward every argument that came after `openclaw setup`, including
+    // unknown flags and `--help`, verbatim to the adapter binary.
+    const rawArgs = process.argv.slice(2);
+    const openclawIdx = rawArgs.indexOf('openclaw');
+    const setupIdx = openclawIdx >= 0 ? rawArgs.indexOf('setup', openclawIdx) : -1;
+    const forwarded = setupIdx >= 0 ? rawArgs.slice(setupIdx + 1) : [];
+
+    const res = spawnSync(process.execPath, [binPath, 'setup', ...forwarded], { stdio: 'inherit' });
+    process.exit(res.status ?? 0);
+  });
 
 // ─── dkg ccl ────────────────────────────────────────────────────────
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1580,29 +1580,20 @@ const openclawCmd = program
 
 openclawCmd
   .command('setup')
-  .description('Set up the DKG OpenClaw adapter (runs npx setup script)')
-  .allowUnknownOption(true)
-  .action(async () => {
-    const { execFileSync } = await import('node:child_process');
-    // Forward args after "openclaw setup" to the adapter setup script.
-    const oclawIdx = process.argv.indexOf('openclaw');
-    const setupIdx = oclawIdx >= 0 ? process.argv.indexOf('setup', oclawIdx + 1) : -1;
-    const extraArgs = setupIdx >= 0 ? process.argv.slice(setupIdx + 1) : [];
+  .description('Set up the DKG OpenClaw adapter (non-interactive, idempotent)')
+  .option('--workspace <dir>', 'Override OpenClaw workspace directory')
+  .option('--name <name>', 'Override agent name')
+  .option('--port <port>', 'Override daemon API port (default: 9200)')
+  .option('--no-fund', 'Skip wallet funding via faucet')
+  .option('--no-verify', 'Skip post-setup verification')
+  .option('--no-start', 'Skip daemon start (configure only)')
+  .option('--dry-run', 'Preview changes without writing anything')
+  .action(async (opts: Record<string, unknown>) => {
     try {
-      // This is a thin convenience wrapper — the primary entry point is:
-      //   npx @origintrail-official/dkg-adapter-openclaw setup
-      // The adapter's own setup script warns if running from an ephemeral
-      // npx cache and advises users to install globally.
-      execFileSync('npx', ['--yes', '@origintrail-official/dkg-adapter-openclaw', 'setup', ...extraArgs], {
-        stdio: 'inherit',
-        shell: process.platform === 'win32',
-      });
+      const { runSetup } = await import('@origintrail-official/dkg-adapter-openclaw');
+      await runSetup(opts);
     } catch (err: any) {
-      if (err.status) {
-        process.exit(err.status);
-      }
-      console.error('\nTo set up the OpenClaw adapter, run:');
-      console.error('  npx @origintrail-official/dkg-adapter-openclaw setup\n');
+      console.error(`\n[setup] ERROR: ${err.message}\n`);
       process.exit(1);
     }
   });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -253,17 +253,29 @@ function isDkgPackageRoot(dir: string): boolean {
 }
 
 /**
- * Return true when `dir` is the DKG monorepo root, as determined by
- * structural markers: a top-level `pnpm-workspace.yaml`, a `packages/`
- * directory, and `project.json`. These together are unlikely to exist
- * in an unrelated consumer workspace that merely happens to also use
- * pnpm.
+ * Return true when `dir` is the DKG monorepo root.
+ *
+ * We combine two layers of evidence so this never matches an unrelated
+ * consumer workspace (e.g. a pnpm/Nx repo that also happens to have a
+ * root `project.json`):
+ *
+ *  1. Structural markers — `pnpm-workspace.yaml`, `packages/`, and
+ *     `project.json` — which are required but not sufficient.
+ *  2. A DKG-specific sub-marker — `packages/cli/package.json` whose
+ *     `name` is exactly `@origintrail-official/dkg`. The package name
+ *     is reserved for us on npm and cannot be spoofed by a consumer
+ *     repo without colliding with our own published package.
  */
 function isDkgMonorepoRoot(dir: string): boolean {
   try {
-    return existsSync(join(dir, 'pnpm-workspace.yaml'))
-      && existsSync(join(dir, 'packages'))
-      && existsSync(join(dir, 'project.json'));
+    if (!existsSync(join(dir, 'pnpm-workspace.yaml'))) return false;
+    if (!existsSync(join(dir, 'packages'))) return false;
+    if (!existsSync(join(dir, 'project.json'))) return false;
+
+    const cliPkgPath = join(dir, 'packages', 'cli', 'package.json');
+    if (!existsSync(cliPkgPath)) return false;
+    const cliPkg = JSON.parse(readFileSync(cliPkgPath, 'utf-8'));
+    return cliPkg?.name === '@origintrail-official/dkg';
   } catch { return false; }
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -239,15 +239,31 @@ export interface ProjectConfig {
 let _projectConfig: ProjectConfig | null = null;
 
 /**
- * Return true when `dir` looks like the DKG repo/package root (has a
- * project.json whose `projectName` is "dkg"). This prevents walking
- * into unrelated ancestor directories in npm-installed layouts.
+ * Return true when `dir` is the published DKG CLI package root, as
+ * determined by an adjacent `package.json` whose `name` is
+ * `@origintrail-official/dkg`. This is resilient to `projectName`
+ * renames in `project.json` and cannot be spoofed by an unrelated app.
  */
-function isDkgRoot(dir: string): boolean {
+function isDkgPackageRoot(dir: string): boolean {
   try {
-    const raw = readFileSync(join(dir, 'project.json'), 'utf-8');
-    const proj = JSON.parse(raw);
-    return proj.projectName === 'dkg';
+    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'));
+    return pkg?.name === '@origintrail-official/dkg'
+      && existsSync(join(dir, 'project.json'));
+  } catch { return false; }
+}
+
+/**
+ * Return true when `dir` is the DKG monorepo root, as determined by
+ * structural markers: a top-level `pnpm-workspace.yaml`, a `packages/`
+ * directory, and `project.json`. These together are unlikely to exist
+ * in an unrelated consumer workspace that merely happens to also use
+ * pnpm.
+ */
+function isDkgMonorepoRoot(dir: string): boolean {
+  try {
+    return existsSync(join(dir, 'pnpm-workspace.yaml'))
+      && existsSync(join(dir, 'packages'))
+      && existsSync(join(dir, 'project.json'));
   } catch { return false; }
 }
 
@@ -255,17 +271,32 @@ function isDkgRoot(dir: string): boolean {
  * Resolve candidate directories where repo-root files (project.json,
  * network/*.json) may live, in priority order.
  *
- * Only directories that pass `isDkgRoot()` are included, so an npm-
- * installed package never accidentally reads a consumer's project.json.
+ * The package-local root (`thisDir/..` in an npm install) is preferred
+ * over any ancestor, so a published package never accidentally reads
+ * a consumer's own `project.json` under `node_modules`. Ancestor
+ * candidates are only included when they look like the DKG monorepo
+ * itself.
  */
 function candidateRoots(): string[] {
   const thisDir = dirname(fileURLToPath(import.meta.url));
-  const candidates = [
-    join(thisDir, '..', '..', '..'),         // monorepo from dist/
-    join(thisDir, '..', '..', '..', '..'),   // monorepo from src/ during dev
-    join(thisDir, '..'),                      // NPM package (files at package root)
+  const out: string[] = [];
+
+  // Package-local root first — in an npm install this is the only
+  // location that should ever win, and it's unambiguous.
+  const pkgRoot = join(thisDir, '..');
+  if (isDkgPackageRoot(pkgRoot)) out.push(pkgRoot);
+
+  // Monorepo ancestors (dev / source checkout). `dist/` and `src/`
+  // live at different depths so both paths are tried.
+  const monorepoCandidates = [
+    join(thisDir, '..', '..', '..'),        // from dist/
+    join(thisDir, '..', '..', '..', '..'),  // from src/ during dev
   ];
-  return candidates.filter(isDkgRoot);
+  for (const dir of monorepoCandidates) {
+    if (isDkgMonorepoRoot(dir)) out.push(dir);
+  }
+
+  return out;
 }
 
 /**
@@ -349,7 +380,7 @@ export function isDkgMonorepo(): boolean {
   if (_isDkgMonorepo !== null) return _isDkgMonorepo;
   const root = repoDir();
   if (!root) { _isDkgMonorepo = false; return false; }
-  _isDkgMonorepo = isDkgRoot(root) && existsSync(join(root, 'pnpm-workspace.yaml'));
+  _isDkgMonorepo = isDkgMonorepoRoot(root);
   return _isDkgMonorepo;
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -239,16 +239,33 @@ export interface ProjectConfig {
 let _projectConfig: ProjectConfig | null = null;
 
 /**
+ * Return true when `dir` looks like the DKG repo/package root (has a
+ * project.json whose `projectName` is "dkg"). This prevents walking
+ * into unrelated ancestor directories in npm-installed layouts.
+ */
+function isDkgRoot(dir: string): boolean {
+  try {
+    const raw = readFileSync(join(dir, 'project.json'), 'utf-8');
+    const proj = JSON.parse(raw);
+    return proj.projectName === 'dkg';
+  } catch { return false; }
+}
+
+/**
  * Resolve candidate directories where repo-root files (project.json,
  * network/*.json) may live, in priority order.
+ *
+ * Only directories that pass `isDkgRoot()` are included, so an npm-
+ * installed package never accidentally reads a consumer's project.json.
  */
 function candidateRoots(): string[] {
   const thisDir = dirname(fileURLToPath(import.meta.url));
-  return [
+  const candidates = [
     join(thisDir, '..', '..', '..'),         // monorepo from dist/
     join(thisDir, '..', '..', '..', '..'),   // monorepo from src/ during dev
     join(thisDir, '..'),                      // NPM package (files at package root)
   ];
+  return candidates.filter(isDkgRoot);
 }
 
 /**
@@ -332,11 +349,7 @@ export function isDkgMonorepo(): boolean {
   if (_isDkgMonorepo !== null) return _isDkgMonorepo;
   const root = repoDir();
   if (!root) { _isDkgMonorepo = false; return false; }
-  try {
-    _isDkgMonorepo = existsSync(join(root, 'project.json')) && existsSync(join(root, 'pnpm-workspace.yaml'));
-  } catch {
-    _isDkgMonorepo = false;
-  }
+  _isDkgMonorepo = isDkgRoot(root) && existsSync(join(root, 'pnpm-workspace.yaml'));
   return _isDkgMonorepo;
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -220,13 +220,74 @@ export function resolveSharedMemoryTtlMs(config: DkgConfig): number | undefined 
 }
 
 let _networkConfig: NetworkConfig | null = null;
+let _networkConfigName: string | null = null;
 
 export function _resetNetworkConfigCache(): void {
   _networkConfig = null;
+  _networkConfigName = null;
+}
+
+export interface ProjectConfig {
+  repo: string;
+  defaultBranch: string;
+  githubUrl: string;
+  projectName: string;
+  syslogAppName: string;
+  defaultNetwork: string;
+}
+
+let _projectConfig: ProjectConfig | null = null;
+
+/**
+ * Resolve candidate directories where repo-root files (project.json,
+ * network/*.json) may live, in priority order.
+ */
+function candidateRoots(): string[] {
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  return [
+    join(thisDir, '..', '..', '..'),         // monorepo from dist/
+    join(thisDir, '..', '..', '..', '..'),   // monorepo from src/ during dev
+    join(thisDir, '..'),                      // NPM package (files at package root)
+  ];
 }
 
 /**
- * Load the network config from network/testnet.json.
+ * Load project.json — the single source of truth for repo name,
+ * branch, GitHub URL, and default network. Values here drive the
+ * startup banner, auto-update fallbacks, and network selection.
+ *
+ * To rename the repo or change the default branch/network, edit
+ * project.json at the repo root — all runtime code follows.
+ */
+export function loadProjectConfig(): ProjectConfig {
+  if (_projectConfig) return _projectConfig;
+  for (const root of candidateRoots()) {
+    try {
+      const raw = readFileSync(join(root, 'project.json'), 'utf-8');
+      _projectConfig = JSON.parse(raw) as ProjectConfig;
+      return _projectConfig;
+    } catch { /* try next */ }
+  }
+  _projectConfig = {
+    repo: 'OriginTrail/dkg-v9',
+    defaultBranch: 'v10-rc',
+    githubUrl: 'https://github.com/OriginTrail/dkg-v9',
+    projectName: 'dkg',
+    syslogAppName: 'dkg',
+    defaultNetwork: 'testnet',
+  };
+  return _projectConfig;
+}
+
+export function _resetProjectConfigCache(): void {
+  _projectConfig = null;
+}
+
+/**
+ * Load a network config from network/<name>.json.
+ *
+ * @param network - Network name (e.g. 'testnet', 'mainnet'). Defaults to
+ *   the `defaultNetwork` value from project.json.
  *
  * Candidate paths (tried in order):
  *  1. Monorepo root when running from packages/cli/dist/
@@ -234,22 +295,20 @@ export function _resetNetworkConfigCache(): void {
  *  3. Bundled alongside dist/ in the published NPM package (dist/../network/)
  *
  * Monorepo paths are checked first so that edits to the repo-root
- * network/testnet.json are picked up immediately during development
+ * network/ files are picked up immediately during development
  * without requiring a rebuild of the CLI package.
  */
-export async function loadNetworkConfig(): Promise<NetworkConfig | null> {
-  if (_networkConfig) return _networkConfig;
+export async function loadNetworkConfig(network?: string): Promise<NetworkConfig | null> {
+  const name = network ?? loadProjectConfig().defaultNetwork;
+  if (_networkConfig && _networkConfigName === name) return _networkConfig;
   try {
-    const thisDir = dirname(fileURLToPath(import.meta.url));
-    const candidates = [
-      join(thisDir, '..', '..', '..', 'network', 'testnet.json'),       // monorepo from dist/
-      join(thisDir, '..', '..', '..', '..', 'network', 'testnet.json'), // monorepo from src/ during dev
-      join(thisDir, '..', 'network', 'testnet.json'),                   // NPM package (network/ at package root)
-    ];
+    const file = `${name}.json`;
+    const candidates = candidateRoots().map(root => join(root, 'network', file));
     for (const path of candidates) {
       try {
         const raw = await readFile(path, 'utf-8');
         _networkConfig = JSON.parse(raw) as NetworkConfig;
+        _networkConfigName = name;
         return _networkConfig;
       } catch { /* try next */ }
     }
@@ -274,8 +333,7 @@ export function isDkgMonorepo(): boolean {
   const root = repoDir();
   if (!root) { _isDkgMonorepo = false; return false; }
   try {
-    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'));
-    _isDkgMonorepo = pkg.name === 'dkg-v9';
+    _isDkgMonorepo = existsSync(join(root, 'project.json')) && existsSync(join(root, 'pnpm-workspace.yaml'));
   } catch {
     _isDkgMonorepo = false;
   }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -271,23 +271,26 @@ function isDkgMonorepoRoot(dir: string): boolean {
  * Resolve candidate directories where repo-root files (project.json,
  * network/*.json) may live, in priority order.
  *
- * The package-local root (`thisDir/..` in an npm install) is preferred
- * over any ancestor, so a published package never accidentally reads
- * a consumer's own `project.json` under `node_modules`. Ancestor
- * candidates are only included when they look like the DKG monorepo
- * itself.
+ * Ordering rationale:
+ *   - In a monorepo checkout the DKG root is the single source of
+ *     truth, so any detected monorepo ancestor MUST win. Otherwise,
+ *     once `packages/cli/build` has copied `project.json` and
+ *     `network/*.json` into `packages/cli/`, those stale artifacts
+ *     would shadow edits made to the root files until the next
+ *     rebuild — breaking the intended "edit root config, rerun" dev
+ *     flow.
+ *   - In a published npm install there is no monorepo ancestor, so
+ *     we fall back to the package-local root (identified unambiguously
+ *     by its `package.json.name`). This also guarantees we never
+ *     accidentally read a consumer's own `project.json` from
+ *     `node_modules/..`.
  */
 function candidateRoots(): string[] {
   const thisDir = dirname(fileURLToPath(import.meta.url));
   const out: string[] = [];
 
-  // Package-local root first — in an npm install this is the only
-  // location that should ever win, and it's unambiguous.
-  const pkgRoot = join(thisDir, '..');
-  if (isDkgPackageRoot(pkgRoot)) out.push(pkgRoot);
-
-  // Monorepo ancestors (dev / source checkout). `dist/` and `src/`
-  // live at different depths so both paths are tried.
+  // Monorepo ancestors first (dev / source checkout). `dist/` and
+  // `src/` live at different depths, so both paths are tried.
   const monorepoCandidates = [
     join(thisDir, '..', '..', '..'),        // from dist/
     join(thisDir, '..', '..', '..', '..'),  // from src/ during dev
@@ -295,6 +298,11 @@ function candidateRoots(): string[] {
   for (const dir of monorepoCandidates) {
     if (isDkgMonorepoRoot(dir)) out.push(dir);
   }
+
+  // Package-local root as the fallback — the only location that ever
+  // wins in a published install, and unambiguous via its package.json.
+  const pkgRoot = join(thisDir, '..');
+  if (isDkgPackageRoot(pkgRoot)) out.push(pkgRoot);
 
   return out;
 }

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync } from 'node:fs';
 import { mkdir, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
-import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, gitCommandEnv, gitCommandArgs, slotEntryPoint } from './config.js';
+import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, gitCommandEnv, gitCommandArgs, slotEntryPoint } from './config.js';
 
 export const _migrationIo = {
   execSync: execSync as (...args: any[]) => any,
@@ -55,18 +55,19 @@ export async function migrateToBlueGreen(
   let sourceRepo = localRepo ?? '';
   let sourceBranch = process.env.DKG_BRANCH?.trim() || 'main';
   if (!hasLocalRepo) {
+    const proj = loadProjectConfig();
     sourceRepo = normalizeCloneRepo(
       process.env.DKG_REPO
         ?? config?.autoUpdate?.repo
         ?? network?.autoUpdate?.repo
-        ?? 'https://github.com/OriginTrail/dkg-v9.git',
+        ?? `${proj.githubUrl}.git`,
     );
     sourceBranch = (
       process.env.DKG_BRANCH
       ?? config?.autoUpdate?.branch
       ?? network?.autoUpdate?.branch
-      ?? 'main'
-    ).trim() || 'main';
+      ?? proj.defaultBranch
+    ).trim() || proj.defaultBranch;
     if (!opts.allowRemoteBootstrap) {
       log('Migration: no local checkout with .git; skipping remote bootstrap in this mode.');
       return;

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -79,29 +79,28 @@ describe('loadNetworkConfig', () => {
     }
   });
 
+  it('loads a specific network by name', async () => {
+    const { _resetNetworkConfigCache } = await import('../src/config.js');
+    _resetNetworkConfigCache();
+    const config = await loadNetworkConfig('testnet');
+    if (!config) {
+      expect(config).toBeNull();
+      return;
+    }
+    expect(config.networkName).toMatch(/testnet/i);
+  });
+
   it('returns null when network config file does not exist', async () => {
     const { _resetNetworkConfigCache } = await import('../src/config.js');
     _resetNetworkConfigCache();
-    const origDir = process.cwd();
-    try {
-      process.chdir('/tmp');
-      const config = await loadNetworkConfig();
-      if (config !== null) {
-        // Running from monorepo — loadNetworkConfig resolves via import.meta.url
-        // not cwd, so testnet.json is always reachable.  Verify it loaded validly.
-        expect(typeof config.networkName).toBe('string');
-      } else {
-        expect(config).toBeNull();
-      }
-    } finally {
-      process.chdir(origDir);
-    }
+    const config = await loadNetworkConfig('nonexistent-network');
+    expect(config).toBeNull();
   });
 
 });
 
 describe('isDkgMonorepo', () => {
-  it('returns true when running from the dkg-v9 monorepo', () => {
+  it('returns true when running from the DKG monorepo', () => {
     const result = isDkgMonorepo();
     if (repoDir() === null) {
       expect(result).toBe(false);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "9.0.0-beta.6",
+  "version": "10.0.0-rc.1",
   "description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp-server",
-  "version": "9.0.0-beta.6",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node-ui/src/gelf-push-worker.ts
+++ b/packages/node-ui/src/gelf-push-worker.ts
@@ -165,7 +165,7 @@ export class LogPushWorker {
       const sd = `[dkg@0 peer="${sdEscape(this.peerId)}" op="${sdEscape(entry.operationName)}" opid="${sdEscape(entry.operationId)}" mod="${sdEscape(entry.module)}" net="${sdEscape(this.network)}" ${extra}]`;
       const msg = entry.message.replace(/[\r\n]+/g, ' ').slice(0, 8192);
       const hostname = this.nodeName.replace(/[^A-Za-z0-9.\-]/g, '-') || 'dkg-node';
-      const line = `<${pri}>1 ${ts} ${hostname} dkg-v9 - - ${sd} ${msg}\n`;
+      const line = `<${pri}>1 ${ts} ${hostname} dkg - - ${sd} ${msg}\n`;
 
       try {
         this.socket.write(line);

--- a/packages/node-ui/test/log-push-worker.test.ts
+++ b/packages/node-ui/test/log-push-worker.test.ts
@@ -77,7 +77,7 @@ describe('LogPushWorker', () => {
     const line = result[0];
     // PRI = FACILITY_LOCAL0 * 8 + severity(info=6) = 16*8+6 = 134
     expect(line).toMatch(/^<134>1 /);
-    expect(line).toContain(' dkg-v9 ');
+    expect(line).toContain(' dkg ');
     expect(line).toContain(' tars ');
     expect(line).toContain('[dkg@0 ');
     expect(line).toContain('peer="12D3KooWTestPeer"');

--- a/packages/origin-trail-game/package.json
+++ b/packages/origin-trail-game/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-app-origin-trail-game",
-  "version": "0.1.0",
+  "version": "10.0.0-rc.1",
   "description": "OriginTrail Game — a multiplayer game on the DKG. Installable DKG app.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "0.0.1",
+  "version": "10.0.0-rc.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@origintrail-official/dkg-adapter-openclaw':
+        specifier: workspace:*
+        version: link:../adapter-openclaw
       '@origintrail-official/dkg-agent':
         specifier: workspace:*
         version: link:../agent
@@ -349,12 +352,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0))
-      vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)
-
-  packages/digital-twin:
-    devDependencies:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.11)(happy-dom@20.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(tsx@4.21.0)

--- a/project.json
+++ b/project.json
@@ -1,0 +1,8 @@
+{
+  "repo": "OriginTrail/dkg-v9",
+  "defaultBranch": "v10-rc",
+  "githubUrl": "https://github.com/OriginTrail/dkg-v9",
+  "projectName": "dkg",
+  "syslogAppName": "dkg",
+  "defaultNetwork": "testnet"
+}

--- a/scripts/update-repo-refs.js
+++ b/scripts/update-repo-refs.js
@@ -34,14 +34,43 @@ function update(filePath) {
   updated++;
 }
 
-const pkgsDir = path.join(root, 'packages');
-for (const dir of fs.readdirSync(pkgsDir).sort()) {
-  const p = path.join(pkgsDir, dir, 'package.json');
-  if (fs.existsSync(p)) update(p);
+// Recursively find every tracked package.json below the repo root so
+// the tool matches its own contract ("all package.json files") even as
+// the monorepo grows new top-level folders (apps/, tools/, etc.).
+// Skip build outputs, vendored deps, and version-control noise.
+const SKIP = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  '.git',
+  '.turbo',
+  '.next',
+  'coverage',
+  '.pnpm-store',
+  '.cache',
+]);
+
+function walk(dir) {
+  const found = [];
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+  catch { return found; }
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (SKIP.has(entry.name)) continue;
+    // Skip hidden dirs (except well-known repo ones) to avoid editor/
+    // tooling state like .vscode/, .idea/, etc.
+    if (entry.name.startsWith('.') && entry.name !== '.github') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...walk(full));
+    } else if (entry.isFile() && entry.name === 'package.json') {
+      found.push(full);
+    }
+  }
+  return found;
 }
 
-const demoPath = path.join(root, 'demo', 'package.json');
-if (fs.existsSync(demoPath)) update(demoPath);
+for (const pkgJson of walk(root)) update(pkgJson);
 
 if (updated === 0) {
   console.log('All repository URLs already match project.json — nothing to do.');

--- a/scripts/update-repo-refs.js
+++ b/scripts/update-repo-refs.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Bulk-update repository URLs across all package.json files to match
+ * the values in project.json. Run this after renaming the GitHub repo
+ * or changing the URL in project.json.
+ *
+ * Usage:
+ *   node scripts/update-repo-refs.js            # dry-run (default)
+ *   node scripts/update-repo-refs.js --apply     # write changes
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const dryRun = !process.argv.includes('--apply');
+const root = path.resolve(__dirname, '..');
+const proj = JSON.parse(fs.readFileSync(path.join(root, 'project.json'), 'utf-8'));
+const repoUrl = proj.githubUrl + '.git';
+let updated = 0;
+
+function update(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const pkg = JSON.parse(raw);
+  if (!pkg.repository?.url || pkg.repository.url === repoUrl) return;
+  const old = pkg.repository.url;
+  pkg.repository.url = repoUrl;
+  if (dryRun) {
+    console.log(`  [dry-run] ${path.relative(root, filePath)}: ${old} → ${repoUrl}`);
+  } else {
+    fs.writeFileSync(filePath, JSON.stringify(pkg, null, 2) + '\n');
+    console.log(`  ${path.relative(root, filePath)}: ${old} → ${repoUrl}`);
+  }
+  updated++;
+}
+
+const pkgsDir = path.join(root, 'packages');
+for (const dir of fs.readdirSync(pkgsDir).sort()) {
+  const p = path.join(pkgsDir, dir, 'package.json');
+  if (fs.existsSync(p)) update(p);
+}
+
+const demoPath = path.join(root, 'demo', 'package.json');
+if (fs.existsSync(demoPath)) update(demoPath);
+
+if (updated === 0) {
+  console.log('All repository URLs already match project.json — nothing to do.');
+} else if (dryRun) {
+  console.log(`\n${updated} file(s) would be updated. Run with --apply to write.`);
+} else {
+  console.log(`\n${updated} file(s) updated.`);
+}


### PR DESCRIPTION
# v10-rc npm publishing + OpenClaw bundling

Sets up continuous npm publishing for v10-rc and bundles the OpenClaw adapter so users can install and run a node with one command.

## Changes

- **`project.json`** at repo root — single source of truth for repo name, default branch, GitHub URL, and default network. Runtime code (CLI, migration, config, markitdown bundler, elizaos adapter, node-ui syslog) reads from it, so repo rename / branch change is a one-file edit.
- **OpenClaw bundled** — `@origintrail-official/dkg-adapter-openclaw` is now a workspace dep of `@origintrail-official/dkg`. `dkg openclaw setup` imports `runSetup` directly instead of shelling out to `npx`. No second install needed.
- **Version bump** — all packages to `10.0.0-rc.1`.
- **CI** — `npm-continuous-publish.yml` triggers on `v10-rc`, publishes under `--tag latest`. One commented line to update when the branch moves.
- **Helper** — `scripts/update-repo-refs.js` rewrites all `package.json` `repository.url` fields from `project.json` (dry-run by default).

## End-user flow after merge

```bash
npm install -g @origintrail-official/dkg
dkg init
dkg start
dkg openclaw setup
```

## Deferred

- `mainnet.json` + CLI mainnet selection — lands when mainnet contracts are ready. Flipping `project.json.defaultNetwork` is the switch.

## Repo rename / branch change playbook

1. Edit `project.json`.
2. Run `node scripts/update-repo-refs.js --apply`.
3. Update the `branches:` line in `npm-continuous-publish.yml`.