### PR TITLE
fix(cli): build Node UI bundle during blue-green update

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -128,7 +128,7 @@ dkg update 9.0.0-beta.2 --allow-prerelease --no-verify-tag
 
 ## 7) Post-update verification
 
-`build:runtime` builds runtime packages and the Node UI static bundle. Git-based blue-green updates also verify `packages/node-ui/dist-ui/index.html` before activation, so nodes updating from an older updater still prepare the UI through the target ref's build script.
+Git-based blue-green updates run runtime packages and the Node UI static bundle as separate timed build steps, then verify `packages/node-ui/dist-ui/index.html` before activation. `build:runtime` remains a UI-inclusive compatibility wrapper so nodes updating from an older updater still prepare the UI through the target ref's build script.
 
 After each update:
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -128,6 +128,8 @@ dkg update 9.0.0-beta.2 --allow-prerelease --no-verify-tag
 
 ## 7) Post-update verification
 
+`build:runtime` builds runtime packages and the Node UI static bundle. Git-based blue-green updates also verify `packages/node-ui/dist-ui/index.html` before activation, so nodes updating from an older updater still prepare the UI through the target ref's build script.
+
 After each update:
 
 ```bash
@@ -136,6 +138,8 @@ cat "$DKG_HOME/releases/active"
 cat "$DKG_HOME/.current-commit"
 cat "$DKG_HOME/.current-version"
 test ! -f "$DKG_HOME/.update-pending.json" && echo "pending state cleared"
+SLOT="$(readlink -f "$DKG_HOME/releases/current")"
+test -f "$SLOT/packages/node-ui/dist-ui/index.html" && echo "Node UI static bundle ready"
 ```
 
 ## 8) Rollback

--- a/docs/testing/AUTO_UPDATE_LOCAL_TESTING.md
+++ b/docs/testing/AUTO_UPDATE_LOCAL_TESTING.md
@@ -74,12 +74,16 @@ DKG_HOME="$DKG_HOME" dkg update 9.0.5 --no-verify-tag
 
 ## 5) Validate swap and metadata after each update
 
+Git-based blue-green updates require the Node UI static bundle before swapping. `build:runtime` now also emits the bundle so nodes updating from an older updater still prepare the UI, and the new updater keeps a pre-swap bundle check.
+
 ```bash
 readlink "$DKG_HOME/releases/current"
 cat "$DKG_HOME/releases/active"
 cat "$DKG_HOME/.current-commit"
 cat "$DKG_HOME/.current-version"
 test ! -f "$DKG_HOME/.update-pending.json" && echo "pending state cleared"
+SLOT="$(readlink -f "$DKG_HOME/releases/current")"
+test -f "$SLOT/packages/node-ui/dist-ui/index.html" && echo "Node UI static bundle ready"
 ```
 
 ## 6) Rollback test

--- a/docs/testing/AUTO_UPDATE_LOCAL_TESTING.md
+++ b/docs/testing/AUTO_UPDATE_LOCAL_TESTING.md
@@ -74,7 +74,7 @@ DKG_HOME="$DKG_HOME" dkg update 9.0.5 --no-verify-tag
 
 ## 5) Validate swap and metadata after each update
 
