### PR TITLE
fix(adapter-openclaw): auto-patch openclaw.json for full-runtime tool registration

### DIFF
--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -1021,6 +1021,18 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
     if (currentMatchesMerge) {
       delete config.channels['dkg-ui'];
       log('Removed channels.dkg-ui (created by merge, unchanged since)');
+      // If the container is now empty AND we created the channel (inferred from
+      // previousChannelsDkgUi === null), remove the empty `channels: {}` orphan
+      // so a connect → disconnect round trip returns the config to its
+      // pre-merge shape byte-for-byte.
+      if (
+        config.channels
+        && typeof config.channels === 'object'
+        && Object.keys(config.channels).length === 0
+      ) {
+        delete config.channels;
+        log('Removed empty channels container (no other channels remaining)');
+      }
     } else if (currentChannel) {
       log('Preserving channels.dkg-ui — user-modified since merge');
     }

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -19,6 +19,7 @@ import { createRequire } from 'node:module';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { isDeepStrictEqual } from 'node:util';
 import type { DkgOpenClawConfig } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -679,34 +680,47 @@ export function mergeOpenClawConfig(
   // api.registerTool is a noop — see openclaw/src/plugins/loader.ts:816 and
   // openclaw/src/config/channel-configured-shared.ts:21 for the check).
   //
-  // Port derivation: prefer the adapter's own configured channel port from
-  // `entryConfig.channel.port` so this top-level entry stays in sync with
-  // `plugins.entries.adapter-openclaw.config.channel.port`. Falls back to the
-  // openclaw.plugin.json configSchema default (9201) when unspecified.
-  const entryChannelPort = (entryConfig?.channel as { port?: unknown } | undefined)?.port;
-  const adapterChannelPort = typeof entryChannelPort === 'number' && Number.isInteger(entryChannelPort)
-    ? entryChannelPort
+  // Port derivation reads from the POST-MERGE `plugins.entries.adapter-openclaw
+  // .config.channel.port`, not the incoming `entryConfig.channel.port`. The
+  // entry-config merge above applies first-wins semantics: when the user
+  // already has a custom adapter port (e.g. 9300), it's preserved on the entry
+  // even if the caller passed a default `entryConfig`. Reading the post-merge
+  // state keeps the top-level `channels.dkg-ui.port` in sync with whatever the
+  // adapter entry actually resolved to. Falls back to the openclaw.plugin.json
+  // configSchema default (9201) when no port is set anywhere.
+  const mergedChannel = entryForConfig.config?.channel as { port?: unknown } | undefined;
+  const mergedChannelPort = mergedChannel?.port;
+  const adapterChannelPort = typeof mergedChannelPort === 'number' && Number.isInteger(mergedChannelPort)
+    ? mergedChannelPort
     : 9201;
   if (!config.channels || typeof config.channels !== 'object') {
     config.channels = {};
   }
   const dkgUiChannel = config.channels['dkg-ui'];
   if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
-    // Channel absent before merge → on disconnect, delete it.
+    // Channel absent before merge → on disconnect, delete it (only if still
+    // matches the shape we wrote). Capture both the prior absence (`null`) and
+    // the exact value we're about to write so unmerge can deep-equal-compare
+    // and leave user post-merge edits alone.
+    const created = { enabled: true, port: adapterChannelPort };
     if (adapterEntryForCapture && !('previousChannelsDkgUi' in adapterEntryForCapture)) {
       adapterEntryForCapture.previousChannelsDkgUi = null;
+      adapterEntryForCapture.mergedChannelsDkgUi = { ...created };
     }
-    config.channels['dkg-ui'] = { enabled: true, port: adapterChannelPort };
+    config.channels['dkg-ui'] = created;
     log(`Created channels.dkg-ui with port ${adapterChannelPort} to keep plugin in full runtime mode`);
   } else {
     // Check whether the existing entry has any non-`enabled` key.
     const hasNonEnabledKey = Object.keys(dkgUiChannel).some((k) => k !== 'enabled');
     if (!hasNonEnabledKey) {
-      // Capture the degenerate shape so disconnect can restore it verbatim.
+      // Capture the degenerate shape + exact merge output so disconnect can
+      // restore verbatim iff the channel hasn't been edited since.
+      const upgraded = { ...dkgUiChannel, port: adapterChannelPort };
       if (adapterEntryForCapture && !('previousChannelsDkgUi' in adapterEntryForCapture)) {
         adapterEntryForCapture.previousChannelsDkgUi = { ...dkgUiChannel };
+        adapterEntryForCapture.mergedChannelsDkgUi = { ...upgraded };
       }
-      config.channels['dkg-ui'] = { ...dkgUiChannel, port: adapterChannelPort };
+      config.channels['dkg-ui'] = upgraded;
       log(`Added port ${adapterChannelPort} to channels.dkg-ui to keep plugin in full runtime mode`);
     }
     // Otherwise leave the user's customizations alone. No capture because we
@@ -855,6 +869,11 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
   // Defined string / object = restore verbatim. `undefined` = no capture, leave as-is.
   let previousToolsProfile: string | null | undefined;
   let previousChannelsDkgUi: Record<string, unknown> | null | undefined;
+  // Exact merge-produced shape of channels.dkg-ui, captured at merge time.
+  // Used as a deep-equal ownership check on unmerge — a loose "has a port key"
+  // guard would also match post-merge user edits (auth tokens, custom fields,
+  // port changes) and clobber them on disconnect.
+  let mergedChannelsDkgUi: Record<string, unknown> | undefined;
   const entry = config.plugins?.entries?.[pluginId];
   if (entry && typeof entry === 'object') {
     if (typeof entry.previousMemorySlotOwner === 'string') {
@@ -865,6 +884,9 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
     }
     if ('previousChannelsDkgUi' in entry) {
       previousChannelsDkgUi = entry.previousChannelsDkgUi;
+    }
+    if (entry.mergedChannelsDkgUi && typeof entry.mergedChannelsDkgUi === 'object') {
+      mergedChannelsDkgUi = entry.mergedChannelsDkgUi as Record<string, unknown>;
     }
   }
 
@@ -907,24 +929,33 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
     }
   }
 
-  // Restore or clear channels.dkg-ui iff it still holds the shape merge produced.
-  // If the user has re-customized the channel since merge, leave their value
-  // untouched. We detect "merge-produced" by checking that the current channel
-  // is an object with at least a `port` key (since merge always writes `port`).
+  // Restore or clear channels.dkg-ui iff the current value DEEP-EQUALS the exact
+  // shape merge wrote. A loose "has a port key" check would also match user edits
+  // made after install (post-merge port change, added auth/custom fields) and
+  // clobber them on disconnect. Using `isDeepStrictEqual` against the captured
+  // `mergedChannelsDkgUi` is strict ownership: any divergence from the merge
+  // output — including the user re-customizing the port — means the user now
+  // owns this channel, and we leave it alone.
   const currentChannel = config.channels && typeof config.channels === 'object'
     ? (config.channels['dkg-ui'] as Record<string, unknown> | undefined)
     : undefined;
