### PR TITLE
chore(devnet): fail-fast on partial bootstrap and discovery failures

### DIFF
--- a/scripts/devnet-test-publish.sh
+++ b/scripts/devnet-test-publish.sh
@@ -135,11 +135,19 @@ const path = require("path");
   const devnetDir = process.env.DEVNET_DIR;
   const hostingCount = Number(process.env.HOSTING_NODE_COUNT || "6");
   if (!devnetDir) throw new Error("DEVNET_DIR not set");
+  // Distinguish FILE-level failures (missing/malformed wallets.json —
+  // unexpected post-bootstrap, treat as fatal) from NO-IDENTITY (edge
+  // nodes have valid wallets.json but no on-chain identity by design,
+  // so this is silently expected). Without this split, a corrupt
+  // wallets.json on one core node would silently shrink the roster
+  // and let the smoke test pass against fewer hosting nodes than
+  // intended. Codex follow-up to PR #368.
   const ids = [];
+  const failures = [];
   for (let i = 1; i <= hostingCount; i++) {
     const walletsPath = path.join(devnetDir, "node" + i, "wallets.json");
     if (!fs.existsSync(walletsPath)) {
-      console.error("node " + i + ": missing " + walletsPath + " — skipping");
+      failures.push("node " + i + ": missing " + walletsPath);
       continue;
     }
     let opAddr;
@@ -147,17 +155,22 @@ const path = require("path");
       const w = JSON.parse(fs.readFileSync(walletsPath, "utf8"));
       const op0 = Array.isArray(w.wallets) ? w.wallets[0] : null;
       if (!op0 || !op0.privateKey) {
-        console.error("node " + i + ": wallets.json has no wallets[0].privateKey — skipping");
+        failures.push("node " + i + ": wallets.json has no wallets[0].privateKey");
         continue;
       }
       opAddr = new ethers.Wallet(op0.privateKey).address;
     } catch (e) {
-      console.error("node " + i + ": failed to parse wallets.json: " + (e?.message || e));
+      failures.push("node " + i + ": failed to parse wallets.json: " + (e?.message || e));
       continue;
     }
     const id = await identity.getIdentityId(opAddr);
     if (id > 0n) ids.push(id);
-    else console.error("node " + i + ": opWallet " + opAddr + " has no identity — skipping");
+    // No identity → edge node, by design (dkg-agent.ts skips
+    // ensureProfile for effectiveRole==='edge'). Silent skip is
+    // intentional here.
+  }
+  if (failures.length > 0) {
+    throw new Error("hosting-node discovery failures (refusing partial roster):\n  " + failures.join("\n  "));
   }
   if (ids.length === 0) {
     throw new Error("no hosting-node identities found — devnet identity registration may still be pending");

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -945,6 +945,17 @@ cmd_start() {
         } catch (e) { console.log('Ask failed for node ' + (i+1) + ': ' + e.message); }
       }
       console.log('Staked 50k TRAC for ' + staked + '/' + coreCount + ' core node(s), ask set for ' + asked + '/' + coreCount);
+      // Defense-in-depth: a partial-stake bootstrap (probe failure +
+      // skip, or createConviction revert + skip) currently logs
+      // 'staked X/Y' and continues. Operators may miss the count
+      // mismatch and only notice when downstream publish/ACK smoke
+      // tests fail with much less obvious symptoms. Refuse to
+      // declare bootstrap successful unless every core node is
+      // staked. Codex follow-up to PR #368.
+      if (staked < coreCount) {
+        console.error('FATAL: only ' + staked + '/' + coreCount + ' core node(s) staked — refusing to declare devnet ready');
+        process.exit(1);
+      }
     })();
   " 2>&1 | while read -r line; do log "$line"; done
 


### PR DESCRIPTION
## Context

Defense-in-depth follow-up to #368. The two findings Codex flagged on
PR #368's final round are about silently degraded states where
`devnet.sh start` or `devnet-test-publish.sh` produces a green-looking
outcome against a reduced roster, and downstream symptoms surface far
from the root cause.

Both failure modes are essentially impossible in practice on a
deterministic devnet (deployments are deterministic, `getNodeStakeV10`
is a `mapping` view, the `lostCores` guard upstream of
`devnet-test-publish.sh` already aborts bootstrap on bad
`wallets.json`), but \"impossible\" silent failures are precisely the
ones that produce the worst debugging experience when they do fire —
the operator looks at downstream errors with no signal at the source.

## Changes

### `scripts/devnet.sh` — bootstrap stake guard

```diff
       console.log('Staked 50k TRAC for ' + staked + '/' + coreCount + ' core node(s), ask set for ' + asked + '/' + coreCount);
+      if (staked < coreCount) {
+        console.error('FATAL: only ' + staked + '/' + coreCount + ' core node(s) staked — refusing to declare devnet ready');
+        process.exit(1);
+      }
```

`set -euo pipefail` is already at the top of the script, so a non-zero
exit from the embedded `node -e` block propagates and aborts
`cmd_start` cleanly. This catches:

- The Codex round-7 case: `getNodeStakeV10` probe exhaustion → silent
  skip-to-avoid-double-stake.
- The pre-existing `Stake failed for node X` catch path that also
  logs-and-continues without bumping `staked`.

### `scripts/devnet-test-publish.sh` — hosting-node discovery

Split the skip reasons into FILE-level failures (missing/malformed
`wallets.json` — fatal) and NO-IDENTITY (edge nodes are expected to
lack identities by design — silent). Previously both collapsed into
a silent `continue`, so a corrupt `wallets.json` on one core node
would shrink the roster and let the smoke test pass against fewer
hosting nodes than intended.

```diff
   const ids = [];
+  const failures = [];
   for (let i = 1; i <= hostingCount; i++) {
     ...
     if (!fs.existsSync(walletsPath)) {
-      console.error(\"node \" + i + \": missing \" + walletsPath + \" — skipping\");
+      failures.push(\"node \" + i + \": missing \" + walletsPath);
       continue;
     }
     ...
   }
+  if (failures.length > 0) {
+    throw new Error(\"hosting-node discovery failures (refusing partial roster):\\n  \" + failures.join(\"\\n  \"));
+  }
```

Edge nodes still skip silently — that's the correct behaviour
(`dkg-agent.ts` skips `ensureProfile` for `effectiveRole === 'edge'`,
so they have no identity by design).

## Scope

Only `scripts/devnet*.sh` touched. ~10 added lines per file. No
changes to production code, no new logic, just fail-fast guards.

## Test plan

- [ ] `./scripts/devnet.sh clean && ./scripts/devnet.sh start 6` —
      still completes successfully on the happy path.
- [ ] Manually corrupt one core node's `wallets.json` between
      bootstrap and `devnet-test-publish.sh` — script should now
      throw with `hosting-node discovery failures (refusing partial
      roster): node N: ...` instead of silently running against a
      reduced roster.
- [ ] `./scripts/devnet-test.sh` — passes the same baseline as
      before.

## Out of scope

- Extracting the wallets.json parser into a shared helper (Codex's
  earlier 🟡 on `devnet-test-publish.sh:147`). The two callers'
  needs are similar enough that a shared helper is plausible, but
  it's a separate refactor.

Made with [Cursor](https://cursor.com)