### PR TITLE
fix(random-sampling): resolve CG names with "/" so v9-style <owner>/<slug> CGs sync

### DIFF
--- a/packages/random-sampling/src/kc-extractor.ts
+++ b/packages/random-sampling/src/kc-extractor.ts
@@ -153,9 +153,10 @@ export async function extractV10KCFromStore(
   }
   const metaGraph = contextGraphMetaUri(cgName, cgIdStr);
   const dataGraph = contextGraphDataUri(cgName, cgIdStr);
-  // No assertSafeIri on derived URIs — they are constructed from a
-  // numeric bigint stringification + a CG name we just round-tripped
-  // through SPARQL, and the helpers are part of the trusted core surface.
+  // No assertSafeIri on derived URIs — `cgIdStr` is a bigint stringification
+  // and `cgName` was already gated by an `assertSafeIri(contextGraphMetaUri(name, '0'))`
+  // probe inside `resolveContextGraphNameFromOnChainId`, so the derived URIs
+  // are safe by construction.
 
   // 1. Resolve UAL via dkg:batchId. Use a typed integer literal to
   //    avoid string-prefix collisions (kcId 1 vs 10) — same lookup
@@ -277,9 +278,21 @@ async function resolveContextGraphNameFromOnChainId(
   const cgUri = stripQuotes(result.bindings[0]['cgUri'] ?? '');
   if (!cgUri.startsWith(CG_URI_PREFIX)) return null;
   const name = cgUri.slice(CG_URI_PREFIX.length);
-  // Reject empty / dangerous names. CG names are normally safe slugs
-  // (lowercase + hyphens) but we don't gate that here.
-  if (!name || name.includes('/') || name.includes(' ')) return null;
+  if (!name) return null;
+  // The name is later interpolated into a SPARQL IRI (`<did:dkg:context-graph:<name>/...>`),
+  // so we must reject anything that would break out of an IRI literal — but we cannot
+  // reject `/` here, because v9-style CG names use the `<owner_address>/<slug>` namespacing
+  // pattern (e.g. "0xb08…4794c/laptop-smoke") and would otherwise be silently dropped,
+  // surfacing as `KCNotFoundError` even when the FinalizationHandler has already promoted
+  // the data to canonical. That mismatch broke RS proof submission across the entire
+  // testnet — see PR notes for the on-chain reproduction.
+  // Validate via `assertSafeIri` on the *derived* meta-graph URI, which is the actual
+  // injection surface; rely on it instead of an overly tight name-level allowlist.
+  try {
+    assertSafeIri(contextGraphMetaUri(name, '0'));
+  } catch {
+    return null;
+  }
   return name;
 }
 

