### PR TITLE
fix(adapter-openclaw): resolve dkg CLI absolute path for daemon start

### DIFF
--- a/packages/adapter-openclaw/src/resolve-dkg-cli.ts
+++ b/packages/adapter-openclaw/src/resolve-dkg-cli.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve the DKG CLI entrypoint so setup can invoke `dkg start` without
+ * depending on shell PATH resolution.
+ *
+ * Context: `pnpm dkg openclaw setup` in a cloned monorepo does not put the
+ * `dkg` bin on PATH for child processes, so `execSync('dkg start')` fails
+ * with "dkg: not found". Global installs and `pnpm exec dkg ...` do put it
+ * on PATH. This resolver produces an absolute entrypoint that works in all
+ * three contexts, and is spawned via `process.execPath` (node) so that
+ * Windows — which does not honor `.js` shebangs — works the same as POSIX.
+ *
+ * Resolution order:
+ *   1. `DKG_CLI_PATH` env var — explicit override.
+ *   2. `require.resolve('@origintrail-official/dkg')` — works when the CLI
+ *      package is resolvable from adapter-openclaw (global install).
+ *   3. `process.argv[1]` — when the adapter runs inside the CLI process,
+ *      argv[1] is the CLI entrypoint itself. This handles `pnpm dkg ...`.
+ */
+
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { basename } from 'node:path';
+
+export interface ResolvedDkgCli {
+  /** Absolute path to the node executable to spawn. */
+  node: string;
+  /** Absolute path to the CLI entrypoint JS file. */
+  cliPath: string;
+}
+
+export function resolveDkgCli(): ResolvedDkgCli {
+  const node = process.execPath;
+
+  const override = process.env.DKG_CLI_PATH;
+  if (override && override.trim().length > 0) {
+    if (!existsSync(override)) {
+      throw new Error(
+        `DKG_CLI_PATH is set to "${override}" but that file does not exist.`,
+      );
+    }
+    return { node, cliPath: override };
+  }
+
+  try {
+    const require = createRequire(import.meta.url);
+    const cliPath = require.resolve('@origintrail-official/dkg');
+    if (existsSync(cliPath)) {
+      return { node, cliPath };
+    }
+  } catch { /* fall through to argv[1] */ }
+
+  const argv1 = process.argv[1];
+  if (argv1 && basename(argv1) === 'cli.js' && existsSync(argv1)) {
+    return { node, cliPath: argv1 };
+  }
+
+  throw new Error(
+    'Could not resolve the DKG CLI entrypoint. ' +
+    'Set DKG_CLI_PATH to the absolute path of the CLI (e.g. ' +
+    '/path/to/packages/cli/dist/cli.js) and try again.',
+  );
+}

--- a/packages/adapter-openclaw/src/resolve-dkg-cli.ts
+++ b/packages/adapter-openclaw/src/resolve-dkg-cli.ts
@@ -11,15 +11,20 @@
  *
  * Resolution order:
  *   1. `DKG_CLI_PATH` env var — explicit override.
