### PR TITLE
fix(random-sampling): force createChallenge when unsolved cached challenge is past wall-clock period boundary

### DIFF
--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -302,6 +302,27 @@ export interface ProofPeriodStatus {
    * treat `false` as "skip this tick, retry on the next block".
    */
   isValid: boolean;
+  /**
+   * Currently-active proofing period duration in blocks, as the contract
+   * computes it for the current epoch (read via
+   * `RandomSampling.getActiveProofingPeriodDurationInBlocks()` →
+   * `RandomSamplingStorage.getEpochProofingPeriodDurationInBlocks(currentEpoch)`).
+   *
+   * The chain's `updateAndGetActiveProofPeriodStartBlock()` rolls the
+   * cursor forward using THIS value, not the duration baked into a
+   * cached `NodeChallenge`. Off-chain wall-clock staleness checks must
+   * therefore consult this live value (Codex round 2 on PR #369): if a
+   * governance action changes the proofing duration mid-flight, the
+   * cached `existing.proofingPeriodDurationInBlocks` no longer reflects
+   * the on-chain expiry boundary, and rotating off `existing.duration`
+   * alone would re-introduce the same `kc-not-synced` deadlock that
+   * the unsolved-stale check exists to prevent.
+   *
+   * Optional only because legacy adapters that pre-date this field may
+   * not populate it; consumers MUST treat `undefined` as "skip the
+   * live-duration staleness path and fall back to the cached duration".
+   */
+  proofingPeriodDurationInBlocks?: bigint;
 }
 
 /**

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2703,29 +2703,34 @@ export class EVMChainAdapter implements ChainAdapter {
     // If a governance change shortens the duration mid-flight, off-chain
     // staleness checks against the cached duration would underestimate
     // expiry and re-deadlock at the rollover boundary. Pull the live
-    // duration in parallel with the status read so the prover can compare
+    // duration alongside the status read so the prover can compare
     // wall-clock against the same value the contract uses for rollover.
     //
-    // Codex round 3 — keep the live-duration read STRICTLY best-effort:
-    // a transient RPC blip, partial rollout, or older RS deployment that
-    // doesn't expose `getActiveProofingPeriodDurationInBlocks` must NOT
-    // make the whole `getActiveProofPeriodStatus()` reject. Use
-    // `Promise.allSettled` so we keep the (already-correct) status read
-    // and let the duration silently fall back to `undefined`, which the
-    // prover treats as "use the cached challenge duration" — the
-    // pre-fix behaviour. The tradeoff: during such an outage the
-    // governance-shortens-duration edge case temporarily regresses to
-    // the cached value; that's strictly better than the alternative,
-    // which would surface the duration RPC failure as a `rs.loop.tick-threw`
-    // and gate every other prover read on a non-essential field.
-    const [statusResult, durationResult] = await Promise.allSettled([
+    // Codex round 3 + 4 — keep the live-duration read STRICTLY best-effort:
+    // a transient RPC blip, partial rollout, or an older RS deployment
+    // that omits the method from its ABI must NOT make the whole
+    // `getActiveProofPeriodStatus()` reject. Naive `Promise.allSettled`
+    // is NOT enough — `rs.getActiveProofingPeriodDurationInBlocks()`
+    // would throw synchronously (`TypeError: ... is not a function`)
+    // before `allSettled` can wrap it when the method is missing
+    // entirely. Wrap the lookup + call in a never-rejecting helper
+    // that resolves to `undefined` for any failure mode (missing fn,
+    // sync throw, async revert, RPC outage, decode error).
+    const readDurationBestEffort = async (): Promise<bigint | undefined> => {
+      try {
+        const fn = (rs as unknown as { getActiveProofingPeriodDurationInBlocks?: () => Promise<unknown> })
+          .getActiveProofingPeriodDurationInBlocks;
+        if (typeof fn !== 'function') return undefined;
+        const v = await fn.call(rs);
+        return BigInt(v as never);
+      } catch {
+        return undefined;
+      }
+    };
+    const [raw, proofingPeriodDurationInBlocks] = await Promise.all([
       rs.getActiveProofPeriodStatus(),
-      rs.getActiveProofingPeriodDurationInBlocks(),
+      readDurationBestEffort(),
     ]);
-    if (statusResult.status === 'rejected') throw statusResult.reason;
-    const raw = statusResult.value;
-    const proofingPeriodDurationInBlocks =
-      durationResult.status === 'fulfilled' ? BigInt(durationResult.value) : undefined;
     return {
       activeProofPeriodStartBlock: BigInt(raw.activeProofPeriodStartBlock ?? raw[0]),
       isValid: Boolean(raw.isValid ?? raw[1]),

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2696,10 +2696,23 @@ export class EVMChainAdapter implements ChainAdapter {
     await this.init();
     const { rs } = await this.getRandomSampling();
 
-    const raw = await rs.getActiveProofPeriodStatus();
+    // Codex round 2 on PR #369: the cached `NodeChallenge.proofingPeriodDurationInBlocks`
+    // is whatever the contract used at challenge-creation time. The chain's
+    // `updateAndGetActiveProofPeriodStartBlock()` rolls forward using the
+    // CURRENT epoch's duration via `getActiveProofingPeriodDurationInBlocks()`.
+    // If a governance change shortens the duration mid-flight, off-chain
+    // staleness checks against the cached duration would underestimate
+    // expiry and re-deadlock at the rollover boundary. Pull the live
+    // duration in parallel with the status read so the prover can compare
+    // wall-clock against the same value the contract uses for rollover.
+    const [raw, durationRaw] = await Promise.all([
+      rs.getActiveProofPeriodStatus(),
+      rs.getActiveProofingPeriodDurationInBlocks(),
+    ]);
     return {
       activeProofPeriodStartBlock: BigInt(raw.activeProofPeriodStartBlock ?? raw[0]),
       isValid: Boolean(raw.isValid ?? raw[1]),
+      proofingPeriodDurationInBlocks: BigInt(durationRaw),
     };
   }
 

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2705,14 +2705,31 @@ export class EVMChainAdapter implements ChainAdapter {
     // expiry and re-deadlock at the rollover boundary. Pull the live
     // duration in parallel with the status read so the prover can compare
     // wall-clock against the same value the contract uses for rollover.
-    const [raw, durationRaw] = await Promise.all([
+    //
+    // Codex round 3 — keep the live-duration read STRICTLY best-effort:
+    // a transient RPC blip, partial rollout, or older RS deployment that
+    // doesn't expose `getActiveProofingPeriodDurationInBlocks` must NOT
+    // make the whole `getActiveProofPeriodStatus()` reject. Use
+    // `Promise.allSettled` so we keep the (already-correct) status read
+    // and let the duration silently fall back to `undefined`, which the
+    // prover treats as "use the cached challenge duration" — the
+    // pre-fix behaviour. The tradeoff: during such an outage the
+    // governance-shortens-duration edge case temporarily regresses to
+    // the cached value; that's strictly better than the alternative,
+    // which would surface the duration RPC failure as a `rs.loop.tick-threw`
+    // and gate every other prover read on a non-essential field.
+    const [statusResult, durationResult] = await Promise.allSettled([
       rs.getActiveProofPeriodStatus(),
       rs.getActiveProofingPeriodDurationInBlocks(),
     ]);
+    if (statusResult.status === 'rejected') throw statusResult.reason;
+    const raw = statusResult.value;
+    const proofingPeriodDurationInBlocks =
+      durationResult.status === 'fulfilled' ? BigInt(durationResult.value) : undefined;
     return {
       activeProofPeriodStartBlock: BigInt(raw.activeProofPeriodStartBlock ?? raw[0]),
       isValid: Boolean(raw.isValid ?? raw[1]),
-      proofingPeriodDurationInBlocks: BigInt(durationRaw),
+      proofingPeriodDurationInBlocks,
     };
   }
 

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -63,6 +63,20 @@ const DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS = 5 * 60 * 1000;
 const DURATION_PROBE_TIMEOUT_MS = 2000;
 
 /**
+ * Upper bound on the in-flight duration probe slot age. The single-flight
+ * guard reuses a pending probe to bound RPC cardinality at 1, but if the
+ * underlying `eth_call` never settles (hung provider, dropped websocket)
+ * the slot would otherwise stay populated forever and suppress every
+ * fresh probe. After this many ms we abandon the slot regardless and
+ * let the next call start a new probe — capping leaked-handle growth
+ * to one per `MAX_PROBE_AGE_MS` window instead of one per tick. Set
+ * generously above `DURATION_PROBE_TIMEOUT_MS` so honest slow paths
+ * (high RPC latency, congested chain) still benefit from single-flight.
+ * Codex round 8 on PR #369.
+ */
+const MAX_PROBE_AGE_MS = 30_000;
+
+/**
  * Substrings we treat as "the Hub no longer recognises this contract
  * as a registered participant" — i.e. the cached address is stale and
  * the next call should re-resolve from the Hub. Conservative match on
@@ -276,11 +290,28 @@ export class EVMChainAdapter implements ChainAdapter {
    * naively issuing one new probe per tick would accumulate one
    * stuck request per tick on a hung provider. Instead we reuse the
    * same in-flight promise across overlapping calls — at most one
-   * probe is ever pending against the provider at a time. The slot
-   * clears in `.finally`, so a probe that eventually settles unblocks
-   * the next call to issue a fresh one.
+   * probe is ever pending against the provider at a time.
+   *
+   * Codex round 8 on PR #369: also track the RS pair-cache generation
+   * the probe was started against AND a wall-clock creation timestamp.
+   *   - Generation guard: a TTL refresh of `randomSamplingPairCache`
+   *     re-resolves `rs` to a possibly-new contract WITHOUT calling
+   *     `invalidateRandomSamplingPair()`. We must NOT pair a fresh
+   *     `getActiveProofPeriodStatus()` from the new contract with a
+   *     duration probe started against the old contract, so we drop
+   *     the slot whenever the cache generation has moved.
+   *   - Max-age guard: `Promise.race` returns `undefined` to the
+   *     caller on timeout, but the underlying `eth_call` may
+   *     never settle (truly hung provider). Without an upper
+   *     bound on slot age, a single hung probe would suppress
+   *     every fresh probe forever. After `MAX_PROBE_AGE_MS` we
+   *     abandon the slot regardless; the orphan promise still has
+   *     its `.finally` attached but the slot identity check inside
+   *     it correctly does nothing.
    */
   private inflightDurationProbe: Promise<bigint | undefined> | undefined;
