### PR TITLE
feat(config,ci): align repo refs + branch with renamed dkg repo, make…

### DIFF
--- a/.github/workflows/npm-continuous-publish.yml
+++ b/.github/workflows/npm-continuous-publish.yml
@@ -9,7 +9,7 @@ name: Continuous NPM Publish
 
 on:
   push:
-    branches: [v10-rc]  # ← change this when the release branch moves
+    branches: [main]  # ← change this when the release branch moves
 
 permissions:
   contents: read

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -8,6 +8,6 @@
   },
   "autoUpdate": {
     "enabled": true,
-    "branch": "v10-rc"
+    "branch": "main"
   }
 }

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -8,6 +8,6 @@
   },
   "autoUpdate": {
     "enabled": true,
-    "branch": "v10-rc"
+    "branch": "main"
   }
 }

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -8,6 +8,6 @@
   },
   "autoUpdate": {
     "enabled": true,
-    "branch": "v10-rc"
+    "branch": "main"
   }
 }

--- a/network/testnet.json
+++ b/network/testnet.json
@@ -12,8 +12,8 @@
   "defaultNodeRole": "edge",
   "autoUpdate": {
     "enabled": true,
-    "repo": "OriginTrail/dkg-v9",
-    "branch": "v10-rc",
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
     "checkIntervalMinutes": 5
   },
   "chain": {

--- a/packages/cli/scripts/bundle-markitdown-binaries.mjs
+++ b/packages/cli/scripts/bundle-markitdown-binaries.mjs
@@ -48,7 +48,7 @@ function loadDefaultReleaseRepo() {
       if (proj.repo) return proj.repo;
     } catch { /* try next */ }
   }
-  return 'OriginTrail/dkg-v9';
+  return 'OriginTrail/dkg';
 }
 export const DEFAULT_RELEASE_REPO = loadDefaultReleaseRepo();
 const DEFAULT_PACKAGE_DIR = resolve(__dirname, '..');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,7 +15,7 @@ import yaml from 'js-yaml';
 import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir,
-  loadNetworkConfig, loadProjectConfig, releasesDir, activeSlot, swapSlot,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
 } from './config.js';