-  const currentChannelLooksMergeShaped =
-    !!currentChannel && typeof currentChannel === 'object' && 'port' in currentChannel;
+  const currentMatchesMerge =
+    !!currentChannel
+    && !!mergedChannelsDkgUi
+    && isDeepStrictEqual(currentChannel, mergedChannelsDkgUi);
   if (previousChannelsDkgUi === null) {
-    if (currentChannelLooksMergeShaped) {
+    if (currentMatchesMerge) {
       delete config.channels['dkg-ui'];
-      log('Removed channels.dkg-ui (created by merge)');
+      log('Removed channels.dkg-ui (created by merge, unchanged since)');
+    } else if (currentChannel) {
+      log('Preserving channels.dkg-ui — user-modified since merge');
     }
   } else if (previousChannelsDkgUi && typeof previousChannelsDkgUi === 'object') {
-    if (currentChannelLooksMergeShaped) {
+    if (currentMatchesMerge) {
       config.channels['dkg-ui'] = { ...previousChannelsDkgUi };
       log('Restored channels.dkg-ui to pre-merge state');
+    } else if (currentChannel) {
+      log('Preserving channels.dkg-ui — user-modified since merge');
     }
   }
 

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -697,11 +697,19 @@ export function mergeOpenClawConfig(
   // state keeps the top-level `channels.dkg-ui.port` in sync with whatever the
   // adapter entry actually resolved to. Falls back to the openclaw.plugin.json
   // configSchema default (9201) when no port is set anywhere.
-  const mergedChannel = entryForConfig.config?.channel as { port?: unknown } | undefined;
+  const mergedChannel = entryForConfig.config?.channel as { port?: unknown; enabled?: unknown } | undefined;
   const mergedChannelPort = mergedChannel?.port;
   const adapterChannelPort = typeof mergedChannelPort === 'number' && Number.isInteger(mergedChannelPort)
     ? mergedChannelPort
     : 9201;
+  // Preserve the user's explicit `enabled` value from the adapter entry. If they
+  // set `plugins.entries.adapter-openclaw.config.channel.enabled = false`, we
+  // must not silently re-enable the channel here — even though the top-level
+  // `channels.dkg-ui` entry still needs a non-`enabled` key (the `port` below)
+  // to satisfy OpenClaw's meaningful-config check and keep the plugin in full
+  // runtime mode.
+  const adapterChannelEnabled =
+    typeof mergedChannel?.enabled === 'boolean' ? mergedChannel.enabled : true;
   if (!config.channels || typeof config.channels !== 'object') {
     config.channels = {};
   }
@@ -717,7 +725,7 @@ export function mergeOpenClawConfig(
   if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
     // Channel absent before merge → on disconnect, delete it (only if still
     // matches the shape we wrote).
-    const created = { enabled: true, port: adapterChannelPort };
+    const created = { enabled: adapterChannelEnabled, port: adapterChannelPort };
     if (adapterEntryForCapture) {
       if (!('previousChannelsDkgUi' in adapterEntryForCapture)) {
         adapterEntryForCapture.previousChannelsDkgUi = null; // first-wins

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -651,35 +651,66 @@ export function mergeOpenClawConfig(
   // `CORE_TOOL_PROFILES` allowlist (applied at registry resolution) filters
   // plugin-registered tools out of the default `"coding"` profile, making
   // `dkg_*` invisible to the agent even when the plugin loads in full mode.
+  //
+  // Capture the pre-merge profile onto the adapter entry so `unmergeOpenClawConfig`
+  // can restore it on disconnect. First-wins: once captured, re-running merge
+  // does not clobber the original (matches the `previousMemorySlotOwner` pattern).
+  // `null` sentinel = "absent before merge" → disconnect should delete the key.
+  const adapterEntryForCapture = config.plugins.entries[pluginId] as Record<string, any>;
   if (!config.tools.profile) {
+    if (adapterEntryForCapture && !('previousToolsProfile' in adapterEntryForCapture)) {
+      adapterEntryForCapture.previousToolsProfile = null;
+    }
     config.tools.profile = 'full';
     log('Set tools.profile = "full" to expose plugin tools');
   } else if (config.tools.profile === 'coding') {
+    if (adapterEntryForCapture && !('previousToolsProfile' in adapterEntryForCapture)) {
+      adapterEntryForCapture.previousToolsProfile = 'coding';
+    }
     config.tools.profile = 'full';
     log('Upgraded tools.profile from "coding" to "full" to expose plugin tools');
   }
   // If the user explicitly set "minimal" or "messaging", respect that — they may
   // have restricted the profile intentionally and can re-expand with alsoAllow.
+  // No capture because we didn't mutate.
 
   // Ensure channels.dkg-ui has at least one non-`enabled` key so OpenClaw's
   // loader keeps the plugin in `full` runtime mode (not `setup-runtime`, where
   // api.registerTool is a noop — see openclaw/src/plugins/loader.ts:816 and
   // openclaw/src/config/channel-configured-shared.ts:21 for the check).
+  //
+  // Port derivation: prefer the adapter's own configured channel port from
+  // `entryConfig.channel.port` so this top-level entry stays in sync with
+  // `plugins.entries.adapter-openclaw.config.channel.port`. Falls back to the
+  // openclaw.plugin.json configSchema default (9201) when unspecified.
+  const entryChannelPort = (entryConfig?.channel as { port?: unknown } | undefined)?.port;
+  const adapterChannelPort = typeof entryChannelPort === 'number' && Number.isInteger(entryChannelPort)
+    ? entryChannelPort
+    : 9201;
   if (!config.channels || typeof config.channels !== 'object') {
     config.channels = {};
   }
   const dkgUiChannel = config.channels['dkg-ui'];
   if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
-    config.channels['dkg-ui'] = { enabled: true, port: 9201 };
-    log('Created channels.dkg-ui with port 9201 to keep plugin in full runtime mode');
+    // Channel absent before merge → on disconnect, delete it.
+    if (adapterEntryForCapture && !('previousChannelsDkgUi' in adapterEntryForCapture)) {
+      adapterEntryForCapture.previousChannelsDkgUi = null;
+    }
+    config.channels['dkg-ui'] = { enabled: true, port: adapterChannelPort };
+    log(`Created channels.dkg-ui with port ${adapterChannelPort} to keep plugin in full runtime mode`);
   } else {
     // Check whether the existing entry has any non-`enabled` key.
     const hasNonEnabledKey = Object.keys(dkgUiChannel).some((k) => k !== 'enabled');
     if (!hasNonEnabledKey) {
-      config.channels['dkg-ui'] = { ...dkgUiChannel, port: 9201 };
-      log('Added port 9201 to channels.dkg-ui to keep plugin in full runtime mode');
+      // Capture the degenerate shape so disconnect can restore it verbatim.
+      if (adapterEntryForCapture && !('previousChannelsDkgUi' in adapterEntryForCapture)) {
+        adapterEntryForCapture.previousChannelsDkgUi = { ...dkgUiChannel };
+      }
+      config.channels['dkg-ui'] = { ...dkgUiChannel, port: adapterChannelPort };
+      log(`Added port ${adapterChannelPort} to channels.dkg-ui to keep plugin in full runtime mode`);
     }
-    // Otherwise leave the user's customizations alone.
+    // Otherwise leave the user's customizations alone. No capture because we
+    // didn't mutate — disconnect must not touch a user-owned channel.
   }
 
   // Elect the adapter into OpenClaw's memory slot. Combined with
@@ -820,9 +851,21 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
   // That ordering lets a failed skill cleanup retry against the still-present
   // authority pointer instead of relying on a return value we discard on crash.
   let previousMemorySlotOwner: string | undefined;
+  // `null` sentinel (captured from merge) = key was absent before merge → delete it.
+  // Defined string / object = restore verbatim. `undefined` = no capture, leave as-is.
+  let previousToolsProfile: string | null | undefined;
+  let previousChannelsDkgUi: Record<string, unknown> | null | undefined;
   const entry = config.plugins?.entries?.[pluginId];
-  if (entry && typeof entry === 'object' && typeof entry.previousMemorySlotOwner === 'string') {
-    previousMemorySlotOwner = entry.previousMemorySlotOwner;
+  if (entry && typeof entry === 'object') {
+    if (typeof entry.previousMemorySlotOwner === 'string') {
+      previousMemorySlotOwner = entry.previousMemorySlotOwner;
+    }
+    if ('previousToolsProfile' in entry) {
+      previousToolsProfile = entry.previousToolsProfile;
+    }
+    if ('previousChannelsDkgUi' in entry) {
+      previousChannelsDkgUi = entry.previousChannelsDkgUi;
+    }
   }
 
   // Delete the adapter entry entirely. The adapter owns this entry — all of
@@ -845,6 +888,43 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
     } else {
       delete config.plugins.slots.memory;
       log(`Cleared plugins.slots.memory (was "${pluginId}")`);
+    }
+  }
+
+  // Restore or clear tools.profile iff it still holds the "full" value we wrote.
+  // If the user changed it since the merge, leave their value untouched — we
+  // only reverse the adapter's own claim on the slot, matching the slots.memory
+  // semantics above.
+  if (previousToolsProfile === null) {
+    if (config.tools && typeof config.tools === 'object' && 'profile' in config.tools && config.tools.profile === 'full') {
+      delete config.tools.profile;
+      log('Removed tools.profile (set to "full" by merge)');
+    }
+  } else if (typeof previousToolsProfile === 'string') {
+    if (config.tools && typeof config.tools === 'object' && config.tools.profile === 'full') {
+      config.tools.profile = previousToolsProfile;
+      log(`Restored tools.profile to "${previousToolsProfile}"`);
+    }
+  }
+
+  // Restore or clear channels.dkg-ui iff it still holds the shape merge produced.
+  // If the user has re-customized the channel since merge, leave their value
+  // untouched. We detect "merge-produced" by checking that the current channel
+  // is an object with at least a `port` key (since merge always writes `port`).
+  const currentChannel = config.channels && typeof config.channels === 'object'
+    ? (config.channels['dkg-ui'] as Record<string, unknown> | undefined)
+    : undefined;
+  const currentChannelLooksMergeShaped =
+    !!currentChannel && typeof currentChannel === 'object' && 'port' in currentChannel;
+  if (previousChannelsDkgUi === null) {
+    if (currentChannelLooksMergeShaped) {
+      delete config.channels['dkg-ui'];
+      log('Removed channels.dkg-ui (created by merge)');
+    }
+  } else if (previousChannelsDkgUi && typeof previousChannelsDkgUi === 'object') {
+    if (currentChannelLooksMergeShaped) {
+      config.channels['dkg-ui'] = { ...previousChannelsDkgUi };
+      log('Restored channels.dkg-ui to pre-merge state');
     }
   }
 

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -697,6 +697,7 @@ export function mergeOpenClawConfig(
     config.channels = {};
   }
   const dkgUiChannel = config.channels['dkg-ui'];
+  const lastMergedChannel = adapterEntryForCapture?.mergedChannelsDkgUi as Record<string, unknown> | undefined;
   if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
     // Channel absent before merge → on disconnect, delete it (only if still
     // matches the shape we wrote). Capture both the prior absence (`null`) and
@@ -722,9 +723,40 @@ export function mergeOpenClawConfig(
       }
       config.channels['dkg-ui'] = upgraded;
       log(`Added port ${adapterChannelPort} to channels.dkg-ui to keep plugin in full runtime mode`);
+    } else if (lastMergedChannel && isDeepStrictEqual(dkgUiChannel, lastMergedChannel)) {
+      // Channel is byte-identical to what we wrote last time → still adapter-
+      // owned. Refresh it with the current `adapterChannelPort` so a re-run
+      // after the user edits `plugins.entries.adapter-openclaw.config.channel.port`
+      // (or passes a different port via entryConfig) propagates to the top-level
+      // channel instead of leaving the old adapter-written port in place.
+      // `previousChannelsDkgUi` is first-wins (keeps the original user state),
+      // but `mergedChannelsDkgUi` tracks the latest adapter output so the
+      // unmerge ownership check sees the refreshed value.
+      const refreshed: Record<string, unknown> = { ...dkgUiChannel, port: adapterChannelPort };
+      if (!isDeepStrictEqual(refreshed, lastMergedChannel)) {
+        if (adapterEntryForCapture) {
+          adapterEntryForCapture.mergedChannelsDkgUi = { ...refreshed };
+        }
+        config.channels['dkg-ui'] = refreshed;
+        log(`Refreshed channels.dkg-ui.port to ${adapterChannelPort} (last merge output preserved)`);
+      }
+      // else: already up to date — no-op keeps idempotency on successive re-runs.
     }
-    // Otherwise leave the user's customizations alone. No capture because we
+    // Otherwise the user has modified channels.dkg-ui since install (or created
+    // it themselves with non-enabled keys). Leave alone. No capture because we
     // didn't mutate — disconnect must not touch a user-owned channel.
+  }
+
+  // Capture the full `config.tools` shape AFTER all merge mutations (profile +
+  // alsoAllow). Unmerge uses this as a deep-equal ownership check: if the user
+  // has edited anything under `tools` since our merge, we leave our mutations
+  // alone rather than risk clobbering the surrounding section. Always overwrite
+  // on re-merge — unlike `previousToolsProfile` (first-wins to preserve the
+  // ORIGINAL user value), this snapshot tracks our LATEST output, so re-running
+  // stays idempotent because merge always produces the same post-merge shape
+  // from the same inputs.
+  if (adapterEntryForCapture) {
+    adapterEntryForCapture.mergedToolsShape = structuredClone(config.tools);
   }
 
   // Elect the adapter into OpenClaw's memory slot. Combined with
@@ -869,11 +901,13 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
   // Defined string / object = restore verbatim. `undefined` = no capture, leave as-is.
   let previousToolsProfile: string | null | undefined;
   let previousChannelsDkgUi: Record<string, unknown> | null | undefined;
-  // Exact merge-produced shape of channels.dkg-ui, captured at merge time.
-  // Used as a deep-equal ownership check on unmerge — a loose "has a port key"
-  // guard would also match post-merge user edits (auth tokens, custom fields,
-  // port changes) and clobber them on disconnect.
+  // Exact merge-produced shapes, captured at merge time. Used as deep-equal
+  // ownership checks on unmerge — a loose "holds our string" / "has a port key"
+  // guard would also match post-merge user edits (custom fields under `tools`,
+  // auth tokens / port changes on `channels.dkg-ui`) and clobber them on
+  // disconnect.
   let mergedChannelsDkgUi: Record<string, unknown> | undefined;
+  let mergedToolsShape: Record<string, unknown> | undefined;
   const entry = config.plugins?.entries?.[pluginId];
   if (entry && typeof entry === 'object') {
     if (typeof entry.previousMemorySlotOwner === 'string') {
@@ -887,6 +921,9 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
     }
     if (entry.mergedChannelsDkgUi && typeof entry.mergedChannelsDkgUi === 'object') {
       mergedChannelsDkgUi = entry.mergedChannelsDkgUi as Record<string, unknown>;
+    }
+    if (entry.mergedToolsShape && typeof entry.mergedToolsShape === 'object') {
+      mergedToolsShape = entry.mergedToolsShape as Record<string, unknown>;
     }
   }
 
@@ -913,20 +950,33 @@ export function unmergeOpenClawConfig(openclawConfigPath: string): UnmergeResult
     }
   }
 
-  // Restore or clear tools.profile iff it still holds the "full" value we wrote.
-  // If the user changed it since the merge, leave their value untouched — we
-  // only reverse the adapter's own claim on the slot, matching the slots.memory
-  // semantics above.
-  if (previousToolsProfile === null) {
-    if (config.tools && typeof config.tools === 'object' && 'profile' in config.tools && config.tools.profile === 'full') {
-      delete config.tools.profile;
-      log('Removed tools.profile (set to "full" by merge)');
-    }
-  } else if (typeof previousToolsProfile === 'string') {
-    if (config.tools && typeof config.tools === 'object' && config.tools.profile === 'full') {
-      config.tools.profile = previousToolsProfile;
+  // Restore or clear tools.profile iff the current `config.tools` DEEP-EQUALS
+  // the exact shape merge wrote. The bare `=== 'full'` check would fire even
+  // after the user added unrelated fields under `tools` (e.g. tools.web), so
+  // we'd quietly revert their profile alongside a section they're actively
+  // using. Matching the channels.dkg-ui pattern: compare the whole `tools`
+  // object against the captured `mergedToolsShape` snapshot — any divergence
+  // (added field, removed field, changed value anywhere under `tools`) means
+  // the user now owns this section and we leave the profile alone.
+  const currentTools = config.tools && typeof config.tools === 'object'
+    ? (config.tools as Record<string, unknown>)
+    : undefined;
+  const toolsMatchMerge =
+    !!currentTools
+    && !!mergedToolsShape
+    && isDeepStrictEqual(currentTools, mergedToolsShape);
+  if (toolsMatchMerge) {
+    if (previousToolsProfile === null) {
+      if ('profile' in currentTools) {
+        delete currentTools.profile;
+        log('Removed tools.profile (set to "full" by merge, unchanged since)');
+      }
+    } else if (typeof previousToolsProfile === 'string') {
+      currentTools.profile = previousToolsProfile;
       log(`Restored tools.profile to "${previousToolsProfile}"`);
     }
+  } else if (previousToolsProfile !== undefined && currentTools) {
+    log('Preserving tools.profile — tools section user-modified since merge');
   }
 
   // Restore or clear channels.dkg-ui iff the current value DEEP-EQUALS the exact

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -647,6 +647,41 @@ export function mergeOpenClawConfig(
     log('Added "group:plugins" to tools.alsoAllow');
   }
 
+  // Ensure tools.profile exposes plugin-registered tools. OpenClaw's
+  // `CORE_TOOL_PROFILES` allowlist (applied at registry resolution) filters
+  // plugin-registered tools out of the default `"coding"` profile, making
+  // `dkg_*` invisible to the agent even when the plugin loads in full mode.
+  if (!config.tools.profile) {
+    config.tools.profile = 'full';
+    log('Set tools.profile = "full" to expose plugin tools');
+  } else if (config.tools.profile === 'coding') {
+    config.tools.profile = 'full';
+    log('Upgraded tools.profile from "coding" to "full" to expose plugin tools');
+  }
+  // If the user explicitly set "minimal" or "messaging", respect that — they may
+  // have restricted the profile intentionally and can re-expand with alsoAllow.
+
+  // Ensure channels.dkg-ui has at least one non-`enabled` key so OpenClaw's
+  // loader keeps the plugin in `full` runtime mode (not `setup-runtime`, where
+  // api.registerTool is a noop — see openclaw/src/plugins/loader.ts:816 and
+  // openclaw/src/config/channel-configured-shared.ts:21 for the check).
+  if (!config.channels || typeof config.channels !== 'object') {
+    config.channels = {};
+  }
+  const dkgUiChannel = config.channels['dkg-ui'];
+  if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
+    config.channels['dkg-ui'] = { enabled: true, port: 9201 };
+    log('Created channels.dkg-ui with port 9201 to keep plugin in full runtime mode');
+  } else {
+    // Check whether the existing entry has any non-`enabled` key.
+    const hasNonEnabledKey = Object.keys(dkgUiChannel).some((k) => k !== 'enabled');
+    if (!hasNonEnabledKey) {
+      config.channels['dkg-ui'] = { ...dkgUiChannel, port: 9201 };
+      log('Added port 9201 to channels.dkg-ui to keep plugin in full runtime mode');
+    }
+    // Otherwise leave the user's customizations alone.
+  }
+
   // Elect the adapter into OpenClaw's memory slot. Combined with
   // "kind": "memory" in openclaw.plugin.json and api.registerMemoryCapability(...)
   // inside DkgNodePlugin.register(), this replaces the default memory-core

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -636,7 +636,13 @@ export function mergeOpenClawConfig(
     log(`Set plugins.entries.${pluginId}.config.installedWorkspace = "${installedWorkspace}"`);
   }
 
-  // Ensure plugin-registered tools are visible to the agent
+  // Ensure plugin-registered tools are visible to the agent. Track whether THIS
+  // merge pass actually mutates anything under `config.tools` so `mergedToolsShape`
+  // can be refreshed only when we've genuinely written to the section. If the user
+  // has already settled the tools section (or has intentionally changed it after an
+  // earlier merge), no mutation fires here and the snapshot stays whatever a prior
+  // merge captured — preserving the correct ownership semantics for unmerge.
+  let mutatedTools = false;
   if (!config.tools) config.tools = {};
   if (!Array.isArray(config.tools.alsoAllow)) {
     // Preserve existing string value if present
@@ -645,6 +651,7 @@ export function mergeOpenClawConfig(
   }
   if (!config.tools.alsoAllow.includes('group:plugins')) {
     config.tools.alsoAllow.push('group:plugins');
+    mutatedTools = true;
     log('Added "group:plugins" to tools.alsoAllow');
   }
 
@@ -663,12 +670,14 @@ export function mergeOpenClawConfig(
       adapterEntryForCapture.previousToolsProfile = null;
     }
     config.tools.profile = 'full';
+    mutatedTools = true;
     log('Set tools.profile = "full" to expose plugin tools');
   } else if (config.tools.profile === 'coding') {
     if (adapterEntryForCapture && !('previousToolsProfile' in adapterEntryForCapture)) {
       adapterEntryForCapture.previousToolsProfile = 'coding';
     }
     config.tools.profile = 'full';
+    mutatedTools = true;
     log('Upgraded tools.profile from "coding" to "full" to expose plugin tools');
   }
   // If the user explicitly set "minimal" or "messaging", respect that — they may
@@ -696,17 +705,24 @@ export function mergeOpenClawConfig(
   if (!config.channels || typeof config.channels !== 'object') {
     config.channels = {};
   }
+  // `previousChannelsDkgUi` is first-wins — it captures the ORIGINAL pre-merge
+  // user state (absent / degenerate) at the very first install so unmerge can
+  // restore verbatim. `mergedChannelsDkgUi` tracks our LATEST output and MUST
+  // be refreshed on every write, since a later re-merge (e.g. after the user
+  // deletes or strips channels.dkg-ui, forcing us to re-create at a different
+  // port) would otherwise leave a stale snapshot and break the deep-equal
+  // ownership check on disconnect.
   const dkgUiChannel = config.channels['dkg-ui'];
   const lastMergedChannel = adapterEntryForCapture?.mergedChannelsDkgUi as Record<string, unknown> | undefined;
   if (!dkgUiChannel || typeof dkgUiChannel !== 'object') {
     // Channel absent before merge → on disconnect, delete it (only if still
-    // matches the shape we wrote). Capture both the prior absence (`null`) and
-    // the exact value we're about to write so unmerge can deep-equal-compare
-    // and leave user post-merge edits alone.
+    // matches the shape we wrote).
     const created = { enabled: true, port: adapterChannelPort };
-    if (adapterEntryForCapture && !('previousChannelsDkgUi' in adapterEntryForCapture)) {
-      adapterEntryForCapture.previousChannelsDkgUi = null;
-      adapterEntryForCapture.mergedChannelsDkgUi = { ...created };
+    if (adapterEntryForCapture) {
+      if (!('previousChannelsDkgUi' in adapterEntryForCapture)) {
+        adapterEntryForCapture.previousChannelsDkgUi = null; // first-wins
+      }
+      adapterEntryForCapture.mergedChannelsDkgUi = { ...created }; // always refresh
     }
     config.channels['dkg-ui'] = created;
     log(`Created channels.dkg-ui with port ${adapterChannelPort} to keep plugin in full runtime mode`);
@@ -714,12 +730,13 @@ export function mergeOpenClawConfig(
     // Check whether the existing entry has any non-`enabled` key.
     const hasNonEnabledKey = Object.keys(dkgUiChannel).some((k) => k !== 'enabled');
     if (!hasNonEnabledKey) {
-      // Capture the degenerate shape + exact merge output so disconnect can
-      // restore verbatim iff the channel hasn't been edited since.
+      // Degenerate shape → upgrade.
       const upgraded = { ...dkgUiChannel, port: adapterChannelPort };
-      if (adapterEntryForCapture && !('previousChannelsDkgUi' in adapterEntryForCapture)) {
-        adapterEntryForCapture.previousChannelsDkgUi = { ...dkgUiChannel };
-        adapterEntryForCapture.mergedChannelsDkgUi = { ...upgraded };
+      if (adapterEntryForCapture) {
+        if (!('previousChannelsDkgUi' in adapterEntryForCapture)) {
+          adapterEntryForCapture.previousChannelsDkgUi = { ...dkgUiChannel }; // first-wins
+        }
+        adapterEntryForCapture.mergedChannelsDkgUi = { ...upgraded }; // always refresh
       }
       config.channels['dkg-ui'] = upgraded;
       log(`Added port ${adapterChannelPort} to channels.dkg-ui to keep plugin in full runtime mode`);
@@ -729,9 +746,6 @@ export function mergeOpenClawConfig(
       // after the user edits `plugins.entries.adapter-openclaw.config.channel.port`
       // (or passes a different port via entryConfig) propagates to the top-level
       // channel instead of leaving the old adapter-written port in place.
-      // `previousChannelsDkgUi` is first-wins (keeps the original user state),
-      // but `mergedChannelsDkgUi` tracks the latest adapter output so the
-      // unmerge ownership check sees the refreshed value.
       const refreshed: Record<string, unknown> = { ...dkgUiChannel, port: adapterChannelPort };
       if (!isDeepStrictEqual(refreshed, lastMergedChannel)) {
         if (adapterEntryForCapture) {
@@ -743,19 +757,29 @@ export function mergeOpenClawConfig(
       // else: already up to date — no-op keeps idempotency on successive re-runs.
     }
     // Otherwise the user has modified channels.dkg-ui since install (or created
-    // it themselves with non-enabled keys). Leave alone. No capture because we
+    // it themselves with non-enabled keys). Leave alone. No refresh because we
     // didn't mutate — disconnect must not touch a user-owned channel.
   }
 
   // Capture the full `config.tools` shape AFTER all merge mutations (profile +
-  // alsoAllow). Unmerge uses this as a deep-equal ownership check: if the user
-  // has edited anything under `tools` since our merge, we leave our mutations
-  // alone rather than risk clobbering the surrounding section. Always overwrite
-  // on re-merge — unlike `previousToolsProfile` (first-wins to preserve the
-  // ORIGINAL user value), this snapshot tracks our LATEST output, so re-running
-  // stays idempotent because merge always produces the same post-merge shape
-  // from the same inputs.
-  if (adapterEntryForCapture) {
+  // alsoAllow) — but ONLY when this pass actually mutated `config.tools`.
+  // Unmerge uses this as a deep-equal ownership check: if the user has edited
+  // anything under `tools` since our last write, we leave our mutations alone.
+  //
+  // Gating on `mutatedTools` matters for the re-run case where an earlier merge
+  // set `profile: "full"` + captured the snapshot, the user later changed the
+  // profile to `"minimal"` and added other `tools.*` fields, and now setup runs
+  // again: our profile block no longer mutates (respects "minimal"), alsoAllow
+  // is already present (no push), so we don't touch `config.tools` at all. If
+  // we unconditionally overwrote `mergedToolsShape` with the user's current
+  // tools shape, unmerge would then see a perfect deep-equal match and revert
+  // `previousToolsProfile` — silently clobbering the user's "minimal" choice.
+  // Keeping the snapshot at the PRIOR adapter output means unmerge's deep-equal
+  // fails (correct ownership: user now owns the section) and the revert is
+  // skipped. On the no-op first merge (tools.profile already "full" + alsoAllow
+  // already present), no snapshot is captured at all — also correct, because we
+  // never took ownership of the section.
+  if (mutatedTools && adapterEntryForCapture) {
     adapterEntryForCapture.mergedToolsShape = structuredClone(config.tools);
   }
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -633,6 +633,23 @@ describe('mergeOpenClawConfig', () => {
     expect(secondRun).toBe(firstRun);
     expect(secondBackupCount).toBe(firstBackupCount);
   });
+
+  // PR #250 review comment 2 — keep top-level channels.dkg-ui.port in sync with
+  // the adapter entry's own config.channel.port so the plugin doesn't end up
+  // looking at two different ports in two different places.
+  it('channels.dkg-ui.port: derives from entryConfig.channel.port when provided', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true, port: 9300 },
+    } as AdapterEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -861,6 +878,91 @@ describe('unmergeOpenClawConfig', () => {
     const result = unmergeOpenClawConfig(configPath);
 
     expect(result.previousMemorySlotOwner).toBeUndefined();
+  });
+
+  // PR #250 review comment 1 — round-trip restoration of tools.profile +
+  // channels.dkg-ui. Without these, a connect→disconnect cycle would leave
+  // openclaw.json permanently widened.
+  it('round-trip: absent tools.profile + absent channels.dkg-ui → merge → unmerge restores absent', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    // After merge: both keys are now present.
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.tools.profile).toBe('full');
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+
+    unmergeOpenClawConfig(configPath);
+
+    // After unmerge: both keys are gone.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.tools?.profile).toBeUndefined();
+    expect(afterUnmerge.channels?.['dkg-ui']).toBeUndefined();
+  });
+
+  it('round-trip: "coding" profile + degenerate { enabled: true } channel → merge → unmerge restores prior values', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'coding' },
+      channels: { 'dkg-ui': { enabled: true } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    // After merge: profile upgraded, channel port added.
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.tools.profile).toBe('full');
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+
+    unmergeOpenClawConfig(configPath);
+
+    // After unmerge: both restored to pre-merge shape.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.tools.profile).toBe('coding');
+    expect(afterUnmerge.channels['dkg-ui']).toEqual({ enabled: true });
+  });
+
+  it('round-trip: explicit "minimal" profile preserved through merge + unmerge', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'minimal' },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    // Merge leaves "minimal" alone — no capture, no mutation.
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.tools.profile).toBe('minimal');
+
+    unmergeOpenClawConfig(configPath);
+
+    // Unmerge still leaves "minimal" alone — nothing to restore, we never captured.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.tools.profile).toBe('minimal');
+  });
+
+  it('round-trip: user-customized channels.dkg-ui (non-enabled key) preserved through merge + unmerge', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      channels: { 'dkg-ui': { enabled: true, port: 9999, customField: 'user-owned' } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    // Merge leaves the user channel alone — no capture, no mutation.
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9999, customField: 'user-owned' });
+
+    unmergeOpenClawConfig(configPath);
+
+    // Unmerge still leaves it alone.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9999, customField: 'user-owned' });
   });
 });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -1048,10 +1048,34 @@ describe('unmergeOpenClawConfig', () => {
 
     unmergeOpenClawConfig(configPath);
 
-    // After unmerge: both keys are gone.
+    // After unmerge: both keys are gone, and the channels container is also
+    // removed (not left as `channels: {}`) so the round-trip returns the
+    // config to its pre-merge shape.
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.tools?.profile).toBeUndefined();
+    expect(afterUnmerge.channels).toBeUndefined();
+  });
+
+  it('round-trip: pre-existing sibling channel preserved when channels.dkg-ui is removed on unmerge', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      channels: { telegram: { enabled: true, botToken: 'abc' } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    // After merge: telegram still present, dkg-ui added.
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.channels.telegram).toEqual({ enabled: true, botToken: 'abc' });
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+
+    unmergeOpenClawConfig(configPath);
+
+    // After unmerge: dkg-ui gone, telegram preserved, channels container retained.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.channels?.['dkg-ui']).toBeUndefined();
+    expect(afterUnmerge.channels?.telegram).toEqual({ enabled: true, botToken: 'abc' });
   });
 
   it('round-trip: "coding" profile + degenerate { enabled: true } channel → merge → unmerge restores prior values', () => {

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -1078,6 +1078,30 @@ describe('unmergeOpenClawConfig', () => {
     expect(afterUnmerge.channels?.telegram).toEqual({ enabled: true, botToken: 'abc' });
   });
 
+  it('merge: respects user-disabled channel on adapter entry (does not silently re-enable)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    // User has explicitly disabled the channel on the adapter entry.
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: { channel: { enabled: false, port: 9201 } },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    // Entry-level enabled=false is preserved by first-wins merge.
+    expect(afterMerge.plugins.entries['adapter-openclaw'].config.channel.enabled).toBe(false);
+    // Top-level channels.dkg-ui MUST honor the user's disable — we only add the
+    // `port` key here so OpenClaw's meaningful-config check still fires.
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: false, port: 9201 });
+  });
+
   it('round-trip: "coding" profile + degenerate { enabled: true } channel → merge → unmerge restores prior values', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -683,6 +683,54 @@ describe('mergeOpenClawConfig', () => {
     expect(config.plugins.entries['adapter-openclaw'].config.channel.port).toBe(9300);
     expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
   });
+
+  // PR #250 review comment 7 — after a first merge, the channel is strictly
+  // adapter-owned (byte-identical to mergedChannelsDkgUi). A re-run with a
+  // different port must refresh the top-level channel, not leave the stale
+  // port in place. The strict user-edit guard from comment 3 shouldn't
+  // prevent adapter-owned refresh.
+  it('re-merge refreshes channels.dkg-ui.port when the channel still matches last merge output', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    // First merge with default entryConfig → creates { enabled: true, port: 9201 }.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterFirst.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
+
+    // Simulate the user (or a later setup run) updating the adapter entry's
+    // channel port to 9300 directly on the entry config.
+    afterFirst.plugins.entries['adapter-openclaw'].config.channel.port = 9300;
+    writeFileSync(configPath, JSON.stringify(afterFirst, null, 2) + '\n');
+
+    // Re-merge with default entryConfig (no port) — first-wins preserves 9300
+    // on the entry, and the adapter-owned channel should refresh to match.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterSecond.plugins.entries['adapter-openclaw'].config.channel.port).toBe(9300);
+    expect(afterSecond.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
+    // mergedChannelsDkgUi tracks the latest adapter output.
+    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
+  });
+
+  it('re-merge idempotency: unchanged adapter-owned channel produces byte-identical JSON', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const firstRun = readFileSync(configPath, 'utf-8');
+    const firstBackups = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
+
+    // Re-run with identical state — the refresh branch must be a no-op.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const secondRun = readFileSync(configPath, 'utf-8');
+    const secondBackups = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
+
+    expect(secondRun).toBe(firstRun);
+    expect(secondBackups).toBe(firstBackups);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1083,6 +1131,51 @@ describe('unmergeOpenClawConfig', () => {
     // output.
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9500, foo: 'bar' });
+  });
+
+  // PR #250 review comment 8 — mergedToolsShape snapshot gates tools.profile
+  // revert on the full `tools` section being untouched. User edits anywhere
+  // under `tools` mean the whole section is user-owned; we leave it alone.
+  it('round-trip: user adds unrelated tools field post-merge → unmerge preserves profile', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.tools.profile).toBe('full');
+
+    // Simulate user adding an unrelated tools field — profile stays "full".
+    const userEdited = {
+      ...afterMerge,
+      tools: { ...afterMerge.tools, web: { enabled: false } },
+    };
+    writeFileSync(configPath, JSON.stringify(userEdited, null, 2) + '\n');
+
+    unmergeOpenClawConfig(configPath);
+
+    // Profile stays "full" — the tools section diverges from mergedToolsShape
+    // (it has a new `web` field), so we treat the whole section as user-owned.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.tools.profile).toBe('full');
+    expect(afterUnmerge.tools.web).toEqual({ enabled: false });
+  });
+
+  it('round-trip: unchanged tools section → unmerge reverts "coding" profile', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'coding' },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.tools.profile).toBe('full');
+
+    // No post-merge edits — tools matches mergedToolsShape → revert runs.
+    unmergeOpenClawConfig(configPath);
+
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.tools.profile).toBe('coding');
   });
 });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -650,6 +650,39 @@ describe('mergeOpenClawConfig', () => {
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
   });
