### PR TITLE
fix(cli/test): mcp-setup PRIOR DKG_HOME uses tmpHome path, not /some/external

### DIFF
--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -1591,7 +1591,14 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     // Post-fix: try/finally wraps the action body. The finally
     // restores the prior `DKG_HOME` value (or unsets it if it wasn't
     // set going in) on BOTH throw and normal exit.
-    const PRIOR = '/some/external/dkg-home';
+    //
+    // Using a tmpHome-rooted path here, not a hardcoded system path
+    // like `/some/external/dkg-home`: the action mkdirs `dkgDirPath`
+    // before the (stubbed-to-throw) startDaemon, so the path needs
+    // to be writable on the runner. The test invariant (DKG_HOME
+    // pointing somewhere OTHER than the default `~/.dkg`) is the
+    // same regardless of which tmpdir-rooted path we pick.
+    const PRIOR = join(tmpHome, 'external-dkg-home');
     process.env.DKG_HOME = PRIOR;
 
     // Force a throw mid-action: stub `startDaemon` to reject. By
@@ -2140,7 +2147,15 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     // previousDkgHome BEFORE the cascade; the try/finally restore
     // MUST still use that captured value. This test pins the
     // invariant for both the env-set and env-unset cases.
-    const PRIOR = '/some/external/dkg-home';
+    //
+    // Using a tmpHome-rooted path here, not a hardcoded system path
+    // like `/some/external/dkg-home`: the action mkdirs `dkgDirPath`
+    // (the writeDkgConfig stub creates it for completeness), so
+    // the path needs to be writable on the runner. The test
+    // invariant (DKG_HOME pointing somewhere OTHER than the default
+    // `~/.dkg`) is the same regardless of which tmpdir-rooted path
+    // we pick.
+    const PRIOR = join(tmpHome, 'external-dkg-home');
     process.env.DKG_HOME = PRIOR;
     mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
 


### PR DESCRIPTION
## Summary

- Two tests in `packages/cli/test/mcp-setup.test.ts` (added during PR #394 / #381) hardcoded `const PRIOR = '/some/external/dkg-home'` as a "DKG_HOME pointing outside the default `~/.dkg`" sentinel.
- The path was decorative — the test invariant only requires "not `~/.dkg`". But the action's bootstrap step (and the `writeDkgConfig` stub) `mkdirSync`s `dkgDirPath`, which on Fix 14's cascade picks up `PRIOR` when env is set. On Linux CI runners that mkdir gets `EACCES` (the runner can't write outside `/home/runner/`).
- Tests passed locally during the PR #394 review iteration but were latent CI failures, only surfacing once main's `Build packages` stopped failing first.
- **Fix:** replace both occurrences with `join(tmpHome, 'external-dkg-home')`. `tmpHome` is `mkdtempSync`'d in `beforeEach` and torn down in `afterEach`. Same test invariant, no permission issues.

## Related

- Original tests added in PR #394 (V10 MCP consolidation), Round-3 FIX 3 (try/finally DKG_HOME restore) + Round-8 FIX 14 (cascade preserves DKG_HOME)
- Sister PR [#438](https://github.com/OriginTrail/dkg/pull/438) — unblocks the npm publish workflow (different failure)
- Pre-existing 5 `adapter-openclaw` faucet test failures are NOT included here (separate root cause; flagged but out of scope per [the team-lead's call])

## Files changed

| File | What |
|------|------|
| `packages/cli/test/mcp-setup.test.ts` | Two occurrences of `'/some/external/dkg-home'` → `join(tmpHome, 'external-dkg-home')` (lines ~1594 and ~2143). Comment block on each test explains why we don't hardcode a system path. |

## Test plan

- [x] Local `npx vitest run test/mcp-setup.test.ts` → 98/98 pass.
- [ ] CI's `Bura: cli` job passes on this PR's branch (will run automatically).
- [ ] After merge: `Bura: cli` passes on `main`.

## Out of scope

- 5 `adapter-openclaw setup.test.ts > runSetup Step 5 — faucet funding` failures — pre-existing, unrelated to PR #394; investigate separately.
- The `/some/external/dkg-home` references in mcp-lead's earlier round-9 / round-15 follow-up tests were for the same FIX 3/14 invariants but used different test bodies; those don't touch this hardcoded path. Verified by grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)