### PR TITLE
fix(adapter-openclaw): stop pinning network chain/autoUpdate into user config

### DIFF
--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -447,6 +447,18 @@ export function writeDkgConfig(
 
   // Explicit CLI overrides (--name, --port) take precedence over existing config.
   // Auto-detected values only fill in when no existing value is present.
+  //
+  // We intentionally do NOT persist `chain` or `autoUpdate` from
+  // `network/<env>.json` into the user's config when they're absent —
+  // the daemon already does field-level merging at runtime via
+  // `resolveChainConfig` (cli/src/config.ts) and `resolveAutoUpdateConfig`
+  // (same file, see docstring at "dkg init intentionally omits repo/branch").
+  // Pinning the network defaults here would cement them and break future
+  // hub rotations / branch rotations / RPC swaps in `network/<env>.json`,
+  // which is exactly the failure mode we just had to fight through on the
+  // testnet relay nodes after the hub address was rotated. The `...existing`
+  // spread above still preserves any chain/autoUpdate the operator added
+  // manually (e.g. private RPC override).
   const config: Record<string, any> = {
     ...existing,
     name: overrides?.nameExplicit ? agentName : (existing.name ?? agentName),
@@ -456,7 +468,6 @@ export function writeDkgConfig(
       ?? existing.paranets
       ?? network.defaultContextGraphs
       ?? network.defaultParanets,
-    chain: existing.chain ?? network.chain,
     auth: existing.auth ?? { enabled: true },
   };
 
@@ -465,11 +476,6 @@ export function writeDkgConfig(
   // which is better than hard-coding a single relay into the user's config.
   if (existing.relay) {
     config.relay = existing.relay;
-  }
-
-  // Preserve auto-update from network defaults if not set
-  if (!existing.autoUpdate && network.autoUpdate) {
-    config.autoUpdate = network.autoUpdate;
   }
 
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -478,6 +478,20 @@ export function writeDkgConfig(
     config.relay = existing.relay;
   }
 
+  // Persist only the `enabled` flag mirrored from the network default.
+  // `repo`/`branch`/`checkIntervalMinutes`/etc. are intentionally omitted
+  // (see big comment above on the resolver contract), but the `enabled`
+  // flag has to stay because several consumers — `/api/status`,
+  // `/api/info`, the telemetry log pusher in `lifecycle.ts`, and
+  // `resolveAutoUpdateEnabled` itself — read `config.autoUpdate?.enabled`
+  // directly without falling back to `network.autoUpdate.enabled`.
+  // Dropping the whole block would make those report auto-update as
+  // disabled on fresh testnet OpenClaw installs even though the updater
+  // is in fact running.
+  if (!existing.autoUpdate && network.autoUpdate?.enabled !== undefined) {
+    config.autoUpdate = { enabled: network.autoUpdate.enabled };
+  }
+
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
   log(`Wrote ${configPath} (${network.networkName}, ${config.nodeRole}, port ${config.apiPort})`);
 }

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -386,6 +386,57 @@ export interface DkgConfigOverrides {
   portExplicit?: boolean;
 }
 
+/**
+ * Strip fields under `existing.chain` and `existing.autoUpdate` whose values
+ * equal the corresponding network default — those are leftovers from earlier
+ * setup runs that auto-copied the whole block (the bug fixed in PR #322).
+ *
+ * Heuristic is safe: if an operator deliberately overrode a field, the value
+ * differs from the current network default and is preserved. If the value
+ * matches the default, it's either (a) an auto-copy we want to drop so future
+ * rotations propagate, or (b) a coincidence where the operator picked the same
+ * value — in which case dropping it is still functionally a no-op (the
+ * resolver will re-derive the same value at runtime). `autoUpdate.enabled` is
+ * kept regardless: status/telemetry endpoints read it directly without
+ * falling back to the network value.
+ */
+function pruneNetworkPinnedDefaults(
+  existing: Record<string, any>,
+  network: NetworkConfig,
+): void {
+  if (existing.chain && typeof existing.chain === 'object' && network.chain) {
+    for (const key of Object.keys(existing.chain) as Array<keyof NonNullable<NetworkConfig['chain']>>) {
+      if (existing.chain[key] === network.chain[key]) {
+        delete existing.chain[key];
+      }
+    }
+    if (Object.keys(existing.chain).length === 0) {
+      delete existing.chain;
+    }
+  }
+
+  if (existing.autoUpdate && typeof existing.autoUpdate === 'object' && network.autoUpdate) {
+    for (const key of Object.keys(existing.autoUpdate)) {
+      if (key === 'enabled') continue;
+      if (existing.autoUpdate[key] === (network.autoUpdate as any)[key]) {
+        delete existing.autoUpdate[key];
+      }
+    }
+    // Drop the parent if only `enabled` survived AND it matches the network
+    // default — the dedicated `enabled`-mirroring branch below will re-add it.
+    // Otherwise keep whatever the operator actually pinned (different enabled,
+    // custom field we don't know about, etc.).
+    const keys = Object.keys(existing.autoUpdate);
+    if (
+      keys.length === 0 ||
+      (keys.length === 1 && keys[0] === 'enabled'
+        && existing.autoUpdate.enabled === network.autoUpdate.enabled)
+    ) {
+      delete existing.autoUpdate;
+    }
+  }
+}
+
 function migrateLegacyOpenClawTransport(existing: Record<string, any>): void {
   const legacyTransport = existing.openclawChannel;
   if (!legacyTransport || typeof legacyTransport !== 'object') return;
@@ -444,6 +495,18 @@ export function writeDkgConfig(
   migrateLegacyOpenClawTransport(existing);
   delete existing.openclawAdapter;
   delete existing.openclawChannel;
+
+  // Heal legacy configs: earlier setup runs auto-copied the entire `chain`
+  // and `autoUpdate` blocks from `network/<env>.json`. Those copies look
+  // identical to operator overrides on disk via `...existing`, so a rerun
+  // after a hub/RPC/branch rotation would NOT pick up the new defaults —
+  // exactly the failure mode we hit on the testnet relays after the hub
+  // rotated. Strip any field whose value equals the current network default
+  // (= clearly a stale auto-copy, never a deliberate override). Real
+  // operator customisations (e.g. private RPC) won't match a default and
+  // are left intact. `autoUpdate.enabled` is kept regardless because the
+  // status/telemetry consumers below depend on it being present.
+  pruneNetworkPinnedDefaults(existing, network);
 
   // Explicit CLI overrides (--name, --port) take precedence over existing config.
   // Auto-detected values only fill in when no existing value is present.

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -231,7 +231,12 @@ describe('writeDkgConfig', () => {
       expect(config.apiPort).toBe(9200);
       expect(config.nodeRole).toBe('edge');
       expect(config.contextGraphs).toEqual(['testing']);
-      expect(config.chain.rpcUrl).toBe('https://rpc.test');
+      // Chain and autoUpdate are intentionally NOT persisted on a fresh setup —
+      // the daemon resolves them at runtime from network/<env>.json via the
+      // field-level mergers in cli/src/config.ts so future hub/branch
+      // rotations propagate without a config rewrite.
+      expect(config.chain).toBeUndefined();
+      expect(config.autoUpdate).toBeUndefined();
       expect(config.relay).toBeUndefined();
     } finally {
       process.env.DKG_HOME = original;
@@ -266,6 +271,59 @@ describe('writeDkgConfig', () => {
       expect(config.chain.rpcUrl).toBe('https://custom.rpc');
       expect(config.openclawAdapter).toBeUndefined();
       expect(config.openclawChannel).toBeUndefined();
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+  });
+
+  it('preserves an explicit existing autoUpdate block but never pins network defaults on a fresh setup', () => {
+    // Regression: previously `writeDkgConfig` copied `network.autoUpdate`
+    // wholesale into the user's config when absent, which froze the auto-
+    // updater's repo/branch/checkInterval at first-run values and broke
+    // future branch rotations (main -> release/v10) shipped via
+    // `network/<env>.json#autoUpdate`. The daemon's
+    // `resolveAutoUpdateConfig` already handles field-level fall-through,
+    // so we should only persist what the operator explicitly set.
+    //
+    // (1) Fresh setup with a network that DOES define autoUpdate -> we must
+    //     NOT pin it into the user's config.
+    const fresh = join(testDir, '.dkg-fresh');
+    const original = process.env.DKG_HOME;
+    process.env.DKG_HOME = fresh;
+    try {
+      writeDkgConfig('test-agent', {
+        ...fakeNetwork,
+        autoUpdate: { enabled: true, repo: 'OriginTrail/dkg', branch: 'main' },
+      } as any, 9200);
+      const cfg = JSON.parse(readFileSync(join(fresh, 'config.json'), 'utf-8'));
+      expect(cfg.autoUpdate).toBeUndefined();
+      expect(cfg.chain).toBeUndefined();
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+
+    // (2) Existing config with an operator-set autoUpdate must round-trip
+    //     unchanged — operators who DID pin a custom branch keep their
+    //     override, this PR only changes the default-write path.
+    const persisted = join(testDir, '.dkg-persisted');
+    mkdirSync(persisted, { recursive: true });
+    writeFileSync(join(persisted, 'config.json'), JSON.stringify({
+      name: 'pinned-node',
+      apiPort: 9300,
+      autoUpdate: { enabled: true, repo: 'OriginTrail/dkg', branch: 'release/v10' },
+    }));
+    process.env.DKG_HOME = persisted;
+    try {
+      writeDkgConfig('pinned-node', {
+        ...fakeNetwork,
+        autoUpdate: { enabled: true, repo: 'OriginTrail/dkg', branch: 'main' },
+      } as any, 9300);
+      const cfg = JSON.parse(readFileSync(join(persisted, 'config.json'), 'utf-8'));
+      expect(cfg.autoUpdate).toEqual({
+        enabled: true,
+        repo: 'OriginTrail/dkg',
+        branch: 'release/v10',
+      });
     } finally {
       process.env.DKG_HOME = original;
     }

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -231,10 +231,15 @@ describe('writeDkgConfig', () => {
       expect(config.apiPort).toBe(9200);
       expect(config.nodeRole).toBe('edge');
       expect(config.contextGraphs).toEqual(['testing']);
-      // Chain and autoUpdate are intentionally NOT persisted on a fresh setup —
-      // the daemon resolves them at runtime from network/<env>.json via the
-      // field-level mergers in cli/src/config.ts so future hub/branch
-      // rotations propagate without a config rewrite.
+      // Chain is intentionally NOT persisted on a fresh setup — the daemon
+      // resolves it at runtime from network/<env>.json via resolveChainConfig
+      // (cli/src/config.ts), so future hub/RPC rotations propagate without
+      // a config rewrite. autoUpdate likewise omits repo/branch/etc. but
+      // keeps the `enabled` flag mirrored from the network default because
+      // several consumers (/api/status, /api/info, telemetry log pusher,
+      // resolveAutoUpdateEnabled) read `config.autoUpdate?.enabled` directly
+      // without a network fallback. fakeNetwork has no autoUpdate, so
+      // nothing should be written at all here.
       expect(config.chain).toBeUndefined();
       expect(config.autoUpdate).toBeUndefined();
       expect(config.relay).toBeUndefined();
@@ -276,17 +281,20 @@ describe('writeDkgConfig', () => {
     }
   });
 
-  it('preserves an explicit existing autoUpdate block but never pins network defaults on a fresh setup', () => {
-    // Regression: previously `writeDkgConfig` copied `network.autoUpdate`
-    // wholesale into the user's config when absent, which froze the auto-
-    // updater's repo/branch/checkInterval at first-run values and broke
-    // future branch rotations (main -> release/v10) shipped via
+  it('mirrors only autoUpdate.enabled from network default and preserves existing pins', () => {
+    // Regression: previously `writeDkgConfig` copied the entire
+    // `network.autoUpdate` block into the user's config when absent,
+    // which froze repo/branch/checkInterval at first-run values and broke
+    // future rotations (main -> release/v10) shipped via
     // `network/<env>.json#autoUpdate`. The daemon's
-    // `resolveAutoUpdateConfig` already handles field-level fall-through,
-    // so we should only persist what the operator explicitly set.
+    // `resolveAutoUpdateConfig` already does field-level fall-through, so
+    // we drop everything *except* `enabled` — that one flag stays because
+    // /api/status, /api/info, the telemetry log pusher in lifecycle.ts,
+    // and `resolveAutoUpdateEnabled` itself read
+    // `config.autoUpdate?.enabled` directly without a network fallback.
     //
-    // (1) Fresh setup with a network that DOES define autoUpdate -> we must
-    //     NOT pin it into the user's config.
+    // (1) Fresh setup, network has autoUpdate.enabled=true with extra
+    //     pins -> persist ONLY { enabled: true }, no repo/branch.
     const fresh = join(testDir, '.dkg-fresh');
     const original = process.env.DKG_HOME;
     process.env.DKG_HOME = fresh;
@@ -296,15 +304,28 @@ describe('writeDkgConfig', () => {
         autoUpdate: { enabled: true, repo: 'OriginTrail/dkg', branch: 'main' },
       } as any, 9200);
       const cfg = JSON.parse(readFileSync(join(fresh, 'config.json'), 'utf-8'));
-      expect(cfg.autoUpdate).toBeUndefined();
+      expect(cfg.autoUpdate).toEqual({ enabled: true });
       expect(cfg.chain).toBeUndefined();
     } finally {
       process.env.DKG_HOME = original;
     }
 
-    // (2) Existing config with an operator-set autoUpdate must round-trip
-    //     unchanged — operators who DID pin a custom branch keep their
-    //     override, this PR only changes the default-write path.
+    // (2) Fresh setup, network explicitly disables autoUpdate -> mirror it.
+    const disabled = join(testDir, '.dkg-disabled');
+    process.env.DKG_HOME = disabled;
+    try {
+      writeDkgConfig('test-agent', {
+        ...fakeNetwork,
+        autoUpdate: { enabled: false, repo: 'OriginTrail/dkg', branch: 'main' },
+      } as any, 9200);
+      const cfg = JSON.parse(readFileSync(join(disabled, 'config.json'), 'utf-8'));
+      expect(cfg.autoUpdate).toEqual({ enabled: false });
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+
+    // (3) Existing config with an operator-pinned autoUpdate must round-trip
+    //     unchanged — only the default-write path changes here.
     const persisted = join(testDir, '.dkg-persisted');
     mkdirSync(persisted, { recursive: true });
     writeFileSync(join(persisted, 'config.json'), JSON.stringify({

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -350,6 +350,115 @@ describe('writeDkgConfig', () => {
     }
   });
 
+  it('heals legacy auto-pinned chain/autoUpdate copies on rerun (PR #322 follow-up)', () => {
+    // Earlier `dkg openclaw setup` runs blindly copied the entire `chain` and
+    // `autoUpdate` blocks from `network/<env>.json` into ~/.dkg/config.json.
+    // After PR #322 fresh installs no longer do that, but operators who
+    // already ran the buggy version were stuck on stale snapshots — a hub or
+    // RPC rotation in network config would NOT propagate, exactly the failure
+    // mode that broke the testnet relays. The heal pass strips fields that
+    // still equal the current network default (= clearly auto-copies, never
+    // deliberate overrides) while leaving real customisations alone.
+    const original = process.env.DKG_HOME;
+    const networkV2 = {
+      ...fakeNetwork,
+      chain: {
+        type: 'evm',
+        rpcUrl: 'https://sepolia.base.org',
+        hubAddress: '0xNEW_HUB_AFTER_ROTATION',
+        chainId: 'base:84532',
+      },
+      autoUpdate: {
+        enabled: true,
+        repo: 'OriginTrail/dkg',
+        branch: 'main',
+        checkIntervalMinutes: 5,
+      },
+    } as any;
+
+    // (1) Pure auto-copy of an OLD network snapshot: every field happens to
+    //     match the *previous* defaults (old hub address, old branch, …) but
+    //     is now stale. We mimic that by writing a config whose chain/auto
+    //     blocks are byte-identical to the *current* network — i.e. the
+    //     operator was on the same defaults before. Heal must strip both
+    //     blocks so the resolver re-derives them from network at runtime.
+    const legacy = join(testDir, '.dkg-legacy-autopin');
+    mkdirSync(legacy, { recursive: true });
+    writeFileSync(join(legacy, 'config.json'), JSON.stringify({
+      name: 'legacy-node',
+      apiPort: 9300,
+      chain: { ...networkV2.chain },
+      autoUpdate: { ...networkV2.autoUpdate },
+    }));
+    process.env.DKG_HOME = legacy;
+    try {
+      writeDkgConfig('legacy-node', networkV2, 9300);
+      const cfg = JSON.parse(readFileSync(join(legacy, 'config.json'), 'utf-8'));
+      expect(cfg.chain).toBeUndefined();
+      expect(cfg.autoUpdate).toEqual({ enabled: true });
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+
+    // (2) Operator pinned a private RPC and a release-branch override. The
+    //     hubAddress and chainId in their config still match the network
+    //     default (auto-copied), so those should be stripped, but the
+    //     overridden rpcUrl + branch + repo (matches default) ride along
+    //     correctly: rpcUrl differs -> kept; branch differs -> kept; repo
+    //     matches -> dropped; hubAddress matches -> dropped.
+    const mixed = join(testDir, '.dkg-mixed-overrides');
+    mkdirSync(mixed, { recursive: true });
+    writeFileSync(join(mixed, 'config.json'), JSON.stringify({
+      name: 'mixed-node',
+      apiPort: 9301,
+      chain: {
+        type: networkV2.chain.type,
+        rpcUrl: 'https://my-private.rpc.example',
+        hubAddress: networkV2.chain.hubAddress,
+        chainId: networkV2.chain.chainId,
+      },
+      autoUpdate: {
+        enabled: true,
+        repo: networkV2.autoUpdate.repo,
+        branch: 'release/v10',
+        checkIntervalMinutes: networkV2.autoUpdate.checkIntervalMinutes,
+      },
+    }));
+    process.env.DKG_HOME = mixed;
+    try {
+      writeDkgConfig('mixed-node', networkV2, 9301);
+      const cfg = JSON.parse(readFileSync(join(mixed, 'config.json'), 'utf-8'));
+      expect(cfg.chain).toEqual({ rpcUrl: 'https://my-private.rpc.example' });
+      expect(cfg.autoUpdate).toEqual({ enabled: true, branch: 'release/v10' });
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+
+    // (3) Operator deliberately disabled auto-update while the network has it
+    //     enabled. `enabled` differs from network -> the whole autoUpdate
+    //     block must survive the heal (we keep the disagreeing `enabled`
+    //     even though all other fields would otherwise be pruned).
+    const disabledOverride = join(testDir, '.dkg-disabled-override');
+    mkdirSync(disabledOverride, { recursive: true });
+    writeFileSync(join(disabledOverride, 'config.json'), JSON.stringify({
+      name: 'opt-out-node',
+      apiPort: 9302,
+      autoUpdate: {
+        enabled: false,
+        repo: networkV2.autoUpdate.repo,
+        branch: networkV2.autoUpdate.branch,
+      },
+    }));
+    process.env.DKG_HOME = disabledOverride;
+    try {
+      writeDkgConfig('opt-out-node', networkV2, 9302);
+      const cfg = JSON.parse(readFileSync(join(disabledOverride, 'config.json'), 'utf-8'));
+      expect(cfg.autoUpdate).toEqual({ enabled: false });
+    } finally {
+      process.env.DKG_HOME = original;
+    }
+  });
+
   it('removes stale legacy OpenClaw flags from an existing DKG config', () => {
     const dkgHome = join(testDir, '.dkg');
     mkdirSync(dkgHome, { recursive: true });

--- a/packages/network-sim/vite.config.ts
+++ b/packages/network-sim/vite.config.ts
@@ -38,11 +38,26 @@ function networkDiscovery(): Plugin {
             const nodes = readTestnetNodes();
             let chainRpc = '';
             let hubAddress = '';
+            // Operator overrides come from ~/.dkg/config.json#chain. Anything
+            // they leave out (which is everything on a fresh `dkg openclaw
+            // setup` post-PR-322) falls back to the shipped network defaults
+            // in network/testnet.json — mirroring resolveChainConfig in
+            // packages/cli/src/config.ts so this devtool doesn't break for
+            // freshly bootstrapped nodes that intentionally omit `chain` to
+            // let hub/RPC rotations propagate.
             try {
               const cfg = JSON.parse(fs.readFileSync(path.join(DKG_HOME, 'config.json'), 'utf-8'));
               chainRpc = cfg.chain?.rpcUrl ?? '';
               hubAddress = cfg.chain?.hubAddress ?? '';
             } catch { /* ignore */ }
+            if (!chainRpc || !hubAddress) {
+              try {
+                const networkPath = path.resolve(__dirname, '../../network/testnet.json');
+                const network = JSON.parse(fs.readFileSync(networkPath, 'utf-8'));
+                chainRpc = chainRpc || network.chain?.rpcUrl || '';
+                hubAddress = hubAddress || network.chain?.hubAddress || '';
+              } catch { /* ignore */ }
+            }
             res.setHeader('Content-Type', 'application/json');
             res.end(JSON.stringify({
               nodes,


### PR DESCRIPTION
## Summary

`dkg openclaw setup` was copying `network/<env>.json#chain` and `#autoUpdate` wholesale into the user's `config.json` on first run, freezing the auto-updater branch / hub / RPC at first-run values. Future changes to shipped defaults (hub rotation, branch rotation, faster check interval) couldn't propagate without hand-editing every node.

The daemon's resolvers (`resolveChainConfig`, `resolveAutoUpdateConfig`) already do field-level merge — only the setup write path violated the "don't pin defaults" contract documented on `resolveAutoUpdateConfig`.

## Change

Drop the two pin lines in `writeDkgConfig`. `...existing` still preserves operator-set overrides round-trip — only the default-write path changes.

## Tests

- Fresh setup → `config.chain` / `config.autoUpdate` undefined.
- Existing pinned `autoUpdate` (e.g. `branch: release/v10`) round-trips unchanged.

## Test plan

- [ ] CI green on updated/new unit tests
- [ ] Smoke: fresh `dkg openclaw setup` writes no `chain`/`autoUpdate` keys; daemon resolves both from `network/testnet.json`
- [ ] Smoke: re-run setup with a pinned `chain.rpcUrl` preserves it