### PR TITLE
fix(devnet): align wallets.json + identity probe + stake signer with PR 366

### DIFF
--- a/scripts/devnet-test-publish.sh
+++ b/scripts/devnet-test-publish.sh
@@ -10,8 +10,13 @@
 #   1. Reads ContextGraphs / ContextGraphStorage / IdentityStorage /
 #      KnowledgeCollectionStorage addresses from
 #      packages/evm-module/deployments/localhost_contracts.json.
-#   2. Discovers hosting-node identity ids by looping over the first 6 devnet
-#      signers and querying IdentityStorage.getIdentityId(signer.address).
+#   2. Discovers hosting-node identity ids by reading each devnet node's
+#      .devnet/nodeN/wallets.json, deriving the operational wallet[0]
+#      address, and querying IdentityStorage.getIdentityId(opAddress).
+#      Pre-PR #366 the operational + admin keys were the same Hardhat
+#      signer, so iterating provider.listAccounts() worked. Post-PR #366
+#      identities are registered against random operational wallets only,
+#      so Hardhat signers no longer resolve to any identity.
 #   3. Creates a fresh open-policy V10 context graph on-chain via
 #      ContextGraphs.createContextGraph(hostingNodes, [], 1, 0, 1, ZeroAddress, 0).
 #      Uses staticCall to preview the returned numeric cgId, then sends the
@@ -40,6 +45,9 @@ NODE_NUM="${DEVNET_TEST_NODE:-1}"
 API_PORT_BASE=9201
 API_PORT=$((API_PORT_BASE + NODE_NUM - 1))
 CONFIRM_TIMEOUT="${CONFIRM_TIMEOUT:-60}"
+# Match scripts/devnet.sh's default node count when probing for hosting-node
+# identities. Override if you start devnet with a different size.
+HOSTING_NODE_COUNT="${HOSTING_NODE_COUNT:-6}"
 
 CONTRACTS_JSON="$REPO_ROOT/packages/evm-module/deployments/localhost_contracts.json"
 EVM_ABI_DIR="$REPO_ROOT/packages/evm-module/abi"
