### PR TITLE
chore(release): align all monorepo packages to 10.0.0-rc.2

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-demo",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/adapter-autoresearch/package.json
+++ b/packages/adapter-autoresearch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-autoresearch",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "description": "Autoresearch adapter — collaborative autonomous ML research over the Decentralized Knowledge Graph",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V9 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/openclaw.plugin.json
+++ b/packages/adapter-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "adapter-openclaw",
   "name": "DKG Node UI Bridge",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "description": "Connects a local OpenClaw agent to a DKG V10 node for node-backed chat, memory, and agent-network capabilities.",
   "kind": "memory",
   "channels": ["dkg-ui"],

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/attested-assets/package.json
+++ b/packages/attested-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-attested-assets",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/src/index.ts
+++ b/packages/random-sampling/src/index.ts
@@ -18,7 +18,7 @@
  * registered.
  */
 
-export const RANDOM_SAMPLING_PACKAGE_VERSION = '10.0.0-rc.1';
+export const RANDOM_SAMPLING_PACKAGE_VERSION = '10.0.0-rc.2';
 
 export {
   extractV10KCFromStore,

--- a/packages/random-sampling/test/skeleton.test.ts
+++ b/packages/random-sampling/test/skeleton.test.ts
@@ -3,6 +3,6 @@ import { RANDOM_SAMPLING_PACKAGE_VERSION } from '../src/index.js';
 
 describe('@origintrail-official/dkg-random-sampling — skeleton', () => {
   it('exposes a version constant matching the rest of the workspace', () => {
-    expect(RANDOM_SAMPLING_PACKAGE_VERSION).toBe('10.0.0-rc.1');
+    expect(RANDOM_SAMPLING_PACKAGE_VERSION).toBe('10.0.0-rc.2');
   });
 });

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.1",
+  "version": "10.0.0-rc.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

After PR #357 merged, the monorepo had drift: 4 packages at `10.0.0-rc.2` (root, `@origintrail-official/dkg`, evm-module, mcp-server) and 17 still at `10.0.0-rc.1` (15 public + 2 private). This bumps the lagging 17 so the next manual `pnpm -r publish --tag latest` from the `v10.0.0-rc.2` tag publishes a **coherent** set of versions where `@origintrail-official/dkg` resolves matching versions of its workspace deps.

Also updates the three mirror sites:
- `packages/random-sampling/src/index.ts` — `RANDOM_SAMPLING_PACKAGE_VERSION` constant
- `packages/random-sampling/test/skeleton.test.ts` — its assertion
- `packages/adapter-openclaw/openclaw.plugin.json` — plugin manifest version

Left unchanged on purpose:
- `packages/cli/test/chain-reset-wipe.test.ts:51` — literal fixture value for chain-reset behaviour
- `.github/workflows/npm-continuous-publish.yml:3` — example in a comment
- `@origintrail-official/dkg-mcp` (`0.1.0`) — distinct internal versioning track

## Test plan

- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm -r build` clean
- [x] `dkg-random-sampling` tests pass (42/42) including the bumped version assertion
- [ ] Once green: merge → tag `v10.0.0-rc.2` → run `release.yml` → manual `pnpm -r publish --no-git-checks --tag latest`


Made with [Cursor](https://cursor.com)