### PR TITLE
config: field-level merge for chain (operator partial overrides)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,8 @@ import yaml from 'js-yaml';
 import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, releasesDir, activeSlot, swapSlot,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveChainConfig,
+  releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
 } from './config.js';
@@ -318,10 +319,13 @@ program
       };
     }
 
-    // Chain configuration
-    const defaultRpcUrl = existing.chain?.rpcUrl ?? network?.chain?.rpcUrl;
-    const defaultHubAddress = existing.chain?.hubAddress ?? network?.chain?.hubAddress;
-    const defaultChainId = existing.chain?.chainId ?? network?.chain?.chainId;
+    // Chain configuration. Field-merge: existing config wins per-field over
+    // network defaults so an operator who's only customised RPC keeps that
+    // override even after `dkg init` re-prompts.
+    const chainDefaults = resolveChainConfig(existing, network);
+    const defaultRpcUrl = chainDefaults?.rpcUrl;
+    const defaultHubAddress = chainDefaults?.hubAddress;
+    const defaultChainId = chainDefaults?.chainId;
 
     console.log('\nBlockchain Configuration:');
     const rpcUrl = await ask('RPC URL', defaultRpcUrl);
@@ -391,7 +395,14 @@ program
         }`,
       );
     }
-    console.log(`  chain:      ${config.chain ? `${config.chain.rpcUrl} (hub: ${config.chain.hubAddress?.slice(0, 10)}...)` : '(not configured)'}`);
+    {
+      // Display the effective (config + network) merged view, so an operator
+      // who only set rpcUrl still sees the inherited hub from the network.
+      const effective = resolveChainConfig(config, network);
+      console.log(`  chain:      ${effective?.rpcUrl && effective?.hubAddress
+        ? `${effective.rpcUrl} (hub: ${effective.hubAddress.slice(0, 10)}...)`
+        : '(not configured)'}`);
+    }
     if (network) {
       console.log(`  network:    ${network.networkName}`);
     }
@@ -2545,9 +2556,10 @@ program
         process.exit(1);
       }
 
-      const rpcUrl = config.chain?.rpcUrl ?? network?.chain?.rpcUrl;
-      const hubAddress = config.chain?.hubAddress ?? network?.chain?.hubAddress;
-      const chainId = config.chain?.chainId ?? network?.chain?.chainId ?? '(unknown)';
+      const chainResolved = resolveChainConfig(config, network);
+      const rpcUrl = chainResolved?.rpcUrl;
+      const hubAddress = chainResolved?.hubAddress;
+      const chainId = chainResolved?.chainId ?? '(unknown)';
 
       let provider: ethers.JsonRpcProvider | null = null;
       let token: ethers.Contract | null = null;
@@ -2614,8 +2626,9 @@ program
         process.exit(1);
       }
 
-      const rpcUrl = config.chain?.rpcUrl ?? network?.chain?.rpcUrl;
-      const hubAddress = config.chain?.hubAddress ?? network?.chain?.hubAddress;
+      const chainResolved = resolveChainConfig(config, network);
+      const rpcUrl = chainResolved?.rpcUrl;
+      const hubAddress = chainResolved?.hubAddress;
       if (!rpcUrl || !hubAddress) {
         console.error('Chain not configured. Run "dkg init" and set RPC URL + Hub address.');
         process.exit(1);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -156,7 +156,15 @@ export interface DkgConfig {
   contextGraphs?: string[];
   paranets?: string[];
   autoUpdate?: AutoUpdateConfig;
-  chain?: ChainConfig;
+  /**
+   * Chain config. Field-merged on top of `network/<env>.json#chain` via
+   * `resolveChainConfig()`, so an operator can override individual fields
+   * (e.g. just `rpcUrl` to point at a private RPC) without having to
+   * restate `hubAddress` and `chainId`. Fields omitted here inherit the
+   * network defaults — including future hub rotations propagated by the
+   * auto-updater pulling a fresh network/<env>.json.
+   */
+  chain?: Partial<ChainConfig>;
   /** Optional LLM for the Node UI chatbot (natural language → SPARQL, answers). */
   llm?: LlmConfig;
   /** Block explorer URL for TX links (default: derived from chainId). */
@@ -404,6 +412,43 @@ export function resolveAutoUpdateConfig(
     ...(sshCommand ? { sshCommand } : {}),
     checkIntervalMinutes,
   };
