### PR TITLE
fix: address PR #431 round-3 Codex review (3 follow-up bugs)

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2631,14 +2631,29 @@ export class DKGAgent {
 
     // Populate `contextGraphsServed` so peers can discover which CGs this
     // node hosts via the public agent profile, but ONLY include CGs whose
-    // accessPolicy is open. `isPrivateContextGraph` is the same predicate
-    // the responder consults to gate sync requests, so the discovery layer
-    // and the data-plane access control stay consistent. System CGs
-    // (`agents`, `ontology`) are excluded — they are universal and don't
-    // need to be re-advertised in every profile.
+    // accessPolicy is open AND we are actively serving (subscribed=true).
+    //
+    // `isPrivateContextGraph` is the same predicate the responder consults
+    // to gate sync requests, so the discovery layer and the data-plane
+    // access control stay consistent.
+    //
+    // The `subscribed === true` filter is what Codex review on PR #431
+    // (round 3) flagged. `discoverContextGraphsFromStore()` seeds entries
+    // for OPEN CGs we merely learned about with `subscribed: false` (we
+    // don't auto-subscribe public CGs — explicit user opt-in only). Without
+    // this filter, those discovery-only entries would be advertised in
+    // `contextGraphsServed`, so other peers would route join attempts to a
+    // node that doesn't actually host the CG. The curated/private discovery
+    // path immediately calls `subscribeToContextGraph()` (which flips
+    // `subscribed: true`) before adding to the gossip mesh, so this filter
+    // does not regress invited-curated discovery.
+    //
+    // System CGs (`agents`, `ontology`) are excluded — they are universal
+    // and don't need to be re-advertised in every profile.
     const publicServed: string[] = [];
-    for (const id of this.subscribedContextGraphs.keys()) {
+    for (const [id, sub] of this.subscribedContextGraphs) {
       if (id === SYSTEM_PARANETS.AGENTS || id === SYSTEM_PARANETS.ONTOLOGY) continue;
+      if (!sub.subscribed) continue;
       if (await this.isPrivateContextGraph(id)) continue;
       publicServed.push(id);
     }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1794,6 +1794,62 @@ describe('DKGAgent (integration)', () => {
       await agent.stop().catch(() => {});
     }
   }, 15000);
+
+  it('publishProfile excludes discovery-only entries (subscribed=false)', async () => {
+    // Codex review on PR #434 (round 2) flagged that the
+    // `subscribed === true` filter in publishProfile had no regression
+    // test, so the discovery-only leak could come back unnoticed. This
+    // exercises the actual `discoverContextGraphsFromStore()` path:
+    // we seed the local triple store with ontology triples for an OPEN
+    // CG the agent didn't explicitly subscribe to, run discovery (which
+    // adds the entry with subscribed=false because we don't auto-
+    // subscribe public CGs), then publish the profile and assert the
+    // discovered-only CG was filtered out of contextGraphsServed.
+    const store = new OxigraphStore();
+    const agent = await DKGAgent.create({
+      name: 'DiscoveryFilterHost',
+      framework: 'DKG',
+      listenPort: 0,
+      store,
+      skills: [],
+      chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+    });
+    await agent.start();
+
+    try {
+      await agent.createContextGraph({
+        id: 'normal-public',
+        name: 'Normal Public',
+      });
+
+      const ontologyGraph = paranetDataGraphUri(SYSTEM_PARANETS.ONTOLOGY);
+      const discoveredUri = 'did:dkg:context-graph:discovered-only';
+      const seedQuads: Quad[] = [
+        { subject: discoveredUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PARANET, graph: ontologyGraph },
+        { subject: discoveredUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Discovered Only"', graph: ontologyGraph },
+      ];
+      await store.insert(seedQuads);
+
+      const newlyDiscovered = await agent.discoverContextGraphsFromStore();
+      expect(newlyDiscovered).toBeGreaterThan(0);
+
+      await agent.publishProfile();
+
+      const agentsGraph = paranetDataGraphUri(SYSTEM_PARANETS.AGENTS);
+      const result = await store.query(
+        `SELECT ?served WHERE { GRAPH <${agentsGraph}> { ?h <https://dkg.origintrail.io/skill#contextGraphsServed> ?served } }`,
+      );
+      expect(result.type).toBe('bindings');
+      const served = result.type === 'bindings'
+        ? (result.bindings.map(b => b['served']).filter(Boolean) as string[])
+        : [];
+      const joined = served.join(',');
+      expect(joined).toContain('normal-public');
+      expect(joined).not.toContain('discovered-only');
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  }, 15000);
 });
 
 describe('Genesis Knowledge', () => {

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -54,7 +54,7 @@ interface RelayTarget {
  * Circuit-relay addresses are checked separately by callers because the
  * "peer record is dialable" signal merges both classes.
  */
-function isLocalOrInternalHostname(host: string): boolean {
+export function isLocalOrInternalHostname(host: string): boolean {
   if (typeof host !== 'string' || host.length === 0) return true;
   const h = host.toLowerCase();
   if (h === 'localhost') return true;
@@ -67,7 +67,7 @@ function isLocalOrInternalHostname(host: string): boolean {
   return false;
 }
 
-function isPublicLikeAddress(addr: string): boolean {
+export function isPublicLikeAddress(addr: string): boolean {
   const dnsMatch = addr.match(/^\/(?:dns|dns4|dns6|dnsaddr)\/([^/]+)\//);
   if (dnsMatch) return !isLocalOrInternalHostname(dnsMatch[1]);
   const ipv4 = addr.match(/^\/ip4\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\//);

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -54,8 +54,22 @@ interface RelayTarget {
  * Circuit-relay addresses are checked separately by callers because the
  * "peer record is dialable" signal merges both classes.
  */
+function isLocalOrInternalHostname(host: string): boolean {
+  if (typeof host !== 'string' || host.length === 0) return true;
+  const h = host.toLowerCase();
+  if (h === 'localhost') return true;
+  if (h.endsWith('.local') || h.endsWith('.localhost')) return true;
+  if (h.endsWith('.test') || h.endsWith('.example')) return true;
+  if (h.endsWith('.invalid') || h.endsWith('.localdomain')) return true;
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(h)) return true;
+  if (/^\[?[0-9a-f:]+\]?$/.test(h) && h.includes(':')) return true;
+  if (!h.includes('.')) return true;
+  return false;
+}
+
 function isPublicLikeAddress(addr: string): boolean {
-  if (/^\/(?:dns|dns4|dns6|dnsaddr)\//.test(addr)) return true;
+  const dnsMatch = addr.match(/^\/(?:dns|dns4|dns6|dnsaddr)\/([^/]+)\//);
+  if (dnsMatch) return !isLocalOrInternalHostname(dnsMatch[1]);
   const ipv4 = addr.match(/^\/ip4\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\//);
   if (ipv4) {
     const o = ipv4[1].split('.').map(Number);

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -73,7 +73,7 @@ export function isPublicLikeAddress(addr: string): boolean {
   const ipv4 = addr.match(/^\/ip4\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\//);
   if (ipv4) {
     const o = ipv4[1].split('.').map(Number);
-    if (o.some((n) => Number.isNaN(n))) return false;
+    if (o.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
     if (o[0] === 0 || o[0] === 127) return false;
     if (o[0] === 10) return false;
     if (o[0] === 172 && o[1] >= 16 && o[1] <= 31) return false;

--- a/packages/core/test/address-classifier.test.ts
+++ b/packages/core/test/address-classifier.test.ts
@@ -40,6 +40,16 @@ describe('isPublicLikeAddress (daemon-side dialability classifier)', () => {
       expect(isPublicLikeAddress('/ip4/169.254.1.5/tcp/9090/p2p/12D3Koo')).toBe(false);
       expect(isPublicLikeAddress('/ip4/100.105.212.110/tcp/57550/p2p/12D3Koo')).toBe(false);
     });
+    // Codex review on PR #434 (round 2) caught a real drift between this
+    // and the UI copy: the old core parser only checked NaN, so an octet
+    // like 999 would slip through and be classified as "public". The UI
+    // copy already had the 0..255 range check. Mirrored test ensures the
+    // core copy now matches.
+    it('rejects out-of-range IPv4 octets (drift fence vs UI 0..255 check)', () => {
+      expect(isPublicLikeAddress('/ip4/999.1.1.1/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip4/256.0.0.1/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip4/-1.2.3.4/tcp/9090/p2p/12D3Koo')).toBe(false);
+    });
     it('rejects loopback + link-local + ULA IPv6', () => {
       expect(isPublicLikeAddress('/ip6/::1/tcp/9090/p2p/12D3Koo')).toBe(false);
       expect(isPublicLikeAddress('/ip6/fe80::1/tcp/9090/p2p/12D3Koo')).toBe(false);

--- a/packages/core/test/address-classifier.test.ts
+++ b/packages/core/test/address-classifier.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { isPublicLikeAddress, isLocalOrInternalHostname } from '../src/node.js';
+
+// Twin of `packages/node-ui/test/share-project-modal.test.ts`. The two
+// classifiers (`isPublicLikeAddress` here and `isMultiaddrRemotelyDialable`
+// in node-ui) MUST stay behaviourally aligned — the daemon uses one to
+// decide when to log "Node is remotely-dialable", and the ShareProjectModal
+// uses the other to decide whether to enable the V10 peer-id invite.
+// Codex review on PR #434 (round 1) flagged that adding a second copy
+// without core-side tests guarantees future drift. These tests are the
+// regression fence for the daemon-side copy; they intentionally mirror
+// the cases in share-project-modal.test.ts. If you change one, change the
+// other.
+
+describe('isPublicLikeAddress (daemon-side dialability classifier)', () => {
+  describe('public-looking — accepted', () => {
+    it('accepts public IPv4 + tcp', () => {
+      expect(isPublicLikeAddress('/ip4/178.156.252.147/tcp/9090/p2p/12D3Koo')).toBe(true);
+    });
+    it('accepts dns / dns4 / dnsaddr with a public-looking host', () => {
+      expect(isPublicLikeAddress('/dns4/relay.example.com/tcp/443/p2p/12D3Koo')).toBe(true);
+      expect(isPublicLikeAddress('/dnsaddr/relay.origintrail.network/p2p/12D3Koo')).toBe(true);
+    });
+    it('accepts global-unicast IPv6', () => {
+      expect(isPublicLikeAddress('/ip6/2a01:4ff:f4:843b::1/tcp/9090/p2p/12D3Koo')).toBe(true);
+    });
+  });
+
+  describe('not public — rejected', () => {
+    it('rejects loopback IPv4', () => {
+      expect(isPublicLikeAddress('/ip4/127.0.0.1/tcp/57550/p2p/12D3Koo')).toBe(false);
+    });
+    it('rejects RFC1918 ranges', () => {
+      expect(isPublicLikeAddress('/ip4/10.0.0.5/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip4/172.16.0.1/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip4/172.31.255.255/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip4/192.168.0.171/tcp/57550/p2p/12D3Koo')).toBe(false);
+    });
+    it('rejects link-local + CGNAT', () => {
+      expect(isPublicLikeAddress('/ip4/169.254.1.5/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip4/100.105.212.110/tcp/57550/p2p/12D3Koo')).toBe(false);
+    });
+    it('rejects loopback + link-local + ULA IPv6', () => {
+      expect(isPublicLikeAddress('/ip6/::1/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip6/fe80::1/tcp/9090/p2p/12D3Koo')).toBe(false);
+      expect(isPublicLikeAddress('/ip6/fc00::1/tcp/9090/p2p/12D3Koo')).toBe(false);
+    });
+
+    // Codex review on PR #434 (round 1) flagged that the dns* path of the
+    // daemon-side classifier was identical to the UI's, so the same
+    // hostname rejections must hold here. Mirror of the UI cases.
+    describe('rejects local/internal hostnames behind /dns*/ (matches UI)', () => {
+      it('rejects literal localhost', () => {
+        expect(isPublicLikeAddress('/dns/localhost/tcp/9090/p2p/12D3Koo')).toBe(false);
+        expect(isPublicLikeAddress('/dns4/localhost/tcp/9090/p2p/12D3Koo')).toBe(false);
+      });
+      it('rejects mDNS .local', () => {
+        expect(isPublicLikeAddress('/dns/raspberrypi.local/tcp/9090/p2p/12D3Koo')).toBe(false);
+      });
+      it('rejects RFC 6761 reserved TLDs', () => {
+        expect(isPublicLikeAddress('/dns/foo.test/tcp/9090/p2p/12D3Koo')).toBe(false);
+        expect(isPublicLikeAddress('/dns/host.example/tcp/9090/p2p/12D3Koo')).toBe(false);
+        expect(isPublicLikeAddress('/dns/x.invalid/tcp/9090/p2p/12D3Koo')).toBe(false);
+        expect(isPublicLikeAddress('/dns/y.localhost/tcp/9090/p2p/12D3Koo')).toBe(false);
+      });
+      it('rejects IP literals embedded in /dns*/', () => {
+        expect(isPublicLikeAddress('/dns/127.0.0.1/tcp/9090/p2p/12D3Koo')).toBe(false);
+      });
+      it('rejects single-label hostnames (no dot)', () => {
+        expect(isPublicLikeAddress('/dns/internal-relay/tcp/9090/p2p/12D3Koo')).toBe(false);
+      });
+    });
+  });
+});
+
+describe('isLocalOrInternalHostname', () => {
+  it('treats empty / non-string as local (defensive)', () => {
+    expect(isLocalOrInternalHostname('')).toBe(true);
+    expect(isLocalOrInternalHostname(undefined as unknown as string)).toBe(true);
+  });
+  it('treats public FQDNs as non-local', () => {
+    expect(isLocalOrInternalHostname('relay.origintrail.network')).toBe(false);
+    expect(isLocalOrInternalHostname('a.b.c.example.com')).toBe(false);
+  });
+});

--- a/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
@@ -449,12 +449,26 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
                 </div>
                 <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 4 }}>
                   Share this with collaborators. They paste it into <strong>Join Project</strong> on their node.
-                  Their daemon dials your node by peer id over the libp2p DHT, so the invite stays
-                  valid even if your relay or public IP changes.
-                  {allowedAgents.length > 0 ? (
-                    <> The invitee must have their agent address on the allowlist, or they can submit a signed join request for your approval.</>
+                  {inviteReady ? (
+                    <>
+                      {' '}Their daemon dials your node by peer id over the libp2p DHT, so the
+                      invite stays valid even if your relay or public IP changes.
+                      {allowedAgents.length > 0 ? (
+                        <> The invitee must have their agent address on the allowlist, or they can submit a signed join request for your approval.</>
+                      ) : (
+                        <> Since no allowlist is set, anyone with this code can join.</>
+                      )}
+                    </>
                   ) : (
-                    <> Since no allowlist is set, anyone with this code can join.</>
+                    <>
+                      {' '}This is the bare project ID — sufficient for <em>open</em> projects
+                      (joiners discover via gossip without dialing your node).
+                      {allowedAgents.length > 0 ? (
+                        <> Because this project has an allowlist, joiners would also need to dial your node to submit a signed join request — that path won't work until AutoRelay negotiates a circuit-relay reservation. Re-open this modal then to copy the peer-id-enhanced form.</>
+                      ) : (
+                        <> For curated projects, re-open this modal once AutoRelay has negotiated to copy the peer-id-enhanced form.</>
+                      )}
+                    </>
                   )}
                 </div>
               </div>

--- a/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
+++ b/packages/node-ui/src/ui/components/Modals/ShareProjectModal.tsx
@@ -26,10 +26,36 @@ function truncAddr(addr: string): string {
 }
 
 /**
+ * Reject DNS hostnames that no remote peer could resolve to a public
+ * address: `localhost`, mDNS `.local`, RFC 6761 reserved TLDs (`.test`,
+ * `.example`, `.invalid`, `.localhost`), `.localdomain`, IPv4/IPv6
+ * literals embedded in the DNS field, and single-label hostnames
+ * (which usually only resolve via a corporate DNS suffix).
+ *
+ * Codex review on PR #431 (round 3) flagged that the previous heuristic
+ * blanket-accepted every dns multiaddr, so a freshly-started node
+ * announcing /dns/localhost/tcp/9090/p2p/xxx would pass the invite gate
+ * and produce a guaranteed-broken invite.
+ */
+export function isLocalOrInternalHostname(host: string): boolean {
+  if (typeof host !== 'string' || host.length === 0) return true;
+  const h = host.toLowerCase();
+  if (h === 'localhost') return true;
+  if (h.endsWith('.local') || h.endsWith('.localhost')) return true;
+  if (h.endsWith('.test') || h.endsWith('.example')) return true;
+  if (h.endsWith('.invalid') || h.endsWith('.localdomain')) return true;
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(h)) return true;
+  if (/^\[?[0-9a-f:]+\]?$/.test(h) && h.includes(':')) return true;
+  if (!h.includes('.')) return true;
+  return false;
+}
+
+/**
  * Cheap heuristic: would a remote dialer have ANY chance of reaching us
  * via this multiaddr? A remote-dialable address is one of:
  *   • `/p2p-circuit/...` — relay reservation, dialable through the relay.
- *   • `/dns(4|6|addr)/...` — domain-based, presumed public.
+ *   • `/dns(4|6|addr)/<host>/...` — domain-based, host is a publicly
+ *     resolvable FQDN (NOT `localhost`, `*.local`, `*.test`, etc.).
  *   • `/ip4/<public>/...` — non-RFC1918, non-loopback, non-CGNAT.
  *   • `/ip6/<global-unicast>/...` — not loopback, not link-local, not ULA.
  * Conservative: anything we can't classify counts as NOT dialable, so the
@@ -37,11 +63,16 @@ function truncAddr(addr: string): string {
  * invite. The joiner's DHT walk would surface the same negative answer
  * eventually, but we'd rather fail fast on the curator side than make the
  * joiner sit through a 90s catchup deadline.
+ *
+ * KEEP IN SYNC with `isPublicLikeAddress` in
+ * `packages/core/src/node.ts` — the daemon uses the same predicate to
+ * decide when to log "Node is remotely-dialable".
  */
 export function isMultiaddrRemotelyDialable(addr: string): boolean {
   if (typeof addr !== 'string' || addr.length === 0) return false;
   if (addr.includes('/p2p-circuit/')) return true;
-  if (/^\/(?:dns|dns4|dns6|dnsaddr)\//.test(addr)) return true;
+  const dnsMatch = addr.match(/^\/(?:dns|dns4|dns6|dnsaddr)\/([^/]+)\//);
+  if (dnsMatch) return !isLocalOrInternalHostname(dnsMatch[1]);
 
   const ipv4 = addr.match(/^\/ip4\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\//);
   if (ipv4) {
@@ -386,11 +417,13 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
                     border: '1px solid rgba(245, 158, 11, 0.3)',
                     color: 'var(--accent-amber, #f59e0b)',
                   }}>
-                    <strong>Invite not ready yet.</strong> Your node has no remotely-dialable
-                    address yet — it hasn't established a circuit-relay reservation or a public
-                    interface. Wait a few seconds for AutoRelay to negotiate, then re-open this
-                    modal. Sharing the invite now would produce a peer record that joiners
-                    cannot reach.
+                    <strong>Peer-id invite not ready yet.</strong> Your node has no
+                    remotely-dialable address yet (no circuit-relay reservation, no public
+                    interface). The invite below is the bare project ID — joiners can subscribe
+                    if the project is <em>open</em>, but for <em>curated</em> projects they need
+                    to dial this node directly to send a join request, which won't work until
+                    AutoRelay negotiates a reservation. Re-open this modal in a few seconds to
+                    pick up the peer-id-enhanced form.
                   </div>
                 )}
                 <div style={{ position: 'relative' }}>
@@ -399,21 +432,19 @@ export function ShareProjectModal({ open, onClose, contextGraphId, contextGraphN
                     borderRadius: 6, padding: '10px 12px', fontSize: 11, lineHeight: 1.6,
                     fontFamily: 'var(--font-mono)', color: 'var(--text-primary)',
                     overflow: 'auto', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all',
-                    opacity: inviteReady ? 1 : 0.55,
                   }}>
                     {invitePayload}
                   </pre>
                   <button
                     className="v10-modal-btn primary"
                     onClick={() => copyToClipboard(invitePayload, 'invite')}
-                    disabled={!inviteReady}
                     style={{
                       position: 'absolute', top: 6, right: 6, fontSize: 10, padding: '4px 10px', height: 26,
-                      cursor: inviteReady ? 'pointer' : 'not-allowed',
+                      cursor: 'pointer',
                     }}
-                    title={inviteReady ? undefined : 'Waiting for circuit-relay reservation'}
+                    title={inviteReady ? undefined : 'Bare project ID (works for open projects). Wait for AutoRelay to upgrade to a peer-id invite for curated projects.'}
                   >
-                    {copied === 'invite' ? 'Copied' : 'Copy Invite'}
+                    {copied === 'invite' ? 'Copied' : (inviteReady ? 'Copy Invite' : 'Copy Project ID')}
                   </button>
                 </div>
                 <div style={{ fontSize: 10, color: 'var(--text-tertiary)', marginTop: 4 }}>

--- a/packages/node-ui/test/share-project-modal.test.ts
+++ b/packages/node-ui/test/share-project-modal.test.ts
@@ -38,6 +38,14 @@ describe('isMultiaddrRemotelyDialable', () => {
       expect(isMultiaddrRemotelyDialable('/ip4/169.254.1.5/tcp/9090/p2p/12D3Koo...')).toBe(false);
       expect(isMultiaddrRemotelyDialable('/ip4/100.105.212.110/tcp/57550/p2p/12D3Koo...')).toBe(false);
     });
+    // Mirror of the core test in `packages/core/test/address-classifier.test.ts`.
+    // Codex flagged on PR #434 (round 2) that the core copy was accepting
+    // out-of-range octets while this copy already rejected them — a real drift.
+    it('rejects out-of-range IPv4 octets', () => {
+      expect(isMultiaddrRemotelyDialable('/ip4/999.1.1.1/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      expect(isMultiaddrRemotelyDialable('/ip4/256.0.0.1/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      expect(isMultiaddrRemotelyDialable('/ip4/-1.2.3.4/tcp/9090/p2p/12D3Koo...')).toBe(false);
+    });
     it('rejects loopback + link-local + ULA IPv6', () => {
       expect(isMultiaddrRemotelyDialable('/ip6/::1/tcp/9090/p2p/12D3Koo...')).toBe(false);
       expect(isMultiaddrRemotelyDialable('/ip6/fe80::1/tcp/9090/p2p/12D3Koo...')).toBe(false);

--- a/packages/node-ui/test/share-project-modal.test.ts
+++ b/packages/node-ui/test/share-project-modal.test.ts
@@ -15,9 +15,9 @@ describe('isMultiaddrRemotelyDialable', () => {
     it('accepts public IPv4 + tcp', () => {
       expect(isMultiaddrRemotelyDialable('/ip4/178.156.252.147/tcp/9090/p2p/12D3Koo...')).toBe(true);
     });
-    it('accepts dns / dns4 / dnsaddr', () => {
+    it('accepts dns / dns4 / dnsaddr with a public-looking host', () => {
       expect(isMultiaddrRemotelyDialable('/dns4/relay.example.com/tcp/443/p2p/12D3Koo...')).toBe(true);
-      expect(isMultiaddrRemotelyDialable('/dnsaddr/example.com/p2p/12D3Koo...')).toBe(true);
+      expect(isMultiaddrRemotelyDialable('/dnsaddr/relay.origintrail.network/p2p/12D3Koo...')).toBe(true);
     });
     it('accepts global-unicast IPv6', () => {
       expect(isMultiaddrRemotelyDialable('/ip6/2a01:4ff:f4:843b::1/tcp/9090/p2p/12D3Koo...')).toBe(true);
@@ -46,6 +46,31 @@ describe('isMultiaddrRemotelyDialable', () => {
     it('rejects garbage / empty', () => {
       expect(isMultiaddrRemotelyDialable('')).toBe(false);
       expect(isMultiaddrRemotelyDialable('not-a-multiaddr')).toBe(false);
+    });
+
+    // Codex review on the post-merge diff of PR #431 (round 3) flagged
+    // that the previous `dns*` path was a blanket-accept. Tighten the gate
+    // so common local/internal hostnames don't slip through.
+    describe('rejects local/internal hostnames behind /dns*/', () => {
+      it('rejects literal localhost', () => {
+        expect(isMultiaddrRemotelyDialable('/dns/localhost/tcp/9090/p2p/12D3Koo...')).toBe(false);
+        expect(isMultiaddrRemotelyDialable('/dns4/localhost/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      });
+      it('rejects mDNS .local', () => {
+        expect(isMultiaddrRemotelyDialable('/dns/raspberrypi.local/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      });
+      it('rejects RFC 6761 reserved TLDs (.test, .example, .invalid, .localhost)', () => {
+        expect(isMultiaddrRemotelyDialable('/dns/foo.test/tcp/9090/p2p/12D3Koo...')).toBe(false);
+        expect(isMultiaddrRemotelyDialable('/dns/host.example/tcp/9090/p2p/12D3Koo...')).toBe(false);
+        expect(isMultiaddrRemotelyDialable('/dns/x.invalid/tcp/9090/p2p/12D3Koo...')).toBe(false);
+        expect(isMultiaddrRemotelyDialable('/dns/y.localhost/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      });
+      it('rejects IP literals embedded in /dns*/', () => {
+        expect(isMultiaddrRemotelyDialable('/dns/127.0.0.1/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      });
+      it('rejects single-label hostnames (no dot)', () => {
+        expect(isMultiaddrRemotelyDialable('/dns/internal-relay/tcp/9090/p2p/12D3Koo...')).toBe(false);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to merged PR #431. Codex's third pass on `4ee3422e` (the final commit before merge) surfaced 3 new issues that didn't get caught before the merge button was clicked. All three fixed here:

| # | Severity | File | Issue |
|---|---|---|---|
| 1 | 🔴 Bug | `packages/agent/src/dkg-agent.ts:2640` | `publishProfile()` advertised CGs we merely *discovered* (subscribed:false). Other peers routed join attempts to nodes that don't host them. |
| 2 | 🟡 Issue | `ShareProjectModal.tsx:44` + `core/src/node.ts:58` | dns multiaddr heuristic blanket-accepted `localhost`, `*.local`, internal hostnames. |
| 3 | 🟡 Issue | `ShareProjectModal.tsx:409` | Copy button disabled even for the bare-cgId fallback, blocking the open-project workflow. |

### Fix details

**(1) `subscribedContextGraphs` filter.** `discoverContextGraphsFromStore()` seeds entries for open/public CGs with `subscribed: false` (we don't auto-subscribe public CGs; user must opt in via Join). Without filtering, those entries were ending up in `contextGraphsServed` so other peers thought we hosted them. Added `if (!sub.subscribed) continue;` before the privacy-policy check. The curated/private discovery path immediately calls `subscribeToContextGraph()` (flips to true) so invited-curated discovery is not affected.

**(2) `dns*` heuristic.** Tightened to reject:
- literal `localhost`
- mDNS `.local`
- RFC 6761 reserved TLDs (`.test`, `.example`, `.invalid`, `.localhost`)
- `.localdomain`
- IP literals embedded in the dns field (`/dns/127.0.0.1/...`)
- single-label hostnames (no dot)

Both copies of the heuristic — `isMultiaddrRemotelyDialable` in `node-ui` (drives invite-ready gate) and `isPublicLikeAddress` in `core` (drives the daemon "remotely-dialable" log) — are updated in lockstep. File-level comments call this out so they don't drift.

**(3) Bare-cgId Copy button.** The `inviteReady=false` fallback already produces a valid bare-cgId invite, which is sufficient for OPEN projects (the joiner discovers the curator via gossip without needing a peer-id dial). Button is now always enabled; warning text rewrites to:
> *"Peer-id invite not ready yet. ... The invite below is the bare project ID — joiners can subscribe if the project is open, but for curated projects they need to dial this node directly to send a join request, which won't work until AutoRelay negotiates a reservation."*

Button label flips to **"Copy Project ID"** while not-ready and **"Copy Invite"** once the peer-id form is available, signalling the difference.

## Test plan

- [x] 27/27 `share-project-modal.test.ts` + `join-project-modal.test.ts` vitest pass (added 5 new cases for hostname rejection: `localhost`, `.local`, RFC 6761 TLDs, IP literals, single-label).
- [x] Full `dkg-node-ui` vitest suite green (415 tests).
- [x] Full `dkg-agent` vitest suite green (359 tests).
- [x] No new lint errors.
- [ ] Codex re-review (automatic on push).
- [ ] Optional: re-run the PR #431 devnet smoke recipe to confirm no regression on the daemon "remotely-dialable" log path with the new hostname heuristic. Devnet announces only ip4 addrs, so the hostname tightening doesn't affect that path.

## Notes for reviewers

- This PR is intentionally narrow: only the 3 issues from Codex's round-3 review. The chain-driven relay registry (drafted as `production_mainnet/04_NETWORK_RELAY_REGISTRY.md` in `dkgv10-spec`) is a separate, larger effort.
- No test for the `publishProfile` filter — `subscribedContextGraphs` and `isPrivateContextGraph` are private fields/methods on `DkgAgent` and the existing test surface doesn't cover `publishProfile`'s body. The fix is a 1-line predicate; the cost/benefit of plumbing a public test seam isn't worth it for this PR. Happy to revisit if reviewers disagree.

Made with [Cursor](https://cursor.com)