### PR TITLE
Add `dkg integration` CLI: list / info / install from the registry

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -52,6 +52,7 @@ import {
   DAEMON_EXIT_CODE_RESTART,
 } from './daemon.js';
 import { migrateToBlueGreen } from './migration.js';
+import { registerIntegrationCommands } from './integrations/commands.js';
 
 /** Commander action callbacks receive parsed .option() values with loose types. */
 type ActionOpts = Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -2993,5 +2994,9 @@ program
     console.log(`Rolled back: current → slot ${target}`);
     console.log('Daemon stopped. Run "dkg start" to start with the rolled-back version.');
   });
+
+// ─── dkg integration ─────────────────────────────────────────────────
+
+registerIntegrationCommands(program);
 
 program.parse();

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -99,14 +99,28 @@ export function registerIntegrationCommands(program: Command): void {
           process.exit(3);
         }
 
-        console.log(`Installing ${entry.name} (${entry.slug}) [${entry.trustTier}]`);
-        console.log(`  repo:    ${entry.repo}`);
-        console.log(`  pinned:  ${entry.commit.slice(0, 12)}`);
+        const verb = opts.dryRun ? 'Would install' : 'Installing';
+        console.log(`${verb} ${entry.name} (${entry.slug}) [${entry.trustTier}]`);
+        console.log(`  repo:          ${entry.repo}`);
+        // The commit is the registry-review target, audited when the entry was
+        // merged (see security-checks.mjs in dkg-integrations). It is NOT an
+        // install-time enforcement — cli installs pull the pinned package@version
+        // from npm, and mcp installs launch the pinned args via npx. Bind-
+        // between-tarball-and-commit is provided by npm provenance at publish
+        // time; the registry CI refuses to merge entries whose pinned npm
+        // version lacks an attestation. See `npm view <pkg>@<version> dist`
+        // for the publish-time signature metadata.
+        console.log(`  review commit: ${entry.commit.slice(0, 12)}  (registry-audited; not enforced at install time)`);
         console.log('');
 
         switch (entry.install.kind) {
           case 'cli': {
             const result = await installCli({ entry, dryRun: opts.dryRun });
+            if (opts.dryRun) {
+              console.log('');
+              console.log(`Dry-run: no changes made. Re-run without --dry-run to install.`);
+              break;
+            }
             console.log('');
             console.log(`Installed ${entry.install.package}@${entry.install.version}.`);
             console.log(`Run \`${result.binary} --help\` to get started.`);
@@ -114,6 +128,11 @@ export function registerIntegrationCommands(program: Command): void {
               console.log('');
               for (const line of result.postInstructions) console.log(line);
             }
+            console.log('');
+            console.log(
+              `Verify publish-time provenance (ties the tarball to a Git commit):\n` +
+                `  npm view ${entry.install.package}@${entry.install.version} dist`,
+            );
             break;
           }
           case 'mcp': {
@@ -156,7 +175,7 @@ function printEntryHuman(e: IntegrationEntry): void {
   console.log(`  slug:         ${e.slug}`);
   console.log(`  description:  ${e.description}`);
   console.log(`  repo:         ${e.repo}`);
-  console.log(`  commit:       ${e.commit}`);
+  console.log(`  review commit: ${e.commit}  (audited at registry merge; install pulls from npm)`);
   console.log(`  license:      ${e.license}`);
   console.log(`  memory:       ${e.memoryLayers.join(', ')}`);
   console.log(`  primitives:   ${e.v10PrimitivesUsed.join(', ')}`);

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -31,26 +31,34 @@ export function registerIntegrationCommands(program: Command): void {
     .action(async (opts: { tier: string; json?: boolean }) => {
       try {
         const cfg = resolveRegistryConfig();
-        const all = await fetchAllEntries(cfg);
+        const { entries, failures } = await fetchAllEntries(cfg);
         const min = parseTier(opts.tier);
-        const filtered = all.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
+        const filtered = entries.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
 
         if (opts.json) {
-          console.log(JSON.stringify(filtered, null, 2));
+          console.log(JSON.stringify({ entries: filtered, failures }, null, 2));
           return;
         }
 
         if (filtered.length === 0) {
           console.log(`No integrations at tier "${min}" or above.`);
-          return;
+        } else {
+          console.log(`Showing ${filtered.length} integration(s) at tier ${min}+:\n`);
+          for (const e of filtered) {
+            console.log(`  ${e.slug.padEnd(24)}  [${e.trustTier}]  ${e.name}`);
+            console.log(`    ${e.description.slice(0, 120)}${e.description.length > 120 ? '…' : ''}`);
+            console.log(`    install: ${e.install.kind} · memory: ${e.memoryLayers.join(', ')} · ${e.repo}`);
+            console.log('');
+          }
         }
 
-        console.log(`Showing ${filtered.length} integration(s) at tier ${min}+:\n`);
-        for (const e of filtered) {
-          console.log(`  ${e.slug.padEnd(24)}  [${e.trustTier}]  ${e.name}`);
-          console.log(`    ${e.description.slice(0, 120)}${e.description.length > 120 ? '…' : ''}`);
-          console.log(`    install: ${e.install.kind} · memory: ${e.memoryLayers.join(', ')} · ${e.repo}`);
-          console.log('');
+        // Surface failures as warnings rather than aborting — one broken
+        // community entry shouldn't hide every verified one.
+        if (failures.length > 0) {
+          console.warn(`Skipped ${failures.length} unreadable registry entr${failures.length === 1 ? 'y' : 'ies'}:`);
+          for (const f of failures) {
+            console.warn(`  ${f.slug}: ${f.error}`);
+          }
         }
       } catch (err) {
         console.error(`Failed to list integrations: ${toMessage(err)}`);
@@ -83,7 +91,8 @@ export function registerIntegrationCommands(program: Command): void {
     .option('--allow-community', 'Allow installing community-tier entries (not peer-reviewed)')
     .option('--dry-run', 'Print what would happen without executing any install step')
     .option('--api-url <url>', 'DKG node HTTP API URL to wire into integrations', 'http://127.0.0.1:9200')
-    .action(async (slug: string, opts: { allowCommunity?: boolean; dryRun?: boolean; apiUrl: string }) => {
+    .option('--no-verify-provenance', 'Skip publish-time provenance + repo-match verification for cli installs')
+    .action(async (slug: string, opts: { allowCommunity?: boolean; dryRun?: boolean; apiUrl: string; verifyProvenance: boolean }) => {
       try {
         const cfg = resolveRegistryConfig();
         const entry = await fetchEntry(slug, cfg);
@@ -115,24 +124,31 @@ export function registerIntegrationCommands(program: Command): void {
 
         switch (entry.install.kind) {
           case 'cli': {
-            const result = await installCli({ entry, dryRun: opts.dryRun });
+            const result = await installCli({
+              entry,
+              dryRun: opts.dryRun,
+              skipProvenance: opts.verifyProvenance === false,
+            });
             if (opts.dryRun) {
               console.log('');
               console.log(`Dry-run: no changes made. Re-run without --dry-run to install.`);
+              console.log(`Note: provenance is only checked on a real install (skipped in dry-run).`);
               break;
             }
             console.log('');
             console.log(`Installed ${entry.install.package}@${entry.install.version}.`);
+            if (result.provenance?.ok) {
+              console.log(
+                `Provenance verified: npm tarball is attested and bound to ${result.provenance.found.repositoryUrl ?? entry.repo}.`,
+              );
+            } else if (opts.verifyProvenance === false) {
+              console.log(`Provenance: skipped (--no-verify-provenance).`);
+            }
             console.log(`Run \`${result.binary} --help\` to get started.`);
             if (result.postInstructions.length > 0) {
               console.log('');
               for (const line of result.postInstructions) console.log(line);
             }
-            console.log('');
-            console.log(
-              `Verify publish-time provenance (ties the tarball to a Git commit):\n` +
-                `  npm view ${entry.install.package}@${entry.install.version} dist`,
-            );
             break;
           }
           case 'mcp': {
@@ -191,8 +207,11 @@ function printEntryHuman(e: IntegrationEntry): void {
       break;
     case 'mcp':
       console.log(`    command:    ${e.install.command} ${e.install.args.join(' ')}`);
-      if (e.install.clientCompatibility) {
-        console.log(`    clients:    ${e.install.clientCompatibility.join(', ')}`);
+      if (e.install.supportedClients) {
+        console.log(`    clients:    ${e.install.supportedClients.join(', ')}`);
+      }
+      if (e.install.envRequired) {
+        console.log(`    env needed: ${e.install.envRequired.join(', ')}`);
       }
       break;
     case 'service':

--- a/packages/cli/src/integrations/commands.ts
+++ b/packages/cli/src/integrations/commands.ts
@@ -1,0 +1,217 @@
+// Wires up the `dkg integration ...` subcommand tree on a Commander program.
+//
+// Exposed:
+//   dkg integration list          - enumerate entries in the registry
+//   dkg integration info <slug>   - show one entry
+//   dkg integration install <slug> [--allow-community] [--dry-run]
+//
+// Only install kinds currently in the registry (cli, mcp) are implemented.
+// Other kinds print an explicit "not implemented in this CLI version" error
+// pointing at the entry's repo and registry page so users can follow manual
+// install instructions.
+
+import type { Command } from 'commander';
+import { installCli } from './install-cli.js';
+import { installMcp } from './install-mcp.js';
+import { fetchAllEntries, fetchEntry, resolveRegistryConfig } from './registry-client.js';
+import type { IntegrationEntry, TrustTier } from './schema.js';
+
+const TIER_RANK: Record<TrustTier, number> = { community: 0, verified: 1, featured: 2 };
+
+export function registerIntegrationCommands(program: Command): void {
+  const integrationCmd = program
+    .command('integration')
+    .description('Install and inspect community DKG integrations from the registry');
+
+  integrationCmd
+    .command('list')
+    .description('List integrations available in the registry')
+    .option('--tier <tier>', 'Minimum trust tier: community | verified | featured', 'verified')
+    .option('--json', 'Print the raw registry entries as JSON')
+    .action(async (opts: { tier: string; json?: boolean }) => {
+      try {
+        const cfg = resolveRegistryConfig();
+        const all = await fetchAllEntries(cfg);
+        const min = parseTier(opts.tier);
+        const filtered = all.filter((e) => TIER_RANK[e.trustTier] >= TIER_RANK[min]);
+
+        if (opts.json) {
+          console.log(JSON.stringify(filtered, null, 2));
+          return;
+        }
+
+        if (filtered.length === 0) {
+          console.log(`No integrations at tier "${min}" or above.`);
+          return;
+        }
+
+        console.log(`Showing ${filtered.length} integration(s) at tier ${min}+:\n`);
+        for (const e of filtered) {
+          console.log(`  ${e.slug.padEnd(24)}  [${e.trustTier}]  ${e.name}`);
+          console.log(`    ${e.description.slice(0, 120)}${e.description.length > 120 ? '…' : ''}`);
+          console.log(`    install: ${e.install.kind} · memory: ${e.memoryLayers.join(', ')} · ${e.repo}`);
+          console.log('');
+        }
+      } catch (err) {
+        console.error(`Failed to list integrations: ${toMessage(err)}`);
+        process.exit(1);
+      }
+    });
+
+  integrationCmd
+    .command('info <slug>')
+    .description('Show full registry metadata for one integration')
+    .option('--json', 'Print the raw entry as JSON')
+    .action(async (slug: string, opts: { json?: boolean }) => {
+      try {
+        const cfg = resolveRegistryConfig();
+        const entry = await fetchEntry(slug, cfg);
+        if (opts.json) {
+          console.log(JSON.stringify(entry, null, 2));
+          return;
+        }
+        printEntryHuman(entry);
+      } catch (err) {
+        console.error(`Failed to load integration "${slug}": ${toMessage(err)}`);
+        process.exit(1);
+      }
+    });
+
+  integrationCmd
+    .command('install <slug>')
+    .description('Install an integration from the registry')
+    .option('--allow-community', 'Allow installing community-tier entries (not peer-reviewed)')
+    .option('--dry-run', 'Print what would happen without executing any install step')
+    .option('--api-url <url>', 'DKG node HTTP API URL to wire into integrations', 'http://127.0.0.1:9200')
+    .action(async (slug: string, opts: { allowCommunity?: boolean; dryRun?: boolean; apiUrl: string }) => {
+      try {
+        const cfg = resolveRegistryConfig();
+        const entry = await fetchEntry(slug, cfg);
+
+        if (entry.trustTier === 'community' && !opts.allowCommunity) {
+          console.error(
+            `Refusing to install community-tier integration "${entry.slug}" without --allow-community.\n\n` +
+              `Community-tier entries are contributor-submitted and have not been peer-reviewed by the\n` +
+              `OriginTrail core team. Read ${entry.repo} and the security declaration before proceeding:\n\n` +
+              formatSecurity(entry) +
+              `\n\nRe-run with --allow-community to install anyway.`,
+          );
+          process.exit(3);
+        }
+
+        console.log(`Installing ${entry.name} (${entry.slug}) [${entry.trustTier}]`);
+        console.log(`  repo:    ${entry.repo}`);
+        console.log(`  pinned:  ${entry.commit.slice(0, 12)}`);
+        console.log('');
+
+        switch (entry.install.kind) {
+          case 'cli': {
+            const result = await installCli({ entry, dryRun: opts.dryRun });
+            console.log('');
+            console.log(`Installed ${entry.install.package}@${entry.install.version}.`);
+            console.log(`Run \`${result.binary} --help\` to get started.`);
+            if (result.postInstructions.length > 0) {
+              console.log('');
+              for (const line of result.postInstructions) console.log(line);
+            }
+            break;
+          }
+          case 'mcp': {
+            await installMcp({ entry, apiUrl: opts.apiUrl });
+            break;
+          }
+          case 'service':
+          case 'agent-plugin':
+          case 'manual':
+            console.error(
+              `Install kind "${entry.install.kind}" is declared by this entry but not yet supported by the CLI.\n` +
+                `Follow the manual instructions at ${entry.repo} for now. ` +
+                `Automated support is planned for a follow-up release.`,
+            );
+            process.exit(2);
+            break;
+          default: {
+            const _exhaustive: never = entry.install as never;
+            void _exhaustive;
+            console.error(
+              `Unknown install kind in registry entry. The CLI may be out of date; try upgrading it.`,
+            );
+            process.exit(2);
+          }
+        }
+      } catch (err) {
+        console.error(`Install failed: ${toMessage(err)}`);
+        process.exit(1);
+      }
+    });
+}
+
+function parseTier(tier: string): TrustTier {
+  if (tier === 'community' || tier === 'verified' || tier === 'featured') return tier;
+  throw new Error(`Unknown tier "${tier}". Expected one of: community, verified, featured.`);
+}
+
+function printEntryHuman(e: IntegrationEntry): void {
+  console.log(`${e.name}  [${e.trustTier}]`);
+  console.log(`  slug:         ${e.slug}`);
+  console.log(`  description:  ${e.description}`);
+  console.log(`  repo:         ${e.repo}`);
+  console.log(`  commit:       ${e.commit}`);
+  console.log(`  license:      ${e.license}`);
+  console.log(`  memory:       ${e.memoryLayers.join(', ')}`);
+  console.log(`  primitives:   ${e.v10PrimitivesUsed.join(', ')}`);
+  console.log(`  interfaces:   ${e.publicInterfacesUsed.join(', ')}`);
+  if (e.maintainer) {
+    console.log(`  maintainer:   ${e.maintainer.github}${e.maintainer.name ? ` (${e.maintainer.name})` : ''}`);
+  }
+  console.log(`  install:      ${e.install.kind}`);
+  switch (e.install.kind) {
+    case 'cli':
+      console.log(`    package:    ${e.install.package}@${e.install.version}`);
+      console.log(`    binary:     ${e.install.binary}`);
+      break;
+    case 'mcp':
+      console.log(`    command:    ${e.install.command} ${e.install.args.join(' ')}`);
+      if (e.install.clientCompatibility) {
+        console.log(`    clients:    ${e.install.clientCompatibility.join(', ')}`);
+      }
+      break;
+    case 'service':
+      if (e.install.runtime === 'docker' && e.install.docker) {
+        console.log(`    docker:     ${e.install.docker.image}${e.install.docker.digest ? `@${e.install.docker.digest}` : ''}`);
+      } else if (e.install.runtime === 'npm-global' && e.install.npmGlobal) {
+        console.log(`    npm global: ${e.install.npmGlobal.package}@${e.install.npmGlobal.version}`);
+      }
+      break;
+    case 'agent-plugin':
+      console.log(`    framework:  ${e.install.framework}`);
+      console.log(`    package:    ${e.install.package}@${e.install.version}`);
+      break;
+    case 'manual':
+      console.log(`    steps:      ${e.install.steps.length} manual step(s); see registry entry.`);
+      break;
+  }
+  console.log('');
+  console.log(formatSecurity(e));
+  if (e.fitNotes) {
+    console.log('');
+    console.log(`  fit notes:   ${e.fitNotes}`);
+  }
+  if (e.designBrief) console.log(`  design:      ${e.designBrief}`);
+}
+
+function formatSecurity(e: IntegrationEntry): string {
+  const lines: string[] = ['  security:'];
+  const egress = e.security.networkEgress ?? [];
+  const writes = e.security.writeAuthority ?? [];
+  const creds = e.security.credentialsHandled ?? [];
+  lines.push(`    network:      ${egress.length === 0 ? 'none (local DKG node only)' : egress.join(', ')}`);
+  lines.push(`    writes:       ${writes.length === 0 ? 'none' : writes.join('; ')}`);
+  lines.push(`    credentials:  ${creds.length === 0 ? 'none' : creds.join(', ')}`);
+  if (e.security.notes) lines.push(`    notes:        ${e.security.notes}`);
+  return lines.join('\n');
+}
+
+function toMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/cli/src/integrations/install-cli.ts
+++ b/packages/cli/src/integrations/install-cli.ts
@@ -1,0 +1,105 @@
+// Installer for registry entries with `install.kind === "cli"`.
+//
+// These are one-shot binaries the user invokes directly after install (e.g.
+// dkg-hello-world). We install them globally via the local npm, pinned to the
+// exact version declared in the entry. We deliberately do NOT use npx — the
+// entry promises a binary and a pinned version; npm -g gives contributors a
+// stable PATH entry and idempotent re-installs.
+
+import { spawn } from 'node:child_process';
+import type { InstallCli, IntegrationEntry } from './schema.js';
+
+export interface InstallCliOptions {
+  entry: IntegrationEntry;
+  dryRun?: boolean;
+  logger?: (msg: string) => void;
+}
+
+export interface InstallCliResult {
+  command: string;
+  args: string[];
+  exitCode: number;
+  binary: string;
+  postInstructions: string[];
+}
+
+function assertCli(spec: IntegrationEntry['install']): asserts spec is InstallCli {
+  if (spec.kind !== 'cli') {
+    throw new Error(`install-cli received non-cli install spec (kind=${spec.kind})`);
+  }
+}
+
+export async function installCli(options: InstallCliOptions): Promise<InstallCliResult> {
+  const { entry, dryRun = false, logger = console.log } = options;
+  assertCli(entry.install);
+  const { package: pkg, version, binary } = entry.install;
+
+  const command = 'npm';
+  const args = ['install', '--global', `${pkg}@${version}`];
+
+  logger(`Installing ${pkg}@${version} globally via npm...`);
+  logger(`  ${command} ${args.join(' ')}`);
+
+  if (dryRun) {
+    return {
+      command,
+      args,
+      exitCode: 0,
+      binary,
+      postInstructions: buildPostInstructions(entry),
+    };
+  }
+
+  const exitCode = await runCommand(command, args);
+  if (exitCode !== 0) {
+    throw new Error(`npm install failed with exit code ${exitCode}. See output above for details.`);
+  }
+
+  return {
+    command,
+    args,
+    exitCode,
+    binary,
+    postInstructions: buildPostInstructions(entry),
+  };
+}
+
+// Post-install instructions include env vars the integration requires and the
+// usageHint block from the registry entry. We do NOT silently write any env
+// files; the user's shell is their own territory.
+function buildPostInstructions(entry: IntegrationEntry): string[] {
+  if (entry.install.kind !== 'cli') return [];
+  const lines: string[] = [];
+  const env = entry.install.envRequired ?? [];
+
+  if (env.length > 0) {
+    lines.push(`Required environment:`);
+    for (const name of env) {
+      if (name === 'DKG_AUTH_TOKEN') {
+        lines.push(`  ${name}  — pull from \`dkg auth show\` or ~/.dkg/auth.token`);
+      } else if (name === 'DKG_API_URL') {
+        lines.push(`  ${name}    — default http://127.0.0.1:9200`);
+      } else {
+        lines.push(`  ${name}`);
+      }
+    }
+  }
+
+  if (entry.install.usageHint) {
+    lines.push('');
+    lines.push('Usage:');
+    for (const line of entry.install.usageHint.split('\n')) {
+      lines.push(`  ${line}`);
+    }
+  }
+
+  return lines;
+}
+
+function runCommand(cmd: string, args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? 1));
+  });
+}

--- a/packages/cli/src/integrations/install-cli.ts
+++ b/packages/cli/src/integrations/install-cli.ts
@@ -7,6 +7,8 @@
 // stable PATH entry and idempotent re-installs.
 
 import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { dkgDir } from '../config.js';
 import type { InstallCli, IntegrationEntry } from './schema.js';
 
 export interface InstallCliOptions {
@@ -76,7 +78,7 @@ function buildPostInstructions(entry: IntegrationEntry): string[] {
     lines.push(`Required environment:`);
     for (const name of env) {
       if (name === 'DKG_AUTH_TOKEN') {
-        lines.push(`  ${name}  — pull from \`dkg auth show\` or ~/.dkg/auth.token`);
+        lines.push(`  ${name}  — pull from \`dkg auth show\` or ${join(dkgDir(), 'auth.token')}`);
       } else if (name === 'DKG_API_URL') {
         lines.push(`  ${name}    — default http://127.0.0.1:9200`);
       } else {

--- a/packages/cli/src/integrations/install-cli.ts
+++ b/packages/cli/src/integrations/install-cli.ts
@@ -10,10 +10,23 @@ import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { dkgDir } from '../config.js';
 import type { InstallCli, IntegrationEntry } from './schema.js';
+import { verifyNpmProvenance, type ProvenanceCheckResult } from './verify-npm-provenance.js';
+
+export type ProvenanceVerifier = (
+  pkg: string,
+  version: string,
+  expectedRepo: string,
+) => Promise<ProvenanceCheckResult>;
+
+// Injectable so tests can exercise the install flow without spawning npm.
+export type InstallRunner = (cmd: string, args: string[]) => Promise<number>;
 
 export interface InstallCliOptions {
   entry: IntegrationEntry;
   dryRun?: boolean;
+  skipProvenance?: boolean;
+  verifier?: ProvenanceVerifier;
+  runner?: InstallRunner;
   logger?: (msg: string) => void;
 }
 
@@ -23,6 +36,7 @@ export interface InstallCliResult {
   exitCode: number;
   binary: string;
   postInstructions: string[];
+  provenance?: ProvenanceCheckResult;
 }
 
 function assertCli(spec: IntegrationEntry['install']): asserts spec is InstallCli {
@@ -32,12 +46,42 @@ function assertCli(spec: IntegrationEntry['install']): asserts spec is InstallCl
 }
 
 export async function installCli(options: InstallCliOptions): Promise<InstallCliResult> {
-  const { entry, dryRun = false, logger = console.log } = options;
+  const {
+    entry,
+    dryRun = false,
+    skipProvenance = false,
+    verifier = verifyNpmProvenance,
+    runner = runCommand,
+    logger = console.log,
+  } = options;
   assertCli(entry.install);
   const { package: pkg, version, binary } = entry.install;
 
   const command = 'npm';
   const args = ['install', '--global', `${pkg}@${version}`];
+
+  // Provenance gate: verify BEFORE we touch the user's global npm. We skip
+  // this in dry-run (no side effects to guard) and when the caller passes
+  // --no-verify-provenance (e.g. installing a pre-release dev tarball with
+  // no attestation yet, or an air-gapped registry that doesn't sign).
+  let provenance: ProvenanceCheckResult | undefined;
+  if (!dryRun && !skipProvenance) {
+    logger(`Verifying publish-time provenance for ${pkg}@${version}...`);
+    provenance = await verifier(pkg, version, entry.repo);
+    if (!provenance.ok) {
+      logger('');
+      logger('  Provenance check FAILED:');
+      for (const r of provenance.reasons) logger(`    - ${r}`);
+      logger('');
+      throw new Error(
+        `Refusing to install ${pkg}@${version}: the tarball on npm is not ` +
+          `cryptographically bound to ${entry.repo}. Re-run with --no-verify-provenance ` +
+          `to install anyway.`,
+      );
+    }
+    logger(`  ok — tarball is attested and points at ${entry.repo}.`);
+    logger('');
+  }
 
   logger(`Installing ${pkg}@${version} globally via npm...`);
   logger(`  ${command} ${args.join(' ')}`);
@@ -49,10 +93,11 @@ export async function installCli(options: InstallCliOptions): Promise<InstallCli
       exitCode: 0,
       binary,
       postInstructions: buildPostInstructions(entry),
+      provenance,
     };
   }
 
-  const exitCode = await runCommand(command, args);
+  const exitCode = await runner(command, args);
   if (exitCode !== 0) {
     throw new Error(`npm install failed with exit code ${exitCode}. See output above for details.`);
   }
@@ -63,6 +108,7 @@ export async function installCli(options: InstallCliOptions): Promise<InstallCli
     exitCode,
     binary,
     postInstructions: buildPostInstructions(entry),
+    provenance,
   };
 }
 

--- a/packages/cli/src/integrations/install-mcp.ts
+++ b/packages/cli/src/integrations/install-mcp.ts
@@ -15,6 +15,7 @@
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { dkgDir } from '../config.js';
 import type { InstallMcp, IntegrationEntry } from './schema.js';
 
 export interface InstallMcpOptions {
@@ -39,10 +40,12 @@ function assertMcp(spec: IntegrationEntry['install']): asserts spec is InstallMc
 
 // Best-effort token read from the standard daemon-written path. Matches the
 // format produced by `dkg auth rotate` (a leading comment line + the token).
+// Resolves the path via dkgDir() so DKG_HOME and the monorepo's .dkg-dev
+// fallback are respected — matches where the rest of the CLI writes auth.
 // If we can't find one, we emit a placeholder and let the user fill it in.
 async function readLocalToken(): Promise<string | undefined> {
   try {
-    const raw = await readFile(join(homedir(), '.dkg', 'auth.token'), 'utf8');
+    const raw = await readFile(join(dkgDir(), 'auth.token'), 'utf8');
     for (const line of raw.split(/\r?\n/)) {
       const t = line.trim();
       if (t && !t.startsWith('#')) return t;

--- a/packages/cli/src/integrations/install-mcp.ts
+++ b/packages/cli/src/integrations/install-mcp.ts
@@ -60,16 +60,42 @@ export async function installMcp(options: InstallMcpOptions): Promise<InstallMcp
   const { entry, apiUrl = 'http://127.0.0.1:9200', logger = console.log } = options;
   assertMcp(entry.install);
 
-  const token = (await readLocalToken()) ?? '<DKG_AUTH_TOKEN>';
+  // Registry schema: entries declare the env var NAMES they need via
+  // `envRequired`. DKG_API_URL and DKG_AUTH_TOKEN are auto-filled if
+  // listed; every other name is rendered as a placeholder the user fills
+  // in. Entries that do NOT list DKG_AUTH_TOKEN never get the local admin
+  // token embedded — that is the security boundary. Auto-injecting the
+  // token into every MCP block would hand the node's write authority to
+  // any third-party server the moment the user pastes the snippet.
+  const envRequired = entry.install.envRequired ?? [];
+  const entryWantsToken = envRequired.includes('DKG_AUTH_TOKEN');
+  const entryWantsApiUrl = envRequired.includes('DKG_API_URL');
 
-  const env: Record<string, string> = { ...(entry.install.env ?? {}) };
-  for (const [k, v] of Object.entries(env)) {
-    env[k] = v
-      .replace('${DKG_API_URL}', apiUrl)
-      .replace('${DKG_AUTH_TOKEN}', token);
+  let localToken: string | undefined;
+  if (entryWantsToken) {
+    localToken = await readLocalToken();
   }
-  if (!('DKG_API_URL' in env)) env.DKG_API_URL = apiUrl;
-  if (!('DKG_AUTH_TOKEN' in env)) env.DKG_AUTH_TOKEN = token;
+  const tokenPlaceholder = '<DKG_AUTH_TOKEN>';
+  let tokenUsed = false;
+
+  const env: Record<string, string> = {};
+  if (entryWantsApiUrl) {
+    env.DKG_API_URL = apiUrl;
+  }
+  if (entryWantsToken) {
+    if (localToken) {
+      env.DKG_AUTH_TOKEN = localToken;
+      tokenUsed = true;
+    } else {
+      env.DKG_AUTH_TOKEN = tokenPlaceholder;
+    }
+  }
+  // Any other env vars the entry declares get placeholder slots the user
+  // must fill in manually — we don't invent values for unknown names.
+  for (const name of envRequired) {
+    if (name === 'DKG_API_URL' || name === 'DKG_AUTH_TOKEN') continue;
+    env[name] = `<${name}>`;
+  }
 
   const serverBlock: Record<string, unknown> = {
     command: entry.install.command,
@@ -98,9 +124,18 @@ export async function installMcp(options: InstallMcpOptions): Promise<InstallMcp
   logger('');
   logger('Common config locations:');
   for (const { client, path } of suggestedPaths) logger(`  ${client}: ${path}`);
-  if (token === '<DKG_AUTH_TOKEN>') {
+  if (entryWantsToken && !localToken) {
     logger('');
-    logger('No local DKG auth token found — replace <DKG_AUTH_TOKEN> with the value from `dkg auth show`.');
+    logger(`No local DKG auth token found — replace ${tokenPlaceholder} with the value from \`dkg auth show\`.`);
+  }
+  if (!entryWantsToken) {
+    logger('');
+    logger('This entry does not declare DKG_AUTH_TOKEN in envRequired, so no local token was embedded in the block.');
+  }
+  const userMustFill = envRequired.filter((n) => n !== 'DKG_API_URL' && n !== 'DKG_AUTH_TOKEN');
+  if (userMustFill.length > 0) {
+    logger('');
+    logger(`The following env values are not auto-filled — replace the placeholders before use: ${userMustFill.join(', ')}`);
   }
   if (entry.install.usageHint) {
     logger('');
@@ -108,5 +143,11 @@ export async function installMcp(options: InstallMcpOptions): Promise<InstallMcp
     for (const line of entry.install.usageHint.split('\n')) logger(`  ${line}`);
   }
 
-  return { serverKey, serverBlock, mcpJson, suggestedPaths, token: token === '<DKG_AUTH_TOKEN>' ? undefined : token };
+  return {
+    serverKey,
+    serverBlock,
+    mcpJson,
+    suggestedPaths,
+    token: tokenUsed ? localToken : undefined,
+  };
 }

--- a/packages/cli/src/integrations/install-mcp.ts
+++ b/packages/cli/src/integrations/install-mcp.ts
@@ -1,0 +1,109 @@
+// Installer for registry entries with `install.kind === "mcp"`.
+//
+// MCP servers get wired into a specific MCP client's config (Cursor has
+// ~/.cursor/mcp.json, Claude Desktop has its own path, etc). Client configs
+// are opinionated JSON files users hand-edit and fork quickly across
+// clients; silently rewriting them is a great way to clobber someone's
+// custom setup.
+//
+// So this "installer" is deliberately non-invasive: it renders the exact
+// JSON block the user should paste into the client's mcp.json, with their
+// DKG auth token and API URL prefilled, and prints the standard config
+// paths. An explicit --write-client flag to auto-merge into a client file
+// is left to a follow-up PR.
+
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { InstallMcp, IntegrationEntry } from './schema.js';
+
+export interface InstallMcpOptions {
+  entry: IntegrationEntry;
+  apiUrl?: string;
+  logger?: (msg: string) => void;
+}
+
+export interface InstallMcpResult {
+  serverKey: string;
+  serverBlock: Record<string, unknown>;
+  mcpJson: string;
+  suggestedPaths: Array<{ client: string; path: string }>;
+  token?: string;
+}
+
+function assertMcp(spec: IntegrationEntry['install']): asserts spec is InstallMcp {
+  if (spec.kind !== 'mcp') {
+    throw new Error(`install-mcp received non-mcp install spec (kind=${spec.kind})`);
+  }
+}
+
+// Best-effort token read from the standard daemon-written path. Matches the
+// format produced by `dkg auth rotate` (a leading comment line + the token).
+// If we can't find one, we emit a placeholder and let the user fill it in.
+async function readLocalToken(): Promise<string | undefined> {
+  try {
+    const raw = await readFile(join(homedir(), '.dkg', 'auth.token'), 'utf8');
+    for (const line of raw.split(/\r?\n/)) {
+      const t = line.trim();
+      if (t && !t.startsWith('#')) return t;
+    }
+  } catch {
+    // fall through — no token file is a normal state on a fresh machine.
+  }
+  return undefined;
+}
+
+export async function installMcp(options: InstallMcpOptions): Promise<InstallMcpResult> {
+  const { entry, apiUrl = 'http://127.0.0.1:9200', logger = console.log } = options;
+  assertMcp(entry.install);
+
+  const token = (await readLocalToken()) ?? '<DKG_AUTH_TOKEN>';
+
+  const env: Record<string, string> = { ...(entry.install.env ?? {}) };
+  for (const [k, v] of Object.entries(env)) {
+    env[k] = v
+      .replace('${DKG_API_URL}', apiUrl)
+      .replace('${DKG_AUTH_TOKEN}', token);
+  }
+  if (!('DKG_API_URL' in env)) env.DKG_API_URL = apiUrl;
+  if (!('DKG_AUTH_TOKEN' in env)) env.DKG_AUTH_TOKEN = token;
+
+  const serverBlock: Record<string, unknown> = {
+    command: entry.install.command,
+    args: entry.install.args,
+    env,
+  };
+
+  const serverKey = entry.slug;
+  const mcpJson = JSON.stringify({ mcpServers: { [serverKey]: serverBlock } }, null, 2);
+
+  const suggestedPaths: InstallMcpResult['suggestedPaths'] = [
+    { client: 'Cursor', path: join(homedir(), '.cursor', 'mcp.json') },
+    {
+      client: 'Claude Desktop (macOS)',
+      path: join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
+    },
+    {
+      client: 'Claude Desktop (Windows)',
+      path: '%APPDATA%\\Claude\\claude_desktop_config.json',
+    },
+  ];
+
+  logger('This integration runs as an MCP server. Add the block below to your MCP client\'s config:');
+  logger('');
+  logger(mcpJson);
+  logger('');
+  logger('Common config locations:');
+  for (const { client, path } of suggestedPaths) logger(`  ${client}: ${path}`);
+  if (token === '<DKG_AUTH_TOKEN>') {
+    logger('');
+    logger('No local DKG auth token found — replace <DKG_AUTH_TOKEN> with the value from `dkg auth show`.');
+  }
+  if (entry.install.usageHint) {
+    logger('');
+    logger('Usage:');
+    for (const line of entry.install.usageHint.split('\n')) logger(`  ${line}`);
+  }
+
+  return { serverKey, serverBlock, mcpJson, suggestedPaths, token: token === '<DKG_AUTH_TOKEN>' ? undefined : token };
+}

--- a/packages/cli/src/integrations/registry-client.ts
+++ b/packages/cli/src/integrations/registry-client.ts
@@ -76,6 +76,15 @@ export async function fetchEntry(slug: string, cfg: RegistryConfig): Promise<Int
         `The CLI may be out of date; check your dkg-integrations schema version.`,
     );
   }
+  // Guard against a registry file being a copy/rename artifact from another entry:
+  // `dkg integration install foo` must never return an entry that declares a different
+  // slug (and therefore a different npm package / install surface).
+  if (body.slug !== slug) {
+    throw new Error(
+      `Registry entry at "${slug}.json" declares slug "${body.slug}". ` +
+        `Refusing to install: filename and declared slug must match.`,
+    );
+  }
   return body;
 }
 

--- a/packages/cli/src/integrations/registry-client.ts
+++ b/packages/cli/src/integrations/registry-client.ts
@@ -4,7 +4,10 @@
 // List goes via the GitHub Contents API; individual entries go via raw.githubusercontent.com.
 // Both can be overridden via DKG_REGISTRY_INDEX_URL / DKG_REGISTRY_RAW_BASE for offline
 // tests and staging registries. If GITHUB_TOKEN is set we pass it so unauthenticated
-// rate limits (60 req/hr) don't hit contributor shells behind shared NATs.
+// rate limits (60 req/hr) don't hit contributor shells behind shared NATs — but only
+// when the target host is GitHub-owned. A user pointing DKG_REGISTRY_RAW_BASE at a
+// staging server must opt in explicitly via DKG_REGISTRY_TOKEN; otherwise a developer's
+// ambient GITHUB_TOKEN would leak to a non-GitHub endpoint.
 
 import { IntegrationEntry, isIntegrationEntry } from './schema.js';
 
@@ -17,6 +20,7 @@ export interface RegistryConfig {
   indexUrl: string;
   rawBase: string;
   githubToken?: string;
+  customRegistryToken?: string;
 }
 
 export function resolveRegistryConfig(env: NodeJS.ProcessEnv = process.env): RegistryConfig {
@@ -24,22 +28,41 @@ export function resolveRegistryConfig(env: NodeJS.ProcessEnv = process.env): Reg
     indexUrl: env.DKG_REGISTRY_INDEX_URL ?? DEFAULT_INDEX_URL,
     rawBase: env.DKG_REGISTRY_RAW_BASE ?? DEFAULT_RAW_BASE,
     githubToken: env.GITHUB_TOKEN || env.GH_TOKEN,
+    customRegistryToken: env.DKG_REGISTRY_TOKEN,
   };
 }
 
-function headers(cfg: RegistryConfig, accept: string): HeadersInit {
+export function isGithubHost(url: string): boolean {
+  try {
+    const h = new URL(url).hostname.toLowerCase();
+    return (
+      h === 'api.github.com' ||
+      h === 'raw.githubusercontent.com' ||
+      h === 'github.com' ||
+      h.endsWith('.github.com')
+    );
+  } catch {
+    return false;
+  }
+}
+
+function headers(cfg: RegistryConfig, targetUrl: string, accept: string): HeadersInit {
   const h: Record<string, string> = {
     Accept: accept,
     'User-Agent': 'dkg-cli-integrations/1',
   };
-  if (cfg.githubToken) h.Authorization = `Bearer ${cfg.githubToken}`;
+  if (isGithubHost(targetUrl)) {
+    if (cfg.githubToken) h.Authorization = `Bearer ${cfg.githubToken}`;
+  } else if (cfg.customRegistryToken) {
+    h.Authorization = `Bearer ${cfg.customRegistryToken}`;
+  }
   return h;
 }
 
 // Lists every *.json entry in the registry except the TEMPLATE.json scaffold.
 // Returns just the slugs; callers fetch full entries on demand.
 export async function listSlugs(cfg: RegistryConfig): Promise<string[]> {
-  const res = await fetch(cfg.indexUrl, { headers: headers(cfg, 'application/vnd.github+json') });
+  const res = await fetch(cfg.indexUrl, { headers: headers(cfg, cfg.indexUrl, 'application/vnd.github+json') });
   if (!res.ok) {
     throw new Error(
       `Failed to list registry entries: ${res.status} ${res.statusText}. ` +
@@ -62,7 +85,7 @@ export async function fetchEntry(slug: string, cfg: RegistryConfig): Promise<Int
     throw new Error(`Invalid slug "${slug}". Expected lowercase, digits, and hyphens only.`);
   }
   const url = `${cfg.rawBase}/${slug}.json`;
-  const res = await fetch(url, { headers: headers(cfg, 'application/json') });
+  const res = await fetch(url, { headers: headers(cfg, url, 'application/json') });
   if (res.status === 404) {
     throw new Error(`Integration "${slug}" not found in the registry (${url}).`);
   }
@@ -88,7 +111,30 @@ export async function fetchEntry(slug: string, cfg: RegistryConfig): Promise<Int
   return body;
 }
 
-export async function fetchAllEntries(cfg: RegistryConfig): Promise<IntegrationEntry[]> {
+export interface FetchAllResult {
+  entries: IntegrationEntry[];
+  failures: Array<{ slug: string; error: string }>;
+}
+
+// Best-effort bulk fetch. A malformed or temporarily-unreachable entry must
+// not take down the entire `dkg integration list` — a single bad community
+// submission shouldn't hide the verified/featured entries users actually
+// care about. We collect per-entry failures and return them alongside the
+// good entries; the caller decides how to surface them.
+export async function fetchAllEntries(cfg: RegistryConfig): Promise<FetchAllResult> {
   const slugs = await listSlugs(cfg);
-  return Promise.all(slugs.map((s) => fetchEntry(s, cfg)));
+  const entries: IntegrationEntry[] = [];
+  const failures: Array<{ slug: string; error: string }> = [];
+  await Promise.all(
+    slugs.map(async (s) => {
+      try {
+        entries.push(await fetchEntry(s, cfg));
+      } catch (err) {
+        failures.push({ slug: s, error: err instanceof Error ? err.message : String(err) });
+      }
+    }),
+  );
+  entries.sort((a, b) => a.slug.localeCompare(b.slug));
+  failures.sort((a, b) => a.slug.localeCompare(b.slug));
+  return { entries, failures };
 }

--- a/packages/cli/src/integrations/registry-client.ts
+++ b/packages/cli/src/integrations/registry-client.ts
@@ -1,0 +1,85 @@
+// Registry client: talks to the public DKG integration registry
+// (https://github.com/OriginTrail/dkg-integrations) over HTTPS.
+//
+// List goes via the GitHub Contents API; individual entries go via raw.githubusercontent.com.
+// Both can be overridden via DKG_REGISTRY_INDEX_URL / DKG_REGISTRY_RAW_BASE for offline
+// tests and staging registries. If GITHUB_TOKEN is set we pass it so unauthenticated
+// rate limits (60 req/hr) don't hit contributor shells behind shared NATs.
+
+import { IntegrationEntry, isIntegrationEntry } from './schema.js';
+
+const DEFAULT_INDEX_URL =
+  'https://api.github.com/repos/OriginTrail/dkg-integrations/contents/integrations?ref=main';
+const DEFAULT_RAW_BASE =
+  'https://raw.githubusercontent.com/OriginTrail/dkg-integrations/main/integrations';
+
+export interface RegistryConfig {
+  indexUrl: string;
+  rawBase: string;
+  githubToken?: string;
+}
+
+export function resolveRegistryConfig(env: NodeJS.ProcessEnv = process.env): RegistryConfig {
+  return {
+    indexUrl: env.DKG_REGISTRY_INDEX_URL ?? DEFAULT_INDEX_URL,
+    rawBase: env.DKG_REGISTRY_RAW_BASE ?? DEFAULT_RAW_BASE,
+    githubToken: env.GITHUB_TOKEN || env.GH_TOKEN,
+  };
+}
+
+function headers(cfg: RegistryConfig, accept: string): HeadersInit {
+  const h: Record<string, string> = {
+    Accept: accept,
+    'User-Agent': 'dkg-cli-integrations/1',
+  };
+  if (cfg.githubToken) h.Authorization = `Bearer ${cfg.githubToken}`;
+  return h;
+}
+
+// Lists every *.json entry in the registry except the TEMPLATE.json scaffold.
+// Returns just the slugs; callers fetch full entries on demand.
+export async function listSlugs(cfg: RegistryConfig): Promise<string[]> {
+  const res = await fetch(cfg.indexUrl, { headers: headers(cfg, 'application/vnd.github+json') });
+  if (!res.ok) {
+    throw new Error(
+      `Failed to list registry entries: ${res.status} ${res.statusText}. ` +
+        `Check that the registry is reachable (${cfg.indexUrl}) and, if rate-limited, set GITHUB_TOKEN.`,
+    );
+  }
+  const body = (await res.json()) as Array<{ name: string; type?: string }>;
+  if (!Array.isArray(body)) {
+    throw new Error(`Registry index did not return an array. Got: ${JSON.stringify(body).slice(0, 200)}`);
+  }
+  return body
+    .filter((f) => f.type !== 'dir' && f.name.endsWith('.json') && f.name !== 'TEMPLATE.json')
+    .map((f) => f.name.replace(/\.json$/, ''))
+    .sort();
+}
+
+export async function fetchEntry(slug: string, cfg: RegistryConfig): Promise<IntegrationEntry> {
+  // Slug constraints mirror the registry schema; guard against directory-traversal sneaking in.
+  if (!/^[a-z0-9][a-z0-9-]{0,60}$/.test(slug)) {
+    throw new Error(`Invalid slug "${slug}". Expected lowercase, digits, and hyphens only.`);
+  }
+  const url = `${cfg.rawBase}/${slug}.json`;
+  const res = await fetch(url, { headers: headers(cfg, 'application/json') });
+  if (res.status === 404) {
+    throw new Error(`Integration "${slug}" not found in the registry (${url}).`);
+  }
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${slug}: ${res.status} ${res.statusText}`);
+  }
+  const body = await res.json();
+  if (!isIntegrationEntry(body)) {
+    throw new Error(
+      `Registry entry for "${slug}" does not match the expected shape. ` +
+        `The CLI may be out of date; check your dkg-integrations schema version.`,
+    );
+  }
+  return body;
+}
+
+export async function fetchAllEntries(cfg: RegistryConfig): Promise<IntegrationEntry[]> {
+  const slugs = await listSlugs(cfg);
+  return Promise.all(slugs.map((s) => fetchEntry(s, cfg)));
+}

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -29,8 +29,13 @@ export interface InstallMcp {
   kind: 'mcp';
   command: string;
   args: string[];
-  env?: Record<string, string>;
-  clientCompatibility?: string[];
+  // Env var NAMES the MCP server expects. Per the registry schema,
+  // DKG_AUTH_TOKEN and DKG_API_URL are auto-filled by the installer when
+  // listed here; other names are rendered as placeholders the user must
+  // fill in. Entries that DO NOT list DKG_AUTH_TOKEN never get the
+  // local admin token injected — that's the security boundary.
+  envRequired?: string[];
+  supportedClients?: string[];
   usageHint?: string;
 }
 
@@ -127,10 +132,13 @@ export function isIntegrationEntry(value: unknown): value is IntegrationEntry {
     if (m !== 'WM' && m !== 'SWM' && m !== 'VM') return false;
   }
   if (!isStringArray(o.v10PrimitivesUsed)) return false;
+  // publicInterfacesUsed is rendered but not dispatched on, so accept any
+  // string here. Hard-rejecting unknown values would stop older CLIs from
+  // reading otherwise-valid registry entries as soon as the registry adds a
+  // new interface label — forward-compat beats strictness for display-only
+  // fields. trustTier, memoryLayers, and install.kind stay strict below
+  // because the CLI branches on them.
   if (!isStringArray(o.publicInterfacesUsed)) return false;
-  for (const p of o.publicInterfacesUsed as unknown[]) {
-    if (p !== 'http-api' && p !== 'cli' && p !== 'mcp') return false;
-  }
 
   // Trust tier: direct input to the `--allow-community` gate.
   if (o.trustTier !== 'community' && o.trustTier !== 'verified' && o.trustTier !== 'featured') {
@@ -175,8 +183,8 @@ function isValidInstallSpec(v: unknown): boolean {
       return (
         typeof v.command === 'string' &&
         isStringArray(v.args) &&
-        (v.env === undefined || isStringRecord(v.env)) &&
-        (v.clientCompatibility === undefined || isStringArray(v.clientCompatibility))
+        (v.envRequired === undefined || isStringArray(v.envRequired)) &&
+        (v.supportedClients === undefined || isStringArray(v.supportedClients))
       );
     case 'service':
       return v.runtime === 'docker' || v.runtime === 'npm-global';
@@ -193,7 +201,3 @@ function isValidInstallSpec(v: unknown): boolean {
   }
 }
 
-function isStringRecord(v: unknown): boolean {
-  if (!isPlainObject(v)) return false;
-  return Object.values(v).every((x) => typeof x === 'string');
-}

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -1,0 +1,112 @@
+// TypeScript shape of a DKG integration registry entry.
+//
+// Mirrors schema/integration.schema.json in OriginTrail/dkg-integrations. Only
+// the fields the CLI actually consumes are typed strongly; the rest ride in
+// `[unknownExtras: string]: unknown` so a schema bump in the registry doesn't
+// break the CLI without a corresponding code change here.
+
+export type TrustTier = 'community' | 'verified' | 'featured';
+export type MemoryLayer = 'WM' | 'SWM' | 'VM';
+export type PublicInterface = 'http-api' | 'cli' | 'mcp';
+
+export type InstallSpec =
+  | InstallCli
+  | InstallMcp
+  | InstallService
+  | InstallAgentPlugin
+  | InstallManual;
+
+export interface InstallCli {
+  kind: 'cli';
+  package: string;
+  version: string;
+  binary: string;
+  envRequired?: string[];
+  usageHint?: string;
+}
+
+export interface InstallMcp {
+  kind: 'mcp';
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  clientCompatibility?: string[];
+  usageHint?: string;
+}
+
+export interface InstallService {
+  kind: 'service';
+  runtime: 'docker' | 'npm-global';
+  docker?: {
+    image: string;
+    digest?: string;
+    ports?: Array<{ container: number; host?: number }>;
+    env?: Record<string, string>;
+  };
+  npmGlobal?: {
+    package: string;
+    version: string;
+    binary: string;
+    env?: Record<string, string>;
+  };
+  usageHint?: string;
+}
+
+export interface InstallAgentPlugin {
+  kind: 'agent-plugin';
+  framework: string;
+  package: string;
+  version: string;
+  registrationHint?: string;
+  usageHint?: string;
+}
+
+export interface InstallManual {
+  kind: 'manual';
+  steps: string[];
+  usageHint?: string;
+}
+
+export interface IntegrationEntry {
+  slug: string;
+  name: string;
+  description: string;
+  category?: string[];
+  maintainer: { github: string; name?: string; email?: string };
+  repo: string;
+  commit: string;
+  license: string;
+  schemaVersion?: string;
+  requiresDkgNodeVersion?: string;
+  memoryLayers: MemoryLayer[];
+  v10PrimitivesUsed: string[];
+  publicInterfacesUsed: PublicInterface[];
+  targetAgents?: string[];
+  install: InstallSpec;
+  security: {
+    networkEgress?: string[];
+    writeAuthority?: string[];
+    credentialsHandled?: string[];
+    notes?: string;
+  };
+  trustTier: TrustTier;
+  designBrief?: string;
+  demo?: string;
+  promotionPath?: string;
+  fitNotes?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [extras: string]: any;
+}
+
+export function isIntegrationEntry(value: unknown): value is IntegrationEntry {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.slug === 'string' &&
+    typeof o.name === 'string' &&
+    typeof o.trustTier === 'string' &&
+    typeof o.install === 'object' &&
+    o.install !== null &&
+    typeof (o.install as Record<string, unknown>).kind === 'string'
+  );
+}

--- a/packages/cli/src/integrations/schema.ts
+++ b/packages/cli/src/integrations/schema.ts
@@ -98,15 +98,102 @@ export interface IntegrationEntry {
   [extras: string]: any;
 }
 
+// Validates the full shape the CLI consumes from a registry entry. The list /
+// info / install paths dereference nested fields like security.writeAuthority,
+// maintainer.github, memoryLayers, and install-kind-specific args; a loose
+// check here would just move the failure site to a confusing later throw. If
+// the registry ever adds new fields, they ride through on `[extras]: any` —
+// but the fields the CLI reads today must be present and the right shape.
 export function isIntegrationEntry(value: unknown): value is IntegrationEntry {
   if (!value || typeof value !== 'object') return false;
   const o = value as Record<string, unknown>;
-  return (
-    typeof o.slug === 'string' &&
-    typeof o.name === 'string' &&
-    typeof o.trustTier === 'string' &&
-    typeof o.install === 'object' &&
-    o.install !== null &&
-    typeof (o.install as Record<string, unknown>).kind === 'string'
-  );
+
+  // Required scalar fields.
+  if (typeof o.slug !== 'string') return false;
+  if (typeof o.name !== 'string') return false;
+  if (typeof o.description !== 'string') return false;
+  if (typeof o.repo !== 'string') return false;
+  if (typeof o.commit !== 'string') return false;
+  if (typeof o.license !== 'string') return false;
+
+  // Maintainer: must have a GitHub handle (used in `info` output + UI).
+  if (!isPlainObject(o.maintainer)) return false;
+  if (typeof (o.maintainer as Record<string, unknown>).github !== 'string') return false;
+
+  // Memory layers / primitives / interfaces: we render them and, for layers,
+  // filter for display. Must be string arrays with known values where we care.
+  if (!isStringArray(o.memoryLayers)) return false;
+  for (const m of o.memoryLayers as unknown[]) {
+    if (m !== 'WM' && m !== 'SWM' && m !== 'VM') return false;
+  }
+  if (!isStringArray(o.v10PrimitivesUsed)) return false;
+  if (!isStringArray(o.publicInterfacesUsed)) return false;
+  for (const p of o.publicInterfacesUsed as unknown[]) {
+    if (p !== 'http-api' && p !== 'cli' && p !== 'mcp') return false;
+  }
+
+  // Trust tier: direct input to the `--allow-community` gate.
+  if (o.trustTier !== 'community' && o.trustTier !== 'verified' && o.trustTier !== 'featured') {
+    return false;
+  }
+
+  // Security declaration: `info` always prints it; must be an object.
+  if (!isPlainObject(o.security)) return false;
+  const sec = o.security as Record<string, unknown>;
+  if (sec.networkEgress !== undefined && !isStringArray(sec.networkEgress)) return false;
+  if (sec.writeAuthority !== undefined && !isStringArray(sec.writeAuthority)) return false;
+  if (sec.credentialsHandled !== undefined && !isStringArray(sec.credentialsHandled)) return false;
+  if (sec.notes !== undefined && typeof sec.notes !== 'string') return false;
+
+  // Install spec: dispatcher and kind-specific fields the installers read.
+  if (!isValidInstallSpec(o.install)) return false;
+
+  return true;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isStringArray(v: unknown): boolean {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+
+function isValidInstallSpec(v: unknown): boolean {
+  if (!isPlainObject(v)) return false;
+  const kind = v.kind;
+  switch (kind) {
+    case 'cli':
+      return (
+        typeof v.package === 'string' &&
+        typeof v.version === 'string' &&
+        typeof v.binary === 'string' &&
+        (v.envRequired === undefined || isStringArray(v.envRequired)) &&
+        (v.usageHint === undefined || typeof v.usageHint === 'string')
+      );
+    case 'mcp':
+      return (
+        typeof v.command === 'string' &&
+        isStringArray(v.args) &&
+        (v.env === undefined || isStringRecord(v.env)) &&
+        (v.clientCompatibility === undefined || isStringArray(v.clientCompatibility))
+      );
+    case 'service':
+      return v.runtime === 'docker' || v.runtime === 'npm-global';
+    case 'agent-plugin':
+      return (
+        typeof v.framework === 'string' &&
+        typeof v.package === 'string' &&
+        typeof v.version === 'string'
+      );
+    case 'manual':
+      return isStringArray(v.steps);
+    default:
+      return false;
+  }
+}
+
+function isStringRecord(v: unknown): boolean {
+  if (!isPlainObject(v)) return false;
+  return Object.values(v).every((x) => typeof x === 'string');
 }

--- a/packages/cli/src/integrations/verify-npm-provenance.ts
+++ b/packages/cli/src/integrations/verify-npm-provenance.ts
@@ -1,0 +1,155 @@
+// Publish-time provenance + repository binding check for cli-kind installs.
+//
+// The bounty-registry workflow claims a "reviewed commit" for each entry, but
+// `npm install --global <pkg>@<version>` pulls a tarball from the npm registry
+// with no intrinsic link back to that commit. The binding that DOES exist lives
+// in the tarball's publish-time provenance attestation (npm's sigstore OIDC
+// bundle, produced by a CI build that signs in the git revision). So before
+// running npm install we shell out to `npm view` and require:
+//
+//   1. the pinned version resolves to a real tarball,
+//   2. that tarball has a provenance attestation attached,
+//   3. it has a registry signature,
+//   4. the package's declared repository.url matches the entry's `repo`.
+//
+// Any of those missing → we refuse to install. A user who is deliberately
+// operating on an un-attested package (e.g. first-party dev tarball mid-PR)
+// can escape via `--no-verify-provenance`.
+//
+// We don't parse / verify the sigstore bundle itself here — `npm audit
+// signatures` does that, and `npm install --global` with npm ≥ 9 also exits
+// non-zero when signature verification fails in certain configs. We only need
+// to confirm the artifact claims to be attested and points at the right repo;
+// npm does the cryptographic verification on install.
+
+import { spawn } from 'node:child_process';
+
+export interface ProvenanceCheckResult {
+  ok: boolean;
+  found: {
+    versionResolvable: boolean;
+    hasProvenance: boolean;
+    hasRegistrySignature: boolean;
+    repositoryUrl?: string;
+  };
+  expectedRepo: string;
+  reasons: string[];
+}
+
+// Uses the system `npm` to query published metadata. We never touch on-disk
+// state here — `npm view` is a read-only registry probe.
+export async function verifyNpmProvenance(
+  pkg: string,
+  version: string,
+  expectedRepo: string,
+): Promise<ProvenanceCheckResult> {
+  const meta = await npmView(pkg, version);
+  const reasons: string[] = [];
+
+  if (meta === null) {
+    reasons.push(`npm view ${pkg}@${version} returned no metadata — package or version not found on the configured registry.`);
+    return {
+      ok: false,
+      found: { versionResolvable: false, hasProvenance: false, hasRegistrySignature: false },
+      expectedRepo,
+      reasons,
+    };
+  }
+
+  const dist = (meta.dist as Record<string, unknown> | undefined) ?? undefined;
+  const hasRegistrySignature = !!(dist && Array.isArray(dist.signatures) && dist.signatures.length > 0);
+  const hasProvenance = !!(
+    dist && typeof dist.attestations === 'object' && dist.attestations !== null
+  );
+  const repoUrl = extractRepoUrl(meta);
+  const normalizedPublished = normalizeRepoUrl(repoUrl);
+  const normalizedExpected = normalizeRepoUrl(expectedRepo);
+  const repoMatches =
+    !!normalizedPublished && !!normalizedExpected && normalizedPublished === normalizedExpected;
+
+  if (!hasProvenance) {
+    reasons.push(`npm tarball for ${pkg}@${version} lacks a publish-time provenance attestation (dist.attestations).`);
+  }
+  if (!hasRegistrySignature) {
+    reasons.push(`npm tarball for ${pkg}@${version} lacks a registry signature (dist.signatures).`);
+  }
+  if (!repoMatches) {
+    reasons.push(
+      `npm repository.url (${repoUrl ?? 'missing'}) does not match the registry entry's repo (${expectedRepo}). ` +
+        `An attested build pointing at a different repo is not proof of provenance for this entry.`,
+    );
+  }
+
+  return {
+    ok: hasProvenance && hasRegistrySignature && repoMatches,
+    found: {
+      versionResolvable: true,
+      hasProvenance,
+      hasRegistrySignature,
+      repositoryUrl: repoUrl,
+    },
+    expectedRepo,
+    reasons,
+  };
+}
+
+function extractRepoUrl(meta: Record<string, unknown>): string | undefined {
+  const repo = meta.repository;
+  if (typeof repo === 'string') return repo;
+  if (repo && typeof repo === 'object') {
+    const url = (repo as Record<string, unknown>).url;
+    if (typeof url === 'string') return url;
+  }
+  return undefined;
+}
+
+// Collapse the many equivalent git URL shapes (git+https://, git://, trailing
+// .git, trailing slashes, protocol prefixes) into a host+path key so a direct
+// string compare is meaningful.
+export function normalizeRepoUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  let s = url.trim();
+  s = s.replace(/^git\+/, '');
+  s = s.replace(/^git:\/\//, 'https://');
+  s = s.replace(/^ssh:\/\/git@/, 'https://');
+  s = s.replace(/^git@([^:]+):/, 'https://$1/');
+  s = s.replace(/\.git$/, '');
+  try {
+    const u = new URL(s);
+    const path = u.pathname.replace(/\/+$/, '').toLowerCase();
+    return `${u.hostname.toLowerCase()}${path}`;
+  } catch {
+    return s.toLowerCase();
+  }
+}
+
+async function npmView(pkg: string, version: string): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    const child = spawn('npm', ['view', `${pkg}@${version}`, '--json'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    child.stdout.on('data', (c) => (out += c.toString()));
+    child.on('error', () => resolve(null));
+    child.on('close', (code) => {
+      if (code !== 0 || !out.trim()) {
+        resolve(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(out);
+        if (Array.isArray(parsed)) {
+          // Multiple versions matched — take the last one (latest that still
+          // satisfies the pin). For an exact-version pin this is always size 1.
+          resolve((parsed[parsed.length - 1] as Record<string, unknown>) ?? null);
+        } else if (parsed && typeof parsed === 'object') {
+          resolve(parsed as Record<string, unknown>);
+        } else {
+          resolve(null);
+        }
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -53,12 +53,57 @@ describe('isIntegrationEntry', () => {
     expect(isIntegrationEntry(baseEntry)).toBe(true);
   });
 
+  it('accepts a well-formed mcp entry', () => {
+    expect(isIntegrationEntry(mcpEntry)).toBe(true);
+  });
+
   it('rejects null, non-objects, and entries missing required keys', () => {
     expect(isIntegrationEntry(null)).toBe(false);
     expect(isIntegrationEntry('string')).toBe(false);
     expect(isIntegrationEntry({})).toBe(false);
     expect(isIntegrationEntry({ slug: 'x', name: 'y', trustTier: 'featured' })).toBe(false);
     expect(isIntegrationEntry({ ...baseEntry, install: { notKind: true } })).toBe(false);
+  });
+
+  it('rejects entries with a missing maintainer.github handle', () => {
+    const bad = { ...baseEntry, maintainer: {} as { github: string } };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects entries with an unknown memory layer', () => {
+    const bad = { ...baseEntry, memoryLayers: ['WM', 'BOGUS'] as unknown as typeof baseEntry.memoryLayers };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects entries with a non-array v10PrimitivesUsed', () => {
+    const bad = { ...baseEntry, v10PrimitivesUsed: 'ContextGraph' as unknown as string[] };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects entries whose security block is malformed', () => {
+    const bad = { ...baseEntry, security: { networkEgress: 'github.com' } as unknown as typeof baseEntry.security };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects an unknown trustTier', () => {
+    const bad = { ...baseEntry, trustTier: 'rogue' as unknown as typeof baseEntry.trustTier };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects a cli install without package/version/binary', () => {
+    const bad = {
+      ...baseEntry,
+      install: { kind: 'cli', package: 'foo' } as unknown as typeof baseEntry.install,
+    };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects an mcp install without args array', () => {
+    const bad = {
+      ...baseEntry,
+      install: { kind: 'mcp', command: 'npx', args: 'not-an-array' } as unknown as typeof baseEntry.install,
+    };
+    expect(isIntegrationEntry(bad)).toBe(false);
   });
 });
 
@@ -144,6 +189,17 @@ describe('fetchEntry', () => {
     globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ not: 'an entry' }), { status: 200 })) as unknown as typeof fetch;
     await expect(fetchEntry('dkg-hello-world', resolveRegistryConfig({}))).rejects.toThrow(/does not match the expected shape/);
   });
+
+  it('rejects payloads whose declared slug disagrees with the filename', async () => {
+    // Registry entry file is dkg-hello-world.json but internal slug says something else —
+    // probably a copy/rename artifact. Installing it would silently swap packages.
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ ...baseEntry, slug: 'something-else' }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    await expect(fetchEntry('dkg-hello-world', resolveRegistryConfig({}))).rejects.toThrow(
+      /declares slug "something-else"/,
+    );
+  });
 });
 
 // ── installCli (dry-run) ──────────────────────────────────────────────────
@@ -169,16 +225,25 @@ describe('installCli', () => {
 
 describe('installMcp', () => {
   let tmpHome: string;
+  let tmpDkgHome: string;
   const originalHome = process.env.HOME;
+  const originalDkgHome = process.env.DKG_HOME;
 
   beforeEach(async () => {
     tmpHome = await mkdtemp(join(tmpdir(), 'dkg-cli-mcp-'));
+    tmpDkgHome = join(tmpHome, '.dkg');
     process.env.HOME = tmpHome;
+    // Pin DKG_HOME so dkgDir() resolves deterministically inside the monorepo —
+    // otherwise the .dkg-dev fallback kicks in and the token-file test becomes
+    // order-sensitive depending on the developer's real home layout.
+    process.env.DKG_HOME = tmpDkgHome;
   });
 
   afterEach(async () => {
     if (originalHome) process.env.HOME = originalHome;
     else delete process.env.HOME;
+    if (originalDkgHome) process.env.DKG_HOME = originalDkgHome;
+    else delete process.env.DKG_HOME;
     await rm(tmpHome, { recursive: true, force: true });
   });
 
@@ -194,10 +259,10 @@ describe('installMcp', () => {
     expect(logs.some((l) => l.includes('mcpServers'))).toBe(true);
   });
 
-  it('substitutes the real token when ~/.dkg/auth.token is present', async () => {
-    await mkdir(join(tmpHome, '.dkg'), { recursive: true });
+  it('substitutes the real token when <DKG_HOME>/auth.token is present', async () => {
+    await mkdir(tmpDkgHome, { recursive: true });
     await writeFile(
-      join(tmpHome, '.dkg', 'auth.token'),
+      join(tmpDkgHome, 'auth.token'),
       '# DKG node API token — treat this like a password\nreal-token-xyz\n',
       'utf8',
     );
@@ -205,5 +270,17 @@ describe('installMcp', () => {
     const parsed = JSON.parse(res.mcpJson);
     expect(parsed.mcpServers['cursor-mcp-dkg'].env.DKG_AUTH_TOKEN).toBe('real-token-xyz');
     expect(res.token).toBe('real-token-xyz');
+  });
+
+  it('honors DKG_HOME when resolving the auth token', async () => {
+    const altHome = await mkdtemp(join(tmpdir(), 'dkg-cli-mcp-alt-'));
+    try {
+      process.env.DKG_HOME = altHome;
+      await writeFile(join(altHome, 'auth.token'), 'alt-token\n', 'utf8');
+      const res = await installMcp({ entry: mcpEntry, apiUrl: 'http://127.0.0.1:9200', logger: () => {} });
+      expect(res.token).toBe('alt-token');
+    } finally {
+      await rm(altHome, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { resolveRegistryConfig, listSlugs, fetchEntry } from '../src/integrations/registry-client.js';
+import { isIntegrationEntry } from '../src/integrations/schema.js';
+import { installCli } from '../src/integrations/install-cli.js';
+import { installMcp } from '../src/integrations/install-mcp.js';
+import type { IntegrationEntry } from '../src/integrations/schema.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const baseEntry: IntegrationEntry = {
+  slug: 'dkg-hello-world',
+  name: 'DKG Hello World',
+  description: 'Test fixture',
+  maintainer: { github: '@OriginTrail/core-developers' },
+  repo: 'https://github.com/OriginTrail/dkg-hello-world',
+  commit: '0000000000000000000000000000000000000000',
+  license: 'Apache-2.0',
+  memoryLayers: ['WM'],
+  v10PrimitivesUsed: ['ContextGraph', 'Assertion'],
+  publicInterfacesUsed: ['http-api'],
+  install: {
+    kind: 'cli',
+    package: '@origintrail/dkg-hello-world',
+    version: '0.1.0',
+    binary: 'dkg-hello-world',
+    envRequired: ['DKG_API_URL', 'DKG_AUTH_TOKEN'],
+    usageHint: 'dkg-hello-world greet "first post"\ndkg-hello-world list',
+  },
+  security: {},
+  trustTier: 'featured',
+};
+
+const mcpEntry: IntegrationEntry = {
+  ...baseEntry,
+  slug: 'cursor-mcp-dkg',
+  name: 'DKG MCP server',
+  install: {
+    kind: 'mcp',
+    command: 'npx',
+    args: ['-y', '@origintrail-official/dkg-mcp@0.1.0'],
+    env: { DKG_API_URL: '${DKG_API_URL}', DKG_AUTH_TOKEN: '${DKG_AUTH_TOKEN}' },
+  },
+};
+
+// ── isIntegrationEntry ────────────────────────────────────────────────────
+
+describe('isIntegrationEntry', () => {
+  it('accepts a well-formed entry', () => {
+    expect(isIntegrationEntry(baseEntry)).toBe(true);
+  });
+
+  it('rejects null, non-objects, and entries missing required keys', () => {
+    expect(isIntegrationEntry(null)).toBe(false);
+    expect(isIntegrationEntry('string')).toBe(false);
+    expect(isIntegrationEntry({})).toBe(false);
+    expect(isIntegrationEntry({ slug: 'x', name: 'y', trustTier: 'featured' })).toBe(false);
+    expect(isIntegrationEntry({ ...baseEntry, install: { notKind: true } })).toBe(false);
+  });
+});
+
+// ── resolveRegistryConfig ─────────────────────────────────────────────────
+
+describe('resolveRegistryConfig', () => {
+  it('falls back to registry defaults when env is empty', () => {
+    const cfg = resolveRegistryConfig({});
+    expect(cfg.indexUrl).toContain('api.github.com');
+    expect(cfg.indexUrl).toContain('dkg-integrations');
+    expect(cfg.rawBase).toContain('raw.githubusercontent.com');
+    expect(cfg.githubToken).toBeUndefined();
+  });
+
+  it('honors overrides', () => {
+    const cfg = resolveRegistryConfig({
+      DKG_REGISTRY_INDEX_URL: 'https://staging.example/index',
+      DKG_REGISTRY_RAW_BASE: 'https://staging.example/raw',
+      GITHUB_TOKEN: 'ghp_xyz',
+    });
+    expect(cfg.indexUrl).toBe('https://staging.example/index');
+    expect(cfg.rawBase).toBe('https://staging.example/raw');
+    expect(cfg.githubToken).toBe('ghp_xyz');
+  });
+});
+
+// ── listSlugs / fetchEntry via mocked fetch ───────────────────────────────
+
+describe('listSlugs', () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('filters out TEMPLATE.json and non-json / directory entries', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify([
+          { name: 'dkg-hello-world.json', type: 'file' },
+          { name: 'cursor-mcp-dkg.json', type: 'file' },
+          { name: 'TEMPLATE.json', type: 'file' },
+          { name: 'README.md', type: 'file' },
+          { name: 'subdir', type: 'dir' },
+        ]),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+
+    const slugs = await listSlugs(resolveRegistryConfig({}));
+    expect(slugs).toEqual(['cursor-mcp-dkg', 'dkg-hello-world']);
+  });
+
+  it('throws a useful error on rate limit / 403', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('{"message":"forbidden"}', { status: 403, statusText: 'Forbidden' })) as unknown as typeof fetch;
+    await expect(listSlugs(resolveRegistryConfig({}))).rejects.toThrow(/Failed to list registry entries: 403/);
+  });
+});
+
+describe('fetchEntry', () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('rejects directory-traversal-style slugs', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 200 })) as unknown as typeof fetch;
+    await expect(fetchEntry('../etc/passwd', resolveRegistryConfig({}))).rejects.toThrow(/Invalid slug/);
+  });
+
+  it('returns a well-shaped entry on success', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(baseEntry), { status: 200 })) as unknown as typeof fetch;
+    const e = await fetchEntry('dkg-hello-world', resolveRegistryConfig({}));
+    expect(e.slug).toBe('dkg-hello-world');
+    expect(e.install.kind).toBe('cli');
+  });
+
+  it('gives a specific message on 404', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('', { status: 404, statusText: 'Not Found' })) as unknown as typeof fetch;
+    await expect(fetchEntry('ghost', resolveRegistryConfig({}))).rejects.toThrow(/not found in the registry/);
+  });
+
+  it('rejects payloads that do not match the schema', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ not: 'an entry' }), { status: 200 })) as unknown as typeof fetch;
+    await expect(fetchEntry('dkg-hello-world', resolveRegistryConfig({}))).rejects.toThrow(/does not match the expected shape/);
+  });
+});
+
+// ── installCli (dry-run) ──────────────────────────────────────────────────
+
+describe('installCli', () => {
+  it('renders the correct npm command in dry-run mode and emits post-instructions', async () => {
+    const logs: string[] = [];
+    const result = await installCli({ entry: baseEntry, dryRun: true, logger: (m) => logs.push(m) });
+    expect(result.command).toBe('npm');
+    expect(result.args).toEqual(['install', '--global', '@origintrail/dkg-hello-world@0.1.0']);
+    expect(result.binary).toBe('dkg-hello-world');
+    expect(result.postInstructions.join('\n')).toContain('DKG_AUTH_TOKEN');
+    expect(result.postInstructions.join('\n')).toContain('dkg-hello-world greet');
+    expect(logs.join('\n')).toContain('npm install --global @origintrail/dkg-hello-world@0.1.0');
+  });
+
+  it('throws when called with a non-cli entry', async () => {
+    await expect(installCli({ entry: mcpEntry, dryRun: true })).rejects.toThrow(/non-cli install spec/);
+  });
+});
+
+// ── installMcp (pure render) ──────────────────────────────────────────────
+
+describe('installMcp', () => {
+  let tmpHome: string;
+  const originalHome = process.env.HOME;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), 'dkg-cli-mcp-'));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('emits a paste-ready mcpServers block with api-url and placeholder token', async () => {
+    const logs: string[] = [];
+    const res = await installMcp({ entry: mcpEntry, apiUrl: 'http://127.0.0.1:9200', logger: (m) => logs.push(m) });
+    const parsed = JSON.parse(res.mcpJson);
+    expect(parsed.mcpServers['cursor-mcp-dkg'].command).toBe('npx');
+    expect(parsed.mcpServers['cursor-mcp-dkg'].args).toEqual(['-y', '@origintrail-official/dkg-mcp@0.1.0']);
+    expect(parsed.mcpServers['cursor-mcp-dkg'].env.DKG_API_URL).toBe('http://127.0.0.1:9200');
+    expect(parsed.mcpServers['cursor-mcp-dkg'].env.DKG_AUTH_TOKEN).toBe('<DKG_AUTH_TOKEN>');
+    expect(res.token).toBeUndefined();
+    expect(logs.some((l) => l.includes('mcpServers'))).toBe(true);
+  });
+
+  it('substitutes the real token when ~/.dkg/auth.token is present', async () => {
+    await mkdir(join(tmpHome, '.dkg'), { recursive: true });
+    await writeFile(
+      join(tmpHome, '.dkg', 'auth.token'),
+      '# DKG node API token — treat this like a password\nreal-token-xyz\n',
+      'utf8',
+    );
+    const res = await installMcp({ entry: mcpEntry, apiUrl: 'http://127.0.0.1:9200', logger: () => {} });
+    const parsed = JSON.parse(res.mcpJson);
+    expect(parsed.mcpServers['cursor-mcp-dkg'].env.DKG_AUTH_TOKEN).toBe('real-token-xyz');
+    expect(res.token).toBe('real-token-xyz');
+  });
+});

--- a/packages/cli/test/integrations.test.ts
+++ b/packages/cli/test/integrations.test.ts
@@ -3,11 +3,19 @@ import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { resolveRegistryConfig, listSlugs, fetchEntry } from '../src/integrations/registry-client.js';
+import {
+  resolveRegistryConfig,
+  listSlugs,
+  fetchEntry,
+  fetchAllEntries,
+  isGithubHost,
+} from '../src/integrations/registry-client.js';
 import { isIntegrationEntry } from '../src/integrations/schema.js';
 import { installCli } from '../src/integrations/install-cli.js';
 import { installMcp } from '../src/integrations/install-mcp.js';
+import { normalizeRepoUrl } from '../src/integrations/verify-npm-provenance.js';
 import type { IntegrationEntry } from '../src/integrations/schema.js';
+import type { ProvenanceCheckResult } from '../src/integrations/verify-npm-provenance.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -42,8 +50,51 @@ const mcpEntry: IntegrationEntry = {
     kind: 'mcp',
     command: 'npx',
     args: ['-y', '@origintrail-official/dkg-mcp@0.1.0'],
-    env: { DKG_API_URL: '${DKG_API_URL}', DKG_AUTH_TOKEN: '${DKG_AUTH_TOKEN}' },
+    envRequired: ['DKG_API_URL', 'DKG_AUTH_TOKEN'],
+    supportedClients: ['cursor', 'claude-code', 'claude-desktop'],
   },
+};
+
+// A community-tier MCP entry that deliberately does NOT declare
+// DKG_AUTH_TOKEN. Used to assert the installer doesn't silently hand the
+// node's admin token to third-party MCP servers.
+const tokenlessMcpEntry: IntegrationEntry = {
+  ...baseEntry,
+  slug: 'third-party-mcp',
+  name: 'Third-party MCP (no token access)',
+  install: {
+    kind: 'mcp',
+    command: 'npx',
+    args: ['-y', '@some-community/mcp@1.0.0'],
+    envRequired: ['SOMETHING_ELSE'],
+  },
+};
+
+const okProvenance: ProvenanceCheckResult = {
+  ok: true,
+  found: {
+    versionResolvable: true,
+    hasProvenance: true,
+    hasRegistrySignature: true,
+    repositoryUrl: 'git+https://github.com/OriginTrail/dkg-hello-world.git',
+  },
+  expectedRepo: 'https://github.com/OriginTrail/dkg-hello-world',
+  reasons: [],
+};
+
+const failedProvenance: ProvenanceCheckResult = {
+  ok: false,
+  found: {
+    versionResolvable: true,
+    hasProvenance: false,
+    hasRegistrySignature: true,
+    repositoryUrl: 'git+https://github.com/evil/lookalike.git',
+  },
+  expectedRepo: 'https://github.com/OriginTrail/dkg-hello-world',
+  reasons: [
+    'npm tarball lacks a publish-time provenance attestation.',
+    'npm repository.url (git+https://github.com/evil/lookalike.git) does not match the registry entry\'s repo.',
+  ],
 };
 
 // ── isIntegrationEntry ────────────────────────────────────────────────────
@@ -104,6 +155,103 @@ describe('isIntegrationEntry', () => {
       install: { kind: 'mcp', command: 'npx', args: 'not-an-array' } as unknown as typeof baseEntry.install,
     };
     expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('rejects an mcp install with a non-string envRequired element', () => {
+    const bad = {
+      ...baseEntry,
+      install: {
+        kind: 'mcp',
+        command: 'npx',
+        args: [],
+        envRequired: ['DKG_API_URL', 42],
+      } as unknown as typeof baseEntry.install,
+    };
+    expect(isIntegrationEntry(bad)).toBe(false);
+  });
+
+  it('accepts unknown publicInterfacesUsed labels (forward compat)', () => {
+    // The CLI only renders this field; it never branches on it. Hard-rejecting
+    // unknown labels would stop older CLIs from reading otherwise-valid entries
+    // as soon as the registry adds a new interface name.
+    const forwardCompat = {
+      ...baseEntry,
+      publicInterfacesUsed: ['http-api', 'some-future-interface'] as unknown as typeof baseEntry.publicInterfacesUsed,
+    };
+    expect(isIntegrationEntry(forwardCompat)).toBe(true);
+  });
+});
+
+// ── isGithubHost + token scoping ──────────────────────────────────────────
+
+describe('isGithubHost', () => {
+  it('recognizes GitHub-owned hosts', () => {
+    expect(isGithubHost('https://api.github.com/repos/foo/bar')).toBe(true);
+    expect(isGithubHost('https://raw.githubusercontent.com/foo/bar/main/x.json')).toBe(true);
+    expect(isGithubHost('https://github.com/foo/bar')).toBe(true);
+  });
+
+  it('rejects non-GitHub hosts and malformed URLs', () => {
+    expect(isGithubHost('https://staging.example.com/registry')).toBe(false);
+    expect(isGithubHost('http://localhost:4873/registry')).toBe(false);
+    expect(isGithubHost('https://raw-githubusercontent.com.evil.example/')).toBe(false);
+    expect(isGithubHost('not a url')).toBe(false);
+  });
+});
+
+describe('registry-client token scoping', () => {
+  // The threat is a developer exporting GITHUB_TOKEN and then pointing
+  // DKG_REGISTRY_INDEX_URL/RAW_BASE at a staging / third-party registry for
+  // testing. Naively forwarding the Authorization header sends the GitHub
+  // PAT to whoever runs that endpoint.
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('forwards GITHUB_TOKEN only to GitHub hosts', async () => {
+    let sentAuth: string | null = null;
+    globalThis.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      sentAuth = (init?.headers as Record<string, string>).Authorization ?? null;
+      return new Response('[]', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const cfg = resolveRegistryConfig({ GITHUB_TOKEN: 'ghp_secret' });
+    await listSlugs(cfg);
+    expect(sentAuth).toBe('Bearer ghp_secret');
+  });
+
+  it('does NOT forward GITHUB_TOKEN to a non-GitHub DKG_REGISTRY_INDEX_URL', async () => {
+    let sentAuth: string | null | undefined;
+    globalThis.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      sentAuth = (init?.headers as Record<string, string>).Authorization ?? null;
+      return new Response('[]', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const cfg = resolveRegistryConfig({
+      GITHUB_TOKEN: 'ghp_secret',
+      DKG_REGISTRY_INDEX_URL: 'https://staging.example.com/index',
+      DKG_REGISTRY_RAW_BASE: 'https://staging.example.com/raw',
+    });
+    await listSlugs(cfg);
+    expect(sentAuth).toBeNull();
+  });
+
+  it('forwards DKG_REGISTRY_TOKEN to a non-GitHub host', async () => {
+    let sentAuth: string | null = null;
+    globalThis.fetch = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      sentAuth = (init?.headers as Record<string, string>).Authorization ?? null;
+      return new Response('[]', { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const cfg = resolveRegistryConfig({
+      GITHUB_TOKEN: 'ghp_should_not_leak',
+      DKG_REGISTRY_TOKEN: 'staging-token',
+      DKG_REGISTRY_INDEX_URL: 'https://staging.example.com/index',
+      DKG_REGISTRY_RAW_BASE: 'https://staging.example.com/raw',
+    });
+    await listSlugs(cfg);
+    expect(sentAuth).toBe('Bearer staging-token');
   });
 });
 
@@ -202,6 +350,63 @@ describe('fetchEntry', () => {
   });
 });
 
+// ── fetchAllEntries resilience ────────────────────────────────────────────
+
+describe('fetchAllEntries', () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it('returns good entries and collects per-entry failures instead of aborting', async () => {
+    // A broken community entry must not hide verified / featured entries.
+    globalThis.fetch = vi.fn(async (url: string | URL) => {
+      const u = url.toString();
+      if (u.includes('/contents/integrations')) {
+        return new Response(
+          JSON.stringify([
+            { name: 'dkg-hello-world.json', type: 'file' },
+            { name: 'broken.json', type: 'file' },
+          ]),
+          { status: 200 },
+        );
+      }
+      if (u.endsWith('/dkg-hello-world.json')) {
+        return new Response(JSON.stringify(baseEntry), { status: 200 });
+      }
+      if (u.endsWith('/broken.json')) {
+        return new Response(JSON.stringify({ definitely: 'not an entry' }), { status: 200 });
+      }
+      return new Response('', { status: 500 });
+    }) as unknown as typeof fetch;
+
+    const { entries, failures } = await fetchAllEntries(resolveRegistryConfig({}));
+    expect(entries.map((e) => e.slug)).toEqual(['dkg-hello-world']);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.slug).toBe('broken');
+    expect(failures[0]?.error).toMatch(/does not match the expected shape/);
+  });
+});
+
+// ── normalizeRepoUrl ──────────────────────────────────────────────────────
+
+describe('normalizeRepoUrl', () => {
+  it('collapses common git URL shapes to a host+path key', () => {
+    const expected = 'github.com/origintrail/dkg-hello-world';
+    expect(normalizeRepoUrl('https://github.com/OriginTrail/dkg-hello-world')).toBe(expected);
+    expect(normalizeRepoUrl('https://github.com/OriginTrail/dkg-hello-world/')).toBe(expected);
+    expect(normalizeRepoUrl('https://github.com/OriginTrail/dkg-hello-world.git')).toBe(expected);
+    expect(normalizeRepoUrl('git+https://github.com/OriginTrail/dkg-hello-world.git')).toBe(expected);
+    expect(normalizeRepoUrl('git://github.com/OriginTrail/dkg-hello-world.git')).toBe(expected);
+    expect(normalizeRepoUrl('git@github.com:OriginTrail/dkg-hello-world.git')).toBe(expected);
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(normalizeRepoUrl(undefined)).toBeUndefined();
+    expect(normalizeRepoUrl('')).toBeUndefined();
+  });
+});
+
 // ── installCli (dry-run) ──────────────────────────────────────────────────
 
 describe('installCli', () => {
@@ -216,8 +421,75 @@ describe('installCli', () => {
     expect(logs.join('\n')).toContain('npm install --global @origintrail/dkg-hello-world@0.1.0');
   });
 
+  it('dry-run does NOT invoke the provenance verifier (no side effects to guard)', async () => {
+    const verifier = vi.fn();
+    await installCli({ entry: baseEntry, dryRun: true, verifier, logger: () => {} });
+    expect(verifier).not.toHaveBeenCalled();
+  });
+
   it('throws when called with a non-cli entry', async () => {
     await expect(installCli({ entry: mcpEntry, dryRun: true })).rejects.toThrow(/non-cli install spec/);
+  });
+});
+
+// ── installCli provenance gate ────────────────────────────────────────────
+
+describe('installCli provenance gate', () => {
+  // The provenance gate is what ties the registry-reviewed commit to the
+  // tarball npm actually hands us. If the gate isn't enforced or the
+  // escape hatch isn't respected, the whole "registry-audited integration"
+  // claim falls apart on install.
+  it('refuses to install when the verifier reports failure', async () => {
+    const verifier = vi.fn(async () => failedProvenance);
+    const logs: string[] = [];
+    await expect(
+      installCli({ entry: baseEntry, verifier, logger: (m) => logs.push(m) }),
+    ).rejects.toThrow(/not cryptographically bound/);
+    expect(verifier).toHaveBeenCalledWith(
+      '@origintrail/dkg-hello-world',
+      '0.1.0',
+      'https://github.com/OriginTrail/dkg-hello-world',
+    );
+    expect(logs.join('\n')).toContain('Provenance check FAILED');
+  });
+
+  it('honors skipProvenance and does not call the verifier', async () => {
+    const verifier = vi.fn(async () => failedProvenance);
+    const runner = vi.fn(async () => 0);
+    const result = await installCli({
+      entry: baseEntry,
+      skipProvenance: true,
+      verifier,
+      runner,
+      logger: () => {},
+    });
+    expect(verifier).not.toHaveBeenCalled();
+    expect(runner).toHaveBeenCalledWith('npm', ['install', '--global', '@origintrail/dkg-hello-world@0.1.0']);
+    expect(result.provenance).toBeUndefined();
+  });
+
+  it('records the provenance result on the returned object when ok', async () => {
+    const verifier = vi.fn(async () => okProvenance);
+    const runner = vi.fn(async () => 0);
+    const logs: string[] = [];
+    const result = await installCli({
+      entry: baseEntry,
+      verifier,
+      runner,
+      logger: (m) => logs.push(m),
+    });
+    expect(verifier).toHaveBeenCalledOnce();
+    expect(runner).toHaveBeenCalledOnce();
+    expect(result.provenance?.ok).toBe(true);
+    expect(logs.join('\n')).toContain('ok — tarball is attested');
+  });
+
+  it('surfaces a non-zero npm exit code as a helpful error', async () => {
+    const verifier = vi.fn(async () => okProvenance);
+    const runner = vi.fn(async () => 13);
+    await expect(
+      installCli({ entry: baseEntry, verifier, runner, logger: () => {} }),
+    ).rejects.toThrow(/npm install failed with exit code 13/);
   });
 });
 
@@ -247,7 +519,7 @@ describe('installMcp', () => {
     await rm(tmpHome, { recursive: true, force: true });
   });
 
-  it('emits a paste-ready mcpServers block with api-url and placeholder token', async () => {
+  it('emits a paste-ready mcpServers block with api-url and placeholder token when envRequired lists them', async () => {
     const logs: string[] = [];
     const res = await installMcp({ entry: mcpEntry, apiUrl: 'http://127.0.0.1:9200', logger: (m) => logs.push(m) });
     const parsed = JSON.parse(res.mcpJson);
@@ -282,5 +554,47 @@ describe('installMcp', () => {
     } finally {
       await rm(altHome, { recursive: true, force: true });
     }
+  });
+
+  it('does NOT embed DKG_AUTH_TOKEN when envRequired does not declare it', async () => {
+    // Core security boundary: a third-party / community MCP server that
+    // doesn't ask for DKG_AUTH_TOKEN must not receive the node's admin
+    // token by default — even if there is a local token on disk.
+    await mkdir(tmpDkgHome, { recursive: true });
+    await writeFile(join(tmpDkgHome, 'auth.token'), 'should-not-leak\n', 'utf8');
+
+    const logs: string[] = [];
+    const res = await installMcp({
+      entry: tokenlessMcpEntry,
+      apiUrl: 'http://127.0.0.1:9200',
+      logger: (m) => logs.push(m),
+    });
+    const parsed = JSON.parse(res.mcpJson);
+    const env = parsed.mcpServers['third-party-mcp'].env;
+    expect(env).not.toHaveProperty('DKG_AUTH_TOKEN');
+    // Also: DKG_API_URL is only auto-added when envRequired asks for it.
+    // This entry only asks for SOMETHING_ELSE, which gets a placeholder.
+    expect(env).not.toHaveProperty('DKG_API_URL');
+    expect(env.SOMETHING_ELSE).toBe('<SOMETHING_ELSE>');
+    expect(res.token).toBeUndefined();
+    expect(logs.join('\n')).toContain('does not declare DKG_AUTH_TOKEN');
+    expect(logs.join('\n')).toContain('SOMETHING_ELSE');
+  });
+
+  it('does not read the local token file when envRequired does not declare DKG_AUTH_TOKEN', async () => {
+    // Belt-and-braces: not only must the token not appear in the output,
+    // we shouldn't even read auth.token from disk. Write a token that
+    // would stand out if it appeared anywhere in the output.
+    await mkdir(tmpDkgHome, { recursive: true });
+    await writeFile(join(tmpDkgHome, 'auth.token'), 'MARKER-SHOULD-NEVER-APPEAR\n', 'utf8');
+    const logs: string[] = [];
+    const res = await installMcp({
+      entry: tokenlessMcpEntry,
+      apiUrl: 'http://127.0.0.1:9200',
+      logger: (m) => logs.push(m),
+    });
+    expect(res.mcpJson).not.toContain('MARKER-SHOULD-NEVER-APPEAR');
+    expect(logs.join('\n')).not.toContain('MARKER-SHOULD-NEVER-APPEAR');
+    expect(res.token).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds the consumer-side command that turns entries in [`OriginTrail/dkg-integrations`](https://github.com/OriginTrail/dkg-integrations) into working installs on a contributor's machine. This is the MVP CLI surface for the v10 integration bounty program: it closes the loop so contributors can actually *install* integrations that get merged to the registry.

## What ships

```
dkg integration list [--tier] [--json]
  Default tier filter is "verified+" — community entries are hidden
  unless the user opts in.

dkg integration info <slug> [--json]
  Full registry metadata for one entry, including the security
  declaration (network egress, writeAuthority surfaces, credentials)
  and the full install spec.

dkg integration install <slug>
  [--allow-community] [--dry-run] [--api-url <url>]
  Trust-tier gate: community tier requires the flag.
  - install.kind=cli  → npm install -g <package>@<pinned-version>
  - install.kind=mcp  → prints a ready-to-paste mcpServers block with
                        local DKG_API_URL and DKG_AUTH_TOKEN prefilled,
                        plus standard config paths for Cursor / Claude
                        Desktop.
```

### Live output against the real registry

```
$ dkg integration list
Showing 2 integration(s) at tier verified+:

  cursor-mcp-dkg   [featured]  DKG MCP server (Cursor, Claude Code, Claude Desktop)
    Exposes the local DKG node as an MCP server so...
    install: mcp · memory: WM, SWM · https://github.com/OriginTrail/dkg-v9

  dkg-hello-world  [featured]  DKG Hello World
    Minimal reference integration for DKG v10. Writes a greeting into...
    install: cli · memory: WM · https://github.com/OriginTrail/dkg-hello-world
```

## Design notes

- **Registry transport.** List via GitHub Contents API, per-entry fetch via `raw.githubusercontent.com`. Both URLs override via `DKG_REGISTRY_INDEX_URL` / `DKG_REGISTRY_RAW_BASE` (useful for offline tests + staging registries). `GITHUB_TOKEN` / `GH_TOKEN` honored to avoid the 60-req/hr unauth ceiling on shared-NAT contributor setups. ⚠️ Registry repo visibility: the registry is currently private; this CLI assumes it will be public by bounty launch.
- **Install kinds.** Only `cli` and `mcp` are implemented — the two kinds currently in the registry. `service`, `agent-plugin`, and `manual` print an explicit "not supported yet, see `<repo>`" error rather than silently doing nothing. Add those kinds when we have seed entries that use them.
- **MCP install is print-only.** Silently rewriting `~/.cursor/mcp.json` or `claude_desktop_config.json` risks clobbering someone's custom setup. An opt-in `--write-client <name>` flag is a clean follow-up PR.
- **Traversal guard.** `fetchEntry` validates slugs against ``/^[a-z0-9][a-z0-9-]{0,60}$/`` before building URLs — protects against a rogue `DKG_REGISTRY_RAW_BASE` + adversarial slug.
- **Types.** Schema types in ``packages/cli/src/integrations/schema.ts`` mirror the JSON Schema. Only the fields the CLI reads are typed strongly; schema additions in the registry won't break the CLI until we want them to.

## Out of scope (deliberately)

- ``dkg integration uninstall`` — needs a local install-state lockfile design (what did we install, with what binary, how do we find the npm entry point to remove).
- ``dkg integration status`` — same dependency.
- Auto-merge into a specific MCP client's config file (``--write-client``).
- ``service`` / ``agent-plugin`` / ``manual`` install-kind executors.
- Provenance verification on install. The registry's ``security-checks.mjs`` already enforces npm provenance pre-merge; re-verifying at install time is a nice defense-in-depth but not required for MVP.

## Test plan

- [x] 14 unit tests in ``test/integrations.test.ts``: schema guard, registry URL resolution, ``listSlugs`` (TEMPLATE filtering, 403 messaging), ``fetchEntry`` (traversal guard, 404, schema-mismatch), ``installCli`` (dry-run shape + post-instructions), ``installMcp`` (token substitution from ``~/.dkg/auth.token``, HOME isolation via a tmp dir).
- [x] ``pnpm --filter @origintrail-official/dkg build`` clean.
- [x] Live end-to-end against ``OriginTrail/dkg-integrations``:
  - ``dkg integration list`` returns the two featured entries.
  - ``dkg integration info dkg-hello-world`` renders the expected block.
  - ``dkg integration install dkg-hello-world --dry-run`` prints ``npm install --global @origintrail/dkg-hello-world@0.1.0`` and the right post-instructions.
  - ``dkg integration install cursor-mcp-dkg`` emits an ``mcpServers`` JSON block with the local auth token correctly substituted.
- [ ] Reviewer: run the three commands locally once the registry is public, confirm install path works.

## Related

- Registry repo: https://github.com/OriginTrail/dkg-integrations
- Reference integration: https://github.com/OriginTrail/dkg-hello-world

Made with [Cursor](https://cursor.com)