+}
+
+/**
+ * Field-level merge of the effective chain configuration.
+ *
+ * Precedence per field: `~/.dkg/config.json#chain` → `network/<env>.json#chain`.
+ * Returns `undefined` when neither source provides a chain block.
+ *
+ * Rationale: the daemon previously read chain via `config.chain ?? network.chain`
+ * (whole-object fallback), which meant an operator who set just `rpcUrl` in their
+ * local config would lose `hubAddress` / `chainId` from the network file and
+ * crash deeper inside ethers. With per-field merge, operators can override
+ * individual fields (e.g. swap public RPC for a private one) and still inherit
+ * the rest — including future hub rotations the auto-updater pulls down.
+ *
+ * The return type is `Partial<ChainConfig>` because either source may be
+ * partial; consumers that need both `rpcUrl` and `hubAddress` (lifecycle,
+ * publisher-runner) MUST guard for those fields before passing to the agent.
+ */
+export function resolveChainConfig(
+  config: Pick<DkgConfig, 'chain'> | null | undefined,
+  network: Pick<NetworkConfig, 'chain'> | null | undefined,
+): Partial<ChainConfig> | undefined {
+  const cfg = config?.chain;
+  const net = network?.chain;
+  if (!cfg && !net) return undefined;
+  const merged: Partial<ChainConfig> = {
+    type: cfg?.type ?? net?.type ?? 'evm',
+  };
+  const rpcUrl = cfg?.rpcUrl ?? net?.rpcUrl;
+  if (rpcUrl !== undefined) merged.rpcUrl = rpcUrl;
+  const hubAddress = cfg?.hubAddress ?? net?.hubAddress;
+  if (hubAddress !== undefined) merged.hubAddress = hubAddress;
+  const chainId = cfg?.chainId ?? net?.chainId;
+  if (chainId !== undefined) merged.chainId = chainId;
+  if (cfg?.mockIdentityId !== undefined) merged.mockIdentityId = cfg.mockIdentityId;
+  return merged;
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -439,18 +439,18 @@ export function resolveChainConfig(
   const net = network?.chain;
   if (!cfg && !net) return undefined;
 
-  // Short-circuit when the operator opts in to mock mode in their local
-  // config. We MUST NOT inherit EVM fields (rpcUrl/hubAddress/chainId)
-  // from network.chain in that case — otherwise we produce a hybrid view
-  // that the daemon partially honours: lifecycle wires up a MockChainAdapter
-  // (correct), but publisher-runner, the wallet/balance/RPC-health routes,
-  // and `dkg set-ask` see those inherited fields and try to talk to the
-  // real chain. Mock is an isolated test-only mode; keep the operator's
-  // own fields and stop.
+  // Short-circuit when the operator opts in to mock mode. We strip
+  // rpcUrl/hubAddress entirely (both inherited-from-network AND any stale
+  // values left over in the operator's own config from a previous EVM
+  // setup) so no downstream consumer can hit a real chain by accident.
+  // Without this, lifecycle.ts/publisher-runner.ts/status.ts/`dkg set-ask`
+  // all gate on `rpcUrl && hubAddress` but not on `type`, so a hybrid
+  // `{ type: 'mock', rpcUrl: '<real>', hubAddress: '<real>' }` would wire
+  // up MockChainAdapter (correct) AND open a real ethers.JsonRpcProvider
+  // / EVMChainAdapter against the live network in parallel. MockChainAdapter
+  // only needs chainId; rpcUrl/hubAddress are meaningless in mock mode.
   if (cfg?.type === 'mock') {
     const mockMerged: Partial<ChainConfig> = { type: 'mock' };
-    if (cfg.rpcUrl !== undefined) mockMerged.rpcUrl = cfg.rpcUrl;
-    if (cfg.hubAddress !== undefined) mockMerged.hubAddress = cfg.hubAddress;
     if (cfg.chainId !== undefined) mockMerged.chainId = cfg.chainId;
     if (cfg.mockIdentityId !== undefined) mockMerged.mockIdentityId = cfg.mockIdentityId;
     return mockMerged;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -438,6 +438,24 @@ export function resolveChainConfig(
   const cfg = config?.chain;
   const net = network?.chain;
   if (!cfg && !net) return undefined;
+
+  // Short-circuit when the operator opts in to mock mode in their local
+  // config. We MUST NOT inherit EVM fields (rpcUrl/hubAddress/chainId)
+  // from network.chain in that case — otherwise we produce a hybrid view
+  // that the daemon partially honours: lifecycle wires up a MockChainAdapter
+  // (correct), but publisher-runner, the wallet/balance/RPC-health routes,
+  // and `dkg set-ask` see those inherited fields and try to talk to the
+  // real chain. Mock is an isolated test-only mode; keep the operator's
+  // own fields and stop.
+  if (cfg?.type === 'mock') {
+    const mockMerged: Partial<ChainConfig> = { type: 'mock' };
+    if (cfg.rpcUrl !== undefined) mockMerged.rpcUrl = cfg.rpcUrl;
+    if (cfg.hubAddress !== undefined) mockMerged.hubAddress = cfg.hubAddress;
+    if (cfg.chainId !== undefined) mockMerged.chainId = cfg.chainId;
+    if (cfg.mockIdentityId !== undefined) mockMerged.mockIdentityId = cfg.mockIdentityId;
+    return mockMerged;
+  }
+
   const merged: Partial<ChainConfig> = {
     type: cfg?.type ?? net?.type ?? 'evm',
   };

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -70,6 +70,7 @@ import {
   saveConfig,
   loadNetworkConfig,
   resolveAutoUpdateConfig,
+  resolveChainConfig,
   dkgDir,
   writePid,
   removePid,
@@ -472,8 +473,10 @@ export async function runDaemonInner(
     log(`  ${w.address}`);
   }
 
-  // Build chain config from CLI config or network config
-  const chainBase = config.chain ?? network?.chain;
+  // Field-level merge of CLI config + network/<env>.json#chain.
+  // Operators can override individual fields (e.g. just rpcUrl) without
+  // restating the rest; missing fields fall back to the network defaults.
+  const chainBase = resolveChainConfig(config, network);
 
   // Relay: prefer config.relay, fall back to network testnet.json relays so
   // local nodes connect without having run init or set relay manually.
@@ -530,7 +533,10 @@ export async function runDaemonInner(
       options: config.store.options,
     } : undefined,
     chainAdapter: mockChainAdapter,
-    chainConfig: chainBase ? {
+    // Only forward chain to the agent when both required fields resolved.
+    // resolveChainConfig() may return a partial block if neither config nor
+    // network supplies one of them; the agent expects rpcUrl + hubAddress.
+    chainConfig: chainBase?.rpcUrl && chainBase?.hubAddress ? {
       rpcUrl: chainBase.rpcUrl,
       hubAddress: chainBase.hubAddress,
       operationalKeys: opWallets.wallets.map((w) => w.privateKey),
@@ -591,12 +597,19 @@ export async function runDaemonInner(
   await agent.start();
   await agent.publishProfile();
 
+  const publisherChainBase = chainBase?.rpcUrl && chainBase?.hubAddress
+    ? {
+        rpcUrl: chainBase.rpcUrl,
+        hubAddress: chainBase.hubAddress,
+        chainId: chainBase.chainId,
+      }
+    : undefined;
   publisherRuntime = await startPublisherRuntimeIfEnabled({
     dataDir: dkgDir(),
     config,
     store: agent.store,
     keypair: agent.wallet.keypair,
-    chainBase,
+    chainBase: publisherChainBase,
     ackTransportFactory: () => ({
       publisherPeerId: agent.peerId,
       gossipPublish: async (topic: string, data: Uint8Array) => {

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -73,6 +73,7 @@ import {
   loadConfig,
   saveConfig,
   loadNetworkConfig,
+  resolveChainConfig,
   dkgDir,
   writePid,
   removePid,
@@ -656,7 +657,7 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
           gasCost: chain.gasCostWei,
           tracCost: chain.tokenAmount,
         });
-        const chainId = (config.chain ?? network?.chain)?.chainId;
+        const chainId = resolveChainConfig(config, network)?.chainId;
         tracker.setTxHash(
           ctx,
           chain.txHash,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -73,6 +73,7 @@ import {
   loadConfig,
   saveConfig,
   loadNetworkConfig,
+  resolveChainConfig,
   dkgDir,
   writePid,
   removePid,
@@ -479,7 +480,7 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
           gasUsed: chain.gasUsed,
           gasPrice: chain.effectiveGasPrice,
         });
-        const chainId = (config.chain ?? network?.chain)?.chainId;
+        const chainId = resolveChainConfig(config, network)?.chainId;
         tracker.setTxHash(
           ctx,
           chain.txHash,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -73,6 +73,7 @@ import {
   loadConfig,
   saveConfig,
   loadNetworkConfig,
+  resolveChainConfig,
   dkgDir,
   writePid,
   removePid,
@@ -408,7 +409,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       a.includes("/p2p-circuit/"),
     );
     const networkId = await computeNetworkId();
-    const chainConf = config.chain ?? network?.chain;
+    const chainConf = resolveChainConfig(config, network);
     const blockExplorerUrl =
       config.blockExplorerUrl ?? deriveBlockExplorerUrl(chainConf?.chainId);
     const identityId = agent.publisher.getIdentityId();
@@ -449,7 +450,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
   if (req.method === "GET" && path === "/api/info") {
     const allConns = agent.node.libp2p.getConnections();
     const uniquePeers = new Set(allConns.map((c) => c.remotePeer.toString()));
-    const chainConf = config.chain ?? network?.chain;
+    const chainConf = resolveChainConfig(config, network);
     const now = Date.now();
 
     return jsonResponse(res, 200, {
@@ -584,13 +585,13 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
   ) {
     return jsonResponse(res, 200, {
       wallets: opWallets.wallets.map((w) => w.address),
-      chainId: (config.chain ?? network?.chain)?.chainId,
+      chainId: resolveChainConfig(config, network)?.chainId,
     });
   }
 
   // GET /api/wallets/balances — ETH + TRAC per wallet, RPC health
   if (req.method === "GET" && path === "/api/wallets/balances") {
-    const chain = config.chain ?? network?.chain;
+    const chain = resolveChainConfig(config, network);
     const rpcUrl = chain?.rpcUrl;
     const hubAddress = chain?.hubAddress;
     const chainId = chain?.chainId ?? null;
@@ -660,7 +661,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
 
   // GET /api/chain/rpc-health
   if (req.method === "GET" && path === "/api/chain/rpc-health") {
-    const chain = config.chain ?? network?.chain;
+    const chain = resolveChainConfig(config, network);
     const rpcUrl = chain?.rpcUrl;
     if (!rpcUrl) {
       return jsonResponse(res, 200, {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -4,7 +4,7 @@ import { EVMChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain
 import { TypedEventBus, type Ed25519Keypair } from '@origintrail-official/dkg-core';
 import { ACKCollector, AsyncLiftRunner, DKGPublisher, TripleStoreAsyncLiftPublisher, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions } from '@origintrail-official/dkg-publisher';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
-import { loadNetworkConfig, type DkgConfig } from './config.js';
+import { loadNetworkConfig, resolveChainConfig, type DkgConfig } from './config.js';
 import { loadPublisherWallets } from './publisher-wallets.js';
 
 export interface PublisherRuntime {
@@ -98,11 +98,20 @@ export async function createPublisherRuntime(args: {
   const network = await loadNetworkConfig();
   const keypair = await loadOrCreateAgentWallet(args.dataDir);
   const store = await createPublisherStore(args.dataDir, args.config);
+  // Field-merge config + network/<env>.json#chain, then guard for the
+  // strict { rpcUrl, hubAddress, chainId? } shape the publisher runtime
+  // expects. If either required field is missing, pass undefined and let
+  // the runtime fall back to NoChainAdapter (publisher won't have on-chain
+  // finality but still functions).
+  const merged = resolveChainConfig(args.config, network);
+  const chainBase = merged?.rpcUrl && merged?.hubAddress
+    ? { rpcUrl: merged.rpcUrl, hubAddress: merged.hubAddress, chainId: merged.chainId }
+    : undefined;
   return createPublisherRuntimeFromBase({
     dataDir: args.dataDir,
     keypair: keypair.keypair,
     store,
-    chainBase: args.config.chain ?? network?.chain,
+    chainBase,
     pollIntervalMs: args.pollIntervalMs,
     errorBackoffMs: args.errorBackoffMs,
     closeStoreOnStop: true,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -18,6 +18,7 @@ import {
   isDkgMonorepo,
   dkgDir,
   repoDir,
+  resolveChainConfig,
 } from '../src/config.js';
 
 describe('removePid / removeApiPort (catch path)', () => {
@@ -178,5 +179,84 @@ describe('localAgentIntegrations config round-trip', () => {
     expect(loaded.localAgentIntegrations?.openclaw?.transport?.gatewayUrl).toBe('http://gateway.local:3030');
     expect(loaded.localAgentIntegrations?.openclaw?.manifest?.version).toBe('2026.4.12');
     expect(loaded.localAgentIntegrations?.openclaw?.runtime?.status).toBe('ready');
+  });
+});
+
+describe('resolveChainConfig (field-level merge)', () => {
+  const fullNetworkChain = {
+    type: 'evm' as const,
+    rpcUrl: 'https://network.example/rpc',
+    hubAddress: '0xNETWORKHUB000000000000000000000000000000',
+    chainId: 'base:84532',
+  };
+
+  it('returns undefined when neither config nor network supplies a chain block', () => {
+    expect(resolveChainConfig({}, null)).toBeUndefined();
+    expect(resolveChainConfig({}, { chain: undefined })).toBeUndefined();
+    expect(resolveChainConfig(null, null)).toBeUndefined();
+  });
+
+  it('falls back to the network chain when config has no override', () => {
+    const merged = resolveChainConfig({}, { chain: fullNetworkChain });
+    expect(merged).toEqual({
+      type: 'evm',
+      rpcUrl: fullNetworkChain.rpcUrl,
+      hubAddress: fullNetworkChain.hubAddress,
+      chainId: fullNetworkChain.chainId,
+    });
+  });
+
+  it('overrides only the fields the operator set, inheriting the rest from network', () => {
+    // Operator wants their private RPC but should inherit hub + chainId.
+    const merged = resolveChainConfig(
+      { chain: { rpcUrl: 'https://my-private-rpc.example/abc' } },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.rpcUrl).toBe('https://my-private-rpc.example/abc');
+    expect(merged?.hubAddress).toBe(fullNetworkChain.hubAddress);
+    expect(merged?.chainId).toBe(fullNetworkChain.chainId);
+    expect(merged?.type).toBe('evm');
+  });
+
+  it('overrides hub independently of rpcUrl (multichain forward-compat)', () => {
+    const merged = resolveChainConfig(
+      { chain: { hubAddress: '0xOPERATORHUB0000000000000000000000000000' } },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.hubAddress).toBe('0xOPERATORHUB0000000000000000000000000000');
+    expect(merged?.rpcUrl).toBe(fullNetworkChain.rpcUrl);
+    expect(merged?.chainId).toBe(fullNetworkChain.chainId);
+  });
+
+  it('returns a partial block when only config supplies fields (no network)', () => {
+    const merged = resolveChainConfig(
+      { chain: { rpcUrl: 'https://standalone.example/rpc' } },
+      null,
+    );
+    expect(merged?.rpcUrl).toBe('https://standalone.example/rpc');
+    expect(merged?.hubAddress).toBeUndefined();
+    expect(merged?.chainId).toBeUndefined();
+    // Callers (lifecycle, publisher-runner) MUST guard for the missing
+    // hubAddress before passing to the agent.
+  });
+
+  it('preserves explicit `type: "mock"` and `mockIdentityId` override (test-only path)', () => {
+    const merged = resolveChainConfig(
+      { chain: { type: 'mock', mockIdentityId: '42' } },
+      { chain: fullNetworkChain },
+    );
+    expect(merged?.type).toBe('mock');
+    expect(merged?.mockIdentityId).toBe('42');
+    // Hub/RPC inherit, but the daemon's mock branch ignores them.
+    expect(merged?.hubAddress).toBe(fullNetworkChain.hubAddress);
+  });
+
+  it('does not return undefined fields as own keys (clean shape for downstream spread)', () => {
+    const merged = resolveChainConfig(
+      { chain: { rpcUrl: 'https://only-rpc.example' } },
+      null,
+    );
+    expect(merged).toBeDefined();
+    expect(Object.keys(merged ?? {})).toEqual(['type', 'rpcUrl']);
   });
 });

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -258,8 +258,8 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(merged?.chainId).toBeUndefined();
   });
 
-  it('keeps the operator\'s own fields under mock mode (no merge in either direction)', () => {
-    // A test fixture that pins a mock chainId (e.g. to exercise a specific
+  it('keeps mock-relevant fields (chainId, mockIdentityId) under mock mode', () => {
+    // A test fixture that pins a mock chainId (to exercise a specific
     // chain identifier inside MockChainAdapter) must round-trip without
     // network inheritance.
     const merged = resolveChainConfig(
@@ -277,6 +277,36 @@ describe('resolveChainConfig (field-level merge)', () => {
       chainId: 'mock:31337',
       mockIdentityId: '7',
     });
+  });
+
+  it('strips stale rpcUrl/hubAddress from operator config under mock mode', () => {
+    // Regression: an operator who flips an existing EVM config to mock
+    // without deleting rpcUrl/hubAddress would otherwise leave a hybrid
+    // resolved view. Every consumer that gates on `rpcUrl && hubAddress`
+    // (publisher-runner, the wallet/balance/rpc-health routes, `dkg set-ask`,
+    // and lifecycle's chainConfig forward to DKGAgent) would then open a
+    // real ethers.JsonRpcProvider against the operator's stale URL while
+    // lifecycle simultaneously wires up MockChainAdapter. resolveChainConfig
+    // must drop these fields so that mock mode is fully isolated.
+    const merged = resolveChainConfig(
+      {
+        chain: {
+          type: 'mock',
+          rpcUrl: 'https://stale-rpc.example',
+          hubAddress: '0xDEADBEEF00000000000000000000000000000000',
+          chainId: 'mock:31337',
+          mockIdentityId: '9',
+        },
+      },
+      { chain: fullNetworkChain },
+    );
+    expect(merged).toEqual({
+      type: 'mock',
+      chainId: 'mock:31337',
+      mockIdentityId: '9',
+    });
+    expect(merged?.rpcUrl).toBeUndefined();
+    expect(merged?.hubAddress).toBeUndefined();
   });
 
   it('does not return undefined fields as own keys (clean shape for downstream spread)', () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -240,15 +240,43 @@ describe('resolveChainConfig (field-level merge)', () => {
     // hubAddress before passing to the agent.
   });
 
-  it('preserves explicit `type: "mock"` and `mockIdentityId` override (test-only path)', () => {
+  it('does NOT inherit EVM fields from network when config opts into mock mode', () => {
+    // Critical: a hybrid `{ type: 'mock' }` config that inherits the
+    // network's rpcUrl/hubAddress/chainId would have lifecycle.ts wire up
+    // a MockChainAdapter (correct), but publisher-runner, the wallet/
+    // balance/rpc-health routes, and `dkg set-ask` would see "chain
+    // configured" via the inherited fields and start hitting the real
+    // network. Mock mode must short-circuit the merge.
     const merged = resolveChainConfig(
       { chain: { type: 'mock', mockIdentityId: '42' } },
       { chain: fullNetworkChain },
     );
     expect(merged?.type).toBe('mock');
     expect(merged?.mockIdentityId).toBe('42');
-    // Hub/RPC inherit, but the daemon's mock branch ignores them.
-    expect(merged?.hubAddress).toBe(fullNetworkChain.hubAddress);
+    expect(merged?.rpcUrl).toBeUndefined();
+    expect(merged?.hubAddress).toBeUndefined();
+    expect(merged?.chainId).toBeUndefined();
+  });
+
+  it('keeps the operator\'s own fields under mock mode (no merge in either direction)', () => {
+    // A test fixture that pins a mock chainId (e.g. to exercise a specific
+    // chain identifier inside MockChainAdapter) must round-trip without
+    // network inheritance.
+    const merged = resolveChainConfig(
+      {
+        chain: {
+          type: 'mock',
+          chainId: 'mock:31337',
+          mockIdentityId: '7',
+        },
+      },
+      { chain: fullNetworkChain },
+    );
+    expect(merged).toEqual({
+      type: 'mock',
+      chainId: 'mock:31337',
+      mockIdentityId: '7',
+    });
   });
 
   it('does not return undefined fields as own keys (clean shape for downstream spread)', () => {


### PR DESCRIPTION
## Why

If a node operator wants to override a single chain field (typically `rpcUrl`), they currently have to copy the **whole** `chain` block into `~/.dkg/config.json` — `hubAddress`, `chainId`, `type`, the lot. This is because the daemon resolves chain via whole-object fallback (`config.chain ?? network.chain`).

Side effect: hub rotations shipped via `network/<env>.json` bypass any node with a custom RPC until the operator edits their config manually.

## What

Switch chain resolution to **per-field merge** (same precedence pattern as `resolveAutoUpdateConfig`). Local config overrides only the fields it sets; the rest inherit from `network/<env>.json` (kept fresh by the auto-updater).

```json
{ "chain": { "rpcUrl": "https://my-private-rpc.example/..." } }