### PR TITLE
Release: auto-register operational ACK wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 ## [Unreleased]
 
 ### Added
-- (Changes go here for the next release.)
+- **Persisted profile admin wallet**: `wallets.json` now contains a distinct admin wallet alongside operational wallets so newly-created profiles do not lose their admin key.
+- **Operational wallet self-healing for ACK signing**: core nodes now auto-register configured operational ACK signer wallets on-chain for their profile identity during startup.
+- **`Profile.addOperationalWallets(uint72,address[])` facade**: profile admins can add operational-only keys without using the lower-level generic key-management surface.
+- **End-to-end ACK signer registration coverage**: a real Hardhat/libp2p test now verifies startup registration, StorageACK signing by the confirmed key, and refusal to sign after the key is removed on-chain.
 
 ### Changed
-- (Optional.)
+- **Admin-only operational wallet registration**: `Profile.addOperationalWallets` requires a profile admin key; operational keys can no longer add more operational keys.
+- **New profile creation uses the persisted admin wallet**: `EVMChainAdapter.ensureProfile` now uses `chainConfig.adminPrivateKey` for the profile admin address instead of creating an unrecoverable random admin wallet.
+- **StorageACK signing is gated by on-chain confirmation**: core nodes only register/sign with ACK keys confirmed as `OPERATIONAL_KEY` for the node identity.
 
 ### Fixed
-- (Optional.)
+- **Invalid ACKs from unregistered wallets**: ACK handlers no longer produce signatures from local keys that are not confirmed operational wallets on-chain.
 
 ---
 

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -702,14 +702,39 @@ export function readWallets(): string[] {
     warn('wallets.json is malformed or still being written — skipping');
     return [];
   }
-  // The daemon writes { wallets: [{ address, privateKey }] }.
-  // Handle this shape first, then fall back to other formats.
+  // The daemon writes { adminWallet, wallets: [{ address, privateKey }] }.
+  // Include admin first so profile/key-management transactions have gas, then
+  // fall back to the legacy operational-only array shapes.
   const walletList: any[] = Array.isArray(raw?.wallets) ? raw.wallets
     : Array.isArray(raw) ? raw
     : [];
