### PR TITLE
Inject proper agent identifier and teach claw to use it

### DIFF
--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -177,6 +177,8 @@ function formatChatContext(entries: ChatContextEntry[]): string {
   return [
     'Context for this chat turn:',
     'If "target_context_graph" is present below, treat it as authoritative for this turn unless the user explicitly overrides it in the same message.',
+    'If "current_agent_address" is present below, use it as the primary `agent_address` for `view: "working-memory"` reads.',
+    'Do not assume the peer ID is the right working-memory identity unless the tool result or graph naming proves it.',
     ...lines,
   ].join('\n');
 }

--- a/packages/adapter-openclaw/src/DkgMemoryPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgMemoryPlugin.ts
@@ -56,6 +56,18 @@ export const AGENT_CONTEXT_GRAPH = 'agent-context';
 export const CHAT_TURNS_ASSERTION = 'chat-turns';
 export const PROJECT_MEMORY_ASSERTION = 'memory';
 
+function buildDkgMemoryPromptSections(): string[] {
+  return [
+    'DKG memory rules:',
+    '- To inspect whether a project has data, check all three layers explicitly: `working-memory`, `shared-working-memory`, and `verified-memory`.',
+    '- For `working-memory`, prefer the injected `current_agent_address` from the turn context when present.',
+    '- If `current_agent_address` is absent, use the local node\'s default `agent_address` fallback.',
+    '- Do not assume a libp2p peer ID is the correct WM identity unless the tool or graph naming proves it.',
+    '- If a WM read comes back empty but the user expects data, retry with alternate identity forms before concluding the project is empty: wallet/address form first, then DID form, then peer ID if needed.',
+    '- Do not claim a project is empty until you have exhausted WM identity variants and also checked SWM and VM.',
+  ];
+}
+
 const NS = {
   schema: 'http://schema.org/',
 };
@@ -611,6 +623,7 @@ export class DkgMemoryPlugin {
     }
 
     const capability: MemoryPluginCapability = {
+      promptBuilder: () => buildDkgMemoryPromptSections(),
       runtime: buildDkgMemoryRuntime(this.client, this.resolver, api.logger),
     };
     api.registerMemoryCapability(capability);

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -1127,7 +1127,9 @@ export class DkgNodePlugin {
           'layer to read: `working-memory` (WM — per-agent), `shared-working-memory` (SWM — gossip-' +
           'replicated), or `verified-memory` (VM — on-chain anchored); when `view` is supplied, ' +
           '`context_graph_id` is also required. For WM reads, `agent_address` selects whose WM to ' +
-          'read — it defaults to this node\'s agent address (the same default the adapter uses for ' +
+          'read; prefer the injected `current_agent_address` from turn context when present. If a WM ' +
+          'read looks unexpectedly empty, retry alternate identity forms before concluding there is no ' +
+          'WM data. It defaults to this node\'s agent address (the same default the adapter uses for ' +
           'memory-plugin reads). Omit `view` for a cross-graph query routed via the legacy data-' +
           'graph path (unscoped, or scoped when `context_graph_id` is set); use `GRAPH ?g { ... }` ' +
           'for named-graph targeting in that mode.',
@@ -1156,8 +1158,9 @@ export class DkgNodePlugin {
               description:
                 "Optional target for `view: \"working-memory\"` reads — defaults to this node's " +
                 'agent address (matches the default the memory plugin uses for its own WM reads). ' +
-                'Ignored for non-WM views. Supply an explicit value to read another local agent\'s ' +
-                'WM namespace in multi-agent deployments.',
+                'Prefer the injected `current_agent_address` from chat context when available. Accepts ' +
+                'wallet/address form, raw peer ID, or DID form. Ignored for non-WM views. Supply an ' +
+                'explicit value to read another local agent\'s WM namespace in multi-agent deployments.',
             },
           },
           required: ['sparql'],

--- a/packages/adapter-openclaw/test/dkg-memory.test.ts
+++ b/packages/adapter-openclaw/test/dkg-memory.test.ts
@@ -105,6 +105,20 @@ describe('DkgMemoryPlugin.register', () => {
     expect(typeof capability.runtime?.getMemorySearchManager).toBe('function');
   });
 
