### PR TITLE
Fix OpenClaw hook log noise

### DIFF
--- a/packages/adapter-openclaw/openclaw-entry.mjs
+++ b/packages/adapter-openclaw/openclaw-entry.mjs
@@ -90,19 +90,5 @@ export default function (api) {
     log.debug?.(`[dkg-entry] SKILL.md sync skipped: ${err.message}`);
   }
 
-  // Reset singleton on gateway teardown so in-process restart re-registers fresh.
-  // Listen on multiple lifecycle events - whichever the gateway version supports.
-  if (typeof api.on === 'function') {
-    const reset = () => {
-      if (instance) {
-        instance.stop().catch(() => {});
-      }
-      instance = null;
-    };
-    for (const event of ['shutdown', 'close', 'restart', 'reload']) {
-      api.on(event, reset);
-    }
-  }
-
   log.info?.('[dkg-entry] DkgNodePlugin registered');
 }

--- a/packages/adapter-openclaw/openclaw-entry.mjs
+++ b/packages/adapter-openclaw/openclaw-entry.mjs
@@ -6,6 +6,7 @@ import { DkgNodePlugin } from './dist/index.js';
 /** Module-level singleton - prevents duplicate registration during gateway multi-phase init. */
 let instance = null;
 const lifecycleServiceApis = new WeakMap();
