### PR TITLE
docs(readme): add community integrations section + dkg integration CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Once running, open the dashboard at [http://127.0.0.1:9200/ui](http://127.0.0.1:
 
 ---
 
+## Community integrations
+
+Beyond the first-party framework adapters above, DKG V10 supports **community-contributed integrations** — CLIs, MCP servers, agent plugins, and services that run against your local node through its public HTTP API, `dkg` CLI, or MCP interface. They live in contributor-owned repositories and are discovered through the [OriginTrail/dkg-integrations](https://github.com/OriginTrail/dkg-integrations) registry.
+
+```bash
+dkg integration list                 # browse the registry
+dkg integration info <slug>          # inspect a single integration
+dkg integration install <slug>       # install (with publish-time provenance verification for CLI-kind installs)
+```
+
+**Building one:** fork the minimal reference template at [OriginTrail/dkg-hello-world](https://github.com/OriginTrail/dkg-hello-world) — ~150 lines, zero dependencies, demonstrates the full Working Memory write → read round trip. Submission rules (schema, security checks, trust tiers) are in the registry's [CONTRIBUTING.md](https://github.com/OriginTrail/dkg-integrations/blob/main/CONTRIBUTING.md).
+
+---
+
 ## CLI commands
 
 ```bash
@@ -157,6 +171,11 @@ dkg auth status                          # show whether auth is enabled
 
 # Framework adapters
 dkg openclaw setup                       # install & configure the OpenClaw adapter
+
+# Community integrations (registry: OriginTrail/dkg-integrations)
+dkg integration list                     # browse registry entries
+dkg integration info <slug>              # show details for one entry
+dkg integration install <slug>           # install (CLI-kind installs verify npm provenance)
 
 # Update / rollback
 dkg update [--check] [--allow-prerelease]  # update node software
@@ -357,6 +376,7 @@ DKG V10 is a **release candidate** on the testnet. Core capabilities are impleme
 - Dashboard UI with chat memory, SPARQL explorer, project management
 - Framework adapters for OpenClaw, ElizaOS, Hermes, AutoResearch
 - MCP server for Cursor / Claude Code / other coding assistants
+- Community integrations registry (`dkg integration list|info|install`) with install-time provenance verification for CLI-kind installs
 - Blue-green update and rollback flow
 
 Expect rapid iteration and breaking changes. Not yet recommended for production workloads.
@@ -384,5 +404,6 @@ Tier-based thresholds (TORNADO / BURA / KOSAVA) and Solidity lcov checks are doc
 We welcome contributions — bug reports, feature ideas, and pull requests.
 
 - [Open an issue](https://github.com/OriginTrail/dkg-v9/issues) for bugs or feature requests
+- **Build a DKG integration** — submit to the [integrations registry](https://github.com/OriginTrail/dkg-integrations) (see [CONTRIBUTING.md](https://github.com/OriginTrail/dkg-integrations/blob/main/CONTRIBUTING.md) and the [dkg-hello-world](https://github.com/OriginTrail/dkg-hello-world) template)
 - [Join Discord](https://discord.com/invite/xCaY7hvNwD) for questions and discussion
 - [Releases](https://github.com/OriginTrail/dkg-v9/releases)

--- a/README.md
+++ b/README.md
@@ -99,10 +99,14 @@ Once running, open the dashboard at [http://127.0.0.1:9200/ui](http://127.0.0.1:
 Beyond the first-party framework adapters above, DKG V10 supports **community-contributed integrations** — CLIs, MCP servers, agent plugins, and services that run against your local node through its public HTTP API, `dkg` CLI, or MCP interface. They live in contributor-owned repositories and are discovered through the [OriginTrail/dkg-integrations](https://github.com/OriginTrail/dkg-integrations) registry.
 
 ```bash
-dkg integration list                 # browse the registry
-dkg integration info <slug>          # inspect a single integration
-dkg integration install <slug>       # install (with publish-time provenance verification for CLI-kind installs)
+dkg integration list                              # list verified + featured tiers (default)
+dkg integration list --tier community             # include community-tier (contributor-submitted) entries
+dkg integration info <slug>                       # inspect a single entry
+dkg integration install <slug>                    # install — automates `cli` and `mcp` install kinds
+dkg integration install <slug> --allow-community  # required to install a community-tier entry
 ```
+
+By design, `list` shows only verified and featured tiers and `install` refuses community-tier entries unless you opt in — community submissions haven't been peer-reviewed by the OriginTrail core team, so discovering and installing them is an explicit choice. The CLI automates the `cli` and `mcp` install kinds today; `service`, `agent-plugin`, and `manual` kinds aren't auto-installed yet — `install` exits with the entry's repo URL so you can follow its README. For `cli` installs, the CLI verifies the npm tarball's publish-time sigstore provenance against the registry-declared repo before running `npm install --global` (`--no-verify-provenance` to skip).
 
 **Building one:** fork the minimal reference template at [OriginTrail/dkg-hello-world](https://github.com/OriginTrail/dkg-hello-world) — ~150 lines, zero dependencies, demonstrates the full Working Memory write → read round trip. Submission rules (schema, security checks, trust tiers) are in the registry's [CONTRIBUTING.md](https://github.com/OriginTrail/dkg-integrations/blob/main/CONTRIBUTING.md).
 
@@ -173,9 +177,9 @@ dkg auth status                          # show whether auth is enabled
 dkg openclaw setup                       # install & configure the OpenClaw adapter
 
 # Community integrations (registry: OriginTrail/dkg-integrations)
-dkg integration list                     # browse registry entries
+dkg integration list [--tier community]  # default tier filter is `verified`+
 dkg integration info <slug>              # show details for one entry
-dkg integration install <slug>           # install (CLI-kind installs verify npm provenance)
+dkg integration install <slug>           # install cli/mcp kind; --allow-community for community-tier entries
 
 # Update / rollback
 dkg update [--check] [--allow-prerelease]  # update node software


### PR DESCRIPTION
## Summary

README on `main` didn't yet reflect the integrations work that just merged (PR #276) and the registry/template repos that went public today. Four surgical additions, no behavioural change:

1. **New \"Community integrations\" top-level section** between Quick Start and CLI commands — introduces the decoupled registry model, links to [`OriginTrail/dkg-integrations`](https://github.com/OriginTrail/dkg-integrations) and [`OriginTrail/dkg-hello-world`](https://github.com/OriginTrail/dkg-hello-world), and shows the three list/info/install commands inline so a skimming reader gets a working mental model without reading deeper.

2. **CLI commands code block** — add the `dkg integration` trio alongside `dkg openclaw setup`. Every other subsystem is listed here, so the integration command was the one conspicuous omission.

3. **Current maturity bullet list** — call out the integrations registry plus the install-time npm provenance gate, which is the thing that makes the community model safe (repo-match + sigstore attestation checks before `npm i -g`).

4. **Contributing section** — add a bullet pointing external contributors at the registry's CONTRIBUTING.md and the hello-world template. Keeps the distinction sharp: bug reports/features on this repo, new integrations over in the registry.

## Test plan

- [x] Rendered diff reviewed — four clean hunks, no edits outside the intended areas
- [x] All added links resolve to live public repos
- [x] `dkg integration list|info|install` commands listed in CLI block match what PR #276 shipped
- [ ] Reviewer eyeballs the new \"Community integrations\" section reads naturally in context with the rest of the README

Made with [Cursor](https://cursor.com)