### PR TITLE
fix(adapter-openclaw): register tools in setup-runtime mode, not only full

### DIFF
--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -261,8 +261,13 @@ export class DkgNodePlugin {
     // daemon is not yet healthy.
     const runtimeEnabled = fullRuntime || setupRuntime;
 
-    // Only expose the DKG agent tool surface during full runtime.
-    if (fullRuntime) {
+    // Expose the DKG agent tool surface whenever runtime is enabled
+    // (full OR setup-runtime). External/npm-installed plugins only ever
+    // receive setup-runtime mode, so gating on `fullRuntime` alone means
+    // the 13 dkg_* tools never register for them — agents then fall
+    // back to raw HTTP and fail on auth. Same gate as every other
+    // runtime integration in this function.
+    if (runtimeEnabled) {
       for (const tool of this.tools()) {
         api.registerTool(tool);
       }

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -1274,6 +1274,38 @@ describe('DkgNodePlugin', () => {
     expect(String(warnCalls[0]?.[0])).toContain('dkg-node.game.enabled');
   });
 
+  it('registers the full dkg_* tool surface in setup-runtime mode (npm-installed gateways)', () => {
+    // External/npm-installed OpenClaw plugins only ever receive
+    // registrationMode: 'setup-runtime' from the gateway. Regression guard
+    // for the bug where tool registration was gated on `fullRuntime` alone,
+    // leaving npm-installed gateways with zero dkg_* tools and forcing
+    // agents into a broken raw-HTTP fallback.
+    const plugin = new DkgNodePlugin({
+      daemonUrl: 'http://localhost:9200',
+      memory: { enabled: false },
+      channel: { enabled: false },
+    });
+
+    const registeredTools: OpenClawTool[] = [];
+    const mockApi: OpenClawPluginApi = {
+      config: {},
+      registrationMode: 'setup-runtime',
+      registerTool: (tool) => registeredTools.push(tool),
+      registerHook: () => {},
+      on: () => {},
+      logger: {},
+    };
+
+    plugin.register(mockApi);
+
+    expect(registeredTools.length).toBe(13);
+    const toolNames = registeredTools.map((t) => t.name);
+    expect(toolNames).toContain('dkg_context_graph_create');
+    expect(toolNames).toContain('dkg_publish');
+    expect(toolNames).toContain('dkg_query');
+    expect(toolNames).toContain('dkg_find_agents');
+  });
+
   it('upgrades from setup-runtime to full runtime and registers the memory slot capability', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',
@@ -1292,7 +1324,13 @@ describe('DkgNodePlugin', () => {
       workspaceDir: 'C:/tmp/openclaw-upgrade-test',
     };
     plugin.register(setupRuntimeApi);
-    expect(setupRuntimeTools).toHaveLength(0);
+    // setup-runtime IS a runtime mode: external/npm-installed plugins only
+    // ever receive setup-runtime from the gateway, so the dkg_* tool surface
+    // must register here or agents see no tools at all.
+    const setupRuntimeToolNames = setupRuntimeTools.map((t) => t.name);
+    expect(setupRuntimeToolNames).toContain('dkg_context_graph_create');
+    expect(setupRuntimeToolNames).toContain('dkg_publish');
+    expect(setupRuntimeToolNames).toContain('dkg_query');
 
     const fullRuntimeTools: OpenClawTool[] = [];
     const registerMemoryCapability = vi.fn();


### PR DESCRIPTION
## Summary

On npm-installed OpenClaw gateways, the DKG adapter's 13 runtime tools (`dkg_context_graph_create`, `dkg_publish`, `dkg_query`, `dkg_find_agents`, etc.) never appeared in the agent's tool catalog. Agents fell back to raw HTTP and failed on auth. This one-line gate flip fixes it.

## What agents see today (pre-fix)

On any gateway where `registrationMode === 'setup-runtime'` (the mode the gateway uses for **all** external/npm-installed plugins), the plugin's tool surface never registered. The live agent on the user's gateway reports zero `dkg_*` tools. Agents then bypass the typed tool surface and try to speak HTTP directly to `:9200`, which fails auth because the bearer token is owned by the daemon, not the agent.

## Why (root cause)

`packages/adapter-openclaw/src/DkgNodePlugin.ts:265` gated tool registration on `fullRuntime`:

```ts
// Only expose the DKG agent tool surface during full runtime.
if (fullRuntime) {
  for (const tool of this.tools()) {
    api.registerTool(tool);
  }
}
```

But the comment at `DkgNodePlugin.ts:381-390` explicitly documents the constraint:

> The gateway only exposes `api.on` (typed plugin hooks) in `registrationMode === 'full'`. **External plugins get 'setup-runtime'** where both `api.on` and `api.registerHook` are noops.

Line 262 correctly introduces `runtimeEnabled = fullRuntime || setupRuntime` to treat `setup-runtime` as a real runtime mode. That gate is applied consistently to:

- the memory slot (`registerIntegrationModules`, line 278, 304, 326)
- the channel plugin (via `enableFullRuntime` flag passed to `registerIntegrationModules`)
- the local-agent integration (`registerLocalAgentIntegration`, lines 280, 307)
- cross-channel turn persistence (`registerCrossChannelPersistence`, lines 285, 299)

The tool-registration block at line 265 was the **only** place still gated on `fullRuntime` alone. It was an oversight from commit [`f6c9dd0c`](https://github.com/OriginTrail/dkg-v9/commit/f6c9dd0c) (`fix(adapter-openclaw): retry backoff + setup-runtime memory slot + UI selection visibility`), which introduced `runtimeEnabled` specifically to promote `setup-runtime` to a real runtime mode everywhere else but didn't touch this block.

## The fix

One-line change in `DkgNodePlugin.ts`:

```diff
-    // Only expose the DKG agent tool surface during full runtime.
-    if (fullRuntime) {
+    // Expose the DKG agent tool surface whenever runtime is enabled
+    // (full OR setup-runtime). …
+    if (runtimeEnabled) {
       for (const tool of this.tools()) {
         api.registerTool(tool);
       }
     }
```

Plus test updates (see below).

## Why the fix is safe

- **Consistent with every other integration module in the same function.** Memory slot, channel bridge, local-agent integration, and cross-channel persistence all already gate on `runtimeEnabled`. This change brings the tool block in line with the established pattern.
- **`runtimeEnabled` is still false for the two modes that must not register runtime surfaces** — `setup-only` and `cli-metadata`. Both return early / skip the tool block exactly as before (verified: the existing `setup-only` test at `plugin.test.ts:1230` still asserts 0 tools and still passes).
- **`setup-runtime` is already trusted to bring up real network-facing integrations** (channel bridge, integration modules). Registering typed tools is a lighter-weight operation than any of those.
- `this.tools()` is a pure factory over `this.client` — no side effects, safe to call during setup-runtime.

## Tests

- **New regression test:** `plugin.test.ts` — "registers the full dkg_* tool surface in setup-runtime mode (npm-installed gateways)". Asserts all 13 tools register when `registrationMode: 'setup-runtime'`. This is the exact npm-installed gateway scenario.
- **Updated existing test:** the `upgrades from setup-runtime to full runtime and registers the memory slot capability` test previously asserted `expect(setupRuntimeTools).toHaveLength(0)` — that assertion was codifying the bug. Flipped to assert the core `dkg_*` tools register in the initial `setup-runtime` pass.
- All 36 `plugin.test.ts` tests pass locally.
- One pre-existing failure in `adapter-openclaw-extra.test.ts` ([K-9] plugin id vs package name, `RED until reconciled`) is unrelated and already red on `v10-rc` — confirmed by running the test suite on a pristine `v10-rc` checkout.

## Related

- Does **not** supersede #247 — that PR is a complementary safety net for raw-HTTP fallbacks on older, already-deployed gateways.
- Introducing commit: [`f6c9dd0c`](https://github.com/OriginTrail/dkg-v9/commit/f6c9dd0c).

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test` — 36/36 plugin tests pass locally
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw build` — clean tsc
- [ ] Verify on a live npm-installed OpenClaw gateway that `dkg_*` tools appear in the agent's tool catalog
- [ ] Verify agent-initiated `dkg_context_graph_create` / `dkg_query` calls succeed end-to-end against a running daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)