--- a/packages/random-sampling/test/e2e-hardhat-chain.test.ts
+++ b/packages/random-sampling/test/e2e-hardhat-chain.test.ts
@@ -232,7 +232,19 @@ describe('Random Sampling E2E (Hardhat)', () => {
     // We mirror that here so the extractor finds the KC.
     const store = new OxigraphStore();
     const cgIdStr = cgId.toString();
-    const cgName = `cg-${cgIdStr}`;
+    // Use a v9-style `<owner_address>/<slug>` cgName to exercise the
+    // FinalizationHandler ↔ kc-extractor seam end-to-end with the
+    // namespacing pattern that real beacons register on testnet
+    // (e.g. "0xb08…4794c/laptop-smoke"). A pre-PR-#377 build would
+    // short-circuit here in `resolveContextGraphNameFromOnChainId`,
+    // making `prover.tick()` return `kc-not-synced` instead of
+    // `submitted` — exactly the failure mode that suppressed every
+    // RS proof on testnet beacon-04 for 40+ minutes despite chain
+    // challenges firing within seconds of each `Finalization: promoted
+    // SWM snapshot` log line. The unit test in `kc-extractor.test.ts`
+    // covers the resolver in isolation; this one pins the whole
+    // chain-publish → local-store → prover-tick path.
+    const cgName = `0xb08A0F66d5A225D57Dee5fFa6C442e4DC2a4794c/cg-${cgIdStr}`;
     const cgUri = `did:dkg:context-graph:${cgName}`;
     await store.insert([
       {

--- a/packages/random-sampling/test/kc-extractor.test.ts
+++ b/packages/random-sampling/test/kc-extractor.test.ts
@@ -222,6 +222,35 @@ describe('extractV10KCFromStore — happy path / publisher round-trip parity', (
     }
   });
 
+  it('resolves CG names that contain "/" (v9-style <owner>/<slug> namespacing)', async () => {
+    // Regression for a testnet incident where every random-sampling proof on every
+    // beacon went unsubmitted: the CG name resolver in `kc-extractor.ts` rejected
+    // any name containing "/", but real CGs were registered as
+    // "0xb08…4794c/laptop-smoke" — owner-prefixed slugs. The FinalizationHandler
+    // wrote canonical data under `did:dkg:context-graph:<owner>/<slug>/context/<cgId>/_meta`
+    // (which is correct), but the extractor returned `null` from name resolution
+    // and threw `KCNotFoundError` even after data was promoted, blocking proofs
+    // forever. The relevant log line on every beacon was:
+    //   `Finalization: promoted SWM snapshot to context graph 12 …`
+    //   `[rs.tick.kc-not-synced] {"kcId":"6","cgId":"12","err":"KCNotFoundError"}`
+    const fixture: KCFixture = {
+      cgId: 12n,
+      cgName: '0xb08A0F66d5A225D57Dee5fFa6C442e4DC2a4794c/laptop-smoke',
+      kcId: 6n,
+      ual: 'did:dkg:base:84532/0xb08A0F66d5A225D57Dee5fFa6C442e4DC2a4794c/5000001',
+      rootEntities: ['urn:entity:slash-cg'],
+      publicTriples: [
+        { subject: 'urn:entity:slash-cg', predicate: 'urn:p:name', object: '"slash"' },
+      ],
+    };
+    await seedKC(store, fixture);
+
+    const result = await extractV10KCFromStore(store, fixture.cgId, fixture.kcId);
+    expect(result.contextGraphName).toBe(fixture.cgName);
+    expect(result.ual).toBe(fixture.ual);
+    expect(result.triples).toHaveLength(1);
+  });
+
   it('mixes public-triple leaves with private sub-root leaves (publisher symmetry)', async () => {
     const PRIVATE_ROOT = new Uint8Array(32).fill(0xab);
     const fixture: KCFixture = {

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -713,12 +713,12 @@ cmd_start() {
         provider
       );
       // Identity-scoped read used by the duplicate-stake guard below.
-      // ERC-721 balanceOf(opWallet) would also signal "this wallet
-      // owns at least one position", but that's not what the guard
-      // needs to know — an op wallet can hold positions for OTHER
-      // identities, which would skip a needed createConviction for
-      // THIS identity. getNodeStakeV10(idId) reads the per-identity
-      // stake total directly. Codex round 7 on PR #368.
+      // ERC-721 balanceOf(opWallet) would also signal that the op wallet
+      // owns at least one position, but that is not what the guard needs
+      // to know - an op wallet can hold positions for OTHER identities,
+      // which would skip a needed createConviction for THIS identity.
+      // getNodeStakeV10(idId) reads the per-identity stake total
+      // directly. Codex round 7 on PR #368.
       const css = new ethers.Contract(
         c('ConvictionStakingStorage'),
         ['function getNodeStakeV10(uint72) view returns (uint256)'],
@@ -744,8 +744,8 @@ cmd_start() {
       // wallets.json was malformed silently kept the 'edge' default,
       // dropped out of coreIdxs, and the lostCores guard never fired.
       // Reading config first decouples the two failures: now lostCores
-      // correctly catches "I was supposed to be a core but my wallets
-      // are broken".
+      // correctly catches the case where a node was supposed to be a
+      // core but its wallets are broken.
       const configErrors = [];
       for (let i = 1; i <= n; i++) {
         const cPath = '$DEVNET_DIR/node' + i + '/config.json';
@@ -886,7 +886,7 @@ cmd_start() {
         // devnet stake. We detect this by reading the per-identity V10
         // stake total — if the daemon's stake succeeded it's >0 and we skip.
         //
-        // Codex round 5 on PR #368: do NOT fall through to "not staked"
+        // Codex round 5 on PR #368: do NOT fall through to a not-staked
         // on probe failure (transient RPC, decode error). That would
         // re-introduce the double-stake bug this guard exists to prevent.
         // Retry once with backoff; if the probe still fails, refuse to


### PR DESCRIPTION
## Summary

Hotfix for an issue that suppressed **every** Random Sampling proof on testnet despite challenges firing correctly.

`resolveContextGraphNameFromOnChainId` in `kc-extractor.ts` was rejecting any context-graph name containing `/`. Real CGs are commonly registered with owner-prefixed names like `0xb08A0F66d5A225D57Dee5fFa6C442e4DC2a4794c/laptop-smoke` — the v9 `<owner_address>/<slug>` namespacing pattern. The resolver returned `null`, so `extractV10KCFromStore` threw `KCNotFoundError` for every KC in the CG, even after `FinalizationHandler` had already promoted the SWM snapshot to canonical.

## Reproduction (live testnet, beacon-04)

After publishing KC #6 + #7 to context graph 12 (cgName `0xb08…4794c/laptop-smoke`):

```
08:19:35 [FinalizationHandler] Finalization: promoted SWM snapshot to context graph 12 for did:dkg:base:84532/0xb08…4794c/5000001 (tx=0x2a7328ba…)
08:22:27 [FinalizationHandler] Finalization: promoted SWM snapshot to context graph 12 for did:dkg:base:84532/0xb08…4794c/6000001 (tx=0x79b10bdd…)
08:22:48 [DKGAgent] [rs.tick.kc-not-synced] {"kcId":"6","cgId":"12","err":"KCNotFoundError"} [WARN]
   …repeats every ~30s for 40+ minutes…
```

A 10-minute on-chain event watcher across all four beacons observed:
- 6 `ChallengeGenerated` events within 5 seconds (every beacon picked up KC #6/#7)
- **0 `ValidProofSubmitted` events** — proofs never get computed because the extractor short-circuits before even trying to read `_meta`

## Fix

Replace the over-tight name-level allowlist with `assertSafeIri` on the *derived* meta-graph URI, which is the actual SPARQL-injection surface:

```ts
// Before
if (!name || name.includes('/') || name.includes(' ')) return null;

// After
if (!name) return null;
try {
  assertSafeIri(contextGraphMetaUri(name, '0'));
} catch {
  return null;
}
```

This still rejects `<>"{}|\^` and control chars (poisoned ontology entries also can't land in OxigraphStore in the first place), but admits legitimate path-style names. Both ends of the writer/reader handshake (`FinalizationHandler.promoteSharedMemoryToCanonical` writes via `contextGraphMetaUri(contextGraphId, ctxGraphId)`; the extractor now reads via the same helper with the resolved name) end up at the same URI.

## Regression coverage

Two layers of test, both reverse-validated by temporarily restoring the `name.includes('/')` rejection — both fail loud:

1. **Unit (`kc-extractor.test.ts`)** — seeds a CG named `0xb08…4794c/laptop-smoke` and asserts `extractV10KCFromStore` returns triples. With the bug present this throws the EXACT error from testnet: `KCNotFoundError: KC 6 not found in _meta for context graph 12`.
2. **E2E hardhat (`e2e-hardhat-chain.test.ts`)** — switches the local cgName from `cg-<cgIdStr>` to `0xb08…4794c/cg-<cgIdStr>` so the chain-publish → local-store → prover-tick path is run with the v9-style namespacing pattern. Pre-fix the prover returns `kc-not-synced`; post-fix it returns `submitted`.

## Devnet validation

Brought up local devnet (`./scripts/devnet.sh start 6`) with the fixed code, ran the existing baseline `./scripts/devnet-test-random-sampling.sh` (passes against the no-`/` `devnet-test` CG), then created an additional CG with a `/`-name via `POST /api/context-graph/create`:

```
$ curl -X POST .../api/context-graph/create -d '{"id":"0xdeadbeef…/devnet-slash-test","name":"slash test","register":true}'
{"created":"0xdeadbeef…/devnet-slash-test","registered":true,"onChainId":"3"}
```

Published a KC into it (became kcId=2), advanced the chain past the proofing-period boundary, and tailed each prover's WAL:

```
=== node 1 ===  kc-not-synced count: 0
  status=challenge  cgId=3 kcId=2 tx=
  status=extracted  cgId=3 kcId=2 tx=
  status=built      cgId=3 kcId=2 tx=
  status=submitted  cgId=3 kcId=2 tx=0xe3f45c0f1ffd3ad7…   ← slash-CG proof submitted!
=== node 3 ===  kc-not-synced count: 0
  status=challenge  cgId=3 kcId=2 tx=
  status=extracted  cgId=3 kcId=2 tx=
  status=built      cgId=3 kcId=2 tx=
  status=submitted  cgId=3 kcId=2 tx=0x0fbf607383774826…   ← slash-CG proof submitted!
```

`getNodeChallenge(idId).solved == true` for all four identities; identities 1 and 3 picked the slash-CG (cgId=3 / kcId=2). Zero `kc-not-synced` warnings on any node — the bug signature is fully gone in a real-daemon environment.

## Devnet-side fix bundled in

To get devnet running, this PR also fixes three unrelated quoting bugs in `scripts/devnet.sh` introduced in `c09e0261` (Codex round 7 on PR #368) where embedded `"..."` substrings inside JS comments inside multi-line `node -e "…"` blocks made bash truncate the script body — `./scripts/devnet.sh start` was failing 100% of the time with `SyntaxError: Unexpected end of input`. Pure quoting refactor; comment meaning unchanged. Without this, the random-sampling devnet validation above can't be run.

## Test plan

- [x] Unit + e2e regression tests reverse-validated (both fail without fix, pass with fix).
- [x] All 47 random-sampling tests pass (`pnpm --filter @origintrail-official/dkg-random-sampling test`).
- [x] Local devnet end-to-end: `/`-named CG submits proof through full RS pipeline.
- [ ] After merge, redeploy to a beacon and confirm `rs.tick.kc-not-synced` clears + `ValidProofSubmitted` lands on chain for the existing testnet `0xb08…4794c/laptop-smoke` CG.

## Notes for reviewers

- This is independent of #371 / #373 (publisher operational-key discipline) and the planned operator-hardening PR (`--epochs N` flag, `/api/rs/status`, StorageACK success logging, TooLowBalance preflight).
- The `No assertSafeIri on derived URIs` comment in `extractV10KCFromStore` is updated to reflect that the resolver now does the gate.