### PR TITLE
track cg subscription

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -194,6 +194,8 @@ export interface ContextGraphSub {
   subscribed: boolean;
   /** Definition triples exist in the local triple store. */
   synced: boolean;
+  /** Shared-memory catch-up has completed at least once for this subscription. */
+  sharedMemorySynced?: boolean;
   /**
    * Whether the `_meta` graph (allowlist, registration status) has been
    * fetched via authenticated sync or is known from local creation.
@@ -207,6 +209,42 @@ export interface ContextGraphSub {
   participantIdentityIds?: bigint[];
   /** Participant agent addresses (V10 agent identity model). */
   participantAgents?: string[];
+}
+
+export interface ContextGraphSubscriptionRecord {
+  id: string;
+  name?: string;
+  subscribed: boolean;
+  synced: boolean;
+  sharedMemorySynced?: boolean;
+  metaSynced?: boolean;
+  onChainId?: string;
+  syncScoped: boolean;
+}
+
+export interface ContextGraphSubscriptionStore {
+  loadAll(): Promise<ContextGraphSubscriptionRecord[]>;
+  save(record: ContextGraphSubscriptionRecord): Promise<void>;
+  delete(contextGraphId: string): Promise<void>;
+}
+
+export type ContextGraphMemberPrincipalType = 'node' | 'agent' | 'identity';
+export type ContextGraphMemberStatus = 'active' | 'removed' | 'pending';
+
+export interface ContextGraphMembershipRecord {
+  contextGraphId: string;
+  principalType: ContextGraphMemberPrincipalType;
+  principalId: string;
+  role?: string;
+  status: ContextGraphMemberStatus;
+  source?: string;
+  displayName?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ContextGraphMembershipStore {
+  upsert(record: ContextGraphMembershipRecord & { firstSeenAt?: number; updatedAt: number }): Promise<void>;
+  delete(contextGraphId: string, principalType: ContextGraphMemberPrincipalType, principalId: string): Promise<void>;
 }
 
 /** @deprecated Use ContextGraphSub */
@@ -300,6 +338,10 @@ export interface DKGAgentConfig {
   syncContextGraphs?: string[];
   /** TTL for shared memory data in milliseconds. Expired operations are periodically cleaned up. Default: 48 hours. Set to 0 to disable. */
   sharedMemoryTtlMs?: number;
+  /** Durable local store for subscribed context-graph runtime state. */
+  contextGraphSubscriptionStore?: ContextGraphSubscriptionStore;
+  /** Durable local cache for nodes/agents known to be members of a context graph. */
+  contextGraphMembershipStore?: ContextGraphMembershipStore;
 }
 
 /**
@@ -544,6 +586,7 @@ export class DKGAgent {
 
     this.router = new ProtocolRouter(this.node);
     this.gossip = new GossipSubManager(this.node, this.eventBus);
+    await this.rehydrateContextGraphSubscriptions();
 
     // Register protocol handlers
     const accessHandler = new AccessHandler(this.store, this.eventBus);
@@ -781,6 +824,16 @@ export class DKGAgent {
             this.preferredSyncPeers.set(contextGraphId, peerId.toString());
             this.log.info(createOperationContext('system'), `Join request approved for "${contextGraphId}" — auto-subscribing`);
             this.subscribeToContextGraph(contextGraphId);
+            if (approvedAddr) {
+              this.upsertContextGraphMember({
+                contextGraphId,
+                principalType: 'agent',
+                principalId: approvedAddr,
+                role: 'participant',
+                status: 'active',
+                source: 'join-approved',
+              });
+            }
             this.syncContextGraphFromConnectedPeers(contextGraphId, { includeSharedMemory: true }).catch(() => {});
             this.eventBus.emit(DKGEvent.JOIN_APPROVED, {
               contextGraphId,
@@ -830,6 +883,14 @@ export class DKGAgent {
             return new TextEncoder().encode(JSON.stringify({ ok: true, skipped: true }));
           }
           this.log.info(createOperationContext('system'), `Join request rejected for "${contextGraphId}"`);
+          this.upsertContextGraphMember({
+            contextGraphId,
+            principalType: 'agent',
+            principalId: rejectedAddr,
+            role: 'requester',
+            status: 'removed',
+            source: 'join-rejected',
+          });
           this.eventBus.emit(DKGEvent.JOIN_REJECTED, {
             contextGraphId,
             agentAddress: rejectedAddr,
@@ -1495,7 +1556,160 @@ export class DKGAgent {
       if (!sub || sub.metaSynced === true) continue;
       if (await this.hasConfirmedMetaState(contextGraphId)) {
         sub.metaSynced = true;
+        this.persistContextGraphSubscription(contextGraphId);
       }
+    }
+  }
+
+  private setContextGraphSubscription(
+    contextGraphId: string,
+    next: ContextGraphSub,
+    options?: { persist?: boolean },
+  ): ContextGraphSub {
+    this.subscribedContextGraphs.set(contextGraphId, next);
+    if (options?.persist !== false) {
+      this.persistContextGraphSubscription(contextGraphId);
+      if (next.subscribed) {
+        this.persistLocalNodeMembership(contextGraphId);
+      } else {
+        this.deleteContextGraphMember(contextGraphId, 'node', this.peerId);
+      }
+    }
+    return next;
+  }
+
+  markContextGraphSubscriptionState(contextGraphId: string, patch: Partial<ContextGraphSub>): void {
+    const existing = this.subscribedContextGraphs.get(contextGraphId);
+    if (!existing) return;
+    this.setContextGraphSubscription(contextGraphId, { ...existing, ...patch });
+  }
+
+  persistContextGraphSubscriptionState(contextGraphId: string): void {
+    this.persistContextGraphSubscription(contextGraphId);
+  }
+
+  private persistContextGraphSubscription(contextGraphId: string): void {
+    const store = this.config.contextGraphSubscriptionStore;
+    if (!store) return;
+    const sub = this.subscribedContextGraphs.get(contextGraphId);
+    if (!sub?.subscribed) {
+      void store.delete(contextGraphId).catch((err) => {
+        this.log.warn(
+          createOperationContext('system'),
+          `Failed to delete persisted context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+      return;
+    }
+    void store.save({
+      id: contextGraphId,
+      name: sub.name,
+      subscribed: sub.subscribed,
+      synced: sub.synced,
+      sharedMemorySynced: sub.sharedMemorySynced,
+      metaSynced: sub.metaSynced,
+      onChainId: sub.onChainId,
+      syncScoped: (this.config.syncContextGraphs ?? []).includes(contextGraphId),
+    }).catch((err) => {
+      this.log.warn(
+        createOperationContext('system'),
+        `Failed to persist context-graph subscription for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  private normalizeMembershipPrincipal(
+    principalType: ContextGraphMemberPrincipalType,
+    principalId: string,
+  ): string {
+    if (principalType === 'agent' && ethers.isAddress(principalId)) {
+      return ethers.getAddress(principalId);
+    }
+    return principalId;
+  }
+
+  private upsertContextGraphMember(record: ContextGraphMembershipRecord): void {
+    const store = this.config.contextGraphMembershipStore;
+    if (!store) return;
+    const normalizedRecord = {
+      ...record,
+      principalId: this.normalizeMembershipPrincipal(record.principalType, record.principalId),
+    };
+    const updatedAt = Date.now();
+    void store.upsert({ ...normalizedRecord, updatedAt }).catch((err) => {
+      this.log.warn(
+        createOperationContext('system'),
+        `Failed to persist context-graph membership for "${normalizedRecord.contextGraphId}" (${normalizedRecord.principalType}:${normalizedRecord.principalId}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  private deleteContextGraphMember(
+    contextGraphId: string,
+    principalType: ContextGraphMemberPrincipalType,
+    principalId: string,
+  ): void {
+    const store = this.config.contextGraphMembershipStore;
+    if (!store) return;
+    const normalizedPrincipalId = this.normalizeMembershipPrincipal(principalType, principalId);
+    void store.delete(contextGraphId, principalType, normalizedPrincipalId).catch((err) => {
+      this.log.warn(
+        createOperationContext('system'),
+        `Failed to delete context-graph membership for "${contextGraphId}" (${principalType}:${normalizedPrincipalId}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  private persistLocalNodeMembership(contextGraphId: string, source = 'subscription'): void {
+    const sub = this.subscribedContextGraphs.get(contextGraphId);
+    this.upsertContextGraphMember({
+      contextGraphId,
+      principalType: 'node',
+      principalId: this.peerId,
+      role: 'subscriber',
+      status: 'active',
+      source,
+      displayName: this.nodeName,
+      metadata: {
+        subscribed: sub?.subscribed ?? false,
+        synced: sub?.synced ?? false,
+        sharedMemorySynced: sub?.sharedMemorySynced ?? false,
+        metaSynced: sub?.metaSynced ?? false,
+        ...(sub?.onChainId ? { onChainId: sub.onChainId } : {}),
+      },
+    });
+  }
+
+  private async rehydrateContextGraphSubscriptions(): Promise<void> {
+    const store = this.config.contextGraphSubscriptionStore;
+    if (!store) return;
+    const ctx = createOperationContext('init');
+    try {
+      const rows = await store.loadAll();
+      for (const row of rows) {
+        this.setContextGraphSubscription(row.id, {
+          name: row.name,
+          subscribed: row.subscribed,
+          synced: row.synced,
+          sharedMemorySynced: row.sharedMemorySynced,
+          metaSynced: row.metaSynced,
+          onChainId: row.onChainId,
+        }, { persist: false });
+      }
+      for (const row of rows) {
+        if (row.syncScoped) {
+          this.trackSyncContextGraph(row.id);
+        }
+        if (row.subscribed) {
+          this.subscribeToContextGraph(row.id, { trackSyncScope: false, persist: false });
+          this.persistLocalNodeMembership(row.id, 'rehydrated-subscription');
+        }
+      }
+      if (rows.length > 0) {
+        this.log.info(ctx, `Rehydrated ${rows.length} persisted context-graph subscription(s)`);
+      }
+    } catch (err) {
+      this.log.warn(ctx, `Failed to rehydrate persisted context-graph subscriptions: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -2413,6 +2627,27 @@ export class DKGAgent {
       throw new Error('createOnChainContextGraph not available on chain adapter');
     }
     const result = await this.chain.createOnChainContextGraph(params);
+    const contextGraphId = result.contextGraphId.toString();
+    for (const identityId of params.participantIdentityIds) {
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'identity',
+        principalId: identityId.toString(),
+        role: 'hosting-node',
+        status: 'active',
+        source: 'on-chain-registration',
+      });
+    }
+    for (const agentAddress of params.participantAgents ?? []) {
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'agent',
+        principalId: agentAddress,
+        role: 'participant-agent',
+        status: 'active',
+        source: 'on-chain-registration',
+      });
+    }
     this.log.info(ctx, `Created on-chain context graph ${result.contextGraphId} (M=${params.requiredSignatures}, N=${params.participantIdentityIds.length})`);
     return result;
   }
@@ -2869,7 +3104,7 @@ export class DKGAgent {
     });
   }
 
-  subscribeToContextGraph(contextGraphId: string, options?: { trackSyncScope?: boolean }): void {
+  subscribeToContextGraph(contextGraphId: string, options?: { trackSyncScope?: boolean; persist?: boolean }): void {
     if (options?.trackSyncScope !== false) {
       this.trackSyncContextGraph(contextGraphId);
     }
@@ -2878,7 +3113,11 @@ export class DKGAgent {
     if (this.gossipRegistered.has(contextGraphId)) {
       const existing = this.subscribedContextGraphs.get(contextGraphId);
       if (!existing?.subscribed) {
-        this.subscribedContextGraphs.set(contextGraphId, { ...existing, subscribed: true, synced: existing?.synced ?? false });
+        this.setContextGraphSubscription(
+          contextGraphId,
+          { ...existing, subscribed: true, synced: existing?.synced ?? false },
+          { persist: options?.persist },
+        );
       }
       return;
     }
@@ -2893,7 +3132,11 @@ export class DKGAgent {
     this.gossip.subscribe(appTopic);
 
     const existing = this.subscribedContextGraphs.get(contextGraphId);
-    this.subscribedContextGraphs.set(contextGraphId, { ...existing, subscribed: true, synced: existing?.synced ?? false });
+    this.setContextGraphSubscription(
+      contextGraphId,
+      { ...existing, subscribed: true, synced: existing?.synced ?? false },
+      { persist: options?.persist },
+    );
 
     this.gossip.onMessage(publishTopic, async (_topic, data, from) => {
       const gph = this.getOrCreateGossipPublishHandler();
@@ -2949,6 +3192,7 @@ export class DKGAgent {
           getContextGraphOwner: (id) => this.getContextGraphCreator(id),
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
+          persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },
       );
     }
@@ -3216,12 +3460,81 @@ export class DKGAgent {
     await this.store.insert(quads);
     await gm.ensureParanet(opts.id);
 
-    this.subscribedContextGraphs.set(opts.id, {
+    this.setContextGraphSubscription(opts.id, {
       name: opts.name,
       subscribed: !opts.private,
       synced: true,
       metaSynced: true,
     });
+
+    if (opts.private || isCurated) {
+      this.upsertContextGraphMember({
+        contextGraphId: opts.id,
+        principalType: 'node',
+        principalId: this.peerId,
+        role: 'curator',
+        status: 'active',
+        source: 'local-create',
+        displayName: this.nodeName,
+      });
+    }
+
+    const curatorAgentAddress = opts.callerAgentAddress ?? this.defaultAgentAddress;
+    if (curatorAgentAddress) {
+      this.upsertContextGraphMember({
+        contextGraphId: opts.id,
+        principalType: 'agent',
+        principalId: curatorAgentAddress,
+        role: 'curator',
+        status: 'active',
+        source: 'local-create',
+      });
+    }
+
+    for (const peer of opts.allowedPeers ?? []) {
+      this.upsertContextGraphMember({
+        contextGraphId: opts.id,
+        principalType: 'node',
+        principalId: peer,
+        role: 'participant',
+        status: 'active',
+        source: 'allowed-peer',
+      });
+    }
+
+    for (const addr of opts.allowedAgents ?? []) {
+      this.upsertContextGraphMember({
+        contextGraphId: opts.id,
+        principalType: 'agent',
+        principalId: addr,
+        role: 'participant',
+        status: 'active',
+        source: 'allowed-agent',
+      });
+    }
+
+    for (const addr of opts.participantAgents ?? []) {
+      if (!ethers.isAddress(addr)) continue;
+      this.upsertContextGraphMember({
+        contextGraphId: opts.id,
+        principalType: 'agent',
+        principalId: ethers.getAddress(addr),
+        role: 'participant-agent',
+        status: 'active',
+        source: 'participant-agent',
+      });
+    }
+
+    for (const identityId of participantIdentityIds) {
+      this.upsertContextGraphMember({
+        contextGraphId: opts.id,
+        principalType: 'identity',
+        principalId: identityId.toString(),
+        role: 'hosting-node',
+        status: 'active',
+        source: 'participant-identity',
+      });
+    }
 
     // On-chain registration is intentionally NOT done here — per v10 spec
     // §2.2 / §2.3 Context Graphs are a local-first primitive. A CG exists
@@ -3548,6 +3861,7 @@ export class DKGAgent {
         this.subscribeToContextGraph(id, { trackSyncScope: true });
         this.log.info(ctx, `Subscribed to newly registered context graph "${id}"`);
       }
+      this.persistContextGraphSubscription(id);
     }
 
     // Registration status is in _meta — it propagates to peers via sync, not
@@ -3628,6 +3942,14 @@ export class DKGAgent {
 
     // Skip if already in the allowlist (idempotent)
     if (existingAllowlist?.includes(peerId)) {
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'node',
+        principalId: peerId,
+        role: 'participant',
+        status: 'active',
+        source: 'allowed-peer',
+      });
       this.log.info(ctx, `Peer ${peerId} already in allowlist for "${contextGraphId}" — skipping`);
       return;
     }
@@ -3640,6 +3962,26 @@ export class DKGAgent {
     });
 
     await this.store.insert(quadsToInsert);
+
+    if (existingAllowlist === null || existingAllowlist.length === 0) {
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'node',
+        principalId: this.peerId,
+        role: 'curator',
+        status: 'active',
+        source: 'allowed-peer',
+        displayName: this.nodeName,
+      });
+    }
+    this.upsertContextGraphMember({
+      contextGraphId,
+      principalType: 'node',
+      principalId: peerId,
+      role: 'participant',
+      status: 'active',
+      source: 'allowed-peer',
+    });
 
     // Allowlist updates are in _meta and propagate to peers via the
     // authenticated sync protocol, not unauthenticated gossip.
@@ -3685,6 +4027,14 @@ export class DKGAgent {
         object: `"${this.defaultAgentAddress}"`,
         graph: cgMetaGraph,
       });
+      this.upsertContextGraphMember({
+        contextGraphId,
+        principalType: 'agent',
+        principalId: this.defaultAgentAddress,
+        role: 'curator',
+        status: 'active',
+        source: 'allowed-agent',
+      });
     }
 
     quadsToInsert.push({
@@ -3695,6 +4045,14 @@ export class DKGAgent {
     });
 
     await this.store.insert(quadsToInsert);
+    this.upsertContextGraphMember({
+      contextGraphId,
+      principalType: 'agent',
+      principalId: agentAddress,
+      role: 'participant',
+      status: 'active',
+      source: 'allowed-agent',
+    });
 
     this.log.info(ctx, `Invited agent ${agentAddress} to context graph "${contextGraphId}"`);
   }
@@ -3732,6 +4090,7 @@ export class DKGAgent {
       predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
       object: `"${agentAddress}"`,
     });
+    this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
 
     this.log.info(ctx, `Removed agent ${agentAddress} from context graph "${contextGraphId}"`);
   }
@@ -3907,6 +4266,16 @@ export class DKGAgent {
       quads.push({ subject: requestUri, predicate: SCHEMA_NAME, object: `"${agentName}"`, graph: cgMetaGraph });
     }
     await this.store.insert(quads);
+    this.upsertContextGraphMember({
+      contextGraphId,
+      principalType: 'agent',
+      principalId: agentAddress,
+      role: 'requester',
+      status: 'pending',
+      source: 'join-request',
+      ...(agentName ? { displayName: agentName } : {}),
+      metadata: { timestamp },
+    });
     const ctx = createOperationContext('system');
     this.log.info(ctx, `Stored pending join request from ${agentAddress} for "${contextGraphId}"`);
   }
@@ -4048,6 +4417,14 @@ export class DKGAgent {
       object: `"rejected"`,
       graph: cgMetaGraph,
     }]);
+    this.upsertContextGraphMember({
+      contextGraphId,
+      principalType: 'agent',
+      principalId: agentAddress,
+      role: 'requester',
+      status: 'removed',
+      source: 'join-rejected',
+    });
 
     const ctx = createOperationContext('system');
     this.log.info(ctx, `Rejected join request from ${agentAddress} for "${contextGraphId}"`);
@@ -4458,7 +4835,7 @@ export class DKGAgent {
       // `LIMIT 1` made ownership nondeterministic — any subscriber could
       // win the unordered query and look like the curator.
       this.subscribeToContextGraph(opts.id);
-      this.subscribedContextGraphs.set(opts.id, {
+      this.setContextGraphSubscription(opts.id, {
         name: opts.name,
         subscribed: true,
         synced: true,
@@ -4516,7 +4893,7 @@ export class DKGAgent {
     await gm.ensureParanet(opts.id);
 
     this.subscribeToContextGraph(opts.id);
-    this.subscribedContextGraphs.set(opts.id, {
+    this.setContextGraphSubscription(opts.id, {
       name: opts.name,
       subscribed: true,
       synced: true,
@@ -6592,23 +6969,23 @@ export class DKGAgent {
         // `refreshMetaSyncedFlags(newlyDiscovered)` call from
         // `trySyncFromPeer` (see ~#1012) will flip the flag once the
         // allowlist has been fetched via the authenticated sync path.
-        this.subscribedContextGraphs.set(id, {
+        this.setContextGraphSubscription(id, {
           name,
           subscribed: false,
           synced: true,
           metaSynced: false,
           onChainId: undefined,
-        });
+        }, { persist: false });
         this.subscribeToContextGraph(id);
         this.log.info(ctx, `Discovered invited context graph "${name}" (${id}) — auto-subscribed (private/allowlisted)`);
       } else {
-        this.subscribedContextGraphs.set(id, {
+        this.setContextGraphSubscription(id, {
           name,
           subscribed: false,
           synced: true,
           metaSynced: source === 'meta',
           onChainId: undefined,
-        });
+        }, { persist: false });
         this.log.info(ctx, `Discovered context graph "${name}" (${id}) from ${source} store — added as discoverable only`);
       }
       discovered++;
@@ -6660,7 +7037,7 @@ export class DKGAgent {
         continue;
       }
 
-      this.subscribedContextGraphs.set(p.name, {
+      this.setContextGraphSubscription(p.name, {
         name: p.name,
         subscribed: true,
         synced: false,
@@ -7058,4 +7435,3 @@ export class DKGAgent {
   }
 
 }
-

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -21,7 +21,7 @@ export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => vo
 export interface GossipPublishHandlerCallbacks {
   contextGraphExists: (id: string) => Promise<boolean>;
   getContextGraphOwner: (id: string) => Promise<string | null>;
-  subscribeToContextGraph: (id: string, options?: { trackSyncScope?: boolean }) => void;
+  subscribeToContextGraph: (id: string, options?: { trackSyncScope?: boolean; persist?: boolean }) => void;
   /**
    * Same semantics as `DKGAgent#hasConfirmedMetaState`: returns true when the
    * local store already has a trustworthy public announcement for this CG
@@ -35,6 +35,7 @@ export interface GossipPublishHandlerCallbacks {
    * callback returned `false`).
    */
   hasConfirmedMetaState?: (id: string) => Promise<boolean>;
+  persistContextGraphSubscription?: (id: string) => void;
   onPhase?: GossipPhaseCallback;
 }
 
