### PR TITLE
feat(adapter-hermes): private-by-default context graphs (parity with OpenClaw)

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -1570,29 +1570,53 @@ class DKGMemoryProvider(MemoryProvider):
         # flow auto-includes the creator's address in the allowlist (see
         # `packages/agent/src/dkg-agent.ts:3962-3973`), so the creator can
         # immediately read/write the curated CG without a self-invite step.
-        is_public = bool(args.get("public") is True)
+        #
+        # Round 2 — strict type validation: an LLM that emits
+        # `public: "yes"` (string) or any non-boolean value should get a
+        # clear tool error rather than silently defaulting to false (which
+        # would produce the opposite of the agent's intent). Only `True`,
+        # `False`, or omitted are accepted.
+        raw_public = args.get("public")
+        if raw_public is not None and not isinstance(raw_public, bool):
+            return tool_error(
+                f"\"public\" must be a boolean (true or false). Got: {type(raw_public).__name__}."
+            )
+        is_public = raw_public is True
         access_policy: Optional[int] = None if is_public else 1
         raw_allowed = args.get("allowed_agents")
         allowed_agents: Optional[list] = None
-        if not is_public and isinstance(raw_allowed, list):
-            cleaned = [
-                entry.strip()
-                for entry in raw_allowed
-                if isinstance(entry, str) and entry.strip()
-            ]
+        if not is_public and raw_allowed is not None:
+            # Round 2 — strict validation: every entry must be a non-empty
+            # trimmed string that matches the Ethereum address regex.
+            # Previously we silently dropped non-string/blank entries,
+            # which hides LLM-generated mistakes (e.g. `["0xAlice...", 42]`
+            # would create a curated graph without entry 42's owner ever
+            # knowing they were excluded). Fail fast instead.
+            if not isinstance(raw_allowed, list):
+                return tool_error(
+                    f"\"allowed_agents\" must be an array of strings. Got: {type(raw_allowed).__name__}."
+                )
+            eth_addr_re = re.compile(r"^0x[0-9a-fA-F]{40}$")
+            cleaned: list = []
+            for index, entry in enumerate(raw_allowed):
+                if not isinstance(entry, str):
+                    return tool_error(
+                        f"\"allowed_agents[{index}]\" must be a string. Got: {type(entry).__name__}."
+                    )
+                trimmed = entry.strip()
+                if not trimmed:
+                    return tool_error(
+                        f"\"allowed_agents[{index}]\" is empty or whitespace-only. "
+                        "Each entry must be a 0x-prefixed 40-hex-char Ethereum address."
+                    )
+                if not eth_addr_re.match(trimmed):
+                    return tool_error(
+                        f"Invalid Ethereum address in \"allowed_agents[{index}]\": \"{entry}\". "
+                        "Each entry must be a 0x-prefixed 40-hex-char string "
+                        "(e.g. \"0x1234567890abcdef1234567890abcdef12345678\")."
+                    )
+                cleaned.append(trimmed)
             if cleaned:
-                # Validate Ethereum address format up-front so a malformed
-                # input surfaces as a tool-level error rather than bubbling
-                # up as a 500 from the daemon. Mirrors the agent layer's
-                # check at `packages/agent/src/dkg-agent.ts:3918-3922`.
-                eth_addr_re = re.compile(r"^0x[0-9a-fA-F]{40}$")
-                for addr in cleaned:
-                    if not eth_addr_re.match(addr):
-                        return tool_error(
-                            f"Invalid Ethereum address in \"allowed_agents\": \"{addr}\". "
-                            "Each entry must be a 0x-prefixed 40-hex-char string "
-                            "(e.g. \"0x1234567890abcdef1234567890abcdef12345678\")."
-                        )
                 allowed_agents = cleaned
         result = self._client.create_context_graph(
             name,

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -452,7 +452,12 @@ DKG_CREATE_CONTEXT_GRAPH_SCHEMA = {
         "Create a new Context Graph — a bounded knowledge space for a project "
         "or team. Context Graphs organize knowledge into Working Memory, "
         "Shared Memory, and Verified Memory layers. Use dkg_status first to "
-        "check if the Context Graph already exists."
+        "check if the Context Graph already exists. "
+        "Defaults to a curated/private context graph — the creator is "
+        "auto-included in the allowlist and can immediately write to working "
+        "and shared memory. Pass `public: true` for an open/discoverable "
+        "context graph, or `allowed_agents` to invite collaborators "
+        "atomically with creation."
     ),
     "parameters": {
         "type": "object",
@@ -468,6 +473,24 @@ DKG_CREATE_CONTEXT_GRAPH_SCHEMA = {
             "id": {
                 "type": "string",
                 "description": "Optional context graph ID. Auto-generated from name when omitted.",
+            },
+            "public": {
+                "type": "boolean",
+                "description": (
+                    "If true, creates an open/discoverable context graph "
+                    "(anyone can subscribe and read). Default is false — the "
+                    "context graph is curated/private and restricted to "
+                    "allowed_agents (the creator is always auto-included)."
+                ),
+            },
+            "allowed_agents": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional agent addresses (0x...) to add to the curation "
+                    "allowlist at creation time. The creator's own address is "
+                    "auto-added regardless. Ignored when public is true."
+                ),
             },
         },
         "required": ["name"],