+let lifecycleOwnerToken = null;
 
 export default function (api) {
   const log = api.logger ?? console;
@@ -101,11 +102,14 @@ function registerLifecycleService(api, log) {
   if (lifecycleServiceApis.get(api) === instance) return;
 
   const serviceInstance = instance;
+  const serviceToken = {};
   try {
     api.registerService({
       name: 'dkg-adapter-openclaw-runtime',
       start: async () => {},
       stop: async () => {
+        if (lifecycleOwnerToken !== serviceToken) return;
+        lifecycleOwnerToken = null;
         try {
           await serviceInstance.stop();
         } finally {
@@ -116,6 +120,7 @@ function registerLifecycleService(api, log) {
       },
     });
     lifecycleServiceApis.set(api, serviceInstance);
+    lifecycleOwnerToken = serviceToken;
   } catch (err) {
     log.debug?.(`[dkg-entry] lifecycle service registration skipped: ${err.message}`);
   }

--- a/packages/adapter-openclaw/openclaw-entry.mjs
+++ b/packages/adapter-openclaw/openclaw-entry.mjs
@@ -5,6 +5,7 @@ import { DkgNodePlugin } from './dist/index.js';
 
 /** Module-level singleton - prevents duplicate registration during gateway multi-phase init. */
 let instance = null;
+const lifecycleServiceApis = new WeakMap();
 
 export default function (api) {
   const log = api.logger ?? console;
@@ -12,6 +13,7 @@ export default function (api) {
   if (instance) {
     log.info?.('[dkg-entry] Re-registering plugin surfaces (channel, memory, tools) into new registry (gateway multi-phase init)');
     instance.register(api);
+    registerLifecycleService(api, log);
     return;
   }
 
@@ -63,6 +65,7 @@ export default function (api) {
   const dkg = new DkgNodePlugin(config);
   dkg.register(api);
   instance = dkg;
+  registerLifecycleService(api, log);
 
   // Sync SKILL.md to workspace so the agent always reads the latest version.
   // The CLI dist ships the canonical template; the workspace copy goes stale
@@ -91,4 +94,29 @@ export default function (api) {
   }
 
   log.info?.('[dkg-entry] DkgNodePlugin registered');
+}
+
+function registerLifecycleService(api, log) {
+  if (!instance || typeof api.registerService !== 'function') return;
+  if (lifecycleServiceApis.get(api) === instance) return;
+
+  const serviceInstance = instance;
+  try {
+    api.registerService({
+      name: 'dkg-adapter-openclaw-runtime',
+      start: async () => {},
+      stop: async () => {
+        try {
+          await serviceInstance.stop();
+        } finally {
+          if (instance === serviceInstance) {
+            instance = null;
+          }
+        }
+      },
+    });
+    lifecycleServiceApis.set(api, serviceInstance);
+  } catch (err) {
+    log.debug?.(`[dkg-entry] lifecycle service registration skipped: ${err.message}`);
+  }
 }

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -778,10 +778,10 @@ export class DkgNodePlugin {
           // re-assert anchor. Without the wrapper, turn persistence would
           // recover but slot ownership wouldn't bounce back per-message.
           if (internalNeedsRetry('message:received')) {
-            this.hookSurface.install('internal', 'message:received', this.makeMessageReceivedHandler());
+            this.hookSurface.install('internal', 'message:received', this.makeMessageReceivedHandler(), { rareFireExpected: true });
           }
           if (internalNeedsRetry('message:sent')) {
-            this.hookSurface.install('internal', 'message:sent', this.makeMessageSentHandler());
+            this.hookSurface.install('internal', 'message:sent', this.makeMessageSentHandler(), { rareFireExpected: true });
           }
           // T6 — Typed hook retries for setup-runtime → full upgrades on
           // the SAME api object. Without these, `before_prompt_build` and
@@ -808,7 +808,7 @@ export class DkgNodePlugin {
         // circuit (R21.1) prevents double-fires when the previous install
         // succeeded.
         if (legacyNeedsRetry('session_end')) {
-          this.hookSurface.install('legacy', 'session_end', () => this.stop());
+          this.hookSurface.install('legacy', 'session_end', () => this.stop(), { rareFireExpected: true });
         }
         // T11 — Re-evaluate prompt-section install on same-api re-register.
         // The first call under setup-runtime had `isFullMode === false` and
@@ -853,7 +853,7 @@ export class DkgNodePlugin {
     // Routing through `HookSurface.install('legacy', ...)` gives the
     // wrapper the soft-destroyed gate (R21.1) so old wrappers
     // short-circuit after `stop()` has already torn the surface down.
-    this.hookSurface.install('legacy', 'session_end', () => this.stop());
+    this.hookSurface.install('legacy', 'session_end', () => this.stop(), { rareFireExpected: true });
 
     // T52 — Runtime-only hooks (W3 auto-recall, W4a LLM turn capture,
     // W4b non-LLM channel capture) gate on `runtimeHooks`. In setup-
@@ -893,8 +893,8 @@ export class DkgNodePlugin {
     // install (globalThis hook map not yet created at first-register time)
     // still gets retried on the next surface.
     if (!internalHooksAlreadyLive) {
-      this.hookSurface.install('internal', 'message:received', this.makeMessageReceivedHandler());
-      this.hookSurface.install('internal', 'message:sent', this.makeMessageSentHandler());
+      this.hookSurface.install('internal', 'message:received', this.makeMessageReceivedHandler(), { rareFireExpected: true });
+      this.hookSurface.install('internal', 'message:sent', this.makeMessageSentHandler(), { rareFireExpected: true });
     }
 
     // I8 — tool-selection guidance injected into the system prompt every turn.

--- a/packages/adapter-openclaw/test/HookSurface.test.ts
+++ b/packages/adapter-openclaw/test/HookSurface.test.ts
@@ -285,6 +285,33 @@ describe("HookSurface", () => {
       const stats = hs.getDispatchStats();
       expect(stats["typed:agent_end"]?.commitState).toBe("committed-by-timeout");
     });
+
+    it("logs non-rare commit timeouts at warn", async () => {
+      const logger = mkLogger();
+      const hs = new HookSurface(mkApi(), logger, "auto", { commitGraceMs: 10 });
+      hs.install("typed", "agent_end", vi.fn());
+      await new Promise((r) => setTimeout(r, 30));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("typed:agent_end"));
+      expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining("typed:agent_end"));
+    });
+
+    it("logs rare-fire commit timeouts at debug for infrequent hooks", async () => {
+      const logger = mkLogger();
+      const hs = new HookSurface(mkApi(), logger, "auto", { commitGraceMs: 10 });
+      hs.install("legacy", "session_end", vi.fn(), { rareFireExpected: true });
+      hs.install("internal", "message:received", vi.fn(), { rareFireExpected: true });
+      hs.install("internal", "message:sent", vi.fn(), { rareFireExpected: true });
+      await new Promise((r) => setTimeout(r, 30));
+
+      const debugMessages = logger.debug.mock.calls.map((args) => String(args[0]));
+      const warnMessages = logger.warn.mock.calls.map((args) => String(args[0]));
+      expect(debugMessages.some((msg) => msg.includes("legacy:session_end"))).toBe(true);
+      expect(debugMessages.some((msg) => msg.includes("internal:message:received"))).toBe(true);
+      expect(debugMessages.some((msg) => msg.includes("internal:message:sent"))).toBe(true);
+      expect(warnMessages.some((msg) => msg.includes("legacy:session_end"))).toBe(false);
+      expect(warnMessages.some((msg) => msg.includes("internal:message:received"))).toBe(false);
+      expect(warnMessages.some((msg) => msg.includes("internal:message:sent"))).toBe(false);
+    });
   });
 
   describe("N5 partial-install policy", () => {

--- a/packages/adapter-openclaw/test/openclaw-entry.test.ts
+++ b/packages/adapter-openclaw/test/openclaw-entry.test.ts
@@ -35,6 +35,7 @@ describe('openclaw-entry', () => {
     const root = mkdtempSync(join(tmpdir(), 'openclaw-entry-test-'));
     tempRoots.push(root);
     mkdirSync(join(root, 'dist'), { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
     copyFileSync(new URL('../openclaw-entry.mjs', import.meta.url), join(root, 'openclaw-entry.mjs'));
     writeFileSync(
       join(root, 'dist', 'index.js'),

--- a/packages/adapter-openclaw/test/openclaw-entry.test.ts
+++ b/packages/adapter-openclaw/test/openclaw-entry.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const entrySource = () =>
+  readFileSync(new URL('../openclaw-entry.mjs', import.meta.url), 'utf8');
+
+describe('openclaw-entry', () => {
+  it('does not register stale lifecycle event names through api.on', () => {
+    const source = entrySource();
+
+    expect(source).not.toMatch(/api\.on\(\s*['"]shutdown['"]/);
+    expect(source).not.toMatch(/api\.on\(\s*['"]close['"]/);
+    expect(source).not.toMatch(/api\.on\(\s*['"]restart['"]/);
+    expect(source).not.toMatch(/api\.on\(\s*['"]reload['"]/);
+    expect(source).not.toMatch(/\[[^\]]*['"]shutdown['"][^\]]*['"]close['"][^\]]*['"]restart['"][^\]]*['"]reload['"][^\]]*\]/);
+    expect(source).not.toMatch(/api\.on\(\s*event\s*,\s*reset\s*\)/);
+  });
+
+  it('keeps singleton re-registration delegated to DkgNodePlugin.register', () => {
+    const source = entrySource();
+
+    expect(source).toMatch(/if\s*\(\s*instance\s*\)/);
+    expect(source).toMatch(/instance\.register\(api\)/);
+    expect(source).toMatch(/const dkg = new DkgNodePlugin\(config\)/);
+    expect(source).toMatch(/dkg\.register\(api\)/);
+  });
+});

--- a/packages/adapter-openclaw/test/openclaw-entry.test.ts
+++ b/packages/adapter-openclaw/test/openclaw-entry.test.ts
@@ -126,8 +126,15 @@ describe('openclaw-entry', () => {
     entry(firstApi);
     entry(secondApi);
 
+    const instance = globalThis.__openclawEntryTestInstances![0];
     expect(globalThis.__openclawEntryTestInstances).toHaveLength(1);
-    expect(globalThis.__openclawEntryTestInstances![0].registerCalls).toEqual([firstApi, secondApi]);
+    expect(instance.registerCalls).toEqual([firstApi, secondApi]);
     expect(secondApi.registerService).toHaveBeenCalledTimes(1);
+
+    await firstApi.services[0].stop();
+    expect(instance.stopCalls).toBe(0);
+
+    await secondApi.services[0].stop();
+    expect(instance.stopCalls).toBe(1);
   });
 });

--- a/packages/adapter-openclaw/test/openclaw-entry.test.ts
+++ b/packages/adapter-openclaw/test/openclaw-entry.test.ts
@@ -1,27 +1,133 @@
-import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const entrySource = () =>
-  readFileSync(new URL('../openclaw-entry.mjs', import.meta.url), 'utf8');
+type CapturedService = {
+  name: string;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+};
+
+type FakePluginInstance = {
+  config: any;
+  registerCalls: any[];
+  stopCalls: number;
+};
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __openclawEntryTestInstances: FakePluginInstance[] | undefined;
+}
 
 describe('openclaw-entry', () => {
-  it('does not register stale lifecycle event names through api.on', () => {
-    const source = entrySource();
+  const tempRoots: string[] = [];
 
-    expect(source).not.toMatch(/api\.on\(\s*['"]shutdown['"]/);
-    expect(source).not.toMatch(/api\.on\(\s*['"]close['"]/);
-    expect(source).not.toMatch(/api\.on\(\s*['"]restart['"]/);
-    expect(source).not.toMatch(/api\.on\(\s*['"]reload['"]/);
-    expect(source).not.toMatch(/\[[^\]]*['"]shutdown['"][^\]]*['"]close['"][^\]]*['"]restart['"][^\]]*['"]reload['"][^\]]*\]/);
-    expect(source).not.toMatch(/api\.on\(\s*event\s*,\s*reset\s*\)/);
+  afterEach(() => {
+    delete globalThis.__openclawEntryTestInstances;
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
-  it('keeps singleton re-registration delegated to DkgNodePlugin.register', () => {
-    const source = entrySource();
+  async function loadEntryWithFakeRuntime() {
+    const root = mkdtempSync(join(tmpdir(), 'openclaw-entry-test-'));
+    tempRoots.push(root);
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    copyFileSync(new URL('../openclaw-entry.mjs', import.meta.url), join(root, 'openclaw-entry.mjs'));
+    writeFileSync(
+      join(root, 'dist', 'index.js'),
+      [
+        'export class DkgNodePlugin {',
+        '  constructor(config) {',
+        '    this.config = config;',
+        '    this.registerCalls = [];',
+        '    this.stopCalls = 0;',
+        '    globalThis.__openclawEntryTestInstances ??= [];',
+        '    globalThis.__openclawEntryTestInstances.push(this);',
+        '  }',
+        '  register(api) { this.registerCalls.push(api); }',
+        '  async stop() { this.stopCalls += 1; }',
+        '}',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
 
-    expect(source).toMatch(/if\s*\(\s*instance\s*\)/);
-    expect(source).toMatch(/instance\.register\(api\)/);
-    expect(source).toMatch(/const dkg = new DkgNodePlugin\(config\)/);
-    expect(source).toMatch(/dkg\.register\(api\)/);
+    const href = `${pathToFileURL(join(root, 'openclaw-entry.mjs')).href}?t=${Date.now()}-${Math.random()}`;
+    return (await import(href)).default as (api: any) => void;
+  }
+
+  function makeApi(daemonUrl: string) {
+    const services: CapturedService[] = [];
+    return {
+      cfg: {
+        plugins: {
+          entries: {
+            'adapter-openclaw': {
+              config: {
+                daemonUrl,
+                memory: { enabled: true },
+                channel: { enabled: false },
+              },
+            },
+          },
+        },
+      },
+      registerService: vi.fn((service: CapturedService) => { services.push(service); }),
+      registerTool: vi.fn(),
+      registerHook: vi.fn(),
+      on: vi.fn(),
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      services,
+    };
+  }
+
+  it('does not register stale lifecycle event names through api.on', async () => {
+    const entry = await loadEntryWithFakeRuntime();
+    const api = makeApi('http://127.0.0.1:9200');
+
+    entry(api);
+
+    const registeredEvents = api.on.mock.calls.map((call) => call[0]);
+    expect(registeredEvents).not.toContain('shutdown');
+    expect(registeredEvents).not.toContain('close');
+    expect(registeredEvents).not.toContain('restart');
+    expect(registeredEvents).not.toContain('reload');
+  });
+
+  it('uses registerService stop to clear the singleton so reloads pick up fresh config', async () => {
+    const entry = await loadEntryWithFakeRuntime();
+    const firstApi = makeApi('http://127.0.0.1:9200');
+    const secondApi = makeApi('http://127.0.0.1:9300');
+
+    entry(firstApi);
+    const firstInstance = globalThis.__openclawEntryTestInstances![0];
+    expect(firstInstance.config.daemonUrl).toBe('http://127.0.0.1:9200');
+    expect(firstApi.registerService).toHaveBeenCalledTimes(1);
+    expect(firstApi.services[0].name).toBe('dkg-adapter-openclaw-runtime');
+
+    await firstApi.services[0].stop();
+    expect(firstInstance.stopCalls).toBe(1);
+
+    entry(secondApi);
+    const secondInstance = globalThis.__openclawEntryTestInstances![1];
+    expect(globalThis.__openclawEntryTestInstances).toHaveLength(2);
+    expect(secondInstance).not.toBe(firstInstance);
+    expect(secondInstance.config.daemonUrl).toBe('http://127.0.0.1:9300');
+  });
+
+  it('keeps multi-phase singleton re-registration delegated to DkgNodePlugin.register before teardown', async () => {
+    const entry = await loadEntryWithFakeRuntime();
+    const firstApi = makeApi('http://127.0.0.1:9200');
+    const secondApi = makeApi('http://127.0.0.1:9300');
+
+    entry(firstApi);
+    entry(secondApi);
+
+    expect(globalThis.__openclawEntryTestInstances).toHaveLength(1);
+    expect(globalThis.__openclawEntryTestInstances![0].registerCalls).toEqual([firstApi, secondApi]);
+    expect(secondApi.registerService).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import { toEip55Checksum } from '@origintrail-official/dkg-core';
 import { DkgNodePlugin } from '../src/DkgNodePlugin.js';
 import { DkgChannelPlugin } from '../src/DkgChannelPlugin.js';
+import { INTERNAL_HOOK_SYMBOL } from '../src/HookSurface.js';
 import type { OpenClawPluginApi, OpenClawTool } from '../src/types.js';
 
 describe('DkgNodePlugin', () => {
@@ -3396,6 +3397,49 @@ describe('DkgNodePlugin', () => {
     expect(typedEvents).toContain('agent_end');
     expect(typedEvents).toContain('before_compaction');
     expect(typedEvents).toContain('before_reset');
+  });
+
+  it('marks session_end and internal message hooks as rare-fire so startup timeout diagnostics stay quiet', async () => {
+    vi.useFakeTimers();
+    const previousHookMap = (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+    (globalThis as any)[INTERNAL_HOOK_SYMBOL] = new Map();
+    const plugin = new DkgNodePlugin({
+      daemonUrl: 'http://localhost:9200',
+      channel: { enabled: false },
+      memory: { enabled: false },
+    });
+    const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    const mockApi: OpenClawPluginApi = {
+      config: {},
+      registrationMode: 'full',
+      registerTool: () => {},
+      registerHook: vi.fn(),
+      on: vi.fn(),
+      logger,
+    };
+
+    try {
+      plugin.register(mockApi);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const debugMessages = logger.debug.mock.calls.map((args) => String(args[0]));
+      const warnMessages = logger.warn.mock.calls.map((args) => String(args[0]));
+      expect(debugMessages.some((msg) => msg.includes("legacy:session_end"))).toBe(true);
+      expect(debugMessages.some((msg) => msg.includes("internal:message:received"))).toBe(true);
+      expect(debugMessages.some((msg) => msg.includes("internal:message:sent"))).toBe(true);
+      expect(warnMessages.some((msg) => msg.includes("legacy:session_end"))).toBe(false);
+      expect(warnMessages.some((msg) => msg.includes("internal:message:received"))).toBe(false);
+      expect(warnMessages.some((msg) => msg.includes("internal:message:sent"))).toBe(false);
+      expect(warnMessages.some((msg) => msg.includes("typed:agent_end"))).toBe(true);
+    } finally {
+      await plugin.stop();
+      if (previousHookMap === undefined) {
+        delete (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+      } else {
+        (globalThis as any)[INTERNAL_HOOK_SYMBOL] = previousHookMap;
+      }
+      vi.useRealTimers();
+    }
   });
 
   it('R14.2 — handleBeforePromptBuild returns undefined when memoryPlugin exists but is not registered (slot owned by another plugin)', async () => {


### PR DESCRIPTION
## Summary

- Remove stale `openclaw-entry.mjs` lifecycle listener registrations for `shutdown`, `close`, `restart`, and `reload`, which the gateway treats as unknown typed hooks.
- Keep in-process reload safe by registering a supported `dkg-adapter-openclaw-runtime` service stop hook that drains the current plugin and clears the entry singleton before the next load reads fresh config.
- Mark legitimate infrequent hooks as rare-fire expected so startup timeout diagnostics for `session_end`, `internal:message:received`, and `internal:message:sent` downgrade to debug instead of warning.
- Preserve warning-level diagnostics for non-rare hook timeout behavior and add focused regression coverage.

## Related

- Closes #328
- Closes #329

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/openclaw-entry.mjs` | Removes stale unsupported lifecycle listener registration and adds supported service-stop singleton teardown. |
| `packages/adapter-openclaw/src/DkgNodePlugin.ts` | Tags `session_end` and internal message hooks as rare-fire expected in initial and retry install paths. |
| `packages/adapter-openclaw/test/openclaw-entry.test.ts` | Adds executable temp-entry regression coverage for unsupported listener removal, service-stop singleton reset, and fresh config after reload. |
| `packages/adapter-openclaw/test/HookSurface.test.ts` | Verifies rare hook timeouts log at debug while non-rare timeouts still warn. |
| `packages/adapter-openclaw/test/plugin.test.ts` | Verifies plugin-installed rare hooks stay quiet at warn level while a common typed hook still warns. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-core build` - passed; required so adapter tests can resolve the workspace package entry.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test -- test/openclaw-entry.test.ts` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test -- test/HookSurface.test.ts` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test -- test/plugin.test.ts` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw build` - passed.
- [ ] `pnpm --filter @origintrail-official/dkg-adapter-openclaw test` - ran; fails on existing unrelated `[K-9] openclaw.plugin.json id matches package.json name (RED until reconciled)` at `test/adapter-openclaw-extra.test.ts:286`. All other adapter test files passed in that run.