### PR TITLE
fix(cli): gate /api/shared-memory/publish on curator identity

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -6014,6 +6014,23 @@ export class DKGAgent {
   }
 
   /**
+   * Public check for whether a CG is curated (private) vs open.
+   *
+   * Curated CGs restrict VM publish to the registered curator (mirrors
+   * the on-chain `publishPolicy = EVM_PUBLISH_CURATED` configured by
+   * `registerContextGraph` when local access policy is "private" or an
+   * allowlist exists). Open CGs accept publish attempts from any
+   * collaborator and let the chain adapter's `isAuthorizedPublisher`
+   * surface arbitrate.
+   *
+   * HTTP routes use this to decide whether an owner-only preflight is
+   * appropriate before handing off to the publisher.
+   */
+  async isContextGraphCurated(contextGraphId: string): Promise<boolean> {
+    return this.isPrivateContextGraph(contextGraphId);
+  }
+
+  /**
    * Public owner-check used by HTTP routes that need to gate curator-only
    * actions (manifest publish, SWM template rewrites, etc.). Throws a
    * caller-friendly "Only the …" error when the caller isn't the CG's

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1358,6 +1358,18 @@ decisions: []
     expect(chain.createOnChainContextGraphCalls[2]?.publishAuthority).toBe(ethers.getAddress(chain.signerAddress));
     expect(chain.createOnChainContextGraphCalls[2]?.participantAgents).toEqual([]);
 
+    // `isContextGraphCurated` must mirror the EVM publish-policy
+    // mapping above — HTTP routes (see
+    // packages/cli/src/daemon/routes/memory.ts) rely on it to decide
+    // whether to preflight a curator-only owner gate before
+    // `publishFromSharedMemory`. If this ever drifts from the policy
+    // the chain adapter actually enforces, non-curator publishes to
+    // open CGs will be rejected with 403 even though the contract
+    // accepts them (Codex PR#299 review finding).
+    expect(await agent.isContextGraphCurated('register-open-policy')).toBe(false);
+    expect(await agent.isContextGraphCurated('register-curated-policy')).toBe(true);
+    expect(await agent.isContextGraphCurated('register-agent-allowlist-policy')).toBe(true);
+
     await agent.stop().catch(() => {});
   });
 

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -446,25 +446,36 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
       });
     }
 
-    // Spec §2.2 — only the CG's registered curator may promote SWM to VM.
-    // Without this gate, any authenticated caller (including non-curator
-    // peers who legitimately write to SWM) could trigger an on-chain
-    // publish attempt that reverts late in the stack and returns HTTP 200
-    // with `status=tentative` — masking the authorization failure and
-    // leaving a trail of phantom "tentative" metadata on disk. Reject
-    // up-front with a clean 4xx so callers get an explicit,
-    // spec-conformant rejection (matches the project-manifest-publish
-    // gate in context-graph.ts).
-    try {
-      await agent.assertContextGraphOwner(
-        paranetId,
-        requestAgentAddress,
-        "publish shared memory to Verified Memory",
-      );
-    } catch (authErr: unknown) {
-      const msg = authErr instanceof Error ? authErr.message : String(authErr);
-      const code = /has no registered owner/.test(msg) ? 400 : 403;
-      return jsonResponse(res, code, { error: msg });
+    // Policy-aware preflight (spec §2.2):
+    //
+    // - Curated CGs (on-chain `publishPolicy = EVM_PUBLISH_CURATED`,
+    //   which `registerContextGraph` sets for private CGs or any CG
+    //   with an allowlist): only the registered curator may VM-publish.
+    //   Without this gate, non-curator callers hit the on-chain
+    //   `isAuthorizedPublisher` revert deep in the stack and the HTTP
+    //   surface returns 200 with `status=tentative` — masking the
+    //   authorization failure and leaving phantom tentative metadata
+    //   on disk.
+    //
+    // - Open CGs (on-chain `publishPolicy = EVM_PUBLISH_OPEN`): any
+    //   non-zero collaborator may publish per the contract; we must
+    //   NOT gate on curator identity here or we'd reject legitimate
+    //   participant publishes with 403.
+    //
+    // Preflight applies only to the curated branch; open CGs fall
+    // through to the publisher and the chain adapter decides.
+    if (await agent.isContextGraphCurated(paranetId)) {
+      try {
+        await agent.assertContextGraphOwner(
+          paranetId,
+          requestAgentAddress,
+          "publish shared memory to Verified Memory",
+        );
+      } catch (authErr: unknown) {
+        const msg = authErr instanceof Error ? authErr.message : String(authErr);
+        const code = /has no registered owner/.test(msg) ? 400 : 403;
+        return jsonResponse(res, code, { error: msg });
+      }
     }
 
     const ctx = createOperationContext("publishFromSWM");

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -464,6 +464,20 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     //
     // Preflight applies only to the curated branch; open CGs fall
     // through to the publisher and the chain adapter decides.
+    //
+    // Known scope gap (Codex PR#299 review, tracked separately):
+    // `assertContextGraphOwner` compares against the locally stored
+    // `dkg:curator` wallet DID. The on-chain
+    // `ContextGraphs.isAuthorizedPublisher` is richer — for PCA
+    // curators it live-resolves the NFT owner and any
+    // `agentToAccountId`-registered agents. This preflight therefore
+    // over-rejects PCA-delegated agents and post-transfer NFT holders
+    // whose wallets don't match the stale local curator metadata. The
+    // same shape of check is already used by share, invite, rename,
+    // and manifest-publish routes — migrating them all to a
+    // chain-authoritative preflight is a separate follow-up. Until
+    // then, those callers can work around this by publishing from the
+    // wallet recorded as the CG's local curator.
     if (await agent.isContextGraphCurated(paranetId)) {
       try {
         await agent.assertContextGraphOwner(

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -445,6 +445,28 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
           '"subGraphName" and "publishContextGraphId" cannot be used together',
       });
     }
+
+    // Spec §2.2 — only the CG's registered curator may promote SWM to VM.
+    // Without this gate, any authenticated caller (including non-curator
+    // peers who legitimately write to SWM) could trigger an on-chain
+    // publish attempt that reverts late in the stack and returns HTTP 200
+    // with `status=tentative` — masking the authorization failure and
+    // leaving a trail of phantom "tentative" metadata on disk. Reject
+    // up-front with a clean 4xx so callers get an explicit,
+    // spec-conformant rejection (matches the project-manifest-publish
+    // gate in context-graph.ts).
+    try {
+      await agent.assertContextGraphOwner(
+        paranetId,
+        requestAgentAddress,
+        "publish shared memory to Verified Memory",
+      );
+    } catch (authErr: unknown) {
+      const msg = authErr instanceof Error ? authErr.message : String(authErr);
+      const code = /has no registered owner/.test(msg) ? 400 : 403;
+      return jsonResponse(res, code, { error: msg });
+    }
+
     const ctx = createOperationContext("publishFromSWM");
     tracker.start(ctx, {
       contextGraphId: paranetId,


### PR DESCRIPTION
## Summary

Spec §2.2 requires that only a context graph's registered curator may promote SWM to Verified Memory, but the daemon had no caller-level auth check on `/api/shared-memory/publish` (or the legacy `/api/workspace/enshrine` alias). Non-curator callers reached the publisher, hit an on-chain `UnauthorizedPublisher` revert, and got back HTTP 200 with `status=tentative` — masking the authorization failure and leaving phantom tentative metadata on disk.

This PR adds the same owner-check the project-manifest-publish route already uses (`agent.assertContextGraphOwner`), mapping the thrown error to:
- **403** when the caller is authenticated but not the CG's curator
- **400** when the CG has no registered owner yet (tells the caller to `POST /api/context-graph/register` first)

The helper is the single source of truth for "caller is curator" across the daemon, so the semantics here stay in lockstep with share, invite, rename, and manifest-publish gates.

## Motivation

Running `scripts/devnet-test.sh` against latest `main` produces:

\`\`\`
[FAIL] Non-curator publish should be rejected with 4xx, got HTTP 200 status=tentative:
  {\"kcId\":\"0\",\"status\":\"tentative\", ...}
\`\`\`

That's devnet §4e (spec §2.2 negative assertion — the publish-authority guard must produce an explicit 4xx rejection). Today the guard only fires on-chain, and the late revert is swallowed into the tentative response. After this PR the daemon rejects at the HTTP boundary with a clear error message.

## What this does NOT fix

The curator's *own* publishes are also currently failing (devnet §4f / §5 / §10 / §22c) because `registerContextGraph` passes `publishAuthority=ZeroAddress` to the contract — a separate chain-wiring bug that deserves its own PR with contract-level review. This PR only closes the non-curator gap.

## Test plan

- [x] \`pnpm -r build\` — clean build across the monorepo
- [x] \`pnpm exec tsc --noEmit\` in \`packages/cli\` — clean
- [x] \`pnpm test\` in \`packages/cli\` — 21 pre-existing failures on \`main\` (all unrelated: SKILL.md length, scrypt KDF floors, path traversal, document-processor E2E, signed-request auth). No new failures introduced. Verified by stashing the change and re-running \`daemon-http-behavior-extra.test.ts\` — same 6 failures before and after.
- [ ] Run \`scripts/devnet-test.sh\` on a fresh devnet and observe §4e now passes with \`HTTP 403\`.

## Backwards compatibility

- **Legacy \`/api/workspace/enshrine\` alias** is covered by the same branch, so the gate applies uniformly.
- **Locally-created CGs without an on-chain owner** now return 400 (\"has no registered owner\") instead of silently producing a tentative publish. This is arguably *more* correct — you can't VM-publish without a registered CG — but does change the observed HTTP status for a narrow edge case. Callers should register via \`POST /api/context-graph/register\` before invoking publish.

Made with [Cursor](https://cursor.com)