### PR TITLE
fix: refresh npm package metadata for v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate npm metadata points to v10
+        run: pnpm check:npm-metadata
+
       - name: Restore Turbo cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/npm-continuous-publish.yml
+++ b/.github/workflows/npm-continuous-publish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate npm metadata points to v10
+        run: pnpm check:npm-metadata
+
       - name: Build all packages
         run: pnpm build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate npm metadata points to v10
+        run: pnpm check:npm-metadata
+
       - name: Build
         run: pnpm build
 
@@ -271,7 +274,7 @@ jobs:
             sed -n "/^## \[$V\]/,/^## \[/p" CHANGELOG.md | sed '/^## \[/d' | sed '1d' > release_notes.md
           fi
           if [ ! -s release_notes.md ]; then
-            echo "## DKG V9 Node $V" > release_notes.md
+            echo "## DKG V10 Node $V" > release_notes.md
             echo "" >> release_notes.md
             echo "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/v$V/CHANGELOG.md) for details." >> release_notes.md
           fi

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sim:testnet": "SIM_TARGET=testnet pnpm --filter @origintrail-official/dkg-network-sim dev",
     "sim:build": "pnpm --filter @origintrail-official/dkg-network-sim build",
     "mcp": "node packages/mcp-server/dist/index.js",
+    "check:npm-metadata": "node scripts/check-npm-metadata.mjs",
     "index": "node packages/cli/dist/cli.js index",
     "test:evm-integration": "./scripts/test-evm-integration.sh",
     "test:evm": "./scripts/test-evm-integration.sh all",

--- a/packages/adapter-autoresearch/README.md
+++ b/packages/adapter-autoresearch/README.md
@@ -2,7 +2,7 @@
 
 > Collaborative autonomous ML research over the Decentralized Knowledge Graph.
 
-Integrates [Karpathy's autoresearch](https://github.com/karpathy/autoresearch/) with DKG V9, turning single-agent, single-machine research runs into a **decentralized research community**. AI agents publish experiment results as Knowledge Assets, read collective findings from the network, and build on each other's work — across machines, GPUs, and organizations.
+Integrates [Karpathy's autoresearch](https://github.com/karpathy/autoresearch/) with DKG V10, turning single-agent, single-machine research runs into a **decentralized research community**. AI agents publish experiment results as Knowledge Assets, read collective findings from the network, and build on each other's work — across machines, GPUs, and organizations.
 
 ## Why
 
@@ -63,7 +63,7 @@ Results propagate via GossipSub to all paranet subscribers. Every agent sees eve
 
 ### Prerequisites
 
-- A running DKG V9 node (`dkg start`)
+- A running DKG V10 node (`dkg start`)
 - The DKG MCP server built (`pnpm --filter @origintrail-official/dkg-mcp-server build`)
 - The adapter built (`pnpm --filter @origintrail-official/dkg-adapter-autoresearch build`)
 - A clone of [autoresearch](https://github.com/karpathy/autoresearch/) (or a Mac fork — see [Hardware](#hardware))
@@ -77,7 +77,7 @@ Set `DKG_ADAPTERS=autoresearch` when running the MCP server. In your Cursor/IDE 
   "mcpServers": {
     "dkg": {
       "command": "node",
-      "args": ["/path/to/dkg-v9/packages/mcp-server/dist/index.js"],
+      "args": ["/path/to/dkg/packages/mcp-server/dist/index.js"],
       "env": {
         "DKG_ADAPTERS": "autoresearch"
       }
@@ -101,7 +101,7 @@ git clone https://github.com/karpathy/autoresearch.git
 cd autoresearch
 
 # Use the DKG-integrated agent instructions
-cp /path/to/dkg-v9/packages/adapter-autoresearch/program-dkg.md program.md
+cp /path/to/dkg/packages/adapter-autoresearch/program-dkg.md program.md
 
 # One-time data prep (requires GPU)
 uv sync
@@ -313,7 +313,7 @@ Each agent contributes unique findings. GossipSub replicates results to all subs
 
 ## DKG protocol operations used
 
-This adapter uses the following DKG V9 protocol operations:
+This adapter uses the following DKG V10 protocol operations:
 
 | Operation | Protocol | Purpose |
 |---|---|---|

--- a/packages/adapter-autoresearch/package.json
+++ b/packages/adapter-autoresearch/package.json
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/adapter-autoresearch"
   }
 }

--- a/packages/adapter-elizaos/README.md
+++ b/packages/adapter-elizaos/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-adapter-elizaos
 
-[ElizaOS](https://elizaos.ai) plugin adapter for DKG V9. Turns any ElizaOS agent into a DKG node with knowledge publishing, querying, agent discovery, and skill invocation capabilities.
+[ElizaOS](https://elizaos.ai) plugin adapter for DKG V10. Turns any ElizaOS agent into a DKG node with knowledge publishing, querying, agent discovery, and skill invocation capabilities.
 
 ## Features
 

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
   "version": "10.0.0-rc.2",
-  "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V9 node",
+  "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/adapter-elizaos"
   }
 }

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -56,7 +56,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/adapter-openclaw"
   }
 }

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-agent
 
-Agent runtime for DKG V9. Provides the `DKGAgent` class — the primary entry point for building agents that participate in the decentralized knowledge network.
+Agent runtime for DKG V10. Provides the `DKGAgent` class — the primary entry point for building agents that participate in the decentralized knowledge network.
 
 ## Features
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/agent"
   }
 }

