### PR TITLE
Fix Telegram chat turn persistence

### DIFF
--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -12,12 +12,10 @@ import { createHash } from "crypto";
  * Create failures roll back marker snapshots when `commitWatermarkStateSync`
  * fails; `setStateDir` migrates per-session `m`
  * markers, and graceful `DkgChannelPlugin.stop()` drains in-flight first writes.
- * Telegram persistence can arrive through typed `message_received/message_sent`
- * when typed `agent_end` is silent. Those events are normalized into the W4b
- * envelope and deduped against internal `message:received/message:sent` by
- * channel/account/conversation/messageId, outside the Node-UI marker space.
- * Typed W4b replay markers are retained and bound to provider message IDs so
- * repeated reset/compaction replays skip same-text occurrences safely.
+ * Telegram persistence is owned by W4a `agent_end` plus the colon-form
+ * internal W4b hooks (`message:received` / `message:sent`). W4b replay
+ * markers are retained and bound to provider message IDs so repeated
+ * reset/compaction replays skip same-text occurrences safely.
  */
 
 interface Logger {
@@ -130,8 +128,8 @@ export class ChatTurnWriter {
   // first reply are both retained; `onMessageSent` consumes the oldest so the
   // first outbound reply pairs with the first inbound, not the most recent.
   private pendingUserMessages: Map<string, string[]> = new Map();
-  // Parallel metadata queue for pending user messages. Typed `message_sent`
-  // lacks an outbound messageId in OpenClaw 2026.4.15, so we carry the inbound
+  // Parallel metadata queue for pending user messages. Some gateway
+  // `message:sent` envelopes lack an outbound messageId, so we carry the inbound
   // provider messageId forward and use it as the durable W4b turnId
   // discriminator when the outbound envelope cannot provide one.
   private pendingUserMessageMeta: Map<string, PendingUserMessageMeta[]> = new Map();
@@ -2064,20 +2062,49 @@ export class ChatTurnWriter {
     //     intermediate steps that included assistant text alongside
     //     the tool call, so the tool-call step was paired as a turn
     //     and the real final reply ended up paired with an empty user.
-    // Both shapes are handled by accumulating consecutive user messages
-    // into a queue and flushing the queue (joined) into the next
-    // non-tool-call assistant turn. Any assistant carrying tool calls
-    // is treated as intermediate regardless of whether it also has
-    // text content.
+    // Both shapes are handled by accumulating consecutive real user
+    // messages, keeping the latest textual non-tool assistant candidate,
+    // and flushing only when the next real user arrives (or the transcript
+    // ends). Any assistant carrying tool calls is treated as intermediate
+    // regardless of whether it also has text content.
     const pendingUsers: Array<{
       text: string;
       externalTurnIds: string[];
       externalDirect: boolean;
       messageIds: string[];
     }> = [];
+    let pendingAssistant: {
+      text: string;
+      assistantMessageIds: string[];
+    } | null = null;
     let pairIndex = 0;
+    const flushPair = () => {
+      if (!pendingAssistant || pendingUsers.length === 0) return;
+      const userText = pendingUsers.map((pending) => pending.text).join("\n");
+      const externalDirect = pendingUsers.length === 1 && pendingUsers[0].externalDirect;
+      const externalTurnIds = externalDirect
+        ? Array.from(new Set(pendingUsers.flatMap((pending) => pending.externalTurnIds)))
+        : [];
+      const messageIds = Array.from(new Set(pendingUsers.flatMap((pending) => pending.messageIds)));
+      pendingUsers.length = 0;
+      if (pairIndex > savedUpTo) {
+        pairs.push({
+          user: userText,
+          assistant: this.stripRecalledMemory(pendingAssistant.text),
+          pairIndex,
+          externalTurnIds,
+          externalDirect,
+          messageIds,
+          assistantMessageIds: pendingAssistant.assistantMessageIds,
+        });
+      }
+      pendingAssistant = null;
+      pairIndex++;
+    };
     for (const msg of messages) {
+      if (this.isTranscriptScaffoldingMessage(msg)) continue;
       if (msg.role === "user") {
+        flushPair();
         // T28 — Skip image/attachment-only user messages whose
         // `extractText()` returns "" (the multi-modal content array
         // contained no `type === "text"` parts). W4b's
@@ -2097,15 +2124,14 @@ export class ChatTurnWriter {
         }
       } else if (msg.role === "assistant") {
         const text = this.extractText(msg.content);
-        const hasToolCalls = Array.isArray(msg.toolCalls) ? msg.toolCalls.length > 0
-          : Array.isArray(msg.tool_calls) ? msg.tool_calls.length > 0
-          : false;
+        const hasToolCalls = this.hasToolCalls(msg);
         if (hasToolCalls) {
           // Intermediate tool-call step — do NOT count as a pair, do NOT
           // advance pairIndex (the watermark counts user-visible turns),
           // and do NOT consume `pendingUsers`. The next non-tool-call
           // assistant is the real final reply that belongs to the
           // accumulated user side.
+          pendingAssistant = null;
           continue;
         }
         if (pendingUsers.length === 0) {
@@ -2135,30 +2161,42 @@ export class ChatTurnWriter {
           // put so a later real reply gets the same index.
           continue;
         }
-        const userText = pendingUsers.map((pending) => pending.text).join("\n");
-        const externalDirect = pendingUsers.length === 1 && pendingUsers[0].externalDirect;
-        const externalTurnIds = externalDirect
-          ? Array.from(new Set(pendingUsers.flatMap((pending) => pending.externalTurnIds)))
-          : [];
-        const messageIds = Array.from(new Set(pendingUsers.flatMap((pending) => pending.messageIds)));
-        const assistantMessageIds = this.extractMessageIds(msg);
-        pendingUsers.length = 0;
-        if (pairIndex > savedUpTo) {
-          pairs.push({
-            user: userText,
-            assistant: this.stripRecalledMemory(text),
-            pairIndex,
-            externalTurnIds,
-            externalDirect,
-            messageIds,
-            assistantMessageIds,
-          });
-        }
-        pairIndex++;
+        pendingAssistant = {
+          text,
+          assistantMessageIds: this.extractMessageIds(msg),
+        };
       }
       // Skip `tool` and `system` messages — they don't form turns.
     }
+    flushPair();
     return pairs;
+  }
+
+  private hasToolCalls(msg: ChatTurnMessage): boolean {
+    const context = msg.context && typeof msg.context === "object" ? msg.context : {};
+    const metadata = msg.metadata && typeof msg.metadata === "object" ? msg.metadata : {};
+    return [
+      (msg as any).toolCalls,
+      (msg as any).tool_calls,
+      (context as any).toolCalls,
+      (context as any).tool_calls,
+      (metadata as any).toolCalls,
+      (metadata as any).tool_calls,
+    ].some((value) => Array.isArray(value) && value.length > 0);
+  }
+
+  private isTranscriptScaffoldingMessage(msg: ChatTurnMessage): boolean {
+    const role = (msg as any)?.role;
+    if (role === "system" || role === "tool" || role === "function") return true;
+    const context = msg.context && typeof msg.context === "object" ? msg.context : {};
+    const metadata = msg.metadata && typeof msg.metadata === "object" ? msg.metadata : {};
+    const values = [msg as any, context as any, metadata as any];
+    return values.some((value) =>
+      value.toolCallId !== undefined ||
+      value.tool_call_id !== undefined ||
+      value.toolResult === true ||
+      value.tool_result === true,
+    );
   }
 
   /**

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1248,7 +1248,7 @@ export class ChatTurnWriter {
       // so we don't write a turn whose state was about to be wiped.
       const pendingReset = this.pendingResets.get(sessionId);
       if (pendingReset) await pendingReset;
-      this.promotePendingInboundQueueForOutbound(conversationKey, ev);
+      this.promotePendingInboundQueueForOutbound(conversationKey);
       const success = (ev as any)?.context?.success ?? (ev as any)?.success;
       // Drop failed outbound sends: chat history should not show replies the
       // user never received. Consume the SAME set of pending inbounds that
@@ -1722,7 +1722,6 @@ export class ChatTurnWriter {
   private shouldMoveInboundQueueForOutbound(
     existingKey: string,
     targetKey: string,
-    outboundUsesTypedSessionIdFallback: boolean,
   ): boolean {
     const existing = this.parseComposedSessionId(existingKey);
     const target = this.parseComposedSessionId(targetKey);
@@ -1733,25 +1732,20 @@ export class ChatTurnWriter {
     if (existing.conversationId !== target.conversationId) return false;
     const existingWeak = this.isWeakSessionKey(existing.sessionKey);
     const targetWeak = this.isWeakSessionKey(target.sessionKey);
+    if (existingWeak !== targetWeak) return true;
     if (this.pendingQueueUsesTypedSessionFallback(existingKey) && !targetWeak) return true;
-    if (existingWeak === targetWeak) return false;
-    if (targetWeak) return this.pendingQueueUsesTypedSessionFallback(existingKey);
-    return outboundUsesTypedSessionIdFallback;
+    return false;
   }
 
-  private promotePendingInboundQueueForOutbound(targetKey: string, ev: InternalMessageEvent): void {
-    const targetQueue = this.pendingUserMessages.get(targetKey);
-    if (targetQueue && targetQueue.length > 0) return;
-    const outboundUsesTypedSessionIdFallback = (ev as any)?.context?.typedSessionIdFallback === true;
+  private promotePendingInboundQueueForOutbound(targetKey: string): void {
     const candidates: string[] = [];
     for (const [candidateKey, messages] of Array.from(this.pendingUserMessages.entries())) {
       if (candidateKey === targetKey || !messages || messages.length === 0) continue;
-      if (this.shouldMoveInboundQueueForOutbound(candidateKey, targetKey, outboundUsesTypedSessionIdFallback)) {
+      if (this.shouldMoveInboundQueueForOutbound(candidateKey, targetKey)) {
         candidates.push(candidateKey);
       }
     }
-    if (candidates.length !== 1) return;
-    this.movePendingInboundQueue(candidates[0], targetKey);
+    for (const candidateKey of candidates) this.movePendingInboundQueue(candidateKey, targetKey);
   }
 
   private movePendingInboundQueue(fromKey: string, toKey: string): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -183,6 +183,7 @@ export class ChatTurnWriter {
   // persist jobs here, otherwise the reset assumption "all persists for
   // this session are tracked" is silently violated.
   private inFlightPersists: Map<string, Set<Promise<void>>> = new Map();
+  private promotedSessionIds: Map<string, string> = new Map();
   // Per-session reset promises. `onAgentEnd` / `onMessageSent` await these
   // before processing so a compacted message array can't be read against
   // a stale watermark while the reset is still draining.
@@ -695,13 +696,26 @@ export class ChatTurnWriter {
     const job = run();
     bucket.add(job);
     job.finally(() => {
-      const b = this.inFlightPersists.get(sessionId);
-      if (b) {
-        b.delete(job);
-        if (b.size === 0) this.inFlightPersists.delete(sessionId);
-      }
+      this.deleteTrackedPersistJob(sessionId, job);
     }).catch(() => {});
     return job;
+  }
+
+  private deleteTrackedPersistJob(sessionId: string, job: Promise<void>): void {
+    const candidates = new Set([sessionId, this.resolvePromotedSessionId(sessionId)]);
+    let removed = false;
+    for (const candidate of candidates) {
+      const bucket = this.inFlightPersists.get(candidate);
+      if (!bucket) continue;
+      removed = bucket.delete(job) || removed;
+      if (bucket.size === 0) this.inFlightPersists.delete(candidate);
+    }
+    if (removed) return;
+    for (const [key, bucket] of Array.from(this.inFlightPersists.entries())) {
+      if (!bucket.delete(job)) continue;
+      if (bucket.size === 0) this.inFlightPersists.delete(key);
+      break;
+    }
   }
 
   async onBeforeCompaction(event: any, ctx?: any): Promise<void> {
@@ -889,6 +903,7 @@ export class ChatTurnWriter {
       // N turns" no longer maps to the new pair indices. Leaving stale
       // count would skip new pairs in `computeDelta`.
       this.w4bSessionCounts.delete(sessionId);
+      this.clearSessionPromotionAliases(sessionId);
     }
     this.clearMessageHookDedupForSessions(ids);
     // External markers record daemon-success facts from direct-channel
@@ -1168,13 +1183,14 @@ export class ChatTurnWriter {
           try {
             await this.persistOne(sessionId, userText, assistantText, turnId);
             daemonPersisted = true;
+            const completionSessionId = this.resolvePromotedSessionId(sessionId);
             // Post-success: stamp the content-only `w4bOrigin` key on
             // the SHORT-TTL cross-path map (T5) so a later W4a
             // `agent_end` last-pair peek can see that W4b already
             // persisted THIS turn and skip + bumpWatermark, but a
             // repeated same-content turn arriving outside the 5s
             // cross-path window doesn't false-dedup against this stamp.
-            this.markCrossPathStamp(sessionId, this.w4bOriginKey(userText, assistantText));
+            this.markCrossPathStamp(completionSessionId, this.w4bOriginKey(userText, assistantText));
             // R18.2 — Track the W4b session count so a later `agent_end`
             // (typically after a `setup-runtime → full` upgrade) sees a
             // raised `savedUpTo` floor in `computeDelta` and doesn't
@@ -1191,8 +1207,8 @@ export class ChatTurnWriter {
             // that ran out of pending users on chunk 1.
             if (userText) {
               this.w4bSessionCounts.set(
-                sessionId,
-                (this.w4bSessionCounts.get(sessionId) ?? 0) + 1,
+                completionSessionId,
+                (this.w4bSessionCounts.get(completionSessionId) ?? 0) + 1,
               );
               // T17 — Persist the new count to disk via the
               // debounced flush so a process restart preserves
@@ -1202,8 +1218,8 @@ export class ChatTurnWriter {
               // backfill (count resets to 0, watermark file is
               // still -1, savedUpTo computes to -1, computeDelta
               // emits everything).
-              if (!this.commitWatermarkStateSync(sessionId)) {
-                this.scheduleWatermarkFlush(sessionId, { retryOnFailure: true, attempts: 3 });
+              if (!this.commitWatermarkStateSync(completionSessionId)) {
+                this.scheduleWatermarkFlush(completionSessionId, { retryOnFailure: true, attempts: 3 });
                 throw new Error("Failed to write W4b chat-turn watermark");
               }
             }
@@ -1228,18 +1244,21 @@ export class ChatTurnWriter {
             // next outbound will collapse the full queue (old items +
             // new) into one user-side, matching W4a's pairing.
             if (queuedItems.length > 0) {
-              const restored = this.pendingUserMessages.get(conversationKey) ?? [];
+              const restoreKey = this.resolvePromotedSessionId(conversationKey);
+              const restored = this.pendingUserMessages.get(restoreKey) ?? [];
               restored.unshift(...queuedItems);
-              this.pendingUserMessages.set(conversationKey, restored);
-              const restoredMeta = this.pendingUserMessageMeta.get(conversationKey) ?? [];
+              this.pendingUserMessages.set(restoreKey, restored);
+              const restoredMeta = this.pendingUserMessageMeta.get(restoreKey) ?? [];
               restoredMeta.unshift(...queuedMeta);
-              this.pendingUserMessageMeta.set(conversationKey, restoredMeta);
+              this.pendingUserMessageMeta.set(restoreKey, restoredMeta);
             }
             // Release the in-flight reservation so a retry can proceed.
             // No `w4bOrigin` release needed — we don't stamp it pre-persist
             // anymore; only stamping happens post-success above.
             if (outboundDedupKey) this.deleteMessageHookDedupKey(outboundDedupKey);
             this.releaseTurnIdReservation(sessionId, w4bInflight);
+            const failureSessionId = this.resolvePromotedSessionId(sessionId);
+            if (failureSessionId !== sessionId) this.releaseTurnIdReservation(failureSessionId, w4bInflight);
             this.logger.error?.("[ChatTurnWriter.onMessageSent] Persist failed", { err });
           } finally {
             // T10 — Always release the cross-path in-flight reservation,
@@ -1248,6 +1267,8 @@ export class ChatTurnWriter {
             // 5s post-success window; on failure the reservation must
             // not leak to block legitimate later same-content turns.
             this.unmarkCrossPathInflight(sessionId, w4bOriginKey);
+            const finalSessionId = this.resolvePromotedSessionId(sessionId);
+            if (finalSessionId !== sessionId) this.unmarkCrossPathInflight(finalSessionId, w4bOriginKey);
           }
         }).catch(() => {});
       }
@@ -1444,8 +1465,12 @@ export class ChatTurnWriter {
   }
 
   private promoteSessionState(fromSessionId: string, strongSessionId: string): void {
+    this.recordSessionPromotion(fromSessionId, strongSessionId);
     let changed = false;
     let durableChanged = false;
+    if (this.promoteInFlightPersists(fromSessionId, strongSessionId)) {
+      changed = true;
+    }
     if (this.pendingUserMessages.has(fromSessionId) || this.pendingUserMessageMeta.has(fromSessionId)) {
       this.movePendingInboundQueue(fromSessionId, strongSessionId);
       changed = true;
@@ -1496,6 +1521,47 @@ export class ChatTurnWriter {
         fromSessionId,
         strongSessionId,
       });
+    }
+  }
+
+  private recordSessionPromotion(fromSessionId: string, strongSessionId: string): void {
+    const resolvedStrongSessionId = this.resolvePromotedSessionId(strongSessionId);
+    if (!fromSessionId || fromSessionId === resolvedStrongSessionId) return;
+    this.promotedSessionIds.set(fromSessionId, resolvedStrongSessionId);
+    for (const [alias, target] of Array.from(this.promotedSessionIds.entries())) {
+      if (target === fromSessionId) this.promotedSessionIds.set(alias, resolvedStrongSessionId);
+    }
+  }
+
+  private resolvePromotedSessionId(sessionId: string): string {
+    let current = sessionId;
+    const seen = new Set<string>();
+    while (current && !seen.has(current)) {
+      seen.add(current);
+      const next = this.promotedSessionIds.get(current);
+      if (!next || next === current) break;
+      current = next;
+    }
+    if (current && current !== sessionId) this.promotedSessionIds.set(sessionId, current);
+    return current || sessionId;
+  }
+
+  private promoteInFlightPersists(fromSessionId: string, strongSessionId: string): boolean {
+    const source = this.inFlightPersists.get(fromSessionId);
+    if (!source || source.size === 0) {
+      this.inFlightPersists.delete(fromSessionId);
+      return false;
+    }
+    const target = this.inFlightPersists.get(strongSessionId) ?? new Set<Promise<void>>();
+    for (const job of source) target.add(job);
+    this.inFlightPersists.set(strongSessionId, target);
+    this.inFlightPersists.delete(fromSessionId);
+    return true;
+  }
+
+  private clearSessionPromotionAliases(sessionId: string): void {
+    for (const [from, to] of Array.from(this.promotedSessionIds.entries())) {
+      if (from === sessionId || to === sessionId) this.promotedSessionIds.delete(from);
     }
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -188,13 +188,9 @@ export class ChatTurnWriter {
   // persist jobs here, otherwise the reset assumption "all persists for
   // this session are tracked" is silently violated.
   private inFlightPersists: Map<string, Set<Promise<void>>> = new Map();
-  // Job-scoped promotion target for in-flight persists. A conversationless
-  // sessionKey can later appear in many conversations, so promotion must never
-  // become a standing alias for future events.
-  private promotedPersistJobs: Map<Promise<void>, string> = new Map();
   // Job-scoped content origins for active W4b persists. These let a later W4a
-  // skip the exact promoted in-flight turn without copying short-TTL dedupe
-  // maps from a conversationless session into an unrelated concrete chat.
+  // skip the exact in-flight turn without copying queues/counts/jobs from a
+  // conversationless session into an unrelated concrete chat.
   private persistJobOriginKeys: Map<Promise<void>, Set<string>> = new Map();
   // Per-session reset promises. `onAgentEnd` / `onMessageSent` await these
   // before processing so a compacted message array can't be read against
@@ -628,6 +624,12 @@ export class ChatTurnWriter {
             }
             continue;
           }
+          const typedW4bInflightOrigins = this.typedW4bInflightOrigins(
+            user,
+            assistant,
+            messageIds,
+            assistantMessageIds,
+          );
           // W4a turnId mixes pair position into the hash so backfill of
           // two same-text pairs (e.g. user said "hi" twice) produces
           // distinct turnIds and BOTH persist.
@@ -644,6 +646,9 @@ export class ChatTurnWriter {
           // within the TTL window collide on the W4a→W4a self-stamp
           // (R13.1).
           if (i === lastIdx) {
+            if (this.hasAnyInFlightPersistOrigin(typedW4bInflightOrigins)) {
+              continue;
+            }
             const w4bOrigin = this.w4bOriginKey(user, assistant);
             if (this.peekCrossPathStamp(sessionId, w4bOrigin)) {
               // W4b already persisted this pair via `message:sent`. The
@@ -759,6 +764,21 @@ export class ChatTurnWriter {
     return false;
   }
 
+  private hasAnyInFlightPersistOrigin(originKeys: string[]): boolean {
+    const wanted = new Set(originKeys.filter((key) => key.length > 0));
+    if (wanted.size === 0) return false;
+    for (const bucket of this.inFlightPersists.values()) {
+      for (const job of bucket) {
+        const origins = this.persistJobOriginKeys.get(job);
+        if (!origins) continue;
+        for (const origin of wanted) {
+          if (origins.has(origin)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
   private hasW4bInflightOrigin(sessionIds: string[], originKey: string): boolean {
     for (const sessionId of Array.from(new Set(sessionIds))) {
       if (this.peekCrossPathInflight(sessionId, originKey) || this.hasInFlightPersistOrigin(sessionId, originKey)) {
@@ -769,17 +789,12 @@ export class ChatTurnWriter {
   }
 
   private deleteTrackedPersistJob(sessionId: string, job: Promise<void>): void {
-    const promotedSessionId = this.promotedPersistJobs.get(job);
-    const candidates = new Set([sessionId]);
-    if (promotedSessionId) candidates.add(promotedSessionId);
     let removed = false;
-    for (const candidate of candidates) {
-      const bucket = this.inFlightPersists.get(candidate);
-      if (!bucket) continue;
-      removed = bucket.delete(job) || removed;
-      if (bucket.size === 0) this.inFlightPersists.delete(candidate);
+    const bucket = this.inFlightPersists.get(sessionId);
+    if (bucket) {
+      removed = bucket.delete(job);
+      if (bucket.size === 0) this.inFlightPersists.delete(sessionId);
     }
-    this.promotedPersistJobs.delete(job);
     this.persistJobOriginKeys.delete(job);
     if (removed) return;
     for (const [key, bucket] of Array.from(this.inFlightPersists.entries())) {
@@ -1279,6 +1294,12 @@ export class ChatTurnWriter {
         // content turns within a session still get distinct ids
         // because their messageIds differ.
         const w4bDiscriminator = this.w4bDaemonTurnIdDiscriminator(ev, queuedMeta);
+        const w4bMarkerOccurrences = this.typedW4bMarkerOccurrences(w4bDiscriminator, queuedMeta);
+        const w4bInflightMarkerOrigins = this.typedW4bInflightOriginsFromOccurrences(
+          userText,
+          assistantText,
+          w4bMarkerOccurrences,
+        );
         const turnId = this.deterministicTurnId(sessionId, userText, assistantText, w4bDiscriminator);
         // T10 — Reserve cross-path in-flight on W4b-origin BEFORE
         // persistOne so a concurrent W4a `agent_end` fire's
@@ -1296,14 +1317,13 @@ export class ChatTurnWriter {
           try {
             await this.persistOne(sessionId, userText, assistantText, turnId);
             daemonPersisted = true;
-            const completionSessionId = this.resolvePromotedPersistJobSession(sessionId, w4bJob);
             // Post-success: stamp the content-only `w4bOrigin` key on
             // the SHORT-TTL cross-path map (T5) so a later W4a
             // `agent_end` last-pair peek can see that W4b already
             // persisted THIS turn and skip + bumpWatermark, but a
             // repeated same-content turn arriving outside the 5s
             // cross-path window doesn't false-dedup against this stamp.
-            this.markCrossPathStamp(completionSessionId, this.w4bOriginKey(userText, assistantText));
+            this.markCrossPathStamp(sessionId, this.w4bOriginKey(userText, assistantText));
             // R18.2 — Track the W4b session count under the durable session
             // we can prove. Conversationless typed turns keep their isolated
             // conversationless count and add per-message markers; promotion
@@ -1319,17 +1339,16 @@ export class ChatTurnWriter {
             // additional `userText` check here filters chunk-2+ deliveries
             // that ran out of pending users on chunk 1.
             if (userText) {
-              const durableSessionId = this.promotedDurableW4bSessionId(sessionId, completionSessionId);
               const markerChanged = this.markTypedW4bTurnPersisted(
-                durableSessionId,
+                sessionId,
                 userText,
                 assistantText,
-                this.typedW4bMarkerOccurrences(w4bDiscriminator, queuedMeta),
+                w4bMarkerOccurrences,
               );
               const countChanged = true;
               this.w4bSessionCounts.set(
-                durableSessionId,
-                (this.w4bSessionCounts.get(durableSessionId) ?? 0) + 1,
+                sessionId,
+                (this.w4bSessionCounts.get(sessionId) ?? 0) + 1,
               );
               // T17 — Persist the new count/marker to disk via the
               // debounced flush so a process restart preserves the
@@ -1339,8 +1358,8 @@ export class ChatTurnWriter {
               // backfill (count resets to 0, watermark file is
               // still -1, savedUpTo computes to -1, computeDelta
               // emits everything).
-              if ((markerChanged || countChanged) && !this.commitWatermarkStateSync(durableSessionId)) {
-                this.scheduleWatermarkFlush(durableSessionId, { retryOnFailure: true, attempts: 3 });
+              if ((markerChanged || countChanged) && !this.commitWatermarkStateSync(sessionId)) {
+                this.scheduleWatermarkFlush(sessionId, { retryOnFailure: true, attempts: 3 });
                 throw new Error("Failed to write W4b chat-turn watermark");
               }
               this.clearMessageHookInboundDedupKeys(consumedInboundDedupKeys);
@@ -1366,21 +1385,18 @@ export class ChatTurnWriter {
             // next outbound will collapse the full queue (old items +
             // new) into one user-side, matching W4a's pairing.
             if (queuedItems.length > 0) {
-              const restoreKey = this.resolvePromotedPersistJobSession(conversationKey, w4bJob);
-              const restored = this.pendingUserMessages.get(restoreKey) ?? [];
+              const restored = this.pendingUserMessages.get(conversationKey) ?? [];
               restored.unshift(...queuedItems);
-              this.pendingUserMessages.set(restoreKey, restored);
-              const restoredMeta = this.pendingUserMessageMeta.get(restoreKey) ?? [];
+              this.pendingUserMessages.set(conversationKey, restored);
+              const restoredMeta = this.pendingUserMessageMeta.get(conversationKey) ?? [];
               restoredMeta.unshift(...queuedMeta);
-              this.pendingUserMessageMeta.set(restoreKey, restoredMeta);
+              this.pendingUserMessageMeta.set(conversationKey, restoredMeta);
             }
             // Release the in-flight reservation so a retry can proceed.
             // No `w4bOrigin` release needed — we don't stamp it pre-persist
             // anymore; only stamping happens post-success above.
             if (outboundDedupKey) this.deleteMessageHookDedupKey(outboundDedupKey);
             this.releaseTurnIdReservation(sessionId, w4bInflight);
-            const failureSessionId = this.resolvePromotedPersistJobSession(sessionId, w4bJob);
-            if (failureSessionId !== sessionId) this.releaseTurnIdReservation(failureSessionId, w4bInflight);
             this.logger.error?.("[ChatTurnWriter.onMessageSent] Persist failed", { err });
           } finally {
             // T10 — Always release the cross-path in-flight reservation,
@@ -1389,11 +1405,12 @@ export class ChatTurnWriter {
             // 5s post-success window; on failure the reservation must
             // not leak to block legitimate later same-content turns.
             this.unmarkCrossPathInflight(sessionId, w4bOriginKey);
-            const finalSessionId = this.resolvePromotedPersistJobSession(sessionId, w4bJob);
-            if (finalSessionId !== sessionId) this.unmarkCrossPathInflight(finalSessionId, w4bOriginKey);
           }
         });
         this.markPersistJobOrigin(w4bJob, w4bOriginKey);
+        for (const origin of w4bInflightMarkerOrigins) {
+          this.markPersistJobOrigin(w4bJob, origin);
+        }
         w4bJob.catch(() => {});
       }
     } catch (err) {
@@ -1620,29 +1637,6 @@ export class ChatTurnWriter {
     }
   }
 
-  private promoteWeakSessionState(identity: {
-    channelId?: string;
-    accountId?: string;
-    conversationId?: string;
-    sessionKey?: string;
-  }): void {
-    if (!identity.channelId || !identity.sessionKey || this.isWeakSessionKey(identity.sessionKey)) return;
-    const strongSessionId = this.composeSessionId(identity);
-    const candidateSessionIds = new Set<string>();
-    if (identity.conversationId) {
-      // A weak typed session only proves channel/account/conversation, not the
-      // agent-specific sessionKey. Keep conversation-scoped weak state isolated
-      // unless an exact same-message dedupe path rekeys its pending inbound.
-      candidateSessionIds.add(this.composeSessionId({ ...identity, conversationId: "" }));
-    }
-
-    for (const fromSessionId of candidateSessionIds) {
-      if (fromSessionId !== strongSessionId) {
-        this.promoteSessionState(fromSessionId, strongSessionId);
-      }
-    }
-  }
-
   private w4bInflightGuardSessionIds(identity: {
     channelId?: string;
     accountId?: string;
@@ -1657,65 +1651,6 @@ export class ChatTurnWriter {
       }
     }
     return Array.from(ids);
-  }
-
-  private promoteSessionState(fromSessionId: string, strongSessionId: string): void {
-    let changed = false;
-    if (this.promoteInFlightPersists(fromSessionId, strongSessionId)) {
-      changed = true;
-    }
-    if (this.pendingUserMessages.has(fromSessionId) || this.pendingUserMessageMeta.has(fromSessionId)) {
-      this.movePendingInboundQueue(fromSessionId, strongSessionId);
-      changed = true;
-    }
-    for (const [dedupKey, queueKey] of this.messageHookInboundQueueKeys.entries()) {
-      if (queueKey === fromSessionId) {
-        this.messageHookInboundQueueKeys.set(dedupKey, strongSessionId);
-        changed = true;
-      }
-    }
-    for (const [dedupKey, sessionId] of this.messageHookDedupSessionKeys.entries()) {
-      if (sessionId === fromSessionId) {
-        this.messageHookDedupSessionKeys.set(dedupKey, strongSessionId);
-        changed = true;
-      }
-    }
-    if (changed) {
-      this.logger.debug?.("[ChatTurnWriter] Promoted typed-message session identity", {
-        fromSessionId,
-        strongSessionId,
-      });
-    }
-  }
-
-  private resolvePromotedPersistJobSession(sessionId: string, job?: Promise<void>): string {
-    return job ? this.promotedPersistJobs.get(job) ?? sessionId : sessionId;
-  }
-
-  private promotedDurableW4bSessionId(originalSessionId: string, completionSessionId: string): string {
-    if (originalSessionId === completionSessionId) return completionSessionId;
-    const original = this.parseComposedSessionId(originalSessionId);
-    const completion = this.parseComposedSessionId(completionSessionId);
-    if (original && completion && !original.conversationId && completion.conversationId) {
-      return originalSessionId;
-    }
-    return completionSessionId;
-  }
-
-  private promoteInFlightPersists(fromSessionId: string, strongSessionId: string): boolean {
-    const source = this.inFlightPersists.get(fromSessionId);
-    if (!source || source.size === 0) {
-      this.inFlightPersists.delete(fromSessionId);
-      return false;
-    }
-    const target = this.inFlightPersists.get(strongSessionId) ?? new Set<Promise<void>>();
-    for (const job of source) {
-      target.add(job);
-      this.promotedPersistJobs.set(job, strongSessionId);
-    }
-    this.inFlightPersists.set(strongSessionId, target);
-    this.inFlightPersists.delete(fromSessionId);
-    return true;
   }
 
   /**
@@ -2310,6 +2245,31 @@ export class ChatTurnWriter {
     return Array.from(markers);
   }
 
+  private typedW4bInflightOrigin(marker: string): string {
+    return `typed-w4b-marker::${marker}`;
+  }
+
+  private typedW4bInflightOrigins(
+    user: string,
+    assistant: string,
+    messageIds: string[],
+    assistantMessageIds: string[] = [],
+  ): string[] {
+    return this.typedW4bExternalMarkerIds(user, assistant, messageIds, assistantMessageIds)
+      .map((marker) => this.typedW4bInflightOrigin(marker));
+  }
+
+  private typedW4bInflightOriginsFromOccurrences(
+    user: string,
+    assistant: string,
+    occurrences: string[],
+  ): string[] {
+    return occurrences
+      .map((occurrence) => this.typedW4bExternalMarkerId(user, assistant, occurrence))
+      .filter((marker) => marker.length > 0)
+      .map((marker) => this.typedW4bInflightOrigin(marker));
+  }
+
   private findTypedW4bExternalMarker(
     cursorKeys: string[],
     user: string,
@@ -2590,7 +2550,6 @@ export class ChatTurnWriter {
   private deriveSessionId(ctx?: any): string {
     const identity = this.identityFieldsFromPayload(ctx);
     if (!identity.channelId || !identity.sessionKey) return "";
-    this.promoteWeakSessionState(identity);
     return this.composeSessionId(identity);
   }
 
@@ -2657,7 +2616,6 @@ export class ChatTurnWriter {
       conversationId: ctx.conversationId,
       sessionKey: ev.sessionKey,
     };
-    this.promoteWeakSessionState(identity);
     return this.composeSessionId(identity);
   }
 
@@ -2892,7 +2850,6 @@ export class ChatTurnWriter {
       conversationId: ctx.conversationId,
       sessionKey: ev.sessionKey,
     };
-    this.promoteWeakSessionState(identity);
     return this.composeSessionId(identity);
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1044,7 +1044,9 @@ export class ChatTurnWriter {
     const eventContext = event.context && typeof event.context === "object" ? event.context : {};
     const metadata = event.metadata && typeof event.metadata === "object" ? event.metadata : {};
     const content = this.extractTypedMessageContent(event, eventContext, metadata, ctx);
-    if (!content) return null;
+    const successValue = eventContext.success ?? event.success;
+    const isOutboundFailure = direction === "outbound" && successValue === false;
+    if (!content && !isOutboundFailure) return null;
 
     const channelId = firstString(
       ctx.channelId,
@@ -1074,7 +1076,6 @@ export class ChatTurnWriter {
     }
 
     const messageId = this.typedHookMessageId(event, eventContext, metadata, ctx);
-    const successValue = eventContext.success ?? event.success;
     const context: NonNullable<InternalMessageEvent["context"]> = {
       channelId,
       content,
@@ -1693,6 +1694,14 @@ export class ChatTurnWriter {
     if (!existing || !candidate) return false;
     const existingStrong = existing.sessionKey.length > 0 && !this.isWeakSessionKey(existing.sessionKey);
     const candidateStrong = candidate.sessionKey.length > 0 && !this.isWeakSessionKey(candidate.sessionKey);
+    if (existingStrong && candidateStrong) {
+      return (
+        existing.channelId === candidate.channelId &&
+        existing.accountId === candidate.accountId &&
+        existing.conversationId === candidate.conversationId &&
+        existing.sessionKey !== candidate.sessionKey
+      );
+    }
     return candidateStrong && !existingStrong;
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -16,7 +16,7 @@ import { createHash } from "crypto";
  * when typed `agent_end` is silent. Those events are normalized into the W4b
  * envelope and deduped against internal `message:received/message:sent` by
  * channel/account/conversation/messageId, outside the Node-UI marker space.
- * Weak W4b replay markers are additionally bound to provider message IDs so
+ * Typed W4b replay markers are additionally bound to provider message IDs so
  * same-text repeats in one transcript do not suppress the wrong occurrence.
  */
 
@@ -514,7 +514,7 @@ export class ChatTurnWriter {
     if (!sessionId) return;
     const identity = this.identityFieldsFromPayload(ctx);
     const externalCursorKey = this.externalCursorKeyFromSessionKey(identity.sessionKey);
-    const weakConversationCursorKey = this.weakConversationCursorKey(identity);
+    const typedW4bCursorKeys = this.typedW4bMarkerCursorKeys(identity);
     // T4 — Serialize agent_end calls per session via a Promise chain.
     // The full computeDelta + per-pair persist loop runs INSIDE the
     // chain so a later fire's `computeDelta` reads the earlier fire's
@@ -534,7 +534,7 @@ export class ChatTurnWriter {
       .catch(() => undefined)
       .then(async () => {
         if (resetAtSchedule) await resetAtSchedule;
-        await this.runAgentEndPersist(event, sessionId, externalCursorKey, weakConversationCursorKey);
+        await this.runAgentEndPersist(event, sessionId, externalCursorKey, typedW4bCursorKeys);
       });
     this.w4aSessionChains.set(sessionId, work);
     work.finally(() => {
@@ -553,7 +553,7 @@ export class ChatTurnWriter {
     event: AgentEndContext,
     sessionId: string,
     externalCursorKey?: string,
-    weakConversationCursorKey?: string,
+    typedW4bCursorKeys: string[] = [],
   ): Promise<void> {
     try {
       // R18.2 — Take the MAX of W4a's pair-indexed watermark and W4b's
@@ -598,20 +598,23 @@ export class ChatTurnWriter {
             }
             if (externalMarkerAction.skip) continue;
           }
-          const weakMarker = weakConversationCursorKey
-            ? this.weakW4bExternalMarkerIds(user, assistant, messageIds)
-              .find((marker) => this.hasExternalTurnMarker(weakConversationCursorKey, marker)) ?? ""
-            : "";
-          if (weakConversationCursorKey && weakMarker && this.hasExternalTurnMarker(weakConversationCursorKey, weakMarker)) {
-            const previousWeakMarkerCount =
-              this.externalTurnMarkers.get(weakConversationCursorKey)?.get(weakMarker) ?? 0;
+          const typedW4bMarkerHit = this.findTypedW4bExternalMarker(
+            typedW4bCursorKeys,
+            user,
+            assistant,
+            messageIds,
+          );
+          if (typedW4bMarkerHit) {
+            const { cursorKey, marker } = typedW4bMarkerHit;
+            const previousTypedMarkerCount =
+              this.externalTurnMarkers.get(cursorKey)?.get(marker) ?? 0;
             const watermarkSnapshot = this.snapshotWatermarkState(sessionId);
-            this.consumeExternalTurnMarker(weakConversationCursorKey, weakMarker);
+            this.consumeExternalTurnMarker(cursorKey, marker);
             this.bumpWatermark(sessionId, pairIndex);
             if (!this.commitWatermarkStateSync(sessionId)) {
-              this.restoreExternalTurnMarkerCount(weakConversationCursorKey, weakMarker, previousWeakMarkerCount);
+              this.restoreExternalTurnMarkerCount(cursorKey, marker, previousTypedMarkerCount);
               this.restoreWatermarkState(sessionId, watermarkSnapshot);
-              throw new Error("Failed to write weak W4b chat-turn marker consumption");
+              throw new Error("Failed to write typed W4b chat-turn marker consumption");
             }
             continue;
           }
@@ -1224,10 +1227,10 @@ export class ChatTurnWriter {
             // repeated same-content turn arriving outside the 5s
             // cross-path window doesn't false-dedup against this stamp.
             this.markCrossPathStamp(completionSessionId, this.w4bOriginKey(userText, assistantText));
-            // R18.2 — Track the W4b session count so a later `agent_end`
-            // (typically after a `setup-runtime → full` upgrade) sees a
-            // raised `savedUpTo` floor in `computeDelta` and doesn't
-            // re-persist turns W4b already wrote.
+            // R18.2 — Track the W4b session count under the durable session
+            // we can prove. Conversationless typed turns keep their isolated
+            // conversationless count and add per-message markers; promotion
+            // must not copy that count into the first later concrete chat.
             // R20.2 — Only count when the persist consumed BOTH a user
             // message and assistant text — i.e. it represents a complete
             // logical turn pair as `computeDelta` would emit. Counting
@@ -1239,26 +1242,28 @@ export class ChatTurnWriter {
             // additional `userText` check here filters chunk-2+ deliveries
             // that ran out of pending users on chunk 1.
             if (userText) {
-              this.w4bSessionCounts.set(
-                completionSessionId,
-                (this.w4bSessionCounts.get(completionSessionId) ?? 0) + 1,
-              );
-              this.markWeakW4bTurnPersisted(
-                completionSessionId,
+              const durableSessionId = this.promotedDurableW4bSessionId(sessionId, completionSessionId);
+              const markerChanged = this.markTypedW4bTurnPersisted(
+                durableSessionId,
                 userText,
                 assistantText,
-                this.w4bWeakMarkerOccurrences(w4bDiscriminator, queuedMeta),
+                this.typedW4bMarkerOccurrences(w4bDiscriminator, queuedMeta),
               );
-              // T17 — Persist the new count to disk via the
-              // debounced flush so a process restart preserves
-              // the "skip these pairs in computeDelta" floor.
+              const countChanged = true;
+              this.w4bSessionCounts.set(
+                durableSessionId,
+                (this.w4bSessionCounts.get(durableSessionId) ?? 0) + 1,
+              );
+              // T17 — Persist the new count/marker to disk via the
+              // debounced flush so a process restart preserves the
+              // "skip these pairs in computeDelta" fact.
               // Without this, setup-runtime → restart → upgrade
               // to full would replay every W4b-persisted turn as
               // backfill (count resets to 0, watermark file is
               // still -1, savedUpTo computes to -1, computeDelta
               // emits everything).
-              if (!this.commitWatermarkStateSync(completionSessionId)) {
-                this.scheduleWatermarkFlush(completionSessionId, { retryOnFailure: true, attempts: 3 });
+              if ((markerChanged || countChanged) && !this.commitWatermarkStateSync(durableSessionId)) {
+                this.scheduleWatermarkFlush(durableSessionId, { retryOnFailure: true, attempts: 3 });
                 throw new Error("Failed to write W4b chat-turn watermark");
               }
             }
@@ -1362,16 +1367,19 @@ export class ChatTurnWriter {
     if (channelId === "dkg-ui") return "";
     const accountId = firstString(ctx.accountId) ?? "";
     const conversationId = firstString(ctx.conversationId) ?? "";
+    const sessionKey = firstString(ev.sessionKey, ctx.sessionKey) ?? "";
     const messageId = this.messageEventId(ev);
     if (messageId) {
+      const identityParts = conversationId
+        ? [channelId, accountId, conversationId, messageId]
+        : [channelId, accountId, conversationId, sessionKey, messageId];
       return [
         "message-hook",
         direction,
         "msg",
-        this.identityHash([channelId, accountId, conversationId, messageId]),
+        this.identityHash(identityParts),
       ].join("::");
     }
-    const sessionKey = firstString(ev.sessionKey, ctx.sessionKey) ?? "";
     if (direction === "outbound") {
       const inboundIds = pendingMeta
         .map((meta) => meta.messageId)
@@ -1513,30 +1521,6 @@ export class ChatTurnWriter {
       this.movePendingInboundQueue(fromSessionId, strongSessionId);
       changed = true;
     }
-    const weakWatermark = this.cachedWatermarks.get(fromSessionId);
-    if (weakWatermark !== undefined) {
-      this.cachedWatermarks.set(strongSessionId, Math.max(this.cachedWatermarks.get(strongSessionId) ?? -1, weakWatermark));
-      this.cachedWatermarks.delete(fromSessionId);
-      changed = true;
-      durableChanged = true;
-    }
-    const weakW4bCount = this.w4bSessionCounts.get(fromSessionId);
-    if (weakW4bCount !== undefined) {
-      this.w4bSessionCounts.set(strongSessionId, Math.max(this.w4bSessionCounts.get(strongSessionId) ?? 0, weakW4bCount));
-      this.w4bSessionCounts.delete(fromSessionId);
-      changed = true;
-      durableChanged = true;
-    }
-    const weakTimer = this.debounceTimers.get(fromSessionId);
-    if (weakTimer) {
-      clearTimeout(weakTimer.timer);
-      this.debounceTimers.delete(fromSessionId);
-      const existingStrongTimer = this.debounceTimers.get(strongSessionId);
-      const promotedIndex = Math.max(existingStrongTimer?.pendingIndex ?? -1, weakTimer.pendingIndex);
-      this.saveWatermark(strongSessionId, promotedIndex);
-      changed = true;
-      durableChanged = true;
-    }
     for (const [dedupKey, queueKey] of this.messageHookInboundQueueKeys.entries()) {
       if (queueKey === fromSessionId) {
         this.messageHookInboundQueueKeys.set(dedupKey, strongSessionId);
@@ -1564,6 +1548,16 @@ export class ChatTurnWriter {
 
   private resolvePromotedPersistJobSession(sessionId: string, job?: Promise<void>): string {
     return job ? this.promotedPersistJobs.get(job) ?? sessionId : sessionId;
+  }
+
+  private promotedDurableW4bSessionId(originalSessionId: string, completionSessionId: string): string {
+    if (originalSessionId === completionSessionId) return completionSessionId;
+    const original = this.parseComposedSessionId(originalSessionId);
+    const completion = this.parseComposedSessionId(completionSessionId);
+    if (original && completion && !original.conversationId && completion.conversationId) {
+      return originalSessionId;
+    }
+    return completionSessionId;
   }
 
   private promoteInFlightPersists(fromSessionId: string, strongSessionId: string): boolean {
@@ -2166,32 +2160,52 @@ export class ChatTurnWriter {
     return `external-id::${idHash}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
-  private weakW4bExternalMarkerId(user: string, assistant: string, occurrence: string): string {
+  private typedW4bExternalMarkerId(user: string, assistant: string, occurrence: string): string {
     if (!occurrence) return "";
     return `weak-w4b::${this.identityHash([occurrence])}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
-  private weakW4bExternalMarkerIds(user: string, assistant: string, messageIds: string[]): string[] {
+  private typedW4bExternalMarkerIds(user: string, assistant: string, messageIds: string[]): string[] {
     const occurrence = this.w4bInboundMessageDiscriminator(messageIds);
-    const marker = this.weakW4bExternalMarkerId(user, assistant, occurrence);
+    const marker = this.typedW4bExternalMarkerId(user, assistant, occurrence);
     return marker ? [marker] : [];
   }
 
-  private markWeakW4bTurnPersisted(
+  private findTypedW4bExternalMarker(
+    cursorKeys: string[],
+    user: string,
+    assistant: string,
+    messageIds: string[],
+  ): { cursorKey: string; marker: string } | null {
+    const markers = this.typedW4bExternalMarkerIds(user, assistant, messageIds);
+    for (const cursorKey of cursorKeys) {
+      for (const marker of markers) {
+        if (this.hasExternalTurnMarker(cursorKey, marker)) return { cursorKey, marker };
+      }
+    }
+    return null;
+  }
+
+  private markTypedW4bTurnPersisted(
     sessionId: string,
     user: string,
     assistant: string,
     occurrences: string[],
-  ): void {
-    const cursor = this.weakConversationCursorKeyFromSessionId(sessionId);
-    if (!cursor) return;
-    const bucket = this.externalTurnMarkers.get(cursor) ?? new Map<string, number>();
-    for (const occurrence of occurrences) {
-      const marker = this.weakW4bExternalMarkerId(user, assistant, occurrence);
-      if (!marker) continue;
-      bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
+  ): boolean {
+    const cursors = this.typedW4bMarkerCursorKeysFromSessionId(sessionId);
+    if (cursors.length === 0) return false;
+    let changed = false;
+    for (const cursor of cursors) {
+      const bucket = this.externalTurnMarkers.get(cursor) ?? new Map<string, number>();
+      for (const occurrence of occurrences) {
+        const marker = this.typedW4bExternalMarkerId(user, assistant, occurrence);
+        if (!marker) continue;
+        bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
+        changed = true;
+      }
+      if (bucket.size > 0) this.externalTurnMarkers.set(cursor, bucket);
     }
-    if (bucket.size > 0) this.externalTurnMarkers.set(cursor, bucket);
+    return changed;
   }
 
   private consumeExternalTurnMarkersForPair(
@@ -2360,7 +2374,7 @@ export class ChatTurnWriter {
     return `in::${this.identityHash(ids)}`;
   }
 
-  private w4bWeakMarkerOccurrences(
+  private typedW4bMarkerOccurrences(
     discriminator: string,
     pendingMeta: PendingUserMessageMeta[],
   ): string[] {
@@ -2548,6 +2562,44 @@ export class ChatTurnWriter {
     const parsed = this.parseComposedSessionId(sessionId);
     if (!parsed || !this.isWeakSessionKey(parsed.sessionKey) || !parsed.conversationId) return "";
     return `openclaw:weak:${this.identityHash([parsed.channelId, parsed.accountId, parsed.conversationId])}`;
+  }
+
+  private conversationlessSessionCursorKey(parts: {
+    channelId?: string;
+    accountId?: string;
+    sessionKey?: string;
+  }): string {
+    if (!parts.channelId || !parts.sessionKey || this.isWeakSessionKey(parts.sessionKey)) return "";
+    return `openclaw:session:${this.identityHash([
+      this.encodeIdField(this.sanitize(parts.channelId)),
+      this.encodeIdField(this.sanitize(parts.accountId ?? "")),
+      this.encodeIdField(this.sanitize(parts.sessionKey)),
+    ])}`;
+  }
+
+  private conversationlessSessionCursorKeyFromSessionId(sessionId: string): string {
+    const parsed = this.parseComposedSessionId(sessionId);
+    if (!parsed || parsed.conversationId || this.isWeakSessionKey(parsed.sessionKey)) return "";
+    return `openclaw:session:${this.identityHash([parsed.channelId, parsed.accountId, parsed.sessionKey])}`;
+  }
+
+  private typedW4bMarkerCursorKeys(parts: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+    sessionKey?: string;
+  }): string[] {
+    return Array.from(new Set([
+      this.weakConversationCursorKey(parts),
+      this.conversationlessSessionCursorKey(parts),
+    ].filter((key) => key.length > 0)));
+  }
+
+  private typedW4bMarkerCursorKeysFromSessionId(sessionId: string): string[] {
+    return Array.from(new Set([
+      this.weakConversationCursorKeyFromSessionId(sessionId),
+      this.conversationlessSessionCursorKeyFromSessionId(sessionId),
+    ].filter((key) => key.length > 0)));
   }
 
   private collectResetSessionIds(identity: {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1735,6 +1735,7 @@ export class ChatTurnWriter {
     if (existing.conversationId !== target.conversationId) return false;
     const existingWeak = this.isWeakSessionKey(existing.sessionKey);
     const targetWeak = this.isWeakSessionKey(target.sessionKey);
+    if (this.pendingQueueUsesTypedSessionFallback(existingKey) && !targetWeak) return true;
     if (existingWeak === targetWeak) return false;
     if (targetWeak) return this.pendingQueueUsesTypedSessionFallback(existingKey);
     return outboundUsesTypedSessionIdFallback;

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1202,8 +1202,10 @@ export class ChatTurnWriter {
       // makes them get mis-paired with the next unrelated reply. Delete
       // the whole queue here to match the success consumption.
       if (success === false) {
+        const droppedInboundDedupKeys = this.messageHookInboundDedupKeysForQueue(conversationKey);
         this.pendingUserMessages.delete(conversationKey);
         this.pendingUserMessageMeta.delete(conversationKey);
+        this.deleteMessageHookInboundDedupKeys(droppedInboundDedupKeys);
         return;
       }
       // Strip injected `<recalled-memory>` from assistant text — the model may
@@ -1626,6 +1628,12 @@ export class ChatTurnWriter {
       if (this.isNoIdInboundBatchKey(key)) {
         this.deleteMessageHookDedupKey(key);
       }
+    }
+  }
+
+  private deleteMessageHookInboundDedupKeys(keys: string[]): void {
+    for (const key of keys) {
+      this.deleteMessageHookDedupKey(key);
     }
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -970,13 +970,7 @@ export class ChatTurnWriter {
     const ctx = hookCtx && typeof hookCtx === "object" ? hookCtx : {};
     const eventContext = event.context && typeof event.context === "object" ? event.context : {};
     const metadata = event.metadata && typeof event.metadata === "object" ? event.metadata : {};
-    const content = [
-      event.content,
-      event.text,
-      event.body,
-      eventContext.content,
-      metadata.content,
-    ].find((value) => typeof value === "string" && value.trim().length > 0) as string | undefined;
+    const content = this.extractTypedMessageContent(event, eventContext, metadata, ctx);
     if (!content) return null;
 
     const channelId = firstString(
@@ -1013,7 +1007,19 @@ export class ChatTurnWriter {
       return null;
     }
 
-    const messageId = firstString(ctx.messageId, event.messageId, eventContext.messageId, metadata.messageId, metadata.id);
+    const messageId = firstString(
+      ctx.messageId,
+      ctx.MessageId,
+      ctx.message_id,
+      ctx.id,
+      ...this.extractMessageIds({
+        ...event,
+        context: eventContext,
+        metadata,
+        content,
+        role: direction === "inbound" ? "user" : "assistant",
+      } as ChatTurnMessage),
+    );
     const successValue = eventContext.success ?? event.success;
     const context: NonNullable<InternalMessageEvent["context"]> = {
       channelId,
@@ -1031,6 +1037,26 @@ export class ChatTurnWriter {
       text: content,
       context,
     };
+  }
+
+  private extractTypedMessageContent(
+    event: Record<string, unknown>,
+    eventContext: Record<string, unknown>,
+    metadata: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ): string {
+    for (const value of [
+      event.content,
+      event.text,
+      event.body,
+      eventContext.content,
+      metadata.content,
+      ctx.content,
+    ]) {
+      const text = this.extractText(value as ChatTurnMessage["content"]).trim();
+      if (text) return text;
+    }
+    return "";
   }
 
   onMessageReceived(ev: InternalMessageEvent): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -520,6 +520,7 @@ export class ChatTurnWriter {
     const identity = this.identityFieldsFromPayload(ctx);
     const externalCursorKey = this.externalCursorKeyFromSessionKey(identity.sessionKey);
     const typedW4bCursorKeys = this.typedW4bMarkerCursorKeys(identity);
+    const w4bInflightSessionIds = this.w4bInflightGuardSessionIds(identity, sessionId);
     // T4 — Serialize agent_end calls per session via a Promise chain.
     // The full computeDelta + per-pair persist loop runs INSIDE the
     // chain so a later fire's `computeDelta` reads the earlier fire's
@@ -539,7 +540,7 @@ export class ChatTurnWriter {
       .catch(() => undefined)
       .then(async () => {
         if (resetAtSchedule) await resetAtSchedule;
-        await this.runAgentEndPersist(event, sessionId, externalCursorKey, typedW4bCursorKeys);
+        await this.runAgentEndPersist(event, sessionId, externalCursorKey, typedW4bCursorKeys, w4bInflightSessionIds);
       });
     this.w4aSessionChains.set(sessionId, work);
     work.finally(() => {
@@ -559,6 +560,7 @@ export class ChatTurnWriter {
     sessionId: string,
     externalCursorKey?: string,
     typedW4bCursorKeys: string[] = [],
+    w4bInflightSessionIds: string[] = [sessionId],
   ): Promise<void> {
     try {
       // R18.2 — Take the MAX of W4a's pair-indexed watermark and W4b's
@@ -665,7 +667,7 @@ export class ChatTurnWriter {
             // and a future outbound re-pairs; the unchanged watermark
             // means the next `agent_end` will re-yield this pair as
             // backfill (correct retry behavior).
-            if (this.peekCrossPathInflight(sessionId, w4bOrigin) || this.hasInFlightPersistOrigin(sessionId, w4bOrigin)) {
+            if (this.hasW4bInflightOrigin(w4bInflightSessionIds, w4bOrigin)) {
               continue;
             }
           }
@@ -751,6 +753,15 @@ export class ChatTurnWriter {
     if (!bucket) return false;
     for (const job of bucket) {
       if (this.persistJobOriginKeys.get(job)?.has(originKey)) return true;
+    }
+    return false;
+  }
+
+  private hasW4bInflightOrigin(sessionIds: string[], originKey: string): boolean {
+    for (const sessionId of Array.from(new Set(sessionIds))) {
+      if (this.peekCrossPathInflight(sessionId, originKey) || this.hasInFlightPersistOrigin(sessionId, originKey)) {
+        return true;
+      }
     }
     return false;
   }
@@ -1027,19 +1038,7 @@ export class ChatTurnWriter {
       return null;
     }
 
-    const messageId = firstString(
-      ctx.messageId,
-      ctx.MessageId,
-      ctx.message_id,
-      ctx.id,
-      ...this.extractMessageIds({
-        ...event,
-        context: eventContext,
-        metadata,
-        content,
-        role: direction === "inbound" ? "user" : "assistant",
-      } as ChatTurnMessage),
-    );
+    const messageId = this.typedHookMessageId(event, eventContext, metadata, ctx);
     const successValue = eventContext.success ?? event.success;
     const context: NonNullable<InternalMessageEvent["context"]> = {
       channelId,
@@ -1077,6 +1076,28 @@ export class ChatTurnWriter {
       if (text) return text;
     }
     return "";
+  }
+
+  private typedHookMessageId(
+    event: Record<string, unknown>,
+    eventContext: Record<string, unknown>,
+    metadata: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ): string | undefined {
+    return firstString(
+      ctx.messageId,
+      ctx.MessageId,
+      ctx.message_id,
+      event.messageId,
+      event.MessageId,
+      event.message_id,
+      eventContext.messageId,
+      eventContext.MessageId,
+      eventContext.message_id,
+      metadata.messageId,
+      metadata.MessageId,
+      metadata.message_id,
+    );
   }
 
   onMessageReceived(ev: InternalMessageEvent): void {
@@ -1585,6 +1606,22 @@ export class ChatTurnWriter {
         this.promoteSessionState(fromSessionId, strongSessionId);
       }
     }
+  }
+
+  private w4bInflightGuardSessionIds(identity: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+    sessionKey?: string;
+  }, sessionId: string): string[] {
+    const ids = new Set<string>([sessionId]);
+    if (identity.channelId && identity.conversationId) {
+      const weakSession = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
+      if (weakSession) {
+        ids.add(this.composeSessionId({ ...identity, sessionKey: weakSession }));
+      }
+    }
+    return Array.from(ids);
   }
 
   private promoteSessionState(fromSessionId: string, strongSessionId: string): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -57,6 +57,7 @@ interface ComputedChatTurnPair {
   externalTurnIds: string[];
   externalDirect: boolean;
   messageIds: string[];
+  assistantMessageIds: string[];
 }
 
 interface ExternalMarkerAction {
@@ -576,7 +577,7 @@ export class ChatTurnWriter {
       const lastIdx = pairs.length - 1;
       const job = this.trackPersistJob(sessionId, async () => {
         for (let i = 0; i < pairs.length; i++) {
-          const { user, assistant, pairIndex, externalTurnIds, messageIds } = pairs[i];
+          const { user, assistant, pairIndex, externalTurnIds, messageIds, assistantMessageIds } = pairs[i];
           if (!user && !assistant) continue;
           const externalMarkerAction = externalCursorKey
             ? this.consumeExternalTurnMarkersForPair(
@@ -603,6 +604,7 @@ export class ChatTurnWriter {
             user,
             assistant,
             messageIds,
+            assistantMessageIds,
           );
           if (typedW4bMarkerHit) {
             const { cursorKey, marker } = typedW4bMarkerHit;
@@ -1916,6 +1918,7 @@ export class ChatTurnWriter {
           ? Array.from(new Set(pendingUsers.flatMap((pending) => pending.externalTurnIds)))
           : [];
         const messageIds = Array.from(new Set(pendingUsers.flatMap((pending) => pending.messageIds)));
+        const assistantMessageIds = this.extractMessageIds(msg);
         pendingUsers.length = 0;
         if (pairIndex > savedUpTo) {
           pairs.push({
@@ -1925,6 +1928,7 @@ export class ChatTurnWriter {
             externalTurnIds,
             externalDirect,
             messageIds,
+            assistantMessageIds,
           });
         }
         pairIndex++;
@@ -2165,10 +2169,21 @@ export class ChatTurnWriter {
     return `weak-w4b::${this.identityHash([occurrence])}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
-  private typedW4bExternalMarkerIds(user: string, assistant: string, messageIds: string[]): string[] {
-    const occurrence = this.w4bInboundMessageDiscriminator(messageIds);
-    const marker = this.typedW4bExternalMarkerId(user, assistant, occurrence);
-    return marker ? [marker] : [];
+  private typedW4bExternalMarkerIds(
+    user: string,
+    assistant: string,
+    messageIds: string[],
+    assistantMessageIds: string[] = [],
+  ): string[] {
+    const markers = new Set<string>();
+    const inboundOccurrence = this.w4bInboundMessageDiscriminator(messageIds);
+    const inboundMarker = this.typedW4bExternalMarkerId(user, assistant, inboundOccurrence);
+    if (inboundMarker) markers.add(inboundMarker);
+    for (const outboundOccurrence of this.w4bOutboundMessageDiscriminators(assistantMessageIds)) {
+      const outboundMarker = this.typedW4bExternalMarkerId(user, assistant, outboundOccurrence);
+      if (outboundMarker) markers.add(outboundMarker);
+    }
+    return Array.from(markers);
   }
 
   private findTypedW4bExternalMarker(
@@ -2176,8 +2191,9 @@ export class ChatTurnWriter {
     user: string,
     assistant: string,
     messageIds: string[],
+    assistantMessageIds: string[] = [],
   ): { cursorKey: string; marker: string } | null {
-    const markers = this.typedW4bExternalMarkerIds(user, assistant, messageIds);
+    const markers = this.typedW4bExternalMarkerIds(user, assistant, messageIds, assistantMessageIds);
     for (const cursorKey of cursorKeys) {
       for (const marker of markers) {
         if (this.hasExternalTurnMarker(cursorKey, marker)) return { cursorKey, marker };
@@ -2374,12 +2390,24 @@ export class ChatTurnWriter {
     return `in::${this.identityHash(ids)}`;
   }
 
+  private w4bOutboundMessageDiscriminators(messageIds: string[]): string[] {
+    return Array.from(new Set(messageIds
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0)
+      .map((id) => `out::${id}`)));
+  }
+
   private typedW4bMarkerOccurrences(
     discriminator: string,
     pendingMeta: PendingUserMessageMeta[],
   ): string[] {
     const occurrences = new Set<string>();
-    if (discriminator) occurrences.add(discriminator);
+    const normalizedDiscriminator = discriminator.startsWith("msg::")
+      ? discriminator.slice("msg::".length)
+      : discriminator;
+    if (normalizedDiscriminator.startsWith("in::") || normalizedDiscriminator.startsWith("out::")) {
+      occurrences.add(normalizedDiscriminator);
+    }
     const inboundIds = pendingMeta
       .map((meta) => meta.messageId)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
@@ -2564,6 +2592,34 @@ export class ChatTurnWriter {
     return `openclaw:weak:${this.identityHash([parsed.channelId, parsed.accountId, parsed.conversationId])}`;
   }
 
+  private concreteSessionCursorKey(parts: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+    sessionKey?: string;
+  }): string {
+    if (!parts.channelId || !parts.conversationId || !parts.sessionKey || this.isWeakSessionKey(parts.sessionKey)) {
+      return "";
+    }
+    return `openclaw:typed:${this.identityHash([
+      this.encodeIdField(this.sanitize(parts.channelId)),
+      this.encodeIdField(this.sanitize(parts.accountId ?? "")),
+      this.encodeIdField(this.sanitize(parts.conversationId)),
+      this.encodeIdField(this.sanitize(parts.sessionKey)),
+    ])}`;
+  }
+
+  private concreteSessionCursorKeyFromSessionId(sessionId: string): string {
+    const parsed = this.parseComposedSessionId(sessionId);
+    if (!parsed || !parsed.conversationId || !parsed.sessionKey || this.isWeakSessionKey(parsed.sessionKey)) return "";
+    return `openclaw:typed:${this.identityHash([
+      parsed.channelId,
+      parsed.accountId,
+      parsed.conversationId,
+      parsed.sessionKey,
+    ])}`;
+  }
+
   private conversationlessSessionCursorKey(parts: {
     channelId?: string;
     accountId?: string;
@@ -2590,6 +2646,7 @@ export class ChatTurnWriter {
     sessionKey?: string;
   }): string[] {
     return Array.from(new Set([
+      this.concreteSessionCursorKey(parts),
       this.weakConversationCursorKey(parts),
       this.conversationlessSessionCursorKey(parts),
     ].filter((key) => key.length > 0)));
@@ -2597,6 +2654,7 @@ export class ChatTurnWriter {
 
   private typedW4bMarkerCursorKeysFromSessionId(sessionId: string): string[] {
     return Array.from(new Set([
+      this.concreteSessionCursorKeyFromSessionId(sessionId),
       this.weakConversationCursorKeyFromSessionId(sessionId),
       this.conversationlessSessionCursorKeyFromSessionId(sessionId),
     ].filter((key) => key.length > 0)));

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -506,7 +506,9 @@ export class ChatTurnWriter {
     if (ctx?.channelId === "dkg-ui") return;
     const sessionId = this.deriveSessionId(ctx);
     if (!sessionId) return;
-    const externalCursorKey = this.externalCursorKeyFromHookPayload(undefined, ctx);
+    const identity = this.identityFieldsFromPayload(ctx);
+    const externalCursorKey = this.externalCursorKeyFromSessionKey(identity.sessionKey);
+    const weakConversationCursorKey = this.weakConversationCursorKey(identity);
     // T4 — Serialize agent_end calls per session via a Promise chain.
     // The full computeDelta + per-pair persist loop runs INSIDE the
     // chain so a later fire's `computeDelta` reads the earlier fire's
@@ -526,7 +528,7 @@ export class ChatTurnWriter {
       .catch(() => undefined)
       .then(async () => {
         if (resetAtSchedule) await resetAtSchedule;
-        await this.runAgentEndPersist(event, sessionId, externalCursorKey);
+        await this.runAgentEndPersist(event, sessionId, externalCursorKey, weakConversationCursorKey);
       });
     this.w4aSessionChains.set(sessionId, work);
     work.finally(() => {
@@ -541,7 +543,12 @@ export class ChatTurnWriter {
     // ordering; flush() drains via inFlightPersists.
   }
 
-  private async runAgentEndPersist(event: AgentEndContext, sessionId: string, externalCursorKey?: string): Promise<void> {
+  private async runAgentEndPersist(
+    event: AgentEndContext,
+    sessionId: string,
+    externalCursorKey?: string,
+    weakConversationCursorKey?: string,
+  ): Promise<void> {
     try {
       // R18.2 — Take the MAX of W4a's pair-indexed watermark and W4b's
       // session count (minus 1, because count is 1-based). When typed
@@ -584,6 +591,22 @@ export class ChatTurnWriter {
               throw new Error("Failed to write external chat-turn marker consumption");
             }
             if (externalMarkerAction.skip) continue;
+          }
+          const weakMarker = weakConversationCursorKey
+            ? this.weakW4bExternalMarkerId(user, assistant)
+            : "";
+          if (weakConversationCursorKey && weakMarker && this.hasExternalTurnMarker(weakConversationCursorKey, weakMarker)) {
+            const previousWeakMarkerCount =
+              this.externalTurnMarkers.get(weakConversationCursorKey)?.get(weakMarker) ?? 0;
+            const watermarkSnapshot = this.snapshotWatermarkState(sessionId);
+            this.consumeExternalTurnMarker(weakConversationCursorKey, weakMarker);
+            this.bumpWatermark(sessionId, pairIndex);
+            if (!this.commitWatermarkStateSync(sessionId)) {
+              this.restoreExternalTurnMarkerCount(weakConversationCursorKey, weakMarker, previousWeakMarkerCount);
+              this.restoreWatermarkState(sessionId, watermarkSnapshot);
+              throw new Error("Failed to write weak W4b chat-turn marker consumption");
+            }
+            continue;
           }
           // W4a turnId mixes pair position into the hash so backfill of
           // two same-text pairs (e.g. user said "hi" twice) produces
@@ -1210,6 +1233,7 @@ export class ChatTurnWriter {
                 completionSessionId,
                 (this.w4bSessionCounts.get(completionSessionId) ?? 0) + 1,
               );
+              this.markWeakW4bTurnPersisted(completionSessionId, userText, assistantText);
               // T17 — Persist the new count to disk via the
               // debounced flush so a process restart preserves
               // the "skip these pairs in computeDelta" floor.
@@ -2124,6 +2148,19 @@ export class ChatTurnWriter {
     return `external-id::${idHash}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
+  private weakW4bExternalMarkerId(user: string, assistant: string): string {
+    return `weak-w4b::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
+  }
+
+  private markWeakW4bTurnPersisted(sessionId: string, user: string, assistant: string): void {
+    const cursor = this.weakConversationCursorKeyFromSessionId(sessionId);
+    if (!cursor) return;
+    const marker = this.weakW4bExternalMarkerId(user, assistant);
+    const bucket = this.externalTurnMarkers.get(cursor) ?? new Map<string, number>();
+    bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
+    this.externalTurnMarkers.set(cursor, bucket);
+  }
+
   private consumeExternalTurnMarkersForPair(
     sessionKeyCursor: string,
     turnIds: string[],
@@ -2385,12 +2422,6 @@ export class ChatTurnWriter {
     };
   }
 
-  private externalCursorKeyFromHookPayload(event?: any, ctx?: any): string {
-    const ctxFields = this.identityFieldsFromPayload(ctx);
-    const eventFields = this.identityFieldsFromPayload(event);
-    return this.externalCursorKeyFromSessionKey(ctxFields.sessionKey ?? eventFields.sessionKey);
-  }
-
   /**
    * DKG-side session id for an internal message event. Uses the full
    * envelope (`channelId + accountId + conversationId + sessionKey`)
@@ -2444,6 +2475,25 @@ export class ChatTurnWriter {
   private externalCursorKeyFromSessionKey(sessionKey?: unknown): string {
     if (typeof sessionKey !== "string" || sessionKey.trim().length === 0) return "";
     return `openclaw:transcript:${this.encodeIdField(this.sanitize(sessionKey))}`;
+  }
+
+  private weakConversationCursorKey(parts: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+  }): string {
+    if (!parts.channelId || !parts.conversationId) return "";
+    return `openclaw:weak:${this.identityHash([
+      this.encodeIdField(this.sanitize(parts.channelId)),
+      this.encodeIdField(this.sanitize(parts.accountId ?? "")),
+      this.encodeIdField(this.sanitize(parts.conversationId)),
+    ])}`;
+  }
+
+  private weakConversationCursorKeyFromSessionId(sessionId: string): string {
+    const parsed = this.parseComposedSessionId(sessionId);
+    if (!parsed || !this.isWeakSessionKey(parsed.sessionKey) || !parsed.conversationId) return "";
+    return `openclaw:weak:${this.identityHash([parsed.channelId, parsed.accountId, parsed.conversationId])}`;
   }
 
   private collectResetSessionIds(identity: {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1032,14 +1032,7 @@ export class ChatTurnWriter {
     );
     if (channelId === "dkg-ui") return null;
     const accountId = firstString(ctx.accountId, event.accountId, eventContext.accountId, metadata.accountId, metadata.botId);
-    const conversationId = firstString(
-      ctx.conversationId,
-      event.conversationId,
-      eventContext.conversationId,
-      metadata.conversationId,
-      metadata.chatId,
-      metadata.threadId,
-    );
+    const conversationId = this.typedHookConversationId(event, eventContext, metadata, ctx);
     const strongSessionKey = firstString(
       ctx.sessionKey,
       event.sessionKey,
@@ -1116,6 +1109,25 @@ export class ChatTurnWriter {
       metadata.MessageId,
       metadata.message_id,
     );
+  }
+
+  private typedHookConversationId(
+    event: Record<string, unknown>,
+    eventContext: Record<string, unknown>,
+    metadata: Record<string, unknown>,
+    ctx: Record<string, unknown>,
+  ): string | undefined {
+    const explicit = firstString(
+      ctx.conversationId,
+      event.conversationId,
+      eventContext.conversationId,
+      metadata.conversationId,
+    );
+    if (explicit) return explicit;
+    const chatId = firstString(ctx.chatId, event.chatId, eventContext.chatId, metadata.chatId);
+    const threadId = firstString(ctx.threadId, event.threadId, eventContext.threadId, metadata.threadId);
+    if (chatId && threadId) return `${chatId}:${threadId}`;
+    return threadId ?? chatId;
   }
 
   onMessageReceived(ev: InternalMessageEvent): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1427,14 +1427,14 @@ export class ChatTurnWriter {
     const messages = this.pendingUserMessages.get(fromKey);
     if (messages && messages.length > 0) {
       const target = this.pendingUserMessages.get(toKey) ?? [];
-      target.push(...messages);
+      target.unshift(...messages);
       this.pendingUserMessages.set(toKey, target);
       this.pendingUserMessages.delete(fromKey);
     }
     const meta = this.pendingUserMessageMeta.get(fromKey);
     if (meta && meta.length > 0) {
       const target = this.pendingUserMessageMeta.get(toKey) ?? [];
-      target.push(...meta);
+      target.unshift(...meta);
       this.pendingUserMessageMeta.set(toKey, target);
       this.pendingUserMessageMeta.delete(fromKey);
     }
@@ -1450,10 +1450,9 @@ export class ChatTurnWriter {
     const strongSessionId = this.composeSessionId(identity);
     const candidateSessionIds = new Set<string>();
     if (identity.conversationId) {
-      const weakSessionKey = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
-      if (weakSessionKey) {
-        candidateSessionIds.add(this.composeSessionId({ ...identity, sessionKey: weakSessionKey }));
-      }
+      // A weak typed session only proves channel/account/conversation, not the
+      // agent-specific sessionKey. Keep conversation-scoped weak state isolated
+      // unless an exact same-message dedupe path rekeys its pending inbound.
       candidateSessionIds.add(this.composeSessionId({ ...identity, conversationId: "" }));
     }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -625,6 +625,7 @@ export class ChatTurnWriter {
             continue;
           }
           const typedW4bInflightOrigins = this.typedW4bInflightOrigins(
+            typedW4bCursorKeys,
             user,
             assistant,
             messageIds,
@@ -1296,6 +1297,7 @@ export class ChatTurnWriter {
         const w4bDiscriminator = this.w4bDaemonTurnIdDiscriminator(ev, queuedMeta);
         const w4bMarkerOccurrences = this.typedW4bMarkerOccurrences(w4bDiscriminator, queuedMeta);
         const w4bInflightMarkerOrigins = this.typedW4bInflightOriginsFromOccurrences(
+          sessionId,
           userText,
           assistantText,
           w4bMarkerOccurrences,
@@ -1449,6 +1451,11 @@ export class ChatTurnWriter {
   private nextPendingUserArrivalId(): string {
     this.pendingUserMessageSeq = (this.pendingUserMessageSeq + 1) >>> 0;
     return `arrival::${this.pendingUserMessageSeq}`;
+  }
+
+  private pendingUserArrivalOrder(meta?: PendingUserMessageMeta): number {
+    const match = typeof meta?.arrivalId === "string" ? /^arrival::(\d+)$/.exec(meta.arrivalId) : null;
+    return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
   }
 
   private messageHookDedupKey(
@@ -1622,19 +1629,19 @@ export class ChatTurnWriter {
   private movePendingInboundQueue(fromKey: string, toKey: string): void {
     if (fromKey === toKey) return;
     const messages = this.pendingUserMessages.get(fromKey);
+    const meta = this.pendingUserMessageMeta.get(fromKey);
     if (messages && messages.length > 0) {
-      const target = this.pendingUserMessages.get(toKey) ?? [];
-      target.unshift(...messages);
-      this.pendingUserMessages.set(toKey, target);
+      const targetMessages = this.pendingUserMessages.get(toKey) ?? [];
+      const targetMeta = this.pendingUserMessageMeta.get(toKey) ?? [];
+      const merged = [
+        ...targetMessages.map((text, index) => ({ text, meta: targetMeta[index] })),
+        ...messages.map((text, index) => ({ text, meta: meta?.[index] })),
+      ].sort((a, b) => this.pendingUserArrivalOrder(a.meta) - this.pendingUserArrivalOrder(b.meta));
+      this.pendingUserMessages.set(toKey, merged.map((item) => item.text));
+      this.pendingUserMessageMeta.set(toKey, merged.map((item) => item.meta ?? {}));
       this.pendingUserMessages.delete(fromKey);
     }
-    const meta = this.pendingUserMessageMeta.get(fromKey);
-    if (meta && meta.length > 0) {
-      const target = this.pendingUserMessageMeta.get(toKey) ?? [];
-      target.unshift(...meta);
-      this.pendingUserMessageMeta.set(toKey, target);
-      this.pendingUserMessageMeta.delete(fromKey);
-    }
+    this.pendingUserMessageMeta.delete(fromKey);
   }
 
   private w4bInflightGuardSessionIds(identity: {
@@ -2245,29 +2252,46 @@ export class ChatTurnWriter {
     return Array.from(markers);
   }
 
-  private typedW4bInflightOrigin(marker: string): string {
-    return `typed-w4b-marker::${marker}`;
+  private typedW4bInflightOrigin(cursorKey: string, marker: string): string {
+    return `typed-w4b-marker::${this.identityHash([cursorKey, marker])}`;
   }
 
   private typedW4bInflightOrigins(
+    cursorKeys: string[],
     user: string,
     assistant: string,
     messageIds: string[],
     assistantMessageIds: string[] = [],
   ): string[] {
-    return this.typedW4bExternalMarkerIds(user, assistant, messageIds, assistantMessageIds)
-      .map((marker) => this.typedW4bInflightOrigin(marker));
+    return this.typedW4bInflightOriginsForMarkers(
+      cursorKeys,
+      this.typedW4bExternalMarkerIds(user, assistant, messageIds, assistantMessageIds),
+    );
   }
 
   private typedW4bInflightOriginsFromOccurrences(
+    sessionId: string,
     user: string,
     assistant: string,
     occurrences: string[],
   ): string[] {
-    return occurrences
+    const markers = occurrences
       .map((occurrence) => this.typedW4bExternalMarkerId(user, assistant, occurrence))
-      .filter((marker) => marker.length > 0)
-      .map((marker) => this.typedW4bInflightOrigin(marker));
+      .filter((marker) => marker.length > 0);
+    return this.typedW4bInflightOriginsForMarkers(
+      this.typedW4bMarkerCursorKeysFromSessionId(sessionId),
+      markers,
+    );
+  }
+
+  private typedW4bInflightOriginsForMarkers(cursorKeys: string[], markers: string[]): string[] {
+    const origins = new Set<string>();
+    for (const cursorKey of cursorKeys) {
+      for (const marker of markers) {
+        origins.add(this.typedW4bInflightOrigin(cursorKey, marker));
+      }
+    }
+    return Array.from(origins);
   }
 
   private findTypedW4bExternalMarker(

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -230,6 +230,9 @@ export class ChatTurnWriter {
   private messageHookDedup: Map<string, number> = new Map();
   private messageHookInboundQueueKeys: Map<string, string> = new Map();
   private static readonly MESSAGE_HOOK_DEDUP_TTL_MS = 60_000;
+  private static readonly MESSAGE_HOOK_DEDUP_SWEEP_INTERVAL_MS = 5_000;
+  private static readonly MESSAGE_HOOK_DEDUP_MAX_ENTRIES = 2_048;
+  private messageHookLastSweepAt = 0;
   private static readonly WEAK_SESSION_PREFIX = "weak-";
 
   constructor(options: { client: any; logger: Logger; stateDir: string }) {
@@ -1333,13 +1336,30 @@ export class ChatTurnWriter {
     if (!key) return false;
     const now = Date.now();
     const ttl = ChatTurnWriter.MESSAGE_HOOK_DEDUP_TTL_MS;
-    for (const [existingKey, ts] of this.messageHookDedup) {
-      if (now - ts > ttl) {
-        this.messageHookDedup.delete(existingKey);
-        this.messageHookInboundQueueKeys.delete(existingKey);
-      }
+    const existingTs = this.messageHookDedup.get(key);
+    if (existingTs !== undefined) {
+      if (now - existingTs <= ttl) return true;
+      this.messageHookDedup.delete(key);
+      this.messageHookInboundQueueKeys.delete(key);
     }
-    if (this.messageHookDedup.has(key)) return true;
+    if (
+      now - this.messageHookLastSweepAt >= ChatTurnWriter.MESSAGE_HOOK_DEDUP_SWEEP_INTERVAL_MS ||
+      this.messageHookDedup.size >= ChatTurnWriter.MESSAGE_HOOK_DEDUP_MAX_ENTRIES
+    ) {
+      for (const [existingKey, ts] of this.messageHookDedup) {
+        if (now - ts > ttl) {
+          this.messageHookDedup.delete(existingKey);
+          this.messageHookInboundQueueKeys.delete(existingKey);
+        }
+      }
+      this.messageHookLastSweepAt = now;
+    }
+    while (this.messageHookDedup.size >= ChatTurnWriter.MESSAGE_HOOK_DEDUP_MAX_ENTRIES) {
+      const oldestKey = this.messageHookDedup.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.messageHookDedup.delete(oldestKey);
+      this.messageHookInboundQueueKeys.delete(oldestKey);
+    }
     this.messageHookDedup.set(key, now);
     return false;
   }
@@ -1348,8 +1368,8 @@ export class ChatTurnWriter {
     const existing = this.parseComposedSessionId(existingKey);
     const candidate = this.parseComposedSessionId(candidateKey);
     if (!existing || !candidate) return false;
-    const existingStrong = existing.sessionKey.length > 0 && existing.sessionKey !== existing.conversationId;
-    const candidateStrong = candidate.sessionKey.length > 0 && candidate.sessionKey !== candidate.conversationId;
+    const existingStrong = existing.sessionKey.length > 0 && !this.isWeakSessionKey(existing.sessionKey);
+    const candidateStrong = candidate.sessionKey.length > 0 && !this.isWeakSessionKey(candidate.sessionKey);
     return candidateStrong && !existingStrong;
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -230,6 +230,7 @@ export class ChatTurnWriter {
   private messageHookDedup: Map<string, number> = new Map();
   private messageHookInboundQueueKeys: Map<string, string> = new Map();
   private static readonly MESSAGE_HOOK_DEDUP_TTL_MS = 60_000;
+  private static readonly WEAK_SESSION_PREFIX = "weak-";
 
   constructor(options: { client: any; logger: Logger; stateDir: string }) {
     this.client = options.client;
@@ -943,7 +944,7 @@ export class ChatTurnWriter {
       metadata.threadId,
       endpoint,
     );
-    const sessionKey = firstString(
+    const strongSessionKey = firstString(
       ctx.sessionKey,
       event.sessionKey,
       eventContext.sessionKey,
@@ -952,9 +953,8 @@ export class ChatTurnWriter {
       event.sessionId,
       eventContext.sessionId,
       metadata.sessionId,
-      conversationId,
-      endpoint,
     );
+    const sessionKey = strongSessionKey ?? this.weakSessionKey(channelId, accountId, conversationId, endpoint);
     if (!channelId || !sessionKey) {
       this.logger.debug?.("[ChatTurnWriter] Dropping typed message hook without channel/session identity");
       return null;
@@ -1093,7 +1093,7 @@ export class ChatTurnWriter {
       const queuedItems = [...queue];
       const queuedMeta = [...(this.pendingUserMessageMeta.get(conversationKey) ?? [])];
       const userText = queuedItems.join("\n");
-      const outboundDedupKey = this.messageHookDedupKey("outbound", ev, assistantText);
+      const outboundDedupKey = this.messageHookDedupKey("outbound", ev, assistantText, queuedMeta, userText);
       if (this.markMessageHookDuplicate(outboundDedupKey)) {
         this.pendingUserMessages.delete(conversationKey);
         this.pendingUserMessageMeta.delete(conversationKey);
@@ -1284,6 +1284,8 @@ export class ChatTurnWriter {
     direction: "inbound" | "outbound",
     ev: InternalMessageEvent,
     text: string,
+    pendingMeta: PendingUserMessageMeta[] = [],
+    userText = "",
   ): string {
     const ctx = (ev as any)?.context ?? {};
     const channelId = firstString(ctx.channelId, (ev as any)?.channelId) ?? "unknown";
@@ -1300,6 +1302,25 @@ export class ChatTurnWriter {
       ].join("::");
     }
     const sessionKey = firstString(ev.sessionKey, ctx.sessionKey) ?? "";
+    if (direction === "outbound") {
+      const inboundIds = pendingMeta
+        .map((meta) => meta.messageId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (inboundIds.length > 0) {
+        return [
+          "message-hook",
+          direction,
+          "inbound-msg",
+          this.identityHash([channelId, accountId, conversationId, sessionKey, ...inboundIds, text]),
+        ].join("::");
+      }
+      return [
+        "message-hook",
+        direction,
+        "turn-text",
+        this.identityHash([channelId, accountId, conversationId, sessionKey, userText, text]),
+      ].join("::");
+    }
     return [
       "message-hook",
       direction,
@@ -1348,6 +1369,81 @@ export class ChatTurnWriter {
       this.pendingUserMessageMeta.set(toKey, target);
       this.pendingUserMessageMeta.delete(fromKey);
     }
+  }
+
+  private promoteWeakSessionState(identity: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+    sessionKey?: string;
+  }): void {
+    if (!identity.channelId || !identity.sessionKey || this.isWeakSessionKey(identity.sessionKey)) return;
+    const weakSessionKey = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
+    if (!weakSessionKey) return;
+    const weakSessionId = this.composeSessionId({ ...identity, sessionKey: weakSessionKey });
+    const strongSessionId = this.composeSessionId(identity);
+    if (weakSessionId === strongSessionId) return;
+
+    let changed = false;
+    let durableChanged = false;
+    if (this.pendingUserMessages.has(weakSessionId) || this.pendingUserMessageMeta.has(weakSessionId)) {
+      this.movePendingInboundQueue(weakSessionId, strongSessionId);
+      changed = true;
+    }
+    const weakWatermark = this.cachedWatermarks.get(weakSessionId);
+    if (weakWatermark !== undefined) {
+      this.cachedWatermarks.set(strongSessionId, Math.max(this.cachedWatermarks.get(strongSessionId) ?? -1, weakWatermark));
+      this.cachedWatermarks.delete(weakSessionId);
+      changed = true;
+      durableChanged = true;
+    }
+    const weakW4bCount = this.w4bSessionCounts.get(weakSessionId);
+    if (weakW4bCount !== undefined) {
+      this.w4bSessionCounts.set(strongSessionId, Math.max(this.w4bSessionCounts.get(strongSessionId) ?? 0, weakW4bCount));
+      this.w4bSessionCounts.delete(weakSessionId);
+      changed = true;
+      durableChanged = true;
+    }
+    const weakTimer = this.debounceTimers.get(weakSessionId);
+    if (weakTimer) {
+      clearTimeout(weakTimer.timer);
+      this.debounceTimers.delete(weakSessionId);
+      const existingStrongTimer = this.debounceTimers.get(strongSessionId);
+      const promotedIndex = Math.max(existingStrongTimer?.pendingIndex ?? -1, weakTimer.pendingIndex);
+      this.saveWatermark(strongSessionId, promotedIndex);
+      changed = true;
+      durableChanged = true;
+    }
+    for (const [dedupKey, queueKey] of this.messageHookInboundQueueKeys.entries()) {
+      if (queueKey === weakSessionId) {
+        this.messageHookInboundQueueKeys.set(dedupKey, strongSessionId);
+        changed = true;
+      }
+    }
+    durableChanged = this.promoteCompositeSessionKeys(this.recentTurnIds, weakSessionId, strongSessionId) || durableChanged;
+    durableChanged = this.promoteCompositeSessionKeys(this.crossPathStamps, weakSessionId, strongSessionId) || durableChanged;
+    durableChanged = this.promoteCompositeSessionKeys(this.crossPathInflight, weakSessionId, strongSessionId) || durableChanged;
+    if (durableChanged) {
+      this.writeWatermarkFile();
+    } else if (changed) {
+      this.logger.debug?.("[ChatTurnWriter] Promoted weak typed-message session identity", {
+        weakSessionId,
+        strongSessionId,
+      });
+    }
+  }
+
+  private promoteCompositeSessionKeys(map: Map<string, number>, weakSessionId: string, strongSessionId: string): boolean {
+    let changed = false;
+    const prefix = `${weakSessionId}::`;
+    for (const [key, value] of Array.from(map.entries())) {
+      if (!key.startsWith(prefix)) continue;
+      const promotedKey = `${strongSessionId}${key.slice(weakSessionId.length)}`;
+      map.set(promotedKey, Math.max(map.get(promotedKey) ?? 0, value));
+      map.delete(key);
+      changed = true;
+    }
+    return changed;
   }
 
   /**
@@ -1870,6 +1966,25 @@ export class ChatTurnWriter {
       .slice(0, 16);
   }
 
+  private weakSessionKey(
+    channelId?: string,
+    accountId?: string,
+    conversationId?: string,
+    endpoint?: string,
+  ): string {
+    const weakIdentity = firstString(conversationId, endpoint);
+    if (!channelId || !weakIdentity) return "";
+    return `${ChatTurnWriter.WEAK_SESSION_PREFIX}${this.identityHash([
+      channelId,
+      accountId ?? "",
+      weakIdentity,
+    ])}`;
+  }
+
+  private isWeakSessionKey(sessionKey?: unknown): boolean {
+    return typeof sessionKey === "string" && sessionKey.startsWith(ChatTurnWriter.WEAK_SESSION_PREFIX);
+  }
+
   private externalTurnMarkerId(turnId?: unknown, user?: string, assistant?: string): string {
     if (typeof turnId !== "string" || turnId.trim().length === 0) return "";
     const idHash = createHash("sha256").update(turnId.trim()).digest("hex").slice(0, 16);
@@ -2088,6 +2203,7 @@ export class ChatTurnWriter {
   private deriveSessionId(ctx?: any): string {
     const identity = this.identityFieldsFromPayload(ctx);
     if (!identity.channelId || !identity.sessionKey) return "";
+    this.promoteWeakSessionState(identity);
     return this.composeSessionId(identity);
   }
 
@@ -2154,12 +2270,14 @@ export class ChatTurnWriter {
    */
   private deriveSessionIdFromEvent(ev: InternalMessageEvent): string {
     const ctx = (ev as any)?.context ?? {};
-    return this.composeSessionId({
+    const identity = {
       channelId: ctx.channelId ?? (ev as any)?.channelId,
       accountId: ctx.accountId,
       conversationId: ctx.conversationId,
       sessionKey: ev.sessionKey,
-    });
+    };
+    this.promoteWeakSessionState(identity);
+    return this.composeSessionId(identity);
   }
 
   /**
@@ -2289,12 +2407,14 @@ export class ChatTurnWriter {
       return "";
     }
     const ctx = (ev as any)?.context ?? {};
-    return this.composeSessionId({
+    const identity = {
       channelId: ctx.channelId ?? (ev as any)?.channelId,
       accountId: ctx.accountId,
       conversationId: ctx.conversationId,
       sessionKey: ev.sessionKey,
-    });
+    };
+    this.promoteWeakSessionState(identity);
+    return this.composeSessionId(identity);
   }
 
   private extractText(content: string | Array<{ type: string; text?: string }>): string {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1584,7 +1584,12 @@ export class ChatTurnWriter {
 
   private clearMessageHookInboundDedupKeys(keys: string[]): void {
     for (const key of keys) {
-      this.deleteMessageHookDedupKey(key);
+      // Provider messageId keys stay in the TTL cache after the queue is
+      // consumed, so a late retry of the same inbound cannot seed stale text
+      // for the next outbound. Only batch-scoped no-ID keys are disposable.
+      if (this.isNoIdInboundBatchKey(key)) {
+        this.deleteMessageHookDedupKey(key);
+      }
     }
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -99,6 +99,7 @@ export interface InternalMessageEvent {
 interface PendingUserMessageMeta {
   messageId?: string;
   arrivalId?: string;
+  typedSessionIdFallback?: boolean;
 }
 
 /**
@@ -1059,16 +1060,19 @@ export class ChatTurnWriter {
     if (channelId === "dkg-ui") return null;
     const accountId = firstString(ctx.accountId, event.accountId, eventContext.accountId, metadata.accountId, metadata.botId);
     const conversationId = this.typedHookConversationId(event, eventContext, metadata, ctx);
-    const strongSessionKey = firstString(
+    const explicitSessionKey = firstString(
       ctx.sessionKey,
       event.sessionKey,
       eventContext.sessionKey,
       metadata.sessionKey,
+    );
+    const typedSessionIdFallback = firstString(
       ctx.sessionId,
       event.sessionId,
       eventContext.sessionId,
       metadata.sessionId,
     );
+    const strongSessionKey = explicitSessionKey ?? typedSessionIdFallback;
     const sessionKey = strongSessionKey ?? this.weakSessionKey(channelId, accountId, conversationId);
     if (!channelId || !sessionKey) {
       this.logger.debug?.("[ChatTurnWriter] Dropping typed message hook without channel/session identity");
@@ -1085,6 +1089,7 @@ export class ChatTurnWriter {
     if (messageId) context.messageId = messageId;
     if (typeof successValue === "boolean") context.success = successValue;
     if (direction === "outbound" && typeof context.success !== "boolean") context.success = true;
+    if (!explicitSessionKey && typedSessionIdFallback) (context as any).typedSessionIdFallback = true;
 
     return {
       sessionKey,
@@ -1219,7 +1224,11 @@ export class ChatTurnWriter {
       queue.push(text);
       this.pendingUserMessages.set(conversationKey, queue);
       const metaQueue = this.pendingUserMessageMeta.get(conversationKey) ?? [];
-      metaQueue.push({ messageId: this.messageEventId(ev), arrivalId: this.nextPendingUserArrivalId() });
+      metaQueue.push({
+        messageId: this.messageEventId(ev),
+        arrivalId: this.nextPendingUserArrivalId(),
+        typedSessionIdFallback: (ev as any)?.context?.typedSessionIdFallback === true,
+      });
       this.pendingUserMessageMeta.set(conversationKey, metaQueue);
       if (inboundDedupKey) this.messageHookInboundQueueKeys.set(inboundDedupKey, conversationKey);
     } catch (err) {
@@ -1241,6 +1250,7 @@ export class ChatTurnWriter {
       // so we don't write a turn whose state was about to be wiped.
       const pendingReset = this.pendingResets.get(sessionId);
       if (pendingReset) await pendingReset;
+      this.promotePendingInboundQueueForOutbound(conversationKey, ev);
       const success = (ev as any)?.context?.success ?? (ev as any)?.success;
       // Drop failed outbound sends: chat history should not show replies the
       // user never received. Consume the SAME set of pending inbounds that
@@ -1703,6 +1713,46 @@ export class ChatTurnWriter {
       );
     }
     return candidateStrong && !existingStrong;
+  }
+
+  private pendingQueueUsesTypedSessionFallback(queueKey: string): boolean {
+    const messages = this.pendingUserMessages.get(queueKey) ?? [];
+    const meta = this.pendingUserMessageMeta.get(queueKey) ?? [];
+    return messages.length > 0 && messages.every((_, index) => meta[index]?.typedSessionIdFallback === true);
+  }
+
+  private shouldMoveInboundQueueForOutbound(
+    existingKey: string,
+    targetKey: string,
+    outboundUsesTypedSessionIdFallback: boolean,
+  ): boolean {
+    const existing = this.parseComposedSessionId(existingKey);
+    const target = this.parseComposedSessionId(targetKey);
+    if (!existing || !target) return false;
+    if (!target.conversationId) return false;
+    if (existing.channelId !== target.channelId) return false;
+    if (existing.accountId !== target.accountId) return false;
+    if (existing.conversationId !== target.conversationId) return false;
+    const existingWeak = this.isWeakSessionKey(existing.sessionKey);
+    const targetWeak = this.isWeakSessionKey(target.sessionKey);
+    if (existingWeak === targetWeak) return false;
+    if (targetWeak) return this.pendingQueueUsesTypedSessionFallback(existingKey);
+    return outboundUsesTypedSessionIdFallback;
+  }
+
+  private promotePendingInboundQueueForOutbound(targetKey: string, ev: InternalMessageEvent): void {
+    const targetQueue = this.pendingUserMessages.get(targetKey);
+    if (targetQueue && targetQueue.length > 0) return;
+    const outboundUsesTypedSessionIdFallback = (ev as any)?.context?.typedSessionIdFallback === true;
+    const candidates: string[] = [];
+    for (const [candidateKey, messages] of Array.from(this.pendingUserMessages.entries())) {
+      if (candidateKey === targetKey || !messages || messages.length === 0) continue;
+      if (this.shouldMoveInboundQueueForOutbound(candidateKey, targetKey, outboundUsesTypedSessionIdFallback)) {
+        candidates.push(candidateKey);
+      }
+    }
+    if (candidates.length !== 1) return;
+    this.movePendingInboundQueue(candidates[0], targetKey);
   }
 
   private movePendingInboundQueue(fromKey: string, toKey: string): void {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -16,6 +16,8 @@ import { createHash } from "crypto";
  * when typed `agent_end` is silent. Those events are normalized into the W4b
  * envelope and deduped against internal `message:received/message:sent` by
  * channel/account/conversation/messageId, outside the Node-UI marker space.
+ * Weak W4b replay markers are additionally bound to provider message IDs so
+ * same-text repeats in one transcript do not suppress the wrong occurrence.
  */
 
 interface Logger {
@@ -54,6 +56,7 @@ interface ComputedChatTurnPair {
   pairIndex: number;
   externalTurnIds: string[];
   externalDirect: boolean;
+  messageIds: string[];
 }
 
 interface ExternalMarkerAction {
@@ -183,7 +186,10 @@ export class ChatTurnWriter {
   // persist jobs here, otherwise the reset assumption "all persists for
   // this session are tracked" is silently violated.
   private inFlightPersists: Map<string, Set<Promise<void>>> = new Map();
-  private promotedSessionIds: Map<string, string> = new Map();
+  // Job-scoped promotion target for in-flight persists. A conversationless
+  // sessionKey can later appear in many conversations, so promotion must never
+  // become a standing alias for future events.
+  private promotedPersistJobs: Map<Promise<void>, string> = new Map();
   // Per-session reset promises. `onAgentEnd` / `onMessageSent` await these
   // before processing so a compacted message array can't be read against
   // a stale watermark while the reset is still draining.
@@ -570,7 +576,7 @@ export class ChatTurnWriter {
       const lastIdx = pairs.length - 1;
       const job = this.trackPersistJob(sessionId, async () => {
         for (let i = 0; i < pairs.length; i++) {
-          const { user, assistant, pairIndex, externalTurnIds } = pairs[i];
+          const { user, assistant, pairIndex, externalTurnIds, messageIds } = pairs[i];
           if (!user && !assistant) continue;
           const externalMarkerAction = externalCursorKey
             ? this.consumeExternalTurnMarkersForPair(
@@ -593,7 +599,8 @@ export class ChatTurnWriter {
             if (externalMarkerAction.skip) continue;
           }
           const weakMarker = weakConversationCursorKey
-            ? this.weakW4bExternalMarkerId(user, assistant)
+            ? this.weakW4bExternalMarkerIds(user, assistant, messageIds)
+              .find((marker) => this.hasExternalTurnMarker(weakConversationCursorKey, marker)) ?? ""
             : "";
           if (weakConversationCursorKey && weakMarker && this.hasExternalTurnMarker(weakConversationCursorKey, weakMarker)) {
             const previousWeakMarkerCount =
@@ -725,7 +732,9 @@ export class ChatTurnWriter {
   }
 
   private deleteTrackedPersistJob(sessionId: string, job: Promise<void>): void {
-    const candidates = new Set([sessionId, this.resolvePromotedSessionId(sessionId)]);
+    const promotedSessionId = this.promotedPersistJobs.get(job);
+    const candidates = new Set([sessionId]);
+    if (promotedSessionId) candidates.add(promotedSessionId);
     let removed = false;
     for (const candidate of candidates) {
       const bucket = this.inFlightPersists.get(candidate);
@@ -733,6 +742,7 @@ export class ChatTurnWriter {
       removed = bucket.delete(job) || removed;
       if (bucket.size === 0) this.inFlightPersists.delete(candidate);
     }
+    this.promotedPersistJobs.delete(job);
     if (removed) return;
     for (const [key, bucket] of Array.from(this.inFlightPersists.entries())) {
       if (!bucket.delete(job)) continue;
@@ -926,7 +936,6 @@ export class ChatTurnWriter {
       // N turns" no longer maps to the new pair indices. Leaving stale
       // count would skip new pairs in `computeDelta`.
       this.w4bSessionCounts.delete(sessionId);
-      this.clearSessionPromotionAliases(sessionId);
     }
     this.clearMessageHookDedupForSessions(ids);
     // External markers record daemon-success facts from direct-channel
@@ -1201,12 +1210,13 @@ export class ChatTurnWriter {
         // reset gate sees this in-flight write and `Promise.allSettled`s
         // it. Without tracking, a `message:sent` write mid-compaction
         // could land its `saveWatermark()` after the reset clears state.
-        this.trackPersistJob(sessionId, async () => {
+        let w4bJob: Promise<void> | undefined;
+        w4bJob = this.trackPersistJob(sessionId, async () => {
           let daemonPersisted = false;
           try {
             await this.persistOne(sessionId, userText, assistantText, turnId);
             daemonPersisted = true;
-            const completionSessionId = this.resolvePromotedSessionId(sessionId);
+            const completionSessionId = this.resolvePromotedPersistJobSession(sessionId, w4bJob);
             // Post-success: stamp the content-only `w4bOrigin` key on
             // the SHORT-TTL cross-path map (T5) so a later W4a
             // `agent_end` last-pair peek can see that W4b already
@@ -1233,7 +1243,12 @@ export class ChatTurnWriter {
                 completionSessionId,
                 (this.w4bSessionCounts.get(completionSessionId) ?? 0) + 1,
               );
-              this.markWeakW4bTurnPersisted(completionSessionId, userText, assistantText);
+              this.markWeakW4bTurnPersisted(
+                completionSessionId,
+                userText,
+                assistantText,
+                this.w4bWeakMarkerOccurrences(w4bDiscriminator, queuedMeta),
+              );
               // T17 — Persist the new count to disk via the
               // debounced flush so a process restart preserves
               // the "skip these pairs in computeDelta" floor.
@@ -1268,7 +1283,7 @@ export class ChatTurnWriter {
             // next outbound will collapse the full queue (old items +
             // new) into one user-side, matching W4a's pairing.
             if (queuedItems.length > 0) {
-              const restoreKey = this.resolvePromotedSessionId(conversationKey);
+              const restoreKey = this.resolvePromotedPersistJobSession(conversationKey, w4bJob);
               const restored = this.pendingUserMessages.get(restoreKey) ?? [];
               restored.unshift(...queuedItems);
               this.pendingUserMessages.set(restoreKey, restored);
@@ -1281,7 +1296,7 @@ export class ChatTurnWriter {
             // anymore; only stamping happens post-success above.
             if (outboundDedupKey) this.deleteMessageHookDedupKey(outboundDedupKey);
             this.releaseTurnIdReservation(sessionId, w4bInflight);
-            const failureSessionId = this.resolvePromotedSessionId(sessionId);
+            const failureSessionId = this.resolvePromotedPersistJobSession(sessionId, w4bJob);
             if (failureSessionId !== sessionId) this.releaseTurnIdReservation(failureSessionId, w4bInflight);
             this.logger.error?.("[ChatTurnWriter.onMessageSent] Persist failed", { err });
           } finally {
@@ -1291,10 +1306,11 @@ export class ChatTurnWriter {
             // 5s post-success window; on failure the reservation must
             // not leak to block legitimate later same-content turns.
             this.unmarkCrossPathInflight(sessionId, w4bOriginKey);
-            const finalSessionId = this.resolvePromotedSessionId(sessionId);
+            const finalSessionId = this.resolvePromotedPersistJobSession(sessionId, w4bJob);
             if (finalSessionId !== sessionId) this.unmarkCrossPathInflight(finalSessionId, w4bOriginKey);
           }
-        }).catch(() => {});
+        });
+        w4bJob.catch(() => {});
       }
     } catch (err) {
       this.logger.error?.("[ChatTurnWriter.onMessageSent] Error", { err });
@@ -1488,7 +1504,6 @@ export class ChatTurnWriter {
   }
 
   private promoteSessionState(fromSessionId: string, strongSessionId: string): void {
-    this.recordSessionPromotion(fromSessionId, strongSessionId);
     let changed = false;
     let durableChanged = false;
     if (this.promoteInFlightPersists(fromSessionId, strongSessionId)) {
@@ -1547,26 +1562,8 @@ export class ChatTurnWriter {
     }
   }
 
-  private recordSessionPromotion(fromSessionId: string, strongSessionId: string): void {
-    const resolvedStrongSessionId = this.resolvePromotedSessionId(strongSessionId);
-    if (!fromSessionId || fromSessionId === resolvedStrongSessionId) return;
-    this.promotedSessionIds.set(fromSessionId, resolvedStrongSessionId);
-    for (const [alias, target] of Array.from(this.promotedSessionIds.entries())) {
-      if (target === fromSessionId) this.promotedSessionIds.set(alias, resolvedStrongSessionId);
-    }
-  }
-
-  private resolvePromotedSessionId(sessionId: string): string {
-    let current = sessionId;
-    const seen = new Set<string>();
-    while (current && !seen.has(current)) {
-      seen.add(current);
-      const next = this.promotedSessionIds.get(current);
-      if (!next || next === current) break;
-      current = next;
-    }
-    if (current && current !== sessionId) this.promotedSessionIds.set(sessionId, current);
-    return current || sessionId;
+  private resolvePromotedPersistJobSession(sessionId: string, job?: Promise<void>): string {
+    return job ? this.promotedPersistJobs.get(job) ?? sessionId : sessionId;
   }
 
   private promoteInFlightPersists(fromSessionId: string, strongSessionId: string): boolean {
@@ -1576,16 +1573,13 @@ export class ChatTurnWriter {
       return false;
     }
     const target = this.inFlightPersists.get(strongSessionId) ?? new Set<Promise<void>>();
-    for (const job of source) target.add(job);
+    for (const job of source) {
+      target.add(job);
+      this.promotedPersistJobs.set(job, strongSessionId);
+    }
     this.inFlightPersists.set(strongSessionId, target);
     this.inFlightPersists.delete(fromSessionId);
     return true;
-  }
-
-  private clearSessionPromotionAliases(sessionId: string): void {
-    for (const [from, to] of Array.from(this.promotedSessionIds.entries())) {
-      if (from === sessionId || to === sessionId) this.promotedSessionIds.delete(from);
-    }
   }
 
   private promoteCompositeSessionKeys(map: Map<string, number>, fromSessionId: string, strongSessionId: string): boolean {
@@ -1860,6 +1854,7 @@ export class ChatTurnWriter {
       text: string;
       externalTurnIds: string[];
       externalDirect: boolean;
+      messageIds: string[];
     }> = [];
     let pairIndex = 0;
     for (const msg of messages) {
@@ -1878,6 +1873,7 @@ export class ChatTurnWriter {
             text: userText,
             externalTurnIds: this.extractExternalTurnIds(msg),
             externalDirect: this.hasExternalDirectChannelMetadata(msg),
+            messageIds: this.extractMessageIds(msg),
           });
         }
       } else if (msg.role === "assistant") {
@@ -1925,6 +1921,7 @@ export class ChatTurnWriter {
         const externalTurnIds = externalDirect
           ? Array.from(new Set(pendingUsers.flatMap((pending) => pending.externalTurnIds)))
           : [];
+        const messageIds = Array.from(new Set(pendingUsers.flatMap((pending) => pending.messageIds)));
         pendingUsers.length = 0;
         if (pairIndex > savedUpTo) {
           pairs.push({
@@ -1933,6 +1930,7 @@ export class ChatTurnWriter {
             pairIndex,
             externalTurnIds,
             externalDirect,
+            messageIds,
           });
         }
         pairIndex++;
@@ -2017,6 +2015,26 @@ export class ChatTurnWriter {
     }
 
     return Array.from(ids);
+  }
+
+  private extractMessageIds(msg: ChatTurnMessage): string[] {
+    const context = msg.context && typeof msg.context === "object" ? msg.context : {};
+    const metadata = msg.metadata && typeof msg.metadata === "object" ? msg.metadata : {};
+    const messageId = firstString(
+      (msg as any).messageId,
+      (context as any).messageId,
+      (metadata as any).messageId,
+      (msg as any).MessageId,
+      (context as any).MessageId,
+      (metadata as any).MessageId,
+      (msg as any).message_id,
+      (context as any).message_id,
+      (metadata as any).message_id,
+      (msg as any).id,
+      (context as any).id,
+      (metadata as any).id,
+    );
+    return messageId ? [messageId] : [];
   }
 
   private hasExternalDirectChannelMetadata(msg: ChatTurnMessage): boolean {
@@ -2148,17 +2166,32 @@ export class ChatTurnWriter {
     return `external-id::${idHash}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
-  private weakW4bExternalMarkerId(user: string, assistant: string): string {
-    return `weak-w4b::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
+  private weakW4bExternalMarkerId(user: string, assistant: string, occurrence: string): string {
+    if (!occurrence) return "";
+    return `weak-w4b::${this.identityHash([occurrence])}::${this.contentHash(user, this.stripRecalledMemory(assistant))}`;
   }
 
-  private markWeakW4bTurnPersisted(sessionId: string, user: string, assistant: string): void {
+  private weakW4bExternalMarkerIds(user: string, assistant: string, messageIds: string[]): string[] {
+    const occurrence = this.w4bInboundMessageDiscriminator(messageIds);
+    const marker = this.weakW4bExternalMarkerId(user, assistant, occurrence);
+    return marker ? [marker] : [];
+  }
+
+  private markWeakW4bTurnPersisted(
+    sessionId: string,
+    user: string,
+    assistant: string,
+    occurrences: string[],
+  ): void {
     const cursor = this.weakConversationCursorKeyFromSessionId(sessionId);
     if (!cursor) return;
-    const marker = this.weakW4bExternalMarkerId(user, assistant);
     const bucket = this.externalTurnMarkers.get(cursor) ?? new Map<string, number>();
-    bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
-    this.externalTurnMarkers.set(cursor, bucket);
+    for (const occurrence of occurrences) {
+      const marker = this.weakW4bExternalMarkerId(user, assistant, occurrence);
+      if (!marker) continue;
+      bucket.set(marker, (bucket.get(marker) ?? 0) + 1);
+    }
+    if (bucket.size > 0) this.externalTurnMarkers.set(cursor, bucket);
   }
 
   private consumeExternalTurnMarkersForPair(
@@ -2316,8 +2349,29 @@ export class ChatTurnWriter {
     const inboundIds = pendingMeta
       .map((meta) => meta.messageId)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
-    if (inboundIds.length === 0) return "";
-    return `in::${this.identityHash(inboundIds)}`;
+    return this.w4bInboundMessageDiscriminator(inboundIds);
+  }
+
+  private w4bInboundMessageDiscriminator(messageIds: string[]): string {
+    const ids = messageIds
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+    if (ids.length === 0) return "";
+    return `in::${this.identityHash(ids)}`;
+  }
+
+  private w4bWeakMarkerOccurrences(
+    discriminator: string,
+    pendingMeta: PendingUserMessageMeta[],
+  ): string[] {
+    const occurrences = new Set<string>();
+    if (discriminator) occurrences.add(discriminator);
+    const inboundIds = pendingMeta
+      .map((meta) => meta.messageId)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+    const inboundDiscriminator = this.w4bInboundMessageDiscriminator(inboundIds);
+    if (inboundDiscriminator) occurrences.add(inboundDiscriminator);
+    return Array.from(occurrences);
   }
   /**
    * @deprecated Kept temporarily for tests that inspect the dedup-map key

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -191,6 +191,10 @@ export class ChatTurnWriter {
   // sessionKey can later appear in many conversations, so promotion must never
   // become a standing alias for future events.
   private promotedPersistJobs: Map<Promise<void>, string> = new Map();
+  // Job-scoped content origins for active W4b persists. These let a later W4a
+  // skip the exact promoted in-flight turn without copying short-TTL dedupe
+  // maps from a conversationless session into an unrelated concrete chat.
+  private persistJobOriginKeys: Map<Promise<void>, Set<string>> = new Map();
   // Per-session reset promises. `onAgentEnd` / `onMessageSent` await these
   // before processing so a compacted message array can't be read against
   // a stale watermark while the reset is still draining.
@@ -661,7 +665,7 @@ export class ChatTurnWriter {
             // and a future outbound re-pairs; the unchanged watermark
             // means the next `agent_end` will re-yield this pair as
             // backfill (correct retry behavior).
-            if (this.peekCrossPathInflight(sessionId, w4bOrigin)) {
+            if (this.peekCrossPathInflight(sessionId, w4bOrigin) || this.hasInFlightPersistOrigin(sessionId, w4bOrigin)) {
               continue;
             }
           }
@@ -736,6 +740,21 @@ export class ChatTurnWriter {
     return job;
   }
 
+  private markPersistJobOrigin(job: Promise<void>, originKey: string): void {
+    const origins = this.persistJobOriginKeys.get(job) ?? new Set<string>();
+    origins.add(originKey);
+    this.persistJobOriginKeys.set(job, origins);
+  }
+
+  private hasInFlightPersistOrigin(sessionId: string, originKey: string): boolean {
+    const bucket = this.inFlightPersists.get(sessionId);
+    if (!bucket) return false;
+    for (const job of bucket) {
+      if (this.persistJobOriginKeys.get(job)?.has(originKey)) return true;
+    }
+    return false;
+  }
+
   private deleteTrackedPersistJob(sessionId: string, job: Promise<void>): void {
     const promotedSessionId = this.promotedPersistJobs.get(job);
     const candidates = new Set([sessionId]);
@@ -748,6 +767,7 @@ export class ChatTurnWriter {
       if (bucket.size === 0) this.inFlightPersists.delete(candidate);
     }
     this.promotedPersistJobs.delete(job);
+    this.persistJobOriginKeys.delete(job);
     if (removed) return;
     for (const [key, bucket] of Array.from(this.inFlightPersists.entries())) {
       if (!bucket.delete(job)) continue;
@@ -1174,11 +1194,13 @@ export class ChatTurnWriter {
       // before the retry.
       const queuedItems = [...queue];
       const queuedMeta = [...(this.pendingUserMessageMeta.get(conversationKey) ?? [])];
+      const consumedInboundDedupKeys = this.messageHookInboundDedupKeysForQueue(conversationKey);
       const userText = queuedItems.join("\n");
       const outboundDedupKey = this.messageHookDedupKey("outbound", ev, assistantText, queuedMeta, userText);
       if (this.markMessageHookDuplicate(outboundDedupKey, sessionId)) {
         this.pendingUserMessages.delete(conversationKey);
         this.pendingUserMessageMeta.delete(conversationKey);
+        this.clearMessageHookInboundDedupKeys(consumedInboundDedupKeys);
         return;
       }
       this.pendingUserMessages.delete(conversationKey);
@@ -1199,13 +1221,17 @@ export class ChatTurnWriter {
           // same-content turn where W4a fired for turn 1 but skipped
           // turn 2" — much rarer in practice.
           this.consumeCrossPathStamp(sessionId, w4aOrigin);
+          this.clearMessageHookInboundDedupKeys(consumedInboundDedupKeys);
           return; // W4a already wrote
         }
         // T10 — Cross-path in-flight check. If W4a is mid-persist for
         // this pair, skip; W4a will own the persist. We've already
         // consumed the pending user above (line 508), which is correct
         // because W4a IS persisting it.
-        if (this.peekCrossPathInflight(sessionId, w4aOrigin)) return;
+        if (this.peekCrossPathInflight(sessionId, w4aOrigin)) {
+          this.clearMessageHookInboundDedupKeys(consumedInboundDedupKeys);
+          return;
+        }
         // R15.1 — In-flight guard with per-turn discriminator.
         //   The cross-path stamp (`w4bOrigin`, content-only) is held for
         //   3s post-success so W4a's later last-pair peek can find it.
@@ -1294,6 +1320,7 @@ export class ChatTurnWriter {
                 this.scheduleWatermarkFlush(durableSessionId, { retryOnFailure: true, attempts: 3 });
                 throw new Error("Failed to write W4b chat-turn watermark");
               }
+              this.clearMessageHookInboundDedupKeys(consumedInboundDedupKeys);
             }
           } catch (err) {
             if (daemonPersisted) {
@@ -1343,6 +1370,7 @@ export class ChatTurnWriter {
             if (finalSessionId !== sessionId) this.unmarkCrossPathInflight(finalSessionId, w4bOriginKey);
           }
         });
+        this.markPersistJobOrigin(w4bJob, w4bOriginKey);
         w4bJob.catch(() => {});
       }
     } catch (err) {
@@ -1406,6 +1434,14 @@ export class ChatTurnWriter {
         direction,
         "msg",
         this.identityHash([...scopeParts, messageId]),
+      ].join("::");
+    }
+    if (direction === "inbound") {
+      return [
+        "message-hook",
+        direction,
+        "text",
+        this.identityHash([...scopeParts, text]),
       ].join("::");
     }
     if (direction === "outbound") {
@@ -1489,6 +1525,18 @@ export class ChatTurnWriter {
     }
   }
 
+  private messageHookInboundDedupKeysForQueue(queueKey: string): string[] {
+    return Array.from(this.messageHookInboundQueueKeys.entries())
+      .filter(([, currentQueueKey]) => currentQueueKey === queueKey)
+      .map(([key]) => key);
+  }
+
+  private clearMessageHookInboundDedupKeys(keys: string[]): void {
+    for (const key of keys) {
+      this.deleteMessageHookDedupKey(key);
+    }
+  }
+
   private shouldMoveInboundQueue(existingKey: string, candidateKey: string): boolean {
     const existing = this.parseComposedSessionId(existingKey);
     const candidate = this.parseComposedSessionId(candidateKey);
@@ -1541,7 +1589,6 @@ export class ChatTurnWriter {
 
   private promoteSessionState(fromSessionId: string, strongSessionId: string): void {
     let changed = false;
-    let durableChanged = false;
     if (this.promoteInFlightPersists(fromSessionId, strongSessionId)) {
       changed = true;
     }
@@ -1561,12 +1608,7 @@ export class ChatTurnWriter {
         changed = true;
       }
     }
-    durableChanged = this.promoteCompositeSessionKeys(this.recentTurnIds, fromSessionId, strongSessionId) || durableChanged;
-    durableChanged = this.promoteCompositeSessionKeys(this.crossPathStamps, fromSessionId, strongSessionId) || durableChanged;
-    durableChanged = this.promoteCompositeSessionKeys(this.crossPathInflight, fromSessionId, strongSessionId) || durableChanged;
-    if (durableChanged) {
-      this.writeWatermarkFile();
-    } else if (changed) {
+    if (changed) {
       this.logger.debug?.("[ChatTurnWriter] Promoted typed-message session identity", {
         fromSessionId,
         strongSessionId,
@@ -1602,19 +1644,6 @@ export class ChatTurnWriter {
     this.inFlightPersists.set(strongSessionId, target);
     this.inFlightPersists.delete(fromSessionId);
     return true;
-  }
-
-  private promoteCompositeSessionKeys(map: Map<string, number>, fromSessionId: string, strongSessionId: string): boolean {
-    let changed = false;
-    const prefix = `${fromSessionId}::`;
-    for (const [key, value] of Array.from(map.entries())) {
-      if (!key.startsWith(prefix)) continue;
-      const promotedKey = `${strongSessionId}${key.slice(fromSessionId.length)}`;
-      map.set(promotedKey, Math.max(map.get(promotedKey) ?? 0, value));
-      map.delete(key);
-      changed = true;
-    }
-    return changed;
   }
 
   /**

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -7,17 +7,17 @@ import { createHash } from "crypto";
  * `markExternalTurnPersistedDurable` creates content-bound markers only after
  * channel-side daemon `storeChatTurn` succeeds; marker keys include `turnId`
  * plus canonical user/assistant text to avoid false dedupe for reused IDs or
- * content. W4a consumes them in `consumeExternalTurnMarkersForPair` during
+ * content. W4a matches them in `consumeExternalTurnMarkersForPair` during
  * `runAgentEndPersist`, advancing pair watermarks only after durable commit.
- * Create/consume failures roll back marker snapshots when
- * `commitWatermarkStateSync` fails; `setStateDir` migrates per-session `m`
+ * Create failures roll back marker snapshots when `commitWatermarkStateSync`
+ * fails; `setStateDir` migrates per-session `m`
  * markers, and graceful `DkgChannelPlugin.stop()` drains in-flight first writes.
  * Telegram persistence can arrive through typed `message_received/message_sent`
  * when typed `agent_end` is silent. Those events are normalized into the W4b
  * envelope and deduped against internal `message:received/message:sent` by
  * channel/account/conversation/messageId, outside the Node-UI marker space.
- * Typed W4b replay markers are additionally bound to provider message IDs so
- * same-text repeats in one transcript do not suppress the wrong occurrence.
+ * Typed W4b replay markers are retained and bound to provider message IDs so
+ * repeated reset/compaction replays skip same-text occurrences safely.
  */
 
 interface Logger {
@@ -115,6 +115,7 @@ function readEventText(ev: InternalMessageEvent): string {
 function firstString(...values: unknown[]): string | undefined {
   for (const value of values) {
     if (typeof value === "string" && value.trim().length > 0) return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
   }
   return undefined;
 }
@@ -616,16 +617,14 @@ export class ChatTurnWriter {
             assistantMessageIds,
           );
           if (typedW4bMarkerHit) {
-            const { cursorKey, marker } = typedW4bMarkerHit;
-            const previousTypedMarkerCount =
-              this.externalTurnMarkers.get(cursorKey)?.get(marker) ?? 0;
             const watermarkSnapshot = this.snapshotWatermarkState(sessionId);
-            this.consumeExternalTurnMarker(cursorKey, marker);
+            // Typed W4b markers are durable daemon-success facts, not
+            // one-shot tickets. Keep them so later reset/compaction replays
+            // can skip the same provider-message occurrence again.
             this.bumpWatermark(sessionId, pairIndex);
             if (!this.commitWatermarkStateSync(sessionId)) {
-              this.restoreExternalTurnMarkerCount(cursorKey, marker, previousTypedMarkerCount);
               this.restoreWatermarkState(sessionId, watermarkSnapshot);
-              throw new Error("Failed to write typed W4b chat-turn marker consumption");
+              throw new Error("Failed to write typed W4b chat-turn marker watermark");
             }
             continue;
           }

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1721,6 +1721,15 @@ export class ChatTurnWriter {
       this.pendingUserMessages.delete(fromKey);
     }
     this.pendingUserMessageMeta.delete(fromKey);
+    this.rebindMessageHookInboundQueueKeys(fromKey, toKey);
+  }
+
+  private rebindMessageHookInboundQueueKeys(fromKey: string, toKey: string): void {
+    for (const [key, queueKey] of Array.from(this.messageHookInboundQueueKeys.entries())) {
+      if (queueKey !== fromKey) continue;
+      this.messageHookInboundQueueKeys.set(key, toKey);
+      this.messageHookDedupSessionKeys.set(key, toKey);
+    }
   }
 
   private w4bInflightGuardSessionIds(identity: {
@@ -2788,7 +2797,7 @@ export class ChatTurnWriter {
 
   private weakConversationCursorKeyFromSessionId(sessionId: string): string {
     const parsed = this.parseComposedSessionId(sessionId);
-    if (!parsed || !this.isWeakSessionKey(parsed.sessionKey) || !parsed.conversationId) return "";
+    if (!parsed || !parsed.conversationId) return "";
     return `openclaw:weak:${this.identityHash([parsed.channelId, parsed.accountId, parsed.conversationId])}`;
   }
 

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -94,6 +94,7 @@ export interface InternalMessageEvent {
 
 interface PendingUserMessageMeta {
   messageId?: string;
+  arrivalId?: string;
 }
 
 /**
@@ -128,6 +129,7 @@ export class ChatTurnWriter {
   // provider messageId forward and use it as the durable W4b turnId
   // discriminator when the outbound envelope cannot provide one.
   private pendingUserMessageMeta: Map<string, PendingUserMessageMeta[]> = new Map();
+  private pendingUserMessageSeq = 0;
   private debounceTimers: Map<string, { timer: NodeJS.Timeout; pendingIndex: number }> = new Map();
   private watermarkFilePath: string;
   // Cross-path dedup (W4a agent_end vs. W4b message:sent). The gateway fires
@@ -229,6 +231,7 @@ export class ChatTurnWriter {
   private static readonly CROSS_PATH_INFLIGHT_TTL_MS = 60_000;
   private messageHookDedup: Map<string, number> = new Map();
   private messageHookInboundQueueKeys: Map<string, string> = new Map();
+  private messageHookDedupSessionKeys: Map<string, string> = new Map();
   private static readonly MESSAGE_HOOK_DEDUP_TTL_MS = 60_000;
   private static readonly MESSAGE_HOOK_DEDUP_SWEEP_INTERVAL_MS = 5_000;
   private static readonly MESSAGE_HOOK_DEDUP_MAX_ENTRIES = 2_048;
@@ -887,8 +890,7 @@ export class ChatTurnWriter {
       // count would skip new pairs in `computeDelta`.
       this.w4bSessionCounts.delete(sessionId);
     }
-    this.messageHookDedup.clear();
-    this.messageHookInboundQueueKeys.clear();
+    this.clearMessageHookDedupForSessions(ids);
     // External markers record daemon-success facts from direct-channel
     // persists. Preserve them across reset/compaction so the reset W4a replay
     // can still consume the marker instead of duplicating the stored UI turn.
@@ -925,9 +927,6 @@ export class ChatTurnWriter {
     ].find((value) => typeof value === "string" && value.trim().length > 0) as string | undefined;
     if (!content) return null;
 
-    const endpoint = direction === "inbound"
-      ? firstString(event.from, metadata.from, metadata.senderId, metadata.userId)
-      : firstString(event.to, metadata.to, metadata.recipientId, metadata.userId);
     const channelId = firstString(
       ctx.channelId,
       event.channelId,
@@ -945,7 +944,6 @@ export class ChatTurnWriter {
       metadata.conversationId,
       metadata.chatId,
       metadata.threadId,
-      endpoint,
     );
     const strongSessionKey = firstString(
       ctx.sessionKey,
@@ -957,7 +955,7 @@ export class ChatTurnWriter {
       eventContext.sessionId,
       metadata.sessionId,
     );
-    const sessionKey = strongSessionKey ?? this.weakSessionKey(channelId, accountId, conversationId, endpoint);
+    const sessionKey = strongSessionKey ?? this.weakSessionKey(channelId, accountId, conversationId);
     if (!channelId || !sessionKey) {
       this.logger.debug?.("[ChatTurnWriter] Dropping typed message hook without channel/session identity");
       return null;
@@ -1005,20 +1003,23 @@ export class ChatTurnWriter {
       // attachment-only turns.
       if (!text) return;
       const inboundDedupKey = this.messageHookDedupKey("inbound", ev, text);
-      const existingConversationKey = this.messageHookInboundQueueKeys.get(inboundDedupKey);
-      if (existingConversationKey && existingConversationKey !== conversationKey) {
-        if (this.shouldMoveInboundQueue(existingConversationKey, conversationKey)) {
-          this.movePendingInboundQueue(existingConversationKey, conversationKey);
-          this.messageHookInboundQueueKeys.set(inboundDedupKey, conversationKey);
+      if (inboundDedupKey) {
+        const existingConversationKey = this.messageHookInboundQueueKeys.get(inboundDedupKey);
+        if (existingConversationKey && existingConversationKey !== conversationKey) {
+          if (this.shouldMoveInboundQueue(existingConversationKey, conversationKey)) {
+            this.movePendingInboundQueue(existingConversationKey, conversationKey);
+            this.messageHookInboundQueueKeys.set(inboundDedupKey, conversationKey);
+            this.messageHookDedupSessionKeys.set(inboundDedupKey, conversationKey);
+          }
+          return;
         }
-        return;
+        if (this.markMessageHookDuplicate(inboundDedupKey, conversationKey)) return;
       }
-      if (this.markMessageHookDuplicate(inboundDedupKey)) return;
       const queue = this.pendingUserMessages.get(conversationKey) ?? [];
       queue.push(text);
       this.pendingUserMessages.set(conversationKey, queue);
       const metaQueue = this.pendingUserMessageMeta.get(conversationKey) ?? [];
-      metaQueue.push({ messageId: this.messageEventId(ev) });
+      metaQueue.push({ messageId: this.messageEventId(ev), arrivalId: this.nextPendingUserArrivalId() });
       this.pendingUserMessageMeta.set(conversationKey, metaQueue);
       if (inboundDedupKey) this.messageHookInboundQueueKeys.set(inboundDedupKey, conversationKey);
     } catch (err) {
@@ -1097,7 +1098,7 @@ export class ChatTurnWriter {
       const queuedMeta = [...(this.pendingUserMessageMeta.get(conversationKey) ?? [])];
       const userText = queuedItems.join("\n");
       const outboundDedupKey = this.messageHookDedupKey("outbound", ev, assistantText, queuedMeta, userText);
-      if (this.markMessageHookDuplicate(outboundDedupKey)) {
+      if (this.markMessageHookDuplicate(outboundDedupKey, sessionId)) {
         this.pendingUserMessages.delete(conversationKey);
         this.pendingUserMessageMeta.delete(conversationKey);
         return;
@@ -1237,7 +1238,7 @@ export class ChatTurnWriter {
             // Release the in-flight reservation so a retry can proceed.
             // No `w4bOrigin` release needed — we don't stamp it pre-persist
             // anymore; only stamping happens post-success above.
-            if (outboundDedupKey) this.messageHookDedup.delete(outboundDedupKey);
+            if (outboundDedupKey) this.deleteMessageHookDedupKey(outboundDedupKey);
             this.releaseTurnIdReservation(sessionId, w4bInflight);
             this.logger.error?.("[ChatTurnWriter.onMessageSent] Persist failed", { err });
           } finally {
@@ -1283,6 +1284,11 @@ export class ChatTurnWriter {
     return firstString(ctx.messageId, (ev as any)?.messageId);
   }
 
+  private nextPendingUserArrivalId(): string {
+    this.pendingUserMessageSeq = (this.pendingUserMessageSeq + 1) >>> 0;
+    return `arrival::${this.pendingUserMessageSeq}`;
+  }
+
   private messageHookDedupKey(
     direction: "inbound" | "outbound",
     ev: InternalMessageEvent,
@@ -1317,6 +1323,17 @@ export class ChatTurnWriter {
           this.identityHash([channelId, accountId, conversationId, sessionKey, ...inboundIds, text]),
         ].join("::");
       }
+      const arrivalIds = pendingMeta
+        .map((meta) => meta.arrivalId)
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (arrivalIds.length > 0) {
+        return [
+          "message-hook",
+          direction,
+          "arrival",
+          this.identityHash([channelId, accountId, conversationId, sessionKey, ...arrivalIds, text]),
+        ].join("::");
+      }
       return [
         "message-hook",
         direction,
@@ -1324,23 +1341,17 @@ export class ChatTurnWriter {
         this.identityHash([channelId, accountId, conversationId, sessionKey, userText, text]),
       ].join("::");
     }
-    return [
-      "message-hook",
-      direction,
-      "text",
-      this.identityHash([channelId, accountId, conversationId, sessionKey, text]),
-    ].join("::");
+    return "";
   }
 
-  private markMessageHookDuplicate(key: string): boolean {
+  private markMessageHookDuplicate(key: string, sessionId?: string): boolean {
     if (!key) return false;
     const now = Date.now();
     const ttl = ChatTurnWriter.MESSAGE_HOOK_DEDUP_TTL_MS;
     const existingTs = this.messageHookDedup.get(key);
     if (existingTs !== undefined) {
       if (now - existingTs <= ttl) return true;
-      this.messageHookDedup.delete(key);
-      this.messageHookInboundQueueKeys.delete(key);
+      this.deleteMessageHookDedupKey(key);
     }
     if (
       now - this.messageHookLastSweepAt >= ChatTurnWriter.MESSAGE_HOOK_DEDUP_SWEEP_INTERVAL_MS ||
@@ -1348,8 +1359,7 @@ export class ChatTurnWriter {
     ) {
       for (const [existingKey, ts] of this.messageHookDedup) {
         if (now - ts > ttl) {
-          this.messageHookDedup.delete(existingKey);
-          this.messageHookInboundQueueKeys.delete(existingKey);
+          this.deleteMessageHookDedupKey(existingKey);
         }
       }
       this.messageHookLastSweepAt = now;
@@ -1357,11 +1367,29 @@ export class ChatTurnWriter {
     while (this.messageHookDedup.size >= ChatTurnWriter.MESSAGE_HOOK_DEDUP_MAX_ENTRIES) {
       const oldestKey = this.messageHookDedup.keys().next().value as string | undefined;
       if (!oldestKey) break;
-      this.messageHookDedup.delete(oldestKey);
-      this.messageHookInboundQueueKeys.delete(oldestKey);
+      this.deleteMessageHookDedupKey(oldestKey);
     }
     this.messageHookDedup.set(key, now);
+    if (sessionId) this.messageHookDedupSessionKeys.set(key, sessionId);
+    else this.messageHookDedupSessionKeys.delete(key);
     return false;
+  }
+
+  private deleteMessageHookDedupKey(key: string): void {
+    this.messageHookDedup.delete(key);
+    this.messageHookInboundQueueKeys.delete(key);
+    this.messageHookDedupSessionKeys.delete(key);
+  }
+
+  private clearMessageHookDedupForSessions(sessionIds: Iterable<string>): void {
+    const ids = new Set(Array.from(sessionIds).filter((id) => typeof id === "string" && id.length > 0));
+    if (ids.size === 0) return;
+    for (const [key, sessionId] of Array.from(this.messageHookDedupSessionKeys.entries())) {
+      if (ids.has(sessionId)) this.deleteMessageHookDedupKey(key);
+    }
+    for (const [key, queueKey] of Array.from(this.messageHookInboundQueueKeys.entries())) {
+      if (ids.has(queueKey)) this.deleteMessageHookDedupKey(key);
+    }
   }
 
   private shouldMoveInboundQueue(existingKey: string, candidateKey: string): boolean {
@@ -1398,36 +1426,48 @@ export class ChatTurnWriter {
     sessionKey?: string;
   }): void {
     if (!identity.channelId || !identity.sessionKey || this.isWeakSessionKey(identity.sessionKey)) return;
-    const weakSessionKey = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
-    if (!weakSessionKey) return;
-    const weakSessionId = this.composeSessionId({ ...identity, sessionKey: weakSessionKey });
     const strongSessionId = this.composeSessionId(identity);
-    if (weakSessionId === strongSessionId) return;
+    const candidateSessionIds = new Set<string>();
+    if (identity.conversationId) {
+      const weakSessionKey = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
+      if (weakSessionKey) {
+        candidateSessionIds.add(this.composeSessionId({ ...identity, sessionKey: weakSessionKey }));
+      }
+      candidateSessionIds.add(this.composeSessionId({ ...identity, conversationId: "" }));
+    }
 
+    for (const fromSessionId of candidateSessionIds) {
+      if (fromSessionId !== strongSessionId) {
+        this.promoteSessionState(fromSessionId, strongSessionId);
+      }
+    }
+  }
+
+  private promoteSessionState(fromSessionId: string, strongSessionId: string): void {
     let changed = false;
     let durableChanged = false;
-    if (this.pendingUserMessages.has(weakSessionId) || this.pendingUserMessageMeta.has(weakSessionId)) {
-      this.movePendingInboundQueue(weakSessionId, strongSessionId);
+    if (this.pendingUserMessages.has(fromSessionId) || this.pendingUserMessageMeta.has(fromSessionId)) {
+      this.movePendingInboundQueue(fromSessionId, strongSessionId);
       changed = true;
     }
-    const weakWatermark = this.cachedWatermarks.get(weakSessionId);
+    const weakWatermark = this.cachedWatermarks.get(fromSessionId);
     if (weakWatermark !== undefined) {
       this.cachedWatermarks.set(strongSessionId, Math.max(this.cachedWatermarks.get(strongSessionId) ?? -1, weakWatermark));
-      this.cachedWatermarks.delete(weakSessionId);
+      this.cachedWatermarks.delete(fromSessionId);
       changed = true;
       durableChanged = true;
     }
-    const weakW4bCount = this.w4bSessionCounts.get(weakSessionId);
+    const weakW4bCount = this.w4bSessionCounts.get(fromSessionId);
     if (weakW4bCount !== undefined) {
       this.w4bSessionCounts.set(strongSessionId, Math.max(this.w4bSessionCounts.get(strongSessionId) ?? 0, weakW4bCount));
-      this.w4bSessionCounts.delete(weakSessionId);
+      this.w4bSessionCounts.delete(fromSessionId);
       changed = true;
       durableChanged = true;
     }
-    const weakTimer = this.debounceTimers.get(weakSessionId);
+    const weakTimer = this.debounceTimers.get(fromSessionId);
     if (weakTimer) {
       clearTimeout(weakTimer.timer);
-      this.debounceTimers.delete(weakSessionId);
+      this.debounceTimers.delete(fromSessionId);
       const existingStrongTimer = this.debounceTimers.get(strongSessionId);
       const promotedIndex = Math.max(existingStrongTimer?.pendingIndex ?? -1, weakTimer.pendingIndex);
       this.saveWatermark(strongSessionId, promotedIndex);
@@ -1435,30 +1475,36 @@ export class ChatTurnWriter {
       durableChanged = true;
     }
     for (const [dedupKey, queueKey] of this.messageHookInboundQueueKeys.entries()) {
-      if (queueKey === weakSessionId) {
+      if (queueKey === fromSessionId) {
         this.messageHookInboundQueueKeys.set(dedupKey, strongSessionId);
         changed = true;
       }
     }
-    durableChanged = this.promoteCompositeSessionKeys(this.recentTurnIds, weakSessionId, strongSessionId) || durableChanged;
-    durableChanged = this.promoteCompositeSessionKeys(this.crossPathStamps, weakSessionId, strongSessionId) || durableChanged;
-    durableChanged = this.promoteCompositeSessionKeys(this.crossPathInflight, weakSessionId, strongSessionId) || durableChanged;
+    for (const [dedupKey, sessionId] of this.messageHookDedupSessionKeys.entries()) {
+      if (sessionId === fromSessionId) {
+        this.messageHookDedupSessionKeys.set(dedupKey, strongSessionId);
+        changed = true;
+      }
+    }
+    durableChanged = this.promoteCompositeSessionKeys(this.recentTurnIds, fromSessionId, strongSessionId) || durableChanged;
+    durableChanged = this.promoteCompositeSessionKeys(this.crossPathStamps, fromSessionId, strongSessionId) || durableChanged;
+    durableChanged = this.promoteCompositeSessionKeys(this.crossPathInflight, fromSessionId, strongSessionId) || durableChanged;
     if (durableChanged) {
       this.writeWatermarkFile();
     } else if (changed) {
-      this.logger.debug?.("[ChatTurnWriter] Promoted weak typed-message session identity", {
-        weakSessionId,
+      this.logger.debug?.("[ChatTurnWriter] Promoted typed-message session identity", {
+        fromSessionId,
         strongSessionId,
       });
     }
   }
 
-  private promoteCompositeSessionKeys(map: Map<string, number>, weakSessionId: string, strongSessionId: string): boolean {
+  private promoteCompositeSessionKeys(map: Map<string, number>, fromSessionId: string, strongSessionId: string): boolean {
     let changed = false;
-    const prefix = `${weakSessionId}::`;
+    const prefix = `${fromSessionId}::`;
     for (const [key, value] of Array.from(map.entries())) {
       if (!key.startsWith(prefix)) continue;
-      const promotedKey = `${strongSessionId}${key.slice(weakSessionId.length)}`;
+      const promotedKey = `${strongSessionId}${key.slice(fromSessionId.length)}`;
       map.set(promotedKey, Math.max(map.get(promotedKey) ?? 0, value));
       map.delete(key);
       changed = true;
@@ -1990,9 +2036,8 @@ export class ChatTurnWriter {
     channelId?: string,
     accountId?: string,
     conversationId?: string,
-    endpoint?: string,
   ): string {
-    const weakIdentity = firstString(conversationId, endpoint);
+    const weakIdentity = firstString(conversationId);
     if (!channelId || !weakIdentity) return "";
     return `${ChatTurnWriter.WEAK_SESSION_PREFIX}${this.identityHash([
       channelId,
@@ -2377,6 +2422,8 @@ export class ChatTurnWriter {
     for (const key of this.debounceTimers.keys()) add(key);
     for (const key of this.pendingUserMessages.keys()) add(key);
     for (const key of this.pendingUserMessageMeta.keys()) add(key);
+    for (const key of this.messageHookInboundQueueKeys.values()) add(key);
+    for (const key of this.messageHookDedupSessionKeys.values()) add(key);
     for (const key of this.inFlightPersists.keys()) add(key);
     for (const key of this.w4aSessionChains.keys()) add(key);
     for (const key of this.recentTurnIds.keys()) {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -244,9 +244,12 @@ export class ChatTurnWriter {
   private messageHookDedup: Map<string, number> = new Map();
   private messageHookInboundQueueKeys: Map<string, string> = new Map();
   private messageHookDedupSessionKeys: Map<string, string> = new Map();
+  private messageHookNoIdInboundBatch: Set<string> = new Set();
+  private messageHookNoIdInboundBatchClearScheduled = false;
   private static readonly MESSAGE_HOOK_DEDUP_TTL_MS = 60_000;
   private static readonly MESSAGE_HOOK_DEDUP_SWEEP_INTERVAL_MS = 5_000;
   private static readonly MESSAGE_HOOK_DEDUP_MAX_ENTRIES = 2_048;
+  private static readonly MESSAGE_HOOK_NO_ID_INBOUND_PREFIX = "message-hook::inbound::text-batch::";
   private messageHookLastSweepAt = 0;
   private static readonly WEAK_SESSION_PREFIX = "weak-";
 
@@ -1458,12 +1461,13 @@ export class ChatTurnWriter {
       ].join("::");
     }
     if (direction === "inbound") {
+      // Without a provider messageId, only dedupe duplicate hook surfaces
+      // delivered in the same dispatch batch. A longer text cache would drop
+      // legitimate repeated user messages before one assistant reply.
       return [
-        "message-hook",
-        direction,
-        "text",
+        ChatTurnWriter.MESSAGE_HOOK_NO_ID_INBOUND_PREFIX,
         this.identityHash([...scopeParts, text]),
-      ].join("::");
+      ].join("");
     }
     if (direction === "outbound") {
       const inboundIds = pendingMeta
@@ -1500,6 +1504,9 @@ export class ChatTurnWriter {
 
   private markMessageHookDuplicate(key: string, sessionId?: string): boolean {
     if (!key) return false;
+    if (this.isNoIdInboundBatchKey(key)) {
+      return this.markNoIdInboundBatchDuplicate(key, sessionId);
+    }
     const now = Date.now();
     const ttl = ChatTurnWriter.MESSAGE_HOOK_DEDUP_TTL_MS;
     const existingTs = this.messageHookDedup.get(key);
@@ -1529,8 +1536,32 @@ export class ChatTurnWriter {
     return false;
   }
 
+  private isNoIdInboundBatchKey(key: string): boolean {
+    return key.startsWith(ChatTurnWriter.MESSAGE_HOOK_NO_ID_INBOUND_PREFIX);
+  }
+
+  private markNoIdInboundBatchDuplicate(key: string, sessionId?: string): boolean {
+    if (this.messageHookNoIdInboundBatch.has(key)) return true;
+    this.messageHookNoIdInboundBatch.add(key);
+    if (sessionId) this.messageHookDedupSessionKeys.set(key, sessionId);
+    else this.messageHookDedupSessionKeys.delete(key);
+    if (!this.messageHookNoIdInboundBatchClearScheduled) {
+      this.messageHookNoIdInboundBatchClearScheduled = true;
+      queueMicrotask(() => {
+        this.messageHookNoIdInboundBatchClearScheduled = false;
+        const keys = Array.from(this.messageHookNoIdInboundBatch);
+        this.messageHookNoIdInboundBatch.clear();
+        for (const batchKey of keys) {
+          this.deleteMessageHookDedupKey(batchKey);
+        }
+      });
+    }
+    return false;
+  }
+
   private deleteMessageHookDedupKey(key: string): void {
     this.messageHookDedup.delete(key);
+    this.messageHookNoIdInboundBatch.delete(key);
     this.messageHookInboundQueueKeys.delete(key);
     this.messageHookDedupSessionKeys.delete(key);
   }
@@ -2120,9 +2151,6 @@ export class ChatTurnWriter {
       (msg as any).message_id,
       (context as any).message_id,
       (metadata as any).message_id,
-      (msg as any).id,
-      (context as any).id,
-      (metadata as any).id,
     );
     return messageId ? [messageId] : [];
   }

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -1370,16 +1370,16 @@ export class ChatTurnWriter {
     const accountId = firstString(ctx.accountId) ?? "";
     const conversationId = firstString(ctx.conversationId) ?? "";
     const sessionKey = firstString(ev.sessionKey, ctx.sessionKey) ?? "";
+    const scopeParts = conversationId
+      ? [channelId, accountId, conversationId]
+      : [channelId, accountId, conversationId, sessionKey];
     const messageId = this.messageEventId(ev);
     if (messageId) {
-      const identityParts = conversationId
-        ? [channelId, accountId, conversationId, messageId]
-        : [channelId, accountId, conversationId, sessionKey, messageId];
       return [
         "message-hook",
         direction,
         "msg",
-        this.identityHash(identityParts),
+        this.identityHash([...scopeParts, messageId]),
       ].join("::");
     }
     if (direction === "outbound") {
@@ -1391,7 +1391,7 @@ export class ChatTurnWriter {
           "message-hook",
           direction,
           "inbound-msg",
-          this.identityHash([channelId, accountId, conversationId, sessionKey, ...inboundIds, text]),
+          this.identityHash([...scopeParts, ...inboundIds, text]),
         ].join("::");
       }
       const arrivalIds = pendingMeta
@@ -1402,14 +1402,14 @@ export class ChatTurnWriter {
           "message-hook",
           direction,
           "arrival",
-          this.identityHash([channelId, accountId, conversationId, sessionKey, ...arrivalIds, text]),
+          this.identityHash([...scopeParts, ...arrivalIds, text]),
         ].join("::");
       }
       return [
         "message-hook",
         direction,
         "turn-text",
-        this.identityHash([channelId, accountId, conversationId, sessionKey, userText, text]),
+        this.identityHash([...scopeParts, userText, text]),
       ].join("::");
     }
     return "";
@@ -2645,11 +2645,14 @@ export class ChatTurnWriter {
     conversationId?: string;
     sessionKey?: string;
   }): string[] {
-    return Array.from(new Set([
+    const cursors = [
       this.concreteSessionCursorKey(parts),
       this.weakConversationCursorKey(parts),
-      this.conversationlessSessionCursorKey(parts),
-    ].filter((key) => key.length > 0)));
+    ];
+    if (!parts.conversationId) {
+      cursors.push(this.conversationlessSessionCursorKey(parts));
+    }
+    return Array.from(new Set(cursors.filter((key) => key.length > 0)));
   }
 
   private typedW4bMarkerCursorKeysFromSessionId(sessionId: string): string[] {
@@ -2669,6 +2672,12 @@ export class ChatTurnWriter {
   }): string[] {
     const ids = new Set<string>();
     if (identity.sessionId) ids.add(identity.sessionId);
+    if (identity.channelId && identity.conversationId) {
+      const weakSession = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
+      if (weakSession) {
+        ids.add(this.composeSessionId({ ...identity, sessionKey: weakSession }));
+      }
+    }
     if (!identity.channelId || !identity.sessionKey) return Array.from(ids);
     if (typeof identity.accountId !== "string" || typeof identity.conversationId !== "string") {
       return Array.from(ids);

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -12,6 +12,10 @@ import { createHash } from "crypto";
  * Create/consume failures roll back marker snapshots when
  * `commitWatermarkStateSync` fails; `setStateDir` migrates per-session `m`
  * markers, and graceful `DkgChannelPlugin.stop()` drains in-flight first writes.
+ * Telegram persistence can arrive through typed `message_received/message_sent`
+ * when typed `agent_end` is silent. Those events are normalized into the W4b
+ * envelope and deduped against internal `message:received/message:sent` by
+ * channel/account/conversation/messageId, outside the Node-UI marker space.
  */
 
 interface Logger {
@@ -88,6 +92,10 @@ export interface InternalMessageEvent {
   };
 }
 
+interface PendingUserMessageMeta {
+  messageId?: string;
+}
+
 /**
  * Pull the message text out of the envelope, preferring the canonical
  * `context.content` over the test-fixture `text` shorthand.
@@ -99,6 +107,13 @@ function readEventText(ev: InternalMessageEvent): string {
   return "";
 }
 
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
 export class ChatTurnWriter {
   private client: any;
   private logger: Logger;
@@ -108,6 +123,11 @@ export class ChatTurnWriter {
   // first reply are both retained; `onMessageSent` consumes the oldest so the
   // first outbound reply pairs with the first inbound, not the most recent.
   private pendingUserMessages: Map<string, string[]> = new Map();
+  // Parallel metadata queue for pending user messages. Typed `message_sent`
+  // lacks an outbound messageId in OpenClaw 2026.4.15, so we carry the inbound
+  // provider messageId forward and use it as the durable W4b turnId
+  // discriminator when the outbound envelope cannot provide one.
+  private pendingUserMessageMeta: Map<string, PendingUserMessageMeta[]> = new Map();
   private debounceTimers: Map<string, { timer: NodeJS.Timeout; pendingIndex: number }> = new Map();
   private watermarkFilePath: string;
   // Cross-path dedup (W4a agent_end vs. W4b message:sent). The gateway fires
@@ -207,6 +227,9 @@ export class ChatTurnWriter {
   // (e.g. an unhandled throw outside the wrapped try/catch).
   private crossPathInflight: Map<string, number> = new Map();
   private static readonly CROSS_PATH_INFLIGHT_TTL_MS = 60_000;
+  private messageHookDedup: Map<string, number> = new Map();
+  private messageHookInboundQueueKeys: Map<string, string> = new Map();
+  private static readonly MESSAGE_HOOK_DEDUP_TTL_MS = 60_000;
 
   constructor(options: { client: any; logger: Logger; stateDir: string }) {
     this.client = options.client;
@@ -852,6 +875,7 @@ export class ChatTurnWriter {
       // raw `:` (e.g. the `agent:<agentId>:<identity>` keys created in
       // `DkgChannelPlugin`).
       this.pendingUserMessages.delete(sessionId);
+      this.pendingUserMessageMeta.delete(sessionId);
       this.clearSessionTurnIds(sessionId);
       // R18.2 — Reset the W4b session count too. After compaction the
       // `messages[]` array is rewritten, so the W4b count's "I persisted
@@ -859,10 +883,101 @@ export class ChatTurnWriter {
       // count would skip new pairs in `computeDelta`.
       this.w4bSessionCounts.delete(sessionId);
     }
+    this.messageHookDedup.clear();
+    this.messageHookInboundQueueKeys.clear();
     // External markers record daemon-success facts from direct-channel
     // persists. Preserve them across reset/compaction so the reset W4a replay
     // can still consume the marker instead of duplicating the stored UI turn.
     this.writeWatermarkFile();
+  }
+
+  onTypedMessageReceived(event: any, ctx?: any): void {
+    const ev = this.normalizeTypedMessageEvent("inbound", event, ctx);
+    if (!ev) return;
+    this.onMessageReceived(ev);
+  }
+
+  async onTypedMessageSent(event: any, ctx?: any): Promise<void> {
+    const ev = this.normalizeTypedMessageEvent("outbound", event, ctx);
+    if (!ev) return;
+    await this.onMessageSent(ev);
+  }
+
+  private normalizeTypedMessageEvent(
+    direction: "inbound" | "outbound",
+    eventPayload?: any,
+    hookCtx?: any,
+  ): InternalMessageEvent | null {
+    const event = eventPayload && typeof eventPayload === "object" ? eventPayload : {};
+    const ctx = hookCtx && typeof hookCtx === "object" ? hookCtx : {};
+    const eventContext = event.context && typeof event.context === "object" ? event.context : {};
+    const metadata = event.metadata && typeof event.metadata === "object" ? event.metadata : {};
+    const content = [
+      event.content,
+      event.text,
+      event.body,
+      eventContext.content,
+      metadata.content,
+    ].find((value) => typeof value === "string" && value.trim().length > 0) as string | undefined;
+    if (!content) return null;
+
+    const endpoint = direction === "inbound"
+      ? firstString(event.from, metadata.from, metadata.senderId, metadata.userId)
+      : firstString(event.to, metadata.to, metadata.recipientId, metadata.userId);
+    const channelId = firstString(
+      ctx.channelId,
+      event.channelId,
+      eventContext.channelId,
+      metadata.channelId,
+      metadata.originatingChannel,
+      metadata.provider,
+    );
+    if (channelId === "dkg-ui") return null;
+    const accountId = firstString(ctx.accountId, event.accountId, eventContext.accountId, metadata.accountId, metadata.botId);
+    const conversationId = firstString(
+      ctx.conversationId,
+      event.conversationId,
+      eventContext.conversationId,
+      metadata.conversationId,
+      metadata.chatId,
+      metadata.threadId,
+      endpoint,
+    );
+    const sessionKey = firstString(
+      ctx.sessionKey,
+      event.sessionKey,
+      eventContext.sessionKey,
+      metadata.sessionKey,
+      ctx.sessionId,
+      event.sessionId,
+      eventContext.sessionId,
+      metadata.sessionId,
+      conversationId,
+      endpoint,
+    );
+    if (!channelId || !sessionKey) {
+      this.logger.debug?.("[ChatTurnWriter] Dropping typed message hook without channel/session identity");
+      return null;
+    }
+
+    const messageId = firstString(ctx.messageId, event.messageId, eventContext.messageId, metadata.messageId, metadata.id);
+    const successValue = eventContext.success ?? event.success;
+    const context: NonNullable<InternalMessageEvent["context"]> = {
+      channelId,
+      content,
+    };
+    if (accountId) context.accountId = accountId;
+    if (conversationId) context.conversationId = conversationId;
+    if (messageId) context.messageId = messageId;
+    if (typeof successValue === "boolean") context.success = successValue;
+    if (direction === "outbound" && typeof context.success !== "boolean") context.success = true;
+
+    return {
+      sessionKey,
+      direction,
+      text: content,
+      context,
+    };
   }
 
   onMessageReceived(ev: InternalMessageEvent): void {
@@ -886,9 +1001,23 @@ export class ChatTurnWriter {
       // textual inbound. Drop until we add a recoverable representation for
       // attachment-only turns.
       if (!text) return;
+      const inboundDedupKey = this.messageHookDedupKey("inbound", ev, text);
+      const existingConversationKey = this.messageHookInboundQueueKeys.get(inboundDedupKey);
+      if (existingConversationKey && existingConversationKey !== conversationKey) {
+        if (this.shouldMoveInboundQueue(existingConversationKey, conversationKey)) {
+          this.movePendingInboundQueue(existingConversationKey, conversationKey);
+          this.messageHookInboundQueueKeys.set(inboundDedupKey, conversationKey);
+        }
+        return;
+      }
+      if (this.markMessageHookDuplicate(inboundDedupKey)) return;
       const queue = this.pendingUserMessages.get(conversationKey) ?? [];
       queue.push(text);
       this.pendingUserMessages.set(conversationKey, queue);
+      const metaQueue = this.pendingUserMessageMeta.get(conversationKey) ?? [];
+      metaQueue.push({ messageId: this.messageEventId(ev) });
+      this.pendingUserMessageMeta.set(conversationKey, metaQueue);
+      if (inboundDedupKey) this.messageHookInboundQueueKeys.set(inboundDedupKey, conversationKey);
     } catch (err) {
       this.logger.error?.("[ChatTurnWriter.onMessageReceived] Error", { err });
     }
@@ -921,6 +1050,7 @@ export class ChatTurnWriter {
       // the whole queue here to match the success consumption.
       if (success === false) {
         this.pendingUserMessages.delete(conversationKey);
+        this.pendingUserMessageMeta.delete(conversationKey);
         return;
       }
       // Strip injected `<recalled-memory>` from assistant text — the model may
@@ -961,8 +1091,16 @@ export class ChatTurnWriter {
       // string), preserving structure if a later inbound arrives
       // before the retry.
       const queuedItems = [...queue];
+      const queuedMeta = [...(this.pendingUserMessageMeta.get(conversationKey) ?? [])];
       const userText = queuedItems.join("\n");
+      const outboundDedupKey = this.messageHookDedupKey("outbound", ev, assistantText);
+      if (this.markMessageHookDuplicate(outboundDedupKey)) {
+        this.pendingUserMessages.delete(conversationKey);
+        this.pendingUserMessageMeta.delete(conversationKey);
+        return;
+      }
       this.pendingUserMessages.delete(conversationKey);
+      this.pendingUserMessageMeta.delete(conversationKey);
       if (userText || assistantText) {
         // Cross-path dedup, W4b side (T5: short-TTL stamp map):
         //   PEEK w4a-origin — non-mutating; if W4a already wrote this
@@ -998,7 +1136,7 @@ export class ChatTurnWriter {
         //   monotonic in-process sequence when the envelope omits it
         //   (concurrent same-content fires for a single messageId-less
         //   turn are vanishingly rare in that path).
-        const w4bInflight = this.w4bInflightKey(ev, userText, assistantText);
+        const w4bInflight = this.w4bInflightKey(ev, userText, assistantText, queuedMeta);
         if (this.markTurnIdSeen(sessionId, w4bInflight)) return; // concurrent W4b dispatch
         // T33 — Mix the gateway-provided `messageId` (or the
         // monotonic fallback) into the daemon-facing turnId so
@@ -1009,7 +1147,7 @@ export class ChatTurnWriter {
         // is stable across process boundaries. Two LEGITIMATE same-
         // content turns within a session still get distinct ids
         // because their messageIds differ.
-        const w4bDiscriminator = this.w4bDaemonTurnIdDiscriminator(ev);
+        const w4bDiscriminator = this.w4bDaemonTurnIdDiscriminator(ev, queuedMeta);
         const turnId = this.deterministicTurnId(sessionId, userText, assistantText, w4bDiscriminator);
         // T10 — Reserve cross-path in-flight on W4b-origin BEFORE
         // persistOne so a concurrent W4a `agent_end` fire's
@@ -1089,10 +1227,14 @@ export class ChatTurnWriter {
               const restored = this.pendingUserMessages.get(conversationKey) ?? [];
               restored.unshift(...queuedItems);
               this.pendingUserMessages.set(conversationKey, restored);
+              const restoredMeta = this.pendingUserMessageMeta.get(conversationKey) ?? [];
+              restoredMeta.unshift(...queuedMeta);
+              this.pendingUserMessageMeta.set(conversationKey, restoredMeta);
             }
             // Release the in-flight reservation so a retry can proceed.
             // No `w4bOrigin` release needed — we don't stamp it pre-persist
             // anymore; only stamping happens post-success above.
+            if (outboundDedupKey) this.messageHookDedup.delete(outboundDedupKey);
             this.releaseTurnIdReservation(sessionId, w4bInflight);
             this.logger.error?.("[ChatTurnWriter.onMessageSent] Persist failed", { err });
           } finally {
@@ -1131,6 +1273,81 @@ export class ChatTurnWriter {
     if (this.recentTurnIds.has(key)) return true;
     this.recentTurnIds.set(key, now);
     return false;
+  }
+
+  private messageEventId(ev: InternalMessageEvent): string | undefined {
+    const ctx = (ev as any)?.context ?? {};
+    return firstString(ctx.messageId, (ev as any)?.messageId);
+  }
+
+  private messageHookDedupKey(
+    direction: "inbound" | "outbound",
+    ev: InternalMessageEvent,
+    text: string,
+  ): string {
+    const ctx = (ev as any)?.context ?? {};
+    const channelId = firstString(ctx.channelId, (ev as any)?.channelId) ?? "unknown";
+    if (channelId === "dkg-ui") return "";
+    const accountId = firstString(ctx.accountId) ?? "";
+    const conversationId = firstString(ctx.conversationId) ?? "";
+    const messageId = this.messageEventId(ev);
+    if (messageId) {
+      return [
+        "message-hook",
+        direction,
+        "msg",
+        this.identityHash([channelId, accountId, conversationId, messageId]),
+      ].join("::");
+    }
+    const sessionKey = firstString(ev.sessionKey, ctx.sessionKey) ?? "";
+    return [
+      "message-hook",
+      direction,
+      "text",
+      this.identityHash([channelId, accountId, conversationId, sessionKey, text]),
+    ].join("::");
+  }
+
+  private markMessageHookDuplicate(key: string): boolean {
+    if (!key) return false;
+    const now = Date.now();
+    const ttl = ChatTurnWriter.MESSAGE_HOOK_DEDUP_TTL_MS;
+    for (const [existingKey, ts] of this.messageHookDedup) {
+      if (now - ts > ttl) {
+        this.messageHookDedup.delete(existingKey);
+        this.messageHookInboundQueueKeys.delete(existingKey);
+      }
+    }
+    if (this.messageHookDedup.has(key)) return true;
+    this.messageHookDedup.set(key, now);
+    return false;
+  }
+
+  private shouldMoveInboundQueue(existingKey: string, candidateKey: string): boolean {
+    const existing = this.parseComposedSessionId(existingKey);
+    const candidate = this.parseComposedSessionId(candidateKey);
+    if (!existing || !candidate) return false;
+    const existingStrong = existing.sessionKey.length > 0 && existing.sessionKey !== existing.conversationId;
+    const candidateStrong = candidate.sessionKey.length > 0 && candidate.sessionKey !== candidate.conversationId;
+    return candidateStrong && !existingStrong;
+  }
+
+  private movePendingInboundQueue(fromKey: string, toKey: string): void {
+    if (fromKey === toKey) return;
+    const messages = this.pendingUserMessages.get(fromKey);
+    if (messages && messages.length > 0) {
+      const target = this.pendingUserMessages.get(toKey) ?? [];
+      target.push(...messages);
+      this.pendingUserMessages.set(toKey, target);
+      this.pendingUserMessages.delete(fromKey);
+    }
+    const meta = this.pendingUserMessageMeta.get(fromKey);
+    if (meta && meta.length > 0) {
+      const target = this.pendingUserMessageMeta.get(toKey) ?? [];
+      target.push(...meta);
+      this.pendingUserMessageMeta.set(toKey, target);
+      this.pendingUserMessageMeta.delete(fromKey);
+    }
   }
 
   /**
@@ -1646,6 +1863,13 @@ export class ChatTurnWriter {
     return `w4b-content::${this.contentHash(user, assistant)}`;
   }
 
+  private identityHash(parts: string[]): string {
+    return createHash("sha256")
+      .update(JSON.stringify(parts))
+      .digest("hex")
+      .slice(0, 16);
+  }
+
   private externalTurnMarkerId(turnId?: unknown, user?: string, assistant?: string): string {
     if (typeof turnId !== "string" || turnId.trim().length === 0) return "";
     const idHash = createHash("sha256").update(turnId.trim()).digest("hex").slice(0, 16);
@@ -1758,9 +1982,14 @@ export class ChatTurnWriter {
    * envelopes don't exhibit the race in practice.
    */
   private w4bInflightSeq = 0;
-  private w4bInflightKey(ev: InternalMessageEvent, user: string, assistant: string): string {
-    const messageId = (ev as any)?.context?.messageId;
-    if (typeof messageId === "string" && messageId.length > 0) {
+  private w4bInflightKey(
+    ev: InternalMessageEvent,
+    user: string,
+    assistant: string,
+    pendingMeta: PendingUserMessageMeta[] = [],
+  ): string {
+    const messageId = this.w4bMessageDiscriminator(ev, pendingMeta);
+    if (messageId) {
       return `w4b-inflight::msg::${messageId}`;
     }
     this.w4bInflightSeq = (this.w4bInflightSeq + 1) >>> 0;
@@ -1783,14 +2012,30 @@ export class ChatTurnWriter {
    * fallback-counter — but the messageId path is the production case
    * and is unambiguously stable.
    */
-  private w4bDaemonTurnIdDiscriminator(ev: InternalMessageEvent): string {
-    const messageId = (ev as any)?.context?.messageId;
-    if (typeof messageId === "string" && messageId.length > 0) {
+  private w4bDaemonTurnIdDiscriminator(
+    ev: InternalMessageEvent,
+    pendingMeta: PendingUserMessageMeta[] = [],
+  ): string {
+    const messageId = this.w4bMessageDiscriminator(ev, pendingMeta);
+    if (messageId) {
       return `msg::${messageId}`;
     }
     // Reuse the same monotonic counter — fallback is rare and best-effort.
     this.w4bInflightSeq = (this.w4bInflightSeq + 1) >>> 0;
     return `seq::${this.w4bInflightSeq}`;
+  }
+
+  private w4bMessageDiscriminator(
+    ev: InternalMessageEvent,
+    pendingMeta: PendingUserMessageMeta[],
+  ): string {
+    const outboundMessageId = this.messageEventId(ev);
+    if (outboundMessageId) return `out::${outboundMessageId}`;
+    const inboundIds = pendingMeta
+      .map((meta) => meta.messageId)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+    if (inboundIds.length === 0) return "";
+    return `in::${this.identityHash(inboundIds)}`;
   }
   /**
    * @deprecated Kept temporarily for tests that inspect the dedup-map key
@@ -1993,6 +2238,7 @@ export class ChatTurnWriter {
     for (const key of this.w4bSessionCounts.keys()) add(key);
     for (const key of this.debounceTimers.keys()) add(key);
     for (const key of this.pendingUserMessages.keys()) add(key);
+    for (const key of this.pendingUserMessageMeta.keys()) add(key);
     for (const key of this.inFlightPersists.keys()) add(key);
     for (const key of this.w4aSessionChains.keys()) add(key);
     for (const key of this.recentTurnIds.keys()) {

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -521,6 +521,7 @@ export class ChatTurnWriter {
     const externalCursorKey = this.externalCursorKeyFromSessionKey(identity.sessionKey);
     const typedW4bCursorKeys = this.typedW4bMarkerCursorKeys(identity);
     const w4bInflightSessionIds = this.w4bInflightGuardSessionIds(identity, sessionId);
+    const w4aCrossPathSessionIds = this.w4aCrossPathSessionIds(identity, sessionId);
     // T4 — Serialize agent_end calls per session via a Promise chain.
     // The full computeDelta + per-pair persist loop runs INSIDE the
     // chain so a later fire's `computeDelta` reads the earlier fire's
@@ -540,7 +541,14 @@ export class ChatTurnWriter {
       .catch(() => undefined)
       .then(async () => {
         if (resetAtSchedule) await resetAtSchedule;
-        await this.runAgentEndPersist(event, sessionId, externalCursorKey, typedW4bCursorKeys, w4bInflightSessionIds);
+        await this.runAgentEndPersist(
+          event,
+          sessionId,
+          externalCursorKey,
+          typedW4bCursorKeys,
+          w4bInflightSessionIds,
+          w4aCrossPathSessionIds,
+        );
       });
     this.w4aSessionChains.set(sessionId, work);
     work.finally(() => {
@@ -561,6 +569,7 @@ export class ChatTurnWriter {
     externalCursorKey?: string,
     typedW4bCursorKeys: string[] = [],
     w4bInflightSessionIds: string[] = [sessionId],
+    w4aCrossPathSessionIds: string[] = [sessionId],
   ): Promise<void> {
     try {
       // R18.2 — Take the MAX of W4a's pair-indexed watermark and W4b's
@@ -686,7 +695,11 @@ export class ChatTurnWriter {
           // with W4b (earlier pairs are historical backfill). Cleared
           // in `finally` so a failure doesn't leak the reservation.
           const w4aInflightKey = i === lastIdx ? this.w4aOriginKey(user, assistant) : null;
-          if (w4aInflightKey) this.markCrossPathInflight(sessionId, w4aInflightKey);
+          if (w4aInflightKey) {
+            for (const crossPathSessionId of w4aCrossPathSessionIds) {
+              this.markCrossPathInflight(crossPathSessionId, w4aInflightKey);
+            }
+          }
           try {
             await this.persistOne(sessionId, user, assistant, turnId, { pairIndex });
             // T55 — Only stamp W4a-origin for the LAST (live) pair.
@@ -706,7 +719,10 @@ export class ChatTurnWriter {
             // content turn outside the cross-path window doesn't
             // false-dedup.
             if (i === lastIdx) {
-              this.markCrossPathStamp(sessionId, this.w4aOriginKey(user, assistant));
+              const w4aOrigin = this.w4aOriginKey(user, assistant);
+              for (const crossPathSessionId of w4aCrossPathSessionIds) {
+                this.markCrossPathStamp(crossPathSessionId, w4aOrigin);
+              }
             }
           } catch (err) {
             // Release the turnId reservation so a retry can re-attempt.
@@ -714,10 +730,18 @@ export class ChatTurnWriter {
             // now a non-mutating peek (R13.1), so W4a never reserved it.
             this.releaseTurnIdReservation(sessionId, turnId);
             this.logger.error?.("[ChatTurnWriter.onAgentEnd] Persist failed", { err });
-            if (w4aInflightKey) this.unmarkCrossPathInflight(sessionId, w4aInflightKey);
+            if (w4aInflightKey) {
+              for (const crossPathSessionId of w4aCrossPathSessionIds) {
+                this.unmarkCrossPathInflight(crossPathSessionId, w4aInflightKey);
+              }
+            }
             return; // leave watermark at last successful pair
           }
-          if (w4aInflightKey) this.unmarkCrossPathInflight(sessionId, w4aInflightKey);
+          if (w4aInflightKey) {
+            for (const crossPathSessionId of w4aCrossPathSessionIds) {
+              this.unmarkCrossPathInflight(crossPathSessionId, w4aInflightKey);
+            }
+          }
         }
       });
       // T4 — AWAIT the persist job so the per-session chain in
@@ -1122,10 +1146,36 @@ export class ChatTurnWriter {
       event.conversationId,
       eventContext.conversationId,
       metadata.conversationId,
+      ctx.conversation_id,
+      event.conversation_id,
+      eventContext.conversation_id,
+      metadata.conversation_id,
     );
     if (explicit) return explicit;
-    const chatId = firstString(ctx.chatId, event.chatId, eventContext.chatId, metadata.chatId);
-    const threadId = firstString(ctx.threadId, event.threadId, eventContext.threadId, metadata.threadId);
+    const chatId = firstString(
+      ctx.chatId,
+      event.chatId,
+      eventContext.chatId,
+      metadata.chatId,
+      ctx.chat_id,
+      event.chat_id,
+      eventContext.chat_id,
+      metadata.chat_id,
+    );
+    const threadId = firstString(
+      ctx.threadId,
+      event.threadId,
+      eventContext.threadId,
+      metadata.threadId,
+      ctx.thread_id,
+      event.thread_id,
+      eventContext.thread_id,
+      metadata.thread_id,
+      ctx.message_thread_id,
+      event.message_thread_id,
+      eventContext.message_thread_id,
+      metadata.message_thread_id,
+    );
     if (chatId && threadId) return `${chatId}:${threadId}`;
     return threadId ?? chatId;
   }
@@ -1676,6 +1726,21 @@ export class ChatTurnWriter {
       if (weakSession) {
         ids.add(this.composeSessionId({ ...identity, sessionKey: weakSession }));
       }
+    }
+    return Array.from(ids);
+  }
+
+  private w4aCrossPathSessionIds(identity: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+    sessionKey?: string;
+  }, sessionId: string): string[] {
+    const ids = new Set<string>([sessionId]);
+    if (!identity.channelId || !identity.conversationId) return Array.from(ids);
+    const weakSession = this.weakSessionKey(identity.channelId, identity.accountId, identity.conversationId);
+    if (weakSession) {
+      ids.add(this.composeSessionId({ ...identity, sessionKey: weakSession }));
     }
     return Array.from(ids);
   }

--- a/packages/adapter-openclaw/src/ChatTurnWriter.ts
+++ b/packages/adapter-openclaw/src/ChatTurnWriter.ts
@@ -584,6 +584,28 @@ export class ChatTurnWriter {
       const savedUpTo = Math.max(w4aWatermark, w4bCount - 1);
       const pairs = this.computeDelta(event.messages, savedUpTo);
       if (pairs.length === 0) return;
+      // T362 — Cold-start clamp. When no prior watermark exists for this
+      // session (savedUpTo === -1) AND `messages[]` carries more than one
+      // valid pair, the older pairs come from a conversation the adapter
+      // never observed: OpenClaw retains the channel transcript across
+      // sessions while DKG state can be wiped independently. Walking those
+      // historical pairs replays them; the daemon does not idempotently
+      // dedupe (each storeChatExchange mints fresh userMsg/assistantMsg
+      // UUIDs even when turnId matches), so each replayed pair bloats the
+      // chat-turns assertion by ~20 triples. Persist only the latest pair;
+      // bumpWatermark advances to its index and MAX semantics implicitly
+      // claim earlier indices as done. Historical pairs remain in the
+      // OpenClaw transcript for context-window recall — they just do not
+      // retroactively flood DKG. See #359 / PR #362 live-smoke evidence.
+      if (savedUpTo < 0 && pairs.length > 1) {
+        const dropped = pairs.length - 1;
+        this.logger.info?.(
+          `[ChatTurnWriter.onAgentEnd] cold-start clamp: ` +
+          `discarded ${dropped} historical pair(s), ` +
+          `persisting only the latest (sessionId=${sessionId})`
+        );
+        pairs.splice(0, dropped);
+      }
       // Persist sequentially so a transient failure on pair N leaves the
       // watermark at N-1 and the next agent_end call retries from the same
       // point. Without sequencing, a failed middle pair could be skipped
@@ -3075,6 +3097,15 @@ export class ChatTurnWriter {
   }
 
   private loadWatermark(sessionId: string): number {
+    // Prefer the pending debounce value if a saveWatermark is in flight.
+    // saveWatermark schedules a 50ms debounce before committing to
+    // `cachedWatermarks`; without this, two rapid `agent_end` fires
+    // within that window both see -1 from `cachedWatermarks` and would
+    // re-clamp under the cold-start guard (T362). bumpWatermark already
+    // uses this pattern at its own call site; centralizing here keeps
+    // the runAgentEndPersist `savedUpTo` derivation consistent.
+    const pending = this.debounceTimers.get(sessionId);
+    if (pending) return pending.pendingIndex;
     return this.cachedWatermarks.get(sessionId) ?? -1;
   }
 

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -842,13 +842,15 @@ export class DkgNodePlugin {
               this.observedTypedOptions('before_prompt_build'),
             );
           }
-          if (typedNeedsRetry('agent_end')) {
-            this.hookSurface.install(
-              'typed',
-              'agent_end',
-              this.observedTypedHandler('agent_end', (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
-              this.observedTypedOptions('agent_end'),
-            );
+          for (const event of ['agent_end', 'agent.end']) {
+            if (typedNeedsRetry(event)) {
+              this.hookSurface.install(
+                'typed',
+                event,
+                this.observedTypedHandler(event, (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
+                this.observedTypedOptions(event),
+              );
+            }
           }
           for (const event of ['message_received', 'message.received']) {
             if (typedNeedsRetry(event)) {
@@ -960,12 +962,14 @@ export class DkgNodePlugin {
     // and `before_reset` are rare on healthy gateways; tag them so the
     // HookSurface commit-by-timeout warn downgrades to debug (otherwise
     // they false-positive within 30s of startup every time).
-    this.hookSurface.install(
-      'typed',
-      'agent_end',
-      this.observedTypedHandler('agent_end', (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
-      this.observedTypedOptions('agent_end'),
-    );
+    for (const event of ['agent_end', 'agent.end']) {
+      this.hookSurface.install(
+        'typed',
+        event,
+        this.observedTypedHandler(event, (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
+        this.observedTypedOptions(event),
+      );
+    }
     this.hookSurface.install(
       'typed',
       'before_compaction',
@@ -3206,11 +3210,10 @@ export class DkgNodePlugin {
       };
     };
 
-    // Typed probe candidates include the real underscore message events,
-    // installed dotted message aliases, and probe-only dotted W4a aliases
-    // such as `agent.end`. Probe-only candidates are observability guards:
-    // if live smoke shows one firing, we promote it into the real install set
-    // in a source-backed follow-up rather than assuming it dispatches.
+    // Typed probe candidates include the installed lifecycle/message events
+    // plus a few probe-only candidates. Probe-only candidates are
+    // observability guards: if live smoke shows one firing, we promote it
+    // into the real install set in a source-backed follow-up.
     const typedEvents = [
       'before_prompt_build',
       'agent_end',

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -3206,7 +3206,11 @@ export class DkgNodePlugin {
       };
     };
 
-    // Typed hooks (api.on / api.registerHook) use underscore-separated names.
+    // Typed probe candidates include the real underscore message events,
+    // installed dotted message aliases, and probe-only dotted W4a aliases
+    // such as `agent.end`. Probe-only candidates are observability guards:
+    // if live smoke shows one firing, we promote it into the real install set
+    // in a source-backed follow-up rather than assuming it dispatches.
     const typedEvents = [
       'before_prompt_build',
       'agent_end',

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -801,7 +801,7 @@ export class DkgNodePlugin {
         // dispatch primitive is now available.
         const internalNeedsRetry = (event: string) => {
           const s = stats[`internal:${event}`];
-          return s === undefined || s.installedVia === 'none';
+          return s === undefined || s.installedVia === 'none' || !this.internalHookEventIsLive(event);
         };
         const typedNeedsRetry = (event: string) => {
           const s = stats[`typed:${event}`];
@@ -848,6 +848,22 @@ export class DkgNodePlugin {
               'agent_end',
               this.observedTypedHandler('agent_end', (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
               this.observedTypedOptions('agent_end'),
+            );
+          }
+          if (typedNeedsRetry('message_received')) {
+            this.hookSurface.install(
+              'typed',
+              'message_received',
+              this.observedTypedHandler('message_received', this.makeTypedMessageReceivedHandler()),
+              this.observedTypedOptions('message_received'),
+            );
+          }
+          if (typedNeedsRetry('message_sent')) {
+            this.hookSurface.install(
+              'typed',
+              'message_sent',
+              this.observedTypedHandler('message_sent', this.makeTypedMessageSentHandler()),
+              this.observedTypedOptions('message_sent'),
             );
           }
           if (typedNeedsRetry('before_compaction')) {
@@ -905,7 +921,6 @@ export class DkgNodePlugin {
     // (`installedVia === 'globalThis'`). If yes, skip — already live.
     // If no, retry on the new surface; the global map may have
     // appeared between the prior register and this one.
-    const internalHooksAlreadyLive = this.internalHooksAreLive();
     this.hookSurface = new HookSurface(api, api.logger);
     this.hookSurfaceApi = api;
     this.allHookSurfaces.add(this.hookSurface);
@@ -960,6 +975,22 @@ export class DkgNodePlugin {
       this.observedTypedOptions('before_reset', { rareFireExpected: true }),
     );
 
+    // W4b typed message hooks - OpenClaw 2026.4.15 emits these for
+    // Telegram delivery even when typed `agent_end` remains silent. W4a
+    // stays installed above as canonical backfill for gateways that emit it.
+    this.hookSurface.install(
+      'typed',
+      'message_received',
+      this.observedTypedHandler('message_received', this.makeTypedMessageReceivedHandler()),
+      this.observedTypedOptions('message_received'),
+    );
+    this.hookSurface.install(
+      'typed',
+      'message_sent',
+      this.observedTypedHandler('message_sent', this.makeTypedMessageSentHandler()),
+      this.observedTypedOptions('message_sent'),
+    );
+
     // W4b — non-LLM channel capture via internal-hook map (PR #216 mechanism).
     // Internal hooks fire across both `full` and `setup-runtime` modes, so
     // we tack a memory-slot re-assert onto each fire as the mode-independent
@@ -977,8 +1008,10 @@ export class DkgNodePlugin {
     // already succeeded" rather than "first surface" so a failed initial
     // install (globalThis hook map not yet created at first-register time)
     // still gets retried on the next surface.
-    if (!internalHooksAlreadyLive) {
+    if (!this.internalHookEventIsLive('message:received')) {
       this.hookSurface.install('internal', 'message:received', this.makeMessageReceivedHandler(), { rareFireExpected: true });
+    }
+    if (!this.internalHookEventIsLive('message:sent')) {
       this.hookSurface.install('internal', 'message:sent', this.makeMessageSentHandler(), { rareFireExpected: true });
     }
 
@@ -1056,20 +1089,27 @@ export class DkgNodePlugin {
     };
   }
 
+  private makeTypedMessageReceivedHandler() {
+    return (ev: any, ctx?: any) => {
+      try { this.memoryPlugin?.reAssertCapability(); } catch { /* non-fatal */ }
+      return this.chatTurnWriter!.onTypedMessageReceived(ev, ctx);
+    };
+  }
+
+  private makeTypedMessageSentHandler() {
+    return (ev: any, ctx?: any) => {
+      try { this.memoryPlugin?.reAssertCapability(); } catch { /* non-fatal */ }
+      return this.chatTurnWriter!.onTypedMessageSent(ev, ctx);
+    };
+  }
+
   /**
-   * T32 — True if any prior hook surface has SUCCESSFULLY installed an
-   * internal hook (`installedVia: 'globalThis'`). Used by the
-   * `installHooksIfNeeded` rebuild path to gate internal-hook re-install
-   * on actual past success rather than "is this the first surface" —
-   * the prior gate broke the retry path when surface #1 itself failed
-   * to install (e.g., because `globalThis[…internalHookHandlers]` was
-   * absent at first-register time).
+   * True only when a retained surface still owns the adapter wrapper for
+   * this internal event in the current global hook map.
    */
-  private internalHooksAreLive(): boolean {
+  private internalHookEventIsLive(event: string): boolean {
     for (const surface of this.allHookSurfaces) {
-      const stats = surface.getDispatchStats();
-      if (stats['internal:message:received']?.installedVia === 'globalThis') return true;
-      if (stats['internal:message:sent']?.installedVia === 'globalThis') return true;
+      if (surface.ownsCurrentInternalHook(event)) return true;
     }
     return false;
   }
@@ -1137,7 +1177,7 @@ export class DkgNodePlugin {
       const stats = surface.getDispatchStats();
       // T36 — Exempt the surface that currently owns the live process-
       // global internal-hook registration. New surfaces skip installing
-      // internal hooks via `internalHooksAreLive()` (T32), so destroying
+      // internal hooks via adapter-owned live-wrapper checks, so destroying
       // the only owner — even if its typed/legacy hooks have never
       // fired — would unsubscribe the global wrappers and silently
       // disable W4b cross-channel persistence permanently. The
@@ -1146,8 +1186,8 @@ export class DkgNodePlugin {
       // the global registration is via `stop()`, which destroys all
       // surfaces deliberately.
       if (
-        stats['internal:message:received']?.installedVia === 'globalThis' ||
-        stats['internal:message:sent']?.installedVia === 'globalThis'
+        surface.ownsCurrentInternalHook('message:received') ||
+        surface.ownsCurrentInternalHook('message:sent')
       ) {
         continue;
       }
@@ -3159,7 +3199,18 @@ export class DkgNodePlugin {
     };
 
     // Typed hooks (api.on / api.registerHook) use underscore-separated names.
-    const typedEvents = ['before_prompt_build', 'agent_end', 'before_compaction', 'before_reset', 'message_received', 'message_sent'];
+    const typedEvents = [
+      'before_prompt_build',
+      'agent_end',
+      'agent.end',
+      'before_compaction',
+      'before_reset',
+      'message_received',
+      'message_sending',
+      'message_sent',
+      'message.received',
+      'message.sent',
+    ];
     // Internal-hook map (globalThis symbol) uses colon-separated names per
     // openclaw/src/infra/outbound/deliver.ts — probing the underscore form
     // here would never observe the real internal dispatch path and would

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -842,35 +842,13 @@ export class DkgNodePlugin {
               this.observedTypedOptions('before_prompt_build'),
             );
           }
-          for (const event of ['agent_end', 'agent.end']) {
-            if (typedNeedsRetry(event)) {
-              this.hookSurface.install(
-                'typed',
-                event,
-                this.observedTypedHandler(event, (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
-                this.observedTypedOptions(event),
-              );
-            }
-          }
-          for (const event of ['message_received', 'message.received']) {
-            if (typedNeedsRetry(event)) {
-              this.hookSurface.install(
-                'typed',
-                event,
-                this.observedTypedHandler(event, this.makeTypedMessageReceivedHandler()),
-                this.observedTypedOptions(event),
-              );
-            }
-          }
-          for (const event of ['message_sent', 'message.sent']) {
-            if (typedNeedsRetry(event)) {
-              this.hookSurface.install(
-                'typed',
-                event,
-                this.observedTypedHandler(event, this.makeTypedMessageSentHandler()),
-                this.observedTypedOptions(event),
-              );
-            }
+          if (typedNeedsRetry('agent_end')) {
+            this.hookSurface.install(
+              'typed',
+              'agent_end',
+              this.observedTypedHandler('agent_end', (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
+              this.observedTypedOptions('agent_end'),
+            );
           }
           if (typedNeedsRetry('before_compaction')) {
             this.hookSurface.install(
@@ -962,14 +940,12 @@ export class DkgNodePlugin {
     // and `before_reset` are rare on healthy gateways; tag them so the
     // HookSurface commit-by-timeout warn downgrades to debug (otherwise
     // they false-positive within 30s of startup every time).
-    for (const event of ['agent_end', 'agent.end']) {
-      this.hookSurface.install(
-        'typed',
-        event,
-        this.observedTypedHandler(event, (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
-        this.observedTypedOptions(event),
-      );
-    }
+    this.hookSurface.install(
+      'typed',
+      'agent_end',
+      this.observedTypedHandler('agent_end', (ev, ctx) => this.chatTurnWriter!.onAgentEnd(ev, ctx)),
+      this.observedTypedOptions('agent_end'),
+    );
     this.hookSurface.install(
       'typed',
       'before_compaction',
@@ -982,26 +958,6 @@ export class DkgNodePlugin {
       this.observedTypedHandler('before_reset', (ev, ctx) => this.chatTurnWriter!.onBeforeReset(ev, ctx)),
       this.observedTypedOptions('before_reset', { rareFireExpected: true }),
     );
-
-    // W4b typed message hooks - OpenClaw 2026.4.15 emits these for
-    // Telegram delivery even when typed `agent_end` remains silent. W4a
-    // stays installed above as canonical backfill for gateways that emit it.
-    for (const event of ['message_received', 'message.received']) {
-      this.hookSurface.install(
-        'typed',
-        event,
-        this.observedTypedHandler(event, this.makeTypedMessageReceivedHandler()),
-        this.observedTypedOptions(event),
-      );
-    }
-    for (const event of ['message_sent', 'message.sent']) {
-      this.hookSurface.install(
-        'typed',
-        event,
-        this.observedTypedHandler(event, this.makeTypedMessageSentHandler()),
-        this.observedTypedOptions(event),
-      );
-    }
 
     // W4b — non-LLM channel capture via internal-hook map (PR #216 mechanism).
     // Internal hooks fire across both `full` and `setup-runtime` modes, so
@@ -1098,20 +1054,6 @@ export class DkgNodePlugin {
     return (ev: any) => {
       try { this.memoryPlugin?.reAssertCapability(); } catch { /* non-fatal */ }
       return this.chatTurnWriter!.onMessageSent(ev);
-    };
-  }
-
-  private makeTypedMessageReceivedHandler() {
-    return (ev: any, ctx?: any) => {
-      try { this.memoryPlugin?.reAssertCapability(); } catch { /* non-fatal */ }
-      return this.chatTurnWriter!.onTypedMessageReceived(ev, ctx);
-    };
-  }
-
-  private makeTypedMessageSentHandler() {
-    return (ev: any, ctx?: any) => {
-      try { this.memoryPlugin?.reAssertCapability(); } catch { /* non-fatal */ }
-      return this.chatTurnWriter!.onTypedMessageSent(ev, ctx);
     };
   }
 
@@ -3210,21 +3152,14 @@ export class DkgNodePlugin {
       };
     };
 
-    // Typed probe candidates include the installed lifecycle/message events
-    // plus a few probe-only candidates. Probe-only candidates are
-    // observability guards: if live smoke shows one firing, we promote it
-    // into the real install set in a source-backed follow-up.
+    // Typed probe candidates intentionally mirror accepted lifecycle hooks.
+    // Dotted aliases and typed message_* names were rejected or silent on
+    // OpenClaw 2026.4.15, so probing them only adds startup warning noise.
     const typedEvents = [
       'before_prompt_build',
       'agent_end',
-      'agent.end',
       'before_compaction',
       'before_reset',
-      'message_received',
-      'message_sending',
-      'message_sent',
-      'message.received',
-      'message.sent',
     ];
     // Internal-hook map (globalThis symbol) uses colon-separated names per
     // openclaw/src/infra/outbound/deliver.ts — probing the underscore form

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -850,21 +850,25 @@ export class DkgNodePlugin {
               this.observedTypedOptions('agent_end'),
             );
           }
-          if (typedNeedsRetry('message_received')) {
-            this.hookSurface.install(
-              'typed',
-              'message_received',
-              this.observedTypedHandler('message_received', this.makeTypedMessageReceivedHandler()),
-              this.observedTypedOptions('message_received'),
-            );
+          for (const event of ['message_received', 'message.received']) {
+            if (typedNeedsRetry(event)) {
+              this.hookSurface.install(
+                'typed',
+                event,
+                this.observedTypedHandler(event, this.makeTypedMessageReceivedHandler()),
+                this.observedTypedOptions(event),
+              );
+            }
           }
-          if (typedNeedsRetry('message_sent')) {
-            this.hookSurface.install(
-              'typed',
-              'message_sent',
-              this.observedTypedHandler('message_sent', this.makeTypedMessageSentHandler()),
-              this.observedTypedOptions('message_sent'),
-            );
+          for (const event of ['message_sent', 'message.sent']) {
+            if (typedNeedsRetry(event)) {
+              this.hookSurface.install(
+                'typed',
+                event,
+                this.observedTypedHandler(event, this.makeTypedMessageSentHandler()),
+                this.observedTypedOptions(event),
+              );
+            }
           }
           if (typedNeedsRetry('before_compaction')) {
             this.hookSurface.install(
@@ -978,18 +982,22 @@ export class DkgNodePlugin {
     // W4b typed message hooks - OpenClaw 2026.4.15 emits these for
     // Telegram delivery even when typed `agent_end` remains silent. W4a
     // stays installed above as canonical backfill for gateways that emit it.
-    this.hookSurface.install(
-      'typed',
-      'message_received',
-      this.observedTypedHandler('message_received', this.makeTypedMessageReceivedHandler()),
-      this.observedTypedOptions('message_received'),
-    );
-    this.hookSurface.install(
-      'typed',
-      'message_sent',
-      this.observedTypedHandler('message_sent', this.makeTypedMessageSentHandler()),
-      this.observedTypedOptions('message_sent'),
-    );
+    for (const event of ['message_received', 'message.received']) {
+      this.hookSurface.install(
+        'typed',
+        event,
+        this.observedTypedHandler(event, this.makeTypedMessageReceivedHandler()),
+        this.observedTypedOptions(event),
+      );
+    }
+    for (const event of ['message_sent', 'message.sent']) {
+      this.hookSurface.install(
+        'typed',
+        event,
+        this.observedTypedHandler(event, this.makeTypedMessageSentHandler()),
+        this.observedTypedOptions(event),
+      );
+    }
 
     // W4b — non-LLM channel capture via internal-hook map (PR #216 mechanism).
     // Internal hooks fire across both `full` and `setup-runtime` modes, so

--- a/packages/adapter-openclaw/src/HookSurface.ts
+++ b/packages/adapter-openclaw/src/HookSurface.ts
@@ -190,6 +190,7 @@ export class HookSurface {
     const existing = this.installedHandlers.get(key);
     if (existing) {
       if (kind === 'internal' && !this.ownsCurrentInternalHook(event)) {
+        this.clearCommitTimer(key);
         try {
           existing.unsubscribe();
         } catch {
@@ -236,6 +237,7 @@ export class HookSurface {
     if (!unsubscribe) return null;
 
     this.installedHandlers.set(key, { handler, unsubscribe });
+    this.clearCommitTimer(key);
 
     const timer = setTimeout(() => {
       const s = this.stats.get(key);
@@ -506,12 +508,15 @@ export class HookSurface {
     this.stats.set(key, { ...prev, fireCount, commitState: nextState });
 
     if (fireCount === 1) {
-      const timer = this.commitTimers.get(key);
-      if (timer) {
-        clearTimeout(timer);
-        this.commitTimers.delete(key);
-      }
+      this.clearCommitTimer(key);
     }
+  }
+
+  private clearCommitTimer(key: string): void {
+    const timer = this.commitTimers.get(key);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.commitTimers.delete(key);
   }
 }
 

--- a/packages/adapter-openclaw/src/HookSurface.ts
+++ b/packages/adapter-openclaw/src/HookSurface.ts
@@ -42,8 +42,8 @@
  * I4 — deterministic commit timing. After first observed fire OR a 30s
  * grace period (whichever first), each event's `commitState` flips to
  * `committed-by-fire`, `committed-by-peer-fire`, or
- * `committed-by-timeout`. Callers can surface a warn if a typed-hook
- * event never fires within the grace period.
+ * `committed-by-timeout`. Timeout is diagnostic only: a hook can fire later,
+ * at which point stats move to `committed-by-fire`.
  *
  * C5 — double-registration guard. The same `(kind, event, handler)` triple
  * is a no-op on repeat install; we return the existing unsubscribe.
@@ -253,10 +253,11 @@ export class HookSurface {
           const msg =
             `[hook-surface] commit-by-timeout: ${key} never fired within ${this.commitGraceMs}ms. ` +
             `installedVia=${s.installedVia}, fireCount=0.`;
-          // Rare-fire hooks (e.g. before_compaction, before_reset) don't
-          // fire in routine traffic; surface at debug so real install
-          // failures on frequent hooks aren't drowned out by startup noise.
-          if (this.rareFireKeys.has(key)) {
+          // Startup-window timeouts are not proof a hook is dead: live
+          // Telegram smoke showed `agent_end` firing after the 30s window.
+          // Keep install failures loud, but make timeout liveness debug-only
+          // for typed hooks and explicitly rare hooks.
+          if (kind === 'typed' || this.rareFireKeys.has(key)) {
             this.logger.debug?.(msg);
           } else {
             this.logger.warn?.(msg);
@@ -502,7 +503,9 @@ export class HookSurface {
     if (!prev) return;
     const fireCount = prev.fireCount + 1;
     const nextState: CommitState =
-      prev.commitState === 'pending' || prev.commitState === 'committed-by-peer-fire'
+      prev.commitState === 'pending' ||
+      prev.commitState === 'committed-by-peer-fire' ||
+      prev.commitState === 'committed-by-timeout'
         ? 'committed-by-fire'
         : prev.commitState;
     this.stats.set(key, { ...prev, fireCount, commitState: nextState });

--- a/packages/adapter-openclaw/src/HookSurface.ts
+++ b/packages/adapter-openclaw/src/HookSurface.ts
@@ -129,6 +129,12 @@ export class HookSurface {
    */
   private readonly installedHandlers = new Map<string, { handler: HookHandler; unsubscribe: Unsubscribe }>();
   /**
+   * Internal hooks are stored in a mutable process-global map owned by the
+   * gateway. Stats only tell us an install once succeeded; this map lets the
+   * adapter prove its own wrapper is still present in the current live map.
+   */
+  private readonly internalWrappedHandlers = new Map<string, HookHandler>();
+  /**
    * R21.1 — Soft "destroyed" flag. OpenClaw's `api.on` and `api.registerHook`
    * have no unsubscribe primitives, so `destroy()`'s no-op unsubscribes for
    * typed and legacy hooks leave handlers live in the upstream registry.
@@ -183,15 +189,25 @@ export class HookSurface {
 
     const existing = this.installedHandlers.get(key);
     if (existing) {
-      if (existing.handler === handler) {
-        this.logger.debug?.(`[hook-surface] install dedup (same handler): ${key}`);
-        return existing.unsubscribe;
+      if (kind === 'internal' && !this.ownsCurrentInternalHook(event)) {
+        try {
+          existing.unsubscribe();
+        } catch {
+          /* best-effort stale teardown */
+        }
+        this.installedHandlers.delete(key);
+        this.internalWrappedHandlers.delete(event);
+      } else {
+        if (existing.handler === handler) {
+          this.logger.debug?.(`[hook-surface] install dedup (same handler): ${key}`);
+          return existing.unsubscribe;
+        }
+        this.logger.warn?.(
+          `[hook-surface] install REJECTED: ${key} already has a different handler registered. ` +
+            `Unsubscribe the prior install before re-installing.`,
+        );
+        return null;
       }
-      this.logger.warn?.(
-        `[hook-surface] install REJECTED: ${key} already has a different handler registered. ` +
-          `Unsubscribe the prior install before re-installing.`,
-      );
-      return null;
     }
 
     let unsubscribe: Unsubscribe | null;
@@ -263,6 +279,21 @@ export class HookSurface {
   }
 
   /**
+   * True only when this surface's adapter-owned wrapper for `event` is still
+   * present in the current process-global internal hook map.
+   */
+  ownsCurrentInternalHook(event: string): boolean {
+    if (this.destroyed) return false;
+    const wrapped = this.internalWrappedHandlers.get(event);
+    if (!wrapped) return false;
+    const g = globalThis as unknown as Record<symbol, unknown>;
+    const existing = g[INTERNAL_HOOK_SYMBOL];
+    if (!(existing instanceof Map)) return false;
+    const handlers = (existing as Map<string, HookHandler[]>).get(event);
+    return Array.isArray(handlers) && handlers.includes(wrapped);
+  }
+
+  /**
    * Tear down all installed handlers and cancel pending commit timers.
    * Idempotent. Called from `DkgNodePlugin.stop()` via the existing
    * `session_end` legacy hook.
@@ -284,6 +315,7 @@ export class HookSurface {
       }
     }
     this.installedHandlers.clear();
+    this.internalWrappedHandlers.clear();
     for (const timer of this.commitTimers.values()) clearTimeout(timer);
     this.commitTimers.clear();
   }
@@ -387,6 +419,7 @@ export class HookSurface {
     };
 
     hookMap.get(event)!.push(wrapped);
+    this.internalWrappedHandlers.set(event, wrapped);
     this.setStat(key, { installedVia: 'globalThis', commitState: 'pending' });
     this.logger.debug?.(`[hook-surface] installed internal hook via globalThis: ${event}`);
 
@@ -394,6 +427,9 @@ export class HookSurface {
       const arr = hookMap.get(event);
       if (!arr) return;
       hookMap.set(event, arr.filter((h) => h !== wrapped));
+      if (this.internalWrappedHandlers.get(event) === wrapped) {
+        this.internalWrappedHandlers.delete(event);
+      }
     };
   }
 

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -731,14 +731,15 @@ describe("ChatTurnWriter", () => {
     writer.onAgentEnd({
       sessionId: "test",
       messages: [
-        { role: "user", content: "late weak q" },
+        { role: "user", content: "late weak q", metadata: { messageId: "late-weak-in" } },
         { role: "assistant", content: "late weak a" },
       ],
     }, { channelId: "telegram", accountId: "bot", conversationId: "chat-late", sessionKey: "real-sk" });
     await flushMicrotasks();
 
-    expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(false);
-    expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(true);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(true);
+    expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(false);
 
     releaseStore!();
     await writer.flush();
@@ -834,6 +835,8 @@ describe("ChatTurnWriter", () => {
       ],
     }, { channelId: "telegram", accountId: "bot", conversationId: "chat-alias-A", sessionKey: "real-sk" });
     await flushMicrotasks();
+    expect((writer as any).inFlightPersists.has(conversationlessSessionId)).toBe(true);
+    expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(false);
 
     releaseStore!();
     await writer.flush();
@@ -855,6 +858,30 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(conversationlessSessionId);
     expect((writer as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(2);
     expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+  });
+
+  it("T359 - conversationless pending inbound does not promote into an unrelated concrete chat", async () => {
+    const conversationlessSessionId = "openclaw:telegram:bot::real-sk";
+    const concreteSessionId = "openclaw:telegram:bot:chat-concrete-B:real-sk";
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "chat A session-only q", metadata: { messageId: "session-only-in" } },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-B", sessionKey: "real-sk" });
+    await flushMicrotasks();
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "chat B reply must not use chat A user", success: true, metadata: { messageId: "chat-B-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-B", sessionKey: "real-sk" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    expect((writer as any).pendingUserMessages.get(conversationlessSessionId)).toEqual(["chat A session-only q"]);
+    expect((writer as any).pendingUserMessages.has(concreteSessionId)).toBe(false);
   });
 
   it("T359 - typed endpoint-only events without session identity are dropped", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -4445,4 +4445,33 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("u3"); // NOT "u2", not "u2\nu3"
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("ok");
   });
+
+  it("T359 - failed outbound clears inbound messageId dedupe for redelivery", async () => {
+    writer.onMessageReceived({
+      sessionKey: "sk",
+      context: { channelId: "tg", content: "retry after failed send", messageId: "in-redeliver" },
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "sk",
+      context: { channelId: "tg", content: "not delivered", success: false, messageId: "out-failed" },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    expect((writer as any).pendingUserMessages.size).toBe(0);
+
+    writer.onMessageReceived({
+      sessionKey: "sk",
+      context: { channelId: "tg", content: "retry after failed send", messageId: "in-redeliver" },
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "sk",
+      context: { channelId: "tg", content: "delivered on retry", success: true, messageId: "out-redeliver" },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("retry after failed send");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("delivered on retry");
+  });
 });

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -389,6 +389,39 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("bare id q1\nbare id q2");
   });
 
+  it("T359 - transcript bare id does not consume typed W4b replay marker", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "bare replay q", messageId: "bare-replay-in" },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-bare-replay", sessionKey: "sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "bare replay a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-bare-replay", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    await restarted.onBeforeCompaction({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-bare-replay",
+      sessionKey: "sk",
+    });
+
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "bare replay q", id: "bare-replay-in" },
+        { role: "assistant", content: "bare replay a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-bare-replay", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    restarted.flushSync();
+  });
+
   it("T359 - typed and internal W4b surfaces for the same Telegram message persist once", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "same inbound", metadata: { messageId: "same-in-1" } },
@@ -952,6 +985,27 @@ describe("ChatTurnWriter", () => {
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("no id duplicate q");
+  });
+
+  it("T359 - no-messageId repeated inbound text before reply is not collapsed", async () => {
+    const ctx = { channelId: "telegram", accountId: "bot", conversationId: "chat-noid-repeat-before-reply" };
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "repeat before reply" },
+      ctx,
+    );
+    await flushMicrotasks();
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "repeat before reply" },
+      ctx,
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "reply after repeats", success: true },
+      ctx,
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("repeat before reply\nrepeat before reply");
   });
 
   it("T359 - conversationless message-id dedupe is scoped by session key", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -477,7 +477,7 @@ describe("ChatTurnWriter", () => {
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
-        { role: "user", content: "weak marker q" },
+        { role: "user", content: "weak marker q", metadata: { messageId: "weak-marker-in" } },
         { role: "assistant", content: "weak marker a" },
       ],
     }, { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-marker", sessionKey: "agent:main:real" });
@@ -488,6 +488,51 @@ describe("ChatTurnWriter", () => {
     expect((restarted as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
     expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(0);
     expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    restarted.flushSync();
+  });
+
+  it("T359 - per-message weak marker skips only the matching repeated occurrence", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "repeat marker q", metadata: { messageId: "repeat-target-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat-marker" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "repeat marker a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat-marker" },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "repeat marker q", metadata: { messageId: "repeat-older-in" } },
+        { role: "assistant", content: "repeat marker a" },
+        { role: "user", content: "repeat marker q", metadata: { messageId: "repeat-target-in" } },
+        { role: "assistant", content: "repeat marker a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat-marker", sessionKey: "agent:main:real" });
+    await flushMicrotasks();
+
+    const strongSessionId = "openclaw:telegram:bot:chat-repeat-marker:agent%3Amain%3Areal";
+    const olderTurnId = (restarted as any).deterministicTurnId(
+      strongSessionId,
+      "repeat marker q",
+      "repeat marker a",
+      0,
+    );
+    const targetTurnId = (restarted as any).deterministicTurnId(
+      strongSessionId,
+      "repeat marker q",
+      "repeat marker a",
+      1,
+    );
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).toBe(olderTurnId);
+    expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).not.toBe(targetTurnId);
+    expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(1);
     restarted.flushSync();
   });
 
@@ -587,6 +632,61 @@ describe("ChatTurnWriter", () => {
     });
     expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
     expect((writer as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
+  });
+
+  it("T359 - conversationless promotion does not become a standing alias", async () => {
+    let releaseStore: (() => void) | null = null;
+    let storeCalls = 0;
+    mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
+      storeCalls++;
+      if (storeCalls === 1) {
+        await new Promise<void>((resolve) => { releaseStore = resolve; });
+      }
+    });
+    writer = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "alias first q", metadata: { messageId: "alias-first-in" } },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "alias first a", success: true },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    await flushMicrotasks();
+
+    const conversationlessSessionId = "openclaw:telegram:bot::real-sk";
+    const strongSessionId = "openclaw:telegram:bot:chat-alias-A:real-sk";
+    expect((writer as any).inFlightPersists.has(conversationlessSessionId)).toBe(true);
+
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "alias first q", metadata: { messageId: "alias-first-in" } },
+        { role: "assistant", content: "alias first a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-alias-A", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    releaseStore!();
+    await writer.flush();
+    expect((writer as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
+
+    mockClient.storeChatTurn.mockClear();
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "alias second q", metadata: { messageId: "alias-second-in" } },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "alias second a", success: true },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    await writer.flush();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(conversationlessSessionId);
+    expect((writer as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(1);
+    expect((writer as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
   });
 
   it("T359 - typed endpoint-only events without session identity are dropped", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -369,6 +369,26 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T359 - typed hook bare id is not treated as a provider message id", async () => {
+    const ctx = { channelId: "telegram", accountId: "bot", conversationId: "chat-bare-id", id: "chat-object-id" } as any;
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "bare id q1" },
+      ctx,
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "bare id q2" },
+      ctx,
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "bare id a", success: true },
+      ctx,
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("bare id q1\nbare id q2");
+  });
+
   it("T359 - typed and internal W4b surfaces for the same Telegram message persist once", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "same inbound", metadata: { messageId: "same-in-1" } },
@@ -684,6 +704,50 @@ describe("ChatTurnWriter", () => {
       sessionKey: "real-sk",
     });
     expect((writer as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
+  });
+
+  it("T359 - weak conversation W4b in-flight suppresses real-session W4a duplicate", async () => {
+    let releaseStore: (() => void) | null = null;
+    let storeCalls = 0;
+    mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
+      storeCalls++;
+      await new Promise<void>((resolve) => { releaseStore = resolve; });
+    });
+    writer = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "weak inflight q", metadata: { messageId: "weak-inflight-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-inflight" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "weak inflight a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-inflight" },
+    );
+    await flushMicrotasks();
+    expect(storeCalls).toBe(1);
+
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "weak inflight q" },
+        { role: "assistant", content: "weak inflight a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-inflight", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    expect(storeCalls).toBe(1);
+    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "chat-weak-inflight");
+    const weakSessionId = `openclaw:telegram:bot:chat-weak-inflight:${encodeURIComponent(weakSessionKey)}`;
+    const strongSessionId = "openclaw:telegram:bot:chat-weak-inflight:real-sk";
+    expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(true);
+    expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(false);
+
+    releaseStore!();
+    await writer.flush();
+
+    expect(storeCalls).toBe(1);
+    expect((writer as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
+    expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
   });
 
   it("T359 - conversationless promotion does not become a standing alias", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -791,6 +791,30 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("strong typed q");
   });
 
+  it("T359 - conversationless promotion does not move short TTL dedupe maps", async () => {
+    const conversationlessSessionId = "openclaw:telegram:bot::real-sk";
+    const strongSessionId = "openclaw:telegram:bot:chat-ttl:real-sk";
+    const turnKey = "same-ttl-turn";
+    const originKey = (writer as any).w4bOriginKey("ttl q", "ttl a");
+
+    (writer as any).markTurnIdSeen(conversationlessSessionId, turnKey);
+    (writer as any).markCrossPathStamp(conversationlessSessionId, originKey);
+    (writer as any).markCrossPathInflight(conversationlessSessionId, originKey);
+
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-ttl", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    expect((writer as any).peekTurnIdSeen(conversationlessSessionId, turnKey)).toBe(true);
+    expect((writer as any).peekCrossPathStamp(conversationlessSessionId, originKey)).toBe(true);
+    expect((writer as any).peekCrossPathInflight(conversationlessSessionId, originKey)).toBe(true);
+    expect((writer as any).peekTurnIdSeen(strongSessionId, turnKey)).toBe(false);
+    expect((writer as any).peekCrossPathStamp(strongSessionId, originKey)).toBe(false);
+    expect((writer as any).peekCrossPathInflight(strongSessionId, originKey)).toBe(false);
+  });
+
   it("T359 - repeated same-text typed replies without outbound messageIds do not dedupe distinct turns", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "repeat q1", metadata: { messageId: "repeat-in-1" } },
@@ -844,6 +868,26 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).not.toBe(
       mockClient.storeChatTurn.mock.calls[1][3]?.turnId,
     );
+  });
+
+  it("T359 - no-messageId duplicate inbound surfaces queue once", async () => {
+    const ctx = { channelId: "telegram", accountId: "bot", conversationId: "chat-noid-dup" };
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "no id duplicate q" },
+      ctx,
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "no id duplicate q" },
+      ctx,
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "no id duplicate a", success: true },
+      ctx,
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("no id duplicate q");
   });
 
   it("T359 - conversationless message-id dedupe is scoped by session key", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -926,6 +926,31 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("split strong outbound");
   });
 
+  it("T359 - typed sessionId fallback inbound promotes to concrete outbound sessionKey", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "fallback to concrete inbound", metadata: { messageId: "fallback-concrete-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-fallback-concrete", sessionId: "typed-session-c" },
+    );
+
+    await writer.onMessageSent({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-fallback-concrete",
+        content: "concrete outbound",
+        success: true,
+        messageId: "fallback-concrete-out",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-fallback-concrete:internal-sk");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("fallback to concrete inbound");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("concrete outbound");
+  });
+
   it("T359 - queue promotion appends later weak duplicates after earlier strong messages", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "first strong inbound", metadata: { messageId: "order-strong-first" } },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -2906,6 +2906,48 @@ describe("ChatTurnWriter", () => {
     expect(call[2]).toBe("It's rainy today.");
   });
 
+  it("T359 - cold-start W4a persists only the final user-visible reply from tool scaffolding", async () => {
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "assistant", content: "startup greeting" },
+        { role: "user", content: "What do we know about OriginTrail?" },
+        { role: "assistant", content: "I'll inspect memory first." },
+        { role: "user", content: "memory_search raw_hits=0", tool_call_id: "call-memory-1" } as any,
+        { role: "assistant", content: "No memory hits; I'll query the graph." },
+        { role: "function" as any, name: "dkg_query", content: "query result rows" },
+        { role: "assistant", content: "OriginTrail is a decentralized knowledge graph project." },
+      ],
+    };
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    const call = mockClient.storeChatTurn.mock.calls[0];
+    expect(call[1]).toBe("What do we know about OriginTrail?");
+    expect(call[2]).toBe("OriginTrail is a decentralized knowledge graph project.");
+  });
+
+  it("T359 - delayed W4a flushing still preserves ordinary multi-pair backfill", async () => {
+    const event: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "q1" },
+        { role: "assistant", content: "a1" },
+        { role: "user", content: "q2" },
+        { role: "assistant", content: "a2" },
+      ],
+    };
+    writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls.map((call) => [call[1], call[2]])).toEqual([
+      ["q1", "a1"],
+      ["q2", "a2"],
+    ]);
+  });
+
   it("T5 — cross-path stamps live on a SHORTER TTL than the in-flight turnIds (<=10s)", () => {
     // Regression for T5: pre-fix, content-only `w4aOriginKey` /
     // `w4bOriginKey` lived on the 60s `TURNID_TTL_MS` map. Two

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -718,6 +718,33 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T359 - strong typed W4b marker writes weak conversation cursor for session rotation", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "rotated marker q", metadata: { messageId: "rotated-marker-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-rotated-marker", sessionKey: "agent:a" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "rotated marker a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-rotated-marker", sessionKey: "agent:a" },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "rotated marker q", metadata: { messageId: "rotated-marker-in" } },
+        { role: "assistant", content: "rotated marker a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-rotated-marker", sessionKey: "agent:b" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    restarted.flushSync();
+  });
+
   it("T359 - per-message weak marker skips only the matching repeated occurrence", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "repeat marker q", metadata: { messageId: "repeat-target-in" } },
@@ -805,6 +832,67 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-order:real-sk");
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("older weak inbound\nlater strong inbound");
+  });
+
+  it("T359 - queue promotion rebinds all inbound dedupe keys for failed-send redelivery", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "move all first", metadata: { messageId: "move-all-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-move-all" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "move all second", metadata: { messageId: "move-all-2" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-move-all" },
+    );
+    writer.onMessageReceived({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-move-all",
+        content: "move all second",
+        messageId: "move-all-2",
+      },
+    } as any);
+
+    await writer.onMessageSent({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-move-all",
+        content: "failed move all",
+        success: false,
+        messageId: "move-all-failed",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    writer.onMessageReceived({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-move-all",
+        content: "move all first",
+        messageId: "move-all-1",
+      },
+    } as any);
+    await writer.onMessageSent({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-move-all",
+        content: "redelivered move all",
+        success: true,
+        messageId: "move-all-out",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("move all first");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("redelivered move all");
   });
 
   it("T359 - queue promotion appends later weak duplicates after earlier strong messages", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -334,6 +334,34 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("numeric id response");
   });
 
+  it("T359 - Telegram topic fallback conversation includes chat and thread ids", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "topic one q", metadata: { chatId: 12345, threadId: 111, messageId: "topic-1-in" } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-2", content: "topic two q", metadata: { chatId: 12345, threadId: 222, messageId: "topic-2-in" } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "topic one a", success: true, metadata: { chatId: 12345, threadId: 111, messageId: "topic-1-out" } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-2", content: "topic two a", success: true, metadata: { chatId: 12345, threadId: 222, messageId: "topic-2-out" } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls.map((call) => [call[1], call[2]])).toEqual([
+      ["topic one q", "topic one a"],
+      ["topic two q", "topic two a"],
+    ]);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toContain("12345%3A111");
+    expect(mockClient.storeChatTurn.mock.calls[1][0]).toContain("12345%3A222");
+  });
+
   it("T359 - typed message normalization accepts structured and ctx text content", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: [{ type: "text", text: "typed array hello" }] },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -704,7 +704,7 @@ describe("ChatTurnWriter", () => {
     expect((writer as any).pendingUserMessages.size).toBe(0);
   });
 
-  it("T359 - strong typed session without conversation promotes when conversation arrives", async () => {
+  it("T359 - conversationless marker does not suppress concrete W4a without conversation proof", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "strong typed q", metadata: { messageId: "strong-in-1" } },
       { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
@@ -733,8 +733,9 @@ describe("ChatTurnWriter", () => {
     const strongSessionId = "openclaw:telegram:bot:chat-real:real-sk";
     expect((restarted as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
     expect((restarted as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(1);
-    expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(0);
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(strongSessionId);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("strong typed q");
   });
 
   it("T359 - repeated same-text typed replies without outbound messageIds do not dedupe distinct turns", async () => {
@@ -820,6 +821,94 @@ describe("ChatTurnWriter", () => {
       "session A q",
       "session B q",
     ]);
+  });
+
+  it("T359 - outbound dedupe ignores session key once conversation identity is known", () => {
+    const weakSession = (writer as any).weakSessionKey("telegram", "bot", "chat-dedup");
+    const weakInboundKey = (writer as any).messageHookDedupKey(
+      "outbound",
+      {
+        sessionKey: weakSession,
+        context: {
+          channelId: "telegram",
+          accountId: "bot",
+          conversationId: "chat-dedup",
+          content: "dedup a",
+        },
+      },
+      "dedup a",
+      [{ messageId: "dedup-in" }],
+      "dedup q",
+    );
+    const strongInboundKey = (writer as any).messageHookDedupKey(
+      "outbound",
+      {
+        sessionKey: "real-sk",
+        context: {
+          channelId: "telegram",
+          accountId: "bot",
+          conversationId: "chat-dedup",
+          content: "dedup a",
+        },
+      },
+      "dedup a",
+      [{ messageId: "dedup-in" }],
+      "dedup q",
+    );
+    const weakArrivalKey = (writer as any).messageHookDedupKey(
+      "outbound",
+      {
+        sessionKey: weakSession,
+        context: {
+          channelId: "telegram",
+          accountId: "bot",
+          conversationId: "chat-dedup",
+          content: "dedup a",
+        },
+      },
+      "dedup a",
+      [{ arrivalId: "arrival::shared" }],
+      "dedup q",
+    );
+    const strongArrivalKey = (writer as any).messageHookDedupKey(
+      "outbound",
+      {
+        sessionKey: "real-sk",
+        context: {
+          channelId: "telegram",
+          accountId: "bot",
+          conversationId: "chat-dedup",
+          content: "dedup a",
+        },
+      },
+      "dedup a",
+      [{ arrivalId: "arrival::shared" }],
+      "dedup q",
+    );
+
+    expect(weakInboundKey).toBe(strongInboundKey);
+    expect(weakArrivalKey).toBe(strongArrivalKey);
+  });
+
+  it("T359 - concrete reset clears synthetic weak typed session state", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "stale weak q", metadata: { messageId: "stale-weak-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-reset-weak" },
+    );
+
+    const weakSession = (writer as any).weakSessionKey("telegram", "bot", "chat-reset-weak");
+    const weakSessionId = `openclaw:telegram:bot:chat-reset-weak:${weakSession}`;
+    expect((writer as any).pendingUserMessages.get(weakSessionId)).toEqual(["stale weak q"]);
+
+    await writer.onBeforeReset({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-reset-weak",
+      sessionKey: "real-sk",
+    });
+
+    expect((writer as any).pendingUserMessages.has(weakSessionId)).toBe(false);
+    expect((writer as any).pendingUserMessageMeta.has(weakSessionId)).toBe(false);
   });
 
   it("T359 - reset clears only the affected session's message-hook dedupe", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -581,7 +581,7 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("strong move outbound");
   });
 
-  it("T359 - internal-first duplicate typed inbound does not move the queue to weaker identity", async () => {
+  it("T359 - internal-first duplicate typed inbound still persists once when weak outbound arrives first", async () => {
     writer.onMessageReceived({
       sessionKey: "internal-sk",
       context: {
@@ -615,8 +615,9 @@ describe("ChatTurnWriter", () => {
     await flushMicrotasks();
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
-    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-1:internal-sk");
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toContain("chat-1");
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("internal first");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed duplicate outbound");
   });
 
   it("T359 - no-session typed Telegram identities stay isolated by conversation", async () => {
@@ -949,6 +950,89 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-fallback-concrete:internal-sk");
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("fallback to concrete inbound");
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("concrete outbound");
+  });
+
+  it("T359 - weak inbound promotes to concrete outbound without session fallback marker", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "weak only inbound", metadata: { messageId: "weak-only-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-concrete" },
+    );
+
+    await writer.onMessageSent({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-weak-concrete",
+        content: "concrete answer",
+        success: true,
+        messageId: "weak-concrete-out",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-weak-concrete:internal-sk");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("weak only inbound");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("concrete answer");
+  });
+
+  it("T359 - concrete inbound promotes to weak outbound by conversation identity", async () => {
+    writer.onMessageReceived({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-concrete-weak",
+        content: "concrete only inbound",
+        messageId: "concrete-weak-in",
+      },
+    } as any);
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "weak answer", success: true, metadata: { messageId: "concrete-weak-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-weak" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toContain("chat-concrete-weak");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("concrete only inbound");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("weak answer");
+  });
+
+  it("T359 - outbound promotion merges weak sibling into existing concrete queue", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "older weak sibling", metadata: { messageId: "merge-weak-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-merge-sibling" },
+    );
+    writer.onMessageReceived({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-merge-sibling",
+        content: "newer concrete sibling",
+        messageId: "merge-concrete-in",
+      },
+    } as any);
+
+    await writer.onMessageSent({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-merge-sibling",
+        content: "merged sibling answer",
+        success: true,
+        messageId: "merge-sibling-out",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("older weak sibling\nnewer concrete sibling");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("merged sibling answer");
   });
 
   it("T359 - queue promotion appends later weak duplicates after earlier strong messages", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -704,12 +704,76 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("older weak inbound\nlater strong inbound");
   });
 
-  it("T359 - in-flight conversationless W4b completion avoids promoted durable counts", async () => {
-    let releaseStore: (() => void) | null = null;
-    let storeStarted = false;
+  it("T359 - queue promotion appends later weak duplicates after earlier strong messages", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "first strong inbound", metadata: { messageId: "order-strong-first" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-order-append", sessionKey: "real-sk" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "later weak inbound", metadata: { messageId: "order-weak-later" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-order-append" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "later weak inbound", metadata: { messageId: "order-weak-later" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-order-append", sessionKey: "real-sk" },
+    );
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "ordered append answer", success: true, metadata: { messageId: "order-append-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-order-append", sessionKey: "real-sk" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("first strong inbound\nlater weak inbound");
+  });
+
+  it("T359 - conversation-scoped in-flight markers do not suppress another chat with reused messageId", async () => {
+    let releaseFirst: (() => void) | null = null;
+    let storeCalls = 0;
     mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
-      storeStarted = true;
-      await new Promise<void>((resolve) => { releaseStore = resolve; });
+      storeCalls++;
+      if (storeCalls === 1) {
+        await new Promise<void>((resolve) => { releaseFirst = resolve; });
+      }
+    });
+    writer = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "same local text", metadata: { messageId: "local-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-A" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "same local reply", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-A" },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "same local text", metadata: { messageId: "local-1" } },
+        { role: "assistant", content: "same local reply" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-B", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls[1][0]).toBe("openclaw:telegram:bot:chat-B:real-sk");
+
+    releaseFirst!();
+    await writer.flush();
+  });
+
+  it("T359 - in-flight conversationless W4b completion stays isolated from concrete W4a", async () => {
+    let releaseStore: (() => void) | null = null;
+    let storeCalls = 0;
+    mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
+      storeCalls++;
+      if (storeCalls === 1) {
+        await new Promise<void>((resolve) => { releaseStore = resolve; });
+      }
     });
     writer = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
 
@@ -722,7 +786,7 @@ describe("ChatTurnWriter", () => {
       { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
     );
     await flushMicrotasks();
-    expect(storeStarted).toBe(true);
+    expect(storeCalls).toBe(1);
 
     const weakSessionId = "openclaw:telegram:bot::real-sk";
     const strongSessionId = "openclaw:telegram:bot:chat-late:real-sk";
@@ -737,7 +801,8 @@ describe("ChatTurnWriter", () => {
     }, { channelId: "telegram", accountId: "bot", conversationId: "chat-late", sessionKey: "real-sk" });
     await flushMicrotasks();
 
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls[1][0]).toBe(strongSessionId);
     expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(true);
     expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(false);
 

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -316,6 +316,59 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed response");
   });
 
+  it("T359 - typed message normalization accepts structured and ctx text content", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: [{ type: "text", text: "typed array hello" }] },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-array", messageId: "array-in-1" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-array", content: "typed ctx response" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("typed array hello");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed ctx response");
+  });
+
+  it("T359 - typed message normalization preserves alternate provider id fields for replay markers", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "alt id q", message_id: "alt-id-in" },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-alt-id", sessionKey: "sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "alt id a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-alt-id", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+
+    const sessionId = "openclaw:telegram:bot:chat-alt-id:sk";
+    expect((writer as any).w4bSessionCounts.get(sessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    await restarted.onBeforeCompaction({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-alt-id",
+      sessionKey: "sk",
+    });
+
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "alt id q", metadata: { message_id: "alt-id-in" } },
+        { role: "assistant", content: "alt id a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-alt-id", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    expect((restarted as any).cachedWatermarks.get(sessionId)).toBe(0);
+    restarted.flushSync();
+  });
+
   it("T359 - typed and internal W4b surfaces for the same Telegram message persist once", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "same inbound", metadata: { messageId: "same-in-1" } },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -580,7 +580,7 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("older weak inbound\nlater strong inbound");
   });
 
-  it("T359 - in-flight conversationless W4b completion writes to promoted session state", async () => {
+  it("T359 - in-flight conversationless W4b completion avoids promoted durable counts", async () => {
     let releaseStore: (() => void) | null = null;
     let storeStarted = false;
     mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
@@ -619,8 +619,8 @@ describe("ChatTurnWriter", () => {
     releaseStore!();
     await writer.flush();
 
-    expect((writer as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
-    expect((writer as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
+    expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+    expect((writer as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
     expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(false);
     expect((writer as any).crossPathInflight.size).toBe(0);
 
@@ -630,8 +630,7 @@ describe("ChatTurnWriter", () => {
       conversationId: "chat-late",
       sessionKey: "real-sk",
     });
-    expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
-    expect((writer as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
+    expect((writer as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
   });
 
   it("T359 - conversationless promotion does not become a standing alias", async () => {
@@ -670,7 +669,8 @@ describe("ChatTurnWriter", () => {
 
     releaseStore!();
     await writer.flush();
-    expect((writer as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
+    expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+    expect((writer as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(1);
 
     mockClient.storeChatTurn.mockClear();
     writer.onTypedMessageReceived(
@@ -685,8 +685,8 @@ describe("ChatTurnWriter", () => {
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(conversationlessSessionId);
-    expect((writer as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(1);
-    expect((writer as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
+    expect((writer as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(2);
+    expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
   });
 
   it("T359 - typed endpoint-only events without session identity are dropped", async () => {
@@ -724,15 +724,16 @@ describe("ChatTurnWriter", () => {
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
-        { role: "user", content: "strong typed q" },
+        { role: "user", content: "strong typed q", metadata: { messageId: "strong-in-1" } },
         { role: "assistant", content: "strong typed a" },
       ],
     }, { channelId: "telegram", accountId: "bot", conversationId: "chat-real", sessionKey: "real-sk" });
     await flushMicrotasks();
 
     const strongSessionId = "openclaw:telegram:bot:chat-real:real-sk";
-    expect((restarted as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
-    expect((restarted as any).w4bSessionCounts.has(conversationlessSessionId)).toBe(false);
+    expect((restarted as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+    expect((restarted as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(1);
+    expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(0);
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
   });
 
@@ -789,6 +790,36 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).not.toBe(
       mockClient.storeChatTurn.mock.calls[1][3]?.turnId,
     );
+  });
+
+  it("T359 - conversationless message-id dedupe is scoped by session key", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "session A q", metadata: { messageId: "local-in-1" } },
+      { channelId: "telegram", accountId: "bot", sessionKey: "sk-A" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-2", content: "session B q", metadata: { messageId: "local-in-1" } },
+      { channelId: "telegram", accountId: "bot", sessionKey: "sk-B" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "session A a", success: true },
+      { channelId: "telegram", accountId: "bot", sessionKey: "sk-A" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-2", content: "session B a", success: true },
+      { channelId: "telegram", accountId: "bot", sessionKey: "sk-B" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls.map((call) => call[0])).toEqual([
+      "openclaw:telegram:bot::sk-A",
+      "openclaw:telegram:bot::sk-B",
+    ]);
+    expect(mockClient.storeChatTurn.mock.calls.map((call) => call[1])).toEqual([
+      "session A q",
+      "session B q",
+    ]);
   });
 
   it("T359 - reset clears only the affected session's message-hook dedupe", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -895,6 +895,37 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("redelivered move all");
   });
 
+  it("T359 - typed outbound pairs when only one side carries sessionId", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "split strong inbound", metadata: { messageId: "split-strong-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-split-strong", sessionId: "typed-session-a" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "split weak outbound", success: true, metadata: { messageId: "split-weak-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-split-strong" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("split strong inbound");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("split weak outbound");
+
+    mockClient.storeChatTurn.mockClear();
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "split weak inbound", metadata: { messageId: "split-weak-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-split-weak" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "split strong outbound", success: true, metadata: { messageId: "split-strong-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-split-weak", sessionId: "typed-session-b" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("split weak inbound");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("split strong outbound");
+  });
+
   it("T359 - queue promotion appends later weak duplicates after earlier strong messages", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "first strong inbound", metadata: { messageId: "order-strong-first" } },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -454,6 +454,61 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T359 - in-flight weak W4b completion writes to promoted session state", async () => {
+    let releaseStore: (() => void) | null = null;
+    let storeStarted = false;
+    mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
+      storeStarted = true;
+      await new Promise<void>((resolve) => { releaseStore = resolve; });
+    });
+    writer = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "late weak q", metadata: { messageId: "late-weak-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-late" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "late weak a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-late" },
+    );
+    await flushMicrotasks();
+    expect(storeStarted).toBe(true);
+
+    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "chat-late");
+    const weakSessionId = `openclaw:telegram:bot:chat-late:${weakSessionKey}`;
+    const strongSessionId = "openclaw:telegram:bot:chat-late:real-sk";
+    expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(true);
+
+    writer.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "late weak q" },
+        { role: "assistant", content: "late weak a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-late", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(false);
+    expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(true);
+
+    releaseStore!();
+    await writer.flush();
+
+    expect((writer as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
+    expect((writer as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
+    expect((writer as any).inFlightPersists.has(strongSessionId)).toBe(false);
+    expect((writer as any).crossPathInflight.size).toBe(0);
+
+    await writer.onBeforeReset({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-late",
+      sessionKey: "real-sk",
+    });
+    expect((writer as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+    expect((writer as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
+  });
+
   it("T359 - typed endpoint-only events without session identity are dropped", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "endpoint-only q" },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -454,6 +454,53 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T359 - typed endpoint-only events without session identity are dropped", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "endpoint-only q" },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "endpoint-only a", success: true },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    expect((writer as any).pendingUserMessages.size).toBe(0);
+  });
+
+  it("T359 - strong typed session without conversation promotes when conversation arrives", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "strong typed q", metadata: { messageId: "strong-in-1" } },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "strong typed a", success: true },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+
+    const conversationlessSessionId = "openclaw:telegram:bot::real-sk";
+    expect((writer as any).w4bSessionCounts.get(conversationlessSessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "strong typed q" },
+        { role: "assistant", content: "strong typed a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-real", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    const strongSessionId = "openclaw:telegram:bot:chat-real:real-sk";
+    expect((restarted as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
+    expect((restarted as any).w4bSessionCounts.has(conversationlessSessionId)).toBe(false);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+  });
+
   it("T359 - repeated same-text typed replies without outbound messageIds do not dedupe distinct turns", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "repeat q1", metadata: { messageId: "repeat-in-1" } },
@@ -478,6 +525,74 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[1][1]).toBe("repeat q2");
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("same answer");
     expect(mockClient.storeChatTurn.mock.calls[1][2]).toBe("same answer");
+  });
+
+  it("T359 - repeated no-messageId typed user text persists as distinct turns", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "ok" },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-noid" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "ack", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-noid" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "ok" },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-noid" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "ack", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-noid" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls.map((call) => [call[1], call[2]])).toEqual([
+      ["ok", "ack"],
+      ["ok", "ack"],
+    ]);
+    expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).not.toBe(
+      mockClient.storeChatTurn.mock.calls[1][3]?.turnId,
+    );
+  });
+
+  it("T359 - reset clears only the affected session's message-hook dedupe", async () => {
+    const eventA = {
+      sessionKey: "sk-A",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-A",
+        content: "hello A",
+        messageId: "in-A",
+      },
+    } as any;
+    const eventB = {
+      sessionKey: "sk-B",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-B",
+        content: "hello B",
+        messageId: "in-B",
+      },
+    } as any;
+    writer.onMessageReceived(eventA);
+    writer.onMessageReceived(eventB);
+
+    await writer.onBeforeReset({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-B",
+      sessionKey: "sk-B",
+    });
+
+    writer.onMessageReceived(eventA);
+    writer.onMessageReceived(eventB);
+
+    const pending = (writer as any).pendingUserMessages as Map<string, string[]>;
+    expect(pending.get("openclaw:telegram:bot:chat-A:sk-A")).toEqual(["hello A"]);
+    expect(pending.get("openclaw:telegram:bot:chat-B:sk-B")).toEqual(["hello B"]);
   });
 
   it("flushSync clears debounce timers", () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -316,6 +316,29 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed response");
   });
 
+  it("T359 - empty typed outbound failure clears the pending inbound queue", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "failed typed q", metadata: { messageId: "failed-typed-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-failed-typed" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", success: false, metadata: { messageId: "failed-typed-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-failed-typed" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    expect((writer as any).pendingUserMessages.size).toBe(0);
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "later typed a", success: true, metadata: { messageId: "later-typed-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-failed-typed" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+  });
+
   it("T359 - typed message hooks normalize numeric chat and thread ids", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "numeric id hello", metadata: { chatId: 12345 } },
@@ -521,6 +544,41 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("same inbound");
     expect((writer as any).pendingUserMessages.size).toBe(0);
+  });
+
+  it("T359 - same-message strong identity change moves the pending inbound queue", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "strong move inbound", metadata: { messageId: "same-strong-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-strong-move", sessionId: "typed-session" },
+    );
+    writer.onMessageReceived({
+      sessionKey: "internal-session",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-strong-move",
+        content: "strong move inbound",
+        messageId: "same-strong-in",
+      },
+    } as any);
+
+    await writer.onMessageSent({
+      sessionKey: "internal-session",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-strong-move",
+        content: "strong move outbound",
+        success: true,
+        messageId: "same-strong-out",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-strong-move:internal-session");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("strong move inbound");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("strong move outbound");
   });
 
   it("T359 - internal-first duplicate typed inbound does not move the queue to weaker identity", async () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -316,6 +316,24 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed response");
   });
 
+  it("T359 - typed message hooks normalize numeric chat and thread ids", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "numeric id hello", metadata: { chatId: 12345 } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "numeric id response", success: true, metadata: { threadId: 12345 } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "12345");
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(`openclaw:telegram:bot:12345:${weakSessionKey}`);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("numeric id hello");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("numeric id response");
+  });
+
   it("T359 - typed message normalization accepts structured and ctx text content", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: [{ type: "text", text: "typed array hello" }] },
@@ -1396,6 +1414,25 @@ describe("ChatTurnWriter", () => {
     });
     expect((restarted as any).w4bSessionCounts.has(sessionId)).toBe(false);
 
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "concrete marker q", metadata: { messageId: "concrete-marker-in" } },
+        { role: "assistant", content: "concrete marker a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-marker", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    expect((restarted as any).cachedWatermarks.get(sessionId)).toBe(0);
+
+    await restarted.onBeforeCompaction({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-concrete-marker",
+      sessionKey: "sk",
+    });
     mockClient.storeChatTurn.mockClear();
     restarted.onAgentEnd({
       sessionId: "test",

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -310,7 +310,8 @@ describe("ChatTurnWriter", () => {
     await flushMicrotasks();
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
-    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-1:chat-1");
+    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "chat-1");
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(`openclaw:telegram:bot:chat-1:${weakSessionKey}`);
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("typed hello");
     expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed response");
   });
@@ -411,10 +412,72 @@ describe("ChatTurnWriter", () => {
     await flushMicrotasks();
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    const weakSessionA = (writer as any).weakSessionKey("telegram", "bot", "chat-A");
+    const weakSessionB = (writer as any).weakSessionKey("telegram", "bot", "chat-B");
     expect(mockClient.storeChatTurn.mock.calls.map((call) => call[0])).toEqual([
-      "openclaw:telegram:bot:chat-A:chat-A",
-      "openclaw:telegram:bot:chat-B:chat-B",
+      `openclaw:telegram:bot:chat-A:${weakSessionA}`,
+      `openclaw:telegram:bot:chat-B:${weakSessionB}`,
     ]);
+  });
+
+  it("T359 - weak typed session state promotes to real session before W4a backfill", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "weak typed q", metadata: { messageId: "weak-in-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "weak typed a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak" },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+
+    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "chat-weak");
+    const weakSessionId = `openclaw:telegram:bot:chat-weak:${weakSessionKey}`;
+    expect((writer as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "weak typed q" },
+        { role: "assistant", content: "weak typed a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-weak", sessionKey: "real-sk" });
+    await flushMicrotasks();
+
+    const strongSessionId = "openclaw:telegram:bot:chat-weak:real-sk";
+    expect((restarted as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
+    expect((restarted as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    restarted.flushSync();
+  });
+
+  it("T359 - repeated same-text typed replies without outbound messageIds do not dedupe distinct turns", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "repeat q1", metadata: { messageId: "repeat-in-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "same answer", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "repeat q2", metadata: { messageId: "repeat-in-2" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "same answer", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("repeat q1");
+    expect(mockClient.storeChatTurn.mock.calls[1][1]).toBe("repeat q2");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("same answer");
+    expect(mockClient.storeChatTurn.mock.calls[1][2]).toBe("same answer");
   });
 
   it("flushSync clears debounce timers", () => {

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -298,6 +298,125 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn).toHaveBeenCalled();
   });
 
+  it("T359 - typed message hooks persist one Telegram turn without internal sessionKey", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "typed hello", metadata: { messageId: "typed-in-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "typed response", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-1:chat-1");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("typed hello");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("typed response");
+  });
+
+  it("T359 - typed and internal W4b surfaces for the same Telegram message persist once", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "same inbound", metadata: { messageId: "same-in-1" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+    writer.onMessageReceived({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-1",
+        content: "same inbound",
+        messageId: "same-in-1",
+      },
+    } as any);
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "same outbound", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+    await writer.onMessageSent({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-1",
+        content: "same outbound",
+        success: true,
+        messageId: "same-out-1",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("same inbound");
+    expect((writer as any).pendingUserMessages.size).toBe(0);
+  });
+
+  it("T359 - internal-first duplicate typed inbound does not move the queue to weaker identity", async () => {
+    writer.onMessageReceived({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-1",
+        content: "internal first",
+        messageId: "same-in-2",
+      },
+    } as any);
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "internal first", metadata: { messageId: "same-in-2" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "typed duplicate outbound", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-1" },
+    );
+    await writer.onMessageSent({
+      sessionKey: "internal-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-1",
+        content: "internal outbound",
+        success: true,
+        messageId: "same-out-2",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-1:internal-sk");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("internal first");
+  });
+
+  it("T359 - no-session typed Telegram identities stay isolated by conversation", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-A", content: "question A", metadata: { messageId: "typed-A-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-A" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-A", content: "answer A", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-A" },
+    );
+    writer.onTypedMessageReceived(
+      { from: "user-B", content: "question B", metadata: { messageId: "typed-B-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-B" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-B", content: "answer B", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-B" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
+    expect(mockClient.storeChatTurn.mock.calls.map((call) => call[0])).toEqual([
+      "openclaw:telegram:bot:chat-A:chat-A",
+      "openclaw:telegram:bot:chat-B:chat-B",
+    ]);
+  });
+
   it("flushSync clears debounce timers", () => {
     writer.flushSync();
     expect((writer as any).debounceTimers.size).toBe(0);
@@ -469,6 +588,37 @@ describe("ChatTurnWriter", () => {
         { role: "assistant", content: "a1" },
       ],
     }, { channelId: "tg", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    restarted.flushSync();
+  });
+
+  it("T359 - typed W4b restart durability prevents W4a duplicate backfill", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "restart typed q", metadata: { messageId: "typed-restart-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-restart", sessionKey: "sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "restart typed a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-restart", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+
+    const sessionId = "openclaw:telegram:bot:chat-restart:sk";
+    expect((writer as any).w4bSessionCounts.get(sessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    expect((restarted as any).w4bSessionCounts.get(sessionId)).toBe(1);
+
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "restart typed q" },
+        { role: "assistant", content: "restart typed a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-restart", sessionKey: "sk" });
     await flushMicrotasks();
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
@@ -666,6 +816,57 @@ describe("ChatTurnWriter", () => {
 
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("telegram question");
+    restarted.flushSync();
+  });
+
+  it("T359 - typed Telegram W4b and Node-UI external markers both suppress W4a duplicates after restart", async () => {
+    await writer.markExternalTurnPersistedDurable({
+      sessionKey: "agent:main:main",
+      turnId: "node-ui-corr-mixed",
+      user: "node ui question",
+      assistant: "node ui answer",
+    });
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "telegram question", metadata: { messageId: "mixed-telegram-in" } },
+      {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "mixed-chat",
+        sessionKey: "agent:main:main",
+      },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "telegram answer", success: true },
+      {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "mixed-chat",
+        sessionKey: "agent:main:main",
+      },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("telegram question");
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "telegram question" },
+        { role: "assistant", content: "telegram answer" },
+        { role: "user", content: "node ui question", context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-mixed" } },
+        { role: "assistant", content: "node ui answer" },
+      ],
+    }, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "mixed-chat",
+      sessionKey: "agent:main:main",
+    });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
     restarted.flushSync();
   });
 

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -456,6 +456,41 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T359 - weak typed persist marker suppresses later real-session W4a duplicate", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "weak marker q", metadata: { messageId: "weak-marker-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-marker" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "weak marker a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-marker" },
+    );
+    await flushMicrotasks();
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+
+    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "chat-weak-marker");
+    const weakSessionId = `openclaw:telegram:bot:chat-weak-marker:${weakSessionKey}`;
+    expect((writer as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "weak marker q" },
+        { role: "assistant", content: "weak marker a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-weak-marker", sessionKey: "agent:main:real" });
+    await flushMicrotasks();
+
+    const strongSessionId = "openclaw:telegram:bot:chat-weak-marker:agent%3Amain%3Areal";
+    expect((restarted as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+    expect((restarted as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
+    expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(0);
+    expect(mockClient.storeChatTurn).not.toHaveBeenCalled();
+    restarted.flushSync();
+  });
+
   it("T359 - same-message queue promotion preserves inbound arrival order", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "older weak inbound", metadata: { messageId: "order-old" } },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -1069,6 +1069,82 @@ describe("ChatTurnWriter", () => {
     restarted.flushSync();
   });
 
+  it("T359 - concrete typed W4b marker suppresses W4a replay after reset clears counts", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "concrete marker q", metadata: { messageId: "concrete-marker-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-marker", sessionKey: "sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "concrete marker a", success: true },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-marker", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+
+    const sessionId = "openclaw:telegram:bot:chat-concrete-marker:sk";
+    expect((writer as any).w4bSessionCounts.get(sessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    await restarted.onBeforeCompaction({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-concrete-marker",
+      sessionKey: "sk",
+    });
+    expect((restarted as any).w4bSessionCounts.has(sessionId)).toBe(false);
+
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "concrete marker q", metadata: { messageId: "concrete-marker-in" } },
+        { role: "assistant", content: "concrete marker a" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-concrete-marker", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    expect((restarted as any).cachedWatermarks.get(sessionId)).toBe(0);
+    restarted.flushSync();
+  });
+
+  it("T359 - outbound-only typed W4b marker suppresses W4a replay after reset", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "outbound marker q" },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-outbound-marker", sessionKey: "sk" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "outbound marker a", success: true, metadata: { messageId: "outbound-marker-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-outbound-marker", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+
+    const sessionId = "openclaw:telegram:bot:chat-outbound-marker:sk";
+    expect((writer as any).w4bSessionCounts.get(sessionId)).toBe(1);
+
+    const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+    await restarted.onBeforeCompaction({}, {
+      channelId: "telegram",
+      accountId: "bot",
+      conversationId: "chat-outbound-marker",
+      sessionKey: "sk",
+    });
+    expect((restarted as any).w4bSessionCounts.has(sessionId)).toBe(false);
+
+    mockClient.storeChatTurn.mockClear();
+    restarted.onAgentEnd({
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "outbound marker q" },
+        { role: "assistant", content: "outbound marker a", metadata: { messageId: "outbound-marker-out" } },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-outbound-marker", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    expect((restarted as any).cachedWatermarks.get(sessionId)).toBe(0);
+    restarted.flushSync();
+  });
+
   it("T96 - W4b durable write failure retries state flush after daemon success", async () => {
     const writeSpy = vi.spyOn(writer as any, "writeWatermarkFile")
       .mockImplementationOnce(() => false);

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -362,6 +362,23 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[1][0]).toContain("12345%3A222");
   });
 
+  it("T359 - Telegram topic fallback accepts snake_case chat and thread ids", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "snake topic q", metadata: { chat_id: 12345, message_thread_id: 333, message_id: "snake-topic-in" } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "snake topic a", success: true, metadata: { chat_id: 12345, thread_id: 333, message_id: "snake-topic-out" } },
+      { channelId: "telegram", accountId: "bot" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toContain("12345%3A333");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("snake topic q");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("snake topic a");
+  });
+
   it("T359 - typed message normalization accepts structured and ctx text content", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: [{ type: "text", text: "typed array hello" }] },
@@ -3316,6 +3333,68 @@ describe("ChatTurnWriter", () => {
     await flushMicrotasks();
     expect(persistCalls).toBe(1); // still just the W4a call
     // Release W4a so the test cleans up.
+    releasePersist?.();
+    await flushMicrotasks();
+  });
+
+  it("T359 - weak typed W4b skips concrete W4a cross-path stamp", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "weak alias q", metadata: { messageId: "weak-alias-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-w4a-alias" },
+    );
+    writer.onAgentEnd(
+      { sessionId: "test", messages: [
+        { role: "user", content: "weak alias q" },
+        { role: "assistant", content: "weak alias a" },
+      ] },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-w4a-alias", sessionKey: "agent:main:real" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-w4a-alias:agent%3Amain%3Areal");
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "weak alias a", success: true, metadata: { messageId: "weak-alias-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-w4a-alias" },
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("T359 - weak typed W4b sees concrete W4a in-flight alias", async () => {
+    let releasePersist: (() => void) | null = null;
+    let persistCalls = 0;
+    mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
+      persistCalls++;
+      await new Promise<void>((resolve) => {
+        releasePersist = resolve;
+      });
+    });
+    writer = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "weak inflight q", metadata: { messageId: "weak-inflight-in" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-w4a-inflight" },
+    );
+    writer.onAgentEnd(
+      { sessionId: "test", messages: [
+        { role: "user", content: "weak inflight q" },
+        { role: "assistant", content: "weak inflight a" },
+      ] },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-w4a-inflight", sessionKey: "agent:main:real" },
+    );
+    await flushMicrotasks();
+    expect(persistCalls).toBe(1);
+
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "weak inflight a", success: true, metadata: { messageId: "weak-inflight-out" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-w4a-inflight" },
+    );
+    await flushMicrotasks();
+    expect(persistCalls).toBe(1);
+
     releasePersist?.();
     await flushMicrotasks();
   });

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -1026,6 +1026,33 @@ describe("ChatTurnWriter", () => {
     expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("repeat before reply\nrepeat before reply");
   });
 
+  it("T359 - late duplicate inbound messageId does not enqueue stale text after persist", async () => {
+    const ctx = { channelId: "telegram", accountId: "bot", conversationId: "chat-late-dup", sessionKey: "sk" };
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "late duplicate q", metadata: { messageId: "late-dup-in" } },
+      ctx,
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "late duplicate a", success: true, metadata: { messageId: "late-dup-out" } },
+      ctx,
+    );
+    await flushMicrotasks();
+
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "late duplicate q", metadata: { messageId: "late-dup-in" } },
+      ctx,
+    );
+    await writer.onTypedMessageSent(
+      { to: "user-1", content: "next outbound should not pair stale text", success: true, metadata: { messageId: "late-dup-out-2" } },
+      ctx,
+    );
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("late duplicate q");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("late duplicate a");
+  });
+
   it("T359 - conversationless message-id dedupe is scoped by session key", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "session A q", metadata: { messageId: "local-in-1" } },

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -420,7 +420,7 @@ describe("ChatTurnWriter", () => {
     ]);
   });
 
-  it("T359 - weak typed session state promotes to real session before W4a backfill", async () => {
+  it("T359 - weak typed session counts do not auto-promote to an unrelated real session", async () => {
     writer.onTypedMessageReceived(
       { from: "user-1", content: "weak typed q", metadata: { messageId: "weak-in-1" } },
       { channelId: "telegram", accountId: "bot", conversationId: "chat-weak" },
@@ -441,20 +441,66 @@ describe("ChatTurnWriter", () => {
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
-        { role: "user", content: "weak typed q" },
-        { role: "assistant", content: "weak typed a" },
+        { role: "user", content: "fresh real-session q" },
+        { role: "assistant", content: "fresh real-session a" },
       ],
-    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-weak", sessionKey: "real-sk" });
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-weak", sessionKey: "agent:alternate:real" });
     await flushMicrotasks();
 
-    const strongSessionId = "openclaw:telegram:bot:chat-weak:real-sk";
-    expect((restarted as any).w4bSessionCounts.get(strongSessionId)).toBe(1);
-    expect((restarted as any).w4bSessionCounts.has(weakSessionId)).toBe(false);
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(0);
+    const strongSessionId = "openclaw:telegram:bot:chat-weak:agent%3Aalternate%3Areal";
+    expect((restarted as any).w4bSessionCounts.has(strongSessionId)).toBe(false);
+    expect((restarted as any).w4bSessionCounts.get(weakSessionId)).toBe(1);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe(strongSessionId);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("fresh real-session q");
     restarted.flushSync();
   });
 
-  it("T359 - in-flight weak W4b completion writes to promoted session state", async () => {
+  it("T359 - same-message queue promotion preserves inbound arrival order", async () => {
+    writer.onTypedMessageReceived(
+      { from: "user-1", content: "older weak inbound", metadata: { messageId: "order-old" } },
+      { channelId: "telegram", accountId: "bot", conversationId: "chat-order" },
+    );
+    writer.onMessageReceived({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-order",
+        content: "later strong inbound",
+        messageId: "order-later",
+      },
+    } as any);
+    writer.onMessageReceived({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-order",
+        content: "older weak inbound",
+        messageId: "order-old",
+      },
+    } as any);
+
+    await writer.onMessageSent({
+      sessionKey: "real-sk",
+      context: {
+        channelId: "telegram",
+        accountId: "bot",
+        conversationId: "chat-order",
+        content: "ordered answer",
+        success: true,
+        messageId: "order-out",
+      },
+    } as any);
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][0]).toBe("openclaw:telegram:bot:chat-order:real-sk");
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("older weak inbound\nlater strong inbound");
+  });
+
+  it("T359 - in-flight conversationless W4b completion writes to promoted session state", async () => {
     let releaseStore: (() => void) | null = null;
     let storeStarted = false;
     mockClient.storeChatTurn = vi.fn().mockImplementation(async () => {
@@ -465,17 +511,16 @@ describe("ChatTurnWriter", () => {
 
     writer.onTypedMessageReceived(
       { from: "user-1", content: "late weak q", metadata: { messageId: "late-weak-in" } },
-      { channelId: "telegram", accountId: "bot", conversationId: "chat-late" },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
     );
     await writer.onTypedMessageSent(
       { to: "user-1", content: "late weak a", success: true },
-      { channelId: "telegram", accountId: "bot", conversationId: "chat-late" },
+      { channelId: "telegram", accountId: "bot", sessionKey: "real-sk" },
     );
     await flushMicrotasks();
     expect(storeStarted).toBe(true);
 
-    const weakSessionKey = (writer as any).weakSessionKey("telegram", "bot", "chat-late");
-    const weakSessionId = `openclaw:telegram:bot:chat-late:${weakSessionKey}`;
+    const weakSessionId = "openclaw:telegram:bot::real-sk";
     const strongSessionId = "openclaw:telegram:bot:chat-late:real-sk";
     expect((writer as any).inFlightPersists.has(weakSessionId)).toBe(true);
 

--- a/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
+++ b/packages/adapter-openclaw/test/ChatTurnWriter.test.ts
@@ -760,9 +760,26 @@ describe("ChatTurnWriter", () => {
 
     const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
     mockClient.storeChatTurn.mockClear();
+    // T362 — Seed the restarted writer past cold-start; the clamp would
+    // otherwise discard both historical pairs of identical content
+    // before the marker check runs. This test specifically verifies
+    // that markers distinguish two same-content pairs by messageId
+    // (in-session marker behavior, not cold-start replay).
+    restarted.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ],
+    }, { channelId: "telegram", accountId: "bot", conversationId: "chat-repeat-marker", sessionKey: "agent:main:real" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
         { role: "user", content: "repeat marker q", metadata: { messageId: "repeat-older-in" } },
         { role: "assistant", content: "repeat marker a" },
         { role: "user", content: "repeat marker q", metadata: { messageId: "repeat-target-in" } },
@@ -776,18 +793,18 @@ describe("ChatTurnWriter", () => {
       strongSessionId,
       "repeat marker q",
       "repeat marker a",
-      0,
+      1,
     );
     const targetTurnId = (restarted as any).deterministicTurnId(
       strongSessionId,
       "repeat marker q",
       "repeat marker a",
-      1,
+      2,
     );
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
     expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).toBe(olderTurnId);
     expect(mockClient.storeChatTurn.mock.calls[0][3]?.turnId).not.toBe(targetTurnId);
-    expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(1);
+    expect((restarted as any).cachedWatermarks.get(strongSessionId)).toBe(2);
     restarted.flushSync();
   });
 
@@ -2341,12 +2358,28 @@ describe("ChatTurnWriter", () => {
 
     const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
     mockClient.storeChatTurn.mockClear();
+    // T362 — Seed past cold-start so the in-session marker check runs
+    // for both same-content pairs (cold-start clamp would otherwise
+    // discard the first pair entirely, defeating this test's
+    // verification that markers are correlation-bound, not content-only).
+    restarted.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
-        { role: "user", content: "same question" },
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
+        { role: "user", content: "same question" },                                                   // pairIndex 1 — emit
         { role: "assistant", content: "same answer" },
-        { role: "user", content: "same question", context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-2" } },
+        { role: "user", content: "same question", context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-2" } },  // pairIndex 2 — marker hit, skip
         { role: "assistant", content: "same answer" },
       ],
     }, { channelId: "telegram", sessionKey: "agent:main:main" });
@@ -2358,13 +2391,13 @@ describe("ChatTurnWriter", () => {
       (restarted as any).deriveSessionId({ channelId: "telegram", sessionKey: "agent:main:main" }),
       "same question",
       "same answer",
-      0,
+      1,
     );
     const skippedSecondPairTurnId = (restarted as any).deterministicTurnId(
       (restarted as any).deriveSessionId({ channelId: "telegram", sessionKey: "agent:main:main" }),
       "same question",
       "same answer",
-      1,
+      2,
     );
     expect(mockClient.storeChatTurn.mock.calls[0][3]).toEqual({ turnId: expectedFirstPairTurnId });
     expect(mockClient.storeChatTurn.mock.calls[0][3]).not.toEqual({ turnId: skippedSecondPairTurnId });
@@ -2380,12 +2413,28 @@ describe("ChatTurnWriter", () => {
     });
     const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
     mockClient.storeChatTurn.mockClear();
+    // T362 — Seed past cold-start; the clamp would otherwise discard
+    // the historical UI pair and only emit the latest Telegram pair,
+    // defeating this test's verification that BOTH pairs persist
+    // when the external marker doesn't match an exact ID.
+    restarted.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
-        { role: "user", content: "unique ui question", context: { Provider: "dkg-ui" } },
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
+        { role: "user", content: "unique ui question", context: { Provider: "dkg-ui" } },  // emit
         { role: "assistant", content: "unique ui answer" },
-        { role: "user", content: "telegram question" },
+        { role: "user", content: "telegram question" },                                     // emit
         { role: "assistant", content: "telegram answer" },
       ],
     }, { channelId: "telegram", sessionKey: "agent:main:main" });
@@ -2455,9 +2504,25 @@ describe("ChatTurnWriter", () => {
     });
     const restarted = new ChatTurnWriter({ client: mockClient, logger: mockLogger, stateDir });
     mockClient.storeChatTurn.mockClear();
+    // T362 — Seed past cold-start; the clamp would otherwise discard
+    // the first ambiguous pair and only emit the latest, defeating
+    // this test's verification that BOTH ambiguous pairs persist when
+    // the marker can't bind to an exact ID.
+    restarted.onAgentEnd({
+      sessionId: "seed",
+      messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ],
+    }, { channelId: "telegram", sessionKey: "agent:main:main" });
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     restarted.onAgentEnd({
       sessionId: "test",
       messages: [
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
         { role: "user", content: "ambiguous direct text", context: { Provider: "dkg-ui", DkgTurnId: "node-ui-corr-new-id" } },
         { role: "assistant", content: "ambiguous direct answer" },
         { role: "user", content: "ambiguous direct text", context: { Provider: "dkg-ui" } },
@@ -3012,7 +3077,13 @@ describe("ChatTurnWriter", () => {
     expect(call[2]).toBe("OriginTrail is a decentralized knowledge graph project.");
   });
 
-  it("T359 - delayed W4a flushing still preserves ordinary multi-pair backfill", async () => {
+  it("T362 — delayed W4a flushing on cold start clamps to the latest pair (revised T359)", async () => {
+    // Pre-T362, this test exercised the same cold-start replay assumption
+    // as the R2.4 backfill test — feed 2 pairs to a fresh writer and
+    // expect both to persist. With the cold-start clamp in place
+    // (savedUpTo === -1 → discard historical pairs, emit only the
+    // latest), only the most-recent pair lands. Steady-state in-session
+    // backfill is exercised separately by the T362 in-session test.
     const event: AgentEndContext = {
       sessionId: "test",
       messages: [
@@ -3025,11 +3096,10 @@ describe("ChatTurnWriter", () => {
     writer.onAgentEnd(event, { channelId: "telegram", sessionKey: "sk" });
     await flushMicrotasks();
 
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
-    expect(mockClient.storeChatTurn.mock.calls.map((call) => [call[1], call[2]])).toEqual([
-      ["q1", "a1"],
-      ["q2", "a2"],
-    ]);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    const call = mockClient.storeChatTurn.mock.calls[0];
+    expect(call[1]).toBe("q2");
+    expect(call[2]).toBe("a2");
   });
 
   it("T5 — cross-path stamps live on a SHORTER TTL than the in-flight turnIds (<=10s)", () => {
@@ -3283,17 +3353,34 @@ describe("ChatTurnWriter", () => {
   });
 
   it("backfill of identical content STILL persists both pairs even after symmetric dedup (R12.6 + R10.4)", async () => {
-    // Backfill scenario: agent_end fires with messages array containing
-    // two same-content pairs. Pre-fix collision in dedup would drop
-    // the second. The W4b-origin check is gated to LAST pair only, so
-    // the earlier (backfill) pair persists via its own pair-indexed
-    // turnId without false dedup.
+    // Backfill scenario: in-session agent_end fires with messages array
+    // containing two same-content pairs. Pre-fix collision in dedup
+    // would drop the second. The W4b-origin check is gated to LAST
+    // pair only, so the earlier (backfill) pair persists via its own
+    // pair-indexed turnId without false dedup.
+    //
+    // T362 — Seed the writer past cold-start first; the cold-start
+    // clamp would otherwise discard historical pairs and emit only
+    // the latest. This test specifically exercises in-session
+    // backfill (the post-cold-start regime), so we seed and clear.
+    writer.onAgentEnd(
+      { sessionId: "t", messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ]},
+      { channelId: "ch", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     const event: AgentEndContext = {
       sessionId: "t",
       messages: [
-        { role: "user", content: "thanks" },
+        { role: "user", content: "__seed__" },              // pairIndex 0 — savedUpTo
+        { role: "assistant", content: "__seed__reply__" },
+        { role: "user", content: "thanks" },                // pairIndex 1 — emit
         { role: "assistant", content: "you're welcome" },
-        { role: "user", content: "thanks" },
+        { role: "user", content: "thanks" },                // pairIndex 2 — emit
         { role: "assistant", content: "you're welcome" },
       ],
     };
@@ -3373,19 +3460,36 @@ describe("ChatTurnWriter", () => {
   });
 
   it("backfill: W4a persists pair 5 then pair 7 — watermark is 7, not incrementing arithmetic (R11.2)", async () => {
-    // 4 unsaved pairs: indices 0..3 in messages. Set watermark to -1 (fresh).
-    // After all persist, watermark should be at the last persisted pair's
-    // index (3), not whatever cumulative count of persists.
+    // 4 unsaved in-session pairs (indices 1..4). After all persist,
+    // watermark should be at the last persisted pair's index (4), not
+    // cumulative count of persists.
+    //
+    // T362 — Seed past cold-start first; the clamp engages on
+    // savedUpTo === -1 and would otherwise discard the historical
+    // pairs. This test specifically asserts the absolute-pairIndex
+    // watermark advance, which is in-session backfill behavior.
+    writer.onAgentEnd(
+      { sessionId: "t", messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ]},
+      { channelId: "ch", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     const event: AgentEndContext = {
       sessionId: "t",
       messages: [
-        { role: "user", content: "u0" },
+        { role: "user", content: "__seed__" },              // pairIndex 0 — saved
+        { role: "assistant", content: "__seed__reply__" },
+        { role: "user", content: "u0" },                    // pairIndex 1 — emit
         { role: "assistant", content: "a0" },
-        { role: "user", content: "u1" },
+        { role: "user", content: "u1" },                    // pairIndex 2 — emit
         { role: "assistant", content: "a1" },
-        { role: "user", content: "u2" },
+        { role: "user", content: "u2" },                    // pairIndex 3 — emit
         { role: "assistant", content: "a2" },
-        { role: "user", content: "u3" },
+        { role: "user", content: "u3" },                    // pairIndex 4 — emit
         { role: "assistant", content: "a3" },
       ],
     };
@@ -3394,7 +3498,7 @@ describe("ChatTurnWriter", () => {
     await new Promise((r) => setTimeout(r, 70));
     expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(4);
     const watermarks = (writer as any).cachedWatermarks as Map<string, number>;
-    expect(watermarks.get("openclaw:ch:::sk")).toBe(3); // last pairIndex
+    expect(watermarks.get("openclaw:ch:::sk")).toBe(4); // last pairIndex
   });
 
   it("collapses tool-using turn into one (user, final-reply) pair (R10.3)", async () => {
@@ -3422,12 +3526,29 @@ describe("ChatTurnWriter", () => {
     // Pre-fix: same-content pairs collided on the dedup key and only the
     // first persisted. With pairIndex baked into the W4a turnId, both
     // backfill pairs get distinct turnIds and both write.
+    //
+    // T362 — In-session backfill regime; seed first to bypass the
+    // cold-start clamp (which would discard historical pairs and emit
+    // only the latest, defeating this test's purpose of verifying that
+    // two unsaved same-content pairs both persist).
+    writer.onAgentEnd(
+      { sessionId: "t", messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ]},
+      { channelId: "ch", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     const event: AgentEndContext = {
       sessionId: "t",
       messages: [
-        { role: "user", content: "thanks" },
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
+        { role: "user", content: "thanks" },                // emit (pairIndex 1)
         { role: "assistant", content: "you're welcome" },
-        { role: "user", content: "thanks" },
+        { role: "user", content: "thanks" },                // emit (pairIndex 2)
         { role: "assistant", content: "you're welcome" },
       ],
     };
@@ -4079,7 +4200,23 @@ describe("ChatTurnWriter", () => {
     expect(mockLogger.warn).toHaveBeenCalled();
   });
 
-  it("persists every unsaved pair when computeDelta sees multiple (R2.4 backfill)", async () => {
+  it("T362 — cold-start clamp: only the latest pair persists when watermark is missing (R2.4-revised)", async () => {
+    // Pre-T362, this test asserted that all unsaved pairs persist when
+    // computeDelta sees multiple. Live smoke (PR #362) showed that
+    // semantic turned every cold start into a full transcript replay:
+    // OpenClaw retains the channel transcript (Telegram, etc.) across
+    // sessions, while DKG state can be wiped independently. On the first
+    // agent_end after a fresh DKG home, `messages[]` carries the entire
+    // historical transcript; walking those pairs replays each one
+    // (the daemon does not idempotently dedupe — every storeChatExchange
+    // mints fresh userMsg/assistantMsg UUIDs even when turnId matches),
+    // bloating chat-turns by ~20 triples per replayed pair.
+    //
+    // The cold-start clamp inside `runAgentEndPersist` discards
+    // historical pairs when savedUpTo === -1 and emits only the latest.
+    // Subsequent agent_end calls see a non-negative savedUpTo, the
+    // clamp does NOT engage, and within-session backfill works as
+    // before (covered by the next test).
     const event: AgentEndContext = {
       sessionId: "test",
       messages: [
@@ -4091,14 +4228,63 @@ describe("ChatTurnWriter", () => {
     };
     writer.onAgentEnd(event, { channelId: "ch", sessionKey: "sk" });
     await flushMicrotasks();
-    // Both pairs must be written — not just the last one.
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
-    const firstCall = mockClient.storeChatTurn.mock.calls[0];
-    const secondCall = mockClient.storeChatTurn.mock.calls[1];
-    expect(firstCall[1]).toBe("u1");
-    expect(firstCall[2]).toBe("a1");
-    expect(secondCall[1]).toBe("u2");
-    expect(secondCall[2]).toBe("a2");
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    const call = mockClient.storeChatTurn.mock.calls[0];
+    expect(call[1]).toBe("u2");
+    expect(call[2]).toBe("a2");
+    // Watermark must advance to the latest pairIndex (1), implicitly
+    // claiming index 0 as done. Without this advance, the next
+    // agent_end would re-find the historical pair as unsaved.
+    // loadWatermark consults the pending debounce, so no 50ms wait needed.
+    expect((writer as any).loadWatermark("openclaw:ch:::sk")).toBe(1);
+  });
+
+  it("T362 — post-cold-start in-session backfill still emits each unsaved pair", async () => {
+    // Once the cold-start clamp has run and advanced the watermark, a
+    // subsequent agent_end with N new unsaved pairs MUST emit all N.
+    // Within-session backfill is still desirable: e.g., a typed-hook
+    // outage between turn 1 and turn 5 means turns 2..4 sit unsaved
+    // in `messages[]` and need to land on the next agent_end fire.
+    // The clamp only suppresses cold start (savedUpTo === -1), not
+    // legitimate mid-session backfill (savedUpTo >= 0).
+    const seedEvent: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "u1" },
+        { role: "assistant", content: "a1" },
+      ],
+    };
+    writer.onAgentEnd(seedEvent, { channelId: "ch", sessionKey: "sk" });
+    await flushMicrotasks();
+    // Cold start emitted exactly 1 (only pair). Watermark now at 0.
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    mockClient.storeChatTurn.mockClear();
+
+    // Subsequent agent_end with 3 new pairs (u2..u4). savedUpTo = 0,
+    // so pair index 0 is skipped and indices 1, 2, 3 all emit.
+    const backfillEvent: AgentEndContext = {
+      sessionId: "test",
+      messages: [
+        { role: "user", content: "u1" },     // pairIndex 0 — saved
+        { role: "assistant", content: "a1" },
+        { role: "user", content: "u2" },     // pairIndex 1 — emit
+        { role: "assistant", content: "a2" },
+        { role: "user", content: "u3" },     // pairIndex 2 — emit
+        { role: "assistant", content: "a3" },
+        { role: "user", content: "u4" },     // pairIndex 3 — emit
+        { role: "assistant", content: "a4" },
+      ],
+    };
+    writer.onAgentEnd(backfillEvent, { channelId: "ch", sessionKey: "sk" });
+    await flushMicrotasks();
+
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(3);
+    const persisted = mockClient.storeChatTurn.mock.calls.map((call) => [call[1], call[2]]);
+    expect(persisted).toEqual([
+      ["u2", "a2"],
+      ["u3", "a3"],
+      ["u4", "a4"],
+    ]);
   });
 
   it("pending queue collapses into one user-side per outbound (R2.3 / T15)", async () => {
@@ -4243,32 +4429,53 @@ describe("ChatTurnWriter", () => {
   }, 10_000);
 
   it("onBeforeCompaction clears the watermark so post-compaction turns persist (R5.2)", async () => {
-    // First: persist 3 turns so watermark advances to 2.
+    // Pre-compaction setup: seed past cold-start (1 persist), then
+    // an in-session backfill of 2 pairs (post-clamp, in-session
+    // backfill emits all unsaved pairs). Watermark advances to 2.
+    writer.onAgentEnd(
+      { sessionId: "t", messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ]},
+      { channelId: "ch", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     const preEvent: AgentEndContext = {
       sessionId: "t",
       messages: [
-        { role: "user", content: "u1" },
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
+        { role: "user", content: "u1" },                    // emit
         { role: "assistant", content: "a1" },
-        { role: "user", content: "u2" },
+        { role: "user", content: "u2" },                    // emit
         { role: "assistant", content: "a2" },
-        { role: "user", content: "u3" },
-        { role: "assistant", content: "a3" },
       ],
     };
     writer.onAgentEnd(preEvent, { channelId: "ch", sessionKey: "sk" });
     await flushMicrotasks();
     await new Promise((r) => setTimeout(r, 70)); // let the 50ms debounce commit
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(3);
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
 
     mockClient.storeChatTurn.mockClear();
     // Session-scoped reset — must pass the same ctx so the correct
-    // session's watermark is cleared.
+    // session's watermark is cleared. After this, savedUpTo returns
+    // to -1; the next agent_end is again "cold start" for this
+    // session.
     writer.onBeforeCompaction({}, { channelId: "ch", sessionKey: "sk" });
 
-    // After compaction a shorter messages array arrives (representative of
-    // gateway summarization: old turns folded to a single summary pair).
-    // Without the watermark reset, the pair-count cursor at 2 would skip
-    // the first 3 pairs of this new array entirely.
+    // After compaction a shorter messages array arrives (representative
+    // of gateway summarization: old turns folded to a single summary
+    // pair). Without the watermark reset, the pair-count cursor at 2
+    // would skip the first pairs of this new array.
+    // T362 — Post-compaction the cold-start clamp re-engages: only the
+    // latest pair persists, matching the "fresh start" mental model.
+    // Pre-T362 this test asserted 2 post-compaction persists; with the
+    // clamp, the assertion is 1 (the latest pair). Compaction's job
+    // here is verified: the watermark was cleared and a NEW pair lands
+    // (it would NOT land if the watermark had not been cleared, since
+    // the new content's pairIndex 0 would be ≤ the old watermark of 2).
     // Also wait past the 3s dedup TTL so identical-text turns aren't
     // blocked by the cross-path dedup map.
     await new Promise((r) => setTimeout(r, 3100));
@@ -4283,9 +4490,9 @@ describe("ChatTurnWriter", () => {
     };
     writer.onAgentEnd(postEvent, { channelId: "ch", sessionKey: "sk" });
     await flushMicrotasks();
-    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(2);
-    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("summary");
-    expect(mockClient.storeChatTurn.mock.calls[1][1]).toBe("follow-up");
+    expect(mockClient.storeChatTurn).toHaveBeenCalledTimes(1);
+    expect(mockClient.storeChatTurn.mock.calls[0][1]).toBe("follow-up");
+    expect(mockClient.storeChatTurn.mock.calls[0][2]).toBe("reply");
   }, 10_000);
 
   it("onBeforeCompaction resets only the affected session's watermark (R6.1)", async () => {
@@ -4785,17 +4992,34 @@ describe("ChatTurnWriter", () => {
     // reservation gate already in place. Spy on the stamp method to
     // count calls — pre-fix would be 3 (one per persisted pair),
     // post-fix is 1 (only the last).
+    //
+    // T362 — Seed past cold-start so the in-session backfill loop
+    // actually walks 3 pairs (cold-start clamp would otherwise discard
+    // historical pairs and emit only the latest, defeating this test's
+    // purpose of asserting the per-pair stamp gating).
+    writer.onAgentEnd(
+      { sessionId: "test", messages: [
+        { role: "user", content: "__seed__" },
+        { role: "assistant", content: "__seed__reply__" },
+      ]},
+      { channelId: "tg", sessionKey: "sk" },
+    );
+    await flushMicrotasks();
+    mockClient.storeChatTurn.mockClear();
+
     const dkw = writer as any;
     const stampSpy = vi.spyOn(dkw, "markCrossPathStamp");
     const event: AgentEndContext = {
       sessionId: "test",
       messages: [
+        { role: "user", content: "__seed__" },              // saved
+        { role: "assistant", content: "__seed__reply__" },
         { role: "user", content: "u0" },
-        { role: "assistant", content: "a0" },  // pair[0]
+        { role: "assistant", content: "a0" },  // pair[1]
         { role: "user", content: "u1" },
-        { role: "assistant", content: "a1" },  // pair[1]
+        { role: "assistant", content: "a1" },  // pair[2]
         { role: "user", content: "u2" },
-        { role: "assistant", content: "a2" },  // pair[2] (last, live pair)
+        { role: "assistant", content: "a2" },  // pair[3] (last, live pair)
       ],
     };
     writer.onAgentEnd(event, { channelId: "tg", sessionKey: "sk" });
@@ -4806,7 +5030,7 @@ describe("ChatTurnWriter", () => {
     // count how many times the backfill loop stamped, which is
     // exactly the count of calls.
     expect(stampSpy).toHaveBeenCalledTimes(1);
-    // Verify it was the LAST pair that got stamped, not pair[0] or pair[1].
+    // Verify it was the LAST pair that got stamped, not pair[1] or pair[2].
     const lastKey = dkw.w4aOriginKey("u2", "a2");
     expect(stampSpy.mock.calls.some((c: any[]) => c[1] === lastKey)).toBe(true);
     stampSpy.mockRestore();

--- a/packages/adapter-openclaw/test/HookSurface.test.ts
+++ b/packages/adapter-openclaw/test/HookSurface.test.ts
@@ -118,6 +118,30 @@ describe("HookSurface", () => {
       expect(replacement.get("message:sent")).toHaveLength(1);
       expect(hs.ownsCurrentInternalHook("message:sent")).toBe(true);
     });
+
+    it("resets the commit timer when re-installing a stale internal hook", () => {
+      vi.useFakeTimers();
+      try {
+        const logger = mkLogger();
+        const hs = new HookSurface(mkApi(), logger, "auto", { commitGraceMs: 100 });
+        hs.install("internal", "message:sent", vi.fn());
+        vi.advanceTimersByTime(50);
+
+        const replacement = new Map<string, any[]>([["message:sent", []]]);
+        (globalThis as any)[INTERNAL_HOOK_SYMBOL] = replacement;
+        hs.install("internal", "message:sent", vi.fn());
+
+        vi.advanceTimersByTime(49);
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("internal:message:sent"));
+        vi.advanceTimersByTime(1);
+        expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("internal:message:sent"));
+
+        vi.advanceTimersByTime(50);
+        expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("internal:message:sent"));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("legacy kind (api.registerHook)", () => {

--- a/packages/adapter-openclaw/test/HookSurface.test.ts
+++ b/packages/adapter-openclaw/test/HookSurface.test.ts
@@ -332,13 +332,30 @@ describe("HookSurface", () => {
       expect(stats["typed:agent_end"]?.commitState).toBe("committed-by-timeout");
     });
 
-    it("logs non-rare commit timeouts at warn", async () => {
+    it("logs typed commit timeouts at debug because late fires can still prove liveness", async () => {
       const logger = mkLogger();
       const hs = new HookSurface(mkApi(), logger, "auto", { commitGraceMs: 10 });
       hs.install("typed", "agent_end", vi.fn());
       await new Promise((r) => setTimeout(r, 30));
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("typed:agent_end"));
-      expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining("typed:agent_end"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("typed:agent_end"));
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("typed:agent_end"));
+    });
+
+    it("late fire after timeout moves commitState to committed-by-fire", async () => {
+      const handlers = new Map<string, Array<(...args: any[]) => unknown>>();
+      const api = mkApi({
+        on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
+          handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+        }) as any,
+      });
+      const hs = new HookSurface(api, mkLogger(), "auto", { commitGraceMs: 10 });
+      hs.install("typed", "agent_end", vi.fn());
+      await new Promise((r) => setTimeout(r, 30));
+      expect(hs.getDispatchStats()["typed:agent_end"]?.commitState).toBe("committed-by-timeout");
+      handlers.get("agent_end")![0]();
+      const stats = hs.getDispatchStats();
+      expect(stats["typed:agent_end"]?.fireCount).toBe(1);
+      expect(stats["typed:agent_end"]?.commitState).toBe("committed-by-fire");
     });
 
     it("logs rare-fire commit timeouts at debug for infrequent hooks", async () => {

--- a/packages/adapter-openclaw/test/HookSurface.test.ts
+++ b/packages/adapter-openclaw/test/HookSurface.test.ts
@@ -96,6 +96,28 @@ describe("HookSurface", () => {
       expect(hookMapSym.get("message:sent")?.length).toBe(1);
       expect(logger.warn).toHaveBeenCalled();
     });
+
+    it("tracks whether this surface still owns the live internal wrapper", () => {
+      const hs = new HookSurface(mkApi(), mkLogger());
+      hs.install("internal", "message:sent", vi.fn());
+      expect(hs.ownsCurrentInternalHook("message:sent")).toBe(true);
+
+      (globalThis as any)[INTERNAL_HOOK_SYMBOL] = new Map([["message:sent", [vi.fn()]]]);
+      expect(hs.ownsCurrentInternalHook("message:sent")).toBe(false);
+    });
+
+    it("re-installs an internal hook on the same surface after the global map is replaced", () => {
+      const hs = new HookSurface(mkApi(), mkLogger());
+      hs.install("internal", "message:sent", vi.fn());
+      expect(hs.ownsCurrentInternalHook("message:sent")).toBe(true);
+
+      const replacement = new Map<string, any[]>([["message:sent", []]]);
+      (globalThis as any)[INTERNAL_HOOK_SYMBOL] = replacement;
+      const unsub = hs.install("internal", "message:sent", vi.fn());
+      expect(unsub).not.toBeNull();
+      expect(replacement.get("message:sent")).toHaveLength(1);
+      expect(hs.ownsCurrentInternalHook("message:sent")).toBe(true);
+    });
   });
 
   describe("legacy kind (api.registerHook)", () => {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -2687,6 +2687,7 @@ describe('DkgNodePlugin', () => {
     const events = onSpy.mock.calls.map((c: any) => c[0]);
     expect(events).toContain('before_prompt_build');
     expect(events).toContain('agent_end');
+    expect(events).toContain('agent.end');
     expect(events).toContain('before_compaction');
     expect(events).toContain('before_reset');
   });
@@ -2733,6 +2734,7 @@ describe('DkgNodePlugin', () => {
     const events1 = onSpy1.mock.calls.map((c: any) => c[0]);
     expect(events1).toContain('before_prompt_build');
     expect(events1).toContain('agent_end');
+    expect(events1).toContain('agent.end');
 
     // Multi-phase init: gateway hands a NEW api on the next register.
     plugin.register(api2);
@@ -2742,6 +2744,7 @@ describe('DkgNodePlugin', () => {
     const events2 = onSpy2.mock.calls.map((c: any) => c[0]);
     expect(events2).toContain('before_prompt_build');
     expect(events2).toContain('agent_end');
+    expect(events2).toContain('agent.end');
 
     // Critically: api1's handlers were NOT torn down. The `allHookSurfaces`
     // set tracks both surfaces; a future emit against api1 would still
@@ -3392,6 +3395,7 @@ describe('DkgNodePlugin', () => {
     const typedHookEvents = onSpy.mock.calls.map((c: any[]) => c[0]);
     expect(typedHookEvents).toContain('before_prompt_build');
     expect(typedHookEvents).toContain('agent_end');
+    expect(typedHookEvents).toContain('agent.end');
   });
 
   it('T359 - typed message hooks and agent_end are wired to ChatTurnWriter', async () => {
@@ -3425,12 +3429,13 @@ describe('DkgNodePlugin', () => {
       client.storeChatTurn = vi.fn().mockResolvedValue(undefined);
 
       expect(typedHandlers.has('agent_end')).toBe(true);
+      expect(typedHandlers.has('agent.end')).toBe(true);
       expect(typedHandlers.has('message_received')).toBe(true);
       expect(typedHandlers.has('message_sent')).toBe(true);
       expect(typedHandlers.has('message.received')).toBe(true);
       expect(typedHandlers.has('message.sent')).toBe(true);
 
-      typedHandlers.get('agent_end')!(
+      typedHandlers.get('agent.end')!(
         { messages: [{ role: 'user', content: 'healthy q' }, { role: 'assistant', content: 'healthy a' }] },
         { channelId: 'telegram', sessionKey: 'healthy-sk' },
       );
@@ -3611,6 +3616,7 @@ describe('DkgNodePlugin', () => {
     const typedEvents = onSpy.mock.calls.map((c: any[]) => c[0]);
     expect(typedEvents).toContain('before_prompt_build');
     expect(typedEvents).toContain('agent_end');
+    expect(typedEvents).toContain('agent.end');
     expect(typedEvents).toContain('before_compaction');
     expect(typedEvents).toContain('before_reset');
   });

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -2687,7 +2687,6 @@ describe('DkgNodePlugin', () => {
     const events = onSpy.mock.calls.map((c: any) => c[0]);
     expect(events).toContain('before_prompt_build');
     expect(events).toContain('agent_end');
-    expect(events).toContain('agent.end');
     expect(events).toContain('before_compaction');
     expect(events).toContain('before_reset');
   });
@@ -2734,7 +2733,6 @@ describe('DkgNodePlugin', () => {
     const events1 = onSpy1.mock.calls.map((c: any) => c[0]);
     expect(events1).toContain('before_prompt_build');
     expect(events1).toContain('agent_end');
-    expect(events1).toContain('agent.end');
 
     // Multi-phase init: gateway hands a NEW api on the next register.
     plugin.register(api2);
@@ -2744,7 +2742,6 @@ describe('DkgNodePlugin', () => {
     const events2 = onSpy2.mock.calls.map((c: any) => c[0]);
     expect(events2).toContain('before_prompt_build');
     expect(events2).toContain('agent_end');
-    expect(events2).toContain('agent.end');
 
     // Critically: api1's handlers were NOT torn down. The `allHookSurfaces`
     // set tracks both surfaces; a future emit against api1 would still
@@ -3395,10 +3392,9 @@ describe('DkgNodePlugin', () => {
     const typedHookEvents = onSpy.mock.calls.map((c: any[]) => c[0]);
     expect(typedHookEvents).toContain('before_prompt_build');
     expect(typedHookEvents).toContain('agent_end');
-    expect(typedHookEvents).toContain('agent.end');
   });
 
-  it('T359 - typed message hooks and agent_end are wired to ChatTurnWriter', async () => {
+  it('T359 - only supported typed agent_end plus internal message hooks are wired to ChatTurnWriter', async () => {
     const previousHookMap = (globalThis as any)[INTERNAL_HOOK_SYMBOL];
     (globalThis as any)[INTERNAL_HOOK_SYMBOL] = new Map<string, any[]>([
       ['message:received', []],
@@ -3429,31 +3425,32 @@ describe('DkgNodePlugin', () => {
       client.storeChatTurn = vi.fn().mockResolvedValue(undefined);
 
       expect(typedHandlers.has('agent_end')).toBe(true);
-      expect(typedHandlers.has('agent.end')).toBe(true);
-      expect(typedHandlers.has('message_received')).toBe(true);
-      expect(typedHandlers.has('message_sent')).toBe(true);
-      expect(typedHandlers.has('message.received')).toBe(true);
-      expect(typedHandlers.has('message.sent')).toBe(true);
+      expect(typedHandlers.has('agent.end')).toBe(false);
+      expect(typedHandlers.has('message_received')).toBe(false);
+      expect(typedHandlers.has('message_sent')).toBe(false);
+      expect(typedHandlers.has('message.received')).toBe(false);
+      expect(typedHandlers.has('message.sent')).toBe(false);
 
-      typedHandlers.get('agent.end')!(
+      typedHandlers.get('agent_end')!(
         { messages: [{ role: 'user', content: 'healthy q' }, { role: 'assistant', content: 'healthy a' }] },
         { channelId: 'telegram', sessionKey: 'healthy-sk' },
       );
       await (plugin as any).chatTurnWriter.flush();
       expect(client.storeChatTurn).toHaveBeenCalledTimes(1);
 
-      typedHandlers.get('message.received')!(
-        { from: 'user-1', content: 'typed q', metadata: { messageId: 'typed-in-1' } },
-        { channelId: 'telegram', accountId: 'bot', conversationId: 'chat-1' },
-      );
-      await typedHandlers.get('message.sent')!(
-        { to: 'user-1', content: 'typed a', success: true },
-        { channelId: 'telegram', accountId: 'bot', conversationId: 'chat-1' },
-      );
+      const hookMap = (globalThis as any)[INTERNAL_HOOK_SYMBOL] as Map<string, any[]>;
+      hookMap.get('message:received')![0]({
+        sessionKey: 'internal-sk',
+        context: { channelId: 'telegram', conversationId: 'chat-1', content: 'internal q' },
+      });
+      await hookMap.get('message:sent')![0]({
+        sessionKey: 'internal-sk',
+        context: { channelId: 'telegram', conversationId: 'chat-1', content: 'internal a', success: true },
+      });
       await (plugin as any).chatTurnWriter.flush();
       expect(client.storeChatTurn).toHaveBeenCalledTimes(2);
-      expect(client.storeChatTurn.mock.calls[1][1]).toBe('typed q');
-      expect(client.storeChatTurn.mock.calls[1][2]).toBe('typed a');
+      expect(client.storeChatTurn.mock.calls[1][1]).toBe('internal q');
+      expect(client.storeChatTurn.mock.calls[1][2]).toBe('internal a');
     } finally {
       await plugin.stop();
       fs.rmSync(workspaceDir, { recursive: true, force: true });
@@ -3616,7 +3613,6 @@ describe('DkgNodePlugin', () => {
     const typedEvents = onSpy.mock.calls.map((c: any[]) => c[0]);
     expect(typedEvents).toContain('before_prompt_build');
     expect(typedEvents).toContain('agent_end');
-    expect(typedEvents).toContain('agent.end');
     expect(typedEvents).toContain('before_compaction');
     expect(typedEvents).toContain('before_reset');
   });
@@ -3656,7 +3652,8 @@ describe('DkgNodePlugin', () => {
       expect(warnMessages.some((msg) => msg.includes("internal:message:sent"))).toBe(false);
       expect(warnMessages.some((msg) => msg.includes("typed:before_compaction"))).toBe(false);
       expect(warnMessages.some((msg) => msg.includes("typed:before_reset"))).toBe(false);
-      expect(warnMessages.some((msg) => msg.includes("typed:agent_end"))).toBe(true);
+      expect(warnMessages.some((msg) => msg.includes("typed:agent_end"))).toBe(false);
+      expect(debugMessages.some((msg) => msg.includes("typed:agent_end"))).toBe(true);
     } finally {
       await plugin.stop();
       if (previousHookMap === undefined) {

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3394,6 +3394,140 @@ describe('DkgNodePlugin', () => {
     expect(typedHookEvents).toContain('agent_end');
   });
 
+  it('T359 - typed message hooks and agent_end are wired to ChatTurnWriter', async () => {
+    const previousHookMap = (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+    (globalThis as any)[INTERNAL_HOOK_SYMBOL] = new Map<string, any[]>([
+      ['message:received', []],
+      ['message:sent', []],
+    ]);
+    const workspaceDir = fs.mkdtempSync(path.join(tmpdir(), 'dkg-node-t359-typed-'));
+    const typedHandlers = new Map<string, (...args: any[]) => unknown>();
+    const plugin = new DkgNodePlugin({
+      daemonUrl: 'http://localhost:9200',
+      channel: { enabled: false },
+      memory: { enabled: false },
+    });
+    const mockApi: OpenClawPluginApi = {
+      config: {},
+      registrationMode: 'full',
+      registerTool: () => {},
+      registerHook: () => {},
+      on: vi.fn((event: string, handler: (...args: any[]) => unknown) => {
+        typedHandlers.set(event, handler);
+      }) as any,
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      workspaceDir,
+    } as unknown as OpenClawPluginApi;
+
+    try {
+      plugin.register(mockApi);
+      const client = (plugin as any).client;
+      client.storeChatTurn = vi.fn().mockResolvedValue(undefined);
+
+      expect(typedHandlers.has('agent_end')).toBe(true);
+      expect(typedHandlers.has('message_received')).toBe(true);
+      expect(typedHandlers.has('message_sent')).toBe(true);
+
+      typedHandlers.get('agent_end')!(
+        { messages: [{ role: 'user', content: 'healthy q' }, { role: 'assistant', content: 'healthy a' }] },
+        { channelId: 'telegram', sessionKey: 'healthy-sk' },
+      );
+      await (plugin as any).chatTurnWriter.flush();
+      expect(client.storeChatTurn).toHaveBeenCalledTimes(1);
+
+      typedHandlers.get('message_received')!(
+        { from: 'user-1', content: 'typed q', metadata: { messageId: 'typed-in-1' } },
+        { channelId: 'telegram', accountId: 'bot', conversationId: 'chat-1' },
+      );
+      await typedHandlers.get('message_sent')!(
+        { to: 'user-1', content: 'typed a', success: true },
+        { channelId: 'telegram', accountId: 'bot', conversationId: 'chat-1' },
+      );
+      await (plugin as any).chatTurnWriter.flush();
+      expect(client.storeChatTurn).toHaveBeenCalledTimes(2);
+      expect(client.storeChatTurn.mock.calls[1][1]).toBe('typed q');
+      expect(client.storeChatTurn.mock.calls[1][2]).toBe('typed a');
+    } finally {
+      await plugin.stop();
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+      if (previousHookMap === undefined) delete (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+      else (globalThis as any)[INTERNAL_HOOK_SYMBOL] = previousHookMap;
+    }
+  });
+
+  it('T359 - gateway-preloaded internal handlers do not suppress adapter handlers', async () => {
+    const previousHookMap = (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+    const hookMap = new Map<string, any[]>([
+      ['message:received', [vi.fn()]],
+      ['message:sent', [vi.fn()]],
+    ]);
+    (globalThis as any)[INTERNAL_HOOK_SYMBOL] = hookMap;
+    const plugin = new DkgNodePlugin({
+      daemonUrl: 'http://localhost:9200',
+      channel: { enabled: false },
+      memory: { enabled: false },
+    });
+    const mockApi: OpenClawPluginApi = {
+      config: {},
+      registrationMode: 'full',
+      registerTool: () => {},
+      registerHook: () => {},
+      on: () => {},
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    } as unknown as OpenClawPluginApi;
+
+    try {
+      plugin.register(mockApi);
+      expect(hookMap.get('message:received')).toHaveLength(2);
+      expect(hookMap.get('message:sent')).toHaveLength(2);
+    } finally {
+      await plugin.stop();
+      if (previousHookMap === undefined) delete (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+      else (globalThis as any)[INTERNAL_HOOK_SYMBOL] = previousHookMap;
+    }
+  });
+
+  it('T359 - replacing the internal hook map triggers same-api reinstall', async () => {
+    const previousHookMap = (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+    const firstMap = new Map<string, any[]>([
+      ['message:received', []],
+      ['message:sent', []],
+    ]);
+    (globalThis as any)[INTERNAL_HOOK_SYMBOL] = firstMap;
+    const plugin = new DkgNodePlugin({
+      daemonUrl: 'http://localhost:9200',
+      channel: { enabled: false },
+      memory: { enabled: false },
+    });
+    const mockApi: OpenClawPluginApi = {
+      config: {},
+      registrationMode: 'full',
+      registerTool: () => {},
+      registerHook: () => {},
+      on: () => {},
+      logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    } as unknown as OpenClawPluginApi;
+
+    try {
+      plugin.register(mockApi);
+      expect(firstMap.get('message:received')).toHaveLength(1);
+      expect(firstMap.get('message:sent')).toHaveLength(1);
+
+      const replacementMap = new Map<string, any[]>([
+        ['message:received', []],
+        ['message:sent', []],
+      ]);
+      (globalThis as any)[INTERNAL_HOOK_SYMBOL] = replacementMap;
+      plugin.register(mockApi);
+      expect(replacementMap.get('message:received')).toHaveLength(1);
+      expect(replacementMap.get('message:sent')).toHaveLength(1);
+    } finally {
+      await plugin.stop();
+      if (previousHookMap === undefined) delete (globalThis as any)[INTERNAL_HOOK_SYMBOL];
+      else (globalThis as any)[INTERNAL_HOOK_SYMBOL] = previousHookMap;
+    }
+  });
+
   it('R14.3 / T52 / T58 — setup-only registers only session_end (no channel server, no typed/internal hooks)', () => {
     // R14.3: setup-only must NOT wire prompt-injection / turn-
     // persistence handlers (`before_prompt_build`, `agent_end`,

--- a/packages/adapter-openclaw/test/plugin.test.ts
+++ b/packages/adapter-openclaw/test/plugin.test.ts
@@ -3427,6 +3427,8 @@ describe('DkgNodePlugin', () => {
       expect(typedHandlers.has('agent_end')).toBe(true);
       expect(typedHandlers.has('message_received')).toBe(true);
       expect(typedHandlers.has('message_sent')).toBe(true);
+      expect(typedHandlers.has('message.received')).toBe(true);
+      expect(typedHandlers.has('message.sent')).toBe(true);
 
       typedHandlers.get('agent_end')!(
         { messages: [{ role: 'user', content: 'healthy q' }, { role: 'assistant', content: 'healthy a' }] },
@@ -3435,11 +3437,11 @@ describe('DkgNodePlugin', () => {
       await (plugin as any).chatTurnWriter.flush();
       expect(client.storeChatTurn).toHaveBeenCalledTimes(1);
 
-      typedHandlers.get('message_received')!(
+      typedHandlers.get('message.received')!(
         { from: 'user-1', content: 'typed q', metadata: { messageId: 'typed-in-1' } },
         { channelId: 'telegram', accountId: 'bot', conversationId: 'chat-1' },
       );
-      await typedHandlers.get('message_sent')!(
+      await typedHandlers.get('message.sent')!(
         { to: 'user-1', content: 'typed a', success: true },
         { channelId: 'telegram', accountId: 'bot', conversationId: 'chat-1' },
       );

--- a/packages/adapter-openclaw/test/probe.test.ts
+++ b/packages/adapter-openclaw/test/probe.test.ts
@@ -96,8 +96,8 @@ describe('DkgNodePlugin registration-mode probe', () => {
     plugin.register(api);
 
     // Should attempt to register on each event via each mechanism
-    // api.on and api.registerHook are called for each of 6 events
-    const numEvents = 6; // before_prompt_build, agent_end, before_compaction, before_reset, message_received, message_sent
+    // api.on and api.registerHook are called for each typed probe event.
+    const numEvents = 10;
     
     expect(onSpy.mock.calls.length).toBeGreaterThanOrEqual(numEvents);
     expect(registerHookSpy.mock.calls.length).toBeGreaterThanOrEqual(numEvents);
@@ -185,6 +185,9 @@ describe('DkgNodePlugin registration-mode probe', () => {
     const events = onSpy.mock.calls.map((c) => c[0]);
     expect(events).toContain('before_prompt_build');
     expect(events).toContain('agent_end');
+    expect(events).toContain('message_sent');
+    expect(events).toContain('message_sending');
+    expect(events).toContain('message.sent');
   });
 
   it('probe gracefully handles missing globalThis internal-hook map', () => {

--- a/packages/adapter-openclaw/test/probe.test.ts
+++ b/packages/adapter-openclaw/test/probe.test.ts
@@ -95,9 +95,10 @@ describe('DkgNodePlugin registration-mode probe', () => {
     const plugin = new DkgNodePlugin();
     plugin.register(api);
 
-    // Should attempt to register on each event via each mechanism
-    // api.on and api.registerHook are called for each typed probe event.
-    const numEvents = 10;
+    // Should attempt to register on each accepted lifecycle event via each
+    // mechanism. Unsupported typed message/dotted aliases are intentionally
+    // not probed because 2026.4.15 rejects or never fires them.
+    const numEvents = 4;
     
     expect(onSpy.mock.calls.length).toBeGreaterThanOrEqual(numEvents);
     expect(registerHookSpy.mock.calls.length).toBeGreaterThanOrEqual(numEvents);
@@ -185,9 +186,11 @@ describe('DkgNodePlugin registration-mode probe', () => {
     const events = onSpy.mock.calls.map((c) => c[0]);
     expect(events).toContain('before_prompt_build');
     expect(events).toContain('agent_end');
-    expect(events).toContain('message_sent');
-    expect(events).toContain('message_sending');
-    expect(events).toContain('message.sent');
+    expect(events).toContain('before_compaction');
+    expect(events).toContain('before_reset');
+    expect(events).not.toContain('message_sent');
+    expect(events).not.toContain('message_sending');
+    expect(events).not.toContain('message.sent');
   });
 
   it('probe gracefully handles missing globalThis internal-hook map', () => {


### PR DESCRIPTION
## Summary

- Refocus #359 on the live-smoke root cause: the first Telegram `agent_end` after cold gateway boot could over-persist cold-start tool/context scaffolding as many chat turns.
- Keep `agent_end` as the Telegram W4a path and preserve colon-form internal W4b hooks, while removing unsupported typed `message_received` / `message_sent` runtime installs and rejected dotted typed aliases.
- Update `ChatTurnWriter.computeDelta` so tool/function scaffolding is ignored and each real user turn persists only the final assistant candidate; keep PR #356 Node-UI marker behavior covered.
- Downgrade typed hook startup-window timeout liveness to debug and let late hook fires update stats to `committed-by-fire`, so `fireCount=0` after 30s is no longer treated as proof a hook is dead.

## Related

- Fixes #359
- Preserves the direct-channel marker contract from #356

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/ChatTurnWriter.ts` | Filters cold-start transcript scaffolding, delays W4a pair emission until the final assistant candidate, and updates Telegram persistence docs. |
| `packages/adapter-openclaw/src/DkgNodePlugin.ts` | Removes unsupported typed message/dotted installs while keeping `agent_end` and internal `message:received` / `message:sent` wiring. |
| `packages/adapter-openclaw/src/HookSurface.ts` | Makes typed timeout liveness debug-only and updates late-fire commit state. |
| `packages/adapter-openclaw/test/ChatTurnWriter.test.ts` | Adds cold-start W4a over-persist regression and ordinary backfill guard. |
| `packages/adapter-openclaw/test/HookSurface.test.ts` | Covers debug timeout behavior and late-fire state correction. |
| `packages/adapter-openclaw/test/plugin.test.ts` | Covers supported hook wiring and removal of unsupported typed message/dotted hooks. |
| `packages/adapter-openclaw/test/probe.test.ts` | Narrows probe expectations to accepted lifecycle typed hooks. |

## Blocking before merge

- [ ] Manual live Telegram smoke must be posted on this PR: fresh daemon + gateway, first tool-using Telegram turn persists exactly once, gateway restart, second Telegram turn persists exactly once without duplicating the first.
- [ ] Manual smoke should record that typed `message_received` / `message_sent` do not fire on OpenClaw 2026.4.15 and that `agent_end` fires for the tested turn.
- [ ] Keep the PR draft until the live smoke count is clean, because #359 is a live Telegram -> daemon persistence symptom.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run test/HookSurface.test.ts test/probe.test.ts test/plugin.test.ts test/ChatTurnWriter.test.ts test/ChatTurnWriter.crashRecovery.test.ts test/dkg-channel.test.ts test/dkg-client.test.ts` -> 476 tests passed.
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/daemon-openclaw.test.ts -t persist-turn` -> 18 tests passed, 66 skipped.
- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw run build` -> passed.
- [x] `git diff --check` -> passed with CRLF warnings only.
- [ ] `pnpm build:runtime` -> adapter-openclaw build passed, then failed later in existing `@origintrail-official/dkg-random-sampling` TypeScript/module-resolution errors (`@origintrail-official/dkg-core`, `dkg-storage`, `dkg-chain` not found plus `err` unknown typing). CI/baseline should classify before merge.