### PR TITLE
fix(evm): apply conviction multipliers to node scores

### DIFF
--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -254,7 +254,16 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
 
         uint256 epoch = chronos.getCurrentEpoch();
         randomSamplingStorage.incrementEpochNodeValidProofsCount(epoch, identityId);
-        uint256 score18 = calculateNodeScore(identityId);
+
+        // D4+D15+D26 — post-migration the only source of staked TRAC is
+        // the V10 conviction layer. The node score and score-per-stake
+        // denominator must use the same timestamp-accurate effective stake
+        // snapshot: raw TRAC multiplied by active conviction boosts, with
+        // expired boosts drained at this proof's block timestamp.
+        uint40 tsNow = uint40(block.timestamp);
+        convictionStakingStorage.settleNodeTo(identityId, tsNow);
+        uint256 effectiveNodeStake = convictionStakingStorage.getNodeRunningEffectiveStake(identityId);
+        uint256 score18 = _calculateNodeScore(identityId, effectiveNodeStake);
         randomSamplingStorage.addToNodeEpochProofPeriodScore(
             epoch,
             activeProofPeriodStartBlock,
@@ -264,16 +273,6 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         randomSamplingStorage.addToNodeEpochScore(epoch, identityId, score18);
         randomSamplingStorage.addToAllNodesEpochScore(epoch, score18);
 
-        // D4+D15+D26 — post-migration the only source of staked TRAC is
-        // the V10 conviction layer. The denominator is the V10 effective
-        // stake at *this instant*. Under D26 timestamp-accurate accounting
-        // we first settle the node forward to `block.timestamp` (draining
-        // any boost-expiry drops that fell inside the interval since the
-        // last proof) and then read the post-settle running effective
-        // stake.
-        uint40 tsNow = uint40(block.timestamp);
-        convictionStakingStorage.settleNodeTo(identityId, tsNow);
-        uint256 effectiveNodeStake = convictionStakingStorage.getNodeRunningEffectiveStake(identityId);
         if (effectiveNodeStake > 0) {
             uint256 deltaScorePerStake36 = (score18 * SCALE18) / effectiveNodeStake;
             uint256 newLast = randomSamplingStorage.getEpochLastScorePerStake(identityId, epoch) +
@@ -540,7 +539,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
      * Formula: nodeScore(t) = S(t) * (c + 0.86 * P(t) + 0.60 * A(t) * P(t))
      *
      * Where:
-     * - S(t) = sqrt(nodeStake / STAKE_CAP) - sublinear stake scaling
+     * - S(t) = sqrt(nodeEffectiveStake / STAKE_CAP) - sublinear conviction stake scaling
      * - P(t) = K_n / K_total - publishing share over 4 epochs (t-3, t-2, t-1, t)
      * - A(t) = 1 - |nodeAsk - networkPrice| / networkPrice - ask alignment factor
      * - c = 0.002 (STAKE_BASELINE_COEFFICIENT) - small baseline for staked non-publishers
@@ -555,22 +554,23 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
      * @return score18 The calculated node score scaled by 18-decimal for precision
      */
     function calculateNodeScore(uint72 identityId) public view returns (uint256) {
+        return _calculateNodeScore(identityId, convictionStakingStorage.getNodeEffectiveStake(identityId));
+    }
+
+    function _calculateNodeScore(uint72 identityId, uint256 nodeEffectiveStake) internal view returns (uint256) {
         uint256 currentEpoch = chronos.getCurrentEpoch();
 
-        // 1. Stake factor S(t) = sqrt(nodeStake / stakeCap)
+        // 1. Stake factor S(t) = sqrt(nodeEffectiveStake / stakeCap)
         // Using sublinear scaling to reduce stake dominance (RFC-26 Section 4.1)
         //
-        // D15 — post-migration the node's canonical raw TRAC stake is
-        // `ConvictionStakingStorage.nodeStakeV10`. StakingStorage.nodes[id].stake
-        // is V8 legacy and not maintained after V10 cutover; reading it here
-        // would zero-out the stake factor for any V10 node and lock it out
-        // of scoring. Migration is mandatory (user directive) — there are
-        // no V8-only nodes — so the V10 aggregate IS the node stake.
+        // D15/D26 — post-migration the node's scoring stake is V10 effective
+        // stake: raw TRAC multiplied by active conviction multipliers and
+        // timestamp-adjusted for expired boosts. Migration is mandatory (user
+        // directive), so V8 `StakingStorage.nodes[id].stake` is legacy-only.
         uint256 stakeCap = uint256(parametersStorage.maximumStake());
-        uint256 nodeStake = convictionStakingStorage.getNodeStakeV10(identityId);
-        nodeStake = nodeStake > stakeCap ? stakeCap : nodeStake;
-        // S18 = sqrt((nodeStake / stakeCap) * SCALE18) * sqrt(SCALE18)
-        uint256 stakeRatio18 = (nodeStake * SCALE18) / stakeCap;
+        nodeEffectiveStake = nodeEffectiveStake > stakeCap ? stakeCap : nodeEffectiveStake;
+        // S18 = sqrt((nodeEffectiveStake / stakeCap) * SCALE18) * sqrt(SCALE18)
+        uint256 stakeRatio18 = (nodeEffectiveStake * SCALE18) / stakeCap;
         uint256 stakeFactor18 = Math.sqrt(stakeRatio18 * SCALE18);
 
         // 2. Publishing factor P(t) = K_n / K_total over 4 epochs (RFC-26 Section 4.2)

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -30,11 +30,11 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  *     for both deposits (TRAC `transferFrom` to CSS) and withdrawals
  *     (`StakingV10` calls `cs.transferStake`).
  *   - Migration to V10 is MANDATORY: every V8 delegator becomes a V10 NFT
- *     position. `RandomSampling.calculateNodeScore` and the Phase 11
- *     `scorePerStake` denominator therefore read `nodeStakeV10` here, NOT
- *     `StakingStorage.nodes[id].stake`. V8 `StakingStorage` is deployed-but-
- *     unused dead code post-consolidation; only `StakingV10._convertToNFT`
- *     reads it (V8→V10 drain at cutover).
+ *     position. `RandomSampling.calculateNodeScore` therefore reads the
+ *     timestamp-accurate effective stake here (raw TRAC × active conviction
+ *     multipliers), while raw stake gates still read `nodeStakeV10`. V8
+ *     `StakingStorage` is deployed-but-unused dead code post-consolidation;
+ *     only `StakingV10._convertToNFT` reads it (V8→V10 drain at cutover).
  *
  * Rewards model (D19 — compound-into-raw):
  *   - The previous split-bucket model (separate `rewards` sidecar that

--- a/packages/evm-module/test/integration/D26TimeAccurateStaking.test.ts
+++ b/packages/evm-module/test/integration/D26TimeAccurateStaking.test.ts
@@ -29,6 +29,8 @@
 
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
+// @ts-expect-error: No type definitions available for assertion-tools
+import { kcTools } from 'assertion-tools';
 import { expect } from 'chai';
 import hre from 'hardhat';
 
@@ -36,8 +38,15 @@ import {
   Chronos,
   ConvictionStakingStorage,
   Hub,
+  KnowledgeCollectionStorage,
+  ParametersStorage,
+  Profile,
+  RandomSampling,
   RandomSamplingStorage,
+  ShardingTableStorage,
 } from '../../typechain';
+import { sqrt } from '../helpers/math-helpers';
+import { createProfile } from '../helpers/profile-helpers';
 
 const ALICE_ID = 42n;
 
@@ -48,6 +57,10 @@ const THREE_AND_HALF_X = (35n * SCALE18) / 10n;
 const SIX_X = 6n * SCALE18;
 const DAY = 24n * 60n * 60n;
 
+const PROOF_QUADS = [
+  '<urn:s> <urn:p> "o" .',
+];
+
 async function tsNow(): Promise<bigint> {
   return BigInt(await time.latest());
 }
@@ -57,7 +70,12 @@ describe('@integration D26 — time-accurate staking accounting', () => {
   let Hub: Hub;
   let CSS: ConvictionStakingStorage;
   let RSS: RandomSamplingStorage;
+  let RandomSampling: RandomSampling;
+  let ParametersStorage: ParametersStorage;
   let Chronos: Chronos;
+  let KnowledgeCollectionStorage: KnowledgeCollectionStorage;
+  let Profile: Profile;
+  let ShardingTableStorage: ShardingTableStorage;
 
   async function deployFixture() {
     // Mirror the @unit RandomSamplingStorage fixture — it pulls in the full
@@ -77,20 +95,198 @@ describe('@integration D26 — time-accurate staking accounting', () => {
     Hub = await hre.ethers.getContract<Hub>('Hub');
     CSS = await hre.ethers.getContract<ConvictionStakingStorage>('ConvictionStakingStorage');
     RSS = await hre.ethers.getContract<RandomSamplingStorage>('RandomSamplingStorage');
+    RandomSampling = await hre.ethers.getContract<RandomSampling>('RandomSampling');
+    ParametersStorage = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
     Chronos = await hre.ethers.getContract<Chronos>('Chronos');
-    return { accounts, Hub, CSS, RSS, Chronos };
+    KnowledgeCollectionStorage = await hre.ethers.getContract<KnowledgeCollectionStorage>(
+      'KnowledgeCollectionStorage',
+    );
+    Profile = await hre.ethers.getContract<Profile>('Profile');
+    ShardingTableStorage = await hre.ethers.getContract<ShardingTableStorage>(
+      'ShardingTableStorage',
+    );
+    return {
+      accounts,
+      Hub,
+      CSS,
+      RSS,
+      RandomSampling,
+      ParametersStorage,
+      Chronos,
+      KnowledgeCollectionStorage,
+      Profile,
+      ShardingTableStorage,
+    };
   }
 
   beforeEach(async () => {
     hre.helpers.resetDeploymentsJson();
-    ({ accounts, Hub, CSS, RSS, Chronos } = await loadFixture(deployFixture));
+    ({
+      accounts,
+      Hub,
+      CSS,
+      RSS,
+      RandomSampling,
+      ParametersStorage,
+      Chronos,
+      KnowledgeCollectionStorage,
+      Profile,
+      ShardingTableStorage,
+    } = await loadFixture(deployFixture));
   });
+
+  async function expectedBaselineScore(effectiveStake: bigint): Promise<bigint> {
+    const stakeCap = await ParametersStorage.maximumStake();
+    const cappedStake = effectiveStake > stakeCap ? stakeCap : effectiveStake;
+    const stakeRatio18 = (cappedStake * SCALE18) / stakeCap;
+    const stakeFactor18 = sqrt(stakeRatio18 * SCALE18);
+    const baselineComponent18 = (2n * SCALE18) / 1000n;
+    return (stakeFactor18 * baselineComponent18) / SCALE18;
+  }
+
+  async function createProofableKnowledgeCollection(): Promise<bigint> {
+    const chunks = kcTools.splitIntoChunks(PROOF_QUADS, 32);
+    const merkleRoot = kcTools.calculateMerkleRoot(PROOF_QUADS, 32);
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    const args = [
+      accounts[0].address,
+      'd26-submit-proof-regression',
+      merkleRoot,
+      1,
+      32 * chunks.length,
+      currentEpoch,
+      currentEpoch + 1n,
+      0,
+      false,
+      chunks.length,
+    ] as const;
+
+    const knowledgeCollectionId =
+      await KnowledgeCollectionStorage.createKnowledgeCollection.staticCall(...args);
+    await KnowledgeCollectionStorage.createKnowledgeCollection(...args);
+    return knowledgeCollectionId;
+  }
+
+  async function createProofableNode(): Promise<{
+    identityId: bigint;
+    operational: SignerWithAddress;
+  }> {
+    const node = { admin: accounts[1], operational: accounts[2] };
+    const { identityId, nodeId } = await createProfile(Profile, node);
+    const identityId72 = BigInt(identityId);
+
+    await ShardingTableStorage.createNodeObject(1, nodeId, identityId72, 0);
+    await ShardingTableStorage.setIdentityId(0, identityId72);
+    await ShardingTableStorage.incrementNodesCount();
+
+    return { identityId: identityId72, operational: node.operational };
+  }
 
   // --------------------------------------------------------------------
   // 1. Mid-epoch expiry denominator
   // --------------------------------------------------------------------
 
   describe('mid-epoch expiry denominator', () => {
+    it('RandomSampling.calculateNodeScore uses active conviction multipliers', async () => {
+      const raw = (await ParametersStorage.maximumStake()) / 10n;
+      const boostedEffectiveStake = (raw * SIX_X) / SCALE18;
+
+      await CSS.createPosition(1, ALICE_ID, raw, 12, 0);
+
+      expect(await CSS.getNodeStakeV10(ALICE_ID)).to.equal(raw);
+      expect(await CSS.getNodeEffectiveStake(ALICE_ID)).to.equal(boostedEffectiveStake);
+
+      const score = await RandomSampling.calculateNodeScore(ALICE_ID);
+
+      expect(score).to.equal(await expectedBaselineScore(boostedEffectiveStake));
+      expect(score).to.not.equal(await expectedBaselineScore(raw));
+    });
+
+    it('RandomSampling.calculateNodeScore caps boosted effective stake after applying the multiplier', async () => {
+      const maximumStake = await ParametersStorage.maximumStake();
+      const raw = maximumStake / 2n;
+      const boostedEffectiveStake = (raw * SIX_X) / SCALE18;
+
+      await CSS.createPosition(1, ALICE_ID, raw, 12, 0);
+
+      expect(raw).to.be.lessThan(maximumStake);
+      expect(boostedEffectiveStake).to.be.greaterThan(maximumStake);
+      expect(await CSS.getNodeEffectiveStake(ALICE_ID)).to.equal(boostedEffectiveStake);
+
+      const score = await RandomSampling.calculateNodeScore(ALICE_ID);
+
+      expect(score).to.equal(await expectedBaselineScore(boostedEffectiveStake));
+      expect(score).to.equal(await expectedBaselineScore(maximumStake));
+      expect(score).to.not.equal(await expectedBaselineScore(raw));
+    });
+
+    it('RandomSampling.calculateNodeScore simulates expired multiplier drops', async () => {
+      const raw = (await ParametersStorage.maximumStake()) / 10n;
+
+      await CSS.createPosition(1, ALICE_ID, raw, 12, 0);
+      const position = await CSS.getPosition(1);
+      const boostedEffectiveStake = (raw * SIX_X) / SCALE18;
+
+      expect(await CSS.getNodeRunningEffectiveStake(ALICE_ID)).to.equal(boostedEffectiveStake);
+
+      await time.increaseTo(Number(position.expiryTimestamp + 1n));
+
+      expect(await RandomSampling.calculateNodeScore(ALICE_ID)).to.equal(
+        await expectedBaselineScore(raw),
+      );
+      expect(await CSS.getNodeRunningEffectiveStake(ALICE_ID)).to.equal(boostedEffectiveStake);
+    });
+
+    it('RandomSampling.submitProof settles expired multipliers before scoring and checkpointing', async () => {
+      const { identityId, operational } = await createProofableNode();
+      const raw = (await ParametersStorage.maximumStake()) / 10n;
+      const boostedEffectiveStake = (raw * SIX_X) / SCALE18;
+
+      await CSS.createPosition(1, identityId, raw, 12, 0);
+      const position = await CSS.getPosition(1);
+      expect(await CSS.getNodeRunningEffectiveStake(identityId)).to.equal(boostedEffectiveStake);
+
+      await time.increaseTo(Number(position.expiryTimestamp + 1n));
+
+      const knowledgeCollectionId = await createProofableKnowledgeCollection();
+      const chunkId = 0;
+      const { leaf, proof } = kcTools.calculateMerkleProof(PROOF_QUADS, 32, chunkId);
+      const epoch = await Chronos.getCurrentEpoch();
+      await RandomSampling.updateAndGetActiveProofPeriodStartBlock();
+      const { activeProofPeriodStartBlock } = await RandomSampling.getActiveProofPeriodStatus();
+      const proofingPeriodDurationInBlocks =
+        await RandomSampling.getActiveProofingPeriodDurationInBlocks();
+
+      await RSS.setNodeChallenge(identityId, {
+        knowledgeCollectionId,
+        chunkId,
+        knowledgeCollectionStorageContract: await KnowledgeCollectionStorage.getAddress(),
+        epoch,
+        activeProofPeriodStartBlock,
+        proofingPeriodDurationInBlocks,
+        solved: false,
+      });
+
+      const expectedScore = await expectedBaselineScore(raw);
+
+      await RandomSampling.connect(operational).submitProof(leaf, proof);
+
+      expect(await CSS.getNodeRunningEffectiveStake(identityId)).to.equal(raw);
+      expect(await RSS.getEpochNodeValidProofsCount(epoch, identityId)).to.equal(1n);
+      expect(await RSS.getNodeEpochScore(epoch, identityId)).to.equal(expectedScore);
+      expect(await RSS.getAllNodesEpochScore(epoch)).to.equal(expectedScore);
+      expect(await RSS.getNodeEpochProofPeriodScore(identityId, epoch, activeProofPeriodStartBlock)).to.equal(
+        expectedScore,
+      );
+      expect(await RSS.getEpochLastScorePerStake(identityId, epoch)).to.equal(
+        (expectedScore * SCALE18) / raw,
+      );
+      expect(await RSS.findScorePerStakeAt(identityId, epoch, await tsNow())).to.equal(
+        (expectedScore * SCALE18) / raw,
+      );
+      expect((await RSS.getNodeChallenge(identityId)).solved).to.equal(true);
+    });
+
     it('Node effective stake transitions from boosted to raw at exact expiryTimestamp', async () => {
       // Alice opens a 30-day tier-1 position (boost 1.5x on 2000 raw).
       // Effective now: 3000. At +30d it collapses to 2000 (raw tail).


### PR DESCRIPTION
## Summary
- use timestamp-accurate V10 effective stake for RandomSampling node scores
- settle and reuse the same effective stake snapshot during submitProof for node score and score-per-stake accounting
- add D26 regression coverage for active conviction multipliers and post-expiry raw scoring

## Tests
- pnpm exec hardhat test --network hardhat --config hardhat.node.config.ts test/integration/D26TimeAccurateStaking.test.ts
- pnpm exec hardhat test --network hardhat --config hardhat.node.config.ts --grep '@unit RandomSampling'