### PR TITLE
feat(openclaw): consolidate adapter config into openclaw.json entry

### DIFF
--- a/docs/setup/JOIN_TESTNET.md
+++ b/docs/setup/JOIN_TESTNET.md
@@ -238,62 +238,22 @@ Messages are end-to-end encrypted (X25519 + XChaCha20-Poly1305). The relay canno
 
 ## B) OpenClaw Agent
 
-If your machine runs an OpenClaw agent, add DKG as a plugin. Your agent gets DKG tools it can use in conversations.
+If your machine runs an OpenClaw agent, add DKG as a plugin. Your agent gets slot-backed memory on the DKG node plus a chat bridge to the node UI.
 
-### 1. Install
-
-Install inside your workspace directory (the path from `agents.defaults.workspace` in `~/.openclaw/openclaw.json`):
+### One-command setup
 
 ```bash
-cd WORKSPACE_DIR
-npm install @origintrail-official/dkg-adapter-openclaw
+npm install -g @origintrail-official/dkg
+dkg openclaw setup
 ```
 
-### 2. Enable the Plugin
+`dkg openclaw setup` is non-interactive and idempotent. It writes `~/.dkg/config.json`, merges the adapter into `~/.openclaw/openclaw.json` (including `plugins.entries.adapter-openclaw.config` with `daemonUrl`, `memory.enabled`, and `channel.enabled`), syncs the canonical DKG node skill into your OpenClaw workspace, starts the DKG daemon, and verifies the install. Re-running preserves any customizations you made to the plugin entry config.
 
