### PR TITLE
Add generic query-catalog and source-worker publishing flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,6 +17,7 @@ class SourceWorkerConfig {
   +daemonUrl
   +daemonToken
   +handlerModule
+  +handlerExport
   +stateFile
   +sources
 }
@@ -85,10 +86,11 @@ daemon bearer token and selects a handler module that the CLI dynamically import
 and executes in the worker process, so it must be protected like the daemon
 `auth.token` and must not be committed to source control.
 
-The handler module exports `createSourceWorkerDeps(context)`. The CLI passes the
-resolved config plus daemon clients for Shared Working Memory writes and async
-publisher lift jobs. The handler returns the source-specific `getFingerprint`
-and `processSource` hooks.
+The handler module exposes `createSourceWorkerDeps(context)` either through the
+named `handlerExport` selected by config, `default`, `sourceWorker`, or the
+module namespace itself. The CLI passes the resolved config plus daemon clients
+for Shared Working Memory writes and async publisher lift jobs. The selected
+handler returns the source-specific `getFingerprint` and `processSource` hooks.
 
 `getFingerprint(source)` is the content identity contract. Source content that
 affects emitted triples or assets must produce a different fingerprint, and
@@ -113,9 +115,9 @@ participant Publisher as AsyncPublisher API
 
 Operator->>CLI: dkg source-worker run --config worker.json
 CLI->>Config: load and resolve config-relative paths
-Config-->>CLI: daemonUrl, daemonToken, handlerModule, stateFile, sources
+Config-->>CLI: daemonUrl, daemonToken, handlerModule, handlerExport, stateFile, sources
 CLI->>Runner: runConfiguredSourceWorker(configPath)
-Runner->>Handler: dynamic import handlerModule
+Runner->>Handler: dynamic import handlerModule and select handler export
 Handler-->>Runner: createSourceWorkerDeps(context)
 Runner->>State: loadSourceWorkerState(stateFile)
 loop each configured source

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,166 @@
+# DKG V10 Architecture
+
+This document captures the top-level runtime boundaries for the node, CLI, and
+source-worker integration surfaces. Source workers are part of the CLI-operated
+ingestion path used to turn configured source content into Shared Working Memory
+writes and async publisher jobs.
+
+## Component Model
+
+```mermaid
+classDiagram
+direction LR
+class CLI {
+  +sourceWorkerRun(configPath)
+}
+class SourceWorkerConfig {
+  +daemonUrl
+  +daemonToken
+  +handlerModule
+  +stateFile
+  +sources
+}
+class SourceWorkerRunner {
+  +runConfiguredSourceWorker(configPath)
+  +loadHandlerModule(config)
+}
+class SourceWorkerHandlerModule {
+  +createSourceWorkerDeps(context)
+}
+class SourceWorkerDeps {
+  +getFingerprint(source)
+  +processSource(source, fingerprint, state)
+  +getJobStatus(jobId)
+}
+class SourceWorkerStateStore {
+  +loadSourceWorkerState(path)
+  +saveSourceWorkerState(path, state)
+}
+class SharedMemoryWriteClient {
+  +share(contextGraphId, quads, options)
+}
+class AsyncLiftJobClient {
+  +lift(request)
+  +getJobStatus(jobId)
+}
+class DaemonHTTPAPI {
+  +postSharedMemoryWrite()
+  +postPublisherEnqueue()
+  +getPublisherJob()
+}
+class DKGAgent {
+  +writeWorkingMemory()
+  +promoteSharedMemory()
+}
+class AsyncPublisher {
+  +enqueue()
+  +processNext()
+}
+class WorkingMemory
+class SharedWorkingMemory
+class VerifiedMemory
+
+CLI --> SourceWorkerRunner : invokes
+SourceWorkerRunner --> SourceWorkerConfig : loads
+SourceWorkerRunner ..> SourceWorkerHandlerModule : dynamically imports
+SourceWorkerHandlerModule --> SourceWorkerDeps : provides hooks
+SourceWorkerRunner --> SourceWorkerDeps : executes
+SourceWorkerRunner --> SourceWorkerStateStore : reads and writes state
+SourceWorkerRunner --> SharedMemoryWriteClient : wires into handler context
+SourceWorkerRunner --> AsyncLiftJobClient : wires into handler context
+SharedMemoryWriteClient --> DaemonHTTPAPI : bearer token request
+AsyncLiftJobClient --> DaemonHTTPAPI : bearer token request
+DaemonHTTPAPI --> DKGAgent : delegates memory writes
+DaemonHTTPAPI --> AsyncPublisher : delegates lift jobs
+DKGAgent --> WorkingMemory : owns
+DKGAgent --> SharedWorkingMemory : gossips
+AsyncPublisher --> SharedWorkingMemory : reads source data
+AsyncPublisher --> VerifiedMemory : publishes
+```
+
+## Source Worker Workflow
+
+Source-worker configuration is sensitive operator material. It contains the
+daemon bearer token and selects a handler module that the CLI dynamically imports
+and executes in the worker process, so it must be protected like the daemon
+`auth.token` and must not be committed to source control.
+
+The handler module exports `createSourceWorkerDeps(context)`. The CLI passes the
+resolved config plus daemon clients for Shared Working Memory writes and async
+publisher lift jobs. The handler returns the source-specific `getFingerprint`
+and `processSource` hooks.
+
+`getFingerprint(source)` is the content identity contract. Source content that
+affects emitted triples or assets must produce a different fingerprint, and
+unchanged content must keep the same fingerprint across runs. Fingerprints must
+exclude wall-clock time, random values, transient job status, and polling noise.
+
+Worker state is durable process state. Saves use a temp file in the state file's
+directory, fsync the file, rename over the target, and fsync the parent directory
+where the platform supports it. A failed save removes the temp file and preserves
+the previous state file.
+
+```mermaid
+sequenceDiagram
+actor Operator
+participant CLI as dkg CLI
+participant Config as SourceWorkerConfig
+participant Runner as SourceWorkerRunner
+participant Handler as HandlerModule
+participant State as StateFile
+participant SWM as SharedMemory API
+participant Publisher as AsyncPublisher API
+
+Operator->>CLI: dkg source-worker run --config worker.json
+CLI->>Config: load and resolve config-relative paths
+Config-->>CLI: daemonUrl, daemonToken, handlerModule, stateFile, sources
+CLI->>Runner: runConfiguredSourceWorker(configPath)
+Runner->>Handler: dynamic import handlerModule
+Handler-->>Runner: createSourceWorkerDeps(context)
+Runner->>State: loadSourceWorkerState(stateFile)
+loop each configured source
+  Runner->>Handler: getFingerprint(source)
+  alt fingerprint is unchanged and prior job is active or finalized
+    Runner->>Publisher: GET /api/publisher/job?id=jobId
+    Publisher-->>Runner: current job status
+    Runner-->>Runner: skip processSource
+  else source content changed or retry is needed
+    Runner->>Handler: processSource(source, fingerprint, priorState)
+    Handler->>SWM: POST /api/shared-memory/write
+    SWM-->>Handler: shareOperationId
+    Handler->>Publisher: POST /api/publisher/enqueue
+    Publisher-->>Handler: jobId
+    Handler-->>Runner: nextState
+  end
+end
+Runner->>State: write temp file, fsync file, rename, fsync directory
+```
+
+## Main Codex Workflow
+
+The repository workflow uses Codex stages to keep implementation, validation,
+review, architecture documentation, and local commit creation separated. This
+architecture documentation stage only updates declared architecture write
+targets and does not modify code, tests, generated files, dependency files, or
+local deployment state.
+
+```mermaid
+sequenceDiagram
+actor User
+participant Workflow as CodexWorkflowGraph
+participant Implementer as ImplementFocusedChange
+participant Validation as TestsAndCodeReview
+participant DocsAgent as MermaidArchitectureAgent
+participant Architecture as ARCHITECTURE.md
+participant Git as LocalGit
+
+User->>Workflow: continue from failure checkpoint
+Workflow->>Implementer: implement focused source-worker fix
+Implementer-->>Workflow: code and tests changed
+Workflow->>Validation: run focused validation and code review
+Validation-->>Workflow: passed
+Workflow->>DocsAgent: update architecture docs if boundaries changed
+DocsAgent->>Architecture: create or update Mermaid diagrams and prose
+DocsAgent-->>Workflow: documentation stage complete
+Workflow->>Git: create local commits in a later commit stage
+```

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -74,3 +74,5 @@ export {
 } from './random-sampling-bind.js';
 export { monotonicTransition, versionedWrite, type MonotonicStages } from './workspace-consistency.js';
 export { StaleWriteError, type CASCondition } from '@origintrail-official/dkg-publisher';
+export * from './source-worker.js';
+export * from './source-registry.js';

--- a/packages/agent/src/source-registry.ts
+++ b/packages/agent/src/source-registry.ts
@@ -1,0 +1,33 @@
+import type { SourceKindHandler } from './source-worker.js';
+
+export interface SourceRegistry<TSource extends { kind: string }, TAsset = unknown> {
+  register(kind: string, handler: SourceKindHandler<TSource, TAsset>): void;
+  resolve(source: TSource): SourceKindHandler<TSource, TAsset>;
+  has(kind: string): boolean;
+  listKinds(): string[];
+}
+
+export function createSourceRegistry<TSource extends { kind: string }, TAsset = unknown>(
+  seed: Record<string, SourceKindHandler<TSource, TAsset>> = {},
+): SourceRegistry<TSource, TAsset> {
+  const handlers = new Map<string, SourceKindHandler<TSource, TAsset>>(Object.entries(seed));
+
+  return {
+    register(kind: string, handler: SourceKindHandler<TSource, TAsset>) {
+      handlers.set(kind, handler);
+    },
+    resolve(source: TSource): SourceKindHandler<TSource, TAsset> {
+      const handler = handlers.get(source.kind);
+      if (!handler) {
+        throw new Error(`Unsupported source kind: ${source.kind}`);
+      }
+      return handler;
+    },
+    has(kind: string): boolean {
+      return handlers.has(kind);
+    },
+    listKinds(): string[] {
+      return [...handlers.keys()].sort();
+    },
+  };
+}

