### PR TITLE
fix(docs): unblock npm publish — replace stale dkg-v9 repo-name references in mcp-dkg/README

### DIFF
--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -86,13 +86,13 @@ Either way, the resolved registration looks like this — the shape stays unifor
   "mcpServers": {
     "dkg": {
       "command": "/usr/local/bin/node",
-      "args": ["/absolute/path/to/dkg-v9/packages/cli/dist/cli.js", "mcp", "serve"]
+      "args": ["/absolute/path/to/dkg/packages/cli/dist/cli.js", "mcp", "serve"]
     }
   }
 }
 ```
 
-**What does NOT work**: `cd dkg-v9 && dkg mcp setup` (without `--monorepo`). With a globally-installed `dkg`, the running CLI lives at the npm global path — auto-detect sees that location is outside any monorepo and stays in installed mode, registering the global build. Your local edits won't be picked up. Either invoke the local dist directly (Option A) or pass `--monorepo` (Option B).
+**What does NOT work**: `cd dkg && dkg mcp setup` (without `--monorepo`). With a globally-installed `dkg`, the running CLI lives at the npm global path — auto-detect sees that location is outside any monorepo and stays in installed mode, registering the global build. Your local edits won't be picked up. Either invoke the local dist directly (Option A) or pass `--monorepo` (Option B).
 
 **Always rebuild before re-running setup** — skip the rebuild and the registered entry points at a stale `dist/cli.js`, so your edits won't show up.
 


### PR DESCRIPTION
## Summary

- Two `dkg-v9` references in `packages/mcp-dkg/README.md` were stale (the repo was renamed from `dkg-v9` to `dkg` post-clone). Both came from PR #394 docs written when the local clone still bore the old name.
- The `Continuous NPM Publish` workflow on `main` is currently failing at the `Validate npm metadata points to v10` pre-flight step ([failed run 25513820998](https://github.com/OriginTrail/dkg/actions/runs/25513820998)) because `scripts/check-npm-metadata.mjs` flags `/dkg-v9/i` matches in any publishable package's README.
- This change unblocks the publish.

## Related

- Fixes the publish failure on `main` after [#381](https://github.com/OriginTrail/dkg/pull/381) (V10 MCP consolidation merge)
- Pre-flight script: `scripts/check-npm-metadata.mjs` (`FORBIDDEN_PATTERNS = [/dkg-v9/i, /DKG V9/i]`)

## Files changed

| File | What |
|------|------|
| `packages/mcp-dkg/README.md` | Two repo-name placeholder paths updated: `dkg-v9` → `dkg`. Lines 89 (manual JSON example) + 95 (FIX 24 "What does NOT work" callout) |

## Test plan

- [x] Local: `pnpm check:npm-metadata` returns "NPM metadata check passed: no stale v9 references in publishable packages."
- [x] `grep -n "dkg-v9" packages/mcp-dkg/README.md` returns no matches.
- [ ] CI's `Continuous NPM Publish` workflow passes the metadata pre-flight on this PR's branch (will run automatically).
- [ ] After merge: `Continuous NPM Publish` succeeds on `main`.

## Out of scope

Three other `DKG V9` references exist that DO NOT block publish (their packages have `private: true` so `check-npm-metadata.mjs` skips them):

- `packages/evm-module/README.md:3` — "DKG V9 smart contracts and deployment scripts. Forked from V8…"
- `packages/evm-module/package.json:4` — `"description": "DKG V9 smart contracts (forked from V8 dkg-evm-module)"`
- `packages/network-sim/README.md:3` — "Network simulation tool for DKG V9."

These are stale-looking but don't affect the publish. Worth cleaning up in a follow-up — needs a judgment call on whether the contracts are genuinely V9-protocol-generation (in which case the references are accurate, just not aligned with the V10 product brand) or are also stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)