--- a/packages/attested-assets/README.md
+++ b/packages/attested-assets/README.md
@@ -2,7 +2,7 @@
 
 > **Experimental** — This package implements the Attested Knowledge Assets (AKA) protocol, which is under active development. APIs may change.
 
-Session-scoped, multi-party consensus protocol for DKG V9. Enables bounded groups of nodes to run deterministic state machines with cryptographic attestation and quorum-based finality.
+Session-scoped, multi-party consensus protocol for DKG V10. Enables bounded groups of nodes to run deterministic state machines with cryptographic attestation and quorum-based finality.
 
 ## What are Attested Knowledge Assets?
 

--- a/packages/attested-assets/package.json
+++ b/packages/attested-assets/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/attested-assets"
   }
 }

--- a/packages/chain/README.md
+++ b/packages/chain/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-chain
 
-Blockchain abstraction layer for DKG V9. Provides a `ChainAdapter` interface with implementations for EVM chains and testing.
+Blockchain abstraction layer for DKG V10. Provides a `ChainAdapter` interface with implementations for EVM chains and testing.
 
 ## Features
 

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/chain"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/cli"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-core
 
-Foundation package for DKG V9. Provides P2P networking, protocol messaging, cryptographic primitives, and shared utilities used by every other package in the stack.
+Foundation package for DKG V10. Provides P2P networking, protocol messaging, cryptographic primitives, and shared utilities used by every other package in the stack.
 
 ## Features
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/core"
   }
 }

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/epcis"
   }
 }

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -94,7 +94,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/graph-viz"
   }
 }

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -63,7 +63,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/mcp-dkg"
   },
   "keywords": [

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-mcp-server
 
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for DKG V9. Exposes DKG node capabilities as MCP tools, allowing AI assistants (Cursor, Claude Desktop, etc.) to publish, query, and explore the knowledge graph.
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for DKG V10. Exposes DKG node capabilities as MCP tools, allowing AI assistants (Cursor, Claude Desktop, etc.) to publish, query, and explore the knowledge graph.
 
 ## Features
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/mcp-server"
   }
 }

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -55,7 +55,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/node-ui"
   }
 }

--- a/packages/publisher/README.md
+++ b/packages/publisher/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-publisher
 
-Publishing protocol for DKG V9. Handles the complete lifecycle of getting Knowledge Assets from a node into the network — from RDF processing through Merkle tree construction to on-chain finalization.
+Publishing protocol for DKG V10. Handles the complete lifecycle of getting Knowledge Assets from a node into the network — from RDF processing through Merkle tree construction to on-chain finalization.
 
 ## Features
 

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -33,7 +33,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/publisher"
   }
 }

--- a/packages/query/README.md
+++ b/packages/query/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-query
 
-SPARQL query engine for DKG V9. Provides paranet-scoped querying, Knowledge Asset resolution by UAL, and read-only query validation.
+SPARQL query engine for DKG V10. Provides paranet-scoped querying, Knowledge Asset resolution by UAL, and read-only query validation.
 
 ## Features
 

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/query"
   }
 }

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/random-sampling"
   }
 }

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,6 +1,6 @@
 # @origintrail-official/dkg-storage
 