+  private inflightDurationProbeGeneration = -1;
+  private inflightDurationProbeStartedAt = 0;
 
   constructor(config: EVMAdapterConfig) {
     this.provider = new JsonRpcProvider(config.rpcUrl, undefined, { cacheTimeout: -1 });
@@ -2551,6 +2582,8 @@ export class EVMChainAdapter implements ChainAdapter {
     this.contracts.randomSampling = undefined;
     this.contracts.randomSamplingStorage = undefined;
     this.inflightDurationProbe = undefined;
+    this.inflightDurationProbeGeneration = -1;
+    this.inflightDurationProbeStartedAt = 0;
   }
 
   /**
@@ -2784,14 +2817,29 @@ export class EVMChainAdapter implements ChainAdapter {
       ]);
     };
     // Single-flight: if a previous tick's probe is still pending,
-    // reuse it instead of issuing a fresh `eth_call`. This bounds
-    // outstanding-probe cardinality to 1 even when the provider
-    // hangs every request, preventing socket / handle accumulation
-    // on long-lived nodes.
+    // reuse it instead of issuing a fresh `eth_call`. Codex round 8:
+    // first invalidate the slot if (a) the RS pair-cache generation
+    // has moved (TTL-refresh path doesn't call invalidateRandomSamplingPair
+    // but DOES re-resolve the contract → probe was started against the
+    // old contract and must not be paired with the new contract's
+    // status), or (b) the slot is older than MAX_PROBE_AGE_MS (a
+    // truly hung probe must not suppress retries forever).
+    const currentGen = this.randomSamplingPairCache.currentGeneration();
+    const probeAgeMs = this.inflightDurationProbe
+      ? Date.now() - this.inflightDurationProbeStartedAt
+      : 0;
+    if (this.inflightDurationProbe && (
+      this.inflightDurationProbeGeneration !== currentGen ||
+      probeAgeMs > MAX_PROBE_AGE_MS
+    )) {
+      this.inflightDurationProbe = undefined;
+    }
     let probe = this.inflightDurationProbe;
     if (!probe) {
       const fresh = readDurationBestEffort();
       this.inflightDurationProbe = fresh;
+      this.inflightDurationProbeGeneration = currentGen;
+      this.inflightDurationProbeStartedAt = Date.now();
       // `.finally` covers both resolve and reject paths without
       // altering the value the caller observes.
       void fresh.finally(() => {

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -267,6 +267,20 @@ export class EVMChainAdapter implements ChainAdapter {
    */
   private readonly randomSamplingPairCache: HubResolutionCache<{ rs: Contract; rss: Contract }>;
   private hubRotationListenerStarted = false;
+  /**
+   * Single-flight guard for the best-effort
+   * `getActiveProofingPeriodDurationInBlocks()` probe inside
+   * `getActiveProofPeriodStatus()`. Codex round 5 on PR #369: the
+   * 2s `Promise.race` timeout returns `undefined` to the caller but
+   * the underlying `eth_call` is NOT cancellable in ethers v6, so
+   * naively issuing one new probe per tick would accumulate one
+   * stuck request per tick on a hung provider. Instead we reuse the
+   * same in-flight promise across overlapping calls — at most one
+   * probe is ever pending against the provider at a time. The slot
+   * clears in `.finally`, so a probe that eventually settles unblocks
+   * the next call to issue a fresh one.
+   */
+  private inflightDurationProbe: Promise<bigint | undefined> | undefined;
 
   constructor(config: EVMAdapterConfig) {
     this.provider = new JsonRpcProvider(config.rpcUrl, undefined, { cacheTimeout: -1 });
@@ -2756,9 +2770,27 @@ export class EVMChainAdapter implements ChainAdapter {
         timeout,
       ]);
     };
