### PR TITLE
fix(openclaw): align DKG home and state-dir resolution

### DIFF
--- a/packages/adapter-openclaw/openclaw.plugin.json
+++ b/packages/adapter-openclaw/openclaw.plugin.json
@@ -13,6 +13,10 @@
         "default": "http://127.0.0.1:9200",
         "description": "DKG daemon HTTP URL"
       },
+      "stateDir": {
+        "type": "string",
+        "description": "Directory for adapter runtime state such as chat-turn watermarks. Setup writes a workspace-scoped default when available."
+      },
       "memory": {
         "type": "object",
         "properties": {

--- a/packages/adapter-openclaw/openclaw.plugin.json
+++ b/packages/adapter-openclaw/openclaw.plugin.json
@@ -17,6 +17,15 @@
         "type": "string",
         "description": "Directory for adapter runtime state such as chat-turn watermarks. Setup writes a workspace-scoped default when available."
       },
+      "stateDirSource": {
+        "type": "string",
+        "enum": ["setup-default"],
+        "description": "Internal setup metadata marking stateDir as the setup-written workspace default."
+      },
+      "installedWorkspace": {
+        "type": "string",
+        "description": "Internal setup metadata for the workspace that installed this adapter entry."
+      },
       "memory": {
         "type": "object",
         "properties": {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -584,8 +584,8 @@ export class DkgNodePlugin {
     // state. Fall back order:
     //   1. `runtime.state.resolveStateDir()` — gateway-provided, workspace-scoped.
     //   2. `OPENCLAW_STATE_DIR` env override — operator-controlled, opt-in.
-    //   3. `config.stateDir` — setup-persisted, workspace-scoped default.
-    //   4. `api.workspaceDir + .openclaw` — workspace-scoped derived path.
+    //   3. `api.workspaceDir + .openclaw` — gateway-provided current workspace.
+    //   4. `config.stateDir` — setup-persisted fallback for older gateways.
     //   5. `~/.openclaw` — last resort; logged as a warning so ops can fix.
     const workspaceDir = (api as any)?.workspaceDir;
     const homeDir = `${homedir()}/.openclaw`;
@@ -605,8 +605,8 @@ export class DkgNodePlugin {
     const stateDir =
       trimmedNonEmpty((api as any)?.runtime?.state?.resolveStateDir?.()) ??
       trimmedNonEmpty(process.env.OPENCLAW_STATE_DIR) ??
-      trimmedNonEmpty(this.config.stateDir) ??
       (trimmedWorkspaceDir ? `${trimmedWorkspaceDir}/.openclaw` : undefined) ??
+      trimmedNonEmpty(this.config.stateDir) ??
       homeDir;
 
     if (this.chatTurnWriter) {
@@ -661,7 +661,7 @@ export class DkgNodePlugin {
 
     if (stateDir === homeDir) {
       api.logger.warn?.(
-        '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / config.stateDir / api.workspaceDir all unavailable); ' +
+        '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / api.workspaceDir / config.stateDir all unavailable); ' +
         `falling back to '${homeDir}'. Two workspaces on the same machine will share chat-turn watermarks. ` +
         'Set config.stateDir or OPENCLAW_STATE_DIR explicitly to silence this.',
       );

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -45,8 +45,8 @@ import type {
   OpenClawToolResult,
 } from './types.js';
 import { homedir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
-import { existsSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { canonicalPathForCompare } from './state-dir-path.js';
 
 // T44 — same regex as `dkg-core/src/dkg-home.ts` ETH_ADDR_RE. Kept
 // duplicated rather than exposed from dkg-core because the adapter's
@@ -55,24 +55,6 @@ import { existsSync, realpathSync } from 'node:fs';
 const ETH_ADDR_RE_LC = /^0x[0-9a-f]{40}$/;
 function isValidEthAddressString(value: string | undefined): boolean {
   return typeof value === 'string' && ETH_ADDR_RE_LC.test(value.trim().toLowerCase());
-}
-
-function canonicalPathForCompare(path: string): string {
-  const absolute = resolve(path);
-  const missingParts: string[] = [];
-  let existing = absolute;
-  while (!existsSync(existing)) {
-    const parent = dirname(existing);
-    if (parent === existing) break;
-    missingParts.unshift(existing.slice(parent.length + 1));
-    existing = parent;
-  }
-
-  let canonicalBase = existing;
-  try { canonicalBase = realpathSync(existing); } catch { /* keep resolved fallback */ }
-  const canonical = missingParts.reduce((acc, part) => join(acc, part), canonicalBase);
-  const normalized = resolve(canonical);
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
 const OPENCLAW_LOCAL_AGENT_CAPABILITIES = {

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -584,8 +584,9 @@ export class DkgNodePlugin {
     // state. Fall back order:
     //   1. `runtime.state.resolveStateDir()` — gateway-provided, workspace-scoped.
     //   2. `OPENCLAW_STATE_DIR` env override — operator-controlled, opt-in.
-    //   3. `api.workspaceDir + .openclaw` — workspace-scoped derived path.
-    //   4. `~/.openclaw` — last resort; logged as a warning so ops can fix.
+    //   3. `config.stateDir` — setup-persisted, workspace-scoped default.
+    //   4. `api.workspaceDir + .openclaw` — workspace-scoped derived path.
+    //   5. `~/.openclaw` — last resort; logged as a warning so ops can fix.
     const workspaceDir = (api as any)?.workspaceDir;
     const homeDir = `${homedir()}/.openclaw`;
     // T26 — Normalize each source through trim+non-empty before the
@@ -604,6 +605,7 @@ export class DkgNodePlugin {
     const stateDir =
       trimmedNonEmpty((api as any)?.runtime?.state?.resolveStateDir?.()) ??
       trimmedNonEmpty(process.env.OPENCLAW_STATE_DIR) ??
+      trimmedNonEmpty(this.config.stateDir) ??
       (trimmedWorkspaceDir ? `${trimmedWorkspaceDir}/.openclaw` : undefined) ??
       homeDir;
 
@@ -659,9 +661,9 @@ export class DkgNodePlugin {
 
     if (stateDir === homeDir) {
       api.logger.warn?.(
-        '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / api.workspaceDir all unavailable); ' +
+        '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / config.stateDir / api.workspaceDir all unavailable); ' +
         `falling back to '${homeDir}'. Two workspaces on the same machine will share chat-turn watermarks. ` +
-        'Set OPENCLAW_STATE_DIR explicitly to silence this.',
+        'Set config.stateDir or OPENCLAW_STATE_DIR explicitly to silence this.',
       );
     }
     this.chatTurnWriter = new ChatTurnWriter({ client: this.client, logger: api.logger, stateDir });

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -45,7 +45,8 @@ import type {
   OpenClawToolResult,
 } from './types.js';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
 
 // T44 — same regex as `dkg-core/src/dkg-home.ts` ETH_ADDR_RE. Kept
 // duplicated rather than exposed from dkg-core because the adapter's
@@ -54,6 +55,24 @@ import { join, resolve } from 'node:path';
 const ETH_ADDR_RE_LC = /^0x[0-9a-f]{40}$/;
 function isValidEthAddressString(value: string | undefined): boolean {
   return typeof value === 'string' && ETH_ADDR_RE_LC.test(value.trim().toLowerCase());
+}
+
+function canonicalPathForCompare(path: string): string {
+  const absolute = resolve(path);
+  const missingParts: string[] = [];
+  let existing = absolute;
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) break;
+    missingParts.unshift(existing.slice(parent.length + 1));
+    existing = parent;
+  }
+
+  let canonicalBase = existing;
+  try { canonicalBase = realpathSync(existing); } catch { /* keep resolved fallback */ }
+  const canonical = missingParts.reduce((acc, part) => join(acc, part), canonicalBase);
+  const normalized = resolve(canonical);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
 const OPENCLAW_LOCAL_AGENT_CAPABILITIES = {
@@ -607,14 +626,10 @@ export class DkgNodePlugin {
     const configuredStateDir = trimmedNonEmpty(this.config.stateDir);
     const setupWorkspaceDir = trimmedNonEmpty(this.config.installedWorkspace);
     const setupDefaultStateDir = setupWorkspaceDir ? join(setupWorkspaceDir, '.openclaw') : undefined;
-    const normalizeForCompare = (path: string): string => {
-      const normalized = resolve(path);
-      return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-    };
     const configuredIsSetupDefault =
       !!configuredStateDir &&
       !!setupDefaultStateDir &&
-      normalizeForCompare(configuredStateDir) === normalizeForCompare(setupDefaultStateDir);
+      canonicalPathForCompare(configuredStateDir) === canonicalPathForCompare(setupDefaultStateDir);
     const workspaceStateDir = trimmedWorkspaceDir ? join(trimmedWorkspaceDir, '.openclaw') : undefined;
     const stateDir =
       trimmedNonEmpty((api as any)?.runtime?.state?.resolveStateDir?.()) ??

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -45,6 +45,7 @@ import type {
   OpenClawToolResult,
 } from './types.js';
 import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 // T44 — same regex as `dkg-core/src/dkg-home.ts` ETH_ADDR_RE. Kept
 // duplicated rather than exposed from dkg-core because the adapter's
@@ -584,9 +585,10 @@ export class DkgNodePlugin {
     // state. Fall back order:
     //   1. `runtime.state.resolveStateDir()` — gateway-provided, workspace-scoped.
     //   2. `OPENCLAW_STATE_DIR` env override — operator-controlled, opt-in.
-    //   3. `api.workspaceDir + .openclaw` — gateway-provided current workspace.
-    //   4. `config.stateDir` — setup-persisted fallback for older gateways.
-    //   5. `~/.openclaw` — last resort; logged as a warning so ops can fix.
+    //   3. explicit `config.stateDir` — user-controlled config override.
+    //   4. `api.workspaceDir + .openclaw` — gateway-provided current workspace.
+    //   5. setup-owned `config.stateDir` — fallback for older gateways.
+    //   6. `~/.openclaw` — last resort; logged as a warning so ops can fix.
     const workspaceDir = (api as any)?.workspaceDir;
     const homeDir = `${homedir()}/.openclaw`;
     // T26 — Normalize each source through trim+non-empty before the
@@ -602,11 +604,24 @@ export class DkgNodePlugin {
       return t.length > 0 ? t : undefined;
     };
     const trimmedWorkspaceDir = trimmedNonEmpty(workspaceDir);
+    const configuredStateDir = trimmedNonEmpty(this.config.stateDir);
+    const setupWorkspaceDir = trimmedNonEmpty(this.config.installedWorkspace);
+    const setupDefaultStateDir = setupWorkspaceDir ? join(setupWorkspaceDir, '.openclaw') : undefined;
+    const normalizeForCompare = (path: string): string => {
+      const normalized = resolve(path);
+      return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+    };
+    const configuredIsSetupDefault =
+      !!configuredStateDir &&
+      !!setupDefaultStateDir &&
+      normalizeForCompare(configuredStateDir) === normalizeForCompare(setupDefaultStateDir);
+    const workspaceStateDir = trimmedWorkspaceDir ? join(trimmedWorkspaceDir, '.openclaw') : undefined;
     const stateDir =
       trimmedNonEmpty((api as any)?.runtime?.state?.resolveStateDir?.()) ??
       trimmedNonEmpty(process.env.OPENCLAW_STATE_DIR) ??
-      (trimmedWorkspaceDir ? `${trimmedWorkspaceDir}/.openclaw` : undefined) ??
-      trimmedNonEmpty(this.config.stateDir) ??
+      (!configuredIsSetupDefault ? configuredStateDir : undefined) ??
+      workspaceStateDir ??
+      configuredStateDir ??
       homeDir;
 
     if (this.chatTurnWriter) {
@@ -661,7 +676,7 @@ export class DkgNodePlugin {
 
     if (stateDir === homeDir) {
       api.logger.warn?.(
-        '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / api.workspaceDir / config.stateDir all unavailable); ' +
+        '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / config.stateDir / api.workspaceDir all unavailable); ' +
         `falling back to '${homeDir}'. Two workspaces on the same machine will share chat-turn watermarks. ` +
         'Set config.stateDir or OPENCLAW_STATE_DIR explicitly to silence this.',
       );

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -642,20 +642,33 @@ export class DkgNodePlugin {
     if (this.chatTurnWriter) {
       // T18 — Already constructed. If a better stateDir is now
       // available, in-place migrate the writer to the new location.
-      // Only upgrade fallback → workspace-scoped; never the other
-      // direction. Same-path is a no-op.
-      if (this.chatTurnWriterStateDir === stateDir) return;
+      // Only upgrade fallback/setup-owned defaults to a better source;
+      // never migrate away from an explicit user-owned stateDir. Same-path
+      // is a no-op, with canonical comparison covering symlink aliases.
+      const currentStateDir = this.chatTurnWriterStateDir;
+      if (!currentStateDir) return;
+      const currentCanonicalStateDir = canonicalPathForCompare(currentStateDir);
+      const nextCanonicalStateDir = canonicalPathForCompare(stateDir);
+      if (currentCanonicalStateDir === nextCanonicalStateDir) return;
       // T24 — Suppress re-trigger when an async migration to this
       // exact stateDir is already in flight. Without this, two
       // concurrent register() calls before the migration settles
       // would launch two `setStateDir` promises racing on the same
       // writer state.
       if (this.chatTurnWriterMigrationTarget === stateDir) return;
-      const wasFallback = this.chatTurnWriterStateDir === homeDir;
-      const isUpgrade = wasFallback && stateDir !== homeDir;
+      const homeCanonicalStateDir = canonicalPathForCompare(homeDir);
+      const wasFallback = currentCanonicalStateDir === homeCanonicalStateDir;
+      const wasSetupDefault =
+        configuredIsSetupDefault &&
+        !!configuredStateDir &&
+        currentCanonicalStateDir === canonicalPathForCompare(configuredStateDir);
+      const isUpgrade =
+        (wasFallback || wasSetupDefault) &&
+        nextCanonicalStateDir !== homeCanonicalStateDir;
       if (!isUpgrade) return; // Don't downgrade or sidestep.
+      const sourceLabel = wasFallback ? `fallback '${homeDir}'` : `setup-owned '${currentStateDir}'`;
       api.logger.info?.(
-        `[dkg] Migrating ChatTurnWriter stateDir from fallback '${homeDir}' to workspace-scoped '${stateDir}'.`,
+        `[dkg] Migrating ChatTurnWriter stateDir from ${sourceLabel} to '${stateDir}'.`,
       );
       // T21/T22 — `setStateDir` is async: it `await flush()`s
       // in-flight persists/resets/chains BEFORE swapping paths

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -624,9 +624,11 @@ export class DkgNodePlugin {
     };
     const trimmedWorkspaceDir = trimmedNonEmpty(workspaceDir);
     const configuredStateDir = trimmedNonEmpty(this.config.stateDir);
+    const configuredStateDirSource = trimmedNonEmpty(this.config.stateDirSource);
     const setupWorkspaceDir = trimmedNonEmpty(this.config.installedWorkspace);
     const setupDefaultStateDir = setupWorkspaceDir ? join(setupWorkspaceDir, '.openclaw') : undefined;
     const configuredIsSetupDefault =
+      configuredStateDirSource === 'setup-default' &&
       !!configuredStateDir &&
       !!setupDefaultStateDir &&
       canonicalPathForCompare(configuredStateDir) === canonicalPathForCompare(setupDefaultStateDir);
@@ -655,7 +657,10 @@ export class DkgNodePlugin {
       // concurrent register() calls before the migration settles
       // would launch two `setStateDir` promises racing on the same
       // writer state.
-      if (this.chatTurnWriterMigrationTarget === stateDir) return;
+      if (
+        this.chatTurnWriterMigrationTarget &&
+        canonicalPathForCompare(this.chatTurnWriterMigrationTarget) === nextCanonicalStateDir
+      ) return;
       const homeCanonicalStateDir = canonicalPathForCompare(homeDir);
       const wasFallback = currentCanonicalStateDir === homeCanonicalStateDir;
       const wasSetupDefault =

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -67,6 +67,23 @@ const OPENCLAW_LOCAL_AGENT_CAPABILITIES = {
   nodeServedSkill: true,
 } as const;
 
+type ChatTurnWriterStateDirSource =
+  | 'runtime'
+  | 'env'
+  | 'config'
+  | 'workspace'
+  | 'setup-default'
+  | 'home';
+
+const STATE_DIR_SOURCE_PRIORITY: Record<ChatTurnWriterStateDirSource, number> = {
+  runtime: 0,
+  env: 1,
+  config: 2,
+  workspace: 3,
+  'setup-default': 4,
+  home: 5,
+};
+
 const OPENCLAW_LOCAL_AGENT_MANIFEST = {
   packageName: '@origintrail-official/dkg-adapter-openclaw',
   setupEntry: './setup-entry.mjs',
@@ -196,6 +213,7 @@ export class DkgNodePlugin {
   // when a better (workspace-scoped) path becomes available and rebuild
   // the writer at the upgraded location.
   private chatTurnWriterStateDir: string | null = null;
+  private chatTurnWriterStateDirSource: ChatTurnWriterStateDirSource | null = null;
   // T24 — Tracks the target stateDir of an in-flight async migration.
   // The migration is fire-and-forget from `register()` so we need a
   // separate flag from `chatTurnWriterStateDir` (which only flips on
@@ -615,20 +633,53 @@ export class DkgNodePlugin {
       !!setupDefaultStateDir &&
       canonicalPathForCompare(configuredStateDir) === canonicalPathForCompare(setupDefaultStateDir);
     const workspaceStateDir = trimmedWorkspaceDir ? join(trimmedWorkspaceDir, '.openclaw') : undefined;
-    const stateDir =
-      trimmedNonEmpty((api as any)?.runtime?.state?.resolveStateDir?.()) ??
-      trimmedNonEmpty(process.env.OPENCLAW_STATE_DIR) ??
-      (!configuredIsSetupDefault ? configuredStateDir : undefined) ??
-      workspaceStateDir ??
-      configuredStateDir ??
-      homeDir;
+    const runtimeStateDir = trimmedNonEmpty((api as any)?.runtime?.state?.resolveStateDir?.());
+    const envStateDir = trimmedNonEmpty(process.env.OPENCLAW_STATE_DIR);
+    let stateDir = homeDir;
+    let stateDirSource: ChatTurnWriterStateDirSource = 'home';
+    if (runtimeStateDir) {
+      stateDir = runtimeStateDir;
+      stateDirSource = 'runtime';
+    } else if (envStateDir) {
+      stateDir = envStateDir;
+      stateDirSource = 'env';
+    } else if (!configuredIsSetupDefault && configuredStateDir) {
+      stateDir = configuredStateDir;
+      stateDirSource = 'config';
+    } else if (workspaceStateDir) {
+      stateDir = workspaceStateDir;
+      stateDirSource = 'workspace';
+    } else if (configuredStateDir) {
+      stateDir = configuredStateDir;
+      stateDirSource = 'setup-default';
+    }
+
+    const inferCurrentStateDirSource = (currentStateDir: string): ChatTurnWriterStateDirSource => {
+      const current = canonicalPathForCompare(currentStateDir);
+      const matches = (candidate: string | undefined): boolean =>
+        !!candidate && current === canonicalPathForCompare(candidate);
+      if (matches(runtimeStateDir)) return 'runtime';
+      if (matches(envStateDir)) return 'env';
+      if (matches(configuredStateDir)) return configuredIsSetupDefault ? 'setup-default' : 'config';
+      if (matches(workspaceStateDir)) return 'workspace';
+      if (current === canonicalPathForCompare(homeDir)) return 'home';
+      return 'config';
+    };
+    const canMigrateWithinSource = (source: ChatTurnWriterStateDirSource): boolean =>
+      source === 'runtime' || source === 'env' || source === 'workspace';
+    const stateDirSourceLabel = (source: ChatTurnWriterStateDirSource, currentStateDir: string): string => {
+      if (source === 'home') return `fallback '${homeDir}'`;
+      if (source === 'setup-default') return `setup-owned '${currentStateDir}'`;
+      return `${source} '${currentStateDir}'`;
+    };
 
     if (this.chatTurnWriter) {
       // T18 — Already constructed. If a better stateDir is now
       // available, in-place migrate the writer to the new location.
-      // Only upgrade fallback/setup-owned defaults to a better source;
-      // never migrate away from an explicit user-owned stateDir. Same-path
-      // is a no-op, with canonical comparison covering symlink aliases.
+      // Migrate only when the newly resolved source outranks the source that
+      // created the writer, or when the same dynamic source changed value.
+      // Same-path is a no-op, with canonical comparison covering symlink
+      // aliases.
       const currentStateDir = this.chatTurnWriterStateDir;
       if (!currentStateDir) return;
       const currentCanonicalStateDir = canonicalPathForCompare(currentStateDir);
@@ -643,17 +694,19 @@ export class DkgNodePlugin {
         this.chatTurnWriterMigrationTarget &&
         canonicalPathForCompare(this.chatTurnWriterMigrationTarget) === nextCanonicalStateDir
       ) return;
-      const homeCanonicalStateDir = canonicalPathForCompare(homeDir);
-      const wasFallback = currentCanonicalStateDir === homeCanonicalStateDir;
-      const wasSetupDefault =
-        configuredIsSetupDefault &&
-        !!configuredStateDir &&
-        currentCanonicalStateDir === canonicalPathForCompare(configuredStateDir);
+      const currentStateDirSource =
+        this.chatTurnWriterStateDirSource ?? inferCurrentStateDirSource(currentStateDir);
       const isUpgrade =
-        (wasFallback || wasSetupDefault) &&
-        nextCanonicalStateDir !== homeCanonicalStateDir;
+        (
+          STATE_DIR_SOURCE_PRIORITY[stateDirSource] < STATE_DIR_SOURCE_PRIORITY[currentStateDirSource] ||
+          (
+            stateDirSource === currentStateDirSource &&
+            canMigrateWithinSource(stateDirSource)
+          )
+        ) &&
+        stateDirSource !== 'home';
       if (!isUpgrade) return; // Don't downgrade or sidestep.
-      const sourceLabel = wasFallback ? `fallback '${homeDir}'` : `setup-owned '${currentStateDir}'`;
+      const sourceLabel = stateDirSourceLabel(currentStateDirSource, currentStateDir);
       api.logger.info?.(
         `[dkg] Migrating ChatTurnWriter stateDir from ${sourceLabel} to '${stateDir}'.`,
       );
@@ -677,6 +730,7 @@ export class DkgNodePlugin {
       this.chatTurnWriter.setStateDir(stateDir).then(
         () => {
           this.chatTurnWriterStateDir = stateDir;
+          this.chatTurnWriterStateDirSource = stateDirSource;
           this.chatTurnWriterMigrationTarget = null;
         },
         (err: any) => {
@@ -689,7 +743,7 @@ export class DkgNodePlugin {
       return;
     }
 
-    if (stateDir === homeDir) {
+    if (stateDirSource === 'home') {
       api.logger.warn?.(
         '[dkg] Could not resolve a workspace-scoped state dir (api.runtime.state.resolveStateDir / OPENCLAW_STATE_DIR / config.stateDir / api.workspaceDir all unavailable); ' +
         `falling back to '${homeDir}'. Two workspaces on the same machine will share chat-turn watermarks. ` +
@@ -698,6 +752,7 @@ export class DkgNodePlugin {
     }
     this.chatTurnWriter = new ChatTurnWriter({ client: this.client, logger: api.logger, stateDir });
     this.chatTurnWriterStateDir = stateDir;
+    this.chatTurnWriterStateDirSource = stateDirSource;
   }
 
 

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -122,7 +122,7 @@ function isEphemeralPath(p: string): boolean {
 }
 
 function dkgDir(): string {
-  return resolveDkgConfigHome();
+  return resolveDkgConfigHome({ startDir: __dirname });
 }
 
 function openclawDir(): string {

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -29,6 +29,7 @@ import { isDeepStrictEqual } from 'node:util';
 import { requestFaucetFunding, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
 import type { DkgOpenClawConfig } from './types.js';
 import { resolveDkgCli } from './resolve-dkg-cli.js';
+import { sameResolvedPath } from './state-dir-path.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -824,28 +825,6 @@ export type AdapterEntryConfig = Pick<
 
 function defaultStateDirForWorkspace(workspaceDir: string): string {
   return join(workspaceDir, '.openclaw');
-}
-
-function canonicalPathForCompare(path: string): string {
-  const absolute = resolve(path);
-  const missingParts: string[] = [];
-  let existing = absolute;
-  while (!existsSync(existing)) {
-    const parent = dirname(existing);
-    if (parent === existing) break;
-    missingParts.unshift(existing.slice(parent.length + 1));
-    existing = parent;
-  }
-
-  let canonicalBase = existing;
-  try { canonicalBase = realpathSync(existing); } catch { /* keep resolved fallback */ }
-  const canonical = missingParts.reduce((acc, part) => join(acc, part), canonicalBase);
-  const normalized = resolve(canonical);
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-}
-
-function sameResolvedPath(a: string, b: string): boolean {
-  return canonicalPathForCompare(a) === canonicalPathForCompare(b);
 }
 
 export function mergeOpenClawConfig(

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -26,7 +26,7 @@ import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
-import { requestFaucetFunding } from '@origintrail-official/dkg-core';
+import { requestFaucetFunding, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
 import type { DkgOpenClawConfig } from './types.js';
 import { resolveDkgCli } from './resolve-dkg-cli.js';
 
@@ -122,7 +122,7 @@ function isEphemeralPath(p: string): boolean {
 }
 
 function dkgDir(): string {
-  return process.env.DKG_HOME ?? join(homedir(), '.dkg');
+  return resolveDkgConfigHome();
 }
 
 function openclawDir(): string {
@@ -817,7 +817,15 @@ function isAdapterLoadPath(value: string): boolean {
  * can pass any of the same sub-fields the adapter reads at load time,
  * including `channel.port` for advanced bridge-port overrides.
  */
-export type AdapterEntryConfig = Pick<DkgOpenClawConfig, 'daemonUrl' | 'memory' | 'channel'>;
+export type AdapterEntryConfig = Pick<DkgOpenClawConfig, 'daemonUrl' | 'stateDir' | 'memory' | 'channel'>;
+
+function defaultStateDirForWorkspace(workspaceDir: string): string {
+  return join(workspaceDir, '.openclaw');
+}
+
+function sameResolvedPath(a: string, b: string): boolean {
+  return resolve(a) === resolve(b);
+}
 
 export function mergeOpenClawConfig(
   openclawConfigPath: string,
@@ -921,6 +929,29 @@ export function mergeOpenClawConfig(
     typeof existingEntryConfig.installedWorkspace === 'string'
       ? existingEntryConfig.installedWorkspace
       : undefined;
+
+  const existingStateDir =
+    typeof existingEntryConfig.stateDir === 'string' && existingEntryConfig.stateDir.trim()
+      ? existingEntryConfig.stateDir
+      : undefined;
+  const incomingStateDir =
+    typeof entryConfig.stateDir === 'string' && entryConfig.stateDir.trim()
+      ? entryConfig.stateDir
+      : undefined;
+  if (typeof existingEntryConfig.stateDir === 'string' && !existingEntryConfig.stateDir.trim()) {
+    delete existingEntryConfig.stateDir;
+  } else if (
+    existingStateDir &&
+    incomingStateDir &&
+    priorInstalledWorkspace &&
+    sameResolvedPath(existingStateDir, defaultStateDirForWorkspace(priorInstalledWorkspace))
+  ) {
+    // The existing value is the setup-owned default from the previous
+    // workspace, so a workspace migration should move it alongside
+    // installedWorkspace. Any custom value remains first-wins.
+    delete existingEntryConfig.stateDir;
+  }
+
   entryForConfig.config = {
     ...entryConfig,
     ...existingEntryConfig,
@@ -1779,6 +1810,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   const portExplicit = options.port != null;
   const entryConfig: AdapterEntryConfig = {
     daemonUrl: `http://127.0.0.1:${effectivePort}`,
+    stateDir: defaultStateDirForWorkspace(workspaceDir),
     memory: { enabled: true },
     channel: { enabled: true },
   };

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -957,6 +957,7 @@ export function mergeOpenClawConfig(
   const existingStateDir = trimmedNonEmpty(existingEntryConfig.stateDir);
   const incomingStateDir = trimmedNonEmpty(entryConfig.stateDir);
   const incomingStateDirIsSetupDefault =
+    entryConfig.stateDirSource === 'setup-default' &&
     !!incomingStateDir &&
     sameResolvedPath(incomingStateDir, defaultStateDirForWorkspace(installedWorkspace));
   const existingStateDirIsSetupOwned =

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -823,8 +823,26 @@ function defaultStateDirForWorkspace(workspaceDir: string): string {
   return join(workspaceDir, '.openclaw');
 }
 
+function canonicalPathForCompare(path: string): string {
+  const absolute = resolve(path);
+  const missingParts: string[] = [];
+  let existing = absolute;
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) break;
+    missingParts.unshift(existing.slice(parent.length + 1));
+    existing = parent;
+  }
+
+  let canonicalBase = existing;
+  try { canonicalBase = realpathSync(existing); } catch { /* keep resolved fallback */ }
+  const canonical = missingParts.reduce((acc, part) => join(acc, part), canonicalBase);
+  const normalized = resolve(canonical);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
 function sameResolvedPath(a: string, b: string): boolean {
-  return resolve(a) === resolve(b);
+  return canonicalPathForCompare(a) === canonicalPathForCompare(b);
 }
 
 export function mergeOpenClawConfig(

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -943,19 +943,16 @@ export function mergeOpenClawConfig(
   const existingChannel = existingEntryConfig.channel && typeof existingEntryConfig.channel === 'object'
     ? existingEntryConfig.channel
     : {};
+  const trimmedNonEmpty = (value: unknown): string | undefined => {
+    if (typeof value !== 'string') return undefined;
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  };
   const priorInstalledWorkspace =
-    typeof existingEntryConfig.installedWorkspace === 'string'
-      ? existingEntryConfig.installedWorkspace
-      : undefined;
+    trimmedNonEmpty(existingEntryConfig.installedWorkspace);
 
-  const existingStateDir =
-    typeof existingEntryConfig.stateDir === 'string' && existingEntryConfig.stateDir.trim()
-      ? existingEntryConfig.stateDir
-      : undefined;
-  const incomingStateDir =
-    typeof entryConfig.stateDir === 'string' && entryConfig.stateDir.trim()
-      ? entryConfig.stateDir
-      : undefined;
+  const existingStateDir = trimmedNonEmpty(existingEntryConfig.stateDir);
+  const incomingStateDir = trimmedNonEmpty(entryConfig.stateDir);
   if (typeof existingEntryConfig.stateDir === 'string' && !existingEntryConfig.stateDir.trim()) {
     delete existingEntryConfig.stateDir;
   } else if (

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -960,10 +960,11 @@ export function mergeOpenClawConfig(
     delete existingEntryConfig.stateDirSource;
   } else if (existingStateDir) {
     preservedExistingStateDir = true;
-    // A preserved stateDir is user-owned, even when it happens to equal an
-    // old default path. Do not let the incoming setup marker survive the
-    // spread below.
-    delete existingEntryConfig.stateDirSource;
+    // A preserved stateDir is user-owned unless the existing marker proves it
+    // came from setup and no replacement stateDir was supplied.
+    if (!existingStateDirIsSetupOwned || incomingStateDir) {
+      delete existingEntryConfig.stateDirSource;
+    }
   }
 
   entryForConfig.config = {
@@ -975,11 +976,20 @@ export function mergeOpenClawConfig(
     // for the adapter-owned pointer so a re-install updates it cleanly.
     installedWorkspace,
   };
+  const finalStateDir = trimmedNonEmpty(entryForConfig.config.stateDir);
+  const preservedSetupDefault =
+    preservedExistingStateDir &&
+    existingStateDirIsSetupOwned &&
+    !incomingStateDir &&
+    !!finalStateDir &&
+    sameResolvedPath(finalStateDir, existingStateDir);
   if (
     incomingStateDirIsSetupDefault &&
     !preservedExistingStateDir &&
-    trimmedNonEmpty(entryForConfig.config.stateDir) === incomingStateDir
+    finalStateDir === incomingStateDir
   ) {
+    entryForConfig.config.stateDirSource = 'setup-default';
+  } else if (preservedSetupDefault) {
     entryForConfig.config.stateDirSource = 'setup-default';
   } else {
     delete entryForConfig.config.stateDirSource;

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -817,7 +817,10 @@ function isAdapterLoadPath(value: string): boolean {
  * can pass any of the same sub-fields the adapter reads at load time,
  * including `channel.port` for advanced bridge-port overrides.
  */
-export type AdapterEntryConfig = Pick<DkgOpenClawConfig, 'daemonUrl' | 'stateDir' | 'memory' | 'channel'>;
+export type AdapterEntryConfig = Pick<
+  DkgOpenClawConfig,
+  'daemonUrl' | 'stateDir' | 'stateDirSource' | 'memory' | 'channel'
+>;
 
 function defaultStateDirForWorkspace(workspaceDir: string): string {
   return join(workspaceDir, '.openclaw');
@@ -953,18 +956,34 @@ export function mergeOpenClawConfig(
 
   const existingStateDir = trimmedNonEmpty(existingEntryConfig.stateDir);
   const incomingStateDir = trimmedNonEmpty(entryConfig.stateDir);
+  const incomingStateDirIsSetupDefault =
+    !!incomingStateDir &&
+    sameResolvedPath(incomingStateDir, defaultStateDirForWorkspace(installedWorkspace));
+  const existingStateDirIsSetupOwned =
+    existingEntryConfig.stateDirSource === 'setup-default' &&
+    !!existingStateDir &&
+    !!priorInstalledWorkspace &&
+    sameResolvedPath(existingStateDir, defaultStateDirForWorkspace(priorInstalledWorkspace));
+  let preservedExistingStateDir = false;
   if (typeof existingEntryConfig.stateDir === 'string' && !existingEntryConfig.stateDir.trim()) {
     delete existingEntryConfig.stateDir;
+    delete existingEntryConfig.stateDirSource;
   } else if (
     existingStateDir &&
     incomingStateDir &&
-    priorInstalledWorkspace &&
-    sameResolvedPath(existingStateDir, defaultStateDirForWorkspace(priorInstalledWorkspace))
+    existingStateDirIsSetupOwned
   ) {
     // The existing value is the setup-owned default from the previous
     // workspace, so a workspace migration should move it alongside
     // installedWorkspace. Any custom value remains first-wins.
     delete existingEntryConfig.stateDir;
+    delete existingEntryConfig.stateDirSource;
+  } else if (existingStateDir) {
+    preservedExistingStateDir = true;
+    // A preserved stateDir is user-owned, even when it happens to equal an
+    // old default path. Do not let the incoming setup marker survive the
+    // spread below.
+    delete existingEntryConfig.stateDirSource;
   }
 
   entryForConfig.config = {
@@ -976,6 +995,15 @@ export function mergeOpenClawConfig(
     // for the adapter-owned pointer so a re-install updates it cleanly.
     installedWorkspace,
   };
+  if (
+    incomingStateDirIsSetupDefault &&
+    !preservedExistingStateDir &&
+    trimmedNonEmpty(entryForConfig.config.stateDir) === incomingStateDir
+  ) {
+    entryForConfig.config.stateDirSource = 'setup-default';
+  } else {
+    delete entryForConfig.config.stateDirSource;
+  }
   if (!hadConfig) {
     log(`Populated plugins.entries.${pluginId}.config`);
   }
@@ -1826,6 +1854,7 @@ export async function runSetup(options: SetupOptions): Promise<void> {
   const entryConfig: AdapterEntryConfig = {
     daemonUrl: `http://127.0.0.1:${effectivePort}`,
     stateDir: defaultStateDirForWorkspace(workspaceDir),
+    stateDirSource: 'setup-default',
     memory: { enabled: true },
     channel: { enabled: true },
   };

--- a/packages/adapter-openclaw/src/state-dir-path.ts
+++ b/packages/adapter-openclaw/src/state-dir-path.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 
 export function canonicalPathForCompare(path: string): string {
   const absolute = resolve(path);
@@ -8,7 +8,7 @@ export function canonicalPathForCompare(path: string): string {
   while (!existsSync(existing)) {
     const parent = dirname(existing);
     if (parent === existing) break;
-    missingParts.unshift(existing.slice(parent.length + 1));
+    missingParts.unshift(basename(existing));
     existing = parent;
   }
 

--- a/packages/adapter-openclaw/src/state-dir-path.ts
+++ b/packages/adapter-openclaw/src/state-dir-path.ts
@@ -1,0 +1,24 @@
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+export function canonicalPathForCompare(path: string): string {
+  const absolute = resolve(path);
+  const missingParts: string[] = [];
+  let existing = absolute;
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) break;
+    missingParts.unshift(existing.slice(parent.length + 1));
+    existing = parent;
+  }
+
+  let canonicalBase = existing;
+  try { canonicalBase = realpathSync(existing); } catch { /* keep resolved fallback */ }
+  const canonical = missingParts.reduce((acc, part) => join(acc, part), canonicalBase);
+  const normalized = resolve(canonical);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
+export function sameResolvedPath(a: string, b: string): boolean {
+  return canonicalPathForCompare(a) === canonicalPathForCompare(b);
+}

--- a/packages/adapter-openclaw/src/types.ts
+++ b/packages/adapter-openclaw/src/types.ts
@@ -405,7 +405,7 @@ export interface DkgOpenClawConfig {
    * Explicit adapter state directory for file-backed runtime state such as
    * ChatTurnWriter watermarks. Setup writes a workspace-scoped default when
    * it can discover the workspace. Runtime honors this after gateway/env
-   * state sources and before falling back to `api.workspaceDir` or
+   * state sources and the current `api.workspaceDir`, before falling back to
    * `~/.openclaw`.
    */
   stateDir?: string;

--- a/packages/adapter-openclaw/src/types.ts
+++ b/packages/adapter-openclaw/src/types.ts
@@ -410,6 +410,13 @@ export interface DkgOpenClawConfig {
    */
   stateDir?: string;
 
+  /**
+   * Setup-owned metadata for the workspace that installed this adapter entry.
+   * Runtime uses it only to distinguish setup-written stateDir defaults from
+   * explicit user stateDir overrides.
+   */
+  installedWorkspace?: string;
+
   /** DKG memory integration config. */
   memory?: {
     enabled?: boolean;

--- a/packages/adapter-openclaw/src/types.ts
+++ b/packages/adapter-openclaw/src/types.ts
@@ -401,6 +401,15 @@ export interface DkgOpenClawConfig {
    */
   dkgHome?: string;
 
+  /**
+   * Explicit adapter state directory for file-backed runtime state such as
+   * ChatTurnWriter watermarks. Setup writes a workspace-scoped default when
+   * it can discover the workspace. Runtime honors this after gateway/env
+   * state sources and before falling back to `api.workspaceDir` or
+   * `~/.openclaw`.
+   */
+  stateDir?: string;
+
   /** DKG memory integration config. */
   memory?: {
     enabled?: boolean;

--- a/packages/adapter-openclaw/src/types.ts
+++ b/packages/adapter-openclaw/src/types.ts
@@ -404,16 +404,23 @@ export interface DkgOpenClawConfig {
   /**
    * Explicit adapter state directory for file-backed runtime state such as
    * ChatTurnWriter watermarks. Setup writes a workspace-scoped default when
-   * it can discover the workspace. Runtime honors this after gateway/env
-   * state sources and the current `api.workspaceDir`, before falling back to
-   * `~/.openclaw`.
+   * it can discover the workspace. Runtime honors explicit user config after
+   * gateway/env state sources and before the current `api.workspaceDir`;
+   * setup-owned defaults are only a fallback for older gateways.
    */
   stateDir?: string;
 
   /**
+   * Setup-owned provenance marker for `stateDir`. Setup writes this as
+   * `"setup-default"` only when it writes its workspace-scoped default;
+   * absent means a matching `stateDir` must be treated as user-owned.
+   */
+  stateDirSource?: 'setup-default';
+
+  /**
    * Setup-owned metadata for the workspace that installed this adapter entry.
-   * Runtime uses it only to distinguish setup-written stateDir defaults from
-   * explicit user stateDir overrides.
+   * Runtime combines it with `stateDirSource` to distinguish setup-written
+   * stateDir defaults from explicit user stateDir overrides.
    */
   installedWorkspace?: string;
 

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3543,6 +3543,146 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - configured stateDir is used and suppresses the home-fallback warning', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const stateDir = path.join(require('os').tmpdir(), `dkg-t75-config-state-${Date.now()}`);
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const warn = vi.fn();
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn, debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        stateDir.replace(/\\/g, '/') + '/dkg-adapter/chat-turn-watermarks.json',
+      );
+      expect(warn.mock.calls.some((c: any[]) =>
+        String(c[0] ?? '').includes('Could not resolve a workspace-scoped state dir'),
+      )).toBe(false);
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(stateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('T75 - blank configured stateDir is ignored and falls through to api.workspaceDir', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const workspaceDir = path.join(require('os').tmpdir(), `dkg-t75-workspace-${Date.now()}`);
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: '   ',
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        workspaceDir.replace(/\\/g, '/') + '/.openclaw/dkg-adapter/chat-turn-watermarks.json',
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('T75 - OPENCLAW_STATE_DIR still overrides configured stateDir', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    const envStateDir = path.join(require('os').tmpdir(), `dkg-t75-env-state-${Date.now()}`);
+    const configStateDir = path.join(require('os').tmpdir(), `dkg-t75-config-lower-${Date.now()}`);
+    process.env.OPENCLAW_STATE_DIR = envStateDir;
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: configStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        envStateDir.replace(/\\/g, '/') + '/dkg-adapter/chat-turn-watermarks.json',
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(envStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(configStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('T75 - gateway runtime state API overrides env and configured stateDir', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    const runtimeStateDir = path.join(require('os').tmpdir(), `dkg-t75-runtime-state-${Date.now()}`);
+    const envStateDir = path.join(require('os').tmpdir(), `dkg-t75-env-lower-${Date.now()}`);
+    const configStateDir = path.join(require('os').tmpdir(), `dkg-t75-config-lowest-${Date.now()}`);
+    process.env.OPENCLAW_STATE_DIR = envStateDir;
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: configStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        runtime: { state: { resolveStateDir: () => runtimeStateDir } },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        runtimeStateDir.replace(/\\/g, '/') + '/dkg-adapter/chat-turn-watermarks.json',
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(runtimeStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(envStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(configStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
   it('warns once when legacy OriginTrail Game config is still present', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3612,14 +3612,51 @@ describe('DkgNodePlugin', () => {
     }
   });
 
-  it('T75 - api.workspaceDir overrides configured stateDir to avoid stale setup defaults', async () => {
+  it('T75 - explicit configured stateDir overrides api.workspaceDir', async () => {
     const prevEnv = process.env.OPENCLAW_STATE_DIR;
     delete process.env.OPENCLAW_STATE_DIR;
     const workspaceDir = path.join(require('os').tmpdir(), `dkg-t75-current-workspace-${Date.now()}`);
-    const staleConfigStateDir = path.join(require('os').tmpdir(), `dkg-t75-stale-config-${Date.now()}`);
+    const configStateDir = path.join(require('os').tmpdir(), `dkg-t75-custom-config-${Date.now()}`);
     try {
       const plugin = new DkgNodePlugin({
         daemonUrl: 'http://localhost:9200',
+        stateDir: configStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        configStateDir.replace(/\\/g, '/') + '/dkg-adapter/chat-turn-watermarks.json',
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(configStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('T75 - api.workspaceDir overrides setup-owned configured stateDir to avoid stale defaults', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const workspaceDir = path.join(require('os').tmpdir(), `dkg-t75-current-workspace-${Date.now()}`);
+    const staleInstalledWorkspace = path.join(require('os').tmpdir(), `dkg-t75-stale-workspace-${Date.now()}`);
+    const staleConfigStateDir = path.join(staleInstalledWorkspace, '.openclaw');
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        installedWorkspace: staleInstalledWorkspace,
         stateDir: staleConfigStateDir,
         channel: { enabled: false },
         memory: { enabled: false },
@@ -3644,7 +3681,7 @@ describe('DkgNodePlugin', () => {
       if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
       else process.env.OPENCLAW_STATE_DIR = prevEnv;
       try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* best effort */ }
-      try { fs.rmSync(staleConfigStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(staleInstalledWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
     }
   });
 

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3685,6 +3685,51 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - setup-owned stateDir detection handles symlink aliases at runtime', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const realWorkspace = path.join(require('os').tmpdir(), `dkg-t75-real-workspace-${Date.now()}`);
+    const aliasWorkspace = path.join(require('os').tmpdir(), `dkg-t75-alias-workspace-${Date.now()}`);
+    const currentWorkspace = path.join(require('os').tmpdir(), `dkg-t75-current-after-alias-${Date.now()}`);
+    fs.mkdirSync(realWorkspace, { recursive: true });
+    fs.mkdirSync(currentWorkspace, { recursive: true });
+    try {
+      fs.symlinkSync(realWorkspace, aliasWorkspace, 'dir');
+    } catch {
+      return;
+    }
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        installedWorkspace: realWorkspace,
+        stateDir: path.join(aliasWorkspace, '.openclaw'),
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir: currentWorkspace,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        currentWorkspace.replace(/\\/g, '/') + '/.openclaw/dkg-adapter/chat-turn-watermarks.json',
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(aliasWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(realWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(currentWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
   it('T75 - OPENCLAW_STATE_DIR still overrides configured stateDir', async () => {
     const prevEnv = process.env.OPENCLAW_STATE_DIR;
     const envStateDir = path.join(require('os').tmpdir(), `dkg-t75-env-state-${Date.now()}`);

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3612,6 +3612,42 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - api.workspaceDir overrides configured stateDir to avoid stale setup defaults', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const workspaceDir = path.join(require('os').tmpdir(), `dkg-t75-current-workspace-${Date.now()}`);
+    const staleConfigStateDir = path.join(require('os').tmpdir(), `dkg-t75-stale-config-${Date.now()}`);
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: staleConfigStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        workspaceDir.replace(/\\/g, '/') + '/.openclaw/dkg-adapter/chat-turn-watermarks.json',
+      );
+      expect(watermarkPath.replace(/\\/g, '/')).not.toContain(staleConfigStateDir.replace(/\\/g, '/'));
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(staleConfigStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
   it('T75 - OPENCLAW_STATE_DIR still overrides configured stateDir', async () => {
     const prevEnv = process.env.OPENCLAW_STATE_DIR;
     const envStateDir = path.join(require('os').tmpdir(), `dkg-t75-env-state-${Date.now()}`);

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3964,6 +3964,132 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - writer migrates from configured stateDir when runtime state API appears later', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const configStateDir = path.join(require('os').tmpdir(), `dkg-t75-config-first-${Date.now()}`);
+    const runtimeStateDir = path.join(require('os').tmpdir(), `dkg-t75-runtime-later-${Date.now()}`);
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: configStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const apiWithoutRuntime: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiWithoutRuntime);
+      const writer = (plugin as any).chatTurnWriter;
+      expect((plugin as any).chatTurnWriterStateDir.replace(/\\/g, '/')).toBe(
+        configStateDir.replace(/\\/g, '/'),
+      );
+
+      const setStateDirSpy = vi.spyOn(writer, 'setStateDir');
+      const apiWithRuntime: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        runtime: { state: { resolveStateDir: () => runtimeStateDir } },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiWithRuntime);
+      expect(setStateDirSpy).toHaveBeenCalledWith(runtimeStateDir);
+      expect((plugin as any).chatTurnWriter).toBe(writer);
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect((plugin as any).chatTurnWriterStateDir.replace(/\\/g, '/')).toBe(
+        runtimeStateDir.replace(/\\/g, '/'),
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(configStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(runtimeStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('T75 - writer migrates from configured stateDir when OPENCLAW_STATE_DIR appears later', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const configStateDir = path.join(require('os').tmpdir(), `dkg-t75-config-first-env-${Date.now()}`);
+    const envStateDir = path.join(require('os').tmpdir(), `dkg-t75-env-later-${Date.now()}`);
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: configStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const writer = (plugin as any).chatTurnWriter;
+      const setStateDirSpy = vi.spyOn(writer, 'setStateDir');
+
+      process.env.OPENCLAW_STATE_DIR = envStateDir;
+      plugin.register(mockApi);
+      expect(setStateDirSpy).toHaveBeenCalledWith(envStateDir);
+      expect((plugin as any).chatTurnWriter).toBe(writer);
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect((plugin as any).chatTurnWriterStateDir.replace(/\\/g, '/')).toBe(
+        envStateDir.replace(/\\/g, '/'),
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(configStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(envStateDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('T75 - explicit config.stateDir equal to home fallback does not emit fallback warning', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const homeStateDir = path.join(require('os').homedir(), '.openclaw');
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        stateDir: homeStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const warn = vi.fn();
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn, debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      expect(warn.mock.calls.some((args) =>
+        String(args?.[0] ?? '').includes('Could not resolve a workspace-scoped state dir'),
+      )).toBe(false);
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+    }
+  });
+
   it('warns once when legacy OriginTrail Game config is still present', () => {
     const plugin = new DkgNodePlugin({
       daemonUrl: 'http://localhost:9200',

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3658,6 +3658,7 @@ describe('DkgNodePlugin', () => {
         daemonUrl: 'http://localhost:9200',
         installedWorkspace: staleInstalledWorkspace,
         stateDir: staleConfigStateDir,
+        stateDirSource: 'setup-default',
         channel: { enabled: false },
         memory: { enabled: false },
       } as any);
@@ -3685,6 +3686,43 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - config stateDir matching installedWorkspace default is explicit without setup marker', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const workspaceDir = path.join(require('os').tmpdir(), `dkg-t75-current-explicit-default-${Date.now()}`);
+    const configuredWorkspace = path.join(require('os').tmpdir(), `dkg-t75-explicit-default-${Date.now()}`);
+    const configuredStateDir = path.join(configuredWorkspace, '.openclaw');
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        installedWorkspace: configuredWorkspace,
+        stateDir: configuredStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const mockApi: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(mockApi);
+      const watermarkPath: string = ((plugin as any).chatTurnWriter as any).watermarkFilePath;
+      expect(watermarkPath.replace(/\\/g, '/')).toContain(
+        configuredStateDir.replace(/\\/g, '/') + '/dkg-adapter/chat-turn-watermarks.json',
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(configuredWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
   it('T75 - setup-owned configured stateDir migrates when api.workspaceDir appears later', async () => {
     const prevEnv = process.env.OPENCLAW_STATE_DIR;
     delete process.env.OPENCLAW_STATE_DIR;
@@ -3696,6 +3734,7 @@ describe('DkgNodePlugin', () => {
         daemonUrl: 'http://localhost:9200',
         installedWorkspace: staleInstalledWorkspace,
         stateDir: staleConfigStateDir,
+        stateDirSource: 'setup-default',
         channel: { enabled: false },
         memory: { enabled: false },
       } as any);
@@ -3741,6 +3780,73 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - in-flight stateDir migration guard canonicalizes target aliases', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const realWorkspace = path.join(require('os').tmpdir(), `dkg-t75-real-migration-${Date.now()}`);
+    const aliasWorkspace = path.join(require('os').tmpdir(), `dkg-t75-alias-migration-${Date.now()}`);
+    fs.mkdirSync(realWorkspace, { recursive: true });
+    try {
+      fs.symlinkSync(realWorkspace, aliasWorkspace, 'dir');
+    } catch {
+      return;
+    }
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const apiFallback: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiFallback);
+      const writer = (plugin as any).chatTurnWriter;
+      let resolveMigration: (() => void) | undefined;
+      const setStateDirSpy = vi.spyOn(writer, 'setStateDir').mockImplementation(
+        () => new Promise<void>((resolve) => { resolveMigration = resolve; }),
+      );
+
+      const apiWorkspace: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir: realWorkspace,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiWorkspace);
+      expect(setStateDirSpy).toHaveBeenCalledTimes(1);
+
+      const apiRuntimeAlias: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        runtime: { state: { resolveStateDir: () => path.join(aliasWorkspace, '.openclaw') } },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiRuntimeAlias);
+      expect(setStateDirSpy).toHaveBeenCalledTimes(1);
+
+      resolveMigration?.();
+      await new Promise((r) => setTimeout(r, 50));
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(aliasWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(realWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
   it('T75 - setup-owned stateDir detection handles symlink aliases at runtime', async () => {
     const prevEnv = process.env.OPENCLAW_STATE_DIR;
     delete process.env.OPENCLAW_STATE_DIR;
@@ -3759,6 +3865,7 @@ describe('DkgNodePlugin', () => {
         daemonUrl: 'http://localhost:9200',
         installedWorkspace: realWorkspace,
         stateDir: path.join(aliasWorkspace, '.openclaw'),
+        stateDirSource: 'setup-default',
         channel: { enabled: false },
         memory: { enabled: false },
       } as any);

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3685,6 +3685,62 @@ describe('DkgNodePlugin', () => {
     }
   });
 
+  it('T75 - setup-owned configured stateDir migrates when api.workspaceDir appears later', async () => {
+    const prevEnv = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_STATE_DIR;
+    const staleInstalledWorkspace = path.join(require('os').tmpdir(), `dkg-t75-stale-first-${Date.now()}`);
+    const staleConfigStateDir = path.join(staleInstalledWorkspace, '.openclaw');
+    const workspaceDir = path.join(require('os').tmpdir(), `dkg-t75-current-later-${Date.now()}`);
+    try {
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        installedWorkspace: staleInstalledWorkspace,
+        stateDir: staleConfigStateDir,
+        channel: { enabled: false },
+        memory: { enabled: false },
+      } as any);
+      const apiWithoutWorkspace: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiWithoutWorkspace);
+      const writer = (plugin as any).chatTurnWriter;
+      expect((plugin as any).chatTurnWriterStateDir.replace(/\\/g, '/')).toBe(
+        staleConfigStateDir.replace(/\\/g, '/'),
+      );
+
+      const setStateDirSpy = vi.spyOn(writer, 'setStateDir');
+      const apiWithWorkspace: OpenClawPluginApi = {
+        config: {},
+        registrationMode: 'full',
+        registerTool: () => {},
+        registerHook: () => {},
+        on: () => {},
+        logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+        workspaceDir,
+      } as unknown as OpenClawPluginApi;
+      plugin.register(apiWithWorkspace);
+      const targetStateDir = path.join(workspaceDir, '.openclaw');
+      expect(setStateDirSpy).toHaveBeenCalledWith(targetStateDir);
+      expect((plugin as any).chatTurnWriter).toBe(writer);
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect((plugin as any).chatTurnWriterStateDir.replace(/\\/g, '/')).toBe(
+        targetStateDir.replace(/\\/g, '/'),
+      );
+      await plugin.stop();
+    } finally {
+      if (prevEnv === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = prevEnv;
+      try { fs.rmSync(staleInstalledWorkspace, { recursive: true, force: true }); } catch { /* best effort */ }
+      try { fs.rmSync(workspaceDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
   it('T75 - setup-owned stateDir detection handles symlink aliases at runtime', async () => {
     const prevEnv = process.env.OPENCLAW_STATE_DIR;
     delete process.env.OPENCLAW_STATE_DIR;

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -665,6 +665,44 @@ describe('mergeOpenClawConfig', () => {
     expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
   });
 
+  it('updates setup-owned stateDir when the existing value uses a symlink alias', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    const realWs = join(testDir, 'workspace-real');
+    const aliasWs = join(testDir, 'workspace-alias');
+    const secondWs = join(testDir, 'workspace-next');
+    mkdirSync(realWs, { recursive: true });
+    mkdirSync(secondWs, { recursive: true });
+    try {
+      symlinkSync(realWs, aliasWs, 'dir');
+    } catch {
+      return;
+    }
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              installedWorkspace: realWs,
+              stateDir: join(aliasWs, '.openclaw'),
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir: join(secondWs, '.openclaw'),
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, secondWs);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(join(secondWs, '.openclaw'));
+    expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
+  });
+
   it('overrideDaemonUrl option replaces existing daemonUrl (used when --port is explicit)', () => {
     const configPath = join(testDir, 'openclaw.json');
     writeFileSync(configPath, JSON.stringify({

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -17,9 +17,10 @@ vi.mock('@origintrail-official/dkg-core', async () => {
   return {
     ...actual,
     requestFaucetFunding: vi.fn(async () => ({ success: true, funded: ['0.01 ETH', '1000 TRAC'] })),
+    resolveDkgConfigHome: vi.fn((opts) => actual.resolveDkgConfigHome(opts)),
   };
 });
-import { requestFaucetFunding } from '@origintrail-official/dkg-core';
+import { requestFaucetFunding, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
 
 import {
   discoverWorkspace,
@@ -3211,6 +3212,23 @@ describe('runSetup Step 5 — faucet funding', () => {
       else process.env.USERPROFILE = originalUserProfile;
       if (originalOpenclaw === undefined) delete process.env.OPENCLAW_HOME;
       else process.env.OPENCLAW_HOME = originalOpenclaw;
+    }
+  });
+
+  it('passes adapter setup startDir into the shared DKG-home resolver', async () => {
+    const env = setupFaucetEnv();
+    const resolver = vi.mocked(resolveDkgConfigHome);
+    resolver.mockClear();
+    try {
+      await runSetup({ workspace: env.workspace, start: false, verify: false, fund: false });
+
+      expect(resolver.mock.calls.some(([opts]) => {
+        const startDir = (opts as any)?.startDir;
+        return typeof startDir === 'string'
+          && startDir.replace(/\\/g, '/').includes('/packages/adapter-openclaw/src');
+      })).toBe(true);
+    } finally {
+      env.restore();
     }
   });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -563,6 +563,22 @@ describe('mergeOpenClawConfig', () => {
     expect(entryConfig.channel).toEqual({ enabled: true });
   });
 
+  it('writes entry.config.stateDir when setup provides a workspace-scoped default', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+    const stateDir = join(defaultInstalledWorkspace, '.openclaw');
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir,
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(stateDir);
+  });
+
   it('preserves existing entry.config values on re-merge (first-wins semantics)', () => {
     const configPath = join(testDir, 'openclaw.json');
     // Seed: user has a prior merge with a custom daemonUrl and a memory
@@ -595,6 +611,57 @@ describe('mergeOpenClawConfig', () => {
     expect(entryConfig.memory.enabled).toBe(false);
     // Missing sub-object gets filled in from defaults.
     expect(entryConfig.channel).toEqual({ enabled: true });
+  });
+
+  it('preserves a user-owned stateDir on re-merge', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              stateDir: '/user/custom/openclaw-state',
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir: join(defaultInstalledWorkspace, '.openclaw'),
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe('/user/custom/openclaw-state');
+  });
+
+  it('updates setup-owned stateDir when installedWorkspace changes', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    const firstWs = join(testDir, 'workspace-a');
+    const secondWs = join(testDir, 'workspace-b');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir: join(firstWs, '.openclaw'),
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, firstWs);
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir: join(secondWs, '.openclaw'),
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, secondWs);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(join(secondWs, '.openclaw'));
+    expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
   });
 
   it('overrideDaemonUrl option replaces existing daemonUrl (used when --port is explicit)', () => {
@@ -3086,6 +3153,7 @@ describe('runSetup Step 5 — faucet funding', () => {
       // short-circuit Step 7 (merge).
       const cfg = JSON.parse(readFileSync(join(env.openclawHome, 'openclaw.json'), 'utf-8'));
       expect(cfg.plugins.slots.memory).toBe('adapter-openclaw');
+      expect(cfg.plugins.entries['adapter-openclaw'].config.stateDir).toBe(join(env.workspace, '.openclaw'));
     } finally {
       env.restore();
     }
@@ -3103,6 +3171,46 @@ describe('runSetup Step 5 — faucet funding', () => {
       expect(cfg.plugins.slots.memory).toBe('adapter-openclaw');
     } finally {
       env.restore();
+    }
+  });
+
+  it('uses the shared monorepo DKG home when DKG_HOME is unset', async () => {
+    const homeRoot = join(testDir, 'home');
+    const dkgHome = join(homeRoot, '.dkg');
+    const dkgDevHome = join(homeRoot, '.dkg-dev');
+    const openclawHome = join(testDir, '.openclaw-shared-home');
+    const workspace = join(testDir, 'workspace-shared-home');
+    mkdirSync(homeRoot, { recursive: true });
+    mkdirSync(openclawHome, { recursive: true });
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(
+      join(openclawHome, 'openclaw.json'),
+      JSON.stringify({ plugins: {} }, null, 2) + '\n',
+    );
+
+    const originalDkg = process.env.DKG_HOME;
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalOpenclaw = process.env.OPENCLAW_HOME;
+    delete process.env.DKG_HOME;
+    process.env.HOME = homeRoot;
+    process.env.USERPROFILE = homeRoot;
+    process.env.OPENCLAW_HOME = openclawHome;
+
+    try {
+      await runSetup({ workspace, start: false, verify: false, fund: false });
+
+      expect(existsSync(join(dkgDevHome, 'config.json'))).toBe(true);
+      expect(existsSync(join(dkgHome, 'config.json'))).toBe(false);
+    } finally {
+      if (originalDkg === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = originalDkg;
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      if (originalOpenclaw === undefined) delete process.env.OPENCLAW_HOME;
+      else process.env.OPENCLAW_HOME = originalOpenclaw;
     }
   });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -572,6 +572,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir,
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, defaultInstalledWorkspace);
@@ -579,6 +580,23 @@ describe('mergeOpenClawConfig', () => {
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(stateDir);
     expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBe('setup-default');
+  });
+
+  it('does not mark an incoming stateDir as setup-owned without the setup marker', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    writeFileSync(configPath, JSON.stringify({ plugins: {} }));
+    const stateDir = join(defaultInstalledWorkspace, '.openclaw');
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir,
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(stateDir);
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBeUndefined();
   });
 
   it('preserves existing entry.config values on re-merge (first-wins semantics)', () => {
@@ -633,6 +651,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir: join(defaultInstalledWorkspace, '.openclaw'),
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, defaultInstalledWorkspace);
@@ -664,6 +683,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir: join(secondWs, '.openclaw'),
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, secondWs);
@@ -684,6 +704,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir: join(firstWs, '.openclaw'),
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, firstWs);
@@ -691,6 +712,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir: join(secondWs, '.openclaw'),
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, secondWs);
@@ -723,6 +745,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir: join(secondWs, '.openclaw'),
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, secondWs);
@@ -762,6 +785,7 @@ describe('mergeOpenClawConfig', () => {
     mergeOpenClawConfig(configPath, '/path/to/adapter', {
       daemonUrl: 'http://127.0.0.1:9200',
       stateDir: join(secondWs, '.openclaw'),
+      stateDirSource: 'setup-default',
       memory: { enabled: true },
       channel: { enabled: true },
     }, secondWs);

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -578,6 +578,7 @@ describe('mergeOpenClawConfig', () => {
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(stateDir);
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBe('setup-default');
   });
 
   it('preserves existing entry.config values on re-merge (first-wins semantics)', () => {
@@ -638,6 +639,40 @@ describe('mergeOpenClawConfig', () => {
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe('/user/custom/openclaw-state');
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBeUndefined();
+  });
+
+  it('preserves a user-owned stateDir that happens to equal the prior workspace default', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    const firstWs = join(testDir, 'workspace-user-default-a');
+    const secondWs = join(testDir, 'workspace-user-default-b');
+    const userPinnedStateDir = join(firstWs, '.openclaw');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              installedWorkspace: firstWs,
+              stateDir: userPinnedStateDir,
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir: join(secondWs, '.openclaw'),
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, secondWs);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const entryConfig = config.plugins.entries['adapter-openclaw'].config;
+    expect(entryConfig.stateDir).toBe(userPinnedStateDir);
+    expect(entryConfig.stateDirSource).toBeUndefined();
+    expect(entryConfig.installedWorkspace).toBe(secondWs);
   });
 
   it('updates setup-owned stateDir when installedWorkspace changes', () => {
@@ -662,6 +697,7 @@ describe('mergeOpenClawConfig', () => {
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(join(secondWs, '.openclaw'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBe('setup-default');
     expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
   });
 
@@ -677,6 +713,7 @@ describe('mergeOpenClawConfig', () => {
             config: {
               installedWorkspace: `  ${firstWs}  `,
               stateDir: `  ${join(firstWs, '.openclaw')}  `,
+              stateDirSource: 'setup-default',
             },
           },
         },
@@ -715,6 +752,7 @@ describe('mergeOpenClawConfig', () => {
             config: {
               installedWorkspace: realWs,
               stateDir: join(aliasWs, '.openclaw'),
+              stateDirSource: 'setup-default',
             },
           },
         },
@@ -730,6 +768,7 @@ describe('mergeOpenClawConfig', () => {
 
     const config = JSON.parse(readFileSync(configPath, 'utf-8'));
     expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(join(secondWs, '.openclaw'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBe('setup-default');
     expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
   });
 

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -665,6 +665,36 @@ describe('mergeOpenClawConfig', () => {
     expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
   });
 
+  it('updates setup-owned stateDir when existing installedWorkspace and stateDir have surrounding whitespace', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    const firstWs = join(testDir, 'workspace-whitespace-a');
+    const secondWs = join(testDir, 'workspace-whitespace-b');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              installedWorkspace: `  ${firstWs}  `,
+              stateDir: `  ${join(firstWs, '.openclaw')}  `,
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      stateDir: join(secondWs, '.openclaw'),
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, secondWs);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.plugins.entries['adapter-openclaw'].config.stateDir).toBe(join(secondWs, '.openclaw'));
+    expect(config.plugins.entries['adapter-openclaw'].config.installedWorkspace).toBe(secondWs);
+  });
+
   it('updates setup-owned stateDir when the existing value uses a symlink alias', () => {
     const configPath = join(testDir, 'openclaw.json');
     const realWs = join(testDir, 'workspace-real');

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -599,6 +599,36 @@ describe('mergeOpenClawConfig', () => {
     expect(config.plugins.entries['adapter-openclaw'].config.stateDirSource).toBeUndefined();
   });
 
+  it('preserves an existing setup-owned stateDir marker when entryConfig omits stateDir', () => {
+    const configPath = join(testDir, 'openclaw.json');
+    const stateDir = join(defaultInstalledWorkspace, '.openclaw');
+    writeFileSync(configPath, JSON.stringify({
+      plugins: {
+        entries: {
+          'adapter-openclaw': {
+            enabled: true,
+            config: {
+              installedWorkspace: defaultInstalledWorkspace,
+              stateDir,
+              stateDirSource: 'setup-default',
+            },
+          },
+        },
+      },
+    }));
+
+    mergeOpenClawConfig(configPath, '/path/to/adapter', {
+      daemonUrl: 'http://127.0.0.1:9200',
+      memory: { enabled: true },
+      channel: { enabled: true },
+    }, defaultInstalledWorkspace);
+
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    const entryConfig = config.plugins.entries['adapter-openclaw'].config;
+    expect(entryConfig.stateDir).toBe(stateDir);
+    expect(entryConfig.stateDirSource).toBe('setup-default');
+  });
+
   it('preserves existing entry.config values on re-merge (first-wins semantics)', () => {
     const configPath = join(testDir, 'openclaw.json');
     // Seed: user has a prior merge with a custom daemonUrl and a memory

--- a/packages/adapter-openclaw/test/state-dir-path.test.ts
+++ b/packages/adapter-openclaw/test/state-dir-path.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { join, parse } from 'node:path';
+import { canonicalPathForCompare } from '../src/state-dir-path.js';
+
+describe('state-dir path helpers', () => {
+  it('preserves the first character of a missing root-level path segment', () => {
+    const segment = `dkg-missing-root-${Date.now()}`;
+    const rootLevelPath = join(parse(process.cwd()).root, segment);
+
+    expect(canonicalPathForCompare(rootLevelPath).toLowerCase()).toBe(
+      rootLevelPath.toLowerCase(),
+    );
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { writeFile, unlink } from 'node:fs/promises';
 import { ethers } from 'ethers';
-import { requestFaucetFunding, toErrorMessage, hasErrorCode } from '@origintrail-official/dkg-core';
+import { dkgAuthTokenPath, requestFaucetFunding, toErrorMessage, hasErrorCode } from '@origintrail-official/dkg-core';
 import yaml from 'js-yaml';
 import {
   loadConfig, saveConfig, configExists, configPath,
@@ -378,7 +378,7 @@ program
     console.log(`  relay:      ${relayDisplay}`);
     console.log(`  context graphs: ${contextGraphs.length ? contextGraphs.join(', ') : '(none)'}`);
     console.log(`  apiPort:    ${config.apiPort}`);
-    console.log(`  auth:       ${enableAuth ? 'enabled (token in ~/.dkg/auth.token)' : 'disabled'}`);
+    console.log(`  auth:       ${enableAuth ? `enabled (token in ${dkgAuthTokenPath(dkgDir())})` : 'disabled'}`);
     {
       const resolved = resolveAutoUpdateConfig(config, network);
       console.log(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile, mkdir, symlink, rename, unlink, readlink } from 'node:fs/promises';
 import { join, dirname, resolve, basename } from 'node:path';
-import { homedir } from 'node:os';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { isDkgMonorepoRoot, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
 
 export interface AutoUpdateConfig {
   enabled: boolean;
@@ -267,33 +267,6 @@ function isDkgPackageRoot(dir: string): boolean {
 }
 
 /**
- * Return true when `dir` is the DKG monorepo root.
- *
- * We combine two layers of evidence so this never matches an unrelated
- * consumer workspace (e.g. a pnpm/Nx repo that also happens to have a
- * root `project.json`):
- *
- *  1. Structural markers — `pnpm-workspace.yaml`, `packages/`, and
- *     `project.json` — which are required but not sufficient.
- *  2. A DKG-specific sub-marker — `packages/cli/package.json` whose
- *     `name` is exactly `@origintrail-official/dkg`. The package name
- *     is reserved for us on npm and cannot be spoofed by a consumer
- *     repo without colliding with our own published package.
- */
-function isDkgMonorepoRoot(dir: string): boolean {
-  try {
-    if (!existsSync(join(dir, 'pnpm-workspace.yaml'))) return false;
-    if (!existsSync(join(dir, 'packages'))) return false;
-    if (!existsSync(join(dir, 'project.json'))) return false;
-
-    const cliPkgPath = join(dir, 'packages', 'cli', 'package.json');
-    if (!existsSync(cliPkgPath)) return false;
-    const cliPkg = JSON.parse(readFileSync(cliPkgPath, 'utf-8'));
-    return cliPkg?.name === '@origintrail-official/dkg';
-  } catch { return false; }
-}
-
-/**
  * Resolve candidate directories where repo-root files (project.json,
  * network/*.json) may live, in priority order.
  *
@@ -442,12 +415,7 @@ export async function loadNetworkConfig(network?: string): Promise<NetworkConfig
 }
 
 export function dkgDir(): string {
-  if (process.env.DKG_HOME) return process.env.DKG_HOME;
-  const defaultDir = join(homedir(), '.dkg');
-  if (isDkgMonorepo() && !existsSync(join(defaultDir, 'config.json'))) {
-    return join(homedir(), '.dkg-dev');
-  }
-  return defaultDir;
+  return resolveDkgConfigHome({ isDkgMonorepo: isDkgMonorepo() });
 }
 
 let _isDkgMonorepo: boolean | null = null;

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
+import { dkgAuthTokenPath } from '@origintrail-official/dkg-core';
 import {
   loadNetworkConfig,
   loadConfig,
@@ -112,10 +113,16 @@ describe('isDkgMonorepo', () => {
 
 describe('dkgDir', () => {
   const origHome = process.env.DKG_HOME;
+  const origOsHome = process.env.HOME;
+  const origUserProfile = process.env.USERPROFILE;
 
   afterEach(() => {
     if (origHome === undefined) delete process.env.DKG_HOME;
     else process.env.DKG_HOME = origHome;
+    if (origOsHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origOsHome;
+    if (origUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = origUserProfile;
   });
 
   it('returns ~/.dkg-dev when in monorepo without existing ~/.dkg/config.json, else ~/.dkg', () => {
@@ -131,6 +138,38 @@ describe('dkgDir', () => {
   it('respects DKG_HOME override', () => {
     process.env.DKG_HOME = '/tmp/custom-dkg';
     expect(dkgDir()).toBe('/tmp/custom-dkg');
+  });
+
+  it('uses ~/.dkg-dev for monorepo config writes when ~/.dkg/config.json is absent', async () => {
+    delete process.env.DKG_HOME;
+    const tempHome = join(tmpdir(), `dkg-cli-config-home-${randomBytes(4).toString('hex')}`);
+    await mkdir(tempHome, { recursive: true });
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    try {
+      const expected = isDkgMonorepo()
+        ? join(tempHome, '.dkg-dev')
+        : join(tempHome, '.dkg');
+      expect(dkgDir()).toBe(expected);
+      expect(dkgAuthTokenPath(dkgDir())).toBe(join(expected, 'auth.token'));
+    } finally {
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it('uses ~/.dkg for monorepo config writes when ~/.dkg/config.json already exists', async () => {
+    delete process.env.DKG_HOME;
+    const tempHome = join(tmpdir(), `dkg-cli-config-home-${randomBytes(4).toString('hex')}`);
+    const dkgHome = join(tempHome, '.dkg');
+    await mkdir(dkgHome, { recursive: true });
+    await writeFile(join(dkgHome, 'config.json'), '{}\n');
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    try {
+      expect(dkgDir()).toBe(dkgHome);
+    } finally {
+      await rm(tempHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -56,9 +56,9 @@ export function resolveDkgConfigHome(opts: ResolveDkgConfigHomeOptions = {}): st
   return defaultDir;
 }
 
-/** Resolve `<dkgHome>/auth.token`. Defaults to the config-writing DKG home. */
-export function dkgAuthTokenPath(dkgHome?: string): string {
-  return join(dkgHome ?? resolveDkgConfigHome(), 'auth.token');
+/** Resolve `<dkgHome>/auth.token` for an already-resolved DKG home. */
+export function dkgAuthTokenPath(dkgHome: string): string {
+  return join(dkgHome, 'auth.token');
 }
 
 /**

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -56,9 +56,9 @@ export function resolveDkgConfigHome(opts: ResolveDkgConfigHomeOptions = {}): st
   return defaultDir;
 }
 
-/** Resolve `<dkgHome>/auth.token`. Defaults to the legacy simple DKG home. */
+/** Resolve `<dkgHome>/auth.token`. Defaults to the config-writing DKG home. */
 export function dkgAuthTokenPath(dkgHome?: string): string {
-  return join(dkgHome ?? dkgHomeDir(), 'auth.token');
+  return join(dkgHome ?? resolveDkgConfigHome(), 'auth.token');
 }
 
 /**

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -61,7 +61,16 @@ export function dkgAuthTokenPath(dkgHome?: string): string {
   return join(dkgHome ?? dkgHomeDir(), 'auth.token');
 }
 
-/** Return true when `dir` is the DKG monorepo root. */
+/**
+ * Return true when `dir` is the DKG monorepo root.
+ *
+ * Combines structural markers (`pnpm-workspace.yaml`, `packages/`,
+ * `project.json`) with a DKG-specific sub-marker:
+ * `packages/cli/package.json` whose `name` is `@origintrail-official/dkg`.
+ * The structural markers can match an unrelated pnpm/Nx workspace; the
+ * canonical package name is reserved for us on npm and cannot be spoofed
+ * without colliding with our published package.
+ */
 export function isDkgMonorepoRoot(dir: string): boolean {
   try {
     if (!existsSync(join(dir, 'pnpm-workspace.yaml'))) return false;

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -7,13 +7,87 @@
 
 import { readFile } from 'node:fs/promises';
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 
 /** Resolve the DKG home directory ($DKG_HOME or ~/.dkg). */
 export function dkgHomeDir(): string {
   return process.env.DKG_HOME ?? join(homedir(), '.dkg');
+}
+
+export interface ResolveDkgConfigHomeOptions {
+  /** Test/embedding override for the environment object. Defaults to process.env. */
+  env?: Pick<NodeJS.ProcessEnv, 'DKG_HOME'>;
+  /** Test/embedding override for the OS home directory. Defaults to homedir(). */
+  homeDir?: string;
+  /** Explicit monorepo signal. When omitted, the helper detects from its own package path. */
+  isDkgMonorepo?: boolean;
+  /** Optional start directory for monorepo detection. Defaults to this module's directory. */
+  startDir?: string;
+  /** Optional test override for whether `<home>/.dkg/config.json` exists. */
+  configExists?: boolean;
+}
+
+/**
+ * Resolve the DKG home used by config-writing flows such as `dkg init` and
+ * adapter setup.
+ *
+ * This intentionally differs from `resolveDkgHome({ daemonUrl })`: that helper
+ * observes daemon pid/port files for runtime adapter reads, while this helper
+ * mirrors the CLI setup contract:
+ *
+ *   1. `DKG_HOME` wins.
+ *   2. In a DKG monorepo checkout, if `~/.dkg/config.json` does not already
+ *      exist, use `~/.dkg-dev` so development state stays separate from a
+ *      globally installed CLI.
+ *   3. Otherwise use `~/.dkg`.
+ */
+export function resolveDkgConfigHome(opts: ResolveDkgConfigHomeOptions = {}): string {
+  const envHome = opts.env ? opts.env.DKG_HOME : process.env.DKG_HOME;
+  if (envHome) return envHome;
+
+  const home = opts.homeDir ?? homedir();
+  const defaultDir = join(home, '.dkg');
+  const configExists = opts.configExists ?? existsSync(join(defaultDir, 'config.json'));
+  const isMonorepo = opts.isDkgMonorepo ?? findDkgMonorepoRoot(opts.startDir) !== null;
+  if (isMonorepo && !configExists) return join(home, '.dkg-dev');
+  return defaultDir;
+}
+
+/** Resolve `<dkgHome>/auth.token`. Defaults to the legacy simple DKG home. */
+export function dkgAuthTokenPath(dkgHome?: string): string {
+  return join(dkgHome ?? dkgHomeDir(), 'auth.token');
+}
+
+/** Return true when `dir` is the DKG monorepo root. */
+export function isDkgMonorepoRoot(dir: string): boolean {
+  try {
+    if (!existsSync(join(dir, 'pnpm-workspace.yaml'))) return false;
+    if (!existsSync(join(dir, 'packages'))) return false;
+    if (!existsSync(join(dir, 'project.json'))) return false;
+
+    const cliPkgPath = join(dir, 'packages', 'cli', 'package.json');
+    if (!existsSync(cliPkgPath)) return false;
+    const cliPkg = JSON.parse(readFileSync(cliPkgPath, 'utf-8'));
+    return cliPkg?.name === '@origintrail-official/dkg';
+  } catch {
+    return false;
+  }
+}
+
+/** Find the nearest DKG monorepo root at or above `startDir`. */
+export function findDkgMonorepoRoot(
+  startDir = dirname(fileURLToPath(import.meta.url)),
+): string | null {
+  let dir = resolve(startDir);
+  while (true) {
+    if (isDkgMonorepoRoot(dir)) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,10 @@ export {
 } from './errors.js';
 export {
   dkgHomeDir,
+  resolveDkgConfigHome,
+  dkgAuthTokenPath,
+  isDkgMonorepoRoot,
+  findDkgMonorepoRoot,
   resolveDkgHome,
   readDaemonPid,
   isProcessAlive,

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -93,6 +93,30 @@ describe('dkgAuthTokenPath', () => {
   it('formats the auth-token path from the resolved DKG home', () => {
     expect(dkgAuthTokenPath('/tmp/dkg-home')).toBe(join('/tmp/dkg-home', 'auth.token'));
   });
+
+  it('defaults through the config-home resolver', async () => {
+    const original = {
+      DKG_HOME: process.env.DKG_HOME,
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+    };
+    const tempHome = join(tmpdir(), `dkg-auth-token-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempHome, { recursive: true });
+    delete process.env.DKG_HOME;
+    process.env.HOME = tempHome;
+    process.env.USERPROFILE = tempHome;
+    try {
+      expect(dkgAuthTokenPath()).toBe(join(tempHome, '.dkg-dev', 'auth.token'));
+    } finally {
+      if (original.DKG_HOME === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = original.DKG_HOME;
+      if (original.HOME === undefined) delete process.env.HOME;
+      else process.env.HOME = original.HOME;
+      if (original.USERPROFILE === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = original.USERPROFILE;
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('resolveDkgHome', () => {

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -3,7 +3,7 @@ import { writeFile, mkdir, rm, utimes } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { homedir } from 'node:os';
-import { dkgHomeDir, resolveDkgHome, isProcessAlive, readDaemonPid, readDkgApiPort, loadAuthToken, loadAuthTokenSync, loadAgentAuthTokenSync, loadAgentAuthToken, MultipleAgentsError, toEip55Checksum } from '../src/dkg-home.js';
+import { dkgHomeDir, resolveDkgConfigHome, dkgAuthTokenPath, resolveDkgHome, isProcessAlive, readDaemonPid, readDkgApiPort, loadAuthToken, loadAuthTokenSync, loadAgentAuthTokenSync, loadAgentAuthToken, MultipleAgentsError, toEip55Checksum } from '../src/dkg-home.js';
 
 describe('dkgHomeDir', () => {
   const originalEnv = process.env.DKG_HOME;
@@ -21,6 +21,77 @@ describe('dkgHomeDir', () => {
   it('defaults to ~/.dkg', () => {
     delete process.env.DKG_HOME;
     expect(dkgHomeDir()).toBe(join(homedir(), '.dkg'));
+  });
+});
+
+describe('resolveDkgConfigHome', () => {
+  let tempHome: string;
+
+  beforeEach(async () => {
+    tempHome = join(tmpdir(), `dkg-config-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(tempHome, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it('DKG_HOME wins over monorepo and config-file heuristics', () => {
+    expect(resolveDkgConfigHome({
+      env: { DKG_HOME: '/custom/dkg-home' },
+      homeDir: tempHome,
+      isDkgMonorepo: true,
+      configExists: false,
+    })).toBe('/custom/dkg-home');
+  });
+
+  it('treats an injected empty env as DKG_HOME unset', () => {
+    const originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = '/process/dkg-home';
+    try {
+      expect(resolveDkgConfigHome({
+        env: {},
+        homeDir: tempHome,
+        isDkgMonorepo: true,
+        configExists: false,
+      })).toBe(join(tempHome, '.dkg-dev'));
+    } finally {
+      if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = originalDkgHome;
+    }
+  });
+
+  it('uses ~/.dkg-dev in a monorepo when ~/.dkg/config.json does not exist', () => {
+    expect(resolveDkgConfigHome({
+      env: {},
+      homeDir: tempHome,
+      isDkgMonorepo: true,
+      configExists: false,
+    })).toBe(join(tempHome, '.dkg-dev'));
+  });
+
+  it('uses ~/.dkg in a monorepo when ~/.dkg/config.json already exists', () => {
+    expect(resolveDkgConfigHome({
+      env: {},
+      homeDir: tempHome,
+      isDkgMonorepo: true,
+      configExists: true,
+    })).toBe(join(tempHome, '.dkg'));
+  });
+
+  it('uses ~/.dkg outside a monorepo', () => {
+    expect(resolveDkgConfigHome({
+      env: {},
+      homeDir: tempHome,
+      isDkgMonorepo: false,
+      configExists: false,
+    })).toBe(join(tempHome, '.dkg'));
+  });
+});
+
+describe('dkgAuthTokenPath', () => {
+  it('formats the auth-token path from the resolved DKG home', () => {
+    expect(dkgAuthTokenPath('/tmp/dkg-home')).toBe(join('/tmp/dkg-home', 'auth.token'));
   });
 });
 

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -93,30 +93,6 @@ describe('dkgAuthTokenPath', () => {
   it('formats the auth-token path from the resolved DKG home', () => {
     expect(dkgAuthTokenPath('/tmp/dkg-home')).toBe(join('/tmp/dkg-home', 'auth.token'));
   });
-
-  it('defaults through the config-home resolver', async () => {
-    const original = {
-      DKG_HOME: process.env.DKG_HOME,
-      HOME: process.env.HOME,
-      USERPROFILE: process.env.USERPROFILE,
-    };
-    const tempHome = join(tmpdir(), `dkg-auth-token-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    await mkdir(tempHome, { recursive: true });
-    delete process.env.DKG_HOME;
-    process.env.HOME = tempHome;
-    process.env.USERPROFILE = tempHome;
-    try {
-      expect(dkgAuthTokenPath()).toBe(join(tempHome, '.dkg-dev', 'auth.token'));
-    } finally {
-      if (original.DKG_HOME === undefined) delete process.env.DKG_HOME;
-      else process.env.DKG_HOME = original.DKG_HOME;
-      if (original.HOME === undefined) delete process.env.HOME;
-      else process.env.HOME = original.HOME;
-      if (original.USERPROFILE === undefined) delete process.env.USERPROFILE;
-      else process.env.USERPROFILE = original.USERPROFILE;
-      await rm(tempHome, { recursive: true, force: true });
-    }
-  });
 });
 
 describe('resolveDkgHome', () => {


### PR DESCRIPTION
## Summary
- Add a shared core config-home resolver for CLI init/setup flows so `DKG_HOME`, monorepo `~/.dkg-dev`, and `~/.dkg` precedence is consistent.
- Report the actual `dkg init` auth-token path from the resolved DKG home instead of hardcoding `~/.dkg/auth.token`.
- Add OpenClaw adapter `stateDir` config, have setup persist a workspace-scoped default, and make runtime honor source precedence before falling back to `~/.openclaw`.

## Related
Fixes #317
Fixes #318
Fixes #323
Related to #264

## Files changed
- `packages/core/src/dkg-home.ts`, `packages/core/src/index.ts`: shared config-home/auth-token helpers and exports.
- `packages/cli/src/config.ts`, `packages/cli/src/cli.ts`: CLI config-home delegation and corrected init summary output.
- `packages/adapter-openclaw/src/setup.ts`, `packages/adapter-openclaw/src/DkgNodePlugin.ts`, `packages/adapter-openclaw/src/state-dir-path.ts`, `packages/adapter-openclaw/src/types.ts`, `packages/adapter-openclaw/openclaw.plugin.json`: setup/runtime state-dir surface, provenance, canonicalization, and precedence.
- `packages/core/test/dkg-home.test.ts`, `packages/cli/test/config.test.ts`, `packages/adapter-openclaw/test/setup.test.ts`, `packages/adapter-openclaw/test/plugin.test.ts`, `packages/adapter-openclaw/test/state-dir-path.test.ts`: focused regressions for issues #317, #318, #323, and review-discovered state-dir edges.

## Test plan
- `pnpm --filter @origintrail-official/dkg-core test -- test/dkg-home.test.ts`
- `pnpm --filter @origintrail-official/dkg test -- test/config.test.ts`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw test -- test/state-dir-path.test.ts test/setup.test.ts test/plugin.test.ts`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw test -- test/ChatTurnWriter.test.ts test/memory-integration.test.ts test/memory-search-tool.test.ts test/before-prompt-build-hook.test.ts test/HookSurface.test.ts`
- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw build`
- `pnpm build:runtime`
- `git diff --check`