### PR TITLE
Add OpenClaw query catalog tools

### DIFF
--- a/packages/adapter-openclaw/src/DkgNodePlugin.ts
+++ b/packages/adapter-openclaw/src/DkgNodePlugin.ts
@@ -63,6 +63,79 @@ function isValidEthAddressString(value: string | undefined): boolean {
   return typeof value === 'string' && ETH_ADDR_RE_LC.test(value.trim().toLowerCase());
 }
 
+type QueryCatalogToolItem = {
+  slug: string;
+  name: string;
+  description?: string;
+  sparql: string;
+  rank: number;
+  catalogSlug: string;
+  catalogName: string;
+  catalogDescription?: string;
+  catalogRank: number;
+  subGraph: string;
+};
+
+function stripRdfTerm(value: unknown): string {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const maybeValue = (value as Record<string, unknown>).value;
+    if (typeof maybeValue === 'string') return maybeValue;
+  }
+  const raw = String(value ?? '');
+  const decodeLiteral = (literal: string): string => {
+    try {
+      return JSON.parse(literal);
+    } catch {
+      return literal.slice(1, -1);
+    }
+  };
+  const literalMatch = raw.match(/^("[\s\S]*")(\^\^.*|@.*)?$/);
+  if (literalMatch) return decodeLiteral(literalMatch[1]);
+  return raw;
+}
+
+function queryCatalogSlugFromIri(iri: string, marker: string, fallback: string): string {
+  if (!iri) return fallback;
+  return iri.split(marker).pop() ?? iri;
+}
+
+function normalizeQueryCatalogItems(response: Record<string, unknown>): QueryCatalogToolItem[] {
+  const result = response.result as { type?: string; bindings?: unknown[] } | undefined;
+  const bindings = result?.type === 'bindings' && Array.isArray(result.bindings)
+    ? result.bindings
+    : [];
+  return bindings
+    .map((row): QueryCatalogToolItem | null => {
+      if (!row || typeof row !== 'object' || Array.isArray(row)) return null;
+      const r = row as Record<string, unknown>;
+      const qIri = stripRdfTerm(r.q);
+      const catalogIri = stripRdfTerm(r.catalog);
+      const slug = queryCatalogSlugFromIri(qIri, ':query:', qIri);
+      const catalogSlug = queryCatalogSlugFromIri(catalogIri, ':catalog:', 'ui-saved-queries');
+      const sparql = stripRdfTerm(r.sparql);
+      if (!sparql) return null;
+      return {
+        slug,
+        name: stripRdfTerm(r.name) || slug,
+        description: r.description !== undefined ? stripRdfTerm(r.description) : undefined,
+        sparql,
+        rank: Number.parseInt(stripRdfTerm(r.rank) || '99', 10) || 99,
+        catalogSlug,
+        catalogName: stripRdfTerm(r.catalogName) || 'Queries',
+        catalogDescription: r.catalogDescription !== undefined ? stripRdfTerm(r.catalogDescription) : undefined,
+        catalogRank: Number.parseInt(stripRdfTerm(r.catalogRank) || '999', 10) || 999,
+        subGraph: stripRdfTerm(r.subGraph),
+      };
+    })
+    .filter((item): item is QueryCatalogToolItem => item !== null)
+    .sort((a, b) =>
+      a.subGraph.localeCompare(b.subGraph)
+      || a.catalogRank - b.catalogRank
+      || a.rank - b.rank
+      || a.name.localeCompare(b.name),
+    );
+}
+
 const OPENCLAW_LOCAL_AGENT_CAPABILITIES = {
   localChat: true,
   chatAttachments: true,
@@ -2686,6 +2759,46 @@ export class DkgNodePlugin {
         execute: async (_toolCallId, args) => this.handleQuery(args),
       },
       {
+        name: 'dkg_query_catalog_list',
+        description:
+          'List saved SPARQL queries from a context graph profile query catalog. Use this when the user asks ' +
+          'what saved/catalog queries are available for a project or before running a saved query by name. ' +
+          'Returns sorted items with slug, display name, catalog, sub-graph, description, and SPARQL text.',
+        parameters: {
+          type: 'object',
+          properties: {
+            context_graph_id: {
+              type: 'string',
+              description: 'Context graph/project ID whose profile query catalog should be read.',
+            },
+          },
+          required: ['context_graph_id'],
+        },
+        execute: async (_toolCallId, args) => this.handleQueryCatalogList(args),
+      },
+      {
+        name: 'dkg_query_catalog_run',
+        description:
+          'Run a saved SPARQL query from a context graph profile query catalog by slug or exact display name. ' +
+          'Call dkg_query_catalog_list first if the selector is ambiguous. Executes the saved SPARQL against ' +
+          'the same context graph using the standard DKG query route.',
+        parameters: {
+          type: 'object',
+          properties: {
+            context_graph_id: {
+              type: 'string',
+              description: 'Context graph/project ID whose saved query should be used.',
+            },
+            query: {
+              type: 'string',
+              description: 'Saved query slug or exact display name.',
+            },
+          },
+          required: ['context_graph_id', 'query'],
+        },
+        execute: async (_toolCallId, args) => this.handleQueryCatalogRun(args),
+      },
+      {
         name: 'dkg_find_agents',
         description:
           'List DKG agents known to this node — combines the local registry (this node + cached peers from the ' +
@@ -3398,6 +3511,63 @@ export class DkgNodePlugin {
         agentAddress,
       });
       return this.json(result);
+    } catch (err: any) {
+      return this.daemonError(err);
+    }
+  }
+
+  private async handleQueryCatalogList(args: Record<string, unknown>): Promise<OpenClawToolResult> {
+    try {
+      const contextGraphId = String(args.context_graph_id ?? '').trim();
+      if (!contextGraphId) return this.error('"context_graph_id" is required.');
+      const response = await this.client.readQueryCatalog(contextGraphId);
+      const items = normalizeQueryCatalogItems(response);
+      return this.json({
+        contextGraphId,
+        count: items.length,
+        items,
+      });
+    } catch (err: any) {
+      return this.daemonError(err);
+    }
+  }
+
+  private async handleQueryCatalogRun(args: Record<string, unknown>): Promise<OpenClawToolResult> {
+    try {
+      const contextGraphId = String(args.context_graph_id ?? '').trim();
+      const selector = String(args.query ?? '').trim();
+      if (!contextGraphId) return this.error('"context_graph_id" is required.');
+      if (!selector) return this.error('"query" is required.');
+
+      const response = await this.client.readQueryCatalog(contextGraphId);
+      const items = normalizeQueryCatalogItems(response);
+      const slugMatches = items.filter((item) => item.slug === selector);
+      const nameMatches = slugMatches.length > 0
+        ? []
+        : items.filter((item) => item.name === selector);
+      const matches = slugMatches.length > 0 ? slugMatches : nameMatches;
+      if (matches.length === 0) {
+        return this.error(
+          `Saved query not found: ${selector}. Available queries: ${
+            items.map((item) => `${item.slug} (${item.name})`).join(', ') || 'none'
+          }`,
+        );
+      }
+      if (matches.length > 1) {
+        return this.error(
+          `Saved query selector is ambiguous: ${selector}. Matching slugs: ${
+            matches.map((item) => item.slug).join(', ')
+          }`,
+        );
+      }
+
+      const savedQuery = matches[0];
+      const result = await this.client.query(savedQuery.sparql, { contextGraphId });
+      return this.json({
+        contextGraphId,
+        savedQuery,
+        result,
+      });
     } catch (err: any) {
       return this.daemonError(err);
     }

--- a/packages/adapter-openclaw/src/dkg-client.ts
+++ b/packages/adapter-openclaw/src/dkg-client.ts
@@ -223,6 +223,21 @@ export class DkgDaemonClient {
   }
 
   // ---------------------------------------------------------------------------
+  // Query catalog
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Read saved profile query catalog entries for a context graph.
+   *
+   * The daemon stores these as local profile metadata in
+   * `did:dkg:context-graph:<id>/meta/query-catalog`; callers usually run the
+   * returned `prof:sparqlQuery` text through `query()`.
+   */
+  async readQueryCatalog(contextGraphId: string): Promise<Record<string, unknown>> {
+    return this.post('/api/profile/query-catalog/read', { contextGraphId });
+  }
+
+  // ---------------------------------------------------------------------------
   // Shared memory write (SWM layer — NOT used by v1 chat-turn / memory paths)
   // ---------------------------------------------------------------------------
 

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -133,6 +133,8 @@ Drop to HTTP when the operation isn't in the table — participant self-service 
 | `dkg_sub_graph_create` | `POST /api/sub-graph/create` | Register a sub-graph inside a CG |
 | `dkg_sub_graph_list` | `GET /api/sub-graph/list` | List sub-graphs in a CG |
 | `dkg_query` | `POST /api/query` | Read-only SPARQL across assertions in a CG. Pass `view` (`working-memory` / `shared-working-memory` / `verified-memory`) to pick the layer — when `view` is set, `context_graph_id` is required; for WM reads, optional `agent_address` targets another agent's WM (defaults to this node). Omit `view` for a legacy cross-graph data-path query. |
+| `dkg_query_catalog_list` | `POST /api/profile/query-catalog/read` | List saved SPARQL queries declared in the project profile query catalog |
+| `dkg_query_catalog_run` | `POST /api/profile/query-catalog/read` + `POST /api/query` | Run a saved catalog query by slug or exact display name |
 | `dkg_find_agents` | `GET /api/agents` | Discover other agents (best-effort P2P) |
 | `dkg_send_message` | `POST /api/chat` | Send a direct message (best-effort P2P) |
 | `dkg_read_messages` | `GET /api/messages` | Read inbound messages |
@@ -145,6 +147,7 @@ P2P tools fail gracefully when the peer is offline. `dkg_publish` (fresh quads +
 - **Participant self-service join/sign flow** — see §6.
 - **Conditional writes** (`POST /api/shared-memory/conditional-write`) — see §5 SWM.
 - **Async publisher job queue** (`/api/publisher/*`) — see §8.
+- **Query catalog writes** (`POST /api/profile/query-catalog/write`) — see §5 "Saved Query Catalog".
 - **Raw file retrieval** (`GET /api/file/{fileHash}`) — see §7.
 - **Endorse / verify / update** (`POST /api/endorse`, `/verify`, `/update`) — see §5 VM.
 - **SSE event stream** (`GET /api/events`) — see §8.
@@ -227,6 +230,101 @@ The `memory_search` tool is the recommended entry point for free-text memory rec
   - `includeSharedMemory` / `includeWorkspace` — merge SWM into the result set
   - `verifiedGraph` — target a specific VM (on-chain) named graph
 - `POST /api/query-remote` — query a remote peer via P2P. Body: `{ peerId, lookupType, contextGraphId, ual?, entityUri?, rdfType?, sparql?, limit?, timeout? }`. `lookupType` picks the strategy (e.g. `sparql`, `entity`, `rdf-type`). Remote peer ACL is enforced.
+
+### Saved Query Catalog
+
+The query catalog is project profile metadata: saved SPARQL queries attached to
+a context graph and grouped by sub-graph/catalog. In the Node UI it appears in
+the Project view as **Query catalog** above the context-graph query surface and
+inside sub-graph detail views; it is not the Graph Overview.
+
+Use this decision order:
+
+1. When a turn has a clear selected project/context graph
+   (`target_context_graph` or an explicit user-provided context graph) and the
+   user asks a substantive question about that project's data, call
+   `dkg_query_catalog_list` before inventing ad-hoc SPARQL or using broad
+   free-text recall. Skip this first-check only for operational/admin requests
+   such as daemon status, publishing, setup, connectivity, permissions, or
+   explicit writes.
+2. Inspect the returned saved-query candidates (`slug`, `name`, `description`,
+   `catalogName`, and `subGraph`) and choose the query that best matches the
+   user's wording. If exactly one candidate clearly matches, run it with
+   `dkg_query_catalog_run` and answer from the result. Mention the saved query
+   used in one short phrase when useful.
+3. If several candidates plausibly match and the answer depends on which one
+   is used, list the candidate names/slugs and ask the user to choose. If one
+   is clearly the best default, run it and note that other catalog options
+   exist only if the result is incomplete.
+4. If the catalog is empty or no saved query matches the request, continue with
+   the normal lookup path (`memory_search` for broad recall or `dkg_query` for
+   precise SPARQL). Do not pretend a catalog query was used.
+5. If the user asks which saved queries exist, call `dkg_query_catalog_list`
+   with the selected `context_graph_id` and present the useful candidates.
+6. If the user explicitly asks to run a saved query, call
+   `dkg_query_catalog_run` with the selected `context_graph_id` and the saved
+   query slug or exact display name. If the name is ambiguous, list first and
+   ask/choose by slug.
+7. If no query catalog tool is available, use `dkg_query` against the profile
+   graph (`did:dkg:context-graph:<id>/meta/query-catalog`) to read saved
+   queries, then run the selected `prof:sparqlQuery` with `dkg_query`.
+8. Only write or change query catalog entries when the user explicitly asks to
+   save/update catalog queries.
+
+OpenClaw tool path:
+
+- `dkg_query_catalog_list` input: `{ "context_graph_id": "<contextGraphId>" }`
+- `dkg_query_catalog_run` input:
+  `{ "context_graph_id": "<contextGraphId>", "query": "<slug-or-exact-name>" }`
+
+CLI fallback:
+
+```bash
+dkg query-catalog list <context-graph>
+dkg query-catalog run <context-graph> <query-slug-or-exact-name>
+```
+
+HTTP fallback:
+
+- `POST /api/profile/query-catalog/read`
+  Body: `{ "contextGraphId": "<contextGraphId>" }`
+  Returns bindings with `q`, `subGraph`, `catalog`, `name`, `description`,
+  `sparql`, `rank`, `catalogName`, `catalogDescription`, and `catalogRank`.
+- `POST /api/profile/query-catalog/write`
+  Body: `{ "contextGraphId": "<contextGraphId>", "quads": [...] }`
+  The daemon stores these triples in
+  `did:dkg:context-graph:<contextGraphId>/meta/query-catalog` regardless of
+  the incoming quad `graph` field. This route appends profile triples; prefer
+  a new saved-query URI for new saved queries and avoid overwriting unrelated
+  catalog/profile metadata.
+
+Profile RDF shape for writes:
+
+```turtle
+@prefix prof: <http://dkg.io/ontology/profile/> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:dkg:profile:PROJECT:catalog:CATALOG> rdf:type prof:QueryCatalog ;
+  prof:forSubGraph "SUBGRAPH" ;
+  prof:displayName "Catalog name" ;
+  schema:description "Catalog description" ;
+  prof:rank "50"^^xsd:integer .
+
+<urn:dkg:profile:PROJECT:query:QUERY> rdf:type prof:SavedQuery ;
+  prof:forSubGraph "SUBGRAPH" ;
+  prof:inCatalog <urn:dkg:profile:PROJECT:catalog:CATALOG> ;
+  prof:displayName "Saved query name" ;
+  schema:description "What this query returns" ;
+  prof:sparqlQuery "SELECT ?uri WHERE { ?uri ?p ?o } LIMIT 50" ;
+  prof:resultColumn "uri" ;
+  prof:rank "100"^^xsd:integer .
+```
+
+When composing saved SPARQL, keep it read-only (`SELECT`, `ASK`, `CONSTRUCT`,
+or `DESCRIBE`). Prefer returning a stable `?uri` column when the result should
+feed entity-list UI surfaces.
 
 ### Operational constraints
 


### PR DESCRIPTION
Add OpenClaw query catalog tools

Adds OpenClaw adapter support for project query catalogs:
- `dkg_query_catalog_list` to list saved SPARQL queries for a context graph
- `dkg_query_catalog_run` to run a saved query by slug or exact display name
- daemon client wrapper for `/api/profile/query-catalog/read`
- dkg-node skill guidance so agents check saved catalog queries first when a project/context graph is known

