### PR TITLE
fix(adapter-hermes): mint unique subjects, quote literals, full escape coverage in dkg_share (#414)

### DIFF
--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -1376,11 +1376,22 @@ class DKGMemoryProvider(MemoryProvider):
     def _handle_share(self, args: Dict[str, Any]) -> str:
         if self._offline:
             return tool_error("DKG daemon is offline. Cannot share to team.")
-        content = args.get("content", "")
-        if not content:
+        # Type-validate at the runtime boundary. Without this, a malformed MCP
+        # call passing `content: {}` or `False` would crash inside _quote_literal
+        # with AttributeError on .replace, instead of returning a structured
+        # tool_error. Mirrors the OpenClaw boundary checks (PR #413 round 7).
+        if "content" not in args or args["content"] is None or args["content"] == "":
             return tool_error("Content is required.")
+        if not isinstance(args["content"], str):
+            return tool_error('"content" must be a string.')
         if "context_graph" in args:
             return tool_error('"context_graph" is not a supported parameter on dkg_share. Use "context_graph_id".')
+        if "context_graph_id" in args and args["context_graph_id"] is not None and not isinstance(args["context_graph_id"], str):
+            return tool_error('"context_graph_id" must be a string.')
+        sub_graph_name_raw = args.get("sub_graph_name")
+        if sub_graph_name_raw is not None and not isinstance(sub_graph_name_raw, str):
+            return tool_error('"sub_graph_name" must be a string.')
+        content = args["content"]
         # Aligned with OpenClaw: context_graph_id is required (no implicit
         # current-project fallback). Keeps both adapter contracts identical
         # so portable agent code works unchanged across either surface.
@@ -1403,6 +1414,14 @@ class DKGMemoryProvider(MemoryProvider):
             "object": _quote_literal(content),
         }]
         result = self._client.share(cg, quads, sub_graph_name=_first_text(args, "sub_graph_name"))
+        # Only surface the minted subject on a successful write. Hermes'
+        # Python client returns `{success: False, error: ...}` on failures
+        # (it doesn't throw). Attaching subject/root_entities to those
+        # would mask the failure and let chained dkg_shared_memory_publish
+        # calls publish a root entity that was never written. Pass the
+        # raw failure result through untouched.
+        if isinstance(result, dict) and result.get("success") is False:
+            return json.dumps(result)
         # Surface the minted subject so callers can target THIS share in a
         # follow-up `dkg_shared_memory_publish({ root_entities: [...] })`.
         # Field name is snake_case to match the consuming tool's argument

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -1415,12 +1415,14 @@ class DKGMemoryProvider(MemoryProvider):
         }]
         result = self._client.share(cg, quads, sub_graph_name=_first_text(args, "sub_graph_name"))
         # Only surface the minted subject on a successful write. Hermes'
-        # Python client returns `{success: False, error: ...}` on failures
-        # (it doesn't throw). Attaching subject/root_entities to those
-        # would mask the failure and let chained dkg_shared_memory_publish
-        # calls publish a root entity that was never written. Pass the
-        # raw failure result through untouched.
-        if isinstance(result, dict) and result.get("success") is False:
+        # Python client returns failure shapes (`{success: False, error: ...}`,
+        # `{ok: False}`, or bare `{error: ...}`) without throwing — see
+        # client.py:213 and the canonical detector at _client_result_failed
+        # below. Attaching subject/root_entities to a failure would mask it
+        # and let chained dkg_shared_memory_publish calls publish a root
+        # entity that was never written. Use the canonical helper so this
+        # path stays aligned with every other failure check in the module.
+        if _client_result_failed(result):
             return json.dumps(result)
         # Surface the minted subject so callers can target THIS share in a
         # follow-up `dkg_shared_memory_publish({ root_entities: [...] })`.

--- a/packages/adapter-hermes/hermes-plugin/__init__.py
+++ b/packages/adapter-hermes/hermes-plugin/__init__.py
@@ -20,7 +20,9 @@ import logging
 import os
 import hashlib
 import re
+import secrets
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
@@ -1385,13 +1387,31 @@ class DKGMemoryProvider(MemoryProvider):
         cg = _first_text(args, "context_graph_id")
         if not cg:
             return tool_error("context_graph_id is required.")
