### PR TITLE
fix(adapter-openclaw): T76 — memory_search probes ensureNodePeerId on no-keystore nodes

### DIFF
--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -2824,6 +2824,23 @@ export class DkgNodePlugin {
     // eth-shaped agent address (read from agent-keystore.json); if
     // the resolver hasn't probed it yet, we cannot run the fan-out
     // at all.
+    //
+    // T76 — Mirror `dkg_query`'s WM-branch fallback: probe both eth
+    // address AND (when `localKeystoreCheckedAndAbsent` confirmed there's
+    // no keystore) peerId before resolving the default. Without this,
+    // confirmed-no-keystore nodes whose register-time `/api/status` probe
+    // missed startup or failed transiently report `memory_search` as
+    // "not ready" and stay falsely unavailable until the deferred
+    // resolver retry fires. The resolver's fire-and-forget
+    // `ensureNodeAgentAddress` doesn't await, and it never triggers
+    // `ensureNodePeerId` for the keystore-absent case — only the
+    // explicit await chain here does.
+    if (this.nodeAgentAddress === undefined) {
+      await this.ensureNodeAgentAddress().catch(() => {});
+    }
+    if (this.localKeystoreCheckedAndAbsent && this.nodePeerId === undefined) {
+      await this.ensureNodePeerId().catch(() => {});
+    }
     const session = this.memorySessionResolver.getSession(undefined);
     const agentAddress = session?.agentAddress ?? this.memorySessionResolver.getDefaultAgentAddress();
     if (!agentAddress) {

--- a/packages/adapter-openclaw/test/memory-search-tool.test.ts
+++ b/packages/adapter-openclaw/test/memory-search-tool.test.ts
@@ -120,6 +120,92 @@ describe('memory_search tool', () => {
     expect(text).toMatch(/dkgHome/);
   });
 
+  it('T76 — probes ensureNodePeerId on confirmed-no-keystore nodes when nodePeerId is still undefined (mirrors dkg_query WM branch)', async () => {
+    // T76 — Codex flagged: pre-fix, `handleMemorySearch` returned the
+    // "agent eth address not resolved" error whenever the resolver
+    // surfaced no address, even when `localKeystoreCheckedAndAbsent`
+    // was true and the only remaining gap was a missed `/api/status`
+    // peerId probe. The dkg_query WM branch already triggers
+    // `ensureNodePeerId()` in that case; memory_search did not, so
+    // it stayed falsely unavailable until the deferred probe retry
+    // fired (which can be many turns later).
+    //
+    // After the fix, memory_search awaits both `ensureNodeAgentAddress`
+    // and (when keystore is confirmed absent) `ensureNodePeerId`
+    // before resolving the default address.
+    const tool = tools.find((t) => t.name === 'memory_search')!;
+    const client = (plugin as any).client;
+    client.query = vi.fn().mockResolvedValue({ result: { bindings: [] } });
+
+    // Set up the no-keystore-but-peerId-not-yet-probed state.
+    (plugin as any).nodeAgentAddress = undefined;
+    (plugin as any).nodePeerId = undefined;
+    (plugin as any).localKeystoreCheckedAndAbsent = true;
+
+    // Spy on the probe methods. Make `ensureNodePeerId` resolve the
+    // peerId, mirroring what a recovered /api/status call would do.
+    const ensureAgentSpy = vi.fn().mockResolvedValue(undefined);
+    const ensurePeerIdSpy = vi.fn(async () => {
+      (plugin as any).nodePeerId = '12D3KooWRecoveredPeer';
+    });
+    (plugin as any).ensureNodeAgentAddress = ensureAgentSpy;
+    (plugin as any).ensureNodePeerId = ensurePeerIdSpy;
+
+    const result = await tool.execute('t-no-keystore-recover', { query: 'tatooine' });
+
+    // Both probes were awaited.
+    // Called at least once — exact count varies because the resolver's
+    // `getSession` and `getDefaultAgentAddress` also fire it
+    // fire-and-forget. All calls are idempotent (debounced via
+    // `agentAddressProbeInFlight`).
+    expect(ensureAgentSpy).toHaveBeenCalled();
+    expect(ensurePeerIdSpy).toHaveBeenCalled();
+
+    // After the peerId probe lands, the resolver returns the recovered
+    // peerId via `resolveDefaultAgentAddress`, so the tool proceeds with
+    // the search instead of returning the "not ready" error.
+    const text = (result as any).content?.[0]?.text ?? '';
+    expect(text).not.toMatch(/not ready/i);
+    expect((result as any).details?.error).toBeFalsy();
+  });
+
+  it('T76 — does NOT probe ensureNodePeerId when localKeystoreCheckedAndAbsent is false (remote-daemon path)', async () => {
+    // Mirrors dkg_query's T60 guarantee: the peerId fallback is gated
+    // on `localKeystoreCheckedAndAbsent` so remote-daemon deployments
+    // (where probeNodeAgentAddressOnce intentionally skips the keystore
+    // read) don't silently route WM scope to the gateway's local peerId.
+    const tool = tools.find((t) => t.name === 'memory_search')!;
+    const client = (plugin as any).client;
+    client.query = vi.fn().mockResolvedValue({ result: { bindings: [] } });
+
+    (plugin as any).nodeAgentAddress = undefined;
+    (plugin as any).nodePeerId = undefined;
+    (plugin as any).localKeystoreCheckedAndAbsent = false; // remote-daemon: probe skipped
+
+    const ensureAgentSpy = vi.fn().mockResolvedValue(undefined);
+    const ensurePeerIdSpy = vi.fn().mockResolvedValue(undefined);
+    (plugin as any).ensureNodeAgentAddress = ensureAgentSpy;
+    (plugin as any).ensureNodePeerId = ensurePeerIdSpy;
+
+    const result = await tool.execute('t-remote-daemon', { query: 'tatooine' });
+
+    // ensureNodeAgentAddress fires (always best-effort); ensureNodePeerId
+    // does NOT — the gate prevents leaking the gateway's local peerId
+    // into a remote daemon's scope.
+    // Called at least once — exact count varies because the resolver's
+    // `getSession` and `getDefaultAgentAddress` also fire it
+    // fire-and-forget. All calls are idempotent (debounced via
+    // `agentAddressProbeInFlight`).
+    expect(ensureAgentSpy).toHaveBeenCalled();
+    expect(ensurePeerIdSpy).not.toHaveBeenCalled();
+
+    // Without an eth address AND without the keystore-absent flag, the
+    // tool surfaces the "not ready" error so operators see the recovery
+    // knobs (DKG_AGENT_ADDRESS, dkgHome) — NOT a silently-empty result.
+    const text = (result as any).content?.[0]?.text ?? '';
+    expect(text).toMatch(/not ready/i);
+  });
+
   it('re-asserts memory-slot capability before running the search (R7.5 mode-independent anchor)', async () => {
     const tool = tools.find((t) => t.name === 'memory_search')!;
     const client = (plugin as any).client;


### PR DESCRIPTION
## Summary

- Codex flagged on PR #264 (after PR #340 merged) that `handleMemorySearch` returned the "agent eth address not resolved" error whenever the resolver surfaced no address — even when `localKeystoreCheckedAndAbsent` was true and the only remaining gap was a missed `/api/status` peerId probe. The `dkg_query` WM branch already triggers `ensureNodePeerId()` in that case; memory_search didn't, so it stayed falsely unavailable until the deferred resolver retry fired.
- Mirror the `dkg_query` WM branch's await chain in `handleMemorySearch` so memory_search self-heals on the same path.

## Related

- Surfaced by Codex review on PR #264 at 2026-04-30 09:58 (after #340 merge)
- Related to #264

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/DkgNodePlugin.ts` | Add `await ensureNodeAgentAddress()` + gated `await ensureNodePeerId()` at the top of `handleMemorySearch`, mirroring the dkg_query WM branch byte-for-byte. |
| `packages/adapter-openclaw/test/memory-search-tool.test.ts` | Two new T76 regression tests: success path (peerId probe fires and tool recovers) + remote-daemon guard (probe-skipped path doesn't leak gateway peerId into remote scope). |

## Concrete failure trace this fixes

1. Fresh-start gateway against a confirmed-no-keystore daemon (e.g., dev node with auth disabled, or remote daemon where the keystore lives elsewhere).
2. Register-time `/api/status` probe misses startup or fails transiently → `nodePeerId` stays undefined.
3. `localKeystoreCheckedAndAbsent` is set to true after the keystore probe.
4. Agent invokes `memory_search`. The resolver's `getSession` / `getDefaultAgentAddress` fire `ensureNodeAgentAddress` fire-and-forget — but neither awaits, and neither triggers `ensureNodePeerId`.
5. `resolveDefaultAgentAddress()` returns undefined → tool returns "agent eth address not resolved".
6. The agent sees "memory_search not ready" indefinitely until the deferred resolver retry fires (which can be many turns later).

After T76, step 4 awaits both probes. Step 5 sees the recovered peerId and the tool proceeds with the search.

## Pattern parity

The new code is byte-for-byte identical to the existing `dkg_query` WM branch:

```ts
if (this.nodeAgentAddress === undefined) {
  await this.ensureNodeAgentAddress().catch(() => {});
}
if (this.localKeystoreCheckedAndAbsent && this.nodePeerId === undefined) {
  await this.ensureNodePeerId().catch(() => {});
}
```

Same gate (T60 — `localKeystoreCheckedAndAbsent` prevents leaking the gateway's local peerId into a remote daemon's scope). Same `.catch(()=>{})` swallow (transient probe failures surface as the regular "not ready" path, not non-actionable thrown errors).

## Test plan

- [x] `pnpm -F @origintrail-official/dkg-adapter-openclaw build` — clean.
- [x] `pnpm -F @origintrail-official/dkg-adapter-openclaw test` — **679 passed** (was 677, +2 T76 tests), +1 skipped, +1 known K-9 RED carryover (pre-existing, unrelated).
- [x] QA reviewed with byte-for-byte parity check against the dkg_query WM branch; PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)