--- a/packages/agent/src/source-worker.ts
+++ b/packages/agent/src/source-worker.ts
@@ -1,0 +1,165 @@
+import { writeFile, readFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export interface SourceWorkerJobState {
+  fingerprint?: string;
+  lastRunAt?: string;
+  lastJobIds?: string[];
+  lastJobStatuses?: Record<string, string>;
+  lastStatus?: string;
+  lastError?: string;
+  attemptCount?: number;
+  manualReviewRequired?: boolean;
+  manualReviewReason?: string;
+}
+
+export interface SourceWorkerState {
+  sources: Record<string, SourceWorkerJobState>;
+}
+
+export interface SourceWorkerSource {
+  id: string;
+  maxRetries?: number;
+}
+
+export interface SourcePreparationResult<TAsset = unknown> {
+  fingerprint: string;
+  assets: TAsset[];
+  warnings?: string[];
+}
+
+export interface SourceKindHandler<TSource = SourceWorkerSource, TAsset = unknown> {
+  computeFingerprint(source: TSource): Promise<string>;
+  prepare(source: TSource): Promise<SourcePreparationResult<TAsset>>;
+}
+
+export interface SourceWorkerResult {
+  sourceId: string;
+  skipped: boolean;
+  reason?: string;
+  jobIds?: string[];
+  jobStatuses?: Record<string, string>;
+  status?: string;
+  nextState: SourceWorkerJobState;
+}
+
+export interface SourceWorkerDeps<TSource extends SourceWorkerSource> {
+  now(): string;
+  getFingerprint(source: TSource): Promise<string>;
+  processSource(source: TSource, fingerprint: string, state: SourceWorkerJobState | undefined): Promise<SourceWorkerResult>;
+  getJobStatus(jobId: string): Promise<string>;
+}
+
+export async function loadSourceWorkerState(path: string): Promise<SourceWorkerState> {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as SourceWorkerState;
+    return { sources: parsed.sources ?? {} };
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') return { sources: {} };
+    throw error;
+  }
+}
+
+export async function saveSourceWorkerState(path: string, state: SourceWorkerState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+export async function runSourceWorkerOnce<TSource extends SourceWorkerSource>(
+  sources: readonly TSource[],
+  statePath: string,
+  deps: SourceWorkerDeps<TSource>,
+): Promise<SourceWorkerState> {
+  const state = await loadSourceWorkerState(statePath);
+  const nextState: SourceWorkerState = { sources: { ...state.sources } };
+
+  for (const source of sources) {
+    const current = state.sources[source.id];
+    const fingerprint = await deps.getFingerprint(source);
+    const statuses = current?.lastJobIds?.length
+      ? Object.fromEntries(await Promise.all(current.lastJobIds.map(async (jobId) => [jobId, await deps.getJobStatus(jobId)] as const)))
+      : {};
+    const aggregate = aggregateStatuses(statuses);
+
+    if (current?.fingerprint === fingerprint && current.manualReviewRequired) {
+      nextState.sources[source.id] = {
+        ...current,
+        lastRunAt: deps.now(),
+        lastJobStatuses: statuses,
+        lastStatus: 'manual-review-required',
+      };
+      continue;
+    }
+
+    if (current?.fingerprint === fingerprint && isActiveStatus(aggregate)) {
+      nextState.sources[source.id] = {
+        ...current,
+        lastRunAt: deps.now(),
+        lastJobStatuses: statuses,
+        lastStatus: aggregate,
+      };
+      continue;
+    }
+
+    if (current?.fingerprint === fingerprint && isSuccessStatus(aggregate)) {
+      nextState.sources[source.id] = {
+        ...current,
+        lastRunAt: deps.now(),
+        lastJobStatuses: statuses,
+        lastStatus: aggregate,
+      };
+      continue;
+    }
+
+    const nextAttemptCount = current?.fingerprint === fingerprint ? (current.attemptCount ?? 0) + 1 : 1;
+    const maxRetries = source.maxRetries ?? 3;
+    if (current?.fingerprint === fingerprint && nextAttemptCount > maxRetries) {
+      nextState.sources[source.id] = {
+        ...current,
+        lastRunAt: deps.now(),
+        lastJobStatuses: statuses,
+        lastStatus: 'manual-review-required',
+        lastError: `max retries exceeded (${maxRetries})`,
+        attemptCount: nextAttemptCount,
+        manualReviewRequired: true,
+        manualReviewReason: `max retries exceeded (${maxRetries})`,
+      };
+      continue;
+    }
+
+    try {
+      const result = await deps.processSource(source, fingerprint, current);
+      nextState.sources[source.id] = result.nextState;
+    } catch (error: any) {
+      nextState.sources[source.id] = {
+        ...current,
+        fingerprint,
+        lastRunAt: deps.now(),
+        lastStatus: 'failed',
+        lastError: error?.message ?? String(error),
+        attemptCount: nextAttemptCount,
+      };
+    }
+  }
+
+  await saveSourceWorkerState(statePath, nextState);
+  return nextState;
+}
+
+function aggregateStatuses(statuses: Record<string, string>): string {
+  const values = Object.values(statuses);
+  if (values.length === 0) return '';
+  if (values.every((status) => status === 'finalized' || status === 'completed')) return 'finalized';
+  if (values.some((status) => status === 'failed' || status === 'error')) return 'failed';
+  if (values.some((status) => isActiveStatus(status))) return 'in-flight';
+  return values[0] ?? '';
+}
+
+function isSuccessStatus(status: string | undefined): boolean {
+  return status === 'completed' || status === 'finalized' || status === 'no-matching-rows';
+}
+
+function isActiveStatus(status: string | undefined): boolean {
+  return status === 'accepted' || status === 'claimed' || status === 'validated' || status === 'broadcast' || status === 'included' || status === 'queued' || status === 'in-flight';
+}

--- a/packages/agent/src/source-worker.ts
+++ b/packages/agent/src/source-worker.ts
@@ -1,5 +1,6 @@
-import { writeFile, readFile, mkdir } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { open, readFile, mkdir, rename, rm, type FileHandle } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 
 export interface SourceWorkerJobState {
   fingerprint?: string;
@@ -29,6 +30,11 @@ export interface SourcePreparationResult<TAsset = unknown> {
 }
 
 export interface SourceKindHandler<TSource = SourceWorkerSource, TAsset = unknown> {
+  /**
+   * Return a stable fingerprint for source content that affects emitted assets.
+   * Changed content must produce a different fingerprint; unchanged content
+   * must keep the same fingerprint across runs.
+   */
   computeFingerprint(source: TSource): Promise<string>;
   prepare(source: TSource): Promise<SourcePreparationResult<TAsset>>;
 }
@@ -45,6 +51,13 @@ export interface SourceWorkerResult {
 
 export interface SourceWorkerDeps<TSource extends SourceWorkerSource> {
   now(): string;
+  /**
+   * Return a stable fingerprint for source content that affects emitted
+   * triples/assets. Changed content must produce a different fingerprint;
+   * unchanged content must keep the same fingerprint across runs. Do not
+   * include wall-clock time, random values, transient job status, or polling
+   * noise.
+   */
   getFingerprint(source: TSource): Promise<string>;
   processSource(source: TSource, fingerprint: string, state: SourceWorkerJobState | undefined): Promise<SourceWorkerResult>;
   getJobStatus(jobId: string): Promise<string>;
@@ -62,8 +75,27 @@ export async function loadSourceWorkerState(path: string): Promise<SourceWorkerS
 }
 
 export async function saveSourceWorkerState(path: string, state: SourceWorkerState): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true });
+  const tempPath = join(dir, `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+  let tempFile: FileHandle | undefined;
+
+  try {
+    tempFile = await open(tempPath, 'wx');
+    await tempFile.writeFile(JSON.stringify(state, null, 2) + '\n', 'utf8');
+    await tempFile.sync();
+    await tempFile.close();
+    tempFile = undefined;
+
+    await rename(tempPath, path);
+    await syncDirectory(dir);
+  } catch (error) {
+    if (tempFile) {
+      await tempFile.close().catch(() => undefined);
+    }
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function runSourceWorkerOnce<TSource extends SourceWorkerSource>(
@@ -162,4 +194,20 @@ function isSuccessStatus(status: string | undefined): boolean {
 
 function isActiveStatus(status: string | undefined): boolean {
   return status === 'accepted' || status === 'claimed' || status === 'validated' || status === 'broadcast' || status === 'included' || status === 'queued' || status === 'in-flight';
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  let dir: FileHandle | undefined;
+  try {
+    dir = await open(path, 'r');
+    await dir.sync();
+  } catch (error: any) {
+    if (!['EINVAL', 'ENOTSUP', 'EPERM', 'EISDIR'].includes(error?.code)) {
+      throw error;
+    }
+  } finally {
+    if (dir) {
+      await dir.close().catch(() => undefined);
+    }
+  }
 }

--- a/packages/agent/test/source-registry.test.ts
+++ b/packages/agent/test/source-registry.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { createSourceRegistry } from '../src/source-registry.js';
+
+describe('source registry', () => {
+  it('registers and resolves handlers by source kind', async () => {
+    const registry = createSourceRegistry<{ kind: string }, string>();
+    registry.register('demo', {
+      async computeFingerprint() { return 'fp'; },
+      async prepare() { return { fingerprint: 'fp', assets: ['a'] }; },
+    });
+
+    expect(registry.has('demo')).toBe(true);
+    expect(registry.listKinds()).toEqual(['demo']);
+    const handler = registry.resolve({ kind: 'demo' });
+    await expect(handler.computeFingerprint({ kind: 'demo' })).resolves.toBe('fp');
+  });
+
+  it('throws for unsupported source kinds', () => {
+    const registry = createSourceRegistry<{ kind: string }, string>();
+    expect(() => registry.resolve({ kind: 'missing' })).toThrow(/Unsupported source kind/);
+  });
+});

--- a/packages/agent/test/source-worker.test.ts
+++ b/packages/agent/test/source-worker.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runSourceWorkerOnce } from '../src/source-worker.js';
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('source worker runtime', () => {
+  it('skips unchanged finalized jobs and persists reconciled state', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'source-worker-'));
+    cleanup.push(dir);
+    const statePath = join(dir, 'state.json');
+
+    const deps = {
+      now: () => '2026-04-28T00:00:00.000Z',
+      getFingerprint: vi.fn(async () => 'fp-1'),
+      getJobStatus: vi.fn(async () => 'finalized'),
+      processSource: vi.fn(async () => ({
+        sourceId: 'src-1',
+        skipped: false,
+        fingerprint: 'fp-1',
+        status: 'queued',
+        nextState: { fingerprint: 'fp-1', lastStatus: 'queued', lastJobIds: ['job-1'] },
+      })),
+    };
+
+    await runSourceWorkerOnce([{ id: 'src-1', maxRetries: 3 }], statePath, deps);
+    const second = await runSourceWorkerOnce([{ id: 'src-1', maxRetries: 3 }], statePath, deps);
+
+    expect(deps.processSource).toHaveBeenCalledTimes(1);
+    expect(second.sources['src-1']?.lastStatus).toBe('finalized');
+  });
+});

--- a/packages/agent/test/source-worker.test.ts
+++ b/packages/agent/test/source-worker.test.ts
@@ -1,11 +1,13 @@
 import { mkdtemp, readdir, rm } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { runSourceWorkerOnce, saveSourceWorkerState } from '../src/source-worker.js';
 
 const cleanup: string[] = [];
 afterEach(async () => {
+  vi.doUnmock('node:fs/promises');
+  vi.restoreAllMocks();
   await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
 });
 
@@ -33,6 +35,48 @@ describe('source worker runtime', () => {
 
     expect(deps.processSource).toHaveBeenCalledTimes(1);
     expect(second.sources['src-1']?.lastStatus).toBe('finalized');
+  });
+
+  it('reprocesses stable sources only when their content fingerprint changes', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'source-worker-'));
+    cleanup.push(dir);
+    const statePath = join(dir, 'state.json');
+    const fingerprints = ['fp-1', 'fp-1', 'fp-2'];
+    let processed = 0;
+
+    const deps = {
+      now: () => '2026-04-28T00:00:00.000Z',
+      getFingerprint: vi.fn(async () => fingerprints.shift() ?? 'fp-2'),
+      getJobStatus: vi.fn(async () => 'finalized'),
+      processSource: vi.fn(async (source: { id: string }, fingerprint: string) => {
+        processed += 1;
+        return {
+          sourceId: source.id,
+          skipped: false,
+          jobIds: [`job-${processed}`],
+          jobStatuses: { [`job-${processed}`]: 'queued' },
+          status: 'queued',
+          nextState: {
+            fingerprint,
+            lastStatus: 'queued',
+            lastJobIds: [`job-${processed}`],
+            lastJobStatuses: { [`job-${processed}`]: 'queued' },
+          },
+        };
+      }),
+    };
+
+    await runSourceWorkerOnce([{ id: 'src-1', maxRetries: 3 }], statePath, deps);
+    await runSourceWorkerOnce([{ id: 'src-1', maxRetries: 3 }], statePath, deps);
+    const changed = await runSourceWorkerOnce([{ id: 'src-1', maxRetries: 3 }], statePath, deps);
+
+    expect(deps.processSource).toHaveBeenCalledTimes(2);
+    expect(deps.processSource.mock.calls.map((call) => call[1])).toEqual(['fp-1', 'fp-2']);
+    expect(changed.sources['src-1']).toMatchObject({
+      fingerprint: 'fp-2',
+      lastStatus: 'queued',
+      lastJobIds: ['job-2'],
+    });
   });
 
   it('saves state without leaving temp files behind', async () => {
@@ -65,5 +109,82 @@ describe('source worker runtime', () => {
         },
       },
     });
+  });
+
+  it('persists state through same-directory temp write, file fsync, rename, and directory fsync', async () => {
+    vi.resetModules();
+
+    const calls: string[] = [];
+    const fileHandle = {
+      writeFile: vi.fn(async () => {
+        calls.push('writeFile');
+      }),
+      sync: vi.fn(async () => {
+        calls.push('fileSync');
+      }),
+      close: vi.fn(async () => {
+        calls.push('fileClose');
+      }),
+    };
+    const dirHandle = {
+      sync: vi.fn(async () => {
+        calls.push('dirSync');
+      }),
+      close: vi.fn(async () => {
+        calls.push('dirClose');
+      }),
+    };
+    const mkdir = vi.fn(async () => {
+      calls.push('mkdir');
+    });
+    const open = vi.fn(async (path: string, flags: string) => {
+      calls.push(`open:${flags}:${path}`);
+      return flags === 'wx' ? fileHandle : dirHandle;
+    });
+    const rename = vi.fn(async (from: string, to: string) => {
+      calls.push(`rename:${from}->${to}`);
+    });
+    const rmMock = vi.fn(async () => {
+      calls.push('rm');
+    });
+
+    vi.doMock('node:fs/promises', () => ({
+      mkdir,
+      open,
+      readFile: vi.fn(),
+      rename,
+      rm: rmMock,
+    }));
+
+    const { saveSourceWorkerState: saveWithMockedFs } = await import('../src/source-worker.js');
+    const statePath = join(tmpdir(), 'source-worker-state-test', 'state.json');
+    const stateDir = dirname(statePath);
+
+    await saveWithMockedFs(statePath, {
+      sources: {
+        'src-1': {
+          fingerprint: 'fp-1',
+          lastStatus: 'queued',
+        },
+      },
+    });
+
+    const tempPath = String(open.mock.calls[0][0]);
+    expect(dirname(tempPath)).toBe(stateDir);
+    expect(basename(tempPath)).toMatch(/^\.state\.json\.\d+\..+\.tmp$/);
+    expect(mkdir).toHaveBeenCalledWith(stateDir, { recursive: true });
+    expect(fileHandle.writeFile).toHaveBeenCalledWith(expect.stringContaining('"src-1"'), 'utf8');
+    expect(rmMock).not.toHaveBeenCalled();
+    expect(calls).toEqual([
+      'mkdir',
+      `open:wx:${tempPath}`,
+      'writeFile',
+      'fileSync',
+      'fileClose',
+      `rename:${tempPath}->${statePath}`,
+      `open:r:${stateDir}`,
+      'dirSync',
+      'dirClose',
+    ]);
   });
 });

--- a/packages/agent/test/source-worker.test.ts
+++ b/packages/agent/test/source-worker.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { runSourceWorkerOnce } from '../src/source-worker.js';
+import { runSourceWorkerOnce, saveSourceWorkerState } from '../src/source-worker.js';
 
 const cleanup: string[] = [];
 afterEach(async () => {
@@ -33,5 +33,37 @@ describe('source worker runtime', () => {
 
     expect(deps.processSource).toHaveBeenCalledTimes(1);
     expect(second.sources['src-1']?.lastStatus).toBe('finalized');
+  });
+
+  it('saves state without leaving temp files behind', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'source-worker-'));
+    cleanup.push(dir);
+    const statePath = join(dir, 'state.json');
+
+    await saveSourceWorkerState(statePath, {
+      sources: {
+        'src-1': {
+          fingerprint: 'fp-1',
+          lastStatus: 'queued',
+        },
+      },
+    });
+
+    await expect(readdir(dir)).resolves.toEqual(['state.json']);
+    await expect(runSourceWorkerOnce([], statePath, {
+      now: () => '2026-04-28T00:00:00.000Z',
+      getFingerprint: vi.fn(async () => ''),
+      getJobStatus: vi.fn(async () => ''),
+      processSource: vi.fn(async () => {
+        throw new Error('unexpected source processing');
+      }),
+    })).resolves.toMatchObject({
+      sources: {
+        'src-1': {
+          fingerprint: 'fp-1',
+          lastStatus: 'queued',
+        },
+      },
+    });
   });
 });

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -105,6 +105,54 @@ content must keep the same fingerprint across runs. Do not include wall-clock
 time, random values, transient job status, or other polling noise in the
 fingerprint.
 
+Minimal config shape:
+
+```json
+{
+  "pollIntervalMs": 60000,
+  "stateFile": "./state/source-worker.json",
+  "daemonUrl": "http://127.0.0.1:9200",
+  "daemonToken": "<contents of auth.token>",
+  "handlerModule": "./handlers/source-worker.mjs",
+  "handlerExport": "sourceWorker",
+  "sources": [{ "id": "source-1" }]
+}
+```
+
+The handler module is loaded from the config file's directory:
+
+```js
+export const sourceWorker = {
+  createSourceWorkerDeps({ sharedMemory, asyncLift }) {
+    return {
+      async getFingerprint(source) {
+        return source.contentHash;
+      },
+      async processSource(source, fingerprint) {
+        const share = await sharedMemory.share(source.contextGraphId, source.quads);
+        const jobId = await asyncLift.lift({
+          ...source.liftRequest,
+          shareOperationId: share.shareOperationId
+        });
+        return {
+          sourceId: source.id,
+          skipped: false,
+          jobIds: [jobId],
+          jobStatuses: { [jobId]: "queued" },
+          status: "queued",
+          nextState: {
+            fingerprint,
+            lastStatus: "queued",
+            lastJobIds: [jobId],
+            lastJobStatuses: { [jobId]: "queued" }
+          }
+        };
+      },
+    };
+  },
+};
+```
+
 The worker state file is updated with a same-directory temp-file write, file
 fsync, atomic rename, and parent-directory fsync where supported so a crash does
 not truncate the previous state file.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,6 +88,27 @@ dkg query my-project -q "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
 
 Run `dkg <command> --help` for per-command options.
 
+## Source Workers
+
+`dkg source-worker run --config <path>` runs a generic polling worker from a
+JSON config file. Treat that config as sensitive operator material, equivalent
+to the daemon's `auth.token`: it contains `daemonToken` and names a
+`handlerModule` that the CLI dynamically imports and executes in the worker
+process. Store it with the same access controls as `auth.token`, and do not
+commit it to a repository.
+
+Handler modules export `createSourceWorkerDeps(context)`, returning
+`getFingerprint` and `processSource`. `getFingerprint(source)` is the content
+identity contract for the worker: source content changes that affect emitted
+triples/assets must produce a different fingerprint, while unchanged source
+content must keep the same fingerprint across runs. Do not include wall-clock
+time, random values, transient job status, or other polling noise in the
+fingerprint.
+
+The worker state file is updated with a same-directory temp-file write, file
+fsync, atomic rename, and parent-directory fsync where supported so a crash does
+not truncate the previous state file.
+
 ## HTTP API
 
 When the daemon is running, it exposes a local HTTP API (default: `http://localhost:9200`). Key endpoint groups:

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -305,6 +305,10 @@ export class ApiClient {
     });
   }
 
+  async readQueryCatalog(contextGraphId: string): Promise<{ result: QueryResult }> {
+    return this.post('/api/profile/query-catalog/read', { contextGraphId });
+  }
+
   async queryRemote(peerId: string, request: {
     lookupType: string;
     contextGraphId?: string;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,6 +22,7 @@ import {
 } from './config.js';
 import { ApiClient } from './api-client.js';
 import { parsePositiveMsOption } from './publisher-runner.js';
+import { runConfiguredSourceWorker } from './source-worker-runner.js';
 
 function isDaemonUnreachable(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
@@ -2166,6 +2167,26 @@ sharedMemoryCmd
     }
   });
 
+// ─── dkg source-worker ────────────────────────────────────────────────
+
+const sourceWorkerCmd = program
+  .command('source-worker')
+  .description('Run generic source workers against the DKG daemon');
+
+sourceWorkerCmd
+  .command('run')
+  .description('Run a source worker from a JSON config file')
+  .requiredOption('--config <path>', 'Worker config JSON file')
+  .option('--once', 'Run a single iteration and exit')
+  .action(async (opts: ActionOpts) => {
+    try {
+      await runConfiguredSourceWorker(String(opts.config), { once: opts.once === true });
+    } catch (err) {
+      console.error(toErrorMessage(err));
+      process.exit(1);
+    }
+  });
+
 // ─── dkg publisher ────────────────────────────────────────────────────
 
 const publisherCmd = program
@@ -2589,6 +2610,7 @@ program
       const chainResolved = resolveChainConfig(config, network);
       const rpcUrl = chainResolved?.rpcUrl;
       const hubAddress = chainResolved?.hubAddress;
+      const tokenAddress = config.chain?.tokenAddress ?? network?.chain?.tokenAddress;
       const chainId = chainResolved?.chainId ?? '(unknown)';
 
       let provider: ethers.JsonRpcProvider | null = null;
