### PR TITLE
fix(openclaw): use node auth for agent identity probe

### DIFF
--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -18,8 +18,6 @@
 import {
   GET_VIEWS,
   type GetView,
-  loadAgentAuthTokenSync,
-  MultipleAgentsError,
   resolveDkgHome,
   toEip55Checksum,
 } from '@origintrail-official/dkg-core';
@@ -48,10 +46,9 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { canonicalPathForCompare } from './state-dir-path.js';
 
-// T44 — same regex as `dkg-core/src/dkg-home.ts` ETH_ADDR_RE. Kept
-// duplicated rather than exposed from dkg-core because the adapter's
-// only use is the localhost-gate validation; a leaked helper would
-// invite drift over time.
+// Same eth-address shape accepted by `toEip55Checksum`. Kept local so the
+// dkg_query explicit `agent_address` normalization can avoid throwing for
+// non-eth peer IDs, which the daemon still accepts as self-aliases.
 const ETH_ADDR_RE_LC = /^0x[0-9a-f]{40}$/;
 function isValidEthAddressString(value: string | undefined): boolean {
   return typeof value === 'string' && ETH_ADDR_RE_LC.test(value.trim().toLowerCase());
@@ -133,13 +130,9 @@ const AUTO_RECALL_QUERY_MAX_CHARS = 500;
 export class DkgNodePlugin {
   private readonly config: DkgOpenClawConfig;
 
-  // T70 — Resolved DKG home directory. Computed once at register() time via
-  // `resolveDkgHome` (env > live daemon.pid > daemonUrl-port-tiebreak >
-  // mtime > ~/.dkg). Used to read `auth.token` (passed to DkgDaemonClient)
-  // and `agent-keystore.json` (in probeNodeAgentAddressOnce). Solves the
-  // "monorepo daemon writes to ~/.dkg-dev but adapter reads ~/.dkg" gap
-  // without persisting the path to openclaw.json (which would go stale on
-  // npm↔monorepo switch on the same machine).
+  // Resolved DKG home directory. Computed once at register() time via
+  // `resolveDkgHome` so DkgDaemonClient reads the node-level `auth.token`
+  // from the same home directory the running daemon selected.
   private dkgHome!: string;
 
   // HTTP client to daemon — used by all tools and integration modules
@@ -254,36 +247,17 @@ export class DkgNodePlugin {
    */
   private peerIdProbeInFlight: Promise<void> | null = null;
   /**
-   * Node agent eth address, sourced from `~/.dkg-dev/agent-keystore.json` (or
-   * `$DKG_HOME/agent-keystore.json` more generally). The daemon files chat-
-   * turn assertions and per-agent WM under this same eth address — see
-   * `packages/agent/src/dkg-agent.ts:resolveAgentAddress`, which prefers the
-   * keystore-derived `defaultAgentAddress` over the libp2p peerId. Reads in
-   * the daemon's query engine (`packages/query/src/dkg-query-engine.ts:60-72`)
-   * splice this string verbatim into the WM graph URI prefix
-   * `did:dkg:context-graph:${cg}/assertion/${agentAddress}/`, so the adapter
-   * MUST send the same identifier the daemon used for the write — otherwise
-   * recall scopes to a graph that holds zero triples while data lives at a
-   * different URI prefix (the live PR #264 testing bug).
+   * Node agent address returned by `/api/agent/identity`. The daemon resolves
+   * the adapter's node-level Bearer token to its default agent address, which
+   * is the WM namespace used by default-agent assertion writes.
    */
   private nodeAgentAddress: string | undefined;
   /**
    * Debounces concurrent `ensureNodeAgentAddress` calls so a burst of
-   * resolver fires collapses to one keystore read. Mirrors the
-   * `peerIdProbeInFlight` pattern. Null when no read is running.
+   * resolver fires collapses to one daemon identity probe. Mirrors the
+   * `peerIdProbeInFlight` pattern. Null when no probe is running.
    */
   private agentAddressProbeInFlight: Promise<void> | null = null;
-  // T60 — Set true ONLY after a localhost-gated keystore probe
-  // legitimately turns up empty (no keystore file, empty `{}`, or no
-  // valid eth keys). Distinguishes "co-located daemon writes WM under
-  // peerId via `defaultAgentAddress ?? peerId`" (peerId fallback OK)
-  // from "remote daemon — keystore probe intentionally skipped"
-  // (peerId fallback NOT ok; gateway's local peerId doesn't match the
-  // remote daemon's writer-side identity). Multi-agent and other
-  // refuse-to-guess paths leave this false so the resolver returns
-  // undefined → operator sees "not ready" with the recovery knobs
-  // surfaced instead of silently scoping queries to the wrong namespace.
-  private localKeystoreCheckedAndAbsent: boolean = false;
   /**
    * Timer for the one-shot deferred retry after a failed initial probe
    * at register time. Belt-and-suspenders with `ensureNodePeerId`: the
@@ -314,33 +288,16 @@ export class DkgNodePlugin {
   private readonly memorySessionResolver: DkgMemorySessionResolver = {
     getSession: (sessionKey: string | undefined): DkgMemorySession | undefined => {
       const projectContextGraphId = this.channelPlugin?.getSessionProjectContextGraphId(sessionKey);
-      // T31 — `agentAddress` is the daemon's WRITER-side identifier (eth
-      // address from agent-keystore.json), NOT the libp2p peerId from
-      // /api/status. The daemon files chat-turns under the eth address;
-      // sending the peerId here scopes WM reads to a graph URI prefix
-      // that holds zero triples (PR #264 live-test bug). Lazy re-read
-      // mirrors `ensureNodePeerId` so a keystore that appears mid-
-      // session (daemon provisioned identity after gateway start) self-
-      // heals without requiring a gateway restart.
+      // Resolve the daemon's default WM identity lazily. Until the identity
+      // probe lands, `resolveDefaultAgentAddress` keeps the historical peerId
+      // fallback so callers can still make progress during startup.
       if (this.nodeAgentAddress === undefined) {
         void this.ensureNodeAgentAddress();
       }
       return {
         projectContextGraphId,
-        // T56/T60 — Mirror the daemon's writer-side priority
-        // (`packages/cli/src/daemon/lifecycle.ts:346`,
-        // `agent.getDefaultAgentAddress() ?? agent.peerId`), but ONLY
-        // fall back to peerId when we've CONFIRMED via a localhost-
-        // gated keystore probe that no eth identity exists at the
-        // daemon's home dir. For remote daemons (T38 — probe
-        // intentionally skipped) and multi-agent keystores (refuse-
-        // to-guess), `localKeystoreCheckedAndAbsent` stays false so
-        // the resolver returns undefined and the operator gets the
-        // "backend not ready" path with the recovery knobs surfaced.
-        // Without the gate, remote-daemon recall would silently scope
-        // WM to the gateway's local peerId (which the remote daemon
-        // has never heard of) and return empty bindings instead of
-        // surfacing the actual misconfiguration.
+        // Mirror the daemon's writer-side priority:
+        // default agent address when known, otherwise the node peerId.
         agentAddress: this.resolveDefaultAgentAddress(),
       };
     },
@@ -527,15 +484,11 @@ export class DkgNodePlugin {
     // Create daemon client — used by all tools and integration modules
     const daemonUrl = this.config.daemonUrl ?? 'http://127.0.0.1:9200';
 
-    // T70 — Resolve the DKG home directory once for this plugin's lifetime.
-    // Honors `config.dkgHome` first as an explicit operator escape-hatch
-    // (e.g., openclaw.json setting for genuinely unusual deployments where
-    // neither daemon.pid liveness nor api.port mtime gives the right
-    // answer). Otherwise auto-resolves via the daemon's own signals:
-    // env > live daemon.pid > daemonUrl-port-tiebreak > most-recent
-    // api.port mtime > ~/.dkg. This is what makes the adapter switch
-    // automatically between ~/.dkg (npm) and ~/.dkg-dev (monorepo) without
-    // any config writes.
+    // Resolve the DKG home directory once for this plugin's lifetime so the
+    // client loads the same node-level auth.token the running daemon uses.
+    // `config.dkgHome` remains an explicit auth-token home override for
+    // custom `dkg start --home` deployments; it is no longer used for
+    // agent-keystore identity probing.
     this.dkgHome = this.config.dkgHome ?? resolveDkgHome({ daemonUrl });
 
     // Pass the resolved home to the client so its `auth.token` fallback
@@ -1602,14 +1555,11 @@ export class DkgNodePlugin {
         // the same tick) will await the same peer-ID promise instead
         // of firing a duplicate /api/status call. Codex Bug B9.
         await this.ensureNodePeerId();
-        // T31/T63 — Resolve the agent eth address. Combines a sync
-        // keystore read for the agent auth token + an async
-        // `/api/agent/identity` HTTP probe for the canonical eth
-        // (daemon stores `defaultAgentAddress` in EIP-55 form via
-        // `verifyWallet.address`; adapter trusts the response
-        // verbatim). Same debouncing pattern as `ensureNodePeerId`;
-        // runs sequentially after it but neither blocks the other
-        // on retry. Probe completion is awaited so the resolver
+        // Resolve the daemon's default agent identity through
+        // `/api/agent/identity` using the node-level Bearer token already
+        // loaded by DkgDaemonClient. Same debouncing pattern as
+        // `ensureNodePeerId`; runs sequentially after it but neither blocks
+        // the other on retry. Probe completion is awaited so the resolver
         // cache is warm by the time the first slot-backed search /
         // dkg_query / before_prompt_build hook fires.
         await this.ensureNodeAgentAddress();
@@ -1780,228 +1730,37 @@ export class DkgNodePlugin {
   }
 
   /**
-   * T31 — Single-shot read of the node agent eth address from
-   * `<DKG_HOME>/agent-keystore.json` via the dkg-core helper. Honors
-   * `DKG_AGENT_ADDRESS` env override for multi-agent deployments. Multi-
-   * agent keystores without an explicit override log an error and leave
-   * `nodeAgentAddress` undefined — the existing "peer ID not yet
-   * available" warn-and-no-op path in `DkgMemoryPlugin.search` covers
-   * the disabled-recall case until operators set the env var.
+   * Single-shot HTTP probe of the daemon's default agent identity.
    *
-   * Does NOT debounce — caller (`ensureNodeAgentAddress`) handles
-   * concurrent-call dedup via the in-flight promise guard.
+   * Uses the DkgDaemonClient constructor-loaded node-level Bearer token.
+   * The daemon maps that token to its default agent address and returns the
+   * canonical WM namespace identifier used for default-agent writes.
+   *
+   * Does NOT debounce; caller (`ensureNodeAgentAddress`) handles concurrent
+   * call dedup via the in-flight promise guard.
    */
   private async probeNodeAgentAddressOnce(api: OpenClawPluginApi): Promise<void> {
-    // T44 — `DKG_AGENT_ADDRESS` must be a syntactically valid eth address
-    // before it counts as a "trusted operator override" for the localhost
-    // gate. A typo like `DKG_AGENT_ADDRESS=foo` would otherwise satisfy the
-    // truthy-string gate and scope WM to the wrong identity.
-    // T62 — Normalize to canonical EIP-55 form so the value matches the
-    // daemon's storage URI case (the daemon stores `defaultAgentAddress`
-    // in checksum form via `verifyWallet.address`). Operators can supply
-    // lowercase / mixed / all-caps; output is always canonical.
-    const rawExplicit = process.env.DKG_AGENT_ADDRESS;
-    const explicitAddress = isValidEthAddressString(rawExplicit)
-      ? toEip55Checksum(rawExplicit!)
-      : undefined;
-    if (rawExplicit && !explicitAddress) {
-      api.logger.warn?.(
-        `[dkg-memory] DKG_AGENT_ADDRESS env value "${rawExplicit}" is not a valid 0x-prefixed eth address (must match /^0x[0-9a-f]{40}$/i). ` +
-        'Override ignored — falling through to localhost gate / keystore read.',
-      );
-    }
-
-    // T38 — Remote daemon: probe is intentionally skipped unless an explicit
-    // env override is supplied. The gateway's local keystore (if any)
-    // belongs to a different identity, and the daemon is reachable only
-    // over HTTP — but `/api/agent/identity` requires the AGENT auth token,
-    // which the gateway doesn't have for the remote daemon's identity.
-    // With env override: trust verbatim (already EIP-55-normalized above).
-    if (!explicitAddress && !this.daemonIsLocalhost()) {
-      api.logger.warn?.(
-        '[dkg-memory] Daemon URL is non-local; skipping identity probe. ' +
-        'Working-memory reads and writes will return needs_clarification ' +
-        'until either DKG_AGENT_ADDRESS env is set, daemonUrl points at ' +
-        'localhost, or the daemon exposes a node-level identity endpoint.',
-      );
-      return;
-    }
-    if (explicitAddress && !this.daemonIsLocalhost()) {
-      // Operator-asserted identity for a remote daemon. No HTTP probe; we
-      // wouldn't have an agent token to authenticate against the remote.
-      this.nodeAgentAddress = explicitAddress;
-      return;
-    }
-
-    // T64/T66 — Reset the absent-flag at probe entry. The flag drives the
-    // peerId fallback in the resolver chain; if a previous probe ran with
-    // a transient state (file mid-write, stale parse, etc.) and set the
-    // flag, leaving it set is wrong once the keystore stabilizes. Each
-    // probe re-derives the flag from current state.
-    this.localKeystoreCheckedAndAbsent = false;
-
-    // T70 — Use the dkgHome resolved once at register() time. Picks up
-    // ~/.dkg-dev when the running daemon is the monorepo one, ~/.dkg when
-    // it's the npm one — regardless of which the gateway process started
-    // with in `DKG_HOME`.
-    const resolvedDkgHome = this.dkgHome;
-
-    // T63 — Read the agent's auth token from the keystore (no longer the
-    // eth address — that comes from the HTTP probe response).
-    let result: ReturnType<typeof loadAgentAuthTokenSync>;
-    try {
-      result = loadAgentAuthTokenSync(resolvedDkgHome, { explicitAddress });
-    } catch (err: any) {
-      if (err instanceof MultipleAgentsError) {
-        // T31 — multi-agent guardrail. Logger surface has only info/warn/
-        // debug (no `error`); guardrail miss surfaces as warn.
-        api.logger.warn?.(
-          `[dkg-memory] Multi-agent keystore detected (addresses: ${err.addresses.join(', ')}). ` +
-          'Adapter refuses to guess which identity to scope WM queries against. ' +
-          'Set DKG_AGENT_ADDRESS env to disambiguate; recall and search will return needs_clarification until then.',
-        );
-        return;
-      }
-      api.logger.warn?.(
-        `[dkg-memory] Agent auth-token probe threw unexpectedly: ${err?.message ?? err}`,
-      );
-      return;
-    }
-
-    if (result.kind === 'absent') {
-      // T68 — If the operator has supplied `DKG_AGENT_ADDRESS` AND the
-      // keystore is genuinely absent, the env override wins over the
-      // peerId fallback. Use case: localhost daemon in a container/
-      // service-unit split where the gateway can't see the daemon's
-      // home dir, so the operator manually asserts the daemon's
-      // identity. Without this branch the env override would be
-      // silently ignored on local deployments (the remote-daemon
-      // branch above handles non-localhost; this is the localhost
-      // missing-keystore counterpart).
-      if (explicitAddress) {
-        this.nodeAgentAddress = explicitAddress;
-        return;
-      }
-      // T60 — No env override + confirmed-absent keystore. Daemon at
-      // this host writes WM under `defaultAgentAddress ?? peerId` (peerId
-      // case in this scenario), so the resolver's peerId fallback is the
-      // correct scope key. T64 — flag is set ONLY on the genuinely-absent
-      // path; transient-unusable cases below leave it false so the next
-      // probe retries cleanly.
-      this.localKeystoreCheckedAndAbsent = true;
-      const homeLabel = `\`${resolvedDkgHome}/agent-keystore.json\``;
-      api.logger.warn?.(
-        `[dkg-memory] Agent keystore not found — ${homeLabel} is missing or has no eth-shaped keys. ` +
-        'Working-memory reads will use the daemon\'s peer-ID fallback until an agent is provisioned. ' +
-        'If the daemon was started with a custom home dir (e.g. `dkg start --home /path`), ' +
-        'set the adapter `dkgHome` config field or DKG_HOME env to that path. ' +
-        'If the daemon is in a separate container/service unit, set `DKG_AGENT_ADDRESS` to the daemon\'s active agent eth address.',
-      );
-      return;
-    }
-
-    if (result.kind === 'unusable') {
-      // T64 — File is present but unreadable / malformed JSON / missing
-      // authToken. Could be transient (operator mid-write, permission
-      // blip) or operator-fixable. The peerId fallback is UNSAFE here —
-      // the daemon may already be using eth on this host, and routing
-      // to peerId would silently scope reads to the wrong namespace.
-      // Leave the flag at false so the resolver surfaces "not ready"
-      // and the next probe retries.
-      const homeLabel = `\`${resolvedDkgHome}/agent-keystore.json\``;
-      api.logger.warn?.(
-        `[dkg-memory] Agent keystore present but unusable — ${homeLabel} is unreadable, malformed JSON, or has eth entries with no usable authToken. ` +
-        'Working-memory reads and writes will return needs_clarification until the keystore is fixed. ' +
-        'This is treated as a TRANSIENT failure (no peer-ID fallback); a subsequent probe will retry once the keystore stabilizes.',
-      );
-      return;
-    }
-
-    // T63 — HTTP-probe `/api/agent/identity` with the agent token. The
-    // daemon returns the canonical EIP-55 eth address in `agentAddress`;
-    // adapter trusts it verbatim (no client-side checksum conversion).
-    const httpResult = await this.client.getAgentIdentity({ authToken: result.authToken });
+    const httpResult = await this.client.getAgentIdentity();
     if (httpResult.ok && httpResult.identity?.agentAddress) {
       this.nodeAgentAddress = httpResult.identity.agentAddress;
       return;
     }
 
-    // HTTP probe failed (transport / 401 / 5xx). This is a transient
-    // condition — `localKeystoreCheckedAndAbsent` was already reset to
-    // false at probe entry (T64), so the resolver returns undefined and
-    // the next probe retries.
     api.logger.warn?.(
-      `[dkg-memory] Daemon /api/agent/identity probe failed: ${httpResult.error ?? 'unknown error'}. ` +
-      'Working-memory reads and writes will return needs_clarification until the next probe lands. ' +
-      'This is normal during daemon startup; if it persists, check the daemon is healthy and the keystore authToken matches.',
+      `[dkg-memory] Daemon /api/agent/identity probe failed: ${httpResult.error ?? 'identity response missing agentAddress'}. ` +
+      'Working-memory reads will use the node peer ID fallback until the next identity probe lands. ' +
+      'This is normal during daemon startup; if it persists, check the daemon is healthy and the node API token is valid.',
     );
   }
 
   /**
-   * T31 — On-demand best-effort re-read of the node agent eth address,
-   * fired by the memory resolver when a caller asks for the default
-   * agent address and the cached value is still undefined. Mirrors
-   * `ensureNodePeerId`'s shape: debounced via `agentAddressProbeInFlight`,
-   * concurrent callers share one in-flight promise.
-   *
-   * Returns immediately without firing if:
-   * - `nodeAgentAddress` is already populated (no-op),
-   * - the memory resolver API was never cached (register() hasn't run or
-   *   memory module was disabled — nothing to log against),
-   * - a probe is already in flight.
-   */
-  /**
-   * T38 — Whether the configured `daemonUrl` points at the same host
-   * as the gateway. Localhost-only is treated as "co-located" — the
-   * keystore at `<DKG_HOME>/agent-keystore.json` belongs to the same
-   * daemon process the adapter talks to, so its identity is
-   * authoritative for WM scope. Anything else (DNS, public IP, LAN
-   * IP) is remote: the gateway's local keystore is either absent or
-   * an unrelated identity, and using it would silently scope WM
-   * queries to the wrong agent.
-   *
-   * Localhost set: 127.0.0.0/8, ::1, 0.0.0.0, 'localhost'. URL parse
-   * failures default to `false` (treat as remote / unsafe).
-   */
-  /**
-   * T56/T60 — Resolve the WM identifier for default-agent self-reads.
-   * Returns:
-   *   - `nodeAgentAddress` (eth) when the keystore yielded one.
-   *   - `nodePeerId` ONLY when a localhost-gated keystore probe
-   *     legitimately found nothing (`localKeystoreCheckedAndAbsent`).
-   *     Mirrors the daemon's writer-side `defaultAgentAddress ??
-   *     peerId` priority on no-keystore deployments where writes go
-   *     to peerId.
-   *   - `undefined` for every other unresolved state (remote-daemon
-   *     probe skipped, multi-agent refuse-to-guess, probe in flight).
-   *     Lets the existing "backend not ready" error surface with the
-   *     recovery knobs instead of silently scoping queries to the
-   *     wrong namespace.
+   * Resolve the WM identifier for default-agent self-reads.
+   * Mirrors the daemon writer-side priority: default agent address when the
+   * identity endpoint has resolved it, otherwise the node peerId fallback.
    */
   private resolveDefaultAgentAddress(): string | undefined {
-    if (this.nodeAgentAddress !== undefined) return this.nodeAgentAddress;
-    if (this.localKeystoreCheckedAndAbsent) return this.nodePeerId;
-    return undefined;
+    return this.nodeAgentAddress ?? this.nodePeerId;
   }
-
-  private daemonIsLocalhost(): boolean {
-    const url = this.config.daemonUrl ?? 'http://127.0.0.1:9200';
-    try {
-      // T40 — `new URL('http://[::1]:9200').hostname` returns `[::1]`
-      // (with brackets) per WHATWG URL. Strip enclosing brackets
-      // before comparison so IPv6 loopback urls don't get
-      // misclassified as remote.
-      let host = new URL(url).hostname.toLowerCase();
-      if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
-      if (host === 'localhost' || host === '::1' || host === '0.0.0.0') return true;
-      // 127.0.0.0/8 (loopback range)
-      if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
-      return false;
-    } catch {
-      return false;
-    }
-  }
-
   private ensureNodeAgentAddress(): Promise<void> {
     if (this.nodeAgentAddress !== undefined) return Promise.resolve();
     const api = this.memoryResolverApi;
@@ -2305,15 +2064,13 @@ export class DkgNodePlugin {
             agent_address: {
               type: 'string',
               description:
-                "Optional target for `view: \"working-memory\"` reads — defaults to this node's " +
+                "Optional target for `view: \"working-memory\"` reads - defaults to this node's " +
                 'agent address (matches the default the memory plugin uses for its own WM reads). ' +
-                'Prefer the injected `current_agent_address` from chat context when available. T48/T53 — ' +
-                'Recommended shape is a 0x-prefixed eth address (the daemon writes WM under eth ' +
-                'whenever an `agent-keystore.json` identity exists, which is the standard deployment). ' +
+                'Prefer the injected `current_agent_address` from chat context when available. ' +
+                'Recommended shape is a 0x-prefixed eth address for default-agent deployments. ' +
                 'Optionally wrapped in the legacy `did:dkg:agent:` prefix, which is stripped before ' +
-                'forwarding. Bare libp2p peer IDs are also accepted as a self-alias for the default ' +
-                'agent on fresh/no-keystore/auth-disabled nodes (the daemon\'s writer-side falls back ' +
-                'to peerId when no defaultAgentAddress is set). Ignored for non-WM views. Supply an ' +
+                'forwarding. Bare libp2p peer IDs are also accepted as a self-alias for nodes whose ' +
+                'writer-side identity falls back to peerId. Ignored for non-WM views. Supply an ' +
                 'explicit value to read another local agent\'s WM namespace in multi-agent deployments.',
             },
           },
@@ -2820,44 +2577,24 @@ export class DkgNodePlugin {
     // `DkgMemorySearchManager.search` returns [] in BOTH cases, but they
     // mean very different things to the agent: a not-ready response
     // should prompt a retry, an empty-result response should prompt a
-    // different query. T31 — the WM read path keys by the daemon's
-    // eth-shaped agent address (read from agent-keystore.json); if
-    // the resolver hasn't probed it yet, we cannot run the fan-out
-    // at all.
-    //
-    // T76 — Mirror `dkg_query`'s WM-branch fallback: probe both eth
-    // address AND (when `localKeystoreCheckedAndAbsent` confirmed there's
-    // no keystore) peerId before resolving the default. Without this,
-    // confirmed-no-keystore nodes whose register-time `/api/status` probe
-    // missed startup or failed transiently report `memory_search` as
-    // "not ready" and stay falsely unavailable until the deferred
-    // resolver retry fires. The resolver's fire-and-forget
-    // `ensureNodeAgentAddress` doesn't await, and it never triggers
-    // `ensureNodePeerId` for the keystore-absent case — only the
-    // explicit await chain here does.
+    // different query. The WM read path keys by the daemon's default
+    // agent identity. Mirror `dkg_query`: first await the identity probe,
+    // then give the peerId fallback a chance if the default identity is
+    // still unavailable.
     if (this.nodeAgentAddress === undefined) {
       await this.ensureNodeAgentAddress().catch(() => {});
     }
-    if (this.localKeystoreCheckedAndAbsent && this.nodePeerId === undefined) {
+    if (this.resolveDefaultAgentAddress() === undefined) {
       await this.ensureNodePeerId().catch(() => {});
     }
     const session = this.memorySessionResolver.getSession(undefined);
     const agentAddress = session?.agentAddress ?? this.memorySessionResolver.getDefaultAgentAddress();
     if (!agentAddress) {
       return this.error(
-        // T51 — message names the actual missing dependency (agent
-        // eth address, not peerId) and enumerates the operator
-        // recovery knobs so remote/multi-agent setups know where to
-        // look. Co-located default deployments self-heal once the
-        // daemon writes the keystore (typical first few seconds
-        // after gateway start); other shapes need explicit config.
-        'memory_search backend not ready: the node\'s agent eth address has not been ' +
+        'memory_search backend not ready: the node\'s agent identity has not been ' +
         'resolved yet. Retry shortly. This is normal for the first few seconds after ' +
-        'gateway start while the daemon writes `<DKG_HOME>/agent-keystore.json`. If it ' +
-        'persists, check: (a) `DKG_HOME` matches the daemon\'s home dir (or set the ' +
-        'adapter `dkgHome` config), (b) the keystore exists and contains a single eth ' +
-        'address, (c) for multi-agent keystores or remote daemonUrl, set ' +
-        '`DKG_AGENT_ADDRESS` env to the active eth address.',
+        'gateway start while the daemon identity and peer ID probes settle. If it ' +
+        'persists, check that the daemon is healthy and the node API token is valid.',
       );
     }
 
@@ -3019,32 +2756,21 @@ export class DkgNodePlugin {
         ? args.agent_address.trim()
         : undefined;
       if (view === 'working-memory' && agentAddress === undefined) {
-        // T31 — Keystore-present deployments scope WM by the daemon's
-        // writer-side eth address.
-        // T57/T60 — No-keystore deployments fall back to peerId,
-        // matching the daemon's writer-side `defaultAgentAddress ??
-        // peerId` priority. The fallback is ONLY safe when a
-        // localhost-gated probe confirmed no keystore exists
-        // (`localKeystoreCheckedAndAbsent`) — for remote daemons
-        // (T38 — probe skipped) and multi-agent (refuse-to-guess),
-        // peerId would be the gateway's local libp2p ID, which the
-        // remote daemon has never heard of, and the query would
-        // silently scope to a non-existent namespace. Use the
-        // shared `resolveDefaultAgentAddress` helper so the handler
-        // and resolver stay in lockstep.
+        // Mirror the daemon's writer-side `defaultAgentAddress ?? peerId`
+        // priority. First try the identity endpoint; if it has not resolved
+        // yet, ensure the peerId fallback has had a chance to populate.
         if (this.nodeAgentAddress === undefined) {
           await this.ensureNodeAgentAddress().catch(() => {});
         }
-        if (this.localKeystoreCheckedAndAbsent && this.nodePeerId === undefined) {
-          await this.ensureNodePeerId().catch(() => {});
-        }
         agentAddress = this.resolveDefaultAgentAddress();
+        if (agentAddress === undefined) {
+          await this.ensureNodePeerId().catch(() => {});
+          agentAddress = this.resolveDefaultAgentAddress();
+        }
         if (agentAddress === undefined) {
           return this.error(
             '"view: working-memory" requires an agent identity. Supply `agent_address` explicitly, ' +
-              "or retry once the node's agent address (or peer ID) is available. " +
-              "For remote daemons set DKG_AGENT_ADDRESS env; for daemons started with " +
-              "`dkg start --home /custom/path` set the adapter `dkgHome` config or DKG_HOME env.",
+              "or retry once the node's agent address or peer ID is available.",
           );
         }
       }

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -143,34 +143,21 @@ export class DkgDaemonClient {
   }
 
   /**
-   * T63 — Probe the daemon's `/api/agent/identity` route to discover the
-   * canonical agent identity for the supplied agent-bound auth token.
+   * Probe the daemon's `/api/agent/identity` route using the client's normal
+   * constructor-loaded node-level Bearer token.
    *
-   * This replaces the previous T62 path of reading the keystore JSON key
-   * and EIP-55-checksumming it client-side. The daemon already returns
-   * `agentAddress` in canonical EIP-55 form (set from `verifyWallet.address`
-   * at registration), so the adapter trusts the response verbatim and the
-   * checksum helper no longer needs to be applied to keystore reads.
-   *
-   * The endpoint requires AGENT-bound auth (not the node-level token in
-   * `auth.token`). Callers extract the per-agent token from
-   * `agent-keystore.json` (via `loadAgentAuthTokenSync` in dkg-core) and
-   * pass it through `opts.authToken`. The constructor's default node-level
-   * Bearer is bypassed for this call.
-   *
-   * Failure shape mirrors `getStatus()`: `{ ok: false, error }` for
-   * transport / 401 / 5xx so the probe site can branch without try/catch.
+   * The daemon resolves unknown node-level tokens to its default agent address,
+   * so the response is the canonical WM identity the adapter should cache.
+   * Failure shape mirrors `getStatus()`: `{ ok: false, error }` for transport,
+   * 401, and 5xx responses so the probe site can branch without try/catch.
    */
-  async getAgentIdentity(opts: { authToken: string }): Promise<{
+  async getAgentIdentity(): Promise<{
     ok: boolean;
     identity?: AgentIdentity;
     error?: string;
   }> {
     try {
-      const data = await this.get<Record<string, unknown>>(
-        '/api/agent/identity',
-        { Authorization: `Bearer ${opts.authToken}` },
-      );
+      const data = await this.get<Record<string, unknown>>('/api/agent/identity');
       return {
         ok: true,
         identity: {
@@ -763,24 +750,8 @@ export class DkgDaemonClient {
   // HTTP primitives
   // ---------------------------------------------------------------------------
 
-  /**
-   * T63 — `headersOverride` lets callers replace the constructor's
-   * node-level Bearer for a single request. Used by `getAgentIdentity`
-   * which requires the agent-bound auth token (loaded per-request from
-   * the keystore), not the node-level `auth.token`. Without this, the
-   * request would fail with 401 because `/api/agent/identity` rejects
-   * node-level tokens.
-   */
-  private async get<T>(
-    path: string,
-    headersOverride?: Record<string, string>,
-  ): Promise<T> {
-    const headers: Record<string, string> = { 'Accept': 'application/json' };
-    if (headersOverride) {
-      Object.assign(headers, headersOverride);
-    } else {
-      Object.assign(headers, this.authHeaders());
-    }
+  private async get<T>(path: string): Promise<T> {
+    const headers: Record<string, string> = { 'Accept': 'application/json', ...this.authHeaders() };
     const res = await fetch(`${this.baseUrl}${path}`, {
       method: 'GET',
       headers,

--- a/packages/adapter-openclaw/src/types.ts
+++ b/packages/adapter-openclaw/src/types.ts
@@ -388,16 +388,13 @@ export interface DkgOpenClawConfig {
 
   /**
    * Explicit DKG home directory for the daemon the adapter targets via
-   * `daemonUrl`. T42 — when set, the adapter reads the agent eth address
-   * from `<dkgHome>/agent-keystore.json` regardless of the gateway
-   * process's own `DKG_HOME` env. This is the explicit override for
-   * "localhost daemon started with `dkg start --home /custom/path`",
-   * service-unit-managed daemons, or container-isolated daemons where
-   * the gateway's filesystem cannot see the daemon's home dir at the
-   * default path. Falls back to `process.env.DKG_HOME` when undefined.
-   * Ignored when `daemonUrl` is non-localhost (the localhost gate
-   * still applies — remote daemons need the `DKG_AGENT_ADDRESS` env
-   * override or the future daemon endpoint).
+   * `daemonUrl`. Used only for loading the node-level `<dkgHome>/auth.token`
+   * when the daemon runs with a custom home outside the auto-detected
+   * `~/.dkg` / `~/.dkg-dev` homes.
+   *
+   * This is not used for agent identity probing; the adapter resolves the
+   * default agent through `/api/agent/identity` with the node-level Bearer
+   * token.
    */
   dkgHome?: string;
 

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -58,6 +58,59 @@ describe('DkgDaemonClient', () => {
     });
   });
 
+  it('getAgentIdentity uses constructor auth headers', async () => {
+    const authedClient = new DkgDaemonClient({
+      baseUrl: 'http://localhost:9200',
+      apiToken: 'node-token',
+    });
+
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '0x1234567890123456789012345678901234567890',
+        agentDid: 'did:dkg:agent:0x1234567890123456789012345678901234567890',
+        name: 'default-agent',
+        peerId: '12D3KooWPeer',
+        nodeIdentityId: '7',
+      }), { status: 200 }),
+    );
+
+    const result = await authedClient.getAgentIdentity();
+
+    expect(result.ok).toBe(true);
+    expect(result.identity?.agentAddress).toBe('0x1234567890123456789012345678901234567890');
+    expect(fetchCalls[0]?.[0]).toBe('http://localhost:9200/api/agent/identity');
+    expect(fetchCalls[0]?.[1]?.method).toBe('GET');
+    expect(fetchCalls[0]?.[1]?.headers).toMatchObject({
+      Accept: 'application/json',
+      Authorization: 'Bearer node-token',
+    });
+  });
+
+  it('getAgentIdentity works without Authorization when daemon auth is disabled', async () => {
+    const noAuthClient = new DkgDaemonClient({
+      baseUrl: 'http://localhost:9200',
+      apiToken: '',
+    });
+
+    fetchResponses.push(
+      new Response(JSON.stringify({
+        agentAddress: '12D3KooWPeerFallback',
+        agentDid: 'did:dkg:agent:12D3KooWPeerFallback',
+        name: 'default-agent',
+        peerId: '12D3KooWPeerFallback',
+        nodeIdentityId: '0',
+      }), { status: 200 }),
+    );
+
+    const result = await noAuthClient.getAgentIdentity();
+
+    expect(result.ok).toBe(true);
+    expect(result.identity?.agentAddress).toBe('12D3KooWPeerFallback');
+    expect(fetchCalls[0]?.[0]).toBe('http://localhost:9200/api/agent/identity');
+    expect(fetchCalls[0]?.[1]?.headers).toMatchObject({ Accept: 'application/json' });
+    expect(fetchCalls[0]?.[1]?.headers).not.toHaveProperty('Authorization');
+  });
+
   // ---------------------------------------------------------------------------
   // Health
   // ---------------------------------------------------------------------------

--- a/packages/adapter-openclaw/test/memory-search-tool.test.ts
+++ b/packages/adapter-openclaw/test/memory-search-tool.test.ts
@@ -102,7 +102,7 @@ describe('memory_search tool', () => {
     expect(typeof result).toBe('object');
   });
 
-  it('returns "not ready" error when the resolver has no agent eth address yet (R7.6 / T51)', async () => {
+  it('returns "not ready" error when the resolver has no agent identity yet (R7.6 / T51)', async () => {
     const tool = tools.find((t) => t.name === 'memory_search')!;
     // Force resolver to surface no agent address (neither session-bound nor default).
     (plugin as any).memorySessionResolver.getSession = () => undefined;
@@ -112,35 +112,28 @@ describe('memory_search tool', () => {
     const text = (result as any).content?.[0]?.text ?? '';
     // Tool should return the structured "not ready" error, NOT an empty hits list.
     expect(text).toMatch(/not ready/i);
-    // T51 — message names the actual missing dependency (agent eth address)
-    // and surfaces the operator recovery knobs (DKG_HOME/dkgHome/keystore/
-    // DKG_AGENT_ADDRESS) so remote/multi-agent setups know where to look.
-    expect(text).toMatch(/agent eth address/i);
-    expect(text).toMatch(/DKG_AGENT_ADDRESS/);
-    expect(text).toMatch(/dkgHome/);
+    expect(text).toMatch(/agent identity/i);
+    expect(text).toMatch(/node API token/i);
   });
 
-  it('T76 — probes ensureNodePeerId on confirmed-no-keystore nodes when nodePeerId is still undefined (mirrors dkg_query WM branch)', async () => {
+  it('T76 — probes ensureNodePeerId when identity is unresolved and nodePeerId is still undefined (mirrors dkg_query WM branch)', async () => {
     // T76 — Codex flagged: pre-fix, `handleMemorySearch` returned the
     // "agent eth address not resolved" error whenever the resolver
-    // surfaced no address, even when `localKeystoreCheckedAndAbsent`
-    // was true and the only remaining gap was a missed `/api/status`
-    // peerId probe. The dkg_query WM branch already triggers
+    // surfaced no address, even when the only remaining gap was a missed
+    // `/api/status` peerId probe. The dkg_query WM branch already triggers
     // `ensureNodePeerId()` in that case; memory_search did not, so
     // it stayed falsely unavailable until the deferred probe retry
     // fired (which can be many turns later).
     //
     // After the fix, memory_search awaits both `ensureNodeAgentAddress`
-    // and (when keystore is confirmed absent) `ensureNodePeerId`
-    // before resolving the default address.
+    // and `ensureNodePeerId` before resolving the default address.
     const tool = tools.find((t) => t.name === 'memory_search')!;
     const client = (plugin as any).client;
     client.query = vi.fn().mockResolvedValue({ result: { bindings: [] } });
 
-    // Set up the no-keystore-but-peerId-not-yet-probed state.
+    // Set up identity-not-yet-resolved with peerId not yet probed.
     (plugin as any).nodeAgentAddress = undefined;
     (plugin as any).nodePeerId = undefined;
-    (plugin as any).localKeystoreCheckedAndAbsent = true;
 
     // Spy on the probe methods. Make `ensureNodePeerId` resolve the
     // peerId, mirroring what a recovered /api/status call would do.
@@ -169,41 +162,39 @@ describe('memory_search tool', () => {
     expect((result as any).details?.error).toBeFalsy();
   });
 
-  it('T76 — does NOT probe ensureNodePeerId when localKeystoreCheckedAndAbsent is false (remote-daemon path)', async () => {
-    // Mirrors dkg_query's T60 guarantee: the peerId fallback is gated
-    // on `localKeystoreCheckedAndAbsent` so remote-daemon deployments
-    // (where probeNodeAgentAddressOnce intentionally skips the keystore
-    // read) don't silently route WM scope to the gateway's local peerId.
+  it('T76 — probes ensureNodePeerId when identity is unresolved, without the retired keystore-absent gate', async () => {
+    // Mirrors dkg_query's post-#324 fallback chain: the adapter first tries
+    // the daemon identity endpoint, then gives the peerId fallback a chance.
+    // The old local-keystore-absence gate is gone with the local
+    // keystore identity probe.
     const tool = tools.find((t) => t.name === 'memory_search')!;
     const client = (plugin as any).client;
     client.query = vi.fn().mockResolvedValue({ result: { bindings: [] } });
 
     (plugin as any).nodeAgentAddress = undefined;
     (plugin as any).nodePeerId = undefined;
-    (plugin as any).localKeystoreCheckedAndAbsent = false; // remote-daemon: probe skipped
 
     const ensureAgentSpy = vi.fn().mockResolvedValue(undefined);
-    const ensurePeerIdSpy = vi.fn().mockResolvedValue(undefined);
+    const ensurePeerIdSpy = vi.fn(async () => {
+      (plugin as any).nodePeerId = '12D3KooWRecoveredPeerNoKeystoreGate';
+    });
     (plugin as any).ensureNodeAgentAddress = ensureAgentSpy;
     (plugin as any).ensureNodePeerId = ensurePeerIdSpy;
 
-    const result = await tool.execute('t-remote-daemon', { query: 'tatooine' });
+    const result = await tool.execute('t-peerid-fallback-no-keystore-gate', { query: 'tatooine' });
 
-    // ensureNodeAgentAddress fires (always best-effort); ensureNodePeerId
-    // does NOT — the gate prevents leaking the gateway's local peerId
-    // into a remote daemon's scope.
+    // ensureNodeAgentAddress fires first; ensureNodePeerId is no longer
+    // gated by local keystore state.
     // Called at least once — exact count varies because the resolver's
     // `getSession` and `getDefaultAgentAddress` also fire it
     // fire-and-forget. All calls are idempotent (debounced via
     // `agentAddressProbeInFlight`).
     expect(ensureAgentSpy).toHaveBeenCalled();
-    expect(ensurePeerIdSpy).not.toHaveBeenCalled();
+    expect(ensurePeerIdSpy).toHaveBeenCalled();
 
-    // Without an eth address AND without the keystore-absent flag, the
-    // tool surfaces the "not ready" error so operators see the recovery
-    // knobs (DKG_AGENT_ADDRESS, dkgHome) — NOT a silently-empty result.
     const text = (result as any).content?.[0]?.text ?? '';
-    expect(text).toMatch(/not ready/i);
+    expect(text).not.toMatch(/not ready/i);
+    expect((result as any).details?.error).toBeFalsy();
   });
 
   it('re-asserts memory-slot capability before running the search (R7.5 mode-independent anchor)', async () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -890,19 +890,13 @@ describe('DkgNodePlugin', () => {
       expect(body.agentAddress).not.toContain('did:dkg:agent:');
     });
 
-    it('dkg_query falls back to nodePeerId when agent_address is omitted on no-keystore nodes (T57/T60)', async () => {
-      // T57 — handler default for omitted agent_address must mirror
-      // the resolver's `nodeAgentAddress ?? nodePeerId` priority.
-      // T60 — fallback gates on `localKeystoreCheckedAndAbsent` so
-      // remote-daemon (probe-skipped) doesn't silently route to
-      // gateway's local peerId.
+    it('dkg_query falls back to nodePeerId when agent_address is omitted before identity resolves', async () => {
+      // Handler default for omitted agent_address must mirror the
+      // daemon's writer-side `defaultAgentAddress ?? peerId` priority.
       const { fetchMock, byName, plugin } = setupPluginWithFetch({ ok: true });
       (plugin as any).nodeAgentAddress = undefined;
       (plugin as any).nodePeerId = '12D3KooWNoKeystorePeer';
-      // T60 — explicitly mark the local-keystore-confirmed-absent
-      // state. Without this the resolver returns undefined on
-      // remote-daemon paths.
-      (plugin as any).localKeystoreCheckedAndAbsent = true;
+      (plugin as any).ensureNodeAgentAddress = vi.fn().mockResolvedValue(undefined);
       await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
         context_graph_id: 'my-cg',
@@ -915,19 +909,12 @@ describe('DkgNodePlugin', () => {
       expect(body.agentAddress).toBe('12D3KooWNoKeystorePeer');
     });
 
-    it('dkg_query refuses to fall back to nodePeerId on remote-daemon (probe-skipped) — T60', async () => {
-      // T60 — On remote daemonUrl, `probeNodeAgentAddressOnce()`
-      // intentionally skips the keystore read (T38), so
-      // `nodeAgentAddress` stays undefined AND
-      // `localKeystoreCheckedAndAbsent` stays false. The fallback
-      // to gateway's local peerId would silently scope WM to a
-      // namespace the remote daemon has never heard of. Handler
-      // MUST error in that case so the operator sees the
-      // recovery knobs surfaced.
+    it('dkg_query errors when neither daemon identity nor peerId fallback is available', async () => {
       const { fetchMock, byName, plugin } = setupPluginWithFetch({ ok: true });
       (plugin as any).nodeAgentAddress = undefined;
-      (plugin as any).nodePeerId = '12D3KooWGatewayLocal';
-      (plugin as any).localKeystoreCheckedAndAbsent = false;  // remote-daemon: probe skipped
+      (plugin as any).nodePeerId = undefined;
+      (plugin as any).ensureNodeAgentAddress = vi.fn().mockResolvedValue(undefined);
+      (plugin as any).ensureNodePeerId = vi.fn().mockResolvedValue(undefined);
       const result = await byName.get('dkg_query')!.execute('tc', {
         sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1',
         context_graph_id: 'my-cg',
@@ -937,9 +924,8 @@ describe('DkgNodePlugin', () => {
       const text = result.content[0].text;
       expect(text).toContain('working-memory');
       expect(text).toContain('agent identity');
-      // Error names the recovery knobs operators should reach for.
-      expect(text).toContain('DKG_AGENT_ADDRESS');
-      expect(text).toContain('dkgHome');
+      expect(text).not.toContain('DKG_AGENT_ADDRESS');
+      expect(text).not.toContain('dkgHome');
     });
 
     it('dkg_query forwards peerId-form WM agent_address verbatim (T48/T53 — daemon accepts as self-alias on no-keystore nodes)', async () => {
@@ -4586,23 +4572,10 @@ describe('DkgNodePlugin', () => {
     });
   });
 
-  describe('node agent address keystore (T31)', () => {
-    // T31 — The resolver returns `nodeAgentAddress` (eth address from
-    // `<DKG_HOME>/agent-keystore.json`) instead of `nodePeerId` (libp2p
-    // from `/api/status`). These tests exercise the new lazy-read pattern
-    // by setting DKG_HOME to a tmpdir and writing/mutating the keystore
-    // file mid-test. Mirrors the previous B9 lazy re-probe semantics for
-    // the keystore source.
-    // T63 — Adapter HTTP-probes `/api/agent/identity` to get the canonical
-    // eth (already EIP-55 from the daemon). Tests stub `client.getAgentIdentity`
-    // and assert resolver returns whatever the stub responded with.
-    // Test fixtures: keystore JSON keys are LOWERCASE (the form the daemon
-    // writes). Stubs return EIP-55 checksum form (what the daemon's HTTP
-    // response gives). Both forms are derived at runtime.
+  describe('node agent address identity probe (#324)', () => {
     const ETH_PRIMARY_LC = '0x26c9b05a30138b35e84e60a5b778d580065ffbb8';
     const ETH_SECONDARY_LC = '0x949ec97ab4ed1c9fb4c9a70c2dd368065d817b0c';
     const ETH_PRIMARY = toEip55Checksum(ETH_PRIMARY_LC);
-    const ETH_SECONDARY = toEip55Checksum(ETH_SECONDARY_LC);
 
     function makeMockApi(): OpenClawPluginApi {
       return {
@@ -4616,459 +4589,58 @@ describe('DkgNodePlugin', () => {
       } as unknown as OpenClawPluginApi;
     }
 
+    function identityResult(agentAddress: string) {
+      return {
+        ok: true,
+        identity: {
+          agentAddress,
+          agentDid: `did:dkg:agent:${agentAddress}`,
+          name: 'test-agent',
+          peerId: '12D3KooWDaemonPeerFromIdentity',
+          nodeIdentityId: '0',
+        },
+      };
+    }
+
     let tempHome: string;
     let prevDkgHome: string | undefined;
-    let prevAgentEnv: string | undefined;
 
     beforeEach(() => {
-      tempHome = path.join(require('os').tmpdir(), `dkg-node-keystore-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      tempHome = path.join(require('os').tmpdir(), `dkg-node-identity-${Date.now()}-${Math.random().toString(36).slice(2)}`);
       fs.mkdirSync(tempHome, { recursive: true });
       prevDkgHome = process.env.DKG_HOME;
-      prevAgentEnv = process.env.DKG_AGENT_ADDRESS;
       process.env.DKG_HOME = tempHome;
-      delete process.env.DKG_AGENT_ADDRESS;
     });
 
     afterEach(() => {
       if (prevDkgHome === undefined) delete process.env.DKG_HOME;
       else process.env.DKG_HOME = prevDkgHome;
-      if (prevAgentEnv === undefined) delete process.env.DKG_AGENT_ADDRESS;
-      else process.env.DKG_AGENT_ADDRESS = prevAgentEnv;
       try { fs.rmSync(tempHome, { recursive: true, force: true }); } catch { /* best effort */ }
     });
 
-    function writeKeystore(addresses: string[]): void {
-      const payload: Record<string, unknown> = {};
-      for (const addr of addresses) payload[addr] = { authToken: `tok-${addr.toLowerCase()}` };
-      fs.writeFileSync(path.join(tempHome, 'agent-keystore.json'), JSON.stringify(payload));
-    }
-
-    /**
-     * T63 — Stub `client.getAgentIdentity` to return a canned response.
-     * Tests that exercise the local-keystore-with-agent path need this so
-     * the probe doesn't try a real HTTP fetch. Returns the spy so callers
-     * can assert the auth token forwarded matches the keystore entry.
-     */
-    function stubAgentIdentity(plugin: DkgNodePlugin, ethAddress: string): ReturnType<typeof vi.fn> {
-      const spy = vi.fn().mockResolvedValue({
-        ok: true,
-        identity: {
-          agentAddress: ethAddress,
-          agentDid: `did:dkg:agent:${ethAddress}`,
-          name: 'test-agent',
-          peerId: '12D3KooWDaemonPeerFromIdentity',
-          nodeIdentityId: '0',
-        },
-      });
-      (plugin as any).client.getAgentIdentity = spy;
+    function installIdentityClient(plugin: DkgNodePlugin, response: unknown): ReturnType<typeof vi.fn> {
+      const spy = vi.fn().mockResolvedValue(response);
+      (plugin as any).client = { getAgentIdentity: spy };
       return spy;
     }
 
-    it('resolver.getDefaultAgentAddress returns the eth address from the daemon HTTP probe (T31/T63)', async () => {
-      // T63 — Adapter now reads agent token from keystore and HTTP-probes
-      // `/api/agent/identity` to get the canonical eth (already EIP-55).
-      writeKeystore([ETH_PRIMARY_LC]);
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        const spy = stubAgentIdentity(plugin, ETH_PRIMARY);
-        await (plugin as any).ensureNodeAgentAddress();
-        const resolver = (plugin as any).memorySessionResolver;
-        expect(resolver.getDefaultAgentAddress()).toBe(ETH_PRIMARY);
-        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-        // T63 regression — probe forwards the AGENT auth token from the
-        // keystore (NOT the constructor's node-level token).
-        expect(spy).toHaveBeenCalledWith({ authToken: `tok-${ETH_PRIMARY_LC}` });
-      } finally {
-        await plugin.stop();
-      }
-    });
+    function attachResolverApi(plugin: DkgNodePlugin, api: OpenClawPluginApi): void {
+      (plugin as any).memoryResolverApi = api;
+      (plugin as any).dkgHome = tempHome;
+    }
 
-    it('lazily re-reads keystore when the register-time read found no file', async () => {
-      // Keystore absent at register; appears later (e.g. daemon provisions
-      // identity after gateway start).
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        // Stub from the start so the eventual probe doesn't try real HTTP.
-        stubAgentIdentity(plugin, ETH_PRIMARY);
-        // Drive the register-time probe to completion explicitly. With no
-        // keystore, the probe sets `localKeystoreCheckedAndAbsent = true`
-        // and never reaches getAgentIdentity.
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(true);
-        // Drain the .finally microtask so the in-flight promise clears.
-        await new Promise((r) => setImmediate(r));
-
-        // Keystore appears.
-        writeKeystore([ETH_PRIMARY_LC]);
-        // Lazy re-read — fires a fresh probe; keystore now present, so
-        // probe reaches the HTTP stub and sets nodeAgentAddress.
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('multi-agent keystore without DKG_AGENT_ADDRESS fails loud (refuses to guess)', async () => {
-      writeKeystore([ETH_PRIMARY_LC, ETH_SECONDARY_LC]);
-      const api = makeMockApi();
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(api);
-        // Drive the probe directly — `refreshMemoryResolverState` is
-        // fire-and-forget at register-time and the keystore read may
-        // not have landed by the time the test reaches this point.
-        await (plugin as any).ensureNodeAgentAddress();
-        // Refused — `nodeAgentAddress` stays undefined, NOT silently
-        // picked from one of the two keys.
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        // Operator-visible warn fired.
-        const warnCalls = (api.logger.warn as any).mock.calls.map((c: any) => String(c[0]));
-        expect(warnCalls.some((m: string) => m.includes('Multi-agent keystore detected'))).toBe(true);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('DKG_AGENT_ADDRESS env disambiguates a multi-agent keystore', async () => {
-      writeKeystore([ETH_PRIMARY_LC, ETH_SECONDARY_LC]);
-      process.env.DKG_AGENT_ADDRESS = ETH_SECONDARY;
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        const spy = stubAgentIdentity(plugin, ETH_SECONDARY);
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBe(ETH_SECONDARY);
-        // T63 — env disambiguates which keystore entry's authToken to forward.
-        expect(spy).toHaveBeenCalledWith({ authToken: `tok-${ETH_SECONDARY_LC}` });
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('falls back to nodePeerId when nodeAgentAddress is unresolved on confirmed-local-no-keystore (T56/T60)', async () => {
-      // T56 — On fresh / auth-disabled / no-keystore nodes, the
-      // daemon's writer-side falls back to peerId via
-      // `defaultAgentAddress ?? peerId`. Adapter resolver mirrors
-      // that priority. T60 — fallback gates on
-      // `localKeystoreCheckedAndAbsent`, set by `probeNodeAgentAddressOnce`
-      // when a localhost-gated probe legitimately found no keystore.
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        // Drive the probe — empty tempDir yields no keystore →
-        // probe sets `localKeystoreCheckedAndAbsent = true`.
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(true);
-        (plugin as any).nodePeerId = '12D3KooWNoKeystorePeer';
-        const resolver = (plugin as any).memorySessionResolver;
-        expect(resolver.getDefaultAgentAddress()).toBe('12D3KooWNoKeystorePeer');
-        expect(resolver.getSession(undefined)?.agentAddress).toBe('12D3KooWNoKeystorePeer');
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('does NOT fall back to nodePeerId on remote-daemon (probe-skipped) — T60', async () => {
-      // T60 — `probeNodeAgentAddressOnce` skips the keystore read
-      // for non-localhost daemonUrl. `localKeystoreCheckedAndAbsent`
-      // stays false → resolver returns undefined even though
-      // nodePeerId is populated. Without the gate, remote-daemon
-      // recall would silently scope WM to gateway's local peerId
-      // (which the remote daemon has never heard of) instead of
-      // surfacing the actual misconfiguration via the "backend
-      // not ready" path.
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://daemon.example.com:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-        (plugin as any).nodePeerId = '12D3KooWGatewayLocalPeer';
-        const resolver = (plugin as any).memorySessionResolver;
-        expect(resolver.getDefaultAgentAddress()).toBeUndefined();
-        expect(resolver.getSession(undefined)?.agentAddress).toBeUndefined();
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('keystore eth wins over peerId when both are available (T56 — keystore-present deployments)', async () => {
-      // T56 — Keystore-present deployments must keep using eth
-      // (the original Bug A / T31 fix). Fallback only kicks in when
-      // nodeAgentAddress is undefined.
-      writeKeystore([ETH_PRIMARY_LC]);
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        stubAgentIdentity(plugin, ETH_PRIMARY);
-        await (plugin as any).ensureNodeAgentAddress();
-        (plugin as any).nodePeerId = '12D3KooWShouldNotBeReturned';
-        const resolver = (plugin as any).memorySessionResolver;
-        expect(resolver.getDefaultAgentAddress()).toBe(ETH_PRIMARY);
-        expect(resolver.getSession(undefined)?.agentAddress).toBe(ETH_PRIMARY);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('skips keystore read for remote daemonUrl + warns operator (T38)', async () => {
-      // T38 — Remote/custom-daemon setup: gateway's local keystore is
-      // either absent or belongs to a different identity. Reading it
-      // would silently scope WM queries to the wrong agent. Adapter
-      // must skip the read, leave nodeAgentAddress undefined, and
-      // surface an operator-actionable warn.
-      writeKeystore([ETH_PRIMARY_LC]);
-      const api = makeMockApi();
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://daemon.example.com:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(api);
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        const warnCalls = (api.logger.warn as any).mock.calls.map((c: any) => String(c[0]));
-        expect(warnCalls.some((m: string) => m.includes('Daemon URL is non-local'))).toBe(true);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('rejects invalid DKG_AGENT_ADDRESS for the localhost gate, warns, falls through to remote-skip (T44)', async () => {
-      // T44 — `DKG_AGENT_ADDRESS=foo` (typo) must NOT bypass the
-      // localhost gate. Pre-fix: truthy-string check passed → gate
-      // skipped → keystore read with no env override → scoped WM
-      // to the gateway's local identity for a remote-daemon setup.
-      writeKeystore([ETH_PRIMARY_LC]);
-      process.env.DKG_AGENT_ADDRESS = 'foo';
-      const api = makeMockApi();
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://daemon.example.com:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(api);
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        const warnCalls = (api.logger.warn as any).mock.calls.map((c: any) => String(c[0]));
-        expect(warnCalls.some((m: string) => m.includes('not a valid 0x-prefixed eth address'))).toBe(true);
-        expect(warnCalls.some((m: string) => m.includes('Daemon URL is non-local'))).toBe(true);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('treats IPv6 loopback (`http://[::1]:…`) as localhost (T40)', async () => {
-      // T40 — `new URL('http://[::1]:9200').hostname` returns `[::1]`
-      // (with brackets) per WHATWG URL. Without bracket-stripping,
-      // the heuristic misclassifies a local IPv6 daemon as remote
-      // and skips the keystore read, leaving recall/search broken
-      // for an entirely valid local-only deployment.
-      writeKeystore([ETH_PRIMARY_LC]);
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://[::1]:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        stubAgentIdentity(plugin, ETH_PRIMARY);
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('config.dkgHome overrides DKG_HOME for the keystore read (T42)', async () => {
-      // T42 — Operator runs `dkg start --home /custom/path` (or daemon
-      // is service-unit-managed with its own home). Gateway process's
-      // DKG_HOME points elsewhere (or default). Explicit `dkgHome`
-      // config field must reach the keystore read so the adapter
-      // resolves the right identity without env-level coordination.
-      const otherHome = path.join(require('os').tmpdir(), `dkg-other-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-      fs.mkdirSync(otherHome, { recursive: true });
-      try {
-        // Write keystore at OTHER home; leave the env-DKG_HOME tempHome empty.
-        fs.writeFileSync(
-          path.join(otherHome, 'agent-keystore.json'),
-          JSON.stringify({ [ETH_PRIMARY_LC]: { authToken: 'other-home-tok' } }),
-        );
-        const plugin = new DkgNodePlugin({
-          daemonUrl: 'http://localhost:9200',
-          dkgHome: otherHome,
-          memory: { enabled: true },
-          channel: { enabled: false },
-        });
-        try {
-          plugin.register(makeMockApi());
-          stubAgentIdentity(plugin, ETH_PRIMARY);
-          await (plugin as any).ensureNodeAgentAddress();
-          expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-        } finally {
-          await plugin.stop();
-        }
-      } finally {
-        try { fs.rmSync(otherHome, { recursive: true, force: true }); } catch { /* best effort */ }
-      }
-    });
-
-    it('localhost + DKG_AGENT_ADDRESS + missing keystore: env override wins, no peerId fallback (T68)', async () => {
-      // T68 — When the operator supplies `DKG_AGENT_ADDRESS` AND the local
-      // keystore is genuinely absent (e.g., container/service-unit split
-      // where the gateway can't see the daemon's home), the env value
-      // MUST flow into `nodeAgentAddress` directly. Pre-fix the probe
-      // unconditionally set `localKeystoreCheckedAndAbsent = true` on the
-      // missing-keystore branch and the env override was silently
-      // ignored — the resolver returned `nodePeerId` instead of the
-      // operator's asserted eth.
-      process.env.DKG_AGENT_ADDRESS = ETH_PRIMARY;
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        const spy = stubAgentIdentity(plugin, 'unused');
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-        // No HTTP probe — env override short-circuited the resolution.
-        expect(spy).not.toHaveBeenCalled();
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('malformed keystore JSON triggers kind=unusable, NO peerId fallback, transient retry (T64)', async () => {
-      // T64 — File present but malformed (operator mid-write, JSON parse
-      // error, EACCES). The peerId fallback is UNSAFE — the daemon may
-      // already be using eth on this same host. Probe must NOT set the
-      // `localKeystoreCheckedAndAbsent` flag, so the resolver returns
-      // undefined (operator sees "not ready"), and the next probe retries.
-      fs.writeFileSync(path.join(tempHome, 'agent-keystore.json'), '{ this is not json');
-      const api = makeMockApi();
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(api);
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-        const warnCalls = (api.logger.warn as any).mock.calls.map((c: any) => String(c[0]));
-        expect(warnCalls.some((m: string) => m.includes('keystore present but unusable'))).toBe(true);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('keystore eth entry without authToken triggers kind=unusable (T64)', async () => {
-      // Eth key present but no authToken field — malformed entry. Same
-      // semantics as malformed JSON: NO peerId fallback, transient retry.
+    function writePoisonKeystore(): void {
       fs.writeFileSync(
         path.join(tempHome, 'agent-keystore.json'),
-        JSON.stringify({ [ETH_PRIMARY_LC]: { privateKey: '0xpk' } }),
+        JSON.stringify({
+          [ETH_PRIMARY_LC]: { authToken: 'agent-token-that-must-not-be-read' },
+          [ETH_SECONDARY_LC]: { authToken: 'second-token-that-would-have-triggered-multi-agent-branch' },
+        }),
       );
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-      } finally {
-        await plugin.stop();
-      }
-    });
+    }
 
-    it('localKeystoreCheckedAndAbsent resets on each probe (T64/T66 — sticky-flag fix)', async () => {
-      // T64/T66 — After a first probe that sets the flag (legitimate
-      // keystore-absent state), a second probe that finds the keystore
-      // present but mid-write (malformed) MUST clear the flag back to
-      // false. Pre-fix the flag was sticky and the resolver kept routing
-      // to peerId even after the keystore appeared.
-      const plugin = new DkgNodePlugin({
-        daemonUrl: 'http://localhost:9200',
-        memory: { enabled: true },
-        channel: { enabled: false },
-      });
-      try {
-        plugin.register(makeMockApi());
-        // Probe 1 — empty tempHome → kind=absent → flag set.
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(true);
-        await new Promise((r) => setImmediate(r));
-
-        // Probe 2 — malformed JSON appears → kind=unusable → flag MUST
-        // reset to false (transient).
-        fs.writeFileSync(path.join(tempHome, 'agent-keystore.json'), '{ this is not json');
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-        await new Promise((r) => setImmediate(r));
-
-        // Probe 3 — valid keystore appears → flag stays false (real
-        // success path), nodeAgentAddress set from HTTP probe.
-        writeKeystore([ETH_PRIMARY_LC]);
-        stubAgentIdentity(plugin, ETH_PRIMARY);
-        await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-      } finally {
-        await plugin.stop();
-      }
-    });
-
-    it('HTTP probe failure leaves nodeAgentAddress undefined and localKeystoreCheckedAndAbsent false (T63)', async () => {
-      // T63 — A transient HTTP failure (daemon down, 401, 5xx) is NOT a
-      // signal that the keystore is missing. The probe must keep the
-      // door open for retry: nodeAgentAddress stays undefined AND
-      // localKeystoreCheckedAndAbsent stays false (so the resolver
-      // returns undefined → "backend not ready" surfaces, NOT the
-      // peerId fallback which is only correct when keystore is genuinely
-      // absent).
-      writeKeystore([ETH_PRIMARY_LC]);
+    it('caches the daemon default agent from the HTTP identity probe and ignores local keystore content', async () => {
+      writePoisonKeystore();
       const api = makeMockApi();
       const plugin = new DkgNodePlugin({
         daemonUrl: 'http://localhost:9200',
@@ -5076,51 +4648,100 @@ describe('DkgNodePlugin', () => {
         channel: { enabled: false },
       });
       try {
-        plugin.register(api);
-        const failingSpy = vi.fn().mockResolvedValue({ ok: false, error: 'ECONNREFUSED' });
-        (plugin as any).client.getAgentIdentity = failingSpy;
+        attachResolverApi(plugin, api);
+        const spy = installIdentityClient(plugin, identityResult(ETH_PRIMARY));
+
         await (plugin as any).ensureNodeAgentAddress();
-        expect((plugin as any).nodeAgentAddress).toBeUndefined();
-        expect((plugin as any).localKeystoreCheckedAndAbsent).toBe(false);
-        // Forwarded the agent token from the keystore (regression).
-        expect(failingSpy).toHaveBeenCalledWith({ authToken: `tok-${ETH_PRIMARY_LC}` });
-        // Operator-visible warn fired.
-        const warnCalls = (api.logger.warn as any).mock.calls.map((c: any) => String(c[0]));
-        expect(warnCalls.some((m: string) => m.includes('/api/agent/identity probe failed'))).toBe(true);
+
+        const resolver = (plugin as any).memorySessionResolver;
+        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
+        expect(resolver.getDefaultAgentAddress()).toBe(ETH_PRIMARY);
+        expect(resolver.getSession(undefined)?.agentAddress).toBe(ETH_PRIMARY);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy.mock.calls[0]).toEqual([]);
       } finally {
         await plugin.stop();
       }
     });
 
-    it('honors DKG_AGENT_ADDRESS even when daemonUrl is remote (T38)', async () => {
-      // T38 — Operator escape hatch: setting DKG_AGENT_ADDRESS lets
-      // remote-daemon deployments scope WM correctly without waiting
-      // for the daemon-side endpoint to ship.
-      process.env.DKG_AGENT_ADDRESS = ETH_PRIMARY;
+    it('probes daemon identity for non-local daemonUrl instead of skipping to local keystore logic', async () => {
+      writePoisonKeystore();
+      const api = makeMockApi();
       const plugin = new DkgNodePlugin({
         daemonUrl: 'http://daemon.example.com:9200',
         memory: { enabled: true },
         channel: { enabled: false },
       });
       try {
-        plugin.register(makeMockApi());
+        attachResolverApi(plugin, api);
+        const spy = installIdentityClient(plugin, identityResult(ETH_PRIMARY));
+
         await (plugin as any).ensureNodeAgentAddress();
+
         expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
+        expect(spy).toHaveBeenCalledWith();
       } finally {
         await plugin.stop();
       }
     });
 
-    it('T70 — when resolved <dkgHome>/auth.token is briefly missing, client does NOT silently fall back to ~/.dkg/auth.token', async () => {
-      // T70 corner case (caught in QA review): the resolver picks the live
-      // daemon's home (~/.dkg-dev), but its auth.token is briefly absent
-      // (operator deleted it during a token rotation, mid-write, fresh
-      // checkout where the daemon hasn't yet written the token, etc.).
-      // The OTHER home (~/.dkg) has a stale auth.token from a previous
-      // npm-side install. Without `dkgHome` plumbed through DkgClientOptions,
-      // the constructor's `?? loadTokenFromFile()` no-arg fallback would
-      // read the default ~/.dkg/auth.token and silently authenticate with
-      // the wrong identity → 401 on every authenticated daemon call.
+    it('debounces concurrent daemon identity probes', async () => {
+      const api = makeMockApi();
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        memory: { enabled: true },
+        channel: { enabled: false },
+      });
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      try {
+        attachResolverApi(plugin, api);
+        const spy = vi.fn(async () => {
+          await gate;
+          return identityResult(ETH_PRIMARY);
+        });
+        (plugin as any).client = { getAgentIdentity: spy };
+
+        const first = (plugin as any).ensureNodeAgentAddress();
+        const second = (plugin as any).ensureNodeAgentAddress();
+        expect(spy).toHaveBeenCalledTimes(1);
+        release();
+        await Promise.all([first, second]);
+
+        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        await plugin.stop();
+      }
+    });
+
+    it('warns on failed identity probe and keeps the nodePeerId fallback available', async () => {
+      const api = makeMockApi();
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://localhost:9200',
+        memory: { enabled: true },
+        channel: { enabled: false },
+      });
+      try {
+        attachResolverApi(plugin, api);
+        (plugin as any).nodePeerId = '12D3KooWPeerFallback';
+        installIdentityClient(plugin, { ok: false, error: '401 Unauthorized' });
+
+        await (plugin as any).ensureNodeAgentAddress();
+
+        const resolver = (plugin as any).memorySessionResolver;
+        expect((plugin as any).nodeAgentAddress).toBeUndefined();
+        expect(resolver.getDefaultAgentAddress()).toBe('12D3KooWPeerFallback');
+        const warnCalls = (api.logger.warn as any).mock.calls.map((c: any) => String(c[0]));
+        expect(warnCalls.some((m: string) => m.includes('/api/agent/identity probe failed'))).toBe(true);
+        expect(warnCalls.some((m: string) => m.includes('node API token'))).toBe(true);
+        expect(warnCalls.some((m: string) => m.includes('keystore'))).toBe(false);
+      } finally {
+        await plugin.stop();
+      }
+    });
+
+    it('keeps resolved dkgHome scoped to node-level auth.token loading only', async () => {
       delete process.env.DKG_HOME;
 
       const isolatedHome = path.join(require('os').tmpdir(), `dkg-t70-fallback-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -5131,15 +4752,36 @@ describe('DkgNodePlugin', () => {
 
       const prevHome = process.env.HOME;
       const prevUserProfile = process.env.USERPROFILE;
+      const originalFetch = globalThis.fetch;
       process.env.HOME = isolatedHome;
       process.env.USERPROFILE = isolatedHome;
 
+      globalThis.fetch = vi.fn(async (input: any) => {
+        const url = typeof input === 'string' ? input : input?.url ?? '';
+        if (url.includes('/api/status')) {
+          return new Response(JSON.stringify({ peerId: '12D3KooWResolvedHomePeer' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (url.includes('/api/agent/identity')) {
+          return new Response(JSON.stringify(identityResult(ETH_PRIMARY).identity), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (url.includes('/api/context-graph/list')) {
+          return new Response(JSON.stringify({ contextGraphs: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+      }) as any;
+
       try {
-        // Stale npm-side token that MUST NOT bleed into the client.
         fs.writeFileSync(path.join(dkg, 'auth.token'), 'STALE-NPM-TOKEN');
-        // Live monorepo daemon with no auth.token (briefly missing).
         fs.writeFileSync(path.join(dkgDev, 'daemon.pid'), String(process.pid));
-        // (no auth.token in dkgDev — that's the corner case)
 
         const plugin = new DkgNodePlugin({
           daemonUrl: 'http://127.0.0.1:9200',
@@ -5148,16 +4790,13 @@ describe('DkgNodePlugin', () => {
         });
         try {
           plugin.register(makeMockApi());
-          // Resolver correctly picks the live monorepo dir.
           expect((plugin as any).dkgHome).toBe(dkgDev);
-          // CRITICAL invariant — apiToken must be undefined (the resolved
-          // home's auth.token is absent). It must NOT silently pick up
-          // 'STALE-NPM-TOKEN' from the other home.
           expect((plugin as any).client.apiToken).toBeUndefined();
         } finally {
           await plugin.stop();
         }
       } finally {
+        globalThis.fetch = originalFetch;
         if (prevHome === undefined) delete process.env.HOME;
         else process.env.HOME = prevHome;
         if (prevUserProfile === undefined) delete process.env.USERPROFILE;
@@ -5166,99 +4805,65 @@ describe('DkgNodePlugin', () => {
       }
     });
 
-    it('T70 — auto-resolves dkgHome to the live daemon dir when both ~/.dkg and ~/.dkg-dev exist (no env override)', async () => {
-      // T70 — User's monorepo↔npm switch scenario: both home dirs exist on
-      // disk, but only the monorepo daemon is currently alive. Adapter
-      // should pick ~/.dkg-dev automatically, with no openclaw.json edit
-      // and no DKG_HOME env override.
-      //
-      // Test redirects `homedir()` by overriding HOME / USERPROFILE to a
-      // tmp dir, then writes:
-      //   <tmp>/.dkg/daemon.pid       = 999999999      (stale, dead)
-      //   <tmp>/.dkg/api.port         = 9200           (stale)
-      //   <tmp>/.dkg/auth.token       = "wrong-token"  (npm-side stale)
-      //   <tmp>/.dkg-dev/daemon.pid   = process.pid    (alive)
-      //   <tmp>/.dkg-dev/api.port     = 9200           (live)
-      //   <tmp>/.dkg-dev/auth.token   = "right-token"  (monorepo-side live)
-      //   <tmp>/.dkg-dev/agent-keystore.json = { ETH_PRIMARY_LC: { authToken: 'tok-…' } }
-      //
-      // Expected: plugin's resolved dkgHome === <tmp>/.dkg-dev,
-      // its DkgDaemonClient.apiToken === "right-token", and the keystore
-      // probe forwards the dkg-dev keystore's authToken (not dkg's).
+    it('honors config.dkgHome for node-level auth.token without using agent-keystore identity auth', async () => {
+      const customHome = path.join(require('os').tmpdir(), `dkg-custom-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      fs.mkdirSync(customHome, { recursive: true });
+      fs.writeFileSync(path.join(customHome, 'auth.token'), 'CUSTOM-NODE-TOKEN');
+      fs.writeFileSync(
+        path.join(customHome, 'agent-keystore.json'),
+        JSON.stringify({
+          [ETH_PRIMARY_LC]: { authToken: 'agent-token-that-must-not-be-forwarded' },
+          [ETH_SECONDARY_LC]: { authToken: 'second-agent-token-that-must-not-matter' },
+        }),
+      );
 
-      // Force resolveDkgHome out of the env-wins shortcut so it actually
-      // exercises the liveness signal path.
-      delete process.env.DKG_HOME;
-
-      // Redirect `homedir()` to a fresh tmp dir.
-      const isolatedHome = path.join(require('os').tmpdir(), `dkg-t70-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-      const dkg = path.join(isolatedHome, '.dkg');
-      const dkgDev = path.join(isolatedHome, '.dkg-dev');
-      fs.mkdirSync(dkg, { recursive: true });
-      fs.mkdirSync(dkgDev, { recursive: true });
-
-      const prevHome = process.env.HOME;
-      const prevUserProfile = process.env.USERPROFILE;
-      process.env.HOME = isolatedHome;
-      process.env.USERPROFILE = isolatedHome; // Windows
-
-      try {
-        // Stale npm-side state.
-        fs.writeFileSync(path.join(dkg, 'daemon.pid'), '999999999');
-        fs.writeFileSync(path.join(dkg, 'api.port'), '9200');
-        fs.writeFileSync(path.join(dkg, 'auth.token'), 'wrong-token-from-npm-side');
-
-        // Live monorepo-side state — same port (the user's exact scenario).
-        fs.writeFileSync(path.join(dkgDev, 'daemon.pid'), String(process.pid));
-        fs.writeFileSync(path.join(dkgDev, 'api.port'), '9200');
-        fs.writeFileSync(path.join(dkgDev, 'auth.token'), 'right-token-from-monorepo-side');
-        fs.writeFileSync(
-          path.join(dkgDev, 'agent-keystore.json'),
-          JSON.stringify({ [ETH_PRIMARY_LC]: { authToken: `tok-${ETH_PRIMARY_LC}` } }),
-        );
-
-        const plugin = new DkgNodePlugin({
-          daemonUrl: 'http://127.0.0.1:9200',
-          memory: { enabled: true },
-          channel: { enabled: false },
-          // No `dkgHome` override — we want the auto-resolver to fire.
-        });
-        try {
-          plugin.register(makeMockApi());
-
-          // (a) Plugin resolved to the live monorepo dir, not the stale npm one.
-          expect((plugin as any).dkgHome).toBe(dkgDev);
-
-          // (b) DkgDaemonClient picked up the live dir's auth.token (not the
-          //     stale wrong-token from ~/.dkg/auth.token).
-          expect((plugin as any).client.apiToken).toBe('right-token-from-monorepo-side');
-
-          // (c) HTTP probe forwards the keystore's agent token (the keystore
-          //     was only written into ~/.dkg-dev — if the resolver had picked
-          //     ~/.dkg, this would fail with 'absent').
-          const spy = vi.fn().mockResolvedValue({
-            ok: true,
-            identity: {
-              agentAddress: ETH_PRIMARY,
-              agentDid: `did:dkg:agent:${ETH_PRIMARY}`,
-              name: 'test-agent',
-              peerId: '12D3KooWDaemonPeerFromIdentity',
-              nodeIdentityId: '0',
-            },
+      const originalFetch = globalThis.fetch;
+      const identityRequests: RequestInit[] = [];
+      globalThis.fetch = vi.fn(async (input: any, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input?.url ?? '';
+        if (url.includes('/api/status')) {
+          return new Response(JSON.stringify({ peerId: '12D3KooWCustomHomePeer' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
           });
-          (plugin as any).client.getAgentIdentity = spy;
-          await (plugin as any).ensureNodeAgentAddress();
-          expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
-          expect(spy).toHaveBeenCalledWith({ authToken: `tok-${ETH_PRIMARY_LC}` });
-        } finally {
-          await plugin.stop();
         }
+        if (url.includes('/api/agent/identity')) {
+          identityRequests.push(init ?? {});
+          return new Response(JSON.stringify(identityResult(ETH_PRIMARY).identity), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (url.includes('/api/context-graph/list')) {
+          return new Response(JSON.stringify({ contextGraphs: [] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+      }) as any;
+
+      const plugin = new DkgNodePlugin({
+        daemonUrl: 'http://127.0.0.1:9200',
+        dkgHome: customHome,
+        memory: { enabled: true },
+        channel: { enabled: false },
+      });
+      try {
+        plugin.register(makeMockApi());
+        expect((plugin as any).dkgHome).toBe(customHome);
+        expect((plugin as any).client.apiToken).toBe('CUSTOM-NODE-TOKEN');
+
+        await (plugin as any).ensureNodeAgentAddress();
+
+        expect((plugin as any).nodeAgentAddress).toBe(ETH_PRIMARY);
+        expect(identityRequests.length).toBeGreaterThanOrEqual(1);
+        const auth = new Headers(identityRequests.at(-1)?.headers as HeadersInit).get('authorization');
+        expect(auth).toBe('Bearer CUSTOM-NODE-TOKEN');
       } finally {
-        if (prevHome === undefined) delete process.env.HOME;
-        else process.env.HOME = prevHome;
-        if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-        else process.env.USERPROFILE = prevUserProfile;
-        try { fs.rmSync(isolatedHome, { recursive: true, force: true }); } catch { /* best effort */ }
+        await plugin.stop();
+        globalThis.fetch = originalFetch;
+        try { fs.rmSync(customHome, { recursive: true, force: true }); } catch { /* best effort */ }
       }
     });
   });

--- a/packages/core/src/dkg-home.ts
+++ b/packages/core/src/dkg-home.ts
@@ -406,22 +406,13 @@ export async function loadAuthToken(dkgHome?: string): Promise<string | undefine
   return undefined;
 }
 
-const ETH_ADDR_RE = /^0x[0-9a-f]{40}$/;
-
 /**
- * T62 / T63 — EIP-55 mixed-case checksum for an eth address.
+ * EIP-55 mixed-case checksum for an eth address.
  *
- * Originally added to convert lowercase keystore JSON keys to checksum form
- * because the daemon stores chat-turn graph URIs in EIP-55 case. T63 retired
- * that path: the adapter now HTTP-probes `/api/agent/identity` and gets the
- * canonical form directly from the daemon, so this helper's keystore-read
- * use is gone.
- *
- * Retained narrow purpose: normalize the `DKG_AGENT_ADDRESS` env override on
- * remote-daemon deployments (where there's no keystore + no HTTP probe to
- * derive the canonical case). Operators are likely to supply lowercase
- * (matches the keystore JSON they peeked at); silent SPARQL miss is a
- * worse failure mode than a one-shot normalization.
+ * Retained narrow purpose: normalize explicit caller-supplied
+ * `agent_address` values before WM queries. The daemon stores assertion graph
+ * URIs under checksum-case default agent addresses, and SPARQL graph IRIs are
+ * case-sensitive.
  *
  * @param address - hex-encoded eth address, with or without `0x` prefix.
  *                  Case-insensitive on input.
@@ -439,7 +430,7 @@ export function toEip55Checksum(address: string): string {
   for (let i = 0; i < lower.length; i++) {
     const ch = lower[i];
     if (ch >= 'a' && ch <= 'f') {
-      // Each byte yields two hex nibbles. Even index → high nibble.
+      // Each byte yields two hex nibbles. Even index -> high nibble.
       const byte = hashBytes[i >> 1];
       const nibble = i % 2 === 0 ? byte >> 4 : byte & 0x0f;
       out += nibble >= 8 ? ch.toUpperCase() : ch;
@@ -448,225 +439,4 @@ export function toEip55Checksum(address: string): string {
     }
   }
   return out;
-}
-
-/**
- * Thrown by `loadAgentAuthToken*` when the keystore contains more than one
- * eth-address top-level key and no `explicitAddress` override was provided.
- *
- * The single-agent path is the common gateway/dev shape; multi-agent
- * deployments must explicitly disambiguate (typically via the
- * `DKG_AGENT_ADDRESS` env var) so the WM-view scope can never silently route
- * memory writes to one identity and reads to another.
- */
-export class MultipleAgentsError extends Error {
-  readonly addresses: readonly string[];
-  constructor(addresses: readonly string[]) {
-    super(
-      `agent-keystore.json contains ${addresses.length} agent identities (${addresses.join(', ')}); ` +
-      `set DKG_AGENT_ADDRESS to disambiguate.`,
-    );
-    this.name = 'MultipleAgentsError';
-    this.addresses = addresses;
-  }
-}
-
-/**
- * Filter and lowercase eth-address keys from the keystore JSON. Non-eth-shaped
- * keys are dropped (defensive against future schema mixins / corrupted files).
- *
- * T46 — Deduped after lowercasing. A keystore that recorded the same identity
- * under both checksum and lowercase form (e.g. operator hand-edited the file,
- * or two writer paths used different normalisation) would otherwise be flagged
- * as multi-agent and disable WM lookup even though it's a single identity.
- * `Set` over the post-lowercase keys collapses the duplicate to one entry
- * before the multi-agent guardrail counts them.
- *
- * T63 — No longer applies EIP-55 checksumming. The adapter resolves the
- * canonical eth via the daemon's `/api/agent/identity` HTTP probe; this
- * helper is now only used to enumerate keys for the multi-agent guardrail
- * and for case-insensitive matching against an explicit env override.
- */
-function extractEthAddressKeys(parsed: unknown): string[] {
-  if (!parsed || typeof parsed !== 'object') return [];
-  const lc = Object.keys(parsed as Record<string, unknown>)
-    .map((k) => k.toLowerCase())
-    .filter((k) => ETH_ADDR_RE.test(k));
-  return Array.from(new Set(lc));
-}
-
-/**
- * Resolve an explicit override (typically `process.env.DKG_AGENT_ADDRESS`)
- * against the eth-address shape.
- *
- * T63 — Returns the LOWERCASE form for case-insensitive comparison against
- * keystore keys. Callers that need the canonical EIP-55 form for downstream
- * use (the remote-daemon `nodeAgentAddress` set-direct path) should call
- * `toEip55Checksum` themselves on the result.
- *
- * Returns `undefined` if the override is absent or not a valid eth address —
- * the helper's caller then falls through to the keystore read path.
- */
-function resolveExplicitAddress(explicit: string | undefined): string | undefined {
-  if (typeof explicit !== 'string') return undefined;
-  const t = explicit.trim().toLowerCase();
-  if (!ETH_ADDR_RE.test(t)) return undefined;
-  return t;
-}
-
-/**
- * Discriminated result of the keystore agent-auth-token read.
- *
- * T64/T66 — The adapter's probe needs to distinguish three end-states so it
- * can correctly drive the `localKeystoreCheckedAndAbsent` flag (which gates
- * the peerId fallback in `resolveDefaultAgentAddress`):
- *
- * - `'absent'` — file does not exist OR file exists, parses cleanly, and
- *   contains zero eth-shaped keys (legitimate "no agent registered yet"
- *   state). The daemon's `ChatMemoryManager` was almost certainly
- *   constructed with `peerId` (one-shot at lifecycle), so the peerId
- *   fallback is the correct WM scope. Probe sets the flag.
- *
- * - `'unusable'` — file exists but cannot yield a usable token (malformed
- *   JSON, EACCES, eth entries missing `authToken`, or only non-eth keys
- *   that should be eth-shaped). Could be transient (operator mid-write,
- *   permissions blip) or permanently broken — either way, the peerId
- *   fallback is unsafe (the daemon may be using eth on this same host).
- *   Probe does NOT set the flag; warns so operators see the gap.
- *
- * - `{ authToken }` — usable agent token. Probe forwards to the daemon's
- *   `/api/agent/identity` HTTP endpoint.
- *
- * Throws `MultipleAgentsError` for multi-agent without env override
- * (refuse-to-guess); the adapter probe surfaces a warn and the resolver
- * stays at undefined.
- */
-export type KeystoreAuthTokenResult =
-  | { kind: 'token'; authToken: string }
-  | { kind: 'absent' }
-  | { kind: 'unusable' };
-
-/**
- * Load the agent's auth token from `<DKG_HOME>/agent-keystore.json`.
- *
- * T63 — The adapter no longer derives the eth address from the keystore
- * JSON key; instead it reads the agent's auth token here, then HTTP-probes
- * the daemon's `/api/agent/identity` endpoint with that token to get the
- * canonical eth (the daemon already stores it in EIP-55 form via
- * `verifyWallet.address`). Single source of truth, no case-conversion
- * plumbing in the adapter.
- *
- * T64/T66 — Returns a discriminated `KeystoreAuthTokenResult` so the probe
- * can distinguish "no agent yet" (peerId fallback OK) from "file present
- * but unusable" (no fallback — could be transient).
- *
- * The keystore is written by `packages/agent/src/dkg-agent.ts:saveToKeystore`
- * as `{ <lowercase-eth>: { authToken, privateKey? } }`.
- *
- * - Single-agent keystore with usable `authToken`: returns
- *   `{ kind: 'token', authToken }`.
- * - Multi-agent + `explicitAddress` (case-insensitive match) with usable
- *   `authToken` on the matched entry: returns
- *   `{ kind: 'token', authToken }`.
- * - Missing keystore file OR file with zero eth-shaped keys: returns
- *   `{ kind: 'absent' }`.
- * - File present but unreadable/malformed/missing-authToken: returns
- *   `{ kind: 'unusable' }`.
- * - Multi-agent without env: throws `MultipleAgentsError`.
- *
- * T67 — When the keystore has duplicate case variants of the same eth
- * (checksum + lowercase), the helper scans ALL case-insensitive matches
- * and returns the first one with a non-empty `authToken`, instead of
- * giving up on the first match.
- */
-export function loadAgentAuthTokenSync(
-  dkgHome?: string,
-  opts?: { explicitAddress?: string },
-): KeystoreAuthTokenResult {
-  const filePath = join(dkgHome ?? dkgHomeDir(), 'agent-keystore.json');
-  if (!existsSync(filePath)) return { kind: 'absent' };
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
-  } catch {
-    return { kind: 'unusable' };
-  }
-
-  return resolveAuthTokenFromParsed(parsed, opts?.explicitAddress);
-}
-
-/** Async variant of `loadAgentAuthTokenSync`. */
-export async function loadAgentAuthToken(
-  dkgHome?: string,
-  opts?: { explicitAddress?: string },
-): Promise<KeystoreAuthTokenResult> {
-  const filePath = join(dkgHome ?? dkgHomeDir(), 'agent-keystore.json');
-  if (!existsSync(filePath)) return { kind: 'absent' };
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(await readFile(filePath, 'utf-8'));
-  } catch {
-    return { kind: 'unusable' };
-  }
-
-  return resolveAuthTokenFromParsed(parsed, opts?.explicitAddress);
-}
-
-/**
- * Shared resolution body for sync + async `loadAgentAuthToken*`.
- * Walks the parsed keystore, applies the multi-agent guardrail, picks the
- * matching entry, and extracts its `authToken` field.
- *
- * T67 — Scans ALL case-insensitive matches for the chosen key, not just
- * the first one. Keystores that recorded the same identity in both
- * checksum and lowercase form (operator hand-edit, two writer paths with
- * different normalisation) might have one duplicate stale/malformed and
- * another carrying the valid token. Pre-fix the helper picked the first
- * raw match and gave up; post-fix it returns the first usable token.
- */
-function resolveAuthTokenFromParsed(
-  parsed: unknown,
-  explicitAddress: string | undefined,
-): KeystoreAuthTokenResult {
-  const keys = extractEthAddressKeys(parsed);
-  if (keys.length === 0) {
-    // Two sub-cases: (a) parsed value isn't an object at all (malformed
-    // structure that JSON.parse accepted but `extractEthAddressKeys`
-    // rejected — e.g. a JSON literal of `null` or a string), and (b)
-    // parsed object had keys but none were eth-shaped. (a) is genuinely
-    // unusable; (b) is the legitimate "empty keystore" / "non-eth keys
-    // only" state where the daemon almost certainly uses peerId. Without
-    // finer-grained discrimination, `'absent'` is the safer default
-    // (peerId fallback engages) — non-eth-only keystores in practice
-    // mean no agent is registered yet, same end-state as a missing file.
-    if (!parsed || typeof parsed !== 'object') return { kind: 'unusable' };
-    return { kind: 'absent' };
-  }
-
-  let chosenKey: string;
-  if (keys.length === 1) {
-    chosenKey = keys[0];
-  } else {
-    const explicit = resolveExplicitAddress(explicitAddress);
-    if (!explicit) throw new MultipleAgentsError(keys);
-    const match = keys.find((k) => k === explicit);
-    if (!match) throw new MultipleAgentsError(keys);
-    chosenKey = match;
-  }
-
-  // T67 — Collect ALL entries whose key matches the chosen lowercase eth
-  // (case-insensitive). For each, try to extract a usable `authToken`;
-  // return the first one. If every match is malformed, return 'unusable'.
-  const obj = parsed as Record<string, unknown>;
-  const matchingEntries = Object.entries(obj).filter(([k]) => k.toLowerCase() === chosenKey);
-  for (const [, entry] of matchingEntries) {
-    if (!entry || typeof entry !== 'object') continue;
-    const tok = (entry as Record<string, unknown>).authToken;
-    if (typeof tok === 'string' && tok.length > 0) {
-      return { kind: 'token', authToken: tok };
-    }
-  }
-  return { kind: 'unusable' };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,10 +49,6 @@ export {
   readDkgApiPort,
   loadAuthTokenSync,
   loadAuthToken,
-  loadAgentAuthTokenSync,
-  loadAgentAuthToken,
-  type KeystoreAuthTokenResult,
-  MultipleAgentsError,
   toEip55Checksum,
 } from './dkg-home.js';
 export {

--- a/packages/core/test/dkg-home.test.ts
+++ b/packages/core/test/dkg-home.test.ts
@@ -3,7 +3,7 @@ import { writeFile, mkdir, rm, utimes } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { homedir } from 'node:os';
-import { dkgHomeDir, resolveDkgConfigHome, dkgAuthTokenPath, resolveDkgHome, isProcessAlive, readDaemonPid, readDkgApiPort, loadAuthToken, loadAuthTokenSync, loadAgentAuthTokenSync, loadAgentAuthToken, MultipleAgentsError, toEip55Checksum } from '../src/dkg-home.js';
+import { dkgHomeDir, resolveDkgConfigHome, dkgAuthTokenPath, resolveDkgHome, isProcessAlive, readDaemonPid, readDkgApiPort, loadAuthToken, loadAuthTokenSync, toEip55Checksum } from '../src/dkg-home.js';
 
 describe('dkgHomeDir', () => {
   const originalEnv = process.env.DKG_HOME;
@@ -513,178 +513,10 @@ describe('loadAuthToken / loadAuthTokenSync', () => {
   });
 });
 
-describe('loadAgentAuthToken / loadAgentAuthTokenSync (T63/T64/T67)', () => {
-  let tempDir: string;
-  // T63 — Helpers return a discriminated `KeystoreAuthTokenResult`. Test
-  // fixtures are LOWERCASE keystore JSON keys (the standard form the daemon
-  // writes); explicit-address inputs to the helper are lowercased for
-  // case-insensitive matching against keystore keys.
+describe('toEip55Checksum', () => {
   const ETH_A = '0x26c9b05a30138b35e84e60a5b778d580065ffbb8';
-  const ETH_B = '0x949ec97ab4ed1c9fb4c9a70c2dd368065d817b0c';
 
-  beforeEach(async () => {
-    tempDir = join(tmpdir(), `dkg-test-keystore-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    await mkdir(tempDir, { recursive: true });
-  });
-
-  afterEach(async () => {
-    await rm(tempDir, { recursive: true, force: true });
-  });
-
-  it('returns the single agent auth token from a single-agent keystore (sync + async)', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { authToken: 'tok-a', privateKey: '0xpk' } }),
-    );
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'token', authToken: 'tok-a' });
-    expect(await loadAgentAuthToken(tempDir)).toEqual({ kind: 'token', authToken: 'tok-a' });
-  });
-
-  it('returns kind=absent when keystore file does not exist', async () => {
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'absent' });
-    expect(await loadAgentAuthToken(tempDir)).toEqual({ kind: 'absent' });
-  });
-
-  it('returns kind=absent for an empty object keystore (legitimate "no agent yet" — peerId fallback OK)', async () => {
-    await writeFile(join(tempDir, 'agent-keystore.json'), '{}');
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'absent' });
-  });
-
-  it('returns kind=absent for keystore with only non-eth-shaped keys', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ 'not-an-eth-key': { authToken: 'tok' }, '12D3KooWPeerLike': {} }),
-    );
-    // Same end-state semantically as missing file — daemon would also see
-    // no usable agent and write under peerId.
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'absent' });
-  });
-
-  it('returns kind=unusable for malformed JSON (T64 — TRANSIENT, do NOT trigger peerId fallback)', async () => {
-    await writeFile(join(tempDir, 'agent-keystore.json'), '{ this is not json');
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'unusable' });
-    expect(await loadAgentAuthToken(tempDir)).toEqual({ kind: 'unusable' });
-  });
-
-  it('returns kind=unusable when the matched entry is missing the authToken field (T64)', async () => {
-    // Malformed entry — eth key present but no authToken. Could be operator
-    // mid-write or genuinely broken; either way, NOT "no keystore".
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { privateKey: '0xpk' } }),
-    );
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'unusable' });
-  });
-
-  it('returns kind=unusable when authToken field is empty string (T64)', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { authToken: '' } }),
-    );
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'unusable' });
-  });
-
-  it('throws MultipleAgentsError when keystore has multiple eth keys and no explicit override', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { authToken: 'a' }, [ETH_B]: { authToken: 'b' } }),
-    );
-    expect(() => loadAgentAuthTokenSync(tempDir)).toThrow(MultipleAgentsError);
-    await expect(loadAgentAuthToken(tempDir)).rejects.toBeInstanceOf(MultipleAgentsError);
-  });
-
-  it('explicit override disambiguates a multi-agent keystore (case-insensitive match)', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { authToken: 'tok-a' }, [ETH_B]: { authToken: 'tok-b' } }),
-    );
-    // Lowercase input.
-    expect(
-      loadAgentAuthTokenSync(tempDir, { explicitAddress: ETH_B }),
-    ).toEqual({ kind: 'token', authToken: 'tok-b' });
-    // Mixed-case input — same result.
-    expect(
-      loadAgentAuthTokenSync(tempDir, { explicitAddress: '0x949eC97aB4eD1C9fb4C9A70C2dD368065d817B0c' }),
-    ).toEqual({ kind: 'token', authToken: 'tok-b' });
-    // All-caps input — same result.
-    expect(
-      loadAgentAuthTokenSync(tempDir, { explicitAddress: ETH_B.toUpperCase() }),
-    ).toEqual({ kind: 'token', authToken: 'tok-b' });
-  });
-
-  it('explicit override that does not match any keystore entry throws MultipleAgentsError', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { authToken: 'a' }, [ETH_B]: { authToken: 'b' } }),
-    );
-    // Valid eth address, but no entry — refuse to silently fall back.
-    expect(() => loadAgentAuthTokenSync(tempDir, {
-      explicitAddress: '0x1111111111111111111111111111111111111111',
-    })).toThrow(MultipleAgentsError);
-  });
-
-  it('explicit override is ignored on a single-agent keystore (override only matters when disambiguating)', async () => {
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [ETH_A]: { authToken: 'only-tok' } }),
-    );
-    // The single-agent path always returns the only entry's token, regardless
-    // of any explicit override (override is for multi-agent disambiguation only).
-    expect(
-      loadAgentAuthTokenSync(tempDir, { explicitAddress: ETH_B }),
-    ).toEqual({ kind: 'token', authToken: 'only-tok' });
-  });
-
-  it('T46 — dedupes same address recorded in both checksum AND lowercase form (single-agent, not multi)', async () => {
-    const checksumA = '0x26C9B05A30138b35E84E60A5b778d580065FFBB8';
-    const lowercase = ETH_A;
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [checksumA]: { authToken: 'a' }, [lowercase]: { authToken: 'b' } }),
-    );
-    // Dedupe collapses them to one identity. Either entry's `authToken` is
-    // acceptable because `Object.entries` ordering is engine-defined; we just
-    // need to confirm a token returns and no `MultipleAgentsError`.
-    const result = loadAgentAuthTokenSync(tempDir);
-    expect(result.kind).toBe('token');
-    if (result.kind === 'token') {
-      expect(['a', 'b']).toContain(result.authToken);
-    }
-  });
-
-  it('T67 — returns the usable authToken when one duplicate is malformed and another has the token', async () => {
-    // Two case variants of the SAME identity. First entry malformed (no
-    // authToken), second entry usable. Pre-fix the helper picked the first
-    // raw match and returned undefined; post-fix it scans all matches and
-    // returns the first usable token.
-    const checksumA = '0x26C9B05A30138b35E84E60A5b778d580065FFBB8';
-    const lowercase = ETH_A;
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      // First entry: malformed (no authToken); second entry: usable.
-      JSON.stringify({ [checksumA]: { privateKey: '0xpk' }, [lowercase]: { authToken: 'usable-tok' } }),
-    );
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'token', authToken: 'usable-tok' });
-
-    // Reverse order — usable first, malformed second. Should still pick usable.
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [checksumA]: { authToken: 'usable-tok' }, [lowercase]: { privateKey: '0xpk' } }),
-    );
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'token', authToken: 'usable-tok' });
-
-    // Both malformed → kind=unusable.
-    await writeFile(
-      join(tempDir, 'agent-keystore.json'),
-      JSON.stringify({ [checksumA]: { privateKey: '0xpk' }, [lowercase]: { authToken: '' } }),
-    );
-    expect(loadAgentAuthTokenSync(tempDir)).toEqual({ kind: 'unusable' });
-  });
-
-  it('T62 / T63 — toEip55Checksum produces canonical EIP-55 form for known vectors', () => {
-    // Helper retained narrowly for `DKG_AGENT_ADDRESS` env-override
-    // normalization on remote-daemon paths. Spec-vector validation stays so
-    // a future refactor can't silently break it.
+  it('produces canonical EIP-55 form for known vectors', () => {
     expect(toEip55Checksum('0x52908400098527886e0f7030069857d2e4169ee7'))
       .toBe('0x52908400098527886E0F7030069857D2E4169EE7');
     expect(toEip55Checksum('0x8617e340b3d01fa5f11f306f4090fd50e238070d'))
@@ -697,10 +529,8 @@ describe('loadAgentAuthToken / loadAgentAuthTokenSync (T63/T64/T67)', () => {
       .toBe('0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed');
     expect(toEip55Checksum('0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359'))
       .toBe('0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359');
-    // Round-trip: checksumming a checksum value yields the same string.
     const checksumA = toEip55Checksum(ETH_A);
     expect(toEip55Checksum(checksumA)).toBe(checksumA);
-    // Throws on bad input shape.
     expect(() => toEip55Checksum('not-an-address')).toThrow();
     expect(() => toEip55Checksum('0x123')).toThrow();
   });


### PR DESCRIPTION
## Summary
- Use the OpenClaw daemon client's constructor-loaded node-level Bearer token for `/api/agent/identity`.
- Remove adapter keystore-auth branching and `DKG_AGENT_ADDRESS` identity override behavior.
- Keep `DkgOpenClawConfig.dkgHome` only as a node-level `auth.token` home override for custom daemon homes; it is no longer used for identity probing.
- Delete unused core keystore auth-token helpers/exports while keeping `toEip55Checksum` for explicit `agent_address` normalization.

## Related
Fixes #324
Related to #264

## Files changed
- `packages/core/src/dkg-home.ts`, `packages/core/src/index.ts`, `packages/core/test/dkg-home.test.ts`: remove keystore auth-token helper API/tests and keep focused checksum coverage.
- `packages/adapter-openclaw/src/dkg-client.ts`: make `getAgentIdentity()` no-arg and remove per-request header overrides.
- `packages/adapter-openclaw/src/types.ts`: narrow `DkgOpenClawConfig.dkgHome` to node-level auth-token home selection only.
- `packages/adapter-openclaw/src/DkgNodePlugin.ts`: collapse identity probing to the daemon HTTP endpoint while preserving cache, debounce, lazy retry, peer fallback, explicit checksum normalization, and custom auth-token home support.
- `packages/adapter-openclaw/test/dkg-client.test.ts`, `packages/adapter-openclaw/test/memory-search-tool.test.ts`, `packages/adapter-openclaw/test/plugin.test.ts`: replace obsolete keystore-heavy coverage with focused identity-probe and fallback regressions.

## Test plan
- `pnpm --filter @origintrail-official/dkg-core exec vitest run test/dkg-home.test.ts` (52 passed)
- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/plugin.test.ts test/dkg-client.test.ts test/memory-search-tool.test.ts` (193 passed)
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw run build`
- `pnpm --filter @origintrail-official/dkg... build`
- From `packages/cli`: `pnpm exec vitest run ./test/daemon-http-behavior-extra.test.ts -t 'unauthenticated WM read of the node-default agent is allowed'` (1 passed, 39 skipped)
- `git diff --check`
- Source search for removed keystore-auth symbols, `headersOverride`, `DKG_AGENT_ADDRESS`, and adapter identity-probe keystore reads
- Live Tatooine round-trip was not run in this local environment; targeted daemon and adapter regressions cover the auth-enabled and auth-disabled identity paths.