+        # Mint a unique root entity per share. The publisher upserts SWM by
+        # root entity (packages/publisher/src/dkg-publisher.ts:422-429), so
+        # a stable subject would mean each share replaces the previous one
+        # rather than appending a new fact.
+        share_id = f"{int(time.time() * 1000)}-{secrets.token_hex(4)}"
+        subject = f"urn:hermes:{self._agent_name}:shared:{share_id}"
+        # Wrap content as an N-Triples literal. The storage layer's
+        # formatTerm (packages/storage/src/adapters/oxigraph.ts:233-244)
+        # treats any object value not starting with `"` as an IRI, so raw
+        # text like `hello` would be coerced to `<hello>` — invalid IRI.
         quads = [{
-            "subject": f"urn:hermes:{self._agent_name}:shared",
+            "subject": subject,
             "predicate": "urn:hermes:sharedContent",
-            "object": content,
+            "object": _quote_literal(content),
         }]
         result = self._client.share(cg, quads, sub_graph_name=_first_text(args, "sub_graph_name"))
-        return json.dumps(result)
+        # Surface the minted subject so callers can target THIS share in a
+        # follow-up `dkg_shared_memory_publish({ root_entities: [...] })`.
+        # Field name is snake_case to match the consuming tool's argument
+        # shape (matches OpenClaw's response, PR #413).
+        if isinstance(result, dict):
+            response = {**result, "subject": subject, "root_entities": [subject]}
+        else:
+            response = {"raw": result, "subject": subject, "root_entities": [subject]}
+        return json.dumps(response)
 
     def _handle_publish(self, args: Dict[str, Any]) -> str:
         if not self._direct_publish_allowed():
@@ -2108,8 +2128,42 @@ def _required_cg_and_name(args: Dict[str, Any]) -> tuple[str, str]:
     return _first_text(args, "context_graph_id"), _first_text(args, "name")
 
 