+
+  // PR #250 review comment 6 — on re-runs, the adapter entry's existing port
+  // wins (first-wins) over the incoming default. The top-level channel must
+  // match the preserved entry port, not the incoming fallback 9201.
+  it('channels.dkg-ui.port: uses preserved entry.config.channel.port on re-merge even when incoming entryConfig has no port', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              daemonUrl: 'http://127.0.0.1:9200',
+              memory: { enabled: true },
+              channel: { enabled: true, port: 9300 },
+            },
+          },
+        },
+      },
+    }));
+
+    // Incoming entryConfig has no port — first-wins preserves the existing 9300
+    // on the adapter entry, and the top-level channel should inherit it.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true },
+    } as AdapterEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.channel.port).toBe(9300);
+    expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -963,6 +996,93 @@ describe('unmergeOpenClawConfig', () => {
     // Unmerge still leaves it alone.
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9999, customField: 'user-owned' });
+  });
+
+  // PR #250 review comment 3 — post-merge user edits must be preserved by
+  // unmerge. The ownership check is strict deep-equal against the exact shape
+  // merge wrote; any divergence means the user now owns the channel.
+  it('round-trip: user adds field to merge-created channel → unmerge preserves user edit', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    // Seed: no channels.dkg-ui at all.
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+
+    // Simulate the user adding an auth block after merge.
+    const userEdited = {
+      ...afterMerge,
+      channels: {
+        ...afterMerge.channels,
+        'dkg-ui': { ...afterMerge.channels['dkg-ui'], auth: { token: 'xyz' } },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(userEdited, null, 2) + '\n');
+
+    unmergeOpenClawConfig(configPath);
+
+    // User's edit survives — disconnect saw that the channel no longer matches
+    // what merge wrote, so it left the channel entirely alone.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.channels['dkg-ui']).toEqual({
+      enabled: true,
+      port: 9201,
+      auth: { token: 'xyz' },
+    });
+  });
+
+  it('round-trip: user changes port on merge-created channel → unmerge preserves user port', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+
+    // User changes the port.
+    const userEdited = {
+      ...afterMerge,
+      channels: { ...afterMerge.channels, 'dkg-ui': { enabled: true, port: 9500 } },
+    };
+    writeFileSync(configPath, JSON.stringify(userEdited, null, 2) + '\n');
+
+    unmergeOpenClawConfig(configPath);
+
+    // Port 9500 survives — it's not the shape merge wrote.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9500 });
+  });
+
+  it('round-trip: user edits degenerate-upgraded channel → unmerge preserves user edit', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    // Seed: degenerate channel that merge upgrades by adding a port.
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      channels: { 'dkg-ui': { enabled: true } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterMerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterMerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+
+    // User edits post-merge — changes port and adds a field.
+    const userEdited = {
+      ...afterMerge,
+      channels: {
+        ...afterMerge.channels,
+        'dkg-ui': { enabled: true, port: 9500, foo: 'bar' },
+      },
+    };
+    writeFileSync(configPath, JSON.stringify(userEdited, null, 2) + '\n');
+
+    unmergeOpenClawConfig(configPath);
+
+    // The user's shape survives — disconnect did NOT restore the original
+    // `{ enabled: true }` because the current channel diverges from the merge
+    // output.
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.channels['dkg-ui']).toEqual({ enabled: true, port: 9500, foo: 'bar' });
   });
 });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -731,6 +731,77 @@ describe('mergeOpenClawConfig', () => {
     expect(secondRun).toBe(firstRun);
     expect(secondBackups).toBe(firstBackups);
   });
