### PR TITLE
fix(cli): align ChatMemoryManager agentAddress with assertion.write resolution (closes #277)

### DIFF
--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1166,10 +1166,18 @@ export async function runDaemonInner(
     }) => agent.createContextGraph(opts),
     listContextGraphs: () => agent.listContextGraphs(),
   };
+  // Chat-turn writes go through `agent.assertion.write`, which internally
+  // resolves the assertion graph URI from `defaultAgentAddress ?? peerId`
+  // (see `packages/agent/src/dkg-agent.ts::get assertion()`). If we
+  // configure the manager to READ under `agent.peerId` while writes land
+  // under `defaultAgentAddress`, the two sides resolve to structurally
+  // different `contextGraphAssertionUri(cg, <addr>, <name>)` graphs and
+  // reads silently return empty — issue #277.
+  const memoryAgentAddress = agent.getDefaultAgentAddress() ?? agent.peerId;
   const memoryManager = new ChatMemoryManager(
     agentToolsContext,
     config.llm ?? { apiKey: '' },
-    { agentAddress: agent.peerId },
+    { agentAddress: memoryAgentAddress },
   );
   log('Memory manager ready');
   if (config.llm) log('Memory enrichment LLM ready');

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -329,6 +329,29 @@ import {
 
 import { handleRequest } from './handle-request.js';
 
+/**
+ * Resolve the WM agentAddress the daemon hands to `ChatMemoryManager`.
+ *
+ * `agent.assertion.write` (the path chat-turn persistence rides on)
+ * internally resolves the assertion graph URI from
+ * `defaultAgentAddress ?? peerId` — see
+ * `packages/agent/src/dkg-agent.ts::get assertion()`. The memory manager
+ * must read under the SAME address writes land on, or the two sides
+ * resolve to structurally different `contextGraphAssertionUri(...)`
+ * graphs and `/api/memory/sessions` silently returns `[]` (issue #277).
+ *
+ * Extracted as a pure function so the daemon-wiring contract is
+ * unit-testable without booting a real `DKGAgent` (Hardhat / libp2p).
+ * Changes to this resolver MUST stay in lockstep with the agent-side
+ * resolution in `get assertion()`.
+ */
+export function resolveMemoryAgentAddress(agent: {
+  getDefaultAgentAddress(): string | undefined;
+  peerId: string;
+}): string {
+  return agent.getDefaultAgentAddress() ?? agent.peerId;
+}
+
 export async function runDaemon(foreground: boolean): Promise<void> {
   await ensureDkgDir();
   const config = await loadConfig();
@@ -1166,14 +1189,10 @@ export async function runDaemonInner(
     }) => agent.createContextGraph(opts),
     listContextGraphs: () => agent.listContextGraphs(),
   };