- *   2. `require.resolve('@origintrail-official/dkg')` — works when the CLI
- *      package is resolvable from adapter-openclaw (global install).
- *   3. `process.argv[1]` — when the adapter runs inside the CLI process,
+ *   2. `require.resolve('@origintrail-official/dkg')` — fast path when the
+ *      CLI package is resolvable from adapter-openclaw's node_modules scope.
+ *   3. `resolveCliPackageDir()` + `dist/cli.js` — covers monorepo dev,
+ *      local install, and global install via `npm prefix -g`. Required
+ *      because standalone `npm i -g @origintrail-official/dkg-adapter-openclaw`
+ *      installs the adapter without the CLI as a dep, so (2) fails.
+ *   4. `process.argv[1]` — when the adapter runs inside the CLI process,
  *      argv[1] is the CLI entrypoint itself. This handles `pnpm dkg ...`.
  */
 
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { basename } from 'node:path';
+import { basename, join } from 'node:path';
+import { resolveCliPackageDir } from './setup.js';
 
 export interface ResolvedDkgCli {
   /** Absolute path to the node executable to spawn. */
@@ -47,7 +52,20 @@ export function resolveDkgCli(): ResolvedDkgCli {
     if (existsSync(cliPath)) {
       return { node, cliPath };
     }
-  } catch { /* fall through to argv[1] */ }
+  } catch (err: any) {
+    if (err?.code !== 'MODULE_NOT_FOUND' && err?.code !== 'ERR_MODULE_NOT_FOUND') {
+      throw err;
+    }
+    // fall through to the next resolution arm
+  }
+
+  const pkgDir = resolveCliPackageDir();
+  if (pkgDir) {
+    const cliPath = join(pkgDir, 'dist', 'cli.js');
+    if (existsSync(cliPath)) {
+      return { node, cliPath };
+    }
+  }
 
   const argv1 = process.argv[1];
   if (argv1 && basename(argv1) === 'cli.js' && existsSync(argv1)) {
@@ -55,8 +73,11 @@ export function resolveDkgCli(): ResolvedDkgCli {
   }
 
   throw new Error(
-    'Could not resolve the DKG CLI entrypoint. ' +
-    'Set DKG_CLI_PATH to the absolute path of the CLI (e.g. ' +
-    '/path/to/packages/cli/dist/cli.js) and try again.',
+    'Could not resolve the DKG CLI entrypoint. Tried DKG_CLI_PATH, ' +
+    "require.resolve('@origintrail-official/dkg'), resolveCliPackageDir() " +
+    '+ dist/cli.js, and process.argv[1]. Set DKG_CLI_PATH to the absolute ' +
+    'path of the CLI (e.g. /path/to/packages/cli/dist/cli.js, or on a global ' +
+    'install: <npm prefix -g>/lib/node_modules/@origintrail-official/dkg/dist/cli.js) ' +
+    'and try again.',
   );
 }

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -13,7 +13,7 @@
  * Every step is idempotent — re-running is safe.
  */
 
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { accessSync, constants as fsConstants, copyFileSync, existsSync, readFileSync, realpathSync, writeFileSync, mkdirSync, rmdirSync, statSync, unlinkSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join, dirname, resolve } from 'node:path';
@@ -21,6 +21,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
 import type { DkgOpenClawConfig } from './types.js';
+import { resolveDkgCli } from './resolve-dkg-cli.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -456,8 +457,20 @@ export async function startDaemon(apiPort: number): Promise<void> {
 
   log('Starting DKG daemon...');
   try {
-    // Use dkg start which handles the daemon lifecycle
-    execSync('dkg start', { stdio: 'inherit', timeout: 30_000 });
+    // Resolve the CLI entrypoint as an absolute path and spawn via
+    // process.execPath so we don't depend on `dkg` being on PATH — which
+    // `pnpm dkg openclaw setup` does not guarantee in a cloned monorepo.
+    const { node, cliPath } = resolveDkgCli();
+    const result = spawnSync(node, [cliPath, 'start'], {
+      stdio: 'inherit',
+      timeout: 30_000,
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        `dkg start exited with ${result.status ?? `signal ${result.signal}`}`,
+      );
+    }
   } catch (err: any) {
     throw new Error(`Failed to start DKG daemon: ${err.message}`);
   }