-Git-based blue-green updates require the Node UI static bundle before swapping. `build:runtime` now also emits the bundle so nodes updating from an older updater still prepare the UI, and the new updater keeps a pre-swap bundle check.
+Git-based blue-green updates require the Node UI static bundle before swapping. New updaters run `build:runtime:packages` and `build:ui` as separate timed build steps, then keep a pre-swap bundle check. `build:runtime` remains UI-inclusive so nodes updating from an older updater still prepare the UI through the target ref's existing build hook.
 
 ```bash
 readlink "$DKG_HOME/releases/current"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "packageManager": "pnpm@10.28.1",
   "scripts": {
     "build": "turbo build",
-    "build:runtime": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg-adapter-openclaw --filter @origintrail-official/dkg run build && pnpm --filter @origintrail-official/dkg-node-ui run build:ui",
+    "build:runtime:packages": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg-adapter-openclaw --filter @origintrail-official/dkg run build",
+    "build:runtime": "pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui",
     "test": "turbo test",
     "test:coverage": "turbo test:coverage",
     "lint": "turbo lint",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.28.1",
   "scripts": {
     "build": "turbo build",
-    "build:runtime": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg-adapter-openclaw --filter @origintrail-official/dkg run build",
+    "build:runtime": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg-adapter-openclaw --filter @origintrail-official/dkg run build && pnpm --filter @origintrail-official/dkg-node-ui run build:ui",
     "test": "turbo test",
     "test:coverage": "turbo test:coverage",
     "lint": "turbo lint",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "10.0.0-rc.1",
   "private": true,
   "packageManager": "pnpm@10.28.1",
+  "dkgBuild": {
+    "releaseRuntimeBuildScript": "build:runtime:packages"
+  },
   "scripts": {
     "build": "turbo build",
     "build:runtime:packages": "pnpm -r --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-epcis --filter @origintrail-official/dkg-agent --filter @origintrail-official/dkg-graph-viz --filter @origintrail-official/dkg-node-ui --filter @origintrail-official/dkg-adapter-openclaw --filter @origintrail-official/dkg run build",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -53,6 +53,7 @@ import {
   DAEMON_EXIT_CODE_RESTART,
 } from './daemon.js';
 import { migrateToBlueGreen } from './migration.js';
+import { ensureRollbackNodeUiBundle } from './rollback-node-ui.js';
 import { registerIntegrationCommands } from './integrations/commands.js';
 
 /** Commander action callbacks receive parsed .option() values with loose types. */
@@ -544,7 +545,10 @@ program
 
     // Keep blue-green slots initialized for both foreground and daemonized start.
     if (!process.env.DKG_NO_BLUE_GREEN) {
-      await migrateToBlueGreen((msg) => console.log(msg), { allowRemoteBootstrap: false });
+      await migrateToBlueGreen((msg) => console.log(msg), {
+        allowRemoteBootstrap: false,
+        repairLiveNodeUi: true,
+      });
     }
 
     if (opts.foreground) {
@@ -2924,7 +2928,10 @@ program
       return;
     }
 
-    await migrateToBlueGreen((msg) => console.log(msg), { allowRemoteBootstrap: true });
+    await migrateToBlueGreen((msg) => console.log(msg), {
+      allowRemoteBootstrap: true,
+      repairLiveNodeUi: false,
+    });
     console.log('Checking for updates and applying...');
     try {
       const updateStatus = await performUpdateWithStatus(au, (msg) => console.log(msg), {
@@ -2986,6 +2993,9 @@ program
     const targetEntry = slotEntryPoint(targetDir);
     if (!targetEntry) {
       console.error(`Slot ${target} has no build output. Run "dkg update" first to prepare it.`);
+      process.exit(1);
+    }
+    if (!ensureRollbackNodeUiBundle(targetDir, target)) {
       process.exit(1);
     }
 

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -46,6 +46,7 @@ import {
   readCliPackageVersion,
 } from '../extraction/markitdown-bundle-metadata.js';
 import {
+  FULL_BUILD_COMMAND,
   NODE_UI_PACKAGE_NAME_FALLBACKS,
   nodeUiPackageJsonPath,
   nodeUiPackageNamesFromCliPackageJson,
@@ -54,6 +55,7 @@ import {
   nodeUiStaticBuildCommand,
   nodeUiStaticBuildLabel,
   nodeUiStaticIndexPath,
+  runtimeBuildCommandFromPackageJson,
 } from '../node-ui-static.js';
 
 const execAsync = promisify(exec);
@@ -1251,25 +1253,18 @@ async function _performUpdateInner(
       log,
     });
     let usedFullBuildFallback = false;
-    let runtimeBuildCommand = "pnpm build";
+    let runtimeBuildCommand = FULL_BUILD_COMMAND;
     try {
       const rootPkgRaw = await readFile(
         join(targetDir, "package.json"),
         "utf-8",
       );
-      const rootPkg = JSON.parse(rootPkgRaw) as {
-        scripts?: Record<string, string>;
-      };
-      if (typeof rootPkg.scripts?.["build:runtime:packages"] === "string") {
-        runtimeBuildCommand = "pnpm build:runtime:packages";
-      } else if (typeof rootPkg.scripts?.["build:runtime"] === "string") {
-        runtimeBuildCommand = "pnpm build:runtime";
-      }
+      runtimeBuildCommand = runtimeBuildCommandFromPackageJson(rootPkgRaw);
     } catch {
-      runtimeBuildCommand = "pnpm build";
+      runtimeBuildCommand = FULL_BUILD_COMMAND;
     }
 
-    if (runtimeBuildCommand !== "pnpm build") {
+    if (runtimeBuildCommand !== FULL_BUILD_COMMAND) {
       await runBuildStep(execAsync, runtimeBuildCommand, {
         cwd: targetDir,
         timeoutMs: timeouts.build,
@@ -1280,10 +1275,10 @@ async function _performUpdateInner(
       log(
         "Auto-update: target repo has no build:runtime script; falling back to pnpm build.",
       );
-      await runBuildStep(execAsync, "pnpm build", {
+      await runBuildStep(execAsync, FULL_BUILD_COMMAND, {
         cwd: targetDir,
         timeoutMs: timeouts.build,
-        label: "pnpm build",
+        label: FULL_BUILD_COMMAND,
         log,
       });
       usedFullBuildFallback = true;

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -1251,7 +1251,7 @@ async function _performUpdateInner(
       log,
     });
     let usedFullBuildFallback = false;
-    let hasRuntimeBuildScript = false;
+    let runtimeBuildCommand = "pnpm build";
     try {
       const rootPkgRaw = await readFile(
         join(targetDir, "package.json"),
@@ -1260,17 +1260,20 @@ async function _performUpdateInner(
       const rootPkg = JSON.parse(rootPkgRaw) as {
         scripts?: Record<string, string>;
       };
-      hasRuntimeBuildScript =
-        typeof rootPkg.scripts?.["build:runtime"] === "string";
+      if (typeof rootPkg.scripts?.["build:runtime:packages"] === "string") {
+        runtimeBuildCommand = "pnpm build:runtime:packages";
+      } else if (typeof rootPkg.scripts?.["build:runtime"] === "string") {
+        runtimeBuildCommand = "pnpm build:runtime";
+      }
     } catch {
-      hasRuntimeBuildScript = false;
+      runtimeBuildCommand = "pnpm build";
     }
 
-    if (hasRuntimeBuildScript) {
-      await runBuildStep(execAsync, "pnpm build:runtime", {
+    if (runtimeBuildCommand !== "pnpm build") {
+      await runBuildStep(execAsync, runtimeBuildCommand, {
         cwd: targetDir,
         timeoutMs: timeouts.build,
-        label: "pnpm build:runtime",
+        label: runtimeBuildCommand,
         log,
       });
     } else {

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -45,6 +45,16 @@ import {
   expectedBundledMarkItDownBuildMetadata,
   readCliPackageVersion,
 } from '../extraction/markitdown-bundle-metadata.js';
+import {
+  NODE_UI_PACKAGE_NAME_FALLBACKS,
+  nodeUiPackageJsonPath,
+  nodeUiPackageNamesFromCliPackageJson,
+  nodeUiPackageNameFromPackageJson,
+  nodeUiNpmStaticIndexPaths,
+  nodeUiStaticBuildCommand,
+  nodeUiStaticBuildLabel,
+  nodeUiStaticIndexPath,
+} from '../node-ui-static.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -466,6 +476,22 @@ async function _performNpmUpdateInner(
     log(`Auto-update (npm): entry point missing after install. Aborting swap.`);
     return "failed";
   }
+  let npmNodeUiPackageNames = NODE_UI_PACKAGE_NAME_FALLBACKS;
+  try {
+    npmNodeUiPackageNames = nodeUiPackageNamesFromCliPackageJson(
+      await readFile(join(npmPkgDir, "package.json"), "utf-8"),
+    );
+  } catch {
+    // Older packages or damaged installs may not expose readable metadata.
+  }
+  const npmNodeUiIndexes = nodeUiNpmStaticIndexPaths(targetDir, npmNodeUiPackageNames);
+  if (!npmNodeUiIndexes.some((indexFile) => existsSync(indexFile))) {
+    log(
+      `Auto-update (npm): Node UI static bundle missing after install ` +
+        `(${npmNodeUiIndexes.join(', ')}). Aborting swap.`,
+    );
+    return "failed";
+  }
   let resolvedVersion = readCliPackageVersion(npmPkgDir);
   if (!resolvedVersion) {
     resolvedVersion = targetVersion;
@@ -859,8 +885,9 @@ async function cleanGeneratedOutputs(
     const cliPkgDir = join(packagesDir, 'cli');
     await rm(join(cliPkgDir, 'network'), { recursive: true, force: true });
     await rm(join(cliPkgDir, 'project.json'), { force: true });
+    await rm(dirname(nodeUiStaticIndexPath(targetDir)), { recursive: true, force: true });
     log(
-      `Auto-update: cleared stale dist/ (${removedDist} pkgs) + tsconfig.tsbuildinfo (${removedTsBuildInfo} pkgs) + cli/network/ + cli/project.json before build (incremental caches preserved).`,
+      `Auto-update: cleared stale dist/ (${removedDist} pkgs) + tsconfig.tsbuildinfo (${removedTsBuildInfo} pkgs) + cli/network/ + cli/project.json + node-ui/dist-ui before build (incremental caches preserved).`,
     );
   } catch (primaryErr: any) {
     log(
@@ -1329,6 +1356,36 @@ async function _performUpdateInner(
       }
     }
 
+    let nodeUiPackageNames = NODE_UI_PACKAGE_NAME_FALLBACKS;
+    try {
+      nodeUiPackageNames = [nodeUiPackageNameFromPackageJson(
+        await readFile(nodeUiPackageJsonPath(targetDir), 'utf-8'),
+      )];
+    } catch {
+      // Older/broken refs may still have a buildable UI; try known workspace names below.
+    }
+    if (existsSync(nodeUiStaticIndexPath(targetDir))) {
+      log("Auto-update: Node UI static bundle already produced by runtime build.");
+    } else {
+      for (let i = 0; i < nodeUiPackageNames.length; i++) {
+        const nodeUiPackageName = nodeUiPackageNames[i];
+        try {
+          await runBuildStep(execAsync, nodeUiStaticBuildCommand(nodeUiPackageName), {
+            cwd: targetDir,
+            timeoutMs: timeouts.build,
+            label: nodeUiStaticBuildLabel(nodeUiPackageName),
+            log,
+          });
+          break;
+        } catch (err) {
+          if (i === nodeUiPackageNames.length - 1) throw err;
+          log(
+            `Auto-update: ${nodeUiStaticBuildLabel(nodeUiPackageName)} failed; trying ${nodeUiStaticBuildLabel(nodeUiPackageNames[i + 1])}.`,
+          );
+        }
+      }
+    }
+
     log("Auto-update: staging MarkItDown binary for the inactive slot...");
     try {
       await runBuildStep(
@@ -1356,6 +1413,13 @@ async function _performUpdateInner(
   const entryFile = join(targetDir, "packages", "cli", "dist", "cli.js");
   if (!existsSync(entryFile)) {
     log(`Auto-update: build output missing (${entryFile}). Aborting swap.`);
+    return "failed";
+  }
+  const nodeUiIndexFile = nodeUiStaticIndexPath(targetDir);
+  if (!existsSync(nodeUiIndexFile)) {
+    log(
+      `Auto-update: Node UI static bundle missing (${nodeUiIndexFile}). Aborting swap.`,
+    );
     return "failed";
   }
   const bundledMarkItDownAsset = currentBundledMarkItDownAssetName();

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -187,9 +187,25 @@ export async function migrateToBlueGreen(
     throw lastError;
   };
 
+  const runtimeBuildCommand = (slotDir: string): string => {
+    try {
+      const rootPkg = JSON.parse(readFileSync(join(slotDir, 'package.json'), 'utf-8')) as {
+        scripts?: Record<string, string>;
+      };
+      if (typeof rootPkg.scripts?.['build:runtime:packages'] === 'string') {
+        return 'pnpm build:runtime:packages';
+      }
+    } catch {
+      // Older or partial slots fall back to the compatibility wrapper below.
+    }
+    return 'pnpm build:runtime';
+  };
+
   const buildRuntimeAndNodeUi = (slotDir: string): void => {
-    runSlotCommand('pnpm build:runtime', slotDir, BUILD_TIMEOUT_MS);
-    runNodeUiStaticBuild(slotDir);
+    runSlotCommand(runtimeBuildCommand(slotDir), slotDir, BUILD_TIMEOUT_MS);
+    if (!existsSync(nodeUiStaticIndexPath(slotDir))) {
+      runNodeUiStaticBuild(slotDir);
+    }
     assertNodeUiStaticBundle(slotDir);
   };
 

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
 import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, gitCommandEnv, gitCommandArgs, slotReady } from './config.js';
 import {
+  FULL_BUILD_COMMAND,
   isNodeUiGitLayoutSlot,
   NODE_UI_PACKAGE_NAME_FALLBACKS,
   nodeUiPackageJsonPath,
@@ -12,6 +13,7 @@ import {
   nodeUiNpmStaticIndexPaths,
   nodeUiStaticBuildCommand,
   nodeUiStaticIndexPath,
+  runtimeBuildCommandFromPackageJson,
 } from './node-ui-static.js';
 
 function npmCliPackageJsonPath(slotDir: string): string {
@@ -189,16 +191,12 @@ export async function migrateToBlueGreen(
 
   const runtimeBuildCommand = (slotDir: string): string => {
     try {
-      const rootPkg = JSON.parse(readFileSync(join(slotDir, 'package.json'), 'utf-8')) as {
-        scripts?: Record<string, string>;
-      };
-      if (typeof rootPkg.scripts?.['build:runtime:packages'] === 'string') {
-        return 'pnpm build:runtime:packages';
-      }
+      return runtimeBuildCommandFromPackageJson(
+        readFileSync(join(slotDir, 'package.json'), 'utf-8'),
+      );
     } catch {
-      // Older or partial slots fall back to the compatibility wrapper below.
+      return FULL_BUILD_COMMAND;
     }
-    return 'pnpm build:runtime';
   };
 
   const buildRuntimeAndNodeUi = (slotDir: string): void => {

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -1,8 +1,66 @@
-import { existsSync, lstatSync } from 'node:fs';
-import { mkdir, rm, readFile } from 'node:fs/promises';
+import { existsSync, lstatSync, readFileSync } from 'node:fs';
+import { mkdir, rm, readFile, readlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
 import { releasesDir, repoDir, swapSlot, loadConfig, loadNetworkConfig, loadProjectConfig, gitCommandEnv, gitCommandArgs, slotReady } from './config.js';
+import {
+  isNodeUiGitLayoutSlot,
+  NODE_UI_PACKAGE_NAME_FALLBACKS,
+  nodeUiPackageJsonPath,
+  nodeUiPackageNamesFromCliPackageJson,
+  nodeUiPackageNameFromPackageJson,
+  nodeUiNpmStaticIndexPaths,
+  nodeUiStaticBuildCommand,
+  nodeUiStaticIndexPath,
+} from './node-ui-static.js';
+
+function npmCliPackageJsonPath(slotDir: string): string {
+  return join(
+    slotDir,
+    'node_modules',
+    '@origintrail-official',
+    'dkg',
+    'package.json',
+  );
+}
+
+function nodeUiPackageNamesForNpmSlot(slotDir: string): string[] {
+  try {
+    return nodeUiPackageNamesFromCliPackageJson(
+      readFileSync(npmCliPackageJsonPath(slotDir), 'utf-8'),
+    );
+  } catch {
+    return NODE_UI_PACKAGE_NAME_FALLBACKS;
+  }
+}
+
+function npmNodeUiStaticIndexPaths(slotDir: string): string[] {
+  return nodeUiNpmStaticIndexPaths(slotDir, nodeUiPackageNamesForNpmSlot(slotDir));
+}
+
+function hasNpmNodeUiStaticBundle(slotDir: string): boolean {
+  return npmNodeUiStaticIndexPaths(slotDir).some((indexFile) => existsSync(indexFile));
+}
+
+function hasRequiredNodeUiStaticBundle(slotDir: string): boolean {
+  if (isNodeUiGitLayoutSlot(slotDir)) {
+    return existsSync(nodeUiStaticIndexPath(slotDir));
+  }
+  return hasNpmNodeUiStaticBundle(slotDir);
+}
+
+function assertNodeUiStaticBundle(slotDir: string): void {
+  const indexFile = nodeUiStaticIndexPath(slotDir);
+  if (!existsSync(indexFile)) {
+    throw new Error(`Node UI static bundle missing (${indexFile})`);
+  }
+}
+
+function assertNpmNodeUiStaticBundle(slotDir: string): void {
+  if (!hasNpmNodeUiStaticBundle(slotDir)) {
+    throw new Error(`Node UI static bundle missing (${npmNodeUiStaticIndexPaths(slotDir).join(', ')})`);
+  }
+}
 
 export const _migrationIo = {
   execSync: execSync as (...args: any[]) => any,
@@ -10,6 +68,7 @@ export const _migrationIo = {
   repoDir: repoDir as () => string | null,
   loadConfig: loadConfig as () => Promise<any>,
   loadNetworkConfig: loadNetworkConfig as () => Promise<any>,
+  swapSlot: swapSlot as (slot: 'a' | 'b') => Promise<void>,
 };
 
 /**
@@ -18,9 +77,10 @@ export const _migrationIo = {
  */
 export async function migrateToBlueGreen(
   log: (msg: string) => void = console.log,
-  opts: { allowRemoteBootstrap?: boolean } = {},
+  opts: { allowRemoteBootstrap?: boolean; repairLiveNodeUi?: boolean } = {},
 ): Promise<void> {
-  const { execSync, execFileSync, repoDir, loadConfig, loadNetworkConfig } = _migrationIo;
+  const { execSync, execFileSync, repoDir, loadConfig, loadNetworkConfig, swapSlot: swapActiveSlot } = _migrationIo;
+  const repairLiveNodeUi = opts.repairLiveNodeUi ?? true;
   const INSTALL_TIMEOUT_MS = 10 * 60_000;
   const BUILD_TIMEOUT_MS = 15 * 60_000;
   const rDir = releasesDir();
@@ -79,9 +139,135 @@ export async function migrateToBlueGreen(
 
   const slotA = join(rDir, 'a');
   const slotB = join(rDir, 'b');
-  if (hadCurrentLink && slotReady(slotA) && slotReady(slotB)) return;
+  if (
+    hadCurrentLink &&
+    slotReady(slotA) &&
+    slotReady(slotB) &&
+    hasRequiredNodeUiStaticBundle(slotA) &&
+    hasRequiredNodeUiStaticBundle(slotB)
+  ) {
+    return;
+  }
 
   log('Migrating to blue-green release slots...');
+
+  const runSlotCommand = (cmd: string, cwd: string, timeout: number): void => {
+    execSync(cmd, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout,
+    });
+  };
+
+  const resolveNodeUiPackageNames = (slotDir: string): string[] => {
+    try {
+      return [nodeUiPackageNameFromPackageJson(
+        readFileSync(nodeUiPackageJsonPath(slotDir), 'utf-8'),
+      )];
+    } catch {
+      return NODE_UI_PACKAGE_NAME_FALLBACKS;
+    }
+  };
+
+  const runNodeUiStaticBuild = (slotDir: string): void => {
+    let lastError: unknown;
+    for (const packageName of resolveNodeUiPackageNames(slotDir)) {
+      try {
+        runSlotCommand(
+          nodeUiStaticBuildCommand(packageName),
+          slotDir,
+          BUILD_TIMEOUT_MS,
+        );
+        return;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    throw lastError;
+  };
+
+  const buildRuntimeAndNodeUi = (slotDir: string): void => {
+    runSlotCommand('pnpm build:runtime', slotDir, BUILD_TIMEOUT_MS);
+    runNodeUiStaticBuild(slotDir);
+    assertNodeUiStaticBundle(slotDir);
+  };
+
+  const repairNodeUiStaticBundle = (slotDir: string): void => {
+    if (isNodeUiGitLayoutSlot(slotDir)) {
+      runNodeUiStaticBuild(slotDir);
+      assertNodeUiStaticBundle(slotDir);
+      return;
+    }
+
+    assertNpmNodeUiStaticBundle(slotDir);
+  };
+
+  const activeSlotFromCurrent = async (): Promise<'a' | 'b' | null> => {
+    try {
+      const target = (await readlink(currentLink)).trim().split(/[\\/]/).pop();
+      if (target === 'a' || target === 'b') return target;
+    } catch {
+      // Fall back to active metadata below.
+    }
+    try {
+      const activeRaw = (await readFile(join(rDir, 'active'), 'utf-8')).trim();
+      if (activeRaw === 'a' || activeRaw === 'b') return activeRaw;
+    } catch {
+      return null;
+    }
+    return null;
+  };
+
+  const slotReadyWithNodeUi = (label: 'a' | 'b'): boolean => {
+    const slotDir = label === 'a' ? slotA : slotB;
+    return slotReady(slotDir) && hasRequiredNodeUiStaticBundle(slotDir);
+  };
+
+  const hasRestorableSlot = (): boolean =>
+    slotReadyWithNodeUi('a') || slotReadyWithNodeUi('b');
+  let noCurrentRepairError: unknown;
+
+  const ensureNodeUiBundle = (
+    slotDir: string,
+    label: 'a' | 'b',
+    liveSlot: 'a' | 'b' | null,
+  ): void => {
+    if (!slotReady(slotDir) || hasRequiredNodeUiStaticBundle(slotDir)) return;
+    if (liveSlot === label) {
+      if (!repairLiveNodeUi) {
+        log(`  Slot ${label}: Node UI static bundle missing in active slot; leaving live slot untouched.`);
+        return;
+      }
+      log(`  Slot ${label}: Node UI static bundle missing in active slot; rebuilding UI assets in place.`);
+    } else {
+      log(`  Slot ${label}: Node UI static bundle missing; building UI assets.`);
+    }
+    try {
+      repairNodeUiStaticBundle(slotDir);
+      log(`  Slot ${label}: Node UI static bundle built`);
+    } catch (err: any) {
+      if (liveSlot === label) {
+        log(
+          `  Slot ${label}: Node UI static bundle repair failed (${err?.message ?? String(err)}). ` +
+            'Continuing startup with the existing Node UI fallback page.',
+        );
+        return;
+      }
+      if (!liveSlot) {
+        noCurrentRepairError ??= err;
+        log(
+          `  Slot ${label}: Node UI static bundle repair failed (${err?.message ?? String(err)}). ` +
+            'Trying remaining slots before selecting an initial slot.',
+        );
+        return;
+      }
+      log(
+        `  Slot ${label}: Node UI static bundle repair failed (${err?.message ?? String(err)}). ` +
+          'Leaving inactive slot for the next update to rebuild.',
+      );
+    }
+  };
 
   const git = (args: string[], cwd?: string, repoUrl?: string): string =>
     String(execFileSync('git', [...gitCommandArgs(repoUrl, config?.autoUpdate ?? network?.autoUpdate), ...args], {
@@ -99,18 +285,8 @@ export async function migrateToBlueGreen(
     } else {
       git(['clone', '--branch', sourceBranch, sourceRepo, slotA], undefined, sourceRepo);
     }
-    execSync('pnpm install --frozen-lockfile', {
-      cwd: slotA,
-      encoding: 'utf-8',
-      stdio: 'pipe',
-      timeout: INSTALL_TIMEOUT_MS,
-    });
-    execSync('pnpm build:runtime', {
-      cwd: slotA,
-      encoding: 'utf-8',
-      stdio: 'pipe',
-      timeout: BUILD_TIMEOUT_MS,
-    });
+    runSlotCommand('pnpm install --frozen-lockfile', slotA, INSTALL_TIMEOUT_MS);
+    buildRuntimeAndNodeUi(slotA);
     log(`  Slot a: cloned and built from ${hasLocalRepo ? localRepo : sourceRepo}`);
   }
 
@@ -127,18 +303,8 @@ export async function migrateToBlueGreen(
       if (!hasLocalRepo) {
         git(['checkout', sourceBranch], slotB);
       }
-      execSync('pnpm install --frozen-lockfile', {
-        cwd: slotB,
-        encoding: 'utf-8',
-        stdio: 'pipe',
-        timeout: INSTALL_TIMEOUT_MS,
-      });
-      execSync('pnpm build:runtime', {
-        cwd: slotB,
-        encoding: 'utf-8',
-        stdio: 'pipe',
-        timeout: BUILD_TIMEOUT_MS,
-      });
+      runSlotCommand('pnpm install --frozen-lockfile', slotB, INSTALL_TIMEOUT_MS);
+      buildRuntimeAndNodeUi(slotB);
       log(`  Slot b: cloned and built`);
     } catch (err: any) {
       log(`  Slot b: clone/build failed (${err.message}). Retrying clone only.`);
@@ -157,17 +323,39 @@ export async function migrateToBlueGreen(
     }
   }
 
+  const liveSlot = hadCurrentLink ? await activeSlotFromCurrent() : null;
+  ensureNodeUiBundle(slotA, 'a', liveSlot);
+  ensureNodeUiBundle(slotB, 'b', liveSlot);
+
+  if (hadCurrentLink && liveSlot && !slotReadyWithNodeUi(liveSlot)) {
+    if (!repairLiveNodeUi) {
+      log(`Migration complete: active slot ${liveSlot} is missing Node UI static bundle; live slot left untouched.`);
+      return;
+    }
+    log(
+      `Migration complete: active slot ${liveSlot} is missing Node UI static bundle; ` +
+        'startup will continue with the existing Node UI fallback page.',
+    );
+    return;
+  }
+
   if (!hadCurrentLink) {
-    let initialSlot: 'a' | 'b' = 'a';
+    let initialSlot: 'a' | 'b' | null = null;
     try {
       const activeRaw = (await readFile(join(rDir, 'active'), 'utf-8')).trim();
-      if ((activeRaw === 'a' || activeRaw === 'b') && slotReady(join(rDir, activeRaw))) {
+      if ((activeRaw === 'a' || activeRaw === 'b') && slotReadyWithNodeUi(activeRaw)) {
         initialSlot = activeRaw;
       }
     } catch {
       // No prior active metadata; default to a.
     }
-    await swapSlot(initialSlot);
+    initialSlot ??= slotReadyWithNodeUi('a') ? 'a' : null;
+    initialSlot ??= slotReadyWithNodeUi('b') ? 'b' : null;
+    if (!initialSlot) {
+      if (noCurrentRepairError) throw noCurrentRepairError;
+      throw new Error('No blue-green slot has the required Node UI static bundle');
+    }
+    await swapActiveSlot(initialSlot);
     log(`Migration complete: releases/current → ${initialSlot}`);
     return;
   }

--- a/packages/cli/src/node-ui-static.ts
+++ b/packages/cli/src/node-ui-static.ts
@@ -15,27 +15,29 @@ export const NODE_UI_STATIC_BUILD_LABEL = nodeUiStaticBuildLabel();
 export const RUNTIME_PACKAGES_BUILD_COMMAND = 'pnpm build:runtime:packages';
 export const RUNTIME_BUILD_COMMAND = 'pnpm build:runtime';
 export const FULL_BUILD_COMMAND = 'pnpm build';
-export const RUNTIME_BUILD_COMPATIBILITY_WRAPPER =
-  'pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
+export const RELEASE_RUNTIME_BUILD_SCRIPT = 'releaseRuntimeBuildScript';
 
 export function runtimeBuildCommandFromPackageJson(raw: string): string {
   try {
     const rootPkg = JSON.parse(raw) as {
       scripts?: Record<string, string>;
+      dkgBuild?: Record<string, unknown>;
     };
+    const releaseRuntimeBuildScript = rootPkg.dkgBuild?.[RELEASE_RUNTIME_BUILD_SCRIPT];
     const runtimePackagesScript = rootPkg.scripts?.['build:runtime:packages'];
     const runtimeScript = rootPkg.scripts?.['build:runtime'];
     if (
-      typeof runtimePackagesScript === 'string' &&
-      (
-        typeof runtimeScript !== 'string' ||
-        normalizeScript(runtimeScript) === normalizeScript(RUNTIME_BUILD_COMPATIBILITY_WRAPPER)
-      )
+      typeof releaseRuntimeBuildScript === 'string' &&
+      isSafePnpmScriptName(releaseRuntimeBuildScript) &&
+      typeof rootPkg.scripts?.[releaseRuntimeBuildScript] === 'string'
     ) {
-      return RUNTIME_PACKAGES_BUILD_COMMAND;
+      return `pnpm ${releaseRuntimeBuildScript}`;
     }
     if (typeof runtimeScript === 'string') {
       return RUNTIME_BUILD_COMMAND;
+    }
+    if (typeof runtimePackagesScript === 'string') {
+      return RUNTIME_PACKAGES_BUILD_COMMAND;
     }
   } catch {
     // Fall through to the broad build command when metadata is unreadable.
@@ -43,8 +45,8 @@ export function runtimeBuildCommandFromPackageJson(raw: string): string {
   return FULL_BUILD_COMMAND;
 }
 
-function normalizeScript(script: string): string {
-  return script.trim().replace(/\s+/g, ' ');
+function isSafePnpmScriptName(scriptName: string): boolean {
+  return /^[A-Za-z0-9:_-]+$/.test(scriptName);
 }
 
 export function nodeUiPackageJsonPath(slotDir: string): string {

--- a/packages/cli/src/node-ui-static.ts
+++ b/packages/cli/src/node-ui-static.ts
@@ -1,0 +1,102 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const DEFAULT_NODE_UI_PACKAGE_NAME = '@origintrail-official/dkg-node-ui';
+export const LEGACY_NODE_UI_PACKAGE_NAME = '@dkg/node-ui';
+export const NODE_UI_PACKAGE_NAME_FALLBACKS = [
+  DEFAULT_NODE_UI_PACKAGE_NAME,
+  LEGACY_NODE_UI_PACKAGE_NAME,
+];
+
+export const NODE_UI_STATIC_BUILD_COMMAND = nodeUiStaticBuildCommand();
+
+export const NODE_UI_STATIC_BUILD_LABEL = nodeUiStaticBuildLabel();
+
+export function nodeUiPackageJsonPath(slotDir: string): string {
+  return join(slotDir, 'packages', 'node-ui', 'package.json');
+}
+
+export function nodeUiStaticIndexPath(slotDir: string): string {
+  return join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html');
+}
+
+export function nodeUiStaticIndexPaths(slotDir: string): string[] {
+  return [
+    nodeUiStaticIndexPath(slotDir),
+    ...nodeUiNpmStaticIndexPaths(slotDir),
+  ];
+}
+
+export function nodeUiNpmStaticIndexPaths(
+  slotDir: string,
+  packageNames = NODE_UI_PACKAGE_NAME_FALLBACKS,
+): string[] {
+  return packageNames.flatMap((packageName) => {
+    const packagePath = packageName.split('/');
+    return [
+      join(slotDir, 'node_modules', ...packagePath, 'dist-ui', 'index.html'),
+      join(
+        slotDir,
+        'node_modules',
+        '@origintrail-official',
+        'dkg',
+        'node_modules',
+        ...packagePath,
+        'dist-ui',
+        'index.html',
+      ),
+    ];
+  });
+}
+
+export function isNodeUiGitLayoutSlot(
+  slotDir: string,
+  pathExists: (path: string) => boolean = existsSync,
+): boolean {
+  return pathExists(nodeUiPackageJsonPath(slotDir))
+    || pathExists(join(slotDir, 'packages', 'cli', 'dist', 'cli.js'));
+}
+
+export function nodeUiStaticBuildCommand(
+  packageName = DEFAULT_NODE_UI_PACKAGE_NAME,
+): string {
+  return `pnpm --filter ${packageName} run build:ui`;
+}
+
+export function nodeUiStaticBuildLabel(
+  packageName = DEFAULT_NODE_UI_PACKAGE_NAME,
+): string {
+  return `pnpm --filter ${packageName} build:ui`;
+}
+
+export function nodeUiPackageNameFromPackageJson(raw: string): string {
+  try {
+    const name = String((JSON.parse(raw) as { name?: unknown }).name ?? '').trim();
+    return name || DEFAULT_NODE_UI_PACKAGE_NAME;
+  } catch {
+    return DEFAULT_NODE_UI_PACKAGE_NAME;
+  }
+}
+
+export function nodeUiPackageNamesFromCliPackageJson(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as {
+      dependencies?: Record<string, unknown>;
+      optionalDependencies?: Record<string, unknown>;
+      peerDependencies?: Record<string, unknown>;
+    };
+    const dependencySets = [
+      parsed.dependencies,
+      parsed.optionalDependencies,
+      parsed.peerDependencies,
+    ];
+    const declared = NODE_UI_PACKAGE_NAME_FALLBACKS.filter((packageName) =>
+      dependencySets.some((deps) =>
+        deps && Object.prototype.hasOwnProperty.call(deps, packageName),
+      ),
+    );
+    return declared.length > 0 ? declared : NODE_UI_PACKAGE_NAME_FALLBACKS;
+  } catch {
+    return NODE_UI_PACKAGE_NAME_FALLBACKS;
+  }
+}

--- a/packages/cli/src/node-ui-static.ts
+++ b/packages/cli/src/node-ui-static.ts
@@ -15,22 +15,36 @@ export const NODE_UI_STATIC_BUILD_LABEL = nodeUiStaticBuildLabel();
 export const RUNTIME_PACKAGES_BUILD_COMMAND = 'pnpm build:runtime:packages';
 export const RUNTIME_BUILD_COMMAND = 'pnpm build:runtime';
 export const FULL_BUILD_COMMAND = 'pnpm build';
+export const RUNTIME_BUILD_COMPATIBILITY_WRAPPER =
+  'pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 
 export function runtimeBuildCommandFromPackageJson(raw: string): string {
   try {
     const rootPkg = JSON.parse(raw) as {
       scripts?: Record<string, string>;
     };
-    if (typeof rootPkg.scripts?.['build:runtime:packages'] === 'string') {
+    const runtimePackagesScript = rootPkg.scripts?.['build:runtime:packages'];
+    const runtimeScript = rootPkg.scripts?.['build:runtime'];
+    if (
+      typeof runtimePackagesScript === 'string' &&
+      (
+        typeof runtimeScript !== 'string' ||
+        normalizeScript(runtimeScript) === normalizeScript(RUNTIME_BUILD_COMPATIBILITY_WRAPPER)
+      )
+    ) {
       return RUNTIME_PACKAGES_BUILD_COMMAND;
     }
-    if (typeof rootPkg.scripts?.['build:runtime'] === 'string') {
+    if (typeof runtimeScript === 'string') {
       return RUNTIME_BUILD_COMMAND;
     }
   } catch {
     // Fall through to the broad build command when metadata is unreadable.
   }
   return FULL_BUILD_COMMAND;
+}
+
+function normalizeScript(script: string): string {
+  return script.trim().replace(/\s+/g, ' ');
 }
 
 export function nodeUiPackageJsonPath(slotDir: string): string {

--- a/packages/cli/src/node-ui-static.ts
+++ b/packages/cli/src/node-ui-static.ts
@@ -12,12 +12,37 @@ export const NODE_UI_STATIC_BUILD_COMMAND = nodeUiStaticBuildCommand();
 
 export const NODE_UI_STATIC_BUILD_LABEL = nodeUiStaticBuildLabel();
 
+export const RUNTIME_PACKAGES_BUILD_COMMAND = 'pnpm build:runtime:packages';
+export const RUNTIME_BUILD_COMMAND = 'pnpm build:runtime';
+export const FULL_BUILD_COMMAND = 'pnpm build';
+
+export function runtimeBuildCommandFromPackageJson(raw: string): string {
+  try {
+    const rootPkg = JSON.parse(raw) as {
+      scripts?: Record<string, string>;
+    };
+    if (typeof rootPkg.scripts?.['build:runtime:packages'] === 'string') {
+      return RUNTIME_PACKAGES_BUILD_COMMAND;
+    }
+    if (typeof rootPkg.scripts?.['build:runtime'] === 'string') {
+      return RUNTIME_BUILD_COMMAND;
+    }
+  } catch {
+    // Fall through to the broad build command when metadata is unreadable.
+  }
+  return FULL_BUILD_COMMAND;
+}
+
 export function nodeUiPackageJsonPath(slotDir: string): string {
   return join(slotDir, 'packages', 'node-ui', 'package.json');
 }
 
+export function nodeUiStaticDistPath(slotDir: string): string {
+  return join(slotDir, 'packages', 'node-ui', 'dist-ui');
+}
+
 export function nodeUiStaticIndexPath(slotDir: string): string {
-  return join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html');
+  return join(nodeUiStaticDistPath(slotDir), 'index.html');
 }
 
 export function nodeUiStaticIndexPaths(slotDir: string): string[] {

--- a/packages/cli/src/rollback-node-ui.ts
+++ b/packages/cli/src/rollback-node-ui.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, renameSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { toErrorMessage } from '@origintrail-official/dkg-core';
 import {
@@ -21,7 +21,6 @@ export interface RollbackNodeUiIo {
   existsSync: typeof existsSync;
   readFileSync: typeof readFileSync;
   rmSync: typeof rmSync;
-  renameSync: typeof renameSync;
   execSync: typeof execSync;
   log: (message: string) => void;
   error: (message: string) => void;
@@ -31,7 +30,6 @@ const defaultIo: RollbackNodeUiIo = {
   existsSync,
   readFileSync,
   rmSync,
-  renameSync,
   execSync,
   log: console.log,
   error: console.error,
@@ -82,20 +80,12 @@ export function ensureRollbackNodeUiBundle(
   }
 
   const hadExistingGitBundle = io.existsSync(gitIndex);
+  if (hadExistingGitBundle) return true;
+
   const gitDist = nodeUiStaticDistPath(slotDir);
-  const backupDist = `${gitDist}.rollback-backup`;
-  io.log(
-    hadExistingGitBundle
-      ? `Slot ${target} has an existing Node UI static bundle; rebuilding UI assets before rollback...`
-      : `Slot ${target} has no Node UI static bundle; building UI assets before rollback...`,
-  );
+  io.log(`Slot ${target} has no Node UI static bundle; building UI assets before rollback...`);
   try {
-    io.rmSync(backupDist, { recursive: true, force: true });
-    if (hadExistingGitBundle) {
-      io.renameSync(gitDist, backupDist);
-    } else {
-      io.rmSync(gitDist, { recursive: true, force: true });
-    }
+    io.rmSync(gitDist, { recursive: true, force: true });
   } catch (err) {
     io.error(
       `Rollback aborted: failed to clear stale Node UI static bundle for slot ${target} ` +
@@ -124,17 +114,6 @@ export function ensureRollbackNodeUiBundle(
       lastError = new Error(`Node UI static bundle missing (${gitIndex})`);
     } catch (err) {
       lastError = err;
-    }
-  }
-  if (hadExistingGitBundle) {
-    try {
-      io.rmSync(gitDist, { recursive: true, force: true });
-      io.renameSync(backupDist, gitDist);
-    } catch (restoreErr) {
-      io.error(
-        `Rollback warning: failed to restore previous Node UI static bundle for slot ${target} ` +
-          `(${toErrorMessage(restoreErr)}).`,
-      );
     }
   }
   io.error(

--- a/packages/cli/src/rollback-node-ui.ts
+++ b/packages/cli/src/rollback-node-ui.ts
@@ -1,0 +1,103 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { toErrorMessage } from '@origintrail-official/dkg-core';
+import {
+  isNodeUiGitLayoutSlot,
+  NODE_UI_PACKAGE_NAME_FALLBACKS,
+  nodeUiPackageJsonPath,
+  nodeUiPackageNamesFromCliPackageJson,
+  nodeUiPackageNameFromPackageJson,
+  nodeUiNpmStaticIndexPaths,
+  nodeUiStaticBuildCommand,
+  nodeUiStaticBuildLabel,
+  nodeUiStaticIndexPath,
+} from './node-ui-static.js';
+
+const ROLLBACK_UI_BUILD_TIMEOUT_MS = 15 * 60_000;
+
+export interface RollbackNodeUiIo {
+  existsSync: typeof existsSync;
+  readFileSync: typeof readFileSync;
+  execSync: typeof execSync;
+  log: (message: string) => void;
+  error: (message: string) => void;
+}
+
+const defaultIo: RollbackNodeUiIo = {
+  existsSync,
+  readFileSync,
+  execSync,
+  log: console.log,
+  error: console.error,
+};
+
+function nodeUiPackageNamesForRollback(slotDir: string, io: RollbackNodeUiIo): string[] {
+  try {
+    return [nodeUiPackageNameFromPackageJson(
+      io.readFileSync(nodeUiPackageJsonPath(slotDir), 'utf-8'),
+    )];
+  } catch {
+    return NODE_UI_PACKAGE_NAME_FALLBACKS;
+  }
+}
+
+function nodeUiPackageNamesForNpmSlot(slotDir: string, io: RollbackNodeUiIo): string[] {
+  try {
+    return nodeUiPackageNamesFromCliPackageJson(
+      io.readFileSync(join(
+        slotDir,
+        'node_modules',
+        '@origintrail-official',
+        'dkg',
+        'package.json',
+      ), 'utf-8'),
+    );
+  } catch {
+    return NODE_UI_PACKAGE_NAME_FALLBACKS;
+  }
+}
+
+export function ensureRollbackNodeUiBundle(
+  slotDir: string,
+  target: 'a' | 'b',
+  io: RollbackNodeUiIo = defaultIo,
+): boolean {
+  const gitIndex = nodeUiStaticIndexPath(slotDir);
+  const isGitSlot = isNodeUiGitLayoutSlot(slotDir, io.existsSync);
+
+  if (!isGitSlot) {
+    const npmCandidateIndexes = nodeUiNpmStaticIndexPaths(
+      slotDir,
+      nodeUiPackageNamesForNpmSlot(slotDir, io),
+    );
+    if (npmCandidateIndexes.some((indexFile) => io.existsSync(indexFile))) return true;
+    io.error(`Slot ${target} has no Node UI static bundle (${npmCandidateIndexes.join(', ')}). Run "dkg update" first to prepare it.`);
+    return false;
+  }
+
+  if (io.existsSync(gitIndex)) return true;
+  io.log(`Slot ${target} has no Node UI static bundle; building UI assets before rollback...`);
+  let lastError: unknown;
+  const packageNames = nodeUiPackageNamesForRollback(slotDir, io);
+  for (const packageName of packageNames) {
+    try {
+      io.execSync(nodeUiStaticBuildCommand(packageName), {
+        cwd: slotDir,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: ROLLBACK_UI_BUILD_TIMEOUT_MS,
+      });
+      if (io.existsSync(gitIndex)) return true;
+      lastError = new Error(`Node UI static bundle missing (${gitIndex})`);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  io.error(
+    `Rollback aborted: failed to build Node UI static bundle for slot ${target} ` +
+      `with ${packageNames.map(nodeUiStaticBuildLabel).join(', ')} ` +
+      `(${toErrorMessage(lastError)}).`,
+  );
+  return false;
+}

--- a/packages/cli/src/rollback-node-ui.ts
+++ b/packages/cli/src/rollback-node-ui.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { toErrorMessage } from '@origintrail-official/dkg-core';
 import {
@@ -11,6 +11,7 @@ import {
   nodeUiNpmStaticIndexPaths,
   nodeUiStaticBuildCommand,
   nodeUiStaticBuildLabel,
+  nodeUiStaticDistPath,
   nodeUiStaticIndexPath,
 } from './node-ui-static.js';
 
@@ -19,6 +20,7 @@ const ROLLBACK_UI_BUILD_TIMEOUT_MS = 15 * 60_000;
 export interface RollbackNodeUiIo {
   existsSync: typeof existsSync;
   readFileSync: typeof readFileSync;
+  rmSync: typeof rmSync;
   execSync: typeof execSync;
   log: (message: string) => void;
   error: (message: string) => void;
@@ -27,6 +29,7 @@ export interface RollbackNodeUiIo {
 const defaultIo: RollbackNodeUiIo = {
   existsSync,
   readFileSync,
+  rmSync,
   execSync,
   log: console.log,
   error: console.error,
@@ -76,8 +79,21 @@ export function ensureRollbackNodeUiBundle(
     return false;
   }
 
-  if (io.existsSync(gitIndex)) return true;
-  io.log(`Slot ${target} has no Node UI static bundle; building UI assets before rollback...`);
+  const hadExistingGitBundle = io.existsSync(gitIndex);
+  io.log(
+    hadExistingGitBundle
+      ? `Slot ${target} has an existing Node UI static bundle; rebuilding UI assets before rollback...`
+      : `Slot ${target} has no Node UI static bundle; building UI assets before rollback...`,
+  );
+  try {
+    io.rmSync(nodeUiStaticDistPath(slotDir), { recursive: true, force: true });
+  } catch (err) {
+    io.error(
+      `Rollback aborted: failed to clear stale Node UI static bundle for slot ${target} ` +
+        `(${toErrorMessage(err)}).`,
+    );
+    return false;
+  }
   let lastError: unknown;
   const packageNames = nodeUiPackageNamesForRollback(slotDir, io);
   for (const packageName of packageNames) {

--- a/packages/cli/src/rollback-node-ui.ts
+++ b/packages/cli/src/rollback-node-ui.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, renameSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { toErrorMessage } from '@origintrail-official/dkg-core';
 import {
@@ -21,6 +21,7 @@ export interface RollbackNodeUiIo {
   existsSync: typeof existsSync;
   readFileSync: typeof readFileSync;
   rmSync: typeof rmSync;
+  renameSync: typeof renameSync;
   execSync: typeof execSync;
   log: (message: string) => void;
   error: (message: string) => void;
@@ -30,6 +31,7 @@ const defaultIo: RollbackNodeUiIo = {
   existsSync,
   readFileSync,
   rmSync,
+  renameSync,
   execSync,
   log: console.log,
   error: console.error,
@@ -80,13 +82,20 @@ export function ensureRollbackNodeUiBundle(
   }
 
   const hadExistingGitBundle = io.existsSync(gitIndex);
+  const gitDist = nodeUiStaticDistPath(slotDir);
+  const backupDist = `${gitDist}.rollback-backup`;
   io.log(
     hadExistingGitBundle
       ? `Slot ${target} has an existing Node UI static bundle; rebuilding UI assets before rollback...`
       : `Slot ${target} has no Node UI static bundle; building UI assets before rollback...`,
   );
   try {
-    io.rmSync(nodeUiStaticDistPath(slotDir), { recursive: true, force: true });
+    io.rmSync(backupDist, { recursive: true, force: true });
+    if (hadExistingGitBundle) {
+      io.renameSync(gitDist, backupDist);
+    } else {
+      io.rmSync(gitDist, { recursive: true, force: true });
+    }
   } catch (err) {
     io.error(
       `Rollback aborted: failed to clear stale Node UI static bundle for slot ${target} ` +
@@ -104,10 +113,28 @@ export function ensureRollbackNodeUiBundle(
         stdio: 'pipe',
         timeout: ROLLBACK_UI_BUILD_TIMEOUT_MS,
       });
-      if (io.existsSync(gitIndex)) return true;
+      if (io.existsSync(gitIndex)) {
+        try {
+          io.rmSync(backupDist, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup only; the rebuilt UI bundle is ready.
+        }
+        return true;
+      }
       lastError = new Error(`Node UI static bundle missing (${gitIndex})`);
     } catch (err) {
       lastError = err;
+    }
+  }
+  if (hadExistingGitBundle) {
+    try {
+      io.rmSync(gitDist, { recursive: true, force: true });
+      io.renameSync(backupDist, gitDist);
+    } catch (restoreErr) {
+      io.error(
+        `Rollback warning: failed to restore previous Node UI static bundle for slot ${target} ` +
+          `(${toErrorMessage(restoreErr)}).`,
+      );
     }
   }
   io.error(

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -18,6 +18,8 @@ const MOCK_BUNDLER_SCRIPT = [
   "export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';",
   "export const PYINSTALLER_VERSION = '6.19.0';",
 ].join('\n');
+const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
+const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
 let mockBundledCliPackageVersion = CLI_VERSION;
 let mockInstalledPackageVersion = '9.0.0-beta.4-dev.100.abc1234';
 
@@ -213,6 +215,30 @@ function makeFetchOk(sha: string) {
   });
 }
 
+function mockGitUpdateReadFile(
+  currentCommit = 'aaa111',
+  cliVersion = '9.0.0',
+  nodeUiPackageName = '@origintrail-official/dkg-node-ui',
+) {
+  readFileImpl = async (path: any) => {
+    const p = normalizePathString(path);
+    if (p.endsWith('/packages/node-ui/package.json')) {
+      return JSON.stringify({
+        name: nodeUiPackageName,
+        scripts: { 'build:ui': 'vite build' },
+      });
+    }
+    if (p.endsWith('/package.json') && !p.endsWith('/packages/cli/package.json')) {
+      return JSON.stringify({ scripts: { 'build:runtime': 'pnpm build:runtime' } });
+    }
+    if (p.endsWith('/packages/cli/package.json')) {
+      return JSON.stringify({ version: cliVersion });
+    }
+    if (p.endsWith('.update-pending.json')) throw new Error('ENOENT');
+    return currentCommit;
+  };
+}
+
 function getExecCalls() {
   return execCalls.map(c => ({
     cmd: c.cmd,
@@ -344,6 +370,9 @@ describe('blue-green checkForUpdate', () => {
     expect(gitCmds.some(c => c.file === 'git' && c.args[0] === 'checkout' && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm install') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('pnpm build') && c.cwd === targetDir)).toBe(true);
+    expect(existsSyncCalls.some(([p]) =>
+      normalizePathString(p).endsWith('/packages/node-ui/dist-ui/index.html')
+    )).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('bundle-markitdown-binaries.mjs') && c.cwd === targetDir)).toBe(true);
     expect(allCmds.some(c => c.cmd.includes('--force') && c.cwd === targetDir)).toBe(false);
     expect(allCmds.some(c => c.cmd.includes('--best-effort') && c.cwd === targetDir)).toBe(true);
@@ -351,6 +380,66 @@ describe('blue-green checkForUpdate', () => {
 
     const activeDir = '/tmp/dkg-test/releases/a';
     expect(allCmds.every(c => c.cwd !== activeDir)).toBe(true);
+  });
+
+  it('runs the Node UI static build after the runtime build before swapping', async () => {
+    const current = 'aaa111';
+    const latest = 'bbb224';
+    mockGitUpdateReadFile(current);
+    makeFetchOk(latest);
+    let nodeUiBuilt = false;
+    existsSyncImpl = (p: any) => {
+      const path = normalizePathString(p);
+      if (path.endsWith('/packages/node-ui/dist-ui/index.html')) return nodeUiBuilt;
+      return true;
+    };
+    execImpl = async (cmd: string) => {
+      if (cmd === NODE_UI_BUILD_CMD) nodeUiBuilt = true;
+      return { stdout: '', stderr: '' };
+    };
+
+    const result = await performUpdate(AU, () => {});
+    expect(result).toBe(true);
+
+    const targetDir = '/tmp/dkg-test/releases/b';
+    const allCmds = getExecCalls().filter(c => c.cwd === targetDir).map(c => c.cmd);
+    const runtimeIdx = allCmds.indexOf('pnpm build:runtime');
+    const uiIdx = allCmds.indexOf(NODE_UI_BUILD_CMD);
+    expect(runtimeIdx).toBeGreaterThanOrEqual(0);
+    expect(uiIdx).toBeGreaterThan(runtimeIdx);
+    expect(swapSlotCalls).toContain('b');
+    expect(rmCalls.some(([p]) =>
+      normalizePathString(p).endsWith('/packages/node-ui/dist-ui'),
+    )).toBe(true);
+    expect(existsSyncCalls.some(([p]) =>
+      normalizePathString(p).endsWith('/packages/node-ui/dist-ui/index.html')
+    )).toBe(true);
+  });
+
+  it('uses the Node UI workspace package name from the target slot', async () => {
+    const current = 'aaa111';
+    const latest = 'bbb225';
+    mockGitUpdateReadFile(current, '9.0.0-beta.2', '@dkg/node-ui');
+    makeFetchOk(latest);
+    let nodeUiBuilt = false;
+    existsSyncImpl = (p: any) => {
+      const path = normalizePathString(p);
+      if (path.endsWith('/packages/node-ui/dist-ui/index.html')) return nodeUiBuilt;
+      return true;
+    };
+    execImpl = async (cmd: string) => {
+      if (cmd === LEGACY_NODE_UI_BUILD_CMD) nodeUiBuilt = true;
+      return { stdout: '', stderr: '' };
+    };
+
+    const result = await performUpdate(AU, () => {});
+    expect(result).toBe(true);
+
+    const targetDir = '/tmp/dkg-test/releases/b';
+    const allCmds = getExecCalls().filter(c => c.cwd === targetDir).map(c => c.cmd);
+    expect(allCmds).toContain(LEGACY_NODE_UI_BUILD_CMD);
+    expect(allCmds).not.toContain(NODE_UI_BUILD_CMD);
+    expect(swapSlotCalls).toContain('b');
   });
 
   it('continues the update when MarkItDown staging fails inside the best-effort git-update step', async () => {
@@ -507,6 +596,45 @@ describe('blue-green checkForUpdate', () => {
     expect(result).toBe(false);
     expect(swapSlotCalls.length).toBe(0);
     expect(logCalls.some(m => m.includes('build output missing'))).toBe(true);
+  });
+
+  it('aborts swap when the git Node UI static bundle is missing after build', async () => {
+    readFileImpl = async () => 'aaa111';
+    makeFetchOk('newcommit');
+
+    existsSyncImpl = (p: any) => {
+      const path = normalizePathString(p);
+      if (path.endsWith('/packages/node-ui/dist-ui/index.html')) return false;
+      return true;
+    };
+
+    const logCalls: string[] = [];
+    const log = (msg: string) => { logCalls.push(msg); };
+    const result = await performUpdate(AU, log);
+    expect(result).toBe(false);
+    expect(swapSlotCalls.length).toBe(0);
+    expect(logCalls.some(m => m.includes('Node UI static bundle missing'))).toBe(true);
+  });
+
+  it('does not swap when the Node UI static build fails', async () => {
+    readFileImpl = async () => 'aaa111';
+    makeFetchOk('newcommit');
+    existsSyncImpl = (p: any) => {
+      const path = normalizePathString(p);
+      if (path.endsWith('/packages/node-ui/dist-ui/index.html')) return false;
+      return true;
+    };
+    execImpl = async (cmd: string) => {
+      if (cmd === NODE_UI_BUILD_CMD) throw new Error('vite exploded');
+      return { stdout: '', stderr: '' };
+    };
+
+    const logCalls: string[] = [];
+    const log = (msg: string) => { logCalls.push(msg); };
+    const result = await performUpdate(AU, log);
+    expect(result).toBe(false);
+    expect(swapSlotCalls.length).toBe(0);
+    expect(logCalls.some(m => m.includes('build failed') && m.includes('vite exploded'))).toBe(true);
   });
 
   it('continues the swap when the bundled MarkItDown binary is missing after build', async () => {
@@ -978,6 +1106,55 @@ describe('performNpmUpdate', () => {
     expect(swapSlotCalls.length).toBe(0);
   });
 
+  it('returns failed when npm Node UI static bundle is missing after install', async () => {
+    existsSyncImpl = (p: any) => {
+      const path = normalizePathString(p);
+      if (path.endsWith('/dist-ui/index.html')) return false;
+      return true;
+    };
+
+    const logCalls: string[] = [];
+    const log = (msg: string) => { logCalls.push(msg); };
+    const result = await performNpmUpdate('9.0.0-beta.5', log);
+
+    expect(result).toBe('failed');
+    expect(swapSlotCalls.length).toBe(0);
+    expect(logCalls.some(m => m.includes('Node UI static bundle missing'))).toBe(true);
+    expect(existsSyncCalls.some(([path]) =>
+      normalizePathString(path).endsWith('/packages/node-ui/dist-ui/index.html'),
+    )).toBe(false);
+  });
+
+  it('does not accept a legacy npm UI bundle for a current-package npm update', async () => {
+    readFileImpl = async (path: any) => {
+      const normalized = normalizePathString(path);
+      if (normalized.endsWith('.update-pending.json')) throw new Error('ENOENT');
+      if (normalized.endsWith('/node_modules/@origintrail-official/dkg/package.json')) {
+        return JSON.stringify({
+          version: '9.0.0-beta.5',
+          dependencies: { '@origintrail-official/dkg-node-ui': '9.0.0-beta.5' },
+        });
+      }
+      if (normalized.endsWith('package.json')) return JSON.stringify({ version: '9.0.0-beta.5' });
+      throw new Error(`Unexpected readFile: ${normalized}`);
+    };
+    existsSyncImpl = (p: any) => {
+      const path = normalizePathString(p);
+      if (path.endsWith('/node_modules/@origintrail-official/dkg/dist/cli.js')) return true;
+      if (path.includes('/@dkg/node-ui/dist-ui/index.html')) return true;
+      if (path.endsWith('/dist-ui/index.html')) return false;
+      return true;
+    };
+
+    const result = await performNpmUpdate('9.0.0-beta.5', () => {});
+
+    expect(result).toBe('failed');
+    expect(swapSlotCalls.length).toBe(0);
+    expect(existsSyncCalls.some(([path]) =>
+      normalizePathString(path).includes('/@dkg/node-ui/dist-ui/index.html'),
+    )).toBe(false);
+  });
+
   it('continues when the bundled MarkItDown binary is missing after install', async () => {
     mockInstalledPackageVersion = '9.0.0-beta.5';
     existsSyncImpl = (p: any) => {
@@ -1370,7 +1547,7 @@ describe('autoupdater hardening', () => {
   });
 
   it('honours autoUpdate.buildTimeoutMs.contracts when contracts rebuild', async () => {
-    readFileImpl = async () => 'aaa111';
+    mockGitUpdateReadFile();
     makeFetchOk('bbb222');
     let contractsTimeout: number | undefined;
     execImpl = async (cmd: string, opts?: any) => {
@@ -1424,7 +1601,7 @@ describe('autoupdater hardening', () => {
     // change we run `hardhat clean` first to drop ghost outputs from
     // deleted contracts. Scoped to the same trigger as the rebuild so
     // no-change updates still benefit from the Hardhat compile cache.
-    readFileImpl = async () => 'aaa111';
+    mockGitUpdateReadFile();
     makeFetchOk('bbb222');
     const order: string[] = [];
     execImpl = async (cmd: string) => {
@@ -1443,7 +1620,7 @@ describe('autoupdater hardening', () => {
   });
 
   it('contract-diff retries via `git fetch --depth=1` for the missing parent commit before giving up', async () => {
-    readFileImpl = async () => 'aaa111';
+    mockGitUpdateReadFile();
     makeFetchOk('bbb222');
     let firstDiffSeen = false;
     let retryFetchArgs: string[] | null = null;

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -20,6 +20,7 @@ const MOCK_BUNDLER_SCRIPT = [
 ].join('\n');
 const RUNTIME_PACKAGES_BUILD_CMD = 'pnpm build:runtime:packages';
 const RUNTIME_BUILD_CMD = 'pnpm build:runtime';
+const RUNTIME_BUILD_COMPAT_WRAPPER = 'pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
 let mockBundledCliPackageVersion = CLI_VERSION;
@@ -223,7 +224,7 @@ function mockGitUpdateReadFile(
   nodeUiPackageName = '@origintrail-official/dkg-node-ui',
   rootScripts: Record<string, string> = {
     'build:runtime:packages': RUNTIME_PACKAGES_BUILD_CMD,
-    'build:runtime': RUNTIME_BUILD_CMD,
+    'build:runtime': RUNTIME_BUILD_COMPAT_WRAPPER,
   },
 ) {
   readFileImpl = async (path: any) => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -236,7 +236,10 @@ function mockGitUpdateReadFile(
       });
     }
     if (p.endsWith('/package.json') && !p.endsWith('/packages/cli/package.json')) {
-      return JSON.stringify({ scripts: rootScripts });
+      return JSON.stringify({
+        dkgBuild: { releaseRuntimeBuildScript: 'build:runtime:packages' },
+        scripts: rootScripts,
+      });
     }
     if (p.endsWith('/packages/cli/package.json')) {
       return JSON.stringify({ version: cliVersion });

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -18,6 +18,8 @@ const MOCK_BUNDLER_SCRIPT = [
   "export const MARKITDOWN_UPSTREAM_VERSION = '0.1.5';",
   "export const PYINSTALLER_VERSION = '6.19.0';",
 ].join('\n');
+const RUNTIME_PACKAGES_BUILD_CMD = 'pnpm build:runtime:packages';
+const RUNTIME_BUILD_CMD = 'pnpm build:runtime';
 const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
 let mockBundledCliPackageVersion = CLI_VERSION;
@@ -65,7 +67,7 @@ let openSyncCalls: any[][] = [];
 let closeSyncCalls: any[][] = [];
 let writeFileSyncCalls: any[][] = [];
 let unlinkSyncCalls: any[][] = [];
-let execCalls: { cmd: string; cwd: string }[] = [];
+let execCalls: { cmd: string; cwd: string; timeout?: number }[] = [];
 let execFileCalls: { file: string; args: string[]; cwd: string; env: any }[] = [];
 let swapSlotCalls: string[] = [];
 let fetchCalls: any[][] = [];
@@ -163,7 +165,7 @@ function installMocks() {
   _autoUpdateIo.writeFileSync = ((...args: any[]) => { writeFileSyncCalls.push(args); }) as any;
   _autoUpdateIo.unlinkSync = ((...args: any[]) => { unlinkSyncCalls.push(args); }) as any;
   _autoUpdateIo.exec = (async (cmd: any, opts?: any) => {
-    execCalls.push({ cmd: String(cmd), cwd: normalizePathString(opts?.cwd) });
+    execCalls.push({ cmd: String(cmd), cwd: normalizePathString(opts?.cwd), timeout: opts?.timeout });
     return execImpl(String(cmd), opts);
   }) as any;
   _autoUpdateIo.execFile = (async (file: any, args: any[], opts?: any) => {
@@ -219,6 +221,10 @@ function mockGitUpdateReadFile(
   currentCommit = 'aaa111',
   cliVersion = '9.0.0',
   nodeUiPackageName = '@origintrail-official/dkg-node-ui',
+  rootScripts: Record<string, string> = {
+    'build:runtime:packages': RUNTIME_PACKAGES_BUILD_CMD,
+    'build:runtime': RUNTIME_BUILD_CMD,
+  },
 ) {
   readFileImpl = async (path: any) => {
     const p = normalizePathString(path);
@@ -229,7 +235,7 @@ function mockGitUpdateReadFile(
       });
     }
     if (p.endsWith('/package.json') && !p.endsWith('/packages/cli/package.json')) {
-      return JSON.stringify({ scripts: { 'build:runtime': 'pnpm build:runtime' } });
+      return JSON.stringify({ scripts: rootScripts });
     }
     if (p.endsWith('/packages/cli/package.json')) {
       return JSON.stringify({ version: cliVersion });
@@ -243,6 +249,7 @@ function getExecCalls() {
   return execCalls.map(c => ({
     cmd: c.cmd,
     cwd: c.cwd,
+    timeout: c.timeout,
   }));
 }
 
@@ -382,7 +389,7 @@ describe('blue-green checkForUpdate', () => {
     expect(allCmds.every(c => c.cwd !== activeDir)).toBe(true);
   });
 
-  it('runs the Node UI static build after the runtime build before swapping', async () => {
+  it('runs the Node UI static build after the runtime package build before swapping', async () => {
     const current = 'aaa111';
     const latest = 'bbb224';
     mockGitUpdateReadFile(current);
@@ -402,11 +409,15 @@ describe('blue-green checkForUpdate', () => {
     expect(result).toBe(true);
 
     const targetDir = '/tmp/dkg-test/releases/b';
-    const allCmds = getExecCalls().filter(c => c.cwd === targetDir).map(c => c.cmd);
-    const runtimeIdx = allCmds.indexOf('pnpm build:runtime');
+    const targetCalls = getExecCalls().filter(c => c.cwd === targetDir);
+    const allCmds = targetCalls.map(c => c.cmd);
+    const runtimeIdx = allCmds.indexOf(RUNTIME_PACKAGES_BUILD_CMD);
     const uiIdx = allCmds.indexOf(NODE_UI_BUILD_CMD);
     expect(runtimeIdx).toBeGreaterThanOrEqual(0);
     expect(uiIdx).toBeGreaterThan(runtimeIdx);
+    expect(targetCalls.find(c => c.cmd === RUNTIME_PACKAGES_BUILD_CMD)?.timeout).toBe(180_000);
+    expect(targetCalls.find(c => c.cmd === NODE_UI_BUILD_CMD)?.timeout).toBe(180_000);
+    expect(allCmds).not.toContain(RUNTIME_BUILD_CMD);
     expect(swapSlotCalls).toContain('b');
     expect(rmCalls.some(([p]) =>
       normalizePathString(p).endsWith('/packages/node-ui/dist-ui'),
@@ -414,6 +425,23 @@ describe('blue-green checkForUpdate', () => {
     expect(existsSyncCalls.some(([p]) =>
       normalizePathString(p).endsWith('/packages/node-ui/dist-ui/index.html')
     )).toBe(true);
+  });
+
+  it('falls back to build:runtime when the target lacks the runtime-only package script', async () => {
+    const current = 'aaa111';
+    const latest = 'bbb224-runtime-wrapper';
+    mockGitUpdateReadFile(current, '9.0.0', '@origintrail-official/dkg-node-ui', {
+      'build:runtime': RUNTIME_BUILD_CMD,
+    });
+    makeFetchOk(latest);
+
+    const result = await performUpdate(AU, () => {});
+    expect(result).toBe(true);
+
+    const targetDir = '/tmp/dkg-test/releases/b';
+    const allCmds = getExecCalls().filter(c => c.cwd === targetDir).map(c => c.cmd);
+    expect(allCmds).toContain(RUNTIME_BUILD_CMD);
+    expect(allCmds).not.toContain(RUNTIME_PACKAGES_BUILD_CMD);
   });
 
   it('uses the Node UI workspace package name from the target slot', async () => {

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, mkdir, writeFile, readlink, readFile, rm, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { _migrationIo, migrateToBlueGreen } from '../src/migration.js';
 import { repoDir } from '../src/config.js';
 
@@ -11,21 +11,32 @@ let dkgHome: string;
 
 let execSyncCalls: { cmd: string; opts?: any }[] = [];
 let execFileSyncCalls: { binary: string; args: string[]; opts?: any }[] = [];
+const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
+const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
 
 const origIo = { ..._migrationIo };
 
 function installMocks() {
   _migrationIo.execSync = ((cmd: string, opts?: any) => {
     execSyncCalls.push({ cmd, opts });
+    const cwd = opts?.cwd ? String(opts.cwd) : '';
+    if (cwd && cmd === 'pnpm build:runtime') {
+      mkdirSync(join(cwd, 'packages', 'cli', 'dist'), { recursive: true });
+      writeFileSync(join(cwd, 'packages', 'cli', 'dist', 'cli.js'), '');
+    }
+    if (cwd && (cmd === NODE_UI_BUILD_CMD || cmd === LEGACY_NODE_UI_BUILD_CMD)) {
+      mkdirSync(join(cwd, 'packages', 'node-ui', 'dist-ui'), { recursive: true });
+      writeFileSync(join(cwd, 'packages', 'node-ui', 'dist-ui', 'index.html'), '');
+    }
     return 'https://github.com/test/repo.git';
   }) as any;
 
   _migrationIo.execFileSync = ((binary: string, args: string[], opts?: any) => {
     execFileSyncCalls.push({ binary, args: [...args], opts });
-    if (binary === 'git' && args[0] === 'clone') {
+    if (binary === 'git' && args.includes('clone')) {
       const target = args[args.length - 1];
       if (target && !target.startsWith('git') && !target.startsWith('http')) {
-        try { mkdirSync(target, { recursive: true }); } catch {}
+        try { mkdirSync(join(target, '.git'), { recursive: true }); } catch {}
       }
     }
     if (binary === 'git' && args[0] === 'remote' && args[1] === 'get-url') {
@@ -64,16 +75,57 @@ function makeLog(): { fn: (msg: string) => void; calls: string[] } {
   return { fn: (msg: string) => { calls.push(msg); }, calls };
 }
 
+async function writeSlotReady(slotDir: string, includeUi = true): Promise<void> {
+  await mkdir(join(slotDir, '.git'), { recursive: true });
+  await mkdir(join(slotDir, 'packages', 'cli', 'dist'), { recursive: true });
+  await writeFile(join(slotDir, 'packages', 'cli', 'dist', 'cli.js'), '');
+  if (includeUi) {
+    await mkdir(join(slotDir, 'packages', 'node-ui', 'dist-ui'), { recursive: true });
+    await writeFile(join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html'), '');
+  }
+}
+
+async function writeNpmSlotReady(slotDir: string, includeUi = true): Promise<void> {
+  await mkdir(join(slotDir, 'node_modules', '@origintrail-official', 'dkg', 'dist'), { recursive: true });
+  await writeFile(join(slotDir, 'package.json'), '{}');
+  await writeFile(join(slotDir, 'node_modules', '@origintrail-official', 'dkg', 'dist', 'cli.js'), '');
+  if (includeUi) {
+    await mkdir(
+      join(
+        slotDir,
+        'node_modules',
+        '@origintrail-official',
+        'dkg',
+        'node_modules',
+        '@origintrail-official',
+        'dkg-node-ui',
+        'dist-ui',
+      ),
+      { recursive: true },
+    );
+    await writeFile(
+      join(
+        slotDir,
+        'node_modules',
+        '@origintrail-official',
+        'dkg',
+        'node_modules',
+        '@origintrail-official',
+        'dkg-node-ui',
+        'dist-ui',
+        'index.html',
+      ),
+      '',
+    );
+  }
+}
+
 describe('migrateToBlueGreen', () => {
   it('skips migration when releases/current already exists', async () => {
     const rDir = join(dkgHome, 'releases');
     await mkdir(rDir, { recursive: true });
-    await mkdir(join(rDir, 'a', '.git'), { recursive: true });
-    await mkdir(join(rDir, 'b', '.git'), { recursive: true });
-    await mkdir(join(rDir, 'a', 'packages', 'cli', 'dist'), { recursive: true });
-    await mkdir(join(rDir, 'b', 'packages', 'cli', 'dist'), { recursive: true });
-    await writeFile(join(rDir, 'a', 'packages', 'cli', 'dist', 'cli.js'), '');
-    await writeFile(join(rDir, 'b', 'packages', 'cli', 'dist', 'cli.js'), '');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(join(rDir, 'b'));
     await symlink('a', join(rDir, 'current'));
 
     const log = makeLog();
@@ -97,9 +149,7 @@ describe('migrateToBlueGreen', () => {
 
   it('restores current symlink from existing active metadata when valid', async () => {
     const rDir = join(dkgHome, 'releases');
-    await mkdir(join(rDir, 'b', '.git'), { recursive: true });
-    await mkdir(join(rDir, 'b', 'packages', 'cli', 'dist'), { recursive: true });
-    await writeFile(join(rDir, 'b', 'packages', 'cli', 'dist', 'cli.js'), '');
+    await writeSlotReady(join(rDir, 'b'), false);
     await writeFile(join(rDir, 'active'), 'b');
 
     const log = makeLog();
@@ -217,6 +267,240 @@ describe('migrateToBlueGreen', () => {
     const allCmds = execSyncCalls.map(c => c.cmd);
     expect(allCmds.some(cmd => cmd.includes('pnpm install'))).toBe(true);
     expect(allCmds.some(cmd => cmd.includes('pnpm build'))).toBe(true);
+    expect(allCmds.some(cmd => cmd === NODE_UI_BUILD_CMD)).toBe(true);
+    const uiBuildIdx = allCmds.indexOf(NODE_UI_BUILD_CMD);
+    const runtimeBuildIdx = allCmds.indexOf('pnpm build:runtime');
+    expect(uiBuildIdx).toBeGreaterThan(runtimeBuildIdx);
+  });
+
+  it('repairs inactive ready slots that are missing the Node UI static bundle', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    const uiBuilds = execSyncCalls.filter(c => c.cmd === NODE_UI_BUILD_CMD);
+    expect(uiBuilds.map(c => String(c.opts?.cwd))).toEqual([join(rDir, 'b')]);
+    expect(log.calls.some(m => m.includes('Node UI static bundle missing'))).toBe(true);
+    expect(execFileSyncCalls.some(c => c.binary === 'git' && c.args[0] === 'clone')).toBe(false);
+  });
+
+  it('does not run workspace UI build for npm-layout slots missing UI', async () => {
+    const rDir = join(dkgHome, 'releases');
+    const slotB = join(rDir, 'b');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeNpmSlotReady(slotB, false);
+    await writeFile(join(rDir, 'active'), 'a');
+    _migrationIo.swapSlot = (async () => undefined) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    const slotBCmds = execSyncCalls
+      .filter(c => String(c.opts?.cwd) === slotB)
+      .map(c => c.cmd);
+    expect(slotBCmds).not.toContain(NODE_UI_BUILD_CMD);
+    expect(slotBCmds).not.toContain(LEGACY_NODE_UI_BUILD_CMD);
+    expect(log.calls.some(m => m.includes('repair failed') && m.includes('Trying remaining slots'))).toBe(true);
+  });
+
+  it('does not select npm-layout slots that are missing UI', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeNpmSlotReady(join(rDir, 'a'), false);
+    await writeNpmSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'a');
+    const swaps: Array<'a' | 'b'> = [];
+    _migrationIo.swapSlot = (async (slot: 'a' | 'b') => {
+      swaps.push(slot);
+    }) as any;
+
+    const log = makeLog();
+    await expect(migrateToBlueGreen(log.fn)).rejects.toThrow('Node UI static bundle missing');
+
+    expect(swaps).toEqual([]);
+    expect(execSyncCalls.length).toBe(0);
+    expect(log.calls.filter(m => m.includes('Trying remaining slots')).length).toBe(2);
+  });
+
+  it('uses the Node UI workspace package name from each slot during repair', async () => {
+    const rDir = join(dkgHome, 'releases');
+    const slotB = join(rDir, 'b');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(slotB, false);
+    await mkdir(join(slotB, 'packages', 'node-ui'), { recursive: true });
+    await writeFile(
+      join(slotB, 'packages', 'node-ui', 'package.json'),
+      JSON.stringify({ name: '@dkg/node-ui', scripts: { 'build:ui': 'vite build' } }),
+    );
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    const slotBuilds = execSyncCalls
+      .filter(c => String(c.opts?.cwd) === slotB)
+      .map(c => c.cmd);
+    expect(slotBuilds).toContain(LEGACY_NODE_UI_BUILD_CMD);
+    expect(slotBuilds).not.toContain(NODE_UI_BUILD_CMD);
+  });
+
+  it('uses releases/current before stale active metadata when deciding the live slot', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'b');
+    await symlink('a', join(rDir, 'current'));
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    const uiBuilds = execSyncCalls.filter(c => c.cmd === NODE_UI_BUILD_CMD);
+    expect(uiBuilds.map(c => String(c.opts?.cwd))).toEqual([join(rDir, 'b')]);
+  });
+
+  it('repairs a live slot missing UI in place instead of failing over', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'), false);
+    await writeSlotReady(join(rDir, 'b'));
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(await readlink(join(rDir, 'current'))).toBe('a');
+    const uiBuilds = execSyncCalls.filter(c => c.cmd === NODE_UI_BUILD_CMD);
+    expect(uiBuilds.map(c => String(c.opts?.cwd))).toEqual([join(rDir, 'a')]);
+    expect(log.calls.some(m => m.includes('active slot') && m.includes('rebuilding'))).toBe(true);
+  });
+
+  it('leaves live slot untouched when live UI repair is disabled', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'), false);
+    await writeSlotReady(join(rDir, 'b'));
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn, { repairLiveNodeUi: false });
+
+    expect(await readlink(join(rDir, 'current'))).toBe('a');
+    const uiBuilds = execSyncCalls.filter(c => c.cmd === NODE_UI_BUILD_CMD);
+    expect(uiBuilds.map(c => String(c.opts?.cwd))).not.toContain(join(rDir, 'a'));
+    expect(log.calls.some(m => m.includes('active slot') && m.includes('untouched'))).toBe(true);
+  });
+
+  it('repairs live and standby UI when both ready slots are missing UI', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'), false);
+    await writeSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(await readlink(join(rDir, 'current'))).toBe('a');
+    const uiBuilds = execSyncCalls.filter(c => c.cmd === NODE_UI_BUILD_CMD);
+    expect(uiBuilds.map(c => String(c.opts?.cwd))).toEqual([join(rDir, 'a'), join(rDir, 'b')]);
+  });
+
+  it('does not block migration when inactive slot UI repair fails', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+    _migrationIo.execSync = ((cmd: string, opts?: any) => {
+      execSyncCalls.push({ cmd, opts });
+      if (cmd === NODE_UI_BUILD_CMD || cmd === LEGACY_NODE_UI_BUILD_CMD) throw new Error('vite exploded');
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(log.calls.some(m => m.includes('repair failed') && m.includes('next update'))).toBe(true);
+  });
+
+  it('continues startup when live slot UI repair fails instead of rolling back', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'), false);
+    await writeSlotReady(join(rDir, 'b'));
+    await writeFile(join(rDir, 'active'), 'a');
+    await symlink('a', join(rDir, 'current'));
+    _migrationIo.execSync = ((cmd: string, opts?: any) => {
+      execSyncCalls.push({ cmd, opts });
+      if (cmd === NODE_UI_BUILD_CMD || cmd === LEGACY_NODE_UI_BUILD_CMD) throw new Error('vite exploded');
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(await readlink(join(rDir, 'current'))).toBe('a');
+    expect(log.calls.some(m => m.includes('repair failed') && m.includes('fallback page'))).toBe(true);
+  });
+
+  it('restores current to a healthy UI slot when another ready slot repair fails', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'b');
+    _migrationIo.execSync = ((cmd: string, opts?: any) => {
+      execSyncCalls.push({ cmd, opts });
+      if (cmd === NODE_UI_BUILD_CMD || cmd === LEGACY_NODE_UI_BUILD_CMD) throw new Error('vite exploded');
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(await readlink(join(rDir, 'current'))).toBe('a');
+    expect(log.calls.some(m => m.includes('repair failed') && m.includes('Trying remaining slots'))).toBe(true);
+  });
+
+  it('tries both slots before failing no-current UI repair', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'), false);
+    await writeSlotReady(join(rDir, 'b'), false);
+    await writeFile(join(rDir, 'active'), 'a');
+    _migrationIo.execSync = ((cmd: string, opts?: any) => {
+      execSyncCalls.push({ cmd, opts });
+      const cwd = String(opts?.cwd ?? '');
+      if (cmd === NODE_UI_BUILD_CMD || cmd === LEGACY_NODE_UI_BUILD_CMD) {
+        if (cwd.endsWith(`${join('releases', 'a')}`)) throw new Error('vite exploded');
+        mkdirSync(join(cwd, 'packages', 'node-ui', 'dist-ui'), { recursive: true });
+        writeFileSync(join(cwd, 'packages', 'node-ui', 'dist-ui', 'index.html'), '');
+      }
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(await readlink(join(rDir, 'current'))).toBe('b');
+    expect(log.calls.some(m => m.includes('Trying remaining slots'))).toBe(true);
+  });
+
+  it('fails initial migration when no slot can provide the Node UI static bundle', async () => {
+    const rDir = join(dkgHome, 'releases');
+    await writeSlotReady(join(rDir, 'a'), false);
+    await writeSlotReady(join(rDir, 'b'), false);
+    _migrationIo.execSync = ((cmd: string, opts?: any) => {
+      execSyncCalls.push({ cmd, opts });
+      if (cmd === NODE_UI_BUILD_CMD || cmd === LEGACY_NODE_UI_BUILD_CMD) throw new Error('vite exploded');
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await expect(migrateToBlueGreen(log.fn)).rejects.toThrow('vite exploded');
+    expect(existsSync(join(rDir, 'current'))).toBe(false);
   });
 
   it('migration slot B clone uses --dissociate to prevent repo corruption', async () => {
@@ -263,9 +547,7 @@ describe('migrateToBlueGreen', () => {
 
   it('repairs incomplete slots even when current symlink exists', async () => {
     const rDir = join(dkgHome, 'releases');
-    await mkdir(join(rDir, 'a', '.git'), { recursive: true });
-    await mkdir(join(rDir, 'a', 'packages', 'cli', 'dist'), { recursive: true });
-    await writeFile(join(rDir, 'a', 'packages', 'cli', 'dist', 'cli.js'), '');
+    await writeSlotReady(join(rDir, 'a'));
     await mkdir(join(rDir, 'b'), { recursive: true }); // incomplete slot b
     await symlink('a', join(rDir, 'current'));
 
@@ -281,12 +563,8 @@ describe('migrateToBlueGreen', () => {
 
   it('repairs non-symlink releases/current by recreating current symlink', async () => {
     const rDir = join(dkgHome, 'releases');
-    await mkdir(join(rDir, 'a', '.git'), { recursive: true });
-    await mkdir(join(rDir, 'b', '.git'), { recursive: true });
-    await mkdir(join(rDir, 'a', 'packages', 'cli', 'dist'), { recursive: true });
-    await mkdir(join(rDir, 'b', 'packages', 'cli', 'dist'), { recursive: true });
-    await writeFile(join(rDir, 'a', 'packages', 'cli', 'dist', 'cli.js'), '');
-    await writeFile(join(rDir, 'b', 'packages', 'cli', 'dist', 'cli.js'), '');
+    await writeSlotReady(join(rDir, 'a'));
+    await writeSlotReady(join(rDir, 'b'));
     await writeFile(join(rDir, 'active'), 'b');
     await mkdir(join(rDir, 'current'), { recursive: true }); // legacy broken state: directory instead of symlink
 

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -11,6 +11,8 @@ let dkgHome: string;
 
 let execSyncCalls: { cmd: string; opts?: any }[] = [];
 let execFileSyncCalls: { binary: string; args: string[]; opts?: any }[] = [];
+const RUNTIME_PACKAGES_BUILD_CMD = 'pnpm build:runtime:packages';
+const RUNTIME_BUILD_CMD = 'pnpm build:runtime';
 const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
 
@@ -20,7 +22,7 @@ function installMocks() {
   _migrationIo.execSync = ((cmd: string, opts?: any) => {
     execSyncCalls.push({ cmd, opts });
     const cwd = opts?.cwd ? String(opts.cwd) : '';
-    if (cwd && cmd === 'pnpm build:runtime') {
+    if (cwd && (cmd === RUNTIME_PACKAGES_BUILD_CMD || cmd === RUNTIME_BUILD_CMD)) {
       mkdirSync(join(cwd, 'packages', 'cli', 'dist'), { recursive: true });
       writeFileSync(join(cwd, 'packages', 'cli', 'dist', 'cli.js'), '');
     }
@@ -36,7 +38,18 @@ function installMocks() {
     if (binary === 'git' && args.includes('clone')) {
       const target = args[args.length - 1];
       if (target && !target.startsWith('git') && !target.startsWith('http')) {
-        try { mkdirSync(join(target, '.git'), { recursive: true }); } catch {}
+        try {
+          mkdirSync(join(target, '.git'), { recursive: true });
+          writeFileSync(
+            join(target, 'package.json'),
+            JSON.stringify({
+              scripts: {
+                'build:runtime:packages': RUNTIME_PACKAGES_BUILD_CMD,
+                'build:runtime': RUNTIME_BUILD_CMD,
+              },
+            }),
+          );
+        } catch {}
       }
     }
     if (binary === 'git' && args[0] === 'remote' && args[1] === 'get-url') {
@@ -261,6 +274,7 @@ describe('migrateToBlueGreen', () => {
   });
 
   it('migration builds slot A after cloning (not just clone)', async () => {
+    _migrationIo.swapSlot = (async () => undefined) as any;
     const log = makeLog();
     await migrateToBlueGreen(log.fn);
 
@@ -269,8 +283,39 @@ describe('migrateToBlueGreen', () => {
     expect(allCmds.some(cmd => cmd.includes('pnpm build'))).toBe(true);
     expect(allCmds.some(cmd => cmd === NODE_UI_BUILD_CMD)).toBe(true);
     const uiBuildIdx = allCmds.indexOf(NODE_UI_BUILD_CMD);
-    const runtimeBuildIdx = allCmds.indexOf('pnpm build:runtime');
+    const runtimeBuildIdx = allCmds.indexOf(RUNTIME_PACKAGES_BUILD_CMD);
     expect(uiBuildIdx).toBeGreaterThan(runtimeBuildIdx);
+    expect(allCmds).not.toContain(RUNTIME_BUILD_CMD);
+  });
+
+  it('falls back to build:runtime during bootstrap when the runtime-only package script is absent', async () => {
+    const rDir = join(dkgHome, 'releases');
+    _migrationIo.repoDir = () => repoDir();
+    _migrationIo.swapSlot = (async () => undefined) as any;
+    _migrationIo.execFileSync = ((binary: string, args: string[], opts?: any) => {
+      execFileSyncCalls.push({ binary, args: [...args], opts });
+      if (binary === 'git' && args.includes('clone')) {
+        const target = args[args.length - 1];
+        mkdirSync(join(target, '.git'), { recursive: true });
+        writeFileSync(
+          join(target, 'package.json'),
+          JSON.stringify({ scripts: { 'build:runtime': RUNTIME_BUILD_CMD } }),
+        );
+      }
+      if (binary === 'git' && args[0] === 'remote' && args[1] === 'get-url') {
+        return 'https://github.com/test/repo.git';
+      }
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    const slotACmds = execSyncCalls
+      .filter(c => String(c.opts?.cwd) === join(rDir, 'a'))
+      .map(c => c.cmd);
+    expect(slotACmds).toContain(RUNTIME_BUILD_CMD);
+    expect(slotACmds).not.toContain(RUNTIME_PACKAGES_BUILD_CMD);
   });
 
   it('repairs inactive ready slots that are missing the Node UI static bundle', async () => {

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -13,6 +13,7 @@ let execSyncCalls: { cmd: string; opts?: any }[] = [];
 let execFileSyncCalls: { binary: string; args: string[]; opts?: any }[] = [];
 const RUNTIME_PACKAGES_BUILD_CMD = 'pnpm build:runtime:packages';
 const RUNTIME_BUILD_CMD = 'pnpm build:runtime';
+const RUNTIME_BUILD_COMPAT_WRAPPER = 'pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const FULL_BUILD_CMD = 'pnpm build';
 const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
@@ -46,7 +47,7 @@ function installMocks() {
             JSON.stringify({
               scripts: {
                 'build:runtime:packages': RUNTIME_PACKAGES_BUILD_CMD,
-                'build:runtime': RUNTIME_BUILD_CMD,
+                'build:runtime': RUNTIME_BUILD_COMPAT_WRAPPER,
               },
             }),
           );

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -45,6 +45,7 @@ function installMocks() {
           writeFileSync(
             join(target, 'package.json'),
             JSON.stringify({
+              dkgBuild: { releaseRuntimeBuildScript: 'build:runtime:packages' },
               scripts: {
                 'build:runtime:packages': RUNTIME_PACKAGES_BUILD_CMD,
                 'build:runtime': RUNTIME_BUILD_COMPAT_WRAPPER,

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -13,6 +13,7 @@ let execSyncCalls: { cmd: string; opts?: any }[] = [];
 let execFileSyncCalls: { binary: string; args: string[]; opts?: any }[] = [];
 const RUNTIME_PACKAGES_BUILD_CMD = 'pnpm build:runtime:packages';
 const RUNTIME_BUILD_CMD = 'pnpm build:runtime';
+const FULL_BUILD_CMD = 'pnpm build';
 const NODE_UI_BUILD_CMD = 'pnpm --filter @origintrail-official/dkg-node-ui run build:ui';
 const LEGACY_NODE_UI_BUILD_CMD = 'pnpm --filter @dkg/node-ui run build:ui';
 
@@ -22,7 +23,7 @@ function installMocks() {
   _migrationIo.execSync = ((cmd: string, opts?: any) => {
     execSyncCalls.push({ cmd, opts });
     const cwd = opts?.cwd ? String(opts.cwd) : '';
-    if (cwd && (cmd === RUNTIME_PACKAGES_BUILD_CMD || cmd === RUNTIME_BUILD_CMD)) {
+    if (cwd && (cmd === RUNTIME_PACKAGES_BUILD_CMD || cmd === RUNTIME_BUILD_CMD || cmd === FULL_BUILD_CMD)) {
       mkdirSync(join(cwd, 'packages', 'cli', 'dist'), { recursive: true });
       writeFileSync(join(cwd, 'packages', 'cli', 'dist', 'cli.js'), '');
     }
@@ -316,6 +317,37 @@ describe('migrateToBlueGreen', () => {
       .map(c => c.cmd);
     expect(slotACmds).toContain(RUNTIME_BUILD_CMD);
     expect(slotACmds).not.toContain(RUNTIME_PACKAGES_BUILD_CMD);
+  });
+
+  it('falls back to pnpm build during bootstrap when runtime build scripts are absent', async () => {
+    const rDir = join(dkgHome, 'releases');
+    _migrationIo.repoDir = () => repoDir();
+    _migrationIo.swapSlot = (async () => undefined) as any;
+    _migrationIo.execFileSync = ((binary: string, args: string[], opts?: any) => {
+      execFileSyncCalls.push({ binary, args: [...args], opts });
+      if (binary === 'git' && args.includes('clone')) {
+        const target = args[args.length - 1];
+        mkdirSync(join(target, '.git'), { recursive: true });
+        writeFileSync(
+          join(target, 'package.json'),
+          JSON.stringify({ scripts: { build: 'turbo build' } }),
+        );
+      }
+      if (binary === 'git' && args[0] === 'remote' && args[1] === 'get-url') {
+        return 'https://github.com/test/repo.git';
+      }
+      return '';
+    }) as any;
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    const slotACmds = execSyncCalls
+      .filter(c => String(c.opts?.cwd) === join(rDir, 'a'))
+      .map(c => c.cmd);
+    expect(slotACmds).toContain(FULL_BUILD_CMD);
+    expect(slotACmds).not.toContain(RUNTIME_PACKAGES_BUILD_CMD);
+    expect(slotACmds).not.toContain(RUNTIME_BUILD_CMD);
   });
 
   it('repairs inactive ready slots that are missing the Node UI static bundle', async () => {

--- a/packages/cli/test/node-ui-static.test.ts
+++ b/packages/cli/test/node-ui-static.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  RUNTIME_BUILD_COMPATIBILITY_WRAPPER,
   runtimeBuildCommandFromPackageJson,
   nodeUiNpmStaticIndexPaths,
   nodeUiStaticIndexPaths,
@@ -44,9 +45,18 @@ describe('runtimeBuildCommandFromPackageJson', () => {
     expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
       scripts: {
         'build:runtime:packages': '...',
-        'build:runtime': '...',
+        'build:runtime': RUNTIME_BUILD_COMPATIBILITY_WRAPPER,
       },
     }))).toBe('pnpm build:runtime:packages');
+  });
+
+  it('keeps using build:runtime when the wrapper contains extra prep work', () => {
+    expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      scripts: {
+        'build:runtime:packages': '...',
+        'build:runtime': `node prep.js && ${RUNTIME_BUILD_COMPATIBILITY_WRAPPER}`,
+      },
+    }))).toBe('pnpm build:runtime');
   });
 
   it('falls back across build:runtime and pnpm build', () => {

--- a/packages/cli/test/node-ui-static.test.ts
+++ b/packages/cli/test/node-ui-static.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { nodeUiNpmStaticIndexPaths, nodeUiStaticIndexPaths } from '../src/node-ui-static.js';
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+describe('nodeUiStaticIndexPaths', () => {
+  it('includes git and npm slot layouts', () => {
+    const paths = nodeUiStaticIndexPaths('/tmp/dkg-test/releases/b').map(normalizePath);
+
+    expect(paths).toContain('/tmp/dkg-test/releases/b/packages/node-ui/dist-ui/index.html');
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg-node-ui/dist-ui/index.html');
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@dkg/node-ui/dist-ui/index.html');
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg/node_modules/@origintrail-official/dkg-node-ui/dist-ui/index.html');
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg/node_modules/@dkg/node-ui/dist-ui/index.html');
+  });
+
+  it('keeps npm candidates separate from the git workspace artifact', () => {
+    const paths = nodeUiNpmStaticIndexPaths('/tmp/dkg-test/releases/b').map(normalizePath);
+
+    expect(paths).not.toContain('/tmp/dkg-test/releases/b/packages/node-ui/dist-ui/index.html');
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg-node-ui/dist-ui/index.html');
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg/node_modules/@origintrail-official/dkg-node-ui/dist-ui/index.html');
+  });
+
+  it('can scope npm candidates to the expected UI package', () => {
+    const paths = nodeUiNpmStaticIndexPaths(
+      '/tmp/dkg-test/releases/b',
+      ['@origintrail-official/dkg-node-ui'],
+    ).map(normalizePath);
+
+    expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg-node-ui/dist-ui/index.html');
+    expect(paths.some((path) => path.includes('/@dkg/node-ui/'))).toBe(false);
+  });
+});

--- a/packages/cli/test/node-ui-static.test.ts
+++ b/packages/cli/test/node-ui-static.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { nodeUiNpmStaticIndexPaths, nodeUiStaticIndexPaths } from '../src/node-ui-static.js';
+import {
+  runtimeBuildCommandFromPackageJson,
+  nodeUiNpmStaticIndexPaths,
+  nodeUiStaticIndexPaths,
+} from '../src/node-ui-static.js';
 
 function normalizePath(value: string): string {
   return value.replace(/\\/g, '/');
@@ -32,5 +36,26 @@ describe('nodeUiStaticIndexPaths', () => {
 
     expect(paths).toContain('/tmp/dkg-test/releases/b/node_modules/@origintrail-official/dkg-node-ui/dist-ui/index.html');
     expect(paths.some((path) => path.includes('/@dkg/node-ui/'))).toBe(false);
+  });
+});
+
+describe('runtimeBuildCommandFromPackageJson', () => {
+  it('prefers the runtime-only package build script when present', () => {
+    expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      scripts: {
+        'build:runtime:packages': '...',
+        'build:runtime': '...',
+      },
+    }))).toBe('pnpm build:runtime:packages');
+  });
+
+  it('falls back across build:runtime and pnpm build', () => {
+    expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      scripts: { 'build:runtime': '...' },
+    }))).toBe('pnpm build:runtime');
+    expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      scripts: { build: 'turbo build' },
+    }))).toBe('pnpm build');
+    expect(runtimeBuildCommandFromPackageJson('not json')).toBe('pnpm build');
   });
 });

--- a/packages/cli/test/node-ui-static.test.ts
+++ b/packages/cli/test/node-ui-static.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  RUNTIME_BUILD_COMPATIBILITY_WRAPPER,
   runtimeBuildCommandFromPackageJson,
   nodeUiNpmStaticIndexPaths,
   nodeUiStaticIndexPaths,
@@ -41,28 +40,42 @@ describe('nodeUiStaticIndexPaths', () => {
 });
 
 describe('runtimeBuildCommandFromPackageJson', () => {
-  it('prefers the runtime-only package build script when present', () => {
+  it('prefers the explicit release runtime build script when configured', () => {
     expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      dkgBuild: { releaseRuntimeBuildScript: 'build:runtime:packages' },
       scripts: {
         'build:runtime:packages': '...',
-        'build:runtime': RUNTIME_BUILD_COMPATIBILITY_WRAPPER,
+        'build:runtime': 'node prep.js && pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui',
       },
     }))).toBe('pnpm build:runtime:packages');
   });
 
-  it('keeps using build:runtime when the wrapper contains extra prep work', () => {
+  it('keeps using build:runtime when no release runtime build script is configured', () => {
     expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
       scripts: {
         'build:runtime:packages': '...',
-        'build:runtime': `node prep.js && ${RUNTIME_BUILD_COMPATIBILITY_WRAPPER}`,
+        'build:runtime': 'node prep.js && pnpm run build:runtime:packages && pnpm --filter @origintrail-official/dkg-node-ui run build:ui',
       },
     }))).toBe('pnpm build:runtime');
   });
 
-  it('falls back across build:runtime and pnpm build', () => {
+  it('ignores unsafe release runtime script names', () => {
+    expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      dkgBuild: { releaseRuntimeBuildScript: 'build:runtime:packages && bad' },
+      scripts: {
+        'build:runtime:packages && bad': '...',
+        'build:runtime': '...',
+      },
+    }))).toBe('pnpm build:runtime');
+  });
+
+  it('falls back across build:runtime, build:runtime:packages, and pnpm build', () => {
     expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
       scripts: { 'build:runtime': '...' },
     }))).toBe('pnpm build:runtime');
+    expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
+      scripts: { 'build:runtime:packages': '...' },
+    }))).toBe('pnpm build:runtime:packages');
     expect(runtimeBuildCommandFromPackageJson(JSON.stringify({
       scripts: { build: 'turbo build' },
     }))).toBe('pnpm build');

--- a/packages/cli/test/rollback-node-ui.test.ts
+++ b/packages/cli/test/rollback-node-ui.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import type { ExecSyncOptionsWithStringEncoding } from 'node:child_process';
+import { ensureRollbackNodeUiBundle, type RollbackNodeUiIo } from '../src/rollback-node-ui.js';
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function makeIo(overrides: Partial<RollbackNodeUiIo>): RollbackNodeUiIo {
+  return {
+    existsSync: () => false,
+    readFileSync: () => {
+      throw new Error('unexpected read');
+    },
+    execSync: () => '',
+    log: () => {},
+    error: () => {},
+    ...overrides,
+  };
+}
+
+describe('ensureRollbackNodeUiBundle', () => {
+  it('builds a missing git-layout Node UI bundle before rollback can activate the slot', () => {
+    const slotDir = join('tmp', 'releases', 'b');
+    const gitIndex = join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html');
+    let built = false;
+    const commands: string[] = [];
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const io = makeIo({
+      existsSync: (path) => normalizePath(path).endsWith('/packages/cli/dist/cli.js')
+        || (built && path === gitIndex),
+      readFileSync: (path) => {
+        expect(normalizePath(path)).toContain('/packages/node-ui/package.json');
+        return '{"name":"@origintrail-official/dkg-node-ui"}';
+      },
+      execSync: (command: string, options?: ExecSyncOptionsWithStringEncoding) => {
+        commands.push(command);
+        expect(options?.cwd).toBe(slotDir);
+        expect(options?.timeout).toBe(15 * 60_000);
+        built = true;
+        return '';
+      },
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+    });
+
+    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
+    expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
+    expect(logs).toEqual(['Slot b has no Node UI static bundle; building UI assets before rollback...']);
+    expect(errors).toEqual([]);
+  });
+
+  it('fails a git-layout rollback when the UI build cannot produce index.html', () => {
+    const slotDir = join('tmp', 'releases', 'b');
+    const commands: string[] = [];
+    const errors: string[] = [];
+    const io = makeIo({
+      existsSync: (path) => normalizePath(path).endsWith('/packages/cli/dist/cli.js'),
+      readFileSync: () => '{"name":"@origintrail-official/dkg-node-ui"}',
+      execSync: (command: string) => {
+        commands.push(command);
+        throw new Error('vite exploded');
+      },
+      error: (message) => errors.push(message),
+    });
+
+    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(false);
+    expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Rollback aborted: failed to build Node UI static bundle');
+    expect(errors[0]).toContain('vite exploded');
+  });
+
+  it('accepts an npm-layout rollback target that already contains packaged UI assets', () => {
+    const slotDir = join('tmp', 'releases', 'b');
+    const npmIndex = join(
+      slotDir,
+      'node_modules',
+      '@origintrail-official',
+      'dkg-node-ui',
+      'dist-ui',
+      'index.html',
+    );
+    const commands: string[] = [];
+    const io = makeIo({
+      existsSync: (path) => path === npmIndex,
+      readFileSync: (path) => {
+        expect(normalizePath(path)).toContain('/node_modules/@origintrail-official/dkg/package.json');
+        return '{"dependencies":{"@origintrail-official/dkg-node-ui":"10.0.0"}}';
+      },
+      execSync: (command: string) => {
+        commands.push(command);
+        return '';
+      },
+    });
+
+    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
+    expect(commands).toEqual([]);
+  });
+
+  it('fails an npm-layout rollback target that lacks packaged UI assets without attempting a repair build', () => {
+    const slotDir = join('tmp', 'releases', 'b');
+    const commands: string[] = [];
+    const errors: string[] = [];
+    const io = makeIo({
+      existsSync: () => false,
+      readFileSync: () => '{"dependencies":{"@origintrail-official/dkg-node-ui":"10.0.0"}}',
+      execSync: (command: string) => {
+        commands.push(command);
+        return '';
+      },
+      error: (message) => errors.push(message),
+    });
+
+    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(false);
+    expect(commands).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Slot b has no Node UI static bundle');
+    expect(errors[0]).toContain('Run "dkg update" first');
+  });
+});

--- a/packages/cli/test/rollback-node-ui.test.ts
+++ b/packages/cli/test/rollback-node-ui.test.ts
@@ -14,7 +14,6 @@ function makeIo(overrides: Partial<RollbackNodeUiIo>): RollbackNodeUiIo {
       throw new Error('unexpected read');
     },
     rmSync: () => {},
-    renameSync: () => {},
     execSync: () => '',
     log: () => {},
     error: () => {},
@@ -29,7 +28,6 @@ describe('ensureRollbackNodeUiBundle', () => {
     let built = false;
     const commands: string[] = [];
     const removed: string[] = [];
-    const renamed: string[] = [];
     const logs: string[] = [];
     const errors: string[] = [];
     const io = makeIo({
@@ -41,9 +39,6 @@ describe('ensureRollbackNodeUiBundle', () => {
       },
       rmSync: (path) => {
         removed.push(normalizePath(path));
-      },
-      renameSync: (oldPath, newPath) => {
-        renamed.push(`${normalizePath(oldPath)} -> ${normalizePath(newPath)}`);
       },
       execSync: (command: string, options?: ExecSyncOptionsWithStringEncoding) => {
         commands.push(command);
@@ -58,106 +53,41 @@ describe('ensureRollbackNodeUiBundle', () => {
 
     expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
     expect(removed).toEqual([
-      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
       normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui')),
-      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
     ]);
-    expect(renamed).toEqual([]);
     expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
     expect(logs).toEqual(['Slot b has no Node UI static bundle; building UI assets before rollback...']);
     expect(errors).toEqual([]);
   });
 
-  it('rebuilds an existing git-layout Node UI bundle so stale assets cannot satisfy rollback', () => {
+  it('accepts an existing git-layout Node UI bundle without rebuilding during rollback', () => {
     const slotDir = join('tmp', 'releases', 'b');
     const gitIndex = join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html');
-    let cleared = false;
-    let built = false;
     const commands: string[] = [];
     const removed: string[] = [];
-    const renamed: string[] = [];
     const logs: string[] = [];
     const io = makeIo({
       existsSync: (path) => {
         const normalized = normalizePath(path);
         if (normalized.endsWith('/packages/cli/dist/cli.js')) return true;
-        if (path === gitIndex) return !cleared || built;
+        if (path === gitIndex) return true;
         return false;
       },
       readFileSync: () => '{"name":"@origintrail-official/dkg-node-ui"}',
       rmSync: (path) => {
         removed.push(normalizePath(path));
-        cleared = true;
-      },
-      renameSync: (oldPath, newPath) => {
-        renamed.push(`${normalizePath(oldPath)} -> ${normalizePath(newPath)}`);
       },
       execSync: (command: string) => {
         commands.push(command);
-        built = true;
         return '';
       },
       log: (message) => logs.push(message),
     });
 
     expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
-    expect(removed).toEqual([
-      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
-      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
-    ]);
-    expect(renamed).toEqual([
-      `${normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui'))} -> ${normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`)}`,
-    ]);
-    expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
-    expect(logs).toEqual(['Slot b has an existing Node UI static bundle; rebuilding UI assets before rollback...']);
-  });
-
-  it('restores an existing git-layout Node UI bundle when rollback rebuild fails', () => {
-    const slotDir = join('tmp', 'releases', 'b');
-    const gitDist = join(slotDir, 'packages', 'node-ui', 'dist-ui');
-    const gitIndex = join(gitDist, 'index.html');
-    const backupDist = `${gitDist}.rollback-backup`;
-    let activeBundle = true;
-    let backupBundle = false;
-    const commands: string[] = [];
-    const errors: string[] = [];
-    const io = makeIo({
-      existsSync: (path) => {
-        const normalized = normalizePath(path);
-        if (normalized.endsWith('/packages/cli/dist/cli.js')) return true;
-        if (path === gitIndex) return activeBundle;
-        return false;
-      },
-      readFileSync: () => '{"name":"@origintrail-official/dkg-node-ui"}',
-      rmSync: (path) => {
-        if (path === gitDist) activeBundle = false;
-        if (path === backupDist) backupBundle = false;
-      },
-      renameSync: (oldPath, newPath) => {
-        if (oldPath === gitDist && newPath === backupDist) {
-          activeBundle = false;
-          backupBundle = true;
-          return;
-        }
-        if (oldPath === backupDist && newPath === gitDist) {
-          backupBundle = false;
-          activeBundle = true;
-        }
-      },
-      execSync: (command: string) => {
-        commands.push(command);
-        throw new Error('vite exploded');
-      },
-      error: (message) => errors.push(message),
-    });
-
-    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(false);
-    expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
-    expect(activeBundle).toBe(true);
-    expect(backupBundle).toBe(false);
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toContain('Rollback aborted: failed to build Node UI static bundle');
-    expect(errors[0]).toContain('vite exploded');
+    expect(removed).toEqual([]);
+    expect(commands).toEqual([]);
+    expect(logs).toEqual([]);
   });
 
   it('fails a git-layout rollback when the UI build cannot produce index.html', () => {

--- a/packages/cli/test/rollback-node-ui.test.ts
+++ b/packages/cli/test/rollback-node-ui.test.ts
@@ -13,6 +13,7 @@ function makeIo(overrides: Partial<RollbackNodeUiIo>): RollbackNodeUiIo {
     readFileSync: () => {
       throw new Error('unexpected read');
     },
+    rmSync: () => {},
     execSync: () => '',
     log: () => {},
     error: () => {},
@@ -26,6 +27,7 @@ describe('ensureRollbackNodeUiBundle', () => {
     const gitIndex = join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html');
     let built = false;
     const commands: string[] = [];
+    const removed: string[] = [];
     const logs: string[] = [];
     const errors: string[] = [];
     const io = makeIo({
@@ -34,6 +36,9 @@ describe('ensureRollbackNodeUiBundle', () => {
       readFileSync: (path) => {
         expect(normalizePath(path)).toContain('/packages/node-ui/package.json');
         return '{"name":"@origintrail-official/dkg-node-ui"}';
+      },
+      rmSync: (path) => {
+        removed.push(normalizePath(path));
       },
       execSync: (command: string, options?: ExecSyncOptionsWithStringEncoding) => {
         commands.push(command);
@@ -47,9 +52,44 @@ describe('ensureRollbackNodeUiBundle', () => {
     });
 
     expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
+    expect(removed).toEqual([normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui'))]);
     expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
     expect(logs).toEqual(['Slot b has no Node UI static bundle; building UI assets before rollback...']);
     expect(errors).toEqual([]);
+  });
+
+  it('rebuilds an existing git-layout Node UI bundle so stale assets cannot satisfy rollback', () => {
+    const slotDir = join('tmp', 'releases', 'b');
+    const gitIndex = join(slotDir, 'packages', 'node-ui', 'dist-ui', 'index.html');
+    let cleared = false;
+    let built = false;
+    const commands: string[] = [];
+    const removed: string[] = [];
+    const logs: string[] = [];
+    const io = makeIo({
+      existsSync: (path) => {
+        const normalized = normalizePath(path);
+        if (normalized.endsWith('/packages/cli/dist/cli.js')) return true;
+        if (path === gitIndex) return !cleared || built;
+        return false;
+      },
+      readFileSync: () => '{"name":"@origintrail-official/dkg-node-ui"}',
+      rmSync: (path) => {
+        removed.push(normalizePath(path));
+        cleared = true;
+      },
+      execSync: (command: string) => {
+        commands.push(command);
+        built = true;
+        return '';
+      },
+      log: (message) => logs.push(message),
+    });
+
+    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
+    expect(removed).toEqual([normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui'))]);
+    expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
+    expect(logs).toEqual(['Slot b has an existing Node UI static bundle; rebuilding UI assets before rollback...']);
   });
 
   it('fails a git-layout rollback when the UI build cannot produce index.html', () => {

--- a/packages/cli/test/rollback-node-ui.test.ts
+++ b/packages/cli/test/rollback-node-ui.test.ts
@@ -14,6 +14,7 @@ function makeIo(overrides: Partial<RollbackNodeUiIo>): RollbackNodeUiIo {
       throw new Error('unexpected read');
     },
     rmSync: () => {},
+    renameSync: () => {},
     execSync: () => '',
     log: () => {},
     error: () => {},
@@ -28,6 +29,7 @@ describe('ensureRollbackNodeUiBundle', () => {
     let built = false;
     const commands: string[] = [];
     const removed: string[] = [];
+    const renamed: string[] = [];
     const logs: string[] = [];
     const errors: string[] = [];
     const io = makeIo({
@@ -39,6 +41,9 @@ describe('ensureRollbackNodeUiBundle', () => {
       },
       rmSync: (path) => {
         removed.push(normalizePath(path));
+      },
+      renameSync: (oldPath, newPath) => {
+        renamed.push(`${normalizePath(oldPath)} -> ${normalizePath(newPath)}`);
       },
       execSync: (command: string, options?: ExecSyncOptionsWithStringEncoding) => {
         commands.push(command);
@@ -52,7 +57,12 @@ describe('ensureRollbackNodeUiBundle', () => {
     });
 
     expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
-    expect(removed).toEqual([normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui'))]);
+    expect(removed).toEqual([
+      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
+      normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui')),
+      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
+    ]);
+    expect(renamed).toEqual([]);
     expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
     expect(logs).toEqual(['Slot b has no Node UI static bundle; building UI assets before rollback...']);
     expect(errors).toEqual([]);
@@ -65,6 +75,7 @@ describe('ensureRollbackNodeUiBundle', () => {
     let built = false;
     const commands: string[] = [];
     const removed: string[] = [];
+    const renamed: string[] = [];
     const logs: string[] = [];
     const io = makeIo({
       existsSync: (path) => {
@@ -78,6 +89,9 @@ describe('ensureRollbackNodeUiBundle', () => {
         removed.push(normalizePath(path));
         cleared = true;
       },
+      renameSync: (oldPath, newPath) => {
+        renamed.push(`${normalizePath(oldPath)} -> ${normalizePath(newPath)}`);
+      },
       execSync: (command: string) => {
         commands.push(command);
         built = true;
@@ -87,9 +101,63 @@ describe('ensureRollbackNodeUiBundle', () => {
     });
 
     expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(true);
-    expect(removed).toEqual([normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui'))]);
+    expect(removed).toEqual([
+      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
+      normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`),
+    ]);
+    expect(renamed).toEqual([
+      `${normalizePath(join(slotDir, 'packages', 'node-ui', 'dist-ui'))} -> ${normalizePath(`${join(slotDir, 'packages', 'node-ui', 'dist-ui')}.rollback-backup`)}`,
+    ]);
     expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
     expect(logs).toEqual(['Slot b has an existing Node UI static bundle; rebuilding UI assets before rollback...']);
+  });
+
+  it('restores an existing git-layout Node UI bundle when rollback rebuild fails', () => {
+    const slotDir = join('tmp', 'releases', 'b');
+    const gitDist = join(slotDir, 'packages', 'node-ui', 'dist-ui');
+    const gitIndex = join(gitDist, 'index.html');
+    const backupDist = `${gitDist}.rollback-backup`;
+    let activeBundle = true;
+    let backupBundle = false;
+    const commands: string[] = [];
+    const errors: string[] = [];
+    const io = makeIo({
+      existsSync: (path) => {
+        const normalized = normalizePath(path);
+        if (normalized.endsWith('/packages/cli/dist/cli.js')) return true;
+        if (path === gitIndex) return activeBundle;
+        return false;
+      },
+      readFileSync: () => '{"name":"@origintrail-official/dkg-node-ui"}',
+      rmSync: (path) => {
+        if (path === gitDist) activeBundle = false;
+        if (path === backupDist) backupBundle = false;
+      },
+      renameSync: (oldPath, newPath) => {
+        if (oldPath === gitDist && newPath === backupDist) {
+          activeBundle = false;
+          backupBundle = true;
+          return;
+        }
+        if (oldPath === backupDist && newPath === gitDist) {
+          backupBundle = false;
+          activeBundle = true;
+        }
+      },
+      execSync: (command: string) => {
+        commands.push(command);
+        throw new Error('vite exploded');
+      },
+      error: (message) => errors.push(message),
+    });
+
+    expect(ensureRollbackNodeUiBundle(slotDir, 'b', io)).toBe(false);
+    expect(commands).toEqual(['pnpm --filter @origintrail-official/dkg-node-ui run build:ui']);
+    expect(activeBundle).toBe(true);
+    expect(backupBundle).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Rollback aborted: failed to build Node UI static bundle');
+    expect(errors[0]).toContain('vite exploded');
   });
 
   it('fails a git-layout rollback when the UI build cannot produce index.html', () => {


### PR DESCRIPTION
## Summary

- Builds the Node UI Vite static bundle in git blue-green target slots before update activation, resolving the Node UI workspace name from the target ref with current and legacy package-name fallbacks.
- Adds `build:runtime:packages` plus explicit `dkgBuild.releaseRuntimeBuildScript` metadata so new updater/migration code can run runtime packages and Node UI static assets as separate timed steps, while keeping `build:runtime` UI-inclusive for older updaters.
- Requires the correct Node UI `dist-ui/index.html` artifact before update activation can swap: git-layout updates require `packages/node-ui/dist-ui/index.html`, while npm-layout updates require packaged UI candidates declared by installed CLI metadata when readable.
- Keeps rollback as a recovery path: existing git `dist-ui/index.html` is accepted, missing git UI is built before activation, and npm-layout rollback remains deterministic packaged-assets check-only.
- Keeps startup live-slot UI repair best-effort with clear fallback-page logging, and keeps `dkg update` from mutating the currently served slot during migration preflight.

## Related

Fixes #347

## Files changed

| File | What |
|------|------|
| `package.json` | Adds runtime-only `build:runtime:packages`, explicit release runtime build metadata, and keeps `build:runtime` as the UI-inclusive older-updater compatibility wrapper. |
| `packages/cli/src/daemon/auto-update.ts` | Adds target-slot Node UI build command resolution, clears stale git `dist-ui`, strict git UI artifact gating, npm-layout UI gating, shared runtime build command selection, and separate timed `build:ui`. |
| `packages/cli/src/migration.ts` | Builds/repairs git Node UI assets during slot bootstrap with layout-specific readiness, shared runtime build fallback rules, caller-specific live-slot repair behavior, and no-current repair ordering. |
| `packages/cli/src/cli.ts` | Routes rollback through the shared Node UI readiness helper before stopping the daemon or swapping slots. |
| `packages/cli/src/node-ui-static.ts` | Centralizes Node UI package names, build commands, explicit runtime build command selection, git artifact paths, npm artifact candidates, slot layout detection, and installed-package metadata resolution. |
| `packages/cli/src/rollback-node-ui.ts` | Encapsulates rollback UI readiness: existing git UI is accepted, missing git UI is built before activation, and npm slots are packaged-assets check-only. |
| `packages/cli/test/auto-update.test.ts` | Covers UI build ordering/fallback, runtime-only package build preference, runtime wrapper fallback, stale `dist-ui` cleanup, legacy package-name refs, missing git/npm UI artifacts, mixed npm package artifacts, and UI build failure before swap. |
| `packages/cli/test/migration.test.ts` | Covers migration UI build/repair behavior, runtime-only bootstrap preference, runtime wrapper fallback, full build fallback, npm-layout check-only failure, legacy package-name refs, best-effort live repair, and no-current fail-closed/recovery behavior. |
| `packages/cli/test/node-ui-static.test.ts` | Covers git, npm, nested npm, package-scoped Node UI artifact candidates, explicit runtime build command selection, unsafe metadata fallback, and wrapper-drift fallback. |
| `packages/cli/test/rollback-node-ui.test.ts` | Covers git rollback missing-UI repair, existing git UI acceptance, git UI build failure, npm packaged UI success, and npm missing-UI fail-closed behavior. |
| `RELEASE_PROCESS.md` | Documents UI-inclusive blue-green release-slot requirements and the runtime/UI build split. |
| `docs/testing/AUTO_UPDATE_LOCAL_TESTING.md` | Updates local auto-update testing expectations for Node UI static assets. |

## Test plan

- [x] `pnpm install --frozen-lockfile` completed successfully.
- [x] `pnpm build:runtime` passes and produces `packages/node-ui/dist-ui/index.html` through the compatibility wrapper.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build:ui` passes and `packages/node-ui/dist-ui/index.html` exists.
- [x] `pnpm --dir packages/cli exec vitest run --config ..\..\vitest.evm-integration.ts test\node-ui-static.test.ts test\rollback-node-ui.test.ts` passes 12 helper/rollback tests.
- [x] `pnpm --dir packages/cli exec vitest run --config ..\..\vitest.evm-integration.ts test\auto-update.test.ts -t "runtime package build|runtime-only package script|Node UI workspace package name|git Node UI static bundle is missing|Node UI static build fails"` passes 5 focused auto-update tests.
- [x] `pnpm --dir packages/cli exec vitest run --config ..\..\vitest.evm-integration.ts test\auto-update.test.ts -t "runtime package build|runtime-only package script|Node UI workspace package name|git Node UI static bundle is missing|Node UI static build fails|npm Node UI static bundle|legacy npm UI bundle"` previously passed 7 focused auto-update tests.
- [x] `pnpm --dir packages/cli exec vitest run --config ..\..\vitest.evm-integration.ts test\migration.test.ts -t "migration builds slot A|falls back to build:runtime|falls back to pnpm build|npm-layout slots|no slot can provide"` passes 6 focused migration tests.
- [x] `git diff --check` passes.
- [x] Manual old-updater smoke: `dkg update codex/fix-blue-green-ui-build-347 --no-verify-tag`, then `test -f "$SLOT/packages/node-ui/dist-ui/index.html"` prints `PASS: Node UI static bundle ready`.
- [ ] Full local migration/blue-green integration suites are blocked on this Windows machine by existing symlink `EPERM` limitations; GitHub Linux CI previously confirmed `test/migration.test.ts` passes.