-Triple store abstraction layer for DKG V9. Provides a unified API over multiple RDF storage backends with named graph management and private content storage.
+Triple store abstraction layer for DKG V10. Provides a unified API over multiple RDF storage backends with named graph management and private content storage.
 
 ## Features
 

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/OriginTrail/dkg-v9.git",
+    "url": "https://github.com/OriginTrail/dkg.git",
     "directory": "packages/storage"
   }
 }

--- a/scripts/check-npm-metadata.mjs
+++ b/scripts/check-npm-metadata.mjs
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FORBIDDEN_PATTERNS = [
+  /dkg-v9/i,
+  /DKG V9/i,
+];
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGES_DIR = path.join(ROOT_DIR, 'packages');
+
+function firstMatchSample(value) {
+  const normalized = String(value).replace(/\s+/g, ' ').trim();
+  if (!normalized) return '';
+  const lower = normalized.toLowerCase();
+  let matchIndex = -1;
+  for (const pattern of FORBIDDEN_PATTERNS) {
+    const idx = lower.search(new RegExp(pattern.source, 'i'));
+    if (idx !== -1 && (matchIndex === -1 || idx < matchIndex)) {
+      matchIndex = idx;
+    }
+  }
+  if (matchIndex === -1) {
+    return normalized.slice(0, 120);
+  }
+  const start = Math.max(0, matchIndex - 40);
+  const end = Math.min(normalized.length, matchIndex + 100);
+  return normalized.slice(start, end);
+}
+
+function hasForbiddenText(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return FORBIDDEN_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function collectViolations() {
+  const violations = [];
+  const packageDirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true });
+
+  for (const entry of packageDirs) {
+    if (!entry.isDirectory()) continue;
+
+    const packageDir = path.join(PACKAGES_DIR, entry.name);
+    const packageJsonPath = path.join(packageDir, 'package.json');
+    if (!fs.existsSync(packageJsonPath)) continue;
+
+    const pkg = readJson(packageJsonPath);
+    if (pkg.private) continue;
+
+    const repository =
+      typeof pkg.repository === 'string'
+        ? pkg.repository
+        : pkg.repository?.url ?? '';
+    const bugs = typeof pkg.bugs === 'string' ? pkg.bugs : pkg.bugs?.url ?? '';
+
+    const fieldsToCheck = [
+      { field: 'description', value: pkg.description ?? '' },
+      { field: 'repository', value: repository },
+      { field: 'homepage', value: pkg.homepage ?? '' },
+      { field: 'bugs', value: bugs },
+    ];
+
+    for (const field of fieldsToCheck) {
+      if (!hasForbiddenText(field.value)) continue;
+      violations.push({
+        packageName: pkg.name,
+        location: `${path.relative(ROOT_DIR, packageJsonPath)}#${field.field}`,
+        sample: firstMatchSample(field.value),
+      });
+    }
+
+    const readmePath = path.join(packageDir, 'README.md');
+    if (fs.existsSync(readmePath)) {
+      const readme = fs.readFileSync(readmePath, 'utf8');
+      if (hasForbiddenText(readme)) {
+        violations.push({
+          packageName: pkg.name,
+          location: `${path.relative(ROOT_DIR, readmePath)}#content`,
+          sample: firstMatchSample(readme),
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+const violations = collectViolations();
+
+if (violations.length > 0) {
+  console.error('Found stale v9 npm metadata/readme references:\n');
+  for (const violation of violations) {
+    console.error(`- ${violation.packageName}: ${violation.location}`);
+    console.error(`  ${violation.sample}`);
+  }
+  process.exit(1);
+}
+
+console.log('NPM metadata check passed: no stale v9 references in publishable packages.');


### PR DESCRIPTION
## Summary
- update publishable package metadata and package READMEs so npm-facing content no longer references `dkg-v9` / `DKG V9`
- replace stale repository links in package manifests from `OriginTrail/dkg-v9` to `OriginTrail/dkg`
- add `scripts/check-npm-metadata.mjs` and run it in CI, release preflight, and continuous npm publish workflows to block regressions

## Test plan
- [x] Run `pnpm check:npm-metadata`
- [x] Confirm PR diff against `main` only includes metadata/readme/workflow guard changes

Made with [Cursor](https://cursor.com)