### PR TITLE
Codex/benchmark publish async get

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,7 +11,8 @@ memory, exercises synchronous and asynchronous publish paths, queries the
 published marker, and reports timings plus failures. The repository ESBench
 workflow for the same feature stays local to benchmark tooling: it uses a
 deterministic layered DKG client to measure focused WM, SWM, VM, publish, and
-read flows, then renders both the combined report and per-flow HTML pages.
+read flows across generated `10kb`, `100kb`, `2mb`, and `200mb` payloads, then
+renders both the combined report and per-flow HTML pages.
 
 ## Top-Level Components
 

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -94,6 +94,12 @@ Generate the ESBench reports plus a V8 CPU profile and generated flame graph:
 pnpm bench:profile
 ```
 
+Generate the per-flow method trace without CPU profiling:
+
+```bash
+pnpm bench:analysis
+```
+
 Profile a single large generated payload when investigating the heavy path:
 
 ```bash
@@ -106,13 +112,23 @@ This writes:
 - `bench/results/profiles/publish-async-get-<timestamp>.esbench.html`
 - `bench/results/profiles/publish-async-get-<timestamp>.cpuprofile`
 - `bench/results/profiles/publish-async-get-<timestamp>.flamegraph.html`
+- `bench/results/profiles/method-analysis.latest.html`
+- `bench/results/profiles/method-analysis.latest.json`
 - `bench/results/profiles/index.html`
 
 The generated flame graph is a local HTML view built from V8 sampled CPU stacks.
 Width represents aggregated sampled CPU time. Use it to find where CPU time is
 going inside publish, async publish, get, and memory-layer benchmark runs.
 When `bench/results/latest.html` and the focused per-flow pages already exist,
-`pnpm bench:profile` updates their navigation bars with a `CPU profiles` link.
+`pnpm bench:profile` updates their navigation bars with `CPU profiles` and
+`Method analysis` links.
+
+The method analysis report is the place to inspect which benchmark-layer
+methods were invoked for each flow. It separates setup, measured, validation,
+and cleanup phases and reports per-method wall-clock timing with context such as
+payload size, root entity, marker, and quad count. Use it alongside the flame
+graph: the method analysis explains the awaited DKG-layer sequence, while the
+flame graph explains sampled CPU stacks inside the process.
 
 The raw `.cpuprofile` can also be opened in Chrome or Edge DevTools Performance,
 or uploaded locally to Speedscope. CPU profiling adds overhead, so use normal

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -82,7 +82,42 @@ Open the combined HTML file for the full table, or one of the per-flow pages
 when you only need a single DKG memory/publish/read path. The per-flow pages are
 generated from the same result object through
 `ESBENCH_PUBLISH_ASYNC_GET_HTML=1`; they contain benchmark results only and do
-not embed local auth tokens or daemon paths.
+not embed local auth tokens or daemon paths. The combined report and per-flow
+pages include a fixed report navigation bar so the generated HTML files can be
+opened directly from disk without losing the link between the pages.
+
+## CPU Profiles And Flame Graphs
+
+Generate the ESBench reports plus a V8 CPU profile and generated flame graph:
+
+```bash
+pnpm bench:profile
+```
+
+Profile a single large generated payload when investigating the heavy path:
+
+```bash
+DKG_ESBENCH_PAYLOAD_SIZES=200mb pnpm bench:profile
+```
+
+This writes:
+
+- `bench/results/profiles/publish-async-get-<timestamp>.esbench.json`
+- `bench/results/profiles/publish-async-get-<timestamp>.esbench.html`
+- `bench/results/profiles/publish-async-get-<timestamp>.cpuprofile`
+- `bench/results/profiles/publish-async-get-<timestamp>.flamegraph.html`
+- `bench/results/profiles/index.html`
+
+The generated flame graph is a local HTML view built from V8 sampled CPU stacks.
+Width represents aggregated sampled CPU time. Use it to find where CPU time is
+going inside publish, async publish, get, and memory-layer benchmark runs.
+When `bench/results/latest.html` and the focused per-flow pages already exist,
+`pnpm bench:profile` updates their navigation bars with a `CPU profiles` link.
+
+The raw `.cpuprofile` can also be opened in Chrome or Edge DevTools Performance,
+or uploaded locally to Speedscope. CPU profiling adds overhead, so use normal
+`pnpm bench` or `pnpm bench:html` output as the timing baseline and use
+`pnpm bench:profile` for deeper attribution.
 
 ## Baseline Workflow
 

--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -23,6 +23,10 @@ The ESBench suite measures focused memory-layer flows:
 - `upload payload to local working memory`
 - `lift local working memory to shared working memory`
 
+Each flow runs against generated payload sizes of `10kb`, `100kb`, `2mb`, and
+`200mb`. The labels use binary units: `1kb = 1024` bytes and `1mb = 1024 * 1024`
+bytes.
+
 Add new suites under `bench/**/*.bench.ts` as performance-sensitive paths become
 obvious.
 
