### PR TITLE
fix(cli): harden context graph ids and keystores

### DIFF
--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -576,17 +576,8 @@ export function shouldBypassRateLimitForLoopbackTraffic(ip: string, pathname: st
 }
 
 export function isValidContextGraphId(id: string): boolean {
-  if (!id || typeof id !== "string") return false;
-  if (id.length > 256) return false;
-  // Allow URNs, DIDs, simple slug-like identifiers, and URIs
-  if (!/^[\w:/.@\-]+$/.test(id)) return false;
-  if (id.includes('\\')) return false;
-  try {
-    const decoded = decodeURIComponent(id);
-    return !decoded.split('/').some((segment) => segment === '..' || segment === '.');
-  } catch {
-    return false;
-  }
+  if (typeof id !== "string") return false;
+  return validateContextGraphId(id).valid;
 }
 
 export function shortId(peerId: string): string {

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -579,7 +579,14 @@ export function isValidContextGraphId(id: string): boolean {
   if (!id || typeof id !== "string") return false;
   if (id.length > 256) return false;
   // Allow URNs, DIDs, simple slug-like identifiers, and URIs
-  return /^[\w:/.@\-]+$/.test(id);
+  if (!/^[\w:/.@\-]+$/.test(id)) return false;
+  if (id.includes('\\')) return false;
+  try {
+    const decoded = decodeURIComponent(id);
+    return !decoded.split('/').some((segment) => segment === '..' || segment === '.');
+  } catch {
+    return false;
+  }
 }
 
 export function shortId(peerId: string): string {

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -669,7 +669,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // POST /api/context-graph/{id}/add-participant
   const addParticipantMatch = path.match(/^\/api\/context-graph\/([^/]+)\/add-participant$/);
   if (req.method === "POST" && addParticipantMatch) {
-    const contextGraphId = decodeURIComponent(addParticipantMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(addParticipantMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     const { agentAddress } = JSON.parse(body);
@@ -688,7 +689,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // POST /api/context-graph/{id}/remove-participant
   const removeParticipantMatch = path.match(/^\/api\/context-graph\/([^/]+)\/remove-participant$/);
   if (req.method === "POST" && removeParticipantMatch) {
-    const contextGraphId = decodeURIComponent(removeParticipantMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(removeParticipantMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     const { agentAddress } = JSON.parse(body);
@@ -707,7 +709,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // GET /api/context-graph/{id}/participants
   const listParticipantsMatch = path.match(/^\/api\/context-graph\/([^/]+)\/participants$/);
   if (req.method === "GET" && listParticipantsMatch) {
-    const contextGraphId = decodeURIComponent(listParticipantsMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(listParticipantsMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const agents = await agent.getContextGraphAllowedAgents(contextGraphId);
@@ -723,7 +726,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // Otherwise, forward via P2P to all connected peers so the curator receives it.
   const requestJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/request-join$/);
   if (req.method === "POST" && requestJoinMatch) {
-    const contextGraphId = decodeURIComponent(requestJoinMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(requestJoinMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     try {
@@ -753,7 +757,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // GET /api/context-graph/{id}/join-requests — list pending join requests (curator view)
   const joinRequestsMatch = path.match(/^\/api\/context-graph\/([^/]+)\/join-requests$/);
   if (req.method === "GET" && joinRequestsMatch) {
-    const contextGraphId = decodeURIComponent(joinRequestsMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(joinRequestsMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const requests = await agent.listPendingJoinRequests(contextGraphId);
@@ -767,7 +772,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // POST /api/context-graph/{id}/approve-join — approve a pending request
   const approveJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/approve-join$/);
   if (req.method === "POST" && approveJoinMatch) {
-    const contextGraphId = decodeURIComponent(approveJoinMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(approveJoinMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     try {
@@ -784,7 +790,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // POST /api/context-graph/{id}/reject-join — reject a pending request
   const rejectJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/reject-join$/);
   if (req.method === "POST" && rejectJoinMatch) {
-    const contextGraphId = decodeURIComponent(rejectJoinMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(rejectJoinMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     try {
@@ -801,7 +808,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   // POST /api/context-graph/{id}/sign-join — sign a join request and forward to curator via P2P
   const signJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/sign-join$/);
   if (req.method === "POST" && signJoinMatch) {
-    const contextGraphId = decodeURIComponent(signJoinMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(signJoinMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const callerAddress = agent.resolveAgentAddress(
@@ -845,7 +853,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
 
   const manifestPublishMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/publish$/);
   if (req.method === 'POST' && manifestPublishMatch) {
-    const contextGraphId = decodeURIComponent(manifestPublishMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(manifestPublishMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     let body: any = {};
     try { body = JSON.parse(await readBody(req, SMALL_BODY_BYTES) || '{}'); }
@@ -945,7 +954,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
 
   const manifestPlanInstallMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/plan-install$/);
   if (req.method === 'POST' && manifestPlanInstallMatch) {
-    const contextGraphId = decodeURIComponent(manifestPlanInstallMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(manifestPlanInstallMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     let body: any = {};
     try { body = JSON.parse(await readBody(req, SMALL_BODY_BYTES) || '{}'); }
@@ -1039,7 +1049,8 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
 
   const manifestInstallMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/install$/);
   if (req.method === 'POST' && manifestInstallMatch) {
-    const contextGraphId = decodeURIComponent(manifestInstallMatch[1]);
+    const contextGraphId = safeDecodeURIComponent(manifestInstallMatch[1], res);
+    if (contextGraphId === null) return;
     if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     let body: any = {};
     try { body = JSON.parse(await readBody(req, SMALL_BODY_BYTES) || '{}'); }

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -670,6 +670,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const addParticipantMatch = path.match(/^\/api\/context-graph\/([^/]+)\/add-participant$/);
   if (req.method === "POST" && addParticipantMatch) {
     const contextGraphId = decodeURIComponent(addParticipantMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     const { agentAddress } = JSON.parse(body);
     if (!agentAddress || typeof agentAddress !== 'string') {
@@ -688,6 +689,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const removeParticipantMatch = path.match(/^\/api\/context-graph\/([^/]+)\/remove-participant$/);
   if (req.method === "POST" && removeParticipantMatch) {
     const contextGraphId = decodeURIComponent(removeParticipantMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     const { agentAddress } = JSON.parse(body);
     if (!agentAddress || typeof agentAddress !== 'string') {
@@ -706,6 +708,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const listParticipantsMatch = path.match(/^\/api\/context-graph\/([^/]+)\/participants$/);
   if (req.method === "GET" && listParticipantsMatch) {
     const contextGraphId = decodeURIComponent(listParticipantsMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const agents = await agent.getContextGraphAllowedAgents(contextGraphId);
       return jsonResponse(res, 200, { contextGraphId, allowedAgents: agents });
@@ -721,6 +724,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const requestJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/request-join$/);
   if (req.method === "POST" && requestJoinMatch) {
     const contextGraphId = decodeURIComponent(requestJoinMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     try {
       const { agentAddress, signature, timestamp, agentName } = JSON.parse(body);
@@ -750,6 +754,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const joinRequestsMatch = path.match(/^\/api\/context-graph\/([^/]+)\/join-requests$/);
   if (req.method === "GET" && joinRequestsMatch) {
     const contextGraphId = decodeURIComponent(joinRequestsMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const requests = await agent.listPendingJoinRequests(contextGraphId);
       return jsonResponse(res, 200, { contextGraphId, requests });
@@ -763,6 +768,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const approveJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/approve-join$/);
   if (req.method === "POST" && approveJoinMatch) {
     const contextGraphId = decodeURIComponent(approveJoinMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     try {
       const { agentAddress } = JSON.parse(body);
@@ -779,6 +785,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const rejectJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/reject-join$/);
   if (req.method === "POST" && rejectJoinMatch) {
     const contextGraphId = decodeURIComponent(rejectJoinMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     const body = await readBody(req);
     try {
       const { agentAddress } = JSON.parse(body);
@@ -795,6 +802,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const signJoinMatch = path.match(/^\/api\/context-graph\/([^/]+)\/sign-join$/);
   if (req.method === "POST" && signJoinMatch) {
     const contextGraphId = decodeURIComponent(signJoinMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     try {
       const callerAddress = agent.resolveAgentAddress(
         extractBearerToken(req.headers.authorization),
@@ -838,6 +846,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const manifestPublishMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/publish$/);
   if (req.method === 'POST' && manifestPublishMatch) {
     const contextGraphId = decodeURIComponent(manifestPublishMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     let body: any = {};
     try { body = JSON.parse(await readBody(req, SMALL_BODY_BYTES) || '{}'); }
     catch { return jsonResponse(res, 400, { error: 'Invalid JSON body' }); }
@@ -937,6 +946,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const manifestPlanInstallMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/plan-install$/);
   if (req.method === 'POST' && manifestPlanInstallMatch) {
     const contextGraphId = decodeURIComponent(manifestPlanInstallMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     let body: any = {};
     try { body = JSON.parse(await readBody(req, SMALL_BODY_BYTES) || '{}'); }
     catch { return jsonResponse(res, 400, { error: 'Invalid JSON body' }); }
@@ -1030,6 +1040,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
   const manifestInstallMatch = path.match(/^\/api\/context-graph\/([^/]+)\/manifest\/install$/);
   if (req.method === 'POST' && manifestInstallMatch) {
     const contextGraphId = decodeURIComponent(manifestInstallMatch[1]);
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
     let body: any = {};
     try { body = JSON.parse(await readBody(req, SMALL_BODY_BYTES) || '{}'); }
     catch { return jsonResponse(res, 400, { error: 'Invalid JSON body' }); }

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -46,7 +46,13 @@ const MAX_SCRYPT_P = 16;
 const MIN_SALT_BYTES = 16;
 
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
-export function _setScryptN(n: number) { SCRYPT_N = n; }
+export function _setScryptN(n: number) {
+  const estimatedMemoryBytes = 128 * n * SCRYPT_R;
+  if (!Number.isSafeInteger(n) || !isPowerOfTwo(n) || n < MIN_SCRYPT_N || estimatedMemoryBytes > MAX_SCRYPT_MEMORY_BYTES) {
+    throw new Error('Unsupported scrypt N for keystore encryption');
+  }
+  SCRYPT_N = n;
+}
 
 function isPowerOfTwo(value: number): boolean {
   return Number.isInteger(value) && value > 0 && Number.isInteger(Math.log2(value));

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -39,11 +39,10 @@ const SCRYPT_R = 8;
 const SCRYPT_P = 1;
 const DKLEN = 32;
 const MIN_SCRYPT_N = 2 ** 15;
-const MAX_SCRYPT_N = 2 ** 18;
 const MIN_SCRYPT_R = 8;
-const MAX_SCRYPT_R = SCRYPT_R;
 const MIN_SCRYPT_P = 1;
-const MAX_SCRYPT_P = SCRYPT_P;
+const MAX_SCRYPT_MEMORY_BYTES = 256 * 1024 * 1024;
+const MAX_SCRYPT_P = 16;
 const MIN_SALT_BYTES = 16;
 
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
@@ -54,20 +53,18 @@ function isPowerOfTwo(value: number): boolean {
 }
 
 function assertSafeKdfParams(kdfparams: EncryptedKeystore['crypto']['kdfparams']): void {
-  if (!isPowerOfTwo(kdfparams.n) || kdfparams.n < MIN_SCRYPT_N) {
+  if (!Number.isSafeInteger(kdfparams.n) || !isPowerOfTwo(kdfparams.n) || kdfparams.n < MIN_SCRYPT_N) {
     throw new Error('KDF parameters below minimum: scrypt N too low');
   }
-  if (kdfparams.n > MAX_SCRYPT_N) {
-    throw new Error('Unsupported keystore KDF parameters: scrypt N too high');
-  }
-  if (!Number.isInteger(kdfparams.r) || kdfparams.r < MIN_SCRYPT_R) {
+  if (!Number.isSafeInteger(kdfparams.r) || kdfparams.r < MIN_SCRYPT_R) {
     throw new Error('KDF parameters below minimum: scrypt r too low');
   }
-  if (kdfparams.r > MAX_SCRYPT_R) {
-    throw new Error('Unsupported keystore KDF parameters: scrypt r too high');
-  }
-  if (!Number.isInteger(kdfparams.p) || kdfparams.p < MIN_SCRYPT_P) {
+  if (!Number.isSafeInteger(kdfparams.p) || kdfparams.p < MIN_SCRYPT_P) {
     throw new Error('KDF parameters below minimum: scrypt p too low');
+  }
+  const estimatedMemoryBytes = 128 * kdfparams.n * kdfparams.r;
+  if (!Number.isSafeInteger(estimatedMemoryBytes) || estimatedMemoryBytes > MAX_SCRYPT_MEMORY_BYTES) {
+    throw new Error('Unsupported keystore KDF parameters: scrypt memory cost too high');
   }
   if (kdfparams.p > MAX_SCRYPT_P) {
     throw new Error('Unsupported keystore KDF parameters: scrypt p too high');

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -38,15 +38,45 @@ let SCRYPT_N = 2 ** 18;
 const SCRYPT_R = 8;
 const SCRYPT_P = 1;
 const DKLEN = 32;
+const MIN_SCRYPT_N = 2 ** 15;
+const MIN_SCRYPT_R = 8;
+const MIN_SCRYPT_P = 1;
+const MIN_SALT_BYTES = 16;
 
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
 export function _setScryptN(n: number) { SCRYPT_N = n; }
 
-function deriveKey(passphrase: string, salt: Buffer): Buffer {
+function isPowerOfTwo(value: number): boolean {
+  return Number.isInteger(value) && value > 0 && Number.isInteger(Math.log2(value));
+}
+
+function assertSafeKdfParams(kdfparams: EncryptedKeystore['crypto']['kdfparams']): void {
+  if (!isPowerOfTwo(kdfparams.n) || kdfparams.n < MIN_SCRYPT_N) {
+    throw new Error('KDF parameters below minimum: scrypt N too low');
+  }
+  if (!Number.isInteger(kdfparams.r) || kdfparams.r < MIN_SCRYPT_R) {
+    throw new Error('KDF parameters below minimum: scrypt r too low');
+  }
+  if (!Number.isInteger(kdfparams.p) || kdfparams.p < MIN_SCRYPT_P) {
+    throw new Error('KDF parameters below minimum: scrypt p too low');
+  }
+  if (kdfparams.dklen !== DKLEN) {
+    throw new Error(`Invalid dklen: dklen must be ${DKLEN}`);
+  }
+  if (!/^[0-9a-fA-F]+$/.test(kdfparams.salt) || kdfparams.salt.length % 2 !== 0 || kdfparams.salt.length < MIN_SALT_BYTES * 2) {
+    throw new Error(`KDF parameters below minimum: salt too short (minimum ${MIN_SALT_BYTES} bytes)`);
+  }
+}
+
+function deriveKey(
+  passphrase: string,
+  salt: Buffer,
+  params: Pick<EncryptedKeystore['crypto']['kdfparams'], 'n' | 'r' | 'p' | 'dklen'>,
+): Buffer {
   return scryptSync(passphrase, salt, DKLEN, {
-    N: SCRYPT_N,
-    r: SCRYPT_R,
-    p: SCRYPT_P,
+    N: params.n,
+    r: params.r,
+    p: params.p,
     maxmem: 256 * 1024 * 1024,
   });
 }
@@ -56,7 +86,12 @@ export async function encryptKeystore(
   passphrase: string,
 ): Promise<EncryptedKeystore> {
   const salt = randomBytes(32);
-  const key = deriveKey(passphrase, salt);
+  const key = deriveKey(passphrase, salt, {
+    n: SCRYPT_N,
+    r: SCRYPT_R,
+    p: SCRYPT_P,
+    dklen: DKLEN,
+  });
   const iv = randomBytes(12);
 
   const cipher = createCipheriv('aes-256-gcm', key, iv);
@@ -96,8 +131,9 @@ export async function decryptKeystore(
   }
 
   const { kdfparams } = keystore.crypto;
+  assertSafeKdfParams(kdfparams);
   const salt = Buffer.from(kdfparams.salt, 'hex');
-  const key = deriveKey(passphrase, salt);
+  const key = deriveKey(passphrase, salt, kdfparams);
 
   const iv = Buffer.from(keystore.crypto.iv, 'hex');
   const tag = Buffer.from(keystore.crypto.tag, 'hex');

--- a/packages/cli/src/keystore.ts
+++ b/packages/cli/src/keystore.ts
@@ -39,8 +39,11 @@ const SCRYPT_R = 8;
 const SCRYPT_P = 1;
 const DKLEN = 32;
 const MIN_SCRYPT_N = 2 ** 15;
+const MAX_SCRYPT_N = 2 ** 18;
 const MIN_SCRYPT_R = 8;
+const MAX_SCRYPT_R = SCRYPT_R;
 const MIN_SCRYPT_P = 1;
+const MAX_SCRYPT_P = SCRYPT_P;
 const MIN_SALT_BYTES = 16;
 
 /** @internal Allow tests to use lighter scrypt params to avoid memory limits */
@@ -54,11 +57,20 @@ function assertSafeKdfParams(kdfparams: EncryptedKeystore['crypto']['kdfparams']
   if (!isPowerOfTwo(kdfparams.n) || kdfparams.n < MIN_SCRYPT_N) {
     throw new Error('KDF parameters below minimum: scrypt N too low');
   }
+  if (kdfparams.n > MAX_SCRYPT_N) {
+    throw new Error('Unsupported keystore KDF parameters: scrypt N too high');
+  }
   if (!Number.isInteger(kdfparams.r) || kdfparams.r < MIN_SCRYPT_R) {
     throw new Error('KDF parameters below minimum: scrypt r too low');
   }
+  if (kdfparams.r > MAX_SCRYPT_R) {
+    throw new Error('Unsupported keystore KDF parameters: scrypt r too high');
+  }
   if (!Number.isInteger(kdfparams.p) || kdfparams.p < MIN_SCRYPT_P) {
     throw new Error('KDF parameters below minimum: scrypt p too low');
+  }
+  if (kdfparams.p > MAX_SCRYPT_P) {
+    throw new Error('Unsupported keystore KDF parameters: scrypt p too high');
   }
   if (kdfparams.dklen !== DKLEN) {
     throw new Error(`Invalid dklen: dklen must be ${DKLEN}`);

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -646,6 +646,17 @@ describe('CLI-16 — Path traversal in context-graph IDs', () => {
     const body = await res.json().catch(() => ({}));
     expect(body.error).toMatch(/contextGraphId|context graph id|invalid/i);
   });
+
+  it('rejects malformed percent-encoding in context-graph path-param routes', async () => {
+    const d = daemon!;
+    const res = await fetch(urlFor(d, '/api/context-graph/%E0%A4%A/participants'), {
+      method: 'GET',
+      headers: authHeaders(d),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json().catch(() => ({}));
+    expect(body.error).toMatch(/percent-encoding|malformed/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/daemon-http-behavior-extra.test.ts
+++ b/packages/cli/test/daemon-http-behavior-extra.test.ts
@@ -634,6 +634,18 @@ describe('CLI-16 — Path traversal in context-graph IDs', () => {
       expect(body.error).toMatch(/context graph id|invalid/i);
     });
   }
+
+  it('rejects encoded traversal in context-graph path-param routes', async () => {
+    const d = daemon!;
+    const encoded = encodeURIComponent('../etc/passwd');
+    const res = await fetch(urlFor(d, `/api/context-graph/${encoded}/participants`), {
+      method: 'GET',
+      headers: authHeaders(d),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json().catch(() => ({}));
+    expect(body.error).toMatch(/contextGraphId|context graph id|invalid/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/daemon-keystore-extra.test.ts
+++ b/packages/cli/test/daemon-keystore-extra.test.ts
@@ -80,16 +80,7 @@ describe('CLI-1 — scrypt KDF parameter floor (PROD-BUG: not enforced)', () => 
     _setScryptN(SAFE_N);
     const ks = await encryptKeystore(PRIVKEY, PASSPHRASE);
 
-    // Re-encrypt using a toy N so we can faithfully construct a forged
-    // "weak" keystore (same ciphertext+IV+tag would not decrypt if we just
-    // mutated kdfparams because the derived key would differ).
-    _setScryptN(WEAK_N);
-    const weakKs = await encryptKeystore(PRIVKEY, PASSPHRASE);
-    _setScryptN(SAFE_N);
-
-    // Sanity: this really is a weak keystore — the advertised N is the one we
-    // encrypted with.
-    expect(weakKs.crypto.kdfparams.n).toBe(WEAK_N);
+    await expect(() => _setScryptN(WEAK_N)).toThrow(/Unsupported scrypt N/);
 
     // Sanity: the "strong" keystore is rejected if we lie about its N.
     // The loader should fail at KDF validation before attempting GCM.
@@ -97,14 +88,7 @@ describe('CLI-1 — scrypt KDF parameter floor (PROD-BUG: not enforced)', () => 
       decryptKeystore(withKdfParams(ks, { n: WEAK_N }), PASSPHRASE),
     ).rejects.toThrow(/KDF parameters below minimum|scrypt N too low|weak keystore/i);
 
-    // PROD-BUG: the below call SHOULD throw "KDF parameters below minimum"
-    // (or any rejection tied to the cost floor). Instead it returns the
-    // plaintext — which means any attacker who can write a keystore file
-    // can force an O(1)-to-brute-force KDF. See issue #11.
-    //
-    // This assertion stays RED until `decryptKeystore` enforces N >= 2**15,
-    // r >= 8, p >= 1. Leaving red-on-purpose.
-    await expect(decryptKeystore(weakKs, PASSPHRASE)).rejects.toThrow(
+    await expect(decryptKeystore(withKdfParams(ks, { n: WEAK_N }), PASSPHRASE)).rejects.toThrow(
       /KDF parameters below minimum|scrypt cost too low|weak keystore/i,
     );
   });

--- a/packages/cli/test/daemon-keystore-extra.test.ts
+++ b/packages/cli/test/daemon-keystore-extra.test.ts
@@ -150,9 +150,9 @@ describe('CLI-1 — scrypt KDF parameter floor (PROD-BUG: not enforced)', () => 
     const ks = await encryptKeystore(PRIVKEY, PASSPHRASE);
 
     await expect(decryptKeystore(withKdfParams(ks, { n: 2 ** 30 }), PASSPHRASE))
-      .rejects.toThrow(/scrypt N too high|unsupported keystore/i);
-    await expect(decryptKeystore(withKdfParams(ks, { r: 64 }), PASSPHRASE))
-      .rejects.toThrow(/scrypt r too high|unsupported keystore/i);
+      .rejects.toThrow(/memory cost too high|unsupported keystore/i);
+    await expect(decryptKeystore(withKdfParams(ks, { r: 65 }), PASSPHRASE))
+      .rejects.toThrow(/memory cost too high|unsupported keystore/i);
     await expect(decryptKeystore(withKdfParams(ks, { p: 64 }), PASSPHRASE))
       .rejects.toThrow(/scrypt p too high|unsupported keystore/i);
   });

--- a/packages/cli/test/daemon-keystore-extra.test.ts
+++ b/packages/cli/test/daemon-keystore-extra.test.ts
@@ -91,11 +91,11 @@ describe('CLI-1 — scrypt KDF parameter floor (PROD-BUG: not enforced)', () => 
     // encrypted with.
     expect(weakKs.crypto.kdfparams.n).toBe(WEAK_N);
 
-    // Sanity: the "strong" keystore is rejected if we lie about its N
-    // (tampered kdfparams → wrong key → GCM auth failure).
+    // Sanity: the "strong" keystore is rejected if we lie about its N.
+    // The loader should fail at KDF validation before attempting GCM.
     await expect(
       decryptKeystore(withKdfParams(ks, { n: WEAK_N }), PASSPHRASE),
-    ).rejects.toThrow(/Decryption failed/);
+    ).rejects.toThrow(/KDF parameters below minimum|scrypt N too low|weak keystore/i);
 
     // PROD-BUG: the below call SHOULD throw "KDF parameters below minimum"
     // (or any rejection tied to the cost floor). Instead it returns the

--- a/packages/cli/test/daemon-keystore-extra.test.ts
+++ b/packages/cli/test/daemon-keystore-extra.test.ts
@@ -145,6 +145,18 @@ describe('CLI-1 — scrypt KDF parameter floor (PROD-BUG: not enforced)', () => 
     );
   });
 
+  it('refuses KDF parameters above the supported envelope before calling scrypt', async () => {
+    _setScryptN(SAFE_N);
+    const ks = await encryptKeystore(PRIVKEY, PASSPHRASE);
+
+    await expect(decryptKeystore(withKdfParams(ks, { n: 2 ** 30 }), PASSPHRASE))
+      .rejects.toThrow(/scrypt N too high|unsupported keystore/i);
+    await expect(decryptKeystore(withKdfParams(ks, { r: 64 }), PASSPHRASE))
+      .rejects.toThrow(/scrypt r too high|unsupported keystore/i);
+    await expect(decryptKeystore(withKdfParams(ks, { p: 64 }), PASSPHRASE))
+      .rejects.toThrow(/scrypt p too high|unsupported keystore/i);
+  });
+
   it('refuses to decrypt a keystore with a short salt (<16 bytes)', async () => {
     _setScryptN(SAFE_N);
     const ks = await encryptKeystore(PRIVKEY, PASSPHRASE);

--- a/packages/cli/test/http-utils.test.ts
+++ b/packages/cli/test/http-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { isValidContextGraphId } from '../src/daemon/http-utils.js';
+
+describe('isValidContextGraphId', () => {
+  it('rejects traversal path segments', () => {
+    for (const id of [
+      '../etc/passwd',
+      '../../root',
+      './../_private',
+      'legit-cg/../../other-cg',
+      'legit-cg/%2e%2e/other-cg',
+    ]) {
+      expect(isValidContextGraphId(id)).toBe(false);
+    }
+  });
+
+  it('keeps existing slug, DID, URN, and URL-style identifiers valid', () => {
+    for (const id of [
+      'devnet-test',
+      'did:dkg:context-graph:devnet-test',
+      'urn:dkg:project:smart-contracts',
+      'https://example.org/context-graphs/devnet-test',
+      'agent@example.org/context.graph-v1',
+    ]) {
+      expect(isValidContextGraphId(id)).toBe(true);
+    }
+  });
+});

--- a/packages/cli/test/keystore.test.ts
+++ b/packages/cli/test/keystore.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../src/keystore.js';
 
 beforeAll(() => {
-  _setScryptN(2 ** 14);
+  _setScryptN(2 ** 15);
 });
 
 const TEST_KEY = 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -122,13 +122,7 @@ export function validateContextGraphId(id: string): { valid: boolean; reason?: s
   if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };
   if (!/^[\w:/.@\-]+$/.test(id)) return { valid: false, reason: 'Context graph ID contains disallowed characters (allowed: alphanumeric, _, :, /, ., @, -)' };
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(id);
-  } catch {
-    return { valid: false, reason: 'Context graph ID contains malformed percent-encoding' };
-  }
-  if (decoded.split('/').some((segment) => segment === '.' || segment === '..')) {
+  if (id.split('/').some((segment) => segment === '.' || segment === '..')) {
     return { valid: false, reason: 'Context graph ID cannot contain path traversal segments' };
   }
   return { valid: true };

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -122,6 +122,15 @@ export function validateContextGraphId(id: string): { valid: boolean; reason?: s
   if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };
   if (!/^[\w:/.@\-]+$/.test(id)) return { valid: false, reason: 'Context graph ID contains disallowed characters (allowed: alphanumeric, _, :, /, ., @, -)' };
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(id);
+  } catch {
+    return { valid: false, reason: 'Context graph ID contains malformed percent-encoding' };
+  }
+  if (decoded.split('/').some((segment) => segment === '.' || segment === '..')) {
+    return { valid: false, reason: 'Context graph ID cannot contain path traversal segments' };
+  }
   return { valid: true };
 }
 

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -111,10 +111,9 @@ describe('validateContextGraphId', () => {
     expect(validateContextGraphId('a'.repeat(256)).valid).toBe(true);
   });
 
-  it('rejects literal and URL-encoded traversal path segments', () => {
+  it('rejects literal traversal path segments', () => {
     expect(validateContextGraphId('../etc/passwd').valid).toBe(false);
     expect(validateContextGraphId('legit-cg/../../other-cg').valid).toBe(false);
-    expect(validateContextGraphId('legit-cg/%2e%2e/other-cg').valid).toBe(false);
   });
 });
 

--- a/packages/core/test/constants.test.ts
+++ b/packages/core/test/constants.test.ts
@@ -110,6 +110,12 @@ describe('validateContextGraphId', () => {
     expect(validateContextGraphId('a'.repeat(257)).valid).toBe(false);
     expect(validateContextGraphId('a'.repeat(256)).valid).toBe(true);
   });
+
+  it('rejects literal and URL-encoded traversal path segments', () => {
+    expect(validateContextGraphId('../etc/passwd').valid).toBe(false);
+    expect(validateContextGraphId('legit-cg/../../other-cg').valid).toBe(false);
+    expect(validateContextGraphId('legit-cg/%2e%2e/other-cg').valid).toBe(false);
+  });
 });
 
 describe('validateAssertionName', () => {


### PR DESCRIPTION
## Summary
- Reject context graph IDs containing literal or URL-encoded traversal path segments before route handlers create local graphs.
- Validate stored scrypt KDF parameters before keystore decryption, including N/r/p floors, salt length, and dklen.
- Add focused unit coverage for the ID validator and update keystore tests to the documented minimum test cost.

## Test plan
- `pnpm --filter @origintrail-official/dkg build`
- `pnpm exec vitest run packages/cli/test/http-utils.test.ts packages/cli/test/keystore.test.ts packages/cli/test/daemon-keystore-extra.test.ts`

Note: I attempted the HTTP behavior test filter for CLI-16, but that suite requires the shared Hardhat context file and failed locally before test execution because the context file was absent.

Made with [Cursor](https://cursor.com)