### PR TITLE
feat(adapter-openclaw): private-by-default CGs + align dkg_share localOnly with Hermes

### DIFF
--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -2462,7 +2462,10 @@ export class DkgNodePlugin {
           'Create a new context graph on the DKG node. A context graph is a scoped knowledge domain ' +
           'that organizes published knowledge. Use dkg_list_context_graphs first to check if the ' +
           'context graph already exists. Returns the context graph ID and URI (did:dkg:context-graph:<id>). ' +
-          'The ID is auto-generated from the name if not provided.',
+          'The ID is auto-generated from the name if not provided. ' +
+          'Defaults to a curated/private context graph — the creator is auto-included in the allowlist ' +
+          'and can immediately write to working/shared memory. Pass `public: true` for an open/discoverable ' +
+          'context graph, or `allowed_agents` to invite collaborators atomically with creation.',
         parameters: {
           type: 'object',
           properties: {
@@ -2477,6 +2480,15 @@ export class DkgNodePlugin {
             id: {
               type: 'string',
               description: 'Optional custom context graph ID slug. Auto-generated from name if omitted (e.g. "My Research" → "my-research").',
+            },
+            public: {
+              type: 'boolean',
+              description: 'If true, creates an open/discoverable context graph (anyone can subscribe and read). Default is false — the context graph is curated/private and restricted to allowed_agents (the creator is always auto-included).',
+            },
+            allowed_agents: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Optional agent addresses (0x...) to add to the curation allowlist at creation time. The creator\'s own address is auto-added regardless. Ignored when public is true.',
             },
           },
           required: ['name'],
@@ -3474,7 +3486,25 @@ export class DkgNodePlugin {
         );
       }
       const description = args.description ? String(args.description).trim() : undefined;
-      const result = await this.client.createContextGraph(id, name, description);
+      // Privacy-by-default: when `public` is omitted or false, the context
+      // graph is curated (`accessPolicy: 1`). The agent's createContextGraph
+      // flow auto-includes the creator's address in the allowlist (see
+      // `packages/agent/src/dkg-agent.ts:3962-3973`), so the creator can
+      // immediately read/write the curated CG without a self-invite step.
+      const isPublic = args.public === true;
+      const allowedAgents = Array.isArray(args.allowed_agents)
+        ? args.allowed_agents
+            .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+            .filter((entry): entry is string => entry.length > 0)
+        : undefined;
+      const opts: { accessPolicy?: number; allowedAgents?: string[] } = {};
+      if (!isPublic) {
+        opts.accessPolicy = 1;
+      }
+      if (!isPublic && allowedAgents && allowedAgents.length > 0) {
+        opts.allowedAgents = allowedAgents;
+      }
+      const result = await this.client.createContextGraph(id, name, description, opts);
       return this.json(result);
     } catch (err: any) {
       return this.daemonError(err);

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -3497,6 +3497,21 @@ export class DkgNodePlugin {
             .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
             .filter((entry): entry is string => entry.length > 0)
         : undefined;
+      // Validate Ethereum address format up-front so a malformed input
+      // surfaces as a tool-level error instead of bubbling up as a 500
+      // from the daemon. Mirrors the agent layer's check at
+      // `packages/agent/src/dkg-agent.ts:3918-3922`.
+      if (!isPublic && allowedAgents && allowedAgents.length > 0) {
+        const ethAddrRe = /^0x[0-9a-fA-F]{40}$/;
+        for (const addr of allowedAgents) {
+          if (!ethAddrRe.test(addr)) {
+            return this.error(
+              `Invalid Ethereum address in "allowed_agents": "${addr}". ` +
+              'Each entry must be a 0x-prefixed 40-hex-char string (e.g. "0x1234567890abcdef1234567890abcdef12345678").',
+            );
+          }
+        }
+      }
       const opts: { accessPolicy?: number; allowedAgents?: string[] } = {};
       if (!isPublic) {
         opts.accessPolicy = 1;

--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -3491,32 +3491,65 @@ export class DkgNodePlugin {
       // flow auto-includes the creator's address in the allowlist (see
       // `packages/agent/src/dkg-agent.ts:3962-3973`), so the creator can
       // immediately read/write the curated CG without a self-invite step.
-      const isPublic = args.public === true;
-      const allowedAgents = Array.isArray(args.allowed_agents)
-        ? args.allowed_agents
-            .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-            .filter((entry): entry is string => entry.length > 0)
-        : undefined;
-      // Validate Ethereum address format up-front so a malformed input
-      // surfaces as a tool-level error instead of bubbling up as a 500
-      // from the daemon. Mirrors the agent layer's check at
-      // `packages/agent/src/dkg-agent.ts:3918-3922`.
-      if (!isPublic && allowedAgents && allowedAgents.length > 0) {
+      // Round 2 — strict type validation on `public`. Non-boolean values
+      // (e.g. `"yes"`, `1`, `null`) silently became `false` previously,
+      // producing curated CGs when the LLM intended public — the opposite
+      // of the agent's intent. Reject explicitly so the agent gets a
+      // clear correction instead of silent miscategorization.
+      const rawPublic = args.public;
+      if (rawPublic !== undefined && typeof rawPublic !== 'boolean') {
+        return this.error(
+          `"public" must be a boolean (true or false). Got: ${typeof rawPublic}.`,
+        );
+      }
+      const isPublic = rawPublic === true;
+      // Round 2 — strict allowed_agents validation. Previously we
+      // silently dropped non-string / blank entries, which hides
+      // LLM-generated mistakes (e.g. `["0x1234...", 42]` would create a
+      // curated graph WITHOUT 42's intended owner ever knowing they
+      // were excluded). Fail fast on every malformed entry with a
+      // precise index-scoped error so the agent can correct.
+      let allowedAgents: string[] | undefined;
+      if (!isPublic && args.allowed_agents !== undefined) {
+        if (!Array.isArray(args.allowed_agents)) {
+          return this.error(
+            `"allowed_agents" must be an array of strings. Got: ${typeof args.allowed_agents}.`,
+          );
+        }
         const ethAddrRe = /^0x[0-9a-fA-F]{40}$/;
-        for (const addr of allowedAgents) {
-          if (!ethAddrRe.test(addr)) {
+        const cleaned: string[] = [];
+        for (let i = 0; i < args.allowed_agents.length; i++) {
+          const entry = args.allowed_agents[i];
+          if (typeof entry !== 'string') {
             return this.error(
-              `Invalid Ethereum address in "allowed_agents": "${addr}". ` +
-              'Each entry must be a 0x-prefixed 40-hex-char string (e.g. "0x1234567890abcdef1234567890abcdef12345678").',
+              `"allowed_agents[${i}]" must be a string. Got: ${entry === null ? 'null' : typeof entry}.`,
             );
           }
+          const trimmed = entry.trim();
+          if (!trimmed) {
+            return this.error(
+              `"allowed_agents[${i}]" is empty or whitespace-only. ` +
+              'Each entry must be a 0x-prefixed 40-hex-char Ethereum address.',
+            );
+          }
+          if (!ethAddrRe.test(trimmed)) {
+            return this.error(
+              `Invalid Ethereum address in "allowed_agents[${i}]": "${entry}". ` +
+              'Each entry must be a 0x-prefixed 40-hex-char string ' +
+              '(e.g. "0x1234567890abcdef1234567890abcdef12345678").',
+            );
+          }
+          cleaned.push(trimmed);
+        }
+        if (cleaned.length > 0) {
+          allowedAgents = cleaned;
         }
       }
       const opts: { accessPolicy?: number; allowedAgents?: string[] } = {};
       if (!isPublic) {
         opts.accessPolicy = 1;
       }
-      if (!isPublic && allowedAgents && allowedAgents.length > 0) {
+      if (allowedAgents && allowedAgents.length > 0) {
         opts.allowedAgents = allowedAgents;
       }
       const result = await this.client.createContextGraph(id, name, description, opts);

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -238,10 +238,18 @@ export class DkgDaemonClient {
     quads: Array<{ subject: string; predicate: string; object: string; graph?: string }>,
     opts?: { localOnly?: boolean; subGraphName?: string },
   ): Promise<{ shareOperationId: string }> {
+    // SWM data gossips to peers in the context graph's allowlist by default.
+    // Privacy is governed by the CG's curation policy (curated CGs gate
+    // gossip to allowed peers; public CGs gossip to all subscribers).
+    // Callers that explicitly want a local-only write can still pass
+    // `localOnly: true`. Aligned with Hermes's default in
+    // `packages/adapter-hermes/hermes-plugin/client.py` which omits the
+    // field and relies on the daemon's `false` default at
+    // `packages/cli/src/daemon/routes/memory.ts:490`.
     return this.post('/api/shared-memory/write', {
       contextGraphId,
       quads,
-      localOnly: opts?.localOnly ?? true,
+      localOnly: opts?.localOnly ?? false,
       subGraphName: opts?.subGraphName,
     });
   }
@@ -691,8 +699,16 @@ export class DkgDaemonClient {
     id: string,
     name: string,
     description?: string,
+    opts?: { accessPolicy?: number; allowedAgents?: string[] },
   ): Promise<{ created: string; uri: string }> {
-    return this.post('/api/context-graph/create', { id, name, description });
+    const body: Record<string, unknown> = { id, name, description };
+    if (typeof opts?.accessPolicy === 'number') {
+      body.accessPolicy = opts.accessPolicy;
+    }
+    if (Array.isArray(opts?.allowedAgents) && opts.allowedAgents.length > 0) {
+      body.allowedAgents = opts.allowedAgents;
+    }
+    return this.post('/api/context-graph/create', body);
   }
 
   async registerContextGraph(

--- a/packages/adapter-openclaw/test/dkg-client.test.ts
+++ b/packages/adapter-openclaw/test/dkg-client.test.ts
@@ -199,7 +199,12 @@ describe('DkgDaemonClient', () => {
   // Workspace write
   // ---------------------------------------------------------------------------
 
-  it('share should POST quads to /api/shared-memory/write with localOnly defaulted to true', async () => {
+  it('share should POST quads to /api/shared-memory/write with localOnly defaulted to false', async () => {
+    // SWM gossips to peers in the context graph's allowlist by default —
+    // privacy is governed by the CG's curation policy, not by suppressing
+    // gossip. Aligned with Hermes adapter's default and the daemon's own
+    // default at packages/cli/src/daemon/routes/memory.ts:490
+    // (`const localOnly = parsed.localOnly === true`).
     fetchResponses.push(
       new Response(JSON.stringify({ shareOperationId: 'op-1' }), { status: 200 }),
     );
@@ -210,6 +215,18 @@ describe('DkgDaemonClient', () => {
     const body = JSON.parse(fetchCalls[0][1]?.body as string);
     expect(body.contextGraphId).toBe('research-x');
     expect(body.quads).toHaveLength(1);
+    expect(body.localOnly).toBe(false);
+  });
+
+  it('share should pass through localOnly:true when the caller explicitly opts in', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({ shareOperationId: 'op-2' }), { status: 200 }),
+    );
+
+    const quads = [{ subject: 'urn:a', predicate: 'urn:b', object: '"hello"' }];
+    await client.share('research-x', quads, { localOnly: true });
+
+    const body = JSON.parse(fetchCalls[0][1]?.body as string);
     expect(body.localOnly).toBe(true);
   });
 
@@ -685,6 +702,57 @@ describe('DkgDaemonClient', () => {
     expect(body.id).toBe('my-research');
     expect(body.name).toBe('My Research');
     expect(body.description).toBe('A research context graph');
+    // No accessPolicy/allowedAgents passed when caller omits opts — the
+    // tool handler decides the default privacy-mode. The client itself
+    // is parameter-passing only.
+    expect(body.accessPolicy).toBeUndefined();
+    expect(body.allowedAgents).toBeUndefined();
+  });
+
+  it('createContextGraph should pass accessPolicy when caller provides it', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({ created: 'curated', uri: 'did:dkg:context-graph:curated' }), { status: 200 }),
+    );
+
+    await client.createContextGraph('curated', 'Curated', undefined, { accessPolicy: 1 });
+
+    const body = JSON.parse(fetchCalls[0][1]?.body as string);
+    expect(body.accessPolicy).toBe(1);
+    expect(body.allowedAgents).toBeUndefined();
+  });
+
+  it('createContextGraph should pass allowedAgents when caller provides them', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({ created: 'team', uri: 'did:dkg:context-graph:team' }), { status: 200 }),
+    );
+
+    await client.createContextGraph('team', 'Team CG', undefined, {
+      accessPolicy: 1,
+      allowedAgents: ['0xAlice', '0xBob'],
+    });
+
+    const body = JSON.parse(fetchCalls[0][1]?.body as string);
+    expect(body.accessPolicy).toBe(1);
+    expect(body.allowedAgents).toEqual(['0xAlice', '0xBob']);
+  });
+
+  it('createContextGraph should omit allowedAgents when array is empty', async () => {
+    fetchResponses.push(
+      new Response(JSON.stringify({ created: 'solo', uri: 'did:dkg:context-graph:solo' }), { status: 200 }),
+    );
+
+    await client.createContextGraph('solo', 'Solo', undefined, {
+      accessPolicy: 1,
+      allowedAgents: [],
+    });
+
+    const body = JSON.parse(fetchCalls[0][1]?.body as string);
+    expect(body.accessPolicy).toBe(1);
+    // Empty array is dropped — daemon distinguishes "no allowlist" from
+    // "empty allowlist". Sending [] would unhelpfully pin an empty
+    // allowlist when the agent's creator-auto-include logic should
+    // populate it.
+    expect(body.allowedAgents).toBeUndefined();
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/adapter-openclaw/test/list-paranets.test.ts
+++ b/packages/adapter-openclaw/test/list-paranets.test.ts
@@ -496,16 +496,18 @@ describe('dkg_context_graph_create tool', () => {
       new Response(JSON.stringify({ created: 'team', uri: 'did:dkg:context-graph:team' }), { status: 200 }),
     );
 
+    const validAddr1 = '0x' + 'a'.repeat(40);
+    const validAddr2 = '0x' + 'B'.repeat(40);
     const tool = findTool('dkg_context_graph_create');
     await tool.execute('call-allowed', {
       id: 'team',
       name: 'Team CG',
-      allowed_agents: ['0xAlice', '0xBob'],
+      allowed_agents: [validAddr1, validAddr2],
     });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
     expect(body.accessPolicy).toBe(1);
-    expect(body.allowedAgents).toEqual(['0xAlice', '0xBob']);
+    expect(body.allowedAgents).toEqual([validAddr1, validAddr2]);
   });
 
   it('ignores allowed_agents when public:true is passed', async () => {
@@ -515,12 +517,13 @@ describe('dkg_context_graph_create tool', () => {
       new Response(JSON.stringify({ created: 'open-2', uri: 'did:dkg:context-graph:open-2' }), { status: 200 }),
     );
 
+    const validAddr = '0x' + 'a'.repeat(40);
     const tool = findTool('dkg_context_graph_create');
     await tool.execute('call-public-with-allowed', {
       id: 'open-2',
       name: 'Open',
       public: true,
-      allowed_agents: ['0xAlice'],
+      allowed_agents: [validAddr],
     });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
@@ -528,20 +531,76 @@ describe('dkg_context_graph_create tool', () => {
     expect(body.allowedAgents).toBeUndefined();
   });
 
-  it('trims and filters allowed_agents entries', async () => {
+  it('trims and filters allowed_agents entries before validation', async () => {
+    // Whitespace and non-string entries are dropped before format validation,
+    // so trim-then-validate is the correct order.
     ft.addResponses(
       new Response(JSON.stringify({ created: 'trimmed', uri: 'did:dkg:context-graph:trimmed' }), { status: 200 }),
     );
 
+    const validAddr1 = '0x' + 'a'.repeat(40);
+    const validAddr2 = '0x' + 'B'.repeat(40);
     const tool = findTool('dkg_context_graph_create');
     await tool.execute('call-trim', {
       id: 'trimmed',
       name: 'Trim',
-      allowed_agents: ['  0xAlice  ', '', '   ', '0xBob', 42 as unknown as string],
+      allowed_agents: [`  ${validAddr1}  `, '', '   ', validAddr2, 42 as unknown as string],
     });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
-    expect(body.allowedAgents).toEqual(['0xAlice', '0xBob']);
+    expect(body.allowedAgents).toEqual([validAddr1, validAddr2]);
+  });
+
+  it('returns a tool error when allowed_agents contains a malformed address', async () => {
+    // Validation is at the tool layer so a malformed input surfaces as a
+    // user-correctable tool error rather than bubbling up as a daemon 500.
+    // Mirrors the agent-layer regex at `packages/agent/src/dkg-agent.ts:3918`.
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-bad-addr', {
+      id: 'bad-addr',
+      name: 'Bad',
+      allowed_agents: ['0x' + 'a'.repeat(40), 'not-an-address'],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('Invalid Ethereum address');
+    expect(parsed.error).toContain('not-an-address');
+    // Should not have hit the daemon — pre-flight validation.
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('returns a tool error when allowed_agents has a too-short hex value', async () => {
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-short-addr', {
+      id: 'short-addr',
+      name: 'Short',
+      allowed_agents: ['0xabc'],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('Invalid Ethereum address');
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('skips allowed_agents validation entirely when public:true is passed', async () => {
+    // Curation parameters are dropped on public CGs, so even malformed
+    // entries do not produce an error — they're simply ignored.
+    ft.addResponses(
+      new Response(JSON.stringify({ created: 'open-skip', uri: 'did:dkg:context-graph:open-skip' }), { status: 200 }),
+    );
+
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-public-malformed', {
+      id: 'open-skip',
+      name: 'Open Skip',
+      public: true,
+      allowed_agents: ['not-an-address'],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toBeUndefined();
+    const body = JSON.parse(ft.calls[0][1]?.body as string);
+    expect(body.allowedAgents).toBeUndefined();
   });
 });
 

--- a/packages/adapter-openclaw/test/list-paranets.test.ts
+++ b/packages/adapter-openclaw/test/list-paranets.test.ts
@@ -459,6 +459,90 @@ describe('dkg_context_graph_create tool', () => {
 
     expect(parsed.error).toContain('daemon is not reachable');
   });
+
+  it('defaults to curated/private (accessPolicy: 1) when public is not specified', async () => {
+    // Privacy-by-default: omitting `public` produces a curated CG.
+    // The agent's createContextGraph flow auto-includes the creator
+    // in DKG_ALLOWED_AGENT (see packages/agent/src/dkg-agent.ts:3962),
+    // so the creator can immediately read/write without a self-invite.
+    ft.addResponses(
+      new Response(JSON.stringify({ created: 'private', uri: 'did:dkg:context-graph:private' }), { status: 200 }),
+    );
+
+    const tool = findTool('dkg_context_graph_create');
+    await tool.execute('call-default-private', { id: 'private', name: 'Private CG' });
+
+    const body = JSON.parse(ft.calls[0][1]?.body as string);
+    expect(body.accessPolicy).toBe(1);
+    expect(body.allowedAgents).toBeUndefined();
+  });
+
+  it('creates an open/discoverable CG when public:true is passed', async () => {
+    ft.addResponses(
+      new Response(JSON.stringify({ created: 'open', uri: 'did:dkg:context-graph:open' }), { status: 200 }),
+    );
+
+    const tool = findTool('dkg_context_graph_create');
+    await tool.execute('call-public', { id: 'open', name: 'Open CG', public: true });
+
+    const body = JSON.parse(ft.calls[0][1]?.body as string);
+    // public:true → no accessPolicy sent → daemon's "open" default takes over.
+    expect(body.accessPolicy).toBeUndefined();
+    expect(body.allowedAgents).toBeUndefined();
+  });
+
+  it('passes allowed_agents to the daemon when provided alongside curated default', async () => {
+    ft.addResponses(
+      new Response(JSON.stringify({ created: 'team', uri: 'did:dkg:context-graph:team' }), { status: 200 }),
+    );
+
+    const tool = findTool('dkg_context_graph_create');
+    await tool.execute('call-allowed', {
+      id: 'team',
+      name: 'Team CG',
+      allowed_agents: ['0xAlice', '0xBob'],
+    });
+
+    const body = JSON.parse(ft.calls[0][1]?.body as string);
+    expect(body.accessPolicy).toBe(1);
+    expect(body.allowedAgents).toEqual(['0xAlice', '0xBob']);
+  });
+
+  it('ignores allowed_agents when public:true is passed', async () => {
+    // Curation parameters are meaningless on a public CG; the handler
+    // drops them rather than sending a contradictory mix to the daemon.
+    ft.addResponses(
+      new Response(JSON.stringify({ created: 'open-2', uri: 'did:dkg:context-graph:open-2' }), { status: 200 }),
+    );
+
+    const tool = findTool('dkg_context_graph_create');
+    await tool.execute('call-public-with-allowed', {
+      id: 'open-2',
+      name: 'Open',
+      public: true,
+      allowed_agents: ['0xAlice'],
+    });
+
+    const body = JSON.parse(ft.calls[0][1]?.body as string);
+    expect(body.accessPolicy).toBeUndefined();
+    expect(body.allowedAgents).toBeUndefined();
+  });
+
+  it('trims and filters allowed_agents entries', async () => {
+    ft.addResponses(
+      new Response(JSON.stringify({ created: 'trimmed', uri: 'did:dkg:context-graph:trimmed' }), { status: 200 }),
+    );
+
+    const tool = findTool('dkg_context_graph_create');
+    await tool.execute('call-trim', {
+      id: 'trimmed',
+      name: 'Trim',
+      allowed_agents: ['  0xAlice  ', '', '   ', '0xBob', 42 as unknown as string],
+    });
+
+    const body = JSON.parse(ft.calls[0][1]?.body as string);
+    expect(body.allowedAgents).toEqual(['0xAlice', '0xBob']);
+  });
 });
 
 describe('dkg_subscribe tool', () => {

--- a/packages/adapter-openclaw/test/list-paranets.test.ts
+++ b/packages/adapter-openclaw/test/list-paranets.test.ts
@@ -531,9 +531,12 @@ describe('dkg_context_graph_create tool', () => {
     expect(body.allowedAgents).toBeUndefined();
   });
 
-  it('trims and filters allowed_agents entries before validation', async () => {
-    // Whitespace and non-string entries are dropped before format validation,
-    // so trim-then-validate is the correct order.
+  it('trims whitespace-padded valid allowed_agents entries', async () => {
+    // Whitespace padding around an otherwise valid address is trimmed
+    // before validation. Empty, whitespace-only, and non-string entries
+    // are NOT silently dropped — they fail validation (see fail-fast
+    // tests below). LLM-generated bad args should produce a clear tool
+    // error so the agent can correct, not silently lose collaborators.
     ft.addResponses(
       new Response(JSON.stringify({ created: 'trimmed', uri: 'did:dkg:context-graph:trimmed' }), { status: 200 }),
     );
@@ -544,7 +547,7 @@ describe('dkg_context_graph_create tool', () => {
     await tool.execute('call-trim', {
       id: 'trimmed',
       name: 'Trim',
-      allowed_agents: [`  ${validAddr1}  `, '', '   ', validAddr2, 42 as unknown as string],
+      allowed_agents: [`  ${validAddr1}  `, validAddr2],
     });
 
     const body = JSON.parse(ft.calls[0][1]?.body as string);
@@ -564,8 +567,8 @@ describe('dkg_context_graph_create tool', () => {
     const parsed = JSON.parse(result.content[0].text);
 
     expect(parsed.error).toContain('Invalid Ethereum address');
+    expect(parsed.error).toContain('allowed_agents[1]');
     expect(parsed.error).toContain('not-an-address');
-    // Should not have hit the daemon — pre-flight validation.
     expect(ft.calls).toHaveLength(0);
   });
 
@@ -579,6 +582,93 @@ describe('dkg_context_graph_create tool', () => {
     const parsed = JSON.parse(result.content[0].text);
 
     expect(parsed.error).toContain('Invalid Ethereum address');
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('round 2: fails fast when allowed_agents contains a non-string entry', async () => {
+    // LLMs sometimes emit numbers / nulls / dicts in tool args; if we
+    // silently drop them, the agent thinks the participant was added
+    // when it wasn't. Fail with a precise index-scoped error.
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-non-string', {
+      id: 'non-string',
+      name: 'NonString',
+      allowed_agents: ['0x' + 'a'.repeat(40), 42 as unknown as string, '0x' + 'b'.repeat(40)],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('allowed_agents[1]');
+    expect(parsed.error).toContain('must be a string');
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('round 2: fails fast when allowed_agents contains an empty / whitespace-only entry', async () => {
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-empty-entry', {
+      id: 'empty-entry',
+      name: 'EmptyEntry',
+      allowed_agents: ['0x' + 'a'.repeat(40), '   '],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('allowed_agents[1]');
+    expect(parsed.error).toMatch(/empty|whitespace/i);
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('round 2: fails fast when allowed_agents contains null', async () => {
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-null', {
+      id: 'null-entry',
+      name: 'Null',
+      allowed_agents: ['0x' + 'a'.repeat(40), null as unknown as string],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('allowed_agents[1]');
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('round 2: fails fast when allowed_agents is not an array', async () => {
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-not-array', {
+      id: 'not-array',
+      name: 'NotArray',
+      allowed_agents: '0x1234' as unknown as string[],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('"allowed_agents"');
+    expect(parsed.error).toContain('array');
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('round 2: fails fast when public is a non-boolean value', async () => {
+    // An LLM emitting `public: "yes"` or `public: 1` should NOT
+    // silently produce a curated CG (which is the opposite of intent).
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-public-string', {
+      id: 'public-string',
+      name: 'PublicString',
+      public: 'yes' as unknown as boolean,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('"public"');
+    expect(parsed.error).toContain('boolean');
+    expect(ft.calls).toHaveLength(0);
+  });
+
+  it('round 2: fails fast when public is a number', async () => {
+    const tool = findTool('dkg_context_graph_create');
+    const result = await tool.execute('call-public-number', {
+      id: 'public-number',
+      name: 'PublicNumber',
+      public: 1 as unknown as boolean,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.error).toContain('"public"');
     expect(ft.calls).toHaveLength(0);
   });
 

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -185,6 +185,12 @@ before promoting it to SWM (team) or through to VM (chain-anchored).
 
 SWM is for knowledge you've promoted from WM and want peers to see. Data arrives here via `POST /api/assertion/{name}/promote` (from WM) or via direct SWM writes (escape hatch for team-visible data that doesn't need a WM staging step).
 
+> **Visibility.** SWM gossips to peers in the context graph's allowlist.
+> For a **curated** CG (the default — see §6), only listed agents/peers
+> receive the gossip. For an **explicitly public** CG (`public: true` at
+> creation), every peer subscribed to the CG receives the gossip.
+> Working Memory is per-agent regardless of CG visibility.
+
 - `POST /api/shared-memory/write` — write triples directly to SWM (gossip-replicated). Body: `{ contextGraphId, quads, subGraphName? }`. Use the WM → promote path for most workflows; direct SWM writes are for bulk team data that skips the private draft stage.
 - `POST /api/shared-memory/conditional-write` — compare-and-swap write. Body: `{ contextGraphId, quads, conditions: [...], subGraphName? }`. Each condition is `{ subject: IRI, predicate: IRI, expectedValue: string | null }`; `null` means "must not exist", a string must match the current object after N-Triples serialization. Any mismatch throws `StaleWriteError` and leaves SWM unchanged. `conditions` must be non-empty — use `/api/shared-memory/write` for unconditional writes.
 - `POST /api/shared-memory/publish` — promote SWM triples to Verified Memory (costs TRAC)
@@ -255,6 +261,19 @@ The `<recalled-memory>` block is stripped from outgoing assistant text before tu
 
 Context Graphs are scoped knowledge domains with configurable access and governance. In the node UI, context graphs are called **projects** — when a user says "my project" or selects a project in the right-panel dropdown, they mean a context graph.
 
+> **Default privacy model.** Context graphs created via the
+> `dkg_context_graph_create` tool are **curated/private by default** —
+> only agents in the allowlist can read SWM gossip or subscribe to
+> the CG. The creator is auto-included in the allowlist on creation,
+> so they can immediately read and write without an explicit
+> self-invite. Pass `public: true` to create an open/discoverable
+> context graph instead. Pass `allowed_agents: ["0x..."]` to invite
+> collaborators atomically with creation, or use
+> `dkg_participant_add` to invite them later. Working Memory is
+> per-agent regardless of CG visibility. Verified Memory anchors
+> are public on-chain — but the underlying private quads stay local
+> on the publishing node and are gated to allowed peers.
+
 ### Routing: Turn Context Override
 
 When the chat turn includes injected context with `target_context_graph`, treat that value as BOTH:
@@ -315,8 +334,16 @@ Implications:
   - **Mock chain adapter** (`chainId` starts with `mock`): the create-time auto-register path is deliberately skipped to avoid polluting test runs. The CG stays local on create; explicit `register: true` or `/api/context-graph/register` may succeed depending on what the mock implements.
   - **Real chain adapter WITH on-chain identity**: `createContextGraph()` auto-registers on-chain as a best-effort side-effect. Failures are logged as warnings (not surfaced on the create response) and the CG remains local. Passing `register: true` in this regime usually duplicates the auto-register work and returns `200` with `registered: false` + `registerError` + `hint` because the CG is already registered — looks like a failure but isn't one. Use `register: true` here only as an explicit retry hook when the auto-register path failed.
   - **Real chain adapter WITHOUT on-chain identity**: no auto-register on create; CG stays local until `/api/context-graph/register` or `register: true` promotes it.
-  - **Simple CG** (default): pass `{ id, name }`. Creator alone publishes to VM. Add `accessPolicy: 1` + `allowedAgents` for a curated CG.
+  - **Curated CG** (default for the `dkg_context_graph_create` tool): the tool sends `accessPolicy: 1` automatically. The creator is auto-included in `DKG_ALLOWED_AGENT` so they can immediately read/write. Add collaborators with `dkg_participant_add` (or pass `allowed_agents: ["0x..."]` at creation to do it atomically).
+  - **Public CG**: pass `public: true` on the tool (or `accessPolicy: 0` / omit on the raw HTTP route). Anyone can subscribe and read SWM gossip.
   - **Multi-sig CG**: pass `participantIdentityIds: [...]` + `requiredSignatures: M`. Use `register: true` so the participant set and threshold are anchored on-chain. `requiredSignatures` is optional when `private: true`.
+
+  > **Direct HTTP vs tool.** When you call the `dkg_context_graph_create`
+  > tool, it defaults to curated/private (sends `accessPolicy: 1`). When
+  > you call `POST /api/context-graph/create` directly without
+  > `accessPolicy`, the daemon resolves to public/discoverable. The tool
+  > is the recommended surface for agent workflows; raw HTTP is for
+  > programmatic clients that want explicit control.
 - `POST /api/context-graph/register` — register a previously-created local CG on-chain (two-phase creation). Body: `{ id, accessPolicy? }`. Use this to promote a free CG to an on-chain identity before publishing to Verified Memory. `revealOnChain` is deprecated and ignored on the V10 ContextGraphs path.
 - `POST /api/context-graph/rename` — rename a CG (human-readable name only; the ID is immutable). Body: `{ contextGraphId, name }`.
 - `POST /api/context-graph/subscribe` — subscribe to a context graph
@@ -438,6 +465,21 @@ Use the job queue for bulk or long-running publishes, publishes that must surviv
 3. Write triples to Working Memory (`POST /api/assertion/{name}/write`)
 4. When ready to share with peers: promote to SWM (`POST /api/assertion/{name}/promote`)
 5. When ready to publish permanently: publish to VM (`POST /api/shared-memory/publish`)
+
+**Private project for me alone (the default):**
+
+1. `dkg_context_graph_create({ name: "My Notes" })` — curated by default; creator is the only allowed agent.
+2. Write WM and promote to SWM — gossip is gated to the creator's allowlist (just yourself).
+
+**Shared project with a teammate:**
+
+1. `dkg_context_graph_create({ name: "Team X", allowed_agents: ["0xAlice"] })` — curated CG with Alice (and the creator) on the allowlist atomically with creation.
+2. Or, if Alice's address comes later: `dkg_context_graph_create({ name: "Team X" })` followed by `dkg_participant_add({ context_graph_id: "team-x", agent_address: "0xAlice" })`.
+3. Write and promote — SWM gossip is delivered only to the listed peers.
+
+**Open/discoverable project:**
+
+1. `dkg_context_graph_create({ name: "Public Research", public: true })` — explicitly opts out of curation; anyone subscribed receives SWM gossip.
 
 **Import a file into a project:**
 


### PR DESCRIPTION
## Summary

- **Default to curated/private context graphs.** `dkg_context_graph_create` now sends `accessPolicy: 1` to the daemon when the caller doesn't explicitly pass `public: true`. The agent's existing creator-auto-include logic adds the creator's address to `DKG_ALLOWED_AGENT` automatically, so the creator can immediately read/write without a self-invite.
- **Expose two new tool parameters:** `public: boolean` (opt out, default false) and `allowed_agents: string[]` (populate the allowlist atomically with creation; ignored on public CGs).
- **Align `dkg_share` `localOnly` default with Hermes.** OpenClaw previously sent `localOnly: true` while Hermes omitted the field (daemon parses missing as `false`). Aligning to `false` removes the divergence; CG curation governs privacy uniformly.
- **SKILL.md updates** in §5, §6, §10 — visibility callout, default-privacy explanation, tool-vs-HTTP nuance, three new workflow examples (private/shared/public).

## Related

- Fixes the OpenClaw side of the adapter privacy-default flip discussed in private design review.
- Depends on #396 (SWM gossip gating must honor `isPrivateContextGraph()` so curated CGs actually gate). #396 is in flight on a parallel branch; merging this PR before #396 lands does not regress correctness, but the privacy guarantee only kicks in once #396 ships.
- Hermes parity PR ships separately on a sibling branch.
- Follow-up #400 — surface `privateQuads` partition end-to-end on publish tools.

## Files changed

| File | What |
|------|------|
| `packages/adapter-openclaw/src/DkgNodePlugin.ts` | `dkg_context_graph_create` schema gains `public` + `allowed_agents`. Handler defaults to `accessPolicy: 1` when `public !== true`; trims, filters, and ignores `allowed_agents` on public CGs. |
| `packages/adapter-openclaw/src/dkg-client.ts` | `createContextGraph()` accepts an `opts` object with `accessPolicy` and `allowedAgents`. `share()` flips `localOnly` default from `true` → `false` to match Hermes and the daemon's own default. |
| `packages/adapter-openclaw/test/dkg-client.test.ts` | Updated `share` default assertion (`true` → `false`); added explicit-opt-in test; added three `createContextGraph` tests for opts passthrough. |
| `packages/adapter-openclaw/test/list-paranets.test.ts` | Five new tool-level tests for the new `public` and `allowed_agents` parameters. |
| `packages/cli/skills/dkg-node/SKILL.md` | §5 SWM visibility note, §6 default-privacy callout + tool-vs-HTTP clarification, §10 three new workflow examples. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-openclaw exec vitest run` — 980 passing, 2 baseline-debt failures unchanged.
- [x] Specifically run `test/dkg-client.test.ts` and `test/list-paranets.test.ts` — 102 passing across both files (includes the 8 new tests added in this PR).
- [ ] After #396 lands and Hermes parity PR lands: end-to-end smoke test creating a curated CG + sharing SWM via OpenClaw, verifying an outside peer cannot read it (issue #396 acceptance test).
- [ ] Manual smoke: agent calls `dkg_context_graph_create({ name: "Test" })`, verifies `isPrivateContextGraph(testId)` returns `true`, and that creator can immediately write SWM.