@@ -899,7 +922,16 @@ class DKGMemoryProvider(MemoryProvider):
             "TRUST FLOW: Working Memory (local, free) → SHARE → Shared Memory "
             "(team, free) → PUBLISH → Verified Memory (chain, TRAC cost, permanent).\n"
             "Knowledge gains trust as it moves through layers. Only publish when "
-            "findings are verified and ready for permanent record."
+            "findings are verified and ready for permanent record.\n"
+            "\n"
+            "PRIVACY MODEL: Context graphs created via dkg_context_graph_create "
+            "default to curated/private — only listed agents receive Shared "
+            "Memory gossip. The creator is auto-included; invite collaborators "
+            "with dkg_participant_add or pass allowed_agents at creation. Use "
+            "public:true to opt into a discoverable/open context graph. Working "
+            "Memory is per-agent regardless of visibility. Verified Memory "
+            "anchors are public on-chain; the underlying private quads stay "
+            "local on the publishing node."
         )
 
         return "\n\n".join(blocks)
@@ -1533,7 +1565,30 @@ class DKGMemoryProvider(MemoryProvider):
         if not name:
             return tool_error("name is required.")
         description = args.get("description", "")
-        result = self._client.create_context_graph(name, description, cg_id=_first_text(args, "id"))
+        # Privacy-by-default: when `public` is omitted or false, the context
+        # graph is curated (`accessPolicy: 1`). The agent's createContextGraph
+        # flow auto-includes the creator's address in the allowlist (see
+        # `packages/agent/src/dkg-agent.ts:3962-3973`), so the creator can
+        # immediately read/write the curated CG without a self-invite step.
+        is_public = bool(args.get("public") is True)
+        access_policy: Optional[int] = None if is_public else 1
+        raw_allowed = args.get("allowed_agents")
+        allowed_agents: Optional[list] = None
+        if not is_public and isinstance(raw_allowed, list):
+            cleaned = [
+                entry.strip()
+                for entry in raw_allowed
+                if isinstance(entry, str) and entry.strip()
+            ]
+            if cleaned:
+                allowed_agents = cleaned
+        result = self._client.create_context_graph(
+            name,
+            description,
+            cg_id=_first_text(args, "id"),
+            access_policy=access_policy,
+            allowed_agents=allowed_agents,
+        )
         return json.dumps(result)
 
     def _handle_context_graph_invite(self, args: Dict[str, Any]) -> str:

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -1581,6 +1581,18 @@ class DKGMemoryProvider(MemoryProvider):
                 if isinstance(entry, str) and entry.strip()
             ]
             if cleaned:
+                # Validate Ethereum address format up-front so a malformed
+                # input surfaces as a tool-level error rather than bubbling
+                # up as a 500 from the daemon. Mirrors the agent layer's
+                # check at `packages/agent/src/dkg-agent.ts:3918-3922`.
+                eth_addr_re = re.compile(r"^0x[0-9a-fA-F]{40}$")
+                for addr in cleaned:
+                    if not eth_addr_re.match(addr):
+                        return tool_error(
+                            f"Invalid Ethereum address in \"allowed_agents\": \"{addr}\". "
+                            "Each entry must be a 0x-prefixed 40-hex-char string "
+                            "(e.g. \"0x1234567890abcdef1234567890abcdef12345678\")."
+                        )
                 allowed_agents = cleaned
         result = self._client.create_context_graph(
             name,

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -484,18 +484,37 @@ class DKGClient:
         """GET /api/context-graph/list — list subscribed context graphs."""
         return self._get("/api/context-graph/list")
 
-    def create_context_graph(self, name: str, description: str = "", cg_id: Optional[str] = None) -> Dict[str, Any]:
+    def create_context_graph(
+        self,
+        name: str,
+        description: str = "",
+        cg_id: Optional[str] = None,
+        *,
+        access_policy: Optional[int] = None,
+        allowed_agents: Optional[list] = None,
+    ) -> Dict[str, Any]:
         """POST /api/context-graph/create — create a new context graph.
-        Daemon requires both `id` and `name`; auto-generates id from name if not given."""
+        Daemon requires both `id` and `name`; auto-generates id from name if not given.
+
+        `access_policy` and `allowed_agents` are forwarded to the daemon when
+        provided. Pass `access_policy=1` for a curated/private CG; `None` lets
+        the daemon resolve to its default (open). `allowed_agents` populates
+        the allowlist atomically with creation.
+        """
         if not cg_id:
             cg_id = _slugify_context_graph_id(name)
         if not _CG_ID_RE.match(cg_id):
             return {"success": False, "error": "Context graph id must be a lowercase slug using letters, numbers, and hyphens."}
-        return self._post("/api/context-graph/create", {
+        body: Dict[str, Any] = {
             "id": cg_id,
             "name": name,
             "description": description,
-        })
+        }
+        if isinstance(access_policy, int):
+            body["accessPolicy"] = access_policy
+        if isinstance(allowed_agents, list) and allowed_agents:
+            body["allowedAgents"] = allowed_agents
+        return self._post("/api/context-graph/create", body)
 
     def register_context_graph(self, context_graph_id: str, access_policy: Optional[int] = None) -> Dict[str, Any]:
         """POST /api/context-graph/register — register a local CG on-chain."""

--- a/packages/adapter-hermes/hermes-plugin/client.py
+++ b/packages/adapter-hermes/hermes-plugin/client.py
@@ -505,12 +505,32 @@ class DKGClient:
             cg_id = _slugify_context_graph_id(name)
         if not _CG_ID_RE.match(cg_id):
             return {"success": False, "error": "Context graph id must be a lowercase slug using letters, numbers, and hyphens."}
+        # Round 3 — `bool` is a subclass of `int` in Python, so plain
+        # `isinstance(access_policy, int)` accepts `True` / `False` and the
+        # body would carry JSON `true` / `false`. The daemon route at
+        # `packages/cli/src/daemon/routes/context-graph.ts:455` checks
+        # `typeof accessPolicy === 'number'`, which excludes JSON booleans —
+        # the field would be silently dropped and the CG would resolve to
+        # the daemon's default (public), the opposite of a programmatic
+        # caller's intent. Use `type(... ) is int` to exclude bool, and
+        # additionally restrict to the meaningful values {0, 1} since
+        # other ints would be rejected by the agent layer anyway
+        # (`LOCAL_ACCESS_OPEN = 0` / `LOCAL_ACCESS_CURATED = 1`).
+        if access_policy is not None:
+            if type(access_policy) is not int or access_policy not in (0, 1):
+                return {
+                    "success": False,
+                    "error": (
+                        "access_policy must be 0 (open) or 1 (curated). "
+                        f"Got: {type(access_policy).__name__}={access_policy!r}."
+                    ),
+                }
         body: Dict[str, Any] = {
             "id": cg_id,
             "name": name,
             "description": description,
         }
-        if isinstance(access_policy, int):
+        if access_policy is not None:
             body["accessPolicy"] = access_policy
         if isinstance(allowed_agents, list) and allowed_agents:
             body["allowedAgents"] = allowed_agents

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -1654,6 +1654,25 @@ client.create_context_graph(
     access_policy=1,
     allowed_agents=["0x" + "a" * 40, "0x" + "B" * 40],
 )
+
+# Round 3 — access_policy=True (Python bool, which is a subclass of int)
+# would have silently sent JSON true to the daemon under the previous
+# isinstance(access_policy, int) check; the daemon's typeof check would
+# then drop the field and resolve to default-public, the opposite of a
+# programmatic caller's intent. Now rejected at the client layer with a
+# clear error before any daemon contact.
+bool_true_result = client.create_context_graph("BoolTrue", "x", access_policy=True)
+assert bool_true_result["success"] is False, bool_true_result
+assert "access_policy" in bool_true_result["error"], bool_true_result
+bool_false_result = client.create_context_graph("BoolFalse", "x", access_policy=False)
+assert bool_false_result["success"] is False, bool_false_result
+# Round 3 — only meaningful values {0, 1} accepted; other ints rejected.
+out_of_range = client.create_context_graph("Two", "x", access_policy=2)
+assert out_of_range["success"] is False, out_of_range
+assert "0" in out_of_range["error"] and "1" in out_of_range["error"], out_of_range
+# access_policy=0 is the open/discoverable value — accepted.
+client.create_context_graph("OpenExplicit", "x", access_policy=0)
+
 client.subscribe("cg:test", include_shared_memory=True)
 client.write_assertion("a b", "cg:test", [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "sub")
 client.discard_assertion("a b", "cg:test")
@@ -1672,6 +1691,7 @@ assert calls == [
     ("POST", "/api/context-graph/create", {"id": "my-project", "name": "My Project", "description": "desc"}),
     ("POST", "/api/context-graph/create", {"id": "curated", "name": "Curated", "description": "private cg", "accessPolicy": 1}),
     ("POST", "/api/context-graph/create", {"id": "team", "name": "Team", "description": "shared", "accessPolicy": 1, "allowedAgents": [_VALID_ADDR_A, _VALID_ADDR_B]}),
+    ("POST", "/api/context-graph/create", {"id": "openexplicit", "name": "OpenExplicit", "description": "x", "accessPolicy": 0}),
     ("POST", "/api/context-graph/subscribe", {"contextGraphId": "cg:test", "includeSharedMemory": True}),
     ("POST", "/api/assertion/a%20b/write", {"contextGraphId": "cg:test", "quads": [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "subGraphName": "sub"}),
     ("POST", "/api/assertion/a%20b/discard", {"contextGraphId": "cg:test"}),

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -1642,6 +1642,10 @@ client._get = lambda path: calls.append(("GET", path, {})) or {"ok": True}
 bad_cg = client.create_context_graph("Bad", cg_id="Bad:Id")
 assert bad_cg["success"] is False, bad_cg
 client.create_context_graph("My Project", "desc")
+# T-PRIVACY: client passes accessPolicy + allowedAgents through to the daemon
+# verbatim when supplied, and omits them when not.
+client.create_context_graph("Curated", "private cg", access_policy=1)
+client.create_context_graph("Team", "shared", access_policy=1, allowed_agents=["0xAlice", "0xBob"])
 client.subscribe("cg:test", include_shared_memory=True)
 client.write_assertion("a b", "cg:test", [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "sub")
 client.discard_assertion("a b", "cg:test")
@@ -1655,6 +1659,8 @@ client.publish("cg:test", selection=["urn:root"], clear_after=False, sub_graph_n
 
 assert calls == [
     ("POST", "/api/context-graph/create", {"id": "my-project", "name": "My Project", "description": "desc"}),
+    ("POST", "/api/context-graph/create", {"id": "curated", "name": "Curated", "description": "private cg", "accessPolicy": 1}),
+    ("POST", "/api/context-graph/create", {"id": "team", "name": "Team", "description": "shared", "accessPolicy": 1, "allowedAgents": ["0xAlice", "0xBob"]}),
     ("POST", "/api/context-graph/subscribe", {"contextGraphId": "cg:test", "includeSharedMemory": True}),
     ("POST", "/api/assertion/a%20b/write", {"contextGraphId": "cg:test", "quads": [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "subGraphName": "sub"}),
     ("POST", "/api/assertion/a%20b/discard", {"contextGraphId": "cg:test"}),
@@ -2568,6 +2574,117 @@ provider._assertion_id = ""
 provider._cache["queued_writes"] = [{"type": "memory", "action": "replace", "target": "memory", "content": "new fact", "old_text": "cached"}]
 provider._flush_queued_writes()
 assert provider._cache["queued_writes"] == [{"type": "memory", "action": "replace", "target": "memory", "content": "new fact", "old_text": "cached"}], provider._cache
+`;
+    const result = spawnSync('python', ['-B', '-c', script], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
+
+  it('dkg_context_graph_create handler defaults to curated and forwards public + allowed_agents', () => {
+    // Privacy-by-default flip in Hermes parity:
+    //
+    // - No `public` and no `allowed_agents` → handler sends accessPolicy: 1
+    //   (curated). The agent's createContextGraph flow auto-includes the
+    //   creator in DKG_ALLOWED_AGENT (see packages/agent/src/dkg-agent.ts:3962),
+    //   so the creator can immediately read/write without a self-invite.
+    // - `public: true` → handler drops accessPolicy (daemon resolves to open)
+    //   AND drops allowed_agents even if supplied (meaningless on a public CG).
+    // - `allowed_agents: [...]` (no `public`) → handler sends accessPolicy: 1
+    //   AND allowedAgents.
+    // - Whitespace-only / empty / non-string entries in allowed_agents are
+    //   filtered out before forwarding.
+    const script = String.raw`
+import importlib.util
+import json
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+home = Path(tempfile.mkdtemp(prefix="hermes-dkg-create-cg-defaults-"))
+
+agent_pkg = types.ModuleType("agent")
+memory_provider = types.ModuleType("agent.memory_provider")
+class MemoryProvider:
+    pass
+memory_provider.MemoryProvider = MemoryProvider
+sys.modules["agent"] = agent_pkg
+sys.modules["agent.memory_provider"] = memory_provider
+
+tools_pkg = types.ModuleType("tools")
+registry = types.ModuleType("tools.registry")
+def tool_error(message):
+    return json.dumps({"error": message})
+registry.tool_error = tool_error
+sys.modules["tools"] = tools_pkg
+sys.modules["tools.registry"] = registry
+
+constants = types.ModuleType("hermes_constants")
+constants.get_hermes_home = lambda: home
+sys.modules["hermes_constants"] = constants
+
+sys.modules["plugins"] = types.ModuleType("plugins")
+sys.modules["plugins.memory"] = types.ModuleType("plugins.memory")
+sys.modules["plugins.memory.dkg"] = types.ModuleType("plugins.memory.dkg")
+
+plugin_dir = Path(r"${process.cwd().replace(/\\/g, '\\\\')}") / "hermes-plugin"
+
+spec = importlib.util.spec_from_file_location(
+    "plugins.memory.dkg",
+    plugin_dir / "__init__.py",
+    submodule_search_locations=[str(plugin_dir)],
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules["plugins.memory.dkg"] = module
+spec.loader.exec_module(module)
+
+provider = module.DKGMemoryProvider()
+provider._offline = False
+
+class FakeClient:
+    def __init__(self):
+        self.calls = []
+    def create_context_graph(self, name, description="", cg_id=None, *, access_policy=None, allowed_agents=None):
+        self.calls.append({
+            "name": name,
+            "description": description,
+            "cg_id": cg_id,
+            "access_policy": access_policy,
+            "allowed_agents": allowed_agents,
+        })
+        return {"created": cg_id or name, "uri": f"did:dkg:context-graph:{cg_id or name}"}
+
+client = FakeClient()
+provider._client = client
+
+# Default - no public, no allowed_agents -> curated.
+provider._handle_create_cg({"name": "Default", "id": "default"})
+# Explicit public - accessPolicy dropped, allowed_agents ignored.
+provider._handle_create_cg({"name": "Open", "id": "open", "public": True, "allowed_agents": ["0xIgnored"]})
+# Curated with explicit allowlist.
+provider._handle_create_cg({"name": "Team", "id": "team", "allowed_agents": ["0xAlice", "0xBob"]})
+# Curated with allowlist that includes empty / whitespace / non-string entries.
+provider._handle_create_cg({"name": "Trim", "id": "trim", "allowed_agents": ["  0xAlice  ", "", "   ", 42, "0xBob"]})
+
+assert client.calls[0] == {
+    "name": "Default", "description": "", "cg_id": "default",
+    "access_policy": 1, "allowed_agents": None,
+}, client.calls[0]
+assert client.calls[1] == {
+    "name": "Open", "description": "", "cg_id": "open",
+    "access_policy": None, "allowed_agents": None,
+}, client.calls[1]
+assert client.calls[2] == {
+    "name": "Team", "description": "", "cg_id": "team",
+    "access_policy": 1, "allowed_agents": ["0xAlice", "0xBob"],
+}, client.calls[2]
+assert client.calls[3] == {
+    "name": "Trim", "description": "", "cg_id": "trim",
+    "access_policy": 1, "allowed_agents": ["0xAlice", "0xBob"],
+}, client.calls[3]
 `;
     const result = spawnSync('python', ['-B', '-c', script], {
       cwd: process.cwd(),

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2682,8 +2682,8 @@ provider._handle_create_cg({"name": "Default", "id": "default"})
 provider._handle_create_cg({"name": "Open", "id": "open", "public": True, "allowed_agents": ["not-an-address"]})
 # Curated with explicit allowlist (valid 40-hex addresses).
 provider._handle_create_cg({"name": "Team", "id": "team", "allowed_agents": [VALID_A, VALID_B]})
-# Curated with allowlist that includes empty / whitespace / non-string entries.
-provider._handle_create_cg({"name": "Trim", "id": "trim", "allowed_agents": [f"  {VALID_A}  ", "", "   ", 42, VALID_B]})
+# Curated with whitespace-padded valid entries — trimmed but kept.
+provider._handle_create_cg({"name": "Trim", "id": "trim", "allowed_agents": [f"  {VALID_A}  ", VALID_B]})
 # Round 1 — invalid address must surface as a tool error and NOT call client.
 err = json.loads(provider._handle_create_cg({"name": "Bad", "id": "bad", "allowed_agents": [VALID_A, "not-an-address"]}))
 assert "error" in err and "Invalid Ethereum address" in err["error"], err
@@ -2691,6 +2691,34 @@ assert "not-an-address" in err["error"], err
 # Round 1 — too-short hex value also rejected.
 err2 = json.loads(provider._handle_create_cg({"name": "Short", "id": "short", "allowed_agents": ["0xabc"]}))
 assert "error" in err2 and "Invalid Ethereum address" in err2["error"], err2
+
+# Round 2 — fail-fast on non-string entries instead of silently dropping
+# them. LLMs occasionally emit numbers / dicts / nulls in tool args; if we
+# silently drop them, the agent thinks the participant was added when it
+# wasn't. Fail with a precise index-scoped error so the agent can correct.
+err3 = json.loads(provider._handle_create_cg({"name": "Mixed", "id": "mixed", "allowed_agents": [VALID_A, 42, VALID_B]}))
+assert "error" in err3 and "allowed_agents[1]" in err3["error"] and "must be a string" in err3["error"], err3
+
+# Round 2 — fail-fast on empty / whitespace-only entries.
+err4 = json.loads(provider._handle_create_cg({"name": "Empty", "id": "empty", "allowed_agents": [VALID_A, "   "]}))
+assert "error" in err4 and "allowed_agents[1]" in err4["error"] and ("empty" in err4["error"] or "whitespace" in err4["error"]), err4
+
+# Round 2 — fail-fast on null entries.
+err5 = json.loads(provider._handle_create_cg({"name": "Null", "id": "null", "allowed_agents": [VALID_A, None]}))
+assert "error" in err5 and "allowed_agents[1]" in err5["error"], err5
+
+# Round 2 — non-list allowed_agents (e.g. dict, string) rejected.
+err6 = json.loads(provider._handle_create_cg({"name": "NotList", "id": "notlist", "allowed_agents": "0x1234"}))
+assert "error" in err6 and "must be an array" in err6["error"], err6
+
+# Round 2 — non-boolean public rejected (string "yes" should NOT silently
+# fall back to curated; the agent gets a clear error).
+err7 = json.loads(provider._handle_create_cg({"name": "Yes", "id": "yes", "public": "yes"}))
+assert "error" in err7 and "public" in err7["error"] and "boolean" in err7["error"], err7
+
+# Round 2 — non-boolean public rejected (number 1 should NOT be coerced).
+err8 = json.loads(provider._handle_create_cg({"name": "One", "id": "one", "public": 1}))
+assert "error" in err8 and "public" in err8["error"], err8
 
 assert client.calls[0] == {
     "name": "Default", "description": "", "cg_id": "default",
@@ -2708,7 +2736,8 @@ assert client.calls[3] == {
     "name": "Trim", "description": "", "cg_id": "trim",
     "access_policy": 1, "allowed_agents": [VALID_A, VALID_B],
 }, client.calls[3]
-# Bad / short calls must NOT have hit the client — pre-flight validation.
+# All round-1 + round-2 failure paths must NOT have hit the client —
+# pre-flight validation.
 assert len(client.calls) == 4, client.calls
 `;
     const result = spawnSync('python', ['-B', '-c', script], {

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -1643,9 +1643,17 @@ bad_cg = client.create_context_graph("Bad", cg_id="Bad:Id")
 assert bad_cg["success"] is False, bad_cg
 client.create_context_graph("My Project", "desc")
 # T-PRIVACY: client passes accessPolicy + allowedAgents through to the daemon
-# verbatim when supplied, and omits them when not.
+# verbatim when supplied, and omits them when not. The CLIENT layer does NOT
+# validate address format; that's the tool handler's job — the client just
+# forwards bytes to the daemon for the cases where a programmatic caller has
+# already validated upstream.
 client.create_context_graph("Curated", "private cg", access_policy=1)
-client.create_context_graph("Team", "shared", access_policy=1, allowed_agents=["0xAlice", "0xBob"])
+client.create_context_graph(
+    "Team",
+    "shared",
+    access_policy=1,
+    allowed_agents=["0x" + "a" * 40, "0x" + "B" * 40],
+)
 client.subscribe("cg:test", include_shared_memory=True)
 client.write_assertion("a b", "cg:test", [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "sub")
 client.discard_assertion("a b", "cg:test")
@@ -1657,10 +1665,13 @@ client.add_participant("cg:test", "agent")
 client.list_join_requests("cg:test")
 client.publish("cg:test", selection=["urn:root"], clear_after=False, sub_graph_name="sub")
 
+_VALID_ADDR_A = "0x" + "a" * 40
+_VALID_ADDR_B = "0x" + "B" * 40
+
 assert calls == [
     ("POST", "/api/context-graph/create", {"id": "my-project", "name": "My Project", "description": "desc"}),
     ("POST", "/api/context-graph/create", {"id": "curated", "name": "Curated", "description": "private cg", "accessPolicy": 1}),
-    ("POST", "/api/context-graph/create", {"id": "team", "name": "Team", "description": "shared", "accessPolicy": 1, "allowedAgents": ["0xAlice", "0xBob"]}),
+    ("POST", "/api/context-graph/create", {"id": "team", "name": "Team", "description": "shared", "accessPolicy": 1, "allowedAgents": [_VALID_ADDR_A, _VALID_ADDR_B]}),
     ("POST", "/api/context-graph/subscribe", {"contextGraphId": "cg:test", "includeSharedMemory": True}),
     ("POST", "/api/assertion/a%20b/write", {"contextGraphId": "cg:test", "quads": [{"subject": "urn:s", "predicate": "urn:p", "object": '"o"'}], "subGraphName": "sub"}),
     ("POST", "/api/assertion/a%20b/discard", {"contextGraphId": "cg:test"}),
@@ -2660,14 +2671,26 @@ class FakeClient:
 client = FakeClient()
 provider._client = client
 
+VALID_A = "0x" + "a" * 40
+VALID_B = "0x" + "B" * 40
+
 # Default - no public, no allowed_agents -> curated.
 provider._handle_create_cg({"name": "Default", "id": "default"})
-# Explicit public - accessPolicy dropped, allowed_agents ignored.
-provider._handle_create_cg({"name": "Open", "id": "open", "public": True, "allowed_agents": ["0xIgnored"]})
-# Curated with explicit allowlist.
-provider._handle_create_cg({"name": "Team", "id": "team", "allowed_agents": ["0xAlice", "0xBob"]})
+# Explicit public - accessPolicy dropped, allowed_agents ignored even if
+# malformed (validation only runs when public is false, so public CGs never
+# raise on bad allowlist content).
+provider._handle_create_cg({"name": "Open", "id": "open", "public": True, "allowed_agents": ["not-an-address"]})
+# Curated with explicit allowlist (valid 40-hex addresses).
+provider._handle_create_cg({"name": "Team", "id": "team", "allowed_agents": [VALID_A, VALID_B]})
 # Curated with allowlist that includes empty / whitespace / non-string entries.
-provider._handle_create_cg({"name": "Trim", "id": "trim", "allowed_agents": ["  0xAlice  ", "", "   ", 42, "0xBob"]})
+provider._handle_create_cg({"name": "Trim", "id": "trim", "allowed_agents": [f"  {VALID_A}  ", "", "   ", 42, VALID_B]})
+# Round 1 — invalid address must surface as a tool error and NOT call client.
+err = json.loads(provider._handle_create_cg({"name": "Bad", "id": "bad", "allowed_agents": [VALID_A, "not-an-address"]}))
+assert "error" in err and "Invalid Ethereum address" in err["error"], err
+assert "not-an-address" in err["error"], err
+# Round 1 — too-short hex value also rejected.
+err2 = json.loads(provider._handle_create_cg({"name": "Short", "id": "short", "allowed_agents": ["0xabc"]}))
+assert "error" in err2 and "Invalid Ethereum address" in err2["error"], err2
 
 assert client.calls[0] == {
     "name": "Default", "description": "", "cg_id": "default",
@@ -2679,12 +2702,14 @@ assert client.calls[1] == {
 }, client.calls[1]
 assert client.calls[2] == {
     "name": "Team", "description": "", "cg_id": "team",
-    "access_policy": 1, "allowed_agents": ["0xAlice", "0xBob"],
+    "access_policy": 1, "allowed_agents": [VALID_A, VALID_B],
 }, client.calls[2]
 assert client.calls[3] == {
     "name": "Trim", "description": "", "cg_id": "trim",
-    "access_policy": 1, "allowed_agents": ["0xAlice", "0xBob"],
+    "access_policy": 1, "allowed_agents": [VALID_A, VALID_B],
 }, client.calls[3]
+# Bad / short calls must NOT have hit the client — pre-flight validation.
+assert len(client.calls) == 4, client.calls
 `;
     const result = spawnSync('python', ['-B', '-c', script], {
       cwd: process.cwd(),


### PR DESCRIPTION
## Summary

- **Default to curated/private context graphs in Hermes.** `dkg_context_graph_create` now sends `accessPolicy: 1` to the daemon when the caller doesn't explicitly pass `public: true`. The agent's existing creator-auto-include logic adds the creator's address to `DKG_ALLOWED_AGENT` automatically, so the creator can immediately read/write without a self-invite.
- **Expose `public` + `allowed_agents` parameters** on the Hermes tool schema (mirroring OpenClaw PR #401).
- **Update Hermes system_prompt_block** with a PRIVACY MODEL section so the Hermes agent understands the new defaults before its first call.
- The Python client (`client.py`) now accepts `access_policy` and `allowed_agents` keyword arguments and forwards them to the daemon only when supplied — preserves the call shape for callers that don't pass them.

## Related

- Mirrors OpenClaw side in **#401** — both PRs flip the same default for adapter consistency. Either can land first; together they close the divergence.
- Depends on **#396** (SWM gossip gating must honor `isPrivateContextGraph()`). #396 is in flight on a parallel branch; merging this PR before #396 doesn't regress correctness, but the privacy guarantee only kicks in once #396 ships.
- SKILL.md updates ride with PR #401 (single shared SKILL.md across both adapters).
- Follow-up **#400** — surface `privateQuads` partition end-to-end on publish tools.

## Files changed

| File | What |
|------|------|
| `packages/adapter-hermes/hermes-plugin/__init__.py` | Tool schema gains `public` + `allowed_agents`; handler defaults `access_policy=1` when `public !== true` and filters allowlist entries through trim/non-empty/isinstance(str). System_prompt_block gains a PRIVACY MODEL section. |
| `packages/adapter-hermes/hermes-plugin/client.py` | `create_context_graph()` accepts `access_policy` + `allowed_agents` keyword arguments and forwards them to the daemon only when supplied. |
| `packages/adapter-hermes/test/hermes-adapter.test.ts` | Extended the daemon-route routing test with three new `create_context_graph` invocations (default + curated + with allowlist). New `_handle_create_cg` handler test covering default-curated, public-drops-curation, allowlist passthrough, and trim/filter behaviour. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-hermes exec vitest run` — 61 passing.
- [x] New test `dkg_context_graph_create handler defaults to curated and forwards public + allowed_agents` covers all four input shapes.
- [ ] After #396 lands and #401 lands: end-to-end smoke verifying a curated CG created via Hermes properly gates SWM gossip to listed peers.