@@ -88,6 +96,8 @@ CG_ID=$(
   RPC_URL="http://127.0.0.1:${HARDHAT_PORT}" \
   CONTRACTS_JSON="$CONTRACTS_JSON" \
   ABI_DIR="$EVM_ABI_DIR" \
+  DEVNET_DIR="$DEVNET_DIR" \
+  HOSTING_NODE_COUNT="$HOSTING_NODE_COUNT" \
   node -e '
 const { ethers } = require("ethers");
 const fs = require("fs");
@@ -114,15 +124,40 @@ const path = require("path");
   const cgAbi        = loadAbi("ContextGraphs");
   const cgStorageAbi = loadAbi("ContextGraphStorage");
 
-  // Discover hosting-node identity ids from the first 6 devnet signers.
+  // Discover hosting-node identity ids by reading each devnet nodes
+  // wallets.json file and querying IdentityStorage against the operational
+  // wallet[0] address. PR #366 separated admin and operational keys: the
+  // identity is registered against the operational key, not the Hardhat
+  // signer that funded the node. NOTE: avoid an apostrophe in this comment;
+  // the entire JS body lives inside bashs `node -e ...` single-quoted arg,
+  // so any apostrophe here would close the bash quoting prematurely.
   const identity = new ethers.Contract(identityAddr, identityAbi, provider);
-  const signers = await provider.listAccounts();
-  const max = Math.min(signers.length, 6);
+  const devnetDir = process.env.DEVNET_DIR;
+  const hostingCount = Number(process.env.HOSTING_NODE_COUNT || "6");
+  if (!devnetDir) throw new Error("DEVNET_DIR not set");
   const ids = [];
-  for (let i = 0; i < max; i++) {
-    const addr = typeof signers[i] === "string" ? signers[i] : signers[i].address;
-    const id = await identity.getIdentityId(addr);
+  for (let i = 1; i <= hostingCount; i++) {
+    const walletsPath = path.join(devnetDir, "node" + i, "wallets.json");
+    if (!fs.existsSync(walletsPath)) {
+      console.error("node " + i + ": missing " + walletsPath + " — skipping");
+      continue;
+    }
+    let opAddr;
+    try {
+      const w = JSON.parse(fs.readFileSync(walletsPath, "utf8"));
+      const op0 = Array.isArray(w.wallets) ? w.wallets[0] : null;
+      if (!op0 || !op0.privateKey) {
+        console.error("node " + i + ": wallets.json has no wallets[0].privateKey — skipping");
+        continue;
+      }
+      opAddr = new ethers.Wallet(op0.privateKey).address;
+    } catch (e) {
+      console.error("node " + i + ": failed to parse wallets.json: " + (e?.message || e));
+      continue;
+    }
+    const id = await identity.getIdentityId(opAddr);
     if (id > 0n) ids.push(id);
+    else console.error("node " + i + ": opWallet " + opAddr + " has no identity — skipping");
   }
   if (ids.length === 0) {
     throw new Error("no hosting-node identities found — devnet identity registration may still be pending");

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -400,8 +400,14 @@ create_node_config() {
 }
 EOCONF
 
-  # Generate wallets.json: primary Hardhat key + NUM_OP_WALLETS additional
-  # operational wallets for parallel EVM transaction submission.
+  # Generate wallets.json in the post-PR-366 format:
+  #   - adminWallet: primary Hardhat key (pre-funded; used to createProfile +
+  #     register operational keys via Profile.addOperationalWallets)
+  #   - wallets[]: NUM_OP_WALLETS random operational wallets for parallel EVM
+  #     transaction submission (need explicit ETH+TRAC funding below)
+  # The admin/operational separation is enforced on-chain since PR 366 — admin
+  # key holds purpose=ADMIN_KEY, operational keys hold purpose=OPERATIONAL_KEY,
+  # and the two sets MUST be disjoint addresses.
   # Run from a package that has 'ethers' so require() resolves (pnpm workspace).
   local extra_addrs
   extra_addrs=$(cd "$REPO_ROOT/packages/evm-module" && node -e "
@@ -409,14 +415,15 @@ EOCONF
     const { ethers } = require('ethers');
     const fs = require('fs');
     const primary = new ethers.Wallet('${HARDHAT_KEYS[$key_idx]}');
-    const wallets = [{ privateKey: '${HARDHAT_KEYS[$key_idx]}', address: primary.address }];
+    const adminWallet = { privateKey: '${HARDHAT_KEYS[$key_idx]}', address: primary.address };
+    const wallets = [];
     for (let i = 0; i < ${NUM_OP_WALLETS}; i++) {
       const key = '0x' + crypto.randomBytes(32).toString('hex');
       const w = new ethers.Wallet(key);
       wallets.push({ privateKey: key, address: w.address });
     }
-    fs.writeFileSync('$node_dir/wallets.json', JSON.stringify({ wallets }, null, 2));
-    wallets.slice(1).forEach(w => console.log(w.address));
+    fs.writeFileSync('$node_dir/wallets.json', JSON.stringify({ adminWallet, wallets }, null, 2));
+    wallets.forEach(w => console.log(w.address));
   ")
 
   # Fund each additional wallet with ETH (gas) and TRAC (publish payments).
@@ -708,54 +715,84 @@ cmd_start() {
       const stakingV10Addr = c('StakingV10');
       const profile  = new ethers.Contract(c('Profile'),         ['function updateAsk(uint72,uint96)'], provider);
 
-      const signers = await provider.listAccounts();
-      const n = Math.min(signers.length, $NUM_NODES);
+      // Post-PR-366: each node's wallets.json has \`adminWallet\` (the Hardhat key,
+      // which holds purpose=ADMIN_KEY only) and \`wallets[]\` (random op keys
+      // holding purpose=OPERATIONAL_KEY only). The reverse-lookup map
+      // \`IdentityStorage.identityIds\` is operational-only by design (see
+      // IdentityStorage.sol:108-110), so we MUST query identity by op wallet
+      // address, not by admin/Hardhat-key address. createConviction + updateAsk
+      // also need to be signed by the op wallet (the address that owns the
+      // identity in the eyes of the staking + profile contracts).
+      const n = $NUM_NODES;
+      const opSigners = [];
+      const nodeRoles = [];
+      for (let i = 1; i <= n; i++) {
+        const w = JSON.parse(fs.readFileSync('$DEVNET_DIR/node' + i + '/wallets.json', 'utf8'));
+        opSigners.push(new ethers.Wallet(w.wallets[0].privateKey, provider));
+        const cfg = JSON.parse(fs.readFileSync('$DEVNET_DIR/node' + i + '/config.json', 'utf8'));
+        nodeRoles.push(cfg.nodeRole || 'core');
+      }
 
-      // Wait up to 60s for ALL nodes to have identities, not just the first
+      // Wait up to 60s for all CORE nodes to have identities. Edge nodes
+      // never create on-chain profiles by design (dkg-agent.ts skips
+      // ensureProfile for effectiveRole='edge'), so we don't wait on them.
+      // The daemon creates identities eagerly in agent.connect() (dkg-agent.ts
+      // ensureProfile path), typically within ~5s of node start.
+      const coreIdxs = nodeRoles.map((r, i) => r === 'core' ? i : -1).filter(i => i >= 0);
       const nodeIds = new Array(n).fill(0n);
       for (let attempt = 0; attempt < 30; attempt++) {
         let allReady = true;
-        for (let i = 0; i < n; i++) {
+        for (const i of coreIdxs) {
           if (nodeIds[i] === 0n) {
-            nodeIds[i] = await identity.getIdentityId(signers[i].address);
+            nodeIds[i] = await identity.getIdentityId(opSigners[i].address);
           }
           if (nodeIds[i] === 0n) allReady = false;
         }
         if (allReady) break;
-        const ready = nodeIds.filter(id => id > 0n).length;
-        if (attempt % 5 === 4) console.log('Waiting for identities: ' + ready + '/' + n + ' ready...');
+        const ready = coreIdxs.filter(i => nodeIds[i] > 0n).length;
+        if (attempt % 5 === 4) console.log('Waiting for core identities: ' + ready + '/' + coreIdxs.length + ' ready...');
         await new Promise(r => setTimeout(r, 2000));
       }
 
       let staked = 0, asked = 0;
+      const coreCount = coreIdxs.length;
       for (let i = 0; i < n; i++) {
-        const signer = signers[i];
-        const idId = nodeIds[i] || await identity.getIdentityId(signer.address);
-        if (idId === 0n) { console.log('Node ' + (i+1) + ': no identity after 60s, skipping'); continue; }
+        if (nodeRoles[i] !== 'core') continue;
+        const opSigner = opSigners[i];
+        const idId = nodeIds[i] || await identity.getIdentityId(opSigner.address);
+        if (idId === 0n) { console.log('Node ' + (i+1) + ' (core): no identity after 60s, skipping'); continue; }
 
         const stakeAmount = ethers.parseEther('50000');
         const askAmount = ethers.parseEther('1');
         // Lock tier 1 (1-month). Cheapest tier with non-zero multiplier; sufficient
         // for devnet random-sampling soak tests where we need nodeStakeV10 > 0.
         const lockTier = 1;
+
+        // The daemon's publisher shares this op wallet (registered as the
+        // StorageACK signer + first op wallet). It may have submitted txs
+        // already (addKey, addOperationalWallets) by the time we reach here,
+        // so we MUST query the latest nonce explicitly and pass it to each
+        // tx — relying on ethers' default nonce manager would race the daemon
+        // and yield 'nonce has already been used'.
+        let nonce = await provider.getTransactionCount(opSigner.address, 'latest');
         try {
           const deployer = await provider.getSigner(0);
-          await (await token.connect(deployer).mint(signer.address, stakeAmount)).wait();
+          await (await token.connect(deployer).mint(opSigner.address, stakeAmount)).wait();
           // StakingV10.stake pulls TRAC via transferFrom(staker, address(CSS), amount)
           // gated by allowance to StakingV10. Approve StakingV10 here, NOT the NFT —
           // the NFT is only the entry point and never custodies TRAC.
-          await (await token.connect(signer).approve(stakingV10Addr, stakeAmount)).wait();
-          await (await stakingNFT.connect(signer).createConviction(idId, stakeAmount, lockTier)).wait();
+          await (await token.connect(opSigner).approve(stakingV10Addr, stakeAmount, { nonce: nonce++ })).wait();
+          await (await stakingNFT.connect(opSigner).createConviction(idId, stakeAmount, lockTier, { nonce: nonce++ })).wait();
           staked++;
         } catch (e) { console.log('Stake failed for node ' + (i+1) + ': ' + e.message); }
 
         // Set ask price
         try {
-          await (await profile.connect(signer).updateAsk(idId, askAmount)).wait();
+          await (await profile.connect(opSigner).updateAsk(idId, askAmount, { nonce: nonce++ })).wait();
           asked++;
         } catch (e) { console.log('Ask failed for node ' + (i+1) + ': ' + e.message); }
       }
-      console.log('Staked 50k TRAC for ' + staked + '/' + n + ' node(s), ask set for ' + asked + '/' + n);
+      console.log('Staked 50k TRAC for ' + staked + '/' + coreCount + ' core node(s), ask set for ' + asked + '/' + coreCount);
     })();
   " 2>&1 | while read -r line; do log "$line"; done
 

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -725,12 +725,31 @@ cmd_start() {
       // identity in the eyes of the staking + profile contracts).
       const n = $NUM_NODES;
       const opSigners = new Array(n).fill(null);
-      // Codex round 3 on PR #368: default unknown role to 'edge' (safest
-      // failure mode). 'core' would auto-provision an on-chain identity
-      // and stake for a node whose role we cannot confirm, violating the
-      // documented 'edge stays off-chain' invariant.
       const nodeRoles = new Array(n).fill('edge');
-      // Codex round 2 on PR #368: parse each node's wallets.json + config.json
+      // Codex round 4 on PR #368: read config.json FIRST and INDEPENDENTLY
+      // of wallets.json. The previous loop did wallets first and `continue`d
+      // on parse failure BEFORE reading config, so an intended core whose
+      // wallets.json was malformed silently kept the 'edge' default,
+      // dropped out of coreIdxs, and the lostCores guard never fired.
+      // Reading config first decouples the two failures: now lostCores
+      // correctly catches "I was supposed to be a core but my wallets
+      // are broken".
+      const configErrors = [];
+      for (let i = 1; i <= n; i++) {
+        const cPath = '$DEVNET_DIR/node' + i + '/config.json';
+        try {
+          const cfg = JSON.parse(fs.readFileSync(cPath, 'utf8'));
+          // Trust the explicit role; fall back to 'edge' (NOT 'core') if
+          // the field is missing — defaulting unknowns to 'core' would
+          // auto-provision an on-chain identity for a node whose role we
+          // cannot confirm.
+          nodeRoles[i - 1] = cfg.nodeRole || 'edge';
+        } catch (e) {
+          configErrors.push(i);
+          console.log('Node ' + i + ': failed to parse config.json (treating as edge): ' + (e && e.message || e));
+        }
+      }
+      // Codex round 2 on PR #368: parse each node's wallets.json
       // independently. A malformed file (truncated mid-write, missing
       // wallets[0], unparseable JSON) MUST NOT throw and abort staking
       // for every node — log + skip the bad one and let the rest boot.
@@ -738,7 +757,6 @@ cmd_start() {
       // entries never reach createConviction/updateAsk.
       for (let i = 1; i <= n; i++) {
         const wPath = '$DEVNET_DIR/node' + i + '/wallets.json';
-        const cPath = '$DEVNET_DIR/node' + i + '/config.json';
         try {
           const w = JSON.parse(fs.readFileSync(wPath, 'utf8'));
           if (!w || !Array.isArray(w.wallets) || w.wallets.length === 0
@@ -749,15 +767,6 @@ cmd_start() {
           opSigners[i - 1] = new ethers.Wallet(w.wallets[0].privateKey, provider);
         } catch (e) {
           console.log('Node ' + i + ': failed to parse wallets.json: ' + (e && e.message || e));
-          continue;
-        }
-        try {
-          const cfg = JSON.parse(fs.readFileSync(cPath, 'utf8'));
-          // Trust the explicit role; fall back to 'edge' (NOT 'core') if
-          // the field is missing — see comment above on safest default.
-          nodeRoles[i - 1] = cfg.nodeRole || 'edge';
-        } catch (e) {
-          console.log('Node ' + i + ': failed to parse config.json (defaulting nodeRole=edge): ' + (e && e.message || e));
         }
       }
 
@@ -778,6 +787,17 @@ cmd_start() {
           + lostCores.map(String).join(', '));
         console.error('Refusing to bootstrap a partially-provisioned devnet. Fix the wallet files and re-run.');
         process.exit(1);
+      }
+      // Codex round 4 on PR #368: a node whose config.json was unreadable
+      // is now treated as 'edge' and silently skipped from staking. This
+      // is the correct safe default IF the operator intended that node to
+      // be edge — but if they intended it to be core, the lostCores
+      // guard above won't catch it because nodeRoles[i] !== 'core'.
+      // Surface the ambiguity loudly so the operator can confirm intent.
+      if (configErrors.length > 0) {
+        console.error('WARNING: ' + configErrors.length + ' node(s) have unreadable config.json: '
+          + configErrors.map(String).join(', '));
+        console.error('These nodes are being treated as edge (no on-chain stake). Fix config.json if any were intended to be core.');
       }
 
       // Wait up to 60s for all CORE nodes to have identities. Edge nodes

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -771,10 +771,16 @@ cmd_start() {
         // The daemon's publisher shares this op wallet (registered as the
         // StorageACK signer + first op wallet). It may have submitted txs
         // already (addKey, addOperationalWallets) by the time we reach here,
-        // so we MUST query the latest nonce explicitly and pass it to each
-        // tx — relying on ethers' default nonce manager would race the daemon
+        // so we MUST query the nonce explicitly and pass it to each tx —
+        // relying on ethers' default nonce manager would race the daemon
         // and yield 'nonce has already been used'.
-        let nonce = await provider.getTransactionCount(opSigner.address, 'latest');
+        //
+        // Codex round 1 on PR #368: use 'pending' (NOT 'latest') so the
+        // count includes daemon-submitted txs already in the mempool but
+        // not yet mined. 'latest' would still collide with an in-flight
+        // addKey/addOperationalWallets and produce the very nonce error
+        // this code path exists to prevent.
+        let nonce = await provider.getTransactionCount(opSigner.address, 'pending');
         try {
           const deployer = await provider.getSigner(0);
           await (await token.connect(deployer).mint(opSigner.address, stakeAmount)).wait();

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -724,13 +724,35 @@ cmd_start() {
       // also need to be signed by the op wallet (the address that owns the
       // identity in the eyes of the staking + profile contracts).
       const n = $NUM_NODES;
-      const opSigners = [];
-      const nodeRoles = [];
+      const opSigners = new Array(n).fill(null);
+      const nodeRoles = new Array(n).fill('core');
+      // Codex round 2 on PR #368: parse each node's wallets.json + config.json
+      // independently. A malformed file (truncated mid-write, missing
+      // wallets[0], unparseable JSON) MUST NOT throw and abort staking
+      // for every node — log + skip the bad one and let the rest boot.
+      // Downstream loops gate on \`opSigners[i] != null\` so skipped
+      // entries never reach createConviction/updateAsk.
       for (let i = 1; i <= n; i++) {
-        const w = JSON.parse(fs.readFileSync('$DEVNET_DIR/node' + i + '/wallets.json', 'utf8'));
-        opSigners.push(new ethers.Wallet(w.wallets[0].privateKey, provider));
-        const cfg = JSON.parse(fs.readFileSync('$DEVNET_DIR/node' + i + '/config.json', 'utf8'));
-        nodeRoles.push(cfg.nodeRole || 'core');
+        const wPath = '$DEVNET_DIR/node' + i + '/wallets.json';
+        const cPath = '$DEVNET_DIR/node' + i + '/config.json';
+        try {
+          const w = JSON.parse(fs.readFileSync(wPath, 'utf8'));
+          if (!w || !Array.isArray(w.wallets) || w.wallets.length === 0
+              || !w.wallets[0] || !w.wallets[0].privateKey) {
+            console.log('Node ' + i + ': wallets.json missing wallets[0].privateKey, skipping (' + wPath + ')');
+            continue;
+          }
+          opSigners[i - 1] = new ethers.Wallet(w.wallets[0].privateKey, provider);
+        } catch (e) {
+          console.log('Node ' + i + ': failed to parse wallets.json: ' + (e && e.message || e));
+          continue;
+        }
+        try {
+          const cfg = JSON.parse(fs.readFileSync(cPath, 'utf8'));
+          nodeRoles[i - 1] = cfg.nodeRole || 'core';
+        } catch (e) {
+          console.log('Node ' + i + ': failed to parse config.json (defaulting nodeRole=core): ' + (e && e.message || e));
+        }
       }
 
       // Wait up to 60s for all CORE nodes to have identities. Edge nodes
@@ -738,7 +760,10 @@ cmd_start() {
       // ensureProfile for effectiveRole='edge'), so we don't wait on them.
       // The daemon creates identities eagerly in agent.connect() (dkg-agent.ts
       // ensureProfile path), typically within ~5s of node start.
-      const coreIdxs = nodeRoles.map((r, i) => r === 'core' ? i : -1).filter(i => i >= 0);
+      // Skip nodes whose wallets.json failed to parse (opSigners[i] === null).
+      const coreIdxs = nodeRoles
+        .map((r, i) => r === 'core' && opSigners[i] !== null ? i : -1)
+        .filter(i => i >= 0);
       const nodeIds = new Array(n).fill(0n);
       for (let attempt = 0; attempt < 30; attempt++) {
         let allReady = true;
@@ -759,6 +784,7 @@ cmd_start() {
       for (let i = 0; i < n; i++) {
         if (nodeRoles[i] !== 'core') continue;
         const opSigner = opSigners[i];
+        if (!opSigner) { console.log('Node ' + (i+1) + ' (core): wallets.json invalid, skipping'); continue; }
         const idId = nodeIds[i] || await identity.getIdentityId(opSigner.address);
         if (idId === 0n) { console.log('Node ' + (i+1) + ' (core): no identity after 60s, skipping'); continue; }
 
@@ -780,21 +806,39 @@ cmd_start() {
         // not yet mined. 'latest' would still collide with an in-flight
         // addKey/addOperationalWallets and produce the very nonce error
         // this code path exists to prevent.
-        let nonce = await provider.getTransactionCount(opSigner.address, 'pending');
+        //
+        // Codex round 2 on PR #368: re-read 'pending' before EVERY tx
+        // (not once per node loop). The previous code did `nonce++` at
+        // call site so a failed approve advanced the local counter even
+        // though the chain nonce did not, leaving createConviction +
+        // updateAsk to send with an inflated nonce that would either
+        // queue forever or skip a slot. Re-reading 'pending' between
+        // awaits costs one extra eth_call per tx, which is negligible
+        // for a 6-node devnet bootstrap.
+        const sendWithFreshNonce = async (txFactory) => {
+          const freshNonce = await provider.getTransactionCount(opSigner.address, 'pending');
+          const tx = await txFactory(freshNonce);
+          return tx.wait();
+        };
         try {
           const deployer = await provider.getSigner(0);
           await (await token.connect(deployer).mint(opSigner.address, stakeAmount)).wait();
           // StakingV10.stake pulls TRAC via transferFrom(staker, address(CSS), amount)
           // gated by allowance to StakingV10. Approve StakingV10 here, NOT the NFT —
           // the NFT is only the entry point and never custodies TRAC.
-          await (await token.connect(opSigner).approve(stakingV10Addr, stakeAmount, { nonce: nonce++ })).wait();
-          await (await stakingNFT.connect(opSigner).createConviction(idId, stakeAmount, lockTier, { nonce: nonce++ })).wait();
+          await sendWithFreshNonce((freshNonce) =>
+            token.connect(opSigner).approve(stakingV10Addr, stakeAmount, { nonce: freshNonce }));
+          await sendWithFreshNonce((freshNonce) =>
+            stakingNFT.connect(opSigner).createConviction(idId, stakeAmount, lockTier, { nonce: freshNonce }));
           staked++;
         } catch (e) { console.log('Stake failed for node ' + (i+1) + ': ' + e.message); }
 
-        // Set ask price
+        // Set ask price (independent try block — a failed stake must not
+        // skip ask setup; sendWithFreshNonce re-reads 'pending' so it
+        // tolerates the chain nonce having advanced or not).
         try {
-          await (await profile.connect(opSigner).updateAsk(idId, askAmount, { nonce: nonce++ })).wait();
+          await sendWithFreshNonce((freshNonce) =>
+            profile.connect(opSigner).updateAsk(idId, askAmount, { nonce: freshNonce }));
           asked++;
         } catch (e) { console.log('Ask failed for node ' + (i+1) + ': ' + e.message); }
       }

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -725,7 +725,11 @@ cmd_start() {
       // identity in the eyes of the staking + profile contracts).
       const n = $NUM_NODES;
       const opSigners = new Array(n).fill(null);
-      const nodeRoles = new Array(n).fill('core');
+      // Codex round 3 on PR #368: default unknown role to 'edge' (safest
+      // failure mode). 'core' would auto-provision an on-chain identity
+      // and stake for a node whose role we cannot confirm, violating the
+      // documented 'edge stays off-chain' invariant.
+      const nodeRoles = new Array(n).fill('edge');
       // Codex round 2 on PR #368: parse each node's wallets.json + config.json
       // independently. A malformed file (truncated mid-write, missing
       // wallets[0], unparseable JSON) MUST NOT throw and abort staking
@@ -749,10 +753,31 @@ cmd_start() {
         }
         try {
           const cfg = JSON.parse(fs.readFileSync(cPath, 'utf8'));
-          nodeRoles[i - 1] = cfg.nodeRole || 'core';
+          // Trust the explicit role; fall back to 'edge' (NOT 'core') if
+          // the field is missing — see comment above on safest default.
+          nodeRoles[i - 1] = cfg.nodeRole || 'edge';
         } catch (e) {
-          console.log('Node ' + i + ': failed to parse config.json (defaulting nodeRole=core): ' + (e && e.message || e));
+          console.log('Node ' + i + ': failed to parse config.json (defaulting nodeRole=edge): ' + (e && e.message || e));
         }
+      }
+
+      // Codex round 3 on PR #368: fail-fast if a node we INTEND to be
+      // a core (its config.json said so) lost its wallets.json. The
+      // earlier silent-skip here would let cmd_start succeed with a
+      // half-staked devnet, then publish/ACK smoke tests would fail
+      // later with much less obvious symptoms. We treat any node that
+      // BOTH (a) has nodeRole=core AND (b) failed wallet parse as a
+      // hard failure — print diagnostics and exit non-zero so the
+      // operator fixes the wallet file before retrying.
+      const lostCores = [];
+      for (let i = 0; i < n; i++) {
+        if (nodeRoles[i] === 'core' && opSigners[i] === null) lostCores.push(i + 1);
+      }
+      if (lostCores.length > 0) {
+        console.error('FATAL: ' + lostCores.length + ' core node(s) have invalid wallets.json: '
+          + lostCores.map(String).join(', '));
+        console.error('Refusing to bootstrap a partially-provisioned devnet. Fix the wallet files and re-run.');
+        process.exit(1);
       }
 
       // Wait up to 60s for all CORE nodes to have identities. Edge nodes

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -709,14 +709,19 @@ cmd_start() {
       const stakingNFT = new ethers.Contract(
         c('DKGStakingConvictionNFT'),
         // lockTier is uint40 in V10 (L3 — widened from uint8 to support tier ids > 255).
-        // balanceOf(address) is the ERC-721 standard read used by the
-        // duplicate-stake guard below — without it, the probe throws
-        // immediately and the guard falls through to a double-stake.
-        // Codex round 5 on PR #368.
-        [
-          'function createConviction(uint72,uint96,uint40)',
-          'function balanceOf(address) view returns (uint256)',
-        ],
+        ['function createConviction(uint72,uint96,uint40)'],
+        provider
+      );
+      // Identity-scoped read used by the duplicate-stake guard below.
+      // ERC-721 balanceOf(opWallet) would also signal "this wallet
+      // owns at least one position", but that's not what the guard
+      // needs to know — an op wallet can hold positions for OTHER
+      // identities, which would skip a needed createConviction for
+      // THIS identity. getNodeStakeV10(idId) reads the per-identity
+      // stake total directly. Codex round 7 on PR #368.
+      const css = new ethers.Contract(
+        c('ConvictionStakingStorage'),
+        ['function getNodeStakeV10(uint72) view returns (uint256)'],
         provider
       );
       const stakingV10Addr = c('StakingV10');
@@ -878,9 +883,8 @@ cmd_start() {
         // the time this script reaches the staking loop the daemon has
         // (usually) already staked. Running createConviction again would
         // open a SECOND 50k position per core node and silently double the
-        // devnet stake. We detect this by reading the conviction NFT
-        // balance on the operational wallet — if the daemon's stake
-        // succeeded the balance is >0 and we skip.
+        // devnet stake. We detect this by reading the per-identity V10
+        // stake total — if the daemon's stake succeeded it's >0 and we skip.
         //
         // Codex round 5 on PR #368: do NOT fall through to "not staked"
         // on probe failure (transient RPC, decode error). That would
@@ -890,21 +894,27 @@ cmd_start() {
         // decides — rather than silently doubling the stake.
         // updateAsk is INDEPENDENT of stake state, so we still attempt
         // it below regardless of the probe outcome.
+        //
+        // Codex round 7 on PR #368: probe `getNodeStakeV10(idId)` instead
+        // of NFT `balanceOf(opSigner.address)`. The op wallet could hold
+        // positions for OTHER identities (not in our devnet today, but
+        // a wallet-scoped probe is the wrong semantic check); we want
+        // to know whether THIS identity is staked.
         let probeOk = false;
         let shouldStake = false;
         for (let attempt = 0; attempt < 2; attempt++) {
           try {
-            const balance = await stakingNFT.balanceOf(opSigner.address);
+            const nodeStake = await css.getNodeStakeV10(idId);
             probeOk = true;
-            if (balance > 0n) {
+            if (nodeStake > 0n) {
               staked++;
-              console.log('Node ' + (i+1) + ' (core): daemon already staked (NFT balance=' + balance + '), skipping createConviction');
+              console.log('Node ' + (i+1) + ' (core): daemon already staked (nodeStakeV10=' + nodeStake + '), skipping createConviction');
             } else {
               shouldStake = true;
             }
             break;
           } catch (e) {
-            console.log('Node ' + (i+1) + ' (core): NFT balance probe failed (attempt ' + (attempt + 1) + '/2): ' + e.message);
+            console.log('Node ' + (i+1) + ' (core): nodeStakeV10 probe failed (attempt ' + (attempt + 1) + '/2): ' + e.message);
             if (attempt === 0) await new Promise(r => setTimeout(r, 1500));
           }
         }

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -709,7 +709,14 @@ cmd_start() {
       const stakingNFT = new ethers.Contract(
         c('DKGStakingConvictionNFT'),
         // lockTier is uint40 in V10 (L3 — widened from uint8 to support tier ids > 255).
-        ['function createConviction(uint72,uint96,uint40)'],
+        // balanceOf(address) is the ERC-721 standard read used by the
+        // duplicate-stake guard below — without it, the probe throws
+        // immediately and the guard falls through to a double-stake.
+        // Codex round 5 on PR #368.
+        [
+          'function createConviction(uint72,uint96,uint40)',
+          'function balanceOf(address) view returns (uint256)',
+        ],
         provider
       );
       const stakingV10Addr = c('StakingV10');
@@ -873,20 +880,37 @@ cmd_start() {
         // open a SECOND 50k position per core node and silently double the
         // devnet stake. We detect this by reading the conviction NFT
         // balance on the operational wallet — if the daemon's stake
-        // succeeded the balance is >0 and we skip. If the daemon's stake
-        // failed (e.g. transient RPC), balance is 0 and we still do the
-        // bootstrap stake as a fallback.
-        let alreadyStaked = false;
-        try {
-          const balance = await stakingNFT.balanceOf(opSigner.address);
-          if (balance > 0n) {
-            alreadyStaked = true;
-            staked++;
-            console.log('Node ' + (i+1) + ' (core): daemon already staked (NFT balance=' + balance + '), skipping createConviction');
+        // succeeded the balance is >0 and we skip.
+        //
+        // Codex round 5 on PR #368: do NOT fall through to "not staked"
+        // on probe failure (transient RPC, decode error). That would
+        // re-introduce the double-stake bug this guard exists to prevent.
+        // Retry once with backoff; if the probe still fails, refuse to
+        // run createConviction so the operator sees the symptom and
+        // decides — rather than silently doubling the stake.
+        // updateAsk is INDEPENDENT of stake state, so we still attempt
+        // it below regardless of the probe outcome.
+        let probeOk = false;
+        let shouldStake = false;
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            const balance = await stakingNFT.balanceOf(opSigner.address);
+            probeOk = true;
+            if (balance > 0n) {
+              staked++;
+              console.log('Node ' + (i+1) + ' (core): daemon already staked (NFT balance=' + balance + '), skipping createConviction');
+            } else {
+              shouldStake = true;
+            }
+            break;
+          } catch (e) {
+            console.log('Node ' + (i+1) + ' (core): NFT balance probe failed (attempt ' + (attempt + 1) + '/2): ' + e.message);
+            if (attempt === 0) await new Promise(r => setTimeout(r, 1500));
           }
-        } catch (e) { console.log('Node ' + (i+1) + ' (core): NFT balance probe failed (treating as not staked): ' + e.message); }
-
-        if (!alreadyStaked) {
+        }
+        if (!probeOk) {
+          console.log('Node ' + (i+1) + ' (core): cannot verify existing conviction after retry; skipping bootstrap stake to avoid double-stake');
+        } else if (shouldStake) {
           try {
             const deployer = await provider.getSigner(0);
             await (await token.connect(deployer).mint(opSigner.address, stakeAmount)).wait();

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -865,18 +865,41 @@ cmd_start() {
           const tx = await txFactory(freshNonce);
           return tx.wait();
         };
+        // Codex round 4 on PR #368: skip createConviction if the daemon
+        // already opened a position. PR 366 wired `EVMChainAdapter.ensureProfile()`
+        // to open a default 50k V10 conviction during agent startup, so by
+        // the time this script reaches the staking loop the daemon has
+        // (usually) already staked. Running createConviction again would
+        // open a SECOND 50k position per core node and silently double the
+        // devnet stake. We detect this by reading the conviction NFT
+        // balance on the operational wallet — if the daemon's stake
+        // succeeded the balance is >0 and we skip. If the daemon's stake
+        // failed (e.g. transient RPC), balance is 0 and we still do the
+        // bootstrap stake as a fallback.
+        let alreadyStaked = false;
         try {
-          const deployer = await provider.getSigner(0);
-          await (await token.connect(deployer).mint(opSigner.address, stakeAmount)).wait();
-          // StakingV10.stake pulls TRAC via transferFrom(staker, address(CSS), amount)
-          // gated by allowance to StakingV10. Approve StakingV10 here, NOT the NFT —
-          // the NFT is only the entry point and never custodies TRAC.
-          await sendWithFreshNonce((freshNonce) =>
-            token.connect(opSigner).approve(stakingV10Addr, stakeAmount, { nonce: freshNonce }));
-          await sendWithFreshNonce((freshNonce) =>
-            stakingNFT.connect(opSigner).createConviction(idId, stakeAmount, lockTier, { nonce: freshNonce }));
-          staked++;
-        } catch (e) { console.log('Stake failed for node ' + (i+1) + ': ' + e.message); }
+          const balance = await stakingNFT.balanceOf(opSigner.address);
+          if (balance > 0n) {
+            alreadyStaked = true;
+            staked++;
+            console.log('Node ' + (i+1) + ' (core): daemon already staked (NFT balance=' + balance + '), skipping createConviction');
+          }
+        } catch (e) { console.log('Node ' + (i+1) + ' (core): NFT balance probe failed (treating as not staked): ' + e.message); }
+
+        if (!alreadyStaked) {
+          try {
+            const deployer = await provider.getSigner(0);
+            await (await token.connect(deployer).mint(opSigner.address, stakeAmount)).wait();
+            // StakingV10.stake pulls TRAC via transferFrom(staker, address(CSS), amount)
+            // gated by allowance to StakingV10. Approve StakingV10 here, NOT the NFT —
+            // the NFT is only the entry point and never custodies TRAC.
+            await sendWithFreshNonce((freshNonce) =>
+              token.connect(opSigner).approve(stakingV10Addr, stakeAmount, { nonce: freshNonce }));
+            await sendWithFreshNonce((freshNonce) =>
+              stakingNFT.connect(opSigner).createConviction(idId, stakeAmount, lockTier, { nonce: freshNonce }));
+            staked++;
+          } catch (e) { console.log('Stake failed for node ' + (i+1) + ': ' + e.message); }
+        }
 
         // Set ask price (independent try block — a failed stake must not
         // skip ask setup; sendWithFreshNonce re-reads 'pending' so it


### PR DESCRIPTION
## Context

PR #366 made admin and operational keys strictly disjoint at the contract level — `Profile.sol` checks `keyHasPurpose(addr, ADMIN_KEY)` before `addOperationalWallets` and reverts with `AdminEqualsOperational`, and `EVMChainAdapter.ensureProfile()` fail-fasts when no admin signer is configured. `scripts/devnet.sh` predates this change and broke in three related places.

**Symptom on current main:** every node boots, but no node creates an on-chain profile. `devnet.sh` logs `0/6 staked, 0/6 ask set` then bails with:

```
ensureIdentity error: Cannot create profile: adminPrivateKey is required so the profile admin key is not lost.
```

## Three fixes, all in `scripts/devnet.sh`

### 1. `wallets.json` shape

Was: `{ wallets: [primary, ...random] }`
Now: `{ adminWallet: primary, wallets: [...random] }`

`loadOpWallets()` in `op-wallets.ts` now sees an admin wallet, `lifecycle.ts` passes `adminPrivateKey` through to chainConfig, `ensureProfile()` succeeds.

### 2. Identity probe

Was: `getIdentityId(signers[i].address)` (Hardhat key = adminWallet post-PR-366)
Now: `getIdentityId(opWallet[0].address)` (read per-node from `wallets.json`)

The reverse-lookup map `IdentityStorage.identityIds` is operational-only by design (see `IdentityStorage.sol:108-110`), so post-PR-366 it returns `0n` for admin addresses. Edge nodes are now skipped explicitly in the probe loop instead of timing out — they have no on-chain identity by design (`dkg-agent.ts` skips `ensureProfile` for `effectiveRole='edge'`), so the previous *"Node N: no identity after 60s, skipping"* messages were misleading.

### 3. Stake signer + nonce safety

Was: `stakingNFT.connect(signers[i]).createConviction(idId, ...)` (Hardhat key = no identity post-PR-366)
Now: `stakingNFT.connect(opSigner).createConviction(idId, ..., { nonce })`

`createConviction` and `updateAsk` need the op wallet (the address that owns the identity in the eyes of the staking + profile contracts). Explicit `nonce` is also required because the daemon's publisher *shares* this op wallet (it's also the StorageACK signer + first publishing op wallet) and may have submitted txs (`addKey`, `addOperationalWallets`) by the time we reach this block — relying on ethers' default nonce manager would race the daemon and yield `nonce has already been used`.

## Verification

```bash
./scripts/devnet.sh clean && ./scripts/devnet.sh start 6
```

Boots cleanly in ~75s with:
```
[devnet] Staked 50k TRAC for 4/4 core node(s), ask set for 4/4
[devnet] Registered context graph: devnet-test (v10Id=1)
[devnet] Registered context graph: devnet-isolation (v10Id=2)
[devnet] === Devnet Ready ===
```

Then:
```bash
DKG_AUTH=$(cat .devnet/node1/auth.token | grep -v '^#' | tr -d '[:space:]') \
  ./scripts/devnet-test.sh
```

Result: **175/237 PASS, 2 FAIL, 60 WARN**. The 2 failures are unrelated to this PR (peer-count test drift + ACK collector edge pre-filter — both worth separate follow-up tickets).

All PR #366 footprints land in node logs:

```
[DKGAgent] On-chain profile created, identityId=N
[DKGAgent] Registered N operational wallet(s) on-chain for identityId=N
[DKGAgent] Registered V10 StorageACK handler (identity=N, signer=...)
[DKGAgent] V10 Random Sampling prover started (identityId=N)
[DKGAgent] Node role is 'edge' — skipping StorageACK handler registration  ← edges only
```

**RandomSampling end-to-end working too:** 8 proofs submitted on-chain across 4 cores during the smoke run, with non-zero scores in `RandomSamplingStorage.getNodeEpochScore` for each identity. Confirms the V10 staking + RS scoring loop is functional after the fix.

## Test plan for the reviewer

- [ ] `./scripts/devnet.sh clean && ./scripts/devnet.sh start 6` — completes within ~90s with `4/4 core node(s)` staked.
- [ ] No `adminPrivateKey is required` errors in any `.devnet/node*/daemon.log`.
- [ ] `cat .devnet/node1/wallets.json` — confirm new shape `{ adminWallet: {...}, wallets: [...3 random] }`.
- [ ] `./scripts/devnet-test.sh` — passes the same 175 cases as before #366 / no new regressions attributable to this PR.

## Scope

Only `scripts/devnet.sh` is touched. No production code, no other test fixtures.

## Out of scope (separate follow-ups)

- Smoke section 1b "Core sees 6 peers (expected=6, got=8)" — likely libp2p 7.1.0 (PR #319) connection-count semantics drift, not a node bug.
- Smoke section 22 "Publisher job remained accepted" — ACK collector retries against edges that correctly refuse the protocol post-PR-366; needs a peer-role pre-filter in the collector.

Made with [Cursor](https://cursor.com)