### PR TITLE
docs(skill): document token discovery and auth troubleshooting

### DIFF
--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -118,6 +118,24 @@ requests without an explicit caller fall back to the node's default agent.
 **Public endpoints (no auth):** `GET /api/status`, `GET /api/chain/rpc-health`,
 `GET /.well-known/skill.md`.
 
+### Token discovery
+
+**Co-located agents (running on the same machine as the daemon).** The daemon writes its admin token to `~/.dkg/auth.token` on first start. If your adapter provides a DKG client (e.g. the OpenClaw adapter's `DkgDaemonClient`), **prefer the adapter's high-level tools** (`createContextGraph`, `createAssertion`, `promoteAssertion`, etc.) — they load this file automatically and you never need to handle `$TOKEN` yourself. Only fall back to raw HTTP if no adapter tool covers what you need, in which case:
+
+```bash
+TOKEN=$(cat ~/.dkg/auth.token)
+```
+
+**Remote agents (not on the daemon host).** Register your own agent via `POST /api/agent/register` and use the returned `authToken` — see "Agent identity" below. Do not ask the user to paste `~/.dkg/auth.token` from another machine; that's the node's admin credential and should stay on the host that owns the daemon.
+
+**If you get 401 or 403 on a protected route, diagnose in this order:**
+
+1. **Is there a token on the request?** A missing `Authorization` header → 401. If you tried to build a `curl` command without discovering the token first, the adapter's built-in tools should have been your first choice.
+2. **Does the token correspond to an agent the node knows?** Call `GET /api/agent/identity` — the response tells you who the server sees as the caller. If it doesn't match who you think you are, you're holding the wrong token.
+3. **Do you have CG-level access?** A valid token + recognized agent can still get 403 on context-graph operations if the agent isn't a participant / creator of that CG. Check the CG's participant list or use an invite / join flow (§6).
+
+Never guess — `GET /api/agent/identity` is free and definitive. Call it first.
+
 **Agent identity:**
 
 - `POST /api/agent/register` — register a new agent on this node.


### PR DESCRIPTION
## Summary

Fixes the skill-documentation gap that led an agent to fail a project creation with *"need to identify the node auth token first"* — the skill assumed `\$TOKEN` was already known and never told the agent where to find it.

- Add **Token discovery** subsection to §4 Authentication:
  - **Co-located agents:** the daemon writes `~/.dkg/auth.token` on first start. Adapter-provided DKG clients (e.g. the OpenClaw `DkgDaemonClient`) load this automatically — **prefer the adapter's high-level tools** over raw HTTP. Raw-HTTP fallback shows the canonical `TOKEN=\$(cat ~/.dkg/auth.token)`.
  - **Remote agents:** register via `POST /api/agent/register` and use the returned `authToken`. Explicitly warn against asking users to paste the admin token from another host.
  - **401/403 triage:** ordered checklist starting with `GET /api/agent/identity` to confirm who the node sees as the caller.

## Motivation

Seen in the wild: an OpenClaw-connected agent tried to build a `curl` to `/api/context-graph/create`, noticed the route required auth, and bailed with *"Need to identify the node auth token first, because of course the one endpoint we need is not the one that waves us through."* The adapter had the token all along — the agent just didn't know the adapter's tools were the right path, and didn't know `~/.dkg/auth.token` existed as a fallback. This PR closes that doc gap without requiring any code change.

## Test plan

- [ ] Render SKILL.md on GitHub and verify the new §4 subsection reads cleanly between "Public endpoints" and "Agent identity".
- [ ] Spot-check on a local node: `cat ~/.dkg/auth.token` returns a single base64url-style token; `TOKEN=\$(cat ~/.dkg/auth.token) && curl -H \"Authorization: Bearer \$TOKEN\" http://127.0.0.1:9200/api/agent/identity` returns the default agent's identity JSON.
- [ ] Re-run the failing agent scenario with an agent that has read the updated skill; confirm it picks either the adapter's `createContextGraph` tool or the documented `cat ~/.dkg/auth.token` fallback instead of bailing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)