--- a/packages/adapter-openclaw/test/resolve-dkg-cli.test.ts
+++ b/packages/adapter-openclaw/test/resolve-dkg-cli.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  existsSync: (_p: string): boolean => false,
+  requireResolve: null as null | ((specifier: string) => string),
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: (p: string) => hoisted.existsSync(p),
+  };
+});
+
+vi.mock('node:module', async () => {
+  const actual = await vi.importActual<typeof import('node:module')>('node:module');
+  return {
+    ...actual,
+    createRequire: () => ({
+      resolve: (specifier: string) => {
+        if (hoisted.requireResolve == null) {
+          const err = new Error(`Cannot find module '${specifier}'`) as Error & { code?: string };
+          err.code = 'MODULE_NOT_FOUND';
+          throw err;
+        }
+        return hoisted.requireResolve(specifier);
+      },
+    }),
+  };
+});
+
+const { resolveDkgCli } = await import('../src/resolve-dkg-cli.js');
+
+describe('resolveDkgCli', () => {
+  let origEnv: string | undefined;
+  let origArgv1: string | undefined;
+
+  beforeEach(() => {
+    origEnv = process.env.DKG_CLI_PATH;
+    origArgv1 = process.argv[1];
+    delete process.env.DKG_CLI_PATH;
+    hoisted.existsSync = () => false;
+    hoisted.requireResolve = null;
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.DKG_CLI_PATH;
+    else process.env.DKG_CLI_PATH = origEnv;
+    process.argv[1] = origArgv1 as string;
+  });
+
+  it('honors DKG_CLI_PATH when the file exists', () => {
+    const override = '/custom/path/to/cli.js';
+    process.env.DKG_CLI_PATH = override;
+    hoisted.existsSync = (p) => p === override;
+
+    const resolved = resolveDkgCli();
+
+    expect(resolved.node).toBe(process.execPath);
+    expect(resolved.cliPath).toBe(override);
+  });
+
+  it('throws when DKG_CLI_PATH points at a missing file', () => {
+    process.env.DKG_CLI_PATH = '/does/not/exist.js';
+    hoisted.existsSync = () => false;
+
+    expect(() => resolveDkgCli()).toThrow(/DKG_CLI_PATH/);
+  });
+
+  it('falls back to require.resolve when the override is unset', () => {
+    const resolved = '/global/node_modules/@origintrail-official/dkg/dist/cli.js';
+    hoisted.requireResolve = (spec) => {
+      if (spec === '@origintrail-official/dkg') return resolved;
+      throw new Error(`unexpected specifier ${spec}`);
+    };
+    hoisted.existsSync = (p) => p === resolved;
+
+    const result = resolveDkgCli();
+
+    expect(result.node).toBe(process.execPath);
+    expect(result.cliPath).toBe(resolved);
+  });
+
+  it('falls back to process.argv[1] when require.resolve cannot find the CLI', () => {
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.requireResolve = null;
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(argv1);
+  });
+
+  it('ignores argv[1] when it does not point at cli.js', () => {
+    process.argv[1] = '/some/other/script.js';
+    hoisted.requireResolve = null;
+    hoisted.existsSync = () => true;
+
+    expect(() => resolveDkgCli()).toThrow(/Could not resolve the DKG CLI entrypoint/);
+  });
+
+  it('throws a clear error mentioning DKG_CLI_PATH when nothing resolves', () => {
+    process.argv[1] = '/usr/bin/node';
+    hoisted.requireResolve = null;
+    hoisted.existsSync = () => false;
+
+    expect(() => resolveDkgCli()).toThrow(/DKG_CLI_PATH/);
+  });
+
+  it('treats an empty or whitespace-only DKG_CLI_PATH as unset', () => {
+    process.env.DKG_CLI_PATH = '   ';
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(argv1);
+  });
+
+  it('falls through to argv[1] when require.resolve returns a stale path', () => {
+    const stalePath = '/uninstalled/@origintrail-official/dkg/dist/cli.js';
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.requireResolve = () => stalePath;
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(argv1);
+  });
+
+  it('falls through when require.resolve throws a non-MODULE_NOT_FOUND error', () => {
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.requireResolve = () => {
+      throw new Error('unexpected resolver failure');
+    };
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(argv1);
+  });
+
+  it('always returns process.execPath as the node field, including on argv[1] fallback', () => {
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.requireResolve = null;
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.node).toBe(process.execPath);
+  });
+});