@@ -40,6 +44,12 @@ Run benchmarks and write the raw result to `bench/results/latest.json`:
 pnpm bench
 ```
 
+Run a quick subset while iterating on benchmark wiring:
+
+```bash
+DKG_ESBENCH_PAYLOAD_SIZES=10kb pnpm bench
+```
+
 The root ESBench config is `esbench.config.mjs`. It was verified against ESBench `0.8.1`, whose CLI runs suites with `esbench --config <file>` and generates reports from saved result files with `esbench report <patterns...> --config <file>`.
 
 ## HTML Reports
@@ -49,6 +59,10 @@ Generate a benchmark run plus an interactive HTML report:
 ```bash
 pnpm bench:html
 ```
+
+The default run includes the `200mb` generated payload scene and is intentionally
+heavy. Use `DKG_ESBENCH_PAYLOAD_SIZES=10kb,100kb` for a faster local smoke run,
+or pass one of `10kb`, `100kb`, `2mb`, `200mb` to isolate a single size.
 
 The `bench:html` script sets both `ESBENCH_HTML=1` and
 `ESBENCH_PUBLISH_ASYNC_GET_HTML=1`, so the combined report and the focused

--- a/README.md
+++ b/README.md
@@ -210,6 +210,38 @@ Use adapters for OpenClaw, ElizaOS, Hermes, or your own Node.js / TypeScript pro
 
 ---
 
+## Benchmarking
+
+Benchmarking docs live in [`BENCHMARKING.md`](BENCHMARKING.md). The current
+suite covers DKG publish/get and memory-layer flows:
+
+- get/read retrieval
+- synchronous publish with finalization
+- asynchronous publish enqueue and finalization
+- upload payload to local working memory
+- lift local working memory to shared working memory
+
+Run the main local benchmark workflow:
+
+```bash
+pnpm bench
+pnpm bench:html
+pnpm bench:analysis
+pnpm bench:profile
+```
+
+The benchmark matrix uses generated payload sizes of `10kb`, `100kb`, `2mb`,
+and `200mb`. Use `DKG_ESBENCH_PAYLOAD_SIZES=10kb` or
+`DKG_ESBENCH_PAYLOAD_SIZES=200mb` to run a focused subset.
+
+Generated reports are written under `bench/results/`. The combined ESBench HTML
+report is `bench/results/latest.html`; per-flow HTML pages are under
+`bench/results/publish-async-get/`. CPU profiles, flame graphs, and per-method
+analysis reports are under `bench/results/profiles/`, including
+`method-analysis.latest.html` for the invoked-method timing breakdown.
+
+---
+
 ## Setup guides
 
 | Guide | Use it when |

--- a/bench/analyze-publish-async-get.ts
+++ b/bench/analyze-publish-async-get.ts
@@ -1,0 +1,511 @@
+#!/usr/bin/env tsx
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import {
+  createPayload,
+  getSparql,
+  validateQueryContainsMarker,
+} from '../packages/cli/src/benchmark/publish-get/payload.ts';
+import type {
+  BenchmarkConfig,
+  BenchmarkPayload,
+} from '../packages/cli/src/benchmark/publish-get/types.ts';
+import {
+  GENERATED_PAYLOAD_SIZES,
+} from './publish-async-get.bench.ts';
+import { LayeredDkgBenchmarkClient } from './support/layered-dkg-client.ts';
+
+type PayloadSizeLabel = (typeof GENERATED_PAYLOAD_SIZES)[number]['label'];
+type TracePhase = 'setup' | 'measured' | 'validation' | 'cleanup';
+
+interface MethodTrace {
+  flow: string;
+  payloadSize: PayloadSizeLabel;
+  phase: TracePhase;
+  method: string;
+  invokes: string[];
+  detail: string;
+  durationMs: number;
+  success: boolean;
+  context: Record<string, unknown>;
+  error?: string;
+}
+
+interface FlowAnalysis {
+  flow: string;
+  payloadSize: PayloadSizeLabel;
+  totalMs: number;
+  measuredMs: number;
+  traces: MethodTrace[];
+}
+
+interface MethodAnalysisReport {
+  benchmark: 'publish-async-get-method-analysis';
+  generatedAt: string;
+  payloadSizes: PayloadSizeLabel[];
+  flows: FlowAnalysis[];
+}
+
+const DEFAULT_OUTPUT_DIR = 'bench/results/profiles';
+const PUBLISH_ASYNC_GET_PAGES: Array<[string, string]> = [
+  ['get/read retrieval', 'bench/results/publish-async-get/get-read-retrieval.html'],
+  ['synchronous publish with finalization', 'bench/results/publish-async-get/sync-publish-finalization.html'],
+  ['asynchronous publish enqueue and finalization', 'bench/results/publish-async-get/async-publish-finalization.html'],
+  ['upload payload to local working memory', 'bench/results/publish-async-get/working-memory-upload.html'],
+  ['lift local working memory to shared working memory', 'bench/results/publish-async-get/working-to-shared-memory.html'],
+];
+
+export async function main(): Promise<void> {
+  const outputDir = resolve(process.cwd(), process.env.DKG_BENCH_ANALYSIS_DIR ?? DEFAULT_OUTPUT_DIR);
+  const generatedAt = new Date().toISOString();
+  const stamp = generatedAt.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  const report = await createMethodAnalysisReport(resolvePayloadSizeLabels(), generatedAt);
+  const html = renderMethodAnalysisHtml(report);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(resolve(outputDir, `method-analysis-${stamp}.json`), json, 'utf8');
+  await writeFile(resolve(outputDir, `method-analysis-${stamp}.html`), html, 'utf8');
+  await writeFile(resolve(outputDir, 'method-analysis.latest.json'), json, 'utf8');
+  await writeFile(resolve(outputDir, 'method-analysis.latest.html'), html, 'utf8');
+  await linkExistingBenchmarkReports();
+
+  console.log(`[bench:analysis] wrote ${relativePath(resolve(outputDir, 'method-analysis.latest.html'))}`);
+}
+
+export async function createMethodAnalysisReport(
+  payloadSizes = resolvePayloadSizeLabels(),
+  generatedAt = new Date().toISOString(),
+): Promise<MethodAnalysisReport> {
+  const flows: FlowAnalysis[] = [];
+  for (const payloadSize of payloadSizes) {
+    const config = createConfig(payloadSize);
+    flows.push(await analyzeGetFlow(config, payloadSize));
+    flows.push(await analyzeSyncPublishFlow(config, payloadSize));
+    flows.push(await analyzeAsyncPublishFlow(config, payloadSize));
+    flows.push(await analyzeWorkingMemoryUploadFlow(config, payloadSize));
+    flows.push(await analyzeWorkingToSharedMemoryFlow(config, payloadSize));
+  }
+
+  return {
+    benchmark: 'publish-async-get-method-analysis',
+    generatedAt,
+    payloadSizes,
+    flows,
+  };
+}
+
+export function renderMethodAnalysisHtml(report: MethodAnalysisReport): string {
+  const sections = report.payloadSizes.map((payloadSize) => {
+    const flows = report.flows.filter((flow) => flow.payloadSize === payloadSize);
+    return `<section class="payload-section">
+      <h2>${escapeHtml(payloadSize)}</h2>
+      ${flows.map(renderFlowSection).join('\n')}
+    </section>`;
+  }).join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DKG Benchmark Method Analysis</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { background: #f8fafc; color: #111827; margin: 0; }
+    header { background: #111827; color: #f9fafb; padding: 18px 24px; }
+    main { padding: 22px 24px 40px; }
+    a { color: #1d4ed8; }
+    header a { color: #bfdbfe; }
+    .nav { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+    .nav a { border: 1px solid #4b5563; border-radius: 4px; color: #f9fafb; padding: 5px 9px; text-decoration: none; }
+    .meta { color: #d1d5db; font-size: 13px; margin-top: 6px; }
+    .payload-section { margin-bottom: 28px; }
+    .flow { background: white; border: 1px solid #e5e7eb; border-radius: 6px; margin-bottom: 18px; padding: 16px; }
+    .flow-summary { color: #4b5563; display: flex; flex-wrap: wrap; font-size: 13px; gap: 16px; margin: 6px 0 12px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid #e5e7eb; padding: 8px 10px; text-align: left; vertical-align: top; }
+    th { color: #374151; font-size: 12px; text-transform: uppercase; }
+    code { background: #eef2ff; border-radius: 4px; padding: 1px 4px; }
+    .phase { border-radius: 4px; color: white; display: inline-block; min-width: 72px; padding: 2px 6px; text-align: center; }
+    .setup { background: #475569; }
+    .measured { background: #2563eb; }
+    .validation { background: #059669; }
+    .cleanup { background: #7c3aed; }
+    .bar { background: #dbeafe; border-radius: 999px; height: 8px; min-width: 80px; overflow: hidden; }
+    .bar span { background: #2563eb; display: block; height: 100%; }
+    .context { color: #4b5563; font-size: 12px; max-width: 360px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>DKG Benchmark Method Analysis</h1>
+    <div class="meta">Generated ${escapeHtml(report.generatedAt)}. Durations are wall-clock timings from one representative traced run per flow and payload size.</div>
+    <nav class="nav" aria-label="Benchmark analysis links">
+      <a href="../latest.html">ESBench report</a>
+      <a href="./index.html">CPU profiles</a>
+      <a href="./method-analysis.latest.json">Raw method trace JSON</a>
+    </nav>
+  </header>
+  <main>
+    ${sections}
+  </main>
+</body>
+</html>
+`;
+}
+
+async function analyzeGetFlow(config: BenchmarkConfig, payloadSize: PayloadSizeLabel): Promise<FlowAnalysis> {
+  const client = new LayeredDkgBenchmarkClient();
+  return analyzeFlow('get/read retrieval', payloadSize, async (trace) => {
+    const payload = traceSync(trace, 'setup', 'createPayload', [], 'Generate the asset to publish and read back.', () => (
+      createPayload(config, `analysis-get-${payloadSize}`, 1, 'sync', false)
+    ));
+    await traceSharedMemoryWrite(trace, client, config, payload);
+    await traceAsync(trace, 'setup', 'publishFromSharedMemory', ['promoteSharedRoot'], 'Finalize staged shared-memory content into verified memory for the read path.', () => (
+      client.publishFromSharedMemory(config.contextGraphId, { rootEntities: [payload.rootEntity] }, false)
+    ), { rootEntity: payload.rootEntity });
+    const sparql = traceSync(trace, 'measured', 'getSparql', [], 'Build the read query for the published root entity.', () => getSparql(payload.rootEntity));
+    const response = await traceAsync(trace, 'measured', 'query', ['layer'], 'Read the published marker from the configured memory view.', () => (
+      client.query(sparql, config.contextGraphId, { view: config.getView })
+    ), { view: config.getView, rootEntity: payload.rootEntity });
+    traceSync(trace, 'validation', 'validateQueryContainsMarker', [], 'Verify the get result contains the expected benchmark marker.', () => (
+      validateQueryContainsMarker(response.result, payload.marker)
+    ));
+    traceSync(trace, 'cleanup', 'clear', ['Map.clear'], 'Clear all in-memory layers after the representative run.', () => client.clear());
+  });
+}
+
+async function analyzeSyncPublishFlow(config: BenchmarkConfig, payloadSize: PayloadSizeLabel): Promise<FlowAnalysis> {
+  const client = new LayeredDkgBenchmarkClient();
+  return analyzeFlow('synchronous publish with finalization', payloadSize, async (trace) => {
+    const payload = traceSync(trace, 'setup', 'createPayload', [], 'Generate the payload for synchronous publish.', () => (
+      createPayload(config, `analysis-sync-${payloadSize}`, 1, 'sync', false)
+    ));
+    await traceSharedMemoryWrite(trace, client, config, payload);
+    await traceAsync(trace, 'measured', 'publishFromSharedMemory', ['promoteSharedRoot'], 'Synchronously finalize staged shared-memory content into verified memory.', () => (
+      client.publishFromSharedMemory(config.contextGraphId, { rootEntities: [payload.rootEntity] }, false)
+    ), { rootEntity: payload.rootEntity });
+    traceSync(trace, 'cleanup', 'clear', ['Map.clear'], 'Clear all in-memory layers after the representative run.', () => client.clear());
+  });
+}
+
+async function analyzeAsyncPublishFlow(config: BenchmarkConfig, payloadSize: PayloadSizeLabel): Promise<FlowAnalysis> {
+  const client = new LayeredDkgBenchmarkClient();
+  return analyzeFlow('asynchronous publish enqueue and finalization', payloadSize, async (trace) => {
+    const payload = traceSync(trace, 'setup', 'createPayload', [], 'Generate the payload for async publish.', () => (
+      createPayload(config, `analysis-async-${payloadSize}`, 1, 'async', false)
+    ));
+    const prepared = await traceSharedMemoryWrite(trace, client, config, payload);
+    const shareOperationId = prepared.shareOperationId ?? prepared.workspaceOperationId ?? '';
+    const queued = await traceAsync(trace, 'measured', 'publisherEnqueue', ['publisherJobs.set'], 'Enqueue the publish request through the publisher runtime path.', () => (
+      client.publisherEnqueue({
+        contextGraphId: config.contextGraphId,
+        shareOperationId,
+        roots: [payload.rootEntity],
+        namespace: config.namespace,
+        scope: config.scope,
+        authorityProofRef: config.authorityProofRef,
+        swmId: 'swm-main',
+        transitionType: 'CREATE',
+        authorityType: 'owner',
+      })
+    ), { rootEntity: payload.rootEntity, shareOperationId });
+    await traceAsync(trace, 'measured', 'publisherJob', ['promoteSharedRoot'], 'Poll the publisher job and finalize queued content.', () => (
+      client.publisherJob(queued.jobId ?? '')
+    ), { jobId: queued.jobId });
+    traceSync(trace, 'cleanup', 'clear', ['Map.clear'], 'Clear all in-memory layers after the representative run.', () => client.clear());
+  });
+}
+
+async function analyzeWorkingMemoryUploadFlow(config: BenchmarkConfig, payloadSize: PayloadSizeLabel): Promise<FlowAnalysis> {
+  const client = new LayeredDkgBenchmarkClient();
+  return analyzeFlow('upload payload to local working memory', payloadSize, async (trace) => {
+    const payload = traceSync(trace, 'setup', 'createPayload', [], 'Generate the payload to upload into local working memory.', () => (
+      createPayload(config, `analysis-upload-${payloadSize}`, 1, 'sync', false)
+    ));
+    await traceAsync(trace, 'measured', 'writeWorkingMemory', ['createMemoryRecord', 'uniqueSubjects', 'Map.set'], 'Write generated quads into local working memory.', () => (
+      client.writeWorkingMemory(config.contextGraphId, payload.quads)
+    ), payloadContext(payload));
+    traceSync(trace, 'cleanup', 'clear', ['Map.clear'], 'Clear all in-memory layers after the representative run.', () => client.clear());
+  });
+}
+
+async function analyzeWorkingToSharedMemoryFlow(config: BenchmarkConfig, payloadSize: PayloadSizeLabel): Promise<FlowAnalysis> {
+  const client = new LayeredDkgBenchmarkClient();
+  return analyzeFlow('lift local working memory to shared working memory', payloadSize, async (trace) => {
+    const payload = traceSync(trace, 'setup', 'createPayload', [], 'Generate the payload to lift from local to shared memory.', () => (
+      createPayload(config, `analysis-lift-${payloadSize}`, 1, 'sync', false)
+    ));
+    await traceAsync(trace, 'setup', 'writeWorkingMemory', ['createMemoryRecord', 'uniqueSubjects', 'Map.set'], 'Stage generated quads in local working memory.', () => (
+      client.writeWorkingMemory(config.contextGraphId, payload.quads)
+    ), payloadContext(payload));
+    await traceAsync(trace, 'measured', 'liftWorkingMemoryToSharedMemory', ['Map.get', 'Map.set'], 'Lift the selected root from local working memory into shared working memory.', () => (
+      client.liftWorkingMemoryToSharedMemory(config.contextGraphId, [payload.rootEntity])
+    ), { rootEntity: payload.rootEntity });
+    traceSync(trace, 'cleanup', 'clear', ['Map.clear'], 'Clear all in-memory layers after the representative run.', () => client.clear());
+  });
+}
+
+async function analyzeFlow(
+  flow: string,
+  payloadSize: PayloadSizeLabel,
+  fn: (trace: MethodTrace[]) => Promise<void>,
+): Promise<FlowAnalysis> {
+  const traces: MethodTrace[] = [];
+  const started = performance.now();
+  await fn(traces);
+  const normalizedTraces = traces.map((trace) => ({ ...trace, flow, payloadSize }));
+  const totalMs = roundMs(performance.now() - started);
+  const measuredMs = roundMs(normalizedTraces
+    .filter((trace) => trace.phase === 'measured')
+    .reduce((sum, trace) => sum + trace.durationMs, 0));
+  return { flow, payloadSize, totalMs, measuredMs, traces: normalizedTraces };
+}
+
+async function traceSharedMemoryWrite(
+  traces: MethodTrace[],
+  client: LayeredDkgBenchmarkClient,
+  config: BenchmarkConfig,
+  payload: BenchmarkPayload,
+) {
+  return traceAsync(traces, 'setup', 'sharedMemoryWrite', ['writeWorkingMemory', 'liftWorkingMemoryToSharedMemory'], 'Stage generated quads in local memory and lift them into shared working memory.', () => (
+    client.sharedMemoryWrite(config.contextGraphId, payload.quads)
+  ), payloadContext(payload));
+}
+
+async function traceAsync<T>(
+  traces: MethodTrace[],
+  phase: TracePhase,
+  method: string,
+  invokes: string[],
+  detail: string,
+  fn: () => Promise<T>,
+  context: Record<string, unknown> = {},
+): Promise<T> {
+  const started = performance.now();
+  try {
+    const value = await fn();
+    traces.push({ flow: '', payloadSize: '10kb', phase, method, invokes, detail, durationMs: roundMs(performance.now() - started), success: true, context });
+    return value;
+  } catch (error) {
+    traces.push({ flow: '', payloadSize: '10kb', phase, method, invokes, detail, durationMs: roundMs(performance.now() - started), success: false, context, error: errorMessage(error) });
+    throw error;
+  }
+}
+
+function traceSync<T>(
+  traces: MethodTrace[],
+  phase: TracePhase,
+  method: string,
+  invokes: string[],
+  detail: string,
+  fn: () => T,
+  context: Record<string, unknown> = {},
+): T {
+  const started = performance.now();
+  try {
+    const value = fn();
+    traces.push({ flow: '', payloadSize: '10kb', phase, method, invokes, detail, durationMs: roundMs(performance.now() - started), success: true, context: enrichContext(value, context) });
+    return value;
+  } catch (error) {
+    traces.push({ flow: '', payloadSize: '10kb', phase, method, invokes, detail, durationMs: roundMs(performance.now() - started), success: false, context, error: errorMessage(error) });
+    throw error;
+  }
+}
+
+function renderFlowSection(flow: FlowAnalysis): string {
+  const rows = flow.traces.map((trace) => renderTraceRow(trace, flow.totalMs)).join('\n');
+  return `<section class="flow">
+    <h3>${escapeHtml(flow.flow)}</h3>
+    <div class="flow-summary">
+      <span>Total traced wall time: <strong>${flow.totalMs.toFixed(3)} ms</strong></span>
+      <span>Measured benchmark phase: <strong>${flow.measuredMs.toFixed(3)} ms</strong></span>
+      <span>Trace rows: <strong>${flow.traces.length}</strong></span>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Phase</th>
+          <th>Method</th>
+          <th>Invokes</th>
+          <th>Duration</th>
+          <th>Share</th>
+          <th>Why it is here</th>
+          <th>Context</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </section>`;
+}
+
+function renderTraceRow(trace: MethodTrace, totalMs: number): string {
+  const share = totalMs > 0 ? Math.min(100, (trace.durationMs / totalMs) * 100) : 0;
+  return `<tr>
+    <td><span class="phase ${trace.phase}">${escapeHtml(trace.phase)}</span></td>
+    <td><code>${escapeHtml(trace.method)}</code>${trace.success ? '' : `<div>${escapeHtml(trace.error ?? 'failed')}</div>`}</td>
+    <td>${trace.invokes.length ? trace.invokes.map((name) => `<code>${escapeHtml(name)}</code>`).join(' -> ') : ''}</td>
+    <td>${trace.durationMs.toFixed(3)} ms</td>
+    <td><div class="bar" title="${share.toFixed(2)}%"><span style="width: ${share.toFixed(2)}%"></span></div></td>
+    <td>${escapeHtml(trace.detail)}</td>
+    <td class="context">${escapeHtml(JSON.stringify(trace.context))}</td>
+  </tr>`;
+}
+
+function createConfig(payloadSize: PayloadSizeLabel): BenchmarkConfig {
+  return {
+    contextGraphId: 'bench-cg',
+    repeat: 1,
+    warmups: 0,
+    timeoutMs: 120_000,
+    payloadSizeBytes: payloadSizeBytes(payloadSize),
+    fixture: 'generated',
+    outputFormat: 'json',
+    namespace: 'benchmark',
+    scope: 'publish-async-get',
+    authorityProofRef: 'proof:benchmark-local',
+    pollIntervalMs: 1000,
+    asyncSuccessStatuses: ['finalized'],
+    getView: 'verified-memory',
+  };
+}
+
+function resolvePayloadSizeLabels(): PayloadSizeLabel[] {
+  const raw = process.env.DKG_ESBENCH_PAYLOAD_SIZES;
+  if (!raw?.trim()) return GENERATED_PAYLOAD_SIZES.map((size) => size.label);
+  const requested = raw.split(',').map((part) => part.trim().toLowerCase()).filter(Boolean);
+  if (requested.length === 0) return GENERATED_PAYLOAD_SIZES.map((size) => size.label);
+
+  const known = new Set(GENERATED_PAYLOAD_SIZES.map((size) => size.label));
+  for (const label of requested) {
+    if (!known.has(label as PayloadSizeLabel)) {
+      throw new Error(`Unknown DKG_ESBENCH_PAYLOAD_SIZES entry "${label}". Expected one of: ${[...known].join(', ')}`);
+    }
+  }
+  return requested as PayloadSizeLabel[];
+}
+
+function payloadSizeBytes(label: PayloadSizeLabel): number {
+  const size = GENERATED_PAYLOAD_SIZES.find((entry) => entry.label === label);
+  if (!size) throw new Error(`Unknown payload size label: ${label}`);
+  return size.bytes;
+}
+
+function payloadContext(payload: BenchmarkPayload): Record<string, unknown> {
+  return {
+    rootEntity: payload.rootEntity,
+    marker: payload.marker,
+    quadCount: payload.quads.length,
+  };
+}
+
+function enrichContext(value: unknown, context: Record<string, unknown>): Record<string, unknown> {
+  if (isPayload(value)) return { ...context, ...payloadContext(value) };
+  return context;
+}
+
+function isPayload(value: unknown): value is BenchmarkPayload {
+  return Boolean(value && typeof value === 'object' && 'rootEntity' in value && 'marker' in value && 'quads' in value);
+}
+
+function roundMs(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function relativePath(file: string): string {
+  return file.startsWith(process.cwd()) ? file.slice(process.cwd().length + 1) : file;
+}
+
+async function linkExistingBenchmarkReports(): Promise<void> {
+  const reportFiles = [
+    'bench/results/latest.html',
+    ...PUBLISH_ASYNC_GET_PAGES.map(([, file]) => file),
+  ];
+  const targets: Array<[string, string]> = [
+    ['Combined report', 'bench/results/latest.html'],
+    ...PUBLISH_ASYNC_GET_PAGES,
+  ];
+
+  if (existsSync(resolve(process.cwd(), 'bench/results/profiles/index.html'))) {
+    targets.push(['CPU profiles', 'bench/results/profiles/index.html']);
+  }
+  targets.push(['Method analysis', 'bench/results/profiles/method-analysis.latest.html']);
+
+  for (const file of reportFiles) {
+    const reportPath = resolve(process.cwd(), file);
+    if (!existsSync(reportPath)) continue;
+    const html = await readFile(reportPath, 'utf8');
+    await writeFile(reportPath, addLinkedReportNavigation(html, file, targets), 'utf8');
+  }
+}
+
+function addLinkedReportNavigation(html: string, currentFile: string, targets: Array<[string, string]>): string {
+  const start = '<!-- dkg-benchmark-report-nav:start -->';
+  const end = '<!-- dkg-benchmark-report-nav:end -->';
+  const withoutExisting = html.replace(new RegExp(`${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}\\n?`, 'g'), '');
+  const links = targets.map(([label, targetFile]) => {
+    const active = currentFile === targetFile ? ' aria-current="page"' : '';
+    return `<a class="dkg-benchmark-report-nav__link" href="${escapeHtml(relativeReportHref(currentFile, targetFile))}"${active}>${escapeHtml(label)}</a>`;
+  }).join('');
+  const navHtml = `<nav id="dkg-benchmark-report-nav" class="dkg-benchmark-report-nav" aria-label="DKG benchmark reports"><span class="dkg-benchmark-report-nav__title">DKG benchmark reports</span>${links}</nav>`;
+  const block = `${start}
+<style>
+  body.dkg-benchmark-report-linked { padding-top: 48px; }
+  .dkg-benchmark-report-nav { align-items: center; background: #111827; border-bottom: 1px solid #374151; box-shadow: 0 1px 8px rgba(0, 0, 0, .16); color: #f9fafb; display: flex; font: 13px/1.4 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; gap: 8px; left: 0; min-height: 48px; overflow-x: auto; padding: 8px 14px; position: fixed; right: 0; top: 0; z-index: 2147483647; }
+  .dkg-benchmark-report-nav__title { color: #d1d5db; flex: 0 0 auto; font-weight: 700; margin-right: 4px; }
+  .dkg-benchmark-report-nav__link { border: 1px solid #4b5563; border-radius: 4px; color: #f9fafb; flex: 0 0 auto; padding: 4px 8px; text-decoration: none; white-space: nowrap; }
+  .dkg-benchmark-report-nav__link:hover, .dkg-benchmark-report-nav__link:focus { background: #1f2937; }
+  .dkg-benchmark-report-nav__link[aria-current="page"] { background: #2563eb; border-color: #60a5fa; }
+</style>
+<script>
+  window.addEventListener("DOMContentLoaded", function () {
+    if (document.getElementById("dkg-benchmark-report-nav")) return;
+    document.body.classList.add("dkg-benchmark-report-linked");
+    document.body.insertAdjacentHTML("afterbegin", ${JSON.stringify(navHtml)});
+  });
+</script>
+${end}
+`;
+
+  return withoutExisting.includes('</head>')
+    ? withoutExisting.replace('</head>', `${block}</head>`)
+    : `${block}${withoutExisting}`;
+}
+
+function relativeReportHref(fromFile: string, toFile: string): string {
+  const fromParts = fromFile.split('/');
+  fromParts.pop();
+  const toParts = toFile.split('/');
+  while (fromParts.length > 0 && toParts.length > 0 && fromParts[0] === toParts[0]) {
+    fromParts.shift();
+    toParts.shift();
+  }
+  return [...fromParts.map(() => '..'), ...toParts].join('/') || (toFile.split('/').at(-1) ?? toFile);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  });
+}