+
+  // PR #250 review comment 9 — `mergedChannelsDkgUi` must refresh on EVERY
+  // channel write, not just the first-wins capture path. Re-creation or
+  // re-upgrade at a different port on a subsequent merge needs the snapshot
+  // to follow, otherwise unmerge's deep-equal ownership check fails and the
+  // adapter-owned channel is left behind on disconnect.
+  it('re-create after user deletion: mergedChannelsDkgUi tracks the NEW port, previousChannelsDkgUi stays first-wins', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    // First merge at port 9201.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true, port: 9201 },
+    } as AdapterEntryConfig, defaultInstalledWorkspace);
+
+    const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterFirst.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toBeNull();
+    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
+
+    // Simulate user deleting channels.dkg-ui. Also reset entry port so
+    // post-merge resolution picks 9300.
+    delete afterFirst.channels['dkg-ui'];
+    afterFirst.plugins.entries['adapter-openclaw'].config.channel.port = 9300;
+    writeFileSync(configPath, JSON.stringify(afterFirst, null, 2) + '\n');
+
+    // Re-merge: must re-create at 9300 and refresh mergedChannelsDkgUi.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterSecond.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
+    // `previousChannelsDkgUi` stays first-wins (original absent → `null`).
+    expect(afterSecond.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toBeNull();
+    // `mergedChannelsDkgUi` tracks the LATEST output (9300, not stale 9201).
+    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
+  });
+
+  it('re-upgrade degenerate channel: mergedChannelsDkgUi tracks the NEW port, previousChannelsDkgUi stays first-wins', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    // Seed: degenerate channel so the first merge captures
+    // previousChannelsDkgUi = { enabled: true } (first-wins).
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      channels: { 'dkg-ui': { enabled: true } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true, port: 9201 },
+    } as AdapterEntryConfig, defaultInstalledWorkspace);
+
+    const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterFirst.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toEqual({ enabled: true });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9201 });
+
+    // Simulate user stripping channel back to degenerate + bumping entry port.
+    afterFirst.channels['dkg-ui'] = { enabled: true };
+    afterFirst.plugins.entries['adapter-openclaw'].config.channel.port = 9300;
+    writeFileSync(configPath, JSON.stringify(afterFirst, null, 2) + '\n');
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterSecond.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
+    // first-wins preserves the original degenerate shape.
+    expect(afterSecond.plugins.entries['adapter-openclaw'].previousChannelsDkgUi).toEqual({ enabled: true });
+    // Latest-output snapshot follows the new port.
+    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedChannelsDkgUi).toEqual({ enabled: true, port: 9300 });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1176,6 +1247,86 @@ describe('unmergeOpenClawConfig', () => {
 
     const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(afterUnmerge.tools.profile).toBe('coding');
+  });
+
+  // PR #250 review comment 10 — mergedToolsShape must refresh ONLY when this
+  // merge pass actually mutated `config.tools`. Otherwise a re-merge that
+  // respects a later user choice (e.g. profile changed to "minimal") would
+  // overwrite the snapshot with the user's current shape, causing unmerge's
+  // deep-equal to match and silently revert `previousToolsProfile`.
+  it('re-merge after user switches to "minimal": mergedToolsShape stays at prior output, unmerge preserves "minimal"', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'coding' },
+    }));
+
+    // First merge: upgrades "coding" → "full" and captures mergedToolsShape.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterFirst = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterFirst.tools.profile).toBe('full');
+    expect(afterFirst.plugins.entries['adapter-openclaw'].mergedToolsShape)
+      .toEqual({ alsoAllow: ['group:plugins'], profile: 'full' });
+    expect(afterFirst.plugins.entries['adapter-openclaw'].previousToolsProfile).toBe('coding');
+
+    // User switches to "minimal" and adds a post-merge field.
+    afterFirst.tools = { profile: 'minimal', alsoAllow: ['group:plugins'], web: { enabled: false } };
+    writeFileSync(configPath, JSON.stringify(afterFirst, null, 2) + '\n');
+
+    // Re-merge: "minimal" is respected (no profile mutation), alsoAllow already
+    // present (no push). mutatedTools stays false, so the snapshot is NOT
+    // overwritten with the current user shape.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const afterSecond = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterSecond.tools.profile).toBe('minimal');
+    // Snapshot still reflects the FIRST merge's output, not the user's current shape.
+    expect(afterSecond.plugins.entries['adapter-openclaw'].mergedToolsShape)
+      .toEqual({ alsoAllow: ['group:plugins'], profile: 'full' });
+
+    // Unmerge: current tools (`minimal`, with `web` field) ≠ snapshot (`full`)
+    // → deep-equal fails → profile revert is skipped → user's "minimal" survives.
+    unmergeOpenClawConfig(configPath);
+    const afterUnmerge = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(afterUnmerge.tools.profile).toBe('minimal');
+    expect(afterUnmerge.tools.web).toEqual({ enabled: false });
+  });
+
+  it('first-merge no-op on settled tools: mergedToolsShape is NOT captured when nothing was mutated', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    // Config already has profile: "full" and alsoAllow includes "group:plugins".
+    // Merge has nothing to do under `config.tools` — should not capture a snapshot.
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'full', alsoAllow: ['group:plugins'] },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.tools.profile).toBe('full');
+    // No mutation ⇒ no capture. previousToolsProfile also stays absent.
+    expect(config.plugins.entries['adapter-openclaw'].mergedToolsShape).toBeUndefined();
+    expect('previousToolsProfile' in config.plugins.entries['adapter-openclaw']).toBe(false);
+  });
+
+  it('re-merge idempotency on settled tools: snapshot once captured, not re-written on no-op re-merge', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    // First merge creates the settled state + captures the snapshot.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const firstRun = readFileSync(configPath, 'utf-8');
+    const firstBackups = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
+
+    // Second merge: tools is already settled — no mutation should occur.
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const secondRun = readFileSync(configPath, 'utf-8');
+    const secondBackups = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
+
+    // Byte-identical output proves mergedToolsShape wasn't re-written with a
+    // (possibly differently-ordered) new structuredClone.
+    expect(secondRun).toBe(firstRun);
+    expect(secondBackups).toBe(firstBackups);
   });
 });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -524,6 +524,115 @@ describe('mergeOpenClawConfig', () => {
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.entries['adapter-openclaw'].config.daemonUrl).toBe('http://127.0.0.1:9400');
   });