-  const addresses: string[] = [];
+  const operationalAddresses: string[] = [];
+  const operationalSeen = new Set<string>();
   for (const w of walletList) {
-    if (w?.address) addresses.push(w.address);
+    const address = w?.address;
+    if (typeof address !== 'string' || address.length === 0) continue;
+    const key = address.toLowerCase();
+    if (operationalSeen.has(key)) continue;
+    operationalSeen.add(key);
+    operationalAddresses.push(address);
+  }
+  if (operationalAddresses.length === 0) {
+    warn('wallets.json has no operational wallets — skipping faucet funding');
+    return [];
+  }
+
+  const addresses: string[] = [];
+  const seen = new Set<string>();
+  const addAddress = (address: unknown) => {
+    if (typeof address !== 'string' || address.length === 0) return;
+    const key = address.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    addresses.push(address);
+  };
+  addAddress(raw?.adminWallet?.address);
+  for (const address of operationalAddresses) {
+    addAddress(address);
   }
 
   if (addresses.length) {
@@ -723,25 +748,26 @@ export function readWallets(): string[] {
  * only on faucet failure; the caller is expected to continue (funding is
  * best-effort / non-fatal).
  *
- * Addresses are capped at the first 3 to match `requestFaucetFunding`'s
- * server-side cap (`packages/core/src/faucet.ts`). Including more wallets
- * in the body would be rejected by the faucet. When the caller passes >3
- * addresses, the extras are listed in a follow-on note so the operator
- * knows which wallets still need funding (via a separate request or a
- * re-run after cooldown).
+ * Addresses are split into batches of 3 to match the faucet's per-request
+ * cap. Including more wallets in one body would be rejected by the faucet.
  */
 export function logManualFundingInstructions(addresses: string[], faucetUrl: string, mode: string): void {
-  const fundable = addresses.slice(0, 3);
-  const extras = addresses.slice(3);
+  const batches: string[][] = [];
+  for (let i = 0; i < addresses.length; i += 3) {
+    batches.push(addresses.slice(i, i + 3));
+  }
   console.log('\nTo fund wallets manually, run:');
-  console.log(`  curl -X POST "${faucetUrl}" \\`);
-  console.log(`    -H "Content-Type: application/json" \\`);
-  console.log(`    -H "Idempotency-Key: $(date +%s)" \\`);
-  console.log(`    --data-raw '{"mode":"${mode}","wallets":${JSON.stringify(fundable)}}'`);
-  if (extras.length > 0) {
-    console.log(`\nNote: faucet supports up to 3 wallets per call; the command above funds the first 3.`);
-    console.log(`Fund the remaining ${extras.length} wallet(s) with a separate request:`);
-    console.log(`  ${extras.join(', ')}`);
+  batches.forEach((batch, index) => {
+    if (batches.length > 1) {
+      console.log(`  # batch ${index + 1}/${batches.length}`);
+    }
+    console.log(`  curl -X POST "${faucetUrl}" \\`);
+    console.log(`    -H "Content-Type: application/json" \\`);
+    console.log(`    -H "Idempotency-Key: $(date +%s)-${index + 1}" \\`);
+    console.log(`    --data-raw '{"mode":"${mode}","wallets":${JSON.stringify(batch)}}'`);
+  });
+  if (batches.length > 1) {
+    console.log(`\nNote: faucet supports up to 3 wallets per call; run each batch above.`);
   }
   console.log('');
 }
@@ -1929,6 +1955,14 @@ export async function runSetup(options: SetupOptions): Promise<void> {
           const result = await requestFaucetFunding(faucetUrl, faucetMode, walletAddresses, effectiveAgentName);
           if (result.success) {
             log(`Funded: ${result.funded.join(', ')}`);
+            if (result.error) {
+              warn(`Faucet partially completed: ${result.error}`);
+              logManualFundingInstructions(
+                result.failedWallets?.length ? result.failedWallets : walletAddresses,
+                faucetUrl,
+                faucetMode,
+              );
+            }
           } else {
             warn(`Faucet request did not fund any wallets${result.error ? ` (${result.error})` : ''}`);
             logManualFundingInstructions(walletAddresses, faucetUrl, faucetMode);

--- a/packages/adapter-openclaw/test/setup.test.ts
+++ b/packages/adapter-openclaw/test/setup.test.ts
@@ -3306,6 +3306,58 @@ describe('runSetup preflight runs before faucet (C10)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// readWallets — wallets.json parsing
+// ---------------------------------------------------------------------------
+
+describe('readWallets', () => {
+  it('returns admin wallet first, then operational wallets, without duplicates', () => {
+    const dkgHome = join(testDir, '.dkg');
+    const adminAddress = '0xA000000000000000000000000000000000000001';
+    const opAddress = '0xb000000000000000000000000000000000000001';
+    mkdirSync(dkgHome, { recursive: true });
+    writeFileSync(
+      join(dkgHome, 'wallets.json'),
+      JSON.stringify({
+        adminWallet: { address: adminAddress },
+        wallets: [
+          { address: opAddress },
+          { address: adminAddress },
+        ],
+      }),
+    );
+
+    const originalDkg = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    try {
+      expect(readWallets()).toEqual([adminAddress, opAddress]);
+    } finally {
+      process.env.DKG_HOME = originalDkg;
+    }
+  });
+
+  it('does not return an admin-only wallets.json for faucet funding', () => {
+    const dkgHome = join(testDir, '.dkg');
+    const adminAddress = '0xA000000000000000000000000000000000000001';
+    mkdirSync(dkgHome, { recursive: true });
+    writeFileSync(
+      join(dkgHome, 'wallets.json'),
+      JSON.stringify({
+        adminWallet: { address: adminAddress },
+        wallets: [],
+      }),
+    );
+
+    const originalDkg = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    try {
+      expect(readWallets()).toEqual([]);
+    } finally {
+      process.env.DKG_HOME = originalDkg;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // readWalletsWithRetry — retry accounting (C4a extraction)
 // ---------------------------------------------------------------------------
 
@@ -3368,7 +3420,7 @@ describe('logManualFundingInstructions', () => {
     logSpy.mockRestore();
   });
 
-  it('caps the curl body at the first 3 addresses matching the auto-path cap', () => {
+  it('splits manual curl bodies into faucet-sized batches', () => {
     const addrs = [
       '0x1111111111111111111111111111111111111111',
       '0x2222222222222222222222222222222222222222',
@@ -3379,19 +3431,18 @@ describe('logManualFundingInstructions', () => {
     logManualFundingInstructions(addrs, 'https://faucet.example.com/fund', 'v10_base_sepolia');
 
     const logged = logSpy.mock.calls.map(c => String(c[0])).join('\n');
-    // The curl body is built from JSON.stringify(fundable) — assert the
-    // cap by looking for the exact first-three array in the output and
-    // the absence of the 4th/5th addresses inside the curl line.
     expect(logged).toContain(JSON.stringify(addrs.slice(0, 3)));
-    const curlLine = logSpy.mock.calls
+    expect(logged).toContain(JSON.stringify(addrs.slice(3)));
+    const curlLines = logSpy.mock.calls
       .map(c => String(c[0]))
-      .find(line => line.includes('--data-raw'));
-    expect(curlLine).toBeDefined();
-    expect(curlLine).not.toContain(addrs[3]);
-    expect(curlLine).not.toContain(addrs[4]);
+      .filter(line => line.includes('--data-raw'));
+    expect(curlLines).toHaveLength(2);
+    expect(curlLines[0]).not.toContain(addrs[3]);
+    expect(curlLines[1]).toContain(addrs[3]);
+    expect(curlLines[1]).toContain(addrs[4]);
   });
 
-  it('emits a follow-on note listing the omitted wallets when more than 3 are passed', () => {
+  it('emits a note to run each batch when more than 3 addresses are passed', () => {
     const addrs = [
       '0x1111111111111111111111111111111111111111',
       '0x2222222222222222222222222222222222222222',
@@ -3403,9 +3454,7 @@ describe('logManualFundingInstructions', () => {
 
     const logged = logSpy.mock.calls.map(c => String(c[0])).join('\n');
     expect(logged).toMatch(/faucet supports up to 3 wallets/i);
-    expect(logged).toContain('2 wallet');
-    expect(logged).toContain(addrs[3]);
-    expect(logged).toContain(addrs[4]);
+    expect(logged).toMatch(/run each batch/i);
   });
 
   it('does not emit the extras note when exactly 3 (or fewer) addresses are passed', () => {

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -23,6 +23,7 @@ const agent = await DKGAgent.create({
   chainConfig: {
     rpcUrl: 'https://sepolia.base.org',
     hubAddress: '0x...',
+    adminPrivateKey: '0xadminPrivateKey',
     operationalKeys: ['0xprivateKey1'],
   },
 });

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -163,8 +163,13 @@ const GOSSIP_DIAL_TIMEOUT_MS = 10_000;
  */
 const CATCHUP_ON_CONNECT_COOLDOWN_MS = 60_000;
 const RANDOM_SAMPLING_BIND_RETRY_MS = 30_000;
+const STORAGE_ACK_REGISTRATION_RETRY_MS = 30_000;
 
 type RandomSamplingStartResult = 'started' | 'retryable' | 'disabled';
+type ACKSignerResolution = {
+  wallet: ethers.Wallet | null;
+  retryable: boolean;
+};
 
 interface SyncRequestEnvelope {
   contextGraphId: string;
@@ -346,6 +351,10 @@ export interface DKGAgentConfig {
   ackSignerKey?: string;
   /**
    * EVM chain configuration. If omitted, publishing won't have on-chain finality.
+   * `adminPrivateKey` is the private key for the profile admin wallet used
+   * only for profile/key-management transactions. Core nodes using chainConfig
+   * must provide it; edge nodes may omit it and run without profile
+   * creation/key-repair privileges.
    * `operationalKeys` are the private keys for operational wallets.
    * The first key is the primary signer (identity, staking); all are used
    * round-robin for publish TXs to avoid nonce collisions on parallel publishes.
@@ -353,6 +362,7 @@ export interface DKGAgentConfig {
   chainConfig?: {
     rpcUrl: string;
     hubAddress: string;
+    adminPrivateKey?: string;
     operationalKeys: string[];
     chainId?: string;
   };
@@ -406,6 +416,8 @@ export class DKGAgent {
   private randomSamplingHandle: RandomSamplingHandle | null = null;
   private randomSamplingBindRetryTimer: ReturnType<typeof setInterval> | null = null;
   private randomSamplingBindRetryInFlight = false;
+  private storageACKRegistrationRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private storageACKRegistrationRetryInFlight = false;
   private readonly config: DKGAgentConfig;
   private started = false;
   private readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
@@ -518,6 +530,7 @@ export class DKGAgent {
       log.warn(ctx, `No dataDir — triple store is in-memory (data will be lost on restart)`);
     }
 
+    const nodeRole = config.nodeRole ?? 'edge';
     let chain: ChainAdapter;
     let opKeys = config.chainConfig?.operationalKeys;
     if (config.chainAdapter) {
@@ -526,13 +539,24 @@ export class DKGAgent {
         opKeys = [(chain as any).getOperationalPrivateKey()];
       }
     } else if (config.chainConfig && opKeys?.length) {
-      chain = new EVMChainAdapter({
+      const evmConfigBase = {
         rpcUrl: config.chainConfig.rpcUrl,
         privateKey: opKeys[0],
         additionalKeys: opKeys.slice(1),
         hubAddress: config.chainConfig.hubAddress,
         chainId: config.chainConfig.chainId,
-      });
+      };
+      if (config.chainConfig.adminPrivateKey) {
+        chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });
+      } else {
+        if (nodeRole === 'core') {
+          throw new Error(
+            'EVM adminPrivateKey is required for core nodes using chainConfig. ' +
+            'Provide the persisted profile admin key, or pass a pre-built chainAdapter for explicit no-admin mode.',
+          );
+        }
+        chain = new EVMChainAdapter({ ...evmConfigBase, allowNoAdminSigner: true });
+      }
     } else {
       chain = new NoChainAdapter();
     }
@@ -545,7 +569,6 @@ export class DKGAgent {
 
     const port = config.listenPort ?? 0;
     const host = config.listenHost ?? '0.0.0.0';
-    const nodeRole = config.nodeRole ?? 'edge';
     const nodeConfig: DKGNodeConfig = {
       listenAddresses: [`/ip4/${host}/tcp/${port}`],
       announceAddresses: config.announceAddresses,
@@ -586,6 +609,79 @@ export class DKGAgent {
       config, wallet, node, store, publisher, queryEngine, eventBus, chain,
       workspaceOwnedEntities, writeLocks,
     );
+  }
+
+  private getACKSignerCandidateWallets(ctx: OperationContext): ethers.Wallet[] {
+    const operationalKeys = this.config.chainAdapter
+      ? []
+      : (this.config.chainConfig?.operationalKeys ?? []);
+    const keys = [
+      this.config.ackSignerKey,
+      ...operationalKeys,
+      typeof this.chain.getACKSignerKey === 'function' ? this.chain.getACKSignerKey() : undefined,
+    ].filter((key): key is string => Boolean(key));
+
+    const wallets: ethers.Wallet[] = [];
+    const seen = new Set<string>();
+    for (const key of keys) {
+      try {
+        const wallet = new ethers.Wallet(key);
+        const addressKey = wallet.address.toLowerCase();
+        if (seen.has(addressKey)) continue;
+        seen.add(addressKey);
+        wallets.push(wallet);
+      } catch (err) {
+        this.log.warn(ctx, `Ignoring invalid ACK signer key: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return wallets;
+  }
+
+  private async resolveConfirmedACKSigner(
+    identityId: bigint,
+    candidates: ethers.Wallet[],
+    ctx: OperationContext,
+  ): Promise<ACKSignerResolution> {
+    const isOperationalWalletRegistered = this.chain.isOperationalWalletRegistered;
+    if (typeof isOperationalWalletRegistered !== 'function') {
+      this.log.warn(
+        ctx,
+        'V10 StorageACK signer disabled: chain adapter does not implement required on-chain operational wallet confirmation',
+      );
+      return { wallet: null, retryable: false };
+    }
+
+    let sawLookupError = false;
+    for (const wallet of candidates) {
+      try {
+        if (await isOperationalWalletRegistered.call(this.chain, identityId, wallet.address)) {
+          return { wallet, retryable: false };
+        }
+      } catch (err) {
+        sawLookupError = true;
+        this.log.warn(
+          ctx,
+          `Unable to confirm ACK signer ${wallet.address} on-chain: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    if (sawLookupError) {
+      this.log.warn(
+        ctx,
+        `V10 StorageACK handler registration deferred: signer confirmation failed due lookup error(s)`,
+      );
+      return { wallet: null, retryable: true };
+    }
+
+    this.log.warn(
+      ctx,
+      `V10 StorageACK signer disabled: no candidate key is confirmed on-chain as ` +
+      `OPERATIONAL_KEY for identity ${identityId}`,
+    );
+    return { wallet: null, retryable: false };
   }
 
   async start(): Promise<void> {
@@ -641,36 +737,65 @@ export class DKGAgent {
     this.router.register(PROTOCOL_QUERY_REMOTE, queryRemoteHandler.handler);
 
     const effectiveRole = this.config.nodeRole ?? 'edge';
+    const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);
+    let onChainIdentityId = 0n;
 
     // Auto-detect or register on-chain identity.
     // Edge nodes skip profile creation — they operate with agent identity only.
     if (this.chain.chainId !== 'none') {
-      let identityId = 0n;
       try {
-        identityId = await this.chain.getIdentityId();
-        if (identityId === 0n && effectiveRole === 'core') {
+        onChainIdentityId = await this.chain.getIdentityId();
+        if (onChainIdentityId === 0n && effectiveRole === 'core') {
           this.log.info(ctx, `No on-chain identity found, creating profile and staking...`);
-          identityId = await this.chain.ensureProfile({
+          onChainIdentityId = await this.chain.ensureProfile({
             nodeName: this.config.name,
           });
-          this.log.info(ctx, `On-chain profile created, identityId=${identityId}`);
-        } else if (identityId === 0n) {
+          this.log.info(ctx, `On-chain profile created, identityId=${onChainIdentityId}`);
+        } else if (onChainIdentityId === 0n) {
           this.log.info(ctx, `Edge node — skipping on-chain profile creation (agent identity only)`);
         } else {
-          this.log.info(ctx, `On-chain identity found: identityId=${identityId}`);
+          this.log.info(ctx, `On-chain identity found: identityId=${onChainIdentityId}`);
         }
       } catch (err) {
         this.log.warn(ctx, `ensureProfile error: ${err instanceof Error ? err.message : String(err)}`);
         try {
-          identityId = await this.chain.getIdentityId();
-          if (identityId > 0n) {
-            this.log.info(ctx, `Recovered identityId=${identityId} after partial failure`);
+          onChainIdentityId = await this.chain.getIdentityId();
+          if (onChainIdentityId > 0n) {
+            this.log.info(ctx, `Recovered identityId=${onChainIdentityId} after partial failure`);
           }
         } catch { /* ignore */ }
       }
-      if (identityId > 0n) {
-        this.publisher.setIdentityId(identityId);
-        this.log.info(ctx, `Publisher using identityId=${identityId}`);
+      if (onChainIdentityId > 0n) {
+        if (typeof this.chain.ensureOperationalWalletsRegistered === 'function') {
+          try {
+            const registration = await this.chain.ensureOperationalWalletsRegistered({
+              identityId: onChainIdentityId,
+              additionalAddresses: ackSignerCandidates.map((wallet) => wallet.address),
+            });
+            if (registration.registered.length > 0) {
+              this.log.info(
+                ctx,
+                `Registered ${registration.registered.length} operational wallet(s) on-chain for ` +
+                `identityId=${onChainIdentityId}`,
+              );
+            }
+            if (registration.taken.length > 0) {
+              this.log.warn(
+                ctx,
+                `Operational wallet(s) already registered to another identity: ` +
+                registration.taken.map((w) => `${w.address}->${w.identityId}`).join(', '),
+              );
+            }
+          } catch (err) {
+            this.log.warn(
+              ctx,
+              `Operational wallet auto-registration failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+
+        this.publisher.setIdentityId(onChainIdentityId);
+        this.log.info(ctx, `Publisher using identityId=${onChainIdentityId}`);
       } else if (effectiveRole === 'core') {
         this.log.warn(ctx, `No valid on-chain identity — on-chain publishes will be skipped`);
       }
@@ -681,13 +806,22 @@ export class DKGAgent {
     // sign ACKs (the handler would reject immediately) and advertising the
     // protocol confuses peer-role detection based on protocol support.
     if (effectiveRole === 'core') {
-      const ackSignerKeyStr = this.config.ackSignerKey
-        ?? (typeof this.chain.getACKSignerKey === 'function' ? this.chain.getACKSignerKey() : undefined);
-      if (ackSignerKeyStr) {
-        try {
-          const ackSignerWallet = new ethers.Wallet(ackSignerKeyStr);
-          const identityId = await this.chain.getIdentityId();
-          if (identityId > 0n) {
+      if (ackSignerCandidates.length > 0) {
+        let storageACKProtocolRegistered = false;
+        let storageACKProtocolUnregistered = false;
+        const attemptStorageACKRegistration = async (
+          attemptCtx: OperationContext,
+        ): Promise<'registered' | 'retryable' | 'disabled'> => {
+          if (storageACKProtocolRegistered) return 'registered';
+          if (onChainIdentityId > 0n) {
+            const signerResolution = await this.resolveConfirmedACKSigner(
+              onChainIdentityId,
+              ackSignerCandidates,
+              attemptCtx,
+            );
+            const ackSignerWallet = signerResolution.wallet;
+            if (!ackSignerWallet) return signerResolution.retryable ? 'retryable' : 'disabled';
+
             // The V10 ACK digest includes a (chainid, kav10Address) H5 prefix
             // per KnowledgeAssetsV10.sol:362-373. Resolve both from the chain
             // adapter BEFORE constructing the handler so the handler can sign
@@ -702,28 +836,96 @@ export class DKGAgent {
               : undefined;
             if (chainIdForHandler === undefined || kav10AddressForHandler === undefined) {
               this.log.warn(
-                ctx,
+                attemptCtx,
                 `Skipping V10 StorageACK handler: chain adapter does not expose ` +
                 `getEvmChainId() + getKnowledgeAssetsV10Address(); handler cannot build the ` +
                 `H5-prefixed ACK digest that KnowledgeAssetsV10 verifies on-chain`,
               );
-            } else {
-              const ackHandler = new StorageACKHandler(this.store, {
-                nodeRole: effectiveRole,
-                nodeIdentityId: typeof identityId === 'bigint' ? identityId : BigInt(identityId),
-                signerWallet: ackSignerWallet,
-                contextGraphSharedMemoryUri,
-                chainId: chainIdForHandler,
-                kav10Address: kav10AddressForHandler,
-              }, this.eventBus);
-              this.router.register(PROTOCOL_STORAGE_ACK, ackHandler.handler);
-              this.log.info(ctx, `Registered V10 StorageACK handler (identity=${identityId})`);
+              return 'disabled';
             }
+
+            const ackHandler = new StorageACKHandler(this.store, {
+              nodeRole: effectiveRole,
+              nodeIdentityId: onChainIdentityId,
+              signerWallet: ackSignerWallet,
+              contextGraphSharedMemoryUri,
+              chainId: chainIdForHandler,
+              kav10Address: kav10AddressForHandler,
+              isSignerRegistered: async () => {
+                const isOperationalWalletRegistered = this.chain.isOperationalWalletRegistered;
+                if (typeof isOperationalWalletRegistered !== 'function') return false;
+                return isOperationalWalletRegistered.call(
+                  this.chain,
+                  onChainIdentityId,
+                  ackSignerWallet.address,
+                );
+              },
+              onSignerUnregistered: () => {
+                if (storageACKProtocolUnregistered) return;
+                storageACKProtocolUnregistered = true;
+                storageACKProtocolRegistered = false;
+                this.router.unregister(PROTOCOL_STORAGE_ACK);
+                this.log.warn(
+                  attemptCtx,
+                  `Unregistered V10 StorageACK handler: signer ${ackSignerWallet.address} ` +
+                  `is no longer confirmed on-chain for identity=${onChainIdentityId}`,
+                );
+              },
+              onSignerRegistrationLookupFailed: (err) => {
+                this.log.warn(
+                  attemptCtx,
+                  `V10 StorageACK signer registration lookup failed for ${ackSignerWallet.address}; ` +
+                  `keeping handler active: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              },
+            }, this.eventBus);
+            this.router.register(PROTOCOL_STORAGE_ACK, ackHandler.handler);
+            storageACKProtocolRegistered = true;
+            this.clearStorageACKRegistrationRetry();
+            this.log.info(
+              attemptCtx,
+              `Registered V10 StorageACK handler (identity=${onChainIdentityId}, signer=${ackSignerWallet.address})`,
+            );
+            return 'registered';
           } else {
-            this.log.warn(ctx, `Skipping V10 StorageACK handler registration — identity not yet provisioned`);
+            this.log.warn(attemptCtx, `Skipping V10 StorageACK handler registration — identity not yet provisioned`);
+            return 'disabled';
           }
+          return 'disabled';
+        };
+
+        const scheduleStorageACKRegistrationRetry = () => {
+          if (this.storageACKRegistrationRetryTimer || storageACKProtocolRegistered) return;
+          this.log.warn(ctx, `V10 StorageACK handler registration will retry every ${STORAGE_ACK_REGISTRATION_RETRY_MS}ms`);
+          this.storageACKRegistrationRetryTimer = setTimeout(() => {
+            this.storageACKRegistrationRetryTimer = null;
+            if (!this.started || storageACKProtocolRegistered || this.storageACKRegistrationRetryInFlight) return;
+            this.storageACKRegistrationRetryInFlight = true;
+            attemptStorageACKRegistration(createOperationContext('connect'))
+              .then((result) => {
+                if (result === 'retryable') scheduleStorageACKRegistrationRetry();
+              })
+              .catch((err: unknown) => {
+                this.log.warn(
+                  ctx,
+                  `V10 StorageACK handler registration retry failed: ` +
+                  `${err instanceof Error ? err.message : String(err)}`,
+                );
+                scheduleStorageACKRegistrationRetry();
+              })
+              .finally(() => {
+                this.storageACKRegistrationRetryInFlight = false;
+              });
+          }, STORAGE_ACK_REGISTRATION_RETRY_MS);
+          if (this.storageACKRegistrationRetryTimer.unref) this.storageACKRegistrationRetryTimer.unref();
+        };
+
+        try {
+          const result = await attemptStorageACKRegistration(ctx);
+          if (result === 'retryable') scheduleStorageACKRegistrationRetry();
         } catch (err) {
           this.log.warn(ctx, `Skipping V10 StorageACK handler: ${err instanceof Error ? err.message : String(err)}`);
+          scheduleStorageACKRegistrationRetry();
         }
       } else if (typeof this.chain.signACKDigest === 'function') {
         this.log.info(ctx, `V10 StorageACK: adapter has signACKDigest but no extractable key — handler registration deferred until callback signing is supported`);
@@ -1180,6 +1382,12 @@ export class DKGAgent {
     if (!this.randomSamplingBindRetryTimer) return;
     clearInterval(this.randomSamplingBindRetryTimer);
     this.randomSamplingBindRetryTimer = null;
+  }
+
+  private clearStorageACKRegistrationRetry(): void {
+    if (!this.storageACKRegistrationRetryTimer) return;
+    clearTimeout(this.storageACKRegistrationRetryTimer);
+    this.storageACKRegistrationRetryTimer = null;
   }
 
   /**
@@ -7229,6 +7437,8 @@ export class DKGAgent {
       this.swmCleanupTimer = null;
     }
     this.clearRandomSamplingBindRetry();
+    this.clearStorageACKRegistrationRetry();
+    this.storageACKRegistrationRetryInFlight = false;
     if (this.randomSamplingHandle) {
       try { await this.randomSamplingHandle.stop(); } catch { /* swallow on shutdown */ }
       this.randomSamplingHandle = null;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -795,7 +795,9 @@ export class DKGAgent {
         } catch { /* ignore */ }
       }
       if (onChainIdentityId > 0n) {
-        await ensureACKCandidateWalletsRegistered(ctx);
+        if (effectiveRole === 'core') {
+          await ensureACKCandidateWalletsRegistered(ctx);
+        }
 
         this.publisher.setIdentityId(onChainIdentityId);
         this.log.info(ctx, `Publisher using identityId=${onChainIdentityId}`);
@@ -811,13 +813,16 @@ export class DKGAgent {
     if (effectiveRole === 'core') {
       if (ackSignerCandidates.length > 0) {
         let storageACKProtocolRegistered = false;
-        let storageACKProtocolUnregistered = false;
+        let storageACKFailoverInFlight = false;
         const attemptStorageACKRegistration = async (
           attemptCtx: OperationContext,
+          options: { repairWallets?: boolean } = {},
         ): Promise<'registered' | 'retryable' | 'disabled'> => {
           if (storageACKProtocolRegistered) return 'registered';
           if (onChainIdentityId > 0n) {
-            const registrationSucceeded = await ensureACKCandidateWalletsRegistered(attemptCtx);
+            const registrationSucceeded = options.repairWallets === false
+              ? true
+              : await ensureACKCandidateWalletsRegistered(attemptCtx);
             const signerResolution = await this.resolveConfirmedACKSigner(
               onChainIdentityId,
               ackSignerCandidates,
@@ -867,8 +872,8 @@ export class DKGAgent {
                 );
               },
               onSignerUnregistered: () => {
-                if (storageACKProtocolUnregistered) return;
-                storageACKProtocolUnregistered = true;
+                if (storageACKFailoverInFlight) return;
+                storageACKFailoverInFlight = true;
                 storageACKProtocolRegistered = false;
                 this.router.unregister(PROTOCOL_STORAGE_ACK);
                 this.log.warn(
@@ -876,6 +881,26 @@ export class DKGAgent {
                   `Unregistered V10 StorageACK handler: signer ${ackSignerWallet.address} ` +
                   `is no longer confirmed on-chain for identity=${onChainIdentityId}`,
                 );
+                attemptStorageACKRegistration(
+                  createOperationContext('connect'),
+                  { repairWallets: false },
+                )
+                  .then((result) => {
+                    if (result === 'retryable') {
+                      scheduleStorageACKRegistrationRetry({ repairWallets: false });
+                    }
+                  })
+                  .catch((err: unknown) => {
+                    this.log.warn(
+                      attemptCtx,
+                      `V10 StorageACK signer failover failed: ` +
+                      `${err instanceof Error ? err.message : String(err)}`,
+                    );
+                    scheduleStorageACKRegistrationRetry({ repairWallets: false });
+                  })
+                  .finally(() => {
+                    storageACKFailoverInFlight = false;
+                  });
               },
               onSignerRegistrationLookupFailed: (err) => {
                 this.log.warn(
@@ -900,16 +925,16 @@ export class DKGAgent {
           return 'disabled';
         };
 
-        const scheduleStorageACKRegistrationRetry = () => {
+        const scheduleStorageACKRegistrationRetry = (options: { repairWallets?: boolean } = {}) => {
           if (this.storageACKRegistrationRetryTimer || storageACKProtocolRegistered) return;
           this.log.warn(ctx, `V10 StorageACK handler registration will retry every ${STORAGE_ACK_REGISTRATION_RETRY_MS}ms`);
           this.storageACKRegistrationRetryTimer = setTimeout(() => {
             this.storageACKRegistrationRetryTimer = null;
             if (!this.started || storageACKProtocolRegistered || this.storageACKRegistrationRetryInFlight) return;
             this.storageACKRegistrationRetryInFlight = true;
-            attemptStorageACKRegistration(createOperationContext('connect'))
+            attemptStorageACKRegistration(createOperationContext('connect'), options)
               .then((result) => {
-                if (result === 'retryable') scheduleStorageACKRegistrationRetry();
+                if (result === 'retryable') scheduleStorageACKRegistrationRetry(options);
               })
               .catch((err: unknown) => {
                 this.log.warn(
@@ -917,7 +942,7 @@ export class DKGAgent {
                   `V10 StorageACK handler registration retry failed: ` +
                   `${err instanceof Error ? err.message : String(err)}`,
                 );
-                scheduleStorageACKRegistrationRetry();
+                scheduleStorageACKRegistrationRetry(options);
               })
               .finally(() => {
                 this.storageACKRegistrationRetryInFlight = false;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -734,6 +734,40 @@ export class DKGAgent {
     const effectiveRole = this.config.nodeRole ?? 'edge';
     const ackSignerCandidates = this.getACKSignerCandidateWallets(ctx);
     let onChainIdentityId = 0n;
+    const ensureACKCandidateWalletsRegistered = async (
+      attemptCtx: OperationContext,
+    ): Promise<boolean> => {
+      if (onChainIdentityId <= 0n || typeof this.chain.ensureOperationalWalletsRegistered !== 'function') {
+        return true;
+      }
+      try {
+        const registration = await this.chain.ensureOperationalWalletsRegistered({
+          identityId: onChainIdentityId,
+          additionalAddresses: ackSignerCandidates.map((wallet) => wallet.address),
+        });
+        if (registration.registered.length > 0) {
+          this.log.info(
+            attemptCtx,
+            `Registered ${registration.registered.length} operational wallet(s) on-chain for ` +
+            `identityId=${onChainIdentityId}`,
+          );
+        }
+        if (registration.taken.length > 0) {
+          this.log.warn(
+            attemptCtx,
+            `Operational wallet(s) already registered to another identity: ` +
+            registration.taken.map((w) => `${w.address}->${w.identityId}`).join(', '),
+          );
+        }
+        return true;
+      } catch (err) {
+        this.log.warn(
+          attemptCtx,
+          `Operational wallet auto-registration failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return false;
+      }
+    };
 
     // Auto-detect or register on-chain identity.
     // Edge nodes skip profile creation — they operate with agent identity only.
@@ -761,33 +795,7 @@ export class DKGAgent {
         } catch { /* ignore */ }
       }
       if (onChainIdentityId > 0n) {
-        if (typeof this.chain.ensureOperationalWalletsRegistered === 'function') {
-          try {
-            const registration = await this.chain.ensureOperationalWalletsRegistered({
-              identityId: onChainIdentityId,
-              additionalAddresses: ackSignerCandidates.map((wallet) => wallet.address),
-            });
-            if (registration.registered.length > 0) {
-              this.log.info(
-                ctx,
-                `Registered ${registration.registered.length} operational wallet(s) on-chain for ` +
-                `identityId=${onChainIdentityId}`,
-              );
-            }
-            if (registration.taken.length > 0) {
-              this.log.warn(
-                ctx,
-                `Operational wallet(s) already registered to another identity: ` +
-                registration.taken.map((w) => `${w.address}->${w.identityId}`).join(', '),
-              );
-            }
-          } catch (err) {
-            this.log.warn(
-              ctx,
-              `Operational wallet auto-registration failed: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
-        }
+        await ensureACKCandidateWalletsRegistered(ctx);
 
         this.publisher.setIdentityId(onChainIdentityId);
         this.log.info(ctx, `Publisher using identityId=${onChainIdentityId}`);
@@ -809,13 +817,16 @@ export class DKGAgent {
         ): Promise<'registered' | 'retryable' | 'disabled'> => {
           if (storageACKProtocolRegistered) return 'registered';
           if (onChainIdentityId > 0n) {
+            const registrationSucceeded = await ensureACKCandidateWalletsRegistered(attemptCtx);
             const signerResolution = await this.resolveConfirmedACKSigner(
               onChainIdentityId,
               ackSignerCandidates,
               attemptCtx,
             );
             const ackSignerWallet = signerResolution.wallet;
-            if (!ackSignerWallet) return signerResolution.retryable ? 'retryable' : 'disabled';
+            if (!ackSignerWallet) {
+              return (registrationSucceeded && !signerResolution.retryable) ? 'disabled' : 'retryable';
+            }
 
             // The V10 ACK digest includes a (chainid, kav10Address) H5 prefix
             // per KnowledgeAssetsV10.sol:362-373. Resolve both from the chain

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -352,9 +352,10 @@ export interface DKGAgentConfig {
   /**
    * EVM chain configuration. If omitted, publishing won't have on-chain finality.
    * `adminPrivateKey` is the private key for the profile admin wallet used
-   * only for profile/key-management transactions. Core nodes using chainConfig
-   * must provide it; edge nodes may omit it and run without profile
-   * creation/key-repair privileges.
+   * only for profile/key-management transactions. Nodes may omit it when they
+   * already have an on-chain identity and do not need profile creation/key-repair
+   * privileges; profile mutation paths will fail fast if admin authority is
+   * required but unavailable.
    * `operationalKeys` are the private keys for operational wallets.
    * The first key is the primary signer (identity, staking); all are used
    * round-robin for publish TXs to avoid nonce collisions on parallel publishes.
@@ -549,12 +550,6 @@ export class DKGAgent {
       if (config.chainConfig.adminPrivateKey) {
         chain = new EVMChainAdapter({ ...evmConfigBase, adminPrivateKey: config.chainConfig.adminPrivateKey });
       } else {
-        if (nodeRole === 'core') {
-          throw new Error(
-            'EVM adminPrivateKey is required for core nodes using chainConfig. ' +
-            'Provide the persisted profile admin key, or pass a pre-built chainAdapter for explicit no-admin mode.',
-          );
-        }
         chain = new EVMChainAdapter({ ...evmConfigBase, allowNoAdminSigner: true });
       }
     } else {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,5 @@
 export { DKGAgentWallet, type AgentWallet } from './agent-wallet.js';
-export { loadOpWallets, generateWallets, type OpWalletsConfig } from './op-wallets.js';
+export { loadOpWallets, generateWallets, type OpWalletsConfig, type WalletEntry } from './op-wallets.js';
 export {
   generateCustodialAgent, registerSelfSovereignAgent, agentFromPrivateKey,
   generateAgentToken, hashAgentToken, type AgentKeyRecord,

--- a/packages/agent/src/op-wallets.ts
+++ b/packages/agent/src/op-wallets.ts
@@ -72,6 +72,9 @@ export async function loadOpWallets(
 }
 
 export function generateWallets(count: number): OpWalletsConfig {
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error('wallet count must be at least 1');
+  }
   const adminWallet = createWalletEntry();
   const wallets: WalletEntry[] = [];
   for (let i = 0; i < count; i++) {

--- a/packages/agent/src/op-wallets.ts
+++ b/packages/agent/src/op-wallets.ts
@@ -1,21 +1,30 @@
 import { ethers } from 'ethers';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { chmod, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
+export interface WalletEntry {
+  address: string;
+  privateKey: string;
+}
+
 export interface OpWalletsConfig {
-  wallets: Array<{
-    address: string;
-    privateKey: string;
-  }>;
+  /** Administrative wallet used for profile/key-management transactions. */
+  adminWallet?: WalletEntry;
+  /** Hot operational wallets used for node operations and publishing. */
+  wallets: WalletEntry[];
 }
 
 const DEFAULT_WALLET_COUNT = 3;
 
 /**
- * Load operational wallets from `wallets.json` in the data directory.
- * If the file doesn't exist, generates `count` fresh wallets and saves them.
+ * Load admin + operational wallets from `wallets.json` in the data directory.
+ * Legacy files without `adminWallet` remain readable, but profile
+ * key-management/repair features need the real admin key to be added.
+ * If the file doesn't exist, generates one admin wallet plus `count`
+ * operational wallets and saves them.
  * The file is human-readable JSON — users can add/remove/replace keys
- * (e.g. import into MetaMask, replace with hardware-wallet-backed keys, etc.).
+ * (e.g. import into MetaMask, replace admin with a hardware-wallet-backed key,
+ * etc.).
  */
 export async function loadOpWallets(
   dataDir: string,
@@ -25,33 +34,70 @@ export async function loadOpWallets(
 
   try {
     const raw = await readFile(filePath, 'utf-8');
-    const config: OpWalletsConfig = JSON.parse(raw);
-    if (config.wallets?.length > 0) {
-      for (const w of config.wallets) {
-        const derived = new ethers.Wallet(w.privateKey);
-        if (derived.address.toLowerCase() !== w.address.toLowerCase()) {
-          throw new Error(
-            `Address mismatch in wallets.json: expected ${derived.address} but got ${w.address}`,
-          );
+    const parsed = JSON.parse(raw) as Partial<OpWalletsConfig> | WalletEntry[];
+    const existingWallets = Array.isArray(parsed) ? parsed : parsed.wallets;
+    if (!Array.isArray(existingWallets)) {
+      throw new Error('wallets.json must contain a wallets array');
+    }
+    if (existingWallets.length === 0) {
+      throw new Error('wallets.json must contain at least one operational wallet');
+    }
+
+    {
+      const wallets = existingWallets.map((w, index) =>
+        validateWalletEntry(w, `wallets[${index}]`),
+      );
+      const adminWallet = !Array.isArray(parsed) && parsed.adminWallet
+        ? validateWalletEntry(parsed.adminWallet, 'adminWallet')
+        : undefined;
+
+      if (adminWallet) {
+        const adminKey = adminWallet.address.toLowerCase();
+        for (const wallet of wallets) {
+          if (wallet.address.toLowerCase() === adminKey) {
+            throw new Error('adminWallet in wallets.json must be distinct from operational wallets');
+          }
         }
       }
-      return config;
+
+      return { adminWallet, wallets };
     }
   } catch (err: any) {
     if (err.code !== 'ENOENT') throw err;
   }
 
   const config = generateWallets(count);
-  await mkdir(dataDir, { recursive: true });
-  await writeFile(filePath, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
+  await saveOpWallets(dataDir, config);
   return config;
 }
 
 export function generateWallets(count: number): OpWalletsConfig {
-  const wallets: OpWalletsConfig['wallets'] = [];
+  const adminWallet = createWalletEntry();
+  const wallets: WalletEntry[] = [];
   for (let i = 0; i < count; i++) {
-    const w = ethers.Wallet.createRandom();
-    wallets.push({ address: w.address, privateKey: w.privateKey });
+    wallets.push(createWalletEntry());
   }
-  return { wallets };
+  return { adminWallet, wallets };
+}
+
+async function saveOpWallets(dataDir: string, config: OpWalletsConfig): Promise<void> {
+  await mkdir(dataDir, { recursive: true });
+  const filePath = join(dataDir, 'wallets.json');
+  await writeFile(filePath, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
+  await chmod(filePath, 0o600);
+}
+
+function createWalletEntry(): WalletEntry {
+  const wallet = ethers.Wallet.createRandom();
+  return { address: wallet.address, privateKey: wallet.privateKey };
+}
+
+function validateWalletEntry(entry: WalletEntry, path: string): WalletEntry {
+  const derived = new ethers.Wallet(entry.privateKey);
+  if (derived.address.toLowerCase() !== entry.address.toLowerCase()) {
+    throw new Error(
+      `Address mismatch in wallets.json ${path}: expected ${derived.address} but got ${entry.address}`,
+    );
+  }
+  return { address: derived.address, privateKey: derived.privateKey };
 }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -15,7 +15,7 @@ import {
   parseCclPolicy,
 } from '../src/index.js';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { getGenesisQuads, computeNetworkId, PROTOCOL_SYNC, SYSTEM_PARANETS, DKG_ONTOLOGY, paranetDataGraphUri, paranetWorkspaceGraphUri, contextGraphMetaUri, sparqlString } from '@origintrail-official/dkg-core';
+import { getGenesisQuads, computeNetworkId, PROTOCOL_SYNC, PROTOCOL_STORAGE_ACK, SYSTEM_PARANETS, DKG_ONTOLOGY, paranetDataGraphUri, paranetWorkspaceGraphUri, contextGraphMetaUri, sparqlString } from '@origintrail-official/dkg-core';
 import { DKGQueryEngine } from '@origintrail-official/dkg-query';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { EVMChainAdapter, MockChainAdapter, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult } from '@origintrail-official/dkg-chain';
@@ -42,6 +42,24 @@ class CapturingContextGraphChainAdapter extends MockChainAdapter {
       participantAgents: params.participantAgents ? [...params.participantAgents] : undefined,
     });
     return super.createOnChainContextGraph(params);
+  }
+}
+
+class NonRegisteringACKChainAdapter extends MockChainAdapter {
+  async ensureOperationalWalletsRegistered(options?: {
+    identityId?: bigint;
+    additionalAddresses?: string[];
+  }) {
+    return {
+      identityId: options?.identityId ?? (await this.getIdentityId()),
+      registered: [],
+      alreadyRegistered: [],
+      taken: [],
+    };
+  }
+
+  async isOperationalWalletRegistered(): Promise<boolean> {
+    return false;
   }
 }
 
@@ -759,6 +777,103 @@ describe('PeerId key extraction', () => {
 
     await agent.stop();
   }, 10000);
+});
+
+describe('DKGAgent ACK signer gating', () => {
+  it('rejects core chainConfig without a profile admin key', async () => {
+    const operational = ethers.Wallet.createRandom();
+
+    await expect(DKGAgent.create({
+      name: 'CoreMissingAdminKey',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainConfig: {
+        rpcUrl: 'http://127.0.0.1:0',
+        hubAddress: ethers.ZeroAddress,
+        operationalKeys: [operational.privateKey],
+      },
+      nodeRole: 'core',
+    })).rejects.toThrow(/adminPrivateKey is required for core nodes/);
+  });
+
+  it('auto-registers an ACK signer before registering the StorageACK handler', async () => {
+    const primary = ethers.Wallet.createRandom();
+    const ackSigner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', primary.address);
+    chain.seedIdentity(primary.address, 42n);
+
+    const agent = await DKGAgent.create({
+      name: 'AckSignerAutoRegister',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainAdapter: chain,
+      nodeRole: 'core',
+      ackSignerKey: ackSigner.privateKey,
+    });
+
+    try {
+      await agent.start();
+
+      expect(await chain.isOperationalWalletRegistered(42n, ackSigner.address)).toBe(true);
+      expect(agent.node.libp2p.getProtocols()).toContain(PROTOCOL_STORAGE_ACK);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not register StorageACK when no ACK key is confirmed on-chain', async () => {
+    const primary = ethers.Wallet.createRandom();
+    const ackSigner = ethers.Wallet.createRandom();
+    const chain = new NonRegisteringACKChainAdapter('mock:31337', primary.address);
+    chain.seedIdentity(primary.address, 43n);
+
+    const agent = await DKGAgent.create({
+      name: 'AckSignerUnconfirmed',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainAdapter: chain,
+      nodeRole: 'core',
+      ackSignerKey: ackSigner.privateKey,
+    });
+
+    try {
+      await agent.start();
+
+      expect(agent.node.libp2p.getProtocols()).not.toContain(PROTOCOL_STORAGE_ACK);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not source ACK signer candidates from chainConfig when a chainAdapter is supplied', async () => {
+    const primary = ethers.Wallet.createRandom();
+    const staleChainConfigSigner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', primary.address);
+    chain.seedIdentity(primary.address, 44n);
+
+    const agent = await DKGAgent.create({
+      name: 'AckSignerChainAdapterIgnoresChainConfig',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainAdapter: chain,
+      chainConfig: {
+        rpcUrl: 'http://127.0.0.1:0',
+        hubAddress: ethers.ZeroAddress,
+        adminPrivateKey: ethers.Wallet.createRandom().privateKey,
+        operationalKeys: [staleChainConfigSigner.privateKey],
+      },
+      nodeRole: 'core',
+    });
+
+    try {
+      await agent.start();
+
+      expect(await chain.isOperationalWalletRegistered(44n, staleChainConfigSigner.address)).toBe(false);
+      expect(agent.node.libp2p.getProtocols()).not.toContain(PROTOCOL_STORAGE_ACK);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });
 
 describe('DKGAgent (integration)', () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -780,10 +780,10 @@ describe('PeerId key extraction', () => {
 });
 
 describe('DKGAgent ACK signer gating', () => {
-  it('rejects core chainConfig without a profile admin key', async () => {
+  it('allows core chainConfig without a profile admin key for existing no-admin identities', async () => {
     const operational = ethers.Wallet.createRandom();
 
-    await expect(DKGAgent.create({
+    const agent = await DKGAgent.create({
       name: 'CoreMissingAdminKey',
       listenHost: '127.0.0.1',
       listenPort: 0,
@@ -793,7 +793,9 @@ describe('DKGAgent ACK signer gating', () => {
         operationalKeys: [operational.privateKey],
       },
       nodeRole: 'core',
-    })).rejects.toThrow(/adminPrivateKey is required for core nodes/);
+    });
+
+    expect(agent).toBeInstanceOf(DKGAgent);
   });
 
   it('auto-registers an ACK signer before registering the StorageACK handler', async () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -63,6 +63,21 @@ class NonRegisteringACKChainAdapter extends MockChainAdapter {
   }
 }
 
+class FlakyRegistrationACKChainAdapter extends MockChainAdapter {
+  ensureCalls = 0;
+
+  async ensureOperationalWalletsRegistered(options?: {
+    identityId?: bigint;
+    additionalAddresses?: string[];
+  }) {
+    this.ensureCalls += 1;
+    if (this.ensureCalls === 1) {
+      throw new Error('temporary registration failure');
+    }
+    return super.ensureOperationalWalletsRegistered(options);
+  }
+}
+
 let _fileSnapshot: string;
 beforeAll(async () => {
   _fileSnapshot = await takeSnapshot();
@@ -817,6 +832,32 @@ describe('DKGAgent ACK signer gating', () => {
       await agent.start();
 
       expect(await chain.isOperationalWalletRegistered(42n, ackSigner.address)).toBe(true);
+      expect(agent.node.libp2p.getProtocols()).toContain(PROTOCOL_STORAGE_ACK);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('retries operational-wallet registration during StorageACK setup', async () => {
+    const primary = ethers.Wallet.createRandom();
+    const ackSigner = ethers.Wallet.createRandom();
+    const chain = new FlakyRegistrationACKChainAdapter('mock:31337', primary.address);
+    chain.seedIdentity(primary.address, 45n);
+
+    const agent = await DKGAgent.create({
+      name: 'AckSignerRegistrationRetry',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainAdapter: chain,
+      nodeRole: 'core',
+      ackSignerKey: ackSigner.privateKey,
+    });
+
+    try {
+      await agent.start();
+
+      expect(chain.ensureCalls).toBeGreaterThanOrEqual(2);
+      expect(await chain.isOperationalWalletRegistered(45n, ackSigner.address)).toBe(true);
       expect(agent.node.libp2p.getProtocols()).toContain(PROTOCOL_STORAGE_ACK);
     } finally {
       await agent.stop().catch(() => {});

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -864,6 +864,31 @@ describe('DKGAgent ACK signer gating', () => {
     }
   });
 
+  it('does not auto-register ACK signer candidates for edge nodes', async () => {
+    const primary = ethers.Wallet.createRandom();
+    const ackSigner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', primary.address);
+    chain.seedIdentity(primary.address, 46n);
+
+    const agent = await DKGAgent.create({
+      name: 'EdgeAckSignerNoAutoRegister',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      chainAdapter: chain,
+      nodeRole: 'edge',
+      ackSignerKey: ackSigner.privateKey,
+    });
+
+    try {
+      await agent.start();
+
+      expect(await chain.isOperationalWalletRegistered(46n, ackSigner.address)).toBe(false);
+      expect(agent.node.libp2p.getProtocols()).not.toContain(PROTOCOL_STORAGE_ACK);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
   it('does not register StorageACK when no ACK key is confirmed on-chain', async () => {
     const primary = ethers.Wallet.createRandom();
     const ackSigner = ethers.Wallet.createRandom();

--- a/packages/agent/test/e2e-chain.test.ts
+++ b/packages/agent/test/e2e-chain.test.ts
@@ -16,9 +16,10 @@ import {
 let ctx: HardhatContext;
 const agents: DKGAgent[] = [];
 
-function makeChainConfig(operationalKey: string) {
+function makeChainConfig(operationalKey: string, adminPrivateKey: string) {
   return {
     rpcUrl: ctx!.rpcUrl,
+    adminPrivateKey,
     operationalKeys: [operationalKey],
     hubAddress: ctx!.hubAddress,
     chainId: `evm:31337`,
@@ -66,7 +67,7 @@ describe('E2E: DKGAgent with real blockchain', () => {
       name: 'ChainNodeA',
       listenPort: 0,
       skills: [],
-      chainConfig: makeChainConfig(HARDHAT_KEYS.EXTRA1),
+      chainConfig: makeChainConfig(HARDHAT_KEYS.EXTRA1, HARDHAT_KEYS.EXTRA3),
     });
     agents.push(agentA);
 
@@ -74,7 +75,7 @@ describe('E2E: DKGAgent with real blockchain', () => {
       name: 'ChainNodeB',
       listenPort: 0,
       skills: [],
-      chainConfig: makeChainConfig(HARDHAT_KEYS.EXTRA2),
+      chainConfig: makeChainConfig(HARDHAT_KEYS.EXTRA2, HARDHAT_KEYS.PUBLISHER2),
     });
     agents.push(agentB);
 

--- a/packages/agent/test/e2e-finalization.test.ts
+++ b/packages/agent/test/e2e-finalization.test.ts
@@ -156,7 +156,8 @@ describe('E2E: workspace-first publish with real blockchain', () => {
 
     const hub = new Contract(hubAddress, ['function getContractAddress(string) view returns (address)'], provider);
     const tokenAddr = await hub.getContractAddress('Token');
-    const stakingAddr = await hub.getContractAddress('Staking');
+    const stakingV10Addr = await hub.getContractAddress('StakingV10');
+    const stakingNFTAddr = await hub.getContractAddress('DKGStakingConvictionNFT');
     const profileAddr = await hub.getContractAddress('Profile');
     const parametersAddr = await hub.getContractAddress('ParametersStorage');
     const deployerWallet = new Wallet(DEPLOYER_OP_KEY, provider);
@@ -170,13 +171,17 @@ describe('E2E: workspace-first publish with real blockchain', () => {
       'function mint(address, uint256)',
       'function approve(address, uint256) returns (bool)',
     ], deployerWallet);
-    const staking = new Contract(stakingAddr, ['function stake(uint72 identityId, uint96 amount)'], deployerWallet);
+    const stakingNFT = new Contract(
+      stakingNFTAddr,
+      ['function createConviction(uint72 identityId, uint96 amount, uint40 lockTier)'],
+      deployerWallet,
+    );
     const profile = new Contract(profileAddr, ['function updateAsk(uint72 identityId, uint96 ask)'], deployerWallet);
 
     const stakeAmount = ethers.parseEther('50000');
     await (await token.mint(deployerWallet.address, stakeAmount)).wait();
-    await (await token.connect(deployerWallet).approve(stakingAddr, stakeAmount)).wait();
-    await (await staking.stake(deployerProfileId, stakeAmount)).wait();
+    await (await token.connect(deployerWallet).approve(stakingV10Addr, stakeAmount)).wait();
+    await (await stakingNFT.createConviction(deployerProfileId, stakeAmount, 1)).wait();
     await (await profile.updateAsk(deployerProfileId, ethers.parseEther('1'))).wait();
 
     // Create profiles, stake, and set ask for both node wallets
@@ -189,15 +194,17 @@ describe('E2E: workspace-first publish with real blockchain', () => {
       const nodeToken = new Contract(tokenAddr, [
         'function approve(address, uint256) returns (bool)',
       ], nodeWallet);
-      const nodeStaking = new Contract(stakingAddr, [
-        'function stake(uint72 identityId, uint96 amount)',
-      ], nodeWallet);
+      const nodeStakingNFT = new Contract(
+        stakingNFTAddr,
+        ['function createConviction(uint72 identityId, uint96 amount, uint40 lockTier)'],
+        nodeWallet,
+      );
       const nodeProfile = new Contract(profileAddr, [
         'function updateAsk(uint72 identityId, uint96 ask)',
       ], nodeWallet);
 
-      await (await nodeToken.approve(stakingAddr, ethers.parseEther('100000'))).wait();
-      await (await nodeStaking.stake(nodeProfileId, ethers.parseEther('50000'))).wait();
+      await (await nodeToken.approve(stakingV10Addr, ethers.parseEther('100000'))).wait();
+      await (await nodeStakingNFT.createConviction(nodeProfileId, ethers.parseEther('50000'), 1)).wait();
       await (await nodeProfile.updateAsk(nodeProfileId, ethers.parseEther('1'))).wait();
     }
   }, 120_000);

--- a/packages/agent/test/e2e-operational-wallet-acks.test.ts
+++ b/packages/agent/test/e2e-operational-wallet-acks.test.ts
@@ -1,0 +1,209 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { DKGAgent } from '../src/index.js';
+import { NoChainAdapter } from '@origintrail-official/dkg-chain';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import {
+  computePublishACKDigest,
+  contextGraphSharedMemoryUri,
+  decodeStorageACK,
+  encodePublishIntent,
+  PROTOCOL_STORAGE_ACK,
+  type StorageACKMsg,
+} from '@origintrail-official/dkg-core';
+import {
+  computeFlatKCMerkleLeafCountV10,
+  computeFlatKCRootV10,
+} from '../../publisher/src/merkle.js';
+import {
+  createEVMAdapter,
+  createProvider,
+  getSharedContext,
+  HARDHAT_KEYS,
+  revertSnapshot,
+  takeSnapshot,
+} from '../../chain/test/evm-test-context.js';
+import { mintTokens } from '../../chain/test/hardhat-harness.js';
+
+const ACK_CONTEXT_GRAPH_ID = '42';
+const ACK_ENTITY = 'urn:e2e:operational-wallet-ack:entity';
+const ACK_TOKEN_AMOUNT = 1000n;
+const ACK_EPOCHS = 1;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function uint64ToBigInt(value: StorageACKMsg['nodeIdentityId']): bigint {
+  if (typeof value === 'number') return BigInt(value);
+  return (BigInt(value.high >>> 0) << 32n) + BigInt(value.low >>> 0);
+}
+
+function recoverACKSigner(ack: StorageACKMsg, digest: Uint8Array): string {
+  const prefixedHash = ethers.hashMessage(digest);
+  return ethers.recoverAddress(prefixedHash, {
+    r: ethers.hexlify(ack.coreNodeSignatureR),
+    yParityAndS: ethers.hexlify(ack.coreNodeSignatureVS),
+  });
+}
+
+function publicByteSize(quads: Quad[]): number {
+  return new TextEncoder().encode(
+    quads.map((q) => `${q.subject} ${q.predicate} ${q.object}`).join('\n'),
+  ).length;
+}
+
+async function removeOperationalKey(identityId: bigint, walletAddress: string): Promise<void> {
+  const provider = createProvider();
+  const { hubAddress } = getSharedContext();
+  const hub = new ethers.Contract(
+    hubAddress,
+    ['function getContractAddress(string) view returns (address)'],
+    provider,
+  );
+  const identityAddress = await hub.getContractAddress('Identity');
+  const admin = new ethers.Wallet(HARDHAT_KEYS.CORE_ADMIN, provider);
+  const identity = new ethers.Contract(
+    identityAddress,
+    ['function removeKey(uint72 identityId, bytes32 key) external'],
+    admin,
+  );
+  const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [walletAddress]));
+  await (await identity.removeKey(identityId, keyHash)).wait();
+}
+
+let fileSnapshot: string;
+
+beforeAll(async () => {
+  fileSnapshot = await takeSnapshot();
+  const { hubAddress } = getSharedContext();
+  const provider = createProvider();
+  const coreOp = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
+  await mintTokens(
+    provider,
+    hubAddress,
+    HARDHAT_KEYS.DEPLOYER,
+    coreOp.address,
+    ethers.parseEther('50000000'),
+  );
+});
+
+afterAll(async () => {
+  await revertSnapshot(fileSnapshot);
+});
+
+describe('E2E: operational wallet ACK signing', () => {
+  let core: DKGAgent | undefined;
+  let requester: DKGAgent | undefined;
+
+  afterAll(async () => {
+    await requester?.stop().catch(() => {});
+    await core?.stop().catch(() => {});
+  });
+
+  it('auto-registers the ACK signer and signs only while the key is confirmed on-chain', async () => {
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const { coreProfileId } = getSharedContext();
+    const identityId = BigInt(coreProfileId);
+    const ackWallet = new ethers.Wallet(HARDHAT_KEYS.EXTRA1);
+
+    expect(await chain.isOperationalWalletRegistered(identityId, ackWallet.address)).toBe(false);
+
+    core = await DKGAgent.create({
+      name: 'OperationalAckCore',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      skills: [],
+      chainAdapter: chain,
+      nodeRole: 'core',
+      ackSignerKey: HARDHAT_KEYS.EXTRA1,
+    });
+    requester = await DKGAgent.create({
+      name: 'OperationalAckRequester',
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      skills: [],
+      chainAdapter: new NoChainAdapter(),
+      nodeRole: 'edge',
+    });
+
+    await core.start();
+
+    expect(await chain.isOperationalWalletRegistered(identityId, ackWallet.address)).toBe(true);
+    expect(core.node.libp2p.getProtocols()).toContain(PROTOCOL_STORAGE_ACK);
+
+    await requester.start();
+    const coreAddress = core.multiaddrs.find((addr) =>
+      addr.includes('/tcp/') && !addr.includes('/p2p-circuit'),
+    );
+    expect(coreAddress).toBeDefined();
+    await requester.connectTo(coreAddress!);
+    await sleep(800);
+
+    const quads: Quad[] = [
+      {
+        subject: ACK_ENTITY,
+        predicate: 'http://schema.org/name',
+        object: '"Operational ACK"',
+        graph: '',
+      },
+      {
+        subject: ACK_ENTITY,
+        predicate: 'http://schema.org/version',
+        object: '"1"',
+        graph: '',
+      },
+    ];
+    await core.store.insert(
+      quads.map((quad) => ({
+        ...quad,
+        graph: contextGraphSharedMemoryUri(ACK_CONTEXT_GRAPH_ID),
+      })),
+    );
+
+    const merkleRoot = computeFlatKCRootV10(quads, []);
+    const merkleLeafCount = computeFlatKCMerkleLeafCountV10(quads, []);
+    const byteSize = publicByteSize(quads);
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId: ACK_CONTEXT_GRAPH_ID,
+      publisherPeerId: requester.peerId,
+      publicByteSize: byteSize,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: [ACK_ENTITY],
+      epochs: ACK_EPOCHS,
+      tokenAmountStr: ACK_TOKEN_AMOUNT.toString(),
+      merkleLeafCount,
+    });
+
+    const response = await requester.router.send(core.peerId, PROTOCOL_STORAGE_ACK, intent, 20_000);
+    const ack = decodeStorageACK(response);
+
+    expect(uint64ToBigInt(ack.nodeIdentityId)).toBe(identityId);
+    expect(ethers.hexlify(ack.merkleRoot)).toBe(ethers.hexlify(merkleRoot));
+
+    const digest = computePublishACKDigest(
+      await chain.getEvmChainId(),
+      await chain.getKnowledgeAssetsV10Address(),
+      BigInt(ACK_CONTEXT_GRAPH_ID),
+      merkleRoot,
+      1n,
+      BigInt(byteSize),
+      BigInt(ACK_EPOCHS),
+      ACK_TOKEN_AMOUNT,
+      BigInt(merkleLeafCount),
+    );
+    const recovered = recoverACKSigner(ack, digest);
+
+    expect(recovered.toLowerCase()).toBe(ackWallet.address.toLowerCase());
+    expect(await chain.verifyACKIdentity(recovered, identityId)).toBe(true);
+
+    await removeOperationalKey(identityId, ackWallet.address);
+    expect(await chain.isOperationalWalletRegistered(identityId, ackWallet.address)).toBe(false);
+    await expect(
+      requester.router.send(core.peerId, PROTOCOL_STORAGE_ACK, intent, 20_000),
+    ).rejects.toThrow();
+    expect(core.node.libp2p.getProtocols()).not.toContain(PROTOCOL_STORAGE_ACK);
+  }, 60_000);
+});

--- a/packages/agent/test/op-wallets.test.ts
+++ b/packages/agent/test/op-wallets.test.ts
@@ -32,6 +32,14 @@ describe('operational wallet config', () => {
     expect(raw.wallets).toHaveLength(2);
   });
 
+  it('rejects invalid generated wallet counts before writing wallets.json', async () => {
+    const dir = await tempDir();
+
+    expect(() => generateWallets(0)).toThrow('wallet count must be at least 1');
+    await expect(loadOpWallets(dir, 0)).rejects.toThrow('wallet count must be at least 1');
+    await expect(readFile(join(dir, 'wallets.json'), 'utf-8')).rejects.toThrow();
+  });
+
   it('loads legacy operational-only wallets.json without inventing an admin wallet', async () => {
     const dir = await tempDir();
     const operational = ethers.Wallet.createRandom();

--- a/packages/agent/test/op-wallets.test.ts
+++ b/packages/agent/test/op-wallets.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { generateWallets, loadOpWallets } from '../src/op-wallets.js';
+
+const tempDirs: string[] = [];
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'dkg-op-wallets-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('operational wallet config', () => {
+  it('generates and persists one admin wallet plus operational wallets', async () => {
+    const dir = await tempDir();
+
+    const config = await loadOpWallets(dir, 2);
+
+    expect(config.adminWallet?.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(config.wallets).toHaveLength(2);
+    expect(config.wallets.map((w) => w.address)).not.toContain(config.adminWallet?.address);
+
+    const raw = JSON.parse(await readFile(join(dir, 'wallets.json'), 'utf-8'));
+    expect(raw.adminWallet.address).toBe(config.adminWallet?.address);
+    expect(raw.wallets).toHaveLength(2);
+  });
+
+  it('loads legacy operational-only wallets.json without inventing an admin wallet', async () => {
+    const dir = await tempDir();
+    const operational = ethers.Wallet.createRandom();
+    await writeFile(join(dir, 'wallets.json'), JSON.stringify({
+      wallets: [{ address: operational.address, privateKey: operational.privateKey }],
+    }));
+
+    const config = await loadOpWallets(dir);
+    expect(config.adminWallet).toBeUndefined();
+    expect(config.wallets).toEqual([{ address: operational.address, privateKey: operational.privateKey }]);
+
+    const raw = JSON.parse(await readFile(join(dir, 'wallets.json'), 'utf-8'));
+    expect(raw.adminWallet).toBeUndefined();
+  });
+
+  it('rejects existing wallets.json files with no operational wallets', async () => {
+    const dir = await tempDir();
+    const admin = ethers.Wallet.createRandom();
+    await writeFile(join(dir, 'wallets.json'), JSON.stringify({
+      adminWallet: { address: admin.address, privateKey: admin.privateKey },
+      wallets: [],
+    }));
+
+    await expect(loadOpWallets(dir)).rejects.toThrow('at least one operational wallet');
+  });
+
+  it('rejects admin wallets that duplicate an operational wallet', async () => {
+    const dir = await tempDir();
+    const generated = generateWallets(1);
+    const operational = generated.wallets[0];
+    await writeFile(join(dir, 'wallets.json'), JSON.stringify({
+      adminWallet: operational,
+      wallets: [operational],
+    }));
+
+    await expect(loadOpWallets(dir)).rejects.toThrow('adminWallet in wallets.json must be distinct');
+  });
+});

--- a/packages/chain/README.md
+++ b/packages/chain/README.md
@@ -17,6 +17,7 @@ import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 const chain = new EVMChainAdapter({
   rpcUrl: 'https://sepolia.base.org',
   privateKey: process.env.PRIVATE_KEY,
+  adminPrivateKey: process.env.ADMIN_PRIVATE_KEY,
   hubAddress: '0x...',
 });
 

--- a/packages/chain/abi/Profile.json
+++ b/packages/chain/abi/Profile.json
@@ -113,6 +113,22 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "OperationalAddressZero",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "OperationalKeyTaken",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint16",
@@ -121,6 +137,17 @@
       }
     ],
     "name": "OperatorFeeOutOfRange",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "ProfileDoesntExist",
     "type": "error"
   },
   {
@@ -161,6 +188,24 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "address[]",
+        "name": "operationalWallets",
+        "type": "address[]"
+      }
+    ],
+    "name": "addOperationalWallets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "askContract",
     "outputs": [
@@ -179,6 +224,19 @@
     "outputs": [
       {
         "internalType": "contract Chronos",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "convictionStakingStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakingStorage",
         "name": "",
         "type": "address"
       }
@@ -217,19 +275,6 @@
     "name": "createProfile",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "delegatorsInfo",
-    "outputs": [
-      {
-        "internalType": "contract DelegatorsInfo",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -538,10 +538,11 @@ export interface ChainAdapter {
 
   /**
    * Confirm that an address is registered as an OPERATIONAL_KEY for an identity.
-   * Required for V10 ACK signing; adapters that cannot inspect an on-chain
-   * registry must return false or throw so ACK signing remains closed-safe.
+   * V10 ACK signing refuses to proceed when this capability is missing, but the
+   * method stays optional to preserve the public ChainAdapter interface for
+   * adapters that never advertise StorageACK support.
    */
-  isOperationalWalletRegistered(identityId: bigint, address: string): Promise<boolean>;
+  isOperationalWalletRegistered?(identityId: bigint, address: string): Promise<boolean>;
 
   /**
    * Verify that a recovered signer address owns the claimed identity without

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -539,9 +539,9 @@ export interface ChainAdapter {
   /**
    * Confirm that an address is registered as an OPERATIONAL_KEY for an identity.
    * Required for V10 ACK signing; adapters that cannot inspect an on-chain
-   * registry should omit this capability and ACK signing will remain disabled.
+   * registry must return false or throw so ACK signing remains closed-safe.
    */
-  isOperationalWalletRegistered?(identityId: bigint, address: string): Promise<boolean>;
+  isOperationalWalletRegistered(identityId: bigint, address: string): Promise<boolean>;
 
   /**
    * Verify that a recovered signer address owns the claimed identity without

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -384,6 +384,13 @@ export interface UpdateKCParams {
   signatures: Array<{ identityId: bigint; r: Uint8Array; vs: Uint8Array }>;
 }
 
+export interface OperationalWalletRegistrationResult {
+  identityId: bigint;
+  registered: string[];
+  alreadyRegistered: string[];
+  taken: Array<{ address: string; identityId: bigint }>;
+}
+
 /**
  * Chain-agnostic adapter interface for interacting with the DKG Trust Layer.
  *
@@ -522,6 +529,19 @@ export interface ChainAdapter {
 
   /** Verify that a recovered signer address is a registered operational key for the given identity. */
   verifyACKIdentity?(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean>;
+
+  /** Idempotently register local operational wallets for an existing identity. */
+  ensureOperationalWalletsRegistered?(options?: {
+    identityId?: bigint;
+    additionalAddresses?: string[];
+  }): Promise<OperationalWalletRegistrationResult>;
+
+  /**
+   * Confirm that an address is registered as an OPERATIONAL_KEY for an identity.
+   * Required for V10 ACK signing; adapters that cannot inspect an on-chain
+   * registry should omit this capability and ACK signing will remain disabled.
+   */
+  isOperationalWalletRegistered?(identityId: bigint, address: string): Promise<boolean>;
 
   /**
    * Verify that a recovered signer address owns the claimed identity without

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -30,6 +30,7 @@ import type {
   NodeChallenge,
   ProofPeriodStatus,
   CreateChallengeResult,
+  OperationalWalletRegistrationResult,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -62,6 +63,9 @@ const ERROR_ABI_CONTRACTS = [
   'PublishingConvictionAccount',
   'RandomSampling', 'RandomSamplingStorage',
 ];
+
+const ADMIN_KEY_PURPOSE = 1;
+const OPERATIONAL_KEY_PURPOSE = 2;
 
 let _errorInterface: Interface | null = null;
 
@@ -126,7 +130,7 @@ export function enrichEvmError(err: unknown): string | null {
   return decoded.name;
 }
 
-export interface EVMAdapterConfig {
+interface EVMAdapterBaseConfig {
   rpcUrl: string;
   /** Primary operational wallet key (used for identity registration, staking, etc.) */
   privateKey: string;
@@ -135,6 +139,22 @@ export interface EVMAdapterConfig {
   hubAddress: string;
   chainId?: string;
 }
+
+export type EVMAdapterConfig = EVMAdapterBaseConfig & (
+  | {
+      /** Admin wallet key used for profile/key-management transactions. */
+      adminPrivateKey: string;
+      allowNoAdminSigner?: false;
+    }
+  | {
+      /**
+       * Explicit publish/read-only mode for callers that never create profiles
+       * or mutate profile keys. ACK/profile-management paths stay disabled.
+       */
+      allowNoAdminSigner: true;
+      adminPrivateKey?: undefined;
+    }
+);
 
 interface ContractCache {
   hub: Contract;
@@ -170,6 +190,8 @@ export class EVMChainAdapter implements ChainAdapter {
   private readonly signer: Wallet;
   /** All operational signers (includes primary). Used round-robin for publish TXs. */
   private readonly signerPool: Wallet[];
+  /** Admin signer — used only for profile/key-management operations. */
+  private readonly adminSigner?: Wallet;
   private signerIndex = 0;
   private readonly hubAddress: string;
   private contracts: ContractCache;
@@ -181,6 +203,18 @@ export class EVMChainAdapter implements ChainAdapter {
     this.signerPool = [this.signer];
     for (const key of config.additionalKeys ?? []) {
       this.signerPool.push(new Wallet(key, this.provider));
+    }
+    if (config.adminPrivateKey) {
+      this.adminSigner = new Wallet(config.adminPrivateKey, this.provider);
+      const adminAddress = this.adminSigner.address.toLowerCase();
+      if (this.signerPool.some((signer) => signer.address.toLowerCase() === adminAddress)) {
+        throw new Error('EVM adminPrivateKey must be distinct from operational keys');
+      }
+    } else if (!config.allowNoAdminSigner) {
+      throw new Error(
+        'EVM adminPrivateKey is required. Set allowNoAdminSigner=true only for publish/read-only adapters ' +
+        'that never create profiles or mutate profile keys.',
+      );
     }
     this.hubAddress = config.hubAddress;
     this.chainId = config.chainId ?? 'evm:31337';
@@ -232,6 +266,107 @@ export class EVMChainAdapter implements ChainAdapter {
   /** Primary operational private key (hex string with 0x prefix). */
   getOperationalPrivateKey(): string {
     return this.signer.privateKey;
+  }
+
+  private walletKeyHash(address: string): string {
+    return ethers.keccak256(ethers.solidityPacked(['address'], [ethers.getAddress(address)]));
+  }
+
+  private async hasAdminPurpose(
+    identityStorage: Contract,
+    identityId: bigint,
+    address: string,
+  ): Promise<boolean> {
+    return identityStorage.keyHasPurpose(
+      identityId,
+      this.walletKeyHash(address),
+      ADMIN_KEY_PURPOSE,
+    );
+  }
+
+  private async hasOperationalPurpose(
+    identityStorage: Contract,
+    identityId: bigint,
+    address: string,
+  ): Promise<boolean> {
+    return identityStorage.keyHasPurpose(
+      identityId,
+      this.walletKeyHash(address),
+      OPERATIONAL_KEY_PURPOSE,
+    );
+  }
+
+  async isOperationalWalletRegistered(identityId: bigint, address: string): Promise<boolean> {
+    await this.init();
+    const identityStorage = await this.resolveContract('IdentityStorage');
+    return this.hasOperationalPurpose(identityStorage, identityId, address);
+  }
+
+  async ensureOperationalWalletsRegistered(options?: {
+    identityId?: bigint;
+    additionalAddresses?: string[];
+  }): Promise<OperationalWalletRegistrationResult> {
+    await this.init();
+
+    const identityId = options?.identityId ?? (await this.getIdentityId());
+    const result: OperationalWalletRegistrationResult = {
+      identityId,
+      registered: [],
+      alreadyRegistered: [],
+      taken: [],
+    };
+    if (identityId === 0n) return result;
+
+    const identityStorage = await this.resolveContract('IdentityStorage');
+    const candidates = [
+      ...this.signerPool.map((s) => s.address),
+      ...(options?.additionalAddresses ?? []),
+    ];
+    const seen = new Set<string>();
+    const missing: string[] = [];
+
+    for (const candidate of candidates) {
+      const address = ethers.getAddress(candidate);
+      const key = address.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const existingIdentityId = BigInt(await identityStorage.getIdentityId(address));
+      if (existingIdentityId === identityId) {
+        result.alreadyRegistered.push(address);
+      } else if (existingIdentityId === 0n) {
+        missing.push(address);
+      } else {
+        result.taken.push({ address, identityId: existingIdentityId });
+      }
+    }
+
+    if (missing.length === 0) return result;
+
+    if (!this.adminSigner) {
+      throw new Error(
+        `Cannot register operational wallets for identity ${identityId}: ` +
+        'adminPrivateKey is not configured.',
+      );
+    }
+    if (!(await this.hasAdminPurpose(identityStorage, identityId, this.adminSigner.address))) {
+      throw new Error(
+        `Cannot register operational wallets for identity ${identityId}: configured admin wallet ` +
+        `${this.adminSigner.address} is not registered on-chain as an admin key for this identity.`,
+      );
+    }
+
+    const profile = this.contracts.profile!.connect(this.adminSigner) as Contract;
+    const tx = await profile.addOperationalWallets(identityId, missing);
+    await tx.wait();
+
+    for (const address of missing) {
+      if (await this.hasOperationalPurpose(identityStorage, identityId, address)) {
+        result.registered.push(address);
+      }
+    }
+
+    return result;
   }
 
   private async resolveContract(name: string, abiName?: string): Promise<Contract> {
@@ -352,11 +487,15 @@ export class EVMChainAdapter implements ChainAdapter {
     // Step 1: Create profile if none exists
     if (identityId === 0n) {
       const nodeName = options?.nodeName ?? `node-${Date.now()}`;
-      const adminWallet = ethers.Wallet.createRandom();
+      if (!this.adminSigner) {
+        throw new Error(
+          'Cannot create profile: adminPrivateKey is required so the profile admin key is not lost.',
+        );
+      }
       const nodeId = ethers.hexlify(ethers.randomBytes(32));
 
       const tx = await this.contracts.profile!.createProfile(
-        adminWallet.address,
+        this.adminSigner.address,
         [],
         nodeName,
         nodeId,
@@ -426,12 +565,19 @@ export class EVMChainAdapter implements ChainAdapter {
 
   async registerIdentity(proof: IdentityProof): Promise<bigint> {
     await this.init();
+    if (!this.adminSigner) {
+      throw new Error(
+        'Cannot register identity: adminPrivateKey is required so the profile admin key is not lost.',
+      );
+    }
+    const nodeName = `node-${ethers.hexlify(ethers.randomBytes(4)).slice(2)}`;
+    const nodeId = proof.publicKey.length > 0 ? proof.publicKey : ethers.randomBytes(32);
 
     const tx = await this.contracts.profile!.createProfile(
-      this.signer.address,
-      [this.signer.address],
-      '',
-      proof.publicKey,
+      this.adminSigner.address,
+      [],
+      nodeName,
+      nodeId,
       0,
     );
     const receipt = await tx.wait();
@@ -1995,9 +2141,12 @@ export class EVMChainAdapter implements ChainAdapter {
     if (!identityStorage) return false;
 
     // Match on-chain verification: keyHasPurpose(identityId, keccak256(signer), OPERATIONAL_KEY)
-    const OPERATIONAL_KEY = 2;
     const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
-    const hasPurpose: boolean = await identityStorage.keyHasPurpose(claimedIdentityId, keyHash, OPERATIONAL_KEY);
+    const hasPurpose: boolean = await identityStorage.keyHasPurpose(
+      claimedIdentityId,
+      keyHash,
+      OPERATIONAL_KEY_PURPOSE,
+    );
     if (!hasPurpose) return false;
 
     // Verify the identity is a staked core node (spec §9.0: "Core nodes MUST be staked").
@@ -2037,13 +2186,18 @@ export class EVMChainAdapter implements ChainAdapter {
     const identityStorage = await this.resolveContract('IdentityStorage');
     if (!identityStorage) return false;
 
-    const OPERATIONAL_KEY = 2;
     const keyHash = ethers.keccak256(ethers.solidityPacked(['address'], [recoveredAddress]));
-    return identityStorage.keyHasPurpose(claimedIdentityId, keyHash, OPERATIONAL_KEY);
+    return identityStorage.keyHasPurpose(claimedIdentityId, keyHash, OPERATIONAL_KEY_PURPOSE);
   }
 
   async signACKDigest(digest: Uint8Array): Promise<{ r: Uint8Array; vs: Uint8Array } | undefined> {
     try {
+      const identityId = await this.getIdentityId();
+      if (identityId === 0n) return undefined;
+      if (!(await this.isOperationalWalletRegistered(identityId, this.signer.address))) {
+        return undefined;
+      }
+
       const sig = ethers.Signature.from(await this.signer.signMessage(digest));
       return {
         r: ethers.getBytes(sig.r),

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -140,21 +140,16 @@ interface EVMAdapterBaseConfig {
   chainId?: string;
 }
 
-export type EVMAdapterConfig = EVMAdapterBaseConfig & (
-  | {
-      /** Admin wallet key used for profile/key-management transactions. */
-      adminPrivateKey: string;
-      allowNoAdminSigner?: false;
-    }
-  | {
-      /**
-       * Explicit publish/read-only mode for callers that never create profiles
-       * or mutate profile keys. ACK/profile-management paths stay disabled.
-       */
-      allowNoAdminSigner: true;
-      adminPrivateKey?: undefined;
-    }
-);
+export interface EVMAdapterConfig extends EVMAdapterBaseConfig {
+  /** Admin wallet key used for profile/key-management transactions. */
+  adminPrivateKey?: string;
+  /**
+   * Documents that this adapter is intentionally running without admin
+   * authority. Missing admin keys are still accepted for backwards-compatible
+   * publish/read-only usage; admin-only operations fail when invoked.
+   */
+  allowNoAdminSigner?: boolean;
+}
 
 interface ContractCache {
   hub: Contract;
@@ -210,11 +205,6 @@ export class EVMChainAdapter implements ChainAdapter {
       if (this.signerPool.some((signer) => signer.address.toLowerCase() === adminAddress)) {
         throw new Error('EVM adminPrivateKey must be distinct from operational keys');
       }
-    } else if (!config.allowNoAdminSigner) {
-      throw new Error(
-        'EVM adminPrivateKey is required. Set allowNoAdminSigner=true only for publish/read-only adapters ' +
-        'that never create profiles or mutate profile keys.',
-      );
     }
     this.hubAddress = config.hubAddress;
     this.chainId = config.chainId ?? 'evm:31337';

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -26,6 +26,7 @@ import type {
   NodeChallenge,
   ProofPeriodStatus,
   CreateChallengeResult,
+  OperationalWalletRegistrationResult,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -720,6 +721,47 @@ export class MockChainAdapter implements ChainAdapter {
     return false;
   }
 
+  async isOperationalWalletRegistered(identityId: bigint, address: string): Promise<boolean> {
+    return this.verifyACKIdentity(address, identityId);
+  }
+
+  async ensureOperationalWalletsRegistered(options?: {
+    identityId?: bigint;
+    additionalAddresses?: string[];
+  }): Promise<OperationalWalletRegistrationResult> {
+    const identityId = options?.identityId ?? (await this.getIdentityId());
+    const result: OperationalWalletRegistrationResult = {
+      identityId,
+      registered: [],
+      alreadyRegistered: [],
+      taken: [],
+    };
+    if (identityId === 0n) return result;
+
+    const candidates = [this.signerAddress, ...(options?.additionalAddresses ?? [])];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const address = ethers.getAddress(candidate);
+      const key = address.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const existing = [...this.identities.entries()].find(
+        ([addr]) => addr.toLowerCase() === key,
+      );
+      if (existing?.[1] === identityId) {
+        result.alreadyRegistered.push(address);
+      } else if (existing) {
+        result.taken.push({ address, identityId: existing[1] });
+      } else {
+        this.identities.set(address, identityId);
+        result.registered.push(address);
+      }
+    }
+
+    return result;
+  }
+
   async verifySyncIdentity(recoveredAddress: string, claimedIdentityId: bigint): Promise<boolean> {
     return this.verifyACKIdentity(recoveredAddress, claimedIdentityId);
   }
@@ -732,6 +774,10 @@ export class MockChainAdapter implements ChainAdapter {
 
   async signACKDigest(digest: Uint8Array): Promise<{ r: Uint8Array; vs: Uint8Array } | undefined> {
     if (!this.mockACKSigner) return undefined;
+    const identityId = await this.getIdentityId();
+    if (identityId === 0n || !(await this.isOperationalWalletRegistered(identityId, this.mockACKSigner.address))) {
+      return undefined;
+    }
     const { ethers: eth } = await import('ethers');
     const sig = eth.Signature.from(await this.mockACKSigner.signMessage(digest));
     return {

--- a/packages/chain/src/no-chain-adapter.ts
+++ b/packages/chain/src/no-chain-adapter.ts
@@ -45,6 +45,7 @@ export class NoChainAdapter implements ChainAdapter {
   async submitToContextGraph(_kcId: string, _contextGraphId: string): Promise<TxResult> { noChain(); }
   async revealContextGraphMetadata(_contextGraphId: string, _name: string, _description: string): Promise<TxResult> { noChain(); }
   async createKnowledgeAssetsV10(_params: V10PublishDirectParams): Promise<OnChainPublishResult> { noChain(); }
+  async isOperationalWalletRegistered(_identityId: bigint, _address: string): Promise<boolean> { return false; }
   async getKnowledgeAssetsV10Address(): Promise<string> { noChain(); }
   async getEvmChainId(): Promise<bigint> { noChain(); }
   isV10Ready(): boolean { return false; }

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -122,13 +122,13 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
       .toThrow('EVM adminPrivateKey must be distinct from operational keys');
   });
 
-  it('requires adminPrivateKey unless publish/read-only mode is explicit', () => {
+  it('allows missing adminPrivateKey for backwards-compatible publish/read-only adapters', () => {
     expect(() => new EVMChainAdapter({
       rpcUrl: 'http://127.0.0.1:59998',
       privateKey: DEPLOYER_PK,
       hubAddress: '0x0000000000000000000000000000000000000001',
       chainId: 'evm:31337',
-    } as EVMAdapterConfig)).toThrow('EVM adminPrivateKey is required');
+    })).not.toThrow();
 
     expect(() => new EVMChainAdapter({
       rpcUrl: 'http://127.0.0.1:59998',

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -8,11 +8,13 @@ import { decodeEvmError, enrichEvmError, EVMChainAdapter, type EVMAdapterConfig 
 
 const DEPLOYER_PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 const OTHER_PK = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b63b91100';
+const ADMIN_PK = '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a';
 
 function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
   return {
     rpcUrl: 'http://127.0.0.1:59998',
     privateKey: DEPLOYER_PK,
+    adminPrivateKey: ADMIN_PK,
     hubAddress: '0x0000000000000000000000000000000000000001',
     chainId: 'evm:31337',
     ...overrides,
@@ -113,6 +115,28 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const addrs = a.getSignerAddresses();
     expect(addrs).toHaveLength(2);
     expect(addrs[0]).not.toBe(addrs[1]);
+  });
+
+  it('rejects adminPrivateKey when it duplicates an operational key', () => {
+    expect(() => new EVMChainAdapter(minimalConfig({ adminPrivateKey: DEPLOYER_PK })))
+      .toThrow('EVM adminPrivateKey must be distinct from operational keys');
+  });
+
+  it('requires adminPrivateKey unless publish/read-only mode is explicit', () => {
+    expect(() => new EVMChainAdapter({
+      rpcUrl: 'http://127.0.0.1:59998',
+      privateKey: DEPLOYER_PK,
+      hubAddress: '0x0000000000000000000000000000000000000001',
+      chainId: 'evm:31337',
+    } as EVMAdapterConfig)).toThrow('EVM adminPrivateKey is required');
+
+    expect(() => new EVMChainAdapter({
+      rpcUrl: 'http://127.0.0.1:59998',
+      privateKey: DEPLOYER_PK,
+      hubAddress: '0x0000000000000000000000000000000000000001',
+      chainId: 'evm:31337',
+      allowNoAdminSigner: true,
+    })).not.toThrow();
   });
 
   it('getProvider returns JsonRpcProvider', () => {

--- a/packages/chain/test/hardhat-harness.ts
+++ b/packages/chain/test/hardhat-harness.ts
@@ -104,6 +104,7 @@ export function makeAdapterConfig(
   hubAddress: string,
   privateKey: string,
   additionalKeys?: string[],
+  adminPrivateKey?: string,
 ): EVMAdapterConfig {
   return {
     rpcUrl,
@@ -111,7 +112,38 @@ export function makeAdapterConfig(
     hubAddress,
     chainId: `evm:${HARDHAT_CHAIN_ID}`,
     additionalKeys,
+    adminPrivateKey: adminPrivateKey ?? pickDefaultAdminKey(privateKey, additionalKeys ?? []),
   };
+}
+
+function pickDefaultAdminKey(privateKey: string, additionalKeys: string[]): string {
+  const blocked = new Set([privateKey, ...additionalKeys].map((key) => key.toLowerCase()));
+  const preferredByOperational = new Map<string, string>([
+    [HARDHAT_KEYS.CORE_OP.toLowerCase(), HARDHAT_KEYS.CORE_ADMIN],
+    [HARDHAT_KEYS.REC1_OP.toLowerCase(), HARDHAT_KEYS.REC1_ADMIN],
+    [HARDHAT_KEYS.REC2_OP.toLowerCase(), HARDHAT_KEYS.REC2_ADMIN],
+    [HARDHAT_KEYS.REC3_OP.toLowerCase(), HARDHAT_KEYS.REC3_ADMIN],
+  ]);
+  const preferred = preferredByOperational.get(privateKey.toLowerCase());
+  if (preferred && !blocked.has(preferred.toLowerCase())) {
+    return preferred;
+  }
+
+  const candidates = [
+    HARDHAT_KEYS.CORE_ADMIN,
+    HARDHAT_KEYS.REC1_ADMIN,
+    HARDHAT_KEYS.REC2_ADMIN,
+    HARDHAT_KEYS.REC3_ADMIN,
+    HARDHAT_KEYS.EXTRA3,
+    HARDHAT_KEYS.EXTRA2,
+    HARDHAT_KEYS.PUBLISHER2,
+    HARDHAT_KEYS.DEPLOYER,
+  ];
+  const adminKey = candidates.find((candidate) => !blocked.has(candidate.toLowerCase()));
+  if (!adminKey) {
+    throw new Error('No distinct Hardhat admin key available for adapter config');
+  }
+  return adminKey;
 }
 
 export async function createNodeProfile(

--- a/packages/chain/test/mock-adapter-parity.test.ts
+++ b/packages/chain/test/mock-adapter-parity.test.ts
@@ -84,6 +84,9 @@ const MOCK_EXEMPT_FROM_EVM = new Set<string>([
   // ChainAdapter contract. They must remain EVM-only.
   'nextSigner',
   'nextAuthorizedSigner',
+  'walletKeyHash',
+  'hasAdminPurpose',
+  'hasOperationalPurpose',
   'resolveContract',
   'resolveAssetStorage',
   'init',
@@ -131,6 +134,8 @@ const NO_CHAIN_EXEMPT_FROM_EVM = new Set<string>([
   'getMinimumRequiredSignatures',
   'verifyACKIdentity',
   'verifySyncIdentity',
+  'ensureOperationalWalletsRegistered',
+  'isOperationalWalletRegistered',
   'updateKnowledgeCollectionV10',
   'stakeWithLock',
   'getDelegatorConvictionMultiplier',
@@ -189,6 +194,7 @@ describe('MockChainAdapter API parity with EVMChainAdapter [CH-8]', () => {
       rpcUrl: 'http://127.0.0.1:1',
       hubAddress: '0x0000000000000000000000000000000000000001',
       privateKey: '0x' + '1'.repeat(64),
+      allowNoAdminSigner: true,
     });
     expect(mock.chainType).toBe(evm.chainType);
   });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -386,7 +386,10 @@ program
     try {
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
-      walletAddresses = opWallets.wallets.map((w: { address: string }) => w.address);
+      walletAddresses = [
+        ...(opWallets.adminWallet ? [opWallets.adminWallet.address] : []),
+        ...opWallets.wallets.map((w: { address: string }) => w.address),
+      ];
     } catch (err: any) {
       console.warn(`\nWarning: could not generate wallets (${err?.message ?? String(err)}).`);
       console.warn('Wallets will be auto-generated on first "dkg start".');
@@ -431,7 +434,7 @@ program
     // Auto-fund from testnet faucet if available
     if (network?.faucet?.url && walletAddresses.length > 0) {
       if (walletAddresses.length > 3) {
-        console.log(`\nNote: faucet supports up to 3 wallets; funding the first 3.`);
+        console.log(`\nNote: faucet supports up to 3 wallets per request; funding wallets in batches.`);
       }
       console.log(`\nRequesting testnet tokens from faucet...`);
       try {
@@ -440,6 +443,12 @@ program
         );
         if (result.success) {
           console.log(`  Funded: ${result.funded.join(', ')}`);
+          if (result.error) {
+            console.log(`  Faucet partially completed (${result.error}). Retry later for any remaining wallets.`);
+            if (result.failedWallets?.length) {
+              console.log(`  Remaining: ${result.failedWallets.join(', ')}`);
+            }
+          }
         } else if (result.error) {
           console.log(`  Faucet request failed (${result.error}). Fund manually or retry later.`);
         } else {
@@ -2564,7 +2573,7 @@ program
 
 program
   .command('wallet')
-  .description('Show operational wallet addresses and balances')
+  .description('Show admin and operational wallet addresses and balances')
   .action(async () => {
     try {
       const config = await loadConfig();
@@ -2602,6 +2611,22 @@ program
         }
       }
 
+      console.log(`\nAdmin wallet:\n`);
+      if (opWallets.adminWallet) {
+        console.log(`  ${opWallets.adminWallet.address}`);
+        if (provider) {
+          try {
+            const ethBal = await provider.getBalance(opWallets.adminWallet.address);
+            const tracBal = token ? await token.balanceOf(opWallets.adminWallet.address) : 0n;
+            console.log(`  ETH: ${ethers.formatEther(ethBal)}  ${tokenSymbol}: ${ethers.formatEther(tracBal)}`);
+          } catch {
+            console.log('  (unable to query balances)');
+          }
+        }
+      } else {
+        console.log('  (missing from legacy wallets.json; add the profile admin key to enable key management)');
+      }
+
       console.log(`\nOperational wallets (${opWallets.wallets.length}):\n`);
       for (let i = 0; i < opWallets.wallets.length; i++) {
         const addr = opWallets.wallets[i].address;
@@ -2622,7 +2647,11 @@ program
       if (rpcUrl) console.log(`  RPC:   ${rpcUrl}`);
       console.log(`  File:  ~/.dkg/wallets.json`);
       console.log('\nFund these addresses with ETH (gas) and TRAC (staking/publishing).');
-      console.log('The primary wallet is used for identity registration. All wallets are used for publishing.\n');
+      if (opWallets.adminWallet) {
+        console.log('The admin wallet is used for profile key management. The primary operational wallet is used for staking; all operational wallets are used for publishing.\n');
+      } else {
+        console.log('Add the real profile admin key to wallets.json to enable profile key management and operational-wallet repair.\n');
+      }
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -491,8 +491,14 @@ export async function runDaemonInner(
     );
   }
 
-  // Load operational wallets from ~/.dkg/wallets.json (auto-generated on first run)
+  // Load admin + operational wallets from ~/.dkg/wallets.json (auto-generated on first run)
   const opWallets = await loadOpWallets(dkgDir());
+  log(`Admin wallet:`);
+  if (opWallets.adminWallet) {
+    log(`  ${opWallets.adminWallet.address}`);
+  } else {
+    log(`  (missing from legacy wallets.json; auto-registration requires adding the profile admin key)`);
+  }
   log(`Operational wallets (${opWallets.wallets.length}):`);
   for (const w of opWallets.wallets) {
     log(`  ${w.address}`);
@@ -566,6 +572,9 @@ export async function runDaemonInner(
     chainConfig: chainBase?.rpcUrl && chainBase?.hubAddress ? {
       rpcUrl: chainBase.rpcUrl,
       hubAddress: chainBase.hubAddress,
+      ...(opWallets.adminWallet
+        ? { adminPrivateKey: opWallets.adminWallet.privateKey }
+        : {}),
       operationalKeys: opWallets.wallets.map((w) => w.privateKey),
       chainId: chainBase.chainId,
     } : undefined,

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -185,6 +185,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
           privateKey: wallet.privateKey,
           hubAddress: args.chainBase.hubAddress,
           chainId: args.chainBase.chainId,
+          allowNoAdminSigner: true,
         })
       : new NoChainAdapter();
     const identityId = await chain.getIdentityId();

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -99,6 +99,9 @@ export async function requestFaucetFunding(
         }
       }
     } catch (err) {
+      if (!sawSuccess && funded.length === 0 && fundedWallets.size === 0) {
+        throw err;
+      }
       errors.push(`Faucet request failed: ${err instanceof Error ? err.message : String(err)}`);
       for (const wallet of batch) {
         failedWallets.add(wallet);

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -1,6 +1,8 @@
 export interface FaucetResult {
   success: boolean;
   funded: string[];
+  fundedWallets?: string[];
+  failedWallets?: string[];
   error?: string;
 }
 
@@ -11,31 +13,100 @@ export async function requestFaucetFunding(
   nodeName: string,
   _fetch = globalThis.fetch,
 ): Promise<FaucetResult> {
-  const fundable = wallets.slice(0, 3);
-  if (fundable.length === 0) return { success: false, funded: [], error: 'no wallets' };
-  const safeNodeName = nodeName.replace(/[^\x20-\x7E]/g, '_');
-  const res = await _fetch(faucetUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Idempotency-Key': `init-${mode}-${safeNodeName}-${[...fundable].sort().join(',')}`,
-    },
-    body: JSON.stringify({ mode, wallets: fundable, callerId: `dkg-node:${nodeName}` }),
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    return { success: false, funded: [], error: `HTTP ${res.status}: ${text.slice(0, 200)}` };
+  const batches: string[][] = [];
+  for (let i = 0; i < wallets.length; i += 3) {
+    batches.push(wallets.slice(i, i + 3));
   }
-  const data = await res.json() as Record<string, unknown>;
-  const results = Array.isArray(data.results) ? data.results : [];
-  const amounts = results
-    .filter((r: any) => r && typeof r.status === 'string' && r.status === 'success' && typeof r.chainId === 'string')
-    .map((r: any) => {
-      const label = String(r.chainId).includes('eth') ? 'ETH' : 'TRAC';
-      return `${r.amount ?? '?'} ${label}`;
+  if (batches.length === 0) return { success: false, funded: [], error: 'no wallets' };
+
+  const safeNodeName = nodeName.replace(/[^\x20-\x7E]/g, '_');
+  const funded: string[] = [];
+  const fundedWallets = new Set<string>();
+  const failedWallets = new Set<string>();
+  const errors: string[] = [];
+  let sawSuccess = false;
+
+  for (const batch of batches) {
+    const res = await _fetch(faucetUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Idempotency-Key': `init-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
+      },
+      body: JSON.stringify({ mode, wallets: batch, callerId: `dkg-node:${nodeName}` }),
+      signal: AbortSignal.timeout(30_000),
     });
-  const summary = data.summary && typeof data.summary === 'object' ? data.summary as Record<string, unknown> : null;
-  const success = (typeof summary?.success === 'number' && summary.success > 0) || amounts.length > 0;
-  return { success, funded: amounts };
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      errors.push(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+      for (const wallet of batch) failedWallets.add(wallet);
+      continue;
+    }
+    const data = await res.json() as Record<string, unknown>;
+    const results = Array.isArray(data.results) ? data.results : [];
+    const amounts = results
+      .filter((r: any) => r && typeof r.status === 'string' && r.status === 'success' && typeof r.chainId === 'string')
+      .map((r: any) => {
+        const label = String(r.chainId).includes('eth') ? 'ETH' : 'TRAC';
+        return `${r.amount ?? '?'} ${label}`;
+      });
+    const summary = data.summary && typeof data.summary === 'object' ? data.summary as Record<string, unknown> : null;
+    const batchSuccess = (typeof summary?.success === 'number' && summary.success > 0) || amounts.length > 0;
+    sawSuccess ||= batchSuccess;
+    funded.push(...amounts);
+
+    const resultStatusesByAddress = new Map<string, string[]>();
+    for (const result of results) {
+      if (!result || typeof result !== 'object') continue;
+      const record = result as Record<string, unknown>;
+      if (typeof record.address !== 'string' || typeof record.status !== 'string') continue;
+      const key = record.address.toLowerCase();
+      const statuses = resultStatusesByAddress.get(key) ?? [];
+      statuses.push(record.status);
+      resultStatusesByAddress.set(key, statuses);
+    }
+
+    if (resultStatusesByAddress.size > 0) {
+      for (const wallet of batch) {
+        const statuses = resultStatusesByAddress.get(wallet.toLowerCase()) ?? [];
+        if (statuses.length > 0 && statuses.every((status) => status === 'success')) {
+          fundedWallets.add(wallet);
+          failedWallets.delete(wallet);
+        } else {
+          failedWallets.add(wallet);
+          fundedWallets.delete(wallet);
+        }
+      }
+    } else if (batchSuccess) {
+      for (const wallet of batch) {
+        fundedWallets.add(wallet);
+        failedWallets.delete(wallet);
+      }
+    } else {
+      for (const wallet of batch) {
+        failedWallets.add(wallet);
+        fundedWallets.delete(wallet);
+      }
+    }
+  }
+
+  if (failedWallets.size > 0 && errors.length === 0) {
+    errors.push(`Faucet did not fund all wallets: ${Array.from(failedWallets).join(', ')}`);
+  }
+
+  if (errors.length > 0) {
+    return {
+      success: sawSuccess,
+      funded,
+      fundedWallets: Array.from(fundedWallets),
+      failedWallets: Array.from(failedWallets),
+      error: errors.join('; '),
+    };
+  }
+  return {
+    success: sawSuccess,
+    funded,
+    fundedWallets: Array.from(fundedWallets),
+    failedWallets: Array.from(failedWallets),
+  };
 }

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -6,6 +6,8 @@ export interface FaucetResult {
   error?: string;
 }
 
+const EXPECTED_FAUCET_TRANSFERS_PER_WALLET = 2;
+
 export async function requestFaucetFunding(
   faucetUrl: string,
   mode: string,
@@ -54,6 +56,10 @@ export async function requestFaucetFunding(
     const batchSuccess = (typeof summary?.success === 'number' && summary.success > 0) || amounts.length > 0;
     sawSuccess ||= batchSuccess;
     funded.push(...amounts);
+    const summarySuccessCount = typeof summary?.success === 'number' ? summary.success : 0;
+    const successfulTransferCount = Math.max(summarySuccessCount, amounts.length);
+    const expectedTransferCount = batch.length * EXPECTED_FAUCET_TRANSFERS_PER_WALLET;
+    const batchFullyFunded = successfulTransferCount >= expectedTransferCount;
 
     const resultStatusesByAddress = new Map<string, string[]>();
     for (const result of results) {
@@ -69,7 +75,10 @@ export async function requestFaucetFunding(
     if (resultStatusesByAddress.size > 0) {
       for (const wallet of batch) {
         const statuses = resultStatusesByAddress.get(wallet.toLowerCase()) ?? [];
-        if (statuses.length > 0 && statuses.every((status) => status === 'success')) {
+        if (
+          statuses.length >= EXPECTED_FAUCET_TRANSFERS_PER_WALLET &&
+          statuses.every((status) => status === 'success')
+        ) {
           fundedWallets.add(wallet);
           failedWallets.delete(wallet);
         } else {
@@ -77,7 +86,7 @@ export async function requestFaucetFunding(
           fundedWallets.delete(wallet);
         }
       }
-    } else if (batchSuccess) {
+    } else if (batchFullyFunded) {
       for (const wallet of batch) {
         fundedWallets.add(wallet);
         failedWallets.delete(wallet);

--- a/packages/core/src/faucet.ts
+++ b/packages/core/src/faucet.ts
@@ -29,69 +29,77 @@ export async function requestFaucetFunding(
   let sawSuccess = false;
 
   for (const batch of batches) {
-    const res = await _fetch(faucetUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Idempotency-Key': `init-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
-      },
-      body: JSON.stringify({ mode, wallets: batch, callerId: `dkg-node:${nodeName}` }),
-      signal: AbortSignal.timeout(30_000),
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      errors.push(`HTTP ${res.status}: ${text.slice(0, 200)}`);
-      for (const wallet of batch) failedWallets.add(wallet);
-      continue;
-    }
-    const data = await res.json() as Record<string, unknown>;
-    const results = Array.isArray(data.results) ? data.results : [];
-    const amounts = results
-      .filter((r: any) => r && typeof r.status === 'string' && r.status === 'success' && typeof r.chainId === 'string')
-      .map((r: any) => {
-        const label = String(r.chainId).includes('eth') ? 'ETH' : 'TRAC';
-        return `${r.amount ?? '?'} ${label}`;
+    try {
+      const res = await _fetch(faucetUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': `init-${mode}-${safeNodeName}-${[...batch].sort().join(',')}`,
+        },
+        body: JSON.stringify({ mode, wallets: batch, callerId: `dkg-node:${nodeName}` }),
+        signal: AbortSignal.timeout(30_000),
       });
-    const summary = data.summary && typeof data.summary === 'object' ? data.summary as Record<string, unknown> : null;
-    const batchSuccess = (typeof summary?.success === 'number' && summary.success > 0) || amounts.length > 0;
-    sawSuccess ||= batchSuccess;
-    funded.push(...amounts);
-    const summarySuccessCount = typeof summary?.success === 'number' ? summary.success : 0;
-    const successfulTransferCount = Math.max(summarySuccessCount, amounts.length);
-    const expectedTransferCount = batch.length * EXPECTED_FAUCET_TRANSFERS_PER_WALLET;
-    const batchFullyFunded = successfulTransferCount >= expectedTransferCount;
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        errors.push(`HTTP ${res.status}: ${text.slice(0, 200)}`);
+        for (const wallet of batch) failedWallets.add(wallet);
+        continue;
+      }
+      const data = await res.json() as Record<string, unknown>;
+      const results = Array.isArray(data.results) ? data.results : [];
+      const amounts = results
+        .filter((r: any) => r && typeof r.status === 'string' && r.status === 'success' && typeof r.chainId === 'string')
+        .map((r: any) => {
+          const label = String(r.chainId).includes('eth') ? 'ETH' : 'TRAC';
+          return `${r.amount ?? '?'} ${label}`;
+        });
+      const summary = data.summary && typeof data.summary === 'object' ? data.summary as Record<string, unknown> : null;
+      const batchSuccess = (typeof summary?.success === 'number' && summary.success > 0) || amounts.length > 0;
+      sawSuccess ||= batchSuccess;
+      funded.push(...amounts);
+      const summarySuccessCount = typeof summary?.success === 'number' ? summary.success : 0;
+      const successfulTransferCount = Math.max(summarySuccessCount, amounts.length);
+      const expectedTransferCount = batch.length * EXPECTED_FAUCET_TRANSFERS_PER_WALLET;
+      const batchFullyFunded = successfulTransferCount >= expectedTransferCount;
 
-    const resultStatusesByAddress = new Map<string, string[]>();
-    for (const result of results) {
-      if (!result || typeof result !== 'object') continue;
-      const record = result as Record<string, unknown>;
-      if (typeof record.address !== 'string' || typeof record.status !== 'string') continue;
-      const key = record.address.toLowerCase();
-      const statuses = resultStatusesByAddress.get(key) ?? [];
-      statuses.push(record.status);
-      resultStatusesByAddress.set(key, statuses);
-    }
+      const resultStatusesByAddress = new Map<string, string[]>();
+      for (const result of results) {
+        if (!result || typeof result !== 'object') continue;
+        const record = result as Record<string, unknown>;
+        if (typeof record.address !== 'string' || typeof record.status !== 'string') continue;
+        const key = record.address.toLowerCase();
+        const statuses = resultStatusesByAddress.get(key) ?? [];
+        statuses.push(record.status);
+        resultStatusesByAddress.set(key, statuses);
+      }
 
-    if (resultStatusesByAddress.size > 0) {
-      for (const wallet of batch) {
-        const statuses = resultStatusesByAddress.get(wallet.toLowerCase()) ?? [];
-        if (
-          statuses.length >= EXPECTED_FAUCET_TRANSFERS_PER_WALLET &&
-          statuses.every((status) => status === 'success')
-        ) {
+      if (resultStatusesByAddress.size > 0) {
+        for (const wallet of batch) {
+          const statuses = resultStatusesByAddress.get(wallet.toLowerCase()) ?? [];
+          if (
+            statuses.length >= EXPECTED_FAUCET_TRANSFERS_PER_WALLET &&
+            statuses.every((status) => status === 'success')
+          ) {
+            fundedWallets.add(wallet);
+            failedWallets.delete(wallet);
+          } else {
+            failedWallets.add(wallet);
+            fundedWallets.delete(wallet);
+          }
+        }
+      } else if (batchFullyFunded) {
+        for (const wallet of batch) {
           fundedWallets.add(wallet);
           failedWallets.delete(wallet);
-        } else {
+        }
+      } else {
+        for (const wallet of batch) {
           failedWallets.add(wallet);
           fundedWallets.delete(wallet);
         }
       }
-    } else if (batchFullyFunded) {
-      for (const wallet of batch) {
-        fundedWallets.add(wallet);
-        failedWallets.delete(wallet);
-      }
-    } else {
+    } catch (err) {
+      errors.push(`Faucet request failed: ${err instanceof Error ? err.message : String(err)}`);
       for (const wallet of batch) {
         failedWallets.add(wallet);
         fundedWallets.delete(wallet);

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -161,11 +161,40 @@ describe('requestFaucetFunding', () => {
     expect(result.funded).toEqual([]);
   });
 
-  it('propagates network errors', async () => {
+  it('returns failed wallets for network errors', async () => {
     const fetch = (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof globalThis.fetch;
-    await expect(
-      requestFaucetFunding('https://faucet.example.com/fund', 'test', ['0xAAA'], 'test-node', fetch),
-    ).rejects.toThrow('ECONNREFUSED');
+    const result = await requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test', ['0xAAA'], 'test-node', fetch,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.fundedWallets).toEqual([]);
+    expect(result.failedWallets).toEqual(['0xAAA']);
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+
+  it('preserves earlier funded wallets when a later batch throws', async () => {
+    const calls: FetchCall[] = [];
+    const fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: url as any, init: init as RequestInit });
+      if (calls.length === 1) {
+        return new Response(JSON.stringify({
+          summary: { success: 6 },
+          results: [],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      throw new Error('faucet offline');
+    }) as typeof globalThis.fetch;
+
+    const result = await requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test',
+      ['0x1', '0x2', '0x3', '0x4'], 'throwing-node', fetch,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3']);
+    expect(result.failedWallets).toEqual(['0x4']);
+    expect(result.error).toContain('faucet offline');
   });
 
   it('includes nodeName in callerId and Idempotency-Key', async () => {

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -25,10 +25,12 @@ function createTrackingFetch(status: number, body: unknown): { fetch: typeof glo
 describe('requestFaucetFunding', () => {
   it('returns funded amounts on success', async () => {
     const { fetch, calls } = createTrackingFetch(200, {
-      summary: { success: 2, failed: 0 },
+      summary: { success: 4, failed: 0 },
       results: [
-        { chainId: 'eth-sepolia', amount: '0.01', status: 'success' },
-        { chainId: 'trac-base', amount: '1000', status: 'success' },
+        { chainId: 'eth-sepolia', address: '0xAAA', amount: '0.01', status: 'success' },
+        { chainId: 'trac-base', address: '0xAAA', amount: '1000', status: 'success' },
+        { chainId: 'eth-sepolia', address: '0xBBB', amount: '0.01', status: 'success' },
+        { chainId: 'trac-base', address: '0xBBB', amount: '1000', status: 'success' },
       ],
     });
     const result = await requestFaucetFunding(
@@ -36,7 +38,7 @@ describe('requestFaucetFunding', () => {
       ['0xAAA', '0xBBB'], 'test-node', fetch,
     );
     expect(result.success).toBe(true);
-    expect(result.funded).toEqual(['0.01 ETH', '1000 TRAC']);
+    expect(result.funded).toEqual(['0.01 ETH', '1000 TRAC', '0.01 ETH', '1000 TRAC']);
     expect(result.fundedWallets).toEqual(['0xAAA', '0xBBB']);
     expect(result.failedWallets).toEqual([]);
     expect(calls).toHaveLength(1);
@@ -76,7 +78,7 @@ describe('requestFaucetFunding', () => {
       calls.push({ url: url as any, init: init as RequestInit });
       if (calls.length === 1) {
         return new Response(JSON.stringify({
-          summary: { success: 1 },
+          summary: { success: 6 },
           results: [{ chainId: 'eth-sepolia', amount: '0.01', status: 'success' }],
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
@@ -94,6 +96,24 @@ describe('requestFaucetFunding', () => {
     expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3']);
     expect(result.failedWallets).toEqual(['0x4']);
     expect(result.error).toContain('429');
+  });
+
+  it('keeps wallets failed when address-less summaries show only partial transfer success', async () => {
+    const { fetch } = createTrackingFetch(200, {
+      summary: { success: 1, failed: 3 },
+      results: [
+        { chainId: 'eth-sepolia', amount: '0.01', status: 'success' },
+      ],
+    });
+    const result = await requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test', ['0x1', '0x2'], 'partial-summary-node', fetch,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.fundedWallets).toEqual([]);
+    expect(result.failedWallets).toEqual(['0x1', '0x2']);
+    expect(result.error).toContain('0x1');
+    expect(result.error).toContain('0x2');
   });
 
   it('uses per-wallet result addresses to report remaining failed wallets', async () => {

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -37,21 +37,26 @@ describe('requestFaucetFunding', () => {
     );
     expect(result.success).toBe(true);
     expect(result.funded).toEqual(['0.01 ETH', '1000 TRAC']);
+    expect(result.fundedWallets).toEqual(['0xAAA', '0xBBB']);
+    expect(result.failedWallets).toEqual([]);
     expect(calls).toHaveLength(1);
     const reqBody = JSON.parse(calls[0].init.body as string);
     expect(reqBody.wallets).toEqual(['0xAAA', '0xBBB']);
     expect(reqBody.mode).toBe('v10_base_sepolia');
   });
 
-  it('caps wallets at 3', async () => {
+  it('funds wallets in batches of 3', async () => {
     const { fetch, calls } = createTrackingFetch(200, { summary: { success: 1 }, results: [] });
     await requestFaucetFunding(
       'https://faucet.example.com/fund', 'test',
       ['0x1', '0x2', '0x3', '0x4', '0x5'], 'big-node', fetch,
     );
+    expect(calls).toHaveLength(2);
     const reqBody = JSON.parse(calls[0].init.body as string);
     expect(reqBody.wallets).toHaveLength(3);
     expect(reqBody.wallets).toEqual(['0x1', '0x2', '0x3']);
+    const secondReqBody = JSON.parse(calls[1].init.body as string);
+    expect(secondReqBody.wallets).toEqual(['0x4', '0x5']);
   });
 
   it('returns error on HTTP failure', async () => {
@@ -61,6 +66,54 @@ describe('requestFaucetFunding', () => {
     );
     expect(result.success).toBe(false);
     expect(result.error).toContain('429');
+    expect(result.fundedWallets).toEqual([]);
+    expect(result.failedWallets).toEqual(['0xAAA']);
+  });
+
+  it('keeps success=true for partial batch success while surfacing the later error', async () => {
+    const calls: FetchCall[] = [];
+    const fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: url as any, init: init as RequestInit });
+      if (calls.length === 1) {
+        return new Response(JSON.stringify({
+          summary: { success: 1 },
+          results: [{ chainId: 'eth-sepolia', amount: '0.01', status: 'success' }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('rate limited', { status: 429 });
+    }) as typeof globalThis.fetch;
+
+    const result = await requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test',
+      ['0x1', '0x2', '0x3', '0x4'], 'partial-node', fetch,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(result.success).toBe(true);
+    expect(result.funded).toEqual(['0.01 ETH']);
+    expect(result.fundedWallets).toEqual(['0x1', '0x2', '0x3']);
+    expect(result.failedWallets).toEqual(['0x4']);
+    expect(result.error).toContain('429');
+  });
+
+  it('uses per-wallet result addresses to report remaining failed wallets', async () => {
+    const { fetch } = createTrackingFetch(200, {
+      summary: { success: 3, failed: 1 },
+      results: [
+        { chainId: 'eth-sepolia', address: '0x1', amount: '0.01', status: 'success' },
+        { chainId: 'trac-base', address: '0x1', amount: '1000', status: 'success' },
+        { chainId: 'eth-sepolia', address: '0x2', amount: '0.01', status: 'success' },
+        { chainId: 'trac-base', address: '0x2', amount: '0', status: 'cooldown_active' },
+      ],
+    });
+    const result = await requestFaucetFunding(
+      'https://faucet.example.com/fund', 'test', ['0x1', '0x2'], 'mixed-node', fetch,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.fundedWallets).toEqual(['0x1']);
+    expect(result.failedWallets).toEqual(['0x2']);
+    expect(result.error).toContain('0x2');
   });
 
   it('returns no-wallets error for empty array', async () => {

--- a/packages/core/test/faucet.test.ts
+++ b/packages/core/test/faucet.test.ts
@@ -161,16 +161,11 @@ describe('requestFaucetFunding', () => {
     expect(result.funded).toEqual([]);
   });
 
-  it('returns failed wallets for network errors', async () => {
+  it('rejects network errors before any wallet is funded', async () => {
     const fetch = (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof globalThis.fetch;
-    const result = await requestFaucetFunding(
+    await expect(requestFaucetFunding(
       'https://faucet.example.com/fund', 'test', ['0xAAA'], 'test-node', fetch,
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.fundedWallets).toEqual([]);
-    expect(result.failedWallets).toEqual(['0xAAA']);
-    expect(result.error).toContain('ECONNREFUSED');
+    )).rejects.toThrow('ECONNREFUSED');
   });
 
   it('preserves earlier funded wallets when a later batch throws', async () => {

--- a/packages/evm-module/abi/Profile.json
+++ b/packages/evm-module/abi/Profile.json
@@ -113,6 +113,22 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "OperationalAddressZero",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      }
+    ],
+    "name": "OperationalKeyTaken",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint16",
@@ -121,6 +137,17 @@
       }
     ],
     "name": "OperatorFeeOutOfRange",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "ProfileDoesntExist",
     "type": "error"
   },
   {
@@ -159,6 +186,24 @@
     "inputs": [],
     "name": "ZeroAsk",
     "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "address[]",
+        "name": "operationalWallets",
+        "type": "address[]"
+      }
+    ],
+    "name": "addOperationalWallets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
     "inputs": [],

--- a/packages/evm-module/contracts/Identity.sol
+++ b/packages/evm-module/contracts/Identity.sol
@@ -142,6 +142,10 @@ contract Identity is INamed, IVersioned, ContractStatus, IInitializable {
         bytes32 attachedKey;
 
         for (uint256 i; i < operationalWallets.length; ) {
+            if (operationalWallets[i] == address(0)) {
+                revert IdentityLib.OperationalAddressZero();
+            }
+
             operationalKey = keccak256(abi.encodePacked(operationalWallets[i]));
 
             if (operationalKey == bytes32(0)) {

--- a/packages/evm-module/contracts/Profile.sol
+++ b/packages/evm-module/contracts/Profile.sol
@@ -20,7 +20,7 @@ import {Permissions} from "./libraries/Permissions.sol";
 
 contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
     string private constant _NAME = "Profile";
-    string private constant _VERSION = "1.0.0";
+    string private constant _VERSION = "1.1.0";
 
     Ask public askContract;
     Identity public identityContract;
@@ -117,6 +117,91 @@ contract Profile is INamed, IVersioned, ContractStatus, IInitializable {
         id.addOperationalWallets(identityId, operationalWallets);
 
         ps.createProfile(identityId, nodeName, nodeId, initialOperatorFee);
+    }
+
+    function addOperationalWallets(
+        uint72 identityId,
+        address[] calldata operationalWallets
+    ) external onlyAdmin(identityId) {
+        if (profileStorage.getNodeId(identityId).length == 0) {
+            revert ProfileLib.ProfileDoesntExist(identityId);
+        }
+
+        address[] memory walletsToAdd = new address[](operationalWallets.length);
+        uint256 walletsToAddCount;
+        IdentityStorage ids = identityStorage;
+
+        for (uint256 i; i < operationalWallets.length; ) {
+            address operationalWallet = operationalWallets[i];
+            if (operationalWallet == address(0)) {
+                revert IdentityLib.OperationalAddressZero();
+            }
+
+            bytes32 operationalKey = keccak256(abi.encodePacked(operationalWallet));
+            if (ids.keyHasPurpose(identityId, operationalKey, IdentityLib.ADMIN_KEY)) {
+                revert IdentityLib.AdminEqualsOperational();
+            }
+            uint72 existingIdentityId = ids.identityIds(operationalKey);
+
+            if (existingIdentityId == identityId) {
+                unchecked {
+                    i++;
+                }
+                continue;
+            }
+            if (existingIdentityId != 0) {
+                revert IdentityLib.OperationalKeyTaken(operationalKey);
+            }
+
+            bool duplicate;
+            for (uint256 j; j < walletsToAddCount; ) {
+                if (walletsToAdd[j] == operationalWallet) {
+                    duplicate = true;
+                    break;
+                }
+                unchecked {
+                    j++;
+                }
+            }
+
+            if (!duplicate) {
+                walletsToAdd[walletsToAddCount] = operationalWallet;
+                unchecked {
+                    walletsToAddCount++;
+                }
+            }
+
+            unchecked {
+                i++;
+            }
+        }
+
+        if (walletsToAddCount == 0) {
+            return;
+        }
+
+        uint256 totalOperationalWallets = ids.getKeysByPurpose(identityId, IdentityLib.OPERATIONAL_KEY).length +
+            walletsToAddCount;
+        uint256 additionalOperationalWallets = totalOperationalWallets == 0 ? 0 : totalOperationalWallets - 1;
+        uint16 operationalWalletLimit = parametersStorage.opWalletsLimitOnProfileCreation();
+        if (additionalOperationalWallets > operationalWalletLimit) {
+            revert ProfileLib.TooManyOperationalWallets(
+                operationalWalletLimit,
+                additionalOperationalWallets > type(uint16).max
+                    ? type(uint16).max
+                    : uint16(additionalOperationalWallets)
+            );
+        }
+
+        address[] memory compactWalletsToAdd = new address[](walletsToAddCount);
+        for (uint256 i; i < walletsToAddCount; ) {
+            compactWalletsToAdd[i] = walletsToAdd[i];
+            unchecked {
+                i++;
+            }
+        }
+
+        identityContract.addOperationalWallets(identityId, compactWalletsToAdd);
     }
 
     function updateAsk(uint72 identityId, uint96 ask) external onlyIdentityOwner(identityId) {

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -5,6 +5,7 @@ import hre from 'hardhat';
 
 import {
   Hub,
+  IdentityStorage,
   ParametersStorage,
   Profile,
   ProfileStorage,
@@ -16,6 +17,7 @@ import {
 type ProfileFixture = {
   accounts: SignerWithAddress[];
   Hub: Hub;
+  IdentityStorage: IdentityStorage;
   Profile: Profile;
   ParametersStorage: ParametersStorage;
   ProfileStorage: ProfileStorage;
@@ -27,6 +29,7 @@ type ProfileFixture = {
 describe('@unit Profile contract', function () {
   let accounts: SignerWithAddress[];
   let Hub: Hub;
+  let IdentityStorage: IdentityStorage;
   let Profile: Profile;
   let ParametersStorage: ParametersStorage;
   let ProfileStorage: ProfileStorage;
@@ -41,6 +44,8 @@ describe('@unit Profile contract', function () {
   async function deployProfileFixture(): Promise<ProfileFixture> {
     await hre.deployments.fixture(['Profile']);
     Profile = await hre.ethers.getContract<Profile>('Profile');
+    IdentityStorage =
+      await hre.ethers.getContract<IdentityStorage>('IdentityStorage');
     ParametersStorage =
       await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
     ProfileStorage =
@@ -57,6 +62,7 @@ describe('@unit Profile contract', function () {
     return {
       accounts,
       Hub,
+      IdentityStorage,
       Profile,
       ParametersStorage,
       ProfileStorage,
@@ -70,6 +76,7 @@ describe('@unit Profile contract', function () {
     ({
       accounts,
       Hub,
+      IdentityStorage,
       Profile,
       ParametersStorage,
       ProfileStorage,
@@ -83,14 +90,122 @@ describe('@unit Profile contract', function () {
     expect(await Profile.name()).to.equal('Profile');
   });
 
-  it('The contract is version "1.0.0"', async () => {
-    expect(await Profile.version()).to.equal('1.0.0');
+  it('The contract is version "1.1.0"', async () => {
+    expect(await Profile.version()).to.equal('1.1.0');
   });
 
   it('Create a profile with valid inputs, expect to pass', async () => {
     await expect(
       Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000),
     ).to.not.be.reverted;
+  });
+
+  it('Create a profile with additional operational wallets, expect all to be registered', async () => {
+    await Profile.createProfile(accounts[1].address, [accounts[2].address], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    const operationalKey = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [accounts[2].address]),
+    );
+    expect(await IdentityStorage.keyHasPurpose(identityId, operationalKey, 2)).to.equal(true);
+  });
+
+  it('Existing operational wallet cannot add operational wallets after profile creation', async () => {
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.addOperationalWallets(identityId, [accounts[2].address]),
+    ).to.be.revertedWithCustomError(Profile, 'OnlyProfileAdminFunction');
+  });
+
+  it('Admin wallet can add operational wallets after profile creation', async () => {
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[2].address]),
+    ).to.not.be.reverted;
+
+    const operationalKey = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [accounts[2].address]),
+    );
+    expect(await IdentityStorage.keyHasPurpose(identityId, operationalKey, 2)).to.equal(true);
+  });
+
+  it('Cannot add the profile admin wallet as an operational wallet', async () => {
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[1].address]),
+    ).to.be.revertedWithCustomError(Profile, 'AdminEqualsOperational');
+  });
+
+  it('Adding already registered same-identity operational wallets is idempotent', async () => {
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [
+        accounts[0].address,
+        accounts[2].address,
+        accounts[2].address,
+      ]),
+    ).to.not.be.reverted;
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[0].address, accounts[2].address]),
+    ).to.not.be.reverted;
+
+    const operationalKey = hre.ethers.keccak256(
+      hre.ethers.solidityPacked(['address'], [accounts[2].address]),
+    );
+    expect(await IdentityStorage.keyHasPurpose(identityId, operationalKey, 2)).to.equal(true);
+  });
+
+  it('Cannot add an operational wallet already registered to another identity', async () => {
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const nodeId2 =
+      '0x17f38512786964d9e70453371e7c98975d284100d44bd68dab67fe00b525cb66';
+    await Profile.connect(accounts[3]).createProfile(
+      accounts[4].address,
+      [],
+      'Node 2',
+      nodeId2,
+      1000,
+    );
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[3].address]),
+    ).to.be.revertedWithCustomError(Profile, 'OperationalKeyTaken');
+  });
+
+  it('Cannot add the zero address as an operational wallet', async () => {
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [hre.ethers.ZeroAddress]),
+    ).to.be.revertedWithCustomError(Profile, 'OperationalAddressZero');
+  });
+
+  it('Cannot exceed the configured operational wallet limit after profile creation', async () => {
+    await ParametersStorage.setOpWalletsLimitOnProfileCreation(2);
+    await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+    const identityId = await IdentityStorage.getIdentityId(accounts[0].address);
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[2].address]),
+    ).to.not.be.reverted;
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[3].address]),
+    ).to.not.be.reverted;
+
+    await expect(
+      Profile.connect(accounts[1]).addOperationalWallets(identityId, [accounts[4].address]),
+    ).to.be.revertedWithCustomError(Profile, 'TooManyOperationalWallets').withArgs(2, 3);
   });
 
   it('Cannot create a profile with empty node name, expect to fail', async () => {

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -37,6 +37,23 @@ export interface StorageACKHandlerConfig {
    * of the H5 prefix on the V10 ACK digest.
    */
   kav10Address: string;
+  /**
+   * Optional live confirmation hook. When provided, the handler calls it
+   * immediately before signing so removed/unregistered operational keys stop
+   * producing ACKs without needing a process restart.
+   */
+  isSignerRegistered?: () => Promise<boolean>;
+  /**
+   * Called when the live confirmation hook reports the signer is no longer
+   * registered. Agents can use this to stop advertising StorageACK support.
+   */
+  onSignerUnregistered?: () => void | Promise<void>;
+  /**
+   * Called when the live confirmation hook itself fails. The handler keeps
+   * the last confirmed signer state and does not treat lookup errors as
+   * revocation.
+   */
+  onSignerRegistrationLookupFailed?: (err: unknown) => void | Promise<void>;
 }
 
 /**
@@ -242,6 +259,27 @@ export class StorageACKHandler {
       intentTokenAmount,
       BigInt(verifiedLeafCount),
     );
+    if (this.config.isSignerRegistered) {
+      let signerRegistered: boolean | undefined;
+      try {
+        signerRegistered = await this.config.isSignerRegistered();
+      } catch (err) {
+        try {
+          await this.config.onSignerRegistrationLookupFailed?.(err);
+        } catch {
+          // Keep ACK availability independent from logging/callback failures.
+        }
+      }
+      if (signerRegistered === false) {
+        try {
+          await this.config.onSignerUnregistered?.();
+        } catch {
+          // Keep the signing refusal deterministic even if protocol cleanup fails.
+        }
+        throw new Error('StorageACK signer is not confirmed on-chain as an operational wallet');
+      }
+    }
+
     const signature = ethers.Signature.from(
       await this.config.signerWallet.signMessage(digest),
     );

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -49,9 +49,9 @@ export interface StorageACKHandlerConfig {
    */
   onSignerUnregistered?: () => void | Promise<void>;
   /**
-   * Called when the live confirmation hook itself fails. The handler keeps
-   * the last confirmed signer state and does not treat lookup errors as
-   * revocation.
+   * Called when the live confirmation hook itself fails. Lookup errors are
+   * signing blockers because ACKs must only be produced by keys confirmed
+   * registered on-chain at signing time.
    */
   onSignerRegistrationLookupFailed?: (err: unknown) => void | Promise<void>;
 }
@@ -269,6 +269,7 @@ export class StorageACKHandler {
         } catch {
           // Keep ACK availability independent from logging/callback failures.
         }
+        throw new Error('StorageACK signer registration lookup failed; refusing to sign');
       }
       if (signerRegistered === false) {
         try {

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -133,7 +133,7 @@ describe('StorageACKHandler', () => {
     );
   });
 
-  it('continues signing when signer registration lookup has a transient failure', async () => {
+  it('refuses to sign when signer registration lookup fails', async () => {
     const lookupFailed = vi.fn();
     const unregistered = vi.fn();
     const handler = await createHandler(swmQuads, {
@@ -154,9 +154,9 @@ describe('StorageACKHandler', () => {
       merkleLeafCount: swmMerkleLeafCount,
     });
 
-    const response = await handler.handler(intent, fakePeerId);
-    const ack = decodeStorageACK(response);
-    expect(ack.contextGraphId).toBe(contextGraphId);
+    await expect(handler.handler(intent, fakePeerId)).rejects.toThrow(
+      'StorageACK signer registration lookup failed; refusing to sign',
+    );
     expect(lookupFailed).toHaveBeenCalledOnce();
     expect(unregistered).not.toHaveBeenCalled();
   });

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
@@ -39,7 +39,10 @@ describe('StorageACKHandler', () => {
   const coreIdentityId = 42n;
   const fakePeerId = { toString: () => 'publisher-peer' };
 
-  async function createHandler(storeQuads: Quad[]) {
+  async function createHandler(
+    storeQuads: Quad[],
+    configOverrides: Partial<StorageACKHandlerConfig> = {},
+  ) {
     const store = new OxigraphStore();
 
     const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
@@ -57,6 +60,7 @@ describe('StorageACKHandler', () => {
         `did:dkg:context-graph:${cgId}/_shared_memory`,
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
+      ...configOverrides,
     };
 
     return new StorageACKHandler(store as any, config, new TypedEventBus() as any);
@@ -105,6 +109,56 @@ describe('StorageACKHandler', () => {
         ? ack.coreNodeSignatureVS : new Uint8Array(ack.coreNodeSignatureVS)),
     });
     expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
+  });
+
+  it('refuses to sign when the signer is no longer confirmed registered', async () => {
+    const handler = await createHandler(swmQuads, {
+      isSignerRegistered: async () => false,
+    });
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 2,
+      rootEntities: ['urn:entity:1', 'urn:entity:2'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: swmMerkleLeafCount,
+    });
+
+    await expect(handler.handler(intent, fakePeerId)).rejects.toThrow(
+      'StorageACK signer is not confirmed on-chain as an operational wallet',
+    );
+  });
+
+  it('continues signing when signer registration lookup has a transient failure', async () => {
+    const lookupFailed = vi.fn();
+    const unregistered = vi.fn();
+    const handler = await createHandler(swmQuads, {
+      isSignerRegistered: async () => { throw new Error('rpc unavailable'); },
+      onSignerRegistrationLookupFailed: lookupFailed,
+      onSignerUnregistered: unregistered,
+    });
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 2,
+      rootEntities: ['urn:entity:1', 'urn:entity:2'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: swmMerkleLeafCount,
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const ack = decodeStorageACK(response);
+    expect(ack.contextGraphId).toBe(contextGraphId);
+    expect(lookupFailed).toHaveBeenCalledOnce();
+    expect(unregistered).not.toHaveBeenCalled();
   });
 
   it('rejects when SWM has no data', async () => {


### PR DESCRIPTION
## Summary

Release change for persisted profile admin keys, self-healing operational wallet registration, and ACK signer safety.

- add a distinct persisted `adminWallet` to `wallets.json` so new auto-created profiles do not lose their profile admin key
- keep legacy operational-only `wallets.json` files readable without synthesizing a replacement admin key; those nodes run without profile key-repair privileges until the real admin key is added
- reject existing `wallets.json` files with an empty operational wallet set instead of overwriting the file
- add `Profile.addOperationalWallets(uint72,address[])` for operational-only wallet registration by profile admins only
- reject profile admin wallets in `Profile.addOperationalWallets` so admin keys cannot be silently converted into operational ACK keys
- enforce the configured additional-operational-wallet limit across later `Profile.addOperationalWallets` calls, matching `createProfile` semantics where the primary operational key is implicit
- auto-register configured ACK/operational signer wallets during EVM agent startup using the configured profile admin key
- require EVM `adminPrivateKey` by default, with an explicit `allowNoAdminSigner` mode only for publish/read-only adapters that never create profiles or mutate profile keys
- let edge/read-only `DKGAgent` chain config run without `adminPrivateKey` in no-admin mode, while core chain config fails fast unless the persisted profile admin key is supplied
- gate StorageACK handler registration and per-ACK signing on live on-chain `OPERATIONAL_KEY` confirmation; the handler unregisters `/storage-ack` if that confirmation later fails
- defer and retry initial StorageACK handler registration on transient startup signer-confirmation lookup errors instead of disabling ACKs until restart
- treat transient signer-registration lookup failures as availability errors, not revocation; ACK signing continues with the already-confirmed signer and logs a warning
- make `ChainAdapter.isOperationalWalletRegistered` an explicit required capability for ACK-safe adapters
- keep prebuilt `chainAdapter` mode from sourcing ACK signer candidates from ignored/stale `chainConfig.operationalKeys`
- include the admin wallet in CLI/OpenClaw faucet funding and wallet display paths, and fund all generated wallets in faucet-sized batches
- report faucet partial-batch success without hiding the batch error, so operators can retry/manual-fund remaining wallets
- return funded/failed faucet wallet lists and show manual funding instructions only for wallets that still need funds
- treat HTTP 200 faucet responses with mixed per-wallet statuses as partial failures so callers still print the remaining wallets
- require OpenClaw faucet wallet discovery to find at least one operational wallet before returning/funding the admin wallet
- add contract, chain adapter, agent, OpenClaw setup, and real Hardhat/libp2p e2e coverage
- add Unreleased changelog notes for the release

## Release / Deploy Notes

- `Profile` version is bumped to `1.1.0`.
- `packages/evm-module/abi/Profile.json` and `packages/chain/abi/Profile.json` are regenerated.
- The Base Sepolia deployment manifest is left untouched in this PR. After the actual testnet deploy, commit the new `Profile` deployment metadata produced by the official deploy.
- Admin-key management remains separate; this PR only adds operational wallets through an admin-only facade.
- Existing profiles whose admin key was generated randomly and lost cannot be repaired by a newly generated local `adminWallet`. Those nodes need a profile reset/recreate or a one-time admin-key migration before extra operational wallets can be registered.
- Existing legacy `wallets.json` files without `adminWallet` remain readable. They cannot auto-repair/register missing operational wallets until the real profile admin key is added.

## Verification

- `pnpm --filter @origintrail-official/dkg-evm-module compile`
- `pnpm --dir packages/evm-module exec hardhat compile --config hardhat.config.ts --force`
- `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts test/unit/Profile.test.ts`
- `pnpm --filter @origintrail-official/dkg-core build`
- `pnpm --filter @origintrail-official/dkg-chain build`
- `pnpm --filter @origintrail-official/dkg-publisher build`
- `pnpm --filter @origintrail-official/dkg-agent build`
- `pnpm --dir packages/core exec vitest run test/faucet.test.ts`
- `pnpm --dir packages/chain exec vitest run mock-adapter-parity`
- `pnpm --dir packages/publisher exec vitest run test/storage-ack-handler.test.ts`
- `pnpm --dir packages/chain exec vitest run test/evm-adapter.unit.test.ts`
- `pnpm --dir packages/agent exec vitest run test/op-wallets.test.ts`
- `pnpm --dir packages/agent exec vitest run test/agent.test.ts -t "DKGAgent ACK signer gating"`
- `pnpm --dir packages/agent exec vitest run test/e2e-operational-wallet-acks.test.ts`
- `pnpm --dir packages/adapter-openclaw exec vitest run test/setup.test.ts -t readWallets`
- `pnpm --dir packages/adapter-openclaw exec vitest run test/setup.test.ts -t logManualFundingInstructions`
- `pnpm --filter @origintrail-official/dkg-adapter-openclaw build`
- `pnpm --filter @origintrail-official/dkg-chain build`
- `pnpm --filter @origintrail-official/dkg build`
- `git diff --check`