--- a/bench/profile-publish-async-get.mjs
+++ b/bench/profile-publish-async-get.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  renderCpuProfileFlamegraphHtml,
+  renderProfileIndexHtml,
+} from './support/cpu-profile-report.mjs';
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const profileDir = resolve(rootDir, 'bench/results/profiles');
+const esbenchBin = resolve(rootDir, 'node_modules/esbench/lib/host/cli.js');
+
+if (!existsSync(esbenchBin)) {
+  console.error(`ESBench CLI was not found at ${relativeFromRoot(esbenchBin)}. Run pnpm install first.`);
+  process.exit(1);
+}
+
+await mkdir(profileDir, { recursive: true });
+
+const createdAt = new Date().toISOString();
+const profileName = `publish-async-get-${createdAt.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')}.cpuprofile`;
+const profilePath = resolve(profileDir, profileName);
+const reportJsonName = profileName.replace(/\.cpuprofile$/, '.esbench.json');
+const reportHtmlName = profileName.replace(/\.cpuprofile$/, '.esbench.html');
+const reportJsonPath = resolve(profileDir, reportJsonName);
+const reportHtmlPath = resolve(profileDir, reportHtmlName);
+const profileArgs = [
+  '--cpu-prof',
+  '--cpu-prof-dir',
+  profileDir,
+  '--cpu-prof-name',
+  profileName,
+  esbenchBin,
+  '--config',
+  'esbench.config.mjs',
+  ...process.argv.slice(2),
+];
+const env = {
+  ...process.env,
+  ESBENCH_HTML: process.env.ESBENCH_HTML ?? '1',
+  ESBENCH_RESULT: process.env.ESBENCH_RESULT ?? reportJsonPath,
+  ESBENCH_HTML_FILE: process.env.ESBENCH_HTML_FILE ?? reportHtmlPath,
+};
+
+console.log(`[bench:profile] payload sizes: ${env.DKG_ESBENCH_PAYLOAD_SIZES || '10kb,100kb,2mb,200mb'}`);
+console.log(`[bench:profile] writing CPU profile: ${relativeFromRoot(profilePath)}`);
+console.log(`[bench:profile] writing ESBench report: ${relativeFromRoot(reportHtmlPath)}`);
+
+const exitCode = await runNode(profileArgs, env);
+if (exitCode !== 0) process.exit(exitCode);
+
+const profile = JSON.parse(await readFile(profilePath, 'utf8'));
+const flamegraphName = profileName.replace(/\.cpuprofile$/, '.flamegraph.html');
+const flamegraphPath = resolve(profileDir, flamegraphName);
+await writeFile(flamegraphPath, renderCpuProfileFlamegraphHtml(profile, {
+  title: 'DKG publish/async/get CPU flame graph',
+  profileName,
+  generatedAt: createdAt,
+  benchmarkReportHref: `./${reportHtmlName}`,
+  rawProfileHref: `./${profileName}`,
+}), 'utf8');
+
+await writeProfileIndex();
+await linkExistingBenchmarkReports();
+
+console.log(`[bench:profile] wrote flame graph: ${relativeFromRoot(flamegraphPath)}`);
+console.log(`[bench:profile] wrote profile index: ${relativeFromRoot(resolve(profileDir, 'index.html'))}`);
+
+function runNode(args, env) {
+  return new Promise((resolveExitCode) => {
+    const child = spawn(process.execPath, args, {
+      cwd: rootDir,
+      env,
+      stdio: 'inherit',
+    });
+    child.on('error', (error) => {
+      console.error(error);
+      resolveExitCode(1);
+    });
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        console.error(`[bench:profile] profiler run exited from signal ${signal}`);
+        resolveExitCode(1);
+        return;
+      }
+      resolveExitCode(code ?? 1);
+    });
+  });
+}
+
+async function writeProfileIndex() {
+  const files = await readdir(profileDir);
+  const entries = [];
+
+  for (const file of files) {
+    if (!file.endsWith('.cpuprofile')) continue;
+    const profileFile = resolve(profileDir, file);
+    const info = await stat(profileFile);
+    const flamegraphName = file.replace(/\.cpuprofile$/, '.flamegraph.html');
+    const reportHtmlName = file.replace(/\.cpuprofile$/, '.esbench.html');
+    const reportJsonFile = resolve(profileDir, file.replace(/\.cpuprofile$/, '.esbench.json'));
+    entries.push({
+      createdAt: info.mtime.toISOString(),
+      esbenchReportHref: `./${reportHtmlName}`,
+      esbenchReportName: reportHtmlName,
+      flamegraphHref: `./${flamegraphName}`,
+      flamegraphName,
+      profileHref: `./${file}`,
+      profileName: file,
+      payloadSizes: await readProfilePayloadSizes(reportJsonFile),
+      sizeBytes: info.size,
+    });
+  }
+
+  entries.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  await writeFile(resolve(profileDir, 'index.html'), renderProfileIndexHtml(entries, {
+    benchmarkReportHref: '../latest.html',
+  }), 'utf8');
+}
+
+async function readProfilePayloadSizes(reportJsonFile) {
+  try {
+    const report = JSON.parse(await readFile(reportJsonFile, 'utf8'));
+    for (const records of Object.values(report)) {
+      if (!Array.isArray(records)) continue;
+      for (const record of records) {
+        const paramDef = Array.isArray(record?.paramDef) ? record.paramDef : [];
+        const payloadParam = paramDef.find((param) => Array.isArray(param) && param[0] === 'payloadSize');
+        if (Array.isArray(payloadParam?.[1])) return payloadParam[1].join(',');
+      }
+    }
+  } catch {
+    // Older local profile artifacts may not have a companion ESBench JSON file.
+  }
+
+  return process.env.DKG_ESBENCH_PAYLOAD_SIZES || '10kb,100kb,2mb,200mb';
+}
+
+async function linkExistingBenchmarkReports() {
+  const {
+    addLinkedReportNavigation,
+    publishAsyncGetPages,
+  } = await import('../esbench.config.mjs');
+  const reportFiles = [
+    'bench/results/latest.html',
+    ...publishAsyncGetPages.map(([, file]) => file),
+  ];
+  const targets = [
+    ['Combined report', 'bench/results/latest.html'],
+    ...publishAsyncGetPages,
+    ['CPU profiles', 'bench/results/profiles/index.html'],
+  ];
+
+  for (const file of reportFiles) {
+    const reportPath = resolve(rootDir, file);
+    if (!existsSync(reportPath)) continue;
+    const html = await readFile(reportPath, 'utf8');
+    await writeFile(reportPath, addLinkedReportNavigation(html, file, targets), 'utf8');
+  }
+}
+
+function relativeFromRoot(path) {
+  return path.startsWith(rootDir) ? path.slice(rootDir.length + 1) : basename(path);
+}

