### PR TITLE
feat(adapter-openclaw): expose `view` on dkg_query to match HTTP surface

### DIFF
--- a/packages/adapter-openclaw/src/DkgMemoryPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgMemoryPlugin.ts
@@ -673,10 +673,16 @@ function errorMessage(err: unknown): string {
  * string and finds nothing. Normalize once at the boundary and use
  * the correct form at each consumption site. Codex Bug B43.
  */
-const AGENT_DID_PREFIX = 'did:dkg:agent:';
+export const AGENT_DID_PREFIX = 'did:dkg:agent:';
 
-/** Return the raw peer-ID form used for WM view routing. */
-function toAgentPeerId(agentAddress: string): string {
+/**
+ * Return the raw peer-ID form used for WM view routing. Exported so
+ * `DkgNodePlugin.handleQuery` can apply the same B43 normalization
+ * before forwarding `agent_address` / the node peerId fallback to the
+ * daemon (DID-form values otherwise route to a non-existent namespace
+ * and return empty results).
+ */
+export function toAgentPeerId(agentAddress: string): string {
   return agentAddress.startsWith(AGENT_DID_PREFIX)
     ? agentAddress.slice(AGENT_DID_PREFIX.length)
     : agentAddress;

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1121,10 +1121,12 @@ export class DkgNodePlugin {
       {
         name: 'dkg_query',
         description:
-          'Read-only SPARQL query against the local triple store (cross-assertion / cross-CG). Use ' +
-          '`GRAPH ?g { ... }` for named graphs. Pass `view` to pick which memory layer to read: ' +
-          '`working-memory` (WM — per-agent), `shared-working-memory` (SWM — gossip-replicated), ' +
-          'or `verified-memory` (VM — on-chain anchored). Omit `view` for the default (WM semantics).',
+          'Read-only SPARQL query against the local triple store. Pass `view` to pick which memory ' +
+          'layer to read: `working-memory` (WM — per-agent), `shared-working-memory` (SWM — gossip-' +
+          'replicated), or `verified-memory` (VM — on-chain anchored); when `view` is supplied, ' +
+          '`context_graph_id` is required. Omit `view` for a cross-graph query routed via the legacy ' +
+          'data-graph path (unscoped, or scoped when `context_graph_id` is set); use `GRAPH ?g { ... }` ' +
+          'for named-graph targeting in that mode.',
         parameters: {
           type: 'object',
           properties: {
@@ -1134,9 +1136,10 @@ export class DkgNodePlugin {
               type: 'string',
               enum: ['working-memory', 'shared-working-memory', 'verified-memory'],
               description:
-                'Memory layer to read. `working-memory` is the default when omitted; ' +
-                '`shared-working-memory` reads provisional gossip-replicated data; ' +
-                '`verified-memory` reads on-chain anchored data.',
+                'Memory layer to read. `working-memory` is per-agent WM (requires the daemon to ' +
+                'resolve caller identity); `shared-working-memory` reads provisional gossip-replicated ' +
+                'data; `verified-memory` reads on-chain anchored data. Omit to use the legacy cross-' +
+                'graph data-path routing (not layer-scoped).',
             },
           },
           required: ['sparql'],
@@ -1477,10 +1480,17 @@ export class DkgNodePlugin {
       // explicit layers) and gives callers access to VM reads, which the old
       // boolean could never express. Reject the legacy field loudly rather
       // than silently ignoring it, so stale code surfaces the rename instead
-      // of quietly dropping its intent.
+      // of quietly dropping its intent. The error message doesn't recommend a
+      // specific view: the old `true` maps to SWM reads while `false` mapped
+      // to the legacy data-graph routing (omit `view` entirely), so a single
+      // replacement string would flip semantics for half of callers. Name all
+      // three layers and let the caller pick the one matching their intent.
       if (args.include_shared_memory !== undefined) {
         return this.error(
-          '"include_shared_memory" is no longer supported. Use `view: "shared-working-memory"` instead.',
+          '"include_shared_memory" is no longer supported. Pick a memory layer explicitly with ' +
+            '`view`: "working-memory" | "shared-working-memory" | "verified-memory". To preserve ' +
+            'the legacy `include_shared_memory: true` behavior, use `view: "shared-working-memory"`; ' +
+            'to preserve `include_shared_memory: false`, omit `view` entirely.',
         );
       }
       // `context_graph_id` is optional on this tool (omit → unscoped query

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1122,13 +1122,13 @@ export class DkgNodePlugin {
         name: 'dkg_query',
         description:
           'Read-only SPARQL query against the local triple store. Pass `view` to pick which memory ' +
-          'layer to read: `shared-working-memory` (SWM — gossip-replicated) or `verified-memory` (VM ' +
-          '— on-chain anchored); when `view` is supplied, `context_graph_id` is also required. Omit ' +
-          '`view` for a cross-graph query routed via the legacy data-graph path (unscoped, or scoped ' +
-          'when `context_graph_id` is set); use `GRAPH ?g { ... }` for named-graph targeting in that ' +
-          'mode. Working-memory (WM) reads are per-agent and require an `agentAddress` the tool has ' +
-          'no way to plumb safely — call POST `/api/query` directly with `view: "working-memory"` ' +
-          'and the caller identity if you need WM.',
+          'layer to read: `working-memory` (WM — per-agent), `shared-working-memory` (SWM — gossip-' +
+          'replicated), or `verified-memory` (VM — on-chain anchored); when `view` is supplied, ' +
+          '`context_graph_id` is also required. For WM reads, `agent_address` selects whose WM to ' +
+          'read — it defaults to this node\'s agent address (the same default the adapter uses for ' +
+          'memory-plugin reads). Omit `view` for a cross-graph query routed via the legacy data-' +
+          'graph path (unscoped, or scoped when `context_graph_id` is set); use `GRAPH ?g { ... }` ' +
+          'for named-graph targeting in that mode.',
         parameters: {
           type: 'object',
           properties: {
@@ -1142,13 +1142,20 @@ export class DkgNodePlugin {
             view: {
               type: 'string',
               description:
-                'Memory layer to read. Accepted values: `shared-working-memory` (provisional, ' +
-                'gossip-replicated) or `verified-memory` (on-chain anchored). Omit to use the legacy ' +
-                'cross-graph data-path routing (not layer-scoped). `working-memory` is intentionally ' +
-                'not accepted here — it needs an `agentAddress` this tool has no way to plumb safely; ' +
-                'use HTTP POST /api/query with an agent-scoped bearer token for WM reads. ' +
-                'Validation is handler-side (not a JSON-schema enum) so strict-schema hosts still ' +
-                'surface the tailored migration guidance on invalid values.',
+                'Memory layer to read. Accepted values: `working-memory` (per-agent WM; uses ' +
+                '`agent_address` or falls back to this node\'s agent address), `shared-working-memory` ' +
+                '(provisional, gossip-replicated), or `verified-memory` (on-chain anchored). Omit to ' +
+                'use the legacy cross-graph data-path routing (not layer-scoped). Validation is ' +
+                'handler-side (not a JSON-schema enum) so strict-schema hosts still surface the ' +
+                'tailored migration guidance on invalid values.',
+            },
+            agent_address: {
+              type: 'string',
+              description:
+                "Optional target for `view: \"working-memory\"` reads — defaults to this node's " +
+                'agent address (matches the default the memory plugin uses for its own WM reads). ' +
+                'Ignored for non-WM views. Supply an explicit value to read another local agent\'s ' +
+                'WM namespace in multi-agent deployments.',
             },
           },
           required: ['sparql'],
@@ -1508,26 +1515,13 @@ export class DkgNodePlugin {
       // matching a CG whose id is the literal whitespace string.
       const trimmed = typeof args.context_graph_id === 'string' ? args.context_graph_id.trim() : '';
       const contextGraphId = trimmed || undefined;
-      // Schema declares `view` as an enum. Accept only the two valid layer
-      // strings — anything else is a typo/misuse and rejected with the list
-      // of valid options. `working-memory` is intentionally NOT accepted
-      // here: the daemon requires `agentAddress` for WM reads (see
-      // `resolveViewGraphs`), and this tool has no safe way to plumb caller
-      // identity — so admitting WM would silently fall back to the node's
-      // peerId namespace and return the wrong agent's data. Callers who
-      // truly need WM must use HTTP `/api/query` with an explicit
-      // `agentAddress` + agent-scoped bearer token.
-      const VALID_VIEWS = ['shared-working-memory', 'verified-memory'] as const;
+      // Handler-side view validation (no JSON-schema enum, so strict-schema
+      // hosts surface these tailored errors). Valid values mirror the three
+      // layers of the daemon's GET_VIEWS.
+      const VALID_VIEWS = ['working-memory', 'shared-working-memory', 'verified-memory'] as const;
       type View = (typeof VALID_VIEWS)[number];
       let view: View | undefined;
       if (args.view !== undefined) {
-        if (args.view === 'working-memory') {
-          return this.error(
-            '"view: working-memory" is not supported by this tool. WM reads require an explicit ' +
-              '`agentAddress` to target the right agent namespace — use HTTP POST /api/query ' +
-              'directly with `view: "working-memory"` and `agentAddress`.',
-          );
-        }
         if (typeof args.view !== 'string' || !(VALID_VIEWS as readonly string[]).includes(args.view)) {
           return this.error(
             `"view" must be one of: ${VALID_VIEWS.join(', ')}.`,
@@ -1546,9 +1540,32 @@ export class DkgNodePlugin {
             'single CG; omit `view` for an unscoped cross-graph query.',
         );
       }
+      // For WM reads the daemon requires an agentAddress (see
+      // `resolveViewGraphs:60`). Accept an explicit `agent_address` on the
+      // tool and fall back to this node's agent address — the same default
+      // the memory plugin uses for its own WM reads (see
+      // `memorySessionResolver.getDefaultAgentAddress` above). Without the
+      // fallback, callers without an explicit address would get "agentAddress
+      // is required for the working-memory view" from the engine.
+      let agentAddress = typeof args.agent_address === 'string' && args.agent_address.trim() !== ''
+        ? args.agent_address.trim()
+        : undefined;
+      if (view === 'working-memory' && agentAddress === undefined) {
+        if (this.nodePeerId === undefined) {
+          await this.ensureNodePeerId().catch(() => {});
+        }
+        agentAddress = this.nodePeerId;
+        if (agentAddress === undefined) {
+          return this.error(
+            '"view: working-memory" requires an agent identity. Supply `agent_address` explicitly, ' +
+              "or retry once the node's agent address is available.",
+          );
+        }
+      }
       const result = await this.client.query(sparql, {
         contextGraphId,
         view,
+        agentAddress,
       });
       return this.json(result);
     } catch (err: any) {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -23,6 +23,7 @@ import {
 import { DkgChannelPlugin } from './DkgChannelPlugin.js';
 import {
   DkgMemoryPlugin,
+  toAgentPeerId,
   type DkgMemorySession,
   type DkgMemorySessionResolver,
 } from './DkgMemoryPlugin.js';
@@ -1547,6 +1548,14 @@ export class DkgNodePlugin {
       // `memorySessionResolver.getDefaultAgentAddress` above). Without the
       // fallback, callers without an explicit address would get "agentAddress
       // is required for the working-memory view" from the engine.
+      //
+      // B43: normalize DID-form addresses (`did:dkg:agent:<peerId>`) to raw
+      // peer IDs for WM routing, same as `DkgMemoryPlugin` does at its
+      // boundary. The daemon's WM view scopes graphs by the bare peer ID;
+      // forwarding a DID-prefixed value lands the query in a non-existent
+      // namespace and returns empty bindings. Apply to both the explicit
+      // arg and the node-peerId fallback (the latter is typically already
+      // bare, but normalize defensively in case the source ever changes).
       let agentAddress = typeof args.agent_address === 'string' && args.agent_address.trim() !== ''
         ? args.agent_address.trim()
         : undefined;
@@ -1561,6 +1570,9 @@ export class DkgNodePlugin {
               "or retry once the node's agent address is available.",
           );
         }
+      }
+      if (view === 'working-memory' && agentAddress !== undefined) {
+        agentAddress = toAgentPeerId(agentAddress);
       }
       const result = await this.client.query(sparql, {
         contextGraphId,

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -15,6 +15,7 @@
  *     (`POST /api/assertion/create` + `POST /api/assertion/:name/write`),
  *     which the agent reads from `GET /.well-known/skill.md` on startup.
  */
+import { GET_VIEWS, type GetView } from '@origintrail-official/dkg-core';
 import {
   DkgDaemonClient,
   type LocalAgentIntegrationRecord,
@@ -1517,18 +1518,18 @@ export class DkgNodePlugin {
       const trimmed = typeof args.context_graph_id === 'string' ? args.context_graph_id.trim() : '';
       const contextGraphId = trimmed || undefined;
       // Handler-side view validation (no JSON-schema enum, so strict-schema
-      // hosts surface these tailored errors). Valid values mirror the three
-      // layers of the daemon's GET_VIEWS.
-      const VALID_VIEWS = ['working-memory', 'shared-working-memory', 'verified-memory'] as const;
-      type View = (typeof VALID_VIEWS)[number];
-      let view: View | undefined;
+      // hosts still surface these tailored errors). Use the shared
+      // `GET_VIEWS` constant from `@origintrail-official/dkg-core` as the
+      // single source of truth — maintaining a local mirror invited drift
+      // whenever a view was added/removed upstream.
+      let view: GetView | undefined;
       if (args.view !== undefined) {
-        if (typeof args.view !== 'string' || !(VALID_VIEWS as readonly string[]).includes(args.view)) {
+        if (typeof args.view !== 'string' || !(GET_VIEWS as readonly string[]).includes(args.view)) {
           return this.error(
-            `"view" must be one of: ${VALID_VIEWS.join(', ')}.`,
+            `"view" must be one of: ${GET_VIEWS.join(', ')}.`,
           );
         }
-        view = args.view as View;
+        view = args.view as GetView;
       }
       // When a `view` is requested, the daemon requires `context_graph_id`
       // to scope the view resolution (`DKGQueryEngine.query` throws
@@ -1556,17 +1557,21 @@ export class DkgNodePlugin {
       // namespace and returns empty bindings. Apply to both the explicit
       // arg and the node-peerId fallback (the latter is typically already
       // bare, but normalize defensively in case the source ever changes).
-      // Strict type check on `agent_address`: a non-string (e.g. number
-      // passed through by a permissive host) must fail fast, not silently
-      // fall through to the node-peerId default. Otherwise a caller
-      // intending a cross-agent WM read but with a malformed value would
-      // get the node's own WM back — wrong namespace, wrong data, no
-      // error. Only distinguish "absent" from "malformed": undefined means
-      // "use the default"; any other non-string is a caller bug.
-      if (args.agent_address !== undefined && typeof args.agent_address !== 'string') {
-        return this.error('"agent_address" must be a string.');
+      // Strict validation on `agent_address`: anything *present but bogus*
+      // (non-string, or empty/whitespace-only) must fail fast, not silently
+      // fall through to the node-peerId default. A caller intending a
+      // cross-agent WM read with a malformed value would otherwise get the
+      // node's own WM back — wrong namespace, wrong data, no error.
+      // `undefined` (field genuinely absent) still takes the default.
+      if (args.agent_address !== undefined) {
+        if (typeof args.agent_address !== 'string') {
+          return this.error('"agent_address" must be a string.');
+        }
+        if (args.agent_address.trim() === '') {
+          return this.error('"agent_address" must be a non-empty string.');
+        }
       }
-      let agentAddress = typeof args.agent_address === 'string' && args.agent_address.trim() !== ''
+      let agentAddress = typeof args.agent_address === 'string'
         ? args.agent_address.trim()
         : undefined;
       if (view === 'working-memory' && agentAddress === undefined) {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1141,12 +1141,14 @@ export class DkgNodePlugin {
             },
             view: {
               type: 'string',
-              enum: ['shared-working-memory', 'verified-memory'],
               description:
-                'Memory layer to read. `shared-working-memory` reads provisional gossip-replicated ' +
-                'data; `verified-memory` reads on-chain anchored data. Omit to use the legacy cross-' +
-                'graph data-path routing (not layer-scoped). Working-memory is intentionally not in ' +
-                'this enum — it needs an agentAddress not exposed on this tool; use HTTP for WM.',
+                'Memory layer to read. Accepted values: `shared-working-memory` (provisional, ' +
+                'gossip-replicated) or `verified-memory` (on-chain anchored). Omit to use the legacy ' +
+                'cross-graph data-path routing (not layer-scoped). `working-memory` is intentionally ' +
+                'not accepted here — it needs an `agentAddress` this tool has no way to plumb safely; ' +
+                'use HTTP POST /api/query with an agent-scoped bearer token for WM reads. ' +
+                'Validation is handler-side (not a JSON-schema enum) so strict-schema hosts still ' +
+                'surface the tailored migration guidance on invalid values.',
             },
           },
           required: ['sparql'],

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1122,24 +1122,31 @@ export class DkgNodePlugin {
         name: 'dkg_query',
         description:
           'Read-only SPARQL query against the local triple store. Pass `view` to pick which memory ' +
-          'layer to read: `working-memory` (WM — per-agent), `shared-working-memory` (SWM — gossip-' +
-          'replicated), or `verified-memory` (VM — on-chain anchored); when `view` is supplied, ' +
-          '`context_graph_id` is required. Omit `view` for a cross-graph query routed via the legacy ' +
-          'data-graph path (unscoped, or scoped when `context_graph_id` is set); use `GRAPH ?g { ... }` ' +
-          'for named-graph targeting in that mode.',
+          'layer to read: `shared-working-memory` (SWM — gossip-replicated) or `verified-memory` (VM ' +
+          '— on-chain anchored); when `view` is supplied, `context_graph_id` is also required. Omit ' +
+          '`view` for a cross-graph query routed via the legacy data-graph path (unscoped, or scoped ' +
+          'when `context_graph_id` is set); use `GRAPH ?g { ... }` for named-graph targeting in that ' +
+          'mode. Working-memory (WM) reads are per-agent and require an `agentAddress` the tool has ' +
+          'no way to plumb safely — call POST `/api/query` directly with `view: "working-memory"` ' +
+          'and the caller identity if you need WM.',
         parameters: {
           type: 'object',
           properties: {
             sparql: { type: 'string', description: 'SPARQL SELECT, CONSTRUCT, ASK, or DESCRIBE.' },
-            context_graph_id: { type: 'string', description: 'Optional CG scope — omit to query all subscribed CGs.' },
+            context_graph_id: {
+              type: 'string',
+              description:
+                'CG scope. Optional when `view` is omitted (unscoped cross-graph query); required ' +
+                'when `view` is set (view-based routing always targets a single CG).',
+            },
             view: {
               type: 'string',
-              enum: ['working-memory', 'shared-working-memory', 'verified-memory'],
+              enum: ['shared-working-memory', 'verified-memory'],
               description:
-                'Memory layer to read. `working-memory` is per-agent WM (requires the daemon to ' +
-                'resolve caller identity); `shared-working-memory` reads provisional gossip-replicated ' +
+                'Memory layer to read. `shared-working-memory` reads provisional gossip-replicated ' +
                 'data; `verified-memory` reads on-chain anchored data. Omit to use the legacy cross-' +
-                'graph data-path routing (not layer-scoped).',
+                'graph data-path routing (not layer-scoped). Working-memory is intentionally not in ' +
+                'this enum — it needs an agentAddress not exposed on this tool; use HTTP for WM.',
             },
           },
           required: ['sparql'],
@@ -1475,22 +1482,22 @@ export class DkgNodePlugin {
       if (args.paranet_id !== undefined) {
         return this.error('"paranet_id" is not a supported parameter. Use "context_graph_id".');
       }
-      // `include_shared_memory` was removed in favor of `view` — the latter
-      // mirrors the HTTP `/api/query` surface (WM / SWM / VM as three
-      // explicit layers) and gives callers access to VM reads, which the old
-      // boolean could never express. Reject the legacy field loudly rather
-      // than silently ignoring it, so stale code surfaces the rename instead
-      // of quietly dropping its intent. The error message doesn't recommend a
-      // specific view: the old `true` maps to SWM reads while `false` mapped
-      // to the legacy data-graph routing (omit `view` entirely), so a single
-      // replacement string would flip semantics for half of callers. Name all
-      // three layers and let the caller pick the one matching their intent.
+      // `include_shared_memory` was removed in favor of `view`. There is no
+      // one-line replacement: the legacy `true` path unioned the data graph
+      // with SWM (`DKGQueryEngine.query`, line ~229 — wraps the sparql in
+      // both graphs and merges), while `false` used the legacy data-graph
+      // path alone. `view: "shared-working-memory"` reads ONLY SWM and
+      // would drop data-graph-only triples for `true` callers; `view:
+      // "verified-memory"` has different semantics entirely. Surface the
+      // break explicitly rather than pretending a clean migration exists.
       if (args.include_shared_memory !== undefined) {
         return this.error(
-          '"include_shared_memory" is no longer supported. Pick a memory layer explicitly with ' +
-            '`view`: "working-memory" | "shared-working-memory" | "verified-memory". To preserve ' +
-            'the legacy `include_shared_memory: true` behavior, use `view: "shared-working-memory"`; ' +
-            'to preserve `include_shared_memory: false`, omit `view` entirely.',
+          '"include_shared_memory" is no longer supported. There is no exact `view` replacement ' +
+            'for the legacy union-semantics: `true` previously queried the data graph ∪ SWM ' +
+            '(no single `view` reproduces this union). Closest-intent replacements: omit `view` ' +
+            'for the legacy data-graph path, or `view: "shared-working-memory"` for SWM-only, or ' +
+            '`view: "verified-memory"` for on-chain data. If you need the original union exactly, ' +
+            'call POST /api/query directly with `includeSharedMemory: true`.',
         );
       }
       // `context_graph_id` is optional on this tool (omit → unscoped query
@@ -1499,19 +1506,43 @@ export class DkgNodePlugin {
       // matching a CG whose id is the literal whitespace string.
       const trimmed = typeof args.context_graph_id === 'string' ? args.context_graph_id.trim() : '';
       const contextGraphId = trimmed || undefined;
-      // Schema declares `view` as an enum. Accept only the three valid layer
+      // Schema declares `view` as an enum. Accept only the two valid layer
       // strings — anything else is a typo/misuse and rejected with the list
-      // of valid options, matching the daemon's 400 response shape.
-      const VALID_VIEWS = ['working-memory', 'shared-working-memory', 'verified-memory'] as const;
+      // of valid options. `working-memory` is intentionally NOT accepted
+      // here: the daemon requires `agentAddress` for WM reads (see
+      // `resolveViewGraphs`), and this tool has no safe way to plumb caller
+      // identity — so admitting WM would silently fall back to the node's
+      // peerId namespace and return the wrong agent's data. Callers who
+      // truly need WM must use HTTP `/api/query` with an explicit
+      // `agentAddress` + agent-scoped bearer token.
+      const VALID_VIEWS = ['shared-working-memory', 'verified-memory'] as const;
       type View = (typeof VALID_VIEWS)[number];
       let view: View | undefined;
       if (args.view !== undefined) {
+        if (args.view === 'working-memory') {
+          return this.error(
+            '"view: working-memory" is not supported by this tool. WM reads require an explicit ' +
+              '`agentAddress` to target the right agent namespace — use HTTP POST /api/query ' +
+              'directly with `view: "working-memory"` and `agentAddress`.',
+          );
+        }
         if (typeof args.view !== 'string' || !(VALID_VIEWS as readonly string[]).includes(args.view)) {
           return this.error(
             `"view" must be one of: ${VALID_VIEWS.join(', ')}.`,
           );
         }
         view = args.view as View;
+      }
+      // When a `view` is requested, the daemon requires `context_graph_id`
+      // to scope the view resolution (`DKGQueryEngine.query` throws
+      // "view '…' requires a contextGraphId"). Reject locally so the caller
+      // sees a clear, tool-shaped error instead of a cryptic 500 after a
+      // daemon round-trip.
+      if (view !== undefined && contextGraphId === undefined) {
+        return this.error(
+          `"view: ${view}" requires "context_graph_id". View-based routing always targets a ` +
+            'single CG; omit `view` for an unscoped cross-graph query.',
+        );
       }
       const result = await this.client.query(sparql, {
         contextGraphId,

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1556,6 +1556,16 @@ export class DkgNodePlugin {
       // namespace and returns empty bindings. Apply to both the explicit
       // arg and the node-peerId fallback (the latter is typically already
       // bare, but normalize defensively in case the source ever changes).
+      // Strict type check on `agent_address`: a non-string (e.g. number
+      // passed through by a permissive host) must fail fast, not silently
+      // fall through to the node-peerId default. Otherwise a caller
+      // intending a cross-agent WM read but with a malformed value would
+      // get the node's own WM back — wrong namespace, wrong data, no
+      // error. Only distinguish "absent" from "malformed": undefined means
+      // "use the default"; any other non-string is a caller bug.
+      if (args.agent_address !== undefined && typeof args.agent_address !== 'string') {
+        return this.error('"agent_address" must be a string.');
+      }
       let agentAddress = typeof args.agent_address === 'string' && args.agent_address.trim() !== ''
         ? args.agent_address.trim()
         : undefined;

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1122,15 +1122,21 @@ export class DkgNodePlugin {
         name: 'dkg_query',
         description:
           'Read-only SPARQL query against the local triple store (cross-assertion / cross-CG). Use ' +
-          '`GRAPH ?g { ... }` for named graphs.',
+          '`GRAPH ?g { ... }` for named graphs. Pass `view` to pick which memory layer to read: ' +
+          '`working-memory` (WM — per-agent), `shared-working-memory` (SWM — gossip-replicated), ' +
+          'or `verified-memory` (VM — on-chain anchored). Omit `view` for the default (WM semantics).',
         parameters: {
           type: 'object',
           properties: {
             sparql: { type: 'string', description: 'SPARQL SELECT, CONSTRUCT, ASK, or DESCRIBE.' },
             context_graph_id: { type: 'string', description: 'Optional CG scope — omit to query all subscribed CGs.' },
-            include_shared_memory: {
-              type: 'boolean',
-              description: 'Also search Shared Working Memory. Default: false.',
+            view: {
+              type: 'string',
+              enum: ['working-memory', 'shared-working-memory', 'verified-memory'],
+              description:
+                'Memory layer to read. `working-memory` is the default when omitted; ' +
+                '`shared-working-memory` reads provisional gossip-replicated data; ' +
+                '`verified-memory` reads on-chain anchored data.',
             },
           },
           required: ['sparql'],
@@ -1466,23 +1472,40 @@ export class DkgNodePlugin {
       if (args.paranet_id !== undefined) {
         return this.error('"paranet_id" is not a supported parameter. Use "context_graph_id".');
       }
+      // `include_shared_memory` was removed in favor of `view` — the latter
+      // mirrors the HTTP `/api/query` surface (WM / SWM / VM as three
+      // explicit layers) and gives callers access to VM reads, which the old
+      // boolean could never express. Reject the legacy field loudly rather
+      // than silently ignoring it, so stale code surfaces the rename instead
+      // of quietly dropping its intent.
+      if (args.include_shared_memory !== undefined) {
+        return this.error(
+          '"include_shared_memory" is no longer supported. Use `view: "shared-working-memory"` instead.',
+        );
+      }
       // `context_graph_id` is optional on this tool (omit → unscoped query
       // across all subscribed CGs). Trim whitespace so that
       // `{ context_graph_id: "   " }` behaves like an omission rather than
       // matching a CG whose id is the literal whitespace string.
       const trimmed = typeof args.context_graph_id === 'string' ? args.context_graph_id.trim() : '';
       const contextGraphId = trimmed || undefined;
-      // Schema declares include_shared_memory as boolean. If a caller supplies
-      // a string ("true") or any other non-boolean, reject it — silently
-      // coercing to `false` would make callers quietly miss SWM data they
-      // thought they were requesting.
-      if (args.include_shared_memory !== undefined && typeof args.include_shared_memory !== 'boolean') {
-        return this.error('"include_shared_memory" must be a boolean.');
+      // Schema declares `view` as an enum. Accept only the three valid layer
+      // strings — anything else is a typo/misuse and rejected with the list
+      // of valid options, matching the daemon's 400 response shape.
+      const VALID_VIEWS = ['working-memory', 'shared-working-memory', 'verified-memory'] as const;
+      type View = (typeof VALID_VIEWS)[number];
+      let view: View | undefined;
+      if (args.view !== undefined) {
+        if (typeof args.view !== 'string' || !(VALID_VIEWS as readonly string[]).includes(args.view)) {
+          return this.error(
+            `"view" must be one of: ${VALID_VIEWS.join(', ')}.`,
+          );
+        }
+        view = args.view as View;
       }
-      const includeSharedMemory = args.include_shared_memory === true;
       const result = await this.client.query(sparql, {
         contextGraphId,
-        includeSharedMemory: includeSharedMemory || undefined,
+        view,
       });
       return this.json(result);
     } catch (err: any) {

--- a/packages/adapter-openclaw/test/list-paranets.test.ts
+++ b/packages/adapter-openclaw/test/list-paranets.test.ts
@@ -297,19 +297,29 @@ describe('dkg_query tool', () => {
     expect(body.contextGraphId).toBeUndefined();
   });
 
-  it('passes view=shared-working-memory through to the daemon body', async () => {
+  it('passes view=shared-working-memory through to the daemon body (context_graph_id required with view)', async () => {
     ft.addResponses(
       new Response(JSON.stringify({ result: { bindings: [] } }), { status: 200 }),
     );
 
     const tool = findTool('dkg_query');
-    await tool.execute('call-3', { sparql: 'SELECT * WHERE { ?s ?p ?o }', view: 'shared-working-memory' });
+    await tool.execute('call-3', {
+      sparql: 'SELECT * WHERE { ?s ?p ?o }',
+      context_graph_id: 'my-cg',
+      view: 'shared-working-memory',
+    });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
     expect(body.view).toBe('shared-working-memory');
+    expect(body.contextGraphId).toBe('my-cg');
   });
 
-  it('omits view when not set (daemon applies the default WM semantics)', async () => {
+  it('omits view on the wire when not set (daemon then routes via the legacy data-graph path)', async () => {
+    // When `view` is absent, the daemon's DKGQueryEngine.query takes the
+    // "Legacy routing (V9 compat)" branch (see the `if (options?.view)`
+    // skip path), NOT working-memory semantics. The tool MUST forward
+    // the absence faithfully — a silent default here would change
+    // semantics for every caller that omits `view`.
     ft.addResponses(
       new Response(JSON.stringify({ result: { bindings: [] } }), { status: 200 }),
     );

--- a/packages/adapter-openclaw/test/list-paranets.test.ts
+++ b/packages/adapter-openclaw/test/list-paranets.test.ts
@@ -297,19 +297,19 @@ describe('dkg_query tool', () => {
     expect(body.contextGraphId).toBeUndefined();
   });
 
-  it('passes includeSharedMemory when include_shared_memory is true', async () => {
+  it('passes view=shared-working-memory through to the daemon body', async () => {
     ft.addResponses(
       new Response(JSON.stringify({ result: { bindings: [] } }), { status: 200 }),
     );
 
     const tool = findTool('dkg_query');
-    await tool.execute('call-3', { sparql: 'SELECT * WHERE { ?s ?p ?o }', include_shared_memory: true });
+    await tool.execute('call-3', { sparql: 'SELECT * WHERE { ?s ?p ?o }', view: 'shared-working-memory' });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
-    expect(body.includeSharedMemory).toBe(true);
+    expect(body.view).toBe('shared-working-memory');
   });
 
-  it('omits includeSharedMemory when include_shared_memory is not set', async () => {
+  it('omits view when not set (daemon applies the default WM semantics)', async () => {
     ft.addResponses(
       new Response(JSON.stringify({ result: { bindings: [] } }), { status: 200 }),
     );
@@ -318,7 +318,7 @@ describe('dkg_query tool', () => {
     await tool.execute('call-4', { sparql: 'SELECT * WHERE { ?s ?p ?o }' });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
-    expect(body.includeSharedMemory).toBeUndefined();
+    expect(body.view).toBeUndefined();
   });
 });
 

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -118,23 +118,31 @@ describe('DkgNodePlugin', () => {
     const subSchema = byName.get('dkg_subscribe')!.parameters.properties.include_shared_memory.type;
     expect(subSchema).toBe('boolean');
 
-    // dkg_query: `view` is an enum covering the two tool-safe layers of
-    // the daemon's GET_VIEWS. Working-memory is intentionally EXCLUDED —
-    // WM reads need an `agentAddress` this tool has no way to plumb
-    // safely (admitting WM would silently fall back to the node peerId
-    // namespace and return the wrong agent's data). Callers needing WM
-    // use HTTP `/api/query` directly. The legacy `include_shared_memory`
-    // boolean has been removed — there is no exact replacement because
-    // the old `true` path queried the data graph ∪ SWM (union), which
-    // no single `view` reproduces.
+    // dkg_query: `view` is a plain string — validation lives in the
+    // handler, not as a JSON-schema enum. Rationale: strict-schema
+    // hosts would reject invalid values (including `working-memory`,
+    // which we DO want to reach the handler so callers see the
+    // tailored "use HTTP for WM" guidance). Description enumerates
+    // accepted values for discoverability; handler enforces them.
+    // Working-memory is intentionally excluded from the accepted list
+    // — it needs an `agentAddress` this tool has no way to plumb
+    // safely (admitting WM would silently fall back to the node
+    // peerId namespace and return the wrong agent's data). Callers
+    // needing WM use HTTP `/api/query` directly. The legacy
+    // `include_shared_memory` boolean has been removed — there is
+    // no exact replacement because the old `true` path queried the
+    // data graph ∪ SWM (union), which no single `view` reproduces.
     const queryProps = byName.get('dkg_query')!.parameters.properties;
     expect(queryProps).not.toHaveProperty('include_shared_memory');
     expect(queryProps.view.type).toBe('string');
-    expect(queryProps.view.enum).toEqual([
-      'shared-working-memory',
-      'verified-memory',
-    ]);
-    expect(queryProps.view.enum).not.toContain('working-memory');
+    expect(queryProps.view).not.toHaveProperty('enum');
+    // Description must still advertise the accepted values + the WM
+    // escape hatch, so discoverability doesn't regress when the enum
+    // is dropped from the schema.
+    expect(queryProps.view.description).toContain('shared-working-memory');
+    expect(queryProps.view.description).toContain('verified-memory');
+    expect(queryProps.view.description).toContain('working-memory');
+    expect(queryProps.view.description).toContain('/api/query');
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -454,20 +454,33 @@ describe('DkgNodePlugin', () => {
       expect(result.content[0].text).toContain('context_graph_id');
     });
 
-    it('dkg_query rejects the legacy include_shared_memory field and points callers at `view`', async () => {
-      // The boolean was removed in favor of `view` (mirrors the HTTP surface
-      // and exposes VM reads, which the boolean could never express). Stale
-      // callers get a hard error naming the replacement instead of a silent
-      // drop that would quietly alter query results.
+    it('dkg_query rejects the legacy include_shared_memory field with a migration hint covering BOTH true and false cases', async () => {
+      // The boolean was removed in favor of `view`. A single replacement
+      // suggestion is unsafe: `include_shared_memory: true` mapped to
+      // "data-graph ∪ SWM" (closest to `view: "shared-working-memory"`),
+      // while `include_shared_memory: false` mapped to the legacy data-
+      // graph path (no view at all). A one-line hint that named only
+      // `shared-working-memory` would silently flip semantics for
+      // callers who previously sent `false`. Name all three layers AND
+      // the omit-entirely option, so callers with either legacy intent
+      // can migrate without changing behavior.
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
       const result = await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
         include_shared_memory: true,
       });
       expect(fetchMock).not.toHaveBeenCalled();
-      expect(result.content[0].text).toContain('include_shared_memory');
-      expect(result.content[0].text).toContain('view');
-      expect(result.content[0].text).toContain('shared-working-memory');
+      const msg = result.content[0].text;
+      expect(msg).toContain('include_shared_memory');
+      expect(msg).toContain('view');
+      // All three layers named so the caller can pick.
+      expect(msg).toContain('working-memory');
+      expect(msg).toContain('shared-working-memory');
+      expect(msg).toContain('verified-memory');
+      // Must also document the omit-`view` path for the former `false` case —
+      // otherwise callers who passed `include_shared_memory: false` will be
+      // steered toward `shared-working-memory` and get a different result.
+      expect(msg).toMatch(/omit/i);
     });
 
     it('dkg_query rejects an invalid `view` string with the list of valid layers', async () => {
@@ -481,6 +494,29 @@ describe('DkgNodePlugin', () => {
       expect(result.content[0].text).toContain('working-memory');
       expect(result.content[0].text).toContain('shared-working-memory');
       expect(result.content[0].text).toContain('verified-memory');
+    });
+
+    it('dkg_query description accurately describes the no-`view` routing (legacy path, not WM)', () => {
+      // Documented-vs-actual: when `view` is omitted, the daemon +
+      // DKGQueryEngine route through the legacy V9 data-graph path
+      // (`DKGQueryEngine.query` → the `if (options?.view)` branch is
+      // SKIPPED and falls through to "Legacy routing (V9 compat)"). It
+      // is NOT implicit working-memory semantics, despite some stale
+      // comments in the daemon hinting otherwise. This test guards the
+      // tool description against re-introducing the misleading "omit
+      // for WM" claim.
+      const plugin = new DkgNodePlugin();
+      const tools: OpenClawTool[] = [];
+      plugin.register({
+        config: {},
+        registerTool: (t) => tools.push(t),
+        registerHook: () => {},
+        on: () => {},
+        logger: {},
+      });
+      const query = tools.find((t) => t.name === 'dkg_query')!;
+      expect(query.description).not.toMatch(/omit.*WM|omit.*working-memory|default.*WM.*semantics|default.*working-memory/i);
+      expect(query.description).toMatch(/legacy/i);
     });
 
     it('dkg_query forwards the `view` field to the daemon body verbatim', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -120,29 +120,31 @@ describe('DkgNodePlugin', () => {
 
     // dkg_query: `view` is a plain string — validation lives in the
     // handler, not as a JSON-schema enum. Rationale: strict-schema
-    // hosts would reject invalid values (including `working-memory`,
-    // which we DO want to reach the handler so callers see the
-    // tailored "use HTTP for WM" guidance). Description enumerates
-    // accepted values for discoverability; handler enforces them.
-    // Working-memory is intentionally excluded from the accepted list
-    // — it needs an `agentAddress` this tool has no way to plumb
-    // safely (admitting WM would silently fall back to the node
-    // peerId namespace and return the wrong agent's data). Callers
-    // needing WM use HTTP `/api/query` directly. The legacy
-    // `include_shared_memory` boolean has been removed — there is
-    // no exact replacement because the old `true` path queried the
-    // data graph ∪ SWM (union), which no single `view` reproduces.
+    // hosts would otherwise reject typos at the boundary before the
+    // handler can surface the valid-list error. Description
+    // enumerates accepted values for discoverability; handler
+    // enforces them.
+    //
+    // WM reads are supported: the handler defaults `agent_address` to
+    // this node's peerId (matches the memory plugin's default from
+    // `memorySessionResolver.getDefaultAgentAddress`). Callers in
+    // multi-agent deployments can override with an explicit
+    // `agent_address`.
+    //
+    // The legacy `include_shared_memory` boolean is removed — there
+    // is no exact replacement because the old `true` path queried
+    // the data graph ∪ SWM (union), which no single `view` reproduces.
     const queryProps = byName.get('dkg_query')!.parameters.properties;
     expect(queryProps).not.toHaveProperty('include_shared_memory');
     expect(queryProps.view.type).toBe('string');
     expect(queryProps.view).not.toHaveProperty('enum');
-    // Description must still advertise the accepted values + the WM
-    // escape hatch, so discoverability doesn't regress when the enum
-    // is dropped from the schema.
+    // Description advertises all three layers.
+    expect(queryProps.view.description).toContain('working-memory');
     expect(queryProps.view.description).toContain('shared-working-memory');
     expect(queryProps.view.description).toContain('verified-memory');
-    expect(queryProps.view.description).toContain('working-memory');
-    expect(queryProps.view.description).toContain('/api/query');
+    // agent_address is exposed as an optional tool param for WM targeting.
+    expect(queryProps.agent_address.type).toBe('string');
+    expect(queryProps.agent_address.description).toMatch(/working-memory/i);
   });
 
   // ---------------------------------------------------------------------------
@@ -496,25 +498,24 @@ describe('DkgNodePlugin', () => {
       expect(msg).toMatch(/omit/i);
     });
 
-    it('dkg_query rejects `view: "working-memory"` with a pointer to HTTP for agent-scoped WM reads', async () => {
-      // WM reads require an `agentAddress` the tool has no way to plumb
-      // safely. Admitting WM would silently fall back to the node
-      // peerId namespace and return data from the wrong agent. Close
-      // the hole at the tool boundary.
+    it('dkg_query forwards an explicit agent_address to the daemon body for WM reads', async () => {
+      // WM reads are agent-scoped; the daemon requires an agentAddress.
+      // The tool exposes `agent_address` so multi-agent callers can
+      // target another agent's WM namespace.
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
-      const result = await byName.get('dkg_query')!.execute('tc', {
+      await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
         context_graph_id: 'my-cg',
         view: 'working-memory',
+        agent_address: '0xabc123',
       });
-      expect(fetchMock).not.toHaveBeenCalled();
-      const msg = result.content[0].text;
-      expect(msg).toContain('working-memory');
-      expect(msg).toContain('agentAddress');
-      expect(msg).toContain('/api/query');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+      expect(body.view).toBe('working-memory');
+      expect(body.agentAddress).toBe('0xabc123');
     });
 
-    it('dkg_query rejects an invalid `view` string with the list of valid layers (working-memory excluded)', async () => {
+    it('dkg_query rejects an invalid `view` string with the list of valid layers', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
       const result = await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
@@ -523,15 +524,9 @@ describe('DkgNodePlugin', () => {
       expect(fetchMock).not.toHaveBeenCalled();
       const text = result.content[0].text;
       expect(text).toContain('view');
+      expect(text).toContain('working-memory');
       expect(text).toContain('shared-working-memory');
       expect(text).toContain('verified-memory');
-      // Error must NOT advertise bare `working-memory` as an accepted value
-      // from this tool. Use a word-boundary regex (negative lookaround) so
-      // substrings inside `shared-working-memory` don't spoof the check,
-      // and so wording-only refactors of the error prefix don't break this
-      // test. The contract is "bare working-memory does not appear anywhere
-      // in the error" — regardless of how the list is framed.
-      expect(text).not.toMatch(/(?<![-a-z])working-memory(?![-a-z])/);
     });
 
     it('dkg_query rejects a `view` without `context_graph_id` locally (no daemon round-trip)', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -515,6 +515,42 @@ describe('DkgNodePlugin', () => {
       expect(body.agentAddress).toBe('0xabc123');
     });
 
+    it('dkg_query normalizes DID-form agent_address for WM reads (Bug B43)', async () => {
+      // The daemon's WM view scopes graphs by the bare peer ID. A
+      // DID-prefixed value (`did:dkg:agent:<peerId>`) lands the query
+      // in a non-existent namespace and returns empty bindings. The
+      // handler must strip the prefix before forwarding — same B43
+      // normalization `DkgMemoryPlugin` applies at its boundary.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        context_graph_id: 'my-cg',
+        view: 'working-memory',
+        agent_address: 'did:dkg:agent:12D3KooWExamplePeerId',
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+      expect(body.agentAddress).toBe('12D3KooWExamplePeerId');
+      // Bare peer IDs must pass through unchanged (no double-stripping).
+      expect(body.agentAddress).not.toContain('did:dkg:agent:');
+    });
+
+    it('dkg_query does NOT normalize agent_address on non-WM views (it only matters for WM routing)', async () => {
+      // Non-WM views don't use `agentAddress` for graph resolution —
+      // leave the value untouched so other downstream uses (e.g. audit
+      // logging at the daemon) see the caller's original input.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        context_graph_id: 'my-cg',
+        view: 'shared-working-memory',
+        agent_address: 'did:dkg:agent:12D3KooWExamplePeerId',
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+      expect(body.agentAddress).toBe('did:dkg:agent:12D3KooWExamplePeerId');
+    });
+
     it('dkg_query rejects an invalid `view` string with the list of valid layers', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
       const result = await byName.get('dkg_query')!.execute('tc', {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -515,6 +515,45 @@ describe('DkgNodePlugin', () => {
       expect(body.agentAddress).toBe('0xabc123');
     });
 
+    it('dkg_query rejects a whitespace-only agent_address (same silent-namespace-swap risk as non-string)', async () => {
+      // An explicitly-supplied whitespace string is still "caller meant
+      // something here" — treating `"   "` as "missing" and defaulting
+      // to `this.nodePeerId` would silently swap a cross-agent read for
+      // a self-read, same failure mode as the non-string case.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      const result = await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        context_graph_id: 'my-cg',
+        view: 'working-memory',
+        agent_address: '   ',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('agent_address');
+      expect(result.content[0].text).toMatch(/non-empty|empty/i);
+    });
+
+    it('dkg_query `view` validation uses the shared GET_VIEWS from dkg-core (no local mirror)', async () => {
+      // Guard against the local VALID_VIEWS mirror being reintroduced.
+      // When a view is added to core's GET_VIEWS but the adapter
+      // maintains its own list, the tool silently rejects the new
+      // view before the daemon can serve it. The handler must use
+      // the shared constant so this class of drift can't happen.
+      //
+      // We verify behavior (not import graph): the error message lists
+      // exactly the three views core publishes today, and a v9-removed
+      // view is rejected.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      const result = await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        view: 'authoritative', // a REMOVED_VIEWS entry from core
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      const text = result.content[0].text;
+      expect(text).toContain('working-memory');
+      expect(text).toContain('shared-working-memory');
+      expect(text).toContain('verified-memory');
+    });
+
     it('dkg_query rejects a non-string agent_address instead of silently falling back to the node peerId', async () => {
       // Permissive hosts can pass through non-string values. If the
       // handler treated those as "missing", `view: "working-memory"`

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -515,6 +515,25 @@ describe('DkgNodePlugin', () => {
       expect(body.agentAddress).toBe('0xabc123');
     });
 
+    it('dkg_query rejects a non-string agent_address instead of silently falling back to the node peerId', async () => {
+      // Permissive hosts can pass through non-string values. If the
+      // handler treated those as "missing", `view: "working-memory"`
+      // would default to this node's peerId — a caller intending a
+      // cross-agent WM read with a malformed value would silently get
+      // the node's own WM back. Surface the bug instead: reject with
+      // a clear type-error, don't leak namespaces.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      const result = await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        context_graph_id: 'my-cg',
+        view: 'working-memory',
+        agent_address: 12345,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('agent_address');
+      expect(result.content[0].text).toContain('string');
+    });
+
     it('dkg_query normalizes DID-form agent_address for WM reads (Bug B43)', async () => {
       // The daemon's WM view scopes graphs by the bare peer ID. A
       // DID-prefixed value (`did:dkg:agent:<peerId>`) lands the query

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -113,13 +113,22 @@ describe('DkgNodePlugin', () => {
     expect(writeTool.parameters.properties.quads.type).toBe('array');
     expect(writeTool.parameters.properties.quads.items).toBeDefined();
 
-    // dkg_subscribe / dkg_query `include_shared_memory` is boolean-only.
-    // V10-rc is the first product release — no v9 back-compat in the public
-    // tool surface, so the schema and handler only accept the boolean form.
+    // dkg_subscribe: `include_shared_memory` is boolean-only (subscribe is a
+    // catch-up/sync flag, not a memory-layer selector).
     const subSchema = byName.get('dkg_subscribe')!.parameters.properties.include_shared_memory.type;
-    const querySchema = byName.get('dkg_query')!.parameters.properties.include_shared_memory.type;
     expect(subSchema).toBe('boolean');
-    expect(querySchema).toBe('boolean');
+
+    // dkg_query: `view` is an enum mirroring the daemon's GET_VIEWS. The
+    // legacy `include_shared_memory` boolean has been removed — agents pick
+    // the memory layer explicitly (WM / SWM / VM), matching the HTTP surface.
+    const queryProps = byName.get('dkg_query')!.parameters.properties;
+    expect(queryProps).not.toHaveProperty('include_shared_memory');
+    expect(queryProps.view.type).toBe('string');
+    expect(queryProps.view.enum).toEqual([
+      'working-memory',
+      'shared-working-memory',
+      'verified-memory',
+    ]);
   });
 
   // ---------------------------------------------------------------------------
@@ -445,19 +454,50 @@ describe('DkgNodePlugin', () => {
       expect(result.content[0].text).toContain('context_graph_id');
     });
 
-    it('dkg_query rejects a stringified include_shared_memory instead of silently coercing to false', async () => {
-      // Schema declares include_shared_memory as boolean. A permissive host
-      // might still pass `"true"` through. If we silently coerced it to
-      // `false`, the caller would miss SWM data they thought they were
-      // requesting — a worse failure mode than a loud error.
+    it('dkg_query rejects the legacy include_shared_memory field and points callers at `view`', async () => {
+      // The boolean was removed in favor of `view` (mirrors the HTTP surface
+      // and exposes VM reads, which the boolean could never express). Stale
+      // callers get a hard error naming the replacement instead of a silent
+      // drop that would quietly alter query results.
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
       const result = await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
-        include_shared_memory: 'true',
+        include_shared_memory: true,
       });
       expect(fetchMock).not.toHaveBeenCalled();
       expect(result.content[0].text).toContain('include_shared_memory');
-      expect(result.content[0].text).toContain('boolean');
+      expect(result.content[0].text).toContain('view');
+      expect(result.content[0].text).toContain('shared-working-memory');
+    });
+
+    it('dkg_query rejects an invalid `view` string with the list of valid layers', async () => {
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      const result = await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        view: 'long-term-memory', // a v9 view name, removed in v10
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('view');
+      expect(result.content[0].text).toContain('working-memory');
+      expect(result.content[0].text).toContain('shared-working-memory');
+      expect(result.content[0].text).toContain('verified-memory');
+    });
+
+    it('dkg_query forwards the `view` field to the daemon body verbatim', async () => {
+      // Handler-level drift guard: the daemon's /api/query route destructures
+      // `view` from the body. If we renamed the field in the handler, this
+      // test catches the drift.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        context_graph_id: 'my-cg',
+        view: 'verified-memory',
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+      expect(body.view).toBe('verified-memory');
+      expect(body.contextGraphId).toBe('my-cg');
+      expect(body).not.toHaveProperty('includeSharedMemory');
     });
 
     it('dkg_subscribe rejects a stringified include_shared_memory (same rationale as dkg_query)', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -118,17 +118,23 @@ describe('DkgNodePlugin', () => {
     const subSchema = byName.get('dkg_subscribe')!.parameters.properties.include_shared_memory.type;
     expect(subSchema).toBe('boolean');
 
-    // dkg_query: `view` is an enum mirroring the daemon's GET_VIEWS. The
-    // legacy `include_shared_memory` boolean has been removed — agents pick
-    // the memory layer explicitly (WM / SWM / VM), matching the HTTP surface.
+    // dkg_query: `view` is an enum covering the two tool-safe layers of
+    // the daemon's GET_VIEWS. Working-memory is intentionally EXCLUDED —
+    // WM reads need an `agentAddress` this tool has no way to plumb
+    // safely (admitting WM would silently fall back to the node peerId
+    // namespace and return the wrong agent's data). Callers needing WM
+    // use HTTP `/api/query` directly. The legacy `include_shared_memory`
+    // boolean has been removed — there is no exact replacement because
+    // the old `true` path queried the data graph ∪ SWM (union), which
+    // no single `view` reproduces.
     const queryProps = byName.get('dkg_query')!.parameters.properties;
     expect(queryProps).not.toHaveProperty('include_shared_memory');
     expect(queryProps.view.type).toBe('string');
     expect(queryProps.view.enum).toEqual([
-      'working-memory',
       'shared-working-memory',
       'verified-memory',
     ]);
+    expect(queryProps.view.enum).not.toContain('working-memory');
   });
 
   // ---------------------------------------------------------------------------
@@ -454,16 +460,14 @@ describe('DkgNodePlugin', () => {
       expect(result.content[0].text).toContain('context_graph_id');
     });
 
-    it('dkg_query rejects the legacy include_shared_memory field with a migration hint covering BOTH true and false cases', async () => {
-      // The boolean was removed in favor of `view`. A single replacement
-      // suggestion is unsafe: `include_shared_memory: true` mapped to
-      // "data-graph ∪ SWM" (closest to `view: "shared-working-memory"`),
-      // while `include_shared_memory: false` mapped to the legacy data-
-      // graph path (no view at all). A one-line hint that named only
-      // `shared-working-memory` would silently flip semantics for
-      // callers who previously sent `false`. Name all three layers AND
-      // the omit-entirely option, so callers with either legacy intent
-      // can migrate without changing behavior.
+    it('dkg_query rejects the legacy include_shared_memory field with a hint that names the union-semantics break', async () => {
+      // The boolean was removed in favor of `view`. There is NO
+      // one-line replacement: legacy `true` unioned the data graph with
+      // SWM (engine wraps sparql in both and merges), which no single
+      // `view` reproduces. `view: "shared-working-memory"` reads only
+      // SWM and silently drops data-graph triples for `true` callers.
+      // The hint must surface this break explicitly and name the HTTP
+      // escape hatch for callers who need the exact union.
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
       const result = await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
@@ -473,17 +477,36 @@ describe('DkgNodePlugin', () => {
       const msg = result.content[0].text;
       expect(msg).toContain('include_shared_memory');
       expect(msg).toContain('view');
-      // All three layers named so the caller can pick.
-      expect(msg).toContain('working-memory');
+      // Surface the non-equivalence.
+      expect(msg).toMatch(/no exact|no single `view`/i);
+      // Name the HTTP escape hatch for callers who need the original
+      // union semantics — otherwise they have no migration path at all.
+      expect(msg).toContain('/api/query');
+      expect(msg).toContain('includeSharedMemory');
+      // Also name the SWM closest-intent replacement + the omit path.
       expect(msg).toContain('shared-working-memory');
-      expect(msg).toContain('verified-memory');
-      // Must also document the omit-`view` path for the former `false` case —
-      // otherwise callers who passed `include_shared_memory: false` will be
-      // steered toward `shared-working-memory` and get a different result.
       expect(msg).toMatch(/omit/i);
     });
 
-    it('dkg_query rejects an invalid `view` string with the list of valid layers', async () => {
+    it('dkg_query rejects `view: "working-memory"` with a pointer to HTTP for agent-scoped WM reads', async () => {
+      // WM reads require an `agentAddress` the tool has no way to plumb
+      // safely. Admitting WM would silently fall back to the node
+      // peerId namespace and return data from the wrong agent. Close
+      // the hole at the tool boundary.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      const result = await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        context_graph_id: 'my-cg',
+        view: 'working-memory',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      const msg = result.content[0].text;
+      expect(msg).toContain('working-memory');
+      expect(msg).toContain('agentAddress');
+      expect(msg).toContain('/api/query');
+    });
+
+    it('dkg_query rejects an invalid `view` string with the list of valid layers (working-memory excluded)', async () => {
       const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
       const result = await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
@@ -491,9 +514,29 @@ describe('DkgNodePlugin', () => {
       });
       expect(fetchMock).not.toHaveBeenCalled();
       expect(result.content[0].text).toContain('view');
-      expect(result.content[0].text).toContain('working-memory');
       expect(result.content[0].text).toContain('shared-working-memory');
       expect(result.content[0].text).toContain('verified-memory');
+      // Error must NOT advertise bare `working-memory` as an accepted value —
+      // it's explicitly excluded from this tool's enum. Assert the exact
+      // valid-views list the handler emits, so substring matches inside
+      // `shared-working-memory` can't spoof this check.
+      expect(result.content[0].text).toContain('must be one of: shared-working-memory, verified-memory');
+    });
+
+    it('dkg_query rejects a `view` without `context_graph_id` locally (no daemon round-trip)', async () => {
+      // Engine throws "view '…' requires a contextGraphId" — catch it at
+      // the tool boundary so callers see a clean, tool-shaped error
+      // instead of a cryptic 500 from a round-trip.
+      const { fetchMock, byName } = setupPluginWithFetch({ ok: true });
+      const result = await byName.get('dkg_query')!.execute('tc', {
+        sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
+        view: 'shared-working-memory',
+        // context_graph_id intentionally omitted
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      const msg = result.content[0].text;
+      expect(msg).toContain('context_graph_id');
+      expect(msg).toContain('shared-working-memory');
     });
 
     it('dkg_query description accurately describes the no-`view` routing (legacy path, not WM)', () => {
@@ -515,8 +558,15 @@ describe('DkgNodePlugin', () => {
         logger: {},
       });
       const query = tools.find((t) => t.name === 'dkg_query')!;
-      expect(query.description).not.toMatch(/omit.*WM|omit.*working-memory|default.*WM.*semantics|default.*working-memory/i);
+      // Positive: description must call out the legacy routing for the omit case.
       expect(query.description).toMatch(/legacy/i);
+      // Negative: specifically guard against re-introducing the misleading
+      // "omit → WM default" phrasing. Use targeted substrings that would
+      // only appear in the wrong claim, not the correct HTTP escape-hatch
+      // sentence that mentions working-memory by name.
+      expect(query.description).not.toMatch(/omit[^.]*default[^.]*working-memory/i);
+      expect(query.description).not.toMatch(/default[^.]*WM semantics/i);
+      expect(query.description).not.toMatch(/Omit `?view`? for the default/i);
     });
 
     it('dkg_query forwards the `view` field to the daemon body verbatim', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -521,14 +521,17 @@ describe('DkgNodePlugin', () => {
         view: 'long-term-memory', // a v9 view name, removed in v10
       });
       expect(fetchMock).not.toHaveBeenCalled();
-      expect(result.content[0].text).toContain('view');
-      expect(result.content[0].text).toContain('shared-working-memory');
-      expect(result.content[0].text).toContain('verified-memory');
-      // Error must NOT advertise bare `working-memory` as an accepted value —
-      // it's explicitly excluded from this tool's enum. Assert the exact
-      // valid-views list the handler emits, so substring matches inside
-      // `shared-working-memory` can't spoof this check.
-      expect(result.content[0].text).toContain('must be one of: shared-working-memory, verified-memory');
+      const text = result.content[0].text;
+      expect(text).toContain('view');
+      expect(text).toContain('shared-working-memory');
+      expect(text).toContain('verified-memory');
+      // Error must NOT advertise bare `working-memory` as an accepted value
+      // from this tool. Use a word-boundary regex (negative lookaround) so
+      // substrings inside `shared-working-memory` don't spoof the check,
+      // and so wording-only refactors of the error prefix don't break this
+      // test. The contract is "bare working-memory does not appear anywhere
+      // in the error" — regardless of how the list is framed.
+      expect(text).not.toMatch(/(?<![-a-z])working-memory(?![-a-z])/);
     });
 
     it('dkg_query rejects a `view` without `context_graph_id` locally (no daemon round-trip)', async () => {


### PR DESCRIPTION
## Summary

Align the `dkg_query` tool with the HTTP `/api/query` surface by exposing `view: 'working-memory' | 'shared-working-memory' | 'verified-memory'` instead of the `include_shared_memory: boolean` shorthand.

The boolean could only pick between WM and SWM — it had no way to read **Verified Memory** (on-chain anchored). The `view` enum mirrors `GET_VIEWS` from `@origintrail-official/dkg-core` exactly and matches the shape the daemon already accepts on `POST /api/query`.

## Changes

- `dkg_query` schema: replace `include_shared_memory` (boolean) with `view` (enum). Description names all three layers.
- Handler: reject the legacy `include_shared_memory` field with an error naming the replacement (`view: "shared-working-memory"`). Consistent with how we already handle the `paranet_id` → `context_graph_id` rename from PR #254.
- Handler: validate `view` against the three valid layers; reject anything else (e.g. v9's removed `long-term-memory`) with the list of valid options — matches the daemon's 400 response shape.
- `dkg_subscribe` keeps `include_shared_memory` — it's a catch-up sync flag there, not a memory-layer selector. Different semantic surface.

## Test plan

- [x] 60 unit tests in `packages/adapter-openclaw/test/plugin.test.ts` pass (up from 58)
- [x] New: `view` round-trip drift guard (body contains `view`, no `includeSharedMemory`)
- [x] New: `view` validation rejects `long-term-memory` with all three valid layers named
- [x] New: legacy `include_shared_memory` rejection points callers at the replacement
- [x] `tsc --noEmit` clean
- [x] `list-paranets.test.ts` subscribe tests still pass (subscribe surface unchanged)
- [ ] Manual: restart gateway, run `dkg_query` from Sentinel with `view: "verified-memory"`, confirm VM-only results returned

## Rationale

V10 is the first product launch — no v9 back-compat. Since PR #254 just merged with the boolean form, this is the right moment to replace it with the expressive layer selector before any downstream SKILL.md docs ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)