@@ -2598,7 +2620,10 @@ program
       if (rpcUrl) {
         try {
           provider = new ethers.JsonRpcProvider(rpcUrl);
-          if (hubAddress) {
+          if (tokenAddress && tokenAddress !== ethers.ZeroAddress) {
+            token = new ethers.Contract(tokenAddress, ['function balanceOf(address) view returns (uint256)', 'function symbol() view returns (string)'], provider);
+            tokenSymbol = await token.symbol().catch(() => 'TRAC');
+          } else if (hubAddress) {
             const hub = new ethers.Contract(hubAddress, ['function getContractAddress(string) view returns (address)'], provider);
             const tokenAddr = await hub.getContractAddress('Token');
             if (tokenAddr !== ethers.ZeroAddress) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2610,7 +2610,7 @@ program
       const chainResolved = resolveChainConfig(config, network);
       const rpcUrl = chainResolved?.rpcUrl;
       const hubAddress = chainResolved?.hubAddress;
-      const tokenAddress = config.chain?.tokenAddress ?? network?.chain?.tokenAddress;
+      const tokenAddress = chainResolved?.tokenAddress;
       const chainId = chainResolved?.chainId ?? '(unknown)';
 
       let provider: ethers.JsonRpcProvider | null = null;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2176,7 +2176,7 @@ const sourceWorkerCmd = program
 sourceWorkerCmd
   .command('run')
   .description('Run a source worker from a JSON config file')
-  .requiredOption('--config <path>', 'Worker config JSON file')
+  .requiredOption('--config <path>', 'Sensitive worker config JSON file')
   .option('--once', 'Run a single iteration and exit')
   .action(async (opts: ActionOpts) => {
     try {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2856,14 +2856,66 @@ function formatPublisherJobValue(value: unknown, key?: string): unknown {
 }
 
 function stripQuotes(s: string): string {
-  if (s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
-  const match = s.match(/^"(.*)"(\^\^.*|@.*)?$/);
-  if (match) return match[1];
+  const decodeLiteral = (literal: string): string => {
+    try {
+      return JSON.parse(literal);
+    } catch {
+      return literal.slice(1, -1);
+    }
+  };
+  if (s.startsWith('"') && s.endsWith('"')) return decodeLiteral(s);
+  const match = s.match(/^(".*")(\^\^.*|@.*)?$/);
+  if (match) return decodeLiteral(match[1]);
   return s;
 }
 
 function formatQuadObject(object: string): string {
   return /^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)/.test(object) ? `<${object}>` : object;
+}
+
+type QueryCatalogItem = {
+  slug: string;
+  name: string;
+  description?: string;
+  sparql: string;
+  rank: number;
+  catalogSlug: string;
+  catalogName: string;
+  catalogDescription?: string;
+  catalogRank: number;
+  subGraph: string;
+};
+
+async function loadSavedQueriesForCatalog(contextGraphId: string): Promise<QueryCatalogItem[]> {
+  const client = await ApiClient.connect();
+  const result = await client.readQueryCatalog(contextGraphId);
+  const bindings = result.result.type === 'bindings' ? result.result.bindings : [];
+  return bindings
+    .map((row) => {
+      const qIri = stripQuotes(String(row.q ?? ''));
+      const catalogIri = stripQuotes(String(row.catalog ?? ''));
+      const slug = qIri.split(':query:').pop() ?? qIri;
+      const catalogSlug = catalogIri ? (catalogIri.split(':catalog:').pop() ?? catalogIri) : 'ui-saved-queries';
+      return {
+        slug,
+        name: stripQuotes(String(row.name ?? slug)),
+        description: row.description ? stripQuotes(String(row.description)) : undefined,
+        sparql: stripQuotes(String(row.sparql ?? '')),
+        rank: Number.parseInt(stripQuotes(String(row.rank ?? '99')), 10) || 99,
+        catalogSlug,
+        catalogName: stripQuotes(String(row.catalogName ?? 'Queries')),
+        catalogDescription: row.catalogDescription ? stripQuotes(String(row.catalogDescription)) : undefined,
+        catalogRank: Number.parseInt(stripQuotes(String(row.catalogRank ?? '999')), 10) || 999,
+        subGraph: stripQuotes(String(row.subGraph ?? '')),
+      };
+    })
+    .filter((item) => item.sparql.length > 0)
+    .sort((a, b) => a.subGraph.localeCompare(b.subGraph) || a.catalogRank - b.catalogRank || a.rank - b.rank || a.name.localeCompare(b.name));
+}
+
+function findSavedQuery(items: QueryCatalogItem[], selector: string): QueryCatalogItem | undefined {
+  return items.find((item) => item.slug === selector)
+    ?? items.find((item) => item.name === selector);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -2887,6 +2939,59 @@ async function stopDaemonIfRunning(): Promise<boolean> {
 }
 
 // ─── dkg update ──────────────────────────────────────────────────────
+
+// ─── dkg query-catalog ───────────────────────────────────────────────
+
+const queryCatalogCmd = program
+  .command('query-catalog')
+  .description('List and run saved SPARQL queries from the profile catalog');
+
+queryCatalogCmd
+  .command('list <context-graph>')
+  .description('List saved queries in the profile query catalog')
+  .action(async (contextGraphId: string) => {
+    try {
+      const items = await loadSavedQueriesForCatalog(contextGraphId);
+      if (items.length === 0) {
+        console.log(`No saved queries found for ${contextGraphId}.`);
+        return;
+      }
+      console.log(`Saved queries for ${contextGraphId}:\n`);
+      for (const item of items) {
+        console.log(`${item.slug}`);
+        console.log(`  Name:        ${item.name}`);
+        console.log(`  Catalog:     ${item.catalogName} (${item.catalogSlug})`);
+        console.log(`  Sub-graph:   ${item.subGraph}`);
+        if (item.description) console.log(`  Description: ${item.description}`);
+        console.log('');
+      }
+    } catch (err) {
+      console.error(toErrorMessage(err));
+      process.exit(1);
+    }
+  });
+
+queryCatalogCmd
+  .command('run <context-graph> <query>')
+  .description('Run a saved query by slug or exact name')
+  .action(async (contextGraphId: string, selector: string) => {
+    try {
+      const items = await loadSavedQueriesForCatalog(contextGraphId);
+      const match = findSavedQuery(items, selector);
+      if (!match) {
+        console.error(`Saved query not found: ${selector}`);
+        process.exit(1);
+      }
+      const client = await ApiClient.connect();
+      const result = await client.query(match.sparql, contextGraphId);
+      console.log(`Running saved query: ${match.name}`);
+      console.log(`Slug: ${match.slug}\n`);
+      console.log(JSON.stringify(result.result, null, 2));
+    } catch (err) {
+      console.error(toErrorMessage(err));
+      process.exit(1);
+    }
+  });
 
 program
   .command('update [versionOrRef]')

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -85,6 +85,7 @@ export interface NetworkConfig {
     type: 'evm';
     rpcUrl: string;
     hubAddress: string;
+    tokenAddress?: string;
     chainId: string;
   };
   faucet?: {
@@ -117,6 +118,8 @@ export interface ChainConfig {
   rpcUrl: string;
   /** Hub contract address */
   hubAddress: string;
+  /** Optional token contract address override. When omitted, resolve from Hub.Token. */
+  tokenAddress?: string;
   /** Chain identifier (e.g., 'base:84532') */
   chainId?: string;
   /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -532,6 +532,8 @@ export function resolveChainConfig(
   if (rpcUrl !== undefined) merged.rpcUrl = rpcUrl;
   const hubAddress = cfg?.hubAddress ?? net?.hubAddress;
   if (hubAddress !== undefined) merged.hubAddress = hubAddress;
+  const tokenAddress = cfg?.tokenAddress ?? net?.tokenAddress;
+  if (tokenAddress !== undefined) merged.tokenAddress = tokenAddress;
   const chainId = cfg?.chainId ?? net?.chainId;
   if (chainId !== undefined) merged.chainId = chainId;
   if (cfg?.mockIdentityId !== undefined) merged.mockIdentityId = cfg.mockIdentityId;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -681,7 +681,6 @@ export async function runDaemonInner(
   });
 
   await agent.start();
-  await agent.publishProfile();
 
   const publisherChainBase = chainBase?.rpcUrl && chainBase?.hubAddress
     ? {
@@ -690,38 +689,56 @@ export async function runDaemonInner(
         chainId: chainBase.chainId,
       }
     : undefined;
-  publisherRuntime = await startPublisherRuntimeIfEnabled({
-    dataDir: dkgDir(),
-    config,
-    store: agent.store,
-    keypair: agent.wallet.keypair,
-    chainBase: publisherChainBase,
-    ackTransportFactory: () => ({
-      publisherPeerId: agent.peerId,
-      gossipPublish: async (topic: string, data: Uint8Array) => {
-        await agent.gossip.publish(topic, data);
-      },
-      sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
-        return agent.router.send(peerId, protocol, data);
-      },
-      getConnectedCorePeers: () => {
-        const allPeers = agent.node.libp2p
-          .getPeers()
-          .map((p) => p.toString())
-          .filter((id) => id !== agent.peerId);
-        const knownCorePeerIds = (agent as any).knownCorePeerIds as
-          | Set<string>
-          | undefined;
-        if (knownCorePeerIds && knownCorePeerIds.size > 0) {
-          const filtered = allPeers.filter((id) => knownCorePeerIds.has(id));
-          if (filtered.length > 0) return filtered;
-        }
-        return allPeers;
-      },
-      log,
-    }),
-    log,
-  });
+  const startPostApiPublishing = () => {
+    const profileTimer = setTimeout(() => {
+      void agent.publishProfile().catch((err: any) => {
+        log(`Agent profile publish failed: ${err?.message ?? String(err)}`);
+      });
+    }, 0);
+    if (profileTimer.unref) profileTimer.unref();
+
+    const publisherTimer = setTimeout(() => {
+      void startPublisherRuntimeIfEnabled({
+        dataDir: dkgDir(),
+        config,
+        store: agent.store,
+        keypair: agent.wallet.keypair,
+        chainBase: publisherChainBase,
+        ackTransportFactory: () => ({
+          publisherPeerId: agent.peerId,
+          gossipPublish: async (topic: string, data: Uint8Array) => {
+            await agent.gossip.publish(topic, data);
+          },
+          sendP2P: async (peerId: string, protocol: string, data: Uint8Array) => {
+            return agent.router.send(peerId, protocol, data);
+          },
+          getConnectedCorePeers: () => {
+            const allPeers = agent.node.libp2p
+              .getPeers()
+              .map((p) => p.toString())
+              .filter((id) => id !== agent.peerId);
+            const knownCorePeerIds = (agent as any).knownCorePeerIds as
+              | Set<string>
+              | undefined;
+            if (knownCorePeerIds && knownCorePeerIds.size > 0) {
+              const filtered = allPeers.filter((id) => knownCorePeerIds.has(id));
+              if (filtered.length > 0) return filtered;
+            }
+            return allPeers;
+          },
+          log,
+        }),
+        log,
+      })
+        .then((runtime) => {
+          publisherRuntime = runtime;
+        })
+        .catch((err: any) => {
+          log(`Async publisher startup failed: ${err?.message ?? String(err)}`);
+        });
+    }, 0);
+    if (publisherTimer.unref) publisherTimer.unref();
+  };
 
   log(`PeerId: ${agent.peerId}`);
   for (const a of agent.multiaddrs) log(`  ${a}`);
@@ -1669,6 +1686,7 @@ export async function runDaemonInner(
   log(`API listening on http://${apiHost}:${boundPort}`);
   log(`Node UI: http://${apiHost}:${boundPort}/ui`);
   log('Node is running. Use "dkg status" or "dkg peers" to interact.');
+  startPostApiPublishing();
 
   // Graceful shutdown
   let shuttingDown = false;

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -57,7 +57,7 @@ const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import { findReservedSubjectPrefix, isSkolemizedUri } from '@origintrail-official/dkg-publisher';
 import {
   DashboardDB,
@@ -362,6 +362,75 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     requestAgentAddress,
   } = ctx;
 
+
+  // POST /api/profile/query-catalog/write
+  //
+  // UI profile metadata intentionally lives in unregistered `.../meta/...`
+  // graphs. Do not route this through shared-memory sub-graph writes: that
+  // path correctly enforces registered sub-graphs, which is wrong for this
+  // local profile/catalog namespace.
+  if (req.method === "POST" && path === "/api/profile/query-catalog/write") {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+
+    const contextGraphId = parsed.contextGraphId ?? parsed.paranetId;
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
+
+    const { quads } = parsed;
+    if (!Array.isArray(quads) || quads.length === 0) {
+      return jsonResponse(res, 400, {
+        error: 'Missing or invalid "quads" (must be a non-empty array)',
+      });
+    }
+
+    const graph = `did:dkg:context-graph:${contextGraphId}/meta/query-catalog`;
+    try {
+      assertSafeIri(graph);
+      const normalized = quads.map((quad: unknown, index: number) => {
+        if (!quad || typeof quad !== "object" || Array.isArray(quad)) {
+          throw new Error(`quads[${index}] must be an object`);
+        }
+        const q = quad as Record<string, unknown>;
+        if (typeof q.subject !== "string" || q.subject.length === 0) {
+          throw new Error(`quads[${index}].subject must be a non-empty string`);
+        }
+        if (typeof q.predicate !== "string" || q.predicate.length === 0) {
+          throw new Error(`quads[${index}].predicate must be a non-empty string`);
+        }
+        if (typeof q.object !== "string" || q.object.length === 0) {
+          throw new Error(`quads[${index}].object must be a non-empty string`);
+        }
+
+        assertSafeIri(q.subject);
+        assertSafeIri(q.predicate);
+        if (q.object.startsWith('"')) {
+          assertSafeRdfTerm(q.object);
+        } else {
+          assertSafeIri(q.object);
+        }
+
+        return {
+          subject: q.subject,
+          predicate: q.predicate,
+          object: q.object,
+          graph,
+        };
+      });
+
+      await agent.store.insert(normalized);
+      return jsonResponse(res, 200, {
+        ok: true,
+        contextGraphId,
+        graph,
+        triplesWritten: normalized.length,
+      });
+    } catch (err: any) {
+      return jsonResponse(res, 400, {
+        error: err?.message ?? "Invalid query catalog write",
+      });
+    }
+  }
 
   // POST /api/shared-memory/write (V10) or /api/workspace/write (legacy)
   if (

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -432,6 +432,52 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     }
   }
 
+  // POST /api/profile/query-catalog/read { contextGraphId }
+  if (req.method === "POST" && path === "/api/profile/query-catalog/read") {
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body, res);
+    if (!parsed) return;
+
+    const contextGraphId = parsed.contextGraphId ?? parsed.paranetId;
+    if (!validateRequiredContextGraphId(contextGraphId, res)) return;
+
+    const graph = `did:dkg:context-graph:${contextGraphId}/meta/query-catalog`;
+    const query = `PREFIX prof: <http://dkg.io/ontology/profile/>
+PREFIX schema: <http://schema.org/>
+SELECT ?q ?subGraph ?catalog ?name ?description ?sparql ?rank ?catalogName ?catalogDescription ?catalogRank
+WHERE {
+  GRAPH <${graph}> {
+    ?q a prof:SavedQuery ;
+       prof:forSubGraph ?subGraph ;
+       prof:sparqlQuery ?sparql .
+    OPTIONAL { ?q prof:inCatalog ?catalog }
+    OPTIONAL { ?q prof:displayName ?name }
+    OPTIONAL { ?q schema:description ?description }
+    OPTIONAL { ?q prof:rank ?rank }
+    OPTIONAL { ?catalog prof:displayName ?catalogName }
+    OPTIONAL { ?catalog schema:description ?catalogDescription }
+    OPTIONAL { ?catalog prof:rank ?catalogRank }
+  }
+}`;
+
+    try {
+      const result = await agent.store.query(query);
+      const bindings = result.type === "bindings" ? result.bindings : [];
+      return jsonResponse(res, 200, {
+        contextGraphId,
+        graph,
+        result: {
+          type: "bindings",
+          bindings,
+        },
+      });
+    } catch (err: any) {
+      return jsonResponse(res, 400, {
+        error: err?.message ?? "Query catalog read failed",
+      });
+    }
+  }
+
   // POST /api/shared-memory/write (V10) or /api/workspace/write (legacy)
   if (
     req.method === "POST" &&

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -620,12 +620,12 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     }
     try {
       const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const hub = new ethers.Contract(
-        hubAddress,
-        ["function getContractAddress(string) view returns (address)"],
-        provider,
-      );
-      const tokenAddr = await hub.getContractAddress("Token").catch(() => null);
+      const tokenAddr = config.chain?.tokenAddress
+        ?? (await new ethers.Contract(
+          hubAddress,
+          ["function getContractAddress(string) view returns (address)"],
+          provider,
+        ).getContractAddress("Token").catch(() => null));
       let token: ethers.Contract | null = null;
       let tokenSymbol = "TRAC";
       if (tokenAddr && tokenAddr !== ethers.ZeroAddress) {

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -620,7 +620,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     }
     try {
       const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const tokenAddr = config.chain?.tokenAddress
+      const tokenAddr = chain?.tokenAddress
         ?? (await new ethers.Contract(
           hubAddress,
           ["function getContractAddress(string) view returns (address)"],

--- a/packages/cli/src/source-worker-config.ts
+++ b/packages/cli/src/source-worker-config.ts
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+export interface SourceWorkerConfig<TSource = unknown> {
+  pollIntervalMs: number;
+  stateFile: string;
+  daemonUrl: string;
+  daemonToken: string;
+  handlerModule: string;
+  handlerExport?: string;
+  sources: TSource[];
+}
+
+export async function loadSourceWorkerConfig<TSource = unknown>(configPath: string): Promise<SourceWorkerConfig<TSource>> {
+  const resolvedConfigPath = resolve(configPath);
+  const raw = await readFile(resolvedConfigPath, 'utf8');
+  const parsed = JSON.parse(raw) as SourceWorkerConfig<TSource>;
+  if (!Array.isArray(parsed.sources) || parsed.sources.length === 0) {
+    throw new Error('Source worker config must define at least one source');
+  }
+  if (!parsed.handlerModule) {
+    throw new Error('Source worker config must define handlerModule');
+  }
+  return {
+    ...parsed,
+    pollIntervalMs: parsed.pollIntervalMs > 0 ? parsed.pollIntervalMs : 60000,
+    stateFile: resolve(dirname(resolvedConfigPath), parsed.stateFile),
+    daemonUrl: parsed.daemonUrl.replace(/\/$/, ''),
+    handlerModule: resolve(dirname(resolvedConfigPath), parsed.handlerModule),
+  };
+}

--- a/packages/cli/src/source-worker-config.ts
+++ b/packages/cli/src/source-worker-config.ts
@@ -2,9 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 /**
- * Source-worker configs are sensitive operator material, equivalent to
- * auth.token: they contain daemonToken and select handlerModule code that
- * this process dynamically imports and executes.
+ * Source-worker configs are sensitive operator material, equivalent to the
+ * daemon auth.token. They contain daemonToken and select handlerModule code
+ * that this process dynamically imports and executes.
  */
 export interface SourceWorkerConfig<TSource = unknown> {
   pollIntervalMs: number;
@@ -12,6 +12,7 @@ export interface SourceWorkerConfig<TSource = unknown> {
   daemonUrl: string;
   daemonToken: string;
   handlerModule: string;
+  /** Optional named export to load from handlerModule instead of default/sourceWorker. */
   handlerExport?: string;
   sources: TSource[];
 }

--- a/packages/cli/src/source-worker-config.ts
+++ b/packages/cli/src/source-worker-config.ts
@@ -1,6 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
+/**
+ * Source-worker configs are sensitive operator material, equivalent to
+ * auth.token: they contain daemonToken and select handlerModule code that
+ * this process dynamically imports and executes.
+ */
 export interface SourceWorkerConfig<TSource = unknown> {
   pollIntervalMs: number;
   stateFile: string;

--- a/packages/cli/src/source-worker-daemon-client.ts
+++ b/packages/cli/src/source-worker-daemon-client.ts
@@ -1,0 +1,73 @@
+import type { LiftRequest } from '@origintrail-official/dkg-publisher';
+import type { AssetPartitionQuad } from '@origintrail-official/dkg-core';
+
+export interface SharedMemoryWriteResult {
+  shareOperationId: string;
+}
+
+export interface SharedMemoryWriteClient {
+  share(contextGraphId: string, quads: AssetPartitionQuad[], options?: { subGraphName?: string }): Promise<SharedMemoryWriteResult>;
+}
+
+export interface AsyncLiftJobClient {
+  lift(request: LiftRequest): Promise<string>;
+  getJobStatus(jobId: string): Promise<string>;
+}
+
+export function createDaemonSharedMemoryWriteClient(daemonUrl: string, token: string): SharedMemoryWriteClient {
+  return {
+    async share(contextGraphId: string, quads: AssetPartitionQuad[], options: { subGraphName?: string } = {}): Promise<SharedMemoryWriteResult> {
+      const response = await fetch(`${daemonUrl}/api/shared-memory/write`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          contextGraphId,
+          quads,
+          subGraphName: options.subGraphName,
+        }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error((payload as { error?: string }).error ?? `HTTP ${response.status}`);
+      }
+      return { shareOperationId: (payload as { shareOperationId?: string }).shareOperationId ?? '' };
+    },
+  };
+}
+
+export function createDaemonAsyncLiftJobClient(daemonUrl: string, token: string): AsyncLiftJobClient {
+  return {
+    async lift(request: LiftRequest): Promise<string> {
+      const response = await fetch(`${daemonUrl}/api/publisher/enqueue`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error((payload as { error?: string }).error ?? `HTTP ${response.status}`);
+      }
+      const jobId = (payload as { jobId?: string }).jobId;
+      if (!jobId) throw new Error('Async publisher enqueue did not return a job id');
+      return jobId;
+    },
+    async getJobStatus(jobId: string): Promise<string> {
+      const response = await fetch(`${daemonUrl}/api/publisher/job?id=${encodeURIComponent(jobId)}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error((payload as { error?: string }).error ?? `HTTP ${response.status}`);
+      }
+      return (payload as { job?: { status?: string } }).job?.status ?? 'unknown';
+    },
+  };
+}

--- a/packages/cli/src/source-worker-runner.ts
+++ b/packages/cli/src/source-worker-runner.ts
@@ -1,0 +1,137 @@
+import { pathToFileURL } from 'node:url';
+import {
+  loadSourceWorkerState,
+  runSourceWorkerOnce,
+  type SourceWorkerDeps,
+  type SourceWorkerJobState,
+  type SourceWorkerSource,
+} from '@origintrail-official/dkg-agent';
+import {
+  createDaemonAsyncLiftJobClient,
+  createDaemonSharedMemoryWriteClient,
+  type AsyncLiftJobClient,
+  type SharedMemoryWriteClient,
+} from './source-worker-daemon-client.js';
+import { loadSourceWorkerConfig, type SourceWorkerConfig } from './source-worker-config.js';
+
+export interface SourceWorkerHandlerContext<TSource extends SourceWorkerSource = SourceWorkerSource> {
+  config: SourceWorkerConfig<TSource>;
+  sharedMemory: SharedMemoryWriteClient;
+  asyncLift: AsyncLiftJobClient;
+}
+
+export interface SourceWorkerHandlerModule<TSource extends SourceWorkerSource = SourceWorkerSource> {
+  createSourceWorkerDeps(context: SourceWorkerHandlerContext<TSource>): Promise<
+  Pick<SourceWorkerDeps<TSource>, 'getFingerprint' | 'processSource'>
+  > | Pick<SourceWorkerDeps<TSource>, 'getFingerprint' | 'processSource'>;
+}
+
+export async function runConfiguredSourceWorker(configPath: string, options: { once?: boolean } = {}): Promise<void> {
+  const config = await loadSourceWorkerConfig<SourceWorkerSource>(configPath);
+  const sharedMemory = createDaemonSharedMemoryWriteClient(config.daemonUrl, config.daemonToken);
+  const asyncLift = createDaemonAsyncLiftJobClient(config.daemonUrl, config.daemonToken);
+  const handlerModule = await loadHandlerModule(config);
+  const workerDeps = await handlerModule.createSourceWorkerDeps({
+    config,
+    sharedMemory,
+    asyncLift,
+  });
+
+  const deps: SourceWorkerDeps<SourceWorkerSource> = {
+    now() {
+      return new Date().toISOString();
+    },
+    getFingerprint: workerDeps.getFingerprint,
+    processSource: workerDeps.processSource,
+    getJobStatus(jobId: string) {
+      return asyncLift.getJobStatus(jobId);
+    },
+  };
+
+  const runOnce = async () => {
+    const previousState = await loadSourceWorkerState(config.stateFile);
+    const state = await runSourceWorkerOnce(config.sources as SourceWorkerSource[], config.stateFile, deps);
+    for (const source of config.sources as SourceWorkerSource[]) {
+      const priorState = previousState.sources[source.id];
+      const nextState = state.sources[source.id];
+      console.log(formatSourceWorkerMessage(source.id, priorState, nextState));
+    }
+  };
+
+  await runOnce();
+  if (options.once) return;
+
+  let running = false;
+  setInterval(() => {
+    void (async () => {
+      if (running) {
+        console.warn('[source-worker] skipping interval tick because previous run is still in progress');
+        return;
+      }
+      running = true;
+      try {
+        await runOnce();
+      } catch (error) {
+        console.error('[source-worker] loop failed:', error instanceof Error ? error.message : String(error));
+      } finally {
+        running = false;
+      }
+    })();
+  }, config.pollIntervalMs);
+}
+
+async function loadHandlerModule<TSource extends SourceWorkerSource>(
+  config: SourceWorkerConfig<TSource>,
+): Promise<SourceWorkerHandlerModule<TSource>> {
+  const namespace = await import(pathToFileURL(config.handlerModule).href);
+  const candidate = config.handlerExport
+    ? namespace[config.handlerExport]
+    : (namespace.default ?? namespace.sourceWorker ?? namespace);
+  if (!candidate || typeof candidate.createSourceWorkerDeps !== 'function') {
+    throw new Error(
+      `Source worker handler module must export createSourceWorkerDeps()${config.handlerExport ? ` via ${config.handlerExport}` : ''}`,
+    );
+  }
+  return candidate as SourceWorkerHandlerModule<TSource>;
+}
+
+function formatSourceWorkerMessage(
+  sourceId: string,
+  priorState: SourceWorkerJobState | undefined,
+  state: SourceWorkerJobState | undefined,
+): string {
+  if (!state) return `[source-worker] ${sourceId}: no state`;
+  if (state.manualReviewRequired) {
+    return `[source-worker] ${sourceId}: manual review required (${state.manualReviewReason ?? state.lastError ?? 'unknown reason'})`;
+  }
+  const sameFingerprint = Boolean(priorState?.fingerprint && priorState.fingerprint === state.fingerprint);
+  const sameJobs = sameStringArray(priorState?.lastJobIds, state.lastJobIds);
+  if (state.lastStatus === 'finalized' || state.lastStatus === 'completed') {
+    const jobs = state.lastJobIds?.length ? ` jobs=${state.lastJobIds.join(',')}` : '';
+    if (sameFingerprint && sameJobs) {
+      return `[source-worker] ${sourceId}: skipped (${state.lastStatus})${jobs}`;
+    }
+    return `[source-worker] ${sourceId}: published${jobs}`;
+  }
+  if (state.lastStatus === 'failed') {
+    return `[source-worker] ${sourceId}: failed (${state.lastError ?? 'unknown error'})`;
+  }
+  if (state.lastStatus === 'in-flight') {
+    const jobs = state.lastJobIds?.length ? ` jobs=${state.lastJobIds.join(',')}` : '';
+    return `[source-worker] ${sourceId}: in-flight${jobs}`;
+  }
+  if (state.lastStatus === 'no-matching-rows') {
+    return `[source-worker] ${sourceId}: skipped (no-matching-rows)`;
+  }
+  if (state.lastStatus && state.fingerprint) {
+    return `[source-worker] ${sourceId}: skipped (${state.lastStatus})`;
+  }
+  return `[source-worker] ${sourceId}: state updated`;
+}
+
+function sameStringArray(left: readonly string[] | undefined, right: readonly string[] | undefined): boolean {
+  const a = left ?? [];
+  const b = right ?? [];
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}

--- a/packages/cli/src/source-worker-runner.ts
+++ b/packages/cli/src/source-worker-runner.ts
@@ -21,8 +21,13 @@ export interface SourceWorkerHandlerContext<TSource extends SourceWorkerSource =
 }
 
 export interface SourceWorkerHandlerModule<TSource extends SourceWorkerSource = SourceWorkerSource> {
+  /**
+   * Build the source-specific worker hooks. getFingerprint must be stable for
+   * unchanged source content and must change when source content that affects
+   * emitted triples/assets changes.
+   */
   createSourceWorkerDeps(context: SourceWorkerHandlerContext<TSource>): Promise<
-  Pick<SourceWorkerDeps<TSource>, 'getFingerprint' | 'processSource'>
+    Pick<SourceWorkerDeps<TSource>, 'getFingerprint' | 'processSource'>
   > | Pick<SourceWorkerDeps<TSource>, 'getFingerprint' | 'processSource'>;
 }
 

--- a/packages/cli/src/source-worker-runner.ts
+++ b/packages/cli/src/source-worker-runner.ts
@@ -88,6 +88,7 @@ export async function runConfiguredSourceWorker(configPath: string, options: { o
 async function loadHandlerModule<TSource extends SourceWorkerSource>(
   config: SourceWorkerConfig<TSource>,
 ): Promise<SourceWorkerHandlerModule<TSource>> {
+  // handlerModule is trusted operator code selected by the sensitive worker config.
   const namespace = await import(pathToFileURL(config.handlerModule).href);
   const candidate = config.handlerExport
     ? namespace[config.handlerExport]

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -267,6 +267,21 @@ describe('resolveChainConfig (field-level merge)', () => {
     expect(merged?.chainId).toBe(fullNetworkChain.chainId);
   });
 
+  it('merges tokenAddress with operator override precedence', () => {
+    const networkTokenAddress = '0xNETWORKTOKEN000000000000000000000000000';
+    const operatorTokenAddress = '0xOPERATORTOKEN00000000000000000000000000';
+
+    expect(resolveChainConfig(
+      {},
+      { chain: { ...fullNetworkChain, tokenAddress: networkTokenAddress } },
+    )?.tokenAddress).toBe(networkTokenAddress);
+
+    expect(resolveChainConfig(
+      { chain: { tokenAddress: operatorTokenAddress } },
+      { chain: { ...fullNetworkChain, tokenAddress: networkTokenAddress } },
+    )?.tokenAddress).toBe(operatorTokenAddress);
+  });
+
   it('returns a partial block when only config supplies fields (no network)', () => {
     const merged = resolveChainConfig(
       { chain: { rpcUrl: 'https://standalone.example/rpc' } },

--- a/packages/cli/test/source-worker-daemon-client.test.ts
+++ b/packages/cli/test/source-worker-daemon-client.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDaemonAsyncLiftJobClient, createDaemonSharedMemoryWriteClient } from '../src/source-worker-daemon-client.js';
+
+const originalFetch = globalThis.fetch;
+
+describe('source worker daemon client', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn(async (input: any) => {
+      const url = String(input);
+      if (url.includes('/api/shared-memory/write')) {
+        return new Response(JSON.stringify({ shareOperationId: 'swm-1' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.includes('/api/publisher/enqueue')) {
+        return new Response(JSON.stringify({ jobId: 'job-1' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.includes('/api/publisher/job')) {
+        return new Response(JSON.stringify({ job: { status: 'finalized' } }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 404, headers: { 'Content-Type': 'application/json' } });
+    }) as any;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('writes shared memory and enqueues/polls async jobs', async () => {
+    const share = createDaemonSharedMemoryWriteClient('http://127.0.0.1:9200', 'token');
+    const jobs = createDaemonAsyncLiftJobClient('http://127.0.0.1:9200', 'token');
+    await expect(share.share('cg', [{ subject: 'urn:s', predicate: 'urn:p', object: '"o"' }])).resolves.toEqual({ shareOperationId: 'swm-1' });
+    await expect(jobs.lift({
+      swmId: 'swm',
+      shareOperationId: 'swm-1',
+      roots: ['urn:s'],
+      contextGraphId: 'cg',
+      namespace: 'ns',
+      scope: 'scope',
+      transitionType: 'CREATE',
+      authority: { type: 'owner', proofRef: 'proof' },
+    })).resolves.toBe('job-1');
+    await expect(jobs.getJobStatus('job-1')).resolves.toBe('finalized');
+  });
+});

--- a/packages/cli/test/source-worker-runner.test.ts
+++ b/packages/cli/test/source-worker-runner.test.ts
@@ -1,0 +1,151 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runConfiguredSourceWorker } from '../src/source-worker-runner.js';
+
+declare global {
+  var __sourceWorkerRunnerContext: any;
+  var __sourceWorkerRunnerProcessed: any;
+}
+
+const originalFetch = globalThis.fetch;
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  delete globalThis.__sourceWorkerRunnerContext;
+  delete globalThis.__sourceWorkerRunnerProcessed;
+  vi.restoreAllMocks();
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('source worker runner', () => {
+  it('dynamically imports the handler and wires daemon clients into its context', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const dir = await mkdtemp(join(tmpdir(), 'source-worker-runner-'));
+    cleanup.push(dir);
+    const configPath = join(dir, 'worker.json');
+    const handlerPath = join(dir, 'handler.mjs');
+    const statePath = join(dir, 'state.json');
+    const requests: Array<{ url: string; headers: Record<string, string>; body: any }> = [];
+
+    await writeFile(handlerPath, `
+export const namedHandler = {
+  createSourceWorkerDeps(context) {
+    globalThis.__sourceWorkerRunnerContext = {
+      daemonUrl: context.config.daemonUrl,
+      daemonToken: context.config.daemonToken,
+      stateFile: context.config.stateFile,
+      sourceIds: context.config.sources.map((source) => source.id),
+      hasSharedMemory: typeof context.sharedMemory.share === 'function',
+      hasAsyncLift: typeof context.asyncLift.lift === 'function',
+    };
+    return {
+      getFingerprint: async (source) => \`fp-\${source.version}\`,
+      processSource: async (source, fingerprint) => {
+        const share = await context.sharedMemory.share('cg-1', [
+          { subject: 'urn:src', predicate: 'urn:hasId', object: \`"\${source.id}"\` },
+        ], { subGraphName: 'sg-1' });
+        const jobId = await context.asyncLift.lift({
+          swmId: 'swm-1',
+          shareOperationId: share.shareOperationId,
+          roots: ['urn:src'],
+          contextGraphId: 'cg-1',
+          namespace: 'ns',
+          scope: 'scope',
+          transitionType: 'CREATE',
+          authority: { type: 'owner', proofRef: 'proof' },
+        });
+        globalThis.__sourceWorkerRunnerProcessed = {
+          sourceId: source.id,
+          fingerprint,
+          shareOperationId: share.shareOperationId,
+          jobId,
+        };
+        return {
+          sourceId: source.id,
+          skipped: false,
+          jobIds: [jobId],
+          jobStatuses: { [jobId]: 'queued' },
+          status: 'queued',
+          nextState: {
+            fingerprint,
+            lastStatus: 'queued',
+            lastJobIds: [jobId],
+            lastJobStatuses: { [jobId]: 'queued' },
+          },
+        };
+      },
+    };
+  },
+};
+`, 'utf8');
+    await writeFile(configPath, JSON.stringify({
+      pollIntervalMs: 1,
+      stateFile: 'state.json',
+      daemonUrl: 'http://127.0.0.1:9200/',
+      daemonToken: 'secret-token',
+      handlerModule: 'handler.mjs',
+      handlerExport: 'namedHandler',
+      sources: [{ id: 'src-1', version: 'v1' }],
+    }), 'utf8');
+
+    globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string>;
+      requests.push({
+        url,
+        headers,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (url.endsWith('/api/shared-memory/write')) {
+        return new Response(JSON.stringify({ shareOperationId: 'swm-1' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.endsWith('/api/publisher/enqueue')) {
+        return new Response(JSON.stringify({ jobId: 'job-1' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ error: 'unexpected request' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+    }) as any;
+
+    await runConfiguredSourceWorker(configPath, { once: true });
+
+    expect(globalThis.__sourceWorkerRunnerContext).toMatchObject({
+      daemonUrl: 'http://127.0.0.1:9200',
+      daemonToken: 'secret-token',
+      stateFile: statePath,
+      sourceIds: ['src-1'],
+      hasSharedMemory: true,
+      hasAsyncLift: true,
+    });
+    expect(globalThis.__sourceWorkerRunnerProcessed).toEqual({
+      sourceId: 'src-1',
+      fingerprint: 'fp-v1',
+      shareOperationId: 'swm-1',
+      jobId: 'job-1',
+    });
+    expect(requests.map((request) => request.url)).toEqual([
+      'http://127.0.0.1:9200/api/shared-memory/write',
+      'http://127.0.0.1:9200/api/publisher/enqueue',
+    ]);
+    expect(requests.every((request) => request.headers.Authorization === 'Bearer secret-token')).toBe(true);
+    expect(requests[0].body).toMatchObject({
+      contextGraphId: 'cg-1',
+      subGraphName: 'sg-1',
+      quads: [{ subject: 'urn:src', predicate: 'urn:hasId', object: '"src-1"' }],
+    });
+    expect(requests[1].body).toMatchObject({
+      swmId: 'swm-1',
+      shareOperationId: 'swm-1',
+      contextGraphId: 'cg-1',
+    });
+
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    expect(state.sources['src-1']).toMatchObject({
+      fingerprint: 'fp-v1',
+      lastStatus: 'queued',
+      lastJobIds: ['job-1'],
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,3 +64,4 @@ export {
   type ExtractionPipeline,
   ExtractionPipelineRegistry,
 } from './extraction-pipeline.js';
+export * from './transducers.js';

--- a/packages/core/src/transducers.ts
+++ b/packages/core/src/transducers.ts
@@ -1,0 +1,192 @@
+export interface SourceAdapterContext {
+  dataset: string;
+  sourceType: string;
+  sourceRef?: string;
+}
+
+export interface SourceRecord {
+  dataset: string;
+  sourceTable: string;
+  values: Record<string, unknown>;
+  rowNumber?: number;
+  sourceRef?: string;
+}
+
+export interface SourceAdapterResult<TRow = SourceRecord> {
+  rows: TRow[];
+  errors?: string[];
+  warnings?: string[];
+}
+
+export interface SourceAdapter<TInput = unknown, TRow = SourceRecord> {
+  read(
+    input: TInput,
+    context: SourceAdapterContext,
+  ): Promise<SourceAdapterResult<TRow>> | SourceAdapterResult<TRow>;
+}
+
+export interface NormalizedRecord extends SourceRecord {
+  keys: Record<string, string | number | boolean | null>;
+}
+
+export interface NormalizerContext {
+  dataset: string;
+}
+
+export interface NormalizeResult<TRecord = NormalizedRecord> {
+  records: TRecord[];
+  errors?: string[];
+  warnings?: string[];
+}
+
+export interface Normalizer<TRow = SourceRecord, TRecord = NormalizedRecord> {
+  normalize(
+    rows: TRow[],
+    context: NormalizerContext,
+  ): Promise<NormalizeResult<TRecord>> | NormalizeResult<TRecord>;
+}
+
+export interface TransformContext<TRecord = NormalizedRecord> {
+  dataset: string;
+  record: TRecord;
+}
+
+export type Transform<TRecord = NormalizedRecord> = (
+  value: unknown,
+  context: TransformContext<TRecord>,
+) => unknown;
+
+export type TransformRegistry<TRecord = NormalizedRecord> = Record<string, Transform<TRecord>>;
+
+export interface FieldMapping {
+  sourceField: string;
+  targetPredicate: string;
+  required?: boolean;
+  transform?: string;
+}
+
+export interface IdentityContext<TRecord = NormalizedRecord> {
+  dataset: string;
+  classIri: string;
+  record: TRecord;
+}
+
+export interface IdentityStrategy<TRecord = NormalizedRecord> {
+  keyFields: string[];
+  buildId(record: TRecord, context: IdentityContext<TRecord>): string;
+}
+
+export interface RelationRule {
+  predicate: string;
+  sourceDataset: string;
+  targetDataset: string;
+  sourceField: string;
+  targetField: string;
+  many?: boolean;
+}
+
+export interface DatasetMappingSpec<TRecord = NormalizedRecord> {
+  dataset: string;
+  classIri: string;
+  description?: string;
+  identity: IdentityStrategy<TRecord>;
+  fieldMappings: FieldMapping[];
+  relationRules?: RelationRule[];
+}
+
+export interface AssetPartitionQuad {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph?: string;
+}
+
+export interface AssetPartitionAsset {
+  rootEntity: string;
+  quads: AssetPartitionQuad[];
+}
+
+export interface AssetPartitionContext<TNode = Record<string, unknown>> {
+  dataset: string;
+  contextGraphId: string;
+  nodes: readonly TNode[];
+  quads: readonly AssetPartitionQuad[];
+}
+
+export interface AssetPartitionStrategy<TNode = Record<string, unknown>> {
+  partition(
+    context: AssetPartitionContext<TNode>,
+  ): Promise<AssetPartitionAsset[]> | AssetPartitionAsset[];
+}
+
+export interface DatasetTransducerContext<TRecord = NormalizedRecord> {
+  dataset: string;
+  mappingSpec: DatasetMappingSpec<TRecord>;
+}
+
+export interface TransduceResult<TRecord = NormalizedRecord, TNode = Record<string, unknown>> {
+  records: TRecord[];
+  nodes: TNode[];
+  quads: AssetPartitionQuad[];
+  assets: AssetPartitionAsset[];
+  errors?: string[];
+  warnings?: string[];
+}
+
+export interface DatasetTransducer<TInput = unknown, TRecord = NormalizedRecord, TNode = Record<string, unknown>> {
+  transduce(
+    input: TInput,
+    context: DatasetTransducerContext<TRecord>,
+  ): Promise<TransduceResult<TRecord, TNode>> | TransduceResult<TRecord, TNode>;
+}
+
+export function defineSourceAdapter<TInput, TRow>(adapter: SourceAdapter<TInput, TRow>): SourceAdapter<TInput, TRow> {
+  return adapter;
+}
+
+export function readWithSourceAdapter<TInput, TRow>(
+  adapter: SourceAdapter<TInput, TRow>,
+  input: TInput,
+  context: SourceAdapterContext,
+): Promise<SourceAdapterResult<TRow>> | SourceAdapterResult<TRow> {
+  return adapter.read(input, context);
+}
+
+export function defineNormalizer<TRow, TRecord>(normalizer: Normalizer<TRow, TRecord>): Normalizer<TRow, TRecord> {
+  return normalizer;
+}
+
+export function normalizeWith<TRow, TRecord>(
+  normalizer: Normalizer<TRow, TRecord>,
+  rows: TRow[],
+  context: NormalizerContext,
+): Promise<NormalizeResult<TRecord>> | NormalizeResult<TRecord> {
+  return normalizer.normalize(rows, context);
+}
+
+export function defineAssetPartitionStrategy<TNode>(
+  strategy: AssetPartitionStrategy<TNode>,
+): AssetPartitionStrategy<TNode> {
+  return strategy;
+}
+
+export function partitionAssetsWith<TNode>(
+  strategy: AssetPartitionStrategy<TNode>,
+  context: AssetPartitionContext<TNode>,
+) {
+  return strategy.partition(context);
+}
+
+export function defineDatasetTransducer<TInput, TRecord, TNode>(
+  transducer: DatasetTransducer<TInput, TRecord, TNode>,
+): DatasetTransducer<TInput, TRecord, TNode> {
+  return transducer;
+}
+
+export function transduceWith<TInput, TRecord, TNode>(
+  transducer: DatasetTransducer<TInput, TRecord, TNode>,
+  input: TInput,
+  context: DatasetTransducerContext<TRecord>,
+): Promise<TransduceResult<TRecord, TNode>> | TransduceResult<TRecord, TNode> {
+  return transducer.transduce(input, context);
+}

--- a/packages/core/test/transducers.test.ts
+++ b/packages/core/test/transducers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defineSourceAdapter,
+  readWithSourceAdapter,
+  defineNormalizer,
+  normalizeWith,
+  defineDatasetTransducer,
+  transduceWith,
+} from '../src/transducers.js';
+
+describe('core transducer helpers', () => {
+  it('adapts source, normalize, and transduce helpers generically', async () => {
+    const source = defineSourceAdapter<string, { dataset: string; sourceTable: string; values: Record<string, unknown> }>({
+      read(input, context) {
+        return { rows: [{ dataset: context.dataset, sourceTable: context.sourceType, values: { raw: input } }] };
+      },
+    });
+    const sourceRows = await readWithSourceAdapter(source, 'a', { dataset: 'demo', sourceType: 'csv' });
+
+    const normalizer = defineNormalizer<{ dataset: string; sourceTable: string; values: Record<string, unknown> }, { dataset: string; sourceTable: string; values: Record<string, unknown>; keys: Record<string, string | number | boolean | null> }>({
+      normalize(rows) {
+        return { records: rows.map((row) => ({ ...row, keys: { raw: String(row.values.raw ?? '') } })) };
+      },
+    });
+    const normalized = await normalizeWith(normalizer, sourceRows.rows, { dataset: 'demo' });
+
+    const transducer = defineDatasetTransducer<typeof normalized.records, typeof normalized.records[number], { '@id': string }>({
+      transduce(input) {
+        return {
+          records: input,
+          nodes: [{ '@id': 'urn:test:1' }],
+          quads: [{ subject: 'urn:test:1', predicate: 'urn:p', object: '"a"' }],
+          assets: [{ rootEntity: 'urn:test:1', quads: [{ subject: 'urn:test:1', predicate: 'urn:p', object: '"a"' }] }],
+        };
+      },
+    });
+    const result = transduceWith(transducer, normalized.records, {
+      dataset: 'demo',
+      mappingSpec: {
+        dataset: 'demo',
+        classIri: 'urn:test:Class',
+        identity: { keyFields: ['raw'], buildId: () => 'urn:test:1' },
+        fieldMappings: [],
+      },
+    });
+
+    expect(result).toEqual({
+      records: normalized.records,
+      nodes: [{ '@id': 'urn:test:1' }],
+      quads: [{ subject: 'urn:test:1', predicate: 'urn:p', object: '"a"' }],
+      assets: [{ rootEntity: 'urn:test:1', quads: [{ subject: 'urn:test:1', predicate: 'urn:p', object: '"a"' }] }],
+    });
+  });
+});

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -396,6 +396,27 @@ export const publishTriples = async (contextGraphId: string, quads: any[]) => {
   return post<any>('/api/shared-memory/publish', { contextGraphId, selection: 'all', clearAfter: true });
 };
 
+export const writeSharedMemory = (
+  contextGraphId: string,
+  quads: Array<{ subject: string; predicate: string; object: string; graph?: string }>,
+  opts: { subGraphName?: string; localOnly?: boolean } = {},
+) =>
+  post<any>('/api/shared-memory/write', {
+    contextGraphId,
+    quads,
+    ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
+    ...(opts.localOnly !== undefined ? { localOnly: opts.localOnly } : {}),
+  });
+
+export const writeProfileQueryCatalog = (
+  contextGraphId: string,
+  quads: Array<{ subject: string; predicate: string; object: string; graph?: string }>,
+) =>
+  post<any>('/api/profile/query-catalog/write', {
+    contextGraphId,
+    quads,
+  });
+
 // --- Assertions (WM objects) ---
 
 export interface AssertionInfo {

--- a/packages/node-ui/src/ui/hooks/useProjectProfile.ts
+++ b/packages/node-ui/src/ui/hooks/useProjectProfile.ts
@@ -93,10 +93,24 @@ export interface FilterChip {
 export interface SavedQuery {
   slug: string;
   subGraph: string;
+  catalogSlug: string;
+  catalogName: string;
+  catalogDescription?: string;
+  catalogRank: number;
   name: string;
   description?: string;
   sparql: string;
   resultColumn: string;
+  rank: number;
+}
+
+export interface QueryCatalog {
+  slug: string;
+  subGraph: string;
+  name: string;
+  description?: string;
+  rank: number;
+  queries: SavedQuery[];
 }
 
 export interface ProjectProfile {
@@ -109,6 +123,7 @@ export interface ProjectProfile {
   typeBindings: EntityTypeBinding[];
   views: ViewConfig[];
   filterChips: FilterChip[];
+  queryCatalogs: QueryCatalog[];
   savedQueries: SavedQuery[];
   loading: boolean;
   error?: string;
@@ -116,6 +131,7 @@ export interface ProjectProfile {
   forType: (typeIri: string) => EntityTypeBinding | undefined;
   view: (slug: string) => ViewConfig | undefined;
   chipsFor: (subGraphSlug: string) => FilterChip[];
+  savedQueryCatalogsFor: (subGraphSlug: string) => QueryCatalog[];
   savedQueriesFor: (subGraphSlug: string) => SavedQuery[];
 }
 
@@ -235,21 +251,147 @@ WHERE {
 GROUP BY ?chip ?subGraph ?type ?predicate ?label`;
 }
 
+function buildQueryCatalogsQuery(contextGraphId: string): string {
+  return `PREFIX prof: <${PROFILE_NS}>
+PREFIX schema: <http://schema.org/>
+SELECT ?catalog ?subGraph ?name ?description ?rank
+WHERE {
+  GRAPH ?g {
+    ?catalog a prof:QueryCatalog ;
+             prof:forSubGraph ?subGraph .
+    OPTIONAL { ?catalog prof:displayName ?name }
+    OPTIONAL { ?catalog schema:description ?description }
+    OPTIONAL { ?catalog prof:rank ?rank }
+  }
+  ${metaGraphFilter(contextGraphId)}
+}`;
+}
+
 function buildSavedQueriesQuery(contextGraphId: string): string {
   return `PREFIX prof: <${PROFILE_NS}>
 PREFIX schema: <http://schema.org/>
-SELECT ?q ?subGraph ?name ?description ?sparql ?column
+SELECT ?q ?subGraph ?catalog ?name ?description ?sparql ?column ?rank
 WHERE {
   GRAPH ?g {
     ?q a prof:SavedQuery ;
        prof:forSubGraph ?subGraph ;
        prof:sparqlQuery ?sparql .
+    OPTIONAL { ?q prof:inCatalog ?catalog }
     OPTIONAL { ?q prof:displayName ?name }
     OPTIONAL { ?q schema:description ?description }
     OPTIONAL { ?q prof:resultColumn ?column }
+    OPTIONAL { ?q prof:rank ?rank }
   }
   ${metaGraphFilter(contextGraphId)}
 }`;
+}
+
+interface QueryCatalogRowShape extends Record<string, unknown> {}
+interface SavedQueryRowShape extends Record<string, unknown> {}
+
+export function buildQueryCatalogState(
+  catalogRows: readonly QueryCatalogRowShape[],
+  queryRows: readonly SavedQueryRowShape[],
+): {
+  queryCatalogs: QueryCatalog[];
+  savedQueries: SavedQuery[];
+  catalogsBySubGraph: Map<string, QueryCatalog[]>;
+  queriesBySubGraph: Map<string, SavedQuery[]>;
+} {
+  const catalogsByUri = new Map<string, QueryCatalog>();
+
+  for (const row of catalogRows) {
+    const catalogIri = stripIri(row.catalog);
+    if (!catalogIri) continue;
+    const slug = catalogIri.split(':catalog:').pop() ?? catalogIri;
+    catalogsByUri.set(catalogIri, {
+      slug,
+      subGraph: stripLiteral(row.subGraph),
+      name: stripLiteral(row.name) || slug,
+      description: stripLiteral(row.description) || undefined,
+      rank: parseInt10(row.rank) || 99,
+      queries: [],
+    });
+  }
+
+  const queries: SavedQuery[] = queryRows
+    .map(row => {
+      const qIri = stripIri(row.q);
+      const slug = qIri.split(':query:').pop() ?? qIri;
+      const subGraph = stripLiteral(row.subGraph);
+      const catalogIri = stripIri(row.catalog);
+      const catalog = catalogIri ? catalogsByUri.get(catalogIri) : undefined;
+      const implicitCatalogSlug = `default:${subGraph}`;
+      return {
+        slug,
+        subGraph,
+        catalogSlug: catalog?.slug ?? implicitCatalogSlug,
+        catalogName: catalog?.name ?? 'Queries',
+        catalogDescription: catalog?.description,
+        catalogRank: catalog?.rank ?? 999,
+        name: stripLiteral(row.name) || slug,
+        description: stripLiteral(row.description) || undefined,
+        sparql: stripLiteral(row.sparql),
+        resultColumn: stripLiteral(row.column) || '',
+        rank: parseInt10(row.rank) || 99,
+      };
+    })
+    .filter(q => q.subGraph && q.sparql)
+    .sort((a, b) =>
+      a.subGraph.localeCompare(b.subGraph)
+      || a.catalogRank - b.catalogRank
+      || a.catalogName.localeCompare(b.catalogName)
+      || a.rank - b.rank
+      || a.name.localeCompare(b.name),
+    );
+
+  const catalogsByComposite = new Map<string, QueryCatalog>();
+  for (const catalog of catalogsByUri.values()) {
+    catalogsByComposite.set(`${catalog.subGraph}|${catalog.slug}`, { ...catalog, queries: [] });
+  }
+
+  for (const query of queries) {
+    const key = `${query.subGraph}|${query.catalogSlug}`;
+    const existing = catalogsByComposite.get(key);
+    if (existing) {
+      existing.queries.push(query);
+      continue;
+    }
+    catalogsByComposite.set(key, {
+      slug: query.catalogSlug,
+      subGraph: query.subGraph,
+      name: query.catalogName,
+      description: query.catalogDescription,
+      rank: query.catalogRank,
+      queries: [query],
+    });
+  }
+
+  const queryCatalogs = Array.from(catalogsByComposite.values())
+    .filter(catalog => catalog.queries.length > 0)
+    .map(catalog => ({
+      ...catalog,
+      queries: [...catalog.queries].sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name)),
+    }))
+    .sort((a, b) =>
+      a.subGraph.localeCompare(b.subGraph)
+      || a.rank - b.rank
+      || a.name.localeCompare(b.name),
+    );
+
+  const catalogsBySubGraph = new Map<string, QueryCatalog[]>();
+  const queriesBySubGraph = new Map<string, SavedQuery[]>();
+  for (const catalog of queryCatalogs) {
+    const nextCatalogs = catalogsBySubGraph.get(catalog.subGraph) ?? [];
+    nextCatalogs.push(catalog);
+    catalogsBySubGraph.set(catalog.subGraph, nextCatalogs);
+
+    const nextQueries = queriesBySubGraph.get(catalog.subGraph) ?? [];
+    nextQueries.push(...catalog.queries);
+    queriesBySubGraph.set(catalog.subGraph, nextQueries);
+  }
+
+  return { queryCatalogs, savedQueries: queries, catalogsBySubGraph, queriesBySubGraph };
 }
 
 function buildTypeBindingsQuery(contextGraphId: string): string {
@@ -312,11 +454,13 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
   const [typeBindings, setTypeBindings] = useState<EntityTypeBinding[]>([]);
   const [views, setViews] = useState<ViewConfig[]>([]);
   const [filterChips, setFilterChips] = useState<FilterChip[]>([]);
+  const [queryCatalogs, setQueryCatalogs] = useState<QueryCatalog[]>([]);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
   const typeIndexRef = useRef<Map<string, EntityTypeBinding>>(new Map());
   const subIndexRef = useRef<Map<string, SubGraphBinding>>(new Map());
   const viewIndexRef = useRef<Map<string, ViewConfig>>(new Map());
   const chipsBySgRef = useRef<Map<string, FilterChip[]>>(new Map());
+  const queryCatalogsBySgRef = useRef<Map<string, QueryCatalog[]>>(new Map());
   const queriesBySgRef = useRef<Map<string, SavedQuery[]>>(new Map());
 
   useEffect(() => {
@@ -330,12 +474,13 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
       setLoading(true);
       setError(undefined);
       try {
-        const [rootRows, sgRows, typeRows, viewRows, chipRows, queryRows] = await Promise.all([
+        const [rootRows, sgRows, typeRows, viewRows, chipRows, catalogRows, queryRows] = await Promise.all([
           runProjectQuery(buildProfileRootQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildSubGraphBindingsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildTypeBindingsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildViewConfigsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildFilterChipsQuery(contextGraphId), contextGraphId).catch(() => []),
+          runProjectQuery(buildQueryCatalogsQuery(contextGraphId), contextGraphId).catch(() => []),
           runProjectQuery(buildSavedQueriesQuery(contextGraphId), contextGraphId).catch(() => []),
         ]);
         if (cancelled) return;
@@ -432,28 +577,11 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
         }
         chipsBySgRef.current = chipsBySg;
 
-        const queries: SavedQuery[] = queryRows
-          .map(row => {
-            const qIri = stripIri(row.q);
-            const slug = qIri.split(':query:').pop() ?? qIri;
-            return {
-              slug,
-              subGraph: stripLiteral(row.subGraph),
-              name: stripLiteral(row.name) || slug,
-              description: stripLiteral(row.description) || undefined,
-              sparql: stripLiteral(row.sparql),
-              resultColumn: stripLiteral(row.column) || '',
-            };
-          })
-          .filter(q => q.subGraph && q.sparql);
-        setSavedQueries(queries);
-        const queriesBySg = new Map<string, SavedQuery[]>();
-        for (const q of queries) {
-          const list = queriesBySg.get(q.subGraph) ?? [];
-          list.push(q);
-          queriesBySg.set(q.subGraph, list);
-        }
-        queriesBySgRef.current = queriesBySg;
+        const queryCatalogState = buildQueryCatalogState(catalogRows, queryRows);
+        setQueryCatalogs(queryCatalogState.queryCatalogs);
+        setSavedQueries(queryCatalogState.savedQueries);
+        queryCatalogsBySgRef.current = queryCatalogState.catalogsBySubGraph;
+        queriesBySgRef.current = queryCatalogState.queriesBySubGraph;
       } catch (err: any) {
         if (!cancelled) setError(err?.message ?? String(err));
       } finally {
@@ -480,6 +608,10 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
     (slug: string) => chipsBySgRef.current.get(slug) ?? [],
     [],
   );
+  const savedQueryCatalogsFor = useCallback(
+    (slug: string) => queryCatalogsBySgRef.current.get(slug) ?? [],
+    [],
+  );
   const savedQueriesFor = useCallback(
     (slug: string) => queriesBySgRef.current.get(slug) ?? [],
     [],
@@ -495,6 +627,7 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
     typeBindings,
     views,
     filterChips,
+    queryCatalogs,
     savedQueries,
     loading,
     error,
@@ -502,6 +635,7 @@ export function useProjectProfile(contextGraphId: string | undefined): ProjectPr
     forType,
     view,
     chipsFor,
+    savedQueryCatalogsFor,
     savedQueriesFor,
   };
 }
@@ -512,4 +646,3 @@ export const ProjectProfileContext = React.createContext<ProjectProfile | null>(
 export function useProjectProfileContext(): ProjectProfile | null {
   return useContext(ProjectProfileContext);
 }
-

--- a/packages/node-ui/src/ui/styles.css
+++ b/packages/node-ui/src/ui/styles.css
@@ -1554,6 +1554,41 @@ button:focus:not(:focus-visible) { outline: none; }
   color: var(--text-primary);
 }
 .v10-mlv-query-input:focus { border-color: var(--border-strong); }
+.v10-cg-query-view { max-width: 1180px; }
+.v10-cg-query-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: stretch;
+  margin-bottom: 16px;
+}
+.v10-cg-query-textarea {
+  min-height: 156px;
+  resize: vertical;
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  color: var(--text-primary);
+}
+.v10-cg-query-textarea:focus { border-color: var(--border-strong); outline: none; }
+.v10-cg-query-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.v10-cg-query-catalog {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 8px 0 14px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
 .v10-mlv-run-btn {
   padding: 8px 16px;
   border-radius: 6px;
@@ -1565,6 +1600,52 @@ button:focus:not(:focus-visible) { outline: none; }
   transition: all 0.15s;
 }
 .v10-mlv-run-btn:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.v10-mlv-save-btn {
+  padding: 8px 14px;
+  border-radius: 6px;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  font-size: 12px;
+  font-weight: 500;
+  color: #7dd3fc;
+  transition: all 0.15s;
+}
+.v10-mlv-save-btn:hover {
+  border-color: rgba(56, 189, 248, 0.65);
+  color: #bae6fd;
+}
+.v10-cg-query-save-panel {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.6fr) minmax(220px, 1fr) auto;
+  gap: 10px;
+  align-items: end;
+  padding: 12px;
+  margin: -4px 0 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+.v10-cg-query-save-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.v10-cg-query-save-field span {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.v10-cg-query-save-field input {
+  height: 34px;
+  font-family: var(--font-sans);
+}
+.v10-cg-query-save-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
 .v10-mlv-status { font-size: 12px; color: var(--text-tertiary); padding: 8px 0; }
 .v10-mlv-empty { padding: 32px 0; text-align: center; }
 .v10-mlv-empty p { font-size: 12px; color: var(--text-tertiary); }
@@ -1596,7 +1677,11 @@ button:focus:not(:focus-visible) { outline: none; }
 @media (max-width: 900px) {
   .v10-vm-search-header { flex-direction: column; align-items: stretch; }
   .v10-vm-search-controls,
-  .v10-mlv-query-bar { grid-template-columns: 1fr; display: flex; flex-direction: column; }
+  .v10-mlv-query-bar,
+  .v10-cg-query-editor { grid-template-columns: 1fr; display: flex; flex-direction: column; }
+  .v10-cg-query-actions { flex-direction: row; }
+  .v10-cg-query-save-panel { grid-template-columns: 1fr; }
+  .v10-cg-query-save-actions { justify-content: flex-end; }
 }
 
 /* ── Assertion List (WM → SWM) ── */
@@ -2942,6 +3027,7 @@ body.light .v10-me-graph-legend { background: rgba(255,255,255,0.8); }
 .v10-layer-switch-btn:hover { color: var(--text-secondary); background: var(--bg-hover); }
 .v10-layer-switch-btn.active { color: var(--text-primary); }
 .v10-layer-switch-btn.active[data-layer="overview"] { border-bottom-color: var(--text-secondary); }
+.v10-layer-switch-btn.active[data-layer="query"] { border-bottom-color: #38bdf8; }
 .v10-layer-switch-btn.active[data-layer="wm"] { border-bottom-color: #64748b; }
 .v10-layer-switch-btn.active[data-layer="swm"] { border-bottom-color: #f59e0b; }
 .v10-layer-switch-btn.active[data-layer="vm"] { border-bottom-color: #22c55e; }

--- a/packages/node-ui/src/ui/views/ProjectView.tsx
+++ b/packages/node-ui/src/ui/views/ProjectView.tsx
@@ -20,6 +20,7 @@ import {
   PendingJoinRequestsBar,
   MemoryStrip,
   SubGraphOverviewGrid,
+  ContextGraphQueryView,
   LayerDetailView,
   ProvenanceBar,
 } from './project/components.js';
@@ -248,6 +249,10 @@ export function ProjectView({ contextGraphId }: ProjectViewProps) {
           onNodeClick={handleNodeClick}
           onSelectSubGraph={handleSelectSubGraph}
         />
+      )}
+
+      {!activeSubGraph && activeLayer === 'query' && !selectedEntity && (
+        <ContextGraphQueryView contextGraphId={contextGraphId} />
       )}
 
       {/* Layer Detail Views */}

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -2356,7 +2356,7 @@ export function SubGraphDetailView({
   const profile = useProjectProfileContext();
   const binding = profile?.forSubGraph(slug);
   const chips = profile?.chipsFor(slug) ?? [];
-  const savedQueries = profile?.savedQueriesFor(slug) ?? [];
+  const queryCatalogs = profile?.savedQueryCatalogsFor(slug) ?? [];
   const timelinePredicate = binding?.timelinePredicate;
 
   const [activeTab, setActiveTab] = useState<SubGraphTab>('items');
@@ -2601,27 +2601,38 @@ export function SubGraphDetailView({
         />
       </div>
 
-      {savedQueries.length > 0 && (
+      {queryCatalogs.length > 0 && (
         <div className="v10-subgraph-savedqueries">
-          <span className="v10-subgraph-savedqueries-label">Saved queries</span>
-          {savedQueries.map(q => {
-            const isActive = activeQuerySlug === q.slug;
-            return (
-              <button
-                key={q.slug}
-                type="button"
-                className={`v10-subgraph-savedquery${isActive ? ' active' : ''}`}
-                onClick={() => isActive ? clearQuery() : runQuery(q)}
-                title={q.description || q.name}
-                disabled={queryLoading && !isActive}
+          <span className="v10-subgraph-savedqueries-label">Query catalog</span>
+          {queryCatalogs.map(catalog => (
+            <React.Fragment key={catalog.slug}>
+              <span
+                className="v10-subgraph-savedqueries-label"
+                title={catalog.description || catalog.name}
+                style={{ marginLeft: 8, opacity: 0.8 }}
               >
-                <span className="v10-subgraph-savedquery-glyph">
-                  {queryLoading && isActive ? '…' : isActive ? '✓' : '◎'}
-                </span>
-                {q.name}
-              </button>
-            );
-          })}
+                {catalog.name}
+              </span>
+              {catalog.queries.map(q => {
+                const isActive = activeQuerySlug === q.slug;
+                return (
+                  <button
+                    key={q.slug}
+                    type="button"
+                    className={`v10-subgraph-savedquery${isActive ? ' active' : ''}`}
+                    onClick={() => isActive ? clearQuery() : runQuery(q)}
+                    title={q.description || q.name}
+                    disabled={queryLoading && !isActive}
+                  >
+                    <span className="v10-subgraph-savedquery-glyph">
+                      {queryLoading && isActive ? '…' : isActive ? '✓' : '◎'}
+                    </span>
+                    {q.name}
+                  </button>
+                );
+              })}
+            </React.Fragment>
+          ))}
           {queryError && (
             <span className="v10-subgraph-savedquery-error" title={queryError}>✕ query failed</span>
           )}
@@ -2763,4 +2774,3 @@ export function SubGraphDetailView({
     </div>
   );
 }
-

--- a/packages/node-ui/src/ui/views/project/components.tsx
+++ b/packages/node-ui/src/ui/views/project/components.tsx
@@ -6,6 +6,7 @@ import {
   listJoinRequests, approveJoinRequest, rejectJoinRequest,
   listParticipants, listAssertions, promoteAssertion,
   publishSharedMemory, executeQuery,
+  writeProfileQueryCatalog,
   fetchSubGraphs,
   type PendingJoinRequest, type PublishResult, type SubGraphInfo,
 } from '../../api.js';
@@ -17,6 +18,7 @@ import {
 } from '../../hooks/useMemoryEntities.js';
 import {
   useProjectProfile, ProjectProfileContext, useProjectProfileContext,
+  type QueryCatalog,
 } from '../../hooks/useProjectProfile.js';
 import {
   useAgents, AgentsContext, useAgentsContext,
@@ -81,6 +83,13 @@ export function LayerSwitcher({ active, counts, onSwitch, onShare, onImport, onR
         onClick={() => onSwitch('graph-overview')}
       >
         <span className="v10-layer-switch-icon">⌬</span> Graph Overview
+      </button>
+      <button
+        className={`v10-layer-switch-btn ${active === 'query' ? 'active' : ''}`}
+        data-layer="query"
+        onClick={() => onSwitch('query')}
+      >
+        <span className="v10-layer-switch-icon">⟐</span> Query
       </button>
       <button
         className={`v10-layer-switch-btn ${active === 'wm' ? 'active' : ''}`}
@@ -1136,6 +1145,475 @@ export function VerifiedMemoryHeroBanner({ entities, tripleCount, contextGraphId
           Content Hash
         </div>
       </div>
+    </div>
+  );
+}
+
+function contextGraphQueryTemplate(contextGraphId: string): string {
+  return `SELECT ?g ?s ?p ?o WHERE {
+  GRAPH ?g { ?s ?p ?o }
+  ${contextGraphQueryFilter(contextGraphId)}
+}
+LIMIT 1000`;
+}
+
+const CONTEXT_GRAPH_QUERY_SUBGRAPH = '__context_graph';
+const USER_QUERY_CATALOG_SLUG = 'ui-saved-queries';
+const USER_QUERY_CATALOG_NAME = 'Saved queries';
+const USER_QUERY_CATALOG_DESCRIPTION = 'Queries saved from the Query tab.';
+const PROFILE_NS = 'http://dkg.io/ontology/profile/';
+const SCHEMA_NS = 'http://schema.org/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const XSD_INT = 'http://www.w3.org/2001/XMLSchema#int';
+type SavedCatalogQuery = QueryCatalog['queries'][number];
+
+function sparqlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function contextGraphQueryFilter(contextGraphId: string): string {
+  const cgUri = `did:dkg:context-graph:${contextGraphId}`;
+  const cgPrefix = `${cgUri}/`;
+  return `FILTER(
+    (
+      STR(?g) = ${sparqlString(cgUri)} ||
+      STRSTARTS(STR(?g), ${sparqlString(cgPrefix)})
+    ) &&
+    !CONTAINS(STR(?g), "/_private")
+  )`;
+}
+
+function contextGraphBuiltInCatalog(contextGraphId: string): QueryCatalog {
+  const catalogSlug = 'whole-context-graph';
+  const catalogName = 'Whole graph';
+  const catalogRank = -100;
+  const subGraph = CONTEXT_GRAPH_QUERY_SUBGRAPH;
+  const withQueryDefaults = (query: {
+    slug: string;
+    name: string;
+    description: string;
+    sparql: string;
+    resultColumn?: string;
+    rank: number;
+  }) => ({
+    subGraph,
+    catalogSlug,
+    catalogName,
+    catalogDescription: 'Built-in queries for the full context graph.',
+    catalogRank,
+    resultColumn: '',
+    ...query,
+  });
+
+  return {
+    slug: catalogSlug,
+    subGraph,
+    name: catalogName,
+    description: 'Built-in queries for the full context graph.',
+    rank: catalogRank,
+    queries: [
+      withQueryDefaults({
+        slug: 'all-triples',
+        name: 'All triples',
+        description: 'Show triples across every public graph in this context graph.',
+        sparql: contextGraphQueryTemplate(contextGraphId),
+        resultColumn: 'o',
+        rank: 1,
+      }),
+      withQueryDefaults({
+        slug: 'graphs',
+        name: 'Graphs',
+        description: 'List public named graphs and triple counts.',
+        sparql: `SELECT ?g (COUNT(*) AS ?triples) WHERE {
+  GRAPH ?g { ?s ?p ?o }
+  ${contextGraphQueryFilter(contextGraphId)}
+}
+GROUP BY ?g
+ORDER BY DESC(?triples)
+LIMIT 100`,
+        resultColumn: 'g',
+        rank: 2,
+      }),
+      withQueryDefaults({
+        slug: 'types',
+        name: 'Types',
+        description: 'Count entities by RDF type across the context graph.',
+        sparql: `SELECT ?type (COUNT(DISTINCT ?s) AS ?entities) WHERE {
+  GRAPH ?g { ?s a ?type }
+  ${contextGraphQueryFilter(contextGraphId)}
+}
+GROUP BY ?type
+ORDER BY DESC(?entities)
+LIMIT 100`,
+        resultColumn: 'type',
+        rank: 3,
+      }),
+    ],
+  };
+}
+
+function querySlug(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  return slug || 'saved-query';
+}
+
+function profileUri(contextGraphId: string, kind: 'catalog' | 'query', slug: string): string {
+  return `urn:dkg:profile:${encodeURIComponent(contextGraphId)}:${kind}:${encodeURIComponent(slug)}`;
+}
+
+function literal(value: string): string {
+  return JSON.stringify(value);
+}
+
+function intLiteral(value: number): string {
+  return `"${value}"^^<${XSD_INT}>`;
+}
+
+function buildSavedQueryWrite(contextGraphId: string, name: string, description: string, sparql: string): {
+  query: SavedCatalogQuery;
+  quads: Array<{ subject: string; predicate: string; object: string; graph: string }>;
+} {
+  const rank = Date.now();
+  const slug = `${querySlug(name)}-${rank.toString(36)}`;
+  const catalogUri = profileUri(contextGraphId, 'catalog', USER_QUERY_CATALOG_SLUG);
+  const queryUri = profileUri(contextGraphId, 'query', slug);
+  const query: SavedCatalogQuery = {
+    slug,
+    subGraph: CONTEXT_GRAPH_QUERY_SUBGRAPH,
+    catalogSlug: USER_QUERY_CATALOG_SLUG,
+    catalogName: USER_QUERY_CATALOG_NAME,
+    catalogDescription: USER_QUERY_CATALOG_DESCRIPTION,
+    catalogRank: 50,
+    name,
+    description: description || undefined,
+    sparql,
+    resultColumn: '',
+    rank,
+  };
+  const quads = [
+    { subject: catalogUri, predicate: RDF_TYPE, object: `${PROFILE_NS}QueryCatalog`, graph: '' },
+    { subject: catalogUri, predicate: `${PROFILE_NS}forSubGraph`, object: literal(CONTEXT_GRAPH_QUERY_SUBGRAPH), graph: '' },
+    { subject: catalogUri, predicate: `${PROFILE_NS}displayName`, object: literal(USER_QUERY_CATALOG_NAME), graph: '' },
+    { subject: catalogUri, predicate: `${SCHEMA_NS}description`, object: literal(USER_QUERY_CATALOG_DESCRIPTION), graph: '' },
+    { subject: catalogUri, predicate: `${PROFILE_NS}rank`, object: intLiteral(50), graph: '' },
+    { subject: queryUri, predicate: RDF_TYPE, object: `${PROFILE_NS}SavedQuery`, graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}forSubGraph`, object: literal(CONTEXT_GRAPH_QUERY_SUBGRAPH), graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}inCatalog`, object: catalogUri, graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}displayName`, object: literal(name), graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}sparqlQuery`, object: literal(sparql), graph: '' },
+    { subject: queryUri, predicate: `${PROFILE_NS}rank`, object: intLiteral(rank), graph: '' },
+  ];
+  if (description) {
+    quads.push({ subject: queryUri, predicate: `${SCHEMA_NS}description`, object: literal(description), graph: '' });
+  }
+  return { query, quads };
+}
+
+function appendSavedQueryCatalog(catalogs: QueryCatalog[], query: SavedCatalogQuery): QueryCatalog[] {
+  const key = `${CONTEXT_GRAPH_QUERY_SUBGRAPH}|${USER_QUERY_CATALOG_SLUG}`;
+  const next = catalogs.map(catalog => ({
+    ...catalog,
+    queries: [...catalog.queries],
+  }));
+  const existing = next.find(catalog => `${catalog.subGraph}|${catalog.slug}` === key);
+  if (existing) {
+    existing.queries = [...existing.queries, query].sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+    return next;
+  }
+  return [
+    ...next,
+    {
+      slug: USER_QUERY_CATALOG_SLUG,
+      subGraph: CONTEXT_GRAPH_QUERY_SUBGRAPH,
+      name: USER_QUERY_CATALOG_NAME,
+      description: USER_QUERY_CATALOG_DESCRIPTION,
+      rank: 50,
+      queries: [query],
+    },
+  ];
+}
+
+function bindingValue(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'object' && 'value' in (v as any)) return String((v as any).value);
+  return String(v);
+}
+
+function shortenBindingValue(value: string): string {
+  if (!value) return '—';
+  if (value.length <= 140) return value;
+  return `${value.slice(0, 110)}...${value.slice(-24)}`;
+}
+
+export function ContextGraphQueryView({ contextGraphId }: { contextGraphId: string }) {
+  const profile = useProjectProfileContext();
+  const defaultQuery = useMemo(() => contextGraphQueryTemplate(contextGraphId), [contextGraphId]);
+  const [draftQuery, setDraftQuery] = useState(defaultQuery);
+  const [activeQuery, setActiveQuery] = useState(defaultQuery);
+  const [activeCatalogQueryKey, setActiveCatalogQueryKey] = useState<string | null>(null);
+  const [localSavedCatalogs, setLocalSavedCatalogs] = useState<QueryCatalog[]>([]);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveDescription, setSaveDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const builtInCatalog = useMemo(() => contextGraphBuiltInCatalog(contextGraphId), [contextGraphId]);
+  const queryCatalogs = useMemo(
+    () => [builtInCatalog, ...localSavedCatalogs, ...(profile?.queryCatalogs ?? [])],
+    [builtInCatalog, localSavedCatalogs, profile?.queryCatalogs],
+  );
+
+  useEffect(() => {
+    setDraftQuery(defaultQuery);
+    setActiveQuery(defaultQuery);
+    setActiveCatalogQueryKey(null);
+    setLocalSavedCatalogs([]);
+    setSaveOpen(false);
+    setSaveName('');
+    setSaveDescription('');
+    setSaveError(null);
+    setSaveMessage(null);
+  }, [defaultQuery]);
+
+  const { data, loading, error, refresh } = useFetch(
+    () => executeQuery(activeQuery, contextGraphId),
+    [activeQuery, contextGraphId],
+    0,
+  );
+
+  const rows = useMemo(
+    () => (data as any)?.result?.bindings ?? (data as any)?.results?.bindings ?? [],
+    [data],
+  );
+
+  const columns = useMemo(() => {
+    const out: string[] = [];
+    for (const row of rows) {
+      for (const key of Object.keys(row)) {
+        if (!out.includes(key)) out.push(key);
+      }
+    }
+    return out;
+  }, [rows]);
+
+  const runQuery = useCallback(() => {
+    const next = draftQuery.trim();
+    if (!next) return;
+    setActiveCatalogQueryKey(null);
+    if (next === activeQuery) {
+      refresh();
+      return;
+    }
+    setActiveQuery(next);
+  }, [activeQuery, draftQuery, refresh]);
+
+  const resetQuery = useCallback(() => {
+    setDraftQuery(defaultQuery);
+    setActiveCatalogQueryKey(null);
+    if (activeQuery === defaultQuery) refresh();
+    else setActiveQuery(defaultQuery);
+  }, [activeQuery, defaultQuery, refresh]);
+
+  const runCatalogQuery = useCallback((key: string, sparql: string) => {
+    const next = sparql.trim();
+    if (!next) return;
+    setActiveCatalogQueryKey(key);
+    setDraftQuery(next);
+    if (activeQuery === next) {
+      refresh();
+      return;
+    }
+    setActiveQuery(next);
+  }, [activeQuery, refresh]);
+
+  const openSaveForm = useCallback(() => {
+    const firstLine = draftQuery.trim().split('\n').find(line => line.trim());
+    setSaveName(firstLine ? firstLine.replace(/\s+/g, ' ').slice(0, 60) : '');
+    setSaveDescription('');
+    setSaveError(null);
+    setSaveMessage(null);
+    setSaveOpen(true);
+  }, [draftQuery]);
+
+  const saveQuery = useCallback(async (event: React.FormEvent) => {
+    event.preventDefault();
+    const name = saveName.trim();
+    const description = saveDescription.trim();
+    const sparql = draftQuery.trim();
+    if (!name) {
+      setSaveError('Name is required.');
+      return;
+    }
+    if (!sparql) {
+      setSaveError('Query is empty.');
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+    setSaveMessage(null);
+    try {
+      const { query, quads } = buildSavedQueryWrite(contextGraphId, name, description, sparql);
+      await writeProfileQueryCatalog(contextGraphId, quads);
+      setLocalSavedCatalogs(prev => appendSavedQueryCatalog(prev, query));
+      const key = `${query.subGraph}|${query.catalogSlug}|${query.slug}`;
+      setActiveCatalogQueryKey(key);
+      setDraftQuery(query.sparql);
+      if (activeQuery === query.sparql) refresh();
+      else setActiveQuery(query.sparql);
+      setSaveName('');
+      setSaveDescription('');
+      setSaveOpen(false);
+      setSaveMessage('Saved to catalog.');
+    } catch (err: any) {
+      setSaveError(err?.message ?? 'Failed to save query.');
+    } finally {
+      setSaving(false);
+    }
+  }, [activeQuery, contextGraphId, draftQuery, refresh, saveDescription, saveName]);
+
+  return (
+    <div className="v10-memory-layer-view v10-cg-query-view">
+      <div className="v10-mlv-header">
+        <span className="v10-mlv-icon">⟐</span>
+        <div>
+          <h2 className="v10-mlv-title">Context Graph Query</h2>
+          <p className="v10-mlv-desc">Run SPARQL against the full context graph, across sub-graphs and memory layers.</p>
+        </div>
+      </div>
+
+      <div className="v10-cg-query-catalog">
+        <span className="v10-subgraph-savedqueries-label">Query catalog</span>
+        {queryCatalogs.map((catalog) => {
+          const isBuiltIn = catalog.subGraph === CONTEXT_GRAPH_QUERY_SUBGRAPH;
+          const binding = isBuiltIn ? undefined : profile?.forSubGraph(catalog.subGraph);
+          const color = binding?.color ?? '#38bdf8';
+          const label = isBuiltIn ? catalog.name : `${binding?.displayName ?? catalog.subGraph}: ${catalog.name}`;
+          return (
+            <React.Fragment key={`${catalog.subGraph}|${catalog.slug}`}>
+              <span
+                className="v10-subgraph-savedqueries-label"
+                title={catalog.description || label}
+                style={{ marginLeft: 8, opacity: 0.8 }}
+              >
+                {label}
+              </span>
+              {catalog.queries.map((q) => {
+                const key = `${q.subGraph}|${q.catalogSlug}|${q.slug}`;
+                const isActive = activeCatalogQueryKey === key && activeQuery === q.sparql;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    className={`v10-subgraph-savedquery${isActive ? ' active' : ''}`}
+                    onClick={() => runCatalogQuery(key, q.sparql)}
+                    title={q.description || q.name}
+                    style={{ '--sg-color': color } as React.CSSProperties}
+                  >
+                    <span className="v10-subgraph-savedquery-glyph">{isActive ? '✓' : '◎'}</span>
+                    {q.name}
+                  </button>
+                );
+              })}
+            </React.Fragment>
+          );
+        })}
+      </div>
+
+      <div className="v10-cg-query-editor">
+        <textarea
+          className="v10-cg-query-textarea"
+          value={draftQuery}
+          onChange={(e) => {
+            setDraftQuery(e.target.value);
+            setActiveCatalogQueryKey(null);
+          }}
+          spellCheck={false}
+        />
+        <div className="v10-cg-query-actions">
+          <button className="v10-mlv-run-btn" type="button" onClick={runQuery}>Run</button>
+          <button className="v10-mlv-save-btn" type="button" onClick={openSaveForm}>Save</button>
+          <button className="v10-mlv-clear-btn" type="button" onClick={resetQuery}>Reset</button>
+        </div>
+      </div>
+
+      {saveOpen && (
+        <form className="v10-cg-query-save-panel" onSubmit={saveQuery}>
+          <label className="v10-cg-query-save-field">
+            <span>Name</span>
+            <input
+              type="text"
+              value={saveName}
+              onChange={(e) => setSaveName(e.target.value)}
+              placeholder="Query name"
+              maxLength={80}
+            />
+          </label>
+          <label className="v10-cg-query-save-field">
+            <span>Description</span>
+            <input
+              type="text"
+              value={saveDescription}
+              onChange={(e) => setSaveDescription(e.target.value)}
+              placeholder="Optional"
+              maxLength={180}
+            />
+          </label>
+          <div className="v10-cg-query-save-actions">
+            <button type="button" className="v10-mlv-clear-btn" onClick={() => setSaveOpen(false)} disabled={saving}>Cancel</button>
+            <button type="submit" className="v10-mlv-run-btn" disabled={saving}>{saving ? 'Saving...' : 'Save query'}</button>
+          </div>
+        </form>
+      )}
+
+      {saveMessage && <p className="v10-mlv-status" style={{ color: 'var(--accent-green)' }}>{saveMessage}</p>}
+      {saveError && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>{saveError}</p>}
+
+      {loading && <p className="v10-mlv-status">Loading...</p>}
+      {error && <p className="v10-mlv-status" style={{ color: 'var(--accent-red)' }}>Error: {error}</p>}
+
+      {!loading && !error && rows.length === 0 && (
+        <div className="v10-mlv-empty">
+          <p>No results for this query.</p>
+        </div>
+      )}
+
+      {!loading && !error && rows.length > 0 && (
+        <div className="v10-mlv-table-wrap">
+          <div className="v10-mlv-result-count">{rows.length} result{rows.length === 1 ? '' : 's'}</div>
+          <table className="v10-mlv-table">
+            <thead>
+              <tr>
+                {columns.map((column) => (
+                  <th key={column}>{column}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row: Record<string, unknown>, index: number) => (
+                <tr key={index}>
+                  {columns.map((column) => {
+                    const value = bindingValue(row[column]);
+                    return (
+                      <td key={column} className="v10-mlv-cell" title={value}>
+                        {shortenBindingValue(value)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -369,7 +369,8 @@ export function formatTimelineBucket(ym: string): string {
 // Graph / (optional) Timeline / Documents tabs as the layer views. The
 // layer axis becomes a secondary filter in the header via the mini
 // pyramid chips; `profile:FilterChip` rows filter by predicate value;
-// `profile:SavedQuery` pills run SPARQL and narrow the entity list.
+// `profile:QueryCatalog` + `profile:SavedQuery` render grouped SPARQL
+// pills that narrow the entity list.
 export type SubGraphTab = 'items' | 'graph' | 'timeline' | 'docs';
 
 export type SubGraphEntitySort = 'created-desc' | 'created-asc' | 'triples' | 'label';

--- a/packages/node-ui/src/ui/views/project/helpers.ts
+++ b/packages/node-ui/src/ui/views/project/helpers.ts
@@ -10,7 +10,7 @@ import {
   VIZ_PRED_ANCHORED_IN, VIZ_PRED_SIGNED_BY, VIZ_PRED_CONSENSUS,
 } from '../../hooks/useVerifiedMemoryAnchors.js';
 
-export type LayerView = 'overview' | 'graph-overview' | 'wm' | 'swm' | 'vm';
+export type LayerView = 'overview' | 'graph-overview' | 'query' | 'wm' | 'swm' | 'vm';
 export type LayerContentTab = 'items' | 'assertions' | 'graph' | 'docs';
 export const TRUST_COLORS: Record<TrustLevel, string> = {
   verified: '#22c55e',

--- a/packages/node-ui/test/use-project-profile.test.ts
+++ b/packages/node-ui/test/use-project-profile.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildQueryCatalogState } from '../src/ui/hooks/useProjectProfile.js';
+
+describe('buildQueryCatalogState', () => {
+  it('groups saved queries into explicit catalogs and sorts them by rank', () => {
+    const state = buildQueryCatalogState(
+      [
+        {
+          catalog: '<urn:dkg:profile:demo:catalog:triage>',
+          subGraph: 'tasks',
+          name: 'Task triage',
+          description: 'Important task filters',
+          rank: '2',
+        },
+        {
+          catalog: { value: 'urn:dkg:profile:demo:catalog:ops' },
+          subGraph: { value: 'tasks' },
+          name: { value: 'Operations' },
+          rank: { value: '1' },
+        },
+      ],
+      [
+        {
+          q: '<urn:dkg:profile:demo:query:blocked>',
+          subGraph: 'tasks',
+          catalog: '<urn:dkg:profile:demo:catalog:triage>',
+          name: 'Blocked tasks',
+          sparql: 'SELECT ?task WHERE { ?task ?p ?o }',
+          column: 'task',
+          rank: '2',
+        },
+        {
+          q: '<urn:dkg:profile:demo:query:high-priority>',
+          subGraph: 'tasks',
+          catalog: '<urn:dkg:profile:demo:catalog:triage>',
+          name: 'High priority tasks',
+          sparql: 'SELECT ?task WHERE { ?task ?p ?o }',
+          column: 'task',
+          rank: '1',
+        },
+        {
+          q: { value: 'urn:dkg:profile:demo:query:handoffs' },
+          subGraph: { value: 'tasks' },
+          catalog: { value: 'urn:dkg:profile:demo:catalog:ops' },
+          name: { value: 'Handoffs' },
+          sparql: { value: 'SELECT ?task WHERE { ?task ?p ?o }' },
+          column: { value: 'task' },
+          rank: { value: '1' },
+        },
+      ],
+    );
+
+    expect(state.queryCatalogs).toHaveLength(2);
+    expect(state.queryCatalogs[0].slug).toBe('ops');
+    expect(state.queryCatalogs[1].slug).toBe('triage');
+    expect(state.queryCatalogs[1].queries.map(query => query.slug)).toEqual([
+      'high-priority',
+      'blocked',
+    ]);
+    expect(state.queriesBySubGraph.get('tasks')?.map(query => query.slug)).toEqual([
+      'handoffs',
+      'high-priority',
+      'blocked',
+    ]);
+  });
+
+  it('creates an implicit default catalog for legacy saved queries without catalog links', () => {
+    const state = buildQueryCatalogState([], [
+      {
+        q: '<urn:dkg:profile:demo:query:legacy>',
+        subGraph: 'github',
+        name: 'Legacy query',
+        sparql: 'SELECT ?pr WHERE { ?pr ?p ?o }',
+        column: 'pr',
+      },
+    ]);
+
+    expect(state.queryCatalogs).toHaveLength(1);
+    expect(state.queryCatalogs[0]).toMatchObject({
+      slug: 'default:github',
+      subGraph: 'github',
+      name: 'Queries',
+    });
+    expect(state.queryCatalogs[0].queries[0]).toMatchObject({
+      slug: 'legacy',
+      catalogSlug: 'default:github',
+      catalogName: 'Queries',
+    });
+  });
+});

--- a/packages/publisher/src/async-lift-publisher-impl.ts
+++ b/packages/publisher/src/async-lift-publisher-impl.ts
@@ -142,7 +142,9 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
 
   async update(jobId: string, status: LiftJobState, data: Partial<LiftJob> = {}): Promise<void> {
     await this.ensureGraph();
-    const next = this.refreshActiveLease(this.mergeJob(await this.getRequiredJob(jobId), status, data));
+    const current = await this.getRequiredJob(jobId);
+    await this.assertActiveClaimFence(current);
+    const next = this.refreshActiveLease(this.mergeJob(current, status, data));
     this.assertJobMatchesStatus(next);
     await this.writeJob(next);
     await this.syncWalletLockForJob(next);
@@ -733,6 +735,24 @@ export class TripleStoreAsyncLiftPublisher implements AsyncLiftPublisher {
       return lock.claimToken === job.claim.claimToken;
     }
     return true;
+  }
+
+  private async assertActiveClaimFence(job: LiftJob): Promise<void> {
+    const walletId = job.claim?.walletId;
+    if (!walletId) return;
+    const currentLock = await this.readWalletLock(walletId);
+    if (!currentLock) {
+      throw new Error(`stale_claim: wallet lock missing for ${walletId}`);
+    }
+    if (!this.lockMatchesJob(currentLock, job)) {
+      throw new Error(`fence_token_mismatch: wallet lock for ${walletId} no longer matches job ${job.jobId}`);
+    }
+    if (currentLock.status !== 'active') {
+      throw new Error(`stale_claim: wallet lock for ${walletId} is not active`);
+    }
+    if (typeof currentLock.expiresAt === 'number' && currentLock.expiresAt <= this.now()) {
+      throw new Error(`stale_claim: wallet lock for ${walletId} expired`);
+    }
   }
 
   private async withClaimLock<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -153,3 +153,4 @@ export { UpdateHandler } from './update-handler.js';
 export { ChainEventPoller, type ChainEventPollerConfig, type OnContextGraphCreated } from './chain-event-poller.js';
 export { AccessHandler, type AccessPolicy } from './access-handler.js';
 export { AccessClient, type AccessResult } from './access-client.js';
+export * from './share-batching.js';

--- a/packages/publisher/src/share-batching.ts
+++ b/packages/publisher/src/share-batching.ts
@@ -1,0 +1,85 @@
+export interface ShareBatchQuad {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph?: string;
+}
+
+export interface ShareBatchAsset {
+  rootEntity: string;
+  quads: ShareBatchQuad[];
+}
+
+export interface ShareBatch {
+  assets: ShareBatchAsset[];
+  roots: string[];
+  quads: ShareBatchQuad[];
+  estimatedBytes: number;
+}
+
+export const DEFAULT_MAX_SHARE_BATCH_BYTES = 450 * 1024;
+
+export function groupAssetsByRootEntity(assets: readonly ShareBatchAsset[]): ShareBatchAsset[] {
+  const grouped = new Map<string, ShareBatchQuad[]>();
+  for (const asset of assets) {
+    const current = grouped.get(asset.rootEntity) ?? [];
+    grouped.set(asset.rootEntity, [...current, ...asset.quads.map((quad) => ({ ...quad, graph: quad.graph ?? '' }))]);
+  }
+  return Array.from(grouped.entries()).map(([rootEntity, quads]) => ({ rootEntity, quads }));
+}
+
+export function batchAssetsByEstimatedBytes(
+  assets: readonly ShareBatchAsset[],
+  maxBatchBytes = DEFAULT_MAX_SHARE_BATCH_BYTES,
+): ShareBatch[] {
+  const groupedAssets = groupAssetsByRootEntity(assets);
+  const batches: ShareBatch[] = [];
+  let current = emptyBatch();
+
+  for (const asset of groupedAssets) {
+    const assetRoots = [asset.rootEntity];
+    const assetQuads = asset.quads.map((quad) => ({ ...quad, graph: quad.graph ?? '' }));
+    const estimatedBytes = estimatePayloadBytes(assetQuads);
+
+    if (estimatedBytes > maxBatchBytes) {
+      batches.push({
+        assets: [asset],
+        roots: assetRoots,
+        quads: assetQuads,
+        estimatedBytes,
+      });
+      continue;
+    }
+
+    if (current.assets.length > 0 && current.estimatedBytes + estimatedBytes > maxBatchBytes) {
+      batches.push(current);
+      current = emptyBatch();
+    }
+
+    current = {
+      assets: [...current.assets, asset],
+      roots: [...current.roots, ...assetRoots],
+      quads: [...current.quads, ...assetQuads],
+      estimatedBytes: current.estimatedBytes + estimatedBytes,
+    };
+  }
+
+  if (current.assets.length > 0) {
+    batches.push(current);
+  }
+
+  return batches;
+}
+
+function emptyBatch(): ShareBatch {
+  return {
+    assets: [],
+    roots: [],
+    quads: [],
+    estimatedBytes: 0,
+  };
+}
+
+function estimatePayloadBytes(quads: readonly ShareBatchQuad[]): number {
+  return Buffer.byteLength(JSON.stringify({ quads }), 'utf8');
+}

--- a/packages/publisher/test/fencing-and-kc-anchor-extra.test.ts
+++ b/packages/publisher/test/fencing-and-kc-anchor-extra.test.ts
@@ -184,7 +184,7 @@ describe('P-2 (CRITICAL): fencing token — stale worker after health-check rese
     },
   );
 
-  it('PROD-BUG: update() accepts an in-memory LiftJob even when the on-disk claim token has been overwritten by a different worker', async () => {
+  it('rejects update() when the on-disk claim token or wallet lock no longer matches the in-memory job claim', async () => {
     const publisher = createPublisher();
     const jobId = await publisher.lift(request());
     const claimedByA = await publisher.claimNext('wallet-A');
@@ -225,25 +225,11 @@ describe('P-2 (CRITICAL): fencing token — stale worker after health-check rese
     } catch (err) {
       caughtStale = err;
     }
-    // PROD-BUG: update() signs off on this mutation with no fence check,
-    // and the publisher even rewrites the wallet lock for wallet-A
-    // (re-acquiring a lease that the control plane had explicitly
-    // invalidated). Observe: lock came back.
-    expect(caughtStale).toBeNull();
-    expect(await walletLockRowCount('wallet-A')).toBeGreaterThan(0);
-
-    // Make the spec expectation explicit: under a correct fencing
-    // implementation, either the update or the lock recreation would
-    // fail. The two assertions below codify "at least one of these
-    // must be false".
-    const staleWriteAccepted = caughtStale === null;
-    const lockSilentlyRecreated = (await walletLockRowCount('wallet-A')) > 0;
-    // PROD-BUG evidence: BOTH are currently true.
-    expect(
-      staleWriteAccepted && lockSilentlyRecreated,
-      'PROD-BUG: stale worker was allowed to write AND silently regained ' +
-        'a wallet lock the control plane had invalidated. See BUGS_FOUND.md P-2.',
-    ).toBe(false);
+    expect(caughtStale).toBeInstanceOf(Error);
+    if (caughtStale instanceof Error) {
+      expect(caughtStale.message).toMatch(/fenc|stale|lock|claim/i);
+    }
+    expect(await walletLockRowCount('wallet-A')).toBe(0);
   });
 });
 

--- a/packages/publisher/test/share-batching.test.ts
+++ b/packages/publisher/test/share-batching.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { batchAssetsByEstimatedBytes, DEFAULT_MAX_SHARE_BATCH_BYTES, groupAssetsByRootEntity } from '../src/share-batching.js';
+
+describe('share batching helpers', () => {
+  it('groups assets by root entity before batching', () => {
+    const grouped = groupAssetsByRootEntity([
+      { rootEntity: 'urn:root:1', quads: [{ subject: 'urn:root:1', predicate: 'urn:p1', object: '"a"' }] },
+      { rootEntity: 'urn:root:1', quads: [{ subject: 'urn:child:1', predicate: 'urn:p2', object: '"b"' }] },
+    ]);
+
+    expect(grouped).toEqual([
+      {
+        rootEntity: 'urn:root:1',
+        quads: [
+          { subject: 'urn:root:1', predicate: 'urn:p1', object: '"a"', graph: '' },
+          { subject: 'urn:child:1', predicate: 'urn:p2', object: '"b"', graph: '' },
+        ],
+      },
+    ]);
+  });
+
+  it('uses a conservative default below the 512KB SWM gossip cap', () => {
+    expect(DEFAULT_MAX_SHARE_BATCH_BYTES).toBe(450 * 1024);
+    expect(DEFAULT_MAX_SHARE_BATCH_BYTES).toBeLessThan(512 * 1024);
+  });
+
+  it('splits grouped assets when batch byte estimate exceeds threshold', () => {
+    const asset = (id: string, size: number) => ({
+      rootEntity: id,
+      quads: [{ subject: id, predicate: 'urn:test:data', object: JSON.stringify('x'.repeat(size)), graph: '' }],
+    });
+    const batches = batchAssetsByEstimatedBytes([
+      asset('urn:test:1', 200),
+      asset('urn:test:2', 200),
+      asset('urn:test:3', 200),
+    ], 350);
+    expect(batches).toHaveLength(3);
+  });
+});

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -389,6 +389,11 @@ create_node_config() {
   ${relay_value}
   ${store_block}
   "contextGraphs": ["devnet-test", "devnet-isolation"],
+  "publisher": {
+    "enabled": true,
+    "pollIntervalMs": 12000,
+    "errorBackoffMs": 5000
+  },
   ${devnet_auth_block}
   ${rs_block}
   "chain": {
@@ -996,7 +1001,7 @@ cmd_start() {
       reg_resp=$(curl -sS --max-time 30 -X POST \
         -H "$register_auth_header" \
         -H "Content-Type: application/json" \
-        -d "{\"id\":\"$cg\"}" \
+        -d "{\"id\":\"$cg\",\"accessPolicy\":0}" \
         "$register_endpoint" 2>&1 || true)
       if echo "$reg_resp" | grep -q '"onChainId"'; then
         on_chain_id=$(echo "$reg_resp" | python3 -c "import sys,json;print(json.load(sys.stdin).get('onChainId',''))" 2>/dev/null || echo '')

--- a/scripts/import-profile.mjs
+++ b/scripts/import-profile.mjs
@@ -288,7 +288,51 @@ for (const c of chips) {
   for (const v of c.values) emit(uri(id), uri(Profile.P.chipValue), lit(v));
 }
 
-// ── Saved SPARQL queries ──────────────────────────────────────
+// ── Query catalogs + saved SPARQL queries ─────────────────────
+// Query catalogs let any project group generic DKG-native queries into
+// named sets without hardcoding domain logic into the UI. Each catalog is
+// declared in the profile data, scoped to a sub-graph, and contains one or
+// more SavedQuery entries. The UI renders catalogs as grouped query pills.
+const queryCatalogs = [
+  {
+    slug: 'decision-review',
+    sg: 'decisions',
+    name: 'Decision review',
+    description: 'Queries that help reviewers inspect architectural choices and their downstream impact.',
+    rank: 1,
+  },
+  {
+    slug: 'task-triage',
+    sg: 'tasks',
+    name: 'Task triage',
+    description: 'Queries for finding urgent, blocked, or dependency-heavy work items.',
+    rank: 1,
+  },
+  {
+    slug: 'change-impact',
+    sg: 'github',
+    name: 'Change impact',
+    description: 'Queries for spotting high-signal pull requests and code hotspots.',
+    rank: 1,
+  },
+  {
+    slug: 'collaboration',
+    sg: 'chat',
+    name: 'Collaboration',
+    description: 'Queries for surfacing shared working context from people and agents.',
+    rank: 1,
+  },
+];
+for (const c of queryCatalogs) {
+  const id = Profile.uri.catalog(PROJECT_ID, c.slug);
+  emit(uri(id), uri(Common.type), uri(Profile.T.QueryCatalog));
+  emit(uri(id), uri(Profile.P.ofProfile), uri(profileId));
+  emit(uri(id), uri(Profile.P.forSubGraph), lit(c.sg));
+  emit(uri(id), uri(Profile.P.displayName), lit(c.name));
+  emit(uri(id), uri(Common.description), lit(c.description));
+  emit(uri(id), uri(Profile.P.rank), lit(c.rank, XSD.int));
+}
+
 // Rendered as pills above the entity list. Clicking a pill runs the query
 // against /api/sparql/query and displays the result set as the filtered
 // entity list. `resultColumn` tells the UI which SELECT var holds the
@@ -296,9 +340,11 @@ for (const c of chips) {
 const savedQueries = [
   {
     slug: 'decisions-touching-node-ui',
+    catalog: 'decision-review',
     sg: 'decisions',
     name: 'Decisions affecting node-ui',
     description: 'Every decision whose `affects` reaches a file in packages/node-ui.',
+    rank: 1,
     resultColumn: 'decision',
     sparql: `
 SELECT DISTINCT ?decision WHERE {
@@ -309,9 +355,11 @@ SELECT DISTINCT ?decision WHERE {
   },
   {
     slug: 'p0-p1-tasks-in-flight',
+    catalog: 'task-triage',
     sg: 'tasks',
     name: 'P0 / P1 tasks in flight',
     description: 'High-priority tasks currently `in_progress` or `blocked`.',
+    rank: 1,
     resultColumn: 'task',
     sparql: `
 SELECT DISTINCT ?task WHERE {
@@ -326,9 +374,11 @@ SELECT DISTINCT ?task WHERE {
   },
   {
     slug: 'prs-that-affected-vm-packages',
+    catalog: 'change-impact',
     sg: 'github',
     name: 'PRs that touched flagship packages',
     description: 'Closed PRs that changed node-ui or graph-viz — likely VM candidates.',
+    rank: 1,
     resultColumn: 'pr',
     sparql: `
 SELECT DISTINCT ?pr WHERE {
@@ -340,9 +390,11 @@ SELECT DISTINCT ?pr WHERE {
   },
   {
     slug: 'chat-shared-with-me',
+    catalog: 'collaboration',
     sg: 'chat',
     name: 'Chat shared with me',
     description: 'Recent SWM-visible chat sessions from other participants — what are your teammates\' assistants working on?',
+    rank: 1,
     resultColumn: 'session',
     sparql: `
 SELECT DISTINCT ?session WHERE {
@@ -355,9 +407,11 @@ SELECT DISTINCT ?session WHERE {
   },
   {
     slug: 'decisions-with-open-tasks',
+    catalog: 'decision-review',
     sg: 'decisions',
     name: 'Decisions with open tasks',
     description: 'Decisions still tracked by at least one non-done task.',
+    rank: 2,
     resultColumn: 'decision',
     sparql: `
 SELECT DISTINCT ?decision WHERE {
@@ -377,6 +431,8 @@ for (const q of savedQueries) {
   emit(uri(id), uri(Profile.P.forSubGraph), lit(q.sg));
   emit(uri(id), uri(Profile.P.displayName), lit(q.name));
   emit(uri(id), uri(Common.description), lit(q.description));
+  if (q.catalog) emit(uri(id), uri(Profile.P.inCatalog), uri(Profile.uri.catalog(PROJECT_ID, q.catalog)));
+  if (q.rank !== undefined) emit(uri(id), uri(Profile.P.rank), lit(q.rank, XSD.int));
   emit(uri(id), uri(Profile.P.sparqlQuery), lit(q.sparql));
   emit(uri(id), uri(Profile.P.resultColumn), lit(q.resultColumn));
 }

--- a/scripts/lib/ontology.mjs
+++ b/scripts/lib/ontology.mjs
@@ -353,6 +353,7 @@ export const Profile = {
     SubGraphBinding: NS.profile + 'SubGraphBinding',
     EntityTypeBinding: NS.profile + 'EntityTypeBinding',
     ViewConfig: NS.profile + 'ViewConfig',
+    QueryCatalog: NS.profile + 'QueryCatalog',
     // A FilterChip declares an interactive filter for an entity type in a
     // sub-graph page (e.g. status chips for decisions, priority chips for
     // tasks). The UI reads these and renders a chip row above the entity
@@ -392,6 +393,7 @@ export const Profile = {
     // predicate and renders a time-sorted ribbon of the sub-graph's entities.
     timelinePredicate: NS.profile + 'timelinePredicate', // SubGraphBinding -> predicate IRI (a date/dateTime)
     // ── Saved SPARQL queries (ViewConfig extension) ──────────────
+    inCatalog: NS.profile + 'inCatalog',         // SavedQuery -> QueryCatalog
     // A SavedQuery ViewConfig renders as a pill above the entity list. On
     // click the UI runs the query against the project's SPARQL endpoint
     // and displays the result set as the filtered entity list.
@@ -438,6 +440,8 @@ export const Profile = {
       `urn:dkg:profile:${encodeURIComponent(projectId)}:view:${encodeURIComponent(slug)}`,
     chip: (projectId, slug) =>
       `urn:dkg:profile:${encodeURIComponent(projectId)}:chip:${encodeURIComponent(slug)}`,
+    catalog: (projectId, slug) =>
+      `urn:dkg:profile:${encodeURIComponent(projectId)}:catalog:${encodeURIComponent(slug)}`,
     query: (projectId, slug) =>
       `urn:dkg:profile:${encodeURIComponent(projectId)}:query:${encodeURIComponent(slug)}`,
   },


### PR DESCRIPTION
Summary
- add generic QueryCatalog support to v9 profile loading and UI rendering so saved queries can be grouped and displayed as first-class profile resources
- introduce reusable transducer, share-batching, source-registry, and source-worker plumbing, plus dkg source-worker run --config ... [--once], to support generic async source ingestion workflows
- harden async publishing with stale-worker fencing coverage and related targeted tests/build validation


CLI Usage
The new source-worker entrypoint runs a generic ingestion handler from a config file and pushes work through the existing async publish flow.
Run continuously:
```
dkg source-worker run --config /path/to/worker.config.json
```
Run once for cron/manual execution:
```
dkg source-worker run --config /path/to/worker.config.json --once
```

The worker config points the CLI at:
- a handler module and export to load source-specific ingestion logic
- a daemon URL/token for SWM writes and async job polling
- a state file for persistence across runs
This keeps the worker runtime generic in dkg, while allowing source-specific adapters to live outside the core repo.

```
{
  "daemonUrl": "http://127.0.0.1:9200",
  "daemonToken": "your-daemon-token",
  "stateFile": "./.tmp/source-worker-state.json",
  "pollIntervalMs": 30000,
  "handlerModule": "/absolute/path/to/source-worker-handler.js",
  "handlerExport": "createSourceHandler",
  "sources": [
    {
      "id": "example-source",
      "kind": "custom",
      "enabled": true,
      "config": {
        "inputPath": "/data/example.csv",
        "dataset": "example-dataset"
      }
    }
  ]
}
```