--- a/bench/profile-publish-async-get.mjs
+++ b/bench/profile-publish-async-get.mjs
@@ -63,6 +63,7 @@ await writeFile(flamegraphPath, renderCpuProfileFlamegraphHtml(profile, {
   rawProfileHref: `./${profileName}`,
 }), 'utf8');
 
+await runMethodAnalysis(env);
 await writeProfileIndex();
 await linkExistingBenchmarkReports();
 
@@ -121,6 +122,13 @@ async function writeProfileIndex() {
   }), 'utf8');
 }
 
+async function runMethodAnalysis(env) {
+  const exitCode = await runCommand(process.execPath, ['--experimental-strip-types', 'bench/analyze-publish-async-get.ts'], env);
+  if (exitCode !== 0) {
+    throw new Error(`Method analysis failed with exit code ${exitCode}`);
+  }
+}
+
 async function readProfilePayloadSizes(reportJsonFile) {
   try {
     const report = JSON.parse(await readFile(reportJsonFile, 'utf8'));
@@ -151,8 +159,13 @@ async function linkExistingBenchmarkReports() {
   const targets = [
     ['Combined report', 'bench/results/latest.html'],
     ...publishAsyncGetPages,
-    ['CPU profiles', 'bench/results/profiles/index.html'],
   ];
+  if (existsSync(resolve(rootDir, 'bench/results/profiles/index.html'))) {
+    targets.push(['CPU profiles', 'bench/results/profiles/index.html']);
+  }
+  if (existsSync(resolve(rootDir, 'bench/results/profiles/method-analysis.latest.html'))) {
+    targets.push(['Method analysis', 'bench/results/profiles/method-analysis.latest.html']);
+  }
 
   for (const file of reportFiles) {
     const reportPath = resolve(rootDir, file);
@@ -160,6 +173,28 @@ async function linkExistingBenchmarkReports() {
     const html = await readFile(reportPath, 'utf8');
     await writeFile(reportPath, addLinkedReportNavigation(html, file, targets), 'utf8');
   }
+}
+
+function runCommand(command, args, env) {
+  return new Promise((resolveExitCode) => {
+    const child = spawn(command, args, {
+      cwd: rootDir,
+      env,
+      stdio: 'inherit',
+    });
+    child.on('error', (error) => {
+      console.error(error);
+      resolveExitCode(1);
+    });
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        console.error(`[bench:profile] command exited from signal ${signal}`);
+        resolveExitCode(1);
+        return;
+      }
+      resolveExitCode(code ?? 1);
+    });
+  });
 }
 
 function relativeFromRoot(path) {

--- a/bench/publish-async-get.bench.ts
+++ b/bench/publish-async-get.bench.ts
@@ -11,9 +11,18 @@ import type {
 import { benchAsyncWithHooks } from './support/esbench-case-hooks.ts';
 import { LayeredDkgBenchmarkClient } from './support/layered-dkg-client.ts';
 
+export const GENERATED_PAYLOAD_SIZES = [
+  { label: '10kb', bytes: 10 * 1024 },
+  { label: '100kb', bytes: 100 * 1024 },
+  { label: '2mb', bytes: 2 * 1024 * 1024 },
+  { label: '200mb', bytes: 200 * 1024 * 1024 },
+] as const;
+
+type PayloadSizeLabel = (typeof GENERATED_PAYLOAD_SIZES)[number]['label'];
+
 export default defineSuite({
   params: {
-    payloadSizeBytes: [128, 1024],
+    payloadSize: resolvePayloadSizeLabels(),
   },
   baseline: {
     type: 'Name',
@@ -27,7 +36,7 @@ export default defineSuite({
     warmup: 1,
   },
   async setup(scene) {
-    const config = createConfig(scene.params.payloadSizeBytes);
+    const config = createConfig(scene.params.payloadSize as PayloadSizeLabel);
     let sequence = 0;
 
     let readPayload: BenchmarkPayload | undefined;
@@ -54,6 +63,10 @@ export default defineSuite({
             false,
           );
         },
+        afterIteration: () => {
+          readPayload = undefined;
+          readClient.clear();
+        },
       },
     );
 
@@ -75,6 +88,10 @@ export default defineSuite({
         beforeIteration: async () => {
           syncPayload = createPayload(config, `esbench-sync-${sequence++}`, 1, 'sync', false);
           await syncClient.sharedMemoryWrite(config.contextGraphId, syncPayload.quads);
+        },
+        afterIteration: () => {
+          syncPayload = undefined;
+          syncClient.clear();
         },
       },
     );
@@ -113,6 +130,11 @@ export default defineSuite({
           const prepared = await asyncClient.sharedMemoryWrite(config.contextGraphId, asyncPayload.quads);
           asyncShareOperationId = prepared.shareOperationId ?? prepared.workspaceOperationId;
         },
+        afterIteration: () => {
+          asyncPayload = undefined;
+          asyncShareOperationId = undefined;
+          asyncClient.clear();
+        },
       },
     );
 
@@ -131,6 +153,10 @@ export default defineSuite({
       {
         beforeIteration: () => {
           uploadPayload = createPayload(config, `esbench-upload-${sequence++}`, 1, 'sync', false);
+        },
+        afterIteration: () => {
+          uploadPayload = undefined;
+          uploadClient.clear();
         },
       },
     );
@@ -155,18 +181,22 @@ export default defineSuite({
           liftPayload = createPayload(config, `esbench-lift-${sequence++}`, 1, 'sync', false);
           await liftClient.writeWorkingMemory(config.contextGraphId, liftPayload.quads);
         },
+        afterIteration: () => {
+          liftPayload = undefined;
+          liftClient.clear();
+        },
       },
     );
   },
 });
 
-function createConfig(payloadSizeBytes: number): BenchmarkConfig {
+function createConfig(payloadSize: PayloadSizeLabel): BenchmarkConfig {
   return {
     contextGraphId: 'bench-cg',
     repeat: 30,
     warmups: 3,
     timeoutMs: 120_000,
-    payloadSizeBytes,
+    payloadSizeBytes: payloadSizeBytes(payloadSize),
     fixture: 'generated',
     outputFormat: 'json',
     namespace: 'benchmark',
@@ -181,4 +211,26 @@ function createConfig(payloadSizeBytes: number): BenchmarkConfig {
 function requirePayload(payload: BenchmarkPayload | undefined, caseName: string): BenchmarkPayload {
   if (!payload) throw new Error(`No payload was prepared for ${caseName}`);
   return payload;
+}
+
+function resolvePayloadSizeLabels(): PayloadSizeLabel[] {
+  const raw = process.env.DKG_ESBENCH_PAYLOAD_SIZES;
+  if (!raw?.trim()) return GENERATED_PAYLOAD_SIZES.map((size) => size.label);
+
+  const requested = raw.split(',').map((part) => part.trim().toLowerCase()).filter(Boolean);
+  if (requested.length === 0) return GENERATED_PAYLOAD_SIZES.map((size) => size.label);
+
+  const known = new Set(GENERATED_PAYLOAD_SIZES.map((size) => size.label));
+  for (const label of requested) {
+    if (!known.has(label as PayloadSizeLabel)) {
+      throw new Error(`Unknown DKG_ESBENCH_PAYLOAD_SIZES entry "${label}". Expected one of: ${[...known].join(', ')}`);
+    }
+  }
+  return requested as PayloadSizeLabel[];
+}
+
+function payloadSizeBytes(label: PayloadSizeLabel): number {
+  const size = GENERATED_PAYLOAD_SIZES.find((entry) => entry.label === label);
+  if (!size) throw new Error(`Unknown payload size label: ${label}`);
+  return size.bytes;
 }

--- a/bench/support/cpu-profile-report.mjs
+++ b/bench/support/cpu-profile-report.mjs
@@ -1,0 +1,339 @@
+const DEFAULT_WIDTH = 1600;
+const FRAME_HEIGHT = 22;
+const FRAME_GAP = 1;
+const MIN_RENDER_WIDTH = 0.5;
+
+export function buildFlamegraphTree(profile) {
+  if (!profile || !Array.isArray(profile.nodes)) {
+    throw new Error('CPU profile is missing a nodes array');
+  }
+
+  const nodesById = new Map(profile.nodes.map((node) => [node.id, node]));
+  const parentsById = new Map();
+  for (const node of profile.nodes) {
+    for (const childId of node.children ?? []) {
+      parentsById.set(childId, node.id);
+    }
+  }
+
+  const hasTimeDeltas = Array.isArray(profile.timeDeltas) && profile.timeDeltas.length > 0;
+  const root = createFrame('total', 'total', 'total', hasTimeDeltas ? 'ms' : 'samples');
+  const samples = Array.isArray(profile.samples) ? profile.samples : [];
+
+  if (samples.length > 0) {
+    samples.forEach((nodeId, index) => {
+      const weight = hasTimeDeltas ? Math.max(0, Number(profile.timeDeltas[index] ?? 0)) / 1000 : 1;
+      if (weight === 0) return;
+      addStack(root, stackForNode(nodeId, nodesById, parentsById), weight);
+    });
+    root.sampleCount = samples.length;
+    return root;
+  }
+
+  for (const node of profile.nodes) {
+    const hitCount = Math.max(0, Number(node.hitCount ?? 0));
+    if (hitCount === 0) continue;
+    addStack(root, stackForNode(node.id, nodesById, parentsById), hitCount);
+    root.sampleCount += hitCount;
+  }
+
+  return root;
+}
+
+export function renderCpuProfileFlamegraphHtml(profile, options = {}) {
+  const tree = buildFlamegraphTree(profile);
+  const frames = layoutFrames(tree, options.width ?? DEFAULT_WIDTH);
+  const depth = Math.max(0, ...frames.map((frame) => frame.depth));
+  const svgHeight = (depth + 1) * FRAME_HEIGHT + 28;
+  const topFrames = collectSelfTime(tree).slice(0, options.topFrameCount ?? 20);
+  const title = options.title ?? 'CPU Flame Graph';
+  const profileName = options.profileName ?? 'profile.cpuprofile';
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const benchmarkReportHref = options.benchmarkReportHref ?? '../latest.html';
+  const rawProfileHref = options.rawProfileHref ?? `./${profileName}`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f8fafc; color: #111827; }
+    header { background: #111827; color: #f9fafb; padding: 18px 24px; }
+    main { padding: 22px 24px 36px; }
+    a { color: #1d4ed8; }
+    header a { color: #bfdbfe; }
+    .meta { color: #d1d5db; font-size: 13px; margin-top: 6px; }
+    .nav { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+    .nav a { border: 1px solid #4b5563; border-radius: 4px; color: #f9fafb; padding: 5px 9px; text-decoration: none; }
+    .panel { background: white; border: 1px solid #e5e7eb; border-radius: 6px; margin-bottom: 20px; padding: 16px; }
+    .summary { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+    .summary strong { display: block; font-size: 22px; margin-bottom: 2px; }
+    .summary span { color: #4b5563; font-size: 13px; }
+    .flamegraph { overflow-x: auto; }
+    svg { background: #fff; border: 1px solid #e5e7eb; border-radius: 6px; display: block; min-width: ${options.width ?? DEFAULT_WIDTH}px; }
+    .frame rect { stroke: rgba(17, 24, 39, .28); stroke-width: .5; }
+    .frame text { fill: #111827; font-size: 11px; pointer-events: none; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid #e5e7eb; padding: 8px 10px; text-align: left; vertical-align: top; }
+    th { color: #374151; font-size: 12px; text-transform: uppercase; }
+    code { background: #eef2ff; border-radius: 4px; padding: 1px 4px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>${escapeHtml(title)}</h1>
+    <div class="meta">Generated ${escapeHtml(generatedAt)} from ${escapeHtml(profileName)}.</div>
+    <nav class="nav" aria-label="Benchmark profile links">
+      <a href="${escapeHtml(benchmarkReportHref)}">ESBench report</a>
+      <a href="${escapeHtml(rawProfileHref)}">Raw .cpuprofile</a>
+      <a href="./index.html">Profile index</a>
+    </nav>
+  </header>
+  <main>
+    <section class="panel summary" aria-label="Profile summary">
+      <div><strong>${escapeHtml(formatValue(tree.value, tree.unit))}</strong><span>Total sampled CPU time</span></div>
+      <div><strong>${escapeHtml(String(tree.sampleCount))}</strong><span>Samples</span></div>
+      <div><strong>${escapeHtml(String(depth))}</strong><span>Maximum stack depth</span></div>
+    </section>
+    <section class="panel">
+      <h2>Flame Graph</h2>
+      <p>Width represents aggregated sampled CPU time. Frames lower in the graph are callers; frames above them are callees.</p>
+      <div class="flamegraph">${renderFlamegraphSvg(frames, tree, depth, options.width ?? DEFAULT_WIDTH, svgHeight)}</div>
+    </section>
+    <section class="panel">
+      <h2>Top Self-Time Frames</h2>
+      ${renderTopFramesTable(topFrames, tree.unit)}
+    </section>
+  </main>
+</body>
+</html>
+`;
+}
+
+export function renderProfileIndexHtml(entries, options = {}) {
+  const title = options.title ?? 'DKG Benchmark CPU Profiles';
+  const benchmarkReportHref = options.benchmarkReportHref ?? '../latest.html';
+  const rows = entries.map((entry) => `<tr>
+    <td>${escapeHtml(entry.createdAt ?? '')}</td>
+    <td><a href="${escapeHtml(entry.esbenchReportHref)}">${escapeHtml(entry.esbenchReportName)}</a></td>
+    <td><a href="${escapeHtml(entry.flamegraphHref)}">${escapeHtml(entry.flamegraphName)}</a></td>
+    <td><a href="${escapeHtml(entry.profileHref)}">${escapeHtml(entry.profileName)}</a></td>
+    <td>${escapeHtml(entry.payloadSizes ?? '10kb,100kb,2mb,200mb')}</td>
+    <td>${escapeHtml(entry.sizeBytes == null ? '' : formatBytes(entry.sizeBytes))}</td>
+  </tr>`).join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f8fafc; color: #111827; }
+    header { background: #111827; color: #f9fafb; padding: 18px 24px; }
+    main { padding: 22px 24px 36px; }
+    a { color: #1d4ed8; }
+    header a { color: #bfdbfe; }
+    .panel { background: white; border: 1px solid #e5e7eb; border-radius: 6px; padding: 16px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid #e5e7eb; padding: 8px 10px; text-align: left; vertical-align: top; }
+    th { color: #374151; font-size: 12px; text-transform: uppercase; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>${escapeHtml(title)}</h1>
+    <div><a href="${escapeHtml(benchmarkReportHref)}">Open latest ESBench report</a></div>
+  </header>
+  <main>
+    <section class="panel">
+      <table>
+        <thead>
+          <tr><th>Created</th><th>ESBench report</th><th>Flame graph</th><th>Raw profile</th><th>Payload sizes</th><th>Profile size</th></tr>
+        </thead>
+        <tbody>${rows || '<tr><td colspan="6">No CPU profiles generated yet.</td></tr>'}</tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>
+`;
+}
+
+function addStack(root, stack, weight) {
+  const frames = stack.map(frameForNode).filter((frame) => frame.key !== 'root');
+  if (frames.length === 0) return;
+
+  root.value += weight;
+  let cursor = root;
+  for (const frame of frames) {
+    let child = cursor.children.get(frame.key);
+    if (!child) {
+      child = createFrame(frame.key, frame.label, frame.detail, root.unit);
+      cursor.children.set(frame.key, child);
+    }
+    child.value += weight;
+    cursor = child;
+  }
+  cursor.self += weight;
+}
+
+function stackForNode(nodeId, nodesById, parentsById) {
+  const stack = [];
+  const seen = new Set();
+  let currentId = nodeId;
+
+  while (currentId != null && !seen.has(currentId)) {
+    seen.add(currentId);
+    const node = nodesById.get(currentId);
+    if (!node) break;
+    stack.push(node);
+    currentId = parentsById.get(currentId);
+  }
+
+  return stack.reverse();
+}
+
+function frameForNode(node) {
+  const frame = node.callFrame ?? {};
+  const functionName = frame.functionName || '(anonymous)';
+  const url = String(frame.url ?? '');
+  const line = Number.isFinite(frame.lineNumber) && frame.lineNumber >= 0 ? frame.lineNumber + 1 : undefined;
+  const location = url ? `${shortenUrl(url)}${line == null ? '' : `:${line}`}` : '';
+  const label = location ? `${functionName} (${location})` : functionName;
+  const rootNames = new Set(['(root)', 'root']);
+
+  return {
+    key: rootNames.has(functionName) ? 'root' : `${functionName}\0${url}\0${line ?? ''}`,
+    label,
+    detail: location,
+  };
+}
+
+function createFrame(key, label, detail, unit) {
+  return {
+    key,
+    label,
+    detail,
+    unit,
+    value: 0,
+    self: 0,
+    sampleCount: 0,
+    children: new Map(),
+  };
+}
+
+function layoutFrames(root, width) {
+  const frames = [];
+
+  function visit(node, depth, x, frameWidth) {
+    frames.push({ node, depth, x, width: frameWidth });
+    const children = [...node.children.values()].sort((a, b) => b.value - a.value);
+    let childX = x;
+    for (const child of children) {
+      const childWidth = node.value === 0 ? 0 : frameWidth * (child.value / node.value);
+      visit(child, depth + 1, childX, childWidth);
+      childX += childWidth;
+    }
+  }
+
+  visit(root, 0, 0, width);
+  return frames;
+}
+
+function renderFlamegraphSvg(frames, root, maxDepth, width, height) {
+  const content = frames
+    .filter((frame) => frame.width >= MIN_RENDER_WIDTH)
+    .map((frame) => {
+      const y = 14 + (maxDepth - frame.depth) * FRAME_HEIGHT;
+      const boxHeight = FRAME_HEIGHT - FRAME_GAP;
+      const label = labelForWidth(frame.node.label, frame.width);
+      const percent = root.value === 0 ? 0 : (frame.node.value / root.value) * 100;
+      return `<g class="frame">
+        <title>${escapeHtml(`${frame.node.label} - ${formatValue(frame.node.value, root.unit)} (${percent.toFixed(2)}%)`)}</title>
+        <rect x="${frame.x.toFixed(3)}" y="${y}" width="${Math.max(0, frame.width - FRAME_GAP).toFixed(3)}" height="${boxHeight}" fill="${frameColor(frame.node.key)}"></rect>
+        ${label ? `<text x="${(frame.x + 4).toFixed(3)}" y="${y + 14}">${escapeHtml(label)}</text>` : ''}
+      </g>`;
+    })
+    .join('\n');
+
+  return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="CPU flame graph">
+    ${content}
+  </svg>`;
+}
+
+function collectSelfTime(root) {
+  const frames = [];
+
+  function visit(node) {
+    if (node.key !== 'total' && node.self > 0) frames.push(node);
+    for (const child of node.children.values()) visit(child);
+  }
+
+  visit(root);
+  return frames.sort((a, b) => b.self - a.self);
+}
+
+function renderTopFramesTable(frames, unit) {
+  const rows = frames.map((frame) => `<tr>
+    <td>${escapeHtml(frame.label)}</td>
+    <td>${escapeHtml(formatValue(frame.self, unit))}</td>
+    <td>${escapeHtml(formatValue(frame.value, unit))}</td>
+  </tr>`).join('\n');
+
+  return `<table>
+    <thead><tr><th>Frame</th><th>Self time</th><th>Total time</th></tr></thead>
+    <tbody>${rows || '<tr><td colspan="3">No sampled frames found.</td></tr>'}</tbody>
+  </table>`;
+}
+
+function frameColor(key) {
+  const hue = hashString(key) % 360;
+  return `hsl(${hue}, 72%, 72%)`;
+}
+
+function hashString(value) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash + value.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function labelForWidth(label, width) {
+  if (width < 38) return '';
+  const maxChars = Math.floor(width / 7);
+  if (label.length <= maxChars) return label;
+  return `${label.slice(0, Math.max(0, maxChars - 3))}...`;
+}
+
+function formatValue(value, unit) {
+  if (unit === 'ms') return `${value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: value < 10 ? 2 : 0 })} ms`;
+  return `${Math.round(value).toLocaleString()} samples`;
+}
+
+function formatBytes(value) {
+  if (value >= 1024 * 1024) return `${(value / 1024 / 1024).toFixed(2)} MiB`;
+  if (value >= 1024) return `${(value / 1024).toFixed(2)} KiB`;
+  return `${value} B`;
+}
+
+function shortenUrl(url) {
+  return url
+    .replace(/^file:\/\//, '')
+    .replace(process.cwd(), '.')
+    .replace(/\/node_modules\//, '/node_modules/');
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/bench/support/cpu-profile-report.mjs
+++ b/bench/support/cpu-profile-report.mjs
@@ -90,6 +90,7 @@ export function renderCpuProfileFlamegraphHtml(profile, options = {}) {
       <a href="${escapeHtml(benchmarkReportHref)}">ESBench report</a>
       <a href="${escapeHtml(rawProfileHref)}">Raw .cpuprofile</a>
       <a href="./index.html">Profile index</a>
+      <a href="./method-analysis.latest.html">Method analysis</a>
     </nav>
   </header>
   <main>
@@ -148,6 +149,7 @@ export function renderProfileIndexHtml(entries, options = {}) {
   <header>
     <h1>${escapeHtml(title)}</h1>
     <div><a href="${escapeHtml(benchmarkReportHref)}">Open latest ESBench report</a></div>
+    <div><a href="./method-analysis.latest.html">Open latest method analysis</a></div>
   </header>
   <main>
     <section class="panel">

--- a/bench/support/layered-dkg-client.ts
+++ b/bench/support/layered-dkg-client.ts
@@ -47,6 +47,13 @@ export class LayeredDkgBenchmarkClient implements BenchmarkClient {
     };
   }
 
+  clear(): void {
+    this.workingMemory.clear();
+    this.sharedWorkingMemory.clear();
+    this.verifiedMemory.clear();
+    this.publisherJobs.clear();
+  }
+
   async sharedMemoryWrite(contextGraphId: string, quads: Quad[]) {
     const working = await this.writeWorkingMemory(contextGraphId, quads);
     const shared = await this.liftWorkingMemoryToSharedMemory(contextGraphId, uniqueSubjects(quads));

--- a/esbench.config.mjs
+++ b/esbench.config.mjs
@@ -1,8 +1,11 @@
+import { access, readFile, writeFile } from 'node:fs/promises';
+import { dirname, relative, sep } from 'node:path';
 import { defineConfig, htmlReporter, rawReporter, textReporter } from 'esbench/host';
 
 const resultFile = process.env.ESBENCH_RESULT ?? 'bench/results/latest.json';
 const htmlFile = process.env.ESBENCH_HTML_FILE ?? 'bench/results/latest.html';
 const diffFile = process.env.ESBENCH_DIFF ?? null;
+const profileIndexFile = 'bench/results/profiles/index.html';
 export const publishAsyncGetSuite = 'bench/publish-async-get.bench.ts';
 export const publishAsyncGetPages = [
   ['get/read retrieval', 'bench/results/publish-async-get/get-read-retrieval.html'],
@@ -61,6 +64,8 @@ function publishAsyncGetHtmlReporter() {
       renderedFiles.push(page.file);
     }
 
+    await writeLinkedReportNavigation([htmlFile, ...renderedFiles]);
+
     if (renderedFiles.length > 0) {
       const pageList = renderedFiles.map((file) => `- ${file}`).join('\n');
       context.info(`Publish/async/get HTML pages:\n${pageList}`);
@@ -82,4 +87,125 @@ export function filterResultByCase(result, caseName) {
     .filter((record) => record.scenes.some((scene) => Object.keys(scene).length > 0));
 
   return filteredRecords.length > 0 ? { [publishAsyncGetSuite]: filteredRecords } : {};
+}
+
+async function writeLinkedReportNavigation(files) {
+  const uniqueFiles = [...new Set(files)];
+  const targets = [
+    ['Combined report', htmlFile],
+    ...publishAsyncGetPages,
+  ];
+  if (await fileExists(profileIndexFile)) {
+    targets.push(['CPU profiles', profileIndexFile]);
+  }
+
+  await Promise.all(uniqueFiles.map(async (file) => {
+    try {
+      const html = await readFile(file, 'utf8');
+      await writeFile(file, addLinkedReportNavigation(html, file, targets));
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }));
+}
+
+async function fileExists(file) {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function addLinkedReportNavigation(html, currentFile, targets) {
+  const start = '<!-- dkg-benchmark-report-nav:start -->';
+  const end = '<!-- dkg-benchmark-report-nav:end -->';
+  const withoutExisting = html.replace(new RegExp(`${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}\\n?`, 'g'), '');
+  const navHtml = buildNavigationHtml(currentFile, targets);
+  const block = `${start}
+<style>
+  body.dkg-benchmark-report-linked {
+    padding-top: 48px;
+  }
+  .dkg-benchmark-report-nav {
+    align-items: center;
+    background: #111827;
+    border-bottom: 1px solid #374151;
+    box-shadow: 0 1px 8px rgba(0, 0, 0, .16);
+    color: #f9fafb;
+    display: flex;
+    font: 13px/1.4 Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    gap: 8px;
+    left: 0;
+    min-height: 48px;
+    overflow-x: auto;
+    padding: 8px 14px;
+    position: fixed;
+    right: 0;
+    top: 0;
+    z-index: 2147483647;
+  }
+  .dkg-benchmark-report-nav__title {
+    color: #d1d5db;
+    flex: 0 0 auto;
+    font-weight: 700;
+    margin-right: 4px;
+  }
+  .dkg-benchmark-report-nav__link {
+    border: 1px solid #4b5563;
+    border-radius: 4px;
+    color: #f9fafb;
+    flex: 0 0 auto;
+    padding: 4px 8px;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .dkg-benchmark-report-nav__link:hover,
+  .dkg-benchmark-report-nav__link:focus {
+    background: #1f2937;
+  }
+  .dkg-benchmark-report-nav__link[aria-current="page"] {
+    background: #2563eb;
+    border-color: #60a5fa;
+  }
+</style>
+<script>
+  window.addEventListener("DOMContentLoaded", function () {
+    if (document.getElementById("dkg-benchmark-report-nav")) return;
+    document.body.classList.add("dkg-benchmark-report-linked");
+    document.body.insertAdjacentHTML("afterbegin", ${JSON.stringify(navHtml)});
+  });
+</script>
+${end}
+`;
+
+  return withoutExisting.includes('</head>')
+    ? withoutExisting.replace('</head>', `${block}</head>`)
+    : `${block}${withoutExisting}`;
+}
+
+function buildNavigationHtml(currentFile, targets) {
+  const links = targets.map(([label, targetFile]) => {
+    const active = currentFile === targetFile ? ' aria-current="page"' : '';
+    return `<a class="dkg-benchmark-report-nav__link" href="${escapeHtml(relativeHref(currentFile, targetFile))}"${active}>${escapeHtml(label)}</a>`;
+  }).join('');
+
+  return `<nav id="dkg-benchmark-report-nav" class="dkg-benchmark-report-nav" aria-label="DKG benchmark reports"><span class="dkg-benchmark-report-nav__title">DKG benchmark reports</span>${links}</nav>`;
+}
+
+function relativeHref(fromFile, toFile) {
+  return relative(dirname(fromFile), toFile).split(sep).join('/') || toFile.split(sep).pop();
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/esbench.config.mjs
+++ b/esbench.config.mjs
@@ -6,6 +6,7 @@ const resultFile = process.env.ESBENCH_RESULT ?? 'bench/results/latest.json';
 const htmlFile = process.env.ESBENCH_HTML_FILE ?? 'bench/results/latest.html';
 const diffFile = process.env.ESBENCH_DIFF ?? null;
 const profileIndexFile = 'bench/results/profiles/index.html';
+const methodAnalysisFile = 'bench/results/profiles/method-analysis.latest.html';
 export const publishAsyncGetSuite = 'bench/publish-async-get.bench.ts';
 export const publishAsyncGetPages = [
   ['get/read retrieval', 'bench/results/publish-async-get/get-read-retrieval.html'],
@@ -97,6 +98,9 @@ async function writeLinkedReportNavigation(files) {
   ];
   if (await fileExists(profileIndexFile)) {
     targets.push(['CPU profiles', profileIndexFile]);
+  }
+  if (await fileExists(methodAnalysisFile)) {
+    targets.push(['Method analysis', methodAnalysisFile]);
   }
 
   await Promise.all(uniqueFiles.map(async (file) => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "turbo test:coverage",
     "bench": "esbench --config esbench.config.mjs",
     "bench:html": "ESBENCH_HTML=1 ESBENCH_PUBLISH_ASYNC_GET_HTML=1 esbench --config esbench.config.mjs",
+    "bench:profile": "node bench/profile-publish-async-get.mjs",
     "bench:baseline": "ESBENCH_RESULT=bench/results/baseline.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/baseline.html esbench --config esbench.config.mjs",
     "bench:compare": "ESBENCH_DIFF=bench/results/baseline.json ESBENCH_RESULT=bench/results/compare.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/compare.html esbench --config esbench.config.mjs",
     "lint": "turbo lint",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "turbo test:coverage",
     "bench": "esbench --config esbench.config.mjs",
     "bench:html": "ESBENCH_HTML=1 ESBENCH_PUBLISH_ASYNC_GET_HTML=1 esbench --config esbench.config.mjs",
+    "bench:analysis": "node --experimental-strip-types bench/analyze-publish-async-get.ts",
     "bench:profile": "node bench/profile-publish-async-get.mjs",
     "bench:baseline": "ESBENCH_RESULT=bench/results/baseline.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/baseline.html esbench --config esbench.config.mjs",
     "bench:compare": "ESBENCH_DIFF=bench/results/baseline.json ESBENCH_RESULT=bench/results/compare.json ESBENCH_HTML=1 ESBENCH_HTML_FILE=bench/results/compare.html esbench --config esbench.config.mjs",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -139,7 +139,7 @@ pnpm --filter @origintrail-official/dkg benchmark:publish-async-get -- \
   --context-graph-id my-project \
   --repeat 30 \
   --warmups 3 \
-  --payload-size 1024 \
+  --payload-size 10kb \
   --output-format json
 ```
 
@@ -148,6 +148,10 @@ Useful environment variables mirror the flags: `DKG_BENCH_CONTEXT_GRAPH_ID`,
 `DKG_BENCH_PAYLOAD_SIZE`, `DKG_BENCH_FIXTURE`, `DKG_BENCH_OUTPUT_FORMAT`,
 `DKG_BENCH_POLL_INTERVAL_MS`, `DKG_API_PORT`, `DKG_API_URL`, and
 `DKG_AUTH_TOKEN`.
+
+`--payload-size` and `DKG_BENCH_PAYLOAD_SIZE` accept raw bytes or generated-size
+labels such as `10kb`, `100kb`, `2mb`, and `200mb`. The repository ESBench suite
+uses those four generated sizes by default.
 
 The output includes per-operation timing records and summary rows for
 `syncPublish`, `asyncEnqueue`, `asyncCompletion`, and `get`. Each summary reports
@@ -159,7 +163,9 @@ The repository-level ESBench workflow for this same benchmark feature is
 documented in `BENCHMARKING.md`. It uses a deterministic layered DKG client, not
 a live daemon, so the generated reports avoid auth tokens and local node paths.
 `pnpm bench:html` writes the combined ESBench report plus one focused HTML page
-for each benchmark flow:
+for each benchmark flow and payload size. The full default matrix includes the
+`200mb` scene; set `DKG_ESBENCH_PAYLOAD_SIZES=10kb` or another comma-separated
+subset while doing quick local smoke checks:
 
 - get/read retrieval
 - synchronous publish with finalization

--- a/packages/cli/src/benchmark/publish-get/config.ts
+++ b/packages/cli/src/benchmark/publish-get/config.ts
@@ -23,7 +23,7 @@ export function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.e
     warmups: parseOptionalNonNegativeInt(env.DKG_BENCH_WARMUPS, 'DKG_BENCH_WARMUPS') ?? DEFAULT_WARMUPS,
     timeoutMs: parseOptionalPositiveInt(env.DKG_BENCH_TIMEOUT_MS, 'DKG_BENCH_TIMEOUT_MS') ?? DEFAULT_TIMEOUT_MS,
     payloadSizeBytes:
-      parseOptionalPositiveInt(env.DKG_BENCH_PAYLOAD_SIZE, 'DKG_BENCH_PAYLOAD_SIZE') ?? DEFAULT_PAYLOAD_SIZE_BYTES,
+      parseOptionalByteSize(env.DKG_BENCH_PAYLOAD_SIZE, 'DKG_BENCH_PAYLOAD_SIZE') ?? DEFAULT_PAYLOAD_SIZE_BYTES,
     fixture: parseFixture(env.DKG_BENCH_FIXTURE ?? 'generated'),
     outputFormat: parseOutputFormat(env.DKG_BENCH_OUTPUT_FORMAT ?? 'json'),
     namespace: env.DKG_BENCH_NAMESPACE ?? 'benchmark',
@@ -65,7 +65,7 @@ export function parseBenchmarkArgs(argv = process.argv.slice(2), env = process.e
         break;
       case '--payload-size':
       case '--payload-size-bytes':
-        config.payloadSizeBytes = parsePositiveInt(value(), name);
+        config.payloadSizeBytes = parseByteSize(value(), name);
         break;
       case '--fixture':
         config.fixture = parseFixture(value());
@@ -143,6 +143,25 @@ function parseOptionalNonNegativeInt(value: string | undefined, name: string): n
   return value === undefined || value === '' ? undefined : parseNonNegativeInt(value, name);
 }
 
+function parseOptionalByteSize(value: string | undefined, name: string): number | undefined {
+  return value === undefined || value === '' ? undefined : parseByteSize(value, name);
+}
+
+function parseByteSize(value: string, name: string): number {
+  const match = value.trim().toLowerCase().match(/^(\d+)(b|kb|mb)?$/);
+  if (!match) {
+    throw new Error(`${name} must be a positive byte size such as 1024, 10kb, 2mb, or 200mb`);
+  }
+
+  const amount = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error(`${name} must be a positive byte size`);
+  }
+
+  const multiplier = match[2] === 'mb' ? 1024 * 1024 : match[2] === 'kb' ? 1024 : 1;
+  return amount * multiplier;
+}
+
 function parsePositiveInt(value: string, name: string): number {
   const parsed = Number.parseInt(value, 10);
   if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== value.trim()) {
@@ -190,7 +209,7 @@ Options:
   --repeat <n>                   Measured iterations (default ${DEFAULT_REPEAT})
   --warmups <n>                  Warmup iterations excluded from summaries (default ${DEFAULT_WARMUPS})
   --timeout-ms <ms>              Per-operation timeout (default ${DEFAULT_TIMEOUT_MS})
-  --payload-size <bytes>         Generated text payload size target (default ${DEFAULT_PAYLOAD_SIZE_BYTES})
+  --payload-size <size>          Generated text payload size target, e.g. 1024, 10kb, 2mb (default ${DEFAULT_PAYLOAD_SIZE_BYTES})
   --fixture <generated|minimal>  Payload fixture (default generated)
   --output-format <json|ndjson>  Output format (default json)
   --poll-interval-ms <ms>        Async publisher job polling interval (default ${DEFAULT_POLL_INTERVAL_MS})

--- a/packages/cli/test/publish-async-get-benchmark.test.ts
+++ b/packages/cli/test/publish-async-get-benchmark.test.ts
@@ -57,6 +57,31 @@ type CpuProfileReportForTest = {
   renderCpuProfileFlamegraphHtml: (profile: unknown, options?: Record<string, unknown>) => string;
 };
 
+type MethodAnalysisForTest = {
+  renderMethodAnalysisHtml: (report: {
+    benchmark: 'publish-async-get-method-analysis';
+    generatedAt: string;
+    payloadSizes: string[];
+    flows: Array<{
+      flow: string;
+      payloadSize: string;
+      totalMs: number;
+      measuredMs: number;
+      traces: Array<{
+        flow: string;
+        payloadSize: string;
+        phase: string;
+        method: string;
+        invokes: string[];
+        detail: string;
+        durationMs: number;
+        success: boolean;
+        context: Record<string, unknown>;
+      }>;
+    }>;
+  }) => string;
+};
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
   if (originalDkgHome === undefined) delete process.env.DKG_HOME;
@@ -406,16 +431,67 @@ describe('publish async get benchmark', () => {
     expect(html).toContain('Raw .cpuprofile');
   });
 
+  it('renders method analysis with invoked methods and per-step timing', async () => {
+    const { renderMethodAnalysisHtml } = await import('../../../bench/analyze-publish-async-get.ts') as MethodAnalysisForTest;
+    const html = renderMethodAnalysisHtml({
+      benchmark: 'publish-async-get-method-analysis',
+      generatedAt: '2026-05-06T00:00:00.000Z',
+      payloadSizes: ['200mb'],
+      flows: [
+        {
+          flow: 'asynchronous publish enqueue and finalization',
+          payloadSize: '200mb',
+          totalMs: 12,
+          measuredMs: 7,
+          traces: [
+            {
+              flow: 'asynchronous publish enqueue and finalization',
+              payloadSize: '200mb',
+              phase: 'measured',
+              method: 'publisherEnqueue',
+              invokes: ['publisherJobs.set'],
+              detail: 'Enqueue the publish request through the publisher runtime path.',
+              durationMs: 2,
+              success: true,
+              context: { rootEntity: 'urn:test:root', quadCount: 1 },
+            },
+            {
+              flow: 'asynchronous publish enqueue and finalization',
+              payloadSize: '200mb',
+              phase: 'measured',
+              method: 'publisherJob',
+              invokes: ['promoteSharedRoot'],
+              detail: 'Poll the publisher job and finalize queued content.',
+              durationMs: 5,
+              success: true,
+              context: { jobId: 'job-1' },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(html).toContain('DKG Benchmark Method Analysis');
+    expect(html).toContain('asynchronous publish enqueue and finalization');
+    expect(html).toContain('publisherEnqueue');
+    expect(html).toContain('publisherJob');
+    expect(html).toContain('promoteSharedRoot');
+    expect(html).toContain('2.000 ms');
+    expect(html).toContain('5.000 ms');
+  });
+
   it('keeps focused ESBench HTML pages wired into the documented benchmark script', async () => {
     const packageJson = JSON.parse(await readFile(new URL('../../../package.json', import.meta.url), 'utf8')) as {
       scripts?: Record<string, string>;
     };
     const benchHtml = packageJson.scripts?.['bench:html'];
+    const benchAnalysis = packageJson.scripts?.['bench:analysis'];
     const benchProfile = packageJson.scripts?.['bench:profile'];
 
     expect(benchHtml).toContain('ESBENCH_HTML=1');
     expect(benchHtml).toContain('ESBENCH_PUBLISH_ASYNC_GET_HTML=1');
     expect(benchHtml).toContain('esbench --config esbench.config.mjs');
+    expect(benchAnalysis).toBe('node --experimental-strip-types bench/analyze-publish-async-get.ts');
     expect(benchProfile).toBe('node bench/profile-publish-async-get.mjs');
   });
 });

--- a/packages/cli/test/publish-async-get-benchmark.test.ts
+++ b/packages/cli/test/publish-async-get-benchmark.test.ts
@@ -21,6 +21,7 @@ import {
 
 const originalFetch = globalThis.fetch;
 const originalDkgHome = process.env.DKG_HOME;
+const originalEsbenchPayloadSizes = process.env.DKG_ESBENCH_PAYLOAD_SIZES;
 
 type FocusedBenchmarkRecord = {
   baseline: unknown;
@@ -38,10 +39,21 @@ type EsbenchConfigForTest = {
   publishAsyncGetSuite: string;
 };
 
+type EsbenchSuiteForTest = {
+  default: {
+    params?: {
+      payloadSize?: string[];
+    };
+  };
+  GENERATED_PAYLOAD_SIZES: Array<{ label: string; bytes: number }>;
+};
+
 afterEach(() => {
   globalThis.fetch = originalFetch;
   if (originalDkgHome === undefined) delete process.env.DKG_HOME;
   else process.env.DKG_HOME = originalDkgHome;
+  if (originalEsbenchPayloadSizes === undefined) delete process.env.DKG_ESBENCH_PAYLOAD_SIZES;
+  else process.env.DKG_ESBENCH_PAYLOAD_SIZES = originalEsbenchPayloadSizes;
 });
 
 describe('publish async get benchmark', () => {
@@ -55,7 +67,7 @@ describe('publish async get benchmark', () => {
       '--timeout-ms',
       '5000',
       '--payload-size',
-      '256',
+      '10kb',
       '--fixture',
       'minimal',
       '--output-format',
@@ -71,7 +83,7 @@ describe('publish async get benchmark', () => {
       repeat: 7,
       warmups: 2,
       timeoutMs: 5000,
-      payloadSizeBytes: 256,
+      payloadSizeBytes: 10 * 1024,
       fixture: 'minimal',
       outputFormat: 'ndjson',
       apiUrl: 'http://127.0.0.1:9200',
@@ -84,16 +96,23 @@ describe('publish async get benchmark', () => {
       DKG_BENCH_CONTEXT_GRAPH_ID: 'env-cg',
       DKG_BENCH_WARMUPS: '4',
       DKG_BENCH_OUTPUT_FORMAT: 'json',
-      DKG_BENCH_PAYLOAD_SIZE: '512',
+      DKG_BENCH_PAYLOAD_SIZE: '100kb',
     });
 
     expect(config).toMatchObject({
       contextGraphId: 'env-cg',
       repeat: 30,
       warmups: 4,
-      payloadSizeBytes: 512,
+      payloadSizeBytes: 100 * 1024,
       outputFormat: 'json',
     });
+  });
+
+  it('parses generated payload sizes with mb units', () => {
+    expect(parseBenchmarkArgs(['--context-graph-id', 'bench-cg', '--payload-size', '2mb'], {}).payloadSizeBytes)
+      .toBe(2 * 1024 * 1024);
+    expect(parseBenchmarkArgs(['--context-graph-id', 'bench-cg', '--payload-size', '200mb'], {}).payloadSizeBytes)
+      .toBe(200 * 1024 * 1024);
   });
 
   it('aggregates measured timings while excluding warmups', () => {
@@ -247,6 +266,19 @@ describe('publish async get benchmark', () => {
     expect(isLoopbackApiUrl('http://192.168.1.50:9200')).toBe(false);
   });
 
+  it('runs the ESBench suite across the generated payload-size matrix', async () => {
+    delete process.env.DKG_ESBENCH_PAYLOAD_SIZES;
+    const suite = await import('../../../bench/publish-async-get.bench.ts') as EsbenchSuiteForTest;
+
+    expect(suite.GENERATED_PAYLOAD_SIZES).toEqual([
+      { label: '10kb', bytes: 10 * 1024 },
+      { label: '100kb', bytes: 100 * 1024 },
+      { label: '2mb', bytes: 2 * 1024 * 1024 },
+      { label: '200mb', bytes: 200 * 1024 * 1024 },
+    ]);
+    expect(suite.default.params?.payloadSize).toEqual(['10kb', '100kb', '2mb', '200mb']);
+  });
+
   it('keeps ESBench focused HTML scenes aligned with payload-size params', async () => {
     const {
       filterResultByCase,
@@ -259,7 +291,7 @@ describe('publish async get benchmark', () => {
         {
           notes: ['not copied'],
           baseline: { type: 'Name', value: 'synchronous publish with finalization' },
-          paramDef: [['payloadSizeBytes', ['128', '1024']]],
+          paramDef: [['payloadSize', ['10kb', '100kb', '2mb', '200mb']]],
           scenes: [
             {
               'get/read retrieval': { time: [1] },
@@ -284,7 +316,7 @@ describe('publish async get benchmark', () => {
       ['upload payload to local working memory', 'bench/results/publish-async-get/working-memory-upload.html'],
       ['lift local working memory to shared working memory', 'bench/results/publish-async-get/working-to-shared-memory.html'],
     ]);
-    expect(record.paramDef).toEqual([['payloadSizeBytes', ['128', '1024']]]);
+    expect(record.paramDef).toEqual([['payloadSize', ['10kb', '100kb', '2mb', '200mb']]]);
     expect(record.baseline).toEqual({ type: 'Name', value: caseName });
     expect(record.notes).toEqual([]);
     expect(record.scenes).toHaveLength(2);

--- a/packages/cli/test/publish-async-get-benchmark.test.ts
+++ b/packages/cli/test/publish-async-get-benchmark.test.ts
@@ -31,6 +31,11 @@ type FocusedBenchmarkRecord = {
 };
 
 type EsbenchConfigForTest = {
+  addLinkedReportNavigation: (
+    html: string,
+    currentFile: string,
+    targets: Array<[string, string]>,
+  ) => string;
   filterResultByCase: (
     result: Record<string, unknown>,
     caseName: string,
@@ -46,6 +51,10 @@ type EsbenchSuiteForTest = {
     };
   };
   GENERATED_PAYLOAD_SIZES: Array<{ label: string; bytes: number }>;
+};
+
+type CpuProfileReportForTest = {
+  renderCpuProfileFlamegraphHtml: (profile: unknown, options?: Record<string, unknown>) => string;
 };
 
 afterEach(() => {
@@ -324,14 +333,89 @@ describe('publish async get benchmark', () => {
     expect(record.scenes[1]).toEqual({ [caseName]: { time: [3] } });
   });
 
+  it('links the combined ESBench report and focused HTML pages together', async () => {
+    const {
+      addLinkedReportNavigation,
+      publishAsyncGetPages,
+    } = await import('../../../esbench.config.mjs') as EsbenchConfigForTest;
+    const targets: Array<[string, string]> = [
+      ['Combined report', 'bench/results/latest.html'],
+      ...publishAsyncGetPages,
+    ];
+
+    const html = addLinkedReportNavigation(
+      '<!doctype html><html><head><title>Benchmark</title></head><body><main></main></body></html>',
+      'bench/results/publish-async-get/get-read-retrieval.html',
+      targets,
+    );
+    const repeated = addLinkedReportNavigation(
+      html,
+      'bench/results/publish-async-get/get-read-retrieval.html',
+      targets,
+    );
+
+    expect(html).toContain('dkg-benchmark-report-nav');
+    expect(html).toContain('../latest.html');
+    expect(html).toContain('sync-publish-finalization.html');
+    expect(html).toContain('asynchronous publish enqueue and finalization');
+    expect(html).toContain('aria-current=\\"page\\"');
+    expect(html).toContain('DOMContentLoaded');
+    expect(repeated.match(/dkg-benchmark-report-nav:start/g)).toHaveLength(1);
+  });
+
+  it('renders a CPU profile flamegraph HTML report for benchmark analysis', async () => {
+    const { renderCpuProfileFlamegraphHtml } = await import('../../../bench/support/cpu-profile-report.mjs') as CpuProfileReportForTest;
+    const html = renderCpuProfileFlamegraphHtml({
+      nodes: [
+        {
+          id: 1,
+          callFrame: { functionName: '(root)', url: '', lineNumber: 0, columnNumber: 0 },
+          children: [2],
+        },
+        {
+          id: 2,
+          callFrame: {
+            functionName: 'publishFromSharedMemory',
+            url: 'file:///repo/packages/publisher/src/index.ts',
+            lineNumber: 41,
+            columnNumber: 1,
+          },
+          children: [3],
+        },
+        {
+          id: 3,
+          callFrame: {
+            functionName: 'finalizePublish',
+            url: 'file:///repo/packages/agent/src/publisher.ts',
+            lineNumber: 8,
+            columnNumber: 1,
+          },
+        },
+      ],
+      samples: [2, 3, 3],
+      timeDeltas: [1000, 2000, 3000],
+    }, {
+      profileName: 'publish-async-get-test.cpuprofile',
+      generatedAt: '2026-05-06T00:00:00.000Z',
+    });
+
+    expect(html).toContain('<svg');
+    expect(html).toContain('publishFromSharedMemory');
+    expect(html).toContain('finalizePublish');
+    expect(html).toContain('6.00 ms');
+    expect(html).toContain('Raw .cpuprofile');
+  });
+
   it('keeps focused ESBench HTML pages wired into the documented benchmark script', async () => {
     const packageJson = JSON.parse(await readFile(new URL('../../../package.json', import.meta.url), 'utf8')) as {
       scripts?: Record<string, string>;
     };
     const benchHtml = packageJson.scripts?.['bench:html'];
+    const benchProfile = packageJson.scripts?.['bench:profile'];
 
     expect(benchHtml).toContain('ESBENCH_HTML=1');
     expect(benchHtml).toContain('ESBENCH_PUBLISH_ASYNC_GET_HTML=1');
     expect(benchHtml).toContain('esbench --config esbench.config.mjs');
+    expect(benchProfile).toBe('node bench/profile-publish-async-get.mjs');
   });
 });


### PR DESCRIPTION
**Summary**
Adds a DKG benchmark workflow for publish/get and memory-layer flows using ESBench and Vitest.

**Changes**
- Adds benchmarks for:
  - get/read retrieval
  - synchronous publish with finalization
  - asynchronous publish enqueue and finalization
  - upload payload to local working memory
  - lift local working memory to shared working memory
- Adds generated payload-size matrix: `10kb`, `100kb`, `2mb`, `200mb`.
- Adds ESBench HTML reports with linked combined/per-flow pages.
- Adds `bench:analysis` for per-flow invoked-method timing breakdown.
- Adds `bench:profile` for V8 `.cpuprofile` and generated flamegraph HTML.
- Documents benchmark workflow in `README.md` and `BENCHMARKING.md`.

**Validation**
- `pnpm exec tsc -p bench/tsconfig.json --noEmit --pretty false`
- `pnpm --filter @origintrail-official/dkg exec vitest run --configLoader runner publish-async-get-benchmark.test.ts`
- `pnpm bench:html`
- `DKG_ESBENCH_PAYLOAD_SIZES=200mb pnpm bench:profile`

**Notes**
- Generated benchmark outputs are ignored under `bench/results/`.
- No secrets or machine-local paths are committed.