@@ -288,8 +288,16 @@ program
 
     let autoUpdate = existing.autoUpdate;
     if (enableAutoUpdate) {
-      const defaultRepo = existing.autoUpdate?.repo ?? network?.autoUpdate?.repo;
-      const defaultBranch = existing.autoUpdate?.branch ?? network?.autoUpdate?.branch ?? 'main';
+      // Effective upstream defaults — what the node would use if nothing were
+      // persisted in ~/.dkg/config.json. Network config beats project.json.
+      // We persist repo/branch only when they differ from these, so future
+      // changes to the shipped network or project config propagate on the
+      // next daemon run without requiring a config rewrite.
+      const proj = loadProjectConfig();
+      const effectiveRepo = network?.autoUpdate?.repo ?? proj.repo;
+      const effectiveBranch = network?.autoUpdate?.branch ?? proj.defaultBranch;
+      const defaultRepo = existing.autoUpdate?.repo ?? effectiveRepo;
+      const defaultBranch = existing.autoUpdate?.branch ?? effectiveBranch;
       const defaultAllowPrerelease = existing.autoUpdate?.allowPrerelease ?? network?.autoUpdate?.allowPrerelease ?? true;
       const defaultSshKeyPath = existing.autoUpdate?.sshKeyPath ?? network?.autoUpdate?.sshKeyPath ?? '';
       const defaultInterval = existing.autoUpdate?.checkIntervalMinutes ?? network?.autoUpdate?.checkIntervalMinutes ?? 5;
@@ -303,8 +311,8 @@ program
       const interval = parseInt(await ask('Check interval (minutes)', String(defaultInterval)), 10);
       autoUpdate = {
         enabled: true,
-        repo,
-        branch,
+        ...(repo && repo !== effectiveRepo ? { repo } : {}),
+        ...(branch && branch !== effectiveBranch ? { branch } : {}),
         allowPrerelease,
         sshKeyPath: sshKeyPath || undefined,
         checkIntervalMinutes: interval,
@@ -372,15 +380,18 @@ program
     console.log(`  context graphs: ${contextGraphs.length ? contextGraphs.join(', ') : '(none)'}`);
     console.log(`  apiPort:    ${config.apiPort}`);
     console.log(`  auth:       ${enableAuth ? 'enabled (token in ~/.dkg/auth.token)' : 'disabled'}`);
-    console.log(
-      `  autoUpdate: ${
-        config.autoUpdate?.enabled
-          ? `${config.autoUpdate.repo}@${config.autoUpdate.branch}` +
-            `${config.autoUpdate.allowPrerelease ? ' (pre-release allowed)' : ''}` +
-            `${config.autoUpdate.sshKeyPath ? ` (ssh key: ${config.autoUpdate.sshKeyPath})` : ''}`
-          : 'disabled'
-      }`,
-    );
+    {
+      const resolved = resolveAutoUpdateConfig(config, network);
+      console.log(
+        `  autoUpdate: ${
+          resolved
+            ? `${resolved.repo}@${resolved.branch}` +
+              `${resolved.allowPrerelease ? ' (pre-release allowed)' : ''}` +
+              `${resolved.sshKeyPath ? ` (ssh key: ${resolved.sshKeyPath})` : ''}`
+            : 'disabled'
+        }`,
+      );
+    }
     console.log(`  chain:      ${config.chain ? `${config.chain.rpcUrl} (hub: ${config.chain.hubAddress?.slice(0, 10)}...)` : '(not configured)'}`);
     if (network) {
       console.log(`  network:    ${network.networkName}`);
@@ -2794,14 +2805,18 @@ program
   .action(async (versionOrRef: string | undefined, opts: ActionOpts) => {
     const config = await loadConfig();
     const net = await loadNetworkConfig();
-    const proj = loadProjectConfig();
-    const au = config.autoUpdate ?? net?.autoUpdate ?? {
-      enabled: true,
-      repo: proj.repo,
-      branch: proj.defaultBranch,
-      allowPrerelease: true,
-      checkIntervalMinutes: 30,
-    };
+    // Resolve field-by-field across local/network/project so defaults flow
+    // through even when the local config omits repo/branch.
+    const au = resolveAutoUpdateConfig(config, net) ?? (() => {
+      const proj = loadProjectConfig();
+      return {
+        enabled: true,
+        repo: proj.repo,
+        branch: proj.defaultBranch,
+        allowPrerelease: true,
+        checkIntervalMinutes: 30,
+      };
+    })();
     const standalone = isStandaloneInstall();
     const allowPre = opts.allowPrerelease === true ? true : (au.allowPrerelease ?? true);
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -6,8 +6,10 @@ import { fileURLToPath } from 'node:url';
 
 export interface AutoUpdateConfig {
   enabled: boolean;
-  repo: string;
-  branch: string;
+  /** Optional in ~/.dkg/config.json: omit to inherit from network/project config. */
+  repo?: string;
+  /** Optional in ~/.dkg/config.json: omit to inherit from network/project config. */
+  branch?: string;
   /** Allow auto-updating to pre-release versions (e.g. 9.0.5-rc.1). */
   allowPrerelease?: boolean;
   /** Optional SSH private key path for git-based update fetches/clones. */
@@ -337,9 +339,9 @@ export function loadProjectConfig(): ProjectConfig {
     } catch { /* try next */ }
   }
   _projectConfig = {
-    repo: 'OriginTrail/dkg-v9',
-    defaultBranch: 'v10-rc',
-    githubUrl: 'https://github.com/OriginTrail/dkg-v9',
+    repo: 'OriginTrail/dkg',
+    defaultBranch: 'main',
+    githubUrl: 'https://github.com/OriginTrail/dkg',
     projectName: 'dkg',
     syslogAppName: 'dkg',
     defaultNetwork: 'testnet',
@@ -349,6 +351,47 @@ export function loadProjectConfig(): ProjectConfig {
 
 export function _resetProjectConfigCache(): void {
   _projectConfig = null;
+}
+
+/**
+ * Field-level merge of the effective auto-update configuration.
+ *
+ * Precedence per field: `~/.dkg/config.json` → `network/<env>.json` →
+ * `project.json` (or static fallback). Returns null when auto-update is
+ * explicitly disabled in the local config.
+ *
+ * Rationale: `dkg init` intentionally omits `repo`/`branch` from the
+ * persisted config when the user accepts the defaults, so that future
+ * changes to the shipped network/project defaults propagate without a
+ * config rewrite. Callers must therefore resolve the effective values
+ * instead of reading `config.autoUpdate.repo` directly.
+ */
+export function resolveAutoUpdateConfig(
+  config: Pick<DkgConfig, 'autoUpdate'> | null | undefined,
+  network: Pick<NetworkConfig, 'autoUpdate'> | null | undefined,
+): (AutoUpdateConfig & { repo: string; branch: string }) | null {
+  const cfg = config?.autoUpdate;
+  const net = network?.autoUpdate;
+  const enabled = cfg?.enabled ?? net?.enabled ?? false;
+  if (!enabled) return null;
+
+  const proj = loadProjectConfig();
+  const repo = cfg?.repo ?? net?.repo ?? proj.repo;
+  const branch = cfg?.branch ?? net?.branch ?? proj.defaultBranch;
+  const allowPrerelease = cfg?.allowPrerelease ?? net?.allowPrerelease ?? true;
+  const sshKeyPath = cfg?.sshKeyPath ?? net?.sshKeyPath;
+  const sshCommand = cfg?.sshCommand ?? net?.sshCommand;
+  const checkIntervalMinutes = cfg?.checkIntervalMinutes ?? net?.checkIntervalMinutes ?? 30;
+
+  return {
+    enabled: true,
+    repo,
+    branch,
+    allowPrerelease,
+    ...(sshKeyPath ? { sshKeyPath } : {}),
+    ...(sshCommand ? { sshCommand } : {}),
+    checkIntervalMinutes,
+  };
 }
 
 /**

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -69,6 +69,7 @@ import {
   loadConfig,
   saveConfig,
   loadNetworkConfig,
+  resolveAutoUpdateConfig,
   dkgDir,
   writePid,
   removePid,
@@ -711,23 +712,27 @@ export async function runDaemonInner(
   }, PING_INTERVAL_MS);
   if (pingTimer.unref) pingTimer.unref();
 
-  // Version check + auto-update
+  // Version check + auto-update.
+  // The resolver merges repo/branch/interval field-by-field across
+  // ~/.dkg/config.json → network/<env>.json → project.json, so defaults
+  // in the shipped configs take effect even when the local config
+  // omits the field (the common case after `dkg init` with default answers).
   let updateInterval: ReturnType<typeof setInterval> | null = null;
-  const au = config.autoUpdate;
+  const au = resolveAutoUpdateConfig(config, network);
   const standalone = isStandaloneInstall();
-  const hasGitConfig = !!(au?.repo && au?.branch);
+  const hasGitConfig = !!au;
 
   if (standalone || hasGitConfig) {
-    const checkIntervalMs = (au?.checkIntervalMinutes || 30) * 60_000;
+    const checkIntervalMs = (au?.checkIntervalMinutes ?? 30) * 60_000;
     const allowPre = au?.allowPrerelease ?? true;
 
     if (standalone) {
       log(
-        `Auto-update (npm): ${au?.enabled !== false ? "enabled" : "disabled — version check only"} (every ${au?.checkIntervalMinutes ?? 30}min)`,
+        `Auto-update (npm): ${au ? "enabled" : "disabled — version check only"} (every ${au?.checkIntervalMinutes ?? 30}min)`,
       );
-    } else if (hasGitConfig) {
+    } else if (au) {
       log(
-        `Auto-update ${au!.enabled ? "enabled" : "disabled — version check only"}: ${au!.repo}@${au!.branch} (every ${au!.checkIntervalMinutes}min)`,
+        `Auto-update enabled: ${au.repo}@${au.branch} (every ${au.checkIntervalMinutes}min)`,
       );
     }
 
@@ -747,8 +752,8 @@ export async function runDaemonInner(
           updateAvailable = true;
           targetNpmVersion = npmStatus.version;
         }
-      } else if (hasGitConfig) {
-        const commitStatus = await checkForNewCommitWithStatus(au!, log);
+      } else if (au) {
+        const commitStatus = await checkForNewCommitWithStatus(au, log);
         if (commitStatus.status !== "error") {
           daemonState.lastUpdateCheck.upToDate = commitStatus.status === "up-to-date";
           daemonState.lastUpdateCheck.checkedAt = Date.now();
@@ -758,14 +763,14 @@ export async function runDaemonInner(
         updateAvailable = commitStatus.status === "available";
       }
 
-      if (au?.enabled !== false && updateAvailable) {
+      if (au && updateAvailable) {
         daemonState.isUpdating = true;
         let updated = false;
         if (standalone && targetNpmVersion) {
           const status = await performNpmUpdate(targetNpmVersion, log);
           updated = status === "updated";
-        } else if (hasGitConfig) {
-          updated = await checkForUpdate(au!, log);
+        } else {
+          updated = await checkForUpdate(au, log);
         }
         daemonState.isUpdating = false;
         if (updated) {

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
-  "repo": "OriginTrail/dkg-v9",
-  "defaultBranch": "v10-rc",
-  "githubUrl": "https://github.com/OriginTrail/dkg-v9",
+  "repo": "OriginTrail/dkg",
+  "defaultBranch": "main",
+  "githubUrl": "https://github.com/OriginTrail/dkg",
   "projectName": "dkg",
   "syslogAppName": "dkg",
   "defaultNetwork": "testnet"


### PR DESCRIPTION
## Summary

Repository `OriginTrail/dkg-v9` was renamed to `OriginTrail/dkg` and the release branch `v10-rc` was renamed to `main`. This PR:

1. Aligns the autoupdater, npm continuous-publish workflow, and shipped network configs with the new repo + branch names.
2. Adds a small structural fix so future default changes (repo/branch) propagate to existing nodes without having to rewrite `~/.dkg/config.json`.

No README or `package.json` URL sweep — out of scope for this PR.

## Changes

### Repo + branch alignment
- `project.json`: `repo` → `OriginTrail/dkg`, `defaultBranch` → `main`, `githubUrl` updated.
- `packages/cli/src/config.ts`: static `ProjectConfig` fallback mirrors `project.json`.
- `network/testnet.json`: `autoUpdate.repo` → `OriginTrail/dkg`, `autoUpdate.branch` → `main`.
- `network/mainnet-base.json`, `mainnet-gnosis.json`, `mainnet-neuroweb.json`: `autoUpdate.branch` → `main`.
- `packages/cli/scripts/bundle-markitdown-binaries.mjs`: release repo fallback → `OriginTrail/dkg`.
- `.github/workflows/npm-continuous-publish.yml`: trigger on `main` instead of `v10-rc` — restores continuous publish after the branch rename.

### Structural fix — autoUpdate resolves field-by-field
- New `resolveAutoUpdateConfig(config, network)` helper in `packages/cli/src/config.ts`:
  - Merges `~/.dkg/config.json` → `network/<env>.json` → `project.json` **per field**.
  - Returns `null` when auto-update is disabled.
- `AutoUpdateConfig.repo` and `.branch` are now optional.
- `dkg init` (in `packages/cli/src/cli.ts`) no longer persists `repo`/`branch` into `~/.dkg/config.json` when the user accepts the default — so changes to the shipped network/project defaults take effect on the next run without a config rewrite.
- Call sites rewired to the resolver:
  - `packages/cli/src/daemon/lifecycle.ts` — auto-update loop
  - `packages/cli/src/cli.ts` — `dkg update` handler + init summary print

### Backward compatibility
Existing nodes that already have `repo`/`branch` persisted in `~/.dkg/config.json` (e.g. `v10-rc` baked in by Ansible-managed relays) keep their values. The resolver only fills in defaults when fields are absent — no surprise upgrades, no breakage.

## Test plan
- [ ] CI green on this branch.
- [ ] After merge: push to `main` triggers `npm-continuous-publish.yml` and publishes a new `latest` tag.
- [ ] `npm install -g @origintrail-official/dkg` pulls the freshly published version.
- [ ] Fresh `dkg init` on a clean box does **not** write `autoUpdate.repo` / `autoUpdate.branch` into `~/.dkg/config.json` when defaults are accepted.
- [ ] `dkg update` on an existing node (with `repo`/`branch` already persisted) continues to hit the correct remote.
- [ ] Daemon auto-update loop logs show `OriginTrail/dkg@main` as the resolved target on nodes without explicit config.
- [ ] MarkItDown binary bundling script resolves release URLs against `OriginTrail/dkg`.