+    // Single-flight: if a previous tick's probe is still pending,
+    // reuse it instead of issuing a fresh `eth_call`. This bounds
+    // outstanding-probe cardinality to 1 even when the provider
+    // hangs every request, preventing socket / handle accumulation
+    // on long-lived nodes.
+    let probe = this.inflightDurationProbe;
+    if (!probe) {
+      const fresh = readDurationBestEffort();
+      this.inflightDurationProbe = fresh;
+      // `.finally` covers both resolve and reject paths without
+      // altering the value the caller observes.
+      void fresh.finally(() => {
+        if (this.inflightDurationProbe === fresh) {
+          this.inflightDurationProbe = undefined;
+        }
+      });
+      probe = fresh;
+    }
     const [raw, proofingPeriodDurationInBlocks] = await Promise.all([
       rs.getActiveProofPeriodStatus(),
-      withTimeout(readDurationBestEffort(), DURATION_PROBE_TIMEOUT_MS, undefined),
+      withTimeout(probe, DURATION_PROBE_TIMEOUT_MS, undefined),
     ]);
     return {
       activeProofPeriodStartBlock: BigInt(raw.activeProofPeriodStartBlock ?? raw[0]),

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -292,14 +292,19 @@ export class EVMChainAdapter implements ChainAdapter {
    * same in-flight promise across overlapping calls — at most one
    * probe is ever pending against the provider at a time.
    *
-   * Codex round 8 on PR #369: also track the RS pair-cache generation
-   * the probe was started against AND a wall-clock creation timestamp.
-   *   - Generation guard: a TTL refresh of `randomSamplingPairCache`
-   *     re-resolves `rs` to a possibly-new contract WITHOUT calling
-   *     `invalidateRandomSamplingPair()`. We must NOT pair a fresh
-   *     `getActiveProofPeriodStatus()` from the new contract with a
-   *     duration probe started against the old contract, so we drop
-   *     the slot whenever the cache generation has moved.
+   * Codex round 8 on PR #369: also track the `RandomSampling`
+   * Contract instance the probe was started against AND a wall-clock
+   * creation timestamp.
+   *   - Contract-identity guard: a TTL refresh of
+   *     `randomSamplingPairCache` re-resolves `rs` to a freshly
+   *     constructed `Contract` instance WITHOUT calling
+   *     `invalidateRandomSamplingPair()`. The HubResolutionCache
+   *     generation counter is invalidate-only (it is also used by
+   *     `resolveAndAssignRandomSamplingPair()` to detect concurrent
+   *     invalidations, so it must NOT bump on normal refreshes), so
+   *     it can't signal a TTL refresh. Comparing the resolved
+   *     Contract instance by reference is the canonical check: a
+   *     refresh always hands back a new instance.
    *   - Max-age guard: `Promise.race` returns `undefined` to the
    *     caller on timeout, but the underlying `eth_call` may
    *     never settle (truly hung provider). Without an upper
@@ -310,7 +315,7 @@ export class EVMChainAdapter implements ChainAdapter {
    *     it correctly does nothing.
    */
   private inflightDurationProbe: Promise<bigint | undefined> | undefined;
-  private inflightDurationProbeGeneration = -1;
+  private inflightDurationProbeContract: Contract | undefined;
   private inflightDurationProbeStartedAt = 0;
 
   constructor(config: EVMAdapterConfig) {
@@ -2582,7 +2587,7 @@ export class EVMChainAdapter implements ChainAdapter {
     this.contracts.randomSampling = undefined;
     this.contracts.randomSamplingStorage = undefined;
     this.inflightDurationProbe = undefined;
-    this.inflightDurationProbeGeneration = -1;
+    this.inflightDurationProbeContract = undefined;
     this.inflightDurationProbeStartedAt = 0;
   }
 
@@ -2818,18 +2823,19 @@ export class EVMChainAdapter implements ChainAdapter {
     };
     // Single-flight: if a previous tick's probe is still pending,
     // reuse it instead of issuing a fresh `eth_call`. Codex round 8:
-    // first invalidate the slot if (a) the RS pair-cache generation
-    // has moved (TTL-refresh path doesn't call invalidateRandomSamplingPair
-    // but DOES re-resolve the contract → probe was started against the
-    // old contract and must not be paired with the new contract's
-    // status), or (b) the slot is older than MAX_PROBE_AGE_MS (a
-    // truly hung probe must not suppress retries forever).
-    const currentGen = this.randomSamplingPairCache.currentGeneration();
+    // first invalidate the slot if (a) the resolved RS Contract
+    // instance has changed since the probe was started (TTL-refresh
+    // path constructs a fresh Contract WITHOUT calling
+    // invalidateRandomSamplingPair → the probe was started against
+    // the old contract and must not be paired with the new
+    // contract's status), or (b) the slot is older than
+    // MAX_PROBE_AGE_MS (a truly hung probe must not suppress retries
+    // forever).
     const probeAgeMs = this.inflightDurationProbe
       ? Date.now() - this.inflightDurationProbeStartedAt
       : 0;
     if (this.inflightDurationProbe && (
-      this.inflightDurationProbeGeneration !== currentGen ||
+      this.inflightDurationProbeContract !== rs ||
       probeAgeMs > MAX_PROBE_AGE_MS
     )) {
       this.inflightDurationProbe = undefined;
@@ -2838,7 +2844,7 @@ export class EVMChainAdapter implements ChainAdapter {
     if (!probe) {
       const fresh = readDurationBestEffort();
       this.inflightDurationProbe = fresh;
-      this.inflightDurationProbeGeneration = currentGen;
+      this.inflightDurationProbeContract = rs;
       this.inflightDurationProbeStartedAt = Date.now();
       // `.finally` covers both resolve and reject paths without
       // altering the value the caller observes.

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -2533,11 +2533,24 @@ export class EVMChainAdapter implements ChainAdapter {
    * `isRandomSamplingReady()` probe would keep returning `true` after a Hub
    * rotation (until the next `getRandomSampling()` re-populates the
    * handles), giving the prover a stale all-clear.
+   *
+   * Codex round 6 on PR #369: ALSO drop the in-flight duration probe.
+   * The probe was started against the OLD `RandomSampling` contract;
+   * if Hub rotates while it is pending we MUST NOT pair the new
+   * contract's `getActiveProofPeriodStatus()` with the old contract's
+   * duration in the next call. Worse, if the old probe never settles
+   * (hung provider) it would suppress every fresh probe forever via
+   * the single-flight guard. Clearing the slot here lets the next
+   * call issue a fresh probe against the new contract; the now-orphan
+   * old promise is still handled by its `.finally` hook (the slot
+   * identity check inside .finally won't match, so it correctly does
+   * nothing).
    */
   private invalidateRandomSamplingPair(): void {
     this.randomSamplingPairCache.invalidate();
     this.contracts.randomSampling = undefined;
     this.contracts.randomSamplingStorage = undefined;
+    this.inflightDurationProbe = undefined;
   }
 
   /**

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -52,6 +52,17 @@ import { HubResolutionCache } from './hub-resolution-cache.js';
 const DEFAULT_RANDOM_SAMPLING_HUB_REFRESH_MS = 5 * 60 * 1000;
 
 /**
+ * Hard ceiling for the best-effort live `getActiveProofingPeriodDurationInBlocks()`
+ * read inside `getActiveProofPeriodStatus()`. The status read itself is one
+ * `eth_call`; the duration probe is a sibling `eth_call` on the same provider
+ * and should typically resolve in <100ms. If it hasn't returned in 2s the
+ * provider is slow or hanging — fall back to `undefined` and let the prover
+ * use the cached `existing.proofingPeriodDurationInBlocks` rather than
+ * stalling the whole tick. Codex round 5 on PR #369.
+ */
+const DURATION_PROBE_TIMEOUT_MS = 2000;
+
+/**
  * Substrings we treat as "the Hub no longer recognises this contract
  * as a registered participant" — i.e. the cached address is stale and
  * the next call should re-resolve from the Hub. Conservative match on
@@ -2706,16 +2717,24 @@ export class EVMChainAdapter implements ChainAdapter {
     // duration alongside the status read so the prover can compare
     // wall-clock against the same value the contract uses for rollover.
     //
-    // Codex round 3 + 4 — keep the live-duration read STRICTLY best-effort:
+    // Codex round 3 + 4 + 5 — keep the live-duration read STRICTLY best-effort:
     // a transient RPC blip, partial rollout, or an older RS deployment
     // that omits the method from its ABI must NOT make the whole
-    // `getActiveProofPeriodStatus()` reject. Naive `Promise.allSettled`
-    // is NOT enough — `rs.getActiveProofingPeriodDurationInBlocks()`
-    // would throw synchronously (`TypeError: ... is not a function`)
-    // before `allSettled` can wrap it when the method is missing
-    // entirely. Wrap the lookup + call in a never-rejecting helper
-    // that resolves to `undefined` for any failure mode (missing fn,
-    // sync throw, async revert, RPC outage, decode error).
+    // `getActiveProofPeriodStatus()` reject OR stall.
+    //
+    // Naive `Promise.allSettled` is NOT enough —
+    // `rs.getActiveProofingPeriodDurationInBlocks()` would throw
+    // synchronously (`TypeError: ... is not a function`) before
+    // `allSettled` can wrap it when the method is missing entirely.
+    //
+    // Plain `try/catch` is also NOT enough — a hung RPC (provider
+    // accepts the request but never responds) keeps the await pending
+    // forever, blocking the entire status probe even though the
+    // primary `getActiveProofPeriodStatus()` already returned. The
+    // prover can safely continue with the cached challenge duration,
+    // so race the duration read against a short timeout and prefer
+    // `undefined` on slow paths. The prover treats `undefined` as
+    // "fall back to existing.proofingPeriodDurationInBlocks".
     const readDurationBestEffort = async (): Promise<bigint | undefined> => {
       try {
         const fn = (rs as unknown as { getActiveProofingPeriodDurationInBlocks?: () => Promise<unknown> })
@@ -2727,9 +2746,19 @@ export class EVMChainAdapter implements ChainAdapter {
         return undefined;
       }
     };
+    const withTimeout = <T>(p: Promise<T>, ms: number, fallback: T): Promise<T> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<T>((resolve) => {
+        timer = setTimeout(() => resolve(fallback), ms);
+      });
+      return Promise.race([
+        p.then((v) => { if (timer) clearTimeout(timer); return v; }),
+        timeout,
+      ]);
+    };
     const [raw, proofingPeriodDurationInBlocks] = await Promise.all([
       rs.getActiveProofPeriodStatus(),
-      readDurationBestEffort(),
+      withTimeout(readDurationBestEffort(), DURATION_PROBE_TIMEOUT_MS, undefined),
     ]);
     return {
       activeProofPeriodStartBlock: BigInt(raw.activeProofPeriodStartBlock ?? raw[0]),

--- a/packages/chain/src/hub-resolution-cache.ts
+++ b/packages/chain/src/hub-resolution-cache.ts
@@ -40,6 +40,13 @@ export class HubResolutionCache<T> {
    * previous tick's resolve is awaiting the RPC reply would re-cache
    * the **pre-rotation** address — exactly the stale-entry bug this
    * cache was added to fix.
+   *
+   * NOTE: This counter is INVALIDATE-ONLY. It does NOT bump on a
+   * successful TTL-driven re-resolve. Callers that need to detect a
+   * silent contract swap (e.g. via TTL refresh on a stale Hub view)
+   * should compare the resolved value/identity itself rather than
+   * relying solely on this counter — see
+   * `EVMChainAdapter.inflightDurationProbeContract`.
    */
   private generation = 0;
 

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1233,6 +1233,11 @@ export class MockChainAdapter implements ChainAdapter {
     return {
       activeProofPeriodStartBlock: this.rsPeriodCursor,
       isValid: this.rsPeriodIsValid,
+      // Mock mirrors the same duration the in-mock createChallenge bakes
+      // into NodeChallenge.proofingPeriodDurationInBlocks (L1159) so the
+      // off-chain wall-clock staleness check in RandomSamplingProver sees
+      // a self-consistent (status, challenge) pair from the mock chain.
+      proofingPeriodDurationInBlocks: 100n,
     };
   }
 

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -1031,6 +1031,20 @@ export class MockChainAdapter implements ChainAdapter {
   // can reach them via concrete-typed instance access.
   // =====================================================================
 
+  /**
+   * Mock proof period length in blocks. Single source of truth for:
+   *   - `__advanceProofPeriod()` cursor step
+   *   - `createChallenge()` `NodeChallenge.proofingPeriodDurationInBlocks`
+   *   - `getActiveProofPeriodStatus()` `proofingPeriodDurationInBlocks`
+   *
+   * Codex round 3 on PR #369 — these were three separate `100n` literals.
+   * If one drifted the mock would report a self-inconsistent
+   * (status, challenge, cursor) tuple and the prover's wall-clock
+   * staleness logic could be tested against behaviour the mock never
+   * actually simulates. Centralising removes that footgun.
+   */
+  private static readonly RS_MOCK_PERIOD_DURATION_IN_BLOCKS = 100n;
+
   private rsPeriodCursor = 1n;            // activeProofPeriodStartBlock
   private rsEpoch = 1n;
   private rsPeriodIsValid = true;
@@ -1052,7 +1066,7 @@ export class MockChainAdapter implements ChainAdapter {
 
   /** Test helper: advance to a fresh proof period (mirrors a chain rollover). */
   __advanceProofPeriod(): bigint {
-    this.rsPeriodCursor += 100n;
+    this.rsPeriodCursor += MockChainAdapter.RS_MOCK_PERIOD_DURATION_IN_BLOCKS;
     this.rsPeriodIsValid = true;
     return this.rsPeriodCursor;
   }
@@ -1156,7 +1170,7 @@ export class MockChainAdapter implements ChainAdapter {
       knowledgeCollectionStorageContract: kcEntry.kcsContract,
       epoch: this.rsEpoch,
       activeProofPeriodStartBlock: this.rsPeriodCursor,
-      proofingPeriodDurationInBlocks: 100n,
+      proofingPeriodDurationInBlocks: MockChainAdapter.RS_MOCK_PERIOD_DURATION_IN_BLOCKS,
       solved: false,
     };
     this.rsChallenges.set(identityId, challenge);
@@ -1233,11 +1247,7 @@ export class MockChainAdapter implements ChainAdapter {
     return {
       activeProofPeriodStartBlock: this.rsPeriodCursor,
       isValid: this.rsPeriodIsValid,
-      // Mock mirrors the same duration the in-mock createChallenge bakes
-      // into NodeChallenge.proofingPeriodDurationInBlocks (L1159) so the
-      // off-chain wall-clock staleness check in RandomSamplingProver sees
-      // a self-consistent (status, challenge) pair from the mock chain.
-      proofingPeriodDurationInBlocks: 100n,
+      proofingPeriodDurationInBlocks: MockChainAdapter.RS_MOCK_PERIOD_DURATION_IN_BLOCKS,
     };
   }
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -247,6 +247,66 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect((a as any).isContractMissingRevert('not an error')).toBe(false);
   });
 
+  it('getActiveProofPeriodStatus stays best-effort when getActiveProofingPeriodDurationInBlocks rejects (Codex round 3)', async () => {
+    // Codex round 3 on PR #369 — pulling the live duration alongside
+    // status must NOT promote the duration RPC to a hard prerequisite.
+    // If older RS deployments don't expose the method, or a transient
+    // RPC error hits only the second leg, the status read should still
+    // succeed with `proofingPeriodDurationInBlocks: undefined` and the
+    // prover falls back to the cached challenge duration.
+    const a = new EVMChainAdapter(minimalConfig());
+    const fakeRs = {
+      getActiveProofPeriodStatus: async () => ({
+        activeProofPeriodStartBlock: 1234n,
+        isValid: true,
+      }),
+      getActiveProofingPeriodDurationInBlocks: async () => {
+        throw new Error('OlderRSDeploymentDoesNotExposeThisMethod');
+      },
+    };
+    (a as any).init = async () => undefined;
+    (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+    const status = await a.getActiveProofPeriodStatus();
+    expect(status.activeProofPeriodStartBlock).toBe(1234n);
+    expect(status.isValid).toBe(true);
+    expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
+  });
+
+  it('getActiveProofPeriodStatus surfaces the real status read failure (does not swallow the primary leg)', async () => {
+    // The best-effort behaviour from the previous test must NOT extend
+    // to the primary status read — if `getActiveProofPeriodStatus` itself
+    // fails, the prover MUST hear about it (otherwise we'd silently
+    // pin to a fabricated default and the prover's wall-clock check
+    // would compare against a nonsense activeProofPeriodStartBlock).
+    const a = new EVMChainAdapter(minimalConfig());
+    const fakeRs = {
+      getActiveProofPeriodStatus: async () => {
+        throw new Error('UpstreamRPCBadGateway');
+      },
+      getActiveProofingPeriodDurationInBlocks: async () => 600n,
+    };
+    (a as any).init = async () => undefined;
+    (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+    await expect(a.getActiveProofPeriodStatus()).rejects.toThrow('UpstreamRPCBadGateway');
+  });
+
+  it('getActiveProofPeriodStatus populates proofingPeriodDurationInBlocks when both reads succeed', async () => {
+    const a = new EVMChainAdapter(minimalConfig());
+    const fakeRs = {
+      getActiveProofPeriodStatus: async () => ({
+        activeProofPeriodStartBlock: 9000n,
+        isValid: false,
+      }),
+      getActiveProofingPeriodDurationInBlocks: async () => 50n,
+    };
+    (a as any).init = async () => undefined;
+    (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+    const status = await a.getActiveProofPeriodStatus();
+    expect(status.activeProofPeriodStartBlock).toBe(9000n);
+    expect(status.isValid).toBe(false);
+    expect(status.proofingPeriodDurationInBlocks).toBe(50n);
+  });
+
   it('coerces randomSamplingHubRefreshMs<=0 to the default TTL (no "disable refresh" mode)', () => {
     // The "disable refresh entirely" mode is intentionally not
     // supported — without a TTL backstop, a missed Hub event on a

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -250,10 +250,10 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
   it('getActiveProofPeriodStatus stays best-effort when getActiveProofingPeriodDurationInBlocks rejects (Codex round 3)', async () => {
     // Codex round 3 on PR #369 — pulling the live duration alongside
     // status must NOT promote the duration RPC to a hard prerequisite.
-    // If older RS deployments don't expose the method, or a transient
-    // RPC error hits only the second leg, the status read should still
-    // succeed with `proofingPeriodDurationInBlocks: undefined` and the
-    // prover falls back to the cached challenge duration.
+    // If a transient RPC error hits only the second leg, the status
+    // read should still succeed with `proofingPeriodDurationInBlocks:
+    // undefined` and the prover falls back to the cached challenge
+    // duration.
     const a = new EVMChainAdapter(minimalConfig());
     const fakeRs = {
       getActiveProofPeriodStatus: async () => ({
@@ -261,7 +261,7 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
         isValid: true,
       }),
       getActiveProofingPeriodDurationInBlocks: async () => {
-        throw new Error('OlderRSDeploymentDoesNotExposeThisMethod');
+        throw new Error('TransientRpc502BadGateway');
       },
     };
     (a as any).init = async () => undefined;
@@ -269,6 +269,52 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     const status = await a.getActiveProofPeriodStatus();
     expect(status.activeProofPeriodStartBlock).toBe(1234n);
     expect(status.isValid).toBe(true);
+    expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
+  });
+
+  it('getActiveProofPeriodStatus stays best-effort when getActiveProofingPeriodDurationInBlocks is missing entirely (Codex round 4)', async () => {
+    // Codex round 4 on PR #369 — `Promise.allSettled([..., rs.getX()])`
+    // is NOT enough. If older RS deployments omit the method from their
+    // ABI entirely, `rs.getActiveProofingPeriodDurationInBlocks()`
+    // throws SYNCHRONOUSLY (TypeError: ... is not a function) while
+    // building the allSettled input array, before allSettled can wrap
+    // the rejection. Verify the wrapper handles "method literally
+    // doesn't exist" cleanly.
+    const a = new EVMChainAdapter(minimalConfig());
+    // Note: getActiveProofingPeriodDurationInBlocks is NOT defined.
+    const fakeRs = {
+      getActiveProofPeriodStatus: async () => ({
+        activeProofPeriodStartBlock: 7n,
+        isValid: true,
+      }),
+    };
+    (a as any).init = async () => undefined;
+    (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+    const status = await a.getActiveProofPeriodStatus();
+    expect(status.activeProofPeriodStartBlock).toBe(7n);
+    expect(status.isValid).toBe(true);
+    expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
+  });
+
+  it('getActiveProofPeriodStatus stays best-effort when getActiveProofingPeriodDurationInBlocks throws synchronously (Codex round 4)', async () => {
+    // Defence-in-depth for ethers Contract proxies that resolve the
+    // missing-fn into a throw at call-time rather than returning a
+    // rejected promise.
+    const a = new EVMChainAdapter(minimalConfig());
+    const fakeRs = {
+      getActiveProofPeriodStatus: async () => ({
+        activeProofPeriodStartBlock: 42n,
+        isValid: false,
+      }),
+      getActiveProofingPeriodDurationInBlocks: () => {
+        throw new TypeError('this.constructor.getFunction is not a function');
+      },
+    };
+    (a as any).init = async () => undefined;
+    (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+    const status = await a.getActiveProofPeriodStatus();
+    expect(status.activeProofPeriodStartBlock).toBe(42n);
+    expect(status.isValid).toBe(false);
     expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
   });
 

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -353,6 +353,36 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(status.proofingPeriodDurationInBlocks).toBe(50n);
   });
 
+  it('getActiveProofPeriodStatus does not stall when the duration probe hangs (Codex round 5)', async () => {
+    // A provider that accepts the request but never resolves — e.g.
+    // RPC slow path, half-broken websocket — would otherwise pin
+    // every status read until the underlying timeout (often >30s)
+    // and silently freeze the prover loop. The 2s race must kick
+    // in long before the primary status leg comes back, returning
+    // `undefined` so the prover falls back to the cached duration.
+    const a = new EVMChainAdapter(minimalConfig());
+    const fakeRs = {
+      getActiveProofPeriodStatus: async () => ({
+        activeProofPeriodStartBlock: 1234n,
+        isValid: true,
+      }),
+      getActiveProofingPeriodDurationInBlocks: () =>
+        new Promise(() => {/* never resolves */}),
+    };
+    (a as any).init = async () => undefined;
+    (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+    const t0 = Date.now();
+    const status = await a.getActiveProofPeriodStatus();
+    const elapsed = Date.now() - t0;
+    expect(status.activeProofPeriodStartBlock).toBe(1234n);
+    expect(status.isValid).toBe(true);
+    expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
+    // Timeout is 2000ms; pad generously for slow CI but still
+    // well below any realistic provider timeout.
+    expect(elapsed).toBeGreaterThanOrEqual(1900);
+    expect(elapsed).toBeLessThan(4000);
+  });
+
   it('coerces randomSamplingHubRefreshMs<=0 to the default TTL (no "disable refresh" mode)', () => {
     // The "disable refresh entirely" mode is intentionally not
     // supported — without a TTL backstop, a missed Hub event on a

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -434,6 +434,61 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
+  it('invalidateRandomSamplingPair drops the in-flight duration probe so a Hub rotation forces a fresh one (Codex round 7)', async () => {
+    // If a probe was started against the OLD RandomSampling contract
+    // and Hub rotates before it settles:
+    //   - Without this fix: the next status call would pair the new
+    //     contract's status with the old contract's stale duration,
+    //     OR (if the old probe hangs) suppress every fresh probe
+    //     forever via the single-flight guard.
+    //   - With this fix: invalidate() drops the slot; the next call
+    //     issues a fresh probe against the new contract.
+    vi.useFakeTimers();
+    try {
+      const a = new EVMChainAdapter(minimalConfig());
+      const probeCalls = vi.fn();
+      const oldRs = {
+        getActiveProofPeriodStatus: async () => ({
+          activeProofPeriodStartBlock: 1n,
+          isValid: true,
+        }),
+        getActiveProofingPeriodDurationInBlocks: () => {
+          probeCalls();
+          return new Promise(() => {/* old contract probe hangs */});
+        },
+      };
+      const newRs = {
+        getActiveProofPeriodStatus: async () => ({
+          activeProofPeriodStartBlock: 2n,
+          isValid: true,
+        }),
+        getActiveProofingPeriodDurationInBlocks: async () => {
+          probeCalls();
+          return 555n;
+        },
+      };
+      (a as any).init = async () => undefined;
+      (a as any).getRandomSampling = async () => ({ rs: oldRs, rss: {} });
+      const stale = a.getActiveProofPeriodStatus();
+      await vi.advanceTimersByTimeAsync(2001);
+      await stale;
+      expect(probeCalls).toHaveBeenCalledTimes(1);
+      // Simulate Hub rotation: invalidate the RS pair cache.
+      (a as any).invalidateRandomSamplingPair();
+      // Swap in the NEW contract for the next call.
+      (a as any).getRandomSampling = async () => ({ rs: newRs, rss: {} });
+      vi.useRealTimers();
+      const fresh = await a.getActiveProofPeriodStatus();
+      expect(fresh.activeProofPeriodStartBlock).toBe(2n);
+      expect(fresh.proofingPeriodDurationInBlocks).toBe(555n);
+      // Probe must have run against the NEW contract — total
+      // probeCalls is now 2 (old hung + new succeeded).
+      expect(probeCalls).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('getActiveProofPeriodStatus issues a fresh probe after the previous one settles (Codex round 6)', async () => {
     // Once the in-flight probe rejects/resolves, the next call MUST
     // be allowed to issue a new one — otherwise a single transient

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -434,17 +434,21 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
-  it('drops the duration probe slot when RS pair-cache generation moves (TTL refresh, Codex round 8)', async () => {
+  it('drops the duration probe slot when the resolved RS Contract instance changes (TTL refresh, Codex round 8)', async () => {
     // The TTL-refresh path of HubResolutionCache re-resolves the
-    // contract WITHOUT calling invalidateRandomSamplingPair(). A
-    // probe started against the old contract must NOT be paired
-    // with the new contract's status. We bump the generation
-    // manually and verify the next call issues a fresh probe.
+    // contract to a freshly constructed Contract instance WITHOUT
+    // calling invalidateRandomSamplingPair() and WITHOUT bumping
+    // the (invalidate-only) generation counter. A probe started
+    // against the old contract must NOT be paired with the new
+    // contract's status. The guard compares the resolved Contract
+    // by reference identity — a refresh always hands back a new
+    // instance, so this fires on both same-address and changed-
+    // address refreshes.
     vi.useFakeTimers();
     try {
       const a = new EVMChainAdapter(minimalConfig());
       const probeCalls = vi.fn();
-      const fakeRs = {
+      const oldRs = {
         getActiveProofPeriodStatus: async () => ({
           activeProofPeriodStartBlock: 1n,
           isValid: true,
@@ -454,19 +458,22 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
           return new Promise(() => {/* hang */});
         },
       };
+      // Distinct Contract instance with the same shape — simulates
+      // the post-refresh Contract a TTL re-resolve would produce
+      // even when the underlying address is unchanged.
+      const refreshedRs = { ...oldRs };
       (a as any).init = async () => undefined;
-      (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+      (a as any).getRandomSampling = async () => ({ rs: oldRs, rss: {} });
       const first = a.getActiveProofPeriodStatus();
       await vi.advanceTimersByTimeAsync(2001);
       await first;
       expect(probeCalls).toHaveBeenCalledTimes(1);
-      // Bump the cache generation as if a TTL refresh happened.
-      (a as any).randomSamplingPairCache.invalidate();
+      // TTL refresh: re-resolve hands back a fresh Contract instance.
+      (a as any).getRandomSampling = async () => ({ rs: refreshedRs, rss: {} });
       const second = a.getActiveProofPeriodStatus();
       await vi.advanceTimersByTimeAsync(2001);
       await second;
-      // Generation moved, so the slot was dropped and a fresh
-      // probe was started against the (now-current) contract.
+      // Contract identity changed → slot was dropped → fresh probe issued.
       expect(probeCalls).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -434,6 +434,83 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     }
   });
 
+  it('drops the duration probe slot when RS pair-cache generation moves (TTL refresh, Codex round 8)', async () => {
+    // The TTL-refresh path of HubResolutionCache re-resolves the
+    // contract WITHOUT calling invalidateRandomSamplingPair(). A
+    // probe started against the old contract must NOT be paired
+    // with the new contract's status. We bump the generation
+    // manually and verify the next call issues a fresh probe.
+    vi.useFakeTimers();
+    try {
+      const a = new EVMChainAdapter(minimalConfig());
+      const probeCalls = vi.fn();
+      const fakeRs = {
+        getActiveProofPeriodStatus: async () => ({
+          activeProofPeriodStartBlock: 1n,
+          isValid: true,
+        }),
+        getActiveProofingPeriodDurationInBlocks: () => {
+          probeCalls();
+          return new Promise(() => {/* hang */});
+        },
+      };
+      (a as any).init = async () => undefined;
+      (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+      const first = a.getActiveProofPeriodStatus();
+      await vi.advanceTimersByTimeAsync(2001);
+      await first;
+      expect(probeCalls).toHaveBeenCalledTimes(1);
+      // Bump the cache generation as if a TTL refresh happened.
+      (a as any).randomSamplingPairCache.invalidate();
+      const second = a.getActiveProofPeriodStatus();
+      await vi.advanceTimersByTimeAsync(2001);
+      await second;
+      // Generation moved, so the slot was dropped and a fresh
+      // probe was started against the (now-current) contract.
+      expect(probeCalls).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('drops the duration probe slot when it exceeds MAX_PROBE_AGE_MS (Codex round 8)', async () => {
+    // A truly hung probe (underlying eth_call never settles) must
+    // not suppress every fresh probe forever. The age guard kicks
+    // in after 30s and abandons the slot so the next call can
+    // issue a new one — capping leaked-handle growth to one per
+    // 30s window instead of one per tick.
+    vi.useFakeTimers();
+    try {
+      const a = new EVMChainAdapter(minimalConfig());
+      const probeCalls = vi.fn();
+      const fakeRs = {
+        getActiveProofPeriodStatus: async () => ({
+          activeProofPeriodStartBlock: 1n,
+          isValid: true,
+        }),
+        getActiveProofingPeriodDurationInBlocks: () => {
+          probeCalls();
+          return new Promise(() => {/* hang */});
+        },
+      };
+      (a as any).init = async () => undefined;
+      (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+      const first = a.getActiveProofPeriodStatus();
+      await vi.advanceTimersByTimeAsync(2001);
+      await first;
+      expect(probeCalls).toHaveBeenCalledTimes(1);
+      // Fast-forward past MAX_PROBE_AGE_MS (30s).
+      await vi.advanceTimersByTimeAsync(30_001);
+      const second = a.getActiveProofPeriodStatus();
+      await vi.advanceTimersByTimeAsync(2001);
+      await second;
+      // Slot was abandoned by the age guard, fresh probe was started.
+      expect(probeCalls).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('invalidateRandomSamplingPair drops the in-flight duration probe so a Hub rotation forces a fresh one (Codex round 7)', async () => {
     // If a probe was started against the OLD RandomSampling contract
     // and Hub rotates before it settles:

--- a/packages/chain/test/evm-adapter.unit.test.ts
+++ b/packages/chain/test/evm-adapter.unit.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for evm-adapter pure helpers and constructor-only surface (07 EVM_MODULE —
  * revert decoding used across chain operations). No live RPC / Hardhat.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Interface, ethers } from 'ethers';
 import { decodeEvmError, enrichEvmError, EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
 
@@ -353,34 +353,115 @@ describe('EVMChainAdapter constructor / getters (no init)', () => {
     expect(status.proofingPeriodDurationInBlocks).toBe(50n);
   });
 
-  it('getActiveProofPeriodStatus does not stall when the duration probe hangs (Codex round 5)', async () => {
+  it('getActiveProofPeriodStatus does not stall when the duration probe hangs (Codex round 5, fake-timers)', async () => {
     // A provider that accepts the request but never resolves — e.g.
     // RPC slow path, half-broken websocket — would otherwise pin
     // every status read until the underlying timeout (often >30s)
     // and silently freeze the prover loop. The 2s race must kick
     // in long before the primary status leg comes back, returning
     // `undefined` so the prover falls back to the cached duration.
+    //
+    // Codex round 6 on PR #369: drive setTimeout via fake timers
+    // instead of waiting on real wall clock. Real-time assertions
+    // are flaky under loaded CI / long GC pauses.
+    vi.useFakeTimers();
+    try {
+      const a = new EVMChainAdapter(minimalConfig());
+      const fakeRs = {
+        getActiveProofPeriodStatus: async () => ({
+          activeProofPeriodStartBlock: 1234n,
+          isValid: true,
+        }),
+        getActiveProofingPeriodDurationInBlocks: () =>
+          new Promise(() => {/* never resolves */}),
+      };
+      (a as any).init = async () => undefined;
+      (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+      const inflight = a.getActiveProofPeriodStatus();
+      // Advance past DURATION_PROBE_TIMEOUT_MS (2000) to fire the
+      // fallback resolve and let the awaited Promise.all settle.
+      await vi.advanceTimersByTimeAsync(2001);
+      const status = await inflight;
+      expect(status.activeProofPeriodStartBlock).toBe(1234n);
+      expect(status.isValid).toBe(true);
+      expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('getActiveProofPeriodStatus single-flights the duration probe (Codex round 6)', async () => {
+    // A hung probe must NOT cause one stuck `eth_call` per tick —
+    // the adapter has to reuse the in-flight promise across
+    // overlapping calls so cardinality stays at 1. Without this
+    // guard, a long-lived node in a hung-RPC state would leak one
+    // stuck request per tick and eventually exhaust handles.
+    vi.useFakeTimers();
+    try {
+      const a = new EVMChainAdapter(minimalConfig());
+      const probeCalls = vi.fn();
+      const fakeRs = {
+        getActiveProofPeriodStatus: async () => ({
+          activeProofPeriodStartBlock: 7n,
+          isValid: false,
+        }),
+        getActiveProofingPeriodDurationInBlocks: () => {
+          probeCalls();
+          return new Promise(() => {/* never resolves */});
+        },
+      };
+      (a as any).init = async () => undefined;
+      (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
+      // Three back-to-back tick calls; each times out at 2s with
+      // fallback `undefined`. The duration probe MUST be issued
+      // exactly once across all three because the in-flight
+      // promise from tick #1 is still pending.
+      const calls = [
+        a.getActiveProofPeriodStatus(),
+        a.getActiveProofPeriodStatus(),
+        a.getActiveProofPeriodStatus(),
+      ];
+      await vi.advanceTimersByTimeAsync(2001);
+      const results = await Promise.all(calls);
+      for (const r of results) {
+        expect(r.activeProofPeriodStartBlock).toBe(7n);
+        expect(r.isValid).toBe(false);
+        expect(r.proofingPeriodDurationInBlocks).toBeUndefined();
+      }
+      expect(probeCalls).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('getActiveProofPeriodStatus issues a fresh probe after the previous one settles (Codex round 6)', async () => {
+    // Once the in-flight probe rejects/resolves, the next call MUST
+    // be allowed to issue a new one — otherwise a single transient
+    // failure would permanently disable the live duration read.
     const a = new EVMChainAdapter(minimalConfig());
+    const probeCalls = vi.fn();
+    let attempt = 0;
     const fakeRs = {
       getActiveProofPeriodStatus: async () => ({
-        activeProofPeriodStartBlock: 1234n,
+        activeProofPeriodStartBlock: 99n,
         isValid: true,
       }),
-      getActiveProofingPeriodDurationInBlocks: () =>
-        new Promise(() => {/* never resolves */}),
+      getActiveProofingPeriodDurationInBlocks: async () => {
+        probeCalls();
+        attempt += 1;
+        if (attempt === 1) throw new Error('first attempt fails');
+        return 77n;
+      },
     };
     (a as any).init = async () => undefined;
     (a as any).getRandomSampling = async () => ({ rs: fakeRs, rss: {} });
-    const t0 = Date.now();
-    const status = await a.getActiveProofPeriodStatus();
-    const elapsed = Date.now() - t0;
-    expect(status.activeProofPeriodStartBlock).toBe(1234n);
-    expect(status.isValid).toBe(true);
-    expect(status.proofingPeriodDurationInBlocks).toBeUndefined();
-    // Timeout is 2000ms; pad generously for slow CI but still
-    // well below any realistic provider timeout.
-    expect(elapsed).toBeGreaterThanOrEqual(1900);
-    expect(elapsed).toBeLessThan(4000);
+    const first = await a.getActiveProofPeriodStatus();
+    expect(first.proofingPeriodDurationInBlocks).toBeUndefined();
+    // Wait a microtask so the .finally that clears the slot runs.
+    await Promise.resolve();
+    const second = await a.getActiveProofPeriodStatus();
+    expect(second.proofingPeriodDurationInBlocks).toBe(77n);
+    expect(probeCalls).toHaveBeenCalledTimes(2);
   });
 
   it('coerces randomSamplingHubRefreshMs<=0 to the default TTL (no "disable refresh" mode)', () => {

--- a/packages/random-sampling/src/prover.ts
+++ b/packages/random-sampling/src/prover.ts
@@ -148,21 +148,37 @@ export class RandomSamplingProver {
    * `existingIsCurrent` stayed truthy forever and the prover never
    * tried to rotate. Wall-clock comparison breaks the deadlock.)
    *
+   * Codex round 2 on PR #369 — the on-chain
+   * `updateAndGetActiveProofPeriodStartBlock()` rolls forward using
+   * the CURRENT epoch's
+   * `RandomSampling.getActiveProofingPeriodDurationInBlocks()`, NOT
+   * whatever duration was baked into a cached `NodeChallenge` at
+   * creation time. If governance shortens the proofing duration
+   * mid-flight, the cached duration overstates expiry and the same
+   * `kc-not-synced` deadlock reappears at the rollover. So when the
+   * adapter exposes the live duration on `ProofPeriodStatus`
+   * (modern EVM/mock adapters), prefer it; fall back to
+   * `existing.proofingPeriodDurationInBlocks` only for legacy adapters
+   * that don't yet populate the field.
+   *
    * Robust to chain adapters that don't expose `getBlockNumber` (mock
    * / test): falls back to "not stale" so the existing short-circuit
    * behaviour is preserved.
    */
-  private async isCachedChallengeStale(existing: NodeChallenge): Promise<boolean> {
+  private async isCachedChallengeStale(
+    existing: NodeChallenge,
+    liveDurationInBlocks?: bigint,
+  ): Promise<boolean> {
     if (!this.chain.getBlockNumber) return false;
-    if (existing.proofingPeriodDurationInBlocks <= 0n) return false;
+    const duration = liveDurationInBlocks ?? existing.proofingPeriodDurationInBlocks;
+    if (duration <= 0n) return false;
     let currentBlock: number;
     try {
       currentBlock = await this.chain.getBlockNumber();
     } catch {
       return false;
     }
-    const periodEndBlock =
-      existing.activeProofPeriodStartBlock + existing.proofingPeriodDurationInBlocks;
+    const periodEndBlock = existing.activeProofPeriodStartBlock + duration;
     return BigInt(currentBlock) >= periodEndBlock;
   }
 
@@ -220,7 +236,10 @@ export class RandomSamplingProver {
     // always-call would burn a tick + emit confusing reverts on every
     // post-solve poll inside the same period.
     if (existingIsCurrent && existing.solved) {
-      const isStale = await this.isCachedChallengeStale(existing);
+      const isStale = await this.isCachedChallengeStale(
+        existing,
+        status.proofingPeriodDurationInBlocks,
+      );
       if (!isStale) {
         this.log.info('rs.tick.already-solved', {
           epoch: existing.epoch.toString(),
@@ -255,7 +274,10 @@ export class RandomSamplingProver {
     // after the 2026-05-01 RS-contract Hub rotation.
     const unsolvedStale = existingIsCurrent
       && !existing.solved
-      && (await this.isCachedChallengeStale(existing));
+      && (await this.isCachedChallengeStale(
+        existing,
+        status.proofingPeriodDurationInBlocks,
+      ));
     if (unsolvedStale) {
       this.log.info('rs.tick.forcing-rotation', {
         cachedPeriodStart: existing.activeProofPeriodStartBlock.toString(),

--- a/packages/random-sampling/src/prover.ts
+++ b/packages/random-sampling/src/prover.ts
@@ -135,16 +135,24 @@ export class RandomSamplingProver {
   }
 
   /**
-   * Detect "the cached challenge says solved, but its proof period has
-   * already elapsed in wall-clock terms even though no on-chain tx has
-   * advanced the storage cursor yet". Returns true when we should force
-   * a `createChallenge` to make the chain rotate.
+   * Detect "the cached challenge's proof period has already elapsed in
+   * wall-clock terms, even though no on-chain tx has advanced the
+   * `activeProofPeriodStartBlock` storage cursor yet". Returns true
+   * when we should force a `createChallenge` to make the chain rotate.
    *
-   * Robust to chain adapters that don't expose `getBlockNumber` (mock /
-   * test): falls back to "not stale" so the existing short-circuit
+   * Applies to BOTH solved-and-stale (poll-after-success while period
+   * actually rotated) AND unsolved-and-stale (testnet 2026-05-01: an
+   * RS-contract Hub rotation left every node holding an unsolvable
+   * challenge from a long-expired period; with no tx ever calling
+   * submitProof / createChallenge the cursor froze, so
+   * `existingIsCurrent` stayed truthy forever and the prover never
+   * tried to rotate. Wall-clock comparison breaks the deadlock.)
+   *
+   * Robust to chain adapters that don't expose `getBlockNumber` (mock
+   * / test): falls back to "not stale" so the existing short-circuit
    * behaviour is preserved.
    */
-  private async isCachedSolvedStale(existing: NodeChallenge): Promise<boolean> {
+  private async isCachedChallengeStale(existing: NodeChallenge): Promise<boolean> {
     if (!this.chain.getBlockNumber) return false;
     if (existing.proofingPeriodDurationInBlocks <= 0n) return false;
     let currentBlock: number;
@@ -212,7 +220,7 @@ export class RandomSamplingProver {
     // always-call would burn a tick + emit confusing reverts on every
     // post-solve poll inside the same period.
     if (existingIsCurrent && existing.solved) {
-      const isStale = await this.isCachedSolvedStale(existing);
+      const isStale = await this.isCachedChallengeStale(existing);
       if (!isStale) {
         this.log.info('rs.tick.already-solved', {
           epoch: existing.epoch.toString(),
@@ -227,6 +235,7 @@ export class RandomSamplingProver {
       this.log.info('rs.tick.forcing-rotation', {
         cachedPeriodStart: existing.activeProofPeriodStartBlock.toString(),
         statusPeriodStart: status.activeProofPeriodStartBlock.toString(),
+        reason: 'solved-stale',
       });
     }
 
@@ -238,7 +247,23 @@ export class RandomSamplingProver {
 
     let challenge: NodeChallenge;
     let cgId: bigint;
-    if (existingIsCurrent && !existing.solved) {
+    // Same wall-clock stale check as the solved branch above. Without
+    // it, an unsolved challenge whose period has expired (but whose
+    // on-chain cursor never advanced because no submit/create tx
+    // landed) would be reused forever and starve every subsequent
+    // rotation. This is exactly what bricked Base Sepolia testnet
+    // after the 2026-05-01 RS-contract Hub rotation.
+    const unsolvedStale = existingIsCurrent
+      && !existing.solved
+      && (await this.isCachedChallengeStale(existing));
+    if (unsolvedStale) {
+      this.log.info('rs.tick.forcing-rotation', {
+        cachedPeriodStart: existing.activeProofPeriodStartBlock.toString(),
+        statusPeriodStart: status.activeProofPeriodStartBlock.toString(),
+        reason: 'unsolved-stale',
+      });
+    }
+    if (existingIsCurrent && !existing.solved && !unsolvedStale) {
       challenge = existing;
       cgId = await this.chain.getKCContextGraphId(challenge.knowledgeCollectionId);
     } else {

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -273,6 +273,14 @@ describe('RandomSamplingProver — short-circuits', () => {
     // Fix: mirror the wall-clock stale check that already protected
     // the solved branch. If wallclock is past the cached period's
     // boundary, force a rotation regardless of solved/unsolved.
+    //
+    // Codex round 1: the rotated challenge from createChallenge must
+    // sit in a DIFFERENT period than the frozen cached one — otherwise
+    // the test only proves createChallenge was called, not that the
+    // prover actually consumed the rotated challenge downstream. So
+    // make the frozen cursor sit at period 1000 and have createChallenge
+    // return a challenge for the now-current period 9050, then assert
+    // the WAL trail records `periodStartBlock` of the rotated period.
     const fixture: KCFixture = {
       cgId: 11n, kcId: 7n, ual: 'did:dkg:hardhat:31337/0xpub/7',
       rootEntities: ['urn:e:1'],
@@ -280,14 +288,22 @@ describe('RandomSamplingProver — short-circuits', () => {
     };
     const { root, leafCount } = await seedKC(store, fixture);
 
+    const FROZEN_PERIOD = 1000n;
+    const ROTATED_PERIOD = 9050n;
+    const ROTATED_EPOCH = 18n;
+
     const submitProof = vi.fn(async () => ({ hash: '0xfresh', blockNumber: 9000, success: true }));
     const createChallenge = vi.fn(async () => ({
       challenge: makeChallenge({
         knowledgeCollectionId: fixture.kcId,
         chunkId: 0n,
-        // The chain's createChallenge auto-rotates the period internally;
-        // the returned challenge points at the now-current period.
-        activeProofPeriodStartBlock: 1000n,
+        // The chain's createChallenge auto-rotates the period internally
+        // (`updateAndGetActiveProofPeriodStartBlock` runs inside the tx),
+        // so the returned challenge sits in the NEW period — not the
+        // frozen cached one. Test asserts the prover consumes this
+        // rotated period downstream (WAL entries reflect ROTATED_PERIOD).
+        epoch: ROTATED_EPOCH,
+        activeProofPeriodStartBlock: ROTATED_PERIOD,
         proofingPeriodDurationInBlocks: 50n,
       }),
       contextGraphId: fixture.cgId,
@@ -295,17 +311,17 @@ describe('RandomSamplingProver — short-circuits', () => {
     }));
     const chain = makeChain({
       // Status read still reflects the FROZEN cursor — both the
-      // status and the stored challenge agree on period 1000, so
-      // `existingIsCurrent` is truthy. Only the wall-clock check
+      // status and the stored challenge agree on the frozen period,
+      // so `existingIsCurrent` is truthy. Only the wall-clock check
       // can detect that the period actually expired.
-      status: { activeProofPeriodStartBlock: 1000n, isValid: true },
+      status: { activeProofPeriodStartBlock: FROZEN_PERIOD, isValid: true },
       challengeForNode: makeChallenge({
         knowledgeCollectionId: fixture.kcId,
-        activeProofPeriodStartBlock: 1000n,
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
         proofingPeriodDurationInBlocks: 50n,
         solved: false,
       }),
-      // Wallclock is far past period boundary (1000 + 50 = 1050).
+      // Wallclock far past frozen period boundary (1000 + 50 = 1050).
       blockNumber: 9000,
       createChallenge,
       expectedRoot: root,
@@ -313,11 +329,24 @@ describe('RandomSamplingProver — short-circuits', () => {
       cgIdForKc: fixture.cgId,
       submitProof: submitProof as never,
     });
-    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+    const wal = new InMemoryProverWal();
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID, wal });
     const outcome = await prover.tick();
     expect(outcome.kind).toBe('submitted');
     expect(createChallenge).toHaveBeenCalledTimes(1);
     expect(submitProof).toHaveBeenCalledTimes(1);
+
+    // Codex round 1 fix — verify the prover actually advanced to the
+    // rotated period. WAL entries written after `periodKey.periodStartBlock
+    // = challenge.activeProofPeriodStartBlock` (prover.ts L288) all carry
+    // the new period; if the prover had instead reused the frozen cached
+    // challenge they'd carry FROZEN_PERIOD's string and this would fail.
+    const trail = await wal.readAll();
+    const submitted = trail.find((e) => e.status === 'submitted');
+    expect(submitted).toBeDefined();
+    expect(submitted!.periodStartBlock).toBe(ROTATED_PERIOD.toString());
+    expect(submitted!.epoch).toBe(ROTATED_EPOCH.toString());
+    expect(trail.map((e) => e.status)).toEqual(['challenge', 'extracted', 'built', 'submitted']);
     await prover.close();
   });
 

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -496,6 +496,76 @@ describe('RandomSamplingProver — short-circuits', () => {
     await prover.close();
   });
 
+  it('forces createChallenge from the SOLVED branch when wallclock is past live duration (Codex round 4)', async () => {
+    // Codex round 4 on PR #369 — round 2 made the solved branch
+    // consume `status.proofingPeriodDurationInBlocks` for staleness too,
+    // but only the unsolved branch had a wall-clock regression test.
+    // Without symmetric solved-branch coverage, a regression that
+    // reverts `isCachedChallengeStale` to ignoring the live duration
+    // would re-introduce the post-submit deadlock (poll-after-success
+    // while period actually rotated → short-circuit on `already-solved`
+    // → never advance) without failing this suite.
+    //
+    // Setup: cached challenge is SOLVED at FROZEN_PERIOD with a
+    // CACHED_DURATION that would say "still in period" at CURRENT_BLOCK
+    // (cached: 1000+10000 > 5000), but the live duration says "expired"
+    // (live: 1000+50 < 5000). The prover must consult the live duration
+    // and force createChallenge.
+    const fixture: KCFixture = {
+      cgId: 11n, kcId: 7n, ual: 'did:dkg:hardhat:31337/0xpub/7',
+      rootEntities: ['urn:e:1'],
+      publicTriples: [{ subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"' }],
+    };
+    const { root, leafCount } = await seedKC(store, fixture);
+
+    const FROZEN_PERIOD = 1000n;
+    const CACHED_DURATION = 10000n;
+    const LIVE_DURATION = 50n;
+    const CURRENT_BLOCK = 5000;
+    const ROTATED_PERIOD = 5000n;
+
+    const submitProof = vi.fn(async () => ({ hash: '0xnext', blockNumber: CURRENT_BLOCK, success: true }));
+    const createChallenge = vi.fn(async () => ({
+      challenge: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        chunkId: 0n,
+        epoch: 19n,
+        activeProofPeriodStartBlock: ROTATED_PERIOD,
+        proofingPeriodDurationInBlocks: LIVE_DURATION,
+        solved: false,
+      }),
+      contextGraphId: fixture.cgId,
+      hash: '0x', blockNumber: CURRENT_BLOCK, success: true,
+    }));
+    const chain = makeChain({
+      status: {
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        isValid: false,
+        proofingPeriodDurationInBlocks: LIVE_DURATION,
+      },
+      challengeForNode: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        proofingPeriodDurationInBlocks: CACHED_DURATION,
+        solved: true,
+      }),
+      blockNumber: CURRENT_BLOCK,
+      createChallenge,
+      expectedRoot: root,
+      expectedLeafCount: leafCount,
+      cgIdForKc: fixture.cgId,
+      submitProof: submitProof as never,
+    });
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+    const outcome = await prover.tick();
+    // Did NOT short-circuit on `already-solved`; the live-duration
+    // wall-clock check fired and the prover rotated to the new period.
+    expect(outcome.kind).toBe('submitted');
+    expect(createChallenge).toHaveBeenCalledTimes(1);
+    expect(submitProof).toHaveBeenCalledTimes(1);
+    await prover.close();
+  });
+
   it('returns cg-not-found when getKCContextGraphId returns 0', async () => {
     const chain = makeChain({
       status: { activeProofPeriodStartBlock: 1000n, isValid: true },

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -277,10 +277,24 @@ describe('RandomSamplingProver — short-circuits', () => {
     // Codex round 1: the rotated challenge from createChallenge must
     // sit in a DIFFERENT period than the frozen cached one — otherwise
     // the test only proves createChallenge was called, not that the
-    // prover actually consumed the rotated challenge downstream. So
-    // make the frozen cursor sit at period 1000 and have createChallenge
-    // return a challenge for the now-current period 9050, then assert
-    // the WAL trail records `periodStartBlock` of the rotated period.
+    // prover actually consumed the rotated challenge downstream.
+    //
+    // Codex round 2: the fixture must also stay consistent with real
+    // contract invariants. With the cached cursor at FROZEN_PERIOD and
+    // the wall-clock at CURRENT_BLOCK far past the period boundary:
+    //   - getActiveProofPeriodStatus() would report isValid: false
+    //     because block.number > FROZEN_PERIOD + duration (the prover
+    //     deliberately ignores isValid — see tickImpl L185–191 — so
+    //     this is the regime we model)
+    //   - createChallenge()'s internal updateAndGetActiveProofPeriodStartBlock
+    //     advances by `completePeriodsPassed * duration`, which lands
+    //     ROTATED_PERIOD at exactly CURRENT_BLOCK (or earlier), never
+    //     after it. So ROTATED_PERIOD = FROZEN + N*duration <= CURRENT_BLOCK.
+    //
+    // Concrete numbers:
+    //   FROZEN_PERIOD = 1000n, DURATION = 50n, CURRENT_BLOCK = 9000n
+    //   periodsPassed = (9000-1000)/50 = 160
+    //   ROTATED_PERIOD = 1000 + 160*50 = 9000 (lands at CURRENT_BLOCK)
     const fixture: KCFixture = {
       cgId: 11n, kcId: 7n, ual: 'did:dkg:hardhat:31337/0xpub/7',
       rootEntities: ['urn:e:1'],
@@ -289,40 +303,50 @@ describe('RandomSamplingProver — short-circuits', () => {
     const { root, leafCount } = await seedKC(store, fixture);
 
     const FROZEN_PERIOD = 1000n;
-    const ROTATED_PERIOD = 9050n;
+    const DURATION = 50n;
+    const CURRENT_BLOCK = 9000;
+    const ROTATED_PERIOD =
+      FROZEN_PERIOD
+      + BigInt(Math.floor((CURRENT_BLOCK - Number(FROZEN_PERIOD)) / Number(DURATION)))
+        * DURATION;
+    // Sanity-pin the on-chain math at fixture authoring time so future
+    // edits to FROZEN_PERIOD/DURATION/CURRENT_BLOCK can't silently drift
+    // ROTATED_PERIOD into a value the contract could not actually return.
+    expect(ROTATED_PERIOD).toBe(9000n);
     const ROTATED_EPOCH = 18n;
 
-    const submitProof = vi.fn(async () => ({ hash: '0xfresh', blockNumber: 9000, success: true }));
+    const submitProof = vi.fn(async () => ({ hash: '0xfresh', blockNumber: CURRENT_BLOCK, success: true }));
     const createChallenge = vi.fn(async () => ({
       challenge: makeChallenge({
         knowledgeCollectionId: fixture.kcId,
         chunkId: 0n,
-        // The chain's createChallenge auto-rotates the period internally
-        // (`updateAndGetActiveProofPeriodStartBlock` runs inside the tx),
-        // so the returned challenge sits in the NEW period — not the
-        // frozen cached one. Test asserts the prover consumes this
-        // rotated period downstream (WAL entries reflect ROTATED_PERIOD).
         epoch: ROTATED_EPOCH,
         activeProofPeriodStartBlock: ROTATED_PERIOD,
-        proofingPeriodDurationInBlocks: 50n,
+        proofingPeriodDurationInBlocks: DURATION,
       }),
       contextGraphId: fixture.cgId,
-      hash: '0x', blockNumber: 9000, success: true,
+      hash: '0x', blockNumber: CURRENT_BLOCK, success: true,
     }));
     const chain = makeChain({
-      // Status read still reflects the FROZEN cursor — both the
-      // status and the stored challenge agree on the frozen period,
-      // so `existingIsCurrent` is truthy. Only the wall-clock check
-      // can detect that the period actually expired.
-      status: { activeProofPeriodStartBlock: FROZEN_PERIOD, isValid: true },
+      // The cached challenge's period == the on-chain status cursor
+      // (both frozen at FROZEN_PERIOD), so `existingIsCurrent` is true.
+      // status.isValid is FALSE because real contract sets it to
+      // `block.number < activeProofPeriodStartBlock + duration` — at
+      // CURRENT_BLOCK well past the frozen boundary that's necessarily
+      // false. The prover ignores isValid and relies on the wall-clock
+      // check instead, which is exactly what this regression covers.
+      status: {
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        isValid: false,
+        proofingPeriodDurationInBlocks: DURATION,
+      },
       challengeForNode: makeChallenge({
         knowledgeCollectionId: fixture.kcId,
         activeProofPeriodStartBlock: FROZEN_PERIOD,
-        proofingPeriodDurationInBlocks: 50n,
+        proofingPeriodDurationInBlocks: DURATION,
         solved: false,
       }),
-      // Wallclock far past frozen period boundary (1000 + 50 = 1050).
-      blockNumber: 9000,
+      blockNumber: CURRENT_BLOCK,
       createChallenge,
       expectedRoot: root,
       expectedLeafCount: leafCount,
@@ -338,8 +362,8 @@ describe('RandomSamplingProver — short-circuits', () => {
 
     // Codex round 1 fix — verify the prover actually advanced to the
     // rotated period. WAL entries written after `periodKey.periodStartBlock
-    // = challenge.activeProofPeriodStartBlock` (prover.ts L288) all carry
-    // the new period; if the prover had instead reused the frozen cached
+    // = challenge.activeProofPeriodStartBlock` (prover.ts) all carry the
+    // new period; if the prover had instead reused the frozen cached
     // challenge they'd carry FROZEN_PERIOD's string and this would fail.
     const trail = await wal.readAll();
     const submitted = trail.find((e) => e.status === 'submitted');
@@ -347,6 +371,79 @@ describe('RandomSamplingProver — short-circuits', () => {
     expect(submitted!.periodStartBlock).toBe(ROTATED_PERIOD.toString());
     expect(submitted!.epoch).toBe(ROTATED_EPOCH.toString());
     expect(trail.map((e) => e.status)).toEqual(['challenge', 'extracted', 'built', 'submitted']);
+    await prover.close();
+  });
+
+  it('uses live duration from status for staleness when governance shortens proofingPeriodDurationInBlocks mid-flight', async () => {
+    // Codex round 2 on PR #369: `updateAndGetActiveProofPeriodStartBlock`
+    // rolls forward using `getActiveProofingPeriodDurationInBlocks()`
+    // for the current epoch — NOT the duration baked into the cached
+    // `NodeChallenge` at creation time. If governance shortens that
+    // duration after a challenge is cached, the on-chain expiry boundary
+    // is closer than the cached duration would suggest. The prover must
+    // prefer the live `status.proofingPeriodDurationInBlocks` over the
+    // cached one, otherwise rotation regresses to "fires only once the
+    // cached (longer) duration would have expired" — exactly the kind
+    // of latent deadlock this fix is meant to prevent.
+    const fixture: KCFixture = {
+      cgId: 11n, kcId: 7n, ual: 'did:dkg:hardhat:31337/0xpub/7',
+      rootEntities: ['urn:e:1'],
+      publicTriples: [{ subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"' }],
+    };
+    const { root, leafCount } = await seedKC(store, fixture);
+
+    const FROZEN_PERIOD = 1000n;
+    // Cached duration is the LONG one (10000 blocks) baked into the
+    // challenge before the governance change. Wall-clock at block 5000
+    // would NOT be stale by this duration (1000 + 10000 = 11000 > 5000),
+    // so a regression that uses the cached duration would happily reuse
+    // the cached challenge and never call createChallenge → deadlock.
+    const CACHED_DURATION = 10000n;
+    // Live duration is the SHORT one (50 blocks) installed by governance.
+    // Wall-clock at 5000 IS stale by this duration (1000 + 50 = 1050 < 5000),
+    // so the prover must force rotation.
+    const LIVE_DURATION = 50n;
+    const CURRENT_BLOCK = 5000;
+    // After rotation, the chain advances by `completePeriodsPassed * LIVE_DURATION`.
+    // periodsPassed = (5000 - 1000) / 50 = 80 → ROTATED = 1000 + 80*50 = 5000.
+    const ROTATED_PERIOD = 5000n;
+
+    const submitProof = vi.fn(async () => ({ hash: '0xfresh', blockNumber: CURRENT_BLOCK, success: true }));
+    const createChallenge = vi.fn(async () => ({
+      challenge: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        chunkId: 0n,
+        epoch: 19n,
+        activeProofPeriodStartBlock: ROTATED_PERIOD,
+        proofingPeriodDurationInBlocks: LIVE_DURATION,
+      }),
+      contextGraphId: fixture.cgId,
+      hash: '0x', blockNumber: CURRENT_BLOCK, success: true,
+    }));
+    const chain = makeChain({
+      status: {
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        isValid: false,
+        proofingPeriodDurationInBlocks: LIVE_DURATION,
+      },
+      challengeForNode: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        proofingPeriodDurationInBlocks: CACHED_DURATION,
+        solved: false,
+      }),
+      blockNumber: CURRENT_BLOCK,
+      createChallenge,
+      expectedRoot: root,
+      expectedLeafCount: leafCount,
+      cgIdForKc: fixture.cgId,
+      submitProof: submitProof as never,
+    });
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+    const outcome = await prover.tick();
+    expect(outcome.kind).toBe('submitted');
+    expect(createChallenge).toHaveBeenCalledTimes(1);
+    expect(submitProof).toHaveBeenCalledTimes(1);
     await prover.close();
   });
 

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -44,6 +44,10 @@ interface FakeChainState {
   expectedLeafCount: number;
   cgIdForKc: bigint;
   submitProof: (leaf: Uint8Array, proof: Uint8Array[]) => Promise<TxResult>;
+  /** When set, exposes `chain.getBlockNumber` so the wall-clock stale
+   *  check inside the prover engages. Tests that omit this fall back
+   *  to "stale check always false" (the production-safe default). */
+  blockNumber?: number;
 }
 
 function makeChain(state: FakeChainState): ChainAdapter {
@@ -59,6 +63,9 @@ function makeChain(state: FakeChainState): ChainAdapter {
     getKCContextGraphId: vi.fn(async () => state.cgIdForKc),
     submitProof: vi.fn(state.submitProof),
   };
+  if (state.blockNumber !== undefined) {
+    partial.getBlockNumber = vi.fn(async () => state.blockNumber!);
+  }
   return partial as ChainAdapter;
 }
 
@@ -248,6 +255,68 @@ describe('RandomSamplingProver — short-circuits', () => {
     const outcome = await prover.tick();
     expect(outcome.kind).toBe('submitted');
     expect(createChallenge).toHaveBeenCalledTimes(1); // forced fresh
+    expect(submitProof).toHaveBeenCalledTimes(1);
+    await prover.close();
+  });
+
+  it('forces createChallenge when existing unsolved challenge is past its on-chain period boundary by wall-clock', async () => {
+    // Reproduces the Base Sepolia testnet deadlock from 2026-05-01:
+    // After an RS-contract Hub rotation, every staked node held an
+    // unsolved challenge for proof period P. With no submit/create
+    // tx landing post-rotation, the contract's
+    // `activeProofPeriodStartBlock` cursor stayed frozen at P, so
+    // `existing.activeProofPeriodStartBlock === status.activeProofPeriodStartBlock`
+    // remained true forever and the prover happily reused the
+    // unsolvable stale challenge on every tick (kc-not-synced loop)
+    // — never calling createChallenge to advance the period.
+    //
+    // Fix: mirror the wall-clock stale check that already protected
+    // the solved branch. If wallclock is past the cached period's
+    // boundary, force a rotation regardless of solved/unsolved.
+    const fixture: KCFixture = {
+      cgId: 11n, kcId: 7n, ual: 'did:dkg:hardhat:31337/0xpub/7',
+      rootEntities: ['urn:e:1'],
+      publicTriples: [{ subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"' }],
+    };
+    const { root, leafCount } = await seedKC(store, fixture);
+
+    const submitProof = vi.fn(async () => ({ hash: '0xfresh', blockNumber: 9000, success: true }));
+    const createChallenge = vi.fn(async () => ({
+      challenge: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        chunkId: 0n,
+        // The chain's createChallenge auto-rotates the period internally;
+        // the returned challenge points at the now-current period.
+        activeProofPeriodStartBlock: 1000n,
+        proofingPeriodDurationInBlocks: 50n,
+      }),
+      contextGraphId: fixture.cgId,
+      hash: '0x', blockNumber: 9000, success: true,
+    }));
+    const chain = makeChain({
+      // Status read still reflects the FROZEN cursor — both the
+      // status and the stored challenge agree on period 1000, so
+      // `existingIsCurrent` is truthy. Only the wall-clock check
+      // can detect that the period actually expired.
+      status: { activeProofPeriodStartBlock: 1000n, isValid: true },
+      challengeForNode: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        activeProofPeriodStartBlock: 1000n,
+        proofingPeriodDurationInBlocks: 50n,
+        solved: false,
+      }),
+      // Wallclock is far past period boundary (1000 + 50 = 1050).
+      blockNumber: 9000,
+      createChallenge,
+      expectedRoot: root,
+      expectedLeafCount: leafCount,
+      cgIdForKc: fixture.cgId,
+      submitProof: submitProof as never,
+    });
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+    const outcome = await prover.tick();
+    expect(outcome.kind).toBe('submitted');
+    expect(createChallenge).toHaveBeenCalledTimes(1);
     expect(submitProof).toHaveBeenCalledTimes(1);
     await prover.close();
   });

--- a/packages/random-sampling/test/prover.test.ts
+++ b/packages/random-sampling/test/prover.test.ts
@@ -566,6 +566,72 @@ describe('RandomSamplingProver — short-circuits', () => {
     await prover.close();
   });
 
+  it('falls back to existing.proofingPeriodDurationInBlocks when legacy adapter omits status.proofingPeriodDurationInBlocks (Codex round 5)', async () => {
+    // ProofPeriodStatus.proofingPeriodDurationInBlocks is intentionally
+    // optional — older EVM adapters (and any third-party ChainAdapter
+    // implementations) MAY omit it. The prover's `live ?? cached`
+    // fallback guarantees the wall-clock staleness check still works
+    // in that case. Without explicit coverage, a regression that
+    // makes `isCachedChallengeStale` *require* the live field would
+    // re-deadlock against legacy adapters with no test failure.
+    //
+    // Setup: live duration is omitted from status; cached challenge
+    // duration is short enough to be wall-clock-stale at CURRENT_BLOCK.
+    // The prover MUST consult the cached duration, see the staleness,
+    // and force createChallenge instead of reusing the unsolved cache.
+    const fixture: KCFixture = {
+      cgId: 12n, kcId: 8n, ual: 'did:dkg:hardhat:31337/0xpub/8',
+      rootEntities: ['urn:e:1'],
+      publicTriples: [{ subject: 'urn:e:1', predicate: 'urn:p:k', object: '"a"' }],
+    };
+    const { root, leafCount } = await seedKC(store, fixture);
+
+    const FROZEN_PERIOD = 1000n;
+    const CACHED_DURATION = 50n;
+    const CURRENT_BLOCK = 5000;
+    const ROTATED_PERIOD = 5000n;
+
+    const submitProof = vi.fn(async () => ({ hash: '0xnext', blockNumber: CURRENT_BLOCK, success: true }));
+    const createChallenge = vi.fn(async () => ({
+      challenge: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        chunkId: 0n,
+        epoch: 21n,
+        activeProofPeriodStartBlock: ROTATED_PERIOD,
+        proofingPeriodDurationInBlocks: CACHED_DURATION,
+        solved: false,
+      }),
+      contextGraphId: fixture.cgId,
+      hash: '0x', blockNumber: CURRENT_BLOCK, success: true,
+    }));
+    const chain = makeChain({
+      status: {
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        isValid: false,
+        // proofingPeriodDurationInBlocks intentionally omitted —
+        // simulating a legacy adapter that hasn't been updated yet.
+      },
+      challengeForNode: makeChallenge({
+        knowledgeCollectionId: fixture.kcId,
+        activeProofPeriodStartBlock: FROZEN_PERIOD,
+        proofingPeriodDurationInBlocks: CACHED_DURATION,
+        solved: false,
+      }),
+      blockNumber: CURRENT_BLOCK,
+      createChallenge,
+      expectedRoot: root,
+      expectedLeafCount: leafCount,
+      cgIdForKc: fixture.cgId,
+      submitProof: submitProof as never,
+    });
+    const prover = new RandomSamplingProver({ chain, store, identityId: IDENTITY_ID });
+    const outcome = await prover.tick();
+    expect(outcome.kind).toBe('submitted');
+    expect(createChallenge).toHaveBeenCalledTimes(1);
+    expect(submitProof).toHaveBeenCalledTimes(1);
+    await prover.close();
+  });
+
   it('returns cg-not-found when getKCContextGraphId returns 0', async () => {
     const chain = makeChain({
       status: { activeProofPeriodStartBlock: 1000n, isValid: true },


### PR DESCRIPTION
## Summary

Fixes a self-deadlock in the RS prover where an unsolved challenge whose proof period has elapsed in wall-clock terms (but whose on-chain `activeProofPeriodStartBlock` cursor never advanced because no `submit/createChallenge` tx landed) gets reused on every tick forever, never calling `createChallenge` to advance the period.

The `isCachedSolvedStale` helper already protected the analogous `existingIsCurrent && solved` branch (added in #357 in response to a Codex review). This PR generalizes it to also cover the `existingIsCurrent && !solved` branch — the only change is moving the wall-clock check into both branches consistently. Renamed to `isCachedChallengeStale` since it's period-end logic, not solved-specific.

## How this manifested in production (Base Sepolia testnet, 2026-05-01 → today)

Timeline of events:

1. **2026-05-01 17:24 UTC (block 40943995):** New `RandomSampling` contract deployed → Hub rotation. Old daemons start hitting `UnauthorizedAccess(Only Contracts in Hub)` on every tick because they cached the old contract address.
2. **PR #367** (merged today) fixed the Hub-rotation handling — daemons now re-resolve the RS contract via Hub events / on-error invalidation.
3. **But on testnet-op-1 after restarting on the post-#367 build:** the daemon successfully resolved the new RS contract, but every tick logged `rs.tick.kc-not-synced` for `kcId=1, cgId=2` — the **unsolved challenge from epoch 473** that was frozen in storage at the moment of rotation. The on-chain `activeProofPeriodStartBlock` was also still 40943700 (frozen because nothing had called `submitProof`/`createChallenge` for ~28h), so `existingIsCurrent` evaluated truthy and the prover never tried to rotate. Self-deadlock.

The same pattern blocked all 4 staked nodes on testnet (skyocean-core-staging, jpb, beacon-03, testnet-op-1), confirmed via on-chain probe: 0 `ActiveProofPeriodStartBlockSet`, 0 `NodeChallengeSet`, 0 `NodeEpochScoreAdded` events in the 28h since the rotation.

## The fix

```diff
+    // Same wall-clock stale check as the solved branch above. Without
+    // it, an unsolved challenge whose period has expired (but whose
+    // on-chain cursor never advanced because no submit/create tx
+    // landed) would be reused forever and starve every subsequent
+    // rotation. This is exactly what bricked Base Sepolia testnet
+    // after the 2026-05-01 RS-contract Hub rotation.
+    const unsolvedStale = existingIsCurrent
+      && !existing.solved
+      && (await this.isCachedChallengeStale(existing));
+    if (unsolvedStale) {
+      this.log.info('rs.tick.forcing-rotation', {
+        cachedPeriodStart: existing.activeProofPeriodStartBlock.toString(),
+        statusPeriodStart: status.activeProofPeriodStartBlock.toString(),
+        reason: 'unsolved-stale',
+      });
+    }
-    if (existingIsCurrent && !existing.solved) {
+    if (existingIsCurrent && !existing.solved && !unsolvedStale) {
       challenge = existing;
       cgId = await this.chain.getKCContextGraphId(challenge.knowledgeCollectionId);
     } else {
       const created = await this.chain.createChallenge();
```

Existing solved-branch behaviour is preserved by the rename + matching call site.

The `forcing-rotation` log line gains a `reason` field (`'solved-stale'` vs `'unsolved-stale'`) so operators can distinguish the two paths in observability.

## Live verification on testnet-op-1

After deploying this fix and restarting the daemon (`v10.0.0-rc.2, abce7b22+` running on Base Sepolia):

- **Pre-fix (last 28h):** ~3,300+ `rs.loop.tick-threw` errors with `UnauthorizedAccess`; after PR #367 unstuck the Hub-rotation handling: continuous `rs.tick.kc-not-synced` loop on the stale challenge.
- **Post-fix:** `rs.tick.forcing-rotation` with `reason: unsolved-stale` fires every tick; `createChallenge` is dispatched against the new RS contract. ✅

The on-chain period cursor still doesn't advance — but that's a separate, contract-level condition: `_generateChallenge` reverts with `NoEligibleContextGraphError` because no public+active CG holds non-zero per-epoch value in the current epoch (no recent V10 publish activity). That clears the moment any V10 KC publish lands; not something the prover can address.

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-random-sampling test` — 43/43 pass (10 → 11 in `prover.test.ts`)
- [x] New regression test reproduces the deadlock with stub adapter — fails on `main`, passes on this branch
- [x] Live verification on testnet-op-1 confirms `forcing-rotation` triggers and `createChallenge` is called

## Notes for reviewers

- Fallback semantics of `isCachedChallengeStale` when `chain.getBlockNumber` is missing or throws: returns `false` ("not stale"), preserving the existing fast-path. On chains where `getBlockNumber` is unreliable (e.g. flaky public RPC), this means the wrong branch may be taken on a flaky tick — the next healthy tick recovers. Considered acceptable given the alternative is RPC-burn or false rotations.
- The `reason` field on `rs.tick.forcing-rotation` is additive metadata; downstream observability that only switches on the event name is unaffected.


Made with [Cursor](https://cursor.com)