### PR TITLE
fix(openclaw): align dkg-ui health lifecycle

### DIFF
--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -743,8 +743,8 @@ export class DkgChannelPlugin {
     const lifecycleOwner =
       (ctx && typeof ctx === 'object' ? this.gatewayLifecycleOwnersByContext.get(ctx) : undefined) ??
       (signal ? this.gatewayLifecycleOwnersBySignal.get(signal) : undefined) ??
-      this.gatewayLifecyclePendingOwnersByAccount.get(accountId) ??
-      this.gatewayLifecycleOwnersByAccount.get(accountId);
+      this.gatewayLifecycleOwnersByAccount.get(accountId) ??
+      this.gatewayLifecyclePendingOwnersByAccount.get(accountId);
     const activeOwner = this.gatewayLifecycleOwner;
     const pendingOwner = this.gatewayLifecyclePendingOwner;
     if ((activeOwner || pendingOwner) && lifecycleOwner !== activeOwner && lifecycleOwner !== pendingOwner) {

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -665,8 +665,7 @@ export class DkgChannelPlugin {
 
   private reportGatewayLifecycleStopped(ctx: OpenClawGatewayLifecycleContext | null | undefined, lifecycleOwner?: object | null): void {
     if (!ctx) return;
-    ctx.setStatus?.({
-      accountId: ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID,
+    this.setGatewayLifecycleStatus(ctx, {
       running: false,
       connected: false,
       restartPending: false,
@@ -681,6 +680,22 @@ export class DkgChannelPlugin {
   private getGatewayAccountId(ctx: any): string {
     const accountId = typeof ctx?.accountId === 'string' ? ctx.accountId.trim() : '';
     return accountId || DEFAULT_CHANNEL_ACCOUNT_ID;
+  }
+
+  private getGatewayLifecycleStatus(ctx: OpenClawGatewayLifecycleContext): Record<string, unknown> {
+    const status = ctx.getStatus?.();
+    return status && typeof status === 'object' ? status : {};
+  }
+
+  private setGatewayLifecycleStatus(
+    ctx: OpenClawGatewayLifecycleContext,
+    patch: Record<string, unknown>,
+  ): void {
+    ctx.setStatus?.({
+      ...this.getGatewayLifecycleStatus(ctx),
+      ...patch,
+      accountId: this.getGatewayAccountId(ctx),
+    });
   }
 
   private reportUnsupportedGatewayAccount(ctx: any, message: string): void {
@@ -808,8 +823,7 @@ export class DkgChannelPlugin {
       this.gatewayLifecycleOwnersByAccount.set(accountId, lifecycleOwner);
       this.gatewayLifecycleStatusContext = ctx;
       this.gatewayLifecycleStatusOwner = lifecycleOwner;
-      ctx.setStatus?.({
-        accountId: ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID,
+      this.setGatewayLifecycleStatus(ctx, {
         enabled: this.config.enabled !== false,
         configured: true,
         linked: true,

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -678,14 +678,68 @@ export class DkgChannelPlugin {
     }
   }
 
+  private getGatewayAccountId(ctx: any): string {
+    const accountId = typeof ctx?.accountId === 'string' ? ctx.accountId.trim() : '';
+    return accountId || DEFAULT_CHANNEL_ACCOUNT_ID;
+  }
+
+  private reportUnsupportedGatewayAccount(ctx: any, message: string): void {
+    ctx?.setStatus?.({
+      accountId: this.getGatewayAccountId(ctx),
+      enabled: false,
+      configured: false,
+      linked: false,
+      running: false,
+      connected: false,
+      restartPending: false,
+      lastError: message,
+      lastStopAt: Date.now(),
+    });
+  }
+
+  private ensureSupportedGatewayAccount(ctx: any): void {
+    const accountId = this.getGatewayAccountId(ctx);
+    if (accountId === DEFAULT_CHANNEL_ACCOUNT_ID) return;
+    const message = `DKG UI channel only supports the "${DEFAULT_CHANNEL_ACCOUNT_ID}" gateway account`;
+    this.reportUnsupportedGatewayAccount(ctx, message);
+    throw new Error(message);
+  }
+
+  private ignoreUnsupportedGatewayStop(ctx: any): boolean {
+    const accountId = this.getGatewayAccountId(ctx);
+    if (accountId === DEFAULT_CHANNEL_ACCOUNT_ID) return false;
+    this.reportUnsupportedGatewayAccount(ctx, `DKG UI channel does not run gateway account "${accountId}"`);
+    return true;
+  }
+
+  private cancelPendingGatewayLifecycle(ctx: any, lifecycleOwner: object): void {
+    const accountId = this.getGatewayAccountId(ctx);
+    const signal = ctx?.abortSignal as AbortSignal | undefined;
+    if (this.gatewayLifecyclePendingOwner === lifecycleOwner) {
+      this.gatewayLifecyclePendingOwner = null;
+    }
+    if (this.gatewayLifecycleOwner && this.gatewayLifecycleOwner !== lifecycleOwner) {
+      this.gatewayLifecyclePendingOwner = this.gatewayLifecycleOwner;
+    }
+    if (this.gatewayLifecyclePendingOwnersByAccount.get(accountId) === lifecycleOwner) {
+      this.gatewayLifecyclePendingOwnersByAccount.delete(accountId);
+    }
+    if (ctx && typeof ctx === 'object' && this.gatewayLifecycleOwnersByContext.get(ctx) === lifecycleOwner) {
+      this.gatewayLifecycleOwnersByContext.delete(ctx);
+    }
+    if (signal && this.gatewayLifecycleOwnersBySignal.get(signal) === lifecycleOwner) {
+      this.gatewayLifecycleOwnersBySignal.delete(signal);
+    }
+  }
+
   private async stopAbortedGatewayLifecycle(ctx: any, lifecycleOwner?: object): Promise<void> {
     await this.stop({ updateGatewayStatus: false });
     this.reportGatewayLifecycleStopped(ctx, lifecycleOwner);
   }
 
   private async stopCurrentGatewayLifecycle(ctx: any): Promise<void> {
-    const accountId = ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID;
-    const signal = ctx.abortSignal as AbortSignal | undefined;
+    const accountId = this.getGatewayAccountId(ctx);
+    const signal = ctx?.abortSignal as AbortSignal | undefined;
     const lifecycleOwner =
       (ctx && typeof ctx === 'object' ? this.gatewayLifecycleOwnersByContext.get(ctx) : undefined) ??
       (signal ? this.gatewayLifecycleOwnersBySignal.get(signal) : undefined) ??
@@ -696,16 +750,27 @@ export class DkgChannelPlugin {
     if ((activeOwner || pendingOwner) && lifecycleOwner !== activeOwner && lifecycleOwner !== pendingOwner) {
       return;
     }
+    if (
+      lifecycleOwner === pendingOwner &&
+      activeOwner &&
+      activeOwner !== pendingOwner &&
+      this.server?.listening === true &&
+      !this.serverStop &&
+      !this.stopping
+    ) {
+      this.cancelPendingGatewayLifecycle(ctx, lifecycleOwner);
+      return;
+    }
     await this.stopAbortedGatewayLifecycle(ctx, lifecycleOwner);
   }
 
   private async runGatewayLifecycle(ctx: any): Promise<void> {
-    if (ctx.abortSignal?.aborted) {
+    if (ctx?.abortSignal?.aborted) {
       return;
     }
 
-    const accountId = ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID;
-    const signal = ctx.abortSignal as AbortSignal | undefined;
+    const accountId = this.getGatewayAccountId(ctx);
+    const signal = ctx?.abortSignal as AbortSignal | undefined;
     const lifecycleOwner = {};
     this.gatewayLifecyclePendingOwner = lifecycleOwner;
     this.gatewayLifecyclePendingOwnersByAccount.set(accountId, lifecycleOwner);
@@ -725,7 +790,7 @@ export class DkgChannelPlugin {
       if (this.gatewayLifecyclePendingOwner !== lifecycleOwner) {
         return;
       }
-      if (ctx.abortSignal?.aborted) {
+      if (ctx?.abortSignal?.aborted) {
         if (!hadStableBridgeBeforeStart) {
           await this.stopAbortedGatewayLifecycle(ctx, lifecycleOwner);
         }
@@ -757,12 +822,12 @@ export class DkgChannelPlugin {
         port: this.bridgePort || this.port,
       });
 
-      await this.waitForGatewayLifecycleStop(ctx.abortSignal);
+      await this.waitForGatewayLifecycleStop(ctx?.abortSignal);
     } finally {
       const ownsActiveLifecycle =
         this.gatewayLifecycleOwner === lifecycleOwner &&
         this.gatewayLifecyclePendingOwner === lifecycleOwner;
-      if (ctx.abortSignal?.aborted && ownsActiveLifecycle) {
+      if (ctx?.abortSignal?.aborted && ownsActiveLifecycle) {
         await this.stopAbortedGatewayLifecycle(ctx, lifecycleOwner);
       }
       if (this.gatewayLifecycleOwnersByAccount.get(accountId) === lifecycleOwner) {
@@ -922,9 +987,11 @@ export class DkgChannelPlugin {
       },
       gateway: {
         startAccount: async (ctx: any) => {
+          this.ensureSupportedGatewayAccount(ctx);
           await this.runGatewayLifecycle(ctx);
         },
         stopAccount: async (ctx: any) => {
+          if (this.ignoreUnsupportedGatewayStop(ctx)) return;
           await this.stopCurrentGatewayLifecycle(ctx);
         },
       },

--- a/packages/adapter-openclaw/src/DkgChannelPlugin.ts
+++ b/packages/adapter-openclaw/src/DkgChannelPlugin.ts
@@ -26,6 +26,8 @@ import { fileURLToPath } from 'node:url';
 import type {
   ChannelOutboundReply,
   DkgOpenClawConfig,
+  OpenClawChannelAdapter,
+  OpenClawGatewayLifecycleContext,
   OpenClawPluginApi,
 } from './types.js';
 import type { DkgDaemonClient, OpenClawAttachmentRef } from './dkg-client.js';
@@ -375,6 +377,16 @@ export class DkgChannelPlugin {
   private stopping = false;
   private readonly stopWaiters: Array<() => void> = [];
   private stopDrainDeadlineAt: number | null = null;
+  private serverStop: Promise<void> | null = null;
+  private gatewayLifecycleStop: (() => void) | null = null;
+  private gatewayLifecycleOwner: object | null = null;
+  private gatewayLifecyclePendingOwner: object | null = null;
+  private gatewayLifecycleStatusContext: OpenClawGatewayLifecycleContext | null = null;
+  private gatewayLifecycleStatusOwner: object | null = null;
+  private readonly gatewayLifecycleOwnersByAccount = new Map<string, object>();
+  private readonly gatewayLifecyclePendingOwnersByAccount = new Map<string, object>();
+  private readonly gatewayLifecycleOwnersByContext = new WeakMap<object, object>();
+  private readonly gatewayLifecycleOwnersBySignal = new WeakMap<AbortSignal, object>();
   /**
    * Pre-dispatch memory-slot re-assert callback. Set by `DkgNodePlugin`
    * to `memoryPlugin.reAssertCapability.bind(memoryPlugin)`. Called
@@ -540,6 +552,10 @@ export class DkgChannelPlugin {
   // ---------------------------------------------------------------------------
 
   async start(): Promise<void> {
+    if (this.serverStop) await this.serverStop;
+    this.stopping = false;
+    this.stopDrainDeadlineAt = null;
+
     if (this.server?.listening) return;
     if (this.serverStart) return this.serverStart;
 
@@ -590,43 +606,182 @@ export class DkgChannelPlugin {
     await this.serverStart;
   }
 
-  async stop(): Promise<void> {
-    this.stopping = true;
-    this.stopDrainDeadlineAt = Date.now() + STOP_DRAIN_TIMEOUT_MS;
+  async stop(options: { updateGatewayStatus?: boolean } = {}): Promise<void> {
+    if (this.serverStop) return this.serverStop;
+    const updateGatewayStatus = options.updateGatewayStatus !== false;
+    const stopWork = Promise.resolve().then(async () => {
+      this.stopping = true;
+      this.stopDrainDeadlineAt = Date.now() + STOP_DRAIN_TIMEOUT_MS;
 
-    // Reject all pending requests
-    for (const [id, pending] of this.pendingRequests) {
-      clearTimeout(pending.timer);
-      pending.reject(new Error('Channel shutting down'));
-      this.pendingRequests.delete(id);
+      // Reject all pending requests
+      for (const [id, pending] of this.pendingRequests) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error('Channel shutting down'));
+        this.pendingRequests.delete(id);
+      }
+
+      for (const [id, job] of this.pendingTurnPersistence) {
+        if (job.allowDuringShutdown) continue;
+        if (!job.timer) continue;
+        clearTimeout(job.timer);
+        this.deletePendingTurnPersistence(id);
+      }
+
+      if (this.serverStart) {
+        await this.serverStart.catch(() => {});
+      }
+
+      if (this.server) {
+        await new Promise<void>((resolve) => {
+          this.server!.close(() => resolve());
+        });
+        this.server = null;
+      }
+
+      const drained = await this.waitForStopDrain(STOP_DRAIN_TIMEOUT_MS);
+      if (!drained) {
+        this.api?.logger.warn?.(
+          `[dkg-channel] Channel stop timed out after ${STOP_DRAIN_TIMEOUT_MS}ms waiting for turn persistence to drain; continuing shutdown`,
+        );
+        this.clearPendingTurnPersistence();
+      }
+      this.stopDrainDeadlineAt = null;
+      if (updateGatewayStatus) {
+        this.reportGatewayLifecycleStopped(this.gatewayLifecycleStatusContext, this.gatewayLifecycleStatusOwner);
+      }
+      this.gatewayLifecycleStop?.();
+      this.gatewayLifecycleStop = null;
+    });
+
+    this.serverStop = stopWork;
+    try {
+      await stopWork;
+    } finally {
+      if (this.serverStop === stopWork) {
+        this.serverStop = null;
+      }
+    }
+  }
+
+  private reportGatewayLifecycleStopped(ctx: OpenClawGatewayLifecycleContext | null | undefined, lifecycleOwner?: object | null): void {
+    if (!ctx) return;
+    ctx.setStatus?.({
+      accountId: ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID,
+      running: false,
+      connected: false,
+      restartPending: false,
+      lastStopAt: Date.now(),
+    });
+    if (lifecycleOwner && this.gatewayLifecycleStatusOwner === lifecycleOwner) {
+      this.gatewayLifecycleStatusContext = null;
+      this.gatewayLifecycleStatusOwner = null;
+    }
+  }
+
+  private async stopAbortedGatewayLifecycle(ctx: any, lifecycleOwner?: object): Promise<void> {
+    await this.stop({ updateGatewayStatus: false });
+    this.reportGatewayLifecycleStopped(ctx, lifecycleOwner);
+  }
+
+  private async stopCurrentGatewayLifecycle(ctx: any): Promise<void> {
+    const accountId = ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID;
+    const signal = ctx.abortSignal as AbortSignal | undefined;
+    const lifecycleOwner =
+      (ctx && typeof ctx === 'object' ? this.gatewayLifecycleOwnersByContext.get(ctx) : undefined) ??
+      (signal ? this.gatewayLifecycleOwnersBySignal.get(signal) : undefined) ??
+      this.gatewayLifecyclePendingOwnersByAccount.get(accountId) ??
+      this.gatewayLifecycleOwnersByAccount.get(accountId);
+    const activeOwner = this.gatewayLifecycleOwner;
+    const pendingOwner = this.gatewayLifecyclePendingOwner;
+    if ((activeOwner || pendingOwner) && lifecycleOwner !== activeOwner && lifecycleOwner !== pendingOwner) {
+      return;
+    }
+    await this.stopAbortedGatewayLifecycle(ctx, lifecycleOwner);
+  }
+
+  private async runGatewayLifecycle(ctx: any): Promise<void> {
+    if (ctx.abortSignal?.aborted) {
+      return;
     }
 
-    for (const [id, job] of this.pendingTurnPersistence) {
-      if (job.allowDuringShutdown) continue;
-      if (!job.timer) continue;
-      clearTimeout(job.timer);
-      this.deletePendingTurnPersistence(id);
+    const accountId = ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID;
+    const signal = ctx.abortSignal as AbortSignal | undefined;
+    const lifecycleOwner = {};
+    this.gatewayLifecyclePendingOwner = lifecycleOwner;
+    this.gatewayLifecyclePendingOwnersByAccount.set(accountId, lifecycleOwner);
+    if (ctx && typeof ctx === 'object') {
+      this.gatewayLifecycleOwnersByContext.set(ctx, lifecycleOwner);
+    }
+    if (signal) {
+      this.gatewayLifecycleOwnersBySignal.set(signal, lifecycleOwner);
     }
 
-    if (this.serverStart) {
-      await this.serverStart.catch(() => {});
-    }
+    try {
+      const hadStableBridgeBeforeStart =
+        this.server?.listening === true &&
+        !this.serverStop &&
+        !this.stopping;
+      await this.start();
+      if (this.gatewayLifecyclePendingOwner !== lifecycleOwner) {
+        return;
+      }
+      if (ctx.abortSignal?.aborted) {
+        if (!hadStableBridgeBeforeStart) {
+          await this.stopAbortedGatewayLifecycle(ctx, lifecycleOwner);
+        }
+        return;
+      }
+      if (this.serverStop || this.stopping || !this.server?.listening) {
+        if (this.serverStop) await this.serverStop;
+          return;
+      }
 
-    if (this.server) {
-      await new Promise<void>((resolve) => {
-        this.server!.close(() => resolve());
+      this.gatewayLifecycleOwner = lifecycleOwner;
+      if (this.gatewayLifecyclePendingOwnersByAccount.get(accountId) === lifecycleOwner) {
+        this.gatewayLifecyclePendingOwnersByAccount.delete(accountId);
+      }
+      this.gatewayLifecycleOwnersByAccount.set(accountId, lifecycleOwner);
+      this.gatewayLifecycleStatusContext = ctx;
+      this.gatewayLifecycleStatusOwner = lifecycleOwner;
+      ctx.setStatus?.({
+        accountId: ctx.accountId ?? DEFAULT_CHANNEL_ACCOUNT_ID,
+        enabled: this.config.enabled !== false,
+        configured: true,
+        linked: true,
+        running: true,
+        connected: true,
+        restartPending: false,
+        lastError: null,
+        lastStartAt: Date.now(),
+        mode: 'webhook',
+        port: this.bridgePort || this.port,
       });
-      this.server = null;
-    }
 
-    const drained = await this.waitForStopDrain(STOP_DRAIN_TIMEOUT_MS);
-    if (!drained) {
-      this.api?.logger.warn?.(
-        `[dkg-channel] Channel stop timed out after ${STOP_DRAIN_TIMEOUT_MS}ms waiting for turn persistence to drain; continuing shutdown`,
-      );
-      this.clearPendingTurnPersistence();
+      await this.waitForGatewayLifecycleStop(ctx.abortSignal);
+    } finally {
+      const ownsActiveLifecycle =
+        this.gatewayLifecycleOwner === lifecycleOwner &&
+        this.gatewayLifecyclePendingOwner === lifecycleOwner;
+      if (ctx.abortSignal?.aborted && ownsActiveLifecycle) {
+        await this.stopAbortedGatewayLifecycle(ctx, lifecycleOwner);
+      }
+      if (this.gatewayLifecycleOwnersByAccount.get(accountId) === lifecycleOwner) {
+        this.gatewayLifecycleOwnersByAccount.delete(accountId);
+      }
+      if (this.gatewayLifecyclePendingOwnersByAccount.get(accountId) === lifecycleOwner) {
+        this.gatewayLifecyclePendingOwnersByAccount.delete(accountId);
+      }
+      if (this.gatewayLifecyclePendingOwner === lifecycleOwner) {
+        this.gatewayLifecyclePendingOwner = null;
+      }
+      if (this.gatewayLifecycleOwner === lifecycleOwner) {
+        this.gatewayLifecycleOwner = null;
+      }
+      if (this.gatewayLifecycleStatusOwner === lifecycleOwner) {
+        this.gatewayLifecycleStatusContext = null;
+        this.gatewayLifecycleStatusOwner = null;
+      }
     }
-    this.stopDrainDeadlineAt = null;
   }
 
   private deletePendingTurnPersistence(correlationId: string): void {
@@ -735,7 +890,7 @@ export class DkgChannelPlugin {
     return this.sdk;
   }
 
-  private buildRegisteredChannelPlugin() {
+  private buildRegisteredChannelPlugin(): OpenClawChannelAdapter {
     return {
       id: CHANNEL_NAME,
       name: CHANNEL_NAME,
@@ -765,10 +920,38 @@ export class DkgChannelPlugin {
         disabledReason: () => 'disabled',
         unconfiguredReason: () => 'not configured',
       },
+      gateway: {
+        startAccount: async (ctx: any) => {
+          await this.runGatewayLifecycle(ctx);
+        },
+        stopAccount: async (ctx: any) => {
+          await this.stopCurrentGatewayLifecycle(ctx);
+        },
+      },
       start: () => this.start(),
       stop: () => this.stop(),
       onOutbound: (reply: ChannelOutboundReply) => this.handleOutboundReply(reply),
     };
+  }
+
+  private waitForGatewayLifecycleStop(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) return Promise.resolve();
+    return new Promise((resolve) => {
+      this.gatewayLifecycleStop?.();
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        signal?.removeEventListener('abort', finish);
+        if (this.gatewayLifecycleStop === finish) {
+          this.gatewayLifecycleStop = null;
+        }
+        resolve();
+      };
+      this.gatewayLifecycleStop = finish;
+      signal?.addEventListener('abort', finish, { once: true });
+      if (signal?.aborted) finish();
+    });
   }
 
   private resolveRegisteredAccount(accountId?: string): Record<string, unknown> {

--- a/packages/adapter-openclaw/src/types.ts
+++ b/packages/adapter-openclaw/src/types.ts
@@ -99,6 +99,21 @@ export interface OpenClawToolResult {
 // Channel types
 // ---------------------------------------------------------------------------
 
+export interface OpenClawGatewayLifecycleContext {
+  accountId?: string;
+  account?: Record<string, unknown>;
+  cfg?: any;
+  runtime?: any;
+  abortSignal?: AbortSignal;
+  getStatus?: () => Record<string, unknown>;
+  setStatus?: (status: Record<string, unknown>) => void;
+}
+
+export interface OpenClawGatewayLifecycleAdapter {
+  startAccount(ctx: OpenClawGatewayLifecycleContext): Promise<void>;
+  stopAccount(ctx: OpenClawGatewayLifecycleContext): Promise<void>;
+}
+
 /** Inbound message from an external channel into OpenClaw. */
 export interface ChannelInboundMessage {
   /** Channel name (e.g. "dkg-ui"). */
@@ -155,6 +170,8 @@ export interface OpenClawChannelAdapter {
   start?(): Promise<void>;
   /** Called when the gateway stops.  Tear down transport. */
   stop?(): Promise<void>;
+  /** Per-account lifecycle hooks consumed by current OpenClaw gateway monitors. */
+  gateway?: OpenClawGatewayLifecycleAdapter;
   /**
    * Called by the gateway when the agent produces a reply for this channel.
    * The adapter should deliver it via its transport.

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -93,6 +93,11 @@ async function waitForBridgePort(plugin: DkgChannelPlugin): Promise<number> {
   throw new Error('Bridge server did not bind to a port');
 }
 
+async function flushAsyncContinuations(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('DkgChannelPlugin', () => {
   let client: DkgDaemonClient;
   let plugin: DkgChannelPlugin;
@@ -270,6 +275,838 @@ describe('DkgChannelPlugin', () => {
       configured: true,
       linked: true,
     });
+    expect(registeredPlugin.gateway.startAccount).toBeTypeOf('function');
+    expect(registeredPlugin.gateway.stopAccount).toBeTypeOf('function');
+  });
+
+  it('keeps the registered gateway lifecycle running until OpenClaw aborts it', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const controller = new AbortController();
+    const setStatus = vi.fn();
+    let settled = false;
+    const lifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: controller.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    }).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        accountId: 'default',
+        running: true,
+        connected: true,
+        restartPending: false,
+        mode: 'webhook',
+      }));
+    });
+    expect(settled).toBe(false);
+
+    controller.abort();
+    await lifecycle;
+    expect(settled).toBe(true);
+    expect(plugin.isListening).toBe(false);
+  });
+
+  it('does not tear down an active bridge for an already-aborted gateway lifecycle start', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+    await waitForBridgePort(plugin);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const controller = new AbortController();
+    controller.abort();
+    const setStatus = vi.fn();
+
+    await registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: controller.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    });
+
+    expect(plugin.isListening).toBe(true);
+    expect(setStatus).not.toHaveBeenCalled();
+  });
+
+  it('keeps the registered gateway lifecycle pending until stopAccount even without an abort signal', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const setStatus = vi.fn();
+    let settled = false;
+    const lifecycleCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    };
+    const lifecycle = registeredPlugin.gateway.startAccount(lifecycleCtx).then(() => {
+      settled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+    expect(settled).toBe(false);
+
+    await registeredPlugin.gateway.stopAccount(lifecycleCtx);
+    await lifecycle;
+    expect(settled).toBe(true);
+  });
+
+  it('stops the current no-signal lifecycle from a fresh stopAccount context for the same account', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const setStatus = vi.fn();
+    const lifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    });
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    await registeredPlugin.gateway.stopAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    });
+
+    await lifecycle;
+    expect(plugin.isListening).toBe(false);
+  });
+
+  it('stops a pending replacement lifecycle before it reports running', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    };
+    const firstLifecycle = registeredPlugin.gateway.startAccount(firstCtx);
+    await vi.waitFor(() => {
+      expect(firstCtx.setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const replacementCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    };
+    const replacementLifecycle = registeredPlugin.gateway.startAccount(replacementCtx);
+    await registeredPlugin.gateway.stopAccount(replacementCtx);
+
+    await firstLifecycle;
+    await replacementLifecycle;
+    expect(plugin.isListening).toBe(false);
+    expect(replacementCtx.setStatus.mock.calls.some(([status]) => status.running === true)).toBe(false);
+    expect(replacementCtx.setStatus).toHaveBeenCalledWith(expect.objectContaining({
+      running: false,
+      connected: false,
+      restartPending: false,
+    }));
+  });
+
+  it('stops a pending same-account lifecycle from a fresh stop context', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    };
+    const firstLifecycle = registeredPlugin.gateway.startAccount(firstCtx);
+    await vi.waitFor(() => {
+      expect(firstCtx.setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const replacementCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    };
+    const stopStatus = vi.fn();
+    const replacementLifecycle = registeredPlugin.gateway.startAccount(replacementCtx);
+    await registeredPlugin.gateway.stopAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: stopStatus,
+    });
+
+    await firstLifecycle;
+    await replacementLifecycle;
+    expect(plugin.isListening).toBe(false);
+    expect(replacementCtx.setStatus.mock.calls.some(([status]) => status.running === true)).toBe(false);
+    expect(stopStatus).toHaveBeenCalledWith(expect.objectContaining({
+      running: false,
+      connected: false,
+      restartPending: false,
+    }));
+  });
+
+  it('stops the registered gateway lifecycle bridge when OpenClaw stops the channel', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    await plugin.start();
+    expect(plugin.isListening).toBe(true);
+
+    const setStatus = vi.fn();
+    await registeredPlugin.gateway.stopAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: new AbortController().signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    });
+
+    expect(plugin.isListening).toBe(false);
+    expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'default',
+      running: false,
+      connected: false,
+      restartPending: false,
+    }));
+  });
+
+  it('settles plugin-level gateway lifecycle only after bridge shutdown completes', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const setStatus = vi.fn();
+    let settled = false;
+    const lifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    }).then(() => {
+      settled = true;
+    });
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const server = (plugin as any).server;
+    const originalClose = server.close.bind(server);
+    let closeNow: (() => void) | undefined;
+    const closeSpy = vi.spyOn(server, 'close').mockImplementation((callback?: () => void) => {
+      closeNow = () => originalClose(callback);
+      return server;
+    });
+
+    try {
+      const stopPromise = plugin.stop();
+      await vi.waitFor(() => {
+        expect(closeNow).toBeTypeOf('function');
+      });
+      await flushAsyncContinuations();
+
+      expect(settled).toBe(false);
+      expect(setStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+        running: false,
+      }));
+
+      closeNow?.();
+      await stopPromise;
+      await lifecycle;
+
+      expect(settled).toBe(true);
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: false,
+        connected: false,
+        restartPending: false,
+      }));
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('preserves replacement lifecycle status when OpenClaw reuses the same context object', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const setStatus = vi.fn();
+    const lifecycleCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    };
+    const firstLifecycle = registeredPlugin.gateway.startAccount(lifecycleCtx);
+    await vi.waitFor(() => {
+      expect(setStatus.mock.calls.filter(([status]) => status.running === true)).toHaveLength(1);
+    });
+
+    const replacementLifecycle = registeredPlugin.gateway.startAccount(lifecycleCtx);
+    await vi.waitFor(() => {
+      expect(setStatus.mock.calls.filter(([status]) => status.running === true)).toHaveLength(2);
+    });
+    await firstLifecycle;
+
+    await plugin.stop();
+    await replacementLifecycle;
+
+    expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+      running: false,
+      connected: false,
+      restartPending: false,
+    }));
+  });
+
+  it('clears shutdown state when OpenClaw restarts the registered gateway lifecycle', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    await plugin.start();
+
+    await registeredPlugin.gateway.stopAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: new AbortController().signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    });
+    const internal = plugin as unknown as { stopping: boolean };
+    expect(internal.stopping).toBe(true);
+
+    const controller = new AbortController();
+    const lifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: controller.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    });
+    await waitForBridgePort(plugin);
+
+    expect(internal.stopping).toBe(false);
+
+    controller.abort();
+    await lifecycle;
+  });
+
+  it('waits for an in-flight stop before restarting the registered gateway lifecycle', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    await plugin.start();
+    const server = (plugin as any).server;
+    const originalClose = server.close.bind(server);
+    let closeNow: (() => void) | undefined;
+    const closeSpy = vi.spyOn(server, 'close').mockImplementation((callback?: () => void) => {
+      closeNow = () => originalClose(callback);
+      return server;
+    });
+
+    try {
+      const stopPromise = plugin.stop();
+      await vi.waitFor(() => {
+        expect(closeNow).toBeTypeOf('function');
+      });
+
+      const controller = new AbortController();
+      const setStatus = vi.fn();
+      const lifecycle = registeredPlugin.gateway.startAccount({
+        accountId: 'default',
+        account: { accountId: 'default' },
+        cfg: {},
+        runtime: {},
+        abortSignal: controller.signal,
+        getStatus: () => ({ accountId: 'default' }),
+        setStatus,
+      });
+
+      await flushAsyncContinuations();
+      expect(setStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+      }));
+
+      closeNow?.();
+      await stopPromise;
+      await waitForBridgePort(plugin);
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+
+      controller.abort();
+      await lifecycle;
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('ignores different-account stopAccount while a lifecycle is waiting to claim ownership', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    await plugin.start();
+    const server = (plugin as any).server;
+    const originalClose = server.close.bind(server);
+    let closeNow: (() => void) | undefined;
+    const closeSpy = vi.spyOn(server, 'close').mockImplementation((callback?: () => void) => {
+      closeNow = () => originalClose(callback);
+      return server;
+    });
+
+    try {
+      const stopPromise = plugin.stop();
+      await vi.waitFor(() => {
+        expect(closeNow).toBeTypeOf('function');
+      });
+
+      const controller = new AbortController();
+      const setStatus = vi.fn();
+      const lifecycle = registeredPlugin.gateway.startAccount({
+        accountId: 'default',
+        account: { accountId: 'default' },
+        cfg: {},
+        runtime: {},
+        abortSignal: controller.signal,
+        getStatus: () => ({ accountId: 'default' }),
+        setStatus,
+      });
+      await flushAsyncContinuations();
+
+      const unrelatedStopStatus = vi.fn();
+      await registeredPlugin.gateway.stopAccount({
+        accountId: 'other',
+        account: { accountId: 'other' },
+        cfg: {},
+        runtime: {},
+        getStatus: () => ({ accountId: 'other' }),
+        setStatus: unrelatedStopStatus,
+      });
+      expect(unrelatedStopStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+        running: false,
+      }));
+
+      closeNow?.();
+      await stopPromise;
+      await waitForBridgePort(plugin);
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+
+      controller.abort();
+      await lifecycle;
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('waits for an abort-triggered lifecycle stop before starting the replacement lifecycle', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstController = new AbortController();
+    const firstLifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: firstController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: vi.fn(),
+    });
+    await waitForBridgePort(plugin);
+
+    const server = (plugin as any).server;
+    const originalClose = server.close.bind(server);
+    let closeNow: (() => void) | undefined;
+    const closeSpy = vi.spyOn(server, 'close').mockImplementation((callback?: () => void) => {
+      closeNow = () => originalClose(callback);
+      return server;
+    });
+
+    try {
+      firstController.abort();
+      await vi.waitFor(() => {
+        expect(closeNow).toBeTypeOf('function');
+      });
+
+      const replacementController = new AbortController();
+      const replacementStatus = vi.fn();
+      const replacementLifecycle = registeredPlugin.gateway.startAccount({
+        accountId: 'default',
+        account: { accountId: 'default' },
+        cfg: {},
+        runtime: {},
+        abortSignal: replacementController.signal,
+        getStatus: () => ({ accountId: 'default' }),
+        setStatus: replacementStatus,
+      });
+
+      await flushAsyncContinuations();
+      expect(replacementStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+      }));
+
+      closeNow?.();
+      await firstLifecycle;
+      await waitForBridgePort(plugin);
+      expect(replacementStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+
+      replacementController.abort();
+      await replacementLifecycle;
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('does not let a stale aborted lifecycle stop a replacement bridge', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstController = new AbortController();
+    const firstStatus = vi.fn();
+    const firstLifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: firstController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: firstStatus,
+    });
+    await vi.waitFor(() => {
+      expect(firstStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const replacementController = new AbortController();
+    const replacementStatus = vi.fn();
+    firstController.abort();
+    const replacementLifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: replacementController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: replacementStatus,
+    });
+
+    await vi.waitFor(() => {
+      expect(replacementStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+    await firstLifecycle;
+    expect(plugin.isListening).toBe(true);
+
+    replacementController.abort();
+    await replacementLifecycle;
+    expect(plugin.isListening).toBe(false);
+  });
+
+  it('ignores a stale stopAccount request for a replaced lifecycle', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstController = new AbortController();
+    const firstStatus = vi.fn();
+    const firstLifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: firstController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: firstStatus,
+    });
+    await vi.waitFor(() => {
+      expect(firstStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const replacementController = new AbortController();
+    const replacementStatus = vi.fn();
+    firstController.abort();
+    const replacementLifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: replacementController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: replacementStatus,
+    });
+    await vi.waitFor(() => {
+      expect(replacementStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+    await firstLifecycle;
+
+    const staleStopStatus = vi.fn();
+    await registeredPlugin.gateway.stopAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: firstController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: staleStopStatus,
+    });
+
+    expect(plugin.isListening).toBe(true);
+    expect(staleStopStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+      running: false,
+    }));
+
+    replacementController.abort();
+    await replacementLifecycle;
+    expect(plugin.isListening).toBe(false);
+  });
+
+  it('ignores a stale no-signal stopAccount request for a replaced lifecycle', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstStatus = vi.fn();
+    const firstCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: firstStatus,
+    };
+    const firstLifecycle = registeredPlugin.gateway.startAccount(firstCtx);
+    await vi.waitFor(() => {
+      expect(firstStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const replacementStatus = vi.fn();
+    const replacementCtx = {
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: replacementStatus,
+    };
+    const replacementLifecycle = registeredPlugin.gateway.startAccount(replacementCtx);
+    await vi.waitFor(() => {
+      expect(replacementStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+    await firstLifecycle;
+
+    await registeredPlugin.gateway.stopAccount(firstCtx);
+    expect(plugin.isListening).toBe(true);
+    expect(firstStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+      running: false,
+    }));
+
+    await registeredPlugin.gateway.stopAccount(replacementCtx);
+    await replacementLifecycle;
+    expect(plugin.isListening).toBe(false);
+  });
+
+  it('does not stop an active bridge when a lifecycle aborts before claiming post-start ownership', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+    await plugin.start();
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    let abortedReads = 0;
+    const signal: any = {
+      get aborted() {
+        abortedReads += 1;
+        return abortedReads > 1;
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const setStatus = vi.fn();
+
+    await registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus,
+    });
+
+    expect(plugin.isListening).toBe(true);
+    expect(setStatus).not.toHaveBeenCalled();
+  });
+
+  it('does not report running when a replacement lifecycle is aborted while waiting for stop to finish', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    await plugin.start();
+
+    const server = (plugin as any).server;
+    const originalClose = server.close.bind(server);
+    let closeNow: (() => void) | undefined;
+    const closeSpy = vi.spyOn(server, 'close').mockImplementation((callback?: () => void) => {
+      closeNow = () => originalClose(callback);
+      return server;
+    });
+
+    try {
+      const stopPromise = plugin.stop();
+      await vi.waitFor(() => {
+        expect(closeNow).toBeTypeOf('function');
+      });
+
+      const controller = new AbortController();
+      const setStatus = vi.fn();
+      const lifecycle = registeredPlugin.gateway.startAccount({
+        accountId: 'default',
+        account: { accountId: 'default' },
+        cfg: {},
+        runtime: {},
+        abortSignal: controller.signal,
+        getStatus: () => ({ accountId: 'default' }),
+        setStatus,
+      });
+      controller.abort();
+
+      closeNow?.();
+      await stopPromise;
+      await lifecycle;
+
+      expect(plugin.isListening).toBe(false);
+      expect(setStatus.mock.calls.some(([status]) => status.running === true)).toBe(false);
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it('settles the gateway lifecycle wait if abort flips during listener registration', async () => {
+    const signal: any = {
+      aborted: false,
+      removeEventListener: vi.fn(),
+    };
+    signal.addEventListener = vi.fn(() => {
+      signal.aborted = true;
+    });
+
+    await (plugin as any).waitForGatewayLifecycleStop(signal);
+
+    expect(signal.addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(signal.removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
   });
 
   it('should call registerHttpRoute if available', () => {

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -513,7 +513,7 @@ describe('DkgChannelPlugin', () => {
     expect(plugin.isListening).toBe(false);
   });
 
-  it('cancels a pending same-account lifecycle from a fresh stop context without stopping the active bridge', async () => {
+  it('stops the active lifecycle for a fresh same-account stop during a replacement window', async () => {
     const registerChannel = trackFn();
     const api = makeApi({ registerChannel });
     plugin.register(api);
@@ -555,17 +555,14 @@ describe('DkgChannelPlugin', () => {
     });
 
     await replacementLifecycle;
-    expect(plugin.isListening).toBe(true);
+    await firstLifecycle;
+    expect(plugin.isListening).toBe(false);
     expect(replacementCtx.setStatus.mock.calls.some(([status]) => status.running === true)).toBe(false);
-    expect(stopStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+    expect(stopStatus).toHaveBeenCalledWith(expect.objectContaining({
       running: false,
       connected: false,
       restartPending: false,
     }));
-
-    await registeredPlugin.gateway.stopAccount(firstCtx);
-    await firstLifecycle;
-    expect(plugin.isListening).toBe(false);
   });
 
   it('stops the registered gateway lifecycle bridge when OpenClaw stops the channel', async () => {

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -279,6 +279,64 @@ describe('DkgChannelPlugin', () => {
     expect(registeredPlugin.gateway.stopAccount).toBeTypeOf('function');
   });
 
+  it('rejects non-default gateway accounts without preempting the default lifecycle', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const defaultController = new AbortController();
+    const defaultStatus = vi.fn();
+    const defaultLifecycle = registeredPlugin.gateway.startAccount({
+      accountId: 'default',
+      account: { accountId: 'default' },
+      cfg: {},
+      runtime: {},
+      abortSignal: defaultController.signal,
+      getStatus: () => ({ accountId: 'default' }),
+      setStatus: defaultStatus,
+    });
+    await vi.waitFor(() => {
+      expect(defaultStatus).toHaveBeenCalledWith(expect.objectContaining({
+        running: true,
+        connected: true,
+      }));
+    });
+
+    const otherStatus = vi.fn();
+    await expect(registeredPlugin.gateway.startAccount({
+      accountId: 'other',
+      account: { accountId: 'other' },
+      cfg: {},
+      runtime: {},
+      abortSignal: new AbortController().signal,
+      getStatus: () => ({ accountId: 'other' }),
+      setStatus: otherStatus,
+    })).rejects.toThrow(/only supports the "default" gateway account/);
+
+    expect(plugin.isListening).toBe(true);
+    expect(otherStatus).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'other',
+      running: false,
+      connected: false,
+      linked: false,
+    }));
+
+    await registeredPlugin.gateway.stopAccount({
+      accountId: 'other',
+      account: { accountId: 'other' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => ({ accountId: 'other' }),
+      setStatus: otherStatus,
+    });
+    expect(plugin.isListening).toBe(true);
+
+    defaultController.abort();
+    await defaultLifecycle;
+    expect(plugin.isListening).toBe(false);
+  });
+
   it('keeps the registered gateway lifecycle running until OpenClaw aborts it', async () => {
     const registerChannel = trackFn();
     const api = makeApi({ registerChannel });
@@ -410,17 +468,19 @@ describe('DkgChannelPlugin', () => {
     expect(plugin.isListening).toBe(false);
   });
 
-  it('stops a pending replacement lifecycle before it reports running', async () => {
+  it('cancels a pending replacement lifecycle without stopping the active bridge', async () => {
     const registerChannel = trackFn();
     const api = makeApi({ registerChannel });
     plugin.register(api);
 
     const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    const firstController = new AbortController();
     const firstCtx = {
       accountId: 'default',
       account: { accountId: 'default' },
       cfg: {},
       runtime: {},
+      abortSignal: firstController.signal,
       getStatus: () => ({ accountId: 'default' }),
       setStatus: vi.fn(),
     };
@@ -443,18 +503,17 @@ describe('DkgChannelPlugin', () => {
     const replacementLifecycle = registeredPlugin.gateway.startAccount(replacementCtx);
     await registeredPlugin.gateway.stopAccount(replacementCtx);
 
-    await firstLifecycle;
     await replacementLifecycle;
-    expect(plugin.isListening).toBe(false);
+    expect(plugin.isListening).toBe(true);
     expect(replacementCtx.setStatus.mock.calls.some(([status]) => status.running === true)).toBe(false);
-    expect(replacementCtx.setStatus).toHaveBeenCalledWith(expect.objectContaining({
-      running: false,
-      connected: false,
-      restartPending: false,
-    }));
+    expect(firstCtx.setStatus.mock.calls.some(([status]) => status.running === false)).toBe(false);
+
+    firstController.abort();
+    await firstLifecycle;
+    expect(plugin.isListening).toBe(false);
   });
 
-  it('stops a pending same-account lifecycle from a fresh stop context', async () => {
+  it('cancels a pending same-account lifecycle from a fresh stop context without stopping the active bridge', async () => {
     const registerChannel = trackFn();
     const api = makeApi({ registerChannel });
     plugin.register(api);
@@ -495,15 +554,18 @@ describe('DkgChannelPlugin', () => {
       setStatus: stopStatus,
     });
 
-    await firstLifecycle;
     await replacementLifecycle;
-    expect(plugin.isListening).toBe(false);
+    expect(plugin.isListening).toBe(true);
     expect(replacementCtx.setStatus.mock.calls.some(([status]) => status.running === true)).toBe(false);
-    expect(stopStatus).toHaveBeenCalledWith(expect.objectContaining({
+    expect(stopStatus).not.toHaveBeenCalledWith(expect.objectContaining({
       running: false,
       connected: false,
       restartPending: false,
     }));
+
+    await registeredPlugin.gateway.stopAccount(firstCtx);
+    await firstLifecycle;
+    expect(plugin.isListening).toBe(false);
   });
 
   it('stops the registered gateway lifecycle bridge when OpenClaw stops the channel', async () => {
@@ -765,8 +827,10 @@ describe('DkgChannelPlugin', () => {
         getStatus: () => ({ accountId: 'other' }),
         setStatus: unrelatedStopStatus,
       });
-      expect(unrelatedStopStatus).not.toHaveBeenCalledWith(expect.objectContaining({
+      expect(unrelatedStopStatus).toHaveBeenCalledWith(expect.objectContaining({
+        accountId: 'other',
         running: false,
+        connected: false,
       }));
 
       closeNow?.();

--- a/packages/adapter-openclaw/test/dkg-channel.test.ts
+++ b/packages/adapter-openclaw/test/dkg-channel.test.ts
@@ -594,6 +594,63 @@ describe('DkgChannelPlugin', () => {
     }));
   });
 
+  it('normalizes gateway status account ids and preserves fields when reporting stopped', async () => {
+    const registerChannel = trackFn();
+    const api = makeApi({ registerChannel });
+    plugin.register(api);
+
+    const registeredPlugin = (registerChannel.calls[0][0] as any).plugin;
+    let currentStatus: Record<string, unknown> = {
+      accountId: '   ',
+      enabled: true,
+      configured: true,
+      linked: true,
+      mode: 'webhook',
+      port: 9201,
+      displayName: 'DKG UI',
+    };
+    const setStatus = vi.fn((status: Record<string, unknown>) => {
+      currentStatus = status;
+    });
+    const lifecycleCtx = {
+      accountId: '   ',
+      account: { accountId: '   ' },
+      cfg: {},
+      runtime: {},
+      getStatus: () => currentStatus,
+      setStatus,
+    };
+    const lifecycle = registeredPlugin.gateway.startAccount(lifecycleCtx);
+
+    await vi.waitFor(() => {
+      expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+        accountId: 'default',
+        enabled: true,
+        configured: true,
+        linked: true,
+        running: true,
+        connected: true,
+        displayName: 'DKG UI',
+      }));
+    });
+
+    await registeredPlugin.gateway.stopAccount(lifecycleCtx);
+    await lifecycle;
+
+    expect(setStatus).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'default',
+      enabled: true,
+      configured: true,
+      linked: true,
+      running: false,
+      connected: false,
+      restartPending: false,
+      mode: 'webhook',
+      port: expect.any(Number),
+      displayName: 'DKG UI',
+    }));
+  });
+
   it('settles plugin-level gateway lifecycle only after bridge shutdown completes', async () => {
     const registerChannel = trackFn();
     const api = makeApi({ registerChannel });

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -111,12 +111,17 @@ function classifyExplicitOpenClawHealthUrl(
   gatewayBase: string | undefined,
 ): 'bridge' | 'gateway' | undefined {
   if (!healthUrl) return undefined;
-  if (standaloneBridgeBase && healthUrlMatchesBase(healthUrl, standaloneBridgeBase)) {
-    return 'bridge';
+  const bridgeMatch = standaloneBridgeBase && healthUrlMatchesBase(healthUrl, standaloneBridgeBase)
+    ? trimTrailingSlashes(standaloneBridgeBase)
+    : undefined;
+  const gatewayMatch = gatewayBase && healthUrlMatchesBase(healthUrl, gatewayBase)
+    ? trimTrailingSlashes(gatewayBase)
+    : undefined;
+  if (bridgeMatch && gatewayMatch) {
+    return gatewayMatch.length >= bridgeMatch.length ? 'gateway' : 'bridge';
   }
-  if (gatewayBase && healthUrlMatchesBase(healthUrl, gatewayBase)) {
-    return 'gateway';
-  }
+  if (gatewayMatch) return 'gateway';
+  if (bridgeMatch) return 'bridge';
   return undefined;
 }
 

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -117,8 +117,6 @@ function classifyExplicitOpenClawHealthUrl(
   if (gatewayBase && healthUrlMatchesBase(healthUrl, gatewayBase)) {
     return 'gateway';
   }
-  if (standaloneBridgeBase && !gatewayBase) return 'bridge';
-  if (!standaloneBridgeBase && gatewayBase) return 'gateway';
   return undefined;
 }
 

--- a/packages/cli/src/daemon/openclaw.ts
+++ b/packages/cli/src/daemon/openclaw.ts
@@ -100,6 +100,28 @@ export function buildOpenClawGatewayBase(value: string): string {
     : `${value}/api/dkg-channel`;
 }
 
+function healthUrlMatchesBase(healthUrl: string, baseUrl: string): boolean {
+  const base = trimTrailingSlashes(baseUrl);
+  return healthUrl === base || healthUrl.startsWith(`${base}/`);
+}
+
+function classifyExplicitOpenClawHealthUrl(
+  healthUrl: string | undefined,
+  standaloneBridgeBase: string | undefined,
+  gatewayBase: string | undefined,
+): 'bridge' | 'gateway' | undefined {
+  if (!healthUrl) return undefined;
+  if (standaloneBridgeBase && healthUrlMatchesBase(healthUrl, standaloneBridgeBase)) {
+    return 'bridge';
+  }
+  if (gatewayBase && healthUrlMatchesBase(healthUrl, gatewayBase)) {
+    return 'gateway';
+  }
+  if (standaloneBridgeBase && !gatewayBase) return 'bridge';
+  if (!standaloneBridgeBase && gatewayBase) return 'gateway';
+  return undefined;
+}
+
 export async function loadBridgeAuthToken(): Promise<string | undefined> {
   try {
     const raw = await readFile(join(dkgDir(), "auth.token"), "utf-8");
@@ -124,6 +146,9 @@ export function getOpenClawChannelTargets(config: DkgConfig): OpenClawChannelTar
   const explicitGatewayBase = openclawIntegration?.transport.gatewayUrl
     ? trimTrailingSlashes(openclawIntegration.transport.gatewayUrl)
     : undefined;
+  const explicitHealthUrl = openclawIntegration?.transport.healthUrl
+    ? trimTrailingSlashes(openclawIntegration.transport.healthUrl)
+    : undefined;
   const bridgeLooksLikeGateway =
     explicitBridgeBase?.endsWith("/api/dkg-channel") ?? false;
   const standaloneBridgeBase = explicitBridgeBase
@@ -136,6 +161,14 @@ export function getOpenClawChannelTargets(config: DkgConfig): OpenClawChannelTar
   const gatewayBase =
     explicitGatewayBase ??
     (bridgeLooksLikeGateway ? explicitBridgeBase : undefined);
+  const normalizedGatewayBase = gatewayBase
+    ? buildOpenClawGatewayBase(gatewayBase)
+    : undefined;
+  const explicitHealthTarget = classifyExplicitOpenClawHealthUrl(
+    explicitHealthUrl,
+    standaloneBridgeBase,
+    normalizedGatewayBase,
+  );
   const targets: OpenClawChannelTarget[] = [];
   const seenInboundUrls = new Set<string>();
 
@@ -150,16 +183,19 @@ export function getOpenClawChannelTargets(config: DkgConfig): OpenClawChannelTar
       name: "bridge",
       inboundUrl: `${standaloneBridgeBase}/inbound`,
       streamUrl: `${standaloneBridgeBase}/inbound/stream`,
-      healthUrl: `${standaloneBridgeBase}/health`,
+      healthUrl: explicitHealthTarget === 'bridge'
+        ? explicitHealthUrl!
+        : `${standaloneBridgeBase}/health`,
     });
   }
 
-  if (gatewayBase) {
-    const normalizedGatewayBase = buildOpenClawGatewayBase(gatewayBase);
+  if (normalizedGatewayBase) {
     pushTarget({
       name: "gateway",
       inboundUrl: `${normalizedGatewayBase}/inbound`,
-      healthUrl: `${normalizedGatewayBase}/health`,
+      healthUrl: explicitHealthTarget === 'gateway'
+        ? explicitHealthUrl
+        : `${normalizedGatewayBase}/health`,
     });
   }
 

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -220,6 +220,34 @@ describe('OpenClaw channel routing helpers', () => {
     ]);
   });
 
+  it('prefers a nested gateway health URL over a broader bridge base', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://localhost:9301',
+            gatewayUrl: 'http://localhost:9301/api/dkg-channel',
+            healthUrl: 'http://localhost:9301/api/dkg-channel/health',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'bridge',
+        inboundUrl: 'http://localhost:9301/inbound',
+        streamUrl: 'http://localhost:9301/inbound/stream',
+        healthUrl: 'http://localhost:9301/health',
+      },
+      {
+        name: 'gateway',
+        inboundUrl: 'http://localhost:9301/api/dkg-channel/inbound',
+        healthUrl: 'http://localhost:9301/api/dkg-channel/health',
+      },
+    ]);
+  });
+
   it('uses an explicit gateway health URL when only gateway transport is configured', () => {
     expect(getOpenClawChannelTargets(makeConfig({
       localAgentIntegrations: {

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -108,6 +108,139 @@ describe('OpenClaw channel routing helpers', () => {
     ]);
   });
 
+  it('uses an explicit bridge health URL without rewriting the gateway health target', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9301',
+            gatewayUrl: 'http://gateway.local:3030',
+            healthUrl: 'http://127.0.0.1:9301/custom-health',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'bridge',
+        inboundUrl: 'http://127.0.0.1:9301/inbound',
+        streamUrl: 'http://127.0.0.1:9301/inbound/stream',
+        healthUrl: 'http://127.0.0.1:9301/custom-health',
+      },
+      {
+        name: 'gateway',
+        inboundUrl: 'http://gateway.local:3030/api/dkg-channel/inbound',
+        healthUrl: 'http://gateway.local:3030/api/dkg-channel/health',
+      },
+    ]);
+  });
+
+  it('leaves an ambiguous explicit health URL unclassified when both bridge and gateway exist', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://bridge.local:9301',
+            gatewayUrl: 'http://gateway.local:3030',
+            healthUrl: 'http://bridge-health.local/custom-health',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'bridge',
+        inboundUrl: 'http://bridge.local:9301/inbound',
+        streamUrl: 'http://bridge.local:9301/inbound/stream',
+        healthUrl: 'http://bridge.local:9301/health',
+      },
+      {
+        name: 'gateway',
+        inboundUrl: 'http://gateway.local:3030/api/dkg-channel/inbound',
+        healthUrl: 'http://gateway.local:3030/api/dkg-channel/health',
+      },
+    ]);
+  });
+
+  it('uses an explicit gateway health URL without rewriting the bridge health target', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9301',
+            gatewayUrl: 'http://gateway.local:3030',
+            healthUrl: 'http://gateway.local:3030/api/dkg-channel/health/probe',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'bridge',
+        inboundUrl: 'http://127.0.0.1:9301/inbound',
+        streamUrl: 'http://127.0.0.1:9301/inbound/stream',
+        healthUrl: 'http://127.0.0.1:9301/health',
+      },
+      {
+        name: 'gateway',
+        inboundUrl: 'http://gateway.local:3030/api/dkg-channel/inbound',
+        healthUrl: 'http://gateway.local:3030/api/dkg-channel/health/probe',
+      },
+    ]);
+  });
+
+  it('uses explicit gateway health by port when bridge and gateway share a host', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://localhost:9301',
+            gatewayUrl: 'http://localhost:3030',
+            healthUrl: 'http://localhost:3030/api/dkg-channel/health/probe',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'bridge',
+        inboundUrl: 'http://localhost:9301/inbound',
+        streamUrl: 'http://localhost:9301/inbound/stream',
+        healthUrl: 'http://localhost:9301/health',
+      },
+      {
+        name: 'gateway',
+        inboundUrl: 'http://localhost:3030/api/dkg-channel/inbound',
+        healthUrl: 'http://localhost:3030/api/dkg-channel/health/probe',
+      },
+    ]);
+  });
+
+  it('uses an explicit gateway health URL when only gateway transport is configured', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            gatewayUrl: 'http://gateway.local:3030',
+            healthUrl: 'http://gateway.local:3030/api/dkg-channel/health/probe',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'gateway',
+        inboundUrl: 'http://gateway.local:3030/api/dkg-channel/inbound',
+        healthUrl: 'http://gateway.local:3030/api/dkg-channel/health/probe',
+      },
+    ]);
+  });
+
   it('prefers the generic local agent integration transport when OpenClaw is connected through the registry', () => {
     expect(getOpenClawChannelTargets(makeConfig({
       localAgentIntegrations: {
@@ -168,6 +301,129 @@ describe('OpenClaw channel routing helpers', () => {
       { 'Content-Type': 'application/json' },
     );
     expect(gatewayHeaders).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('probes an explicit bridge health URL with bridge authentication', async () => {
+    const origFetch = globalThis.fetch;
+    let requestedUrl = '';
+    let requestedHeaders: HeadersInit | undefined;
+    globalThis.fetch = (async (input, init) => {
+      requestedUrl = String(input);
+      requestedHeaders = init?.headers;
+      return new Response(
+        JSON.stringify({ ok: true, channel: 'dkg-ui' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const result = await probeOpenClawChannelHealth(makeConfig({
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'http://gateway.local:3030',
+              healthUrl: 'http://127.0.0.1:9301/custom-health',
+            },
+          },
+        },
+      }), 'bridge-token', { ignoreBridgeCache: true });
+
+      expect(result.ok).toBe(true);
+      expect(requestedUrl).toBe('http://127.0.0.1:9301/custom-health');
+      expect(requestedHeaders).toMatchObject({
+        'x-dkg-bridge-token': 'bridge-token',
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not probe an ambiguous explicit health URL as bridge health', async () => {
+    const origFetch = globalThis.fetch;
+    const requested: Array<{ url: string; headers: HeadersInit | undefined }> = [];
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      requested.push({ url, headers: init?.headers });
+      if (url.includes('bridge.local')) {
+        return new Response('bridge unavailable', { status: 503 });
+      }
+      return new Response(
+        JSON.stringify({ ok: true, channel: 'dkg-ui' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const result = await probeOpenClawChannelHealth(makeConfig({
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://bridge.local:9301',
+              gatewayUrl: 'http://gateway.local:3030',
+              healthUrl: 'http://bridge-health.local/custom-health',
+            },
+          },
+        },
+      }), 'bridge-token', { ignoreBridgeCache: true });
+
+      expect(result).toMatchObject({ ok: true, target: 'gateway' });
+      expect(requested.map((entry) => entry.url)).toEqual([
+        'http://bridge.local:9301/health',
+        'http://gateway.local:3030/api/dkg-channel/health',
+      ]);
+      expect(requested[0].headers).toMatchObject({
+        'x-dkg-bridge-token': 'bridge-token',
+      });
+      expect(requested[1].headers ?? {}).not.toMatchObject({
+        'x-dkg-bridge-token': 'bridge-token',
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not probe gateway health when the bridge target is healthy', async () => {
+    const origFetch = globalThis.fetch;
+    const requestedUrls: string[] = [];
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.includes('gateway.local')) {
+        return new Response(
+          JSON.stringify({ ok: false, error: 'gateway auth required' }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ ok: true, channel: 'dkg-ui' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const result = await probeOpenClawChannelHealth(makeConfig({
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              gatewayUrl: 'http://gateway.local:3030',
+            },
+          },
+        },
+      }), 'bridge-token', { ignoreBridgeCache: true });
+
+      expect(result).toMatchObject({ ok: true, target: 'bridge' });
+      expect(requestedUrls).toEqual(['http://127.0.0.1:9301/health']);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 
   it('does not cancel the upstream stream on request close events after the body is consumed', async () => {

--- a/packages/cli/test/daemon-openclaw.test.ts
+++ b/packages/cli/test/daemon-openclaw.test.ts
@@ -241,6 +241,28 @@ describe('OpenClaw channel routing helpers', () => {
     ]);
   });
 
+  it('ignores an explicit bridge health URL outside the bridge base', () => {
+    expect(getOpenClawChannelTargets(makeConfig({
+      localAgentIntegrations: {
+        openclaw: {
+          enabled: true,
+          transport: {
+            kind: 'openclaw-channel',
+            bridgeUrl: 'http://127.0.0.1:9301',
+            healthUrl: 'http://bridge-health.local/custom-health',
+          },
+        },
+      },
+    }))).toEqual([
+      {
+        name: 'bridge',
+        inboundUrl: 'http://127.0.0.1:9301/inbound',
+        streamUrl: 'http://127.0.0.1:9301/inbound/stream',
+        healthUrl: 'http://127.0.0.1:9301/health',
+      },
+    ]);
+  });
+
   it('prefers the generic local agent integration transport when OpenClaw is connected through the registry', () => {
     expect(getOpenClawChannelTargets(makeConfig({
       localAgentIntegrations: {
@@ -380,6 +402,48 @@ describe('OpenClaw channel routing helpers', () => {
         'x-dkg-bridge-token': 'bridge-token',
       });
       expect(requested[1].headers ?? {}).not.toMatchObject({
+        'x-dkg-bridge-token': 'bridge-token',
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  it('does not send the bridge token to an unmatched bridge-only explicit health URL', async () => {
+    const origFetch = globalThis.fetch;
+    const requested: Array<{ url: string; headers: HeadersInit | undefined }> = [];
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      requested.push({ url, headers: init?.headers });
+      if (url === 'http://bridge-health.local/custom-health') {
+        return new Response('unexpected custom health probe', { status: 500 });
+      }
+      return new Response(
+        JSON.stringify({ ok: true, channel: 'dkg-ui' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }) as typeof fetch;
+
+    try {
+      const result = await probeOpenClawChannelHealth(makeConfig({
+        localAgentIntegrations: {
+          openclaw: {
+            enabled: true,
+            transport: {
+              kind: 'openclaw-channel',
+              bridgeUrl: 'http://127.0.0.1:9301',
+              healthUrl: 'http://bridge-health.local/custom-health',
+            },
+          },
+        },
+      }), 'bridge-token', { ignoreBridgeCache: true });
+
+      expect(result).toMatchObject({ ok: true, target: 'bridge' });
+      expect(requested).toHaveLength(1);
+      expect(requested[0]).toMatchObject({
+        url: 'http://127.0.0.1:9301/health',
+      });
+      expect(requested[0].headers).toMatchObject({
         'x-dkg-bridge-token': 'bridge-token',
       });
     } finally {

--- a/packages/node-ui/test/openclaw-bridge.test.ts
+++ b/packages/node-ui/test/openclaw-bridge.test.ts
@@ -473,7 +473,12 @@ describe('OpenClaw bridge behavioral tests', () => {
     expect(daemonSrc).toContain('http://127.0.0.1:9201');
     expect(daemonSrc).toContain('const gatewayBase =');
     expect(daemonSrc).toContain('explicitGatewayBase ??');
-    expect(daemonSrc).toContain("healthUrl: `${normalizedGatewayBase}/health`");
+    expect(daemonSrc).toContain('const explicitHealthUrl = openclawIntegration?.transport.healthUrl');
+    expect(daemonSrc).toContain('function classifyExplicitOpenClawHealthUrl');
+    expect(daemonSrc).toContain('const explicitHealthTarget = classifyExplicitOpenClawHealthUrl');
+    expect(daemonSrc).toContain("healthUrl: explicitHealthTarget === 'bridge'");
+    expect(daemonSrc).toContain("healthUrl: explicitHealthTarget === 'gateway'");
+    expect(daemonSrc).toContain(': `${normalizedGatewayBase}/health`,');
     expect(daemonSrc).toContain('function buildOpenClawGatewayBase');
     expect(daemonSrc).toContain('return value.endsWith("/api/dkg-channel")');
     expect(daemonSrc).toContain(': `${value}/api/dkg-channel`;');


### PR DESCRIPTION
## Summary
- Register the DKG UI channel with OpenClaw's managed gateway lifecycle so the health monitor sees `dkg-ui:default` as running while the bridge is alive.
- Keep bridge startup, fallback-port binding, bridge auth, and lifecycle shutdown/restart paths stable across abort, explicit stop, pending replacement, and restart windows.
- Align daemon health routing with explicit bridge/gateway health URLs while avoiding stale fallback ports and avoiding bridge-token auth on unmatched or gateway-scoped probes.
- Preserve gateway lifecycle status metadata and normalize status account IDs so clean stops do not make the default account look unconfigured.

## Related
Fixes #330
Related to #272

## Files changed
- `packages/adapter-openclaw/src/DkgChannelPlugin.ts`: add managed gateway lifecycle handling, ownership guards, status preservation, default-account enforcement, and restart-safe bridge state handling.
- `packages/adapter-openclaw/src/types.ts`: model the gateway lifecycle adapter contract used by the registered channel plugin.
- `packages/adapter-openclaw/test/dkg-channel.test.ts`: cover managed lifecycle registration, abort/stop behavior, replacement races, default-account guards, and status preservation.
- `packages/cli/src/daemon/openclaw.ts`: route explicit health URLs to the correct live bridge/gateway target and avoid auth on ambiguous custom probes.
- `packages/cli/test/daemon-openclaw.test.ts`: cover explicit health URL routing, nested gateway health, bridge health auth, and bridge+gateway health fallback behavior.
- `packages/node-ui/test/openclaw-bridge.test.ts`: update source-contract expectations for explicit health URL routing.

## Test plan
- `pnpm exec vitest run test/dkg-channel.test.ts` from `packages/adapter-openclaw`
- `pnpm exec vitest run test/plugin.test.ts test/dkg-channel.test.ts` from `packages/adapter-openclaw`
- `pnpm exec vitest run test/daemon-openclaw.test.ts` from `packages/cli`
- `pnpm exec vitest run test/openclaw-bridge.test.ts` from `packages/node-ui`
- `pnpm build:runtime`
- GitHub checks: Codex Review, CodeQL, Knip, Build packages, and Kosava node-ui are green on the latest head; broad suite failures remain in existing expected-red/prod-bug areas outside this PR (`query`, `network-sim`, core/storage/chain, publisher/agent/cli shards).