### PR TITLE
fix(storage,query): RDF correctness + crypto hardening + Blazegraph CI (2/4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,22 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # ST-1: the BlazegraphStore parity gate in
+    # adapter-parity-extra.test.ts intentionally fails red when
+    # `BLAZEGRAPH_URL` is missing so a green pass cannot lie about
+    # parity coverage. We boot a real `lyrasis/blazegraph` service
+    # container (NanoSparqlServer on :9999) so the parity test
+    # exercises both adapters against actual engines instead of the
+    # canned node:http stub that ST-1 documents as misleading.
+    services:
+      blazegraph:
+        image: lyrasis/blazegraph:2.1.5
+        ports:
+          # The image declares EXPOSE 9999 but actually starts the
+          # NanoSparqlServer on Jetty's :8080 (verified via
+          # `netstat` inside the container). Map host:9999 -> container:8080
+          # so the rest of this job can keep referring to localhost:9999.
+          - 9999:8080
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -179,9 +195,93 @@ jobs:
       - name: Restore build outputs
         run: tar -xzf /tmp/build-outputs.tgz
 
+      - name: Wait for Blazegraph SPARQL endpoint
+        # NanoSparqlServer needs ~5-15s on a cold start. Poll the
+        # default `kb` namespace's SPARQL endpoint with `ASK {}` for
+        # up to 60s. We use `continue-on-error: true` so a failed
+        # boot does not turn the whole shard red — instead the
+        # storage suite below will run, hit the original ST-1 sentinel,
+        # and surface the missing-engine error in the failure log
+        # exactly like before. That preserves the "no false positives"
+        # contract: silently passing without a real engine is impossible.
+        run: |
+          set -e
+          for i in $(seq 1 30); do
+            if curl -sf "http://localhost:9999/bigdata/namespace/kb/sparql?query=ASK%20%7B%7D" >/dev/null 2>&1; then
+              echo "blazegraph ready after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::warning::blazegraph never became ready within 60s; ST-1 parity test will report"
+        continue-on-error: true
+
+      - name: Create Blazegraph quads-mode namespaces
+        # The `kb` namespace shipped by lyrasis/blazegraph defaults to
+        # triples mode (quads=false), so any GRAPH <…> { … } clause is
+        # silently dropped on insert and the conformance suite gets
+        # surprising results (deleteByPattern over-deletes because all
+        # triples land in the default graph regardless of intent).
+        #
+        # We provision TWO quads-mode namespaces, not one. Vitest runs
+        # files in parallel by default, and `storage.test.ts` issues
+        # `DROP ALL` before every Blazegraph conformance test in its
+        # suite — pointing `adapter-parity-extra.test.ts` at the SAME
+        # namespace meant the conformance suite's `DROP ALL` could
+        # fire mid-parity and wipe its inserted fixture, making the
+        # parity lane flaky.
+        # Isolating per file (not per worker) is sufficient: vitest
+        # serialises tests WITHIN a file, so the conformance suite's
+        # `DROP ALL` between its own tests is fine, and the parity
+        # suite holds exclusive ownership of its own namespace.
+        #
+        # `dkgq`         → conformance / general storage suite
+        #                 (storage.test.ts and other DROP-ALL tests)
+        # `dkgq-parity`  → adapter-parity-extra.test.ts (real Oxigraph
+        #                 ↔ Blazegraph parity), keyed off
+        #                 `BLAZEGRAPH_PARITY_URL` so the parity test
+        #                 runs against an isolated namespace and
+        #                 cannot be wiped mid-run.
+        #
+        # continue-on-error so a failure here surfaces as the storage
+        # suite's missing-engine error rather than a separate red lane.
+        run: |
+          set -e
+          create_namespace() {
+            local ns="$1"
+            local props="/tmp/${ns}.props"
+            # Quads mode requires disabling inference (NoAxioms) and truth
+            # maintenance — Blazegraph rejects the namespace creation
+            # otherwise with: "com.bigdata.rdf.store.AbstractTripleStore.quads
+            # does not support inference".
+            {
+              echo 'com.bigdata.rdf.store.AbstractTripleStore.quads=true'
+              echo 'com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false'
+              echo 'com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms'
+              echo 'com.bigdata.rdf.sail.truthMaintenance=false'
+              echo "com.bigdata.rdf.sail.namespace=${ns}"
+            } > "$props"
+            echo "--- ${props} ---" && cat "$props" && echo '---'
+            curl -fsS -X POST -H 'Content-Type: text/plain' \
+              --data-binary @"$props" \
+              http://localhost:9999/bigdata/namespace
+            # Verify the namespace responds to SPARQL.
+            curl -fsS "http://localhost:9999/bigdata/namespace/${ns}/sparql?query=ASK%20%7B%7D" >/dev/null
+            echo "blazegraph ${ns} (quads) namespace ready"
+          }
+          create_namespace "dkgq"
+          create_namespace "dkgq-parity"
+        continue-on-error: true
+
       - name: "Core (442 tests)"
         run: pnpm --filter @origintrail-official/dkg-core test
       - name: "Storage (78 tests)"
+        env:
+          BLAZEGRAPH_URL: http://localhost:9999/bigdata/namespace/dkgq/sparql
+          # r31-10 (ci.yml:256): isolated namespace for the parity
+          # suite so parallel vitest workers can't have one file's
+          # `DROP ALL` wipe another's fixture mid-test.
+          BLAZEGRAPH_PARITY_URL: http://localhost:9999/bigdata/namespace/dkgq-parity/sparql
         run: pnpm --filter @origintrail-official/dkg-storage test
       - name: "Chain unit (46 tests)"
         run: pnpm --filter @origintrail-official/dkg-chain test

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -9,7 +9,10 @@ import {
   REMOVED_VIEWS,
   TrustLevel,
 } from '@origintrail-official/dkg-core';
-import { emptyQueryResultForKind, validateReadOnlySparql } from './sparql-guard.js';
+import {
+  validateReadOnlySparql,
+  emptyResultForSparql,
+} from './sparql-guard.js';
 
 /**
  * Result of resolving a V10 GET view to concrete graph targets.
@@ -46,6 +49,14 @@ export function resolveViewGraphs(
     agentAddress?: string;
     verifiedGraph?: string;
     assertionName?: string;
+    /**
+     * Spec §12/§14 trust-gradient filter (P-13). When set above
+     * `TrustLevel.SelfAttested`, the verified-memory resolution narrows
+     * to anchored quorum sub-graphs (`.../_verified_memory/…`) only —
+     * the root data graph is removed because it can carry mixed-trust
+     * finalized data. Values above `Endorsed` are rejected until
+     * per-graph trust tagging (Q-1) lands; see body for details.
+     */
     minTrust?: TrustLevel;
   },
 ): ViewResolution {
@@ -141,31 +152,26 @@ export function resolveViewGraphs(
       // finalization).  Any quorum-specific verified-memory sub-graphs live
       // under `_verified_memory/` and are unioned in as well.
       //
-      // P-13: when the caller demands more than SelfAttested, the root data
-      // graph is dropped — only quorum-verified sub-graphs survive.
+      // P-13 (graph-scope) + Q-1 (per-triple) working together:
+      //   - Graph-scope (this function): when `minTrust > SelfAttested`
+      //     the root content graph is dropped (via `requireHighTrust`)
+      //     and only `/_verified_memory/<quorum>` sub-graphs survive.
+      //     That sub-graph prefix is populated only by quorum-verified
+      //     write paths, so the floor for those graphs is implicitly
+      //     `Endorsed`.
+      //   - Per-triple (DKGQueryEngine.queryWithView): when
+      //     `minTrust` is set, `injectMinTrustFilter` rewrites the user
+      //     SPARQL so every subject MUST carry an explicit
+      //     `<http://dkg.io/ontology/trustLevel> "N"` literal with
+      //     `N ≥ minTrust`. Subjects without such metadata are
+      //     silently rejected (fail-closed).
       //
-      // P-13 review follow-up: today the /_verified_memory/* sub-graphs
-      // carry no per-graph trust metadata — any graph in that prefix was
-      // populated by *some* quorum-verified write path, which we treat as
-      // at least `Endorsed`. We cannot yet distinguish `PartiallyVerified`
-      // vs `ConsensusVerified` without knowing the quorum size, so a caller
-      // asking for those higher tiers would silently receive merely
-      // Endorsed data. Reject such requests until Q-1 lands per-graph
-      // trust tagging; Endorsed itself remains honoured.
-      if (
-        opts?.minTrust !== undefined &&
-        opts.minTrust > TrustLevel.Endorsed
-      ) {
-        // Use the "Invalid minTrust" prefix so the daemon's /api/query
-        // classifier maps this rejection to HTTP 400 instead of 500.
-        throw new Error(
-          `Invalid minTrust=${opts.minTrust} for verified-memory: values above Endorsed are not yet ` +
-          `supported — the engine cannot currently prove a ` +
-          `\`/_verified_memory/<quorum>\` sub-graph satisfies PartiallyVerified or ConsensusVerified. ` +
-          `Use minTrust=Endorsed (1) to restrict to quorum-verified sub-graphs, or track Q-1 for ` +
-          `per-graph trust tagging. See packages/query/src/query-engine.ts QueryOptions.minTrust.`,
-        );
-      }
+      // Together this satisfies spec §14 for values above `Endorsed`:
+      // even though the engine cannot yet distinguish a
+      // `PartiallyVerified`-quorum sub-graph from a `ConsensusVerified`
+      // one at the graph level, a caller asking for `ConsensusVerified`
+      // data only ever sees quads whose triples carry the matching
+      // per-triple trust literal, so sub-threshold data cannot leak.
       return {
         graphs: requireHighTrust ? [] : [contextGraphDataUri(contextGraphId)],
         graphPrefixes: [`did:dkg:context-graph:${contextGraphId}/_verified_memory/`],
@@ -295,22 +301,80 @@ export class DKGQueryEngine implements QueryEngine {
     }
 
     if (allGraphs.length === 0) {
-      // PR #239 Codex iter-5: a zero-graph resolution (e.g. a
-      // `verified-memory` query with `minTrust=Endorsed` on a context graph
-      // that has not been populated with any `/_verified_memory/*`
-      // sub-graphs yet) must still respect the requested query form.
-      // Returning `{ bindings: [] }` for an ASK would look like a SELECT
-      // result and break clients that rely on ASK's boolean binding;
-      // CONSTRUCT/DESCRIBE must carry `quads: []`. Delegate to the shared
-      // kind-aware empty-result helper.
-      return emptyQueryResultForKind(sparql);
+      // PR #239 / r17-2: a zero-graph resolution (e.g. a `verified-memory`
+      // query with `minTrust=Endorsed` on a context graph that has not
+      // been populated with any `/_verified_memory/*` sub-graphs yet) must
+      // still respect the requested query form. Returning `{ bindings: [] }`
+      // for an ASK would look like a SELECT result and break clients that
+      // rely on ASK's boolean binding; CONSTRUCT/DESCRIBE must carry
+      // `quads: []`. Delegate to the shared kind-aware empty-result helper.
+      return emptyResultForSparql(sparql);
+    }
+
+    // Spec §14 trust-gradient filter — only enforced on verified-memory
+    // where on-chain-anchored trust metadata is expected to live.
+    // When `minTrust` (or legacy `_minTrust`) is set, rewrite the query so
+    // every subject matched by the user's pattern MUST carry an explicit
+    // `http://dkg.io/ontology/trustLevel` literal whose integer value is
+    // ≥ minTrust. Subjects with no trust metadata are rejected.
+    //
+    // previously, when `injectMinTrustFilter()` could not
+    // safely rewrite the query (e.g. explicit GRAPH, non-BGP first
+    // clause, multi-subject WHERE), we silently ran the ORIGINAL
+    // unfiltered SPARQL. That turned the trust threshold into a no-op in
+    // exactly the shapes most likely to span sensitive data, and a caller
+    // had no signal that their threshold was being ignored. Now the
+    // rewriter MUST succeed or we fail closed — returning an empty result
+    // is the correct behaviour for "no subject meets the trust threshold"
+    // when we cannot prove the threshold was applied.
+    let effectiveSparql = sparql;
+    const effectiveMinTrust = options.minTrust ?? options._minTrust;
+    // `SelfAttested` (0) is the floor and means "no per-triple filter
+    // needed". Skip the rewrite at that level so SELECT queries that
+    // predate trust tagging still see every triple — the graph-scope
+    // resolution above keeps the root data graph in scope at
+    // SelfAttested, so the per-triple filter would otherwise reject
+    // every quad that lacks a `dkg:trustLevel` literal (i.e. every
+    // pre-Q-1 quad).
+    //
+    // we ALSO skip the per-triple filter at `Endorsed`. The graph-
+    // scope resolution above already drops the root data graph and
+    // unions only over `<…>/_verified_memory/{quorum}` sub-graphs,
+    // and any quad that landed in `_verified_memory` is by
+    // definition at least `Endorsed` (the on-chain quorum that
+    // promoted it IS the endorsement). Until the publisher / quorum
+    // writers actually emit `dkg:trustLevel` literals (tracked
+    // upstream), the per-triple join would silently turn every
+    // legitimate `minTrust=Endorsed` query into an empty result.
+    // Levels strictly above Endorsed (`PartiallyVerified`,
+    // `ConsensusVerified`) still require the per-triple filter
+    // because graph-scope alone cannot distinguish those tiers from
+    // a basic Endorsed write — a fail-closed empty result there is
+    // the correct behaviour until writers stamp the literal.
+    if (
+      view === 'verified-memory' &&
+      effectiveMinTrust !== undefined &&
+      effectiveMinTrust > TrustLevel.Endorsed
+    ) {
+      const rewritten = injectMinTrustFilter(sparql, effectiveMinTrust);
+      if (!rewritten) {
+        console.warn(
+          `[DKGQueryEngine] minTrust=${effectiveMinTrust} requested for a query shape ` +
+            `injectMinTrustFilter cannot safely rewrite; returning empty result (fail-closed)`,
+        );
+        // Preserve the query form so CONSTRUCT/DESCRIBE callers see
+        // `{ bindings: [], quads: [] }` rather than a shapeless deny, and
+        // ASK callers see `{ bindings: [{ result: 'false' }] }`.
+        return emptyResultForSparql(sparql);
+      }
+      effectiveSparql = rewritten;
     }
 
     if (allGraphs.length === 1) {
-      return this.execAndNormalize(wrapWithGraph(sparql, allGraphs[0]));
+      return this.execAndNormalize(wrapWithGraph(effectiveSparql, allGraphs[0]));
     }
 
-    return this.queryMultipleGraphs(sparql, allGraphs);
+    return this.queryMultipleGraphs(effectiveSparql, allGraphs);
   }
 
   private async queryMultipleGraphs(sparql: string, graphs: string[]): Promise<QueryResult> {
@@ -425,25 +489,452 @@ export class DKGQueryEngine implements QueryEngine {
 }
 
 /**
+ * Skip past a SPARQL string literal starting at `src[i]`, returning the
+ * index immediately AFTER the closing quote.
+ *
+ * Recognises **all four** SPARQL 1.1 literal forms:
+ *
+ *   - `"…"`         single-line, double-quoted (escape: `\\`, `\"`, `\n`, …)
+ *   - `'…'`         single-line, single-quoted (same escape grammar)
+ *   - `"""…"""`     long-form, double-quoted (may span newlines, contains
+ *                   raw `"`, `'`, `{`, `}`, `#`, `.` without escaping)
+ *   - `'''…'''`     long-form, single-quoted (same as above)
+ *
+ * **Caller contract:** `src[i]` MUST be `"` or `'`; otherwise the function
+ * returns `i` (no advance). The cursor returned points to the first byte
+ * AFTER the literal, ready for the caller to resume its own scan.
+ *
+ * If a literal is unterminated (truncated input) the function consumes
+ * the remainder of the string and returns `src.length`. Callers treat
+ * unterminated literals as "the rest of the input is opaque payload",
+ * which is the safe choice for structural scans (brace balancing,
+ * keyword detection): we do NOT want a stray `{` near the end of a
+ * truncated query body to confuse the surrounding scanner.
+ *
+ * dkg-query-engine.ts:848). The
+ * previous helpers (`stripSparqlLineComments`, `scrubStringsAndComments`,
+ * `findMatchingCloseBrace`, `findWhereBraceStart`, and
+ * `splitTopLevelTripleStatements`) all had their own copy of the
+ * single-line literal scanner and NONE recognised triple-quoted
+ * literals, so a long-form payload like
+ *
+ *     SELECT ?t WHERE { ?s <p> """contains a {brace} and a #comment""" }
+ *
+ * leaked `{`, `}`, `#`, `.`, etc. through the structural scrubber and
+ * the `minTrust` rewriter (and the SPARQL form classifier, and the
+ * triple terminator splitter) misclassified payload as syntax. The
+ * downstream effect was the same fail-closed empty result the
+ * scrubbing was supposed to prevent. Centralising the lex here means
+ * every helper that walks SPARQL source learns triple-quoted handling
+ * in one place.
+ */
+export function skipSparqlStringLiteral(src: string, i: number): number {
+  const n = src.length;
+  if (i >= n) return i;
+  const ch = src[i];
+  if (ch !== '"' && ch !== "'") return i;
+  // Long-form (triple-quoted) literal? Lookahead must match `ch ch ch`.
+  if (i + 2 < n && src[i + 1] === ch && src[i + 2] === ch) {
+    let j = i + 3;
+    while (j < n) {
+      // SPARQL 1.1 long-string grammar (§19.8 STRING_LITERAL_LONG*) allows
+      // `\<x>` style ECHAR escapes — skip the escaped byte so a `\\"` or
+      // a `\\'` does not prematurely terminate. Between escapes, look for
+      // the triple-quote terminator.
+      if (src[j] === '\\' && j + 1 < n) { j += 2; continue; }
+      if (
+        src[j] === ch &&
+        j + 2 < n &&
+        src[j + 1] === ch &&
+        src[j + 2] === ch
+      ) {
+        return j + 3;
+      }
+      j++;
+    }
+    return n;
+  }
+  // Short-form (single-line) literal. SPARQL 1.1 STRING_LITERAL1/2 forbid
+  // unescaped newlines, but we still defensively bail on EOL just like
+  // the previous helpers did.
+  let j = i + 1;
+  while (j < n) {
+    if (src[j] === '\\' && j + 1 < n) { j += 2; continue; }
+    if (src[j] === ch) { return j + 1; }
+    j++;
+  }
+  return j;
+}
+
+/**
+ * Token-aware locator for the explicit `WHERE` keyword at the
+ * top-level of a SPARQL query. Mirrors the lex rules used by
+ * {@link findMatchingCloseBrace} / the fallback path in
+ * {@link findWhereBraceStart}: skips line comments (`# ... \n`),
+ * single/double/triple-quoted string literals (via
+ * {@link skipSparqlStringLiteral}), and IRIREFs (`<...>`) so the
+ * `WHERE` substring can NOT be sourced from inside any of those
+ * payload contexts. The `<` token is disambiguated as IRI-start
+ * vs less-than via the same next-byte allow-list as
+ * {@link findWhereBraceStart}'s fallback.
+ *
+ * Returns the index of the `W` of the `WHERE` keyword, or `-1` if
+ * none is found at top level. Case-insensitive on the keyword
+ * itself, but the surrounding word boundary is enforced (so
+ * identifiers like `WHEREVER` / `aWHERE` do NOT match).
+ */
+function findExplicitWhereTokenIdx(sparql: string): number {
+  const n = sparql.length;
+  const isWordStart = (c: string): boolean =>
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c === '_';
+  const isWordCont = (c: string): boolean =>
+    (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+    (c >= '0' && c <= '9') || c === '_';
+  const isIriStartFirstByte = (c: string): boolean => {
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) return true;
+    return c === '#' || c === '_' || c === '/' || c === '.';
+  };
+  const isIriStart = (idx: number): boolean => {
+    const next = sparql[idx + 1];
+    if (next === undefined) return false;
+    if (!isIriStartFirstByte(next)) return false;
+    for (let j = idx + 1; j < n; j++) {
+      const c = sparql[j];
+      if (c === '>') return true;
+      if (
+        c === '<' || c === '"' || c === '{' || c === '}' ||
+        c === '|' || c === '\\' || c === '^' || c === '`' ||
+        /\s/.test(c)
+      ) return false;
+    }
+    return false;
+  };
+
+  let i = 0;
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      if (isIriStart(i)) {
+        const end = sparql.indexOf('>', i + 1);
+        if (end === -1) return -1;
+        i = end + 1;
+        continue;
+      }
+      i++;
+      continue;
+    }
+    if (isWordStart(ch)) {
+      // Word boundary check: previous char (if any) must NOT be a
+      // word-continuation byte. The outer lexer already skipped
+      // comments/strings/IRIs, so a non-word predecessor means we're
+      // at a real keyword start.
+      const prev = i > 0 ? sparql[i - 1] : '';
+      if (prev && isWordCont(prev)) {
+        // Mid-identifier — skip the rest of the word.
+        let j = i + 1;
+        while (j < n && isWordCont(sparql[j])) j++;
+        i = j;
+        continue;
+      }
+      let j = i + 1;
+      while (j < n && isWordCont(sparql[j])) j++;
+      const word = sparql.substring(i, j);
+      if (word.length === 5 && word.toUpperCase() === 'WHERE') {
+        return i;
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Find the next significant `{` after a given index, skipping
+ * whitespace AND line comments (`# … \n`) but NOT string literals
+ * — SPARQL grammar does not allow a string literal between the
+ * `WHERE` keyword and its opening `{`, so encountering one means
+ * the input is malformed and we should bail (return `-1`).
+ */
+function nextSignificantBraceAfter(sparql: string, startIdx: number): number {
+  const n = sparql.length;
+  let i = startIdx;
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (/\s/.test(ch)) { i++; continue; }
+    if (ch === '{') return i;
+    return -1;
+  }
+  return -1;
+}
+
+/**
+ * Locate the opening `{` of the WHERE clause in a SPARQL query.
+ *
+ * SPARQL 1.1 (§16) allows the `WHERE` keyword to be omitted from
+ * `SELECT`, `DESCRIBE`, and `ASK` queries, and from the second
+ * `GroupGraphPattern` of a `CONSTRUCT`. The legacy callers (`wrapWithGraph`,
+ * `wrapWithGraphUnion`, `injectMinTrustFilter`) all matched only
+ * `WHERE\s*\{`, so any of those legitimate shorthand forms left the
+ * query untouched (no GRAPH wrapping, no trust filter injection) and —
+ * on a `verified-memory` view whose data lives in a named sub-graph —
+ * silently returned `[]` instead of executing against the right graph.
+ *
+ * Strategy:
+ *   1. Prefer the explicit `WHERE { ... }` form.
+ *   2. Otherwise, walk top-level braces (skipping IRIs / quoted
+ *      strings / comments) and use the LAST top-level `{...}`. This
+ *      is correct for every form:
+ *        - `SELECT ?x { ... }`           (1 top-level brace)
+ *        - `ASK { ... }`                 (1)
+ *        - `DESCRIBE ?x { ... }`         (1)
+ *        - `CONSTRUCT { tmpl } { where }`(2 — last is the WHERE)
+ *      `CONSTRUCT WHERE { ... }` already matches the primary path.
+ *
+ * Returns `null` when no top-level `{...}` block is balanced.
+ */
+function findWhereBraceStart(sparql: string): number {
+  // The earlier fast path used a raw regex `/\bWHERE\s*\{/i` which
+  // matches ANY `WHERE` followed by `{` — including ones embedded inside
+  // string literals or comments. Adversarial / obfuscated input
+  // like
+  //   SELECT ("WHERE {" AS ?x) WHERE { ... }
+  // would have the regex hit the literal substring inside the
+  // SELECT projection, then `sparql.indexOf('{', whereIdx)` would
+  // grab the brace just past the literal — and every later
+  // injection (`wrapWithGraph` / `injectMinTrustFilter`) would
+  // rewrite the wrong block, in some cases producing an invalid
+  // query and in others silently filtering against a string-literal
+  // expression rather than the actual WHERE clause.
+  //
+  // Fix: locate the explicit `WHERE` token using the SAME token-
+  // aware scanner the fallback already uses (skips line comments,
+  // single/double/triple-quoted string literals, and IRIREFs;
+  // disambiguates `<` as IRI-start vs less-than via the next-byte
+  // allow-list below). Then advance past inter-keyword whitespace
+  // (and any line comments) before reading the `{`.
+  const whereTokenIdx = findExplicitWhereTokenIdx(sparql);
+  if (whereTokenIdx !== -1) {
+    const idx = nextSignificantBraceAfter(sparql, whereTokenIdx + 'WHERE'.length);
+    return idx;
+  }
+
+  // Fallback: scan for top-level `{` while honouring SPARQL token
+  // boundaries — IRIs (`<...>`), quoted literals, and `#` comments
+  // can all contain stray `{` chars that the regex would
+  // misinterpret as block openers.
+  //
+  // dkg-query-engine.ts:559). The classifier rejects obvious
+  // comparison shapes after `<` and falls back to a forward scan
+  // that confirms a balanced IRIREF body. The r30 cut only rejected
+  // `=`, `<`, and whitespace — a pure forward scan from `<` in
+  // compact comparison syntax like
+  //   `FILTER(?n<10&&?m>5)`
+  // walks `1`, `0`, `&`, `&`, `?`, `m` (none of which are
+  // IRIREF-forbidden per the SPARQL grammar
+  // `[^<>"{}|^`\]-[#x00-#x20]`) and lands on `>`, mis-classifying
+  // the entire `<10&&?m>` as an IRI. The forward scan therefore
+  // CANNOT be trusted alone for compact `<` operators that operate
+  // on numerics / variables / sub-expressions whose body bytes are
+  // all IRIREF-legal.
+  //
+  // r30+ resolution: combine an EXPLICIT next-byte allow-list of
+  // characters that can validly start a real-world SPARQL IRIREF
+  // (ALPHA for absolute IRIs `http:` / `urn:` / `did:` / `file:` /
+  // `_blank-node:`, `#` for fragment-only relatives, `_` for the
+  // legacy blank-node-as-IRI shape, `/` for path-only relatives,
+  // and `.` for path-relative IRIs) with the existing
+  // forbidden-byte forward scan. Anything else after `<` is treated
+  // as a comparison and we advance by ONE byte. This bails fast on
+  // every `<digit`, `<?var`, `<$var`, `<(...)`, `<"lit"`, `<-1`,
+  // `<+1`, `<&`, `<|`, `<!`, `<*`, `<=`, `<<` shape — i.e. the
+  // full set of SPARQL operator contexts in which `<` is overloaded
+  // as less-than.
+  //
+  // Note: this is INTENTIONALLY stricter than the SPARQL grammar
+  // (which technically allows `<10>` as an IRIREF). Real-world
+  // SPARQL queries don't write bare-digit IRIs; falling out of the
+  // IRI branch here just means we treat `<` as a comparison and
+  // advance one byte, which is the safe behaviour for the brace
+  // scan we actually care about.
+  const isIriStartFirstByte = (c: string): boolean => {
+    // ASCII letter? (covers every absolute IRI scheme — `http:`,
+    // `urn:`, `did:`, `file:`, `mailto:`, `tag:`, `data:`, …).
+    if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) return true;
+    // `#fragment` (SPARQL allows fragment-only relative IRIREFs
+    // when the base IRI is set by the query environment), `_blah`
+    // (legacy blank-node-as-IRI), `/path` (path-only relative),
+    // `.something` (path-relative). Everything else is a comparison
+    // operator context.
+    return c === '#' || c === '_' || c === '/' || c === '.';
+  };
+  const isIriStart = (idx: number): boolean => {
+    const next = sparql[idx + 1];
+    if (next === undefined) return false;
+    if (!isIriStartFirstByte(next)) return false;
+    for (let j = idx + 1; j < n; j++) {
+      const c = sparql[j];
+      if (c === '>') return true;
+      // Any IRIREF-forbidden character before `>` proves this `<`
+      // is a comparison, not the start of an IRI.
+      if (
+        c === '<' ||
+        c === '"' ||
+        c === '{' ||
+        c === '}' ||
+        c === '|' ||
+        c === '\\' ||
+        c === '^' ||
+        c === '`' ||
+        /\s/.test(c)
+      ) {
+        return false;
+      }
+    }
+    return false;
+  };
+
+  const n = sparql.length;
+  const opens: number[] = [];
+  let depth = 0;
+  let i = 0;
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '<') {
+      if (isIriStart(i)) {
+        const end = sparql.indexOf('>', i + 1);
+        if (end === -1) return -1;
+        i = end + 1;
+        continue;
+      }
+      // Comparison operator — advance one byte and keep scanning.
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      // dkg-query-engine.ts:848).
+      // Centralised triple-quoted-aware skip — see skipSparqlStringLiteral.
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '{') {
+      if (depth === 0) opens.push(i);
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth < 0) return -1;
+    }
+    i++;
+  }
+  if (depth !== 0 || opens.length === 0) return -1;
+  return opens[opens.length - 1];
+}
+
+/**
+ * Locate the matching `}` for the `{` at `openIdx`, while skipping over
+ * `{` / `}` chars that appear inside SPARQL string literals, line
+ * comments, or IRIREFs.
+ *
+ * — dkg-query-engine.ts:939). The naive
+ * brace-balance loop in `injectMinTrustFilter`, `wrapWithGraph`, and
+ * `wrapWithGraphUnion` counted `{`/`}` blindly. A query like
+ *
+ *     SELECT ?t WHERE { ... FILTER(STR(?t) = "{") }
+ *
+ * has a literal `{` inside a string literal and a single closing `}`
+ * for the WHERE block, so the naive counter ended at depth 1 and
+ * returned `-1`. Every caller treated `-1` as "refuse to rewrite" and
+ * (for `injectMinTrustFilter`) silently fail-closed `minTrust >
+ * Endorsed` queries to an empty result — exactly the literal-heavy
+ * shape the surrounding scrubbing was supposed to enable.
+ *
+ * Returns `-1` if `sparql[openIdx]` is not `{` or no matching close
+ * exists at depth zero.
+ */
+function findMatchingCloseBrace(sparql: string, openIdx: number): number {
+  if (sparql[openIdx] !== '{') return -1;
+  const n = sparql.length;
+  let depth = 0;
+  let i = openIdx;
+  while (i < n) {
+    const ch = sparql[i];
+    if (ch === '#') {
+      // Line comment — skip to newline.
+      while (i < n && sparql[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      // Centralised triple-quoted-aware skip.
+      i = skipSparqlStringLiteral(sparql, i);
+      continue;
+    }
+    if (ch === '<') {
+      // Look ahead for a balanced `>` that delimits an IRIREF body.
+      // IRIREFs cannot contain whitespace or any of `<{}|"^\``, so a
+      // candidate range that contains those chars is treated as a
+      // comparison operator and we fall through to a single-byte
+      // advance. (Mirror of the IRI/comparison disambiguation in
+      // `findWhereBraceStart`.)
+      let foundIri = false;
+      for (let j = i + 1; j < n; j++) {
+        const c = sparql[j];
+        if (c === '>') { foundIri = true; i = j + 1; break; }
+        if (
+          c === '<' || c === '"' || c === '{' || c === '}' ||
+          c === '|' || c === '\\' || c === '^' || c === '`' ||
+          /\s/.test(c)
+        ) {
+          break;
+        }
+      }
+      if (foundIri) continue;
+      // Comparison operator — advance one byte.
+      i++;
+      continue;
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return i;
+      if (depth < 0) return -1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
  * Wraps a SELECT query to scope it to a named graph.
  * If the query already uses GRAPH patterns, returns it unchanged.
  */
 function wrapWithGraph(sparql: string, graphUri: string): string {
   if (sparql.toLowerCase().includes('graph ')) return sparql;
 
-  const whereIdx = sparql.search(/WHERE\s*\{/i);
-  if (whereIdx === -1) return sparql;
+  const braceStart = findWhereBraceStart(sparql);
+  if (braceStart === -1) return sparql;
 
-  const braceStart = sparql.indexOf('{', whereIdx);
-  let depth = 0;
-  let braceEnd = -1;
-  for (let i = braceStart; i < sparql.length; i++) {
-    if (sparql[i] === '{') depth++;
-    else if (sparql[i] === '}') {
-      depth--;
-      if (depth === 0) { braceEnd = i; break; }
-    }
-  }
+  // — dkg-query-engine.ts:939). Use the
+  // literal/comment/IRI-aware helper so a `{` or `}` inside a SPARQL
+  // string literal, line comment, or IRI does NOT confuse the depth
+  // counter and we stop wrapping queries with literal-heavy bodies.
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
   if (braceEnd === -1) return sparql;
 
   const before = sparql.slice(0, braceStart + 1);
@@ -456,31 +947,499 @@ function wrapWithGraph(sparql: string, graphUri: string): string {
 /**
  * Wrap a query so it runs over a union of named graphs in a single execution,
  * preserving LIMIT/ORDER BY/DISTINCT/aggregate semantics.
+ *
+ * the previous revision injected
+ * `VALUES ?_viewGraph { <g1> <g2> … } GRAPH ?_viewGraph { inner }` directly
+ * into the caller's WHERE block. Two failure modes:
+ *
+ *   1. Scope leak — `SELECT *` (or any projection that includes the graph
+ *      variable) over a multi-graph view emitted an extra `_viewGraph`
+ *      column, so downstream consumers saw a mystery binding they didn't
+ *      ask for.
+ *   2. Name collision — a user query that legitimately binds
+ *      `?_viewGraph` (rare but valid) would silently intersect with the
+ *      helper's VALUES list and clamp to the helper's graph URIs.
+ *
+ * The fix is to use an explicit UNION over each graph instead of a
+ * single GRAPH ?var binding. That keeps the inner block's variables
+ * (and only those) in scope — no helper var is introduced at all, so
+ * neither SELECT * leakage nor variable-name collisions can happen.
+ * Single-graph views skip the UNION wrapper entirely and use a plain
+ * `GRAPH <uri>` block.
  */
 function wrapWithGraphUnion(sparql: string, graphUris: string[]): string {
   if (sparql.toLowerCase().includes('graph ')) return sparql;
+  if (graphUris.length === 0) return sparql;
 
-  const whereIdx = sparql.search(/WHERE\s*\{/i);
-  if (whereIdx === -1) return sparql;
+  const braceStart = findWhereBraceStart(sparql);
+  if (braceStart === -1) return sparql;
 
-  const braceStart = sparql.indexOf('{', whereIdx);
-  let depth = 0;
-  let braceEnd = -1;
-  for (let i = braceStart; i < sparql.length; i++) {
-    if (sparql[i] === '{') depth++;
-    else if (sparql[i] === '}') {
-      depth--;
-      if (depth === 0) { braceEnd = i; break; }
-    }
-  }
+  // — dkg-query-engine.ts:939). See
+  // `findMatchingCloseBrace` and the `wrapWithGraph` cousin above.
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
   if (braceEnd === -1) return sparql;
 
   const before = sparql.slice(0, braceStart + 1);
   const inner = sparql.slice(braceStart + 1, braceEnd);
   const after = sparql.slice(braceEnd);
 
-  const valuesClause = graphUris.map((g) => `<${g}>`).join(' ');
-  return `${before} VALUES ?_viewGraph { ${valuesClause} } GRAPH ?_viewGraph { ${inner} } ${after}`;
+  if (graphUris.length === 1) {
+    return `${before} GRAPH <${graphUris[0]}> { ${inner} } ${after}`;
+  }
+
+  const unionBranches = graphUris
+    .map((g) => `{ GRAPH <${g}> { ${inner} } }`)
+    .join(' UNION ');
+  return `${before} ${unionBranches} ${after}`;
+}
+
+/**
+ * Rewrites a SPARQL query so EVERY subject variable used in its WHERE
+ * block also matches `<http://dkg.io/ontology/trustLevel> ?__trustN`
+ * with an integer value ≥ `minTrust`. Subjects with no trust metadata
+ * are filtered out (the required triple is absent).
+ *
+ * The rewriter scans the WHERE block for top-level triple patterns
+ * and collects every distinct subject variable so multi-subject
+ * queries like `?a <p> ?o . ?b <q> ?r` have BOTH `?a` and `?b`
+ * trust-filtered.
+ *
+ * Returns `null` when:
+ *   - no `WHERE { ... }` block can be located;
+ *   - braces are unbalanced;
+ *   - the WHERE contains nested structure (`{`, `GRAPH`, `OPTIONAL`,
+ *     `UNION`, `MINUS`, `SERVICE`, subselect) we cannot safely rewrite;
+ *   - the block contains a constant (IRI/literal/blank) subject — we
+ *     cannot attach a filter to a constant, and silently ignoring the
+ *     constant row would leak sub-threshold data (L1 fail-closed);
+ *   - no subject var is found at all.
+ * Callers treat `null` as "refuse to run".
+ */
+/**
+ * Strip SPARQL line comments (`# … EOL`) from a fragment of SPARQL
+ * WHERE body while preserving `#` that appears inside an IRI
+ * (`<http://…/rdf-ns#type>`) or inside a string literal (`"…#…"`,
+ * `'…#…'`). Used by `injectMinTrustFilter` where a full parser would
+ * be overkill but a naive line-comment regex mangles `rdf:type` etc.
+ *
+ * This is intentionally small: we handle the three grammar contexts
+ * that can legally contain a bare `#` in SPARQL 1.1 (IRI, quoted
+ * literal, line comment) and treat everything else as ordinary code.
+ * Triple-quoted `"""…"""` / `'''…'''` are NOT recognised because
+ * `injectMinTrustFilter` already bails on any WHERE containing tokens
+ * from the multi-line literal grammar (FILTER EXISTS, SELECT, …).
+ */
+function stripSparqlLineComments(src: string): string {
+  let out = '';
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const ch = src[i];
+    if (ch === '<') {
+      const end = src.indexOf('>', i + 1);
+      if (end === -1) { out += src.slice(i); break; }
+      out += src.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      // Centralised triple-quoted-aware skip.
+      const j = skipSparqlStringLiteral(src, i);
+      out += src.slice(i, j);
+      i = j;
+      continue;
+    }
+    if (ch === '#') {
+      const nl = src.indexOf('\n', i);
+      if (nl === -1) { break; }
+      i = nl; // leave the newline so dot-accounting still sees line breaks
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Replace every SPARQL string literal and `# …` comment in `src`
+ * with neutral whitespace, preserving overall byte length. IRIs and
+ * code tokens are passed through verbatim. The returned string is
+ * suitable for STRUCTURAL CHECKS (brace balancing, keyword scans)
+ * that must not be confused by user payloads such as
+ * `"{json: 1}"` or `# OPTIONAL: ...`.
+ *
+ * Triple-quoted
+ * (`"""…"""` / `'''…'''`) literals are NOT recognised because
+ * `injectMinTrustFilter`'s outer pipeline already refuses any WHERE
+ * carrying tokens from the multi-line literal grammar (FILTER EXISTS,
+ * SELECT inside, etc.).
+ */
+function scrubStringsAndComments(src: string): string {
+  const n = src.length;
+  const buf: string[] = new Array(n);
+  let i = 0;
+  while (i < n) {
+    const ch = src[i];
+    if (ch === '<') {
+      const end = src.indexOf('>', i + 1);
+      if (end === -1) {
+        for (let k = i; k < n; k++) buf[k] = src[k];
+        return buf.join('');
+      }
+      for (let k = i; k <= end; k++) buf[k] = src[k];
+      i = end + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      // Centralised triple-quoted-aware skip.
+      const j = skipSparqlStringLiteral(src, i);
+      for (let k = i; k < j; k++) buf[k] = src[k] === '\n' ? '\n' : ' ';
+      i = j;
+      continue;
+    }
+    if (ch === '#') {
+      const nl = src.indexOf('\n', i);
+      const end = nl === -1 ? n : nl;
+      for (let k = i; k < end; k++) buf[k] = ' ';
+      i = end;
+      continue;
+    }
+    buf[i] = ch;
+    i++;
+  }
+  return buf.join('');
+}
+
+/**
+ * Split a SPARQL WHERE body on **top-level** triple terminators, i.e.
+ * dots that live outside quoted literals and outside IRI angle
+ * brackets. The earlier `/\.(?=\s|$)/` regex broke on literal dots
+ * in messages like `?s <p> "hello. world"`, silently fragmenting
+ * the statement so the subject scanner returned garbage and
+ * `_minTrust` fail-closed to `[]` for every text/chat query. This
+ * tokenizer walks the body character
+ * by character, tracks `<…>` and `"…"` / `'…'` scopes (with `\`-escape
+ * handling), and only treats `.` as a separator when it sits at depth
+ * zero and is followed by whitespace or end-of-input. Comments have
+ * already been stripped by {@link stripSparqlLineComments} before we
+ * get here, so `#` is treated as an ordinary character.
+ *
+ * Parentheses and braces would also open top-level scopes in general
+ * SPARQL, but `injectMinTrustFilter` refuses to rewrite any WHERE that
+ * contains `{`, `}`, `FILTER EXISTS`, subselects, or property paths
+ * with grouping (the `/\{|\}/.test(inner)` + token guard above), so
+ * this helper only has to handle the three grammar contexts that can
+ * legally carry a bare `.` in the shapes we rewrite: IRI, string
+ * literal, and top-level statement terminator.
+ */
+function splitTopLevelTripleStatements(body: string): string[] {
+  const out: string[] = [];
+  let start = 0;
+  let i = 0;
+  const n = body.length;
+  while (i < n) {
+    const ch = body[i];
+    if (ch === '<') {
+      const end = body.indexOf('>', i + 1);
+      if (end === -1) { i = n; break; }
+      i = end + 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      // Centralised triple-quoted-aware skip.
+      i = skipSparqlStringLiteral(body, i);
+      continue;
+    }
+    if (ch === '.') {
+      // Terminator only when followed by whitespace OR end-of-input.
+      // This keeps decimals and prefixed-name dots (rdf:type.foo —
+      // rejected upstream anyway) from accidentally splitting, and
+      // matches the original regex semantics on the top-level cases.
+      const next = i + 1 < n ? body[i + 1] : '';
+      if (next === '' || /\s/.test(next)) {
+        const piece = body.slice(start, i).trim();
+        if (piece) out.push(piece);
+        start = i + 1;
+        i += 1;
+        continue;
+      }
+    }
+    i++;
+  }
+  const tail = body.slice(start).trim();
+  if (tail) out.push(tail);
+  return out;
+}
+
+function injectMinTrustFilter(sparql: string, minTrust: number): string | null {
+  // The
+  // pre-fix rewriter only recognised `WHERE\s*\{`, so SPARQL 1.1
+  // shorthand forms (`SELECT ?x { … }`, `ASK { … }`,
+  // `DESCRIBE ?x { … }`, `CONSTRUCT { tmpl } { where }`) returned
+  // `null` and the `minTrust > Endorsed` caller silently fell
+  // through to an empty result. `findWhereBraceStart` normalises
+  // every shape to the WHERE-clause brace position before we apply
+  // the existing depth-counting pass below.
+  const braceStart = findWhereBraceStart(sparql);
+  if (braceStart === -1) return null;
+
+  // — dkg-query-engine.ts:939). The
+  // earlier brace-balance loop counted `{`/`}` inside SPARQL string
+  // literals (e.g. `FILTER(STR(?t) = "{")`), so a literal-heavy WHERE
+  // ended at depth 1 and `injectMinTrustFilter` returned `null` —
+  // which the `_minTrust > Endorsed` caller treats as "refuse to run"
+  // and silently fails closed. Use the literal/comment/IRI-aware
+  // helper so the brace boundaries match what SPARQL actually
+  // parses.
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
+  if (braceEnd === -1) return null;
+
+  const inner = sparql.slice(braceStart + 1, braceEnd);
+
+  // A
+  // leading top-level `VALUES` clause is the canonical SPARQL shape
+  // for batched exact-subject lookups:
+  //
+  //     SELECT ?o WHERE {
+  //       VALUES ?s { <a> <b> <c> }
+  //       ?s <p> ?o .
+  //     }
+  //
+  // the forbidden-tokens regex treated any VALUES as
+  // "unsupported" and `_minTrust` fell through to
+  // `emptyResultForForm(...)`, which turns into a silent `[]` / `false`
+  // even when the bound subjects satisfy the threshold. The contract
+  // we need is:
+  //   (a) bail loudly on complex VALUES we can't reason about
+  //       (multi-var tuples, multi-line, no closing `}`);
+  //   (b) for the common single-var VALUES case, peel it off, run
+  //       the existing subject analysis on the body, and re-emit
+  //       the VALUES binding at the top of the rewritten WHERE so
+  //       the trust filter still applies to each bound IRI.
+  //
+  // Any other location (non-leading, multi-var, parenthesised row
+  // syntax `VALUES (?x ?y) { (<a> "b") }`) still bails because the
+  // flat scanner cannot safely rewrite them.
+  const { valuesClause, bodyAfterValues } = peelLeadingValues(inner);
+  const scanTarget = bodyAfterValues ?? inner;
+
+  // — dkg-query-engine.ts:851).
+  // Pre-fix the unsupported-nesting guard `/\{|\}/.test(scanTarget)`
+  // and the keyword guard below ran on the RAW WHERE body. Any
+  // `{`, `}`, or sensitive keyword that happened to appear inside a
+  // SPARQL string literal (`"{json: 1}"`, `"OPTIONAL field"`,
+  // `"SELECT * FROM x"`) or inside a `# …` line comment caused the
+  // rewriter to bail out and the caller fell through to
+  // `emptyResultForSparql(...)`. That silently fail-closed every
+  // legitimate high-trust query whose payload happened to mention
+  // those tokens — text/JSON/log content is the most common case.
+  //
+  // Scrub literals and comments to neutral spaces BEFORE the
+  // structural / keyword checks so they only see real code tokens.
+  // IRIs are preserved verbatim because IRIREF grammar already
+  // forbids `{`, `}`, `"`, and the keyword tokens we care about.
+  const codeView = scrubStringsAndComments(scanTarget);
+  if (/[{}]/.test(codeView)) return null;
+  if (
+    /\b(GRAPH|OPTIONAL|UNION|MINUS|SERVICE|VALUES|FILTER\s+EXISTS|FILTER\s+NOT\s+EXISTS|SELECT)\b/i.test(codeView)
+  ) {
+    return null;
+  }
+
+  // Strip SPARQL line comments (`# … \n`) so the dot accounting below
+  // doesn't misclassify "# foo ." as a terminating triple — BUT leave
+  // `#` fragments inside IRIs (`<…#…>`) and literals (`"…#…"`) alone.
+  // The naive `/#[^\n]*/g` regex used here previously mangled the
+  // extremely common `rdf:type` shape
+  // `<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>` whenever
+  // `_minTrust` was set, which fail-closes the entire query to `[]`
+  // .
+  const innerCodeOnly = stripSparqlLineComments(scanTarget);
+  const trimmedInner = innerCodeOnly.trim();
+  if (trimmedInner.length === 0) return null;
+
+  // Split on the top-level `.` separator to walk each triple pattern.
+  // use a
+  // quote/IRI-aware tokenizer instead of a naive regex so `?s <p>
+  // "hello. world"` isn't fragmented into broken statements that the
+  // subject scanner then refuses, fail-closing `_minTrust` to `[]`
+  // for every text/chat query. Rejoined dots are preserved for the
+  // emitted query by the clause builder below.
+  const statements = splitTopLevelTripleStatements(trimmedInner);
+
+  const subjectVars = new Set<string>();
+  const subjectIris = new Set<string>();
+  const subjectPrefixed = new Set<string>();
+  for (const stmt of statements) {
+    // top-level `FILTER(...)` / `BIND(... AS ?x)` clauses share the
+    // statement-list with triple patterns and have no subject token.
+    // Pre-fix the subject regex below didn't match either keyword,
+    // returned `null`, and `injectMinTrustFilter()` propagated `null`
+    // — collapsing every query like
+    //   SELECT ?s WHERE { ?s <p> ?o . FILTER(?o > 10) }
+    // into an empty result whenever `minTrust > SelfAttested`.
+    //
+    // Skip these clauses in the subject scan: they don't introduce
+    // new subjects and they survive verbatim because the rewritten
+    // WHERE is built by appending trust-filter triples to the
+    // *original* trimmed inner (see `rewrittenBody` below) — the
+    // FILTER/BIND text stays exactly where the caller put it.
+    //
+    // Anti-recursion: only skip TOP-LEVEL FILTER/BIND. Nested ones
+    // (e.g. `FILTER EXISTS { ... }`) are already rejected by the
+    // `\{|\}` and `FILTER\s+EXISTS` checks at line 753 / 754, so
+    // by the time we reach this loop we're guaranteed to be looking
+    // at a flat FILTER(<expr>) or BIND(<expr> AS ?x).
+    const stmtTrimmed = stmt.trim();
+    if (/^FILTER\s*\(/i.test(stmtTrimmed) || /^BIND\s*\(/i.test(stmtTrimmed)) {
+      continue;
+    }
+    // First non-whitespace token is the subject. Accept:
+    //   - variable (`?x`, `$x`)
+    //   - absolute IRI (`<urn:x>`)
+    //   - blank node (`_:b`)
+    //   - RDF literal (`"…"` with optional type/lang tag)
+    //   - prefixed name (`ex:item`) — SPARQL `PNAME_LN` / `PNAME_NS`.
+    //     Earlier revisions fail-closed `_minTrust` to `[]` for
+    //     every query that used standard `PREFIX ex: <urn:> …`
+    //     syntax, which is the recommended SPARQL shape for exact
+    //     entity lookups.
+    const m = stmt.match(
+      /^\s*([?$]([A-Za-z_]\w*)|<[^>]+>|_:[A-Za-z_]\w*|"[^"]*"(?:\^\^<[^>]+>|@[A-Za-z-]+)?|[A-Za-z][\w-]*:[A-Za-z_][\w-]*|[A-Za-z][\w-]*:)/,
+    );
+    if (!m) return null;
+    const subj = m[1];
+    if (subj.startsWith('?') || subj.startsWith('$')) {
+      subjectVars.add(subj);
+      continue;
+    }
+    // exact-entity lookups like `SELECT ?o WHERE { <e> <p> ?o }` are
+    // the most common SPARQL shape in DKG and must NOT fail closed on
+    // `_minTrust`. The threshold is perfectly enforceable against a
+    // concrete IRI: attach `<iri> <trustLevel> ?t . FILTER(?t >= N)`
+    // to the rewritten WHERE. Blank-node and literal subjects remain
+    // refused — neither can carry trust metadata in our ontology.
+    if (subj.startsWith('<') && subj.endsWith('>')) {
+      subjectIris.add(subj);
+      continue;
+    }
+    // Prefixed name — treat like an IRI at the clause-emission stage.
+    // The original query still carries the `PREFIX` declarations, so
+    // emitting `ex:item <trustLevel> ?t . FILTER(...)` is valid SPARQL
+    // at the same scope. Rejects `_:bn` (starts with `_:`) and
+    // string literals (start with `"`) naturally because this branch
+    // only runs when subj starts with a letter.
+    if (/^[A-Za-z]/.test(subj) && subj.includes(':')) {
+      subjectPrefixed.add(subj);
+      continue;
+    }
+    // Blank-node / literal subject — cannot attach a trust filter.
+    return null;
+  }
+  if (subjectVars.size === 0 && subjectIris.size === 0 && subjectPrefixed.size === 0) return null;
+
+  const extraClauses: string[] = [];
+  let i = 0;
+  for (const subjectVar of subjectVars) {
+    const trustVar = `?__dkgTrust${i++}`;
+    extraClauses.push(
+      `${subjectVar} <http://dkg.io/ontology/trustLevel> ${trustVar} . ` +
+        `FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(${trustVar})) >= ${minTrust})`,
+    );
+  }
+  for (const subjectIri of subjectIris) {
+    const trustVar = `?__dkgTrust${i++}`;
+    extraClauses.push(
+      `${subjectIri} <http://dkg.io/ontology/trustLevel> ${trustVar} . ` +
+        `FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(${trustVar})) >= ${minTrust})`,
+    );
+  }
+  for (const subjectPfx of subjectPrefixed) {
+    const trustVar = `?__dkgTrust${i++}`;
+    extraClauses.push(
+      `${subjectPfx} <http://dkg.io/ontology/trustLevel> ${trustVar} . ` +
+        `FILTER(<http://www.w3.org/2001/XMLSchema#integer>(STR(${trustVar})) >= ${minTrust})`,
+    );
+  }
+
+  // the previous implementation unconditionally inserted
+  // `" . "` between `inner.trim()` and the injected clauses, which
+  // produced `... . . ?s <trustLevel> ...` when the original WHERE
+  // already ended with a dot (the common case) — a SPARQL syntax error
+  // that every rewritten query hit. Here we emit each rewritten triple
+  // with its OWN dot and join them after the original inner block,
+  // always with exactly one separating dot regardless of whether the
+  // caller terminated their final triple pattern.
+  const endsWithDot = /\.\s*$/.test(trimmedInner);
+  const separator = endsWithDot ? ' ' : ' . ';
+  const rewrittenBody = `${trimmedInner}${separator}${extraClauses.join(' ')}`;
+
+  // if the WHERE started with a `VALUES ?s { … }` clause the
+  // peeler set aside, re-emit it at the top of the rewritten body so
+  // the bindings it introduces still drive the trust-filtered BGP.
+  const rewrittenInner = valuesClause
+    ? `${valuesClause} ${rewrittenBody}`
+    : rewrittenBody;
+
+  const before = sparql.slice(0, braceStart + 1);
+  const after = sparql.slice(braceEnd);
+  return `${before} ${rewrittenInner} ${after}`;
+}
+
+/**
+ * peel a single leading top-level `VALUES ?var { … }` clause
+ * off the WHERE body. Returns the clause text (verbatim, including the
+ * trailing `}`) and the remainder so the caller can reason about
+ * triples alone. If the WHERE does NOT start with a VALUES clause, or
+ * the VALUES clause is multi-var (`VALUES (?x ?y) { (<a> "b") }`), has
+ * unbalanced braces, or uses nested parentheses for row syntax, returns
+ * `{ valuesClause: null, bodyAfterValues: null }` so the caller falls
+ * back to refusing the query (the forbidden-tokens regex still trips
+ * on `VALUES`).
+ */
+function peelLeadingValues(inner: string): {
+  valuesClause: string | null;
+  bodyAfterValues: string | null;
+} {
+  const withoutComments = stripSparqlLineComments(inner);
+  const m = withoutComments.match(/^\s*VALUES\s+([?$][A-Za-z_]\w*)\s*\{/i);
+  if (!m) return { valuesClause: null, bodyAfterValues: null };
+
+  const openBraceRel = m[0].length - 1;
+  let depth = 1;
+  let i = openBraceRel + 1;
+  let inString = false;
+  let inIri = false;
+  for (; i < withoutComments.length; i++) {
+    const ch = withoutComments[i];
+    if (inString) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === '"') inString = false;
+      continue;
+    }
+    if (inIri) {
+      if (ch === '>') inIri = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === '<') { inIri = true; continue; }
+    if (ch === '(' || ch === ')') {
+      // Row-tuple syntax — we can't reason about multi-var rows safely.
+      return { valuesClause: null, bodyAfterValues: null };
+    }
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (depth !== 0) return { valuesClause: null, bodyAfterValues: null };
+
+  const closeAbs = i;
+  const valuesClause = withoutComments.slice(0, closeAbs + 1).trim();
+  const bodyAfterValues = withoutComments.slice(closeAbs + 1);
+  return { valuesClause, bodyAfterValues };
 }
 
 function mergeSharedMemoryAndDataResults(

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -4,8 +4,22 @@ export { DKGQueryEngine, resolveViewGraphs, type ViewResolution } from './dkg-qu
 export { QueryHandler } from './query-handler.js';
 export {
   validateReadOnlySparql,
+  detectSparqlQueryForm,
+  emptyResultForForm,
+  emptyResultForSparql,
+  // packages/query/src/index.ts:7).
+  // Re-exported as `@deprecated` aliases (defined in `sparql-guard.ts`)
+  // so downstream consumers of `@origintrail-official/dkg-query` who
+  // imported the legacy symbols don't hit a hard compile failure on
+  // the next minor update. Internal call sites in
+  // `dkg-query-engine.ts` / `dkg-agent.ts` continue to use the
+  // canonical `detectSparqlQueryForm` + `emptyResultForForm` /
+  // `emptyResultForSparql` pair so the drift surface r30-3 closed
+  // stays closed.
   classifySparqlForm,
   emptyQueryResultForKind,
   type SparqlGuardResult,
+  type SparqlQueryForm,
   type SparqlForm,
+  type EmptyQueryResultShape,
 } from './sparql-guard.js';

--- a/packages/query/src/sparql-guard.ts
+++ b/packages/query/src/sparql-guard.ts
@@ -6,7 +6,6 @@
  * This module rejects any SPARQL that attempts mutation operations.
  */
 
-import type { Quad } from '@origintrail-official/dkg-storage';
 import { stripLiteralsAndComments } from './sparql-utils.js';
 import type { QueryResult } from './query-engine.js';
 
@@ -29,6 +28,191 @@ const MUTATING_PATTERN = new RegExp(
 
 // Matches the query form keyword after optional PREFIX/BASE preamble
 const READ_ONLY_FORMS = /^\s*(?:(?:PREFIX|BASE)\s+[^\n]*\n\s*)*(SELECT|CONSTRUCT|ASK|DESCRIBE)\b/i;
+
+/** SPARQL query form — enough to shape a `QueryResult` correctly. */
+export type SparqlQueryForm = 'SELECT' | 'CONSTRUCT' | 'ASK' | 'DESCRIBE' | 'UNKNOWN';
+
+/**
+ * classify a read-only SPARQL
+ * query so callers can produce a result shape that MATCHES what the
+ * query engine would return for a successful-but-empty execution of
+ * the same form:
+ *
+ *   - SELECT  → `{ bindings: [] }`
+ *   - ASK     → `{ bindings: [{ result: 'false' }] }` (the `dkg-query-engine`
+ *               convention: ASK results surface through bindings so
+ *               callers don't need a separate branch)
+ *   - CONSTRUCT / DESCRIBE → `{ bindings: [], quads: [] }`
+ *   - UNKNOWN → `{ bindings: [] }` (safe default; unreachable from
+ *               inside `DKGAgent.query` because `validateReadOnlySparql`
+ *               rejects anything that doesn't match a known form)
+ *
+ * This lets fail-closed branches (WM cross-agent auth denial, private-CG
+ * leak guard, quota exceed, ...) emit a result indistinguishable from
+ * an empty legitimate response, without breaking downstream callers
+ * that branch on the presence of `quads`.
+ */
+export function detectSparqlQueryForm(sparql: string): SparqlQueryForm {
+  const stripped = stripLiteralsAndComments(sparql);
+  const m = READ_ONLY_FORMS.exec(stripped);
+  if (!m) return 'UNKNOWN';
+  const kw = m[1].toUpperCase();
+  if (kw === 'SELECT' || kw === 'CONSTRUCT' || kw === 'ASK' || kw === 'DESCRIBE') {
+    return kw;
+  }
+  return 'UNKNOWN';
+}
+
+/**
+ * Shape of an empty `QueryResult`.
+ *
+ * Now an alias of the canonical `QueryResult` so the empty-shape
+ * contract and the success-shape contract cannot drift. Callers can
+ * treat `EmptyQueryResultShape` and `QueryResult` interchangeably —
+ * the only difference is a structural guarantee that `bindings` is
+ * empty (and `quads`, when present, is `[]`).
+ */
+export type EmptyQueryResultShape = QueryResult;
+
+/**
+ * Build a shape-matched empty `QueryResult` for a given SPARQL form.
+ *
+ * Returns a FRESH object on every call so callers can safely mutate
+ * it (append bindings on a subsequent fallthrough, e.g.) without
+ * worrying about cross-call aliasing.
+ *
+ * — sparql-guard.ts:56). This is the
+ * SINGLE canonical empty-shape builder for the package — there is no
+ * parallel `emptyQueryResultForKind` helper anymore. Any future
+ * change to `QueryResult` only has to update this function and
+ * `detectSparqlQueryForm` (also in this file).
+ */
+export function emptyResultForForm(form: SparqlQueryForm): QueryResult {
+  if (form === 'CONSTRUCT' || form === 'DESCRIBE') {
+    return { bindings: [], quads: [] };
+  }
+  if (form === 'ASK') {
+    return { bindings: [{ result: 'false' }] };
+  }
+  return { bindings: [] };
+}
+
+/**
+ * One-shot ergonomic helper: classify the SPARQL string and build a
+ * shape-matched empty `QueryResult` in a single call. Equivalent to
+ * `emptyResultForForm(detectSparqlQueryForm(sparql))` and exists
+ * solely so callers that don't already need the form for branching
+ * don't have to write the two-step every time.
+ *
+ * — sparql-guard.ts:56) consolidation:
+ * before this consolidation, two parallel pairs lived in this file
+ * (`detectSparqlQueryForm` + `emptyResultForForm` AND
+ * `classifySparqlForm` + `emptyQueryResultForKind`). The legacy pair
+ * is gone; this helper replaces the legacy `emptyQueryResultForKind`
+ * call sites without re-introducing a parallel classifier.
+ */
+export function emptyResultForSparql(sparql: string): QueryResult {
+  return emptyResultForForm(detectSparqlQueryForm(sparql));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// packages/query/src/index.ts:7).
+//
+// r30-3 consolidated two parallel SPARQL form classifier pairs onto
+// the canonical `detectSparqlQueryForm` + `emptyResultForForm` pair
+// and DELETED the legacy `classifySparqlForm` + `emptyQueryResultForKind`
+// + `SparqlForm` symbols outright. The bot's r31-2 thread on
+// `packages/query/src/index.ts:7` flagged the deletion as a source-
+// breaking API change for downstream consumers of
+// `@origintrail-official/dkg-query` even though the package version
+// here is unchanged.
+//
+// Restored as `@deprecated` wrappers + a re-exported type alias.
+// Same semantic behaviour as the legacy pair (notably:
+// `classifySparqlForm` silently mapped unparseable input to
+// `'SELECT'` rather than `'UNKNOWN'`, which the wrapper preserves
+// to keep BYTE-COMPATIBLE branching for any caller that switches
+// on the form). The internal call sites in `dkg-query-engine.ts`
+// and `dkg-agent.ts` continue to use the canonical pair so the
+// drift surface r30-3 closed stays closed.
+//
+// Migration path for consumers:
+//   - `classifySparqlForm(s)` → `detectSparqlQueryForm(s)` (returns
+//     `'UNKNOWN'` instead of silently coercing to `'SELECT'`).
+//   - `emptyQueryResultForKind(form)` → `emptyResultForForm(form)`
+//     (drop-in replacement; same shape, same fresh-object guarantee).
+//   - `SparqlForm` type → `SparqlQueryForm` (adds the `'UNKNOWN'`
+//     variant so unparseable input is observable rather than
+//     silently coerced).
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * @deprecated
+ *
+ * Legacy SPARQL form type. The canonical replacement is
+ * {@link SparqlQueryForm}, which adds an explicit `'UNKNOWN'`
+ * variant so unparseable input is observable rather than silently
+ * coerced to `'SELECT'`. Migrate at your earliest convenience —
+ * this alias will be removed in the next breaking release of
+ * `@origintrail-official/dkg-query`.
+ */
+export type SparqlForm = 'SELECT' | 'CONSTRUCT' | 'ASK' | 'DESCRIBE';
+
+/**
+ * @deprecated
+ *
+ * Legacy classifier preserved as a thin wrapper. Use
+ * {@link detectSparqlQueryForm} for new code — it returns the
+ * richer {@link SparqlQueryForm} type with a `'UNKNOWN'` variant so
+ * unparseable input is observable rather than silently coerced to
+ * `'SELECT'`.
+ *
+ * **Behavioural compat note**: this wrapper preserves the legacy
+ * "unparseable → `'SELECT'`" mapping so any caller that switches
+ * on the returned string keeps branching identically across the
+ * deprecation window. New code should call `detectSparqlQueryForm`
+ * directly and handle the `'UNKNOWN'` variant explicitly — the
+ * silent SELECT coercion is exactly the drift hazard the canonical
+ * helper closes.
+ */
+export function classifySparqlForm(sparql: string): SparqlForm {
+  const form = detectSparqlQueryForm(sparql);
+  if (form === 'UNKNOWN') return 'SELECT';
+  return form;
+}
+
+/**
+ * @deprecated
+ *
+ * Legacy one-shot helper preserved as a thin composition over the
+ * canonical primitives. Use {@link emptyResultForSparql} for new
+ * code (drop-in replacement that exists for the same ergonomic
+ * "single call" reason this helper did) or
+ * {@link emptyResultForForm} when the form is already known.
+ *
+ * **Signature compat**: the legacy `emptyQueryResultForKind`
+ * accepted the raw SPARQL **string** and classified it internally.
+ * Changing the parameter type to `SparqlForm` would silently break
+ * `JS`/`any` callers — they would pass a SPARQL string into a
+ * slot typed as a form discriminator,
+ * and the function returned the SELECT-shaped empty result for
+ * `ASK` / `CONSTRUCT` queries (because the string didn't match any
+ * variant). The signature is restored to `string` here so existing
+ * `emptyQueryResultForKind(query)` call sites compile and behave
+ * identically to the surface, with the form classification
+ * delegated to {@link emptyResultForSparql}.
+ *
+ * Behaviour matches the legacy implementation: for unparseable
+ * input this routes onto the canonical `'SELECT'` empty shape
+ * (`{ bindings: [] }`), preserving downstream callers' branching
+ * across the deprecation window. The `quads`-presence parity that
+ * matters for CONSTRUCT/DESCRIBE branching is unchanged because
+ * the canonical {@link emptyResultForForm} already handles those
+ * forms identically.
+ */
+export function emptyQueryResultForKind(sparql: string): QueryResult {
+  return emptyResultForSparql(sparql);
+}
 
 export interface SparqlGuardResult {
   safe: boolean;
@@ -62,41 +246,3 @@ export function validateReadOnlySparql(sparql: string): SparqlGuardResult {
 
   return { safe: true };
 }
-
-export type SparqlForm = 'SELECT' | 'CONSTRUCT' | 'ASK' | 'DESCRIBE';
-
-/**
- * Classify the query form of a SPARQL string. Used by engines that need to
- * short-circuit a query (e.g. "no graphs resolved") while still returning a
- * result shape that matches the requested form — `QueryResult.bindings: []`
- * is not a valid ASK response (ASK must return a boolean binding) and is not
- * a valid CONSTRUCT/DESCRIBE response either (those must carry `quads: []`).
- */
-export function classifySparqlForm(sparql: string): SparqlForm {
-  const stripped = stripLiteralsAndComments(sparql);
-  const match = READ_ONLY_FORMS.exec(stripped);
-  const form = (match?.[1] ?? 'SELECT').toUpperCase();
-  if (form === 'ASK' || form === 'CONSTRUCT' || form === 'DESCRIBE') {
-    return form;
-  }
-  return 'SELECT';
-}
-
-/**
- * Produce an empty `QueryResult` that matches the requested query form.
- * Centralising this keeps every "nothing to query" short-circuit
- * (access-denied synthetic response, zero-graph resolution, etc.) aligned
- * on a single well-typed contract instead of returning `{ bindings: [] }`
- * for every form.
- */
-export function emptyQueryResultForKind(sparql: string): QueryResult {
-  const form = classifySparqlForm(sparql);
-  if (form === 'ASK') {
-    return { bindings: [{ result: 'false' }] };
-  }
-  if (form === 'CONSTRUCT' || form === 'DESCRIBE') {
-    return { bindings: [], quads: [] as Quad[] };
-  }
-  return { bindings: [] };
-}
-

--- a/packages/query/test/query-engine.test.ts
+++ b/packages/query/test/query-engine.test.ts
@@ -97,6 +97,47 @@ describe('DKGQueryEngine', () => {
     expect(result.bindings.length).toBe(2);
   });
 
+  // the multi-graph wrapper used to
+  // inject `VALUES ?_viewGraph { ... } GRAPH ?_viewGraph { inner }` into
+  // the caller's WHERE block, which leaked an extra `_viewGraph` column
+  // into every `SELECT *` result and collided with user queries that
+  // legitimately bound `?_viewGraph`. The fix is to use explicit UNION
+  // branches per graph, so no helper variable ever enters the user's
+  // variable scope.
+  it('multi-graph views do NOT leak a helper _viewGraph variable into SELECT * results', async () => {
+    await store.insert([
+      q('did:dkg:agent:QmTextBot', 'http://schema.org/name', '"TextBot"', 'did:dkg:context-graph:text-tools'),
+    ]);
+
+    const result = await engine.queryAllContextGraphs(
+      'SELECT * WHERE { ?s <http://schema.org/name> ?name }',
+    );
+    expect(result.bindings.length).toBe(2);
+    // The bindings must NOT include a `_viewGraph` (or any `view*`)
+    // variable — only the user's ?s and ?name.
+    for (const row of result.bindings) {
+      expect(Object.keys(row).sort()).toEqual(['name', 's']);
+    }
+  });
+
+  it('does not collide with user queries that bind a ?_viewGraph variable of their own', async () => {
+    await store.insert([
+      q('did:dkg:agent:QmTextBot', 'http://schema.org/name', '"TextBot"', 'did:dkg:context-graph:text-tools'),
+    ]);
+
+    // If the old implementation had been retained, the caller's
+    // ?_viewGraph binding would be silently clamped to the wrapper's
+    // VALUES list. With the UNION-based fix the caller's variable is
+    // independent and the wrapper introduces none of its own.
+    const result = await engine.queryAllContextGraphs(
+      'SELECT ?name ?_viewGraph WHERE { ?s <http://schema.org/name> ?name . BIND(<http://example.org/g> AS ?_viewGraph) }',
+    );
+    // Everyone gets the same user-supplied bind.
+    for (const row of result.bindings) {
+      expect(row['_viewGraph']).toBe('http://example.org/g');
+    }
+  });
+
   it('queries shared memory graph when graphSuffix is _shared_memory', async () => {
     const sharedMemoryGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
     await store.insert([

--- a/packages/query/test/query-extra.test.ts
+++ b/packages/query/test/query-extra.test.ts
@@ -1,7 +1,7 @@
 /**
  * packages/query — extra QA coverage for spec-gap & prod-bug findings.
  *
- * Findings covered (see .test-audit/BUGS_FOUND.md):
+ * Findings covered (see .test-audit/
  *
  *   Q-1  PROD-BUG  `QueryOptions.minTrust` on `verified-memory` view is a
  *                  *graph-scope* filter, not a per-triple filter. P-13
@@ -78,7 +78,18 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
   // minTrust > SelfAttested). Q-1 is the remaining per-triple half: if a
   // writer ever stamps mixed-trust quads into a single sub-graph, the
   // graph-scope filter cannot catch it. This test pins that gap.
-  it('filters out sub-threshold trust quads WITHIN a verified-memory sub-graph (EXPECTED to fail until Q-1 is fixed)', async () => {
+  //
+  // the per-triple filter is now
+  // skipped at `Endorsed` because no production writer emits
+  // `dkg:trustLevel` literals — applying the join at Endorsed would
+  // collapse legitimate queries against real data. The per-triple
+  // filter still runs at `PartiallyVerified` / `ConsensusVerified`,
+  // where graph-scope alone cannot distinguish the tiers, and where
+  // a fail-closed empty result on un-tagged data is the correct
+  // behaviour. This test now exercises the per-triple filter at
+  // `ConsensusVerified` (the highest tier) — that path is what
+  // production callers asking for the strictest tier will hit.
+  it('filters out sub-threshold trust quads WITHIN a verified-memory sub-graph at ConsensusVerified (Q-1)', async () => {
     const store = new OxigraphStore();
     const engine = new DKGQueryEngine(store);
 
@@ -90,7 +101,7 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
 
     await store.insert([
       quad('urn:low', 'http://schema.org/name', '"LowTrust"', mixedGraph),
-      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.SelfAttested}"`, mixedGraph),
+      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Endorsed}"`, mixedGraph),
       quad('urn:high', 'http://schema.org/name', '"HighTrust"', mixedGraph),
       quad('urn:high', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, mixedGraph),
       // Root-level quad — P-13 graph-scope filter already excludes this.
@@ -102,21 +113,452 @@ describe('[Q-1] DKGQueryEngine minTrust is graph-scope only — PROD-BUG', () =>
       {
         contextGraphId: CG,
         view: 'verified-memory',
-        // Endorsed is the highest tier the engine currently accepts for
-        // union queries (P-13 review: `PartiallyVerified` / `ConsensusVerified`
-        // are rejected at the resolver until per-graph trust tagging lands
-        // under Q-1). The gap below — per-triple filtering within a
-        // /_verified_memory/* sub-graph — is orthogonal and still unmet.
-        minTrust: TrustLevel.Endorsed,
+        minTrust: TrustLevel.ConsensusVerified,
       },
     );
 
     const names = result.bindings.map((b) => b['name']);
-    // Spec §14: only triples at or above the requested trust tier should survive.
-    // Today, per-triple filtering inside a sub-graph is not implemented —
-    // this assertion fails and documents Q-1. P-13's graph-scope filter
-    // alone returns both LowTrust and HighTrust from the mixed sub-graph.
+    // Per-triple filter strips the Endorsed-only `urn:low` quad —
+    // only `urn:high` (which carries `ConsensusVerified`) survives.
     expect(names).toEqual(['"HighTrust"']);
+  });
+
+  // explicit pin that the new
+  // `> Endorsed` threshold leaves Endorsed queries reading from
+  // /_verified_memory/* sub-graphs without applying the per-triple
+  // join. Real production data lands in those sub-graphs WITHOUT a
+  // `dkg:trustLevel` literal (writer-side trust tagging is tracked
+  // upstream), so the previously-applied per-triple filter would
+  // collapse every Endorsed query to `[]`. This test exercises that
+  // exact production shape: data in /_verified_memory/{quorum}
+  // with NO trustLevel triples must still be visible at Endorsed.
+  it('Endorsed reads /_verified_memory/* WITHOUT requiring per-triple trustLevel (graph-scope is the trust gate)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+
+    const subGraph = contextGraphVerifiedMemoryUri(CG, 'no-trust-metadata-quorum');
+    const rootGraph = contextGraphDataUri(CG);
+
+    // Production-shaped data: quads in a quorum sub-graph with NO
+    // trustLevel literals (matches today's publisher write path).
+    await store.insert([
+      quad('urn:prod1', 'http://schema.org/name', '"Production1"', subGraph),
+      quad('urn:prod2', 'http://schema.org/name', '"Production2"', subGraph),
+      // Root-graph data must NOT leak into Endorsed (P-13 graph-scope filter).
+      quad('urn:root', 'http://schema.org/name', '"RootDataGraph"', rootGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      {
+        contextGraphId: CG,
+        view: 'verified-memory',
+        minTrust: TrustLevel.Endorsed,
+      },
+    );
+
+    const names = result.bindings.map((b) => b['name']).sort();
+    // BOTH quorum-sub-graph quads survive (no per-triple filter at
+    // Endorsed) and the root-graph quad is excluded by P-13.
+    expect(names).toEqual(['"Production1"', '"Production2"']);
+  });
+
+  // pin that ConsensusVerified
+  // STILL fails closed on un-tagged production data — the higher
+  // tier requires explicit per-triple metadata, and a fail-closed
+  // empty result is the correct behaviour when writers haven't
+  // started emitting `dkg:trustLevel` yet.
+  it('ConsensusVerified fails CLOSED on production data WITHOUT trustLevel literals', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+
+    const subGraph = contextGraphVerifiedMemoryUri(CG, 'no-trust-metadata-quorum');
+    await store.insert([
+      quad('urn:prod1', 'http://schema.org/name', '"Production1"', subGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?name WHERE { ?s <http://schema.org/name> ?name }',
+      {
+        contextGraphId: CG,
+        view: 'verified-memory',
+        minTrust: TrustLevel.ConsensusVerified,
+      },
+    );
+
+    expect(result.bindings).toEqual([]);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // concrete-
+  // subject queries like `SELECT ?o WHERE { <entity> <p> ?o }` are the
+  // most common SPARQL shape for exact lookups and MUST honor `_minTrust`
+  // (not fail closed with an empty result). The fix attaches
+  // `<entity> <trustLevel> ?t . FILTER(?t >= N)` to the rewritten WHERE.
+  // ─────────────────────────────────────────────────────────────────────────
+  it('honors _minTrust on CONCRETE-SUBJECT queries (exact-entity lookup)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Exact-entity lookup MUST succeed when the entity meets the threshold.
+    const ok = await engine.query(
+      'SELECT ?n WHERE { <urn:e1> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(ok.bindings.map((b) => b['n'])).toEqual(['"Alice"']);
+  });
+
+  it('fails CLOSED on a concrete-subject lookup whose entity is BELOW the trust threshold', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const selfAttestedGraph = contextGraphVerifiedMemoryUri(CG, 'self-attested');
+    await store.insert([
+      quad('urn:low', 'http://schema.org/name', '"Bob"', selfAttestedGraph),
+      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.SelfAttested}"`, selfAttestedGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?n WHERE { <urn:low> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    // Below threshold → empty (the trust filter eliminates the row).
+    expect(result.bindings).toEqual([]);
+  });
+
+  it('fails CLOSED on a concrete-subject lookup whose entity has NO trust metadata at all', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const verifiedGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:bare', 'http://schema.org/name', '"Ghost"', verifiedGraph),
+      // deliberately NO trustLevel quad for <urn:bare>
+    ]);
+    const result = await engine.query(
+      'SELECT ?n WHERE { <urn:bare> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings).toEqual([]);
+  });
+
+  // `rdf:type` style
+  // IRIs contain a `#` fragment. The prior naive `replace(/#[^\n]*/g,'')`
+  // would mangle the IRI into `<http://www.w3.org/1999/02/22-rdf-syntax-ns`
+  // and fail-close every such query to `[]`. Lock the happy path so the
+  // fragment is preserved and the trust filter is injected correctly.
+  it('honors _minTrust when the BGP contains a fragment IRI (rdf:type, xsd, rdfs)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:frag', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://schema.org/Person', consensusGraph),
+      quad('urn:frag', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?t WHERE { <urn:frag> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?t }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['t'])).toEqual(['http://schema.org/Person']);
+  });
+
+  it('still strips real line comments containing a fake terminator (`# … .`)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:cmt', 'http://schema.org/name', '"ok"', consensus),
+      quad('urn:cmt', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+    ]);
+    const sparql = [
+      'SELECT ?n WHERE {',
+      '  <urn:cmt> <http://schema.org/name> ?n . # trailing comment with a fake dot .',
+      '}',
+    ].join('\n');
+    const result = await engine.query(sparql, {
+      contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.map((b) => b['n'])).toEqual(['"ok"']);
+  });
+
+  // the naive
+  // `/\.(?=\s|$)/` split fragmented any query whose literal contained
+  // a sentence-terminating dot ("hello. world", an email address
+  // ending a chat message, a float "3.14 " — anything where `.` was
+  // followed by whitespace inside the string). The rewrite would
+  // then bail out and `_minTrust` would fail-closed to `[]` for
+  // every text/chat query. These two cases pin the fix.
+  it('honors _minTrust when a triple-object literal contains a dot followed by whitespace ("hello. world")', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:msg', 'http://schema.org/text', '"hello. world"', consensus),
+      quad('urn:msg', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+    ]);
+    const result = await engine.query(
+      'SELECT ?t WHERE { <urn:msg> <http://schema.org/text> ?t }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['t'])).toEqual(['"hello. world"']);
+  });
+
+  it('honors _minTrust on a multi-triple BGP where the FIRST literal contains a sentence-terminator dot', async () => {
+    // If the fragmenter splits on the inner-literal dot it will treat
+    // "world" . ?s <p> ... as the start of the next statement — the
+    // subject scanner then refuses the shape and the query returns
+    // [] instead of the join result.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:m', 'http://schema.org/text', '"ack. ok"', consensus),
+      quad('urn:m', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:m', 'http://schema.org/author', '"alice"', consensus),
+    ]);
+    const result = await engine.query(
+      'SELECT ?a WHERE { <urn:m> <http://schema.org/text> "ack. ok" . <urn:m> <http://schema.org/author> ?a }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['a'])).toEqual(['"alice"']);
+  });
+
+  it('honors _minTrust on MIXED concrete + variable subjects in a single BGP', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:p', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:q', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:p', 'http://schema.org/relatedTo', 'urn:q', consensus),
+      quad('urn:q', 'http://schema.org/name', '"q-name"', consensus),
+    ]);
+    const result = await engine.query(
+      'SELECT ?name WHERE { <urn:p> <http://schema.org/relatedTo> ?t . ?t <http://schema.org/name> ?name }',
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['name'])).toEqual(['"q-name"']);
+  });
+
+  // before this
+  // round the `_minTrust` subject matcher only accepted variables,
+  // `<iri>`, blank nodes, and literals. Standard SPARQL with a
+  // `PREFIX ex: <urn:> ...` header and a prefixed-name subject
+  // (`ex:item`) was classified as "unsupported shape" and fail-closed
+  // to `[]` — even though the exact-entity trust filter is perfectly
+  // enforceable. These tests pin the fix: the rewritten WHERE accepts
+  // prefixed-name subjects and attaches the trust-level clause inline.
+  it('honors _minTrust when the subject is a prefixed name (PNAME_LN)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:item', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:item', 'http://example.org/name', '"Alice"', consensus),
+    ]);
+    const sparql = [
+      'PREFIX ex: <urn:>',
+      'PREFIX s: <http://example.org/>',
+      'SELECT ?n WHERE { ex:item s:name ?n }',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['n'])).toEqual(['"Alice"']);
+  });
+
+  it('filters out below-threshold results for prefixed-name subjects', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Unverified}"`, consensus),
+      quad('urn:low', 'http://example.org/name', '"Bob"', consensus),
+    ]);
+    // ex:low has Unverified < ConsensusVerified, so the rewrite MUST
+    // filter it out — not silently drop `_minTrust` and return "Bob".
+    const sparql = [
+      'PREFIX ex: <urn:>',
+      'PREFIX s: <http://example.org/>',
+      'SELECT ?n WHERE { ex:low s:name ?n }',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings).toEqual([]);
+  });
+
+  it('honors _minTrust on mixed prefixed + variable subjects (multi-triple BGP)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:p', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:q', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:p', 'http://schema.org/relatedTo', 'urn:q', consensus),
+      quad('urn:q', 'http://schema.org/name', '"q-name"', consensus),
+    ]);
+    const sparql = [
+      'PREFIX ex: <urn:>',
+      'SELECT ?name WHERE { ex:p <http://schema.org/relatedTo> ?t . ?t <http://schema.org/name> ?name }',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['name'])).toEqual(['"q-name"']);
+  });
+
+  // The
+  // canonical SPARQL shape for batched exact-subject lookups is a
+  // leading `VALUES ?s { … }` clause followed by a BGP that binds
+  // `?s`. Before r23-2 `injectMinTrustFilter` treated ANY occurrence
+  // of `VALUES` as "unsupported shape" and fail-closed to `[]` — even
+  // when every bound subject met the threshold. Callers saw a silent
+  // empty result with no `minTrust`-related error, which is exactly
+  // the false negative the bot flagged. These tests pin the fix:
+  // a single-variable leading VALUES clause is peeled off, the trust
+  // filter is attached to the BGP, and the VALUES binding is
+  // re-emitted verbatim so the engine still restricts subjects.
+  it('honors _minTrust on a leading VALUES ?s { … } clause', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:a', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:b', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:a', 'http://example.org/label', '"A"', consensus),
+      quad('urn:b', 'http://example.org/label', '"B"', consensus),
+    ]);
+    const sparql = [
+      'SELECT ?s ?l WHERE {',
+      '  VALUES ?s { <urn:a> <urn:b> }',
+      '  ?s <http://example.org/label> ?l .',
+      '}',
+      'ORDER BY ?s',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['l'])).toEqual(['"A"', '"B"']);
+  });
+
+  it('filters VALUES-bound subjects that fall below _minTrust', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:hi', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:lo', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Unverified}"`, consensus),
+      quad('urn:hi', 'http://example.org/label', '"H"', consensus),
+      quad('urn:lo', 'http://example.org/label', '"L"', consensus),
+    ]);
+    const sparql = [
+      'SELECT ?l WHERE {',
+      '  VALUES ?s { <urn:hi> <urn:lo> }',
+      '  ?s <http://example.org/label> ?l .',
+      '}',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    // `urn:lo` is Unverified — it must be filtered out, not silently
+    // returned because the rewriter bailed on VALUES.
+    expect(result.bindings.map((b) => b['l'])).toEqual(['"H"']);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  //
+  // A query like
+  //     SELECT ?o WHERE { ?s <p> ?o . FILTER(?o > 10) }
+  // splits into two top-level statements: `?s <p> ?o` and
+  // `FILTER(?o > 10)`. Pre-fix, the subject scanner saw the FILTER
+  // statement, the regex didn't match, `injectMinTrustFilter` returned
+  // null, and the whole query collapsed to `[]` whenever
+  // `minTrust > SelfAttested`. The new behaviour: top-level FILTER /
+  // BIND clauses are skipped during the subject scan and survive
+  // verbatim in the rewritten WHERE (since the rewriter appends trust-
+  // filter triples to the original trimmed inner).
+  // ─────────────────────────────────────────────────────────────────────
+  it('honors _minTrust on a BGP whose top-level statements include a FILTER', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:doc1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:doc2', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:doc1', 'http://schema.org/score', '"5"^^<http://www.w3.org/2001/XMLSchema#integer>', consensus),
+      quad('urn:doc2', 'http://schema.org/score', '"42"^^<http://www.w3.org/2001/XMLSchema#integer>', consensus),
+    ]);
+    const sparql = [
+      'SELECT ?s ?score WHERE {',
+      '  ?s <http://schema.org/score> ?score .',
+      '  FILTER(?score > 10)',
+      '}',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    // Only doc2 has score > 10. Pre-fix this would have returned [] —
+    // not because the data didn't match but because the rewriter
+    // returned null and the caller fail-closed the entire query.
+    expect(result.bindings.map((b) => b['s'])).toEqual(['urn:doc2']);
+  });
+
+  it('honors _minTrust on a BGP whose top-level statements include a BIND', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:x', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensus),
+      quad('urn:x', 'http://schema.org/title', '"Hello"', consensus),
+    ]);
+    const sparql = [
+      'SELECT ?s ?upper WHERE {',
+      '  ?s <http://schema.org/title> ?title .',
+      '  BIND(UCASE(?title) AS ?upper)',
+      '}',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['upper'])).toEqual(['"HELLO"']);
+  });
+
+  it('does not regress: trust-failed FILTER queries still return [] (filter is applied)', async () => {
+    // Negative control: FILTER queries that legitimately match nothing
+    // because the trust threshold excludes the only candidate must
+    // STILL return [] (post-rewrite the trust filter rejects the row).
+    // This pins that we didn't accidentally remove the trust check by
+    // letting FILTER short-circuit the rewriter.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensus = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:lo', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.Unverified}"`, consensus),
+      quad('urn:lo', 'http://schema.org/score', '"99"^^<http://www.w3.org/2001/XMLSchema#integer>', consensus),
+    ]);
+    const sparql = [
+      'SELECT ?s ?score WHERE {',
+      '  ?s <http://schema.org/score> ?score .',
+      '  FILTER(?score > 10)',
+      '}',
+    ].join('\n');
+    const result = await engine.query(
+      sparql,
+      { contextGraphId: CG, view: 'verified-memory', _minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings).toEqual([]);
   });
 });
 
@@ -466,5 +908,690 @@ describe('[Q-6] QueryHandler error taxonomy', () => {
     }, 'p');
     expect(resp.status).toBe('ERROR');
     expect(resp.error).toBe('Internal error processing query');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The pre-fix
+// `injectMinTrustFilter` only matched `WHERE\s*\{`. SPARQL 1.1 allows
+// the `WHERE` keyword to be omitted from `SELECT`, `ASK`, and
+// `DESCRIBE` queries, and from the second `GroupGraphPattern` of a
+// `CONSTRUCT`. Those legitimate shorthand queries used to return
+// `null` from the rewriter and the caller silently fell through to
+// `emptyQueryResultForKind(...)` whenever `minTrust > Endorsed`,
+// turning a valid query into a fail-closed empty result.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('[Q-1] minTrust handles SPARQL 1.1 shorthand WHERE forms', () => {
+  it('rewrites a SELECT shorthand (no WHERE keyword) when minTrust > Endorsed', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?n { <urn:e1> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['n'])).toEqual(['"Alice"']);
+  });
+
+  it('rewrites an ASK shorthand (no WHERE keyword) when minTrust > Endorsed', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    const result = await engine.query(
+      'ASK { <urn:e1> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBeGreaterThan(0);
+    const first = result.bindings[0];
+    expect(first['result'] === 'true' || first['result'] === true).toBe(true);
+  });
+
+  it('fails CLOSED on a SELECT shorthand whose entity is below the trust threshold', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const selfAttestedGraph = contextGraphVerifiedMemoryUri(CG, 'self-attested');
+    await store.insert([
+      quad('urn:low', 'http://schema.org/name', '"Bob"', selfAttestedGraph),
+      quad('urn:low', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.SelfAttested}"`, selfAttestedGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?n { <urn:low> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    // Below threshold → empty (proves the rewriter ran and the FILTER
+    // is enforced; without the shorthand fix this would also be empty
+    // BUT for the wrong reason — `injectMinTrustFilter` returning
+    // null and the caller short-circuiting. The two cases are
+    // distinguishable through the positive shorthand test above.)
+    expect(result.bindings).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// — dkg-query-engine.ts:540 follow-up).
+// `findWhereBraceStart` previously treated EVERY `<` as the start of an IRI
+// and skipped to the next `>`. SPARQL `<` is overloaded as a comparison
+// operator, so queries like `FILTER(?n < 10)` ate the rest of the query
+// and `wrapWithGraph` / `injectMinTrustFilter` no-op'd → wrong-graph hits
+// or silent fail-closed.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('[Q-1] findWhereBraceStart distinguishes IRI from comparison operator', () => {
+  it('honors minTrust on a SELECT whose FILTER uses `<` as less-than (no IRI swallowing)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/age', '"21"^^<http://www.w3.org/2001/XMLSchema#integer>', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Pre-fix: the `<` inside `FILTER(?n < 100)` made findWhereBraceStart
+    // scan to the next `>` (here the IRI's closing `>`), corrupting the
+    // brace search. With the IRI/comparison disambiguator the rewrite
+    // succeeds and the binding is returned.
+    const result = await engine.query(
+      'SELECT ?n WHERE { <urn:e1> <http://schema.org/age> ?n . FILTER(?n < 100) }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+    // Object literal includes the typed-literal serialisation; just
+    // assert the lexical form matches.
+    expect(String(result.bindings[0]['n'])).toContain('21');
+  });
+
+  it('honors minTrust on a SHORTHAND SELECT whose FILTER uses `<=` as comparison', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/age', '"21"^^<http://www.w3.org/2001/XMLSchema#integer>', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Shorthand (no WHERE keyword) + `<=` operator. Pre-fix this
+    // returned `null` from `findWhereBraceStart` because the IRI
+    // scanner ran past the closing `}` looking for `>`. Now the
+    // disambiguator recognises `<=` and skips past the operator.
+    const result = await engine.query(
+      'SELECT ?n { <urn:e1> <http://schema.org/age> ?n . FILTER(?n <= 100) }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // — dkg-query-engine.ts:559).
+  // The r30 cut only rejected `=`, `<`, and whitespace as next-byte
+  // shapes after `<`. Compact comparison forms like `?n<10&&?m>5`
+  // (no whitespace, common in machine-generated SPARQL) made the
+  // forward scan walk `1`,`0`,`&`,`&`,`?`,`m` (none IRIREF-forbidden)
+  // to the next `>`, mis-classifying the entire `<10&&?m>` as an IRI
+  // and corrupting the brace scan. Tighten the next-byte check to a
+  // positive allow-list of real IRIREF first chars (ALPHA / `#` /
+  // `_` / `/` / `.`).
+  // ─────────────────────────────────────────────────────────────────────
+  it('honors minTrust on a SHORTHAND SELECT with COMPACT `?n<10&&?m>5` comparison (no whitespace)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/age', '"21"^^<http://www.w3.org/2001/XMLSchema#integer>', consensusGraph),
+      quad('urn:e1', 'http://schema.org/score', '"50"^^<http://www.w3.org/2001/XMLSchema#integer>', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Pre-fix: `?n<100&&?m>5` walked through the IRI scan, `?` is not
+    // IRIREF-forbidden, so the scanner kept going to the next `>` and
+    // ate the closing `}` along the way → findWhereBraceStart returned
+    // -1 → graph wrap / minTrust filter silently no-op'd → empty.
+    const result = await engine.query(
+      'SELECT ?n ?m { <urn:e1> <http://schema.org/age> ?n . <urn:e1> <http://schema.org/score> ?m . FILTER(?n<100&&?m>5) }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('honors minTrust on `?n < (10 + 5)` — sub-expression with `<(` next-byte', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/age', '"21"^^<http://www.w3.org/2001/XMLSchema#integer>', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // `<(` is not IRIREF-legal; the next-byte rejecter let
+    // `(` through and the forward scan happened to find no `>`,
+    // returning -1. The positive allow-list rejects `(` as a first
+    // IRI byte and treats this as a comparison, advancing one byte.
+    const result = await engine.query(
+      'SELECT ?n { <urn:e1> <http://schema.org/age> ?n . FILTER(?n<(10+50)) }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('honors minTrust on `?n<-1` — negative numeric comparison (next-byte `-`)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/age', '"21"^^<http://www.w3.org/2001/XMLSchema#integer>', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // No row should match (21 < -1 is false), but the rewriter must
+    // still RUN (not fail-closed): pre-fix `<-1` walked into the IRI
+    // branch and corrupted the brace scan. We assert empty bindings
+    // FROM the executed FILTER, not from a silent rewriter bail-out.
+    // Distinguishing shape: the inverse comparison (`?n>-1`, age 21)
+    // returns a row, proving the engine actually executed both.
+    const noMatch = await engine.query(
+      'SELECT ?n { <urn:e1> <http://schema.org/age> ?n . FILTER(?n<-1) }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(noMatch.bindings).toEqual([]);
+
+    const match = await engine.query(
+      'SELECT ?n { <urn:e1> <http://schema.org/age> ?n . FILTER(?n>-1) }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(match.bindings.length).toBe(1);
+  });
+
+  it('still recognises real IRIs that begin with `#`, `_`, `/`, or `.` (allow-list whitelisted starts)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    // Use a real (absolute) IRI for the subject — relative IRI
+    // resolution depends on a base IRI which the engine does not
+    // configure here. The point of this test is that the SCANNER
+    // still treats `<http://...>` as an IRI; the existing alpha
+    // path covers that, and we additionally exercise a `<#frag>`
+    // shape inside a SPARQL `STR()` expression to prove the
+    // allow-list does not over-reject letter-leading shapes.
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Sanity: with a leading absolute-IRI predicate the rewrite still
+    // runs end-to-end (this would already have worked pre-r30-2; the
+    // assertion guards against any over-zealous tightening that broke
+    // ALPHA-leading IRIs).
+    const result = await engine.query(
+      'SELECT ?n { <urn:e1> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.map((b) => b['n'])).toEqual(['"Alice"']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// — dkg-query-engine.ts:851).
+// The unsupported-nesting brace check ran on the RAW WHERE body, so any
+// `{`/`}` inside a string literal (or sensitive keyword inside a comment)
+// caused `injectMinTrustFilter` to bail and the caller fell through to an
+// empty result. Real text/JSON payloads constantly contain those tokens,
+// so legitimate high-trust queries silently fail-closed.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('[Q-1] minTrust survives literals/comments containing braces or keywords', () => {
+  it('honors minTrust when a triple-object literal contains `{` and `}` (JSON payload)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', '"{\\"key\\": 1}"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Pre-fix the literal `"{\"key\": 1}"` made the brace check fire
+    // and `injectMinTrustFilter` returned null → empty result.
+    const result = await engine.query(
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . FILTER(STR(?t) = "{\\"key\\": 1}") }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('honors minTrust when a `# …` comment contains a sensitive keyword like OPTIONAL or SELECT', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Pre-fix the keyword scan saw `OPTIONAL`/`SELECT` inside the
+    // comment and returned null. With comment scrubbing the keyword
+    // check only sees real code tokens.
+    const sparql = [
+      '# OPTIONAL inline comment with SELECT inside — must not bail',
+      'SELECT ?n WHERE {',
+      '  # another comment OPTIONAL { fake } UNION { fake }',
+      '  <urn:e1> <http://schema.org/name> ?n',
+      '}',
+    ].join('\n');
+    const result = await engine.query(sparql, {
+      contextGraphId: CG,
+      view: 'verified-memory',
+      minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.map((b) => b['n'])).toEqual(['"Alice"']);
+  });
+
+  it('still bails (returns empty) on a REAL OPTIONAL { … } block in code', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Sanity: literal-aware scrubbing must NOT relax the genuine
+    // refusal of nested code (OPTIONAL/UNION/etc.) since the flat
+    // subject scanner still cannot reason about them.
+    const result = await engine.query(
+      'SELECT ?n WHERE { <urn:e1> <http://schema.org/name> ?n . OPTIONAL { ?n <http://schema.org/x> ?z } }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// — dkg-query-engine.ts:939). Three call sites
+// in the engine were finding the WHERE-block close-brace by counting `{` and
+// `}` characters with no awareness of strings/comments/IRIs:
+//
+//   • injectMinTrustFilter (line ≈939)
+//   • wrapWithGraph
+//   • wrapWithGraphUnion
+//
+// A SPARQL string literal carrying a single unbalanced `{` (or `}`), or an
+// IRI containing `{`/`}` characters that escape on the lexer side, drove the
+// counter into negative or unmatched territory. The previous tests in this
+// file used a literal with BALANCED braces (`"{\"key\": 1}"`), so they
+// happened to work despite the bug — they did not exercise the unbalanced
+// path. The cases below pin the truly broken inputs and prove the new
+// findMatchingCloseBrace helper handles them.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('[Q-1] minTrust + view wrapping survive UNBALANCED literal braces (bot r30-6)', () => {
+  it('honors minTrust when a string literal contains a SOLITARY unbalanced `{` (no closing `}`)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', '"open-brace {"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // SPARQL: FILTER(STR(?t) = "{")
+    // Pre-fix: the brace counter saw the lone `{` inside the literal as
+    // an extra block opener and the closing `}` of WHERE re-balanced
+    // depth, so the WHERE-end was located at the WRONG `}`. Result was
+    // either malformed SPARQL or fail-closed empty bindings.
+    const result = await engine.query(
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . FILTER(STR(?t) = "open-brace {") }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('honors minTrust when a string literal contains a SOLITARY unbalanced `}` (no opening `{`)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', '"close-brace }"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // SPARQL: FILTER(STR(?t) = "}")
+    // Pre-fix: the brace counter saw the literal `}` as the WHERE-end
+    // immediately after the FILTER opener, truncating the query.
+    const result = await engine.query(
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . FILTER(STR(?t) = "close-brace }") }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('honors minTrust when a `# …` line comment contains an unbalanced `{` or `}`', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // The comment carries a pile of unbalanced braces, mostly the
+    // opening kind. Pre-fix the comment scrub for keyword detection
+    // worked, but the brace counter STILL saw raw text and bailed.
+    const sparql = [
+      'SELECT ?n WHERE {',
+      '  # legacy syntax used to be: { ?s a <X> { fail',
+      '  # and { still { not { closing',
+      '  <urn:e1> <http://schema.org/name> ?n',
+      '}',
+    ].join('\n');
+    const result = await engine.query(sparql, {
+      contextGraphId: CG,
+      view: 'verified-memory',
+      minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.map((b) => b['n'])).toEqual(['"Alice"']);
+  });
+
+  it('still bails (empty) on a real OPTIONAL after the literal-aware brace counter — no semantic regression', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Even with the much smarter brace counter, the existing semantic
+    // refusal of OPTIONAL/UNION/etc. inside the WHERE block still fires
+    // — the only thing the new helper changes is the *location* of the
+    // closing brace, not whether the content is allowed.
+    const result = await engine.query(
+      'SELECT ?n WHERE { <urn:e1> <http://schema.org/name> ?n . OPTIONAL { ?n <http://schema.org/x> ?z } # has "}" comment\n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings).toEqual([]);
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // dkg-query-engine.ts:848). The literal
+  // scanners only recognised single-line `"…"` and `'…'` literals. SPARQL
+  // 1.1 ALSO supports long-form (triple-quoted) literals — `"""…"""` and
+  // `'''…'''` — which can legally contain raw `"`, `'`, newlines, and any
+  // of the structural chars (`{`, `}`, `#`, `.`) without escaping. When a
+  // chat / markdown / JSON payload is encoded as a long-form literal, the
+  // pre-fix scanners walked into the body of the literal as if it were
+  // SPARQL code, miscounted braces or misclassified `#` as a comment, and
+  // the surrounding rewriters (minTrust injection, wrapWithGraph) all
+  // fail-closed to empty. These tests pin the long-form handling end-to-end.
+  // ───────────────────────────────────────────────────────────────────────
+  it('minTrust honors a triple-double-quoted (`"""…"""`) literal containing `{`/`}`/`#`/`.`', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    // Insert a payload whose literal contains every structural char
+    // that the pre-fix scanners misclassified.
+    const payload = '{"k": 1} # not a comment . not a triple terminator';
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', `"${payload.replace(/"/g, '\\"')}"`, consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Use a triple-quoted literal in the query itself. Pre-fix, the
+    // scanner saw the opening `"""` as `"` + `"` + `"` (three single-
+    // line literals: `""`, `""`, …) and then walked into the body.
+    const sparql =
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . ' +
+      `FILTER(STR(?t) = """${payload}""") }`;
+    const result = await engine.query(sparql, {
+      contextGraphId: CG,
+      view: 'verified-memory',
+      minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('minTrust honors a triple-single-quoted (`\'\'\'…\'\'\'`) literal containing structural chars', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    const payload = "}{ # not a comment .";
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', `"${payload}"`, consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    const sparql =
+      "SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . " +
+      `FILTER(STR(?t) = '''${payload}''') }`;
+    const result = await engine.query(sparql, {
+      contextGraphId: CG,
+      view: 'verified-memory',
+      minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('triple-quoted literal containing a SINGLE quote char does not prematurely terminate', async () => {
+    // The scanner must require all THREE terminating quote chars
+    // before treating the literal as closed; a stray `"` inside a
+    // triple-double-quoted literal must not be misread as the close.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    // Payload contains a SINGLE `"` inside the triple-quoted literal.
+    const payload = 'a "lone quote inside" b { } #';
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text',
+        `"${payload.replace(/"/g, '\\"')}"`, consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel',
+        `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    const sparql =
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . ' +
+      `FILTER(STR(?t) = """${payload}""") }`;
+    const result = await engine.query(sparql, {
+      contextGraphId: CG,
+      view: 'verified-memory',
+      minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('skipSparqlStringLiteral atomicity — directly exercises the centralised lex helper', async () => {
+    // Direct unit test of the exported helper. This is the smallest
+    // reproduction of the bot's concern: every other test exercises
+    // it through the engine, which is integration-shaped. Pin the
+    // contract directly so a regression to per-helper duplication
+    // would surface here even if the integration paths still pass.
+    const { skipSparqlStringLiteral } = await import('../src/dkg-query-engine.js') as unknown as {
+      skipSparqlStringLiteral: (src: string, i: number) => number;
+    };
+
+    // Single-line forms.
+    expect(skipSparqlStringLiteral('"abc"X', 0)).toBe(5);
+    expect(skipSparqlStringLiteral("'abc'X", 0)).toBe(5);
+    // Embedded escape — the `\` consumes the next char.
+    expect(skipSparqlStringLiteral('"a\\"b"X', 0)).toBe(6);
+    // Triple-double-quoted with embedded `"` and `{`/`}`.
+    const tdq = '"""a"b{c}d#e."""TAIL';
+    expect(skipSparqlStringLiteral(tdq, 0)).toBe(tdq.indexOf('TAIL'));
+    // Triple-single-quoted with embedded `'`.
+    const tsq = "'''x'y{z}w#q.'''TAIL";
+    expect(skipSparqlStringLiteral(tsq, 0)).toBe(tsq.indexOf('TAIL'));
+    // Triple-quoted with newlines (long-form spans lines).
+    const multi = '"""line1\nline2\nline3"""TAIL';
+    expect(skipSparqlStringLiteral(multi, 0)).toBe(multi.indexOf('TAIL'));
+    // Non-quote start = no advance.
+    expect(skipSparqlStringLiteral('xyz', 0)).toBe(0);
+    // Unterminated literal consumes the rest (defensive — see helper docs).
+    expect(skipSparqlStringLiteral('"unterminated', 0)).toBe('"unterminated'.length);
+    expect(skipSparqlStringLiteral('"""unterminated', 0)).toBe('"""unterminated'.length);
+  });
+
+  it('wrapWithGraph (default-graph filter) survives unbalanced braces inside string literals', async () => {
+    // verified-memory route triggers wrapWithGraph to scope to the
+    // sub-graph URI. If the brace counter mis-locates the WHERE end,
+    // the wrapped query is malformed and the engine returns empty.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', '"unbalanced } trailing"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Note: minTrust is NOT set here, so wrapWithGraph runs but
+    // injectMinTrustFilter does not. Pin wrapWithGraph specifically.
+    const result = await engine.query(
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . FILTER(CONTAINS(STR(?t), "unbalanced }")) }',
+      { contextGraphId: CG, view: 'verified-memory' },
+    );
+    expect(result.bindings.length).toBe(1);
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Pre-fix the WHERE-locator's fast path was a raw regex
+  // `/\bWHERE\s*\{/i` that matched ANY `WHERE` followed by `{` —
+  // including substrings inside a string literal, a `# …` comment, or
+  // an IRI's local name. When the regex hit a payload-side `WHERE {`
+  // first, `sparql.indexOf('{', whereIdx)` grabbed the brace just past
+  // the literal/comment, and downstream `wrapWithGraph` /
+  // `injectMinTrustFilter` rewrote the WRONG block. Best case: the
+  // resulting query was syntactically invalid and the engine returned
+  // empty; worst case: the wrap landed on a SELECT projection
+  // expression and the rewrite silently filtered against a literal.
+  // The fix is a token-aware locator that mirrors the lex rules used
+  // by the rest of the helpers (skips `# …\n` comments, single/
+  // double/triple-quoted literals, and IRIREFs) so the FIRST `WHERE`
+  // it can see is the real top-level one.
+  // ───────────────────────────────────────────────────────────────────────
+  it('minTrust honors a SELECT whose PROJECTION ALIAS literal contains "WHERE {"', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Adversarial / obfuscated shape. The raw regex pre-fix matched
+    // the LITERAL substring `WHERE {` inside the SELECT projection
+    // alias and `wrapWithGraph` then wrapped from the brace just
+    // past the literal — silently filtering against the wrong block.
+    // Token-aware locator skips the literal entirely and lands on
+    // the genuine top-level WHERE.
+    const result = await engine.query(
+      'SELECT (STR("WHERE {") AS ?fake) ?n WHERE { <urn:e1> <http://schema.org/name> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+    expect(result.bindings[0]['n']).toBe('"Alice"');
+    expect(result.bindings[0]['fake']).toBe('"WHERE {"');
+  });
+
+  it('minTrust honors a query whose `# …` COMMENT precedes the real WHERE and contains "WHERE {"', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // The `# WHERE { ... }` line is purely a comment; the engine MUST
+    // ignore it and find the real WHERE on the next line. Pre-fix the
+    // regex hit the comment first and `wrapWithGraph` ran against
+    // garbage; the engine fell through to empty bindings.
+    const sparql = [
+      'SELECT ?n',
+      '# this comment talks about a WHERE { decoy } that must be ignored',
+      'WHERE { <urn:e1> <http://schema.org/name> ?n }',
+    ].join('\n');
+    const result = await engine.query(sparql, {
+      contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.length).toBe(1);
+    expect(result.bindings[0]['n']).toBe('"Alice"');
+  });
+
+  it('minTrust honors a query whose IRI fragment contains the bytes "WHERE"', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    // Insert a quad whose predicate IRI contains the literal bytes
+    // "WHERE" (and an embedded `{`/`}` shape via fragment encoding).
+    // The token-aware locator must NOT mistake the IRI's `WHERE`
+    // substring for the SPARQL keyword.
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/WHEREabouts', '"Sofia"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    const result = await engine.query(
+      'SELECT ?n WHERE { <urn:e1> <http://schema.org/WHEREabouts> ?n }',
+      { contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified },
+    );
+    expect(result.bindings.length).toBe(1);
+    expect(result.bindings[0]['n']).toBe('"Sofia"');
+  });
+
+  it('triple-quoted (`"""…"""`) literal containing "WHERE {" does NOT confuse the locator', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    const decoy = 'decoy SELECT ?x WHERE { ... } more';
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/text', `"${decoy}"`, consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // Triple-quoted literal in the FILTER carries an entire fake
+    // SELECT … WHERE { … } shape. Any regex would match
+    // this `WHERE {` first and `wrapWithGraph` would land on the
+    // brace inside the literal, producing a malformed wrapped query.
+    const sparql =
+      'SELECT ?t WHERE { <urn:e1> <http://schema.org/text> ?t . ' +
+      `FILTER(STR(?t) = """${decoy}""") }`;
+    const result = await engine.query(sparql, {
+      contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.length).toBe(1);
+  });
+
+  it('word-boundary check — `WHEREVER` / `aWHERE` identifiers MUST NOT match (no false-positive keyword promotion)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const consensusGraph = contextGraphVerifiedMemoryUri(CG, 'consensus-verified');
+    await store.insert([
+      quad('urn:e1', 'http://schema.org/name', '"Alice"', consensusGraph),
+      quad('urn:e1', 'http://dkg.io/ontology/trustLevel', `"${TrustLevel.ConsensusVerified}"`, consensusGraph),
+    ]);
+
+    // The query has a SELECT alias `?WHEREVER` (a legal SPARQL
+    // variable name; SPARQL identifiers can include letters). A naive
+    // word-boundary check that matches WHERE inside a longer ident
+    // would mis-locate the keyword start; the token-aware scanner
+    // must reject mid-identifier matches via the `prev-is-word-cont`
+    // check and continue scanning until the real top-level WHERE.
+    //
+    // Note SPARQL var syntax requires `?` prefix, so the actual
+    // identifier seen by the scanner is `WHEREVER` (no `?`). Pin
+    // both branches: alias-as-projection and alias-as-FILTER var.
+    const sparql =
+      'SELECT (?n AS ?WHEREVER) WHERE { <urn:e1> <http://schema.org/name> ?n }';
+    const result = await engine.query(sparql, {
+      contextGraphId: CG, view: 'verified-memory', minTrust: TrustLevel.ConsensusVerified,
+    });
+    expect(result.bindings.length).toBe(1);
+    // The aliased projection variable is `WHEREVER` — pin it so a
+    // regression that mis-locates the WHERE and rewrites against the
+    // wrong block surfaces here too.
+    expect(result.bindings[0]['WHEREVER']).toBe('"Alice"');
   });
 });

--- a/packages/query/test/sparql-form-detection.test.ts
+++ b/packages/query/test/sparql-form-detection.test.ts
@@ -1,0 +1,400 @@
+/**
+ * the fail-closed branches in
+ * `DKGAgent.query()` (WM cross-agent auth denial, private-CG leak
+ * guard, unreadable context graph) must emit a `QueryResult` whose
+ * SHAPE matches the form the caller asked for — otherwise a
+ * `CONSTRUCT`/`DESCRIBE` caller that branches on
+ * `result.quads !== undefined` misreads a deny as a bindings-only
+ * SELECT success.
+ *
+ * These tests pin the two exports that make the shape contract
+ * explicit: `detectSparqlQueryForm` and `emptyResultForForm`.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  detectSparqlQueryForm,
+  emptyResultForForm,
+  emptyResultForSparql,
+  type SparqlQueryForm,
+} from '../src/index.js';
+
+describe('detectSparqlQueryForm', () => {
+  it('classifies SELECT', () => {
+    expect(detectSparqlQueryForm('SELECT ?s WHERE { ?s ?p ?o }')).toBe('SELECT');
+    expect(detectSparqlQueryForm('select ?s where { ?s ?p ?o }')).toBe('SELECT');
+  });
+
+  it('classifies CONSTRUCT', () => {
+    expect(detectSparqlQueryForm('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }')).toBe('CONSTRUCT');
+    expect(detectSparqlQueryForm('construct { ?s ?p ?o } where { ?s ?p ?o }')).toBe('CONSTRUCT');
+  });
+
+  it('classifies ASK', () => {
+    expect(detectSparqlQueryForm('ASK { ?s ?p ?o }')).toBe('ASK');
+    expect(detectSparqlQueryForm('ask { ?s ?p ?o }')).toBe('ASK');
+  });
+
+  it('classifies DESCRIBE', () => {
+    expect(detectSparqlQueryForm('DESCRIBE <urn:x>')).toBe('DESCRIBE');
+    expect(detectSparqlQueryForm('describe <urn:x>')).toBe('DESCRIBE');
+  });
+
+  it('looks through PREFIX / BASE preamble', () => {
+    const q = [
+      'PREFIX ex: <urn:example:>',
+      'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>',
+      'CONSTRUCT { ?s a ex:Thing } WHERE { ?s ?p ?o }',
+    ].join('\n');
+    expect(detectSparqlQueryForm(q)).toBe('CONSTRUCT');
+  });
+
+  it('returns UNKNOWN for mutating / garbage input so callers can fall back safely', () => {
+    expect(detectSparqlQueryForm('INSERT DATA { <urn:x> <urn:p> "y" }')).toBe('UNKNOWN');
+    expect(detectSparqlQueryForm('DROP GRAPH <urn:g>')).toBe('UNKNOWN');
+    expect(detectSparqlQueryForm('')).toBe('UNKNOWN');
+    expect(detectSparqlQueryForm('not-a-query')).toBe('UNKNOWN');
+  });
+});
+
+describe('emptyResultForForm — shape contract', () => {
+  it('SELECT → bindings only, quads absent', () => {
+    const r = emptyResultForForm('SELECT');
+    expect(r.bindings).toEqual([]);
+    expect(r.quads).toBeUndefined();
+    // `quads` missing is the distinguishing trait — readers that
+    // branch on `result.quads !== undefined` must treat this as a
+    // bindings-only result.
+    expect(Object.prototype.hasOwnProperty.call(r, 'quads')).toBe(false);
+  });
+
+  it('CONSTRUCT → bindings:[] AND quads:[] (both present)', () => {
+    const r = emptyResultForForm('CONSTRUCT');
+    expect(r.bindings).toEqual([]);
+    expect(r.quads).toBeDefined();
+    expect(r.quads).toEqual([]);
+  });
+
+  it('DESCRIBE → bindings:[] AND quads:[] (same as CONSTRUCT — both yield triples)', () => {
+    const r = emptyResultForForm('DESCRIBE');
+    expect(r.bindings).toEqual([]);
+    expect(r.quads).toBeDefined();
+    expect(r.quads).toEqual([]);
+  });
+
+  it('ASK → synthetic bindings [{ result: "false" }] matching dkg-query-engine normalization', () => {
+    const r = emptyResultForForm('ASK');
+    // dkg-query-engine surfaces ASK results via bindings; a false
+    // ASK is the safest deny shape (as if the assertion failed).
+    expect(r.bindings).toEqual([{ result: 'false' }]);
+    expect(r.quads).toBeUndefined();
+  });
+
+  it('UNKNOWN → empty bindings (safe default, unreachable from DKGAgent.query)', () => {
+    const r = emptyResultForForm('UNKNOWN');
+    expect(r.bindings).toEqual([]);
+    expect(r.quads).toBeUndefined();
+  });
+
+  it('returns a FRESH object per call — two calls cannot alias each other', () => {
+    // Structural pin: the helper is documented to return a fresh
+    // object on every call so callers that mutate it (appending
+    // bindings before returning, downstream deep-freeze, etc.)
+    // cannot poison a later deny path.
+    const a = emptyResultForForm('CONSTRUCT');
+    const b = emptyResultForForm('CONSTRUCT');
+    expect(a).not.toBe(b);
+    expect(a.bindings).not.toBe(b.bindings);
+    expect(a.quads).not.toBe(b.quads);
+
+    // Mutating one must not affect the other.
+    a.bindings.push({ forged: 'v' });
+    expect(b.bindings).toEqual([]);
+  });
+});
+
+describe('round-trip: form → empty result preserves the `quads` presence distinction', () => {
+  const cases: Array<[string, SparqlQueryForm, boolean]> = [
+    ['SELECT ?s WHERE { ?s ?p ?o }',     'SELECT',    false],
+    ['CONSTRUCT { ?s ?p ?o } WHERE {}',  'CONSTRUCT', true],
+    ['DESCRIBE <urn:x>',                 'DESCRIBE',  true],
+    ['ASK { ?s ?p ?o }',                 'ASK',       false],
+  ];
+  for (const [q, expectedForm, hasQuads] of cases) {
+    it(`${expectedForm}: ${q}`, () => {
+      const form = detectSparqlQueryForm(q);
+      expect(form).toBe(expectedForm);
+      const r = emptyResultForForm(form);
+      expect(Object.prototype.hasOwnProperty.call(r, 'quads')).toBe(hasQuads);
+    });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// — sparql-guard.ts:56). Before this
+// consolidation, `sparql-guard.ts` exported TWO parallel pairs:
+//   (a) detectSparqlQueryForm + emptyResultForForm
+//   (b) classifySparqlForm    + emptyQueryResultForKind
+// (a) returned `UNKNOWN` for unparseable input; (b) silently mapped
+// it to `SELECT`. Two pairs meant the next time ASK/CONSTRUCT shaping
+// changed, only one would get updated and the other call path would
+// reintroduce the malformed empty-response bug. The bot asked for
+// consolidation onto ONE pair.
+//
+// These tests pin the anti-drift contract structurally so any future
+// re-introduction of the legacy pair fails CI:
+//   1. The legacy symbols are no longer exported from the package
+//      barrel.
+//   2. `sparql-guard.ts` source no longer defines the legacy
+//      identifiers.
+//   3. The new ergonomic one-shot helper `emptyResultForSparql`
+//      delegates to `emptyResultForForm(detectSparqlQueryForm(sparql))`
+//      bit-for-bit (no parallel logic path).
+// ─────────────────────────────────────────────────────────────────────
+describe('[r30-3] consolidation: single canonical form-classifier + empty-result builder pair', () => {
+  it('emptyResultForSparql composes the canonical pair (no parallel classifier)', () => {
+    // For every form: emptyResultForSparql(q) must structurally equal
+    // emptyResultForForm(detectSparqlQueryForm(q)). If anyone ever
+    // re-introduces a parallel classifier with subtly different
+    // shaping (the EXACT regression the bot flagged), this assertion
+    // immediately catches the divergence.
+    const queries: string[] = [
+      'SELECT ?s WHERE { ?s ?p ?o }',
+      'CONSTRUCT { ?s ?p ?o } WHERE {}',
+      'DESCRIBE <urn:x>',
+      'ASK { ?s ?p ?o }',
+      'PREFIX ex: <urn:example:>\nSELECT ?s WHERE { ?s ex:p ?o }',
+      'not-a-query',
+      '',
+    ];
+    for (const q of queries) {
+      const oneShot = emptyResultForSparql(q);
+      const twoStep = emptyResultForForm(detectSparqlQueryForm(q));
+      expect(oneShot).toEqual(twoStep);
+      // `quads` presence parity is the property that makes
+      // CONSTRUCT/DESCRIBE callers branch correctly. Pin it both ways.
+      expect(Object.prototype.hasOwnProperty.call(oneShot, 'quads'))
+        .toBe(Object.prototype.hasOwnProperty.call(twoStep, 'quads'));
+    }
+  });
+
+  it('emptyResultForSparql returns a FRESH object (no shared mutable state with emptyResultForForm)', () => {
+    // The convenience wrapper must inherit the freshness guarantee
+    // of the underlying builder — otherwise a caller mutating the
+    // returned `bindings` would poison every later deny that hit
+    // the same form.
+    const a = emptyResultForSparql('CONSTRUCT { ?s ?p ?o } WHERE {}');
+    const b = emptyResultForSparql('CONSTRUCT { ?s ?p ?o } WHERE {}');
+    expect(a).not.toBe(b);
+    expect(a.bindings).not.toBe(b.bindings);
+    expect(a.quads).not.toBe(b.quads);
+    a.bindings.push({ forged: 'v' });
+    expect(b.bindings).toEqual([]);
+  });
+
+  // packages/query/src/index.ts:7).
+  //
+  // r30-3 deleted the legacy `classifySparqlForm` /
+  // `emptyQueryResultForKind` / `SparqlForm` symbols outright; the
+  // bot's r31-2 thread flagged the deletion as a source-breaking
+  // API change for downstream consumers without a version bump.
+  // Restored as `@deprecated` wrappers + a `SparqlForm` type alias
+  // (defined in `sparql-guard.ts`, re-exported from the barrel).
+  //
+  // The anti-drift contract still holds — it just shifted shape:
+  //   - Internal call sites (`dkg-query-engine.ts`, `dkg-agent.ts`)
+  //     continue to use the canonical pair (`detectSparqlQueryForm`
+  //     + `emptyResultForForm` / `emptyResultForSparql`).
+  //   - The deprecated wrappers are PURE COMPOSITION over the
+  //     canonical pair (`classifySparqlForm` =
+  //     `detectSparqlQueryForm` with `'UNKNOWN'` → `'SELECT'`
+  //     mapping; `emptyQueryResultForKind` =
+  //     `emptyResultForForm`). No parallel logic path is
+  //     reintroduced — any future change to ASK/CONSTRUCT shaping
+  //     still has to touch ONE canonical spot.
+  it('the @deprecated `classifySparqlForm` wrapper composes `detectSparqlQueryForm` with the legacy `UNKNOWN → SELECT` mapping', async () => {
+    const { classifySparqlForm, detectSparqlQueryForm } = await import(
+      '../src/index.js'
+    );
+    // Parseable shapes: identical to the canonical classifier.
+    for (const q of [
+      'SELECT ?s WHERE { ?s ?p ?o }',
+      'CONSTRUCT { ?s ?p ?o } WHERE {}',
+      'DESCRIBE <urn:x>',
+      'ASK { ?s ?p ?o }',
+    ]) {
+      expect(classifySparqlForm(q)).toBe(detectSparqlQueryForm(q));
+    }
+    // Unparseable shapes: legacy wrapper coerces to `'SELECT'`,
+    // canonical returns `'UNKNOWN'`. This is the byte-compat
+    // anchor for any downstream caller that switches on the
+    // returned string.
+    for (const q of ['not-a-query', '']) {
+      expect(detectSparqlQueryForm(q)).toBe('UNKNOWN');
+      expect(classifySparqlForm(q)).toBe('SELECT');
+    }
+  });
+
+  it('the @deprecated `emptyQueryResultForKind` wrapper is byte-compatible with `emptyResultForForm` for every legacy form', async () => {
+    const { emptyQueryResultForKind, emptyResultForForm } = await import(
+      '../src/index.js'
+    );
+    for (const form of ['SELECT', 'CONSTRUCT', 'DESCRIBE', 'ASK'] as const) {
+      const legacy = emptyQueryResultForKind(form);
+      const canonical = emptyResultForForm(form);
+      expect(legacy).toEqual(canonical);
+      // `quads`-presence parity is the property that determines
+      // whether CONSTRUCT/DESCRIBE callers branch correctly. Pin
+      // it explicitly so any future shape drift is caught here.
+      expect(Object.prototype.hasOwnProperty.call(legacy, 'quads')).toBe(
+        Object.prototype.hasOwnProperty.call(canonical, 'quads'),
+      );
+    }
+  });
+
+  it('the @deprecated `emptyQueryResultForKind` wrapper inherits the FRESH-object guarantee', async () => {
+    // Same freshness invariant as the canonical builder — the
+    // deprecated wrapper must NOT cache or share return values
+    // across calls.
+    const { emptyQueryResultForKind } = await import('../src/index.js');
+    const a = emptyQueryResultForKind('CONSTRUCT');
+    const b = emptyQueryResultForKind('CONSTRUCT');
+    expect(a).not.toBe(b);
+    expect(a.bindings).not.toBe(b.bindings);
+    expect(a.quads).not.toBe(b.quads);
+    a.bindings.push({ forged: 'v' });
+    expect(b.bindings).toEqual([]);
+  });
+
+  it('the deprecated barrel exports are PRESENT (anti-removal: keeps backwards compat for downstream consumers)', async () => {
+    // r31-2 inverts the r30-3 anti-drift assertion: the legacy
+    // symbols MUST be present on the package barrel so existing
+    // `@origintrail-official/dkg-query` consumers don't hard-fail
+    // on a non-major version bump. If a future refactor removes
+    // them again, this test fails and forces an explicit decision
+    // (deprecate-then-remove with version bump, NOT silent removal).
+    const exports = (await import('../src/index.js')) as Record<string, unknown>;
+    expect(typeof exports.classifySparqlForm).toBe('function');
+    expect(typeof exports.emptyQueryResultForKind).toBe('function');
+    // `SparqlForm` is a type alias and doesn't appear at runtime,
+    // but its source-level presence is asserted by the source guard
+    // below.
+  });
+
+  // packages/query/src/sparql-guard.ts:201).
+  //
+  // r31-2 restored the `@deprecated` `emptyQueryResultForKind` wrapper
+  // but accidentally CHANGED its parameter type from the legacy
+  // `string` (raw SPARQL — the function classified internally) to the
+  // `SparqlForm` discriminator. That silently broke downstream
+  // `emptyQueryResultForKind(query)` callers in two ways:
+  //
+  //   (a) TypeScript callers: stop compiling outright (`string` is
+  //       not assignable to `SparqlForm`).
+  //   (b) `JS` / `as any` callers: the function returns the SELECT-
+  //       shaped empty result for `ASK` / `CONSTRUCT` queries because
+  //       the raw SPARQL string doesn't match any `SparqlForm` variant.
+  //
+  // r31-4 restores the legacy `string` parameter type and delegates to
+  // `emptyResultForSparql()` so existing call sites compile and behave
+  // identically to the surface. These tests pin the contract
+  // structurally so a future "tighten the signature" change can't
+  // re-introduce the regression.
+  it('[r31-4] @deprecated `emptyQueryResultForKind` accepts a raw SPARQL STRING (not a SparqlForm) and routes onto the right empty shape', async () => {
+    const { emptyQueryResultForKind } = await import('../src/index.js');
+
+    // The exact regression the bot flagged: `emptyQueryResultForKind`
+    // called with a real CONSTRUCT query MUST return the CONSTRUCT
+    // empty shape (`{ bindings: [], quads: [] }`), not the SELECT
+    // empty shape. r31-2 returned SELECT for this input because it
+    // typed the param as `SparqlForm` and the raw string didn't match.
+    const construct = emptyQueryResultForKind('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }');
+    expect(construct.bindings).toEqual([]);
+    expect(construct.quads).toBeDefined();
+    expect(construct.quads).toEqual([]);
+
+    // Likewise for DESCRIBE — quads must be present.
+    const describe = emptyQueryResultForKind('DESCRIBE <urn:x>');
+    expect(describe.bindings).toEqual([]);
+    expect(describe.quads).toBeDefined();
+    expect(describe.quads).toEqual([]);
+
+    // And ASK — bindings must be `[{ result: 'false' }]` per the
+    // dkg-query-engine convention.
+    const ask = emptyQueryResultForKind('ASK { ?s ?p ?o }');
+    expect(ask.bindings).toEqual([{ result: 'false' }]);
+    expect(ask.quads).toBeUndefined();
+
+    // SELECT (with PREFIX preamble, exercising the same parser path).
+    const select = emptyQueryResultForKind(
+      'PREFIX ex: <urn:example:>\nSELECT ?s WHERE { ?s ex:p ?o }',
+    );
+    expect(select.bindings).toEqual([]);
+    expect(select.quads).toBeUndefined();
+  });
+
+  it('[r31-4] `emptyQueryResultForKind` is byte-compatible with `emptyResultForSparql` for every parseable input', async () => {
+    // Composition pin: the wrapper IS `emptyResultForSparql`
+    // (no parallel logic path). If anyone ever reintroduces local
+    // form-classification inside the wrapper, this assertion catches
+    // the divergence on every call site.
+    const { emptyQueryResultForKind, emptyResultForSparql } = await import(
+      '../src/index.js'
+    );
+    const queries: string[] = [
+      'SELECT ?s WHERE { ?s ?p ?o }',
+      'CONSTRUCT { ?s ?p ?o } WHERE {}',
+      'DESCRIBE <urn:x>',
+      'ASK { ?s ?p ?o }',
+      'PREFIX ex: <urn:example:>\nSELECT ?s WHERE { ?s ex:p ?o }',
+      'not-a-query',
+      '',
+    ];
+    for (const q of queries) {
+      expect(emptyQueryResultForKind(q)).toEqual(emptyResultForSparql(q));
+    }
+  });
+
+  it('[r31-4] `emptyQueryResultForKind` source signature uses `string` (NOT `SparqlForm`) — anti-drift guard for the param type', () => {
+    // Source-level guard: the legacy `(form: SparqlForm)` signature
+    // is the regression we just fixed. Pin the `(sparql: string)`
+    // signature in the source so a future "small tidy-up" that
+    // restores the `SparqlForm` parameter type fails CI here.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const guardPath = resolve(here, '..', 'src', 'sparql-guard.ts');
+    const src = readFileSync(guardPath, 'utf-8');
+    expect(src).toMatch(
+      /\bexport\s+function\s+emptyQueryResultForKind\s*\(\s*sparql\s*:\s*string\s*\)/,
+    );
+    // Inverse guard: the `(form: SparqlForm)` signature must NOT be
+    // present anymore.
+    expect(src).not.toMatch(
+      /\bexport\s+function\s+emptyQueryResultForKind\s*\(\s*form\s*:\s*SparqlForm\s*\)/,
+    );
+  });
+
+  it('the deprecated wrappers ARE defined in the source AND ARE annotated `@deprecated` (downstream tooling surfaces the migration)', () => {
+    // Source-level guard: the wrappers MUST exist (so the public
+    // surface is whole) AND MUST carry `@deprecated` JSDoc
+    // annotations (so downstream IDEs surface the strikethrough).
+    // This is the reverse of the r30-3 anti-drift guard: the
+    // symbols are intentionally back, but they must be marked
+    // deprecated so callers see the migration path.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const guardPath = resolve(here, '..', 'src', 'sparql-guard.ts');
+    const src = readFileSync(guardPath, 'utf-8');
+    expect(src).toMatch(/\bexport\s+function\s+classifySparqlForm\b/);
+    expect(src).toMatch(/\bexport\s+function\s+emptyQueryResultForKind\b/);
+    expect(src).toMatch(/\bexport\s+type\s+SparqlForm\b/);
+    // JSDoc `@deprecated` tag presence — checked structurally so
+    // a future refactor that drops the deprecation marker (which
+    // would silently un-deprecate the wrappers) is caught here.
+    // The `s` flag makes `.` match newlines so the regex can span
+    // a multi-line JSDoc block ending right before the export.
+    expect(src).toMatch(/@deprecated[\s\S]*?export\s+function\s+classifySparqlForm/);
+    expect(src).toMatch(/@deprecated[\s\S]*?export\s+function\s+emptyQueryResultForKind/);
+    expect(src).toMatch(/@deprecated[\s\S]*?export\s+type\s+SparqlForm/);
+  });
+});

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -52,22 +52,174 @@ export class BlazegraphStore implements TripleStore {
   }
 
   async deleteByPattern(pattern: Partial<DKGQuad>): Promise<number> {
-    const before = await this.countQuads(pattern.graph);
-    const s = pattern.subject ? `<${escapeUri(pattern.subject)}>` : '?s';
+    // The pattern
+    // subject can legitimately be a blank node when callers passed
+    // through a previously-materialised quad row (e.g. the cleanup
+    // path that re-deletes specific bnode-subject quads). Funnel it
+    // through `formatTerm` so `_:b0` stays `_:b0` instead of being
+    // wrapped as the invalid IRI `<_:b0>`. The predicate is still
+    // angle-bracketed because the SPARQL grammar only allows IRIs
+    // in predicate position.
+    const s = pattern.subject ? formatTerm(pattern.subject) : '?s';
     const p = pattern.predicate ? `<${escapeUri(pattern.predicate)}>` : '?p';
     const o = pattern.object ? formatTerm(pattern.object) : '?o';
     const triple = `${s} ${p} ${o}`;
     if (pattern.graph) {
-      await this.sparqlUpdate(
-        `DELETE { GRAPH <${escapeUri(pattern.graph)}> { ${triple} } } WHERE { GRAPH <${escapeUri(pattern.graph)}> { ${triple} } }`,
-      );
-    } else {
-      await this.sparqlUpdate(
-        `DELETE { ?g_ctx { ${triple} } } WHERE { GRAPH ?g_ctx { ${triple} } }`,
-      );
+      // Single-graph case. The intuitive SPARQL-1.1 form
+      //   `DELETE { GRAPH <g> { ?s <p> ?o } } WHERE { GRAPH <g> { ?s <p> ?o } }`
+      // PARSES on Blazegraph 2.1.5 but silently fails to remove
+      // anything through its REST endpoint when the DELETE template
+      // contains variables in the subject/predicate/object position
+      // (the no-graph branch below documents the same issue; the
+      // Oxigraph ↔ Blazegraph parity test `adapter-parity-extra.test.ts`
+      // catches this regression — CI run 24809773517 job 72612008748).
+      //
+      // Mirror the no-graph branch: SELECT every matching tuple first
+      // and issue one `DELETE DATA` per row. That's the ONE form that
+      // round-trips reliably on Blazegraph 2.1.5, matches the
+      // Oxigraph behaviour bit-for-bit, AND gives us an accurate
+      // removed count without having to trust a before/after countQuads
+      // delta (which is itself untrustworthy if the DELETE silently
+      // no-ops and countQuads rounds differently).
+      const projVars: string[] = [];
+      if (!pattern.subject) projVars.push('?s');
+      if (!pattern.predicate) projVars.push('?p');
+      if (!pattern.object) projVars.push('?o');
+      const proj = projVars.length > 0 ? projVars.join(' ') : '*';
+      const selectQ = `SELECT ${proj} WHERE { GRAPH <${escapeUri(pattern.graph)}> { ${triple} } }`;
+      const sel = await this.query(selectQ);
+      if (sel.type !== 'bindings') return 0;
+      let removed = 0;
+      const seen = new Set<string>();
+      for (const row of sel.bindings) {
+        const sx = pattern.subject ?? row['s'];
+        const px = pattern.predicate ?? row['p'];
+        const ox = pattern.object ?? row['o'];
+        if (!sx || !px || !ox) continue;
+        const key = `${sx}\u0001${px}\u0001${ox}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        // The SELECT above
+        // materialises every matching row, which in quads mode
+        // includes blank-node subjects (`_:b0`). Re-serialising
+        // `sx` as `<${escapeUri(sx)}>` turned `_:b0` into the
+        // syntactically invalid IRI `<_:b0>` and the resulting
+        // `DELETE DATA` either errored on the wire or silently
+        // no-op'd, leaving blank-node quads alive forever in
+        // Blazegraph. `formatTerm` already encodes blank nodes
+        // (`_:foo`), explicit IRIs (`<…>`), and bare strings
+        // (wrapped in angle brackets) correctly, so route every
+        // RDF position through it. Predicates stay angle-bracketed
+        // because by RDF spec a predicate can only be an IRI.
+        const tripleData = `${formatTerm(sx)} <${escapeUri(px)}> ${formatTerm(ox)} .`;
+        await this.sparqlUpdate(
+          `DELETE DATA { GRAPH <${escapeUri(pattern.graph)}> { ${tripleData} } }`,
+        );
+        removed++;
+      }
+      return removed;
     }
-    const after = await this.countQuads(pattern.graph);
-    return Math.max(0, before - after);
+
+    // No graph filter: enumerate every matching tuple (named graphs
+    // + default graph), then `DELETE DATA` each one individually.
+    // The SPARQL-1.1 graph-variable templates `DELETE { GRAPH ?g
+    // { ... } } WHERE { GRAPH ?g { ... } }` and `DELETE WHERE
+    // { GRAPH ?g { ... } }` both parse on Blazegraph 2.1.5 but
+    // neither actually removes any quads through its REST endpoint
+    // (it returns 200 OK and a subsequent SELECT still finds the
+    // match). Materialising every (s,p,o,g) tuple and DELETE DATA-
+    // ing them is the only form that round-trips correctly here.
+    const projVars: string[] = [];
+    if (!pattern.subject) projVars.push('?s');
+    if (!pattern.predicate) projVars.push('?p');
+    if (!pattern.object) projVars.push('?o');
+    projVars.push('?g');
+    const proj = projVars.join(' ');
+    const namedQ = `SELECT ${proj} WHERE { GRAPH ?g { ${triple} } }`;
+    const defaultProj = projVars.filter((v) => v !== '?g').join(' ') || '*';
+    const defaultQ = `SELECT ${defaultProj} WHERE { ${triple} }`;
+    let removed = 0;
+    const seen = new Set<string>();
+    const named = await this.query(namedQ);
+    if (named.type === 'bindings') {
+      for (const row of named.bindings) {
+        const sx = pattern.subject ?? row['s'];
+        const px = pattern.predicate ?? row['p'];
+        const ox = pattern.object ?? row['o'];
+        const g = row['g'];
+        if (!sx || !px || !ox || !g) continue;
+        // Same blank-node
+        // round-trip bug as the single-graph branch above: `sx` may
+        // be a bnode (`_:b0`), so funnel it through `formatTerm`
+        // instead of the IRI-only `<${escapeUri(sx)}>` to avoid
+        // emitting the invalid IRI literal `<_:b0>` in the
+        // `DELETE DATA` payload.
+        const tripleData = `${formatTerm(sx)} <${escapeUri(px)}> ${formatTerm(ox)} .`;
+        const key = `${g}\u0001${sx}\u0001${px}\u0001${ox}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        await this.sparqlUpdate(
+          `DELETE DATA { GRAPH <${escapeUri(g)}> { ${tripleData} } }`,
+        );
+        removed++;
+      }
+    }
+    // the previous
+    // revision skipped the default-graph DELETE for any (s,p,o) that
+    // matched a named-graph row earlier in this call. In Blazegraph's
+    // quads mode the unquoted `{ ${triple} }` pattern returns rows
+    // from every graph (default + named), so the suppression avoided
+    // double-counting the same quad — but it ALSO silently dropped a
+    // real default-graph row when the same (s,p,o) happened to exist
+    // in a named graph as well. `deleteByPattern()` is supposed to
+    // remove every match across the store, so we re-query the default-
+    // dataset view AFTER the named deletes. At that point the only
+    // remaining bindings for this pattern are default-graph rows
+    // (named-graph instances are gone). We delete each one with
+    // `DELETE DATA { triple }` (which in Blazegraph targets the
+    // default graph only) and de-dupe via `seen` so an engine that
+    // still echoes the pattern multiple times doesn't inflate the
+    // count.
+    const defAfter = await this.query(defaultQ);
+    if (defAfter.type === 'bindings') {
+      for (const row of defAfter.bindings) {
+        const sx = pattern.subject ?? row['s'];
+        const px = pattern.predicate ?? row['p'];
+        const ox = pattern.object ?? row['o'];
+        if (!sx || !px || !ox) continue;
+        // Same blank-node
+        // round-trip bug as the named-graph branch: route `sx`
+        // through `formatTerm` so a bnode (`_:b0`) is emitted as
+        // `_:b0` and not the invalid IRI `<_:b0>`. Without this the
+        // default-graph DELETE silently no-op'd for blank-node
+        // subjects (the `DELETE DATA` either errored on the wire
+        // or, on lenient engines, never matched the row), which in
+        // turn left blank-node-subject quads pinned in storage and
+        // inflated countQuads-driven assertions.
+        const tripleData = `${formatTerm(sx)} <${escapeUri(px)}> ${formatTerm(ox)} .`;
+        const dedupKey = `__default__\u0001${sx}\u0001${px}\u0001${ox}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+        // ASK before DELETE: guarantees the row we're about to delete
+        // really exists in the default graph (SELECT { triple } alone
+        // is ambiguous in quads mode). If the engine can't represent a
+        // DEFAULT-scoped ASK we fall back to issuing the DELETE
+        // unconditionally — it's a no-op when the triple is absent.
+        let existsInDefault = true;
+        try {
+          const ask = await this.query(
+            `ASK WHERE { ${tripleData} FILTER NOT EXISTS { GRAPH ?__g { ${tripleData} } } }`,
+          );
+          if (ask.type === 'boolean') existsInDefault = ask.value;
+        } catch {
+          // ignore — fall through to the unconditional delete
+        }
+        if (!existsInDefault) continue;
+        await this.sparqlUpdate(`DELETE DATA { ${tripleData} }`);
+        removed++;
+      }
+    }
+    return removed;
   }
 
   async deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number> {

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -21,6 +21,132 @@ export class OxigraphStore implements TripleStore {
   private persistPath: string | undefined;
 
   /**
+   * Side-table preserving the ORIGINAL `^^<datatype>` of typed numeric
+   * literals through round-trips. Oxigraph canonicalizes numeric
+   * subtypes (e.g. `xsd:long` → `xsd:integer`), which loses the
+   * publisher's intent and breaks.
+   *
+   * previously keyed by the lexical value alone, which
+   * corrupted results whenever two quads in the store used the same
+   * lexeme with different declared types (e.g. `"1"^^xsd:int` and
+   * `"1"^^xsd:positiveInteger`). The later insert clobbered the
+   * earlier entry, so BOTH quads read back with the newer datatype.
+   *
+   * Key is now the full quad identity (subject | predicate | value |
+   * graph) so each typed-literal position owns its own declared type.
+   * Collisions only happen when the same position is written twice
+   * with different declared types, which is a genuine overwrite.
+   *
+   * even with the
+   * per-position key, two quads at the same `(s, p, value, g)` with
+   * DIFFERENT declared subtypes (e.g. `"1"^^xsd:int` and
+   * `"1"^^xsd:positiveInteger`) collapse to the SAME single
+   * canonicalised literal in Oxigraph. Silently letting the second
+   * insert overwrite the first meant the readback returned the
+   * latest-written subtype for both — a fail-OPEN data-integrity bug.
+   * The fix below tracks per-position conflicts in
+   * {@link conflictedNumericDatatypeKeys} and per-lexeme conflicts in
+   * {@link conflictedNumericDatatypeLexemes}: once a key (or its
+   * lexeme) conflicts, the side-table refuses to restore the subtype
+   * for that key (and for unkeyed SELECT bindings of the same
+   * lexeme). Callers fall through to Oxigraph's canonical form
+   * (`xsd:integer`) — fail-CLOSED.
+   */
+  private originalNumericDatatype = new Map<string, string>();
+
+  /**
+   * Set of side-table keys whose per-position write history saw two
+   * different declared subtypes. Once a key is in this set we refuse
+   * to restore its subtype (and remove any prior entry from
+   * {@link originalNumericDatatype} so we don't leak the
+   * latest-write-wins value through `restoreOriginalDatatype`).
+   * Persisted alongside the dump so the conflict survives restarts;
+   */
+  private conflictedNumericDatatypeKeys = new Set<string>();
+
+  /**
+   * Set of lexemes (raw value strings) for which any per-position key
+   * conflict has been observed. SELECT bindings strip the position
+   * (we only see the lexeme value), so the lexical-only fallback in
+   * {@link restoreOriginalDatatypeForSelectBinding} consults this set
+   * and refuses to restore — even when the surviving non-conflicting
+   * entries for the same lexeme would otherwise resolve to a single
+   * subtype. Without this guard, a SELECT row hit by the conflicted
+   * position would silently inherit a sibling position's dtype.
+   * Persisted alongside the dump.
+   */
+  private conflictedNumericDatatypeLexemes = new Set<string>();
+
+  private static numericDatatypeKey(
+    subject: string,
+    predicate: string,
+    value: string,
+    graph: string | undefined,
+  ): string {
+    return `${subject}\u0000${predicate}\u0000${value}\u0000${graph ?? ''}`;
+  }
+
+  /**
+   * Reverse of {@link numericDatatypeKey} — extract the lexeme `value`
+   * field from a key. Used by {@link maybeReleaseLexemeMarker} to walk
+   * the remaining conflict-key set when deciding whether the
+   * companion lexeme-level marker is still needed.
+   *
+   * Returns `undefined` for malformed keys (e.g. legacy hydrated keys
+   * whose serialisation predates the 4-segment NUL shape) so the
+   * caller treats them as "lexeme unknown — keep the marker
+   * pessimistically" instead of falsely releasing it.
+   *
+   * oxigraph.ts:169, KK3b).
+   */
+  private static parseLexemeFromNumericDatatypeKey(key: string): string | undefined {
+    const parts = key.split('\u0000');
+    if (parts.length !== 4) return undefined;
+    return parts[2];
+  }
+
+  /**
+   * After removing one or more entries from
+   * {@link conflictedNumericDatatypeKeys}, check whether the
+   * companion lexeme markers in {@link conflictedNumericDatatypeLexemes}
+   * are still warranted. A lexeme marker is only meaningful when AT
+   * LEAST ONE per-key conflict still references that exact lexeme —
+   * once every contributing key has been evicted (e.g. the
+   * conflicting quad was deleted, the graph dropped, or the subject
+   * prefix wiped) the lexeme marker becomes a phantom that
+   * permanently downgrades unrelated future writes for the same
+   * lexeme to Oxigraph's canonical `xsd:integer`.
+   *
+   * oxigraph.ts:169, KK3b). Pre-r31-13
+   * the lexeme marker was kept "pessimistically" forever — once
+   * `"1"` had a transient conflict at any position, EVERY future
+   * SELECT/CONSTRUCT of any `"1"^^xsd:long` literal across the
+   * entire store fell back to `xsd:integer` regardless of whether
+   * any conflict still actually existed in the live quad set, even
+   * after the contributing quad was deleted or the graph was
+   * dropped. This recomputes the marker from ground truth.
+   */
+  private maybeReleaseLexemeMarkers(lexemes: Iterable<string>): void {
+    const candidates = new Set<string>();
+    for (const lex of lexemes) {
+      if (typeof lex === 'string' && lex.length > 0 && this.conflictedNumericDatatypeLexemes.has(lex)) {
+        candidates.add(lex);
+      }
+    }
+    if (candidates.size === 0) return;
+    for (const k of this.conflictedNumericDatatypeKeys) {
+      if (candidates.size === 0) return;
+      const lex = OxigraphStore.parseLexemeFromNumericDatatypeKey(k);
+      if (lex !== undefined && candidates.has(lex)) {
+        candidates.delete(lex);
+      }
+    }
+    for (const lex of candidates) {
+      this.conflictedNumericDatatypeLexemes.delete(lex);
+    }
+  }
+
+  /**
    * @param persistPath  If provided, the store will dump/load N-Quads
    *   to this file path for persistence across restarts. The underlying
    *   store is still in-memory, but data is hydrated on construction
@@ -34,15 +160,220 @@ export class OxigraphStore implements TripleStore {
     }
   }
 
+  /**
+   * Capture publisher-declared numeric subtype before it goes through
+   * Oxigraph (which collapses `xsd:long`, `xsd:int`, `xsd:short`,
+   * `xsd:byte` and friends into `xsd:integer`). The declared type is
+   * keyed per-quad (see {@link originalNumericDatatype}) so two quads
+   * sharing a lexeme but declaring different subtypes each retain
+   * their own declared type on read-back..
+   */
+  private rememberNumericDatatype(q: DKGQuad): void {
+    const term = q.object;
+    if (!term.startsWith('"')) return;
+    const m = term.match(/^"((?:[^"\\]|\\.)*)"\^\^<([^>]+)>$/);
+    if (!m) return;
+    const value = m[1];
+    const dtype = m[2];
+    if (!isNumericSubtype(dtype)) return;
+    const key = OxigraphStore.numericDatatypeKey(q.subject, q.predicate, value, q.graph);
+    // Per-position conflict
+    // detection: if this key is already known-conflicted, no further
+    // writes can disambiguate it. If the key already has a different
+    // declared subtype recorded, mark it (and the lexeme) as conflicted
+    // and remove the now-ambiguous entry so `restoreOriginalDatatype`
+    // can no longer return either side as authoritative — the only
+    // safe answer is Oxigraph's canonicalised form.
+    if (this.conflictedNumericDatatypeKeys.has(key)) {
+      this.conflictedNumericDatatypeLexemes.add(value);
+      return;
+    }
+    const existing = this.originalNumericDatatype.get(key);
+    if (existing !== undefined && existing !== dtype) {
+      this.originalNumericDatatype.delete(key);
+      this.conflictedNumericDatatypeKeys.add(key);
+      this.conflictedNumericDatatypeLexemes.add(value);
+      return;
+    }
+    this.originalNumericDatatype.set(key, dtype);
+  }
+
+  /**
+   * Drop the numeric-subtype side-table entry for a quad that was
+   * just removed from the store. Before this guard,
+   * `delete()` / `deleteByPattern()` / `dropGraph()` /
+   * `deleteBySubjectPrefix()` silently left stale entries behind,
+   * so `restoreOriginalDatatypeForSelectBinding()` could see phantom
+   * subtype conflicts from data that no longer existed (and the
+   * conflicts were persisted across restarts via the sidecar).
+   */
+  private forgetNumericDatatype(q: DKGQuad): void {
+    const term = q.object;
+    if (!term.startsWith('"')) return;
+    const m = term.match(/^"((?:[^"\\]|\\.)*)"\^\^<([^>]+)>$/);
+    if (!m) return;
+    const value = m[1];
+    const dtype = m[2];
+    if (!isNumericSubtype(dtype)) return;
+    const key = OxigraphStore.numericDatatypeKey(q.subject, q.predicate, value, q.graph);
+    this.originalNumericDatatype.delete(key);
+    // When the conflicting
+    // canonical literal at this position is deleted, the conflict
+    // marker becomes meaningless — Oxigraph collapsed both writes
+    // into the single canonical literal that the caller is now
+    // removing, so there is nothing left to restore-or-refuse for
+    // this key. Drop the key marker.
+    //
+    // oxigraph.ts:169, KK3b). The
+    // companion lexeme marker MUST also be re-evaluated against
+    // ground truth: if no remaining conflict-key still references
+    // this lexeme, the lexeme marker is dead too. the
+    // lexeme marker was kept "pessimistically" forever, which made
+    // subtype loss permanent for that literal — every later SELECT
+    // of an otherwise unambiguous `"V"^^...` would fall back to
+    // Oxigraph's canonical `xsd:integer` even after the contributing
+    // quad / graph was gone. `maybeReleaseLexemeMarkers()` walks the
+    // remaining conflict-key set and only releases the lexeme when
+    // no key still contributes.
+    this.conflictedNumericDatatypeKeys.delete(key);
+    this.maybeReleaseLexemeMarkers([value]);
+  }
+
+  /**
+   * Evict side-table entries whose graph suffix matches. Called from
+   * `dropGraph()` / `deleteBySubjectPrefix()` / `deleteByPattern()`
+   * when we don't have the pre-delete quad set to key by directly.
+   * Keys are `s\0p\0value\0g` so we filter on the final `\0g` suffix
+   * (plus optional subject-prefix predicate).
+   */
+  private evictNumericDatatypeForGraph(
+    graphUri: string,
+    subjectPrefix?: string,
+  ): void {
+    const suffix = `\u0000${graphUri}`;
+    for (const k of this.originalNumericDatatype.keys()) {
+      if (!k.endsWith(suffix)) continue;
+      if (subjectPrefix && !k.startsWith(subjectPrefix)) continue;
+      this.originalNumericDatatype.delete(k);
+    }
+    // The conflict-key
+    // markers (kept on a parallel Set keyed by the same `s\0p\0v\0g`
+    // shape) must be evicted in lockstep; otherwise dropping the
+    // graph would leave dangling conflict markers that block
+    // unrelated future writes from the same key shape (e.g. a fresh
+    // graph re-using a UAL pattern).
+    //
+    // oxigraph.ts:169, KK3b). Collect
+    // every lexeme that we drop a key for, then re-evaluate the
+    // companion lexeme markers from ground truth. Without this, a
+    // `dropGraph()` would erase the per-key conflict markers but
+    // leave the lexeme markers behind forever, permanently
+    // downgrading every future write of those literals to Oxigraph's
+    // canonical `xsd:integer` even though no actual conflict
+    // remains anywhere in the live store.
+    const evictedLexemes = new Set<string>();
+    for (const k of this.conflictedNumericDatatypeKeys) {
+      if (!k.endsWith(suffix)) continue;
+      if (subjectPrefix && !k.startsWith(subjectPrefix)) continue;
+      const lex = OxigraphStore.parseLexemeFromNumericDatatypeKey(k);
+      if (lex !== undefined) evictedLexemes.add(lex);
+      this.conflictedNumericDatatypeKeys.delete(k);
+    }
+    if (evictedLexemes.size > 0) {
+      this.maybeReleaseLexemeMarkers(evictedLexemes);
+    }
+  }
+
+  /**
+   * Companion sidecar path that persists the numeric-subtype metadata
+   * across restarts. The main N-Quads dump cannot carry it because
+   * Oxigraph canonicalises `xsd:long`/`xsd:int`/`xsd:short`/`xsd:byte`
+   * to `xsd:integer` BEFORE the dump is emitted — so by the time we
+   * read the file back the original declared type is gone. Writing it
+   * alongside the dump (and reading it on {@link hydrateSync}) is the
+   * only way to keep the side-table useful in `oxigraph-persistent`
+   * across restarts.
+   */
+  private static numericDatatypeSidecarPath(persistPath: string): string {
+    return `${persistPath}.numeric-datatypes.json`;
+  }
+
   private hydrateSync(filePath: string): void {
+    // Track whether
+    // the primary N-Quads dump was actually hydrated before deciding
+    // whether to read the sidecar. Pre-fix the sidecar was loaded
+    // unconditionally — if the dump file was missing, empty, or
+    // corrupt the silent `catch` would leave the store with no quads
+    // while `originalNumericDatatype` was still populated from the
+    // sidecar. The first new `insert()` whose subject reused a
+    // sidecar key would then "restore" the new literal to the OLD
+    // datatype that is no longer represented in the store, silently
+    // corrupting downstream reads.
+    let dumpLoaded = false;
     try {
       if (!existsSync(filePath)) return;
       const data = readFileSync(filePath, 'utf-8') as string;
       if (data.trim()) {
         this.store.load(data, { format: 'application/n-quads' });
+        dumpLoaded = true;
+      } else {
+        // Empty dump file — treat as a fresh store. Don't pull stale
+        // datatype metadata in alongside it.
+        return;
       }
     } catch {
-      // File missing or corrupt — start empty.
+      // File missing or corrupt — start empty AND skip the sidecar
+      // (see above). Returning here is the new fail-closed behaviour.
+      return;
+    }
+    if (!dumpLoaded) return;
+    // `originalNumericDatatype` used
+    // to only be populated by live `insert()` calls, so after a process
+    // restart every `oxigraph-persistent` store lost all numeric-subtype
+    // metadata and `restoreOriginalDatatype*()` collapsed the literals
+    // back to Oxigraph's canonical `xsd:integer`. Hydrate the side-table
+    // from the companion sidecar written by {@link flushNow} so restart
+    // round-trips preserve the publisher-declared subtype.
+    try {
+      const sidecarPath = OxigraphStore.numericDatatypeSidecarPath(filePath);
+      if (!existsSync(sidecarPath)) return;
+      const raw = readFileSync(sidecarPath, 'utf-8');
+      if (!raw.trim()) return;
+      const parsed = JSON.parse(raw) as {
+        entries?: Array<[string, string]>;
+        // Persist the
+        // per-position and per-lexeme conflict sets alongside the
+        // entry map so a restart re-establishes "this position /
+        // lexeme is ambiguous, never restore" instead of silently
+        // forgetting the conflict (which would re-open the
+        // fail-OPEN data-integrity bug the conflict tracking was
+        // added to close).
+        conflictedKeys?: string[];
+        conflictedLexemes?: string[];
+      };
+      const entries = parsed && Array.isArray(parsed.entries) ? parsed.entries : [];
+      for (const entry of entries) {
+        if (
+          Array.isArray(entry) &&
+          entry.length === 2 &&
+          typeof entry[0] === 'string' &&
+          typeof entry[1] === 'string'
+        ) {
+          this.originalNumericDatatype.set(entry[0], entry[1]);
+        }
+      }
+      const conflictedKeys = parsed && Array.isArray(parsed.conflictedKeys)
+        ? parsed.conflictedKeys : [];
+      for (const k of conflictedKeys) {
+        if (typeof k === 'string') this.conflictedNumericDatatypeKeys.add(k);
+      }
+      const conflictedLexemes = parsed && Array.isArray(parsed.conflictedLexemes)
+        ? parsed.conflictedLexemes : [];
+      for (const l of conflictedLexemes) {
+        if (typeof l === 'string') this.conflictedNumericDatatypeLexemes.add(l);
+      }
+    } catch {
+      // Sidecar missing or corrupt — fall back to lexical-only restore.
     }
   }
 
@@ -64,6 +395,25 @@ export class OxigraphStore implements TripleStore {
       await mkdir(dirname(this.persistPath), { recursive: true });
       const nquads = this.store.dump({ format: 'application/n-quads' });
       await writeFile(this.persistPath, nquads, 'utf-8');
+      // persist the numeric-subtype
+      // side-table alongside the dump so hydrateSync() can restore it on
+      // the next boot. Without this sidecar every restart re-canonicalises
+      // `xsd:long`/`xsd:int`/... back to `xsd:integer` on read-back because
+      // Oxigraph has already collapsed the subtype by the time it dumps.
+      const sidecarPath = OxigraphStore.numericDatatypeSidecarPath(this.persistPath);
+      const sidecar = JSON.stringify({
+        // Bumped to v2
+        // because the schema now includes `conflictedKeys` /
+        // `conflictedLexemes` arrays so a restart re-establishes
+        // per-position / per-lexeme conflict markers. v1 sidecars
+        // load fine (the new arrays default to empty); the version
+        // tag is informational for ops grepping the file.
+        version: 2,
+        entries: Array.from(this.originalNumericDatatype.entries()),
+        conflictedKeys: Array.from(this.conflictedNumericDatatypeKeys),
+        conflictedLexemes: Array.from(this.conflictedNumericDatatypeLexemes),
+      });
+      await writeFile(sidecarPath, sidecar, 'utf-8');
     } catch {
       // Best-effort persistence.
     } finally {
@@ -73,6 +423,7 @@ export class OxigraphStore implements TripleStore {
 
   async insert(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
+    for (const q of quads) this.rememberNumericDatatype(q);
     const nquads = quads.map(quadToNQuad).join('\n') + '\n';
     this.store.load(nquads, { format: 'application/n-quads' });
     this.scheduleFlush();
@@ -82,6 +433,7 @@ export class OxigraphStore implements TripleStore {
     for (const q of quads) {
       const oxQuad = toOxQuad(q);
       if (oxQuad) this.store.delete(oxQuad);
+      this.forgetNumericDatatype(q);
     }
     this.scheduleFlush();
   }
@@ -95,6 +447,9 @@ export class OxigraphStore implements TripleStore {
     );
     for (const q of matches) {
       this.store.delete(q);
+      // We have the concrete deleted quads in hand, so do an exact
+      // eviction rather than the graph-wide scan.
+      this.forgetNumericDatatype(fromOxQuad(q));
     }
     if (matches.length > 0) this.scheduleFlush();
     return matches.length;
@@ -119,8 +474,17 @@ export class OxigraphStore implements TripleStore {
     if (first instanceof Map) {
       const bindings = (result as Map<string, OxTerm>[]).map((row) => {
         const obj: Record<string, string> = {};
+        // SELECT results are keyed only by the
+        // binding value (we don't know which quad each binding came
+        // from), so we can only safely restore the declared subtype
+        // when every remembered quad with this lexeme agreed on it.
+        // If two quads in the store declared different xsd subtypes
+        // for the same lexeme (e.g. `"1"^^xsd:int` vs
+        // `"1"^^xsd:positiveInteger`), SELECT cannot pick a side
+        // without the position — so we fall through to Oxigraph's
+        // canonical form instead of silently reporting the wrong type.
         for (const [key, term] of row.entries()) {
-          obj[key] = termToString(term);
+          obj[key] = this.restoreOriginalDatatypeForSelectBinding(termToString(term));
         }
         return obj;
       });
@@ -128,8 +492,94 @@ export class OxigraphStore implements TripleStore {
     }
 
 
-    const quads = (result as OxQuad[]).map(fromOxQuad);
+    const quads = (result as OxQuad[]).map((oxq) => {
+      const dq = fromOxQuad(oxq);
+      dq.object = this.restoreOriginalDatatype(dq);
+      return dq;
+    });
     return { type: 'quads', quads } satisfies ConstructResult;
+  }
+
+  /**
+   * Reverse of `rememberNumericDatatype` — if a CONSTRUCT row
+   * contains a typed literal whose datatype Oxigraph collapsed
+   * (e.g. `xsd:long` → `xsd:integer`), restore the publisher's
+   * original declared type from the side-table keyed by the full
+   * quad identity. Falls through unchanged when no entry exists or
+   * the key is not a known numeric subtype.
+   */
+  private restoreOriginalDatatype(q: DKGQuad): string {
+    const serialized = q.object;
+    if (!serialized.startsWith('"')) return serialized;
+    const m = serialized.match(/^"((?:[^"\\]|\\.)*)"\^\^<([^>]+)>$/);
+    if (!m) return serialized;
+    const value = m[1];
+    const dtype = m[2];
+    if (!isNumericSubtype(dtype)) return serialized;
+    // Prefer the exact quad-identity match — the unambiguous path
+    // when one position declared a specific subtype.
+    const key = OxigraphStore.numericDatatypeKey(q.subject, q.predicate, value, q.graph);
+    // Per-position conflict
+    // short-circuit: if two writes at this exact `(s, p, value, g)`
+    // declared different subtypes, the side-table cannot recover
+    // either source's intent (Oxigraph collapsed both into one
+    // canonical literal). Fall straight through to the canonical
+    // form — do NOT delegate to the lexical-only fallback because
+    // a sibling position with the same lexeme but a single declared
+    // subtype would otherwise silently win.
+    if (this.conflictedNumericDatatypeKeys.has(key)) {
+      return serialized;
+    }
+    const original = this.originalNumericDatatype.get(key);
+    if (original && original !== dtype) {
+      return `"${value}"^^<${original}>`;
+    }
+    // CONSTRUCT results often project quads into the default graph
+    // (`CONSTRUCT { ?s ?p ?o }`), so the per-quad key doesn't line up
+    // with the graph-scoped write-time key. Fall back to the
+    // lexical-only best-effort lookup WITH CONFLICT DETECTION: if
+    // every remembered quad with this lexeme declared the same
+    // subtype, restore it; if two different subtypes were declared
+    // anywhere, refuse to guess and return Oxigraph's canonical form.
+    return this.restoreOriginalDatatypeForSelectBinding(serialized);
+  }
+
+  /**
+   * lexical-only restore for SELECT bindings. Only
+   * returns the declared subtype when EVERY remembered quad that
+   * carried this lexeme declared the SAME subtype — otherwise falls
+   * back to Oxigraph's canonical form. This preserves the common
+   * case (single publisher wrote `"42"^^xsd:long`) while refusing
+   * to guess when the store contains conflicting declarations.
+   */
+  private restoreOriginalDatatypeForSelectBinding(serialized: string): string {
+    if (!serialized.startsWith('"')) return serialized;
+    const m = serialized.match(/^"((?:[^"\\]|\\.)*)"\^\^<([^>]+)>$/);
+    if (!m) return serialized;
+    const value = m[1];
+    const dtype = m[2];
+    if (!isNumericSubtype(dtype)) return serialized;
+    // If ANY per-position
+    // write of this lexeme observed a per-position subtype conflict,
+    // the lexical-only path cannot tell whether THIS binding row came
+    // from the conflicted position or a clean sibling — refuse to
+    // restore so we can't silently inherit a sibling's dtype.
+    if (this.conflictedNumericDatatypeLexemes.has(value)) {
+      return serialized;
+    }
+    let only: string | undefined;
+    // Keys are `s\0p\0value\0g` — scan for entries matching this value.
+    const needle = `\u0000${value}\u0000`;
+    for (const [k, v] of this.originalNumericDatatype) {
+      if (!k.includes(needle)) continue;
+      if (only === undefined) {
+        only = v;
+      } else if (only !== v) {
+        return serialized; // conflict — fall back to Oxigraph canonical
+      }
+    }
+    if (!only || only === dtype) return serialized;
+    return `"${value}"^^<${only}>`;
   }
 
   async hasGraph(graphUri: string): Promise<boolean> {
@@ -148,6 +598,12 @@ export class OxigraphStore implements TripleStore {
 
   async dropGraph(graphUri: string): Promise<void> {
     this.store.update(`DROP SILENT GRAPH <${escapeUri(graphUri)}>`);
+    // every numeric-
+    // subtype key that lived in this graph must be dropped too, so
+    // `restoreOriginalDatatypeForSelectBinding` can't see phantom
+    // conflicts from data that no longer exists (and the conflicts
+    // don't get persisted across restarts via the sidecar).
+    this.evictNumericDatatypeForGraph(graphUri);
     this.scheduleFlush();
   }
 
@@ -175,7 +631,14 @@ export class OxigraphStore implements TripleStore {
       `DELETE { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o } } WHERE { GRAPH <${escapeUri(graphUri)}> { ?s ?p ?o . FILTER(STRSTARTS(STR(?s), "${escapeString(prefix)}")) } }`,
     );
     const removed = before - this.store.size;
-    if (removed > 0) this.scheduleFlush();
+    if (removed > 0) {
+      // evict sidecar
+      // entries for quads that just vanished. We filter by
+      // `startsWith(subjectPrefix)` (keys are `s\0p\0v\0g`) which
+      // mirrors the SPARQL `STRSTARTS(STR(?s), prefix)` filter above.
+      this.evictNumericDatatypeForGraph(graphUri, prefix);
+      this.scheduleFlush();
+    }
     return removed;
   }
 
@@ -257,6 +720,29 @@ function fromOxQuad(oxq: OxQuad): DKGQuad {
     graph:
       oxq.graph.termType === 'DefaultGraph' ? '' : oxq.graph.value,
   };
+}
+
+/** XSD numeric subtypes that Oxigraph silently canonicalises to
+ *  `xsd:integer` — keep this list in sync with the W3C XSD spec
+ *  derived-integer hierarchy. */
+const NUMERIC_SUBTYPES = new Set<string>([
+  'http://www.w3.org/2001/XMLSchema#long',
+  'http://www.w3.org/2001/XMLSchema#int',
+  'http://www.w3.org/2001/XMLSchema#short',
+  'http://www.w3.org/2001/XMLSchema#byte',
+  'http://www.w3.org/2001/XMLSchema#unsignedLong',
+  'http://www.w3.org/2001/XMLSchema#unsignedInt',
+  'http://www.w3.org/2001/XMLSchema#unsignedShort',
+  'http://www.w3.org/2001/XMLSchema#unsignedByte',
+  'http://www.w3.org/2001/XMLSchema#integer',
+  'http://www.w3.org/2001/XMLSchema#nonNegativeInteger',
+  'http://www.w3.org/2001/XMLSchema#positiveInteger',
+  'http://www.w3.org/2001/XMLSchema#negativeInteger',
+  'http://www.w3.org/2001/XMLSchema#nonPositiveInteger',
+]);
+
+function isNumericSubtype(dtype: string): boolean {
+  return NUMERIC_SUBTYPES.has(dtype);
 }
 
 function escapeNQuadsLiteral(s: string): string {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -16,7 +16,7 @@ export { OxigraphWorkerStore } from './adapters/oxigraph-worker.js';
 export { BlazegraphStore } from './adapters/blazegraph.js';
 export { SparqlHttpStore, type SparqlHttpStoreOptions } from './adapters/sparql-http.js';
 export { ContextGraphManager, GraphManager } from './graph-manager.js';
-export { PrivateContentStore } from './private-store.js';
+export { PrivateContentStore, decryptPrivateLiteral } from './private-store.js';
 
 // Side-effect: register built-in adapters
 import './adapters/oxigraph.js';

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -1,4 +1,8 @@
-import { assertSafeIri, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
+import { assertSafeIri, escapeSparqlLiteral, isSafeIri } from '@origintrail-official/dkg-core';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import type { TripleStore, Quad } from './triple-store.js';
 import type { ContextGraphManager } from './graph-manager.js';
 
@@ -8,15 +12,753 @@ import type { ContextGraphManager } from './graph-manager.js';
  * node. The meta graph records which KAs have private triples (via
  * privateMerkleRoot and privateTripleCount).
  */
+/** AES-GCM ciphertext envelope tag — distinguishes private literals
+ *  from any other typed/plain literal that happens to look like
+ *  base64. Versioned so the on-disk format can rotate without
+ *  breaking existing data. */
+const ENC_PREFIX = 'enc:gcm:v1:';
+
+/** Encryption key resolution order:
+ *   1. Explicit constructor `encryptionKey` (32 bytes, hex/base64/raw or
+ *      shorter passphrase — short inputs are SHA-256-stretched so AES-256
+ *      always sees a full 256-bit key).
+ *   2. `DKG_PRIVATE_STORE_KEY` env var (same shape as #1).
+ *   3. A **per-node persisted** key generated at first run and stored on
+ *      disk with 0600 permissions. The path resolves in this order:
+ *        a. `DKG_PRIVATE_STORE_KEY_FILE`
+ *        b. `<DKG_HOME>/private-store.key`
+ *        c. `<homedir()>/.dkg/private-store.key`
+ *      If any directory in the chain is unwritable we fall through to
+ *      step 4 rather than silently crashing.
+ *   4. As a last resort a deterministic `sha256(DEFAULT_KEY_DOMAIN)` —
+ *      which is NOT secret and has to be kept behind a loud warning
+ *      for environments (e.g. read-only FS, sandboxed CI) where
+ *      persisting a key is impossible. Operators who need guaranteed
+ *      confidentiality even in those environments MUST configure
+ *      `DKG_PRIVATE_STORE_KEY` explicitly or turn on strict mode via
+ *      `DKG_PRIVATE_STORE_STRICT_KEY=1` (or `strictKey: true`), which
+ *      turns step 4 into a hard error.
+ *
+ * behaviour: step 3 did not exist, so every node without an
+ * explicit key shared `sha256(DEFAULT_KEY_DOMAIN)` — any attacker with
+ * repo source could decrypt the stored "private" triples across the
+ * whole fleet.
+ */
+const DEFAULT_KEY_DOMAIN = 'dkg-v10/private-store/default-key/v1';
+const PERSISTED_KEY_FILENAME = 'private-store.key';
+let defaultKeyWarned = false;
+/**
+ * Per-path cache of persisted keys. An earlier revision used a
+ * single module-global `cachedPersistedKey: Buffer | null`, which
+ * silently aliased multiple `PrivateContentStore` instances onto
+ * the FIRST node's key whenever one process hosted several nodes
+ * with different `DKG_HOME` / `DKG_PRIVATE_STORE_KEY_FILE` values
+ * (test fixtures, multi-tenant daemons, simulation harnesses).
+ * The second node would:
+ *   1. call `resolvePersistedKeyPath()` → get its OWN path
+ *   2. call `loadOrCreatePersistedKey()` → hit the module-global
+ *      cache populated by node #1, return node #1's key
+ *   3. read/write all private data under node #1's secret, breaking
+ *      crypto isolation.
+ * When the env later flipped back to the original path, cached key
+ * still won and data became unreadable.
+ *
+ * Fix: key the cache by resolved file path. Each node's path maps
+ * to its own key buffer. Writes to the same path still hit the
+ * cache (the round-12-2 intra-process sharing property). Different
+ * paths get different keys.
+ *
+ * The cache is still process-local, unbounded-by-design (the set
+ * of paths a single process opens in its lifetime is inherently
+ * bounded by the number of node instances it hosts — this is
+ * thousands at most, not millions of entries). A hostile caller
+ * that spins up a new path every call would still be bounded by
+ * the filesystem's own limits long before the Map becomes a
+ * memory issue.
+ */
+let persistedKeyWarnedPaths: Set<string> = new Set();
+const persistedKeyByPath: Map<string, Buffer> = new Map();
+
+function strictKeyRequestedFromEnv(): boolean {
+  const v = (process.env.DKG_PRIVATE_STORE_STRICT_KEY ?? '').toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+function resolvePersistedKeyPath(): string {
+  if (process.env.DKG_PRIVATE_STORE_KEY_FILE) {
+    return process.env.DKG_PRIVATE_STORE_KEY_FILE;
+  }
+  if (process.env.DKG_HOME) {
+    return join(process.env.DKG_HOME, PERSISTED_KEY_FILENAME);
+  }
+  return join(homedir(), '.dkg', PERSISTED_KEY_FILENAME);
+}
+
+/**
+ * Load the per-node persisted key, generating it on first run.
+ *
+ * Returns `null` if we cannot read or create the key file (read-only
+ * filesystem, unknown home directory, etc.) so the caller can fall
+ * through to the deterministic last-resort key under a loud warning.
+ *
+ * Failure modes we deliberately tolerate:
+ *   - file exists but is shorter than 32 bytes: treat as corrupt,
+ *     regenerate (we never want a short AES-256 key).
+ *   - dir doesn't exist: `mkdirSync(..., recursive: true)`.
+ *   - write errors: fall through to last-resort key.
+ *
+ * The cached key is process-wide so multiple `PrivateContentStore`
+ * instances on the same node share the same secret without re-reading
+ * the file on every construction.
+ */
+function loadOrCreatePersistedKey(): Buffer | null {
+  const path = resolvePersistedKeyPath();
+  // per-path cache, so two nodes in the same process with
+  // different key files each get THEIR OWN key.
+  const cached = persistedKeyByPath.get(path);
+  if (cached) return cached;
+
+  // private-store.ts:124). The
+  // previous logic had two correctness holes around persistent key
+  // loading:
+  //
+  //   1. If the key file existed but was SHORT (<32 bytes — truncated,
+  //      partial write, FS corruption), the `if (raw.length >= 32)`
+  //      branch silently fell through to the regenerate path below.
+  //      That auto-rotation re-keys the node in place AND overwrites
+  //      the original (possibly recoverable) bytes — every previously
+  //      encrypted private triple is silently stranded with no way for
+  //      the operator to notice.
+  //
+  //   2. The outer `try/catch` swallowed ALL errors (including
+  //      "permission denied", "file is a symlink to /dev/null", etc.)
+  //      and returned `null` so the caller fell back to the global
+  //      deterministic last-resort key. That's a different but related
+  //      stranding: future writes encrypt under last-resort, while
+  //      reads of pre-existing data still need the persisted key, and
+  //      neither side surfaces the problem.
+  //
+  // Fix: TREAT A NON-EMPTY-BUT-INVALID FILE AS A LOUD ERROR. Only
+  // generate a fresh key when the file is genuinely absent. If the
+  // file exists but is short, throw a clear `Error` so the operator
+  // sees the corruption signal at startup. The `DKG_PRIVATE_STORE_KEY`
+  // / `DKG_PRIVATE_STORE_KEY_FILE` env overrides remain available as
+  // an escape hatch for managed-secret deployments. An optional
+  // `DKG_PRIVATE_STORE_KEY_AUTO_RESET=1` lets the operator opt back
+  // into the old auto-regenerate behaviour after they've explicitly
+  // accepted the data-loss trade-off.
+  const fileExists = existsSync(path);
+  if (fileExists) {
+    let raw: Buffer;
+    try {
+      raw = readFileSync(path);
+    } catch (err) {
+      // Read failed entirely (permissions, symlink loop, etc.) —
+      // surface the OS error so the operator can fix it instead of
+      // silently re-keying the node.
+      throw new Error(
+        `[PrivateContentStore] Failed to read persistent private-store key file at ${path}: ` +
+          `${(err as Error).message}. Refusing to fall back to a fresh key (would silently strand existing private triples). ` +
+          'Fix the file, restore from backup, set DKG_PRIVATE_STORE_KEY / DKG_PRIVATE_STORE_KEY_FILE, ' +
+          'or set DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 if you accept losing every previously encrypted private triple.',
+        { cause: err as Error },
+      );
+    }
+    if (raw.length >= 32) {
+      const key = Buffer.from(raw.subarray(0, 32));
+      persistedKeyByPath.set(path, key);
+      return key;
+    }
+    // File exists but is unusable. Loud error — see commentary above.
+    if (process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET === '1') {
+      console.warn(
+        `[PrivateContentStore] Persistent private-store key file at ${path} is corrupt ` +
+          `(length=${raw.length}, expected >= 32). DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 is set, ` +
+          'so a FRESH key will be generated. Every previously encrypted private triple under the old ' +
+          'key is now PERMANENTLY UNRECOVERABLE.',
+      );
+      // Fall through to the generation path below.
+    } else {
+      throw new Error(
+        `[PrivateContentStore] Persistent private-store key file at ${path} is corrupt ` +
+          `(length=${raw.length}, expected >= 32 bytes for AES-256). ` +
+          'Refusing to auto-regenerate (would silently strand every previously encrypted private triple). ' +
+          'Restore the file from backup, set DKG_PRIVATE_STORE_KEY / DKG_PRIVATE_STORE_KEY_FILE to a known-good secret, ' +
+          'or set DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 to accept losing every previously encrypted private triple ' +
+          'and regenerate a fresh key on next start.',
+      );
+    }
+  }
+
+  // First-run path: file is genuinely absent (or auto-reset opted-in).
+  try {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const fresh = randomBytes(32);
+    writeFileSync(path, fresh, { mode: 0o600 });
+    try { chmodSync(path, 0o600); } catch { /* non-POSIX FS */ }
+    if (!persistedKeyWarnedPaths.has(path)) {
+      persistedKeyWarnedPaths.add(path);
+      console.warn(
+        `[PrivateContentStore] Generated per-node private-store key at ${path}. ` +
+          'Back this file up alongside your node data; losing it makes existing ' +
+          'private triples unrecoverable. Override with DKG_PRIVATE_STORE_KEY ' +
+          'or DKG_PRIVATE_STORE_KEY_FILE to use a managed secret instead.',
+      );
+    }
+    persistedKeyByPath.set(path, fresh);
+    return fresh;
+  } catch {
+    // Generation failed (read-only FS, unknown home, etc.). Caller
+    // falls through to the deterministic last-resort key under a loud
+    // warning — same behaviour as before this change. We deliberately
+    // do NOT throw here because some test/dev environments cannot
+    // create the file at all and the operator already accepted the
+    // last-resort fallback in those topologies.
+    return null;
+  }
+}
+
+/** Test-only: drop any cached per-node key so a subsequent call
+ *  re-reads from the (possibly-changed) persistence path. */
+export function __resetPrivateStoreKeyCacheForTests(): void {
+  persistedKeyByPath.clear();
+  defaultKeyWarned = false;
+  persistedKeyWarnedPaths = new Set();
+}
+
+/**
+ * Decode a string-encoded key/passphrase into raw bytes.
+ *
+ * previously any non-hex string fell through to
+ * `Buffer.from(s, 'base64')`, which silently interprets non-base64 input
+ * as truncated garbage. Two callers passing the passphrases `"hunter2"`
+ * and `"hunter2!"` would end up with the SAME key because both decode
+ * to the same leading bytes under a permissive base64 reader.
+ *
+ * Resolution:
+ *   - 64-char hex → decode as hex.
+ *   - Canonical base64 (length multiple of 4, valid alphabet, length >=
+ *     44 so the DECODED length is 32 or more) → decode as base64.
+ *   - Everything else → treat as a UTF-8 passphrase and SHA-256-stretch.
+ */
+function decodeKeyOrPassphrase(s: string): Buffer {
+  if (/^[0-9a-fA-F]{64}$/.test(s)) {
+    return Buffer.from(s, 'hex');
+  }
+  const looksLikeCanonicalBase64 =
+    s.length >= 44 &&
+    s.length % 4 === 0 &&
+    /^[A-Za-z0-9+/]+={0,2}$/.test(s);
+  if (looksLikeCanonicalBase64) {
+    try {
+      const buf = Buffer.from(s, 'base64');
+      if (buf.length >= 32) return buf;
+    } catch {
+      // fall through to passphrase path
+    }
+  }
+  return Buffer.from(s, 'utf8');
+}
+
+/**
+ * Compute the deterministic legacy fallback key.
+ *
+ * nodes (no `DKG_PRIVATE_STORE_KEY` configured) all shared
+ * `sha256(DEFAULT_KEY_DOMAIN)`. the rightly stopped using
+ * that as the preferred key, but a straight flip would strand every
+ * private triple written before the upgrade — the fresh per-node key
+ * cannot decrypt ciphertext sealed under the deterministic key.
+ *
+ * keep the legacy key around as
+ * a **decrypt-only** fallback so existing data remains readable after
+ * upgrade. New writes always use the primary key. The legacy key is
+ * never used to encrypt anything (the confidentiality regression that
+ * ed is preserved — no one sharing a public constant for
+ * fresh data). Once all legacy ciphertext has been re-encrypted or
+ * deleted, operators can drop the fallback entirely by setting
+ * `DKG_PRIVATE_STORE_STRICT_KEY=1` (which disables unconfigured-key
+ * fallbacks altogether).
+ */
+function computeLegacyDefaultDomainKey(): Buffer {
+  return createHash('sha256').update(DEFAULT_KEY_DOMAIN).digest();
+}
+
+/**
+ * Try to decrypt an AES-GCM envelope against a primary key, falling
+ * back to a list of legacy keys if the primary fails.
+ *
+ * AES-GCM authenticates every ciphertext with a 128-bit tag, so a
+ * wrong key surfaces as a `decipher.final()` throw (Error: Unsupported
+ * state or unable to authenticate data) — no silent plaintext
+ * corruption. That lets us safely try keys in order and return the
+ * first that authenticates.
+ *
+ * Returns `null` if NO key in the chain authenticates the ciphertext;
+ * callers turn that into "leave the envelope visible so the operator
+ * can detect the failure".
+ */
+function tryDecryptWithKeyChain(
+  iv: Buffer,
+  tag: Buffer,
+  ct: Buffer,
+  primary: Buffer,
+  legacyKeys: readonly Buffer[],
+): string | null {
+  const chain = [primary, ...legacyKeys];
+  for (const key of chain) {
+    try {
+      const decipher = createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(tag);
+      return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8');
+    } catch {
+      // try next key
+    }
+  }
+  return null;
+}
+
+/**
+ * Stateless mirror of {@link PrivateContentStore}'s seal — used by
+ * pipelines that read private quads back from the underlying store via
+ * raw SPARQL (and therefore see ciphertext envelopes) but want to
+ * reason about plaintext semantics. Examples include the publisher's
+ * `subtractFinalizedExactQuads`, which compares input plaintext quads
+ * against on-disk authoritative quads for exact dedup. Without this,
+ * the subtraction silently misses every private match because
+ * `"plaintext"` never equals `"enc:gcm:v1:…"`.
+ *
+ * The helper resolves the same encryption key (DKG_PRIVATE_STORE_KEY
+ * or the deterministic default-domain hash) so every consumer in the
+ * process round-trips to identical bytes. Non-encrypted literals,
+ * URIs, and blank nodes are returned unchanged.
+ *
+ * when the primary key can't
+ * decrypt (typical on nodes just upgraded past r12-2 that still hold
+ * private triples sealed under the legacy default-domain
+ * key), fall back to the legacy `sha256(DEFAULT_KEY_DOMAIN)` key so
+ * old data remains readable.
+ */
+export function decryptPrivateLiteral(
+  serialized: string,
+  options: { encryptionKey?: Uint8Array | string } = {},
+): string {
+  if (!serialized.startsWith(`"${ENC_PREFIX}`)) return serialized;
+  const m = serialized.match(/^"enc:gcm:v1:([^"]+)"$/);
+  if (!m) return serialized;
+  const primary = resolveEncryptionKey(options.encryptionKey);
+  const legacyKeys = resolveLegacyDecryptionKeys(primary);
+  try {
+    const buf = Buffer.from(m[1], 'base64');
+    const iv = buf.subarray(0, 12);
+    const tag = buf.subarray(12, 28);
+    const ct = buf.subarray(28);
+    const plain = tryDecryptWithKeyChain(Buffer.from(iv), Buffer.from(tag), Buffer.from(ct), primary, legacyKeys);
+    if (plain === null) return serialized;
+    // Strip r6 type-tag prefix (`L|` literal / `I|` IRI). Legacy
+    // envelopes without the tag are returned verbatim for backwards
+    // compatibility — see `PrivateContentStore#decryptLiteral`.
+    if (plain.length >= 2 && plain[1] === '|') return plain.slice(2);
+    return plain;
+  } catch {
+    return serialized;
+  }
+}
+
+/**
+ * Build the decrypt-only fallback-key list.
+ *
+ * Rules:
+ *   - Always include `sha256(DEFAULT_KEY_DOMAIN)` unless it IS the
+ *     primary (no point trying the same key twice — and that happens
+ *     naturally on a read-only/sandbox node whose persisted-key
+ *     creation failed and fell through to the legacy last-resort key
+ *     anyway).
+ *   - Never return an entry that would encrypt. This list is consumed
+ *     by `tryDecryptWithKeyChain` only.
+ */
+function resolveLegacyDecryptionKeys(primary: Buffer): Buffer[] {
+  const legacy = computeLegacyDefaultDomainKey();
+  if (primary.equals(legacy)) return [];
+  return [legacy];
+}
+
+function resolveEncryptionKey(
+  explicit?: Uint8Array | string,
+  options: { strictKey?: boolean } = {},
+): Buffer {
+  const fromExplicit = explicit ?? process.env.DKG_PRIVATE_STORE_KEY;
+  if (fromExplicit) {
+    const buf =
+      typeof fromExplicit === 'string'
+        ? decodeKeyOrPassphrase(fromExplicit)
+        : Buffer.from(fromExplicit);
+    if (buf.length !== 32) {
+      return createHash('sha256').update(buf).digest();
+    }
+    return buf;
+  }
+  // no key configured. If the caller (or the
+  // operator via DKG_PRIVATE_STORE_STRICT_KEY) has opted into strict
+  // mode, refuse to fall back to ANY unconfigured key — strict callers
+  // want a managed secret or nothing at all.
+  const strict = options.strictKey ?? strictKeyRequestedFromEnv();
+  if (strict) {
+    throw new Error(
+      'PrivateContentStore strict mode: DKG_PRIVATE_STORE_KEY is not set ' +
+        'and no encryptionKey was supplied. Refusing to fall back to an ' +
+        'auto-generated per-node key or the deterministic default — ' +
+        'configure a managed secret explicitly.',
+    );
+  }
+  // Preferred default: per-node persisted
+  // key. This gives every unconfigured node a unique secret so
+  // "private" triples are not cross-decryptable across the fleet.
+  const persisted = loadOrCreatePersistedKey();
+  if (persisted) return persisted;
+  // Last resort — persistence failed (read-only FS / CI sandbox / no
+  // HOME). Emit a LOUD warning so the operator can see the gap and
+  // either configure DKG_PRIVATE_STORE_KEY or make the key path
+  // writable. Private triples written under this key are NOT
+  // confidential against anyone with repo access.
+  if (!defaultKeyWarned) {
+    defaultKeyWarned = true;
+    console.warn(
+      '[PrivateContentStore] WARNING: DKG_PRIVATE_STORE_KEY is not set ' +
+        'and the per-node key file could not be created ' +
+        `(${resolvePersistedKeyPath()}). Falling back to a deterministic ` +
+        'default key derived from a public constant — private triples ' +
+        'encrypted under this key are NOT confidential against anyone ' +
+        'with access to this repository. Set DKG_PRIVATE_STORE_KEY to a ' +
+        'per-deployment secret, set DKG_PRIVATE_STORE_KEY_FILE to a ' +
+        'writable path, or set DKG_PRIVATE_STORE_STRICT_KEY=1 to turn ' +
+        'this fallback into an error.',
+    );
+  }
+  return createHash('sha256').update(DEFAULT_KEY_DOMAIN).digest();
+}
+
 export class PrivateContentStore {
   private readonly store: TripleStore;
   private readonly graphManager: ContextGraphManager;
   /** Tracks which rootEntities have private triples on this node. */
   private readonly privateEntities = new Map<string, Set<string>>();
+  /** AES-256-GCM key — used to seal literal objects of private quads
+   *  before they reach the underlying TripleStore (. */
+  private readonly encryptionKey: Buffer;
+  /**
+   * dedup race). The
+   * read-then-insert sequence in {@link storePrivateTriples} would,
+   * under concurrent invocation for the same private graph, let two
+   * writers both observe an empty `existingPlainKeys`, then each
+   * insert their own ciphertext for the SAME `(s,p,o)` plaintext.
+   * Because {@link encryptLiteral} now uses a fresh random IV per
+   * call, the two ciphertexts are byte-distinct, so
+   * the underlying triple store happily keeps both — duplicating the
+   * private quad. This map serialises `storePrivateTriples` calls per
+   * `graphUri` so the read-and-insert pair is atomic from the caller's
+   * perspective. Different graphs still write in parallel.
+   */
+  private readonly perGraphWriteLocks = new Map<string, Promise<void>>();
 
-  constructor(store: TripleStore, graphManager: ContextGraphManager) {
+  constructor(
+    store: TripleStore,
+    graphManager: ContextGraphManager,
+    options: { encryptionKey?: Uint8Array | string; strictKey?: boolean } = {},
+  ) {
     this.store = store;
     this.graphManager = graphManager;
+    this.encryptionKey = resolveEncryptionKey(options.encryptionKey, {
+      strictKey: options.strictKey,
+    });
+  }
+
+  /**
+   * Run `fn` while holding an exclusive lock on `graphUri`. The lock
+   * is released when `fn` resolves OR rejects; queued waiters then
+   * fire in order.
+   *
+   * private-store.ts:491). The lock chain
+   * MUST decouple from the predecessor's success/failure: pre-r31-14
+   * the chain was `prev.then(() => next)` and `await prev` was
+   * outside the try/finally. If any prior writer rejected, `prev`
+   * was a rejected promise — every subsequent waiter inherited the
+   * rejection on `await prev` BEFORE entering the try{} that calls
+   * `release()`. That left `next` pending forever, the in-flight
+   * `chained` rejected, and the `perGraphWriteLocks` entry was never
+   * cleaned up because the cleanup also sat in the `finally`. Net
+   * effect: a single failed `storePrivateTriples()` permanently
+   * BRICKED that graph until process restart — every later writer
+   * for the same graph either threw on the rejected predecessor
+   * before doing anything OR enqueued behind a permanently-pending
+   * `next`.
+   *
+   * Fix: build the chain off `prev.catch(() => {})` so the queue is
+   * resilient to a predecessor's rejection. The lock is purely a
+   * mutex over `fn()`; the success/failure of the previous writer's
+   * own `fn()` is its caller's concern, not the queue's. Also
+   * `await safePrev` (the catch-wrapped variant) so the wait can
+   * never throw before we register the cleanup-on-finally.
+   */
+  private async withGraphWriteLock<T>(
+    graphUri: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const prev = this.perGraphWriteLocks.get(graphUri) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => { release = resolve; });
+    // Swallow predecessor rejections so the queue keeps draining.
+    // The previous writer's caller already saw (or chose to ignore)
+    // the rejection; the lock has no business re-throwing here.
+    const safePrev = prev.catch(() => undefined);
+    const chained = safePrev.then(() => next);
+    this.perGraphWriteLocks.set(graphUri, chained);
+    await safePrev;
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.perGraphWriteLocks.get(graphUri) === chained) {
+        this.perGraphWriteLocks.delete(graphUri);
+      }
+    }
+  }
+
+  /**
+   * AES-256-GCM seal — operates on the LEXICAL value portion of an
+   * RDF literal so the wire and at-rest formats remain valid N-Quads
+   * (a quoted string with no datatype/language). The wrapper preserves
+   * the original literal shape (language tag / datatype IRI) by
+   * embedding it in the plaintext payload before encryption.
+   *
+   * the previous implementation derived the IV as
+   * HMAC-SHA256(key, plaintext) truncated to 96 bits. That is NOT RFC
+   * 8452 AES-GCM-SIV; it is plain AES-GCM with a deterministic IV. Two
+   * identical plaintexts sealed under the same key produce identical
+   * 96-bit IVs, which is exactly the condition AES-GCM forbids — a
+   * single same-key same-nonce collision on two distinct plaintexts
+   * leaks H (the authentication subkey) and lets an attacker forge
+   * arbitrary tags. Even without two distinct plaintexts, determinism
+   * itself is a confidentiality leak: identical plaintexts become
+   * identical ciphertexts, which is visible at the storage layer.
+   *
+   * We now draw a fresh 96-bit random IV for every seal. The downstream
+   * dedup pipeline (async-lift `subtractFinalizedExactQuads`) already
+   * decrypts via {@link decryptPrivateLiteral} before comparing, so
+   * non-deterministic ciphertext does not break it.
+   */
+  private encryptLiteral(serialized: string): string {
+    // Blank nodes are node-local and carry no externally-meaningful
+    // identity, so sealing them would only break dedup — leave as-is.
+    if (serialized.startsWith('_:')) return serialized;
+    // Seal IRI objects in the SAME envelope as literals: an earlier
+    // revision had `encryptLiteral` only wrap values starting with
+    // `"` and pass IRI objects through unchanged, so the N-Quads
+    // dump of a private graph leaked every outgoing edge's target
+    // IRI (e.g. `ex:ssn`, `http://foo/creditCard`). We mark the
+    // wrapped term with
+    // an extra `TAG|` byte inside the ciphertext so the decrypt side
+    // can restore the original term shape (IRI vs literal vs blank).
+    //
+    // Tag values:
+    //   L = original term was a literal (starts with `"`)
+    //   I = original term was an IRI (anything else non-blank)
+    //
+    // The outer envelope is always a valid N-Triples literal so the
+    // underlying TripleStore stays syntactically happy regardless of
+    // the original term kind.
+    const tag = serialized.startsWith('"') ? 'L' : 'I';
+    const plaintext = `${tag}|${serialized}`;
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', this.encryptionKey, iv);
+    const ct = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    const payload = Buffer.concat([iv, authTag, ct]).toString('base64');
+    return `"${ENC_PREFIX}${payload}"`;
+  }
+
+  private decryptLiteral(serialized: string): string {
+    if (!serialized.startsWith(`"${ENC_PREFIX}`)) return serialized;
+    const m = serialized.match(/^"enc:gcm:v1:([^"]+)"$/);
+    if (!m) return serialized;
+    try {
+      const buf = Buffer.from(m[1], 'base64');
+      const iv = buf.subarray(0, 12);
+      const tag = buf.subarray(12, 28);
+      const ct = buf.subarray(28);
+      // fall back to the legacy
+      // `sha256(DEFAULT_KEY_DOMAIN)` key when the primary key fails
+      // to authenticate. This is decrypt-only — `encryptLiteral`
+      // always uses `this.encryptionKey` — so a freshly-upgraded node
+      // whose private triples were sealed under the legacy
+      // deterministic key can still read them, while every new write
+      // goes to the unique per-node key.
+      const legacyKeys = resolveLegacyDecryptionKeys(this.encryptionKey);
+      const plain = tryDecryptWithKeyChain(
+        Buffer.from(iv),
+        Buffer.from(tag),
+        Buffer.from(ct),
+        this.encryptionKey,
+        legacyKeys,
+      );
+      if (plain === null) {
+        // Wrong key or corrupted ciphertext — leave the envelope
+        // visible so callers can detect the failure rather than
+        // silently dropping to "no result".
+        return serialized;
+      }
+      // Legacy (pre-r6) envelopes contained the literal bytes verbatim
+      // with no type tag. Detect them by the absence of the `L|` / `I|`
+      // prefix and return them unchanged so previously-written data
+      // stays readable after the seal-IRI upgrade.
+      if (plain.length < 2 || plain[1] !== '|') return plain;
+      return plain.slice(2);
+    } catch {
+      return serialized;
+    }
+  }
+
+  /**
+   * Read the set of already-present `(s, p, plaintextObject)` triples in
+   * `graphUri` whose `(s, p)` appears in `incoming`, decrypting the
+   * stored ciphertext objects so comparison is on plaintext identity.
+   *
+   * Scoping the SPARQL to only the `(s, p)` pairs the caller is about
+   * to write keeps this bounded: the naive "pull every private quad in
+   * the graph" variant would be O(|graph|) per insert.
+   */
+  private async collectExistingPlaintextKeys(
+    graphUri: string,
+    incoming: Quad[],
+  ): Promise<Set<string>> {
+    const subjects = new Set<string>();
+    const predicates = new Set<string>();
+    for (const q of incoming) {
+      subjects.add(q.subject);
+      predicates.add(q.predicate);
+    }
+    if (subjects.size === 0 || predicates.size === 0) return new Set();
+
+    // — private-store.ts:553). The
+    // dedup query previously assumed every subject was an IRI and
+    // ran `assertSafeIri()` over each — but private RDF can legally
+    // contain blank-node subjects (`_:b0`) and `assertSafeIri()`
+    // throws on them. That throw escaped the surrounding try/catch
+    // (which only wraps `this.store.query(sparql)`, not the SPARQL
+    // construction), so a single blank-node-subject quad anywhere
+    // in the batch failed `storePrivateTriples()` outright instead
+    // of letting it fall back to the no-dedup path.
+    //
+    // Two complications govern the fix:
+    //   1. `assertSafeIri()` on `predicate` is FINE — RDF predicates
+    //      MUST be IRIs, never blank nodes. So we keep that strict.
+    //   2. Blank node IDENTITY is not stable across SPARQL queries
+    //      in the general case (a `_:b0` literal in a fresh query
+    //      may or may not bind to the same store-internal blank
+    //      node, depending on the implementation). So we cannot
+    //      rely on `VALUES ?s { _:b0 }` to dedup correctly even if
+    //      the parser accepted it. Instead, we OMIT the `?s VALUES`
+    //      pin entirely whenever ANY incoming subject is non-IRI
+    //      and rely on the predicate VALUES (always IRIs) +
+    //      post-filter to bound the working set. Predicate VALUES
+    //      alone is still a dramatic narrowing vs reading the
+    //      entire private graph; a private graph that uses the
+    //      same predicate for thousands of subjects already pays
+    //      that scan in `getPrivateTriples()`.
+    //   3. The post-filter still pre-computes the
+    //      `subject\u0001predicate\u0001plain` key BEFORE inserting
+    //      into the dedup set, so a blank-node subject in the
+    //      store still dedups against the SAME blank-node label in
+    //      the incoming batch — which is exactly the contract we
+    //      want for retry idempotency (the same caller writing the
+    //      same `_:b0` twice).
+    let escapedPredicateVals: string;
+    try {
+      escapedPredicateVals = [...predicates]
+        .map((p) => `<${assertSafeIri(p)}>`)
+        .join(' ');
+    } catch {
+      // Predicate that fails `assertSafeIri` is malformed RDF; bail
+      // to no-dedup rather than throwing out of an idempotency
+      // helper.
+      return new Set();
+    }
+
+    let escapedGraph: string;
+    try {
+      escapedGraph = `<${assertSafeIri(graphUri)}>`;
+    } catch {
+      // graphUri is constructed by the privateGraph() helper from
+      // contextGraphId + subGraphName — both already validated
+      // upstream — so this catch is purely defence-in-depth.
+      return new Set();
+    }
+
+    const incomingSubjects = [...subjects];
+    // — private-store.ts:553) — note on
+    // detection. `assertSafeIri()` only rejects characters that would
+    // break SPARQL `<...>` framing; it accepts strings like `_:bn`
+    // because `_` and `:` aren't unsafe glyphs. That meant a previous
+    // attempt at this fix (gating on `assertSafeIri()` not throwing)
+    // still emitted invalid `<_:bn>` IRI tokens for blank-node
+    // subjects, the SPARQL parser rejected the query, and dedup
+    // silently fell back to no-op for ALL mixed batches — including
+    // the IRI subjects that should still have deduped. We now use the
+    // strict `isSafeIri()` check, which requires a `scheme:` prefix
+    // (and so reliably distinguishes IRIs from blank nodes / literals
+    // that happen to be character-safe).
+    const allSubjectsSafe = incomingSubjects.every((s) => isSafeIri(s));
+
+    let sparql: string;
+    if (allSubjectsSafe) {
+      const subjectVals = incomingSubjects
+        .map((s) => `<${assertSafeIri(s)}>`)
+        .join(' ');
+      sparql = `
+        SELECT ?s ?p ?o WHERE {
+          GRAPH ${escapedGraph} {
+            VALUES ?s { ${subjectVals} }
+            VALUES ?p { ${escapedPredicateVals} }
+            ?s ?p ?o .
+          }
+        }
+      `;
+    } else {
+      // At least one blank-node (or otherwise non-IRI) subject.
+      // Drop the subject pin and rely on predicate narrowing +
+      // post-filter against `subjects` set membership.
+      sparql = `
+        SELECT ?s ?p ?o WHERE {
+          GRAPH ${escapedGraph} {
+            VALUES ?p { ${escapedPredicateVals} }
+            ?s ?p ?o .
+          }
+        }
+      `;
+    }
+    const keys = new Set<string>();
+    try {
+      const result = await this.store.query(sparql);
+      if (result.type !== 'bindings') return keys;
+      for (const row of result.bindings) {
+        const subjectStr = row['s'];
+        if (subjectStr === undefined) continue;
+        // Post-filter for the blank-node fallback path: only
+        // dedup against subjects we are about to write. (For the
+        // strict-IRI path the SPARQL VALUES already enforces this.)
+        if (!allSubjectsSafe && !subjects.has(subjectStr)) continue;
+        const plain = this.decryptLiteral(row['o']);
+        keys.add(`${subjectStr}\u0001${row['p']}\u0001${plain}`);
+      }
+    } catch {
+      // If the scoped read fails we fall back to no-dedup: worst case
+      // is the historical behaviour (duplicate ciphertexts) — never a
+      // confidentiality regression.
+    }
+    return keys;
   }
 
   clearCache(key: string): void {
@@ -52,8 +794,50 @@ export class PrivateContentStore {
     assertSafeIri(rootEntity);
 
     const graphUri = this.privateGraph(contextGraphId, subGraphName);
-    const normalized = quads.map((q) => ({ ...q, graph: graphUri }));
-    await this.store.insert(normalized);
+    // ST-2: encrypt the literal `object` BEFORE handing the quad to
+    // the underlying TripleStore. URIs and blank nodes carry no
+    // payload and are passed through unchanged. The resulting
+    // on-disk N-Quads dump contains only ciphertext envelopes
+    // (`enc:gcm:v1:<base64>`); callers retrieve plaintext via
+    // `getPrivateTriples`, which reverses the seal.
+    //
+    // Because `encryptLiteral` uses a fresh random IV per call
+    // (deterministic IVs are forbidden for AES-GCM), a plain
+    // `insert()` would duplicate the quad on every retry / replay
+    // of the same private KA: the store dedups by byte-identical
+    // terms, but ciphertext is never byte-identical across writes.
+    // Dedup here by decrypting the set of existing ciphertext
+    // objects at each `(s, p)` position in this private graph and
+    // skipping any incoming plaintext that is already there. The
+    // comparison is on **plaintext** triple identity, which is the
+    // semantic we want; it preserves random-IV confidentiality
+    // while making the write idempotent.
+    //
+    // Hold a per-graph mutex for the whole "scan existing plaintext
+    // + insert
+    // missing quads" sequence so a second concurrent caller cannot
+    // observe an empty key set in parallel and wind up inserting a
+    // byte-distinct (random-IV) ciphertext for the same `(s,p,o)`
+    // plaintext.
+    await this.withGraphWriteLock(graphUri, async () => {
+      const existingPlainKeys = await this.collectExistingPlaintextKeys(graphUri, quads);
+      const toInsert: Quad[] = [];
+      const seenInBatch = new Set<string>();
+      for (const q of quads) {
+        const key = `${q.subject}\u0001${q.predicate}\u0001${q.object}`;
+        if (existingPlainKeys.has(key)) continue;
+        if (seenInBatch.has(key)) continue;
+        seenInBatch.add(key);
+        toInsert.push({
+          ...q,
+          object: this.encryptLiteral(q.object),
+          graph: graphUri,
+        });
+      }
+      if (toInsert.length > 0) {
+        await this.store.insert(toInsert);
+      }
+    });
 
     const key = this.privateKey(contextGraphId, subGraphName);
     let entities = this.privateEntities.get(key);
@@ -87,7 +871,10 @@ export class PrivateContentStore {
     return result.bindings.map((row) => ({
       subject: row['s'],
       predicate: row['p'],
-      object: row['o'],
+      // Reverse the AES-GCM seal applied at write time so callers see
+      // the original literal value (. Non-encrypted
+      // values (legacy data, URIs, blank nodes) flow through unchanged.
+      object: this.decryptLiteral(row['o']),
       graph: graphUri,
     }));
   }
@@ -117,6 +904,9 @@ export class PrivateContentStore {
     rootEntity: string,
     subGraphName?: string,
   ): Promise<void> {
+    // ST-7: assertSafeIri on the delete path so a malicious rootEntity
+    // cannot smuggle SPARQL-update tokens into `deleteBySubjectPrefix`.
+    assertSafeIri(rootEntity);
     const graphUri = this.privateGraph(contextGraphId, subGraphName);
     await this.store.deleteBySubjectPrefix(graphUri, rootEntity);
     const key = this.privateKey(contextGraphId, subGraphName);

--- a/packages/storage/test/adapter-parity-extra.test.ts
+++ b/packages/storage/test/adapter-parity-extra.test.ts
@@ -1,7 +1,7 @@
 /**
  * ST-1 — adapter-parity misleading-name evidence.
  *
- * See .test-audit/BUGS_FOUND.md "packages/storage" ST-1:
+ * See .test-audit/
  *
  *   `adapter-parity.test.ts` looks like it verifies that OxigraphStore
  *   and BlazegraphStore agree on count / delete semantics, but the
@@ -35,7 +35,20 @@ import { OxigraphStore, BlazegraphStore, type Quad } from '../src/index.js';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const EXISTING_PARITY = join(HERE, 'adapter-parity.test.ts');
 
-const BLAZEGRAPH_URL = process.env.BLAZEGRAPH_URL;
+// ci.yml:256). The storage CI lane
+// runs every test file in parallel by default, and `storage.test.ts`
+// issues `DROP ALL` against `BLAZEGRAPH_URL` before EVERY Blazegraph
+// conformance test. If both files target the same namespace, the
+// conformance suite's `DROP ALL` can fire mid-`adapter-parity-extra`
+// and wipe its inserted fixture — making this lane flaky.
+//
+// Resolution: prefer `BLAZEGRAPH_PARITY_URL` when it's set so the
+// parity suite runs against an isolated namespace (CI provisions
+// `dkgq-parity` in addition to the conformance namespace `dkgq`).
+// Fall back to `BLAZEGRAPH_URL` for local dev / older CI configs
+// that still share a single namespace — local devs can opt into
+// the isolated namespace by exporting both env vars.
+const BLAZEGRAPH_URL = process.env.BLAZEGRAPH_PARITY_URL ?? process.env.BLAZEGRAPH_URL;
 
 // ---------------------------------------------------------------------------
 // (1) Real parity harness — skip with a loud reason when unavailable.

--- a/packages/storage/test/adapter-parity.test.ts
+++ b/packages/storage/test/adapter-parity.test.ts
@@ -37,6 +37,32 @@ describe('TripleStore adapter parity (Oxigraph vs test-server Blazegraph)', () =
             }));
             return;
           }
+          // `BlazegraphStore.deleteByPattern({ graph, subject })` now
+          // materialises matching bindings via a SELECT before issuing
+          // `DELETE DATA` per row — the form that round-trips reliably
+          // on real Blazegraph 2.1.5 (see `blazegraph.ts:54-100` for
+          // why). This stub echoes a single binding for the one
+          // subject the test deletes so the dummy-server parity suite
+          // still drives the same code path as the real CI job
+          // (`adapter-parity-extra.test.ts`).
+          if (
+            decoded.startsWith('SELECT') &&
+            decoded.includes('http://parity.test/s1')
+          ) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              head: { vars: ['p', 'o'] },
+              results: {
+                bindings: [
+                  {
+                    p: { type: 'uri', value: 'http://parity.test/p' },
+                    o: { type: 'literal', value: 'a' },
+                  },
+                ],
+              },
+            }));
+            return;
+          }
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ head: { vars: [] }, results: { bindings: [] } }));
         });

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -165,16 +165,33 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     ).rejects.toThrow(/Blazegraph update failed/);
   });
 
-  it('deleteByPattern returns count delta from before/after COUNT', async () => {
-    let call = 0;
+  // Pre-v10-rc-merge follow-up (storage/blazegraph.ts:54-100). The old
+  // single-graph `deleteByPattern` used a before/after `countQuads` delta
+  // behind a `DELETE { GRAPH <g> { ... } } WHERE { ... }` template, which
+  // silently no-oped on real Blazegraph 2.1.5 REST endpoints (caught by
+  // `adapter-parity-extra.test.ts` against the live service in CI). The
+  // adapter now materialises matching bindings via SELECT and issues one
+  // `DELETE DATA` per row, mirroring the no-graph path. This test pins
+  // that contract: 3 SELECT rows → 3 DELETE DATA calls → removed === 3.
+  it('deleteByPattern (single graph) materialises bindings and issues one DELETE DATA per row', async () => {
+    const updateBodies: string[] = [];
     setFetch(async (_url, init) => {
       const body = String(init?.body ?? '');
+      if (body.startsWith('update=')) {
+        updateBodies.push(decodeURIComponent(body.slice('update='.length)));
+        return new Response(null, { status: 200 });
+      }
       if (body.startsWith('query=')) {
-        call++;
         return new Response(
           JSON.stringify({
-            head: { vars: ['c'] },
-            results: { bindings: [{ c: { type: 'literal', value: call === 1 ? '5' : '2' } }] },
+            head: { vars: ['p', 'o'] },
+            results: {
+              bindings: [
+                { p: { type: 'uri', value: 'http://ex/p1' }, o: { type: 'literal', value: 'a' } },
+                { p: { type: 'uri', value: 'http://ex/p2' }, o: { type: 'literal', value: 'b' } },
+                { p: { type: 'uri', value: 'http://ex/p3' }, o: { type: 'literal', value: 'c' } },
+              ],
+            },
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
@@ -184,6 +201,353 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     const s = new BlazegraphStore(baseUrl);
     const removed = await s.deleteByPattern({ graph: 'http://g', subject: 'http://s' });
     expect(removed).toBe(3);
+    expect(updateBodies).toHaveLength(3);
+    for (const u of updateBodies) {
+      expect(u).toMatch(/DELETE DATA \{ GRAPH <http:\/\/g> \{ <http:\/\/s> <http:\/\/ex\/p\d> "[abc]" \. \} \}/);
+    }
+  });
+
+  // Regression: a SELECT that finds no matching rows must return 0 and
+  // issue ZERO `DELETE DATA` calls. The previous before/after-COUNT
+  // implementation could return a non-zero delta here if countQuads
+  // fluctuated across the two calls for unrelated reasons.
+  it('deleteByPattern (single graph) returns 0 and issues no DELETE DATA when no rows match', async () => {
+    const updateBodies: string[] = [];
+    setFetch(async (_url, init) => {
+      const body = String(init?.body ?? '');
+      if (body.startsWith('update=')) {
+        updateBodies.push(decodeURIComponent(body.slice('update='.length)));
+        return new Response(null, { status: 200 });
+      }
+      if (body.startsWith('query=')) {
+        return new Response(
+          JSON.stringify({
+            head: { vars: ['p', 'o'] },
+            results: { bindings: [] },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(null, { status: 200 });
+    });
+    const s = new BlazegraphStore(baseUrl);
+    const removed = await s.deleteByPattern({ graph: 'http://g', subject: 'http://unknown' });
+    expect(removed).toBe(0);
+    expect(updateBodies).toHaveLength(0);
+  });
+
+  // the previous
+  // revision blanket-skipped the default-graph delete whenever the same
+  // (s,p,o) had any named-graph hit, which silently lost a real
+  // default-graph row when BOTH intentionally existed. The fix runs the
+  // default-dataset SELECT AFTER the named deletes and issues a DELETE
+  // DATA for each remaining row. Pin that a default-graph triple is
+  // deleted even when the same (s,p,o) also exists in a named graph.
+  it('deleteByPattern (no graph) deletes BOTH the named-graph row AND the default-graph row for the same (s,p,o)', async () => {
+    const updates: string[] = [];
+    let selectCall = 0;
+    setFetch(async (_url, init) => {
+      const body = String(init?.body ?? '');
+      if (body.startsWith('update=')) {
+        updates.push(decodeURIComponent(body.slice('update='.length)));
+        return new Response(null, { status: 200 });
+      }
+      if (body.startsWith('query=')) {
+        selectCall++;
+        const decoded = decodeURIComponent(body.slice('query='.length));
+        if (/^SELECT/i.test(decoded.trim()) && /GRAPH \?g/.test(decoded)) {
+          // Named-graph SELECT: return one hit.
+          return new Response(
+            JSON.stringify({
+              head: { vars: ['g'] },
+              results: {
+                bindings: [{ g: { type: 'uri', value: 'http://ex.org/named1' } }],
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (/^SELECT/i.test(decoded.trim())) {
+          // Default-dataset SELECT: report the triple (simulating
+          // Blazegraph quads-mode's default-dataset union view). After
+          // the named delete this row represents a genuine default-
+          // graph instance that MUST be removed.
+          return new Response(
+            JSON.stringify({ head: { vars: [] }, results: { bindings: [{}] } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (/^ASK/i.test(decoded.trim())) {
+          // The default-graph existence check: return TRUE so the
+          // default-graph delete proceeds.
+          return new Response(
+            JSON.stringify({ boolean: true }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      }
+      return new Response(null, { status: 200 });
+    });
+    const s = new BlazegraphStore(baseUrl);
+    const removed = await s.deleteByPattern({
+      subject: 'http://ex.org/s',
+      predicate: 'http://ex.org/p',
+      object: '"o"',
+    });
+    // One delete for the named-graph instance, one for the default-graph
+    // instance = 2 total. Previously the default-graph delete was
+    // suppressed by the `namedHit` gate, returning 1.
+    expect(removed).toBe(2);
+    const namedDelete = updates.find((u) => u.includes('GRAPH <http://ex.org/named1>') && u.includes('DELETE DATA'));
+    const defaultDelete = updates.find((u) => /DELETE DATA\s*\{\s*<http:\/\/ex\.org\/s>/.test(u) && !u.includes('GRAPH'));
+    expect(namedDelete).toBeDefined();
+    expect(defaultDelete).toBeDefined();
+  });
+
+  it('deleteByPattern (no graph) does NOT delete the default-graph row when the ASK probe reports it absent', async () => {
+    const updates: string[] = [];
+    setFetch(async (_url, init) => {
+      const body = String(init?.body ?? '');
+      if (body.startsWith('update=')) {
+        updates.push(decodeURIComponent(body.slice('update='.length)));
+        return new Response(null, { status: 200 });
+      }
+      if (body.startsWith('query=')) {
+        const decoded = decodeURIComponent(body.slice('query='.length));
+        if (/^SELECT/i.test(decoded.trim()) && /GRAPH \?g/.test(decoded)) {
+          return new Response(
+            JSON.stringify({
+              head: { vars: ['g'] },
+              results: { bindings: [{ g: { type: 'uri', value: 'http://ex.org/g1' } }] },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (/^SELECT/i.test(decoded.trim())) {
+          // After the named delete, the default-dataset SELECT still
+          // echoes the triple (because the engine re-checked it and the
+          // named row HAS been removed, so the only remaining row would
+          // be the default one — EXCEPT here the ASK below will say
+          // it's not there, simulating "the named row was the only
+          // place it lived").
+          return new Response(
+            JSON.stringify({ head: { vars: [] }, results: { bindings: [{}] } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        if (/^ASK/i.test(decoded.trim())) {
+          return new Response(
+            JSON.stringify({ boolean: false }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      }
+      return new Response(null, { status: 200 });
+    });
+    const s = new BlazegraphStore(baseUrl);
+    const removed = await s.deleteByPattern({
+      subject: 'http://ex.org/s',
+      predicate: 'http://ex.org/p',
+      object: '"o"',
+    });
+    expect(removed).toBe(1);
+    const defaultDelete = updates.find((u) => /DELETE DATA\s*\{\s*<http:\/\/ex\.org\/s>/.test(u) && !u.includes('GRAPH'));
+    expect(defaultDelete).toBeUndefined();
+  });
+
+  // The previous
+  // revision unconditionally wrapped each materialised SELECT-row
+  // subject (`sx`) as `<${escapeUri(sx)}>` before issuing the
+  // `DELETE DATA`. SELECT bindings in quads mode include blank-node
+  // subjects (e.g. `_:b0`), so a bnode would be re-emitted as the
+  // syntactically invalid IRI `<_:b0>` — Blazegraph either errored
+  // on the wire or, on lenient engines, never matched the row, and
+  // the bnode-subject quad stayed pinned in storage forever.
+  //
+  // The fix funnels the row subject through `formatTerm`, which
+  // already encodes `_:foo` blank nodes correctly. These tests pin
+  // the contract for all three branches (single-graph SELECT, no-
+  // graph named SELECT, no-graph default-dataset SELECT) AND for the
+  // top-level `pattern.subject` itself (line 55) so a caller that
+  // hands a bnode subject to `deleteByPattern` still gets it deleted.
+  describe('deleteByPattern — blank-node round-trip (r31-7 regression)', () => {
+    it('single-graph branch: emits `_:b0` (NOT `<_:b0>`) for materialised bnode subject', async () => {
+      const updates: string[] = [];
+      setFetch(async (_url, init) => {
+        const body = String(init?.body ?? '');
+        if (body.startsWith('update=')) {
+          updates.push(decodeURIComponent(body.slice('update='.length)));
+          return new Response(null, { status: 200 });
+        }
+        if (body.startsWith('query=')) {
+          return new Response(
+            JSON.stringify({
+              head: { vars: ['s', 'p', 'o'] },
+              results: {
+                bindings: [
+                  {
+                    s: { type: 'bnode', value: 'b0' },
+                    p: { type: 'uri', value: 'http://ex/p' },
+                    o: { type: 'literal', value: 'lit' },
+                  },
+                ],
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(null, { status: 200 });
+      });
+      const s = new BlazegraphStore(baseUrl);
+      const removed = await s.deleteByPattern({ graph: 'http://g' });
+      expect(removed).toBe(1);
+      expect(updates).toHaveLength(1);
+      const body = updates[0];
+      // The bnode lexeme MUST appear as `_:b0`, not as `<_:b0>`.
+      expect(body).toContain('_:b0 <http://ex/p>');
+      expect(body).not.toContain('<_:b0>');
+      expect(body).toMatch(/DELETE DATA \{ GRAPH <http:\/\/g> \{ _:b0 <http:\/\/ex\/p> "lit" \. \} \}/);
+    });
+
+    it('no-graph (named) branch: emits `_:b0` (NOT `<_:b0>`) for materialised bnode subject', async () => {
+      const updates: string[] = [];
+      setFetch(async (_url, init) => {
+        const body = String(init?.body ?? '');
+        if (body.startsWith('update=')) {
+          updates.push(decodeURIComponent(body.slice('update='.length)));
+          return new Response(null, { status: 200 });
+        }
+        if (body.startsWith('query=')) {
+          const decoded = decodeURIComponent(body.slice('query='.length));
+          if (/GRAPH \?g/.test(decoded)) {
+            return new Response(
+              JSON.stringify({
+                head: { vars: ['s', 'p', 'o', 'g'] },
+                results: {
+                  bindings: [
+                    {
+                      s: { type: 'bnode', value: 'b1' },
+                      p: { type: 'uri', value: 'http://ex/p' },
+                      o: { type: 'literal', value: 'lit' },
+                      g: { type: 'uri', value: 'http://ex.org/g' },
+                    },
+                  ],
+                },
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+          // Default-dataset SELECT after the named delete: no rows.
+          return new Response(
+            JSON.stringify({ head: { vars: ['s', 'p', 'o'] }, results: { bindings: [] } }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(null, { status: 200 });
+      });
+      const s = new BlazegraphStore(baseUrl);
+      const removed = await s.deleteByPattern({});
+      expect(removed).toBe(1);
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toContain('_:b1 <http://ex/p>');
+      expect(updates[0]).not.toContain('<_:b1>');
+    });
+
+    it('no-graph (default) branch: emits `_:b0` (NOT `<_:b0>`) when default-dataset SELECT returns a bnode subject', async () => {
+      const updates: string[] = [];
+      setFetch(async (_url, init) => {
+        const body = String(init?.body ?? '');
+        if (body.startsWith('update=')) {
+          updates.push(decodeURIComponent(body.slice('update='.length)));
+          return new Response(null, { status: 200 });
+        }
+        if (body.startsWith('query=')) {
+          const decoded = decodeURIComponent(body.slice('query='.length));
+          if (/^SELECT/i.test(decoded.trim()) && /GRAPH \?g/.test(decoded)) {
+            // Named SELECT: nothing.
+            return new Response(
+              JSON.stringify({ head: { vars: ['s', 'p', 'o', 'g'] }, results: { bindings: [] } }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+          if (/^SELECT/i.test(decoded.trim())) {
+            // Default-dataset SELECT: bnode-subject hit.
+            return new Response(
+              JSON.stringify({
+                head: { vars: ['s', 'p', 'o'] },
+                results: {
+                  bindings: [
+                    {
+                      s: { type: 'bnode', value: 'b2' },
+                      p: { type: 'uri', value: 'http://ex/p' },
+                      o: { type: 'literal', value: 'lit' },
+                    },
+                  ],
+                },
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+          if (/^ASK/i.test(decoded.trim())) {
+            return new Response(
+              JSON.stringify({ boolean: true }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+        }
+        return new Response(null, { status: 200 });
+      });
+      const s = new BlazegraphStore(baseUrl);
+      const removed = await s.deleteByPattern({});
+      expect(removed).toBe(1);
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toContain('_:b2 <http://ex/p>');
+      expect(updates[0]).not.toContain('<_:b2>');
+    });
+
+    it('top-level pattern.subject branch: caller-supplied bnode subject round-trips as `_:bX` (NOT `<_:bX>`)', async () => {
+      // White-box: when the caller passes `{ subject: '_:b9' }`, the
+      // SELECT triple template (`triple` at line 58) and the per-row
+      // DELETE template both need to keep `_:b9` as `_:b9` instead of
+      // wrapping it as the invalid IRI `<_:b9>`.
+      const queriesSeen: string[] = [];
+      const updates: string[] = [];
+      setFetch(async (_url, init) => {
+        const body = String(init?.body ?? '');
+        if (body.startsWith('update=')) {
+          updates.push(decodeURIComponent(body.slice('update='.length)));
+          return new Response(null, { status: 200 });
+        }
+        if (body.startsWith('query=')) {
+          const decoded = decodeURIComponent(body.slice('query='.length));
+          queriesSeen.push(decoded);
+          return new Response(
+            JSON.stringify({
+              head: { vars: ['p', 'o'] },
+              results: {
+                bindings: [
+                  { p: { type: 'uri', value: 'http://ex/p' }, o: { type: 'literal', value: 'lit' } },
+                ],
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(null, { status: 200 });
+      });
+      const s = new BlazegraphStore(baseUrl);
+      const removed = await s.deleteByPattern({ graph: 'http://g', subject: '_:b9' });
+      expect(removed).toBe(1);
+      // SELECT must use `_:b9` as the subject, not `<_:b9>`.
+      const selectQ = queriesSeen.find((q) => /^SELECT/i.test(q.trim()));
+      expect(selectQ).toBeDefined();
+      expect(selectQ!).toContain('_:b9');
+      expect(selectQ!).not.toContain('<_:b9>');
+      // DELETE DATA must use `_:b9` as the subject, not `<_:b9>`.
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toContain('_:b9 <http://ex/p>');
+      expect(updates[0]).not.toContain('<_:b9>');
+    });
   });
 
   it('deleteBySubjectPrefix returns count delta', async () => {

--- a/packages/storage/test/graph-manager-extra.test.ts
+++ b/packages/storage/test/graph-manager-extra.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Targeted coverage for ContextGraphManager paths not exercised by
+ * adapter-parity-extra / storage tests:
+ *
+ *   - ensureSubGraph (lines 70-77): creates the sub-graph + its _meta /
+ *     _private / shared_memory / shared_memory_meta companion graphs.
+ *   - Deprecated V9 aliases (lines 148-176): workspaceGraphUri,
+ *     workspaceMetaGraphUri, ensureParanet, listParanets, hasParanet,
+ *     dropParanet.
+ *
+ * All tests run against a real OxigraphStore — zero mocks.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { OxigraphStore, ContextGraphManager, GraphManager, type Quad } from '../src/index.js';
+import {
+  contextGraphSharedMemoryUri,
+  contextGraphSharedMemoryMetaUri,
+  contextGraphSubGraphUri,
+  contextGraphSubGraphMetaUri,
+  contextGraphSubGraphPrivateUri,
+} from '@origintrail-official/dkg-core';
+
+/**
+ * Oxigraph only materializes a named graph when it contains at least one
+ * quad — `createGraph` is a no-op. For tests that rely on `listGraphs` /
+ * `hasGraph`, seed each ensured graph with a single marker triple so the
+ * store actually has something to list.
+ */
+async function seed(store: OxigraphStore, graphs: string[]): Promise<void> {
+  const quads: Quad[] = graphs.map((g) => ({
+    subject: 'http://example.org/s',
+    predicate: 'http://example.org/p',
+    object: '"marker"',
+    graph: g,
+  }));
+  await store.insert(quads);
+}
+
+describe('ContextGraphManager — ensureSubGraph + deprecated V9 aliases', () => {
+  let dir: string;
+  let store: OxigraphStore;
+  let gm: ContextGraphManager;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'dkg-gm-'));
+    store = new OxigraphStore(join(dir, 'db'));
+    gm = new ContextGraphManager(store);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('ensureSubGraph creates the expected five graphs for a (cg, sub) pair', async () => {
+    await gm.ensureSubGraph('cg-x', 'news');
+    // Oxigraph creates lazily — seed each graph so listGraphs can see them.
+    await seed(store, [
+      contextGraphSubGraphUri('cg-x', 'news'),
+      contextGraphSubGraphMetaUri('cg-x', 'news'),
+      contextGraphSubGraphPrivateUri('cg-x', 'news'),
+      contextGraphSharedMemoryUri('cg-x', 'news'),
+      contextGraphSharedMemoryMetaUri('cg-x', 'news'),
+    ]);
+
+    const all = await store.listGraphs();
+    expect(all).toContain(contextGraphSubGraphUri('cg-x', 'news'));
+    expect(all).toContain(contextGraphSubGraphMetaUri('cg-x', 'news'));
+    expect(all).toContain(contextGraphSubGraphPrivateUri('cg-x', 'news'));
+    expect(all).toContain(contextGraphSharedMemoryUri('cg-x', 'news'));
+    expect(all).toContain(contextGraphSharedMemoryMetaUri('cg-x', 'news'));
+  });
+
+  it('ensureSubGraph also ensures the owning context graph (idempotent)', async () => {
+    await gm.ensureSubGraph('cg-y', 's1');
+    // Context graph was implicitly ensured; calling ensureContextGraph again
+    // must be a no-op (the early-return branch at line 80 fires).
+    await gm.ensureContextGraph('cg-y');
+    // Seed the data graph so hasContextGraph (which greps the store) sees it.
+    await seed(store, [gm.dataGraphUri('cg-y')]);
+    expect(await gm.hasContextGraph('cg-y')).toBe(true);
+  });
+
+  it('ensureContextGraph is idempotent — second call is a no-op', async () => {
+    await gm.ensureContextGraph('cg-idem');
+    // Second invocation hits the `ensuredContextGraphs.has(...) → return` branch.
+    await gm.ensureContextGraph('cg-idem');
+    await seed(store, [gm.dataGraphUri('cg-idem')]);
+    expect(await gm.hasContextGraph('cg-idem')).toBe(true);
+  });
+
+  it('listSubGraphs returns registered sub-graph names only (excluding reserved graphs)', async () => {
+    await gm.ensureSubGraph('cg-ls', 'alpha');
+    await gm.ensureSubGraph('cg-ls', 'beta');
+    await seed(store, [
+      contextGraphSubGraphUri('cg-ls', 'alpha'),
+      contextGraphSubGraphUri('cg-ls', 'beta'),
+    ]);
+    const subs = await gm.listSubGraphs('cg-ls');
+    expect(new Set(subs)).toEqual(new Set(['alpha', 'beta']));
+  });
+
+  it('listContextGraphs returns exactly the context graphs ensured (not sub-graphs or reserved graphs)', async () => {
+    await gm.ensureContextGraph('cg-a');
+    await gm.ensureContextGraph('cg-b');
+    await gm.ensureSubGraph('cg-a', 'inner');
+    // Seed the data graph of each cg so listGraphs sees them. The reserved
+    // `_meta` / `_private` / `_shared_memory*` companions and the sub-graph
+    // are seeded only via their data URIs, exercising the stripping logic
+    // in listContextGraphs.
+    await seed(store, [
+      gm.dataGraphUri('cg-a'),
+      gm.metaGraphUri('cg-a'),
+      gm.privateGraphUri('cg-a'),
+      gm.sharedMemoryUri('cg-a'),
+      gm.sharedMemoryMetaUri('cg-a'),
+      gm.dataGraphUri('cg-b'),
+      contextGraphSubGraphUri('cg-a', 'inner'),
+    ]);
+    const roots = await gm.listContextGraphs();
+    expect(new Set(roots)).toEqual(new Set(['cg-a', 'cg-b']));
+  });
+
+  it('dropContextGraph drops every companion graph and flips hasContextGraph to false', async () => {
+    await gm.ensureContextGraph('cg-drop');
+    await seed(store, [
+      gm.dataGraphUri('cg-drop'),
+      gm.metaGraphUri('cg-drop'),
+      gm.privateGraphUri('cg-drop'),
+    ]);
+    expect(await gm.hasContextGraph('cg-drop')).toBe(true);
+
+    await gm.dropContextGraph('cg-drop');
+    expect(await gm.hasContextGraph('cg-drop')).toBe(false);
+
+    const all = await store.listGraphs();
+    expect(all).not.toContain(gm.dataGraphUri('cg-drop'));
+    expect(all).not.toContain(gm.metaGraphUri('cg-drop'));
+    expect(all).not.toContain(gm.privateGraphUri('cg-drop'));
+  });
+
+  // ───────── Deprecated V9 aliases ─────────
+
+  it('workspaceGraphUri is an alias for sharedMemoryUri (V9 compat)', () => {
+    expect(gm.workspaceGraphUri('cg-legacy')).toBe(gm.sharedMemoryUri('cg-legacy'));
+  });
+
+  it('workspaceMetaGraphUri is an alias for sharedMemoryMetaUri (V9 compat)', () => {
+    expect(gm.workspaceMetaGraphUri('cg-legacy')).toBe(gm.sharedMemoryMetaUri('cg-legacy'));
+  });
+
+  it('ensureParanet delegates to ensureContextGraph', async () => {
+    await gm.ensureParanet('pn-legacy');
+    await seed(store, [gm.dataGraphUri('pn-legacy')]);
+    expect(await gm.hasContextGraph('pn-legacy')).toBe(true);
+  });
+
+  it('listParanets delegates to listContextGraphs', async () => {
+    await gm.ensureParanet('pn-1');
+    await gm.ensureParanet('pn-2');
+    await seed(store, [gm.dataGraphUri('pn-1'), gm.dataGraphUri('pn-2')]);
+    const out = await gm.listParanets();
+    expect(new Set(out)).toEqual(new Set(['pn-1', 'pn-2']));
+  });
+
+  it('hasParanet delegates to hasContextGraph', async () => {
+    expect(await gm.hasParanet('pn-missing')).toBe(false);
+    await gm.ensureParanet('pn-present');
+    await seed(store, [gm.dataGraphUri('pn-present')]);
+    expect(await gm.hasParanet('pn-present')).toBe(true);
+  });
+
+  it('dropParanet delegates to dropContextGraph', async () => {
+    await gm.ensureParanet('pn-todrop');
+    await seed(store, [gm.dataGraphUri('pn-todrop')]);
+    expect(await gm.hasParanet('pn-todrop')).toBe(true);
+    await gm.dropParanet('pn-todrop');
+    expect(await gm.hasParanet('pn-todrop')).toBe(false);
+  });
+
+  it('GraphManager is a back-compat alias extending ContextGraphManager', () => {
+    const legacy = new GraphManager(store);
+    expect(legacy).toBeInstanceOf(ContextGraphManager);
+    expect(legacy.dataGraphUri('cg-legacy')).toBe(gm.dataGraphUri('cg-legacy'));
+  });
+});

--- a/packages/storage/test/oxigraph-extra.test.ts
+++ b/packages/storage/test/oxigraph-extra.test.ts
@@ -3,7 +3,7 @@
  * runs against a real in-process Oxigraph engine (+ real N-Quads file
  * for durability).
  *
- * Findings covered (see .test-audit/BUGS_FOUND.md "packages/storage"):
+ * Findings covered (see .test-audit/
  *
  *   ST-5  oxigraph-persistent durability — close and re-open from the
  *          same path must recover every quad.
@@ -27,7 +27,7 @@
  *          insert → query → re-insert → query without loss.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -90,6 +90,141 @@ describe('oxigraph-persistent — durability [ST-5]', () => {
     await expect(
       createTripleStore({ backend: 'oxigraph-persistent' }),
     ).rejects.toThrow(/oxigraph-persistent requires options\.path/);
+  });
+
+  // the numeric-subtype side-table used
+  // to live only in memory, so `oxigraph-persistent` lost every publisher-
+  // declared `xsd:long` / `xsd:int` / `xsd:short` / `xsd:byte` on restart
+  // and `restoreOriginalDatatype*()` collapsed them back to Oxigraph's
+  // canonical `xsd:integer`. The fix persists the side-table to a
+  // `<persistPath>.numeric-datatypes.json` sidecar and hydrates it on
+  // startup — this test pins that contract.
+  it('numeric-subtype declarations survive a restart (xsd:long/xsd:int/xsd:short preserved)', async () => {
+    try {
+      const LONG = 'http://www.w3.org/2001/XMLSchema#long';
+      const INT = 'http://www.w3.org/2001/XMLSchema#int';
+      const SHORT = 'http://www.w3.org/2001/XMLSchema#short';
+      const g = 'urn:dkg:subtype:graph';
+      const s1 = new OxigraphStore(persistPath);
+      await s1.insert([
+        { subject: 'urn:num:a', predicate: 'http://ex.org/v', object: `"9223372036854775807"^^<${LONG}>`, graph: g },
+        { subject: 'urn:num:b', predicate: 'http://ex.org/v', object: `"123456"^^<${INT}>`, graph: g },
+        { subject: 'urn:num:c', predicate: 'http://ex.org/v', object: `"777"^^<${SHORT}>`, graph: g },
+      ]);
+      await s1.close();
+
+      // Fresh instance — must rebuild the side-table from the sidecar.
+      const s2 = new OxigraphStore(persistPath);
+      const r = await s2.query(
+        `SELECT ?s ?o WHERE { GRAPH <${g}> { ?s <http://ex.org/v> ?o } } ORDER BY ?s`,
+      );
+      expect(r.type).toBe('bindings');
+      if (r.type !== 'bindings') return;
+      const byS: Record<string, string> = {};
+      for (const row of r.bindings) byS[row['s'] as string] = row['o'] as string;
+      expect(byS['urn:num:a']).toBe(`"9223372036854775807"^^<${LONG}>`);
+      expect(byS['urn:num:b']).toBe(`"123456"^^<${INT}>`);
+      expect(byS['urn:num:c']).toBe(`"777"^^<${SHORT}>`);
+      await s2.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Pre-fix the
+  // numeric-datatype sidecar was hydrated unconditionally — even when
+  // the primary N-Quads dump was missing, empty, or corrupt. That left
+  // stale subtype metadata in `originalNumericDatatype` while the store
+  // was empty, so the first new `insert()` whose subject reused a
+  // sidecar key would silently "restore" the new literal to the OLD
+  // datatype that no longer existed in the store. The fix gates sidecar
+  // hydration on a successful dump load. Regression test:
+  //   1. Persist a real (subtype + sidecar) pair.
+  //   2. Delete the dump, leaving only the sidecar.
+  //   3. Insert a NEW literal at the same subject/predicate with the
+  //      DEFAULT canonical xsd:integer encoding.
+  //   4. Read it back. The literal MUST come back as
+  //      `"…"^^<xsd:integer>`, NOT silently re-typed to the stale
+  //      `xsd:long` from the surviving sidecar.
+  it('sidecar is NOT hydrated when the primary dump is missing (no stale subtype leak)', async () => {
+    try {
+      const LONG = 'http://www.w3.org/2001/XMLSchema#long';
+      const INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+      const g = 'urn:dkg:subtype:graph';
+
+      const s1 = new OxigraphStore(persistPath);
+      await s1.insert([
+        { subject: 'urn:reuse', predicate: 'http://ex.org/v', object: `"42"^^<${LONG}>`, graph: g },
+      ]);
+      await s1.close();
+
+      // Sanity: the sidecar exists alongside the dump.
+      expect(existsSync(persistPath)).toBe(true);
+      expect(existsSync(`${persistPath}.numeric-datatypes.json`)).toBe(true);
+
+      // Simulate a partial restore: delete the primary dump but
+      // leave the sidecar behind.
+      unlinkSync(persistPath);
+      expect(existsSync(persistPath)).toBe(false);
+      expect(existsSync(`${persistPath}.numeric-datatypes.json`)).toBe(true);
+
+      // Reopen — store starts empty, sidecar must NOT be hydrated.
+      const s2 = new OxigraphStore(persistPath);
+      // Insert a fresh literal at the same subject/predicate using
+      // the canonical xsd:integer datatype. If the stale sidecar
+      // had been hydrated, the store would re-tag this literal as
+      // xsd:long when reading it back.
+      await s2.insert([
+        { subject: 'urn:reuse', predicate: 'http://ex.org/v', object: `"99"^^<${INTEGER}>`, graph: g },
+      ]);
+
+      const r = await s2.query(
+        `SELECT ?o WHERE { GRAPH <${g}> { <urn:reuse> <http://ex.org/v> ?o } }`,
+      );
+      expect(r.type).toBe('bindings');
+      if (r.type !== 'bindings') return;
+      expect(r.bindings).toHaveLength(1);
+      // No stale xsd:long ressurection — the new literal keeps its
+      // canonical xsd:integer typing.
+      expect(r.bindings[0]['o']).toBe(`"99"^^<${INTEGER}>`);
+      await s2.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Companion regression: an EMPTY primary dump must also skip the
+  // sidecar (treats empty-but-present the same as missing).
+  it('sidecar is NOT hydrated when the primary dump is present-but-empty', async () => {
+    try {
+      const LONG = 'http://www.w3.org/2001/XMLSchema#long';
+      const INTEGER = 'http://www.w3.org/2001/XMLSchema#integer';
+      const g = 'urn:dkg:subtype:graph';
+
+      const s1 = new OxigraphStore(persistPath);
+      await s1.insert([
+        { subject: 'urn:reuse2', predicate: 'http://ex.org/v', object: `"7"^^<${LONG}>`, graph: g },
+      ]);
+      await s1.close();
+
+      // Truncate the dump to an empty file (the sidecar persists).
+      writeFileSync(persistPath, '');
+
+      const s2 = new OxigraphStore(persistPath);
+      await s2.insert([
+        { subject: 'urn:reuse2', predicate: 'http://ex.org/v', object: `"55"^^<${INTEGER}>`, graph: g },
+      ]);
+      const r = await s2.query(
+        `SELECT ?o WHERE { GRAPH <${g}> { <urn:reuse2> <http://ex.org/v> ?o } }`,
+      );
+      expect(r.type).toBe('bindings');
+      if (r.type !== 'bindings') return;
+      expect(r.bindings).toHaveLength(1);
+      expect(r.bindings[0]['o']).toBe(`"55"^^<${INTEGER}>`);
+      await s2.close();
+    } finally {
+      cleanup();
+    }
   });
 
   it('delete then close also flushes — reopen shows deletion', async () => {
@@ -350,7 +485,7 @@ describe('N-Quads typed-literal round-trip — regression for issue #34 [ST-12]'
   // `packages/publisher/src/dkg-publisher.ts#parseRdfInt`, which enumerates
   // xsd:integer / xsd:long explicitly) can mis-parse or drop values.
   // This is the spec-drift that issue #34 tracks — see
-  // BUGS_FOUND.md ST-12 / DUP #34. The test stays RED to keep the bug
+  // . The test stays RED to keep the bug
   // visible until the storage layer either (a) stops normalising or
   // (b) documents the normalisation and callers are updated.
 
@@ -423,5 +558,384 @@ describe('N-Quads typed-literal round-trip — regression for issue #34 [ST-12]'
     }
     await src.close();
     await sink.close();
+  });
+});
+
+// =======================================================================
+// per-position numeric-
+// subtype conflict detection. The previous side-table happily let a
+// later insert at the SAME `(s, p, value, g)` overwrite a different
+// declared subtype, so a SELECT readback silently returned the
+// latest-written subtype for both writes. We now mark the position
+// (and the lexeme) as conflicted and refuse to restore — the caller
+// gets Oxigraph's canonical form (`xsd:integer`).
+// =======================================================================
+describe('OxigraphStore — per-position numeric-subtype conflict (r31-8 regression)', () => {
+  const XSD = 'http://www.w3.org/2001/XMLSchema';
+  const intType = `${XSD}#int`;
+  const positiveIntegerType = `${XSD}#positiveInteger`;
+  const integerType = `${XSD}#integer`;
+  const longType = `${XSD}#long`;
+  const subject = 'urn:dkg:r31-8:s';
+  const predicate = 'http://ex.org/v';
+  const graph = 'urn:dkg:r31-8:g';
+
+  it('two writes at the same (s,p,value,g) with DIFFERENT declared subtypes fall back to canonical (NOT silently latest-write-wins)', async () => {
+    const store = new OxigraphStore();
+    // Write 1: declares xsd:int.
+    await store.insert([
+      { subject, predicate, object: `"1"^^<${intType}>`, graph },
+    ]);
+    // Write 2: same lexeme/position but a different declared subtype.
+    // Oxigraph collapses both literals to `"1"^^xsd:integer` in the
+    // store, so SELECT can ONLY see one canonicalised quad. Without
+    // r31-8, the side-table would silently report the LAST-written
+    // subtype — for either logical source.
+    await store.insert([
+      { subject, predicate, object: `"1"^^<${positiveIntegerType}>`, graph },
+    ]);
+
+    const r = await store.query(
+      `SELECT ?o WHERE { GRAPH <${graph}> { <${subject}> <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    expect(r.bindings).toHaveLength(1);
+    // r31-8 contract: when the per-position subtype is ambiguous, the
+    // restorer MUST fall back to Oxigraph's canonical xsd:integer
+    // form. Returning either xsd:int OR xsd:positiveInteger here
+    // would be a fail-OPEN restoration.
+    expect(r.bindings[0]['o']).toBe(`"1"^^<${integerType}>`);
+    expect(r.bindings[0]['o']).not.toBe(`"1"^^<${intType}>`);
+    expect(r.bindings[0]['o']).not.toBe(`"1"^^<${positiveIntegerType}>`);
+    await store.close();
+  });
+
+  it('CONSTRUCT round-trip on a per-position-conflicted lexeme returns canonical xsd:integer (NOT either source subtype)', async () => {
+    const store = new OxigraphStore();
+    await store.insert([
+      { subject, predicate, object: `"7"^^<${intType}>`, graph },
+    ]);
+    await store.insert([
+      { subject, predicate, object: `"7"^^<${positiveIntegerType}>`, graph },
+    ]);
+
+    const c = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${graph}> { ?s ?p ?o } }`,
+    );
+    expect(c.type).toBe('quads');
+    if (c.type !== 'quads') return;
+    expect(c.quads).toHaveLength(1);
+    expect(c.quads[0].object).toBe(`"7"^^<${integerType}>`);
+    await store.close();
+  });
+
+  it('two writes at the same position with the SAME declared subtype do NOT mark a conflict (idempotent inserts stay restorable)', async () => {
+    const store = new OxigraphStore();
+    // Same key, same dtype — must NOT trip the conflict detector.
+    await store.insert([
+      { subject, predicate, object: `"42"^^<${longType}>`, graph },
+    ]);
+    await store.insert([
+      { subject, predicate, object: `"42"^^<${longType}>`, graph },
+    ]);
+
+    const r = await store.query(
+      `SELECT ?o WHERE { GRAPH <${graph}> { <${subject}> <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    expect(r.bindings).toHaveLength(1);
+    // Idempotent insert preserves the original declared subtype.
+    expect(r.bindings[0]['o']).toBe(`"42"^^<${longType}>`);
+    await store.close();
+  });
+
+  it('a SELECT binding whose lexeme matches a per-position-conflicted lexeme refuses lexical-only restore (no sibling-dtype leak)', async () => {
+    const store = new OxigraphStore();
+    // Position A in graph A: conflicting xsd:int + xsd:positiveInteger.
+    await store.insert([
+      { subject: 'urn:dkg:r31-8:a', predicate, object: `"5"^^<${intType}>`, graph },
+    ]);
+    await store.insert([
+      { subject: 'urn:dkg:r31-8:a', predicate, object: `"5"^^<${positiveIntegerType}>`, graph },
+    ]);
+    // Position B in a DIFFERENT graph but same lexeme `5` with a
+    // single declared subtype. The lexical fallback would otherwise
+    // pick xsd:long — but because the lexeme appears in
+    // `conflictedNumericDatatypeLexemes`, even non-conflicted SELECT
+    // rows with this lexeme must refuse to restore.
+    await store.insert([
+      { subject: 'urn:dkg:r31-8:b', predicate, object: `"5"^^<${longType}>`, graph: 'urn:dkg:r31-8:other-graph' },
+    ]);
+
+    // Run a SELECT across BOTH graphs that strips position
+    // information (no GRAPH binding in projection) — the binding row
+    // for the conflicted position would otherwise inherit b's xsd:long
+    // through the lexical-only fallback.
+    const r = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH ?g { ?s <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    // Find the row for subject :a (the conflicted lexeme position).
+    const aRow = r.bindings.find((b) => b['s'] === 'urn:dkg:r31-8:a');
+    expect(aRow).toBeDefined();
+    if (!aRow) return;
+    // r31-8 contract: lexeme-level conflict refusal scopes to ANY
+    // SELECT row carrying the conflicted lexeme, so we must NOT
+    // restore it as xsd:long here.
+    expect(aRow['o']).toBe(`"5"^^<${integerType}>`);
+    expect(aRow['o']).not.toBe(`"5"^^<${longType}>`);
+    await store.close();
+  });
+});
+
+// =======================================================================
+// oxigraph.ts:169, KK3b): when the last
+// per-key conflict marker for a lexeme is evicted (because the
+// contributing quad was deleted, the graph dropped, or the subject
+// prefix wiped) the COMPANION lexeme-level marker MUST also be
+// recomputed against ground truth. the lexeme marker was
+// kept "pessimistically" forever, so once `"V"` had a transient
+// conflict at any position EVERY future write of any
+// `"V"^^xsd:<numeric>` literal across the entire store fell back to
+// canonical xsd:integer regardless of whether any conflict still
+// existed.
+// =======================================================================
+describe('OxigraphStore — lexeme-marker GC after conflict-key eviction (r31-13 KK3b regression)', () => {
+  const XSD = 'http://www.w3.org/2001/XMLSchema';
+  const intType = `${XSD}#int`;
+  const positiveIntegerType = `${XSD}#positiveInteger`;
+  const integerType = `${XSD}#integer`;
+  const longType = `${XSD}#long`;
+  const predicate = 'http://ex.org/v';
+
+  it('after delete() removes the contributing quad, a FRESH write of the same lexeme on a clean key is restorable to its declared subtype (lexeme marker GC\'d)', async () => {
+    const store = new OxigraphStore();
+    const subject = 'urn:dkg:r31-13-kk3b:s';
+    const graph = 'urn:dkg:r31-13-kk3b:g';
+
+    await store.insert([
+      { subject, predicate, object: `"9"^^<${intType}>`, graph },
+    ]);
+    await store.insert([
+      { subject, predicate, object: `"9"^^<${positiveIntegerType}>`, graph },
+    ]);
+
+    {
+      const r = await store.query(
+        `SELECT ?o WHERE { GRAPH <${graph}> { <${subject}> <${predicate}> ?o } }`,
+      );
+      expect(r.type).toBe('bindings');
+      if (r.type !== 'bindings') return;
+      expect(r.bindings).toHaveLength(1);
+      expect(r.bindings[0]['o']).toBe(`"9"^^<${integerType}>`);
+    }
+
+    // Delete the conflicting canonical literal at this position.
+    // r31-8 already drops the per-key conflict marker; r31-13
+    // additionally GCs the lexeme-level marker because no remaining
+    // key still conflicts on `"9"`.
+    await store.delete([
+      { subject, predicate, object: `"9"^^<${integerType}>`, graph },
+    ]);
+
+    // Fresh write of the same lexeme on a clean key — pre-KK3b the
+    // stale lexeme marker would have permanently downgraded this
+    // restore to xsd:integer, even though there is no remaining
+    // conflict anywhere in the store.
+    const otherSubject = 'urn:dkg:r31-13-kk3b:other';
+    const otherGraph = 'urn:dkg:r31-13-kk3b:other-graph';
+    await store.insert([
+      { subject: otherSubject, predicate, object: `"9"^^<${longType}>`, graph: otherGraph },
+    ]);
+
+    const r = await store.query(
+      `SELECT ?o WHERE { GRAPH <${otherGraph}> { <${otherSubject}> <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    expect(r.bindings).toHaveLength(1);
+    expect(r.bindings[0]['o']).toBe(`"9"^^<${longType}>`);
+    expect(r.bindings[0]['o']).not.toBe(`"9"^^<${integerType}>`);
+    await store.close();
+  });
+
+  it('after dropGraph() wipes the contributing graph, a fresh write of the same lexeme in a different graph is restorable (evict path GCs lexeme marker)', async () => {
+    const store = new OxigraphStore();
+    const conflictGraph = 'urn:dkg:r31-13-kk3b:dropme';
+    const subject = 'urn:dkg:r31-13-kk3b:dropsubject';
+
+    await store.insert([
+      { subject, predicate, object: `"3"^^<${intType}>`, graph: conflictGraph },
+    ]);
+    await store.insert([
+      { subject, predicate, object: `"3"^^<${positiveIntegerType}>`, graph: conflictGraph },
+    ]);
+
+    await store.dropGraph(conflictGraph);
+
+    // Fresh write of the same lexeme in a fully unrelated graph.
+    // Pre-KK3b the lexeme-level marker survived dropGraph and
+    // permanently downgraded this restore.
+    const cleanSubject = 'urn:dkg:r31-13-kk3b:cleansubject';
+    const cleanGraph = 'urn:dkg:r31-13-kk3b:cleangraph';
+    await store.insert([
+      { subject: cleanSubject, predicate, object: `"3"^^<${longType}>`, graph: cleanGraph },
+    ]);
+
+    const r = await store.query(
+      `SELECT ?o WHERE { GRAPH <${cleanGraph}> { <${cleanSubject}> <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    expect(r.bindings).toHaveLength(1);
+    expect(r.bindings[0]['o']).toBe(`"3"^^<${longType}>`);
+    expect(r.bindings[0]['o']).not.toBe(`"3"^^<${integerType}>`);
+    await store.close();
+  });
+
+  it('lexeme marker is RETAINED while ANOTHER per-key conflict still references that lexeme (partial eviction must not over-release)', async () => {
+    const store = new OxigraphStore();
+    const lexeme = '11';
+    const conflictPredicate = 'http://ex.org/conflict';
+    const aSubject = 'urn:dkg:r31-13-kk3b:guard:a';
+    const bSubject = 'urn:dkg:r31-13-kk3b:guard:b';
+    const aGraph = 'urn:dkg:r31-13-kk3b:guard:agraph';
+    const bGraph = 'urn:dkg:r31-13-kk3b:guard:bgraph';
+
+    // Conflict #1: subject A in graph A.
+    await store.insert([
+      { subject: aSubject, predicate: conflictPredicate, object: `"${lexeme}"^^<${intType}>`, graph: aGraph },
+    ]);
+    await store.insert([
+      { subject: aSubject, predicate: conflictPredicate, object: `"${lexeme}"^^<${positiveIntegerType}>`, graph: aGraph },
+    ]);
+    // Conflict #2: subject B in graph B (independent key, same lexeme).
+    await store.insert([
+      { subject: bSubject, predicate: conflictPredicate, object: `"${lexeme}"^^<${intType}>`, graph: bGraph },
+    ]);
+    await store.insert([
+      { subject: bSubject, predicate: conflictPredicate, object: `"${lexeme}"^^<${positiveIntegerType}>`, graph: bGraph },
+    ]);
+
+    // Drop graph A — releases conflict-key #1 only. Conflict-key #2
+    // still references lexeme `11`, so the lexeme marker MUST stay.
+    await store.dropGraph(aGraph);
+
+    // Fresh write of the same lexeme on a clean key — the lexeme
+    // marker must still suppress lexical-only restore here, because
+    // ambiguity for `11` is still real (subject B in graph B).
+    const guardSubject = 'urn:dkg:r31-13-kk3b:guard:fresh';
+    const guardGraph = 'urn:dkg:r31-13-kk3b:guard:freshgraph';
+    await store.insert([
+      { subject: guardSubject, predicate: conflictPredicate, object: `"${lexeme}"^^<${longType}>`, graph: guardGraph },
+    ]);
+
+    // Project across all graphs without binding ?g so the lexical
+    // fallback would fire if the lexeme marker had been mistakenly
+    // released.
+    const r = await store.query(
+      `SELECT ?s ?o WHERE { GRAPH ?g { ?s <${conflictPredicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    const guardRow = r.bindings.find((b) => b['s'] === guardSubject);
+    expect(guardRow).toBeDefined();
+    if (!guardRow) return;
+    // Must remain canonical because lexeme `11` is still ambiguous
+    // somewhere in the live store.
+    expect(guardRow['o']).toBe(`"${lexeme}"^^<${integerType}>`);
+    expect(guardRow['o']).not.toBe(`"${lexeme}"^^<${longType}>`);
+
+    // Now drop graph B too — lexeme `11` finally has no remaining
+    // contributing key. The lexeme marker MUST now be released, and
+    // a fresh write on yet another clean key must restore correctly.
+    await store.dropGraph(bGraph);
+
+    const finalSubject = 'urn:dkg:r31-13-kk3b:guard:final';
+    const finalGraph = 'urn:dkg:r31-13-kk3b:guard:finalgraph';
+    await store.insert([
+      { subject: finalSubject, predicate: conflictPredicate, object: `"${lexeme}"^^<${longType}>`, graph: finalGraph },
+    ]);
+    const r2 = await store.query(
+      `SELECT ?o WHERE { GRAPH <${finalGraph}> { <${finalSubject}> <${conflictPredicate}> ?o } }`,
+    );
+    expect(r2.type).toBe('bindings');
+    if (r2.type !== 'bindings') return;
+    expect(r2.bindings).toHaveLength(1);
+    expect(r2.bindings[0]['o']).toBe(`"${lexeme}"^^<${longType}>`);
+    await store.close();
+  });
+
+  it('after deleteBySubjectPrefix() wipes the contributing subject, a fresh write of the same lexeme in another subject is restorable', async () => {
+    const store = new OxigraphStore();
+    // Conflict on subject prefix `urn:dkg:r31-13-kk3b:wipe:`.
+    const conflictSubject = 'urn:dkg:r31-13-kk3b:wipe:conflict';
+    const conflictGraph = 'urn:dkg:r31-13-kk3b:wipe:graph';
+
+    await store.insert([
+      { subject: conflictSubject, predicate, object: `"77"^^<${intType}>`, graph: conflictGraph },
+    ]);
+    await store.insert([
+      { subject: conflictSubject, predicate, object: `"77"^^<${positiveIntegerType}>`, graph: conflictGraph },
+    ]);
+
+    await store.deleteBySubjectPrefix(conflictGraph, 'urn:dkg:r31-13-kk3b:wipe:');
+
+    // Fresh write — must NOT be downgraded by a stale lexeme marker.
+    const cleanSubject = 'urn:dkg:r31-13-kk3b:wipe:clean';
+    await store.insert([
+      { subject: cleanSubject, predicate, object: `"77"^^<${longType}>`, graph: conflictGraph },
+    ]);
+
+    const r = await store.query(
+      `SELECT ?o WHERE { GRAPH <${conflictGraph}> { <${cleanSubject}> <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    expect(r.bindings).toHaveLength(1);
+    expect(r.bindings[0]['o']).toBe(`"77"^^<${longType}>`);
+    expect(r.bindings[0]['o']).not.toBe(`"77"^^<${integerType}>`);
+    await store.close();
+  });
+
+  it('forgetNumericDatatype on a non-numeric quad does NOT release unrelated lexeme markers', async () => {
+    const store = new OxigraphStore();
+    const subject = 'urn:dkg:r31-13-kk3b:noop:s';
+    const graph = 'urn:dkg:r31-13-kk3b:noop:g';
+
+    // Establish a real conflict on lexeme `13` so a lexeme marker exists.
+    await store.insert([
+      { subject, predicate, object: `"13"^^<${intType}>`, graph },
+    ]);
+    await store.insert([
+      { subject, predicate, object: `"13"^^<${positiveIntegerType}>`, graph },
+    ]);
+
+    // Delete an UNRELATED non-numeric quad — must not GC anything.
+    await store.insert([
+      { subject, predicate: 'http://ex.org/label', object: '"hello"', graph },
+    ]);
+    await store.delete([
+      { subject, predicate: 'http://ex.org/label', object: '"hello"', graph },
+    ]);
+
+    // Lexeme marker for `13` must still suppress restore on a fresh key.
+    const cleanSubject = 'urn:dkg:r31-13-kk3b:noop:clean';
+    const cleanGraph = 'urn:dkg:r31-13-kk3b:noop:cleangraph';
+    await store.insert([
+      { subject: cleanSubject, predicate, object: `"13"^^<${longType}>`, graph: cleanGraph },
+    ]);
+
+    const r = await store.query(
+      `SELECT ?o WHERE { GRAPH <${cleanGraph}> { <${cleanSubject}> <${predicate}> ?o } }`,
+    );
+    expect(r.type).toBe('bindings');
+    if (r.type !== 'bindings') return;
+    expect(r.bindings).toHaveLength(1);
+    expect(r.bindings[0]['o']).toBe(`"13"^^<${integerType}>`);
+    await store.close();
   });
 });

--- a/packages/storage/test/private-store-extra.test.ts
+++ b/packages/storage/test/private-store-extra.test.ts
@@ -2,7 +2,7 @@
  * Extra coverage for PrivateContentStore and named-graph confidentiality
  * model. No mocks — every test runs against a real OxigraphStore.
  *
- * Findings covered (see .test-audit/BUGS_FOUND.md, "packages/storage"):
+ * Findings covered (see .test-audit/
  *
  *   ST-2  PROD-BUG — PrivateContentStore is documented as encrypted private
  *          storage but src/private-store.ts only remaps the graph URI. The
@@ -49,7 +49,7 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
   // The literal object is persisted verbatim by Oxigraph. Any operator
   // with read access to the on-disk N-Quads file or the SPARQL endpoint
   // can recover the plaintext. README claims otherwise — see
-  // BUGS_FOUND.md ST-2. Leaving this test RED is the evidence.
+  // . Leaving this test RED is the evidence.
 
   const SECRET = 'SECRET_PLAINTEXT_AAAA';
   let tempDir: string;
@@ -83,10 +83,13 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
     }
   });
 
-  it('a second, unrelated SPARQL client can read the secret verbatim', async () => {
-    // The "confidentiality" model is purely a query-routing convention:
-    // whoever queries `GRAPH <…/_private> { ?s ?p ?o }` gets everything.
-    // No capability check, no encryption key. Demonstrates the gap.
+  it('a second, unrelated SPARQL client must NOT see the plaintext literal', async () => {
+    // FIXED (ST-2): PrivateContentStore now seals the literal `object`
+    // with AES-256-GCM before handing the quad to the TripleStore. A
+    // raw SPARQL caller (no PrivateContentStore decrypt) sees only the
+    // `enc:gcm:v1:<base64>` envelope. PrivateContentStore.getPrivateTriples
+    // reverses the seal and returns the original literal — exercised
+    // by the "round-trip" assertion below.
     const store = new OxigraphStore();
     const gm = new ContextGraphManager(store);
     const ps = new PrivateContentStore(store, gm);
@@ -95,17 +98,505 @@ describe('PrivateContentStore — at-rest confidentiality [ST-2]', () => {
       { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
     ]);
 
-    // Simulate an unrelated caller that just knows the graph URI.
     const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
-    const result = await store.query(
+    const raw = await store.query(
       `SELECT ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
     );
-    expect(result.type).toBe('bindings');
-    if (result.type !== 'bindings') return;
-    const objects = result.bindings.map((b) => b['o']);
-    // PROD-BUG: plaintext readable by anyone with SPARQL access.
-    // See BUGS_FOUND.md ST-2.
-    expect(objects).toContain(`"${SECRET}"`);
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+    const rawObjects = raw.bindings.map((b) => b['o']);
+    // Raw SPARQL view: only the AES-GCM envelope is observable.
+    expect(rawObjects.join(' ')).not.toContain(SECRET);
+    expect(rawObjects.some((o) => o.startsWith('"enc:gcm:v1:'))).toBe(true);
+
+    // Authorised path round-trips: getPrivateTriples decrypts.
+    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(decrypted.map((q) => q.object)).toContain(`"${SECRET}"`);
+  });
+
+  // Random IV is
+  // required, but
+  // the write path MUST stay idempotent on plaintext identity — otherwise
+  // every replay / retry of the same private KA stacks another
+  // ciphertext row and `getPrivateTriples` starts returning duplicates.
+  it('storePrivateTriples is idempotent on plaintext (no dup rows on replay)', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    const quads = [
+      { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
+      { subject: ROOT, predicate: 'http://schema.org/creditCard', object: `"4111-1111-1111-1111"`, graph: '' },
+    ];
+
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads);
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads);
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads);
+
+    const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const raw = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+    // Exactly two ciphertext rows survive, one per distinct (s,p,plaintext).
+    expect(raw.bindings.length).toBe(2);
+
+    const roundTripped = (await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT))
+      .map((q) => `${q.subject}|${q.predicate}|${q.object}`)
+      .sort();
+    expect(roundTripped).toEqual([
+      `${ROOT}|http://schema.org/creditCard|"4111-1111-1111-1111"`,
+      `${ROOT}|http://schema.org/ssn|"${SECRET}"`,
+    ]);
+  });
+
+  it('concurrent storePrivateTriples for the same (s,p,o) cannot bypass dedup (read-then-insert race)', async () => {
+    // Pre-fix: `storePrivateTriples` snapshotted existing plaintext keys
+    // BEFORE inserting, with no mutual exclusion. Two concurrent writers
+    // for the same (s,p,o) plaintext would both observe an empty key
+    // set, then each insert their own random-IV ciphertext — and the
+    // store kept both because the underlying triple store dedups by
+    // byte-identical terms only. Post-fix: the per-graph mutex makes
+    // the read-and-insert pair atomic so only the FIRST writer's
+    // ciphertext lands; the SECOND sees the freshly inserted key and
+    // skips.
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    const sharedQuad = {
+      subject: ROOT,
+      predicate: 'http://schema.org/ssn',
+      object: `"${SECRET}"`,
+      graph: '',
+    };
+
+    // Fire 8 concurrent writers for the same plaintext.
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [sharedQuad]),
+      ),
+    );
+
+    const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const raw = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+    expect(raw.bindings.length).toBe(1);
+
+    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(decrypted.length).toBe(1);
+    expect(decrypted[0].object).toBe(`"${SECRET}"`);
+  });
+
+  // — private-store.ts:553). Pre-fix
+  // the dedup query unconditionally wrapped every incoming subject
+  // in `<${assertSafeIri(subject)}>`. RDF allows blank-node subjects
+  // (`_:b0`), and `assertSafeIri()` throws on them — that throw
+  // escaped the surrounding try/catch (which only wrapped
+  // `store.query`, not the SPARQL CONSTRUCTION) and `storePrivateTriples()`
+  // failed outright instead of falling back to the no-dedup path.
+  // Tests below pin both the now-survives behaviour and that
+  // dedup STILL works correctly for blank-node-subject quads.
+  it('storePrivateTriples accepts blank-node subjects (does not throw on _:b0)', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    // RDF blank node as subject is legal. Pre-fix this would throw
+    // inside `assertSafeIri('_:b0')`.
+    const quads = [
+      { subject: '_:b0', predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
+      { subject: '_:b0', predicate: 'http://schema.org/role', object: '"holder"', graph: '' },
+    ];
+    await expect(
+      ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads),
+    ).resolves.not.toThrow();
+
+    // The two private rows actually landed (encrypted at rest).
+    const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const raw = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+    expect(raw.bindings.length).toBe(2);
+  });
+
+  it('storePrivateTriples with a MIX of IRI and blank-node subjects survives — IRI subjects still dedup, blank-node subjects do not (correct RDF semantics)', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    const quads = [
+      { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
+      { subject: '_:bn', predicate: 'http://schema.org/role', object: '"holder"', graph: '' },
+    ];
+    // Pre-fix: the dedup path emitted `<_:bn>` as a SPARQL IRI,
+    // oxigraph rejected it, the surrounding catch silently dropped
+    // ALL dedup (including the IRI subject's), and a replay
+    // duplicated every row. Post-fix the SPARQL query downshifts to
+    // a predicate-only VALUES + subject-membership post-filter when
+    // a non-IRI subject is detected, so the IRI subject still
+    // dedups correctly.
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads);
+
+    // Replay the same batch.
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, quads);
+
+    const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const raw = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+
+    // Expected count = 3:
+    //   - IRI subject: 1 row (dedup succeeded — pre-fix this would
+    //     have leaked a duplicate due to the silent catch).
+    //   - Blank-node subject: 2 rows. RDF blank-node labels have
+    //     document-local scope; oxigraph mints a fresh internal
+    //     identifier on each `store.insert()` call, so a `_:bn`
+    //     stored in call #1 is NOT the same node as a `_:bn`
+    //     stored in call #2. This is correct per the RDF 1.1
+    //     concepts spec — blank-node label equality across
+    //     separate documents/transactions is undefined.
+    //
+    // Pre-fix this assertion was unreachable for a different
+    // reason (the dedup catch was silent, so both calls landed
+    // verbatim and we'd have got 4). The 3-row landing is what
+    // demonstrates the fix: the IRI half deduped where it
+    // previously didn't.
+    expect(raw.bindings.length).toBe(3);
+
+    // Strong guard: the IRI subject row appears exactly once
+    // (i.e. the dedup actually fired for it — no false positive
+    // from "well, 3 rows is between 2 and 4").
+    const iriRows = raw.bindings.filter((row) => row['s'] === ROOT);
+    expect(iriRows.length).toBe(1);
+    // And the blank-node rows are 2 — both kept (correct per RDF).
+    const bnRows = raw.bindings.filter(
+      (row) => typeof row['s'] === 'string' && row['s'].startsWith('_:'),
+    );
+    expect(bnRows.length).toBe(2);
+  });
+
+  it('storePrivateTriples with a MIX of IRI and blank-node subjects — replaying ONLY the IRI subject still dedups (regression guard for the silent-catch bug)', async () => {
+    // The mixed-batch case above shows the IRI dedup survives
+    // when blank-node subjects are also present in the SAME batch.
+    // This test pins the inverse case: if a later call replays
+    // ONLY the IRI subject, dedup must STILL fire (the in-batch
+    // blank node should not have left durable state that breaks
+    // dedup for subsequent IRI-only batches).
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    const mixedBatch = [
+      { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
+      { subject: '_:bn', predicate: 'http://schema.org/role', object: '"holder"', graph: '' },
+    ];
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, mixedBatch);
+
+    const iriOnlyReplay = [
+      { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
+    ];
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, iriOnlyReplay);
+
+    const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const raw = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+    // Mixed batch: 2 rows. IRI-only replay deduped: 0 new rows.
+    // Total: 2.
+    expect(raw.bindings.length).toBe(2);
+    expect(raw.bindings.filter((r) => r['s'] === ROOT).length).toBe(1);
+  });
+
+  it('blank-node-only batch still benefits from predicate-narrowed dedup path (no full-graph scan)', async () => {
+    // Plant an unrelated row in the private graph that uses a
+    // DIFFERENT predicate and therefore must NOT show up in the
+    // predicate-narrowed query. If the fallback accidentally
+    // dropped predicate narrowing too, this row would slip into
+    // the dedup set and (depending on plaintext collision) cause
+    // bogus dedup hits.
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [
+      { subject: ROOT, predicate: 'http://schema.org/UNRELATED', object: `"${SECRET}"`, graph: '' },
+    ]);
+
+    const blankNodeBatch = [
+      { subject: '_:x', predicate: 'http://schema.org/role', object: `"${SECRET}"`, graph: '' },
+    ];
+    // Same plaintext but different predicate AND different subject.
+    // The predicate-narrowed VALUES filter must keep the unrelated
+    // row out of the dedup set, so this insert MUST land.
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, blankNodeBatch);
+
+    const privateGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const raw = await store.query(
+      `SELECT ?s ?p ?o WHERE { GRAPH <${privateGraph}> { ?s ?p ?o } }`,
+    );
+    expect(raw.type).toBe('bindings');
+    if (raw.type !== 'bindings') return;
+    expect(raw.bindings.length).toBe(2);
+  });
+
+  it('storePrivateTriples still adds NEW plaintext alongside existing (no false-positive dedup)', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [
+      { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"${SECRET}"`, graph: '' },
+    ]);
+    // Same (s,p) but a DIFFERENT plaintext — this is a new, distinct triple
+    // and must not be swallowed by the dedup.
+    await ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [
+      { subject: ROOT, predicate: 'http://schema.org/ssn', object: `"OTHER_SECRET"`, graph: '' },
+    ]);
+
+    const roundTripped = (await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT))
+      .map((q) => q.object)
+      .sort();
+    expect(roundTripped).toEqual([`"${SECRET}"`, `"OTHER_SECRET"`].sort());
+  });
+
+  // =======================================================================
+  // private-store.ts:491, KwH_): the
+  // per-graph write lock built its chain off `prev.then(() => next)`
+  // and `await prev` was OUTSIDE the try/finally that would call
+  // `release()`. A single rejected `storePrivateTriples()` therefore:
+  //   1. left `next` permanently pending (try block never ran →
+  //      release() never called)
+  //   2. set `chained = prev.then(...)` which forwarded the rejection
+  //      to every subsequent waiter for the SAME graph
+  //   3. the next waiter's `await prev` threw before reaching its own
+  //      try/finally, so its release() never fired either
+  // Net effect: ONE failed write permanently bricked the graph until
+  // process restart. Fix: chain off `prev.catch(() => undefined)` so
+  // a predecessor's rejection is decoupled from queue progress.
+  // =======================================================================
+  it('(KwH_): a rejected storePrivateTriples does NOT brick the per-graph write lock — subsequent writers still drain', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    // Force the FIRST write to throw INSIDE the lock-held region by
+    // monkey-patching `store.insert`, which `storePrivateTriples`
+    // calls inside the `withGraphWriteLock` block. The first insert
+    // throws; subsequent inserts behave normally.
+    const realInsert = store.insert.bind(store);
+    let insertCallCount = 0;
+    (store as any).insert = async (quads: any) => {
+      insertCallCount += 1;
+      if (insertCallCount === 1) {
+        throw new Error('simulated fault inside the locked region');
+      }
+      return realInsert(quads);
+    };
+
+    const goodQuad = {
+      subject: ROOT,
+      predicate: 'http://schema.org/ssn',
+      object: `"${SECRET}"`,
+      graph: '',
+    };
+
+    // 1. First write throws (the simulated fault), and the lock MUST
+    //    NOT permanently brick. this leaked a pending
+    //    `next` — every subsequent caller hung forever.
+    await expect(
+      ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [goodQuad]),
+    ).rejects.toThrow(/simulated fault inside the locked region/);
+
+    // 2. Second write must succeed. The pre-fix code rejected here
+    //    on `await prev` (because prev was rejected), bypassing the
+    //    try/finally that would have released the lock. Use a
+    //    timeout to detect the hang and surface a clear error.
+    const timeoutPromise = new Promise((_resolve, reject) =>
+      setTimeout(() => reject(new Error('TIMED OUT — lock is bricked')), 5_000),
+    );
+    await expect(
+      Promise.race([
+        ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [goodQuad]),
+        timeoutPromise,
+      ]),
+    ).resolves.toBeUndefined();
+
+    // 3. Third write — the lock map cleanup path must also work:
+    //    the queue has fully drained, and a fresh write should grab
+    //    a clean lock entry. This catches the secondary symptom
+    //    where the recovered lock entry never gets `delete()`d
+    //    from `perGraphWriteLocks` and accumulates over time.
+    await expect(
+      ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [goodQuad]),
+    ).resolves.toBeUndefined();
+
+    // The good quad survives at-rest exactly once (idempotent).
+    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(decrypted.length).toBe(1);
+    expect(decrypted[0].object).toBe(`"${SECRET}"`);
+  });
+
+  it('(KwH_): concurrent waiters queued behind a rejecting writer all complete (no waiter inherits the rejection)', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    const realInsert = store.insert.bind(store);
+    let insertCallCount = 0;
+    let unblockFirstWriter: () => void = () => {};
+    const firstWriterGate = new Promise<void>((resolve) => {
+      unblockFirstWriter = resolve;
+    });
+    (store as any).insert = async (quads: any) => {
+      insertCallCount += 1;
+      if (insertCallCount === 1) {
+        // Hold the lock until we've enqueued the followup writers,
+        // then throw. This pins the queueing order: writers 2 and 3
+        // are waiting on `prev` (the lock chain) when the first
+        // writer rejects.
+        await firstWriterGate;
+        throw new Error('simulated rejected first writer');
+      }
+      return realInsert(quads);
+    };
+
+    const sharedQuad = {
+      subject: ROOT,
+      predicate: 'http://schema.org/ssn',
+      object: `"${SECRET}"`,
+      graph: '',
+    };
+
+    const writerA = ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [sharedQuad]);
+    // Force the lock chain to register two more queued waiters
+    // BEFORE the first writer rejects. these inherited
+    // the rejected `prev` and never even started.
+    const writerB = ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [sharedQuad]);
+    const writerC = ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [sharedQuad]);
+
+    // Yield to make sure writerB / writerC are properly queued.
+    await new Promise((r) => setImmediate(r));
+    unblockFirstWriter();
+
+    await expect(writerA).rejects.toThrow(/simulated rejected first writer/);
+    // Both queued waiters MUST complete normally (no rejection
+    // inherited from the bad predecessor). Use a Promise.race
+    // against a timeout to surface a hang explicitly.
+    const timeoutPromise = new Promise((_resolve, reject) =>
+      setTimeout(() => reject(new Error('TIMED OUT — queued waiter inherited rejection')), 5_000),
+    );
+    await expect(Promise.race([writerB, timeoutPromise])).resolves.toBeUndefined();
+    await expect(Promise.race([writerC, timeoutPromise])).resolves.toBeUndefined();
+
+    // Idempotent dedup still works end-to-end.
+    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(decrypted.length).toBe(1);
+  });
+
+  it('(KwH_): a poisoned (rejected) predecessor in the lock map does NOT cascade-reject queued writers', async () => {
+    // White-box test for the strongest bug variant (cli/private-store.ts:491).
+    // The fix's defensive contract is: even if a rejected promise ends
+    // up as the predecessor in `perGraphWriteLocks` (whether by
+    // future refactor, an unhandled rejection in the lock plumbing,
+    // or a poisoning by an adversarial caller), every subsequently-
+    // queued writer for that graph MUST still run cleanly. The
+    // pre-fix code did `await prev` outside the try/finally, so a
+    // rejected `prev` skipped `release()` and the queued writer never
+    // got to start. The fix's `safePrev = prev.catch(() => undefined)`
+    // guarantees the queue keeps draining.
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    // Reach into the private lock map and seed it with a directly-
+    // rejected promise. This is the most aggressive simulation of a
+    // poisoned predecessor — it pins that the lock layer itself is
+    // rejection-resilient. The graph URI used by storePrivateTriples
+    // is `<contextGraphPrivateUri(CONTEXT_GRAPH)>` (the production
+    // helper resolves it identically each call).
+    const targetGraph = contextGraphPrivateUri(CONTEXT_GRAPH);
+    const poisoned = Promise.reject(new Error('poisoned predecessor'));
+    // Attach a no-op handler so Node doesn't surface this as an
+    // unhandled-rejection log line in CI; the lock impl itself
+    // catches via `safePrev` so no test-side handler is required at
+    // runtime, but vitest's listeners still complain about the
+    // bare rejection literal we're synthesising.
+    poisoned.catch(() => undefined);
+    (ps as any).perGraphWriteLocks.set(targetGraph, poisoned);
+
+    const goodQuad = {
+      subject: ROOT,
+      predicate: 'http://schema.org/ssn',
+      object: `"${SECRET}"`,
+      graph: '',
+    };
+
+    // Pre-fix: this hung forever (await prev threw before try{};
+    // release() never fired; subsequent writers also hung). Race it
+    // against a hard timeout to surface a regression as a clear
+    // error rather than vitest's generic test timeout.
+    const timeout = new Promise((_resolve, reject) =>
+      setTimeout(() => reject(new Error('TIMED OUT — rejected predecessor poisoned the lock')), 5_000),
+    );
+    await expect(
+      Promise.race([
+        ps.storePrivateTriples(CONTEXT_GRAPH, ROOT, [goodQuad]),
+        timeout,
+      ]),
+    ).resolves.toBeUndefined();
+
+    // Round-trip succeeds.
+    const decrypted = await ps.getPrivateTriples(CONTEXT_GRAPH, ROOT);
+    expect(decrypted.length).toBe(1);
+    expect(decrypted[0].object).toBe(`"${SECRET}"`);
+  });
+
+  it('(KwH_): per-graph rejection does NOT poison OTHER graphs (independent locks stay clean)', async () => {
+    const store = new OxigraphStore();
+    const gm = new ContextGraphManager(store);
+    const ps = new PrivateContentStore(store, gm);
+
+    const realInsert = store.insert.bind(store);
+    let insertCallCount = 0;
+    (store as any).insert = async (quads: any) => {
+      insertCallCount += 1;
+      // Reject the very first insert (graph-A's first write); all
+      // subsequent inserts go through. The other graph's lock chain
+      // is independent and must continue working regardless of what
+      // the bad graph's queue is doing.
+      if (insertCallCount === 1) {
+        throw new Error('simulated fault on graph A');
+      }
+      return realInsert(quads);
+    };
+
+    const quadA = { subject: ROOT, predicate: 'http://schema.org/a', object: `"A"`, graph: '' };
+    const quadB = { subject: ROOT, predicate: 'http://schema.org/b', object: `"B"`, graph: '' };
+
+    await expect(
+      ps.storePrivateTriples('graph-A', ROOT, [quadA]),
+    ).rejects.toThrow(/simulated fault on graph A/);
+
+    // Different graph — totally separate lock chain. MUST work.
+    await expect(
+      ps.storePrivateTriples('graph-B', ROOT, [quadB]),
+    ).resolves.toBeUndefined();
+
+    // The originally-bricked graph is also recoverable on its own.
+    await expect(
+      ps.storePrivateTriples('graph-A', ROOT, [quadA]),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -355,7 +846,6 @@ describe('PrivateContentStore — SPARQL injection defence [ST-7]', () => {
     // no immediate SPARQL injection, but a later hasPrivateTriples /
     // getPrivateTriples / deletePrivateTriples call with the same string
     // will blow up. Tracker should reject unsafe IRIs at the entry point.
-    // See BUGS_FOUND.md ST-7.
     const unsafe = 'did:dkg:agent:evil> <http://attacker/';
     await expect(
       ps.storePrivateTriples(CONTEXT_GRAPH, unsafe, [

--- a/packages/storage/test/private-store-key-resolution.test.ts
+++ b/packages/storage/test/private-store-key-resolution.test.ts
@@ -1,0 +1,895 @@
+/**
+ * Targeted coverage for the key-resolution and standalone decrypt paths in
+ * `private-store.ts` that the existing private-store-extra tests don't
+ * exercise (lines 56-70 + 74-89 + 159-164 in the v8 report).
+ *
+ * The paths:
+ *   - decryptPrivateLiteral  (module export, stateless)
+ *   - resolveEncryptionKey   (hex/base64/short-input/explicit-bytes branches)
+ *   - encrypt→decrypt round-trip with an explicit 32-byte key
+ *   - decrypt-with-wrong-key returns the envelope unchanged (never throws)
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  OxigraphStore,
+  ContextGraphManager,
+  PrivateContentStore,
+  type Quad,
+} from '../src/index.js';
+import {
+  decryptPrivateLiteral,
+  __resetPrivateStoreKeyCacheForTests,
+} from '../src/private-store.js';
+
+function makeFreshStore() {
+  const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-key-'));
+  const store = new OxigraphStore(join(dir, 'db'));
+  return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe('decryptPrivateLiteral (standalone export) — envelope handling', () => {
+  it('returns non-encrypted literals unchanged', () => {
+    const plain = '"hello world"';
+    expect(decryptPrivateLiteral(plain)).toBe(plain);
+    expect(decryptPrivateLiteral('<http://example.org/s>')).toBe('<http://example.org/s>');
+    expect(decryptPrivateLiteral('_:b0')).toBe('_:b0');
+  });
+
+  it('returns the serialized string unchanged when it starts with the envelope but body is malformed', () => {
+    // Envelope prefix present but the content is not base64-decodable to a
+    // valid 12+16+ct structure — the helper must never throw, only pass
+    // the serialized form through.
+    const malformed = '"enc:gcm:v1:not-base64-at-all!!!"';
+    const out = decryptPrivateLiteral(malformed);
+    // Either we get the original back (catch triggered) or a plain "" — in
+    // both cases the helper MUST NOT throw.
+    expect(typeof out).toBe('string');
+  });
+
+  it('returns the envelope unchanged when decryption fails with the wrong key', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-1');
+      const psA = new PrivateContentStore(store, gm, { encryptionKey: 'A'.repeat(64) });
+      await psA.storePrivateTriples(
+        'cg-1',
+        'did:dkg:agent:A',
+        [{ subject: 'did:dkg:agent:A', predicate: 'http://example.org/p', object: '"secret"', graph: '' }] as Quad[],
+      );
+      // Pull ciphertext via a raw SPARQL query to bypass the in-instance decrypt.
+      const result = await store.query(`
+        SELECT ?o WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 1
+      `);
+      const ciphertext = (result as any).bindings[0].o as string;
+      expect(ciphertext.startsWith('"enc:gcm:v1:')).toBe(true);
+
+      // Now decrypt with a DIFFERENT key — function must not throw and
+      // must not return plaintext. Returning the envelope unchanged is
+      // the documented "wrong key" signal.
+      const wrong = decryptPrivateLiteral(ciphertext, { encryptionKey: 'B'.repeat(64) });
+      expect(wrong).toBe(ciphertext);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('resolveEncryptionKey via PrivateContentStore constructor — branch coverage', () => {
+  it('accepts a 64-char hex key (32 bytes) and round-trips correctly', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-hex');
+      const hexKey = '0'.repeat(64); // 32 bytes of 0x00
+      const ps = new PrivateContentStore(store, gm, { encryptionKey: hexKey });
+      await ps.storePrivateTriples('cg-hex', 'did:dkg:agent:X', [
+        { subject: 'did:dkg:agent:X', predicate: 'http://example.org/p', object: '"secret-hex"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-hex', 'did:dkg:agent:X');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"secret-hex"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('accepts a base64-encoded 32-byte key', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-b64');
+      const b64 = Buffer.alloc(32, 7).toString('base64');
+      const ps = new PrivateContentStore(store, gm, { encryptionKey: b64 });
+      await ps.storePrivateTriples('cg-b64', 'did:dkg:agent:Y', [
+        { subject: 'did:dkg:agent:Y', predicate: 'http://example.org/p', object: '"secret-b64"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-b64', 'did:dkg:agent:Y');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"secret-b64"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('SHA-256-stretches a short passphrase into a 32-byte key (round-trips)', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-short');
+      // A short passphrase — not 64 hex chars, so the hex branch is skipped
+      // and it falls to the base64 branch, which decodes to a non-32-byte
+      // buffer and triggers the SHA-256 stretch.
+      const ps = new PrivateContentStore(store, gm, { encryptionKey: 'hunter2' });
+      await ps.storePrivateTriples('cg-short', 'did:dkg:agent:Z', [
+        { subject: 'did:dkg:agent:Z', predicate: 'http://example.org/p', object: '"secret-short"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-short', 'did:dkg:agent:Z');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"secret-short"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('accepts a raw Uint8Array key and round-trips', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-bytes');
+      const key = new Uint8Array(32).fill(42);
+      const ps = new PrivateContentStore(store, gm, { encryptionKey: key });
+      await ps.storePrivateTriples('cg-bytes', 'did:dkg:agent:W', [
+        { subject: 'did:dkg:agent:W', predicate: 'http://example.org/p', object: '"secret-bytes"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-bytes', 'did:dkg:agent:W');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"secret-bytes"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // with no explicit key, two
+  // instances in the same PROCESS now share the persisted per-node key
+  // (either by reading the existing file or by the in-process cache
+  // populated when ps1 generated it). This preserves the intra-process
+  // dedup property the old deterministic default provided but limits
+  // the key's blast radius to this one node's key file.
+  it('per-node persisted key: two PrivateContentStore instances in the same process share the same key and round-trip data', async () => {
+    const { store, cleanup } = makeFreshStore();
+    const keyDir = mkdtempSync(join(tmpdir(), 'dkg-ps-persist-'));
+    const keyFile = join(keyDir, 'private-store.key');
+    const prev = process.env.DKG_PRIVATE_STORE_KEY;
+    const prevFile = process.env.DKG_PRIVATE_STORE_KEY_FILE;
+    delete process.env.DKG_PRIVATE_STORE_KEY;
+    process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+    __resetPrivateStoreKeyCacheForTests();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-persisted');
+      const ps1 = new PrivateContentStore(store, gm);
+      const ps2 = new PrivateContentStore(store, gm);
+
+      await ps1.storePrivateTriples('cg-persisted', 'did:dkg:agent:D', [
+        { subject: 'did:dkg:agent:D', predicate: 'http://example.org/p', object: '"secret-default"', graph: '' },
+      ] as Quad[]);
+
+      const read = await ps2.getPrivateTriples('cg-persisted', 'did:dkg:agent:D');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"secret-default"');
+      // The key file must have been created with exactly 32 bytes.
+      expect(existsSync(keyFile)).toBe(true);
+      expect(readFileSync(keyFile).length).toBe(32);
+    } finally {
+      if (prev !== undefined) process.env.DKG_PRIVATE_STORE_KEY = prev;
+      if (prevFile === undefined) delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+      else process.env.DKG_PRIVATE_STORE_KEY_FILE = prevFile;
+      __resetPrivateStoreKeyCacheForTests();
+      rmSync(keyDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('picks DKG_PRIVATE_STORE_KEY from env when no explicit option is supplied', async () => {
+    const { store, cleanup } = makeFreshStore();
+    const prev = process.env.DKG_PRIVATE_STORE_KEY;
+    process.env.DKG_PRIVATE_STORE_KEY = '1'.repeat(64);
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-env');
+      const ps = new PrivateContentStore(store, gm);
+      await ps.storePrivateTriples('cg-env', 'did:dkg:agent:E', [
+        { subject: 'did:dkg:agent:E', predicate: 'http://example.org/p', object: '"secret-env"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-env', 'did:dkg:agent:E');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"secret-env"');
+    } finally {
+      if (prev === undefined) delete process.env.DKG_PRIVATE_STORE_KEY;
+      else process.env.DKG_PRIVATE_STORE_KEY = prev;
+      cleanup();
+    }
+  });
+});
+
+// -------------------------------------------------------------------------
+// the unconfigured-key fallback
+// MUST no longer share `sha256(DEFAULT_KEY_DOMAIN)` across nodes. The
+// new behaviour: generate and persist a per-node 32-byte random key at
+// `DKG_PRIVATE_STORE_KEY_FILE` (or `<DKG_HOME>/private-store.key`, or
+// `<homedir()>/.dkg/private-store.key`). Two nodes with different key
+// files must be cryptographically isolated.
+// -------------------------------------------------------------------------
+describe('per-node persisted key isolates unconfigured nodes from each other', () => {
+  const savedEnv = {
+    DKG_PRIVATE_STORE_KEY: process.env.DKG_PRIVATE_STORE_KEY,
+    DKG_PRIVATE_STORE_KEY_FILE: process.env.DKG_PRIVATE_STORE_KEY_FILE,
+    DKG_PRIVATE_STORE_STRICT_KEY: process.env.DKG_PRIVATE_STORE_STRICT_KEY,
+  };
+
+  beforeEach(() => {
+    delete process.env.DKG_PRIVATE_STORE_KEY;
+    delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+    delete process.env.DKG_PRIVATE_STORE_STRICT_KEY;
+    __resetPrivateStoreKeyCacheForTests();
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    __resetPrivateStoreKeyCacheForTests();
+  });
+
+  it('two nodes with different key files cannot decrypt each other\'s private triples', async () => {
+    const nodeADir = mkdtempSync(join(tmpdir(), 'dkg-ps-node-a-'));
+    const nodeBDir = mkdtempSync(join(tmpdir(), 'dkg-ps-node-b-'));
+    const keyFileA = join(nodeADir, 'private-store.key');
+    const keyFileB = join(nodeBDir, 'private-store.key');
+    const { store: storeA, cleanup: cleanupA } = makeFreshStore();
+    const { store: storeB, cleanup: cleanupB } = makeFreshStore();
+    try {
+      // Node A writes under its own persisted key.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFileA;
+      __resetPrivateStoreKeyCacheForTests();
+      const gmA = new ContextGraphManager(storeA);
+      await gmA.ensureContextGraph('cg-nodeA');
+      const psA = new PrivateContentStore(storeA, gmA);
+      await psA.storePrivateTriples('cg-nodeA', 'did:dkg:agent:A', [
+        { subject: 'did:dkg:agent:A', predicate: 'http://example.org/p', object: '"nodeA-secret"', graph: '' },
+      ] as Quad[]);
+
+      // Pull the ciphertext from A's store via raw SPARQL.
+      const ctResult = await storeA.query(`SELECT ?o WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 1`);
+      const ciphertextFromA = (ctResult as any).bindings[0].o as string;
+      expect(ciphertextFromA.startsWith('"enc:gcm:v1:')).toBe(true);
+
+      // Switch to Node B's key file and verify the envelope does NOT
+      // decrypt — decryptPrivateLiteral must return the envelope
+      // unchanged (the documented "wrong key" signal), never plaintext.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFileB;
+      __resetPrivateStoreKeyCacheForTests();
+      const decryptedUnderB = decryptPrivateLiteral(ciphertextFromA);
+      expect(decryptedUnderB).toBe(ciphertextFromA);
+      expect(decryptedUnderB).not.toBe('"nodeA-secret"');
+
+      // Also: Node B generating its own key must produce a DIFFERENT
+      // 32-byte secret. Files must exist, both 32 bytes, byte-unequal.
+      const gmB = new ContextGraphManager(storeB);
+      await gmB.ensureContextGraph('cg-nodeB');
+      const psB = new PrivateContentStore(storeB, gmB);
+      await psB.storePrivateTriples('cg-nodeB', 'did:dkg:agent:B', [
+        { subject: 'did:dkg:agent:B', predicate: 'http://example.org/p', object: '"nodeB-secret"', graph: '' },
+      ] as Quad[]);
+      expect(existsSync(keyFileA)).toBe(true);
+      expect(existsSync(keyFileB)).toBe(true);
+      const rawA = readFileSync(keyFileA);
+      const rawB = readFileSync(keyFileB);
+      expect(rawA.length).toBe(32);
+      expect(rawB.length).toBe(32);
+      expect(rawA.equals(rawB)).toBe(false);
+    } finally {
+      cleanupA();
+      cleanupB();
+      rmSync(nodeADir, { recursive: true, force: true });
+      rmSync(nodeBDir, { recursive: true, force: true });
+    }
+  });
+
+  it('persisted key file is reused across process restarts (simulated via cache reset)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-reuse-'));
+    const keyFile = join(dir, 'private-store.key');
+    const { store, cleanup } = makeFreshStore();
+    try {
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      __resetPrivateStoreKeyCacheForTests();
+
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-reuse');
+      const ps1 = new PrivateContentStore(store, gm);
+      await ps1.storePrivateTriples('cg-reuse', 'did:dkg:agent:R', [
+        { subject: 'did:dkg:agent:R', predicate: 'http://example.org/p', object: '"persisted-across-restart"', graph: '' },
+      ] as Quad[]);
+      const originalKey = readFileSync(keyFile);
+      expect(originalKey.length).toBe(32);
+
+      // Simulate a process restart — drop the in-memory cache but
+      // leave the file on disk. The new instance MUST read the same
+      // key and decrypt the existing data.
+      __resetPrivateStoreKeyCacheForTests();
+      const ps2 = new PrivateContentStore(store, gm);
+      const read = await ps2.getPrivateTriples('cg-reuse', 'did:dkg:agent:R');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"persisted-across-restart"');
+      // The file must NOT have been rewritten.
+      expect(readFileSync(keyFile).equals(originalKey)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('strict mode (DKG_PRIVATE_STORE_STRICT_KEY=1) refuses both the persisted and deterministic fallbacks', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      process.env.DKG_PRIVATE_STORE_STRICT_KEY = '1';
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-strict');
+      expect(() => new PrivateContentStore(store, gm)).toThrow(/strict mode/i);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('explicit `strictKey: true` option overrides the env (belt + suspenders)', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      delete process.env.DKG_PRIVATE_STORE_STRICT_KEY;
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-strict-opt');
+      expect(() => new PrivateContentStore(store, gm, { strictKey: true })).toThrow(
+        /strict mode/i,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // private-store.ts:124). Pre-fix, a
+  // truncated / corrupted persisted key file silently fell through to the
+  // "generate a fresh key" branch, re-keying the node in place and stranding
+  // every previously encrypted private triple under the now-overwritten
+  // original. The new behaviour is fail-loud: throw a clear error so the
+  // operator sees the corruption signal at startup. An explicit
+  // `DKG_PRIVATE_STORE_KEY_AUTO_RESET=1` env opt-in restores the old auto-
+  // regenerate behaviour for operators who explicitly accept the data loss.
+  // ────────────────────────────────────────────────────────────────────────
+  it('corrupted persisted key file (length < 32) THROWS instead of silently re-keying the node', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-corrupt-'));
+    const keyFile = join(dir, 'private-store.key');
+    const { store, cleanup } = makeFreshStore();
+    try {
+      // Pre-seed a truncated key file (e.g. partial write, FS corruption).
+      const fs = await import('node:fs');
+      fs.writeFileSync(keyFile, Buffer.from([0xab, 0xcd, 0xef])); // 3 bytes — too short
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      delete process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET;
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-corrupt');
+
+      // Pre-fix: this would have silently regenerated the key. Post-fix:
+      // the constructor (which calls into loadOrCreatePersistedKey) MUST
+      // throw with a corrupt-key error.
+      expect(() => new PrivateContentStore(store, gm)).toThrow(
+        /persistent private-store key file.*corrupt|length=3, expected >= 32/i,
+      );
+
+      // The corruption signal must NOT have been overwritten by an
+      // auto-regenerated key — operators rely on the file contents
+      // surviving as forensic evidence.
+      const onDisk = readFileSync(keyFile);
+      expect(onDisk.length).toBe(3);
+      expect(onDisk.equals(Buffer.from([0xab, 0xcd, 0xef]))).toBe(true);
+    } finally {
+      delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+      __resetPrivateStoreKeyCacheForTests();
+      rmSync(dir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('empty persisted key file (zero bytes — partial write before any data flushed) ALSO throws', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-empty-'));
+    const keyFile = join(dir, 'private-store.key');
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const fs = await import('node:fs');
+      fs.writeFileSync(keyFile, Buffer.alloc(0));
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      delete process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET;
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-empty');
+
+      expect(() => new PrivateContentStore(store, gm)).toThrow(
+        /private-store key file.*corrupt|length=0/i,
+      );
+    } finally {
+      delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+      __resetPrivateStoreKeyCacheForTests();
+      rmSync(dir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('DKG_PRIVATE_STORE_KEY_AUTO_RESET=1 lets the operator opt back into auto-regenerate after explicit acceptance', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-reset-'));
+    const keyFile = join(dir, 'private-store.key');
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const fs = await import('node:fs');
+      fs.writeFileSync(keyFile, Buffer.from([0x01, 0x02])); // truncated
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET = '1';
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-reset');
+
+      // With the explicit opt-in env set, construction succeeds —
+      // a fresh 32-byte key has been generated and persisted.
+      const ps = new PrivateContentStore(store, gm);
+      await ps.storePrivateTriples('cg-reset', 'did:dkg:agent:R', [
+        { subject: 'did:dkg:agent:R', predicate: 'http://example.org/p', object: '"after-reset"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-reset', 'did:dkg:agent:R');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"after-reset"');
+
+      // The file is now 32 bytes — the fresh key.
+      const onDisk = readFileSync(keyFile);
+      expect(onDisk.length).toBe(32);
+      // The original 2-byte content has been overwritten — that's the
+      // documented data-loss trade-off the env opt-in accepts.
+      expect(onDisk.subarray(0, 2).equals(Buffer.from([0x01, 0x02]))).toBe(false);
+    } finally {
+      delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+      delete process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET;
+      __resetPrivateStoreKeyCacheForTests();
+      rmSync(dir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('a HEALTHY persisted key file is still loaded normally (no false positives on the corruption check)', async () => {
+    // Counterpoint: a 32-byte file (or a 33-byte file — the helper
+    // takes the first 32 bytes) must continue to load without
+    // throwing. This pins the normal happy-path against the new
+    // corruption check.
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-healthy-'));
+    const keyFile = join(dir, 'private-store.key');
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const fs = await import('node:fs');
+      const healthyKey = Buffer.alloc(32, 0x42);
+      fs.writeFileSync(keyFile, healthyKey);
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      delete process.env.DKG_PRIVATE_STORE_KEY_AUTO_RESET;
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-healthy');
+
+      const ps = new PrivateContentStore(store, gm);
+      await ps.storePrivateTriples('cg-healthy', 'did:dkg:agent:H', [
+        { subject: 'did:dkg:agent:H', predicate: 'http://example.org/p', object: '"healthy-data"', graph: '' },
+      ] as Quad[]);
+      const read = await ps.getPrivateTriples('cg-healthy', 'did:dkg:agent:H');
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"healthy-data"');
+
+      // Original key bytes preserved — no spurious rewrite.
+      expect(readFileSync(keyFile).equals(healthyKey)).toBe(true);
+    } finally {
+      delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+      __resetPrivateStoreKeyCacheForTests();
+      rmSync(dir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+});
+
+// -------------------------------------------------------------------------
+// when the r12-2 flip switched the
+// preferred unconfigured-node key from `sha256(DEFAULT_KEY_DOMAIN)` to a
+// per-node persisted key, every node that previously ran without
+// `DKG_PRIVATE_STORE_KEY` had its existing private ciphertext stranded.
+// The fix adds the legacy deterministic key as a DECRYPT-ONLY fallback
+// so old data remains readable after upgrade while new writes still go
+// to the unique per-node key.
+// -------------------------------------------------------------------------
+describe('legacy DEFAULT_KEY_DOMAIN fallback keeps pre-r12 private ciphertext readable after upgrade', () => {
+  const savedEnv = {
+    DKG_PRIVATE_STORE_KEY: process.env.DKG_PRIVATE_STORE_KEY,
+    DKG_PRIVATE_STORE_KEY_FILE: process.env.DKG_PRIVATE_STORE_KEY_FILE,
+    DKG_PRIVATE_STORE_STRICT_KEY: process.env.DKG_PRIVATE_STORE_STRICT_KEY,
+  };
+
+  beforeEach(() => {
+    delete process.env.DKG_PRIVATE_STORE_KEY;
+    delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+    delete process.env.DKG_PRIVATE_STORE_STRICT_KEY;
+    __resetPrivateStoreKeyCacheForTests();
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    __resetPrivateStoreKeyCacheForTests();
+  });
+
+  it('legacy-sealed ciphertext (written under sha256(DEFAULT_KEY_DOMAIN)) is still readable after upgrade to a persisted key', async () => {
+    const { store, cleanup } = makeFreshStore();
+    const keyDir = mkdtempSync(join(tmpdir(), 'dkg-ps-r15-'));
+    const keyFile = join(keyDir, 'private-store.key');
+    try {
+      // Step 1: simulate node behaviour by explicitly sealing with
+      // the deterministic legacy key. We pass `DEFAULT_KEY_DOMAIN` as a
+      // passphrase — the constructor SHA-256-stretches it, reproducing
+      // the exact bytes `resolveEncryptionKey` used as the legacy
+      // fallback in r12-2 and earlier.
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-legacy');
+      const legacyWriter = new PrivateContentStore(store, gm, {
+        encryptionKey: 'dkg-v10/private-store/default-key/v1',
+      });
+      await legacyWriter.storePrivateTriples('cg-legacy', 'did:dkg:agent:L', [
+        { subject: 'did:dkg:agent:L', predicate: 'http://example.org/p', object: '"legacy-payload"', graph: '' },
+      ] as Quad[]);
+
+      // Step 2: upgrade — new instance has no explicit key but has a
+      // fresh per-node persisted key file. This mirrors what a v10 node
+      // sees on first boot after pulling the r12-2 change.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      __resetPrivateStoreKeyCacheForTests();
+      const upgradedReader = new PrivateContentStore(store, gm);
+      const read = await upgradedReader.getPrivateTriples('cg-legacy', 'did:dkg:agent:L');
+
+      // Step 3: the fallback chain finds the legacy key and recovers
+      // the plaintext — without r15-1 this returned the envelope
+      // unchanged (data stranded).
+      expect(read).toHaveLength(1);
+      expect(read[0].object).toBe('"legacy-payload"');
+      // The persisted file must have been created with 32 bytes —
+      // proves we're genuinely on a instance, not falling
+      // back to the legacy path for writes.
+      expect(existsSync(keyFile)).toBe(true);
+      expect(readFileSync(keyFile).length).toBe(32);
+    } finally {
+      rmSync(keyDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('new writes always use the per-node persisted key, not the legacy fallback (fallback is decrypt-only)', async () => {
+    const { store, cleanup } = makeFreshStore();
+    const keyDir = mkdtempSync(join(tmpdir(), 'dkg-ps-r15-writes-'));
+    const keyFile = join(keyDir, 'private-store.key');
+    try {
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      __resetPrivateStoreKeyCacheForTests();
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-write');
+      const ps = new PrivateContentStore(store, gm);
+      await ps.storePrivateTriples('cg-write', 'did:dkg:agent:N', [
+        { subject: 'did:dkg:agent:N', predicate: 'http://example.org/p', object: '"new-write"', graph: '' },
+      ] as Quad[]);
+
+      // Grab the ciphertext.
+      const result = await store.query(`SELECT ?o WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 1`);
+      const ciphertext = (result as any).bindings[0].o as string;
+      expect(ciphertext.startsWith('"enc:gcm:v1:')).toBe(true);
+
+      // Verify a store that ONLY knows the legacy deterministic key
+      // cannot decrypt the new write — if r15-1 were mis-applied
+      // (e.g. flipping encryption to also try the legacy key) this
+      // would leak plaintext.
+      const legacyOnlyReader = new PrivateContentStore(store, gm, {
+        encryptionKey: 'dkg-v10/private-store/default-key/v1',
+      });
+      const legacyRead = await legacyOnlyReader.getPrivateTriples('cg-write', 'did:dkg:agent:N');
+      expect(legacyRead).toHaveLength(1);
+      // Under a legacy-only key the new ciphertext is unreadable — the
+      // envelope is returned verbatim, plaintext is NOT exposed.
+      expect(legacyRead[0].object).toBe(ciphertext);
+      expect(legacyRead[0].object).not.toBe('"new-write"');
+    } finally {
+      rmSync(keyDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('decryptPrivateLiteral (standalone) also falls back to the legacy key for pre-r12 ciphertext', async () => {
+    const { store, cleanup } = makeFreshStore();
+    const keyDir = mkdtempSync(join(tmpdir(), 'dkg-ps-r15-export-'));
+    const keyFile = join(keyDir, 'private-store.key');
+    try {
+      // Write with the legacy key.
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-export');
+      const writer = new PrivateContentStore(store, gm, {
+        encryptionKey: 'dkg-v10/private-store/default-key/v1',
+      });
+      await writer.storePrivateTriples('cg-export', 'did:dkg:agent:X', [
+        { subject: 'did:dkg:agent:X', predicate: 'http://example.org/p', object: '"exported-legacy"', graph: '' },
+      ] as Quad[]);
+      const result = await store.query(`SELECT ?o WHERE { GRAPH ?g { ?s ?p ?o } } LIMIT 1`);
+      const legacyCiphertext = (result as any).bindings[0].o as string;
+
+      // Upgrade: no explicit key, new per-node key file. The standalone
+      // `decryptPrivateLiteral` export (used by publisher subtraction
+      // etc.) must still recover the plaintext via the legacy fallback.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = keyFile;
+      __resetPrivateStoreKeyCacheForTests();
+      const recovered = decryptPrivateLiteral(legacyCiphertext);
+      expect(recovered).toBe('"exported-legacy"');
+    } finally {
+      rmSync(keyDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  it('ciphertext under a TRULY unknown key (neither primary nor legacy) still returns the envelope (no silent leak)', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-unknown');
+      const writer = new PrivateContentStore(store, gm, {
+        encryptionKey: 'A'.repeat(64), // 32 hex bytes of 0xAA — not legacy, not the reader's key
+      });
+      await writer.storePrivateTriples('cg-unknown', 'did:dkg:agent:U', [
+        { subject: 'did:dkg:agent:U', predicate: 'http://example.org/p', object: '"unrecoverable"', graph: '' },
+      ] as Quad[]);
+
+      // Reader with a different explicit key — neither key in the
+      // chain (primary = reader key, legacy fallback = sha256 default)
+      // authenticates this ciphertext. Must NOT leak plaintext.
+      const reader = new PrivateContentStore(store, gm, {
+        encryptionKey: 'B'.repeat(64),
+      });
+      const read = await reader.getPrivateTriples('cg-unknown', 'did:dkg:agent:U');
+      expect(read).toHaveLength(1);
+      expect(read[0].object.startsWith('"enc:gcm:v1:')).toBe(true);
+      expect(read[0].object).not.toBe('"unrecoverable"');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// the persisted-key cache must be keyed
+// by file path, NOT module-global. Otherwise a single process hosting two
+// nodes (test fixtures, multi-tenant daemon, simulation harness) silently
+// aliases both onto the FIRST node's key, breaking crypto isolation.
+// ---------------------------------------------------------------------------
+describe('persisted key cache is keyed by resolved file path', () => {
+  let prevKeyFile: string | undefined;
+  let prevHome: string | undefined;
+  beforeEach(() => {
+    prevKeyFile = process.env.DKG_PRIVATE_STORE_KEY_FILE;
+    prevHome = process.env.DKG_HOME;
+    __resetPrivateStoreKeyCacheForTests();
+  });
+  afterEach(() => {
+    if (prevKeyFile === undefined) delete process.env.DKG_PRIVATE_STORE_KEY_FILE;
+    else process.env.DKG_PRIVATE_STORE_KEY_FILE = prevKeyFile;
+    if (prevHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = prevHome;
+    __resetPrivateStoreKeyCacheForTests();
+  });
+
+  it('two PATHS in the same process → two DIFFERENT keys (no aliasing)', () => {
+    const dirA = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-b-'));
+    const fileA = join(dirA, 'private-store.key');
+    const fileB = join(dirB, 'private-store.key');
+    try {
+      // Node A boots, generates its key at path A.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileA;
+      const { store: storeA, cleanup: cleanA } = makeFreshStore();
+      try {
+        const gmA = new ContextGraphManager(storeA);
+        // eslint-disable-next-line no-void
+        void new PrivateContentStore(storeA, gmA); // triggers key creation
+      } finally {
+        cleanA();
+      }
+      const keyA = readFileSync(fileA);
+
+      // Node B boots in the SAME process with a different key path.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileB;
+      const { store: storeB, cleanup: cleanB } = makeFreshStore();
+      try {
+        const gmB = new ContextGraphManager(storeB);
+        // eslint-disable-next-line no-void
+        void new PrivateContentStore(storeB, gmB); // triggers key creation
+      } finally {
+        cleanB();
+      }
+      const keyB = readFileSync(fileB);
+
+      // r16-3 core invariant: distinct paths → distinct keys. Under the
+      // module-global cache, B would have returned A's key
+      // without ever touching disk at `fileB`.
+      expect(keyA.length).toBe(32);
+      expect(keyB.length).toBe(32);
+      expect(keyA.equals(keyB)).toBe(false);
+      // Sanity: each path carries its OWN file on disk.
+      expect(existsSync(fileA)).toBe(true);
+      expect(existsSync(fileB)).toBe(true);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('node B CANNOT read data sealed by node A when they run in the same process with different key paths (crypto isolation)', async () => {
+    const dirA = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-iso-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-iso-b-'));
+    const fileA = join(dirA, 'private-store.key');
+    const fileB = join(dirB, 'private-store.key');
+    // Deliberately share the underlying triple-store: this simulates
+    // the nightmare scenario the bot flagged — a multi-tenant process
+    // where node B accidentally queries node A's graph DB. Pre-r16-3
+    // the cache alias made plaintext recoverable; after r16-3 it is
+    // not, because B holds a DIFFERENT 32-byte secret.
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-iso');
+
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileA;
+      __resetPrivateStoreKeyCacheForTests();
+      const nodeA = new PrivateContentStore(store, gm);
+      await nodeA.storePrivateTriples('cg-iso', 'did:dkg:agent:S', [
+        { subject: 'did:dkg:agent:S', predicate: 'http://example.org/p', object: '"secret-on-A"', graph: '' },
+      ] as Quad[]);
+
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileB;
+      __resetPrivateStoreKeyCacheForTests();
+      const nodeB = new PrivateContentStore(store, gm);
+      const readB = await nodeB.getPrivateTriples('cg-iso', 'did:dkg:agent:S');
+      expect(readB).toHaveLength(1);
+      // B must NOT see A's plaintext — under the alias bug
+      // this returned "secret-on-A". Now B sees only the envelope.
+      expect(readB[0].object).not.toBe('"secret-on-A"');
+      expect(readB[0].object.startsWith('"enc:gcm:v1:')).toBe(true);
+
+      // Sanity: flip back to A and confirm A still decrypts its own
+      // data. This proves r16-3 didn't break the intra-process sharing
+      // property for a single path — it only disaggregated across paths.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileA;
+      __resetPrivateStoreKeyCacheForTests();
+      const nodeAAgain = new PrivateContentStore(store, gm);
+      const readA = await nodeAAgain.getPrivateTriples('cg-iso', 'did:dkg:agent:S');
+      expect(readA).toHaveLength(1);
+      expect(readA[0].object).toBe('"secret-on-A"');
+    } finally {
+      cleanup();
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('the SAME path stays cached across instances (no re-generation, no re-read) — only the cache KEY changed, not the sharing property', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-share-'));
+    const file = join(dir, 'private-store.key');
+    try {
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = file;
+      __resetPrivateStoreKeyCacheForTests();
+
+      const { store, cleanup } = makeFreshStore();
+      try {
+        const gm = new ContextGraphManager(store);
+        await gm.ensureContextGraph('cg-share');
+        // First instance: file is generated on disk.
+        const ps1 = new PrivateContentStore(store, gm);
+        await ps1.storePrivateTriples('cg-share', 'did:dkg:agent:K', [
+          { subject: 'did:dkg:agent:K', predicate: 'http://example.org/p', object: '"shared"', graph: '' },
+        ] as Quad[]);
+        const keyBytes1 = readFileSync(file);
+
+        // Second instance in the SAME process with the SAME path:
+        // MUST see the same secret (the r12-2 intra-process sharing
+        // property r16-3 preserves).
+        const ps2 = new PrivateContentStore(store, gm);
+        const read = await ps2.getPrivateTriples('cg-share', 'did:dkg:agent:K');
+        expect(read).toHaveLength(1);
+        expect(read[0].object).toBe('"shared"');
+
+        // The on-disk key is untouched — we never regenerated it.
+        const keyBytes2 = readFileSync(file);
+        expect(keyBytes1.equals(keyBytes2)).toBe(true);
+      } finally {
+        cleanup();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('__resetPrivateStoreKeyCacheForTests drops ALL paths, not just the last one used', async () => {
+    const dirA = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-reset-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'dkg-ps-r16-3-reset-b-'));
+    const fileA = join(dirA, 'private-store.key');
+    const fileB = join(dirB, 'private-store.key');
+    try {
+      // Warm the cache for path A.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileA;
+      const { store: sA, cleanup: cA } = makeFreshStore();
+      try { void new PrivateContentStore(sA, new ContextGraphManager(sA)); } finally { cA(); }
+
+      // Warm the cache for path B as well.
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileB;
+      const { store: sB, cleanup: cB } = makeFreshStore();
+      try { void new PrivateContentStore(sB, new ContextGraphManager(sB)); } finally { cB(); }
+
+      // Reset must flush BOTH entries. We re-observe by deleting the
+      // on-disk key files and asking for a store under path A again —
+      // it must regenerate (not serve a stale cached buffer).
+      __resetPrivateStoreKeyCacheForTests();
+      rmSync(fileA, { force: true });
+      rmSync(fileB, { force: true });
+      expect(existsSync(fileA)).toBe(false);
+      expect(existsSync(fileB)).toBe(false);
+
+      process.env.DKG_PRIVATE_STORE_KEY_FILE = fileA;
+      const { store: sA2, cleanup: cA2 } = makeFreshStore();
+      try {
+        void new PrivateContentStore(sA2, new ContextGraphManager(sA2));
+      } finally {
+        cA2();
+      }
+      // New file regenerated → cache was truly empty after reset.
+      expect(existsSync(fileA)).toBe(true);
+      expect(readFileSync(fileA).length).toBe(32);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('PrivateContentStore.decryptLiteral — returns envelope on bad key (defence-in-depth)', () => {
+  it('wrong key: the instance decrypt method leaves the envelope visible so callers can detect the failure', async () => {
+    const { store, cleanup } = makeFreshStore();
+    try {
+      const gm = new ContextGraphManager(store);
+      await gm.ensureContextGraph('cg-wk');
+      const writer = new PrivateContentStore(store, gm, { encryptionKey: 'A'.repeat(64) });
+      await writer.storePrivateTriples('cg-wk', 'did:dkg:agent:W', [
+        { subject: 'did:dkg:agent:W', predicate: 'http://example.org/p', object: '"top-secret"', graph: '' },
+      ] as Quad[]);
+
+      // Reader with a DIFFERENT key — getPrivateTriples should pull the
+      // rows but return the envelope string verbatim as the literal.
+      const reader = new PrivateContentStore(store, gm, { encryptionKey: 'B'.repeat(64) });
+      const read = await reader.getPrivateTriples('cg-wk', 'did:dkg:agent:W');
+      expect(read).toHaveLength(1);
+      expect(read[0].object.startsWith('"enc:gcm:v1:')).toBe(true); // envelope visible
+      expect(read[0].object).not.toBe('"top-secret"'); // never leaks plaintext
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -164,7 +164,27 @@ tripleStoreConformanceSuite('OxigraphStore (factory)', async () => createTripleS
 // Set BLAZEGRAPH_URL=http://127.0.0.1:9999/bigdata/namespace/test/sparql to enable.
 const blazeUrl = process.env.BLAZEGRAPH_URL;
 if (blazeUrl) {
-  tripleStoreConformanceSuite('BlazegraphStore', async () => new BlazegraphStore(blazeUrl));
+  // Blazegraph is a stateful, shared service — every test in the
+  // conformance suite is built around an empty store, so we must
+  // wipe the entire kb namespace before handing the adapter to a
+  // new test. The cheapest reliable wipe is `DROP ALL`, which
+  // removes every named graph and the default graph in a single
+  // SPARQL update. This keeps the conformance suite hermetic
+  // across re-runs and across the OxigraphStore baseline (which
+  // is naturally per-test because it's in-memory).
+  tripleStoreConformanceSuite('BlazegraphStore', async () => {
+    const store = new BlazegraphStore(blazeUrl);
+    const res = await fetch(blazeUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `update=${encodeURIComponent('DROP ALL')}`,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Blazegraph DROP ALL failed (${res.status}): ${text.slice(0, 200)}`);
+    }
+    return store;
+  });
 }
 // NOTE: previously this branch ran `it.skip('requires a running Blazegraph …', () => {})`
 // as a placeholder to surface the skip in the reporter. That empty stub added

--- a/packages/storage/test/vitest.setup.ts
+++ b/packages/storage/test/vitest.setup.ts
@@ -1,0 +1,28 @@
+/**
+ * Global vitest setup for `@origintrail-official/dkg-storage`.
+ *
+ * `PrivateContentStore` now
+ * generates and persists a per-node 32-byte random key at
+ * `DKG_PRIVATE_STORE_KEY_FILE` (or `<DKG_HOME>/private-store.key`, or
+ * `<homedir()>/.dkg/private-store.key`). Without this setup, tests
+ * that instantiate `new PrivateContentStore(store, gm)` without
+ * passing an explicit key would write into the developer's real
+ * `~/.dkg/` directory. We pin the key path to a per-session temp
+ * directory so the tests stay hermetic — no pollution, no leaking
+ * secrets between unrelated repos that happen to share a $HOME.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const sessionDir = mkdtempSync(join(tmpdir(), 'dkg-storage-test-'));
+process.env.DKG_PRIVATE_STORE_KEY_FILE = join(sessionDir, 'private-store.key');
+
+// Best-effort cleanup — vitest workers share this process so a single
+// top-level `afterAll` hook is unreliable. Relying on process exit
+// handlers is simplest and robust against crashes.
+process.on('exit', () => {
+  try {
+    rmSync(sessionDir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});

--- a/packages/storage/vitest.config.ts
+++ b/packages/storage/vitest.config.ts
@@ -4,6 +4,7 @@ import { tornadoStorageCoverage } from '../../vitest.coverage';
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
+    setupFiles: ['./test/vitest.setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov', 'json-summary'],

--- a/vitest.coverage.ts
+++ b/vitest.coverage.ts
@@ -61,10 +61,10 @@ export const tornadoPublisherCoverage: CoverageThresholds = {
 };
 
 export const tornadoStorageCoverage: CoverageThresholds = {
-  lines: 57,
-  functions: 52,
-  branches: 39,
-  statements: 53,
+  lines: 85,
+  functions: 81,
+  branches: 63,
+  statements: 79,
 };
 
 export const tornadoAgentCoverage: CoverageThresholds = {


### PR DESCRIPTION
## Summary

PR **2 of 4** in the split of #327. Each slice is a single architectural layer to keep reviews tractable.

This PR carries the storage/query layer: RDF correctness, AES-GCM-SIV nonce hardening, SPARQL guard fixes, and the CI infrastructure to run real Blazegraph parity tests.

## Changes by category

### Storage bug fixes
- **ST-1** — \`BlazegraphStore\` parity gate. The \`adapter-parity-extra\` test intentionally fails red when \`BLAZEGRAPH_URL\` is missing so a green pass cannot lie about parity coverage. \`blazegraph.ts\` hardened to surface engine errors clearly instead of silently falling back to a stub.
- **ST-2** — AES-GCM-SIV deterministic nonce derivation in \`private-store.ts\`. Previous derivation could collide for repeated plaintexts on the same key, breaking SIV's misuse-resistance guarantee.
- **ST-12** — Typed-literal round-trip preservation in \`oxigraph.ts\` (and \`blazegraph.ts\` parity). \`xsd:dateTime\` / \`xsd:integer\` / \`xsd:decimal\` values now round-trip with their explicit datatype IRIs intact; previously they were narrowed to \`xsd:string\` on read.

### Query bug fixes
- **Q-1** — \`minTrust\` enforcement in \`DKGQueryEngine\`. The threshold was documented but never actually filtered results below it; queries could return assets from nodes the operator had explicitly configured as untrusted.
- \`sparql-guard.ts\` — query-form detection now correctly distinguishes \`SELECT\` / \`CONSTRUCT\` / \`ASK\` / \`DESCRIBE\` before applying form-specific guards. Previously \`CONSTRUCT\` and \`DESCRIBE\` could bypass the read-only guard meant for \`SELECT\`.

### CI — Blazegraph service container
The storage shard now boots a real \`lyrasis/blazegraph:2.1.5\` container and provisions **two** quads-mode namespaces:
- \`dkgq\` — conformance / general storage suite (DROP-ALL tests)
- \`dkgq-parity\` — \`adapter-parity-extra\` (real Oxigraph ↔ Blazegraph parity)

Two namespaces (not one) because vitest parallelises files but serialises tests within a file: pointing the parity suite at the SAME namespace as the conformance suite let the latter's \`DROP ALL\` fire mid-parity and wipe the parity fixture.

Quads mode is required (not Blazegraph's default triples mode), otherwise \`GRAPH <…> { … }\` clauses are silently dropped on insert.

### Tests added
- \`private-store-key-resolution.test.ts\` (new, +895 lines)
- \`query-extra.test.ts\` (+1153 lines) — minTrust + per-cg trust isolation
- \`sparql-form-detection.test.ts\` (new, +400 lines)
- \`vitest.setup.ts\` (new) — per-file storage adapter setup

### Coverage ratchet
- \`tornadoStorageCoverage\` 57/52/39/53 → 85/81/63/79.

## Sequencing context

This is **slice 2 of 4** from the #327 split:
1. contracts + chain — #331 (open)
2. **This PR** — storage + query (~7k lines)
3. operator: cli + mcp-server + adapter-openclaw + core + epcis (~6.9k lines)
4. pipeline: publisher + agent + network-sim (~10.2k lines)

## Test plan

- [ ] CI green on this branch (Blazegraph service must boot and provision both namespaces)
- [ ] \`pnpm --filter @origintrail-official/dkg-storage test\` locally with \`BLAZEGRAPH_URL\` + \`BLAZEGRAPH_PARITY_URL\` set
- [ ] \`pnpm --filter @origintrail-official/dkg-query test\` locally
- [ ] Verify ST-2 with a quick fuzz: same plaintext + same key → distinct ciphertexts (no nonce collision)


Made with [Cursor](https://cursor.com)