+
+  // PR A — tools.profile patch. Ensures plugin-registered `dkg_*` tools are
+  // visible to the agent by upgrading the common default `"coding"` profile
+  // (whose allowlist filters out plugin tools) to `"full"`, while respecting
+  // explicit restrictive profiles ("minimal", "messaging").
+  it('tools.profile: upgrades "coding" → "full"', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'coding' },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.tools.profile).toBe('full');
+  });
+
+  it('tools.profile: respects explicit "minimal" (no change)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'minimal' },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.tools.profile).toBe('minimal');
+  });
+
+  it('tools.profile: respects explicit "messaging" (no change)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      tools: { profile: 'messaging' },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.tools.profile).toBe('messaging');
+  });
+
+  it('tools.profile: sets "full" when absent', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.tools.profile).toBe('full');
+  });
+
+  // PR A — channels.dkg-ui patch. Without at least one non-`enabled` key on
+  // the channel entry, OpenClaw's loader demotes the plugin to setup-runtime
+  // mode where `api.registerTool` is a noop. A port pin is the cheapest
+  // non-`enabled` key that satisfies `hasMeaningfulChannelConfigShallow`.
+  it('channels.dkg-ui: creates { enabled: true, port: 9201 } when missing', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+  });
+
+  it('channels.dkg-ui: adds port to degenerate { enabled: true }', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      channels: { 'dkg-ui': { enabled: true } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9201 });
+  });
+
+  it('channels.dkg-ui: preserves existing user port (no change)', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {},
+      channels: { 'dkg-ui': { enabled: true, port: 9300 } },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.channels['dkg-ui']).toEqual({ enabled: true, port: 9300 });
+  });
+
+  it('is idempotent on tools.profile + channels.dkg-ui — byte-identical output on second run', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const firstRun = readFileSync(configPath, 'utf-8');
+    const firstBackupCount = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', defaultEntryConfig, defaultInstalledWorkspace);
+    const secondRun = readFileSync(configPath, 'utf-8');
+    const secondBackupCount = readdirSync(testDir).filter((f: string) => f.startsWith('openclaw.json.bak.')).length;
+
+    expect(secondRun).toBe(firstRun);
+    expect(secondBackupCount).toBe(firstBackupCount);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

On npm-installed OpenClaw gateways, the DKG adapter's `dkg_*` tools were invisible to the agent. `mergeOpenClawConfig()` now patches two additional keys in `openclaw.json` so a freshly-installed adapter registers tools end-to-end.

## Root cause

Two config-driven gates filter plugin-registered tools out on a default OpenClaw install:

1. **`tools.profile`** — `"coding"` (OpenClaw's common default) uses the `CORE_TOOL_PROFILES` allowlist which excludes plugin-registered tools (`openclaw/src/plugins/registry.ts:1150`). Even when the plugin loads in full runtime, `dkg_*` tools get filtered out at resolve time.

2. **`channels.dkg-ui`** — V10's `openclaw.plugin.json` declares `"channels": ["dkg-ui"]`. OpenClaw's loader at `openclaw/src/plugins/loader.ts:816` demotes any declared-channel plugin to `setup-runtime` mode unless the user's `openclaw.json` has a `channels.<channel>` entry with at least one non-`enabled` key (the `hasMeaningfulChannelConfigShallow` check at `openclaw/src/config/channel-configured-shared.ts:21`). In `setup-runtime` mode, `api.registerTool` is wired to a noop — the plugin executes, but zero tools land.

User verified empirically that setting both keys makes all 13 `dkg_*` tools visible to Sentinel.

This replaces PR #249, which was based on the wrong premise that toggling our own `fullRuntime`→`runtimeEnabled` flag would fix it. It cannot: the demotion to `setup-runtime` happens before our code gets to register anything.

## What changed

In `packages/adapter-openclaw/src/setup.ts` → `mergeOpenClawConfig()`, right after the existing `tools.alsoAllow: ["group:plugins"]` block (added in commit `ae5667b3`):

**`tools.profile` patch**
- Absent → set `"full"`
- `"coding"` → upgrade to `"full"` (with explicit upgrade log line)
- `"minimal"` / `"messaging"` / anything else → respect as intentional (user can re-expand with `alsoAllow`)

**`channels.dkg-ui` patch**
- Missing → create `{ enabled: true, port: 9201 }`
- Degenerate `{ enabled: true }` → add `port: 9201` (satisfies `hasMeaningfulChannelConfigShallow`)
- Already has any non-`enabled` key (user-customized port, etc.) → leave untouched

Both patches are idempotent: a second run produces byte-identical JSON with no new `.bak` file.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw build` — passes
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test` — 306/308 pass (308 tests total, +8 from this PR). One pre-existing RED test K-9 (`plugin.id` vs `package.json.name`, deliberately red until reconciled) unrelated to this PR; one skipped pre-existing.
- [x] 8 new test cases in `test/setup.test.ts`:
  1. `tools.profile`: upgrades `"coding"` → `"full"`
  2. `tools.profile`: respects explicit `"minimal"` (no change)
  3. `tools.profile`: respects explicit `"messaging"` (no change)
  4. `tools.profile`: sets `"full"` when absent
  5. `channels.dkg-ui`: creates `{ enabled: true, port: 9201 }` when missing
  6. `channels.dkg-ui`: adds port to degenerate `{ enabled: true }`
  7. `channels.dkg-ui`: preserves existing user port (`9300`)
  8. Idempotency: both patches produce byte-identical JSON on second run

### End-to-end verification (post-merge)

Once merged + auto-published to npm, reinstall `@origintrail-official/dkg` fresh:

1. Run `openclaw gateway run --force` (or equivalent).
2. Check `~/.openclaw/openclaw.json`:
   ```bash
   jq '.tools.profile, .channels["dkg-ui"]' ~/.openclaw/openclaw.json
   ```
   Expect `"full"` and `{ "enabled": true, "port": 9201 }`.
3. Ask Sentinel-equivalent agent: *"List all `dkg_*` tools."* Expect 13 entries.
4. Run `dkg_status` — expects valid response (proves full-runtime registration succeeded).

## Notes for reviewers

- Preflight guards (`verifyMemorySlotInvariants` etc.) already in `mergeOpenClawConfig` are untouched.
- This PR is the blocker for PR B (tool surface expansion, assigned to `tool-surface-extender`) and PR C (SKILL.md tool-vs-HTTP docs).
- PR #249 (`fix/adapter-openclaw-tool-registration-setup-runtime`) should be closed with a comment pointing to this PR.