### PR TITLE
fix libp2p recursion issue

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1078,9 +1078,9 @@ export class DKGAgent {
    * to incoming gossip with an opportunistic dial, we restore the path long
    * before the application-layer sync protocol is invoked.
    *
-   * Best-effort only: we try peerStore-known multiaddrs first, then fall
-   * back to constructing `/p2p-circuit` multiaddrs through each configured
-   * relay. Failures are logged but never surface to the caller.
+   * Best-effort only: for each configured relay that we are already connected
+   * to, construct an explicit `/p2p-circuit` multiaddr and dial. Failures are
+   * logged but never surface to the caller.
    */
   private async maybeDialGossipSender(peerIdStr: string): Promise<void> {
     const selfPeerId = this.node.libp2p.peerId.toString();
@@ -1101,30 +1101,24 @@ export class DKGAgent {
     const shortPeer = peerIdStr.slice(-8);
 
     const { peerIdFromString } = await import('@libp2p/peer-id');
-    let peerId: ReturnType<typeof peerIdFromString>;
     try {
-      peerId = peerIdFromString(peerIdStr);
+      peerIdFromString(peerIdStr);
     } catch (err) {
       this.log.warn(ctx, `Skipping gossip redial for invalid peer id ${shortPeer}: ${err instanceof Error ? err.message : String(err)}`);
       return;
     }
 
-    // First pass: let libp2p try whatever addresses it already knows about
-    // for this peer (direct multiaddrs from identify, previous relay
-    // addresses from peerStore, etc.).
-    try {
-      await this.node.libp2p.dial(peerId, { signal: AbortSignal.timeout(GOSSIP_DIAL_TIMEOUT_MS) });
-      this.log.info(ctx, `Reconnect-on-gossip: dialed ${shortPeer} via peerStore`);
-      return;
-    } catch (err) {
-      this.log.info(ctx, `Reconnect-on-gossip: peerStore dial to ${shortPeer} failed (${err instanceof Error ? err.message : String(err)}); trying relay fallbacks`);
-    }
-
-    // Relay fallback: for each configured relay, construct an explicit
-    // circuit-relay multiaddr and dial. The first relay with a valid
-    // reservation for the sender wins.
     const relays = this.config.relayPeers ?? [];
+    const connectedPeers = new Set(this.node.libp2p.getPeers().map(p => p.toString()));
+    let skippedRelays = 0;
+
     for (const relayAddr of relays) {
+      const relayPeerId = relayAddr.match(/\/p2p\/([^/]+)/)?.[1];
+      if (relayPeerId == null || !connectedPeers.has(relayPeerId)) {
+        skippedRelays++;
+        continue;
+      }
+
       const circuitAddr = `${relayAddr}/p2p-circuit/p2p/${peerIdStr}`;
       try {
         await this.node.libp2p.dial(
@@ -1139,7 +1133,7 @@ export class DKGAgent {
       }
     }
 
-    this.log.info(ctx, `Reconnect-on-gossip: no path to ${shortPeer} via peerStore or ${relays.length} relay(s); will retry after cooldown`);
+    this.log.info(ctx, `Reconnect-on-gossip: no path to ${shortPeer} via ${relays.length - skippedRelays}/${relays.length} connected relay(s); will retry after cooldown`);
   }
 
   /**

--- a/packages/agent/test/p2p-resilience.test.ts
+++ b/packages/agent/test/p2p-resilience.test.ts
@@ -26,9 +26,13 @@ function freshPeerIdString(): string {
   return id;
 }
 
+function relayAddrFor(peerId: string): string {
+  return `/ip4/127.0.0.1/tcp/4001/p2p/${peerId}`;
+}
+
 describe('p2p resilience hooks', () => {
   describe('reconnect-on-gossip', () => {
-    it('dials the sender of a gossip message when not already connected', async () => {
+    it('dials the sender of a gossip message via a connected relay circuit', async () => {
       const agent = await DKGAgent.create({
         name: 'ReconnectOnGossipBasic',
         listenHost: '127.0.0.1',
@@ -38,7 +42,15 @@ describe('p2p resilience hooks', () => {
         await agent.start();
 
         const dialSpy = vi.spyOn(agent.node.libp2p, 'dial').mockResolvedValue({} as any);
+        const relayPeer = freshPeerIdString();
+        const relayAddr = relayAddrFor(relayPeer);
         const remotePeer = freshPeerIdString();
+        (agent as any).config.relayPeers = [relayAddr];
+
+        const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+        vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+          () => [...origGetPeers(), peerIdFromString(relayPeer)],
+        );
 
         agent.eventBus.emit(DKGEvent.GOSSIP_MESSAGE, {
           topic: 'dkg/context-graph/test/pub',
@@ -51,7 +63,35 @@ describe('p2p resilience hooks', () => {
           await new Promise(r => setTimeout(r, 20));
         }
 
-        expect(dialSpy).toHaveBeenCalled();
+        expect(dialSpy).toHaveBeenCalledTimes(1);
+        expect(dialSpy.mock.calls[0]?.[0].toString()).toBe(`${relayAddr}/p2p-circuit/p2p/${remotePeer}`);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+    it('does not dial when configured relays are not connected', async () => {
+      const agent = await DKGAgent.create({
+        name: 'ReconnectOnGossipSkipsDisconnectedRelay',
+        listenHost: '127.0.0.1',
+        chainAdapter: new MockChainAdapter(),
+      });
+      try {
+        await agent.start();
+
+        const dialSpy = vi.spyOn(agent.node.libp2p, 'dial').mockResolvedValue({} as any);
+        const relayPeer = freshPeerIdString();
+        const remotePeer = freshPeerIdString();
+        (agent as any).config.relayPeers = [relayAddrFor(relayPeer)];
+
+        agent.eventBus.emit(DKGEvent.GOSSIP_MESSAGE, {
+          topic: 'dkg/context-graph/test/pub',
+          data: new Uint8Array(),
+          from: remotePeer,
+        });
+
+        await new Promise(r => setTimeout(r, 150));
+        expect(dialSpy).not.toHaveBeenCalled();
       } finally {
         await agent.stop().catch(() => {});
       }
@@ -126,7 +166,15 @@ describe('p2p resilience hooks', () => {
         // Mocked dial always rejects so no real path is created; we only
         // care about how many times maybeDialGossipSender *attempted* it.
         const dialSpy = vi.spyOn(agent.node.libp2p, 'dial').mockRejectedValue(new Error('no route'));
+        const relayPeer = freshPeerIdString();
+        const relayAddr = relayAddrFor(relayPeer);
         const remotePeer = freshPeerIdString();
+        (agent as any).config.relayPeers = [relayAddr];
+
+        const origGetPeers = agent.node.libp2p.getPeers.bind(agent.node.libp2p);
+        vi.spyOn(agent.node.libp2p, 'getPeers').mockImplementation(
+          () => [...origGetPeers(), peerIdFromString(relayPeer)],
+        );
 
         for (let i = 0; i < 5; i++) {
           agent.eventBus.emit(DKGEvent.GOSSIP_MESSAGE, {
@@ -136,14 +184,12 @@ describe('p2p resilience hooks', () => {
           });
         }
 
-        // Let the async dial attempts settle. With no relayPeers configured
-        // the method returns after the single peerStore dial, so ~200ms is
-        // plenty.
+        // Let the async dial attempt settle.
         await new Promise(r => setTimeout(r, 250));
 
-        // All 5 bursts should collapse to exactly 1 dial attempt via the
-        // peerStore path (no relayPeers configured → no relay fallbacks).
+        // All 5 bursts should collapse to exactly 1 explicit relay circuit dial.
         expect(dialSpy).toHaveBeenCalledTimes(1);
+        expect(dialSpy.mock.calls[0]?.[0].toString()).toBe(`${relayAddr}/p2p-circuit/p2p/${remotePeer}`);
       } finally {
         await agent.stop().catch(() => {});
       }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Why is it needed? -->

## Changes
 ## Summary
  - Remove reconnect-on-gossip peerStore dialing to avoid libp2p recursive progress callback stack overflows.
  - Dial only explicit `/p2p-circuit` multiaddrs through configured relays that are already connected.
  - Update p2p resilience tests for connected relay dialing, disconnected relay skipping, and cooldown behavior.

  ## Verification
  - `pnpm --filter @origintrail-official/dkg-agent exec vitest run test/p2p-resilience.test.ts`
<!-- Key changes, grouped logically. -->

-

## Test Plan

<!-- How was this tested? What should reviewers check? -->

- [x] Tests pass locally (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Manually tested with `dkg start` (if applicable)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
