### PR TITLE
chore: release v10.0.0-rc.4 (depends on #377 + #372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 
 ---
 
+## [10.0.0-rc.4] - 2026-05-04
+
+Hotfix on top of `v10.0.0-rc.3`. **Restores random-sampling proof submission for v9-style `<owner>/<slug>` context graphs on testnet** and brings the deployed Base Sepolia `Profile` contract into line with what the post-PR-#366 daemon expects, so `op[1]` / `op[2]` ACK signer auto-registration finally lands on-chain. No `chainResetMarker` change — per-node state (oxigraph store, RS WAL, publish journals) is preserved across the operator update.
+
+### Fixed
+- **V9-style `<owner>/<slug>` context graph names no longer fail `extractV10KCFromStore`** (#377): the kc-extractor's `resolveContextGraphNameFromOnChainId` previously rejected any CG name containing `/`, so finalized KCs surfaced as `KCNotFoundError` in `[rs.tick.kc-not-synced]` and silently dropped every random-sampling proof submission for slash-named CGs (which is the v9 namespacing convention `<owner_address>/<slug>`). Validation now uses `assertSafeIri` on the *derived* meta-graph URI — the actual SPARQL injection surface — instead of an over-tight name-level allowlist that was conflating namespacing with safety. Reproduced first as a unit test in `kc-extractor.test.ts` and then end-to-end in `e2e-hardhat-chain.test.ts`; both regression-tested by reverting the resolver fix and confirming the new tests fail.
+- **`scripts/devnet.sh` no longer crashes with `SyntaxError: Unexpected end of input` on startup** (#377): three JavaScript comments inside `node -e ...` blocks contained unescaped inner double-quotes that bash interpreted as string delimiters, truncating the script. Comments rephrased to avoid embedded double-quotes — necessary precondition for validating the kc-extractor fix on a local devnet.
+
+### Changed
+- **Base Sepolia (chainId 84532): `Profile` upgraded `v1.0.0` → `v1.1.0`, `Identity` re-deployed (`v1.0.0`, source-only zero-address-check tightening) so it stays in lockstep with the Profile that calls into it** (#372). The new Profile carries the `addOperationalWallets(uint72, address[])` external function the post-PR-#366 `ensureProfile` flow expects when registering the operational ACK wallet trio; without this upgrade the daemon failed silently with `Operational wallet auto-registration failed: missing revert data ... to: 0x4Ad9B99C…0493A` and only `op[0]` ever made it on-chain. Both contracts are pure logic (zero per-identity state) so no migration is required — existing identities 1-14, including freshly-recreated beacon-01 with 50,000 v9TRAC stake on identity 14, are unaffected. Hub mappings updated atomically via `Hub.setAndReinitializeContracts` (tx [`0xf7c8dfe2…1914`](https://sepolia.basescan.org/tx/0xf7c8dfe2c242bec2ee64f648757aba5b8d3b567b2129c3ebe89849abe8221914)).
+
+---
+
 ## [10.0.0-rc.3] - 2026-05-03
 
 Operator hardening on top of `v10.0.0-rc.2`. No contract redeploy — `chainResetMarker` unchanged, no per-node state wipe is triggered. Ships the admin / operational wallet key split, RandomSampling Hub-rotation self-refresh, prover stale-period detection, and devnet bootstrap fail-fast guards.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v9",
-  "version": "10.0.0-rc.3",
+  "version": "10.0.0-rc.4",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.3",
+  "version": "10.0.0-rc.4",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {


### PR DESCRIPTION
## Summary

Release-prep for **v10.0.0-rc.4**, a hotfix on top of `v10.0.0-rc.3`. Bumps root + `packages/cli` versions from `10.0.0-rc.3` → `10.0.0-rc.4` and adds a new `[10.0.0-rc.4] - 2026-05-04` section to `CHANGELOG.md` describing what landed.

> **DRAFT — depends on #377 + #372 landing on `main` first.** Once both are merged, this branch should be rebased onto the new `main`, marked ready for review, merged, and tagged.

## What's in this rc

- **#377 — `fix(random-sampling): resolve CG names with "/" so v9-style <owner>/<slug> CGs sync`**
  Restores random-sampling proof submission on testnet for slash-named CGs, which is most of them. The kc-extractor's `resolveContextGraphNameFromOnChainId` was rejecting any CG name containing `/`, so finalized KCs surfaced as `KCNotFoundError` and silently dropped every RS proof for v9-style namespaces. Validation now uses `assertSafeIri` on the derived meta-graph URI (the actual SPARQL injection surface) instead of an over-tight name-level allowlist. Reproduced first as a unit test, then end-to-end in hardhat, then validated on a local devnet (registered a `0xdeadbeef…/devnet-slash-test` CG, published into it, mined past the proofing-period boundary, observed `solved=true` on chain with **zero `kc-not-synced` warnings**).

- **#372 — `chore(deploy): upgrade Profile + Identity on Base Sepolia (enable 3-op-wallet ACK flow)`**
  `Profile` `v1.0.0` → `v1.1.0` and `Identity` re-deploy in lockstep. The new Profile carries the `addOperationalWallets(uint72, address[])` external function the post-PR-#366 `ensureProfile` flow expects; without it `op[1]`/`op[2]` ACK signer registration silently failed and only `op[0]` ever made it on-chain. Both contracts are pure logic; no per-identity state migration is required.

## Cut-over checklist (after merge)

```bash
# 1. confirm main is at this rc commit
git checkout main && git pull --ff-only ghorigin main
git rev-parse --short HEAD   # should be the chore: release v10.0.0-rc.4 commit

# 2. tag and push
git tag -a v10.0.0-rc.4 -m "DKG v10.0.0 rc 4 — RS extractor /-cgname hotfix + Base Sepolia Profile v1.1.0"
git push ghorigin v10.0.0-rc.4

# 3. wait for the Release workflow to build MarkItDown binaries + cut the GH Release
gh run watch --repo OriginTrail/dkg

# 4. publish to npm from a clean checkout at the tag (OTP prompt)
git checkout v10.0.0-rc.4
pnpm install --frozen-lockfile && pnpm build
pnpm -r publish --no-git-checks --tag latest

# 5. roll a single canary beacon first
ssh beacon-04 'sudo systemctl stop dkg && dkg update --check && dkg update 10.0.0-rc.4 --allow-prerelease && sudo systemctl start dkg'

# 6. verify on canary BEFORE rolling the rest:
#    - tail journalctl for `[rs.tick.kc-not-synced]` — should NOT appear for slash-named CGs
#    - publish a slash-named test CG + KC, confirm ValidProofSubmitted lands on chain
#    - confirm op[1]/op[2] ACK auto-registration succeeds (no "missing revert data" warnings)

# 7. roll remaining beacons; rollback path is `dkg rollback` if anything regresses
```

## Out of scope (deferred to v10.0.0-rc.5)

The other open testnet-incident PRs ship in the next rc:
- **#371** — `fix(publisher): drop random fallback wallet + audit Wallet.createRandom`
- **#374** — `fix(agent): refuse to register a CG that can never satisfy global quorum`

Phase B operator-hardening (`--epochs N` flag, `/api/rs/status` endpoint, StorageACK success/rejection logs, TooLowBalance preflight) is not yet opened and ships in rc.5 or rc.6 depending on review velocity.

## Test plan

- [ ] Confirm CHANGELOG `[10.0.0-rc.4]` section accurately reflects what merged in #377 and #372 (re-verify after both merge — rebase if rewording is needed)
- [ ] Confirm `package.json` + `packages/cli/package.json` are both at `10.0.0-rc.4` and no other monorepo `package.json` files were bumped (matches the rc.2 → rc.3 release policy)
- [ ] After tagging, confirm the Release workflow uploads all three MarkItDown binaries (`markitdown-linux-x64`, `markitdown-darwin-arm64`, `markitdown-win32-x64.exe`) to the GH Release
- [ ] After `pnpm -r publish`, `npm view @origintrail-official/dkg version` returns `10.0.0-rc.4`
- [ ] On a single canary beacon: `dkg update 10.0.0-rc.4 --allow-prerelease` succeeds, `readlink "$DKG_HOME/releases/current"` points at the new slot, `cat "$DKG_HOME/.current-version"` reads `10.0.0-rc.4`, no `.update-pending.json`
- [ ] On the canary: publish into a slash-named CG, observe `ValidProofSubmitted` event on chain within one proofing period, zero `[rs.tick.kc-not-synced]` warnings
- [ ] On the canary: restart with all 3 op-wallet keys configured, confirm `op[1]` and `op[2]` are visible on `Profile.getOperationalKeys(identityId)` (no silent `op[0]`-only registration)

Made with [Cursor](https://cursor.com)