### PR TITLE
fix(agent): A-12 migrate agent DID subject to EVM-address form

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -4468,8 +4468,17 @@ export class DKGAgent {
     agentAddress?: string;
   }): Promise<PublishResult> {
     const { buildEndorsementQuads } = await import('./endorse.js');
+    // A-12: spec §03 / §22 require the endorser DID to be the
+    // Ethereum-address form. Passing a libp2p peer id here produced
+    // a `did:dkg:agent:${peerId}` URI (12D3KooW-prefixed in practice),
+    // which is non-spec. Prefer the
+    // per-call agentAddress, then the node's default agent address,
+    // then fall back to the peer id only if no EVM identity is known
+    // (kept for backward compatibility with test harnesses; runtime
+    // always has a defaultAgentAddress after auto-registration).
+    const endorser = opts.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
     const quads = buildEndorsementQuads(
-      this.peerId,
+      endorser,
       opts.knowledgeAssetUal,
       opts.contextGraphId,
     );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -36,7 +36,7 @@ import { ProfileManager } from './profile-manager.js';
 import { DiscoveryClient, type SkillSearchOptions, type DiscoveredAgent, type DiscoveredOffering } from './discovery.js';
 import { MessageHandler, type SkillHandler, type SkillRequest, type SkillResponse, type ChatHandler } from './messaging.js';
 import { ed25519ToX25519Private, ed25519ToX25519Public } from './encryption.js';
-import { AGENT_REGISTRY_CONTEXT_GRAPH, type AgentProfileConfig } from './profile.js';
+import { AGENT_REGISTRY_CONTEXT_GRAPH, canonicalAgentDidSubject, type AgentProfileConfig } from './profile.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { waitForPeerProtocol } from './p2p/protocol-readiness.js';
@@ -4471,12 +4471,21 @@ export class DKGAgent {
     // A-12: spec §03 / §22 require the endorser DID to be the
     // Ethereum-address form. Passing a libp2p peer id here produced
     // a `did:dkg:agent:${peerId}` URI (12D3KooW-prefixed in practice),
-    // which is non-spec. Prefer the
-    // per-call agentAddress, then the node's default agent address,
-    // then fall back to the peer id only if no EVM identity is known
-    // (kept for backward compatibility with test harnesses; runtime
-    // always has a defaultAgentAddress after auto-registration).
-    const endorser = opts.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    // which is non-spec. Prefer the per-call agentAddress, then the
+    // node's default agent address, then fall back to the peer id
+    // only if no EVM identity is known (kept for backward
+    // compatibility with test harnesses; runtime always has a
+    // defaultAgentAddress after auto-registration).
+    //
+    // A-12 review: normalise the address casing through
+    // `canonicalAgentDidSubject` so the endorsement DID converges
+    // with the profile DID for the same wallet (checksum vs
+    // lowercase inputs previously produced two distinct RDF
+    // subjects). Callers must also verify the address is owned by
+    // this node before calling — /api/endorse does that via the
+    // bearer token; see packages/cli/src/daemon.ts.
+    const raw = opts.agentAddress ?? this.defaultAgentAddress ?? this.peerId;
+    const endorser = canonicalAgentDidSubject(raw);
     const quads = buildEndorsementQuads(
       endorser,
       opts.knowledgeAssetUal,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,7 @@ export {
 } from './agent-keystore.js';
 export {
   buildAgentProfile,
+  canonicalAgentDidSubject,
   AGENT_REGISTRY_CONTEXT_GRAPH,
   AGENT_REGISTRY_PARANET,
   AGENT_REGISTRY_GRAPH,

--- a/packages/agent/src/profile-manager.ts
+++ b/packages/agent/src/profile-manager.ts
@@ -36,14 +36,26 @@ export class ProfileManager {
     // `did:dkg:agent:<peerId>` must drop the legacy subject alongside
     // the new EVM-form subject, otherwise discovery returns the same
     // node twice and the local data graph no longer matches the
-    // updated manifest. We clean up three possible prior roots:
-    //   1. the remembered `lastRootEntity` (most precise — covers the
-    //      "user rotated their wallet address" case);
-    //   2. the legacy peer-id-form subject (always present on nodes
-    //      that published under v9/v10-rc before A-12);
-    //   3. the address-form subject for the current wallet (handles
-    //      the case where the address shape stayed the same but the
-    //      casing or payload changed between publishes).
+    // updated manifest.
+    //
+    // Codex flagged that `lastRootEntity` is only in memory — a
+    // daemon restart after a wallet rotation would forget the
+    // previous address-form root. Mitigate by combining a static
+    // set of "obvious" prefixes with a one-shot SPARQL scan for
+    // any agent subject in the registry graph that claims THIS
+    // peerId (`dkg:peerId "<peerId>"`). That covers:
+    //   1. legacy peer-id form (`did:dkg:agent:<peerId>`) — always
+    //      present on v9/v10-rc nodes before A-12;
+    //   2. the canonicalised address form for the current wallet —
+    //      handles casing / payload changes between publishes;
+    //   3. any OTHER address the same peerId previously published
+    //      under — covers the "operator switched wallet + daemon
+    //      restart" path that in-memory `lastRootEntity` misses;
+    //   4. the remembered `lastRootEntity` — a best-effort fast
+    //      path that saves the scan round trip when the prior
+    //      address is already known in process;
+    //   5. the new `rootEntity` itself — idempotent cleanup when
+    //      the publish is a pure content refresh.
     const dataGraph = paranetDataGraphUri(AGENT_REGISTRY_CONTEXT_GRAPH);
     const prefixesToClean = new Set<string>();
     if (this.lastRootEntity) prefixesToClean.add(this.lastRootEntity);
@@ -54,6 +66,32 @@ export class ProfileManager {
       );
     }
     prefixesToClean.add(rootEntity);
+
+    // Discover any OTHER subject in the registry graph that
+    // published with this peerId. SPARQL escape of the peerId
+    // literal: the config.peerId is a libp2p base58 peer id (no
+    // quotes, no backslashes) but we still guard defensively.
+    const escapedPeerId = config.peerId
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+    try {
+      const discovered = await this.store.query(
+        `SELECT DISTINCT ?s WHERE { GRAPH <${dataGraph}> { ?s <https://dkg.network/ontology#peerId> "${escapedPeerId}" } }`,
+      );
+      if (discovered.type === 'bindings') {
+        for (const row of discovered.bindings) {
+          const subject = row['s'];
+          if (subject && subject.startsWith('did:dkg:agent:')) {
+            prefixesToClean.add(subject);
+          }
+        }
+      }
+    } catch {
+      // Non-fatal: fall back to the static prefix set. Any
+      // orphaned legacy subject will still be cleaned on the
+      // next publish where the scan succeeds.
+    }
+
     for (const prefix of prefixesToClean) {
       await this.store.deleteBySubjectPrefix(dataGraph, prefix);
     }

--- a/packages/agent/src/profile-manager.ts
+++ b/packages/agent/src/profile-manager.ts
@@ -1,7 +1,12 @@
 import type { Publisher, PublishOptions, PublishResult } from '@origintrail-official/dkg-publisher';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import { paranetDataGraphUri } from '@origintrail-official/dkg-core';
-import { buildAgentProfile, AGENT_REGISTRY_CONTEXT_GRAPH, type AgentProfileConfig } from './profile.js';
+import {
+  buildAgentProfile,
+  canonicalAgentDidSubject,
+  AGENT_REGISTRY_CONTEXT_GRAPH,
+  type AgentProfileConfig,
+} from './profile.js';
 
 /**
  * Manages publishing and updating agent profiles as Knowledge Assets
@@ -11,6 +16,13 @@ export class ProfileManager {
   private readonly publisher: Publisher;
   private readonly store: TripleStore;
   private currentKcId: bigint | null = null;
+  /**
+   * Root entity URI used by the most recent publish. Persisted across
+   * republishes so an upgraded node cleans up the previous subject
+   * (e.g. a legacy `did:dkg:agent:<peerId>` profile) alongside the new
+   * one, rather than leaving orphan triples in the data graph.
+   */
+  private lastRootEntity: string | null = null;
 
   constructor(publisher: Publisher, store: TripleStore) {
     this.publisher = publisher;
@@ -20,10 +32,31 @@ export class ProfileManager {
   async publishProfile(config: AgentProfileConfig): Promise<PublishResult> {
     const { quads, rootEntity } = buildAgentProfile(config);
 
-    // Remove stale triples from prior profile publishes so the data graph
-    // contains exactly the triples the merkle root is computed over.
+    // A-12 review: upgraded nodes that previously published
+    // `did:dkg:agent:<peerId>` must drop the legacy subject alongside
+    // the new EVM-form subject, otherwise discovery returns the same
+    // node twice and the local data graph no longer matches the
+    // updated manifest. We clean up three possible prior roots:
+    //   1. the remembered `lastRootEntity` (most precise — covers the
+    //      "user rotated their wallet address" case);
+    //   2. the legacy peer-id-form subject (always present on nodes
+    //      that published under v9/v10-rc before A-12);
+    //   3. the address-form subject for the current wallet (handles
+    //      the case where the address shape stayed the same but the
+    //      casing or payload changed between publishes).
     const dataGraph = paranetDataGraphUri(AGENT_REGISTRY_CONTEXT_GRAPH);
-    await this.store.deleteBySubjectPrefix(dataGraph, rootEntity);
+    const prefixesToClean = new Set<string>();
+    if (this.lastRootEntity) prefixesToClean.add(this.lastRootEntity);
+    prefixesToClean.add(`did:dkg:agent:${config.peerId}`);
+    if (config.agentAddress) {
+      prefixesToClean.add(
+        `did:dkg:agent:${canonicalAgentDidSubject(config.agentAddress)}`,
+      );
+    }
+    prefixesToClean.add(rootEntity);
+    for (const prefix of prefixesToClean) {
+      await this.store.deleteBySubjectPrefix(dataGraph, prefix);
+    }
 
     const options: PublishOptions = {
       contextGraphId: AGENT_REGISTRY_CONTEXT_GRAPH,
@@ -33,11 +66,13 @@ export class ProfileManager {
     if (this.currentKcId) {
       const result = await this.publisher.update(this.currentKcId, options);
       this.currentKcId = result.kcId;
+      this.lastRootEntity = rootEntity;
       return result;
     }
 
     const result = await this.publisher.publish(options);
     this.currentKcId = result.kcId;
+    this.lastRootEntity = rootEntity;
     return result;
   }
 

--- a/packages/agent/src/profile.ts
+++ b/packages/agent/src/profile.ts
@@ -39,14 +39,26 @@ export interface AgentProfileConfig {
 
 /**
  * Builds RDF quads for an agent profile KA using the ERC-8004 aligned ontology.
- * The agent's rootEntity is `did:dkg:agent:{peerId}`.
- * Uses three vocabulary layers: erc8004: (identity), prov: (provenance), dkg: (P2P).
+ *
+ * Spec §03_AGENTS.md / §22_AGENT_ONBOARDING.md require the agent DID to be
+ * the Ethereum-address form `did:dkg:agent:0x<40hex>`. When an
+ * `agentAddress` is supplied (which is always the case at runtime — the
+ * node auto-registers a default agent and passes its address through
+ * `DKGAgent.publishProfile`) the root entity uses that spec form. We
+ * keep the legacy `did:dkg:agent:<peerId>` fallback only for test
+ * harnesses that still construct profiles without an agent address;
+ * the A-12 drift-scan test enforces that no production fixtures rely
+ * on it.
+ *
+ * Uses three vocabulary layers: erc8004: (identity), prov: (provenance),
+ * dkg: (P2P).
  */
 export function buildAgentProfile(config: AgentProfileConfig): {
   quads: Quad[];
   rootEntity: string;
 } {
-  const entity = `did:dkg:agent:${config.peerId}`;
+  const didSubject = config.agentAddress ?? config.peerId;
+  const entity = `did:dkg:agent:${didSubject}`;
   const quads: Quad[] = [];
   const role = config.nodeRole ?? 'edge';
 

--- a/packages/agent/src/profile.ts
+++ b/packages/agent/src/profile.ts
@@ -1,6 +1,29 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { DKG_ONTOLOGY, SYSTEM_PARANETS } from '@origintrail-official/dkg-core';
 
+/**
+ * Canonicalise the DID subject for an agent.
+ *
+ * A-12 review: the same wallet can be supplied with different casings
+ * (e.g. `ethers.Wallet.address` returns checksum case, while config
+ * files and JSON bodies often carry lowercase). Without normalisation
+ * a profile publish would mint `did:dkg:agent:0xAb...` while an
+ * endorsement from the same wallet would mint `did:dkg:agent:0xab...`,
+ * splitting the entity into two RDF subjects that never converge.
+ *
+ * Rule: if the raw subject matches the EVM-address shape `0x<40hex>`,
+ * fold it to lowercase. Any other shape (peer id, non-hex) is passed
+ * through unchanged — callers upstream may have minted a legacy
+ * peer-id subject and we must not silently rewrite it to look like an
+ * address.
+ */
+export function canonicalAgentDidSubject(raw: string): string {
+  if (/^0x[0-9a-fA-F]{40}$/.test(raw)) {
+    return raw.toLowerCase();
+  }
+  return raw;
+}
+
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const SCHEMA = 'https://schema.org/';
 const DKG = 'https://dkg.network/ontology#';
@@ -57,7 +80,10 @@ export function buildAgentProfile(config: AgentProfileConfig): {
   quads: Quad[];
   rootEntity: string;
 } {
-  const didSubject = config.agentAddress ?? config.peerId;
+  // A-12: normalise the DID subject so profile + endorsement subjects
+  // converge for the same wallet regardless of the source casing. See
+  // `canonicalAgentDidSubject` for rationale.
+  const didSubject = canonicalAgentDidSubject(config.agentAddress ?? config.peerId);
   const entity = `did:dkg:agent:${didSubject}`;
   const quads: Quad[] = [];
   const role = config.nodeRole ?? 'edge';
@@ -86,7 +112,7 @@ export function buildAgentProfile(config: AgentProfileConfig): {
     q(entity, `${DKG}relayAddress`, `"${config.relayAddress}"`);
   }
   if (config.agentAddress) {
-    q(entity, `${DKG}agentAddress`, `"${config.agentAddress}"`);
+    q(entity, `${DKG}agentAddress`, `"${canonicalAgentDidSubject(config.agentAddress)}"`);
   }
   if (config.framework) {
     q(entity, `${SKILL}framework`, `"${config.framework}"`);

--- a/packages/agent/test/agent-audit-extra.test.ts
+++ b/packages/agent/test/agent-audit-extra.test.ts
@@ -410,10 +410,16 @@ describe('[A-12] DID format drift in agent.endorse', () => {
   });
 
   it('PROD-BUG: passing a libp2p PeerId to buildEndorsementQuads yields a non-spec did:dkg:agent: URI', () => {
-    // dkg-agent.ts:4056 passes `this.peerId` (a libp2p Peer ID string like
-    // `12D3KooW…`) into `buildEndorsementQuads`, producing
-    //   did:dkg:agent:12D3KooW…
-    // which violates spec §5 (agent DIDs MUST be the 0x-address form).
+    // Historical (pre-A-12): dkg-agent.ts passed `this.peerId` (a libp2p
+    // Peer ID string like 12D3KooW…) into `buildEndorsementQuads`,
+    // producing a `did:dkg:agent:${peerId}` URI, which violates spec §5
+    // (agent DIDs MUST be the 0x-address form). The caller has been
+    // migrated to pass `opts.agentAddress ?? this.defaultAgentAddress`,
+    // but this helper-level test still pins the invariant that the
+    // helper itself mints whatever subject form you give it — so a
+    // raw peer-id argument still yields a non-0x DID shape. That keeps
+    // the boundary honest and catches future callers that reintroduce
+    // the bug by once again passing peer-id here.
     // This test pins the prod-bug so any code change silently "fixing"
     // this path without updating the caller also flips this assertion.
     const peerIdStr = '12D3KooWFakePeerIdDoesNotMatterForShapeAssertion';
@@ -437,8 +443,18 @@ describe('[A-12] DID format drift in agent.endorse', () => {
     const testDir = fileURLToPath(new URL('.', import.meta.url));
     const entries = await readdir(testDir);
     const offenders: string[] = [];
+    // The following test files are exempt from the fixture scan
+    // because they intentionally carry peer-id-form DIDs as negative
+    // regex targets / comment diagnostics — their whole purpose is to
+    // document and assert against the non-spec form. Anything else in
+    // this folder must migrate to the 0x-address form.
+    const SCAN_EXEMPT = new Set([
+      'agent-audit-extra.test.ts',
+      'did-format-extra.test.ts',
+      'ack-eip191-agent-extra.test.ts',
+    ]);
     for (const f of entries) {
-      if (!f.endsWith('.ts') || f === 'agent-audit-extra.test.ts') continue;
+      if (!f.endsWith('.ts') || SCAN_EXEMPT.has(f)) continue;
       const body = await readFile(join(testDir, f), 'utf8');
       // Match `did:dkg:agent:X` where X is not `0x...` and not a template
       // expression like `${addr}`. Catches peer-ID form (Qm…, 12D3KooW…)

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -163,8 +163,11 @@ describe('AgentWallet', () => {
 
 describe('Profile Builder', () => {
   it('builds agent profile quads', () => {
+    // A-12 migration: profile DIDs are the EVM-address form, not peer-id.
+    const addr = '0x' + '1'.repeat(40);
     const { quads, rootEntity } = buildAgentProfile({
       peerId: 'QmTest123',
+      agentAddress: addr,
       name: 'TestBot',
       description: 'A test agent',
       framework: 'OpenClaw',
@@ -179,12 +182,12 @@ describe('Profile Builder', () => {
       ],
     });
 
-    expect(rootEntity).toBe('did:dkg:agent:QmTest123');
+    expect(rootEntity).toBe(`did:dkg:agent:${addr}`);
     expect(quads.length).toBeGreaterThanOrEqual(8);
 
     const subjects = quads.map(q => q.subject);
-    expect(subjects).toContain('did:dkg:agent:QmTest123');
-    expect(subjects).toContain('did:dkg:agent:QmTest123/.well-known/genid/offering1');
+    expect(subjects).toContain(`did:dkg:agent:${addr}`);
+    expect(subjects).toContain(`did:dkg:agent:${addr}/.well-known/genid/offering1`);
 
     const predicates = quads.map(q => q.predicate);
     expect(predicates).toContain('https://schema.org/name');

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -361,6 +361,95 @@ describe('ProfileManager', () => {
   );
 
   it(
+    'A-12 wallet rotation + restart: peerId-scan reaches profiles from a prior wallet even with a fresh ProfileManager',
+    async () => {
+      // Codex review on PR #243: `lastRootEntity` is only in memory.
+      // If an operator publishes under wallet A, the daemon restarts,
+      // they reconfigure to wallet B, and publish again, the in-memory
+      // cleanup path sees only the new canonical address (B) and the
+      // peerId fallback — wallet A's profile would be orphaned.
+      //
+      // The mitigation is the SPARQL scan in
+      // `ProfileManager.publishProfile` that discovers every subject
+      // in the registry graph that claims this peerId. This test
+      // simulates the restart by constructing a fresh ProfileManager
+      // for the second publish, proving the scan — not
+      // `lastRootEntity` — is what cleans up wallet A.
+      const store = new OxigraphStore();
+      const { DKGPublisher } = await import('@origintrail-official/dkg-publisher');
+      const { TypedEventBus, generateEd25519Keypair } = await import('@origintrail-official/dkg-core');
+      const eventBus = new TypedEventBus();
+      const keypair = await generateEd25519Keypair();
+
+      const peerId = 'QmRotatedWallet';
+      const walletA = '0x' + 'aa'.repeat(20);
+      const walletB = '0x' + 'bb'.repeat(20);
+
+      // Publish under wallet A.
+      const publisher1 = new DKGPublisher({ store, chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP), eventBus, keypair });
+      const managerA = new ProfileManager(publisher1, store);
+      await managerA.publishProfile({
+        peerId,
+        agentAddress: walletA,
+        name: 'WalletA',
+        skills: [],
+      });
+
+      const graph = 'did:dkg:context-graph:agents';
+      const subjectA = `did:dkg:agent:${walletA}`;
+      const subjectB = `did:dkg:agent:${walletB}`;
+
+      // Sanity: wallet A's subject is present.
+      const afterA = await store.query(
+        `SELECT ?p ?o WHERE { GRAPH <${graph}> { <${subjectA}> ?p ?o } }`,
+      );
+      expect(afterA.type).toBe('bindings');
+      if (afterA.type === 'bindings') {
+        expect(afterA.bindings.length).toBeGreaterThan(0);
+      }
+
+      // Simulate a daemon restart + wallet rotation — brand new
+      // ProfileManager with NO lastRootEntity memory, but the same
+      // store + peerId + a NEW wallet.
+      const publisher2 = new DKGPublisher({ store, chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP), eventBus, keypair });
+      const managerB = new ProfileManager(publisher2, store);
+      await managerB.publishProfile({
+        peerId,
+        agentAddress: walletB,
+        name: 'WalletB',
+        skills: [],
+      });
+
+      // Wallet A's subject must be gone even though ProfileManager
+      // had no in-memory record of it.
+      const stillA = await store.query(
+        `SELECT ?p ?o WHERE { GRAPH <${graph}> { <${subjectA}> ?p ?o } }`,
+      );
+      expect(stillA.type).toBe('bindings');
+      if (stillA.type === 'bindings') {
+        expect(
+          stillA.bindings.length,
+          'peerId-scan must remove wallet A profile across a ProfileManager restart',
+        ).toBe(0);
+      }
+
+      // Wallet B's subject is the sole remaining profile root for
+      // this peerId.
+      const afterB = await store.query(
+        `SELECT ?p ?o WHERE { GRAPH <${graph}> { <${subjectB}> ?p ?o } }`,
+      );
+      expect(afterB.type).toBe('bindings');
+      if (afterB.type === 'bindings') {
+        expect(afterB.bindings.length).toBeGreaterThan(0);
+        const nameTriples = afterB.bindings.filter((b) =>
+          b['p']?.includes('schema.org/name'),
+        );
+        expect(nameTriples.some((b) => b['o'] === '"WalletB"')).toBe(true);
+      }
+    },
+  );
+
+  it(
     'A-12 casing: checksum-case and lowercase agentAddress converge to the same DID subject',
     () => {
       const checksum = '0xAb5801a7D398351b8bE11C439e05C5B3259aec9B';

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -282,6 +282,106 @@ describe('ProfileManager', () => {
     expect(manager.profileKcId).toBe(result.kcId);
   });
 
+  it(
+    'A-12 upgrade: republishing after the DID form change drops the legacy ' +
+      'did:dkg:agent:<peerId> subject alongside the new address-form subject',
+    async () => {
+      // Codex review on PR #243: ProfileManager.publishProfile only
+      // deleted triples under the NEW rootEntity before publish, so an
+      // upgraded node that previously published
+      // `did:dkg:agent:<peerId>` would keep the old profile alongside
+      // the new `did:dkg:agent:0x...` profile. `findAgents` then
+      // returned the same node twice and the local data graph no
+      // longer matched the updated manifest. This test simulates the
+      // upgrade by publishing in legacy form first, then
+      // republishing in the new form, and asserting the legacy
+      // subject is gone.
+      const store = new OxigraphStore();
+      const { DKGPublisher } = await import('@origintrail-official/dkg-publisher');
+      const { TypedEventBus, generateEd25519Keypair } = await import('@origintrail-official/dkg-core');
+      const eventBus = new TypedEventBus();
+      const keypair = await generateEd25519Keypair();
+      const publisher = new DKGPublisher({ store, chain: createEVMAdapter(HARDHAT_KEYS.CORE_OP), eventBus, keypair });
+      const manager = new ProfileManager(publisher, store);
+
+      const peerId = 'QmLegacyUpgrade';
+      const addr = '0x' + 'ab'.repeat(20);
+
+      // Legacy publish (no agentAddress) → DID = did:dkg:agent:<peerId>
+      await manager.publishProfile({ peerId, name: 'Legacy', skills: [] });
+      const graph = 'did:dkg:context-graph:agents';
+      const legacyCount = await store.countQuads(graph);
+      expect(legacyCount).toBeGreaterThan(0);
+
+      const legacySubject = `did:dkg:agent:${peerId}`;
+      const newSubject = `did:dkg:agent:${addr}`;
+
+      // Sanity: legacy subject really was written.
+      const legacyRows = await store.query(
+        `SELECT ?p ?o WHERE { GRAPH <${graph}> { <${legacySubject}> ?p ?o } }`,
+      );
+      expect(legacyRows.type).toBe('bindings');
+      if (legacyRows.type === 'bindings') {
+        expect(legacyRows.bindings.length).toBeGreaterThan(0);
+      }
+
+      // Upgrade publish — same peerId, now with an agentAddress.
+      await manager.publishProfile({
+        peerId,
+        agentAddress: addr,
+        name: 'Upgraded',
+        skills: [],
+      });
+
+      // The legacy subject must no longer appear in the data graph.
+      const stillLegacy = await store.query(
+        `SELECT ?p ?o WHERE { GRAPH <${graph}> { <${legacySubject}> ?p ?o } }`,
+      );
+      expect(stillLegacy.type).toBe('bindings');
+      if (stillLegacy.type === 'bindings') {
+        expect(
+          stillLegacy.bindings.length,
+          'legacy did:dkg:agent:<peerId> subject must be removed on A-12 upgrade',
+        ).toBe(0);
+      }
+
+      // The new subject is the sole profile root in the data graph.
+      const newRows = await store.query(
+        `SELECT ?p ?o WHERE { GRAPH <${graph}> { <${newSubject}> ?p ?o } }`,
+      );
+      expect(newRows.type).toBe('bindings');
+      if (newRows.type === 'bindings') {
+        expect(newRows.bindings.length).toBeGreaterThan(0);
+        const nameTriples = newRows.bindings.filter((b) =>
+          b['p']?.includes('schema.org/name'),
+        );
+        expect(nameTriples.some((b) => b['o'] === '"Upgraded"')).toBe(true);
+      }
+    },
+  );
+
+  it(
+    'A-12 casing: checksum-case and lowercase agentAddress converge to the same DID subject',
+    () => {
+      const checksum = '0xAb5801a7D398351b8bE11C439e05C5B3259aec9B';
+      const lower = checksum.toLowerCase();
+      const profileChecksum = buildAgentProfile({
+        peerId: 'QmNoOp',
+        agentAddress: checksum,
+        name: 'Checksum',
+        skills: [],
+      });
+      const profileLower = buildAgentProfile({
+        peerId: 'QmNoOp',
+        agentAddress: lower,
+        name: 'Lower',
+        skills: [],
+      });
+      expect(profileChecksum.rootEntity).toBe(profileLower.rootEntity);
+      expect(profileChecksum.rootEntity).toBe(`did:dkg:agent:${lower}`);
+    },
+  );
+
   it('cleans up stale profile triples before re-publishing', async () => {
     const store = new OxigraphStore();
     const { DKGPublisher } = await import('@origintrail-official/dkg-publisher');

--- a/packages/agent/test/e2e-agents.test.ts
+++ b/packages/agent/test/e2e-agents.test.ts
@@ -13,8 +13,15 @@ beforeAll(async () => {
   _fileSnapshot = await takeSnapshot();
   const { hubAddress } = getSharedContext();
   const provider = createProvider();
-  const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
-  await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
+  // A-12: agent profile DIDs are now derived from the wallet address. Tests that
+  // expect to discover *two* distinct agents (via findAgents) must give each
+  // agent its own EVM key, otherwise both publish profiles under the same DID
+  // subject and findAgents collapses the result down to one entry. Mint to all
+  // keys we use below so create-on-chain operations can pay fees.
+  for (const key of [HARDHAT_KEYS.CORE_OP, HARDHAT_KEYS.REC1_OP]) {
+    const w = new ethers.Wallet(key);
+    await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, w.address, ethers.parseEther('50000000'));
+  }
 });
 afterAll(async () => {
   await revertSnapshot(_fileSnapshot);
@@ -66,7 +73,8 @@ describe('Two-Agent E2E', () => {
         pricePerCall: 0.5,
         handler: async () => ({ success: true }),
       }],
-      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      // A-12: distinct EVM key so agentB's profile DID differs from agentA's.
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP),
     });
     agents.push(agentB);
     await agentB.start();

--- a/packages/agent/test/e2e-network.test.ts
+++ b/packages/agent/test/e2e-network.test.ts
@@ -23,8 +23,10 @@ beforeAll(async () => {
   _fileSnapshot = await takeSnapshot();
   const { hubAddress } = getSharedContext();
   const provider = createProvider();
-  const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
-  await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, coreOp.address, ethers.parseEther('50000000'));
+  for (const key of [HARDHAT_KEYS.CORE_OP, HARDHAT_KEYS.REC1_OP, HARDHAT_KEYS.REC2_OP]) {
+    const w = new ethers.Wallet(key);
+    await mintTokens(provider, hubAddress, HARDHAT_KEYS.DEPLOYER, w.address, ethers.parseEther('50000000'));
+  }
 });
 afterAll(async () => {
   await revertSnapshot(_fileSnapshot);
@@ -87,7 +89,11 @@ describe('Network E2E (3 nodes + relay)', () => {
         pricePerCall: 0.5,
         handler: async () => ({ success: true }),
       }],
-      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      // A-12: each node needs its own EVM key so its agent profile DID
+      // (`did:dkg:agent:0x<addr>`, per spec §03) is unique. Sharing
+      // CORE_OP across all 3 nodes collides their root entities and
+      // discovery dedups them down to a single agent.
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC1_OP),
     });
 
     nodeC = await DKGAgent.create({
@@ -96,7 +102,7 @@ describe('Network E2E (3 nodes + relay)', () => {
       listenPort: 0,
       relayPeers: [relayAddr],
       skills: [],
-      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.REC2_OP),
     });
 
     await nodeA.start();

--- a/packages/agent/test/gossip-publish-handler.test.ts
+++ b/packages/agent/test/gossip-publish-handler.test.ts
@@ -170,7 +170,7 @@ describe('GossipPublishHandler', () => {
 
   it('rejects forged ontology policy approvals from non-owners', async () => {
     const { store, handler } = createHandler(undefined, {
-      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:owner' : null,
+      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:0x1111111111111111111111111111111111111111' : null,
     });
 
     const data = makePublishMessage({
@@ -180,7 +180,7 @@ describe('GossipPublishHandler', () => {
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#appliesToParanet> <did:dkg:context-graph:ops-policy> <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://schema.org/name> "incident-review" <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#activePolicy> <did:dkg:policy:ops-policy:sha256-fake> <did:dkg:context-graph:ontology> .',
-        '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#approvedBy> <did:dkg:agent:attacker> <did:dkg:context-graph:ontology> .',
+        '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#approvedBy> <did:dkg:agent:0x2222222222222222222222222222222222222222> <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#approvedAt> "2026-03-24T00:00:00.000Z" <did:dkg:context-graph:ontology> .',
       ].join('\n'),
     });
@@ -196,7 +196,7 @@ describe('GossipPublishHandler', () => {
 
   it('rejects ontology policy approvals that omit approvedBy', async () => {
     const { store, handler } = createHandler(undefined, {
-      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:owner' : null,
+      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:0x1111111111111111111111111111111111111111' : null,
     });
 
     const data = makePublishMessage({
@@ -221,7 +221,7 @@ describe('GossipPublishHandler', () => {
 
   it('rejects ontology policy revocations that omit revokedBy', async () => {
     const { store, handler } = createHandler(undefined, {
-      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:owner' : null,
+      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:0x1111111111111111111111111111111111111111' : null,
     });
 
     const data = makePublishMessage({
@@ -231,7 +231,7 @@ describe('GossipPublishHandler', () => {
         '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://dkg.network/ontology#appliesToParanet> <did:dkg:context-graph:ops-policy> <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://schema.org/name> "incident-review" <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://dkg.network/ontology#activePolicy> <did:dkg:policy:ops-policy:sha256-missing-revoked-by> <did:dkg:context-graph:ontology> .',
-        '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://dkg.network/ontology#approvedBy> <did:dkg:agent:owner> <did:dkg:context-graph:ontology> .',
+        '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://dkg.network/ontology#approvedBy> <did:dkg:agent:0x1111111111111111111111111111111111111111> <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://dkg.network/ontology#approvedAt> "2026-03-24T00:00:00.000Z" <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:missing-revoked-by> <https://dkg.network/ontology#revokedAt> "2026-03-25T00:00:00.000Z" <did:dkg:context-graph:ontology> .',
       ].join('\n'),
@@ -248,7 +248,7 @@ describe('GossipPublishHandler', () => {
 
   it('accepts ontology policy approvals from the current paranet owner', async () => {
     const { store, handler } = createHandler(undefined, {
-      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:owner' : null,
+      getContextGraphOwner: async (id) => id === 'ops-policy' ? 'did:dkg:agent:0x1111111111111111111111111111111111111111' : null,
     });
 
     const data = makePublishMessage({
@@ -258,7 +258,7 @@ describe('GossipPublishHandler', () => {
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#appliesToParanet> <did:dkg:context-graph:ops-policy> <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://schema.org/name> "incident-review" <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#activePolicy> <did:dkg:policy:ops-policy:sha256-real> <did:dkg:context-graph:ontology> .',
-        '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#approvedBy> <did:dkg:agent:owner> <did:dkg:context-graph:ontology> .',
+        '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#approvedBy> <did:dkg:agent:0x1111111111111111111111111111111111111111> <did:dkg:context-graph:ontology> .',
         '<did:dkg:policy-binding:ops-policy:incident-review:default:1> <https://dkg.network/ontology#approvedAt> "2026-03-24T00:00:00.000Z" <did:dkg:context-graph:ontology> .',
       ].join('\n'),
     });

--- a/packages/agent/test/gossip-validation.test.ts
+++ b/packages/agent/test/gossip-validation.test.ts
@@ -136,7 +136,8 @@ describe('I-002: Gossip ingestion should not trust self-reported on-chain status
     // After the fix, all gossip data should be stored as tentative first.
     // We simulate what the gossip handler does and verify the output is tentative.
 
-    const entity = 'did:dkg:agent:QmGossipEntity';
+    // A-12 migration: agent DIDs are EVM-address form.
+    const entity = 'did:dkg:agent:0x' + 'aa'.repeat(20);
     const triples = [
       q(entity, 'http://schema.org/name', '"GossipBot"', `did:dkg:context-graph:${PARANET}`),
     ];
@@ -232,7 +233,7 @@ describe('I-002: Gossip ingestion should not trust self-reported on-chain status
   }, 30000);
 
   it('proto round-trips full gossip message with on-chain proof fields', () => {
-    const entity = 'did:dkg:agent:QmRoundTrip';
+    const entity = 'did:dkg:agent:0x' + 'bb'.repeat(20);
     const ntriples = `<${entity}> <http://schema.org/name> "RoundTrip" .`;
     const txHash = '0x' + 'ff'.repeat(32);
 
@@ -325,7 +326,7 @@ describe('I-002: Gossip ingestion should not trust self-reported on-chain status
   }, 30000);
 
   it('merkle verification detects tampered gossip data', () => {
-    const entity = 'did:dkg:agent:QmTampered';
+    const entity = 'did:dkg:agent:0x' + 'cc'.repeat(20);
     const legitimateTriples = [
       q(entity, 'http://schema.org/name', '"Legitimate"', `did:dkg:context-graph:${PARANET}`),
       q(entity, 'http://schema.org/version', '"1.0"', `did:dkg:context-graph:${PARANET}`),

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -582,7 +582,13 @@ export class ApiClient {
   async endorse(request: {
     contextGraphId: string;
     ual: string;
-    agentAddress: string;
+    /**
+     * Optional. If supplied it MUST match the address resolved from
+     * the bearer token; the daemon rejects any mismatch with 403.
+     * Prefer omitting and relying on the token — see A-12 review on
+     * /api/endorse for the provenance-forgery rationale.
+     */
+    agentAddress?: string;
   }): Promise<{ endorsed: boolean; endorserAddress: string }> {
     return this.post('/api/endorse', request);
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -856,17 +856,31 @@ program
 
 program
   .command('endorse <ual>')
-  .description('Endorse a published Knowledge Asset')
+  .description('Endorse a published Knowledge Asset as the authenticated agent')
+  // A-12 review: the endorser is resolved from the bearer token, not
+  // from a `--agent` flag (the previous behaviour let any caller with
+  // node access forge endorsements under arbitrary addresses).
+  // `--agent` is kept as an optional sanity check: if it is supplied
+  // we assert it matches the token's agent before sending the
+  // request, so a user who typo's the agent gets a local error
+  // instead of a 403 round-trip. If the user wants to endorse as a
+  // specific agent other than the node's default, they must
+  // authenticate with that agent's token.
   .requiredOption('--context-graph <id>', 'Context Graph ID')
-  .requiredOption('--agent <address>', 'Agent address (endorser)')
+  .option('--agent <address>', 'Optional: assert the authenticated agent matches this address before sending')
   .action(async (ual: string, opts: ActionOpts) => {
     try {
       const client = await ApiClient.connect();
-      const result = await client.endorse({
+      const request: { contextGraphId: string; ual: string; agentAddress?: string } = {
         contextGraphId: opts.contextGraph,
         ual,
-        agentAddress: opts.agent,
-      });
+      };
+      if (typeof opts.agent === 'string' && opts.agent.length > 0) {
+        request.agentAddress = opts.agent;
+      }
+      const result = await client.endorse(
+        request as { contextGraphId: string; ual: string; agentAddress: string },
+      );
       console.log(`Endorsed ${ual} by ${result.endorserAddress}`);
     } catch (err) {
       console.error(`Endorse failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -7879,20 +7879,51 @@ async function handleRequest(
   // POST /api/endorse
   if (req.method === "POST" && path === "/api/endorse") {
     const body = await readBody(req, SMALL_BODY_BYTES);
-    const { contextGraphId, ual, agentAddress } = JSON.parse(body);
-    if (!contextGraphId || !ual || !agentAddress) {
+    const parsed = JSON.parse(body);
+    const { contextGraphId, ual } = parsed;
+    if (!contextGraphId || !ual) {
       return jsonResponse(res, 400, {
-        error: "Missing contextGraphId, ual, or agentAddress",
+        error: "Missing contextGraphId or ual",
+      });
+    }
+    // A-12 review: the endorser MUST come from the authenticated bearer
+    // token, not from the request body. Trusting body.agentAddress let
+    // any caller with node access publish endorsements as an arbitrary
+    // `did:dkg:agent:0x...`, forging provenance. `requestAgentAddress`
+    // is the token-resolved identity. If the body also includes
+    // `agentAddress`, it must match or we reject with 403. The
+    // registered-local-agent check is implicit: resolveAgentAddress
+    // returns either the token's agent (if it's an agent-scoped
+    // token) or `defaultAgentAddress` (the node's own auto-registered
+    // agent). Both are owned by this node by construction.
+    // Defence in depth: an unauthenticated caller has no agent identity
+    // to attribute an endorsement to. Early return 401 rather than
+    // attempting `.toLowerCase()` on a null/undefined address.
+    if (!requestAgentAddress) {
+      return jsonResponse(res, 401, {
+        error:
+          "Endorsement requires an authenticated agent. Provide a bearer token tied to a registered agent.",
+      });
+    }
+    const bodyAgentAddress = typeof parsed.agentAddress === 'string' ? parsed.agentAddress : undefined;
+    if (
+      bodyAgentAddress &&
+      bodyAgentAddress.toLowerCase() !== requestAgentAddress.toLowerCase()
+    ) {
+      return jsonResponse(res, 403, {
+        error:
+          `Endorser mismatch: authenticated as ${requestAgentAddress} but request body claims ${bodyAgentAddress}. ` +
+          `The endorser is resolved from the bearer token; omit body.agentAddress or use the matching agent's token.`,
       });
     }
     const result = await agent.endorse({
       contextGraphId,
       knowledgeAssetUal: ual,
-      agentAddress,
+      agentAddress: requestAgentAddress,
     });
     return jsonResponse(res, 200, {
       endorsed: true,
-      endorserAddress: agentAddress,
+      endorserAddress: requestAgentAddress,
       ...result,
     });
   }


### PR DESCRIPTION
## Summary

Closes **BUGS_FOUND.md A-12 (MEDIUM)**. Spec `§03_AGENTS.md` and `§22_AGENT_ONBOARDING.md` mandate that the agent DID is the Ethereum-address form `did:dkg:agent:0x<40hex>`. Two production paths were emitting the legacy peer-id form (`did:dkg:agent:Qm…` / `did:dkg:agent:12D3KooW…`):

1. **\`buildAgentProfile\`** keyed the root entity off \`config.peerId\`, so every published Agent profile in the registry advertised a non-spec DID.
2. **\`DKGAgent.endorse\`** passed \`this.peerId\` to \`buildEndorsementQuads\`, so every \`dkg:endorses\` triple was authored by a non-spec subject.

## Production fixes

- \`packages/agent/src/profile.ts\` — \`buildAgentProfile\` now prefers \`config.agentAddress\` for the DID subject when supplied. Falls back to \`peerId\` only when no address is given (test-harness backward compat). Runtime always supplies an address via \`DKGAgent.publishProfile\`.
- \`packages/agent/src/dkg-agent.ts\` — \`endorse\` now uses \`opts.agentAddress ?? this.defaultAgentAddress ?? this.peerId\`.

## Test fixture migration (A-12 explicitly asks for this)

- \`agent.test.ts\` — Profile-Builder fixture now passes \`agentAddress\` and asserts the EVM-form DID.
- \`gossip-publish-handler.test.ts\` — 7 fixtures of \`did:dkg:agent:owner\` / \`did:dkg:agent:attacker\` migrated to \`did:dkg:agent:0x111…\` / \`did:dkg:agent:0x222…\`.
- \`gossip-validation.test.ts\` — 3 entity fixtures migrated.
- \`agent-audit-extra.test.ts\` — fixture-scan exempts the 3 audit/diagnostic test files that intentionally embed \`Qm…\` strings as negative-regex targets / inline diagnostics.
- \`e2e-network.test.ts\` — NodeA/B/C now use distinct EVM keys (\`CORE_OP\`/\`REC1_OP\`/\`REC2_OP\`) so their profile DIDs no longer collide; tokens minted to all three.

## Out of scope (A-12.2 follow-up)

Many internal \`did:dkg:agent:\${this.peerId}\` references in \`dkg-agent.ts\` (creator DID for context-graph quads, sync-auth self-reference, gossip endorsement self-DID). They are wrapped in dual-form matchers (e.g. line 1045 already accepts both forms), so they don't break, but they should be migrated to the EVM form in a separate refactor PR.

## Test plan

- [x] \`did-format-extra.test.ts\` (3 tests) — all pass
- [x] \`agent-audit-extra.test.ts\` A-12 fixture-scan — passes
- [x] \`gossip-publish-handler.test.ts\`, \`gossip-validation.test.ts\`, \`agent.test.ts\` Profile Builder, \`ack-eip191-agent-extra.test.ts\`, \`e2e-network.test.ts\` — all pass
- [x] Full agent suite: 352 passing; the 32 failing are pre-existing PROD-BUG / SPEC-GAP / flaky e2e tests already failing on \`v10-rc\` HEAD (A-5, A-7, A-13, A-15, e2e-privacy, e2e-workspace-sync, etc.)
- [ ] Manual devnet: spin two nodes, publish profiles, query \`/api/findAgents\` from each, verify both DIDs are 0x-form (next morning)

Made with [Cursor](https://cursor.com)