-  // Chat-turn writes go through `agent.assertion.write`, which internally
-  // resolves the assertion graph URI from `defaultAgentAddress ?? peerId`
-  // (see `packages/agent/src/dkg-agent.ts::get assertion()`). If we
-  // configure the manager to READ under `agent.peerId` while writes land
-  // under `defaultAgentAddress`, the two sides resolve to structurally
-  // different `contextGraphAssertionUri(cg, <addr>, <name>)` graphs and
-  // reads silently return empty — issue #277.
-  const memoryAgentAddress = agent.getDefaultAgentAddress() ?? agent.peerId;
+  // See `resolveMemoryAgentAddress` for the write/read-URI invariant
+  // this encodes (issue #277). The helper is exported purely so the
+  // daemon-wiring contract stays unit-testable without a real agent.
+  const memoryAgentAddress = resolveMemoryAgentAddress(agent);
   const memoryManager = new ChatMemoryManager(
     agentToolsContext,
     config.llm ?? { apiKey: '' },

--- a/packages/cli/test/daemon-lifecycle-memory-agent-address.test.ts
+++ b/packages/cli/test/daemon-lifecycle-memory-agent-address.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Daemon-wiring guard for `resolveMemoryAgentAddress` — the single point
+ * where `runDaemonInner` picks the `agentAddress` it hands to
+ * `ChatMemoryManager`.
+ *
+ * Why this file exists: the semantic regression test at
+ * `packages/node-ui/test/chat-memory-persistence-regression.test.ts`
+ * pins the write/read contract on `ChatMemoryManager` but constructs the
+ * manager directly, so it can't catch a `lifecycle.ts` revert that puts
+ * `agent.peerId` back into the constructor call. This file locks the
+ * wiring by exercising the pure resolver that owns that decision.
+ *
+ * The resolver must stay in lockstep with the agent-side resolution in
+ * `packages/agent/src/dkg-agent.ts::get assertion()` (which uses
+ * `this.defaultAgentAddress ?? this.peerId`). Changes here need matching
+ * changes there — and vice versa.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveMemoryAgentAddress } from '../src/daemon.js';
+
+describe('resolveMemoryAgentAddress — daemon WM-agentAddress wiring', () => {
+  it(
+    'returns the default agent address when one is registered (production case: ' +
+      'must match what `agent.assertion.write` uses internally)',
+    () => {
+      const agent = {
+        getDefaultAgentAddress: () => '0xbb765f337e251c1f18dfbec1a45ca56001b15e54',
+        peerId: '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu',
+      };
+      expect(resolveMemoryAgentAddress(agent)).toBe(
+        '0xbb765f337e251c1f18dfbec1a45ca56001b15e54',
+      );
+      expect(resolveMemoryAgentAddress(agent)).not.toBe(agent.peerId);
+    },
+  );
+
+  it(
+    'falls back to peerId when no default agent is registered (dev/test case: ' +
+      '`autoRegisterDefaultAgent` skipped because no operational key)',
+    () => {
+      const agent = {
+        getDefaultAgentAddress: () => undefined,
+        peerId: '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu',
+      };
+      expect(resolveMemoryAgentAddress(agent)).toBe(
+        '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu',
+      );
+    },
+  );
+
+  it(
+    'an empty-string default-agent address is NOT coerced to the peerId fallback — ' +
+      'the resolver mirrors the agent-side `?? this.peerId` nullish-coalescing exactly. ' +
+      'Returning peerId here when the agent side returns "" would recreate the exact ' +
+      'write/read-graph-URI mismatch #277 fixed.',
+    () => {
+      const agent = {
+        getDefaultAgentAddress: () => '',
+        peerId: '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu',
+      };
+      // `??` treats '' as defined, so the resolver returns '' — the same
+      // value `this.defaultAgentAddress ?? this.peerId` produces in
+      // `dkg-agent.ts::get assertion()`. Both sides stay aligned, which
+      // is the only invariant that matters for #277. Whether empty
+      // string is semantically valid as an agentAddress is a separate
+      // caller-bug question; fixing it here would silently desync from
+      // the agent side.
+      expect(resolveMemoryAgentAddress(agent)).toBe('');
+    },
+  );
+});