-**Merge** these into the `plugins` section of `~/.openclaw/openclaw.json` (don't remove existing entries):
+Alternatively, the DKG node UI's right-panel "Connect OpenClaw" button runs the same setup flow in-process — clicking it from a fresh install is equivalent to running `dkg openclaw setup` on the command line.
 
-```json
-{
-  "plugins": {
-    "load": {
-      "paths": ["~/path/to/workspace/node_modules/@origintrail-official/dkg-adapter-openclaw"]
-    },
-    "entries": {
-      "adapter-openclaw": {
-        "enabled": true
-      }
-    }
-  }
-}
-```
+Once setup completes, restart the OpenClaw gateway if it doesn't auto-reload, then ask your agent about the DKG node to verify connectivity (e.g. `dkg_status`).
 
-- `load.paths` must use a `~/` prefix path (replace `$HOME` with `~` in your workspace path, append `/node_modules/@origintrail-official/dkg-adapter-openclaw`). Bare relative paths break across platforms.
-- The `entries` key must be `adapter-openclaw` (the plugin manifest ID), not the npm package name.
-- Only `enabled: boolean` is allowed in `plugins.entries` — no other keys.
-
-### 3. Configure the Node
-
-Add a `"dkg-node"` block to your workspace's `config.json`:
-
-```json
-{
-  "dkg-node": {
-    "name": "my-openclaw-agent",
-    "description": "An AI agent on the DKG testnet",
-    "dataDir": ".dkg/openclaw",
-    "relayPeers": [
-      "/ip4/167.71.33.105/tcp/9090/p2p/12D3KooWEpSGSVRZx3DqBijai85PLitzWjMzyFVMP4qeqSBUinxj"
-    ],
-    "chainConfig": {
-      "rpcUrl": "https://sepolia.base.org",
-      "hubAddress": "0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6"
-    }
-  }
-}
-```
-
-### 4. EVM Private Key
+### EVM Private Key
 
 Add your private key to `~/.openclaw/.env` (never in config files):
 
@@ -302,34 +262,6 @@ DKG_EVM_PRIVATE_KEY=0xYOUR_PRIVATE_KEY_HERE
 ```
 
 Without a key, P2P networking and queries still work. On-chain publishing requires a funded Base Sepolia wallet.
-
-### 5. SKILL.md
-
-Copy the skill file into your workspace (replace the path with your actual workspace directory):
-
-```bash
-mkdir -p /path/to/your/workspace/skills/dkg-node
-cp node_modules/@origintrail-official/dkg-adapter-openclaw/skills/dkg-node/SKILL.md /path/to/your/workspace/skills/dkg-node/SKILL.md
-```
-
-### 6. Restart and Verify
-
-```bash
-openclaw gateway restart
-```
-
-Ask your agent to call `dkg_status`. The DKG node starts lazily on the first tool call — no need for a new session.
-
-### Available Tools
-
-| Tool | What it does |
-|------|-------------|
-| `dkg_status` | Show node status: peer ID, connected peers, multiaddrs |
-| `dkg_publish` | Publish RDF triples to a DKG paranet |
-| `dkg_query` | Run a SPARQL query against the local knowledge graph |
-| `dkg_find_agents` | Discover agents by framework or skill type |
-| `dkg_send_message` | Send an encrypted chat message to another agent |
-| `dkg_invoke_skill` | Call a remote agent's skill over the network |
 
 ### Using the CLI Alongside
 

--- a/packages/adapter-openclaw/README.md
+++ b/packages/adapter-openclaw/README.md
@@ -29,7 +29,7 @@ npm install -g @origintrail-official/dkg
 dkg openclaw setup
 ```
 
-The setup flow is non-interactive and idempotent. It writes `~/.dkg/config.json`, merges the adapter into `~/.openclaw/openclaw.json`, writes `WORKSPACE_DIR/config.json`, starts the daemon if requested, and verifies the node.
+The setup flow is non-interactive and idempotent. It writes `~/.dkg/config.json`, merges the adapter into `~/.openclaw/openclaw.json` (including the adapter's runtime config under `plugins.entries.adapter-openclaw.config`), starts the daemon if requested, and verifies the node.
 
 The node UI's right-panel "Connect OpenClaw" button runs this same setup flow in-process — clicking it from a fresh install is equivalent to running `dkg openclaw setup` on the command line (issue #198).
 
@@ -53,21 +53,20 @@ A healthy setup should satisfy all of the following:
 | File | Owner | Purpose |
 | --- | --- | --- |
 | `~/.dkg/config.json` | DKG node | node config: networking, chain, auth, API |
-| `WORKSPACE_DIR/config.json` | adapter setup | adapter-facing `dkg-node` config such as daemon URL, memory, and channel flags |
-| `~/.openclaw/openclaw.json` | OpenClaw | plugin loading config |
+| `~/.openclaw/openclaw.json` | OpenClaw | plugin loading config; the adapter's runtime config also lives here under `plugins.entries.adapter-openclaw.config` |
 
 ## Adapter Config
 
-These keys live under `"dkg-node"` in `WORKSPACE_DIR/config.json`.
+These keys live under `plugins.entries.adapter-openclaw.config` in `~/.openclaw/openclaw.json`. `dkg openclaw setup` populates them with first-wins semantics — customizations survive re-runs unless `--port` is passed explicitly (which refreshes `daemonUrl`).
 
 | Key | Default | Purpose |
 | --- | --- | --- |
-| `daemonUrl` | `http://127.0.0.1:9200` | DKG daemon HTTP URL |
-| `memory.enabled` | `false` (`true` after setup) | register the DKG memory-slot capability on attach (slot-backed recall via `api.registerMemoryCapability`; no adapter-side write tool — writes go through SKILL.md direct routes) |
-| `channel.enabled` | `false` (`true` after setup) | enable the DKG UI to OpenClaw bridge |
-| `channel.port` | `9201` | standalone bridge port when gateway route registration is unavailable |
+| `daemonUrl` | `http://127.0.0.1:9200` | DKG daemon HTTP URL (env `DKG_DAEMON_URL` overrides at runtime) |
+| `memory.enabled` | `true` after setup | register the DKG memory-slot capability on attach (slot-backed recall via `api.registerMemoryCapability`; no adapter-side write tool — writes go through SKILL.md direct routes) |
+| `channel.enabled` | `true` after setup | enable the DKG UI to OpenClaw bridge |
+| `channel.port` | `9201` (optional) | standalone bridge port when gateway route registration is unavailable; setup does not write this key — set it manually on the entry config if you need to override the default |
 
-The legacy `memory.memoryDir` and `memory.watchDebounceMs` config keys, the filesystem-watcher + `/api/memory/import` ingestion flow they configured, and the `dkg_memory_import` / `dkg_memory_search` adapter tools that previously wrapped the daemon routes were all retired in the openclaw-dkg-primary-memory work. Memory now flows exclusively through `api.registerMemoryCapability` for slot-backed recall reads (handled by `DkgMemorySearchManager`, which fans out four parallel SPARQL queries — one against `agent-context` / `chat-turns` in working memory plus three against the resolved project CG's `memory` assertion with `view: 'working-memory'`, `'shared-working-memory'`, and `'verified-memory'` — and ranks the merged results with a trust-weighted score) and through the daemon routes documented in `packages/cli/skills/dkg-node/SKILL.md` for writes (`POST /api/assertion/create` on the first write to a fresh project CG, then `POST /api/assertion/:name/write` for each write after that).
+Memory flows exclusively through `api.registerMemoryCapability` for slot-backed recall reads (handled by `DkgMemorySearchManager`, which fans out four parallel SPARQL queries — one against `agent-context` / `chat-turns` in working memory plus three against the resolved project CG's `memory` assertion with `view: 'working-memory'`, `'shared-working-memory'`, and `'verified-memory'` — and ranks the merged results with a trust-weighted score) and through the daemon routes documented in `packages/cli/skills/dkg-node/SKILL.md` for writes (`POST /api/assertion/create` on the first write to a fresh project CG, then `POST /api/assertion/:name/write` for each write after that).
 
 ## Notes
 

--- a/packages/adapter-openclaw/README.md
+++ b/packages/adapter-openclaw/README.md
@@ -66,6 +66,8 @@ These keys live under `plugins.entries.adapter-openclaw.config` in `~/.openclaw/
 | `channel.enabled` | `true` after setup | enable the DKG UI to OpenClaw bridge |
 | `channel.port` | `9201` (optional) | standalone bridge port when gateway route registration is unavailable; setup does not write this key — set it manually on the entry config if you need to override the default |
 
+**Disconnect semantics.** The node UI's "Disconnect" button removes `plugins.entries.adapter-openclaw` entirely from `~/.openclaw/openclaw.json`, including any customized `config` values. If you had set a non-default `daemonUrl` (for example via `dkg openclaw setup --port 9300` or a remote daemon URL), re-run `dkg openclaw setup --port <N>` after Reconnect to restore it. Default-port users see no visible difference across a Disconnect/Reconnect cycle.
+
 Memory flows exclusively through `api.registerMemoryCapability` for slot-backed recall reads (handled by `DkgMemorySearchManager`, which fans out four parallel SPARQL queries — one against `agent-context` / `chat-turns` in working memory plus three against the resolved project CG's `memory` assertion with `view: 'working-memory'`, `'shared-working-memory'`, and `'verified-memory'` — and ranks the merged results with a trust-weighted score) and through the daemon routes documented in `packages/cli/skills/dkg-node/SKILL.md` for writes (`POST /api/assertion/create` on the first write to a fresh project CG, then `POST /api/assertion/:name/write` for each write after that).
 
 ## Notes

--- a/packages/adapter-openclaw/openclaw-entry.mjs
+++ b/packages/adapter-openclaw/openclaw-entry.mjs
@@ -15,16 +15,28 @@ export default function (api) {
     return;
   }
 
+  // Mirror the fallback order used by isMemorySlotOwnedByThisAdapter in
+  // DkgMemoryPlugin.ts — some OpenClaw gateway versions expose the merged
+  // config on api.cfg / runtime.cfg instead of api.config.
+  const anyApi = api;
+  const runtime = anyApi?.runtime;
+  const mergedConfig =
+    anyApi?.cfg ??
+    anyApi?.config ??
+    runtime?.cfg ??
+    runtime?.config ??
+    {};
+
   // Workspace directory is still needed for the SKILL.md sync below and for
   // downstream auto-detection, even though per-workspace config.json is gone.
-  let workspaceDir = api.config?.agents?.defaults?.workspace;
+  let workspaceDir = mergedConfig?.agents?.defaults?.workspace;
   if (!workspaceDir) {
-    workspaceDir = api.config?.workspace ?? api.workspaceDir;
+    workspaceDir = mergedConfig?.workspace ?? api.workspaceDir;
   }
 
   // Read DKG config from the OpenClaw plugin entry
   // (plugins.entries["adapter-openclaw"].config in openclaw.json).
-  const entryConfig = api.config?.plugins?.entries?.['adapter-openclaw']?.config ?? {};
+  const entryConfig = mergedConfig?.plugins?.entries?.['adapter-openclaw']?.config ?? {};
   const config = { ...entryConfig };
 
   // Deep-clone integration sub-configs so we don't mutate the incoming config.

--- a/packages/adapter-openclaw/openclaw-entry.mjs
+++ b/packages/adapter-openclaw/openclaw-entry.mjs
@@ -15,53 +15,34 @@ export default function (api) {
     return;
   }
 
-  // Read DKG config from workspace config.json (not openclaw.json)
+  // Workspace directory is still needed for the SKILL.md sync below and for
+  // downstream auto-detection, even though per-workspace config.json is gone.
   let workspaceDir = api.config?.agents?.defaults?.workspace;
   if (!workspaceDir) {
     workspaceDir = api.config?.workspace ?? api.workspaceDir;
   }
 
-  let wsConfig = {};
-  if (workspaceDir) {
-    try {
-      const raw = readFileSync(join(workspaceDir, 'config.json'), 'utf-8');
-      wsConfig = JSON.parse(raw)['dkg-node'] || {};
-    } catch (err) {
-      log.warn?.(`[dkg-entry] Failed to read config.json from ${workspaceDir}: ${err.message}`);
-    }
-  } else {
-    log.warn?.('[dkg-entry] No workspace directory found - using defaults only');
-  }
+  // Read DKG config from the OpenClaw plugin entry
+  // (plugins.entries["adapter-openclaw"].config in openclaw.json).
+  const entryConfig = api.config?.plugins?.entries?.['adapter-openclaw']?.config ?? {};
+  const config = { ...entryConfig };
 
-  // Build config from workspace settings
-  const config = { ...wsConfig };
+  // Deep-clone integration sub-configs so we don't mutate the incoming config.
+  if (entryConfig.memory) config.memory = { ...entryConfig.memory };
+  if (entryConfig.channel) config.channel = { ...entryConfig.channel };
 
-  // Override daemon URL from environment if set
+  // Env override: DKG_DAEMON_URL trumps the config-file value.
   if (process.env.DKG_DAEMON_URL) {
     config.daemonUrl = process.env.DKG_DAEMON_URL;
   }
 
-  // Deep-clone integration sub-configs
-  if (wsConfig.memory) {
-    config.memory = { ...wsConfig.memory };
-    // Do NOT auto-populate `config.memory.memoryDir` here. The key was
-    // retired with the openclaw-dkg-primary-memory workstream along
-    // with the retirement warning itself (that warning was removed in
-    // commit 66211977 — first-product-release has no legacy install
-    // base to migrate from). We still clone `wsConfig.memory` to preserve
-    // any other fields operators may have set in their workspace config.
-  }
-  if (wsConfig.channel) {
-    config.channel = { ...wsConfig.channel };
-  }
-
-  // Pass workspace directory to the API for auto-detection
+  // Pass workspace directory to the API for auto-detection.
   if (workspaceDir && !api.workspaceDir) {
     api.workspaceDir = workspaceDir;
   }
 
   log.info?.(
-    `[dkg-entry] config - daemonUrl: ${config.daemonUrl ?? 'http://127.0.0.1:9200'}, `
+    `[dkg-entry] config (from openclaw.json entry config) - daemonUrl: ${config.daemonUrl ?? 'http://127.0.0.1:9200'}, `
       + `memory.enabled: ${config.memory?.enabled}, `
       + `channel.enabled: ${config.channel?.enabled}, `
       + `registrationMode: ${api.registrationMode ?? 'full'}`,

--- a/packages/adapter-openclaw/src/index.ts
+++ b/packages/adapter-openclaw/src/index.ts
@@ -8,6 +8,7 @@ export {
   unmergeOpenClawConfig,
   verifyMemorySlotInvariants,
   verifyUnmergeInvariants,
+  type AdapterEntryConfig,
   type SetupOptions,
 } from './setup.js';
 // Codex Bug B24: the `DkgMemoryPlugin` class no longer exposes the legacy

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -19,6 +19,7 @@ import { createRequire } from 'node:module';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import type { DkgOpenClawConfig } from './types.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -477,11 +478,14 @@ function isAdapterLoadPath(value: string): boolean {
     || normalized.includes('/packages/adapter-openclaw/');
 }
 
-export interface AdapterEntryConfig {
-  daemonUrl: string;
-  memory: { enabled: boolean };
-  channel: { enabled: boolean };
-}
+/**
+ * Shape of `plugins.entries.adapter-openclaw.config` that
+ * `mergeOpenClawConfig` accepts. A `Pick` of `DkgOpenClawConfig` so the
+ * write-path stays aligned with the runtime's config contract: callers
+ * can pass any of the same sub-fields the adapter reads at load time,
+ * including `channel.port` for advanced bridge-port overrides.
+ */
+export type AdapterEntryConfig = Pick<DkgOpenClawConfig, 'daemonUrl' | 'memory' | 'channel'>;
 
 export function mergeOpenClawConfig(
   openclawConfigPath: string,

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -5,10 +5,10 @@
  *  1. Discover OpenClaw workspace and agent name
  *  2. Write ~/.dkg/config.json with testnet defaults
  *  3. Start the DKG daemon
- *  4. Merge adapter plugin into ~/.openclaw/openclaw.json
- *  5. Write workspace config.json with feature flags
- *  6. Copy the canonical DKG node skill into the OpenClaw workspace
- *  7. Verify setup
+ *  4. Merge adapter plugin into ~/.openclaw/openclaw.json (including
+ *     plugins.entries.adapter-openclaw.config with feature flags)
+ *  5. Copy the canonical DKG node skill into the OpenClaw workspace
+ *  6. Verify setup
  *
  * Every step is idempotent — re-running is safe.
  */
@@ -477,7 +477,18 @@ function isAdapterLoadPath(value: string): boolean {
     || normalized.includes('/packages/adapter-openclaw/');
 }
 
-export function mergeOpenClawConfig(openclawConfigPath: string, adapterPath: string): void {
+export interface AdapterEntryConfig {
+  daemonUrl: string;
+  memory: { enabled: boolean };
+  channel: { enabled: boolean };
+}
+
+export function mergeOpenClawConfig(
+  openclawConfigPath: string,
+  adapterPath: string,
+  entryConfig: AdapterEntryConfig,
+  options?: { overrideDaemonUrl?: boolean },
+): void {
   if (!openclawConfigPath || !existsSync(openclawConfigPath)) {
     // If we got here via --workspace override, the openclaw.json path may be unknown.
     // Try the default location.
@@ -539,6 +550,34 @@ export function mergeOpenClawConfig(openclawConfigPath: string, adapterPath: str
     log(`Re-enabled ${pluginId} in plugins.entries`);
   } else {
     log(`${pluginId} already in plugins.entries`);
+  }
+
+  // Populate entry.config with first-wins semantics: user-customized values
+  // survive re-runs (same pattern as previousMemorySlotOwner). Sub-objects
+  // (memory, channel) are shallow-merged per-key so new defaults added in a
+  // later release flow in while user overrides for existing keys hold.
+  // When `overrideDaemonUrl` is set (caller passed --port explicitly), the
+  // new `daemonUrl` wins over any existing value.
+  const entryForConfig = config.plugins.entries[pluginId];
+  const hadConfig = entryForConfig.config && typeof entryForConfig.config === 'object';
+  const existingEntryConfig: Record<string, any> = hadConfig ? { ...entryForConfig.config } : {};
+  if (options?.overrideDaemonUrl) {
+    delete existingEntryConfig.daemonUrl;
+  }
+  const existingMemory = existingEntryConfig.memory && typeof existingEntryConfig.memory === 'object'
+    ? existingEntryConfig.memory
+    : {};
+  const existingChannel = existingEntryConfig.channel && typeof existingEntryConfig.channel === 'object'
+    ? existingEntryConfig.channel
+    : {};
+  entryForConfig.config = {
+    ...entryConfig,
+    ...existingEntryConfig,
+    memory: { ...entryConfig.memory, ...existingMemory },
+    channel: { ...entryConfig.channel, ...existingChannel },
+  };
+  if (!hadConfig) {
+    log(`Populated plugins.entries.${pluginId}.config`);
   }
 
   // Ensure plugin-registered tools are visible to the agent
@@ -609,11 +648,11 @@ export function mergeOpenClawConfig(openclawConfigPath: string, adapterPath: str
  * would have written:
  *   - removes `"adapter-openclaw"` from `plugins.allow`
  *   - filters `plugins.load.paths` by the same `isAdapterLoadPath` predicate
- *   - flips `plugins.entries["adapter-openclaw"].enabled = false` (keeps other fields)
+ *   - removes `plugins.entries["adapter-openclaw"]` entirely (including any
+ *     `config` sub-object — the adapter owns the whole entry)
  *   - restores `plugins.slots.memory` to the prior owner captured during merge
- *     (`entries["adapter-openclaw"].previousMemorySlotOwner`), or clears it
- *     when no prior owner was persisted. Either way, strips the
- *     `previousMemorySlotOwner` metadata so a future merge re-captures fresh.
+ *     (`entries["adapter-openclaw"].previousMemorySlotOwner`, read before the
+ *     entry is deleted), or clears it when no prior owner was persisted.
  *
  * Leaves `tools.alsoAllow` (shared with other plugins), workspace `config.json`
  * (user-owned), and any workspace `SKILL.md` copies alone. Idempotent — a
@@ -681,20 +720,14 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): void {
     previousMemorySlotOwner = entry.previousMemorySlotOwner;
   }
 
-  // Flip entry.enabled to false (preserve other plugin-specific fields) and
-  // strip the previousMemorySlotOwner marker so a future merge re-captures
-  // whatever's in the slot at that point rather than restoring stale state.
-  if (config.plugins && config.plugins.entries) {
-    const entryForWrite = config.plugins.entries[pluginId];
-    if (entryForWrite && typeof entryForWrite === 'object') {
-      if (entryForWrite.enabled !== false) {
-        entryForWrite.enabled = false;
-        log(`Disabled ${pluginId} in plugins.entries`);
-      }
-      if ('previousMemorySlotOwner' in entryForWrite) {
-        delete entryForWrite.previousMemorySlotOwner;
-      }
-    }
+  // Delete the adapter entry entirely. The adapter owns this entry — all of
+  // its fields (enabled, config, previousMemorySlotOwner) are setup-written,
+  // so there's no user-customizable state to preserve. A fresh merge will
+  // rebuild everything from scratch, including re-capturing the current slot
+  // owner into previousMemorySlotOwner.
+  if (config.plugins && config.plugins.entries && pluginId in config.plugins.entries) {
+    delete config.plugins.entries[pluginId];
+    log(`Removed ${pluginId} from plugins.entries`);
   }
 
   // Restore or clear slots.memory iff it still points at the adapter. If the
@@ -779,53 +812,14 @@ export function verifyUnmergeInvariants(configPath: string): string | null {
   }
   const entry = plugins?.entries?.[pluginId];
   if (entry && typeof entry === 'object' && entry.enabled === true) {
-    return `plugins.entries["${pluginId}"].enabled is still true`;
+    return `plugins.entries["${pluginId}"] is still present with enabled=true`;
   }
 
   return null;
 }
 
 // ---------------------------------------------------------------------------
-// Step 6: Write workspace config
-// ---------------------------------------------------------------------------
-
-export function writeWorkspaceConfig(workspaceDir: string, apiPort: number, portExplicit?: boolean): void {
-  const configPath = join(workspaceDir, 'config.json');
-
-  let existing: Record<string, any> = {};
-  if (existsSync(configPath)) {
-    try {
-      existing = JSON.parse(readFileSync(configPath, 'utf-8'));
-    } catch {
-      warn(`Could not parse ${configPath} — will overwrite`);
-    }
-  }
-
-  // Deep-merge: preserve existing dkg-node sub-config.
-  // daemonUrl is only overridden when --port is explicitly passed; otherwise
-  // the existing value is kept so custom URLs (e.g. remote daemons) survive re-runs.
-  // Feature flags default to true on first run but are not overridden on re-runs
-  // so that user-configured `false` values are respected.
-  const dkgNode = existing['dkg-node'] ?? {};
-  const nextDkgNode = {
-    ...dkgNode,
-    daemonUrl: portExplicit ? `http://127.0.0.1:${apiPort}` : (dkgNode.daemonUrl ?? `http://127.0.0.1:${apiPort}`),
-    memory: { enabled: true, ...dkgNode.memory },
-    channel: { enabled: true, ...dkgNode.channel },
-  };
-  if (nextDkgNode.game !== undefined) {
-    delete nextDkgNode.game;
-    log('Removed legacy dkg-node.game config from workspace config');
-  }
-  existing['dkg-node'] = nextDkgNode;
-
-  mkdirSync(workspaceDir, { recursive: true });
-  writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n');
-  log('Wrote workspace config (memory=on, channel=on)');
-}
-
-// ---------------------------------------------------------------------------
-// Step 7: Copy the canonical DKG node skill into the OpenClaw workspace
+// Step 6: Copy the canonical DKG node skill into the OpenClaw workspace
 // ---------------------------------------------------------------------------
 
 export function installCanonicalNodeSkill(
@@ -840,7 +834,7 @@ export function installCanonicalNodeSkill(
 }
 
 // ---------------------------------------------------------------------------
-// Step 8: Verify
+// Step 7: Verify
 // ---------------------------------------------------------------------------
 
 export async function verifySetup(
@@ -1041,21 +1035,21 @@ export async function runSetup(options: SetupOptions): Promise<void> {
       '         npm install -g @origintrail-official/dkg',
     );
   }
+  const portExplicit = options.port != null;
+  const entryConfig: AdapterEntryConfig = {
+    daemonUrl: `http://127.0.0.1:${effectivePort}`,
+    memory: { enabled: true },
+    channel: { enabled: true },
+  };
   if (!dryRun) {
-    mergeOpenClawConfig(openclawConfigPath, resolvedAdapterPath);
+    mergeOpenClawConfig(openclawConfigPath, resolvedAdapterPath, entryConfig, {
+      overrideDaemonUrl: portExplicit,
+    });
   } else {
     log(`[dry-run] Would merge adapter (${resolvedAdapterPath}) into openclaw.json`);
   }
 
-  // Step 6: Write workspace config
-  throwIfAborted();
-  if (!dryRun) {
-    writeWorkspaceConfig(workspaceDir, effectivePort, options.port != null);
-  } else {
-    log('[dry-run] Would write workspace config.json');
-  }
-
-  // Step 7: Copy the canonical DKG node skill into the OpenClaw workspace
+  // Step 6: Copy the canonical DKG node skill into the OpenClaw workspace
   throwIfAborted();
   if (!dryRun) {
     installCanonicalNodeSkill(workspaceDir);
@@ -1067,7 +1061,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   // after config changes, but manual restart remains the safe fallback.
   log('Reload the OpenClaw gateway if it does not auto-restart after the config update');
 
-  // Step 8: Verify
+  // Step 7: Verify
   throwIfAborted();
   if (shouldVerify && !dryRun) {
     await verifySetup(effectivePort, { openclawConfigPath });

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -10,11 +10,20 @@ import {
   mergeOpenClawConfig,
   unmergeOpenClawConfig,
   verifyUnmergeInvariants,
-  writeWorkspaceConfig,
   installCanonicalNodeSkill,
   openclawConfigPath,
   runSetup,
+  type AdapterEntryConfig,
 } from '../src/setup.js';
+
+// Default entryConfig fixture used by most mergeOpenClawConfig call sites
+// (the new third positional arg after D2). Cases that assert specific
+// entry.config values seed their own.
+const defaultEntryConfig: AdapterEntryConfig = {
+  daemonUrl: 'http://127.0.0.1:9200',
+  memory: { enabled: true },
+  channel: { enabled: true },
+};
 import { homedir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -222,20 +231,26 @@ describe('mergeOpenClawConfig', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.allow).toContain('adapter-openclaw');
     expect(config.plugins.load.paths).toContain('/path/to/adapter');
-    expect(config.plugins.entries['adapter-openclaw']).toEqual({ enabled: true });
+    const entry = config.plugins.entries['adapter-openclaw'];
+    expect(entry.enabled).toBe(true);
+    expect(entry.config).toEqual({
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true },
+    });
   });
 
   it('is idempotent — no duplicates on second run', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.allow.filter((x: string) => x === 'adapter-openclaw')).toHaveLength(1);
@@ -253,7 +268,7 @@ describe('mergeOpenClawConfig', () => {
       someOtherKey: 123,
     }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.allow).toContain('other-plugin');
@@ -267,7 +282,7 @@ describe('mergeOpenClawConfig', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const files = readdirSync(testDir);
     const backups = files.filter((f: string) => f.startsWith('openclaw.json.bak.'));
@@ -278,7 +293,7 @@ describe('mergeOpenClawConfig', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, 'C:\\Users\\test\\adapter');
+    mergeOpenClawConfig(configPath, 'C:\\Users\\test\\adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.load.paths[0]).toBe('C:/Users/test/adapter');
@@ -301,7 +316,7 @@ describe('mergeOpenClawConfig', () => {
       },
     }));
 
-    mergeOpenClawConfig(configPath, 'C:\\Projects\\dkg-v9\\packages\\adapter-openclaw');
+    mergeOpenClawConfig(configPath, 'C:\\Projects\\dkg-v9\\packages\\adapter-openclaw', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.load.paths).toEqual([
@@ -314,7 +329,7 @@ describe('mergeOpenClawConfig', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.slots).toBeDefined();
@@ -332,7 +347,7 @@ describe('mergeOpenClawConfig', () => {
       },
     }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.slots.memory).toBe('adapter-openclaw');
@@ -348,7 +363,7 @@ describe('mergeOpenClawConfig', () => {
       },
     }));
 
-    expect(() => mergeOpenClawConfig(configPath, '/path/to/adapter')).toThrow(/contextEngine/);
+    expect(() => mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig)).toThrow(/contextEngine/);
   });
 
   it('overwrites a different plugins.slots.memory value with a log line', () => {
@@ -359,7 +374,7 @@ describe('mergeOpenClawConfig', () => {
       },
     }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.slots.memory).toBe('adapter-openclaw');
@@ -369,11 +384,11 @@ describe('mergeOpenClawConfig', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     const firstRun = readFileSync(configPath, 'utf-8');
     const firstBackupCount = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     const secondRun = readFileSync(configPath, 'utf-8');
     const secondBackupCount = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
 
@@ -388,7 +403,7 @@ describe('mergeOpenClawConfig', () => {
       plugins: { slots: { memory: 'memory-core' } },
     }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.slots.memory).toBe('adapter-openclaw');
@@ -402,15 +417,101 @@ describe('mergeOpenClawConfig', () => {
     }));
 
     // First merge captures "memory-core" into the entry.
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterFirst.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
 
     // Second merge: slot is already the adapter, so the capture branch won't
     // fire — and even if it did, the first-wins guard keeps the original.
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterSecond.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
+  });
+
+  // D2 — entry.config is the single source of truth for DkgNodePlugin runtime
+  // config. Fresh merge populates it; re-merge preserves user-customized values
+  // (first-wins), matching the previousMemorySlotOwner pattern.
+  it('writes entry.config with daemonUrl/memory/channel on fresh merge', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true },
+    });
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const entryConfig = config.plugins.entries['adapter-openclaw'].config;
+    expect(entryConfig.daemonUrl).toBe('http://127.0.0.1:9200');
+    expect(entryConfig.memory).toEqual({ enabled: true });
+    expect(entryConfig.channel).toEqual({ enabled: true });
+  });
+
+  it('preserves existing entry.config values on re-merge (first-wins semantics)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    // Seed: user has a prior merge with a custom daemonUrl and a memory
+    // block with enabled:false. The channel block is absent — re-merge
+    // should fill it in from defaults without touching existing keys.
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              daemonUrl: 'http://custom:9300',
+              memory: { enabled: false },
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true },
+    });
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const entryConfig = config.plugins.entries['adapter-openclaw'].config;
+    // User-customized values survive.
+    expect(entryConfig.daemonUrl).toBe('http://custom:9300');
+    expect(entryConfig.memory.enabled).toBe(false);
+    // Missing sub-object gets filled in from defaults.
+    expect(entryConfig.channel).toEqual({ enabled: true });
+  });
+
+  it('overrideDaemonUrl option replaces existing daemonUrl (used when --port is explicit)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              daemonUrl: 'http://custom:9300',
+              memory: { enabled: true },
+              channel: { enabled: true },
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(
+      configPath,
+      '/path/to/adapter',
+      {
+        daemonUrl: 'http://127.0.0.1:9400',
+        memory: { enabled: true },
+        channel: { enabled: true },
+      },
+      { overrideDaemonUrl: true },
+    );
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.daemonUrl).toBe('http://127.0.0.1:9400');
   });
 });
 