@@ -217,6 +218,7 @@ export class GossipPublishHandler {
               : false;
             if (confirmed) {
               sub.metaSynced = true;
+              this.callbacks.persistContextGraphSubscription?.(request.paranetId);
             } else {
               this.log.warn(ctx, `Gossip publish deferred: context graph "${request.paranetId}" _meta not yet synced — defaulting to deny`);
               return;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -55,6 +55,12 @@ export {
   DKGAgent,
   type DKGAgentConfig,
   type ContextGraphSub,
+  type ContextGraphMemberPrincipalType,
+  type ContextGraphMemberStatus,
+  type ContextGraphMembershipRecord,
+  type ContextGraphMembershipStore,
+  type ContextGraphSubscriptionRecord,
+  type ContextGraphSubscriptionStore,
   type ParanetSub,
   type PeerHealth,
 } from './dkg-agent.js';

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1755,6 +1755,190 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
     }
   });
 
+  it('persists runtime subscriptions and rehydrates them on restart', async () => {
+    const persisted = new Map<string, any>();
+    const persistedMembers = new Map<string, any>();
+    const subscriptionStore = {
+      loadAll: async () => [...persisted.values()],
+      save: async (record: any) => {
+        persisted.set(record.id, { ...record });
+      },
+      delete: async (contextGraphId: string) => {
+        persisted.delete(contextGraphId);
+      },
+    };
+    const membershipStore = {
+      upsert: async (record: any) => {
+        persistedMembers.set(`${record.contextGraphId}|${record.principalType}|${record.principalId}`, { ...record });
+      },
+      delete: async (contextGraphId: string, principalType: string, principalId: string) => {
+        persistedMembers.delete(`${contextGraphId}|${principalType}|${principalId}`);
+      },
+    };
+
+    const agentA = await DKGAgent.create({
+      name: 'PersistedSubscriptionsA',
+      listenHost: '127.0.0.1',
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      contextGraphSubscriptionStore: subscriptionStore,
+      contextGraphMembershipStore: membershipStore,
+    });
+
+    let agentAPeerId = '';
+    try {
+      await agentA.start();
+      agentAPeerId = agentA.peerId;
+      agentA.subscribeToContextGraph('persisted-cg');
+      agentA.markContextGraphSubscriptionState('persisted-cg', {
+        synced: true,
+        sharedMemorySynced: true,
+        metaSynced: true,
+        onChainId: '0x1234',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      await agentA.stop().catch(() => {});
+    }
+
+    expect(persisted.get('persisted-cg')).toMatchObject({
+      id: 'persisted-cg',
+      subscribed: true,
+      synced: true,
+      sharedMemorySynced: true,
+      metaSynced: true,
+      onChainId: '0x1234',
+      syncScoped: true,
+    });
+    expect(persistedMembers.get(`persisted-cg|node|${agentAPeerId}`)).toMatchObject({
+      contextGraphId: 'persisted-cg',
+      principalType: 'node',
+      principalId: agentAPeerId,
+      role: 'subscriber',
+      status: 'active',
+      source: 'subscription',
+    });
+
+    const agentB = await DKGAgent.create({
+      name: 'PersistedSubscriptionsB',
+      listenHost: '127.0.0.1',
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      contextGraphSubscriptionStore: subscriptionStore,
+      contextGraphMembershipStore: membershipStore,
+    });
+
+    try {
+      await agentB.start();
+      expect(agentB.getSubscribedContextGraphs().get('persisted-cg')).toMatchObject({
+        subscribed: true,
+        synced: true,
+        sharedMemorySynced: true,
+        metaSynced: true,
+        onChainId: '0x1234',
+      });
+      expect((agentB as any).config.syncContextGraphs ?? []).toContain('persisted-cg');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(persistedMembers.get(`persisted-cg|node|${agentB.peerId}`)).toMatchObject({
+        contextGraphId: 'persisted-cg',
+        principalType: 'node',
+        principalId: agentB.peerId,
+        status: 'active',
+        source: 'rehydrated-subscription',
+      });
+    } finally {
+      await agentB.stop().catch(() => {});
+    }
+  });
+
+  it('rehydrates persisted subscriptions without forcing sync scope', async () => {
+    const subscriptionStore = {
+      loadAll: async () => [{
+        id: 'discovered-cg',
+        name: 'Discovered CG',
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        onChainId: '0xabcd',
+        syncScoped: false,
+      }],
+      save: async () => {},
+      delete: async () => {},
+    };
+
+    const agent = await DKGAgent.create({
+      name: 'PersistedSubscriptionsNoScope',
+      listenHost: '127.0.0.1',
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      contextGraphSubscriptionStore: subscriptionStore,
+    });
+
+    try {
+      await agent.start();
+      expect(agent.getSubscribedContextGraphs().get('discovered-cg')).toMatchObject({
+        subscribed: true,
+        synced: false,
+        sharedMemorySynced: false,
+        metaSynced: false,
+        onChainId: '0xabcd',
+      });
+      expect((agent as any).config.syncContextGraphs ?? []).not.toContain('discovered-cg');
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('canonicalizes Ethereum agent membership principals before persistence', async () => {
+    const persistedMembers = new Map<string, any>();
+    const deletedMembers: string[] = [];
+    const membershipStore = {
+      upsert: async (record: any) => {
+        persistedMembers.set(`${record.contextGraphId}|${record.principalType}|${record.principalId}`, { ...record });
+      },
+      delete: async (contextGraphId: string, principalType: string, principalId: string) => {
+        const key = `${contextGraphId}|${principalType}|${principalId}`;
+        deletedMembers.push(key);
+        persistedMembers.delete(key);
+      },
+    };
+    const lowercaseAddress = '0x86b8521581b87e21ebd730cbba110e1480454d6d';
+    const checksumAddress = ethers.getAddress(lowercaseAddress);
+
+    const agent = await DKGAgent.create({
+      name: 'MembershipPrincipalCanonical',
+      listenHost: '127.0.0.1',
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      contextGraphMembershipStore: membershipStore,
+    });
+
+    try {
+      await agent.start();
+      await agent.createContextGraph({
+        id: 'membership-canonical-cg',
+        name: 'Membership Canonical',
+        accessPolicy: 1,
+        allowedAgents: [lowercaseAddress],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(persistedMembers.get(`membership-canonical-cg|agent|${checksumAddress}`)).toMatchObject({
+        contextGraphId: 'membership-canonical-cg',
+        principalType: 'agent',
+        principalId: checksumAddress,
+        role: 'participant',
+        status: 'active',
+        source: 'allowed-agent',
+      });
+      expect(persistedMembers.has(`membership-canonical-cg|agent|${lowercaseAddress}`)).toBe(false);
+
+      await agent.removeAgentFromContextGraph('membership-canonical-cg', lowercaseAddress);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(deletedMembers).toContain(`membership-canonical-cg|agent|${checksumAddress}`);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('syncContextGraphFromConnectedPeers returns empty stats without peers', async () => {
     const agent = await DKGAgent.create({
       name: 'RuntimeCatchupNoPeers',

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -515,6 +515,8 @@ export async function runDaemonInner(
       })()
     : undefined;
 
+  const dashDb = new DashboardDB({ dataDir: dkgDir() });
+
   const agent = await DKGAgent.create({
     name: config.name,
     framework: "DKG",
@@ -537,6 +539,53 @@ export async function runDaemonInner(
       chainId: chainBase.chainId,
     } : undefined,
     sharedMemoryTtlMs: resolveSharedMemoryTtlMs(config),
+    contextGraphSubscriptionStore: {
+      loadAll: async () => dashDb.listContextGraphSubscriptions().map((row) => ({
+        id: row.context_graph_id,
+        name: row.name ?? undefined,
+        subscribed: row.subscribed === 1,
+        synced: row.synced === 1,
+        sharedMemorySynced: row.shared_memory_synced == null ? undefined : row.shared_memory_synced === 1,
+        metaSynced: row.meta_synced == null ? undefined : row.meta_synced === 1,
+        onChainId: row.on_chain_id ?? undefined,
+        syncScoped: row.sync_scoped === 1,
+      })),
+      save: async (record) => {
+        dashDb.upsertContextGraphSubscription({
+          context_graph_id: record.id,
+          name: record.name ?? null,
+          subscribed: record.subscribed ? 1 : 0,
+          synced: record.synced ? 1 : 0,
+          shared_memory_synced: record.sharedMemorySynced == null ? null : record.sharedMemorySynced ? 1 : 0,
+          meta_synced: record.metaSynced == null ? null : record.metaSynced ? 1 : 0,
+          on_chain_id: record.onChainId ?? null,
+          sync_scoped: record.syncScoped ? 1 : 0,
+          updated_at: Date.now(),
+        });
+      },
+      delete: async (contextGraphId) => {
+        dashDb.deleteContextGraphSubscription(contextGraphId);
+      },
+    },
+    contextGraphMembershipStore: {
+      upsert: async (record) => {
+        dashDb.upsertContextGraphMember({
+          context_graph_id: record.contextGraphId,
+          principal_type: record.principalType,
+          principal_id: record.principalId,
+          role: record.role ?? null,
+          status: record.status,
+          source: record.source ?? null,
+          display_name: record.displayName ?? null,
+          metadata: record.metadata ? JSON.stringify(record.metadata) : null,
+          first_seen_at: record.firstSeenAt ?? record.updatedAt,
+          updated_at: record.updatedAt,
+        });
+      },
+      delete: async (contextGraphId, principalType, principalId) => {
+        dashDb.deleteContextGraphMember(contextGraphId, principalType, principalId);
+      },
+    },
   });
 
   let publisherRuntime: PublisherRuntime | null = null;
@@ -780,7 +829,6 @@ export async function runDaemonInner(
 
   // --- Dashboard DB + Metrics ---
 
-  const dashDb = new DashboardDB({ dataDir: dkgDir() });
   chatDb = dashDb;
   log("Dashboard DB initialized at " + join(dkgDir(), "node-ui.db"));
 

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -1137,6 +1137,50 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
 
     const shouldSyncSharedMemory =
       (includeSharedMemory ?? includeWorkspace) !== false;
+
+    const subMap = agent.getSubscribedContextGraphs();
+    const existingSub = subMap?.get(paranetId);
+    const existingJobId = catchupTracker.latestByParanet.get(paranetId);
+    const existingJob = existingJobId ? catchupTracker.jobs.get(existingJobId) : undefined;
+
+    if (existingSub?.subscribed) {
+      if (existingJob && (existingJob.status === "queued" || existingJob.status === "running")) {
+        return jsonResponse(res, 200, {
+          subscribed: paranetId,
+          catchup: {
+            status: existingJob.status,
+            includeWorkspace: existingJob.includeWorkspace,
+            jobId: existingJob.jobId,
+          },
+        });
+      }
+
+      if (existingSub.synced && (!shouldSyncSharedMemory || existingSub.sharedMemorySynced)) {
+        const jobId = existingJob?.jobId ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+        if (!existingJob) {
+          const syntheticJob: CatchupJob = {
+            jobId,
+            paranetId,
+            includeWorkspace: shouldSyncSharedMemory,
+            status: "done",
+            queuedAt: Date.now(),
+            startedAt: Date.now(),
+            finishedAt: Date.now(),
+          };
+          catchupTracker.jobs.set(jobId, syntheticJob);
+          catchupTracker.latestByParanet.set(paranetId, jobId);
+        }
+        return jsonResponse(res, 200, {
+          subscribed: paranetId,
+          catchup: {
+            status: "done",
+            includeWorkspace: shouldSyncSharedMemory,
+            jobId,
+          },
+        });
+      }
+    }
+
     console.log(`[subscribe] contextGraph=${paranetId} includeSharedMemory=${shouldSyncSharedMemory}`);
     agent.subscribeToContextGraph(paranetId);
 
@@ -1205,15 +1249,12 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
 
         if (job.status === "done") {
           if (cleanResponse) {
-            const subMap = (agent as any).subscribedContextGraphs as
-              | Map<string, { subscribed: boolean; synced: boolean; metaSynced?: boolean; name?: string; [k: string]: unknown }>
-              | undefined;
-            const sub = subMap?.get(paranetId);
-            if (sub) {
-              sub.synced = true;
-              const hasContent = await agent.contextGraphHasLocalContent(paranetId).catch(() => false);
-              if (hasContent) sub.metaSynced = true;
-            }
+            const hasContent = await agent.contextGraphHasLocalContent(paranetId).catch(() => false);
+            agent.markContextGraphSubscriptionState(paranetId, {
+              synced: true,
+              ...(shouldSyncSharedMemory ? { sharedMemorySynced: true } : {}),
+              ...(hasContent ? { metaSynced: true } : {}),
+            });
           } else if (result.peersTried > 0) {
             job.status = "failed";
             job.error = "Sync did not complete — all reachable peers failed (timeouts or transport errors). Retry once the network is healthier.";

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -396,6 +396,20 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     return;
   }
 
+  // GET /api/context-graph/{id}/members — local SQL membership cache.
+  // Kept in this early route group so the cache has a lightweight read path.
+  const contextGraphMembersMatch = path.match(/^\/api\/context-graph\/([^/]+)\/members$/);
+  if (req.method === "GET" && contextGraphMembersMatch) {
+    const contextGraphId = decodeURIComponent(contextGraphMembersMatch[1]);
+    if (!isValidContextGraphId(contextGraphId)) {
+      return jsonResponse(res, 400, { error: 'Invalid context graph id' });
+    }
+    return jsonResponse(res, 200, {
+      contextGraphId,
+      members: dashDb.listContextGraphMembers(contextGraphId),
+    });
+  }
+
   // GET /api/status
   if (req.method === "GET" && path === "/api/status") {
     const allConns = agent.node.libp2p.getConnections();

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 import { join } from 'node:path';
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 9;
 const DEFAULT_RETENTION_DAYS = 90;
 
 export interface DashboardDBOptions {
@@ -216,6 +216,57 @@ export class DashboardDB {
       `);
     }
 
+    if (version < 7) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS context_graph_subscriptions (
+          context_graph_id TEXT PRIMARY KEY,
+          name TEXT,
+          subscribed INTEGER NOT NULL,
+          synced INTEGER NOT NULL,
+          meta_synced INTEGER,
+          on_chain_id TEXT,
+          sync_scoped INTEGER NOT NULL DEFAULT 1,
+          updated_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_cg_subs_sync_scoped
+          ON context_graph_subscriptions(sync_scoped);
+      `);
+    }
+
+    if (version < 8) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS context_graph_memberships (
+          context_graph_id TEXT NOT NULL,
+          principal_type TEXT NOT NULL,
+          principal_id TEXT NOT NULL,
+          role TEXT,
+          status TEXT NOT NULL,
+          source TEXT,
+          display_name TEXT,
+          metadata TEXT,
+          first_seen_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY (context_graph_id, principal_type, principal_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_cg_members_context
+          ON context_graph_memberships(context_graph_id);
+        CREATE INDEX IF NOT EXISTS idx_cg_members_principal
+          ON context_graph_memberships(principal_type, principal_id);
+        CREATE INDEX IF NOT EXISTS idx_cg_members_status
+          ON context_graph_memberships(status);
+      `);
+    }
+
+    if (version < 9) {
+      const columns = this.db.prepare('PRAGMA table_info(context_graph_subscriptions)').all() as Array<{ name: string }>;
+      if (!columns.some((column) => column.name === 'shared_memory_synced')) {
+        this.db.exec(`
+          ALTER TABLE context_graph_subscriptions
+            ADD COLUMN shared_memory_synced INTEGER;
+        `);
+      }
+    }
+
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
 
     const savedRetention = this.db.prepare("SELECT value FROM settings WHERE key = 'retentionDays'").get() as { value: string } | undefined;
@@ -272,6 +323,125 @@ export class DashboardDB {
     return this.db.prepare(
       'SELECT * FROM metric_snapshots ORDER BY ts DESC LIMIT 1',
     ).get() as MetricSnapshotRow | undefined;
+  }
+
+  upsertContextGraphSubscription(record: {
+    context_graph_id: string;
+    name?: string | null;
+    subscribed: number;
+    synced: number;
+    shared_memory_synced?: number | null;
+    meta_synced?: number | null;
+    on_chain_id?: string | null;
+    sync_scoped: number;
+    updated_at: number;
+  }): void {
+    this.stmt('upsertContextGraphSubscription', `
+      INSERT INTO context_graph_subscriptions (
+        context_graph_id, name, subscribed, synced, shared_memory_synced, meta_synced,
+        on_chain_id, sync_scoped, updated_at
+      ) VALUES (
+        @context_graph_id, @name, @subscribed, @synced, @shared_memory_synced, @meta_synced,
+        @on_chain_id, @sync_scoped, @updated_at
+      )
+      ON CONFLICT(context_graph_id) DO UPDATE SET
+        name = excluded.name,
+        subscribed = excluded.subscribed,
+        synced = excluded.synced,
+        shared_memory_synced = excluded.shared_memory_synced,
+        meta_synced = excluded.meta_synced,
+        on_chain_id = excluded.on_chain_id,
+        sync_scoped = excluded.sync_scoped,
+        updated_at = excluded.updated_at
+    `).run({
+      context_graph_id: record.context_graph_id,
+      name: record.name ?? null,
+      subscribed: record.subscribed,
+      synced: record.synced,
+      shared_memory_synced: record.shared_memory_synced ?? null,
+      meta_synced: record.meta_synced ?? null,
+      on_chain_id: record.on_chain_id ?? null,
+      sync_scoped: record.sync_scoped,
+      updated_at: record.updated_at,
+    });
+  }
+
+  listContextGraphSubscriptions(): ContextGraphSubscriptionRow[] {
+    return this.db.prepare(
+      'SELECT * FROM context_graph_subscriptions ORDER BY context_graph_id ASC',
+    ).all() as ContextGraphSubscriptionRow[];
+  }
+
+  deleteContextGraphSubscription(contextGraphId: string): void {
+    this.stmt('deleteContextGraphSubscription', 'DELETE FROM context_graph_subscriptions WHERE context_graph_id = ?').run(contextGraphId);
+  }
+
+  upsertContextGraphMember(record: {
+    context_graph_id: string;
+    principal_type: ContextGraphMemberPrincipalType;
+    principal_id: string;
+    role?: string | null;
+    status: ContextGraphMemberStatus;
+    source?: string | null;
+    display_name?: string | null;
+    metadata?: string | null;
+    first_seen_at?: number | null;
+    updated_at: number;
+  }): void {
+    const firstSeenAt = record.first_seen_at ?? record.updated_at;
+    this.stmt('upsertContextGraphMember', `
+      INSERT INTO context_graph_memberships (
+        context_graph_id, principal_type, principal_id, role, status, source,
+        display_name, metadata, first_seen_at, updated_at
+      ) VALUES (
+        @context_graph_id, @principal_type, @principal_id, @role, @status, @source,
+        @display_name, @metadata, @first_seen_at, @updated_at
+      )
+      ON CONFLICT(context_graph_id, principal_type, principal_id) DO UPDATE SET
+        role = excluded.role,
+        status = excluded.status,
+        source = excluded.source,
+        display_name = excluded.display_name,
+        metadata = excluded.metadata,
+        first_seen_at = context_graph_memberships.first_seen_at,
+        updated_at = excluded.updated_at
+    `).run({
+      context_graph_id: record.context_graph_id,
+      principal_type: record.principal_type,
+      principal_id: record.principal_id,
+      role: record.role ?? null,
+      status: record.status,
+      source: record.source ?? null,
+      display_name: record.display_name ?? null,
+      metadata: record.metadata ?? null,
+      first_seen_at: firstSeenAt,
+      updated_at: record.updated_at,
+    });
+  }
+
+  listContextGraphMembers(contextGraphId?: string): ContextGraphMemberRow[] {
+    if (contextGraphId) {
+      return this.db.prepare(`
+        SELECT * FROM context_graph_memberships
+        WHERE context_graph_id = ?
+        ORDER BY principal_type ASC, principal_id ASC
+      `).all(contextGraphId) as ContextGraphMemberRow[];
+    }
+    return this.db.prepare(`
+      SELECT * FROM context_graph_memberships
+      ORDER BY context_graph_id ASC, principal_type ASC, principal_id ASC
+    `).all() as ContextGraphMemberRow[];
+  }
+
+  deleteContextGraphMember(
+    contextGraphId: string,
+    principalType: ContextGraphMemberPrincipalType,
+    principalId: string,
+  ): void {
+    this.stmt(
+      'deleteContextGraphMember',
+      'DELETE FROM context_graph_memberships WHERE context_graph_id = ? AND principal_type = ? AND principal_id = ?',
+    ).run(contextGraphId, principalType, principalId);
   }
 
   getSnapshotHistory(from: number, to: number, maxPoints = 500): MetricSnapshotRow[] {
@@ -1263,6 +1433,34 @@ export interface ChatPersistenceHealthRow {
   failed_count: number;
   overdue_pending_count: number;
   oldest_pending_queued_at: number | null;
+}
+
+export interface ContextGraphSubscriptionRow {
+  context_graph_id: string;
+  name: string | null;
+  subscribed: number;
+  synced: number;
+  shared_memory_synced: number | null;
+  meta_synced: number | null;
+  on_chain_id: string | null;
+  sync_scoped: number;
+  updated_at: number;
+}
+
+export type ContextGraphMemberPrincipalType = 'node' | 'agent' | 'identity';
+export type ContextGraphMemberStatus = 'active' | 'removed' | 'pending';
+
+export interface ContextGraphMemberRow {
+  context_graph_id: string;
+  principal_type: ContextGraphMemberPrincipalType;
+  principal_id: string;
+  role: string | null;
+  status: ContextGraphMemberStatus;
+  source: string | null;
+  display_name: string | null;
+  metadata: string | null;
+  first_seen_at: number;
+  updated_at: number;
 }
 
 export interface SpendingPeriod {

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -12,6 +12,10 @@ export type {
   LogRow,
   QueryHistoryRow,
   SavedQueryRow,
+  ContextGraphSubscriptionRow,
+  ContextGraphMemberPrincipalType,
+  ContextGraphMemberStatus,
+  ContextGraphMemberRow,
 } from './db.js';
 
 export { StructuredLogger } from './structured-logger.js';

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -362,3 +362,94 @@ describe('DashboardDB — schema idempotency', () => {
     db = new DashboardDB({ dataDir: dir });
   });
 });
+
+describe('DashboardDB — context graph subscriptions', () => {
+  it('persists shared-memory sync state across upserts', () => {
+    db.upsertContextGraphSubscription({
+      context_graph_id: 'project-a',
+      name: 'Project A',
+      subscribed: 1,
+      synced: 1,
+      shared_memory_synced: 0,
+      meta_synced: 1,
+      on_chain_id: '0xabc',
+      sync_scoped: 1,
+      updated_at: 1000,
+    });
+
+    expect(db.listContextGraphSubscriptions()).toMatchObject([{
+      context_graph_id: 'project-a',
+      shared_memory_synced: 0,
+      meta_synced: 1,
+      sync_scoped: 1,
+    }]);
+
+    db.upsertContextGraphSubscription({
+      context_graph_id: 'project-a',
+      name: 'Project A',
+      subscribed: 1,
+      synced: 1,
+      shared_memory_synced: 1,
+      meta_synced: 1,
+      on_chain_id: '0xabc',
+      sync_scoped: 1,
+      updated_at: 2000,
+    });
+
+    expect(db.listContextGraphSubscriptions()).toMatchObject([{
+      context_graph_id: 'project-a',
+      shared_memory_synced: 1,
+      updated_at: 2000,
+    }]);
+  });
+});
+
+describe('DashboardDB — context graph memberships', () => {
+  it('upserts, lists, and deletes node/agent membership rows', () => {
+    db.upsertContextGraphMember({
+      context_graph_id: 'project-a',
+      principal_type: 'node',
+      principal_id: 'peer-1',
+      role: 'subscriber',
+      status: 'active',
+      source: 'subscription',
+      display_name: 'Node 1',
+      metadata: JSON.stringify({ synced: false }),
+      first_seen_at: 1000,
+      updated_at: 1000,
+    });
+    db.upsertContextGraphMember({
+      context_graph_id: 'project-a',
+      principal_type: 'agent',
+      principal_id: '0x1111111111111111111111111111111111111111',
+      role: 'participant',
+      status: 'active',
+      source: 'allowed-agent',
+      updated_at: 1100,
+    });
+
+    expect(db.listContextGraphMembers('project-a')).toHaveLength(2);
+
+    db.upsertContextGraphMember({
+      context_graph_id: 'project-a',
+      principal_type: 'node',
+      principal_id: 'peer-1',
+      role: 'curator',
+      status: 'active',
+      source: 'local-create',
+      first_seen_at: 2000,
+      updated_at: 2000,
+    });
+
+    const node = db.listContextGraphMembers('project-a').find((m) => m.principal_type === 'node');
+    expect(node?.role).toBe('curator');
+    expect(node?.source).toBe('local-create');
+    expect(node?.first_seen_at).toBe(1000);
+    expect(node?.updated_at).toBe(2000);
+
+    db.deleteContextGraphMember('project-a', 'agent', '0x1111111111111111111111111111111111111111');
+    const remaining = db.listContextGraphMembers('project-a');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].principal_id).toBe('peer-1');
+  });
+});


### PR DESCRIPTION
Summary
- Persist context graph subscription state across daemon restarts by adding durable subscription storage, rehydration on startup, and explicit tracking for shared-memory catch-up completion.
- Add a local membership cache for context graph nodes, agents, and identities, and keep it updated from subscription, allowlist, join request, and on-chain registration flows.
- Expose the cached membership/subscription data through the daemon and dashboard DB, and add coverage for persistence, rehydration, and membership canonicalization.