### PR TITLE
Codex/issue 396 private policy swm gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -386,7 +386,9 @@ class AgentKeyStore {
   +selectDefaultOrFallbackSigner()
   +selectAllowedSigner(contextGraphId)
 }
-class AgentGateMetadata {
+class ContextGraphAccessMetadata {
+  +DKG_ACCESS_POLICY
+  +DKG_ALLOWED_PEER
   +DKG_ALLOWED_AGENT
   +DKG_PARTICIPANT_AGENT
 }
@@ -402,6 +404,8 @@ class GossipEnvelope {
 class SharedMemoryHandler {
   +handle(data, from)
   +verifyAgentEnvelope()
+  +contextGraphHasPrivateAccessPolicy()
+  +getContextGraphAllowedPeers()
 }
 class AsyncPublisher {
   +enqueue()
@@ -426,10 +430,10 @@ DaemonHTTPAPI --> AsyncPublisher : delegates lift jobs
 DKGAgent --> WorkingMemory : owns
 DKGAgent --> SharedWorkingMemory : gossips
 DKGAgent --> AgentKeyStore : selects local signing agent
-DKGAgent --> AgentGateMetadata : reads agent gates
+DKGAgent --> ContextGraphAccessMetadata : reads agent gates
 DKGAgent --> GossipEnvelope : wraps signed SWM gossip
 GossipEnvelope --> SharedMemoryHandler : delivered on SWM topic
-SharedMemoryHandler --> AgentGateMetadata : authorizes gated writers
+SharedMemoryHandler --> ContextGraphAccessMetadata : reads access policy and gates
 SharedMemoryHandler --> SharedWorkingMemory : stores accepted writes
 AsyncPublisher --> SharedWorkingMemory : reads source data
 AsyncPublisher --> VerifiedMemory : publishes
@@ -450,6 +454,18 @@ agent-gated. For gated graphs, `SharedMemoryHandler` requires a current signed
 `GossipEnvelope`, verifies the claimed agent address against the recovered
 signature, checks that the envelope context graph matches the payload, and
 rejects writers outside the allowed or participant agent set.
+
+Receiver-side access checks also treat explicit `DKG_ACCESS_POLICY = "private"`
+metadata in either the context graph `_meta` graph or the ontology graph as
+private context graph metadata. If such a graph has no `DKG_ALLOWED_PEER`,
+`DKG_ALLOWED_AGENT`, or `DKG_PARTICIPANT_AGENT` gate, `SharedMemoryHandler`
+fails closed and rejects received SWM gossip rather than accepting it as open.
+`DKG_ALLOWED_PEER` remains a libp2p peer-id allowlist, while the agent gates
+remain signed-envelope checks.
+
+`GossipEnvelope` signing authenticates the SWM writer and binds the payload to
+the claimed context graph, but it does not encrypt GossipSub payload bytes.
+Operators should treat SWM gossip contents as visible to subscribed peers.
 
 ```mermaid
 sequenceDiagram
@@ -481,11 +497,18 @@ else context graph is not agent-gated
   end
 end
 Gossip->>Handler: deliver SWM topic message
-Handler->>Meta: read accepted agent writers
-alt receiver graph is agent-gated
-  Handler->>Handler: require envelope and verify signature, timestamp, and writer
+Handler->>Meta: read DKG_ACCESS_POLICY, DKG_ALLOWED_PEER, and agent gates
+alt private access policy has no gossip allowlist
+  Handler->>Handler: reject write fail closed
+else gossip allowlist exists
+  opt agent writer gate exists
+    Handler->>Handler: require envelope and verify signature, timestamp, and writer
+  end
+  opt peer allowlist exists
+    Handler->>Handler: require sender peer id in DKG_ALLOWED_PEER
+  end
   Handler->>SWM: store accepted write
-else receiver graph is not agent-gated
+else receiver graph is open
   Handler->>Handler: decode envelope or legacy raw payload
   Handler->>SWM: store accepted write
 end

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -455,7 +455,7 @@ rejects writers outside the allowed or participant agent set.
 sequenceDiagram
 actor Writer as Local agent process
 participant Agent as DKGAgent
-participant Keys as LocalAgentKeys
+participant Keys as AgentKeyStore
 participant Meta as ContextGraphMeta
 participant Gossip as GossipSub
 participant Handler as SharedMemoryHandler

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -379,6 +379,29 @@ class DaemonHTTPAPI {
 class DKGAgent {
   +writeWorkingMemory()
   +promoteSharedMemory()
+  +encodeWorkspaceGossipMessage()
+  +publishWorkspaceGossip()
+}
+class AgentKeyStore {
+  +selectDefaultOrFallbackSigner()
+  +selectAllowedSigner(contextGraphId)
+}
+class AgentGateMetadata {
+  +DKG_ALLOWED_AGENT
+  +DKG_PARTICIPANT_AGENT
+}
+class GossipEnvelope {
+  +version
+  +type
+  +contextGraphId
+  +agentAddress
+  +timestamp
+  +signature
+  +payload
+}
+class SharedMemoryHandler {
+  +handle(data, from)
+  +verifyAgentEnvelope()
 }
 class AsyncPublisher {
   +enqueue()
@@ -402,8 +425,70 @@ DaemonHTTPAPI --> DKGAgent : delegates memory writes
 DaemonHTTPAPI --> AsyncPublisher : delegates lift jobs
 DKGAgent --> WorkingMemory : owns
 DKGAgent --> SharedWorkingMemory : gossips
+DKGAgent --> AgentKeyStore : selects local signing agent
+DKGAgent --> AgentGateMetadata : reads agent gates
+DKGAgent --> GossipEnvelope : wraps signed SWM gossip
+GossipEnvelope --> SharedMemoryHandler : delivered on SWM topic
+SharedMemoryHandler --> AgentGateMetadata : authorizes gated writers
+SharedMemoryHandler --> SharedWorkingMemory : stores accepted writes
 AsyncPublisher --> SharedWorkingMemory : reads source data
 AsyncPublisher --> VerifiedMemory : publishes
+```
+
+## Shared Memory Gossip Authentication
+
+Shared Working Memory gossip is authenticated at the agent layer when a local
+agent private key is available. For non-agent-gated context graphs, the sender
+prefers the configured default agent key and falls back to another local signing
+agent; if no local signing key exists, the legacy raw SWM payload remains valid.
+
+For agent-gated context graphs, `DKG_ALLOWED_AGENT` and
+`DKG_PARTICIPANT_AGENT` metadata define the accepted writer set. Outgoing SWM
+gossip must be signed by one of those local agents, otherwise the write is not
+broadcast. Receivers accept legacy raw SWM only when the graph is not
+agent-gated. For gated graphs, `SharedMemoryHandler` requires a current signed
+`GossipEnvelope`, verifies the claimed agent address against the recovered
+signature, checks that the envelope context graph matches the payload, and
+rejects writers outside the allowed or participant agent set.
+
+```mermaid
+sequenceDiagram
+actor Writer as Local agent process
+participant Agent as DKGAgent
+participant Keys as LocalAgentKeys
+participant Meta as ContextGraphMeta
+participant Gossip as GossipSub
+participant Handler as SharedMemoryHandler
+participant SWM as SharedWorkingMemory
+
+Writer->>Agent: share or promote SWM write
+Agent->>Meta: read DKG_ALLOWED_AGENT and DKG_PARTICIPANT_AGENT
+alt context graph is agent-gated
+  Agent->>Keys: select local allowed signing key
+  alt no allowed private key
+    Agent-->>Writer: abort SWM gossip
+  else allowed private key exists
+    Agent->>Agent: encode signed GossipEnvelope
+    Agent->>Gossip: publish signed envelope
+  end
+else context graph is not agent-gated
+  Agent->>Keys: select default or fallback local signing key
+  alt signing key exists
+    Agent->>Agent: encode signed GossipEnvelope
+    Agent->>Gossip: publish signed envelope
+  else no signing key
+    Agent->>Gossip: publish legacy raw SWM payload
+  end
+end
+Gossip->>Handler: deliver SWM topic message
+Handler->>Meta: read accepted agent writers
+alt receiver graph is agent-gated
+  Handler->>Handler: require envelope and verify signature, timestamp, and writer
+  Handler->>SWM: store accepted write
+else receiver graph is not agent-gated
+  Handler->>Handler: decode envelope or legacy raw payload
+  Handler->>SWM: store accepted write
+end
 ```
 
 ## Source Worker Workflow
@@ -484,7 +569,7 @@ participant Architecture as ARCHITECTURE.md
 participant Git as LocalGit
 
 User->>Workflow: continue from failure checkpoint
-Workflow->>Implementer: implement focused source-worker fix
+Workflow->>Implementer: implement focused code change
 Implementer-->>Workflow: code and tests changed
 Workflow->>Validation: run focused validation and code review
 Validation-->>Workflow: passed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ create assertion ──► write triples ──► promote ──► publish ─
 
 All on-chain publishing goes through SWM first — the chain transaction is a finality signal that seals data peers already hold via gossip. Assertions themselves carry a durable lifecycle record (`created → promoted → published → finalized`, or `discarded`) in the context graph's `_meta` graph, so their history is auditable independently of the data.
 
+SWM gossip is signed when the node has a local agent private key. Context graphs
+that declare `DKG_ALLOWED_AGENT` or `DKG_PARTICIPANT_AGENT` require a signed
+`GossipEnvelope` from one of those agent addresses; unsigned legacy SWM payloads
+are accepted only for context graphs without agent gates.
+
 ---
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ All on-chain publishing goes through SWM first — the chain transaction is a fi
 SWM gossip is signed when the node has a local agent private key. Context graphs
 that declare `DKG_ALLOWED_AGENT` or `DKG_PARTICIPANT_AGENT` require a signed
 `GossipEnvelope` from one of those agent addresses; unsigned legacy SWM payloads
-are accepted only for context graphs without agent gates.
+are accepted only for context graphs without agent gates. Signatures authenticate
+the writer, but do not encrypt GossipSub payload bytes.
 
 ---
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -8,7 +8,7 @@ Agent runtime for DKG V10. Provides the `DKGAgent` class — the primary entry p
 - **Wallet management** — `DKGAgentWallet` for Ed25519 (P2P identity) and ECDSA (on-chain signing) key pairs, with persistent key storage and operational wallet support
 - **Agent profiles** — `ProfileManager` for publishing and updating agent skill profiles to the agent registry paranet
 - **Discovery** — `DiscoveryClient` for finding other agents by name, skill keywords, or semantic search over published profiles
-- **Signed shared memory gossip** — SWM writes are wrapped in a signed gossip envelope when a local agent key is available, and agent-gated context graphs require a local `DKG_ALLOWED_AGENT` or `DKG_PARTICIPANT_AGENT` signing key before broadcasting
+- **Signed shared memory gossip** — SWM writes are wrapped in a signed gossip envelope when a local agent key is available, and agent-gated context graphs require a local `DKG_ALLOWED_AGENT` or `DKG_PARTICIPANT_AGENT` signing key before broadcasting; signatures authenticate writers, but do not encrypt GossipSub payload bytes
 - **Encrypted messaging** — Ed25519-to-X25519 key conversion, ECDH shared secrets, and encrypted P2P message channels
 - **Skill invocation** — `MessageHandler` for receiving and responding to skill requests; `SkillHandler` and `ChatHandler` for registering custom capabilities
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -8,6 +8,7 @@ Agent runtime for DKG V10. Provides the `DKGAgent` class — the primary entry p
 - **Wallet management** — `DKGAgentWallet` for Ed25519 (P2P identity) and ECDSA (on-chain signing) key pairs, with persistent key storage and operational wallet support
 - **Agent profiles** — `ProfileManager` for publishing and updating agent skill profiles to the agent registry paranet
 - **Discovery** — `DiscoveryClient` for finding other agents by name, skill keywords, or semantic search over published profiles
+- **Signed shared memory gossip** — SWM writes are wrapped in a signed gossip envelope when a local agent key is available, and agent-gated context graphs require a local `DKG_ALLOWED_AGENT` or `DKG_PARTICIPANT_AGENT` signing key before broadcasting
 - **Encrypted messaging** — Ed25519-to-X25519 key conversion, ECDH shared secrets, and encrypted P2P message channels
 - **Skill invocation** — `MessageHandler` for receiving and responding to skill requests; `SkillHandler` and `ChatHandler` for registering custom capabilities
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2865,15 +2865,18 @@ export class DKGAgent {
     return this._publish(contextGraphId, input as Quad[], undefined, thirdArg ?? fourthArg);
   }
 
-  private getDefaultWorkspaceGossipSigningAgent(): (AgentKeyRecord & { privateKey: string }) | null {
-    if (!this.defaultAgentAddress) return null;
-    const defaultAddress = this.defaultAgentAddress.toLowerCase();
+  private getWorkspaceGossipSigningAgent(): (AgentKeyRecord & { privateKey: string }) | null {
+    const defaultAddress = this.defaultAgentAddress?.toLowerCase();
+    let fallback: (AgentKeyRecord & { privateKey: string }) | null = null;
     for (const record of this.localAgents.values()) {
-      if (record.agentAddress.toLowerCase() === defaultAddress && record.privateKey) {
-        return { ...record, privateKey: record.privateKey };
+      if (!record.privateKey) continue;
+      const signingRecord = { ...record, privateKey: record.privateKey };
+      if (defaultAddress && record.agentAddress.toLowerCase() === defaultAddress) {
+        return signingRecord;
       }
+      fallback ??= signingRecord;
     }
-    return null;
+    return fallback;
   }
 
   private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
@@ -2924,7 +2927,7 @@ export class DKGAgent {
   ): Promise<(AgentKeyRecord & { privateKey: string }) | null> {
     const allowedAgents = await this.getContextGraphAgentGateAddresses(contextGraphId);
     if (!allowedAgents) {
-      return this.getDefaultWorkspaceGossipSigningAgent();
+      return this.getWorkspaceGossipSigningAgent();
     }
 
     const allowedSet = new Set(allowedAgents.map((agent) => agent.toLowerCase()));

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -530,6 +530,7 @@ export class DKGAgent {
   private started = false;
   private readonly subscribedContextGraphs = new Map<string, ContextGraphSub>();
   private readonly gossipRegistered = new Set<string>();
+  private readonly sharedMemoryGossipRegistered = new Set<string>();
   private readonly seenOnChainIds = new Set<string>();
   private readonly peerHealth = new Map<string, PeerHealth>();
   private readonly knownCorePeerIds = new Set<string>();
@@ -1729,10 +1730,33 @@ export class DKGAgent {
     contextGraphIds: string[],
   ): Promise<SharedMemorySyncResult> {
     const ctx = createOperationContext('sync');
+    const allowedContextGraphIds: string[] = [];
+    for (const contextGraphId of contextGraphIds) {
+      if (await this.canUseSharedMemoryForContextGraph(contextGraphId)) {
+        allowedContextGraphIds.push(contextGraphId);
+      } else {
+        this.log.warn(ctx, `Skipping SWM sync for unauthorized or unconfirmed context graph "${contextGraphId}"`);
+      }
+    }
+    if (allowedContextGraphIds.length === 0) {
+      return {
+        insertedTriples: 0,
+        fetchedMetaTriples: 0,
+        fetchedDataTriples: 0,
+        insertedMetaTriples: 0,
+        insertedDataTriples: 0,
+        bytesReceived: 0,
+        resumedPhases: 0,
+        emptyResponses: 0,
+        droppedDataTriples: 0,
+        failedPeers: 0,
+        deniedPhases: 0,
+      };
+    }
     return runSharedMemorySync({
       ctx,
       remotePeerId,
-      contextGraphIds,
+      contextGraphIds: allowedContextGraphIds,
       createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
       fetchSyncPages: this.fetchSyncPages.bind(this),
       processSharedMemoryBatch: (wsDataQuads, wsMetaQuads) => this.getOrCreateSyncVerifyWorker().processSharedMemoryBatch(wsDataQuads, wsMetaQuads),
@@ -2036,6 +2060,7 @@ export class DKGAgent {
       if (await this.hasConfirmedMetaState(contextGraphId)) {
         sub.metaSynced = true;
         this.persistContextGraphSubscription(contextGraphId);
+        this.queueSharedMemoryGossipSubscription(contextGraphId);
       }
     }
   }
@@ -2229,6 +2254,17 @@ export class DKGAgent {
       }`,
     );
     return ontologyResult.type === 'boolean' && ontologyResult.value === true;
+  }
+
+  private async hasConfirmedSharedMemoryMetaState(contextGraphId: string): Promise<boolean> {
+    return this.hasConfirmedMetaState(contextGraphId);
+  }
+
+  private async canUseSharedMemoryForContextGraph(contextGraphId: string): Promise<boolean> {
+    if (!(await this.hasConfirmedSharedMemoryMetaState(contextGraphId))) {
+      return false;
+    }
+    return this.canReadContextGraph(contextGraphId);
   }
 
   private async verifySyncedDataInWorker(
@@ -2922,6 +2958,16 @@ export class DKGAgent {
     return sawAgentGate ? agents : null;
   }
 
+  private hasLocalAgentInGate(agentGateAddresses: readonly string[]): boolean {
+    const allowedSet = new Set(agentGateAddresses.map((agent) => agent.toLowerCase()));
+    for (const record of this.localAgents.values()) {
+      if (allowedSet.has(record.agentAddress.toLowerCase())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private async resolveWorkspaceGossipSigningAgent(
     contextGraphId: string,
   ): Promise<(AgentKeyRecord & { privateKey: string }) | null> {
@@ -3460,6 +3506,19 @@ export class DKGAgent {
       throw new Error(`SPARQL rejected: ${readOnlyGuard.reason}`);
     }
 
+    const targetsSharedMemory =
+      opts.graphSuffix === '_shared_memory'
+      || opts.includeSharedMemory === true
+      || opts.view === 'shared-working-memory';
+    if (
+      opts.contextGraphId
+      && targetsSharedMemory
+      && !(await this.canUseSharedMemoryForContextGraph(opts.contextGraphId))
+    ) {
+      this.log.info(ctx, `Shared memory query denied for unauthorized or unconfirmed context graph "${opts.contextGraphId}"`);
+      return emptyQueryResultForKind(sparql);
+    }
+
     if (opts.contextGraphId && !(await this.canReadContextGraph(opts.contextGraphId))) {
       this.log.info(ctx, `Query denied for private context graph "${opts.contextGraphId}"`);
       // A-1 follow-up review: synthetic deny must match the SPARQL form
@@ -3614,9 +3673,26 @@ export class DKGAgent {
       return true;
     }
 
+    const agentGateAddresses = await this.getContextGraphAgentGateAddresses(contextGraphId);
+    const allowedPeers = await this.getContextGraphAllowedPeers(contextGraphId);
+
+    // Mixed legacy peer-id and V10 agent gates are conjunctive: a node must
+    // be invited by peer id and also hold a local allowed agent identity.
+    if (agentGateAddresses !== null && allowedPeers !== null) {
+      return allowedPeers.includes(this.peerId) && this.hasLocalAgentInGate(agentGateAddresses);
+    }
+
+    if (agentGateAddresses !== null && this.hasLocalAgentInGate(agentGateAddresses)) {
+      return true;
+    }
+
     const participants = await this.getPrivateContextGraphParticipants(contextGraphId);
 
-    // No participant list at all → allow creator / locally-subscribed nodes
+    if ((!participants || participants.length === 0) && allowedPeers !== null) {
+      return allowedPeers.includes(this.peerId);
+    }
+
+    // No participant or peer list at all → allow creator / locally-subscribed nodes
     if (!participants || participants.length === 0) {
       return this.subscribedContextGraphs.has(contextGraphId)
         || (this.config.syncContextGraphs ?? []).includes(contextGraphId);
@@ -3640,7 +3716,6 @@ export class DKGAgent {
     // Legacy peer-ID allowlist: `inviteToContextGraph` writes `DKG_ALLOWED_PEER`
     // quads. Honor them for local reads so a peer-ID-invited node can query
     // the data it just synced.
-    const allowedPeers = await this.getContextGraphAllowedPeers(contextGraphId);
     if (allowedPeers?.includes(this.peerId)) {
       return true;
     }
@@ -3778,6 +3853,7 @@ export class DKGAgent {
 
     // Idempotent: skip if gossip handlers already installed for this context graph.
     if (this.gossipRegistered.has(contextGraphId)) {
+      this.queueSharedMemoryGossipSubscription(contextGraphId);
       const existing = this.subscribedContextGraphs.get(contextGraphId);
       if (!existing?.subscribed) {
         this.setContextGraphSubscription(
@@ -3791,11 +3867,9 @@ export class DKGAgent {
     this.gossipRegistered.add(contextGraphId);
 
     const publishTopic = paranetPublishTopic(contextGraphId);
-    const swmTopic = paranetWorkspaceTopic(contextGraphId);
     const appTopic = paranetAppTopic(contextGraphId);
 
     this.gossip.subscribe(publishTopic);
-    this.gossip.subscribe(swmTopic);
     this.gossip.subscribe(appTopic);
 
     const existing = this.subscribedContextGraphs.get(contextGraphId);
@@ -3810,10 +3884,7 @@ export class DKGAgent {
       await gph.handlePublishMessage(data, contextGraphId, undefined, from);
     });
 
-    this.gossip.onMessage(swmTopic, async (_topic, data, from) => {
-      const wh = this.getOrCreateSharedMemoryHandler();
-      await wh.handle(data, from);
-    });
+    this.queueSharedMemoryGossipSubscription(contextGraphId);
 
     const updateTopic = paranetUpdateTopic(contextGraphId);
     this.gossip.subscribe(updateTopic);
@@ -3827,6 +3898,32 @@ export class DKGAgent {
     this.gossip.onMessage(finalizationTopic, async (_topic, data) => {
       const fh = this.getOrCreateFinalizationHandler();
       await fh.handleFinalizationMessage(data, contextGraphId);
+    });
+  }
+
+  private queueSharedMemoryGossipSubscription(contextGraphId: string): void {
+    void this.ensureSharedMemoryGossipSubscription(contextGraphId).catch((err) => {
+      this.log.warn(
+        createOperationContext('system'),
+        `SWM gossip subscription check failed for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
+
+  private async ensureSharedMemoryGossipSubscription(contextGraphId: string): Promise<void> {
+    if (this.sharedMemoryGossipRegistered.has(contextGraphId)) return;
+    const ctx = createOperationContext('system');
+    if (!(await this.canUseSharedMemoryForContextGraph(contextGraphId))) {
+      this.log.warn(ctx, `SWM gossip subscription denied for "${contextGraphId}": local node is not authorized`);
+      return;
+    }
+
+    const swmTopic = paranetWorkspaceTopic(contextGraphId);
+    this.sharedMemoryGossipRegistered.add(contextGraphId);
+    this.gossip.subscribe(swmTopic);
+    this.gossip.onMessage(swmTopic, async (_topic, data, from) => {
+      const wh = this.getOrCreateSharedMemoryHandler();
+      await wh.handle(data, from);
     });
   }
 
@@ -6549,6 +6646,7 @@ export class DKGAgent {
       verifyIdentity: typeof verifyIdentity === 'function' ? verifyIdentity.bind(this.chain) : undefined,
       getParticipants: (contextGraphId) => this.getPrivateContextGraphParticipants(contextGraphId),
       getAllowedPeers: (contextGraphId) => this.getContextGraphAllowedPeers(contextGraphId),
+      getAgentGateAddresses: (contextGraphId) => this.getContextGraphAgentGateAddresses(contextGraphId),
       refreshMetaFromCurator: (contextGraphId) => this.refreshMetaFromCurator(contextGraphId),
       logWarn: (ctx, message) => this.log.warn(ctx, message),
       logInfo: (ctx, message) => this.log.info(ctx, message),

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2056,10 +2056,12 @@ export class DKGAgent {
   private async refreshMetaSyncedFlags(contextGraphIds: Iterable<string>): Promise<void> {
     for (const contextGraphId of contextGraphIds) {
       const sub = this.subscribedContextGraphs.get(contextGraphId);
-      if (!sub || sub.metaSynced === true) continue;
+      if (!sub) continue;
       if (await this.hasConfirmedMetaState(contextGraphId)) {
-        sub.metaSynced = true;
-        this.persistContextGraphSubscription(contextGraphId);
+        if (sub.metaSynced !== true) {
+          sub.metaSynced = true;
+          this.persistContextGraphSubscription(contextGraphId);
+        }
         this.queueSharedMemoryGossipSubscription(contextGraphId);
       }
     }
@@ -2260,11 +2262,17 @@ export class DKGAgent {
     return this.hasConfirmedMetaState(contextGraphId);
   }
 
-  private async canUseSharedMemoryForContextGraph(contextGraphId: string): Promise<boolean> {
+  private async canUseSharedMemoryForContextGraph(
+    contextGraphId: string,
+    opts: { callerAgentAddress?: string } = {},
+  ): Promise<boolean> {
     if (!(await this.hasConfirmedSharedMemoryMetaState(contextGraphId))) {
       return false;
     }
-    return this.canReadContextGraph(contextGraphId);
+    return this.canReadContextGraph(contextGraphId, {
+      callerAgentAddress: opts.callerAgentAddress,
+      allowSubscriptionFallback: false,
+    });
   }
 
   private async verifySyncedDataInWorker(
@@ -3510,22 +3518,6 @@ export class DKGAgent {
       opts.graphSuffix === '_shared_memory'
       || opts.includeSharedMemory === true
       || opts.view === 'shared-working-memory';
-    if (
-      opts.contextGraphId
-      && targetsSharedMemory
-      && !(await this.canUseSharedMemoryForContextGraph(opts.contextGraphId))
-    ) {
-      this.log.info(ctx, `Shared memory query denied for unauthorized or unconfirmed context graph "${opts.contextGraphId}"`);
-      return emptyQueryResultForKind(sparql);
-    }
-
-    if (opts.contextGraphId && !(await this.canReadContextGraph(opts.contextGraphId))) {
-      this.log.info(ctx, `Query denied for private context graph "${opts.contextGraphId}"`);
-      // A-1 follow-up review: synthetic deny must match the SPARQL form
-      // so ASK / CONSTRUCT / DESCRIBE clients get `false` / empty-quads
-      // instead of a SELECT-shaped `{ bindings: [] }`.
-      return emptyQueryResultForKind(sparql);
-    }
 
     // A-1: Working-Memory isolation. When the caller is authenticated
     // (an outer layer like the daemon's `/api/query` route has resolved
@@ -3564,6 +3556,27 @@ export class DKGAgent {
       );
     }
     const callerAgentAddressStr = opts.callerAgentAddress;
+
+    if (
+      opts.contextGraphId
+      && targetsSharedMemory
+      && !(await this.canUseSharedMemoryForContextGraph(opts.contextGraphId, {
+        callerAgentAddress: callerAgentAddressStr,
+      }))
+    ) {
+      this.log.info(ctx, `Shared memory query denied for unauthorized or unconfirmed context graph "${opts.contextGraphId}"`);
+      return emptyQueryResultForKind(sparql);
+    }
+
+    if (opts.contextGraphId && !(await this.canReadContextGraph(opts.contextGraphId, {
+      callerAgentAddress: callerAgentAddressStr,
+    }))) {
+      this.log.info(ctx, `Query denied for private context graph "${opts.contextGraphId}"`);
+      // A-1 follow-up review: synthetic deny must match the SPARQL form
+      // so ASK / CONSTRUCT / DESCRIBE clients get `false` / empty-quads
+      // instead of a SELECT-shaped `{ bindings: [] }`.
+      return emptyQueryResultForKind(sparql);
+    }
 
     // A-1 canonicalization (Codex PR #242 iter-9 re-review): the
     // node's default agent has TWO identifiers that key the same WM
@@ -3637,7 +3650,9 @@ export class DKGAgent {
     // read to prevent data leakage via unscoped or FROM-less SPARQL.
     let excludeGraphPrefixes: string[] | undefined;
     if (!opts.contextGraphId) {
-      excludeGraphPrefixes = await this.getDisallowedGraphPrefixes();
+      excludeGraphPrefixes = await this.getDisallowedGraphPrefixes({
+        callerAgentAddress: callerAgentAddressStr,
+      });
       // Per spec Axiom 1 every shared query must be resolved within a CG.
       // Reject explicit GRAPH/FROM clauses that reference private CGs the
       // caller cannot read — post-filtering alone cannot prevent leaks via
@@ -3668,7 +3683,19 @@ export class DKGAgent {
     return result;
   }
 
-  private async canReadContextGraph(contextGraphId: string): Promise<boolean> {
+  private isAgentAddressAllowed(agentAddress: string | undefined, agentGateAddresses: readonly string[]): boolean {
+    if (!agentAddress) return false;
+    const normalized = agentAddress.toLowerCase();
+    return agentGateAddresses.some((agent) => agent.toLowerCase() === normalized);
+  }
+
+  private async canReadContextGraph(
+    contextGraphId: string,
+    opts: {
+      callerAgentAddress?: string;
+      allowSubscriptionFallback?: boolean;
+    } = {},
+  ): Promise<boolean> {
     if (!(await this.isPrivateContextGraph(contextGraphId))) {
       return true;
     }
@@ -3678,12 +3705,18 @@ export class DKGAgent {
 
     // Mixed legacy peer-id and V10 agent gates are conjunctive: a node must
     // be invited by peer id and also hold a local allowed agent identity.
+    const agentGateAllowed = agentGateAddresses === null
+      ? false
+      : opts.callerAgentAddress
+        ? this.isAgentAddressAllowed(opts.callerAgentAddress, agentGateAddresses)
+        : this.hasLocalAgentInGate(agentGateAddresses);
+
     if (agentGateAddresses !== null && allowedPeers !== null) {
-      return allowedPeers.includes(this.peerId) && this.hasLocalAgentInGate(agentGateAddresses);
+      return allowedPeers.includes(this.peerId) && agentGateAllowed;
     }
 
-    if (agentGateAddresses !== null && this.hasLocalAgentInGate(agentGateAddresses)) {
-      return true;
+    if (agentGateAddresses !== null) {
+      return agentGateAllowed;
     }
 
     const participants = await this.getPrivateContextGraphParticipants(contextGraphId);
@@ -3692,10 +3725,22 @@ export class DKGAgent {
       return allowedPeers.includes(this.peerId);
     }
 
-    // No participant or peer list at all → allow creator / locally-subscribed nodes
+    // No participant or peer list at all. Durable CG reads preserve the legacy
+    // subscribed-node fallback, but SWM must fail closed here because SWM
+    // GossipSub carries plaintext bytes.
     if (!participants || participants.length === 0) {
+      if (opts.allowSubscriptionFallback === false) {
+        return false;
+      }
       return this.subscribedContextGraphs.has(contextGraphId)
         || (this.config.syncContextGraphs ?? []).includes(contextGraphId);
+    }
+
+    if (
+      opts.callerAgentAddress
+      && participants.some((p) => p.toLowerCase() === opts.callerAgentAddress!.toLowerCase())
+    ) {
+      return true;
     }
 
     // Check if any local agent address is in the participants list
@@ -3723,7 +3768,7 @@ export class DKGAgent {
     // Edge nodes without an on-chain identity (identityId 0n) fall back to
     // subscription-based access — the subscription itself is an authorization
     // (the node was invited or created this CG).
-    if (myIdentityId === 0n) {
+    if (myIdentityId === 0n && opts.allowSubscriptionFallback !== false) {
       return this.subscribedContextGraphs.has(contextGraphId);
     }
 
@@ -3734,7 +3779,7 @@ export class DKGAgent {
    * Returns graph URI prefixes for private CGs the caller cannot read.
    * Used to exclude them from unscoped queries.
    */
-  private async getDisallowedGraphPrefixes(): Promise<string[]> {
+  private async getDisallowedGraphPrefixes(opts: { callerAgentAddress?: string } = {}): Promise<string[]> {
     const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
     const result = await this.store.query(
       `SELECT ?cg WHERE {
@@ -3753,7 +3798,9 @@ export class DKGAgent {
       const match = cgUri.match(/^<?did:dkg:context-graph:([^>]+)>?$/);
       if (!match) continue;
       const contextGraphId = match[1];
-      if (await this.canReadContextGraph(contextGraphId)) continue;
+      if (await this.canReadContextGraph(contextGraphId, {
+        callerAgentAddress: opts.callerAgentAddress,
+      })) continue;
       // Exclude all named graphs under this CG (data, _meta, _shared_memory, etc.)
       prefixes.push(`did:dkg:context-graph:${contextGraphId}`);
     }
@@ -3902,7 +3949,7 @@ export class DKGAgent {
   }
 
   private queueSharedMemoryGossipSubscription(contextGraphId: string): void {
-    void this.ensureSharedMemoryGossipSubscription(contextGraphId).catch((err) => {
+    void this.reconcileSharedMemoryGossipSubscription(contextGraphId).catch((err) => {
       this.log.warn(
         createOperationContext('system'),
         `SWM gossip subscription check failed for "${contextGraphId}": ${err instanceof Error ? err.message : String(err)}`,
@@ -3910,15 +3957,23 @@ export class DKGAgent {
     });
   }
 
-  private async ensureSharedMemoryGossipSubscription(contextGraphId: string): Promise<void> {
-    if (this.sharedMemoryGossipRegistered.has(contextGraphId)) return;
+  private async reconcileSharedMemoryGossipSubscription(contextGraphId: string): Promise<void> {
+    const swmTopic = paranetWorkspaceTopic(contextGraphId);
+    const isRegistered = this.sharedMemoryGossipRegistered.has(contextGraphId);
     const ctx = createOperationContext('system');
     if (!(await this.canUseSharedMemoryForContextGraph(contextGraphId))) {
+      if (isRegistered) {
+        this.gossip.unsubscribe(swmTopic);
+        this.sharedMemoryGossipRegistered.delete(contextGraphId);
+        this.log.warn(ctx, `SWM gossip unsubscribed for "${contextGraphId}": local node is no longer authorized`);
+        return;
+      }
       this.log.warn(ctx, `SWM gossip subscription denied for "${contextGraphId}": local node is not authorized`);
       return;
     }
 
-    const swmTopic = paranetWorkspaceTopic(contextGraphId);
+    if (isRegistered) return;
+
     this.sharedMemoryGossipRegistered.add(contextGraphId);
     this.gossip.subscribe(swmTopic);
     this.gossip.onMessage(swmTopic, async (_topic, data, from) => {
@@ -4864,6 +4919,7 @@ export class DKGAgent {
       object: `"${agentAddress}"`,
     });
     this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
+    this.queueSharedMemoryGossipSubscription(contextGraphId);
 
     this.log.info(ctx, `Removed agent ${agentAddress} from context graph "${contextGraphId}"`);
   }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -10,6 +10,10 @@ import {
   computeACKDigest,
   encodePublishRequest,
   encodeKAUpdateRequest,
+  encodeGossipEnvelope,
+  computeGossipSigningPayload,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
   encodeFinalizationMessage, type FinalizationMessageMsg,
   getGenesisQuads, computeNetworkId, SYSTEM_PARANETS, DKG_ONTOLOGY,
   Logger, createOperationContext, sparqlString, escapeSparqlLiteral,
@@ -2861,6 +2865,118 @@ export class DKGAgent {
     return this._publish(contextGraphId, input as Quad[], undefined, thirdArg ?? fourthArg);
   }
 
+  private getDefaultWorkspaceGossipSigningAgent(): (AgentKeyRecord & { privateKey: string }) | null {
+    if (!this.defaultAgentAddress) return null;
+    const defaultAddress = this.defaultAgentAddress.toLowerCase();
+    for (const record of this.localAgents.values()) {
+      if (record.agentAddress.toLowerCase() === defaultAddress && record.privateKey) {
+        return { ...record, privateKey: record.privateKey };
+      }
+    }
+    return null;
+  }
+
+  private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
+    const seen = new Set<string>();
+    const agents: string[] = [];
+    let sawAgentGate = false;
+    const add = (value: string | undefined) => {
+      if (!value || !ethers.isAddress(value)) return;
+      const checksum = ethers.getAddress(value);
+      const key = checksum.toLowerCase();
+      if (seen.has(key)) return;
+      seen.add(key);
+      agents.push(checksum);
+    };
+
+    const subscriptionAgents = this.subscribedContextGraphs.get(contextGraphId)?.participantAgents ?? [];
+    if (subscriptionAgents.length > 0) sawAgentGate = true;
+    for (const agentAddress of subscriptionAgents) {
+      add(agentAddress);
+    }
+
+    const contextGraphUri = paranetDataGraphUri(contextGraphId);
+    const cgMetaGraph = paranetMetaGraphUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?agent WHERE {
+        GRAPH <${cgMetaGraph}> {
+          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
+          UNION
+          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
+        }
+      }`,
+    );
+    if (result.type === 'bindings') {
+      if (result.bindings.length > 0) sawAgentGate = true;
+      for (const row of result.bindings) {
+        const raw = row['agent'];
+        if (typeof raw === 'string') {
+          add(raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, ''));
+        }
+      }
+    }
+
+    return sawAgentGate ? agents : null;
+  }
+
+  private async resolveWorkspaceGossipSigningAgent(
+    contextGraphId: string,
+  ): Promise<(AgentKeyRecord & { privateKey: string }) | null> {
+    const allowedAgents = await this.getContextGraphAgentGateAddresses(contextGraphId);
+    if (!allowedAgents) {
+      return this.getDefaultWorkspaceGossipSigningAgent();
+    }
+
+    const allowedSet = new Set(allowedAgents.map((agent) => agent.toLowerCase()));
+    for (const record of this.localAgents.values()) {
+      if (record.privateKey && allowedSet.has(record.agentAddress.toLowerCase())) {
+        return { ...record, privateKey: record.privateKey };
+      }
+    }
+
+    throw new Error(`Cannot gossip SWM write for agent-gated context graph "${contextGraphId}": no local allowed signing agent key`);
+  }
+
+  private async encodeWorkspaceGossipMessage(contextGraphId: string, message: Uint8Array): Promise<Uint8Array> {
+    const signer = await this.resolveWorkspaceGossipSigningAgent(contextGraphId);
+    if (!signer) {
+      return message;
+    }
+
+    const timestamp = new Date().toISOString();
+    const payload = new Uint8Array(message);
+    const signingPayload = computeGossipSigningPayload(
+      GOSSIP_TYPE_WORKSPACE_PUBLISH,
+      contextGraphId,
+      timestamp,
+      payload,
+    );
+    const signature = await new ethers.Wallet(signer.privateKey).signMessage(signingPayload);
+    return encodeGossipEnvelope({
+      version: GOSSIP_ENVELOPE_VERSION,
+      type: GOSSIP_TYPE_WORKSPACE_PUBLISH,
+      contextGraphId,
+      agentAddress: signer.agentAddress,
+      timestamp,
+      signature: ethers.getBytes(signature),
+      payload,
+    });
+  }
+
+  private async publishWorkspaceGossip(
+    contextGraphId: string,
+    message: Uint8Array,
+    ctx: OperationContext,
+  ): Promise<void> {
+    const topic = paranetWorkspaceTopic(contextGraphId);
+    const wireMessage = await this.encodeWorkspaceGossipMessage(contextGraphId, message);
+    try {
+      await this.gossip.publish(topic, wireMessage);
+    } catch {
+      this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
+    }
+  }
+
   async publishAsync(
     contextGraphIdOrUal: string,
     content: PublishAsyncContent,
@@ -2938,12 +3054,7 @@ export class DKGAgent {
     });
 
     if (!opts?.localOnly) {
-      const topic = paranetWorkspaceTopic(contextGraphId);
-      try {
-        await this.gossip.publish(topic, message);
-      } catch {
-        this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
-      }
+      await this.publishWorkspaceGossip(contextGraphId, message, ctx);
     }
 
     return { captureID };
@@ -3063,12 +3174,7 @@ export class DKGAgent {
       subGraphName: opts?.subGraphName,
     });
     if (!opts?.localOnly) {
-      const topic = paranetWorkspaceTopic(contextGraphId);
-      try {
-        await this.gossip.publish(topic, message);
-      } catch {
-        this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
-      }
+      await this.publishWorkspaceGossip(contextGraphId, message, ctx);
     }
     return { shareOperationId };
   }
@@ -3094,12 +3200,7 @@ export class DKGAgent {
       subGraphName: opts?.subGraphName,
     });
     if (!opts?.localOnly) {
-      const topic = paranetWorkspaceTopic(contextGraphId);
-      try {
-        await this.gossip.publish(topic, message);
-      } catch {
-        this.log.warn(ctx, `No peers subscribed to ${topic} yet`);
-      }
+      await this.publishWorkspaceGossip(contextGraphId, message, ctx);
     }
     return { shareOperationId };
   }
@@ -3767,6 +3868,7 @@ export class DKGAgent {
       this.sharedMemoryHandler = new SharedMemoryHandler(this.store, this.eventBus, {
         sharedMemoryOwnedEntities: this.workspaceOwnedEntities,
         writeLocks: this.writeLocks,
+        localAgentAddresses: () => [...this.localAgents.keys()],
       });
     }
     return this.sharedMemoryHandler;
@@ -8084,9 +8186,8 @@ export class DKGAgent {
           { ...opts, publisherPeerId: agent.node.peerId.toString() },
         );
         if (gossipMessage) {
-          const topic = paranetWorkspaceTopic(contextGraphId);
           try {
-            await agent.gossip.publish(topic, gossipMessage);
+            await agent.publishWorkspaceGossip(contextGraphId, gossipMessage, createOperationContext('share'));
           } catch (err: any) {
             agent.log.warn(createOperationContext('share'), `Promote gossip failed (local SWM committed): ${err?.message ?? err}`);
           }

--- a/packages/agent/src/sync/auth/request-authorize.ts
+++ b/packages/agent/src/sync/auth/request-authorize.ts
@@ -22,6 +22,7 @@ interface AuthorizeSyncRequestParams {
   verifyIdentity?: (recoveredAddress: string, claimedIdentityId: bigint) => Promise<boolean>;
   getParticipants: (contextGraphId: string) => Promise<string[] | null>;
   getAllowedPeers: (contextGraphId: string) => Promise<string[] | null>;
+  getAgentGateAddresses: (contextGraphId: string) => Promise<string[] | null>;
   refreshMetaFromCurator: (contextGraphId: string) => Promise<boolean>;
   logWarn: (ctx: OperationContext, message: string) => void;
   logInfo: (ctx: OperationContext, message: string) => void;
@@ -39,6 +40,7 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
     verifyIdentity,
     getParticipants,
     getAllowedPeers,
+    getAgentGateAddresses,
     refreshMetaFromCurator,
     logWarn,
     logInfo,
@@ -114,38 +116,38 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
   }
 
   let participants = await getParticipants(request.contextGraphId);
-  let allowed = participants?.some((p) =>
+  let agentGateAddresses = await getAgentGateAddresses(request.contextGraphId);
+  let allowedPeers = await getAllowedPeers(request.contextGraphId);
+  const isParticipantAllowed = () => participants?.some((p) =>
     p.toLowerCase() === recoveredAddress.toLowerCase() ||
     (requesterIdentityId > 0n && p === String(requesterIdentityId)),
   ) ?? false;
-
-  if (!allowed) {
-    const allowedPeers = await getAllowedPeers(request.contextGraphId);
-    if (allowedPeers?.includes(remotePeerId)) {
-      allowed = true;
+  const isAgentGateAllowed = () => agentGateAddresses?.some((agent) =>
+    agent.toLowerCase() === recoveredAddress.toLowerCase(),
+  ) ?? false;
+  const isPeerAllowed = () => allowedPeers?.includes(remotePeerId) ?? false;
+  const resolveAllowed = () => {
+    if (agentGateAddresses !== null && allowedPeers !== null) {
+      return isPeerAllowed() && isAgentGateAllowed();
     }
-  }
+    return isParticipantAllowed() || isPeerAllowed();
+  };
+
+  let allowed = resolveAllowed();
 
   if (!allowed) {
     const refreshed = await refreshMetaFromCurator(request.contextGraphId);
     if (refreshed) {
       participants = await getParticipants(request.contextGraphId);
-      allowed = participants?.some((p) =>
-        p.toLowerCase() === recoveredAddress.toLowerCase() ||
-        p === String(requesterIdentityId),
-      ) ?? false;
-      if (!allowed) {
-        const freshPeers = await getAllowedPeers(request.contextGraphId);
-        if (freshPeers?.includes(remotePeerId)) {
-          allowed = true;
-        }
-      }
+      agentGateAddresses = await getAgentGateAddresses(request.contextGraphId);
+      allowedPeers = await getAllowedPeers(request.contextGraphId);
+      allowed = resolveAllowed();
     }
   }
 
   logInfo(
     ctx,
-    `Private sync auth for "${request.contextGraphId}": identityId=${requesterIdentityId.toString()} signer=${recoveredAddress} requesterAgentAddress=${request.requesterAgentAddress ?? 'n/a'} participantCount=${participants?.length ?? 0} allowed=${allowed}`,
+    `Private sync auth for "${request.contextGraphId}": identityId=${requesterIdentityId.toString()} signer=${recoveredAddress} requesterAgentAddress=${request.requesterAgentAddress ?? 'n/a'} participantCount=${participants?.length ?? 0} agentGateCount=${agentGateAddresses?.length ?? 0} peerAllowed=${isPeerAllowed()} allowed=${allowed}`,
   );
 
   if (allowed) {

--- a/packages/agent/test/swm-agent-gate-access.test.ts
+++ b/packages/agent/test/swm-agent-gate-access.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  contextGraphSharedMemoryUri,
+  DKG_ONTOLOGY,
+  paranetWorkspaceTopic,
+  SYSTEM_PARANETS,
+} from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent, agentFromPrivateKey, type AgentKeyRecord } from '../src/index.js';
+
+const LOCAL_PEER_ID = '12D3KooWAgentGateLocal';
+
+interface DKGAgentInternals {
+  localAgents: Map<string, AgentKeyRecord>;
+  defaultAgentAddress?: string;
+  canReadContextGraph(contextGraphId: string): Promise<boolean>;
+  canUseSharedMemoryForContextGraph(contextGraphId: string): Promise<boolean>;
+}
+
+class FakeGossip {
+  readonly subscribed = new Set<string>();
+
+  subscribe(topic: string): void {
+    this.subscribed.add(topic);
+  }
+
+  unsubscribe(topic: string): void {
+    this.subscribed.delete(topic);
+  }
+
+  onMessage(): void {}
+
+  async publish(): Promise<void> {}
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+async function createAgent(): Promise<{ agent: DKGAgent; internals: DKGAgentInternals; gossip: FakeGossip }> {
+  const agent = await DKGAgent.create({
+    name: `SwmAgentGateAccess-${Math.random().toString(36).slice(2)}`,
+    chainAdapter: new MockChainAdapter(),
+  });
+  const gossip = new FakeGossip();
+  Object.defineProperty(agent, 'peerId', { value: LOCAL_PEER_ID, configurable: true });
+  (agent as unknown as { gossip: FakeGossip }).gossip = gossip;
+  return { agent, internals: agent as unknown as DKGAgentInternals, gossip };
+}
+
+async function insertAccessMeta(
+  agent: DKGAgent,
+  contextGraphId: string,
+  options: {
+    accessPolicy?: 'private' | 'public';
+    allowedPeers?: string[];
+    agentGatePredicate?: string;
+    agentAddress?: string;
+  },
+): Promise<void> {
+  const contextGraphUri = contextGraphDataUri(contextGraphId);
+  const metaGraph = contextGraphMetaUri(contextGraphId);
+  const quads = [
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_PARANET,
+      graph: metaGraph,
+    },
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+      object: `"${options.accessPolicy ?? 'private'}"`,
+      graph: metaGraph,
+    },
+  ];
+
+  for (const peerId of options.allowedPeers ?? []) {
+    quads.push({
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+      object: `"${peerId}"`,
+      graph: metaGraph,
+    });
+  }
+
+  if (options.agentGatePredicate && options.agentAddress) {
+    quads.push({
+      subject: contextGraphUri,
+      predicate: options.agentGatePredicate,
+      object: `"${options.agentAddress}"`,
+      graph: metaGraph,
+    });
+  }
+
+  await agent.store.insert(quads);
+}
+
+async function insertOntologyContextGraph(agent: DKGAgent, contextGraphId: string): Promise<void> {
+  await agent.store.insert([{
+    subject: contextGraphDataUri(contextGraphId),
+    predicate: DKG_ONTOLOGY.RDF_TYPE,
+    object: DKG_ONTOLOGY.DKG_PARANET,
+    graph: contextGraphDataUri(SYSTEM_PARANETS.ONTOLOGY),
+  }]);
+}
+
+async function insertSharedMemorySecret(agent: DKGAgent, contextGraphId: string, value: string): Promise<string> {
+  const subject = `urn:test:${contextGraphId}:root:secret`;
+  await agent.store.insert([{
+    subject,
+    predicate: 'https://schema.org/name',
+    object: `"${value}"`,
+    graph: contextGraphSharedMemoryUri(contextGraphId),
+  }]);
+  return subject;
+}
+
+async function querySharedMemoryName(agent: DKGAgent, contextGraphId: string, subject: string) {
+  return agent.query(
+    `SELECT ?name WHERE { <${subject}> <https://schema.org/name> ?name }`,
+    { contextGraphId, view: 'shared-working-memory' },
+  );
+}
+
+describe('DKGAgent SWM agent-gate access', () => {
+  it('does not subscribe to the SWM topic before context graph metadata is confirmed', async () => {
+    const { agent, gossip } = await createAgent();
+    const contextGraphId = 'swm-agent-unknown';
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(false);
+  });
+
+  it('subscribes to SWM for ontology-confirmed open context graphs without local _meta', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'swm-open-ontology-only';
+    await insertOntologyContextGraph(agent, contextGraphId);
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(await internals.canReadContextGraph(contextGraphId)).toBe(true);
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId)).toBe(true);
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(true);
+  });
+
+  it('preserves peer-only SWM access for a DKG_ALLOWED_PEER context graph', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'swm-peer-invite-read';
+    await insertAccessMeta(agent, contextGraphId, {
+      allowedPeers: [agent.peerId],
+    });
+    const subject = await insertSharedMemorySecret(agent, contextGraphId, 'PeerInviteSecret');
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(await internals.canReadContextGraph(contextGraphId)).toBe(true);
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId)).toBe(true);
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(true);
+    const result = await querySharedMemoryName(agent, contextGraphId, subject);
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]?.['name']).toBe('"PeerInviteSecret"');
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('denies peer-allowed/no-agent SWM receive, sync, and query for %s', async (_label, predicate) => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = `swm-agent-deny-${_label.toLowerCase()}`;
+    const allowed = ethers.Wallet.createRandom();
+    await insertAccessMeta(agent, contextGraphId, {
+      allowedPeers: [agent.peerId],
+      agentGatePredicate: predicate,
+      agentAddress: allowed.address,
+    });
+    const subject = await insertSharedMemorySecret(agent, contextGraphId, `${_label}Secret`);
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(await internals.canReadContextGraph(contextGraphId)).toBe(false);
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId)).toBe(false);
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(false);
+    await expect(agent.syncSharedMemoryFromPeer('12D3KooWAgentGateRemote', [contextGraphId])).resolves.toBe(0);
+    const result = await querySharedMemoryName(agent, contextGraphId, subject);
+    expect(result.bindings).toHaveLength(0);
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('allows SWM read/query only when DKG_ALLOWED_PEER and %s both pass', async (_label, predicate) => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = `swm-agent-allow-${_label.toLowerCase()}`;
+    const allowedWallet = ethers.Wallet.createRandom();
+    const allowedRecord = agentFromPrivateKey(allowedWallet.privateKey, 'allowed');
+    internals.localAgents.set(allowedRecord.agentAddress, allowedRecord);
+    internals.defaultAgentAddress = allowedRecord.agentAddress;
+    await insertAccessMeta(agent, contextGraphId, {
+      allowedPeers: [agent.peerId],
+      agentGatePredicate: predicate,
+      agentAddress: allowedRecord.agentAddress,
+    });
+    const subject = await insertSharedMemorySecret(agent, contextGraphId, `${_label}Secret`);
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(await internals.canReadContextGraph(contextGraphId)).toBe(true);
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId)).toBe(true);
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(true);
+    const result = await querySharedMemoryName(agent, contextGraphId, subject);
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]?.['name']).toBe(`"${_label}Secret"`);
+  });
+});

--- a/packages/agent/test/swm-agent-gate-access.test.ts
+++ b/packages/agent/test/swm-agent-gate-access.test.ts
@@ -17,7 +17,11 @@ interface DKGAgentInternals {
   localAgents: Map<string, AgentKeyRecord>;
   defaultAgentAddress?: string;
   canReadContextGraph(contextGraphId: string): Promise<boolean>;
-  canUseSharedMemoryForContextGraph(contextGraphId: string): Promise<boolean>;
+  canUseSharedMemoryForContextGraph(
+    contextGraphId: string,
+    opts?: { callerAgentAddress?: string },
+  ): Promise<boolean>;
+  reconcileSharedMemoryGossipSubscription(contextGraphId: string): Promise<void>;
 }
 
 class FakeGossip {
@@ -119,10 +123,15 @@ async function insertSharedMemorySecret(agent: DKGAgent, contextGraphId: string,
   return subject;
 }
 
-async function querySharedMemoryName(agent: DKGAgent, contextGraphId: string, subject: string) {
+async function querySharedMemoryName(
+  agent: DKGAgent,
+  contextGraphId: string,
+  subject: string,
+  opts: { callerAgentAddress?: string } = {},
+) {
   return agent.query(
     `SELECT ?name WHERE { <${subject}> <https://schema.org/name> ?name }`,
-    { contextGraphId, view: 'shared-working-memory' },
+    { contextGraphId, view: 'shared-working-memory', ...opts },
   );
 }
 
@@ -135,6 +144,24 @@ describe('DKGAgent SWM agent-gate access', () => {
     await flushAsync();
 
     expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(false);
+  });
+
+  it('does not subscribe to SWM for explicit private context graphs without an enforceable allowlist', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'swm-private-no-allowlist';
+    await insertAccessMeta(agent, contextGraphId, {
+      accessPolicy: 'private',
+    });
+    const subject = await insertSharedMemorySecret(agent, contextGraphId, 'NoAllowlistSecret');
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(await internals.canReadContextGraph(contextGraphId)).toBe(true);
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId)).toBe(false);
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(false);
+    const result = await querySharedMemoryName(agent, contextGraphId, subject);
+    expect(result.bindings).toHaveLength(0);
   });
 
   it('subscribes to SWM for ontology-confirmed open context graphs without local _meta', async () => {
@@ -167,6 +194,69 @@ describe('DKGAgent SWM agent-gate access', () => {
     const result = await querySharedMemoryName(agent, contextGraphId, subject);
     expect(result.bindings).toHaveLength(1);
     expect(result.bindings[0]?.['name']).toBe('"PeerInviteSecret"');
+  });
+
+  it('scopes SWM queries to the authenticated caller agent on multi-agent nodes', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'swm-agent-caller-scope';
+    const allowedWallet = ethers.Wallet.createRandom();
+    const deniedWallet = ethers.Wallet.createRandom();
+    const allowedRecord = agentFromPrivateKey(allowedWallet.privateKey, 'allowed');
+    const deniedRecord = agentFromPrivateKey(deniedWallet.privateKey, 'denied');
+    internals.localAgents.set(allowedRecord.agentAddress, allowedRecord);
+    internals.localAgents.set(deniedRecord.agentAddress, deniedRecord);
+    internals.defaultAgentAddress = allowedRecord.agentAddress;
+    await insertAccessMeta(agent, contextGraphId, {
+      agentGatePredicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      agentAddress: allowedRecord.agentAddress,
+    });
+    const subject = await insertSharedMemorySecret(agent, contextGraphId, 'CallerScopeSecret');
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(true);
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId, {
+      callerAgentAddress: deniedRecord.agentAddress,
+    })).toBe(false);
+    const deniedResult = await querySharedMemoryName(agent, contextGraphId, subject, {
+      callerAgentAddress: deniedRecord.agentAddress,
+    });
+    expect(deniedResult.bindings).toHaveLength(0);
+    const allowedResult = await querySharedMemoryName(agent, contextGraphId, subject, {
+      callerAgentAddress: allowedRecord.agentAddress,
+    });
+    expect(allowedResult.bindings).toHaveLength(1);
+    expect(allowedResult.bindings[0]?.['name']).toBe('"CallerScopeSecret"');
+  });
+
+  it('unsubscribes from SWM when the local agent loses its allowlist entry', async () => {
+    const { agent, internals, gossip } = await createAgent();
+    const contextGraphId = 'swm-agent-revoked';
+    const allowedWallet = ethers.Wallet.createRandom();
+    const allowedRecord = agentFromPrivateKey(allowedWallet.privateKey, 'allowed');
+    internals.localAgents.set(allowedRecord.agentAddress, allowedRecord);
+    internals.defaultAgentAddress = allowedRecord.agentAddress;
+    await insertAccessMeta(agent, contextGraphId, {
+      agentGatePredicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      agentAddress: allowedRecord.agentAddress,
+    });
+
+    agent.subscribeToContextGraph(contextGraphId);
+    await flushAsync();
+
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(true);
+
+    await agent.store.deleteByPattern({
+      graph: contextGraphMetaUri(contextGraphId),
+      subject: contextGraphDataUri(contextGraphId),
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: `"${allowedRecord.agentAddress}"`,
+    });
+    await internals.reconcileSharedMemoryGossipSubscription(contextGraphId);
+
+    expect(await internals.canUseSharedMemoryForContextGraph(contextGraphId)).toBe(false);
+    expect(gossip.subscribed.has(paranetWorkspaceTopic(contextGraphId))).toBe(false);
   });
 
   it.each([

--- a/packages/agent/test/swm-gossip-signing.test.ts
+++ b/packages/agent/test/swm-gossip-signing.test.ts
@@ -3,8 +3,11 @@ import { ethers } from 'ethers';
 import {
   computeGossipSigningPayload,
   decodeGossipEnvelope,
+  DKG_ONTOLOGY,
   GOSSIP_TYPE_WORKSPACE_PUBLISH,
   GOSSIP_ENVELOPE_VERSION,
+  contextGraphDataUri,
+  contextGraphMetaUri,
 } from '@origintrail-official/dkg-core';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
 import { DKGAgent, agentFromPrivateKey, type AgentKeyRecord } from '../src/index.js';
@@ -13,6 +16,41 @@ interface DKGAgentInternals {
   localAgents: Map<string, AgentKeyRecord>;
   defaultAgentAddress?: string;
   encodeWorkspaceGossipMessage(contextGraphId: string, message: Uint8Array): Promise<Uint8Array>;
+}
+
+async function insertAgentGate(
+  agent: DKGAgent,
+  contextGraphId: string,
+  predicate: string,
+  agentAddress: string,
+): Promise<void> {
+  await agent.store.insert([{
+    subject: contextGraphDataUri(contextGraphId),
+    predicate,
+    object: `"${agentAddress}"`,
+    graph: contextGraphMetaUri(contextGraphId),
+  }]);
+}
+
+function expectSignedEnvelope(
+  wireMessage: Uint8Array,
+  contextGraphId: string,
+  payload: Uint8Array,
+  expectedAgentAddress: string,
+): void {
+  const envelope = decodeGossipEnvelope(wireMessage);
+
+  expect(envelope.version).toBe(GOSSIP_ENVELOPE_VERSION);
+  expect(envelope.type).toBe(GOSSIP_TYPE_WORKSPACE_PUBLISH);
+  expect(envelope.contextGraphId).toBe(contextGraphId);
+  expect(envelope.agentAddress).toBe(expectedAgentAddress);
+  expect(Array.from(envelope.payload)).toEqual(Array.from(payload));
+
+  const recovered = ethers.verifyMessage(
+    computeGossipSigningPayload(envelope.type, envelope.contextGraphId, envelope.timestamp, envelope.payload),
+    ethers.hexlify(envelope.signature),
+  );
+  expect(recovered).toBe(expectedAgentAddress);
 }
 
 describe('DKGAgent SWM gossip signing', () => {
@@ -34,18 +72,66 @@ describe('DKGAgent SWM gossip signing', () => {
     const contextGraphId = 'open-swm-cg';
     const payload = new TextEncoder().encode('raw shared-memory payload');
     const wireMessage = await internals.encodeWorkspaceGossipMessage(contextGraphId, payload);
-    const envelope = decodeGossipEnvelope(wireMessage);
+    expectSignedEnvelope(wireMessage, contextGraphId, payload, fallbackRecord.agentAddress);
+  });
 
-    expect(envelope.version).toBe(GOSSIP_ENVELOPE_VERSION);
-    expect(envelope.type).toBe(GOSSIP_TYPE_WORKSPACE_PUBLISH);
-    expect(envelope.contextGraphId).toBe(contextGraphId);
-    expect(envelope.agentAddress).toBe(fallbackRecord.agentAddress);
-    expect(Array.from(envelope.payload)).toEqual(Array.from(payload));
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('wraps agent-gated SWM gossip with the local %s key', async (_label, predicate) => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGatedSigner',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const internals = agent as unknown as DKGAgentInternals;
 
-    const recovered = ethers.verifyMessage(
-      computeGossipSigningPayload(envelope.type, envelope.contextGraphId, envelope.timestamp, envelope.payload),
-      ethers.hexlify(envelope.signature),
-    );
-    expect(recovered).toBe(fallbackRecord.agentAddress);
+    const defaultRecord = agentFromPrivateKey(ethers.Wallet.createRandom().privateKey, 'default');
+    const gatedRecord = agentFromPrivateKey(ethers.Wallet.createRandom().privateKey, 'gated');
+
+    internals.localAgents.set(defaultRecord.agentAddress, defaultRecord);
+    internals.localAgents.set(gatedRecord.agentAddress, gatedRecord);
+    internals.defaultAgentAddress = defaultRecord.agentAddress;
+
+    const contextGraphId = `gated-swm-cg-${predicate.endsWith('allowedAgent') ? 'allowed' : 'participant'}`;
+    await insertAgentGate(agent, contextGraphId, predicate, gatedRecord.agentAddress);
+
+    const payload = new TextEncoder().encode('gated shared-memory payload');
+    const wireMessage = await internals.encodeWorkspaceGossipMessage(contextGraphId, payload);
+
+    expectSignedEnvelope(wireMessage, contextGraphId, payload, gatedRecord.agentAddress);
+  });
+
+  it('rejects outgoing agent-gated SWM gossip when no local allowed signing key exists', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmGatedNoSigner',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const internals = agent as unknown as DKGAgentInternals;
+
+    const localRecord = agentFromPrivateKey(ethers.Wallet.createRandom().privateKey, 'local');
+    const remoteAllowed = ethers.Wallet.createRandom();
+    internals.localAgents.set(localRecord.agentAddress, localRecord);
+    internals.defaultAgentAddress = localRecord.agentAddress;
+
+    const contextGraphId = 'gated-swm-cg-no-local-signer';
+    await insertAgentGate(agent, contextGraphId, DKG_ONTOLOGY.DKG_ALLOWED_AGENT, remoteAllowed.address);
+
+    const payload = new TextEncoder().encode('gated payload without a local signer');
+    await expect(internals.encodeWorkspaceGossipMessage(contextGraphId, payload))
+      .rejects.toThrow(/no local allowed signing agent key/);
+  });
+
+  it('keeps legacy raw SWM gossip for open graphs when no local signing key exists', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmOpenNoSigner',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const internals = agent as unknown as DKGAgentInternals;
+
+    const contextGraphId = 'open-swm-cg-no-signer';
+    const payload = new TextEncoder().encode('legacy raw shared-memory payload');
+    const wireMessage = await internals.encodeWorkspaceGossipMessage(contextGraphId, payload);
+
+    expect(Array.from(wireMessage)).toEqual(Array.from(payload));
   });
 });

--- a/packages/agent/test/swm-gossip-signing.test.ts
+++ b/packages/agent/test/swm-gossip-signing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import {
+  computeGossipSigningPayload,
+  decodeGossipEnvelope,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+  GOSSIP_ENVELOPE_VERSION,
+} from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent, agentFromPrivateKey, type AgentKeyRecord } from '../src/index.js';
+
+interface DKGAgentInternals {
+  localAgents: Map<string, AgentKeyRecord>;
+  defaultAgentAddress?: string;
+  encodeWorkspaceGossipMessage(contextGraphId: string, message: Uint8Array): Promise<Uint8Array>;
+}
+
+describe('DKGAgent SWM gossip signing', () => {
+  it('wraps open-graph SWM gossip with a local agent key even when the default cannot sign', async () => {
+    const agent = await DKGAgent.create({
+      name: 'SwmFallbackSigner',
+      chainAdapter: new MockChainAdapter(),
+    });
+    const internals = agent as unknown as DKGAgentInternals;
+
+    const defaultRecord = agentFromPrivateKey(ethers.Wallet.createRandom().privateKey, 'default');
+    delete defaultRecord.privateKey;
+    const fallbackRecord = agentFromPrivateKey(ethers.Wallet.createRandom().privateKey, 'fallback');
+
+    internals.localAgents.set(defaultRecord.agentAddress, defaultRecord);
+    internals.localAgents.set(fallbackRecord.agentAddress, fallbackRecord);
+    internals.defaultAgentAddress = defaultRecord.agentAddress;
+
+    const contextGraphId = 'open-swm-cg';
+    const payload = new TextEncoder().encode('raw shared-memory payload');
+    const wireMessage = await internals.encodeWorkspaceGossipMessage(contextGraphId, payload);
+    const envelope = decodeGossipEnvelope(wireMessage);
+
+    expect(envelope.version).toBe(GOSSIP_ENVELOPE_VERSION);
+    expect(envelope.type).toBe(GOSSIP_TYPE_WORKSPACE_PUBLISH);
+    expect(envelope.contextGraphId).toBe(contextGraphId);
+    expect(envelope.agentAddress).toBe(fallbackRecord.agentAddress);
+    expect(Array.from(envelope.payload)).toEqual(Array.from(payload));
+
+    const recovered = ethers.verifyMessage(
+      computeGossipSigningPayload(envelope.type, envelope.contextGraphId, envelope.timestamp, envelope.payload),
+      ethers.hexlify(envelope.signature),
+    );
+    expect(recovered).toBe(fallbackRecord.agentAddress);
+  });
+});

--- a/packages/core/src/proto/gossip-envelope.ts
+++ b/packages/core/src/proto/gossip-envelope.ts
@@ -43,6 +43,10 @@ export interface GossipEnvelopeMsg {
   payload: Uint8Array;
 }
 
+export const GOSSIP_ENVELOPE_VERSION = '10.0.0';
+export const GOSSIP_TYPE_WORKSPACE_PUBLISH = 'share-write';
+export const GOSSIP_ENVELOPE_FRESHNESS_MS = 5 * 60 * 1000;
+
 export function encodeGossipEnvelope(msg: GossipEnvelopeMsg): Uint8Array {
   return GossipEnvelopeSchema.encode(
     GossipEnvelopeSchema.create(msg),
@@ -55,9 +59,23 @@ export function decodeGossipEnvelope(buf: Uint8Array): GossipEnvelopeMsg {
 
 const textEncoder = new TextEncoder();
 
+function uint32Be(value: number): Uint8Array {
+  const buf = new Uint8Array(4);
+  new DataView(buf.buffer).setUint32(0, value, false);
+  return buf;
+}
+
+function framedField(value: Uint8Array): Uint8Array {
+  const len = uint32Be(value.length);
+  const framed = new Uint8Array(len.length + value.length);
+  framed.set(len, 0);
+  framed.set(value, len.length);
+  return framed;
+}
+
 /**
  * Compute the signing payload for a gossip envelope.
- * Signs: type + contextGraphId + timestamp + payload
+ * Signs length-framed fields: type, contextGraphId, timestamp, payload.
  */
 export function computeGossipSigningPayload(
   type: string,
@@ -65,9 +83,18 @@ export function computeGossipSigningPayload(
   timestamp: string,
   payload: Uint8Array,
 ): Uint8Array {
-  const prefix = textEncoder.encode(`${type}${contextGraphId}${timestamp}`);
-  const combined = new Uint8Array(prefix.length + payload.length);
-  combined.set(prefix, 0);
-  combined.set(payload, prefix.length);
+  const fields = [
+    framedField(textEncoder.encode(type)),
+    framedField(textEncoder.encode(contextGraphId)),
+    framedField(textEncoder.encode(timestamp)),
+    framedField(payload),
+  ];
+  const total = fields.reduce((sum, field) => sum + field.length, 0);
+  const combined = new Uint8Array(total);
+  let offset = 0;
+  for (const field of fields) {
+    combined.set(field, offset);
+    offset += field.length;
+  }
   return combined;
 }

--- a/packages/core/src/proto/gossip-envelope.ts
+++ b/packages/core/src/proto/gossip-envelope.ts
@@ -15,13 +15,17 @@ import protobuf from 'protobufjs';
 const { Type, Field } = protobuf;
 
 /**
- * V10 GossipSub message envelope.
+ * V10 GossipSub authentication envelope.
  *
- * All GossipSub messages are wrapped in this envelope which provides:
+ * GossipSub protocols that can authenticate an agent writer wrap the payload
+ * in this envelope, which provides:
  * - Protocol version ("10.0.0")
  * - Message type discrimination
  * - Context graph binding
  * - Agent identity and signature for authentication
+ *
+ * Legacy raw SWM payloads remain valid only for non-agent-gated context graphs
+ * when no local signing key is available.
  */
 
 export const GossipEnvelopeSchema = new Type('GossipEnvelope')

--- a/packages/core/src/proto/index.ts
+++ b/packages/core/src/proto/index.ts
@@ -86,6 +86,9 @@ export {
 
 export {
   type GossipEnvelopeMsg,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+  GOSSIP_ENVELOPE_FRESHNESS_MS,
   encodeGossipEnvelope,
   decodeGossipEnvelope,
   computeGossipSigningPayload,

--- a/packages/core/test/v10-proto.test.ts
+++ b/packages/core/test/v10-proto.test.ts
@@ -196,11 +196,15 @@ describe('computeGossipSigningPayload', () => {
     expect(a).not.toEqual(b);
   });
 
-  it('concatenates prefix with payload bytes', () => {
+  it('length-frames fields before payload bytes', () => {
     const payload = new Uint8Array([0xde, 0xad]);
     const result = computeGossipSigningPayload('t', 'c', '1', payload);
-    const prefix = new TextEncoder().encode('tc1');
-    expect(result).toEqual(new Uint8Array([...prefix, 0xde, 0xad]));
+    expect(result).toEqual(new Uint8Array([
+      0, 0, 0, 1, 0x74,
+      0, 0, 0, 1, 0x63,
+      0, 0, 0, 1, 0x31,
+      0, 0, 0, 2, 0xde, 0xad,
+    ]));
   });
 });
 

--- a/packages/core/test/v10-protocol-coverage.test.ts
+++ b/packages/core/test/v10-protocol-coverage.test.ts
@@ -15,9 +15,8 @@ import {
 // ─────────────────────────────────────────────────────────────────────────────
 // Audit findings covered:
 //
-// C-6  computeGossipSigningPayload concatenates type|cgId|timestamp|payload
-//      with no length prefix. ('a'+'bc') and ('ab'+'c') would produce the
-//      same prefix ('abc'). Test that length-confusion is detected.
+// C-6  computeGossipSigningPayload must length-frame type|cgId|timestamp|payload
+//      so ('a'+'bc') and ('ab'+'c') cannot produce the same signed bytes.
 //
 // C-7  Existing v10-proto.test.ts round-trips do NOT assert nodeIdentityId
 //      on StorageACK or verifiedMemoryId/batchId on VerifyProposal. A proto
@@ -44,21 +43,12 @@ function bytes(n: number, fill = 0): Uint8Array {
 }
 
 describe('computeGossipSigningPayload — length-confusion safety [C-6]', () => {
-  // The signing payload is `${type}${contextGraphId}${timestamp}` || payload.
-  // Without length prefixes between fields, an attacker who controls one
-  // field can shift bytes between fields and produce the same signed bytes.
-  // This test pins the current behaviour as a finding: a single-byte shift
-  // across the type / contextGraphId boundary collides today.
-
-  it('same concatenation byte-stream from different field splits collides (length-confusion)', () => {
+  it('same concatenation byte-stream from different field splits does not collide', () => {
     const ts = '2026-01-01T00:00:00Z';
     const payload = new Uint8Array([1, 2, 3, 4]);
     const a = computeGossipSigningPayload('a', 'bc' + 'tail', ts, payload);
     const b = computeGossipSigningPayload('ab', 'c' + 'tail', ts, payload);
-    // If this passes (a equals b), the protocol is vulnerable to type/cgId
-    // length confusion. If it fails (a !== b), the implementation has been
-    // hardened with length prefixes — update the test to reflect the fix.
-    expect(a).toEqual(b);
+    expect(a).not.toEqual(b);
   });
 
   it('different timestamps produce different payloads', () => {
@@ -73,14 +63,18 @@ describe('computeGossipSigningPayload — length-confusion safety [C-6]', () => 
     expect(a).not.toEqual(b);
   });
 
-  it('payload bytes appear AFTER the prefix (regression: prefix before payload)', () => {
+  it('payload bytes are length-framed after metadata fields', () => {
     const type = 'T';
     const cgId = 'CG';
     const ts = 'TS';
     const payload = new Uint8Array([0xAB, 0xCD]);
     const p = computeGossipSigningPayload(type, cgId, ts, payload);
-    // Expected: 'T' 'C' 'G' 'T' 'S' 0xAB 0xCD = bytes 84,67,71,84,83,171,205
-    expect(Array.from(p)).toEqual([84, 67, 71, 84, 83, 0xAB, 0xCD]);
+    expect(Array.from(p)).toEqual([
+      0, 0, 0, 1, 84,
+      0, 0, 0, 2, 67, 71,
+      0, 0, 0, 2, 84, 83,
+      0, 0, 0, 2, 0xAB, 0xCD,
+    ]);
   });
 });
 

--- a/packages/publisher/README.md
+++ b/packages/publisher/README.md
@@ -6,7 +6,7 @@ Publishing protocol for DKG V10. Handles the complete lifecycle of getting Knowl
 
 - **DKGPublisher** — high-level publishing API: submit RDF, get back a finalized Knowledge Collection UAL
 - **PublishHandler** — P2P protocol handler that processes incoming publish requests from other nodes, validates data, stores triples, and returns signed ACKs
-- **WorkspaceHandler** — feeless "workspace mode" publishing for local-only or staging workflows
+- **WorkspaceHandler** — feeless Shared Working Memory handling for local-only or staging workflows, including signed gossip envelope verification for agent-gated context graphs
 - **Context Graphs** — `createContextGraph` and `publishToContextGraph` for M/N signature-gated subgraphs within paranets
 - **Context Oracle** — `ContextOracle` class providing verifiable read operations on Context Graphs: `queryWithProofs` (SPARQL with Merkle inclusion proofs), `entityWithProofs` (entity lookup with proofs), and `proveTriple` (single triple existence proof). Provenance triples are scoped to subjects discovered in the query results for efficiency.
 - **Merkle trees** — per-KA triple hashing, public/private sub-roots, and collection-level Merkle root computation

--- a/packages/publisher/README.md
+++ b/packages/publisher/README.md
@@ -6,7 +6,7 @@ Publishing protocol for DKG V10. Handles the complete lifecycle of getting Knowl
 
 - **DKGPublisher** — high-level publishing API: submit RDF, get back a finalized Knowledge Collection UAL
 - **PublishHandler** — P2P protocol handler that processes incoming publish requests from other nodes, validates data, stores triples, and returns signed ACKs
-- **WorkspaceHandler** — feeless Shared Working Memory handling for local-only or staging workflows, including signed gossip envelope verification for agent-gated context graphs
+- **SharedMemoryHandler** — feeless Shared Working Memory handling for local-only or staging workflows, including signed gossip envelope verification for agent-gated context graphs; signatures authenticate writers, but do not encrypt GossipSub payload bytes
 - **Context Graphs** — `createContextGraph` and `publishToContextGraph` for M/N signature-gated subgraphs within paranets
 - **Context Oracle** — `ContextOracle` class providing verifiable read operations on Context Graphs: `queryWithProofs` (SPARQL with Merkle inclusion proofs), `entityWithProofs` (entity lookup with proofs), and `proveTriple` (single triple existence proof). Provenance triples are scoped to subjects discovered in the query results for efficiency.
 - **Merkle trees** — per-KA triple hashing, public/private sub-roots, and collection-level Merkle root computation

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -148,7 +148,7 @@ export {
   type AsyncLiftPublishSuccess,
   type AsyncLiftPublishFailureInput,
 } from './async-lift-publish-result.js';
-export { WorkspaceHandler, WorkspaceHandler as SharedMemoryHandler } from './workspace-handler.js';
+export { SharedMemoryHandler, WorkspaceHandler } from './workspace-handler.js';
 export { UpdateHandler } from './update-handler.js';
 export { ChainEventPoller, type ChainEventPollerConfig, type OnContextGraphCreated } from './chain-event-poller.js';
 export { AccessHandler, type AccessPolicy } from './access-handler.js';

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1,7 +1,7 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
 import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { EventBus } from '@origintrail-official/dkg-core';
-import { Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
+import { Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import type { PhaseCallback } from './publisher.js';
 import {
   decodeGossipEnvelope,
@@ -160,9 +160,9 @@ export class SharedMemoryHandler {
         return;
       }
 
-      const allowedAgents = await this.getContextGraphAllowedAgents(contextGraphId);
-      if (allowedAgents !== null) {
-        const verified = await this.verifyAgentEnvelope(envelope, payload, contextGraphId, allowedAgents, ctx);
+      const agentGateAddresses = await this.getContextGraphAgentGateAddresses(contextGraphId);
+      if (agentGateAddresses !== null) {
+        const verified = await this.verifyAgentEnvelope(envelope, payload, contextGraphId, agentGateAddresses, ctx);
         if (!verified) return;
       }
 
@@ -373,7 +373,7 @@ export class SharedMemoryHandler {
     envelope: GossipEnvelopeMsg | undefined,
     payload: Uint8Array,
     contextGraphId: string,
-    allowedAgents: string[],
+    agentGateAddresses: string[],
     ctx: import('@origintrail-official/dkg-core').OperationContext,
   ): Promise<boolean> {
     if (!envelope) {
@@ -421,15 +421,15 @@ export class SharedMemoryHandler {
       return false;
     }
 
-    const allowedSet = new Set(allowedAgents.map((agent) => agent.toLowerCase()));
-    if (!allowedSet.has(recovered.toLowerCase())) {
+    const agentGateSet = new Set(agentGateAddresses.map((agent) => agent.toLowerCase()));
+    if (!agentGateSet.has(recovered.toLowerCase())) {
       this.log.warn(ctx, `SWM write rejected: agent ${recovered} is not allowed for context graph "${contextGraphId}"`);
       return false;
     }
 
     if (this.localAgentAddresses) {
       const localAgents = await this.localAgentAddresses();
-      const localAllowed = localAgents.some((agent) => allowedSet.has(agent.toLowerCase()));
+      const localAllowed = localAgents.some((agent) => agentGateSet.has(agent.toLowerCase()));
       if (!localAllowed) {
         this.log.warn(ctx, `SWM write rejected: local node has no allowed agent for context graph "${contextGraphId}"`);
         return false;
@@ -460,20 +460,18 @@ export class SharedMemoryHandler {
   }
 
   /**
-   * Returns the agent-address allowlist for a context graph, or null if the
-   * graph is not agent-gated. Includes local allowedAgent entries and
-   * on-chain participantAgent metadata.
+   * Returns the accepted SWM writer agent addresses for a context graph, or
+   * null if the graph is not agent-gated. Includes DKG_ALLOWED_AGENT and
+   * DKG_PARTICIPANT_AGENT metadata.
    */
-  private async getContextGraphAllowedAgents(contextGraphId: string): Promise<string[] | null> {
-    const DKG_ALLOWED_AGENT = 'https://dkg.network/ontology#allowedAgent';
-    const DKG_PARTICIPANT_AGENT = 'https://dkg.network/ontology#participantAgent';
+  private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
       `SELECT ?agent WHERE { GRAPH <${cgMeta}> {
-        { <${cgData}> <${DKG_ALLOWED_AGENT}> ?agent }
+        { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
         UNION
-        { <${cgData}> <${DKG_PARTICIPANT_AGENT}> ?agent }
+        { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
       } }`,
     );
     if (result.type !== 'bindings' || result.bindings.length === 0) {

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1,7 +1,7 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
 import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { EventBus } from '@origintrail-official/dkg-core';
-import { Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri, DKG_ONTOLOGY, SYSTEM_PARANETS } from '@origintrail-official/dkg-core';
 import type { PhaseCallback } from './publisher.js';
 import {
   decodeGossipEnvelope,
@@ -161,13 +161,20 @@ export class SharedMemoryHandler {
       }
 
       const agentGateAddresses = await this.getContextGraphAgentGateAddresses(contextGraphId);
+      const allowedPeers = await this.getContextGraphAllowedPeers(contextGraphId);
+      const hasPrivateAccessPolicy = await this.contextGraphHasPrivateAccessPolicy(contextGraphId);
+
+      if (hasPrivateAccessPolicy && agentGateAddresses === null && allowedPeers === null) {
+        this.log.warn(ctx, `SWM write rejected: private context graph "${contextGraphId}" has no gossip allowlist`);
+        return;
+      }
+
       if (agentGateAddresses !== null) {
         const verified = await this.verifyAgentEnvelope(envelope, payload, contextGraphId, agentGateAddresses, ctx);
         if (!verified) return;
       }
 
       // Enforce peer allowlist for curated CGs
-      const allowedPeers = await this.getContextGraphAllowedPeers(contextGraphId);
       if (allowedPeers !== null && !allowedPeers.includes(fromPeerId)) {
         this.log.warn(ctx, `SWM write rejected: peer "${fromPeerId}" not in allowlist for context graph "${contextGraphId}"`);
         return;
@@ -444,11 +451,10 @@ export class SharedMemoryHandler {
    * is set (open CG — all peers allowed).
    */
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
-    const DKG_ALLOWED_PEER = 'https://dkg.network/ontology#allowedPeer';
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${cgMeta}> { <${cgData}> <${DKG_ALLOWED_PEER}> ?peer } }`,
+      `SELECT ?peer WHERE { GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer } }`,
     );
     if (result.type !== 'bindings' || result.bindings.length === 0) {
       return null;
@@ -484,6 +490,36 @@ export class SharedMemoryHandler {
       .filter((v) => ethers.isAddress(v))
       .map((v) => ethers.getAddress(v));
     return [...new Set(agents)];
+  }
+
+  private async contextGraphHasPrivateAccessPolicy(contextGraphId: string): Promise<boolean> {
+    if ((Object.values(SYSTEM_PARANETS) as string[]).includes(contextGraphId)) {
+      return false;
+    }
+
+    const ontologyGraph = contextGraphDataUri(SYSTEM_PARANETS.ONTOLOGY);
+    const cgMeta = contextGraphMetaUri(contextGraphId);
+    const cgData = contextGraphDataUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?policy WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        } UNION {
+          GRAPH <${cgMeta}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') {
+      return false;
+    }
+    return result.bindings.some((row) => {
+      const policy = row['policy'];
+      return typeof policy === 'string' && stripRdfLiteral(policy) === 'private';
+    });
   }
 
   /**

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -3,13 +3,31 @@ import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { EventBus } from '@origintrail-official/dkg-core';
 import { Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
 import type { PhaseCallback } from './publisher.js';
-import { decodeWorkspacePublishRequest, assertSafeIri, assertSafeRdfTerm, validateSubGraphName, contextGraphSubGraphUri } from '@origintrail-official/dkg-core';
-import type { WorkspaceCASConditionMsg } from '@origintrail-official/dkg-core';
+import {
+  decodeGossipEnvelope,
+  decodeWorkspacePublishRequest,
+  computeGossipSigningPayload,
+  assertSafeIri,
+  assertSafeRdfTerm,
+  validateSubGraphName,
+  contextGraphSubGraphUri,
+  GOSSIP_ENVELOPE_FRESHNESS_MS,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+} from '@origintrail-official/dkg-core';
+import type { GossipEnvelopeMsg, WorkspaceCASConditionMsg, WorkspacePublishRequestMsg } from '@origintrail-official/dkg-core';
+import { ethers } from 'ethers';
 import { validatePublishRequest } from './validation.js';
 import { generateShareMetadata, generateOwnershipQuads, generateSubGraphRegistration } from './metadata.js';
 import { parseSimpleNQuads } from './publish-handler.js';
 import { storeWorkspaceOperationPublicQuads } from './workspace-resolution.js';
 import type { KAManifestEntry } from './publisher.js';
+
+interface WorkspaceGossipDecodeResult {
+  request: WorkspacePublishRequestMsg;
+  envelope?: GossipEnvelopeMsg;
+  payload: Uint8Array;
+}
 
 /**
  * Handles incoming shared memory topic messages (GossipSub).
@@ -23,6 +41,8 @@ export class SharedMemoryHandler {
   /** Per-context-graph map of rootEntity → creatorPeerId. Shared with publisher when used by agent. */
   private readonly sharedMemoryOwnedEntities: Map<string, Map<string, string>> = new Map();
   private readonly writeLocks: Map<string, Promise<void>>;
+  private readonly localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+  private readonly now: () => number;
   private readonly log = new Logger('SharedMemoryHandler');
 
   constructor(
@@ -31,6 +51,8 @@ export class SharedMemoryHandler {
     options?: {
       sharedMemoryOwnedEntities?: Map<string, Map<string, string>>;
       writeLocks?: Map<string, Promise<void>>;
+      localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+      now?: () => number;
     },
   ) {
     this.store = store;
@@ -40,6 +62,8 @@ export class SharedMemoryHandler {
       this.sharedMemoryOwnedEntities = options.sharedMemoryOwnedEntities;
     }
     this.writeLocks = options?.writeLocks ?? new Map();
+    this.localAgentAddresses = options?.localAgentAddresses;
+    this.now = options?.now ?? (() => Date.now());
   }
 
   private async withWriteLocks<T>(keys: string[], fn: () => Promise<T>): Promise<T> {
@@ -121,7 +145,8 @@ export class SharedMemoryHandler {
     let ctx = createOperationContext('share');
     try {
       onPhase?.('decode', 'start');
-      const request = decodeWorkspacePublishRequest(data);
+      const decoded = this.decodeWorkspaceGossipMessage(data);
+      const { request, envelope, payload } = decoded;
       if (request.operationId) {
         ctx = createOperationContext('share', request.operationId);
       }
@@ -133,6 +158,12 @@ export class SharedMemoryHandler {
       if (publisherPeerId !== fromPeerId) {
         this.log.warn(ctx, `SWM write rejected: payload publisherPeerId "${publisherPeerId}" does not match sender "${fromPeerId}"`);
         return;
+      }
+
+      const allowedAgents = await this.getContextGraphAllowedAgents(contextGraphId);
+      if (allowedAgents !== null) {
+        const verified = await this.verifyAgentEnvelope(envelope, payload, contextGraphId, allowedAgents, ctx);
+        if (!verified) return;
       }
 
       // Enforce peer allowlist for curated CGs
@@ -314,6 +345,100 @@ export class SharedMemoryHandler {
     }
   }
 
+  private decodeWorkspaceGossipMessage(data: Uint8Array): WorkspaceGossipDecodeResult {
+    try {
+      const envelope = decodeGossipEnvelope(data);
+      if (
+        envelope.version === GOSSIP_ENVELOPE_VERSION &&
+        envelope.type === GOSSIP_TYPE_WORKSPACE_PUBLISH &&
+        envelope.payload &&
+        envelope.payload.length > 0
+      ) {
+        return {
+          request: decodeWorkspacePublishRequest(envelope.payload),
+          envelope,
+          payload: new Uint8Array(envelope.payload),
+        };
+      }
+    } catch {
+      // Legacy raw workspace messages are still valid for non-agent-gated CGs.
+    }
+    return {
+      request: decodeWorkspacePublishRequest(data),
+      payload: data,
+    };
+  }
+
+  private async verifyAgentEnvelope(
+    envelope: GossipEnvelopeMsg | undefined,
+    payload: Uint8Array,
+    contextGraphId: string,
+    allowedAgents: string[],
+    ctx: import('@origintrail-official/dkg-core').OperationContext,
+  ): Promise<boolean> {
+    if (!envelope) {
+      this.log.warn(ctx, `SWM write rejected: unsigned workspace gossip for agent-gated context graph "${contextGraphId}"`);
+      return false;
+    }
+
+    if (envelope.version !== GOSSIP_ENVELOPE_VERSION || envelope.type !== GOSSIP_TYPE_WORKSPACE_PUBLISH) {
+      this.log.warn(ctx, `SWM write rejected: invalid gossip envelope type/version for context graph "${contextGraphId}"`);
+      return false;
+    }
+    if (envelope.contextGraphId !== contextGraphId) {
+      this.log.warn(ctx, `SWM write rejected: envelope contextGraphId "${envelope.contextGraphId}" does not match payload "${contextGraphId}"`);
+      return false;
+    }
+    if (!envelope.signature || envelope.signature.length === 0) {
+      this.log.warn(ctx, `SWM write rejected: missing agent signature for context graph "${contextGraphId}"`);
+      return false;
+    }
+
+    const timestampMs = Date.parse(envelope.timestamp);
+    if (!Number.isFinite(timestampMs) || Math.abs(this.now() - timestampMs) > GOSSIP_ENVELOPE_FRESHNESS_MS) {
+      this.log.warn(ctx, `SWM write rejected: stale or invalid gossip timestamp "${envelope.timestamp}"`);
+      return false;
+    }
+
+    let claimedAgent: string;
+    let recovered: string;
+    try {
+      claimedAgent = ethers.getAddress(envelope.agentAddress);
+      const signingPayload = computeGossipSigningPayload(
+        envelope.type,
+        envelope.contextGraphId,
+        envelope.timestamp,
+        payload,
+      );
+      recovered = ethers.verifyMessage(signingPayload, ethers.hexlify(envelope.signature));
+    } catch (err) {
+      this.log.warn(ctx, `SWM write rejected: invalid agent signature (${err instanceof Error ? err.message : String(err)})`);
+      return false;
+    }
+
+    if (recovered.toLowerCase() !== claimedAgent.toLowerCase()) {
+      this.log.warn(ctx, `SWM write rejected: recovered signer ${recovered} does not match envelope agent ${claimedAgent}`);
+      return false;
+    }
+
+    const allowedSet = new Set(allowedAgents.map((agent) => agent.toLowerCase()));
+    if (!allowedSet.has(recovered.toLowerCase())) {
+      this.log.warn(ctx, `SWM write rejected: agent ${recovered} is not allowed for context graph "${contextGraphId}"`);
+      return false;
+    }
+
+    if (this.localAgentAddresses) {
+      const localAgents = await this.localAgentAddresses();
+      const localAllowed = localAgents.some((agent) => allowedSet.has(agent.toLowerCase()));
+      if (!localAllowed) {
+        this.log.warn(ctx, `SWM write rejected: local node has no allowed agent for context graph "${contextGraphId}"`);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   /**
    * Returns the peer allowlist for a context graph, or null if no allowlist
    * is set (open CG — all peers allowed).
@@ -331,7 +456,36 @@ export class SharedMemoryHandler {
     return result.bindings
       .map(row => row['peer'])
       .filter((v): v is string => typeof v === 'string')
-      .map(v => v.replace(/^"|"$/g, ''));
+      .map(stripRdfLiteral);
+  }
+
+  /**
+   * Returns the agent-address allowlist for a context graph, or null if the
+   * graph is not agent-gated. Includes local allowedAgent entries and
+   * on-chain participantAgent metadata.
+   */
+  private async getContextGraphAllowedAgents(contextGraphId: string): Promise<string[] | null> {
+    const DKG_ALLOWED_AGENT = 'https://dkg.network/ontology#allowedAgent';
+    const DKG_PARTICIPANT_AGENT = 'https://dkg.network/ontology#participantAgent';
+    const cgMeta = contextGraphMetaUri(contextGraphId);
+    const cgData = contextGraphDataUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?agent WHERE { GRAPH <${cgMeta}> {
+        { <${cgData}> <${DKG_ALLOWED_AGENT}> ?agent }
+        UNION
+        { <${cgData}> <${DKG_PARTICIPANT_AGENT}> ?agent }
+      } }`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) {
+      return null;
+    }
+    const agents = result.bindings
+      .map(row => row['agent'])
+      .filter((v): v is string => typeof v === 'string')
+      .map(stripRdfLiteral)
+      .filter((v) => ethers.isAddress(v))
+      .map((v) => ethers.getAddress(v));
+    return [...new Set(agents)];
   }
 
   /**
@@ -373,4 +527,10 @@ function parseCountLiteral(val: string | false | undefined): number {
   const stripped = val.replace(/^"/, '').replace(/"(\^\^<[^>]+>)?$/, '');
   const n = Number(stripped);
   return Number.isFinite(n) ? n : NaN;
+}
+
+function stripRdfLiteral(value: string): string {
+  return value
+    .replace(/^"/, '')
+    .replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, '');
 }

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -12,12 +12,14 @@ import {
   encodeWorkspacePublishRequest,
   GOSSIP_ENVELOPE_VERSION,
   GOSSIP_TYPE_WORKSPACE_PUBLISH,
+  SYSTEM_PARANETS,
 } from '@origintrail-official/dkg-core';
 import { SharedMemoryHandler } from '../src/index.js';
 
 const CONTEXT_GRAPH_ID = 'workspace-handler-agent-gate';
 const DATA_GRAPH = contextGraphDataUri(CONTEXT_GRAPH_ID);
 const META_GRAPH = contextGraphMetaUri(CONTEXT_GRAPH_ID);
+const ONTOLOGY_GRAPH = contextGraphDataUri(SYSTEM_PARANETS.ONTOLOGY);
 const WORKSPACE_GRAPH = contextGraphSharedMemoryUri(CONTEXT_GRAPH_ID);
 const PEER_ID = '12D3KooWAgentGatePeer';
 const ENTITY = 'urn:test:workspace-handler-agent-gate';
@@ -68,6 +70,15 @@ async function insertAgentGate(predicate: string, agentAddress: string): Promise
   }]);
 }
 
+async function insertPrivateAccessPolicy(graph: string): Promise<void> {
+  await store.insert([{
+    subject: DATA_GRAPH,
+    predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+    object: '"private"',
+    graph,
+  }]);
+}
+
 async function expectStoredName(name: string): Promise<void> {
   const result = await store.query(
     `SELECT ?o WHERE { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
@@ -98,11 +109,47 @@ describe('SharedMemoryHandler agent-gated gossip', () => {
     });
   });
 
-  it('accepts legacy raw SWM gossip for non-agent-gated context graphs', async () => {
+  it('accepts legacy raw SWM gossip for open context graphs with no policy or allowlist', async () => {
     await handler.handle(workspaceMessage('Raw Open', 'ws-agent-gate-raw-open'), PEER_ID);
 
     await expectStoredName('Raw Open');
     expect(workspaceOwned.get(CONTEXT_GRAPH_ID)?.get(ENTITY)).toBe(PEER_ID);
+  });
+
+  it.each([
+    ['_meta', META_GRAPH],
+    ['ontology', ONTOLOGY_GRAPH],
+  ])('rejects legacy raw SWM gossip for explicit private accessPolicy in the %s with no gossip allowlist', async (_label, graph) => {
+    await insertPrivateAccessPolicy(graph);
+
+    await handler.handle(workspaceMessage('Private Raw', `ws-agent-gate-private-raw-${_label}`), PEER_ID);
+
+    await expectWorkspaceEmpty();
+  });
+
+  it('rejects legacy raw SWM gossip for explicit private accessPolicy with only DKG_ALLOWED_AGENT', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    await insertPrivateAccessPolicy(META_GRAPH);
+    await insertAgentGate(DKG_ONTOLOGY.DKG_ALLOWED_AGENT, allowed.address);
+
+    await handler.handle(workspaceMessage('Private Agent Raw', 'ws-agent-gate-private-agent-raw'), PEER_ID);
+
+    await expectWorkspaceEmpty();
+  });
+
+  it('accepts signed SWM gossip for explicit private accessPolicy from a DKG_ALLOWED_AGENT writer', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+    });
+    await insertPrivateAccessPolicy(META_GRAPH);
+    await insertAgentGate(DKG_ONTOLOGY.DKG_ALLOWED_AGENT, allowed.address);
+
+    const raw = workspaceMessage('Private Agent Signed', 'ws-agent-gate-private-agent-signed');
+    await handler.handle(await signWorkspaceMessage(allowed, raw), PEER_ID);
+
+    await expectStoredName('Private Agent Signed');
   });
 
   it.each([

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -41,7 +41,11 @@ function workspaceMessage(name: string, operationId: string): Uint8Array {
   });
 }
 
-async function signWorkspaceMessage(wallet: ethers.Wallet, payload: Uint8Array): Promise<Uint8Array> {
+async function signWorkspaceMessage(
+  wallet: ethers.Wallet,
+  payload: Uint8Array,
+  claimedAgentAddress = wallet.address,
+): Promise<Uint8Array> {
   const timestamp = new Date().toISOString();
   const signingPayload = computeGossipSigningPayload(
     GOSSIP_TYPE_WORKSPACE_PUBLISH,
@@ -54,7 +58,7 @@ async function signWorkspaceMessage(wallet: ethers.Wallet, payload: Uint8Array):
     version: GOSSIP_ENVELOPE_VERSION,
     type: GOSSIP_TYPE_WORKSPACE_PUBLISH,
     contextGraphId: CONTEXT_GRAPH_ID,
-    agentAddress: wallet.address,
+    agentAddress: claimedAgentAddress,
     timestamp,
     signature: ethers.getBytes(signature),
     payload,
@@ -66,6 +70,15 @@ async function insertAgentGate(predicate: string, agentAddress: string): Promise
     subject: DATA_GRAPH,
     predicate,
     object: `"${agentAddress}"`,
+    graph: META_GRAPH,
+  }]);
+}
+
+async function insertPeerGate(peerId: string): Promise<void> {
+  await store.insert([{
+    subject: DATA_GRAPH,
+    predicate: DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+    object: `"${peerId}"`,
     graph: META_GRAPH,
   }]);
 }
@@ -197,5 +210,55 @@ describe('SharedMemoryHandler agent-gated gossip', () => {
     await handler.handle(await signWorkspaceMessage(denied, raw), PEER_ID);
 
     await expectWorkspaceEmpty();
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('rejects legacy raw SWM gossip when DKG_ALLOWED_PEER is combined with %s', async (_label, predicate) => {
+    const allowed = ethers.Wallet.createRandom();
+    await insertPeerGate(PEER_ID);
+    await insertAgentGate(predicate, allowed.address);
+
+    await handler.handle(workspaceMessage('Mixed Raw', `ws-agent-gate-mixed-raw-${_label}`), PEER_ID);
+
+    await expectWorkspaceEmpty();
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('rejects signed SWM gossip with a forged %s envelope claim even when DKG_ALLOWED_PEER passes', async (_label, predicate) => {
+    const allowed = ethers.Wallet.createRandom();
+    const denied = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+    });
+    await insertPeerGate(PEER_ID);
+    await insertAgentGate(predicate, allowed.address);
+
+    const raw = workspaceMessage('Mixed Forged', `ws-agent-gate-mixed-forged-${_label}`);
+    await handler.handle(await signWorkspaceMessage(denied, raw, allowed.address), PEER_ID);
+
+    await expectWorkspaceEmpty();
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('accepts signed SWM gossip only when DKG_ALLOWED_PEER and %s both pass', async (label, predicate) => {
+    const allowed = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+    });
+    await insertPeerGate(PEER_ID);
+    await insertAgentGate(predicate, allowed.address);
+
+    const raw = workspaceMessage(`${label} Mixed Signed`, `ws-agent-gate-mixed-signed-${label}`);
+    await handler.handle(await signWorkspaceMessage(allowed, raw), PEER_ID);
+
+    await expectStoredName(`${label} Mixed Signed`);
   });
 });

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TypedEventBus,
+  computeGossipSigningPayload,
+  contextGraphDataUri,
+  contextGraphMetaUri,
+  contextGraphSharedMemoryUri,
+  DKG_ONTOLOGY,
+  encodeGossipEnvelope,
+  encodeWorkspacePublishRequest,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+} from '@origintrail-official/dkg-core';
+import { SharedMemoryHandler } from '../src/index.js';
+
+const CONTEXT_GRAPH_ID = 'workspace-handler-agent-gate';
+const DATA_GRAPH = contextGraphDataUri(CONTEXT_GRAPH_ID);
+const META_GRAPH = contextGraphMetaUri(CONTEXT_GRAPH_ID);
+const WORKSPACE_GRAPH = contextGraphSharedMemoryUri(CONTEXT_GRAPH_ID);
+const PEER_ID = '12D3KooWAgentGatePeer';
+const ENTITY = 'urn:test:workspace-handler-agent-gate';
+
+let store: OxigraphStore;
+let workspaceOwned: Map<string, Map<string, string>>;
+let handler: SharedMemoryHandler;
+
+function workspaceMessage(name: string, operationId: string): Uint8Array {
+  return encodeWorkspacePublishRequest({
+    paranetId: CONTEXT_GRAPH_ID,
+    nquads: new TextEncoder().encode(
+      `<${ENTITY}> <http://schema.org/name> "${name}" <${DATA_GRAPH}> .`,
+    ),
+    manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+    publisherPeerId: PEER_ID,
+    workspaceOperationId: operationId,
+    timestampMs: Date.now(),
+  });
+}
+
+async function signWorkspaceMessage(wallet: ethers.Wallet, payload: Uint8Array): Promise<Uint8Array> {
+  const timestamp = new Date().toISOString();
+  const signingPayload = computeGossipSigningPayload(
+    GOSSIP_TYPE_WORKSPACE_PUBLISH,
+    CONTEXT_GRAPH_ID,
+    timestamp,
+    payload,
+  );
+  const signature = await wallet.signMessage(signingPayload);
+  return encodeGossipEnvelope({
+    version: GOSSIP_ENVELOPE_VERSION,
+    type: GOSSIP_TYPE_WORKSPACE_PUBLISH,
+    contextGraphId: CONTEXT_GRAPH_ID,
+    agentAddress: wallet.address,
+    timestamp,
+    signature: ethers.getBytes(signature),
+    payload,
+  });
+}
+
+async function insertAgentGate(predicate: string, agentAddress: string): Promise<void> {
+  await store.insert([{
+    subject: DATA_GRAPH,
+    predicate,
+    object: `"${agentAddress}"`,
+    graph: META_GRAPH,
+  }]);
+}
+
+async function expectStoredName(name: string): Promise<void> {
+  const result = await store.query(
+    `SELECT ?o WHERE { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
+  );
+  expect(result.type).toBe('bindings');
+  if (result.type === 'bindings') {
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]?.['o']).toBe(`"${name}"`);
+  }
+}
+
+async function expectWorkspaceEmpty(): Promise<void> {
+  const result = await store.query(
+    `ASK { GRAPH <${WORKSPACE_GRAPH}> { <${ENTITY}> ?p ?o } }`,
+  );
+  expect(result.type).toBe('boolean');
+  if (result.type === 'boolean') {
+    expect(result.value).toBe(false);
+  }
+}
+
+describe('SharedMemoryHandler agent-gated gossip', () => {
+  beforeEach(() => {
+    store = new OxigraphStore();
+    workspaceOwned = new Map();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+    });
+  });
+
+  it('accepts legacy raw SWM gossip for non-agent-gated context graphs', async () => {
+    await handler.handle(workspaceMessage('Raw Open', 'ws-agent-gate-raw-open'), PEER_ID);
+
+    await expectStoredName('Raw Open');
+    expect(workspaceOwned.get(CONTEXT_GRAPH_ID)?.get(ENTITY)).toBe(PEER_ID);
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('rejects legacy raw SWM gossip for %s-gated context graphs', async (_label, predicate) => {
+    const allowed = ethers.Wallet.createRandom();
+    await insertAgentGate(predicate, allowed.address);
+
+    await handler.handle(workspaceMessage('Unsigned Gated', `ws-agent-gate-raw-${_label}`), PEER_ID);
+
+    await expectWorkspaceEmpty();
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('accepts signed SWM gossip from a %s writer', async (label, predicate) => {
+    const allowed = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+    });
+    await insertAgentGate(predicate, allowed.address);
+
+    const raw = workspaceMessage(`${label} Signed`, `ws-agent-gate-signed-${label}`);
+    await handler.handle(await signWorkspaceMessage(allowed, raw), PEER_ID);
+
+    await expectStoredName(`${label} Signed`);
+  });
+
+  it.each([
+    ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
+    ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],
+  ])('rejects signed SWM gossip from an unauthorized %s writer', async (_label, predicate) => {
+    const allowed = ethers.Wallet.createRandom();
+    const denied = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+    });
+    await insertAgentGate(predicate, allowed.address);
+
+    const raw = workspaceMessage('Denied Signed', `ws-agent-gate-denied-${_label}`);
+    await handler.handle(await signWorkspaceMessage(denied, raw), PEER_ID);
+
+    await expectWorkspaceEmpty();
+  });
+});

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -2,8 +2,15 @@ import { describe, it, expect, beforeEach, beforeAll, afterAll, afterEach } from
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { GraphManager } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
-import { TypedEventBus } from '@origintrail-official/dkg-core';
-import { generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import {
+  TypedEventBus,
+  generateEd25519Keypair,
+  encodeWorkspacePublishRequest,
+  encodeGossipEnvelope,
+  computeGossipSigningPayload,
+  GOSSIP_ENVELOPE_VERSION,
+  GOSSIP_TYPE_WORKSPACE_PUBLISH,
+} from '@origintrail-official/dkg-core';
 import {
   DKGPublisher,
   SharedMemoryHandler,
@@ -23,6 +30,30 @@ const ENTITY = 'urn:test:entity:1';
 
 function q(s: string, p: string, o: string, g = ''): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
+}
+
+async function signWorkspaceMessage(
+  wallet: ethers.Wallet,
+  contextGraphId: string,
+  payload: Uint8Array,
+  timestamp = new Date().toISOString(),
+): Promise<Uint8Array> {
+  const signingPayload = computeGossipSigningPayload(
+    GOSSIP_TYPE_WORKSPACE_PUBLISH,
+    contextGraphId,
+    timestamp,
+    payload,
+  );
+  const signature = await wallet.signMessage(signingPayload);
+  return encodeGossipEnvelope({
+    version: GOSSIP_ENVELOPE_VERSION,
+    type: GOSSIP_TYPE_WORKSPACE_PUBLISH,
+    contextGraphId,
+    agentAddress: wallet.address,
+    timestamp,
+    signature: ethers.getBytes(signature),
+    payload,
+  });
 }
 
 beforeAll(async () => {
@@ -502,6 +533,144 @@ describe('SharedMemoryHandler', () => {
       expect(result.bindings[0]['o']).toBe('"Handler Test"');
     }
     expect(workspaceOwned.get(PARANET)?.has(ENTITY)).toBe(true);
+  });
+
+  it('rejects raw workspace gossip when the context graph is agent-gated', async () => {
+    const wallet = ethers.Wallet.createRandom();
+    await store.insert([{
+      subject: DATA_GRAPH,
+      predicate: 'https://dkg.network/ontology#allowedAgent',
+      object: `"${wallet.address}"`,
+      graph: `did:dkg:context-graph:${PARANET}/_meta`,
+    }]);
+
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Unsigned" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      paranetId: PARANET,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      workspaceOperationId: 'ws-unsigned-agent-gate',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    const gm = new GraphManager(store);
+    await gm.ensureContextGraph(PARANET);
+    const askResult = await store.query(
+      `ASK { GRAPH <${gm.workspaceGraphUri(PARANET)}> { <${ENTITY}> ?p ?o } }`,
+    );
+    expect(askResult.type).toBe('boolean');
+    if (askResult.type === 'boolean') {
+      expect(askResult.value).toBe(false);
+    }
+  });
+
+  it('treats malformed allowedAgent metadata as gated instead of open', async () => {
+    await store.insert([{
+      subject: DATA_GRAPH,
+      predicate: 'https://dkg.network/ontology#allowedAgent',
+      object: '"not-an-address"',
+      graph: `did:dkg:context-graph:${PARANET}/_meta`,
+    }]);
+
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Malformed Gate" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      paranetId: PARANET,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      workspaceOperationId: 'ws-malformed-agent-gate',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    const gm = new GraphManager(store);
+    await gm.ensureContextGraph(PARANET);
+    const askResult = await store.query(
+      `ASK { GRAPH <${gm.workspaceGraphUri(PARANET)}> { <${ENTITY}> ?p ?o } }`,
+    );
+    expect(askResult.type).toBe('boolean');
+    if (askResult.type === 'boolean') {
+      expect(askResult.value).toBe(false);
+    }
+  });
+
+  it('accepts signed workspace gossip from an allowed agent', async () => {
+    const wallet = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [wallet.address],
+    });
+    await store.insert([{
+      subject: DATA_GRAPH,
+      predicate: 'https://dkg.network/ontology#allowedAgent',
+      object: `"${wallet.address}"`,
+      graph: `did:dkg:context-graph:${PARANET}/_meta`,
+    }]);
+
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Signed" <${DATA_GRAPH}> .`;
+    const raw = encodeWorkspacePublishRequest({
+      paranetId: PARANET,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      workspaceOperationId: 'ws-signed-agent-gate',
+      timestampMs: Date.now(),
+    });
+    const msg = await signWorkspaceMessage(wallet, PARANET, raw);
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    const gm = new GraphManager(store);
+    await gm.ensureContextGraph(PARANET);
+    const result = await store.query(
+      `SELECT ?o WHERE { GRAPH <${gm.workspaceGraphUri(PARANET)}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
+    );
+    expect(result.type).toBe('bindings');
+    if (result.type === 'bindings') {
+      expect(result.bindings[0]?.['o']).toBe('"Signed"');
+    }
+  });
+
+  it('rejects signed workspace gossip from an agent outside the allowlist', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    const denied = ethers.Wallet.createRandom();
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+    });
+    await store.insert([{
+      subject: DATA_GRAPH,
+      predicate: 'https://dkg.network/ontology#allowedAgent',
+      object: `"${allowed.address}"`,
+      graph: `did:dkg:context-graph:${PARANET}/_meta`,
+    }]);
+
+    const nquads = `<${ENTITY}> <http://schema.org/name> "Denied" <${DATA_GRAPH}> .`;
+    const raw = encodeWorkspacePublishRequest({
+      paranetId: PARANET,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      workspaceOperationId: 'ws-denied-agent-gate',
+      timestampMs: Date.now(),
+    });
+    const msg = await signWorkspaceMessage(denied, PARANET, raw);
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    const gm = new GraphManager(store);
+    await gm.ensureContextGraph(PARANET);
+    const askResult = await store.query(
+      `ASK { GRAPH <${gm.workspaceGraphUri(PARANET)}> { <${ENTITY}> ?p ?o } }`,
+    );
+    expect(askResult.type).toBe('boolean');
+    if (askResult.type === 'boolean') {
+      expect(askResult.value).toBe(false);
+    }
   });
 
   it('rejects message when rootEntity was created by a different peer (Rule 4)', async () => {


### PR DESCRIPTION
 Main changes:

  - Gates SWM topic subscription through authorization.
  - Blocks unauthorized SWM sync.
  - Blocks unauthorized SWM queries on the node level (directly subscribing to the gosipsub is still possible).
  - Keeps open/public graphs working with legacy raw SWM gossip.
  - Preserves peer allowlist behavior.
  - Preserves signed agent-gated SWM writes.
  - Adds regression tests for unknown, public, peer-only, denied agent-gated, and allowed agent-gated SWM
    access.