+  it('registers a prompt builder that teaches WM identity selection', () => {
+    const api = makeApi();
+    plugin.register(api);
+
+    const capability = api.registerMemoryCapability.mock.calls[0][0] as MemoryPluginCapability;
+    const sections = capability.promptBuilder?.({ availableTools: new Set(), citationsMode: undefined }) ?? [];
+
+    expect(sections.join('\n')).toContain('current_agent_address');
+    expect(sections.join('\n')).toContain('working-memory');
+    expect(sections.join('\n')).toContain('shared-working-memory');
+    expect(sections.join('\n')).toContain('verified-memory');
+    expect(sections.join('\n')).toContain('retry with alternate identity forms');
+  });
+
   it('registers only the memory slot capability, no conventional memory tools (Codex B-retire)', () => {
     const api = makeApi();
     plugin.register(api);

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -669,6 +669,25 @@ describe('DkgNodePlugin', () => {
       expect(query.description).not.toMatch(/Omit `?view`? for the default/i);
     });
 
+    it('dkg_query description steers WM reads toward current_agent_address and retries identity variants', () => {
+      const plugin = new DkgNodePlugin();
+      const tools: OpenClawTool[] = [];
+      plugin.register({
+        config: {},
+        registerTool: (t) => tools.push(t),
+        registerHook: () => {},
+        on: () => {},
+        logger: {},
+      });
+      const query = tools.find((t) => t.name === 'dkg_query')!;
+      const agentAddress = query.parameters.properties.agent_address as { description?: string };
+
+      expect(query.description).toContain('current_agent_address');
+      expect(query.description).toMatch(/retry alternate identity forms/i);
+      expect(agentAddress.description).toContain('current_agent_address');
+      expect(agentAddress.description).toMatch(/wallet\/address form, raw peer ID, or DID form/i);
+    });
+
     it('dkg_query forwards the `view` field to the daemon body verbatim', async () => {
       // Handler-level drift guard: the daemon's /api/query route destructures
       // `view` from the body. If we renamed the field in the handler, this

--- a/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
+++ b/packages/node-ui/src/ui/components/Shell/PanelRight.tsx
@@ -3,6 +3,7 @@ import { useJourneyStore } from '../../stores/journey.js';
 import { useProjectsStore, type ContextGraph } from '../../stores/projects.js';
 import {
   importFile,
+  type AgentIdentity,
   type ImportFileResult,
   type LocalAgentChatAttachmentRef,
   type LocalAgentChatContextEntry,
@@ -14,6 +15,7 @@ import {
   disconnectLocalAgentIntegration,
   fetchAgents,
   fetchConnections,
+  fetchCurrentAgent,
   getDefaultLocalAgentSessionId,
   fetchLocalAgentHistory,
   fetchLocalAgentIntegrations,
@@ -141,14 +143,42 @@ function draftToAttachmentRef(draft: LocalAgentAttachmentDraft): LocalAgentChatA
   };
 }
 
-function buildChatContextEntries(projects: ContextGraph[], activeProjectId: string | null): LocalAgentChatContextEntry[] {
-  if (!activeProjectId) return [];
-  const displayName = getProjectDisplayName(projects, activeProjectId);
-  return [{
-    key: 'target_context_graph',
-    label: 'Target context graph',
-    value: displayName === activeProjectId ? activeProjectId : `${displayName} (${activeProjectId})`,
-  }];
+function buildChatContextEntries(
+  projects: ContextGraph[],
+  activeProjectId: string | null,
+  currentAgent: AgentIdentity | null,
+): LocalAgentChatContextEntry[] {
+  const entries: LocalAgentChatContextEntry[] = [];
+  if (activeProjectId) {
+    const displayName = getProjectDisplayName(projects, activeProjectId);
+    entries.push({
+      key: 'target_context_graph',
+      label: 'Target context graph',
+      value: displayName === activeProjectId ? activeProjectId : `${displayName} (${activeProjectId})`,
+    });
+  }
+  if (currentAgent?.agentAddress) {
+    entries.push({
+      key: 'current_agent_address',
+      label: 'Current agent address',
+      value: currentAgent.agentAddress,
+    });
+  }
+  if (currentAgent?.agentDid) {
+    entries.push({
+      key: 'current_agent_did',
+      label: 'Current agent DID',
+      value: currentAgent.agentDid,
+    });
+  }
+  if (currentAgent?.peerId) {
+    entries.push({
+      key: 'current_agent_peer_id',
+      label: 'Current agent peer ID',
+      value: currentAgent.peerId,
+    });
+  }
+  return entries;
 }
 
 function mapHistoryMessage(message: LocalAgentHistoryMessage): LocalAgentMessage {
@@ -1034,6 +1064,7 @@ export function PanelRight() {
   const [peerAgents, setPeerAgents] = useState<AgentInfo[]>([]);
   const [connections, setConnections] = useState<{ total: number; direct: number; relayed: number }>({ total: 0, direct: 0, relayed: 0 });
   const [peerLoading, setPeerLoading] = useState(true);
+  const [currentAgent, setCurrentAgent] = useState<AgentIdentity | null>(null);
 
   const [integrations, setIntegrations] = useState<LocalAgentIntegration[]>([]);
   const [selectedIntegrationId, setSelectedIntegrationId] = useState('openclaw');
@@ -1346,6 +1377,10 @@ export function PanelRight() {
   }, [loadSessions, refreshPeers, refreshLocalIntegrations]);
 
   useEffect(() => {
+    fetchCurrentAgent().then(setCurrentAgent).catch(() => {});
+  }, []);
+
+  useEffect(() => {
     const intervalId = setInterval(() => {
       loadSessions();
       refreshPeers();
@@ -1435,7 +1470,7 @@ export function PanelRight() {
 
       controller = new AbortController();
       localAbortRef.current = controller;
-      const contextEntries = buildChatContextEntries(availableProjects, activeProjectId);
+      const contextEntries = buildChatContextEntries(availableProjects, activeProjectId, currentAgent);
 
       const result = await streamLocalAgentChat(integrationId, text, {
         correlationId,
@@ -1497,6 +1532,7 @@ export function PanelRight() {
     activeProjectId,
     advance,
     availableProjects,
+    currentAgent,
     loadSessions,
     localInput,
     localSending,

--- a/packages/node-ui/test/panel-right.component.test.ts
+++ b/packages/node-ui/test/panel-right.component.test.ts
@@ -18,6 +18,7 @@ const fetchAgentsMock = vi.fn();
 const fetchConnectionsMock = vi.fn();
 const fetchLocalAgentIntegrationsMock = vi.fn();
 const fetchLocalAgentHistoryMock = vi.fn();
+const fetchCurrentAgentMock = vi.fn();
 const streamLocalAgentChatMock = vi.fn();
 const connectLocalAgentIntegrationMock = vi.fn();
 const disconnectLocalAgentIntegrationMock = vi.fn();
@@ -31,6 +32,7 @@ vi.mock('../src/ui/api.js', async () => {
     fetchConnections: fetchConnectionsMock,
     fetchLocalAgentIntegrations: fetchLocalAgentIntegrationsMock,
     fetchLocalAgentHistory: fetchLocalAgentHistoryMock,
+    fetchCurrentAgent: fetchCurrentAgentMock,
     streamLocalAgentChat: streamLocalAgentChatMock,
     connectLocalAgentIntegration: connectLocalAgentIntegrationMock,
     disconnectLocalAgentIntegration: disconnectLocalAgentIntegrationMock,
@@ -76,6 +78,13 @@ describe('PanelRight component', () => {
       target: 'local',
     }] });
     fetchLocalAgentHistoryMock.mockResolvedValue([]);
+    fetchCurrentAgentMock.mockResolvedValue({
+      agentAddress: 'peer-self',
+      agentDid: 'did:dkg:agent:peer-self',
+      name: 'Self',
+      peerId: 'peer-self',
+      nodeIdentityId: 'node-self',
+    });
     streamLocalAgentChatMock.mockResolvedValue({ text: 'Roger that', correlationId: 'corr-1' });
     apiFetchMemorySessionsMock.mockResolvedValue({ sessions: [] });
   });
@@ -172,11 +181,28 @@ describe('PanelRight component', () => {
     });
 
     expect(streamLocalAgentChatMock).toHaveBeenCalledWith('openclaw', 'Check memory', expect.objectContaining({
-      contextEntries: [{
-        key: 'target_context_graph',
-        label: 'Target context graph',
-        value: 'Origin Trail Game (origin-trail-game)',
-      }],
+      contextEntries: [
+        {
+          key: 'target_context_graph',
+          label: 'Target context graph',
+          value: 'Origin Trail Game (origin-trail-game)',
+        },
+        {
+          key: 'current_agent_address',
+          label: 'Current agent address',
+          value: 'peer-self',
+        },
+        {
+          key: 'current_agent_did',
+          label: 'Current agent DID',
+          value: 'did:dkg:agent:peer-self',
+        },
+        {
+          key: 'current_agent_peer_id',
+          label: 'Current agent peer ID',
+          value: 'peer-self',
+        },
+      ],
     }));
     expect(container.textContent).toContain('Roger that');
 


### PR DESCRIPTION
Summary
- Inject the current DKG agent identity into OpenClaw chat turn context from the UI, alongside the selected target context graph.
- Teach the adapter prompt and dkg_query tool guidance to treat current_agent_address as the primary identity for working-memory reads and to retry identity variants before concluding a project is empty.
- Add/extend focused UI and adapter tests to lock in the new context injection and WM retrieval guidance.
