### PR TITLE
imporove skill to start looking in the dkg right away

### DIFF
--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -280,6 +280,39 @@ When the chat turn includes injected context with `target_context_graph`, treat 
 1. **The authoritative target context graph for tool routing on this turn** — default all DKG reads, writes, imports, promotions, publishes, and queries in that turn to this value unless the user explicitly overrides it in the same message.
 2. **The user's currently-selected project in the UI** — when the user asks introspective questions like "which project am I on?", "what is currently selected?", "do you see that I have X selected?", answer directly from this field. Do not claim you cannot see the UI state. The field IS the UI state: the right-side panel project dropdown stamps it onto every turn envelope before the turn reaches you, so its presence means the user has that project selected and its absence means they have nothing selected.
 
+### Context-First Lookup
+
+For any substantive user request related to the current project, consult the selected project context graph before substantive project work. Use it as the default first source of project context so the agent reuses prior findings, tasks, decisions, and stored facts instead of re-deriving them from scratch.
+
+Exceptions:
+
+- Skip the lookup for trivial acknowledgements, greetings, or simple confirmations.
+- Skip the lookup for purely local or operational requests that do not depend on project memory.
+- Skip or narrow the lookup when the user explicitly tells you to ignore project memory or use another source first.
+
+Fallback behavior:
+
+- If no `target_context_graph` is present and the user does not name a project, first try to infer the intended project from the recent conversation.
+- If the target project is still ambiguous, ask a short clarification question before doing project-scoped work.
+
+Lookup scope:
+
+- Start with the cheapest useful lookup.
+- Prefer narrow graph queries, entity lookups, or recent-memory checks over broad scans when they are sufficient.
+- Avoid repeated or heavy graph queries unless the task actually needs them.
+
+Conflict handling:
+
+- If project memory conflicts with the user's current instruction, the repository, or fresh runtime evidence, do not blindly trust memory.
+- Call out the conflict briefly, prefer fresh evidence for execution, and write corrected context back to memory when appropriate.
+
+Minimum behavior:
+
+1. Identify the selected project context graph from `target_context_graph` or from explicit user instruction.
+2. Query the project context graph for relevant context before substantive work.
+3. Use what you find to shape the response, tool choice, and next actions.
+4. When the turn produces durable new information, write it back to the appropriate memory layer.
+
 Implications:
 
 - If `target_context_graph` is present, the user is on that project. State this explicitly when asked.


### PR DESCRIPTION

## Summary
- add a context-first lookup rule to the DKG node skill for substantive project-related requests
- define exceptions, fallback behavior, lightweight lookup guidance, and conflict handling so agents use project memory without over-querying or trusting stale graph state

## Why
Agents should default to consulting the selected project context graph before substantive project work so they reuse shared memory instead of re-deriving context each turn.

At the same time, the rule needs guardrails:
- trivial or purely operational turns should not trigger unnecessary graph lookups
- ambiguous project selection should lead to a short clarification
- fresh repo/runtime evidence should win over stale memory when they conflict