@@ -426,17 +527,16 @@ describe('unmergeOpenClawConfig', () => {
     }));
 
     // Merge → captures "memory-core" as previousMemorySlotOwner.
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterMerge.plugins.slots.memory).toBe('adapter-openclaw');
     expect(afterMerge.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBe('memory-core');
 
-    // Unmerge → restores "memory-core" and strips the metadata.
+    // Unmerge → restores "memory-core" and removes the entry entirely.
     unmergeOpenClawConfig(configPath);
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.plugins.slots.memory).toBe('memory-core');
-    expect(afterUnmerge.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBeUndefined();
-    expect(afterUnmerge.plugins.entries['adapter-openclaw'].enabled).toBe(false);
+    expect(afterUnmerge.plugins.entries['adapter-openclaw']).toBeUndefined();
   });
 
   it('clears plugins.slots.memory when no prior owner was persisted', () => {
@@ -444,7 +544,7 @@ describe('unmergeOpenClawConfig', () => {
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
     // Merge on a clean config — no previousMemorySlotOwner is captured.
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterMerge.plugins.slots.memory).toBe('adapter-openclaw');
     expect(afterMerge.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBeUndefined();
@@ -460,7 +560,7 @@ describe('unmergeOpenClawConfig', () => {
     // fresh install that hasn't configured a memory provider yet.
     writeFileSync(configPath, JSON.stringify({ plugins: {} }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     unmergeOpenClawConfig(configPath);
 
     const final = JSON.parse(readFileSync(configPath, 'utf-8'));
@@ -474,7 +574,7 @@ describe('unmergeOpenClawConfig', () => {
       plugins: { slots: { memory: 'memory-core' } },
     }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     unmergeOpenClawConfig(configPath);
     const firstBackupCount = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
     const firstContent = readFileSync(configPath, 'utf-8');
@@ -493,7 +593,7 @@ describe('unmergeOpenClawConfig', () => {
       plugins: { slots: { memory: 'memory-core' } },
     }));
 
-    mergeOpenClawConfig(configPath, '/path/to/adapter');
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
     // Simulate external modification: user swaps in a different memory plugin.
     const intermediate = JSON.parse(readFileSync(configPath, 'utf-8'));
     intermediate.plugins.slots.memory = 'some-other-memory-plugin';
@@ -502,9 +602,9 @@ describe('unmergeOpenClawConfig', () => {
     unmergeOpenClawConfig(configPath);
 
     const final = JSON.parse(readFileSync(configPath, 'utf-8'));
-    // We don't clobber the user's new choice, and we clean up our marker.
+    // We don't clobber the user's new choice, and the adapter entry is gone.
     expect(final.plugins.slots.memory).toBe('some-other-memory-plugin');
-    expect(final.plugins.entries['adapter-openclaw'].previousMemorySlotOwner).toBeUndefined();
+    expect(final.plugins.entries['adapter-openclaw']).toBeUndefined();
   });
 
   // PR #228 Codex N4 — a missing openclaw.json is treated as already-
@@ -555,7 +655,7 @@ describe('unmergeOpenClawConfig', () => {
     mkdirSync(defaultHome, { recursive: true });
     const defaultConfigPath = join(defaultHome, 'openclaw.json');
     writeFileSync(defaultConfigPath, JSON.stringify({ plugins: {} }, null, 2) + '\n');
-    mergeOpenClawConfig(defaultConfigPath, '/path/to/adapter');
+    mergeOpenClawConfig(defaultConfigPath, '/path/to/adapter', defaultEntryConfig);
     const defaultContentBefore = readFileSync(defaultConfigPath, 'utf-8');
     const defaultBackupsBefore = readdirSync(defaultHome).filter(
       (f: string) => f.startsWith('openclaw.json.bak.'),
@@ -584,6 +684,24 @@ describe('unmergeOpenClawConfig', () => {
     // And the explicit path didn't get a freshly-created file either.
     expect(existsSync(explicitMissingPath)).toBe(false);
   });
+
+  // D1 — unmerge deletes the adapter entry entirely (including its config
+  // sub-object). The adapter owns every field on this entry post-D2, so there
+  // is no user-customizable state to preserve.
+  it('removes the adapter entry entirely on unmerge (including entry.config)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    // Merge populates entry + entry.config.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig);
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.plugins.entries['adapter-openclaw'].config).toBeDefined();
+
+    unmergeOpenClawConfig(configPath);
+
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.plugins.entries['adapter-openclaw']).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -591,7 +709,28 @@ describe('unmergeOpenClawConfig', () => {
 // ---------------------------------------------------------------------------
 
 describe('verifyUnmergeInvariants', () => {
-  it('returns null when every field `mergeOpenClawConfig` writes has been unwound', () => {
+  it('returns null when every field `mergeOpenClawConfig` writes has been unwound (entry absent)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          plugins: {
+            allow: [],
+            load: { paths: [] },
+            entries: {},
+            slots: {},
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+
+    expect(verifyUnmergeInvariants(configPath)).toBeNull();
+  });
+
+  it('returns null when entry exists but is disabled (defensive — absent is the normal post-unmerge state)', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(
       configPath,
@@ -665,7 +804,7 @@ describe('verifyUnmergeInvariants', () => {
     expect(result).toContain('/home/me/packages/adapter-openclaw');
   });
 
-  it('returns a descriptive string when plugins.entries["adapter-openclaw"].enabled is still true', () => {
+  it('returns a descriptive string when plugins.entries["adapter-openclaw"] is still present with enabled=true', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(
       configPath,
@@ -680,7 +819,7 @@ describe('verifyUnmergeInvariants', () => {
     );
 
     expect(verifyUnmergeInvariants(configPath)).toMatch(
-      /plugins\.entries\["adapter-openclaw"\]\.enabled is still true/,
+      /plugins\.entries\["adapter-openclaw"\] is still present with enabled=true/,
     );
   });
 
@@ -755,93 +894,6 @@ describe('openclaw.plugin.json manifest', () => {
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
     expect(manifest.kind).toBe('memory');
     expect(manifest.id).toBe('adapter-openclaw');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// writeWorkspaceConfig
-// ---------------------------------------------------------------------------
-
-describe('writeWorkspaceConfig', () => {
-  it('creates workspace config with defaults', () => {
-    const ws = join(testDir, 'workspace');
-    mkdirSync(ws, { recursive: true });
-
-    writeWorkspaceConfig(ws, 9200);
-
-    const config = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
-    expect(config['dkg-node'].daemonUrl).toBe('http://127.0.0.1:9200');
-    expect(config['dkg-node'].memory.enabled).toBe(true);
-    expect(config['dkg-node'].channel.enabled).toBe(true);
-    expect(config['dkg-node'].game).toBeUndefined();
-  });
-
-  it('preserves existing workspace config keys', () => {
-    const ws = join(testDir, 'workspace');
-    mkdirSync(ws, { recursive: true });
-    writeFileSync(join(ws, 'config.json'), JSON.stringify({
-      'some-other-plugin': { key: 'value' },
-    }));
-
-    writeWorkspaceConfig(ws, 9200);
-
-    const config = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
-    expect(config['some-other-plugin']).toEqual({ key: 'value' });
-    expect(config['dkg-node']).toBeDefined();
-  });
-
-  it('removes legacy game config from the workspace dkg-node block', () => {
-    const ws = join(testDir, 'workspace');
-    mkdirSync(ws, { recursive: true });
-    writeFileSync(join(ws, 'config.json'), JSON.stringify({
-      'dkg-node': {
-        daemonUrl: 'http://127.0.0.1:9200',
-        memory: { enabled: true },
-        channel: { enabled: true },
-        game: { enabled: true },
-      },
-    }));
-
-    writeWorkspaceConfig(ws, 9200);
-
-    const config = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
-    expect(config['dkg-node'].game).toBeUndefined();
-  });
-
-  it('preserves existing daemonUrl when --port not explicit', () => {
-    const ws = join(testDir, 'workspace');
-    mkdirSync(ws, { recursive: true });
-    writeFileSync(join(ws, 'config.json'), JSON.stringify({
-      'dkg-node': {
-        daemonUrl: 'http://custom:8080',
-        memory: { enabled: false, watchDebounceMs: 3000 },
-      },
-    }));
-
-    writeWorkspaceConfig(ws, 9200);
-
-    const config = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
-    // daemonUrl is preserved when portExplicit is not set
-    expect(config['dkg-node'].daemonUrl).toBe('http://custom:8080');
-    // Sub-config keys like watchDebounceMs are preserved
-    expect(config['dkg-node'].memory.watchDebounceMs).toBe(3000);
-    // User-configured enabled: false is respected on re-runs (idempotent)
-    expect(config['dkg-node'].memory.enabled).toBe(false);
-  });
-
-  it('overrides daemonUrl when --port is explicit', () => {
-    const ws = join(testDir, 'workspace');
-    mkdirSync(ws, { recursive: true });
-    writeFileSync(join(ws, 'config.json'), JSON.stringify({
-      'dkg-node': {
-        daemonUrl: 'http://custom:8080',
-      },
-    }));
-
-    writeWorkspaceConfig(ws, 9200, true);
-
-    const config = JSON.parse(readFileSync(join(ws, 'config.json'), 'utf-8'));
-    expect(config['dkg-node'].daemonUrl).toBe('http://127.0.0.1:9200');
   });
 });
 

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -28,8 +28,16 @@ import {
   shouldBypassRateLimitForLoopbackTraffic,
   updateLocalAgentIntegration,
 } from '../src/daemon.js';
-import { mergeOpenClawConfig } from '@origintrail-official/dkg-adapter-openclaw';
+import { mergeOpenClawConfig, type AdapterEntryConfig } from '@origintrail-official/dkg-adapter-openclaw';
 import type { DkgConfig } from '../src/config.js';
+
+// Default entryConfig fixture matching the shape `runSetup` builds at
+// Step 5 — same values setup writes into plugins.entries.adapter-openclaw.config.
+const testEntryConfig: AdapterEntryConfig = {
+  daemonUrl: 'http://127.0.0.1:9200',
+  memory: { enabled: true },
+  channel: { enabled: true },
+};
 
 function makeConfig(overrides: Partial<DkgConfig> = {}): DkgConfig {
   return {
@@ -1495,7 +1503,7 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
     // the temp-HOME openclaw.json. This is the highest-fidelity stand-in we can
     // get without spinning up a real daemon in the test.
     const runSetup = async () => {
-      mergeOpenClawConfig(openclawConfigPath, adapterPath);
+      mergeOpenClawConfig(openclawConfigPath, adapterPath, testEntryConfig);
     };
     const restartGateway = async () => {};
     const waitForReady = async () => ({ ok: true as const, target: 'bridge' });
@@ -1537,7 +1545,16 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
     const merged = JSON.parse(mergedRaw);
     expect(merged.plugins.slots.memory).toBe('adapter-openclaw');
     expect(merged.plugins.allow).toContain('adapter-openclaw');
-    expect(merged.plugins.entries['adapter-openclaw']).toEqual({ enabled: true });
+    const mergedEntry = merged.plugins.entries['adapter-openclaw'];
+    expect(mergedEntry.enabled).toBe(true);
+    // D2: adapter runtime config lives in the plugin entry now (was
+    // $WORKSPACE_DIR/config.json before PR #232). Full shape — daemonUrl,
+    // memory.enabled, channel.enabled — is what openclaw-entry.mjs reads.
+    expect(mergedEntry.config).toBeDefined();
+    expect(typeof mergedEntry.config.daemonUrl).toBe('string');
+    expect(mergedEntry.config.daemonUrl).toMatch(/^http:\/\/127\.0\.0\.1:/);
+    expect(mergedEntry.config.memory.enabled).toBe(true);
+    expect(mergedEntry.config.channel.enabled).toBe(true);
     // Windows-path normalization assertion: mergeOpenClawConfig normalizes backslashes to
     // forward slashes before storing the path.
     const storedPaths = merged.plugins.load.paths as string[];
@@ -1556,7 +1573,7 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
 
   it('scenario 2: post-Connect Disconnect reverse-merges adapter wiring and writes a .bak.<ts>', async () => {
     // Seed a pre-merged openclaw.json (as if Connect already ran).
-    mergeOpenClawConfig(openclawConfigPath, adapterPath);
+    mergeOpenClawConfig(openclawConfigPath, adapterPath, testEntryConfig);
 
     // Sanity: adapter is fully wired before disconnect.
     const before = JSON.parse(readFileSync(openclawConfigPath, 'utf-8'));
@@ -1569,7 +1586,8 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
     const after = JSON.parse(readFileSync(openclawConfigPath, 'utf-8'));
     expect(after.plugins.slots.memory).toBeUndefined();
     expect(after.plugins.allow).not.toContain('adapter-openclaw');
-    expect(after.plugins.entries['adapter-openclaw'].enabled).toBe(false);
+    // D1: adapter entry is removed entirely on unmerge (not just disabled).
+    expect(after.plugins.entries['adapter-openclaw']).toBeUndefined();
     const remainingPaths = (after.plugins.load.paths ?? []) as string[];
     expect(remainingPaths.some((p) => /packages[\\/]adapter-openclaw/.test(p))).toBe(false);
     // tools.alsoAllow is intentionally NOT reverted (shared with other plugins per D1 decision).
@@ -1589,7 +1607,7 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
     // `normalizeExplicitLocalAgentDisconnectBody` BEFORE computing `explicitDisconnect`.
 
     // Seed a pre-merged openclaw.json (as if Connect already ran).
-    mergeOpenClawConfig(openclawConfigPath, adapterPath);
+    mergeOpenClawConfig(openclawConfigPath, adapterPath, testEntryConfig);
     const before = JSON.parse(readFileSync(openclawConfigPath, 'utf-8'));
     expect(before.plugins.slots.memory).toBe('adapter-openclaw');
 
@@ -1607,7 +1625,8 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
     const after = JSON.parse(readFileSync(openclawConfigPath, 'utf-8'));
     expect(after.plugins.slots.memory).toBeUndefined();
     expect(after.plugins.allow).not.toContain('adapter-openclaw');
-    expect(after.plugins.entries['adapter-openclaw'].enabled).toBe(false);
+    // D1: adapter entry is removed entirely on unmerge.
+    expect(after.plugins.entries['adapter-openclaw']).toBeUndefined();
   });
 
   it('scenario 2c: reverse-setup surfaces non-slot invariant failures via verifyUnmergeInvariants (Codex N3)', async () => {
@@ -1620,7 +1639,7 @@ describe('OpenClaw UI Connect/Disconnect/Refresh fresh-HOME integration (issue #
     // defers to the adapter's `verifyUnmergeInvariants`, which covers all four invariants.
 
     // Seed a pre-merged openclaw.json (as if Connect already ran).
-    mergeOpenClawConfig(openclawConfigPath, adapterPath);
+    mergeOpenClawConfig(openclawConfigPath, adapterPath, testEntryConfig);
     const before = JSON.parse(readFileSync(openclawConfigPath, 'utf-8'));
     expect(before.plugins.slots.memory).toBe('adapter-openclaw');
     expect(before.plugins.allow).toContain('adapter-openclaw');


### PR DESCRIPTION
## Summary

- OpenClaw adapter runtime config (`daemonUrl`, `memory.enabled`, `channel.enabled`) moves from a separate `$WORKSPACE_DIR/config.json` file into `plugins.entries.adapter-openclaw.config` in `~/.openclaw/openclaw.json`. Two-file setup surface instead of three.
- Disconnect now removes `plugins.entries.adapter-openclaw` entirely instead of flipping `enabled: false`. Eliminates the `stale config entry ignored` warning OpenClaw emits on restart after disconnect.
- `writeWorkspaceConfig` and the workspace-config read path in `openclaw-entry.mjs` are both deleted. No migration shim — pre-launch product, no released install base.

## Related

- Fixes #232
- Follow-up to PR #228 (commit `05d3d0d8`)

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/setup.ts` | Extend `mergeOpenClawConfig` signature with `entryConfig` + optional `overrideDaemonUrl` flag; rewrite `unmergeOpenClawConfig` to delete the entry entirely (preserves the pre-deletion `previousMemorySlotOwner` read intact for round-2 slot-restore); delete `writeWorkspaceConfig`; renumber step comments. |
| `packages/adapter-openclaw/src/index.ts` | Export new `AdapterEntryConfig` type. |
| `packages/adapter-openclaw/openclaw-entry.mjs` | Read config from `api.config?.plugins?.entries?.['adapter-openclaw']?.config` instead of `$WORKSPACE_DIR/config.json`. `DKG_DAEMON_URL` env-override + workspaceDir auto-detect for SKILL.md sync preserved. |
| `packages/adapter-openclaw/test/setup.test.ts` | Delete `writeWorkspaceConfig` describe block; extend merge tests with entry.config + first-wins + override-daemonUrl cases; flip unmerge + verify assertions from "enabled: false" to entry-absent. |
| `packages/adapter-openclaw/README.md` | Config Files table drops the `WORKSPACE_DIR/config.json` row. Adapter Config section rewritten to point at `plugins.entries.adapter-openclaw.config`. |
| `packages/cli/test/daemon-openclaw.test.ts` | Scenario 1 extended with entry.config shape assertions; scenarios 2 + 2b flipped to assert the entry is absent post-disconnect; scenario 2c unchanged. |

## Test plan

- [x] `pnpm build` from repo root — 19/19 turbo tasks green.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test` — `setup.test.ts` 54/54 green; adapter suite 264/265 (the single RED is a preexisting canary named `plugin id equals package name` in an "RED until reconciled" describe block; not introduced by this PR).
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/daemon-openclaw.test.ts` — 68/68 green.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui test` — 434 passed + 38 skipped, unchanged from v10-rc baseline.
- [x] **Live matrix on a fresh temp HOME (22/22 assertions)**:
  - Fresh setup writes `entry.config` with `daemonUrl=http://127.0.0.1:9200`, `memory.enabled=true`, `channel.enabled=true`. `$WORKSPACE_DIR/config.json` never created. Log reads `Populated plugins.entries.adapter-openclaw.config`. Re-run byte-identical.
  - `dkg openclaw setup --port 9300` on fresh HOME → `entry.config.daemonUrl = http://127.0.0.1:9300`.
  - `--port 9300` then no-port re-run → custom `daemonUrl` preserved (first-wins via `overrideDaemonUrl` gate).
  - UI Disconnect → `plugins.entries.adapter-openclaw` **is absent**; `plugins.slots.memory` cleared; `verifyUnmergeInvariants` returns null. Gateway auto-restart after Disconnect has NO `plugins.entries.adapter-openclaw: plugin not found` warning (primary bug-fix signal).
  - UI Connect after Disconnect → entry resurrects with `config` fully populated.
  - Workspace `config.json` never created across the setup → disconnect → reconnect cycle.
- [x] Repo-wide greps: `rg writeWorkspaceConfig` → 0 hits; `rg "workspace.*config\.json" packages/adapter-openclaw` → 3 hits, all comments describing the retirement; `rg "WORKSPACE_DIR.*config\.json"` → 1 hit, a "before PR #232" retirement comment in `daemon-openclaw.test.ts`.

## Decisions

### D1 — Delete `plugins.entries.adapter-openclaw` entirely on unmerge

Round 2 of PR #228 flipped `enabled: false` and stripped the `previousMemorySlotOwner` marker but preserved the entry object. Live testing showed OpenClaw emits a `plugins.entries.adapter-openclaw: plugin not found (stale config entry ignored; remove it from plugins config)` warning on the next gateway restart. The adapter owns that entire entry — no user-configurable fields — so we delete it unconditionally. The `previousMemorySlotOwner` read remains positioned before the deletion, so round-2 slot-restore semantics are preserved intact.

### D2 — Runtime config in the OpenClaw plugin entry

Brave and other OpenClaw plugins keep their config in `plugins.entries.<id>.config`. The adapter's runtime config now lives there too:

```json
"plugins": {
  "entries": {
    "adapter-openclaw": {
      "config": {
        "daemonUrl": "http://127.0.0.1:9200",
        "memory": { "enabled": true },
        "channel": { "enabled": true }
      },
      "enabled": true
    }
  }
}
```

Setup writes these values via `mergeOpenClawConfig` with first-wins spread semantics — user edits survive re-runs. `--port N` on re-run refreshes the `daemonUrl` specifically via an `overrideDaemonUrl` gate, without clobbering the rest of the entry config. `openclaw-entry.mjs` reads from `api.config?.plugins?.entries?.['adapter-openclaw']?.config`. `DKG_DAEMON_URL` env-override still wins, consistent with the pre-existing semantics.

### D3 — Retire `$WORKSPACE_DIR/config.json` entirely

Pre-launch product, no released install base. Nothing outside the adapter consumes the `dkg-node` key in that file (verified by repo-wide grep). No migration helper, no legacy-read fallback, no deprecated shim — `writeWorkspaceConfig` and its call site are deleted outright, along with the workspace-read block in `openclaw-entry.mjs`. Step comments in `runSetup` renumbered (merge = 5, install skill = 6, verify = 7). The adapter README drops the `WORKSPACE_DIR/config.json` row from Config Files and rewrites the Adapter Config section to describe the new entry-config shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