+_ECHAR_REPLACEMENTS = {
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
 def _quote_literal(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r") + '"'
+    """
+    Wrap a free-text string as an N-Triples literal.
+
+    Escapes the full set the daemon's storage parser requires:
+    * the two structural ECHARs (`\\` and `"`) first, so subsequent
+      escape introducers don't get themselves doubled;
+    * the five common ECHAR control bytes (`\\b`, `\\t`, `\\n`, `\\f`, `\\r`);
+    * every remaining ASCII control byte (0x00-0x1F and 0x7F) as a
+      `\\uXXXX` UCHAR escape — without this, inputs containing NUL,
+      VT, DEL, etc. produce an invalid literal that the parser rejects.
+
+    Mirrors the OpenClaw side of the parity hardening (PR #413, defensive
+    post-pass over `escapeDkgRdfLiteral`). The TypeScript canonical helper
+    has the same gap upstream — see issue #416.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    out: List[str] = []
+    for ch in escaped:
+        code = ord(ch)
+        if ch in _ECHAR_REPLACEMENTS:
+            out.append(_ECHAR_REPLACEMENTS[ch])
+        elif code < 0x20 or code == 0x7F:
+            out.append(f"\\u{code:04X}")
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'
 
 
 def _uri_segment(value: Any, fallback: str) -> str:

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2915,17 +2915,30 @@ assert "error" in err_sub and "sub_graph_name" in err_sub["error"], err_sub
 assert client.calls == [], client.calls
 
 # Round 2 — daemon failures must pass through untouched. The Python client
-# returns {success: False, error: ...} on errors (it doesn't throw), so a
-# write that 4xx'd at the daemon would otherwise have synthetic subject /
-# root_entities attached, masking the failure for chained publish calls.
+# returns failure shapes ({success: False}, {ok: False}, or bare {error: ...})
+# on errors (it doesn't throw), so a write that 4xx'd at the daemon would
+# otherwise have synthetic subject / root_entities attached, masking the
+# failure for chained publish calls. _handle_share routes through
+# _client_result_failed() so all three shapes are caught the same way as
+# elsewhere in the module.
 class FailingClient:
+    def __init__(self, failure):
+        self.failure = failure
     def share(self, *args, **kwargs):
-        return {"success": False, "error": "context graph not registered"}
-provider._client = FailingClient()
-fail_result = json.loads(provider.handle_tool_call("dkg_share", {"content": "x", "context_graph_id": "cg:test"}))
-assert fail_result.get("success") is False, fail_result
-assert "subject" not in fail_result, fail_result
-assert "root_entities" not in fail_result, fail_result
+        return self.failure
+
+for failure_shape in [
+    {"success": False, "error": "context graph not registered"},
+    {"ok": False, "error": "auth required"},
+    {"error": "stream closed"},
+]:
+    provider._client = FailingClient(failure_shape)
+    fail_result = json.loads(provider.handle_tool_call("dkg_share", {"content": "x", "context_graph_id": "cg:test"}))
+    assert "subject" not in fail_result, (failure_shape, fail_result)
+    assert "root_entities" not in fail_result, (failure_shape, fail_result)
+    # Failure result must pass through untouched.
+    for key, expected in failure_shape.items():
+        assert fail_result.get(key) == expected, (failure_shape, fail_result)
 provider._client = client
 `;
     const result = spawnSync('python', ['-B', '-c', script], {

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2775,4 +2775,134 @@ assert len(client.calls) == 4, client.calls
 
     expect(result.status, result.stderr || result.stdout).toBe(0);
   });
+
+  it('dkg_share mints unique subjects per call, N-Triples-quotes content, and surfaces snake_case root_entities', () => {
+    // Closes OriginTrail/dkg#414 — the same three SWM-write bugs PR #413
+    // fixed for OpenClaw, applied to Hermes:
+    //   1. Constant subject → publisher upserts and overwrites prior shares.
+    //   2. Raw content → storage parser coerces to invalid IRI.
+    //   3. Partial _quote_literal escaping → control bytes leak through.
+    const script = String.raw`
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+home = Path(tempfile.mkdtemp(prefix="hermes-dkg-share-hardening-"))
+
+agent_pkg = types.ModuleType("agent")
+memory_provider = types.ModuleType("agent.memory_provider")
+class MemoryProvider:
+    pass
+memory_provider.MemoryProvider = MemoryProvider
+sys.modules["agent"] = agent_pkg
+sys.modules["agent.memory_provider"] = memory_provider
+
+tools_pkg = types.ModuleType("tools")
+registry = types.ModuleType("tools.registry")
+def tool_error(message):
+    return json.dumps({"error": message})
+registry.tool_error = tool_error
+sys.modules["tools"] = tools_pkg
+sys.modules["tools.registry"] = registry
+
+constants = types.ModuleType("hermes_constants")
+constants.get_hermes_home = lambda: home
+sys.modules["hermes_constants"] = constants
+
+sys.modules["plugins"] = types.ModuleType("plugins")
+sys.modules["plugins.memory"] = types.ModuleType("plugins.memory")
+sys.modules["plugins.memory.dkg"] = types.ModuleType("plugins.memory.dkg")
+
+plugin_dir = Path(r"${process.cwd().replace(/\\/g, '\\\\')}") / "hermes-plugin"
+
+spec = importlib.util.spec_from_file_location(
+    "plugins.memory.dkg",
+    plugin_dir / "__init__.py",
+    submodule_search_locations=[str(plugin_dir)],
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules["plugins.memory.dkg"] = module
+spec.loader.exec_module(module)
+
+provider = module.DKGMemoryProvider()
+provider._offline = False
+provider._agent_name = "tester"
+
+class CapturingClient:
+    def __init__(self):
+        self.calls = []
+    def share(self, context_graph_id, quads, sub_graph_name=None):
+        self.calls.append({
+            "context_graph_id": context_graph_id,
+            "quads": quads,
+            "sub_graph_name": sub_graph_name,
+        })
+        return {"shareOperationId": f"swm-{len(self.calls)}", "triplesWritten": len(quads)}
+
+client = CapturingClient()
+provider._client = client
+
+# Bug 1 fix — successive shares mint distinct subjects so the publisher
+# does not upsert and overwrite prior facts.
+r1 = json.loads(provider.handle_tool_call("dkg_share", {"content": "first fact", "context_graph_id": "cg:test"}))
+r2 = json.loads(provider.handle_tool_call("dkg_share", {"content": "second fact", "context_graph_id": "cg:test"}))
+subject1 = client.calls[0]["quads"][0]["subject"]
+subject2 = client.calls[1]["quads"][0]["subject"]
+assert subject1 != subject2, (subject1, subject2)
+assert re.match(r"^urn:hermes:tester:shared:\d+-[0-9a-f]+$", subject1), subject1
+assert re.match(r"^urn:hermes:tester:shared:\d+-[0-9a-f]+$", subject2), subject2
+
+# Response shape parity with OpenClaw: subject + snake_case root_entities.
+assert r1["subject"] == subject1, r1
+assert r1["root_entities"] == [subject1], r1
+assert r1.get("rootEntities") is None, r1
+assert "shareOperationId" in r1, r1
+
+# Bug 2 fix — content is wrapped as an N-Triples literal (quoted) before
+# being handed to the daemon, not as a bare string the storage layer would
+# coerce to an IRI.
+obj1 = client.calls[0]["quads"][0]["object"]
+assert obj1.startswith('"') and obj1.endswith('"'), obj1
+assert obj1 == '"first fact"', obj1
+
+# Bug 3 fix — _quote_literal escapes the full ECHAR set (\\, ", \\b, \\t,
+# \\n, \\f, \\r) and UCHAR-encodes any other ASCII control bytes (NUL, VT,
+# DEL, etc.) so a payload with mixed control characters round-trips cleanly.
+r3 = json.loads(provider.handle_tool_call("dkg_share", {
+    "content": "a\nb\rc\td\fe\bf \"q\" \\ end",
+    "context_graph_id": "cg:test",
+}))
+obj_echar = client.calls[2]["quads"][0]["object"]
+assert obj_echar == '"a\\nb\\rc\\td\\fe\\bf \\"q\\" \\\\ end"', obj_echar
+
+NUL = chr(0x00)
+VT = chr(0x0B)
+DEL = chr(0x7F)
+r4 = json.loads(provider.handle_tool_call("dkg_share", {
+    "content": f"x{NUL}y{VT}z{DEL}",
+    "context_graph_id": "cg:test",
+}))
+obj_uchar = client.calls[3]["quads"][0]["object"]
+assert obj_uchar == '"x\\u0000y\\u000Bz\\u007F"', obj_uchar
+
+# sub_graph_name still plumbs through, schema unchanged on that axis.
+provider.handle_tool_call("dkg_share", {"content": "scoped", "context_graph_id": "cg:test", "sub_graph_name": "protocols"})
+assert client.calls[4]["sub_graph_name"] == "protocols", client.calls[4]
+
+# Schema parity with OpenClaw — content + context_graph_id required, sub_graph_name optional.
+share_schema = next(s for s in provider.get_tool_schemas() if s["name"] == "dkg_share")
+assert share_schema["parameters"]["required"] == ["content", "context_graph_id"], share_schema
+assert "sub_graph_name" in share_schema["parameters"]["properties"], share_schema
+`;
+    const result = spawnSync('python', ['-B', '-c', script], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
 });

--- a/packages/adapter-hermes/test/hermes-adapter.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.test.ts
@@ -2897,6 +2897,36 @@ assert client.calls[4]["sub_graph_name"] == "protocols", client.calls[4]
 share_schema = next(s for s in provider.get_tool_schemas() if s["name"] == "dkg_share")
 assert share_schema["parameters"]["required"] == ["content", "context_graph_id"], share_schema
 assert "sub_graph_name" in share_schema["parameters"]["properties"], share_schema
+
+# Round 1 — type validation at the runtime boundary. Malformed MCP payloads
+# must surface a structured tool_error rather than crashing inside
+# _quote_literal with AttributeError on .replace.
+client.calls.clear()
+err_obj = json.loads(provider.handle_tool_call("dkg_share", {"content": {}, "context_graph_id": "cg:test"}))
+assert "error" in err_obj and "must be a string" in err_obj["error"], err_obj
+err_bool = json.loads(provider.handle_tool_call("dkg_share", {"content": False, "context_graph_id": "cg:test"}))
+# False also trips the "Content is required" check before the type check;
+# either is acceptable as long as it's a structured error and no daemon call fired.
+assert "error" in err_bool, err_bool
+err_cg = json.loads(provider.handle_tool_call("dkg_share", {"content": "hello", "context_graph_id": ["cg:test"]}))
+assert "error" in err_cg and ("context_graph_id" in err_cg["error"]), err_cg
+err_sub = json.loads(provider.handle_tool_call("dkg_share", {"content": "hello", "context_graph_id": "cg:test", "sub_graph_name": 42}))
+assert "error" in err_sub and "sub_graph_name" in err_sub["error"], err_sub
+assert client.calls == [], client.calls
+
+# Round 2 — daemon failures must pass through untouched. The Python client
+# returns {success: False, error: ...} on errors (it doesn't throw), so a
+# write that 4xx'd at the daemon would otherwise have synthetic subject /
+# root_entities attached, masking the failure for chained publish calls.
+class FailingClient:
+    def share(self, *args, **kwargs):
+        return {"success": False, "error": "context graph not registered"}
+provider._client = FailingClient()
+fail_result = json.loads(provider.handle_tool_call("dkg_share", {"content": "x", "context_graph_id": "cg:test"}))
+assert fail_result.get("success") is False, fail_result
+assert "subject" not in fail_result, fail_result
+assert "root_entities" not in fail_result, fail_result
+provider._client = client
 `;
     const result = spawnSync('python', ['-B', '-c', script], {
       cwd: process.cwd(),


### PR DESCRIPTION
## Summary

Mirrors the three SWM-write fixes PR #413 landed for OpenClaw, applied to Hermes' equivalent `dkg_share` path. All three bugs were in identical shape on both adapters because they share the same daemon code path; the OpenClaw side fixed them in #413 and #414 was filed to track the parallel Hermes work.

- **Constant-subject upsert** — `_handle_share` used a stable `urn:hermes:<agent_name>:shared` per agent. The publisher's delete-then-insert upsert (`packages/publisher/src/dkg-publisher.ts:422-429`) replaced each prior share. Now mints a unique `share_id` per call (`{int(time.time() * 1000)}-{secrets.token_hex(4)}`).
- **IRI-coerced content** — The storage layer's `formatTerm` (`packages/storage/src/adapters/oxigraph.ts:233-244`) wraps any object value not starting with `"` in angle brackets as an IRI. Raw `content` was being coerced to `<content>` — invalid IRI. Now wrapped via `_quote_literal()` before dispatch.
- **Partial `_quote_literal` escape coverage** — Covered only `\`, `"`, `\n`, `\r`. Inputs with `\t`/`\f`/`\b` or other ASCII control bytes (NUL, VT, DEL) produced invalid N-Triples literals. Extended to cover the full ECHAR set + UCHAR-encode any remaining 0x00-0x1F or 0x7F bytes. The canonical TypeScript helper has the same gap upstream — tracked separately in #416.
- **Response-shape parity with OpenClaw** — `_handle_share` now returns the minted `subject` and snake_case `root_entities` so agents chaining `dkg_share` → `dkg_shared_memory_publish({ root_entities: ... })` can pass the value through without case translation.

The extended `_quote_literal` also strengthens the other call sites that use it (e.g. `_write_memory_target_to_assertion`) — strictly a correctness improvement; no behavior change for content without control bytes.

## Related

- Fixes #414
- Mirrors #413 (OpenClaw side of the same hardening, already merged)
- #416 — canonical TS `escapeDkgRdfLiteral` has the same gap upstream; landing it would let us simplify the OpenClaw post-pass

## Files changed

| File | What |
|------|------|
| `packages/adapter-hermes/hermes-plugin/__init__.py` | Adds `secrets`/`time` imports. Updates `_handle_share` to mint unique subjects, wrap content via `_quote_literal()`, and return `subject` + `root_entities`. Extends `_quote_literal` with the full ECHAR set plus UCHAR encoding for remaining ASCII control bytes. |
| `packages/adapter-hermes/test/hermes-adapter.test.ts` | New test asserts: two consecutive shares produce distinct unique subjects; content is wrapped as N-Triples literal; full ECHAR set escaped; NUL/VT/DEL UCHAR-encoded; `sub_graph_name` still plumbs through; snake_case `root_entities` in response. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-adapter-hermes exec vitest run` — **62 passed** (was 61, +1 new dkg_share hardening test).
- [x] Cross-impact check: extended `_quote_literal` does not break the other call sites at `__init__.py:1992` and `:2189` (test re-derives expectations via the helper itself).
- [ ] Manual smoke (post-merge or pre-merge in dev): two successive `dkg_share` calls in Hermes chat against the same CG should both land in SWM (verify via SPARQL count); content with embedded newlines and quotes round-trips correctly; chained `dkg_share` → `dkg_shared_memory_publish({ root_entities: ... })` accepts the value as-is.

## Migration impact

Pure correctness fix. No daemon route or wire format changes. No tool surface changes. Existing call sites continue to work — they just now produce well-formed N-Triples literals and unique-per-share root entities instead of silently corrupting / overwriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)