--- a/packages/node-ui/test/chat-memory-persistence-regression.test.ts
+++ b/packages/node-ui/test/chat-memory-persistence-regression.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Regression test for GitHub issue #277.
+ *
+ * Symptom: `/api/openclaw-channel/persist-turn` returns HTTP 200 and
+ * `ChatMemoryManager.storeChatExchange` reports success, but
+ * `getRecentChats()` returns `{ sessions: [] }` and `getSession()`
+ * returns `null` for the same session that was just persisted.
+ *
+ * Root cause: chat-turn WRITES flow through `agent.assertion.write`
+ * which internally resolves the assertion graph URI from
+ * `defaultAgentAddress ?? peerId` (see
+ * `packages/agent/src/dkg-agent.ts::get assertion()`). Reads were
+ * configured with `{ agentAddress: agent.peerId }` — a fixed peerId.
+ * When the node has a default agent registered (the production case:
+ * `autoRegisterDefaultAgent` runs on boot whenever an operational key
+ * exists, and operators register agents explicitly), `defaultAgentAddress`
+ * is the agent's EVM address, NOT the libp2p peerId. Writes land in
+ *   `did:dkg:context-graph:<cg>/assertion/<evmAddress>/<assertion>`
+ * while reads query
+ *   `did:dkg:context-graph:<cg>/assertion/<peerId>/<assertion>`
+ * — a structurally different graph URI (see
+ * `packages/core/src/constants.ts::contextGraphAssertionUri`).
+ *
+ * The fix in `packages/cli/src/daemon/lifecycle.ts` configures
+ * ChatMemoryManager with `agent.getDefaultAgentAddress() ?? agent.peerId`
+ * so writes and reads resolve to the same assertion graph URI.
+ *
+ * This test uses a lightweight `MemoryToolContext` fake that models
+ * only the one invariant that matters for #277: writes and reads of
+ * `view: 'working-memory'` must route through the same
+ * `contextGraphAssertionUri(cg, agentAddress, assertion)` key. No chain,
+ * no libp2p, no hardhat — we pin the wiring contract directly.
+ */
+import { describe, it, expect } from 'vitest';
+import { ChatMemoryManager } from '../src/chat-memory.js';
+import { contextGraphAssertionUri } from '@origintrail-official/dkg-core';
+
+// `agent.assertion.write` internally uses `defaultAgentAddress ?? peerId`
+// to key the assertion graph URI, so our fake models the exact same
+// dispatch. Writes are keyed by the fake's `writeAgentAddress` (the
+// value the production wrapper forwards to `agent.assertion.write`).
+// Reads are keyed by the `agentAddress` ChatMemoryManager passes in its
+// WM query options.
+function buildStoreBackedTools(writeAgentAddress: string) {
+  // graphUri -> quads written under it
+  const store = new Map<string, any[]>();
+
+  const tools = {
+    query: async (
+      sparql: string,
+      opts?: {
+        contextGraphId?: string;
+        view?: string;
+        agentAddress?: string;
+        assertionName?: string;
+      },
+    ) => {
+      if (opts?.view !== 'working-memory' || !opts.contextGraphId || !opts.agentAddress || !opts.assertionName) {
+        return { bindings: [] };
+      }
+      const graphUri = contextGraphAssertionUri(
+        opts.contextGraphId,
+        opts.agentAddress,
+        opts.assertionName,
+      );
+      const quads = store.get(graphUri) ?? [];
+      return executeMiniSparql(sparql, quads);
+    },
+    share: async () => ({ shareOperationId: 'noop' }),
+    createAssertion: async (contextGraphId: string, name: string) => {
+      const graphUri = contextGraphAssertionUri(contextGraphId, writeAgentAddress, name);
+      if (!store.has(graphUri)) store.set(graphUri, []);
+      return { assertionUri: graphUri, alreadyExists: false };
+    },
+    writeAssertion: async (contextGraphId: string, name: string, quads: any[]) => {
+      const graphUri = contextGraphAssertionUri(contextGraphId, writeAgentAddress, name);
+      const bucket = store.get(graphUri) ?? [];
+      bucket.push(...quads);
+      store.set(graphUri, bucket);
+      return { written: quads.length };
+    },
+    publishFromSharedMemory: async () => ({}),
+    createContextGraph: async () => {},
+    listContextGraphs: async () => [{ id: 'agent-context', name: 'Agent Context' }],
+  };
+
+  return { tools, store };
+}
+
+// Minimal SPARQL "executor" sufficient for `getRecentChats` and
+// `getSession`'s query shapes. It's not general — it runs against the
+// bucket of quads for the resolved assertion graph and answers the
+// specific patterns ChatMemoryManager emits.
+function executeMiniSparql(sparql: string, quads: any[]): any {
+  const s = sparql.replace(/\s+/g, ' ').trim();
+  const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+  const SCHEMA = 'http://schema.org/';
+  const DKG_ONT = 'http://dkg.io/ontology/';
+
+  // Known sessions prefetch:
+  //   SELECT ?sid WHERE { ?s rdf:type schema:Conversation . ?s dkg:sessionId ?sid }
+  if (s.includes('SELECT ?sid') && s.includes('sessionId')) {
+    const bindings: any[] = [];
+    for (const q of quads) {
+      if (q.predicate === `${DKG_ONT}sessionId`) {
+        bindings.push({ sid: q.object });
+      }
+    }
+    return { bindings };
+  }
+
+  // getRecentChats sessions query:
+  //   SELECT ?s ?sid (MAX(?mts) AS ?latest) WHERE { ?s a schema:Conversation . ?s dkg:sessionId ?sid . OPTIONAL { ?m schema:isPartOf ?s . ?m schema:dateCreated ?mts } }
+  if (s.includes('(MAX(?mts) AS ?latest)')) {
+    const sessions = new Map<string, string>();
+    for (const q of quads) {
+      if (q.predicate === `${DKG_ONT}sessionId`) {
+        sessions.set(q.subject, String(q.object));
+      }
+    }
+    const bindings = [...sessions.entries()].map(([s, sid]) => ({ s, sid }));
+    return { bindings };
+  }
+
+  // getRecentChats messages query:
+  //   SELECT ?session ?author ?text ?ts WHERE { VALUES ?session { ... } ?m schema:isPartOf ?session . ?m schema:author ?author . ?m schema:text ?text . ?m schema:dateCreated ?ts }
+  if (s.includes('SELECT ?session ?author ?text ?ts') && s.includes('VALUES ?session')) {
+    const match = s.match(/VALUES \?session \{ ([^}]+) \}/);
+    const sessionUris = match
+      ? [...match[1].matchAll(/<([^>]+)>/g)].map((m) => m[1])
+      : [];
+    const bySession = new Map<string, { author: string; text: string; ts: string }[]>();
+    for (const q of quads) {
+      if (q.predicate === `${SCHEMA}isPartOf` && sessionUris.includes(q.object)) {
+        const msg = q.subject;
+        const authorQ = quads.find((x) => x.subject === msg && x.predicate === `${SCHEMA}author`);
+        const textQ = quads.find((x) => x.subject === msg && x.predicate === `${SCHEMA}text`);
+        const tsQ = quads.find((x) => x.subject === msg && x.predicate === `${SCHEMA}dateCreated`);
+        if (!authorQ || !textQ || !tsQ) continue;
+        const list = bySession.get(q.object) ?? [];
+        list.push({
+          session: q.object,
+          author: authorQ.object,
+          text: textQ.object,
+          ts: tsQ.object,
+        } as any);
+        bySession.set(q.object, list);
+      }
+    }
+    const bindings: any[] = [];
+    for (const [session, msgs] of bySession.entries()) {
+      for (const msg of msgs) {
+        bindings.push({ session, ...msg });
+      }
+    }
+    return { bindings };
+  }
+
+  // getSession messages query:
+  //   SELECT ?m ?author ?text ?ts ?turnId ?persistenceState ?attachmentRefs ?failureReason WHERE { ?m schema:isPartOf <session> ... }
+  if (s.includes('SELECT ?m ?author ?text ?ts') && s.includes('isPartOf')) {
+    const sessionMatch = s.match(/isPartOf> <([^>]+)>/);
+    const sessionUri = sessionMatch?.[1];
+    if (!sessionUri) return { bindings: [] };
+    const bindings: any[] = [];
+    for (const q of quads) {
+      if (q.predicate === `${SCHEMA}isPartOf` && q.object === sessionUri) {
+        const msg = q.subject;
+        const authorQ = quads.find((x) => x.subject === msg && x.predicate === `${SCHEMA}author`);
+        const textQ = quads.find((x) => x.subject === msg && x.predicate === `${SCHEMA}text`);
+        const tsQ = quads.find((x) => x.subject === msg && x.predicate === `${SCHEMA}dateCreated`);
+        if (!authorQ || !textQ || !tsQ) continue;
+        bindings.push({
+          m: msg,
+          author: authorQ.object,
+          text: textQ.object,
+          ts: tsQ.object,
+        });
+      }
+    }
+    return { bindings };
+  }
+
+  // Stats / counts / other queries — not exercised by this regression test.
+  return { bindings: [] };
+}
+
+describe('issue #277 — OpenClaw chat-turn persistence round-trip', () => {
+  const EVM_ADDR = '0xbb765f337e251c1f18dfbec1a45ca56001b15e54';
+  const PEER_ID = '12D3KooWFHUALUrdSfrVHSxtCRCJC9xvxS7nYfM6T1sbYVak9HTu';
+
+  it(
+    'pre-fix wiring (reads keyed on peerId while writes land under defaultAgentAddress) ' +
+      'reproduces the empty read — contract pin for why the fix matters',
+    async () => {
+      // `agent.assertion.write` resolves to `defaultAgentAddress ?? peerId`;
+      // with a default agent registered (production norm) this is the EVM
+      // address. The fake routes writes accordingly.
+      const { tools } = buildStoreBackedTools(EVM_ADDR);
+
+      // BUGGY wiring: reads keyed on peerId — pre-fix lifecycle.ts.
+      const manager = new ChatMemoryManager(tools as any, { apiKey: '' }, {
+        agentAddress: PEER_ID,
+      });
+
+      await manager.storeChatExchange('openclaw:dkg-ui', 'hello', 'reply', undefined, {
+        turnId: 'turn-1',
+      });
+
+      const recent = await manager.getRecentChats(5);
+      expect(
+        recent,
+        'this mis-wiring is the exact shape of #277: storeChatExchange ' +
+          'reports success but getRecentChats returns [] because reads ' +
+          'query a different assertion graph URI than writes landed in',
+      ).toHaveLength(0);
+
+      const session = await manager.getSession('openclaw:dkg-ui');
+      expect(
+        session,
+        'getSession returns null for the same reason — peerId-keyed WM ' +
+          'graph URI is structurally different from EVM-keyed write URI',
+      ).toBeNull();
+    },
+  );
+
+  it(
+    'fixed wiring (reads and writes keyed on the same agentAddress) surfaces ' +
+      'the stored chat turn on immediate getRecentChats / getSession — the ' +
+      'invariant lifecycle.ts must preserve',
+    async () => {
+      // The fix in `packages/cli/src/daemon/lifecycle.ts` configures
+      // ChatMemoryManager with `agent.getDefaultAgentAddress() ?? agent.peerId`
+      // — the SAME value `agent.assertion.write` resolves internally.
+      const { tools } = buildStoreBackedTools(EVM_ADDR);
+      const manager = new ChatMemoryManager(tools as any, { apiKey: '' }, {
+        agentAddress: EVM_ADDR,
+      });
+
+      await manager.storeChatExchange(
+        'openclaw:dkg-ui',
+        'hello from user',
+        'reply from agent',
+        undefined,
+        { turnId: 'turn-1' },
+      );
+
+      const recent = await manager.getRecentChats(5);
+      expect(recent).toHaveLength(1);
+      expect(recent[0].session).toBe('openclaw:dkg-ui');
+      expect(recent[0].messages.length).toBeGreaterThanOrEqual(2);
+
+      const session = await manager.getSession('openclaw:dkg-ui');
+      expect(session).not.toBeNull();
+      expect(session!.session).toBe('openclaw:dkg-ui');
+      expect(session!.messages.some((m) => m.text === 'hello from user')).toBe(true);
+      expect(session!.messages.some((m) => m.text === 'reply from agent')).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #277 — OpenClaw chat turns reported as persisted but `getRecentChats()` returned empty.

**Always-latent bug, not a regression.** Pre-refactor `daemon.ts` and post-refactor `daemon/lifecycle.ts` both wired `ChatMemoryManager` with `{ agentAddress: agent.peerId }` — byte-identical. Verified: `git show a8b91606:packages/cli/src/daemon.ts` vs `git show 788c9214:packages/cli/src/daemon/lifecycle.ts` produce identical `new ChatMemoryManager(...)` output. The bug surfaces only when a default agent is registered with an EVM address distinct from `peerId`, which has become the common case since `autoRegisterDefaultAgent` runs on boot for any node with an operational key. Dev/test setups without an operational key mask it (both sides resolve to `peerId`).

## Root cause

`agent.assertion.write` resolves the assertion graph URI from `this.defaultAgentAddress ?? this.peerId` internally (`packages/agent/src/dkg-agent.ts:6722`). But `ChatMemoryManager` was configured to read under the bare `agent.peerId`. Result:

- Writes land under `did:dkg:context-graph:<cg>/assertion/<evmAddr>/<assertion>`
- Reads query `did:dkg:context-graph:<cg>/assertion/<peerId>/<assertion>`
- Different graphs per `contextGraphAssertionUri` (`packages/core/src/constants.ts:90`)
- `[dkg-channel] Turn persisted to DKG graph` logs success; `getRecentChats()` returns `[]`

## Fix

Single-line wiring change in `packages/cli/src/daemon/lifecycle.ts:1169-1177`:

```ts
const memoryAgentAddress = agent.getDefaultAgentAddress() ?? agent.peerId;
const memoryManager = new ChatMemoryManager(
  agentToolsContext,
  config.llm ?? { apiKey: '' },
  { agentAddress: memoryAgentAddress },
);
```

Mirrors exactly what `agent.assertion` resolves (`defaultAgentAddress ?? peerId`). `getDefaultAgentAddress()` returns `string | undefined` cleanly (`dkg-agent.ts:1781-1783`) — no empty-string / zero-address footgun. When no default agent is registered (dev/test), the `?? peerId` fallback preserves today's behavior.

## Test coverage

New file: `packages/node-ui/test/chat-memory-persistence-regression.test.ts` (2 tests, both passing). Uses a lightweight store-backed fake `MemoryToolContext` keyed by `contextGraphAssertionUri(cg, agentAddress, name)` — the exact URI builder the real storage layer uses:

- **Test 1**: pre-fix mis-wiring (`agentAddress: PEER_ID`, fake writes under `EVM_ADDR`) reproduces the #277 empty-read symptom (`getRecentChats() === []`, `getSession() === null`).
- **Test 2**: fixed wiring (both sides on `EVM_ADDR`) — turn round-trips correctly.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui test` — **397 passed, 38 skipped, 0 failed** across 19 files.
- [x] `pnpm --filter @origintrail-official/dkg test chat-memory-persistence-regression` — **2/2 pass**.
- [x] `pnpm --filter @origintrail-official/dkg test daemon-openclaw` — **73/73 pass**.
- [x] `packages/agent` WM-isolation suite on branch — **9/9 pass** (confirms iter-9 alias defense still holds).
- [x] `npx tsc --noEmit` in both `packages/cli` and `packages/node-ui` — clean.
- [ ] Manual verification on a live DKG node with a registered default agent: exchange turns with Sentinel, refresh browser, confirm `GET /api/memory/sessions` returns at least one entry AND Sessions tab in Node UI shows the OpenClaw session.

## Follow-ups filed

- **#279** — Add cli-side wiring guard for `memoryManager.agentAddress` matching `agent.assertion` resolution. Current test pins the semantic contract but doesn't guard `lifecycle.ts` wiring from future reverts (discovered by QA manually reverting the fix and watching the test still pass).

## Known follow-ups NOT blocking this PR

- Stale comment in `packages/agent/src/dkg-agent.ts:2600-2614` cites ChatMemoryManager as a reason for the iter-9 alias defense; ChatMemoryManager no longer uses peerId after this fix. The defense itself is still needed (for `dkg_query` WM reads that accept peerId-form identity), but the comment is now misleading. Cleanup candidate.
- Longer-term: parameterize `agent.assertion(agentAddress?)` so callers can pass their intended identity explicitly, or deprecate the `peerId` alias at the storage layer. Out of scope here.
- Orthogonal: `contextGraphAssertionUri` doesn't normalize EVM address case. Different sources (checksummed vs lowercase) produce different URIs. Same class of silent-empty bug. Separate issue if/when encountered.
- Related-but-separate: #261 (UI only hydrates the default `openclaw:dkg-ui` session URI, not identity-suffixed variants). Confirmed orthogonal to this fix during QA.

Closes #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)