--- a/packages/adapter-openclaw/test/resolve-dkg-cli.test.ts
+++ b/packages/adapter-openclaw/test/resolve-dkg-cli.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
 
 const hoisted = vi.hoisted(() => ({
   existsSync: (_p: string): boolean => false,
   requireResolve: null as null | ((specifier: string) => string),
+  requireResolveError: null as null | (Error & { code?: string }),
+  resolveCliPackageDir: (): string | null => null,
 }));
 
 vi.mock('node:fs', async () => {
@@ -19,6 +22,7 @@ vi.mock('node:module', async () => {
     ...actual,
     createRequire: () => ({
       resolve: (specifier: string) => {
+        if (hoisted.requireResolveError) throw hoisted.requireResolveError;
         if (hoisted.requireResolve == null) {
           const err = new Error(`Cannot find module '${specifier}'`) as Error & { code?: string };
           err.code = 'MODULE_NOT_FOUND';
@@ -29,6 +33,14 @@ vi.mock('node:module', async () => {
     }),
   };
 });
+
+// Fully replace ../src/setup.js so the resolver can depend on
+// `resolveCliPackageDir` without pulling setup.ts's transitive imports into
+// this test. setup.ts itself imports from resolve-dkg-cli.ts, so mocking the
+// whole module also avoids the import cycle that full evaluation would hit.
+vi.mock('../src/setup.js', () => ({
+  resolveCliPackageDir: () => hoisted.resolveCliPackageDir(),
+}));
 
 const { resolveDkgCli } = await import('../src/resolve-dkg-cli.js');
 
@@ -42,6 +54,8 @@ describe('resolveDkgCli', () => {
     delete process.env.DKG_CLI_PATH;
     hoisted.existsSync = () => false;
     hoisted.requireResolve = null;
+    hoisted.requireResolveError = null;
+    hoisted.resolveCliPackageDir = () => null;
   });
 
   afterEach(() => {
@@ -82,10 +96,11 @@ describe('resolveDkgCli', () => {
     expect(result.cliPath).toBe(resolved);
   });
 
-  it('falls back to process.argv[1] when require.resolve cannot find the CLI', () => {
+  it('falls back to process.argv[1] when no earlier arm resolves', () => {
     const argv1 = '/clone/packages/cli/dist/cli.js';
     process.argv[1] = argv1;
     hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => null;
     hoisted.existsSync = (p) => p === argv1;
 
     const result = resolveDkgCli();
@@ -96,6 +111,7 @@ describe('resolveDkgCli', () => {
   it('ignores argv[1] when it does not point at cli.js', () => {
     process.argv[1] = '/some/other/script.js';
     hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => null;
     hoisted.existsSync = () => true;
 
     expect(() => resolveDkgCli()).toThrow(/Could not resolve the DKG CLI entrypoint/);
@@ -104,6 +120,7 @@ describe('resolveDkgCli', () => {
   it('throws a clear error mentioning DKG_CLI_PATH when nothing resolves', () => {
     process.argv[1] = '/usr/bin/node';
     hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => null;
     hoisted.existsSync = () => false;
 
     expect(() => resolveDkgCli()).toThrow(/DKG_CLI_PATH/);
@@ -120,39 +137,131 @@ describe('resolveDkgCli', () => {
     expect(result.cliPath).toBe(argv1);
   });
 
-  it('falls through to argv[1] when require.resolve returns a stale path', () => {
+  it('falls through to resolveCliPackageDir when require.resolve returns a stale path', () => {
     const stalePath = '/uninstalled/@origintrail-official/dkg/dist/cli.js';
-    const argv1 = '/clone/packages/cli/dist/cli.js';
-    process.argv[1] = argv1;
+    const cliPkgDir = '/global/lib/node_modules/@origintrail-official/dkg';
+    const cliEntry = join(cliPkgDir, 'dist', 'cli.js');
     hoisted.requireResolve = () => stalePath;
-    hoisted.existsSync = (p) => p === argv1;
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    hoisted.existsSync = (p) => p === cliEntry;
 
     const result = resolveDkgCli();
 
-    expect(result.cliPath).toBe(argv1);
-  });
-
-  it('falls through when require.resolve throws a non-MODULE_NOT_FOUND error', () => {
-    const argv1 = '/clone/packages/cli/dist/cli.js';
-    process.argv[1] = argv1;
-    hoisted.requireResolve = () => {
-      throw new Error('unexpected resolver failure');
-    };
-    hoisted.existsSync = (p) => p === argv1;
-
-    const result = resolveDkgCli();
-
-    expect(result.cliPath).toBe(argv1);
+    expect(result.cliPath).toBe(cliEntry);
   });
 
   it('always returns process.execPath as the node field, including on argv[1] fallback', () => {
     const argv1 = '/clone/packages/cli/dist/cli.js';
     process.argv[1] = argv1;
     hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => null;
     hoisted.existsSync = (p) => p === argv1;
 
     const result = resolveDkgCli();
 
     expect(result.node).toBe(process.execPath);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Arm 3 — resolveCliPackageDir() + dist/cli.js
+  // Added during PR #260 review round 1 (Codex comment on resolve-dkg-cli.ts).
+  // ---------------------------------------------------------------------------
+
+  it('arm 3: returns resolveCliPackageDir() + dist/cli.js when env and require.resolve fail', () => {
+    const cliPkgDir = '/usr/lib/node_modules/@origintrail-official/dkg';
+    const cliEntry = join(cliPkgDir, 'dist', 'cli.js');
+    hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    hoisted.existsSync = (p) => p === cliEntry;
+
+    const result = resolveDkgCli();
+
+    expect(result.node).toBe(process.execPath);
+    expect(result.cliPath).toBe(cliEntry);
+  });
+
+  it('arm 3 miss: falls through to argv[1] when dist/cli.js is missing under the package dir', () => {
+    const cliPkgDir = '/usr/lib/node_modules/@origintrail-official/dkg';
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    // Everything under cliPkgDir returns false; only argv1 exists.
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(argv1);
+  });
+
+  it('arm 3 null: falls through to argv[1] when resolveCliPackageDir returns null', () => {
+    const argv1 = '/clone/packages/cli/dist/cli.js';
+    process.argv[1] = argv1;
+    hoisted.requireResolve = null;
+    hoisted.resolveCliPackageDir = () => null;
+    hoisted.existsSync = (p) => p === argv1;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(argv1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Narrowed require.resolve catch — only swallow MODULE_NOT_FOUND /
+  // ERR_MODULE_NOT_FOUND; surface everything else (corrupted install,
+  // filesystem perms, etc.) rather than hiding it behind the fallback arms.
+  // ---------------------------------------------------------------------------
+
+  it('narrowed catch: MODULE_NOT_FOUND falls through cleanly', () => {
+    const cliPkgDir = '/usr/lib/node_modules/@origintrail-official/dkg';
+    const cliEntry = join(cliPkgDir, 'dist', 'cli.js');
+    const err = new Error("Cannot find module '@origintrail-official/dkg'") as Error & { code?: string };
+    err.code = 'MODULE_NOT_FOUND';
+    hoisted.requireResolveError = err;
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    hoisted.existsSync = (p) => p === cliEntry;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(cliEntry);
+  });
+
+  it('narrowed catch: ERR_MODULE_NOT_FOUND also falls through cleanly', () => {
+    const cliPkgDir = '/usr/lib/node_modules/@origintrail-official/dkg';
+    const cliEntry = join(cliPkgDir, 'dist', 'cli.js');
+    const err = new Error('Cannot find package …') as Error & { code?: string };
+    err.code = 'ERR_MODULE_NOT_FOUND';
+    hoisted.requireResolveError = err;
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    hoisted.existsSync = (p) => p === cliEntry;
+
+    const result = resolveDkgCli();
+
+    expect(result.cliPath).toBe(cliEntry);
+  });
+
+  it('narrowed catch: EACCES rethrows instead of silently falling through', () => {
+    const err = new Error('permission denied') as Error & { code?: string };
+    err.code = 'EACCES';
+    hoisted.requireResolveError = err;
+    // Set up downstream arms as if they would succeed — to prove the catch
+    // did not swallow the real error and quietly continue.
+    const cliPkgDir = '/usr/lib/node_modules/@origintrail-official/dkg';
+    const cliEntry = join(cliPkgDir, 'dist', 'cli.js');
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    hoisted.existsSync = (p) => p === cliEntry;
+
+    expect(() => resolveDkgCli()).toThrow(/permission denied|EACCES/);
+  });
+
+  it('narrowed catch: a plain Error (no code) rethrows', () => {
+    hoisted.requireResolveError = new Error('unexpected resolver failure') as Error & { code?: string };
+    // Downstream arms would otherwise succeed — proves rethrow.
+    const cliPkgDir = '/usr/lib/node_modules/@origintrail-official/dkg';
+    const cliEntry = join(cliPkgDir, 'dist', 'cli.js');
+    hoisted.resolveCliPackageDir = () => cliPkgDir;
+    hoisted.existsSync = (p) => p === cliEntry;
+
+    expect(() => resolveDkgCli()).toThrow(/unexpected resolver failure/);
   });
 });


### PR DESCRIPTION
## Summary

- `pnpm dkg openclaw setup` in a cloned monorepo aborted at `Starting DKG daemon...` because `execSync('dkg start', ...)` in `setup.ts` relied on the child shell finding `dkg` on PATH — which pnpm does not guarantee for children of root scripts. The failure tripped before `mergeOpenClawConfig()` wrote the user-visible adapter config.
- Replace the shell-out with a small resolver that produces an absolute path to the CLI entrypoint, then spawn it via `process.execPath` using `spawnSync`. This removes the PATH dependency without changing lifecycle/PID/polling behavior.
- Resolution order (first match wins): `DKG_CLI_PATH` env var → `require.resolve('@origintrail-official/dkg')` (global-install case) → `process.argv[1]` when it ends in `cli.js` (the adapter is running inside the CLI process itself, so `argv[1]` is the CLI entrypoint we want to re-invoke). Fails fast with a clear error mentioning `DKG_CLI_PATH` if nothing resolves.
- Implements **Option A** from issue #252. No new dependencies, no unrelated refactors.

## Related

- Closes #252
- Context: PR #250 — users testing that change against a cloned repo were the most common way to hit this bug.

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/resolve-dkg-cli.ts` | New helper: `resolveDkgCli()` returns `{ node, cliPath }`. Pure function of `process.env`, `process.argv`, and `createRequire(import.meta.url)`. |
| `packages/adapter-openclaw/src/setup.ts` | `startDaemon()` now calls the resolver and uses `spawnSync(node, [cliPath, 'start'], ...)` instead of `execSync('dkg start', ...)`. Preserves the existing error-wrapping. |
| `packages/adapter-openclaw/test/resolve-dkg-cli.test.ts` | New vitest suite: 10 tests covering env override, `require.resolve` success, `argv[1]` fallback, the three failure paths (missing override, stale `require.resolve` result, non-`MODULE_NOT_FOUND` throw), the empty-env treatment, and the invariant that `node` is always `process.execPath`. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw build` — clean TypeScript build.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test` — 383 passing / 1 pre-existing unrelated RED test that exists on `v10-rc` as well (`openclaw.plugin.json id matches package.json name (RED until reconciled)`). +10 net tests from this PR.
- [x] `npx vitest run test/resolve-dkg-cli.test.ts` from `packages/adapter-openclaw` — 10 / 10 pass.
- [x] **Live repro of the bug on `v10-rc` baseline**: stripping `dkg` from PATH and calling the pre-fix `execSync('dkg start')` path reproduces `'dkg' is not recognized as an internal or external command` / `Command failed: dkg start`, matching the issue exactly.
- [x] **Live verification of the fix**: with `dkg` stripped from PATH and `process.argv[1]` pointing at `packages/cli/dist/cli.js` (the `pnpm dkg openclaw setup` shape), `startDaemon()` successfully spawned the daemon (`Node: Cashew (PID ...)`). The remaining "health check timed out" was an artifact of the test using a bogus port; behavior is otherwise identical to the previous code.
- [ ] Reviewer smoke test: in a fresh clone without a global `dkg` install, run `pnpm install && pnpm build:runtime && pnpm dkg openclaw setup --no-verify` and confirm it no longer aborts with `dkg: not found`.
- [ ] Reviewer smoke test: confirm `pnpm exec dkg openclaw setup` and a global `dkg openclaw setup` both still work (they route through the same resolver, preferring `require.resolve` in the global case and `argv[1]` in the pnpm case).