### PR TITLE
fix(openclaw): avoid setup timeout during slot migration

### DIFF
--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -19,14 +19,14 @@
  * Every step is idempotent — re-running is safe.
  */
 
-import { execSync, spawnSync } from 'node:child_process';
-import { accessSync, constants as fsConstants, copyFileSync, existsSync, readFileSync, realpathSync, writeFileSync, mkdirSync, rmdirSync, statSync, unlinkSync } from 'node:fs';
+import { execSync, spawnSync, type SpawnSyncOptions } from 'node:child_process';
+import { accessSync, constants as fsConstants, copyFileSync, existsSync, lstatSync, readFileSync, realpathSync, writeFileSync, mkdirSync, rmdirSync, statSync, unlinkSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { isDeepStrictEqual } from 'node:util';
-import { requestFaucetFunding, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
+import { blueGreenSlotReady, findPackageRepoDir, requestFaucetFunding, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
 import type { DkgOpenClawConfig } from './types.js';
 import { resolveDkgCli } from './resolve-dkg-cli.js';
 import { sameResolvedPath } from './state-dir-path.js';
@@ -564,6 +564,45 @@ export function writeDkgConfig(
 // Step 5: Start DKG daemon
 // ---------------------------------------------------------------------------
 
+const DKG_START_TIMEOUT_MS = 30_000;
+const DKG_START_MIGRATION_TIMEOUT_MS = 60 * 60_000;
+
+function hasLocalRepoForCli(cliPath: string): boolean {
+  let physicalCliPath = cliPath;
+  try {
+    physicalCliPath = realpathSync(cliPath);
+  } catch {
+    // `resolveDkgCli` surfaces missing CLI paths later; keep timeout detection conservative here.
+  }
+  const repo = findPackageRepoDir(dirname(physicalCliPath));
+  return Boolean(repo && existsSync(join(repo, '.git')));
+}
+
+function blueGreenMigrationMayRunDuringStart(cliPath: string): boolean {
+  if (process.env.DKG_NO_BLUE_GREEN) return false;
+  if (!hasLocalRepoForCli(cliPath)) return false;
+
+  const releasesPath = join(dkgDir(), 'releases');
+  const currentLink = join(releasesPath, 'current');
+
+  try {
+    if (!lstatSync(currentLink).isSymbolicLink()) return true;
+  } catch {
+    return true;
+  }
+
+  return !blueGreenSlotReady(join(releasesPath, 'a'))
+    || !blueGreenSlotReady(join(releasesPath, 'b'));
+}
+
+function daemonStartSpawnOptions(cliPath: string): SpawnSyncOptions {
+  const options: SpawnSyncOptions = { stdio: 'inherit' };
+  options.timeout = blueGreenMigrationMayRunDuringStart(cliPath)
+    ? DKG_START_MIGRATION_TIMEOUT_MS
+    : DKG_START_TIMEOUT_MS;
+  return options;
+}
+
 export async function startDaemon(apiPort: number): Promise<void> {
   // Check if already running
   const pidPath = join(dkgDir(), 'daemon.pid');
@@ -597,10 +636,7 @@ export async function startDaemon(apiPort: number): Promise<void> {
     // process.execPath so we don't depend on `dkg` being on PATH — which
     // `pnpm dkg openclaw setup` does not guarantee in a cloned monorepo.
     const { node, cliPath } = resolveDkgCli();
-    const result = spawnSync(node, [cliPath, 'start'], {
-      stdio: 'inherit',
-      timeout: 30_000,
-    });
+    const result = spawnSync(node, [cliPath, 'start'], daemonStartSpawnOptions(cliPath));
     if (result.error) throw result.error;
     if (result.status !== 0) {
       throw new Error(

--- a/packages/adapter-openclaw/test/setup-start-daemon.test.ts
+++ b/packages/adapter-openclaw/test/setup-start-daemon.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const resolvedDkgCli = vi.hoisted(() => ({ node: 'node-bin', cliPath: 'cli-path' }));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawnSync: spawnSyncMock,
+  };
+});
+
+vi.mock('../src/resolve-dkg-cli.js', () => ({
+  resolveDkgCli: () => resolvedDkgCli,
+}));
+
+vi.mock('@origintrail-official/dkg-core', async () => {
+  const actual = await vi.importActual<typeof import('@origintrail-official/dkg-core')>(
+    '@origintrail-official/dkg-core',
+  );
+  return {
+    ...actual,
+    requestFaucetFunding: vi.fn(),
+    resolveDkgConfigHome: () => {
+      if (!process.env.DKG_HOME) throw new Error('DKG_HOME must be set for this test');
+      return process.env.DKG_HOME;
+    },
+  };
+});
+
+import { startDaemon } from '../src/setup.js';
+
+const MIGRATION_START_TIMEOUT_MS = 60 * 60_000;
+
+describe('startDaemon blue-green migration timeout handling', () => {
+  let testDir: string;
+  let dkgHome: string;
+  let cliRepo: string;
+  let originalDkgHome: string | undefined;
+  let originalNoBlueGreen: string | undefined;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `dkg-start-daemon-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    dkgHome = join(testDir, '.dkg');
+    cliRepo = join(testDir, 'repo');
+    mkdirSync(dkgHome, { recursive: true });
+    mkdirSync(join(cliRepo, '.git'), { recursive: true });
+    mkdirSync(join(cliRepo, 'packages', 'cli', 'dist'), { recursive: true });
+    writeFileSync(join(cliRepo, 'package.json'), '{}\n');
+    writeFileSync(join(cliRepo, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+    writeFileSync(join(cliRepo, 'project.json'), '{}\n');
+    writeFileSync(
+      join(cliRepo, 'packages', 'cli', 'package.json'),
+      JSON.stringify({ name: '@origintrail-official/dkg' }) + '\n',
+    );
+    writeFileSync(join(cliRepo, 'packages', 'cli', 'dist', 'cli.js'), '');
+    originalDkgHome = process.env.DKG_HOME;
+    originalNoBlueGreen = process.env.DKG_NO_BLUE_GREEN;
+    process.env.DKG_HOME = dkgHome;
+    delete process.env.DKG_NO_BLUE_GREEN;
+    resolvedDkgCli.cliPath = join(cliRepo, 'packages', 'cli', 'dist', 'cli.js');
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 0, signal: null, error: undefined });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = originalDkgHome;
+    if (originalNoBlueGreen === undefined) delete process.env.DKG_NO_BLUE_GREEN;
+    else process.env.DKG_NO_BLUE_GREEN = originalNoBlueGreen;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function spawnOptions(): Record<string, unknown> {
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    return spawnSyncMock.mock.calls[0][2] as Record<string, unknown>;
+  }
+
+  function seedReadySlot(slot: 'a' | 'b', layout: 'git' | 'npm' = 'git'): void {
+    const slotDir = join(dkgHome, 'releases', slot);
+    const entryDir = layout === 'git'
+      ? join(slotDir, 'packages', 'cli', 'dist')
+      : join(slotDir, 'node_modules', '@origintrail-official', 'dkg', 'dist');
+    mkdirSync(entryDir, { recursive: true });
+    writeFileSync(join(entryDir, 'cli.js'), '');
+    writeFileSync(join(slotDir, 'package.json'), '{}\n');
+  }
+
+  function seedCurrentSymlink(target: 'a' | 'b' = 'a'): void {
+    const releasesDir = join(dkgHome, 'releases');
+    const current = join(releasesDir, 'current');
+    try {
+      symlinkSync(target, current, 'dir');
+    } catch {
+      symlinkSync(join(releasesDir, target), current, 'junction');
+    }
+  }
+
+  it('uses the migration-aware spawn timeout when releases/current is missing', async () => {
+    await startDaemon(9200);
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'node-bin',
+      [resolvedDkgCli.cliPath, 'start'],
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+    expect(spawnOptions()).toMatchObject({ timeout: MIGRATION_START_TIMEOUT_MS });
+  });
+
+  it('uses the migration-aware spawn timeout when releases/current is not a symlink', async () => {
+    mkdirSync(join(dkgHome, 'releases', 'current'), { recursive: true });
+
+    await startDaemon(9200);
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'node-bin',
+      [resolvedDkgCli.cliPath, 'start'],
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+    expect(spawnOptions()).toMatchObject({ timeout: MIGRATION_START_TIMEOUT_MS });
+  });
+
+  it('keeps the normal spawn timeout when blue-green slots are ready', async () => {
+    seedReadySlot('a');
+    seedReadySlot('b');
+    seedCurrentSymlink('a');
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({
+      stdio: 'inherit',
+      timeout: 30_000,
+    });
+  });
+
+  it('uses the migration-aware spawn timeout when an inactive slot needs repair', async () => {
+    seedReadySlot('a');
+    mkdirSync(join(dkgHome, 'releases', 'b'), { recursive: true });
+    seedCurrentSymlink('a');
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({ timeout: MIGRATION_START_TIMEOUT_MS });
+  });
+
+  it('keeps the normal spawn timeout when npm-layout blue-green slots are ready', async () => {
+    seedReadySlot('a', 'npm');
+    seedReadySlot('b', 'npm');
+    seedCurrentSymlink('a');
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({ timeout: 30_000 });
+  });
+
+  it('keeps the normal spawn timeout when blue-green migration is disabled', async () => {
+    process.env.DKG_NO_BLUE_GREEN = '1';
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({ timeout: 30_000 });
+  });
+
+  it('keeps the normal spawn timeout when the CLI is not running from a local checkout', async () => {
+    resolvedDkgCli.cliPath = join(testDir, 'standalone', 'dist', 'cli.js');
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({ timeout: 30_000 });
+  });
+
+  it('uses the migration-aware spawn timeout when the CLI path is symlinked into a local DKG checkout', async () => {
+    const linkedPackageParent = join(testDir, 'host-repo', 'node_modules', '@origintrail-official');
+    const linkedPackage = join(linkedPackageParent, 'dkg');
+    mkdirSync(linkedPackageParent, { recursive: true });
+    symlinkSync(cliRepo, linkedPackage, 'junction');
+    resolvedDkgCli.cliPath = join(linkedPackage, 'packages', 'cli', 'dist', 'cli.js');
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({ timeout: MIGRATION_START_TIMEOUT_MS });
+  });
+
+  it('uses the migration-aware spawn timeout when the CLI is inside any git package workspace', async () => {
+    const hostRepo = join(testDir, 'host-repo');
+    mkdirSync(join(hostRepo, '.git'), { recursive: true });
+    mkdirSync(join(hostRepo, 'packages', 'cli', 'dist'), { recursive: true });
+    writeFileSync(join(hostRepo, 'package.json'), '{}\n');
+    writeFileSync(join(hostRepo, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n');
+    writeFileSync(join(hostRepo, 'project.json'), '{}\n');
+    writeFileSync(
+      join(hostRepo, 'packages', 'cli', 'package.json'),
+      JSON.stringify({ name: '@example/not-dkg' }) + '\n',
+    );
+    resolvedDkgCli.cliPath = join(hostRepo, 'node_modules', '@origintrail-official', 'dkg', 'dist', 'cli.js');
+
+    await startDaemon(9200);
+
+    expect(spawnOptions()).toMatchObject({ timeout: MIGRATION_START_TIMEOUT_MS });
+  });
+
+  it('surfaces spawn errors clearly when daemon start fails', async () => {
+    seedReadySlot('a');
+    seedReadySlot('b');
+    seedCurrentSymlink('a');
+    spawnSyncMock.mockReturnValueOnce({
+      status: null,
+      signal: null,
+      error: new Error('spawnSync node ETIMEDOUT'),
+    });
+
+    await expect(startDaemon(9200)).rejects.toThrow(
+      /Failed to start DKG daemon: spawnSync node ETIMEDOUT/,
+    );
+    expect(spawnOptions()).toMatchObject({ timeout: 30_000 });
+  });
+
+  it('surfaces non-zero dkg start exits clearly', async () => {
+    seedReadySlot('a');
+    seedReadySlot('b');
+    seedCurrentSymlink('a');
+    spawnSyncMock.mockReturnValueOnce({ status: 1, signal: null, error: undefined });
+
+    await expect(startDaemon(9200)).rejects.toThrow(
+      /Failed to start DKG daemon: dkg start exited with 1/,
+    );
+    expect(spawnOptions()).toMatchObject({ timeout: 30_000 });
+  });
+});

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,8 +1,14 @@
 import { readFile, writeFile, mkdir, symlink, rename, unlink, readlink } from 'node:fs/promises';
-import { join, dirname, resolve, basename } from 'node:path';
+import { join, dirname, basename } from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { isDkgMonorepoRoot, resolveDkgConfigHome } from '@origintrail-official/dkg-core';
+import {
+  blueGreenSlotEntryPoint,
+  blueGreenSlotReady,
+  findPackageRepoDir,
+  isDkgMonorepoRoot,
+  resolveDkgConfigHome,
+} from '@origintrail-official/dkg-core';
 
 /**
  * Per-step build timeouts (milliseconds) used by the git-based auto-update
@@ -536,13 +542,7 @@ export function isDkgMonorepo(): boolean {
  * Works from packages/cli/dist/ (compiled) or packages/cli/src/ (dev).
  */
 export function findRepoDir(startDir: string): string | null {
-  let dir = resolve(startDir);
-  while (true) {
-    if (existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'packages'))) return dir;
-    const parent = dirname(dir);
-    if (parent === dir) return null;
-    dir = parent;
-  }
+  return findPackageRepoDir(startDir);
 }
 
 export function repoDir(): string | null {
@@ -747,9 +747,10 @@ export function isStandaloneInstall(): boolean {
  * NPM layout (node_modules/@origintrail-official/dkg/dist/cli.js).
  */
 export function slotEntryPoint(slotDir: string): string | null {
-  const gitPath = join(slotDir, 'packages', 'cli', 'dist', 'cli.js');
-  if (existsSync(gitPath)) return gitPath;
-  const npmPath = join(slotDir, 'node_modules', '@origintrail-official', 'dkg', 'dist', 'cli.js');
-  if (existsSync(npmPath)) return npmPath;
-  return null;
+  return blueGreenSlotEntryPoint(slotDir);
+}
+
+/** Return true when a blue-green slot has an entry point and install metadata. */
+export function slotReady(slotDir: string): boolean {
+  return blueGreenSlotReady(slotDir);
 }

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync } from 'node:fs';
 import { mkdir, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
-import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, gitCommandEnv, gitCommandArgs, slotEntryPoint } from './config.js';
+import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, gitCommandEnv, gitCommandArgs, slotReady } from './config.js';
 
 export const _migrationIo = {
   execSync: execSync as (...args: any[]) => any,
@@ -79,11 +79,6 @@ export async function migrateToBlueGreen(
 
   const slotA = join(rDir, 'a');
   const slotB = join(rDir, 'b');
-  const slotReady = (slotDir: string) => {
-    const entry = slotEntryPoint(slotDir);
-    if (!entry) return false;
-    return existsSync(join(slotDir, '.git')) || existsSync(join(slotDir, 'package.json'));
-  };
   if (hadCurrentLink && slotReady(slotA) && slotReady(slotB)) return;
 
   log('Migrating to blue-green release slots...');

--- a/packages/core/src/blue-green.ts
+++ b/packages/core/src/blue-green.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/** Find the nearest package workspace root used by the CLI migration path. */
+export function findPackageRepoDir(startDir: string): string | null {
+  let dir = resolve(startDir);
+  while (true) {
+    if (existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'packages'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Resolve the CLI entry point within a blue-green slot.
+ * Supports both git layout (packages/cli/dist/cli.js) and
+ * NPM layout (node_modules/@origintrail-official/dkg/dist/cli.js).
+ */
+export function blueGreenSlotEntryPoint(slotDir: string): string | null {
+  const gitPath = join(slotDir, 'packages', 'cli', 'dist', 'cli.js');
+  if (existsSync(gitPath)) return gitPath;
+  const npmPath = join(slotDir, 'node_modules', '@origintrail-official', 'dkg', 'dist', 'cli.js');
+  if (existsSync(npmPath)) return npmPath;
+  return null;
+}
+
+/** Return true when a blue-green slot has an entry point and install metadata. */
+export function blueGreenSlotReady(slotDir: string): boolean {
+  const entry = blueGreenSlotEntryPoint(slotDir);
+  if (!entry) return false;
+  return existsSync(join(slotDir, '.git')) || existsSync(join(slotDir, 'package.json'));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,11 @@ export {
   type GenesisQuad,
 } from './genesis.js';
 export { withRetry, type RetryOptions } from './retry.js';
+export {
+  findPackageRepoDir,
+  blueGreenSlotEntryPoint,
+  blueGreenSlotReady,
+} from './blue-green.js';
 export { requestFaucetFunding, type FaucetResult } from './faucet.js';
 export {
   assertSafeIri,

--- a/packages/core/test/blue-green.test.ts
+++ b/packages/core/test/blue-green.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  blueGreenSlotEntryPoint,
+  blueGreenSlotReady,
+  findPackageRepoDir,
+} from '../src/index.js';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(join(tmpdir(), 'dkg-core-blue-green-'));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+describe('blue-green shared helpers', () => {
+  it('findPackageRepoDir walks up to the package workspace root used by CLI migration', async () => {
+    const repo = join(testDir, 'host-repo');
+    const nested = join(repo, 'node_modules', '@origintrail-official', 'dkg', 'dist');
+    await mkdir(join(repo, 'packages'), { recursive: true });
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(repo, 'package.json'), '{}\n');
+
+    expect(findPackageRepoDir(nested)).toBe(repo);
+  });
+
+  it('findPackageRepoDir returns null when no package workspace root exists', async () => {
+    const nested = join(testDir, 'standalone', 'dist');
+    await mkdir(nested, { recursive: true });
+
+    expect(findPackageRepoDir(nested)).toBeNull();
+  });
+
+  it('blueGreenSlotEntryPoint supports git-layout slots', async () => {
+    const slot = join(testDir, 'slot-a');
+    const entry = join(slot, 'packages', 'cli', 'dist', 'cli.js');
+    await mkdir(join(slot, 'packages', 'cli', 'dist'), { recursive: true });
+    await writeFile(entry, '');
+
+    expect(blueGreenSlotEntryPoint(slot)).toBe(entry);
+  });
+
+  it('blueGreenSlotEntryPoint supports npm-layout slots', async () => {
+    const slot = join(testDir, 'slot-a');
+    const entry = join(slot, 'node_modules', '@origintrail-official', 'dkg', 'dist', 'cli.js');
+    await mkdir(join(slot, 'node_modules', '@origintrail-official', 'dkg', 'dist'), { recursive: true });
+    await writeFile(entry, '');
+
+    expect(blueGreenSlotEntryPoint(slot)).toBe(entry);
+  });
+
+  it('blueGreenSlotReady requires both an entry point and install metadata', async () => {
+    const slot = join(testDir, 'slot-a');
+    const entryDir = join(slot, 'packages', 'cli', 'dist');
+    await mkdir(entryDir, { recursive: true });
+    await writeFile(join(entryDir, 'cli.js'), '');
+
+    expect(blueGreenSlotReady(slot)).toBe(false);
+
+    await writeFile(join(slot, 'package.json'), '{}\n');
+
+    expect(blueGreenSlotReady(slot)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Retarget PR #341 to `main` after `feat/dkg-memory-integration` was merged into `main`, and rebase the focused timeout fix onto latest `origin/main` with no conflicts.
- Adjust `dkg openclaw setup` daemon start so starts that may run blue-green migration or slot repair use a bounded 60 minute timeout instead of the normal 30 second timeout.
- Keep the normal 30 second timeout when blue-green is disabled, the CLI is truly non-local, or both blue-green slots are ready.
- Share the CLI-style package repo finder and blue-green slot readiness helpers through `@origintrail-official/dkg-core` so setup and `migrateToBlueGreen()` use the same predicates.
- Resolve linked/symlinked CLI paths before repo detection and continue surfacing spawn errors/non-zero exits as actionable setup failures.

## Related
Fixes #316

## Files changed
- `packages/core/src/blue-green.ts` adds shared package repo and blue-green slot helper predicates, with focused core tests in `packages/core/test/blue-green.test.ts`.
- `packages/cli/src/config.ts` and `packages/cli/src/migration.ts` keep the CLI wrapper API while delegating repo/slot readiness logic to the shared core helpers.
- `packages/adapter-openclaw/src/setup.ts` uses the shared helpers to choose the setup-side daemon-start timeout.
- `packages/adapter-openclaw/test/setup-start-daemon.test.ts` adds focused `spawnSync` coverage for first-run migration, slot repair, ready slots, disabled blue-green, non-local CLIs, package-workspace local CLIs, symlinked local CLI paths, and failure surfacing.

## Test plan
- `pnpm install --frozen-lockfile` (needed because this worktree initially had no `node_modules`; local install artifacts are ignored)
- `pnpm --filter @origintrail-official/dkg-core build` (passed after retarget to `main`)
- `pnpm --filter @origintrail-official/dkg-core exec vitest run test/blue-green.test.ts` (5 passed after retarget to `main`)
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/setup-start-daemon.test.ts` (11 passed after retarget to `main`)
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/setup-entry.test.ts test/setup.test.ts` (post-retarget: 161 passed, 1 skipped, 1 failed in inherited `writeDkgConfig` autoUpdate expectation outside this PR diff)
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw build` (passed after retarget to `main`)
- `pnpm --filter @origintrail-official/dkg... build` (passed after retarget to `main`, including CLI after dependency packages were built)
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw test` (pre-retarget: 683 passed, then failed one pre-existing red test in `test/adapter-openclaw-extra.test.ts` for plugin id/package-name mismatch marked `RED until reconciled`)
- `pnpm --filter @origintrail-official/dkg exec vitest run test/slot-helpers.test.ts` (pre-retarget: blocked by Windows `EPERM` in symlink-dependent tests; the non-symlink repo helper tests in that file passed)
- `pnpm --filter @origintrail-official/dkg exec vitest run test/migration.test.ts --reporter=verbose` (pre-retarget: blocked by Windows `EPERM` while creating `releases/current` / `current.tmp` symlinks)
