### PR TITLE
[codex] Raise SWM gossip payload cap to 10MB

### DIFF
--- a/packages/agent/scripts/ci-shard-agent.mjs
+++ b/packages/agent/scripts/ci-shard-agent.mjs
@@ -64,7 +64,7 @@ const WEIGHTS = {
   'test/v10-ack-provider.test.ts': 1131,
   'test/finalization-promote-extra.test.ts': 1058,
   'test/wm-multi-agent-isolation-extra.test.ts': 1022,
-  'test/swm-512kb-boundary-extra.test.ts': 1000,
+  'test/swm-10mb-boundary-extra.test.ts': 1000,
 };
 const DEFAULT_WEIGHT = 500;
 

--- a/packages/agent/test/swm-10mb-boundary-extra.test.ts
+++ b/packages/agent/test/swm-10mb-boundary-extra.test.ts
@@ -1,9 +1,9 @@
 /**
- * SHARE / SWM 512 KB gossip-size boundary, exercised from the agent layer.
+ * SHARE / SWM 10 MB gossip-size boundary, exercised from the agent layer.
  *
  * Audit findings covered:
  *   A-2 (CRITICAL) — `DKGPublisher#_shareImpl` rejects encoded SWM messages
- *        larger than `MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024`. The agent's
+ *        larger than the DKG gossip payload cap. The agent's
  *        `DKGAgent#share` is the only user-facing entry point. We pin:
  *          1. Positive: a payload whose encoded size is safely below the
  *             limit succeeds and produces a shareOperationId + SWM quads
@@ -13,7 +13,7 @@
  *             split-into-smaller-share() batches.
  *          3. Boundary: callers that hit the limit see a *clear* error, not
  *             a silent libp2p-level drop. Error message contains both the
- *             observed KB and the 512 KB limit so operators can react.
+ *             observed KB and the 10 MB limit so operators can react.
  *
  * No mocks — real `DKGAgent` + real libp2p + real chain (only used to boot
  * the agent; share() never submits a tx).
@@ -21,6 +21,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ethers } from 'ethers';
 import { DKGAgent } from '../src/index.js';
+import { DKG_GOSSIP_MAX_MESSAGE_BYTES } from '@origintrail-official/dkg-core';
 import {
   HARDHAT_KEYS,
   createEVMAdapter,
@@ -65,12 +66,12 @@ afterAll(async () => {
   await revertSnapshot(_fileSnapshot);
 });
 
-describe('A-2: SHARE 512 KB gossip-size boundary', () => {
-  it('share() with a payload well BELOW 512 KB succeeds and lands in SWM', async () => {
+describe('A-2: SHARE 10 MB gossip-size boundary', () => {
+  it('share() with a payload well below 10 MB succeeds and lands in SWM', async () => {
     const cgId = freshCgId('bnd-lo');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Lo', description: '' });
 
-    // Target ~100 KB of literal payload — well under the 512 KB cap.
+    // Target ~100 KB of literal payload — well under the 10 MB cap.
     // Split across multiple literals to mimic realistic agent output.
     const chunkCount = 10;
     const chunkLen = 10 * 1024; // 10 KB per chunk
@@ -96,13 +97,12 @@ describe('A-2: SHARE 512 KB gossip-size boundary', () => {
     }
   });
 
-  it('share() with a payload WELL ABOVE 512 KB is rejected with the expected error message', async () => {
+  it('share() with a payload well above 10 MB is rejected with the expected error message', async () => {
     const cgId = freshCgId('bnd-hi');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Hi', description: '' });
 
-    // One literal of ~700 KB — guaranteed to push the encoded message
-    // past the 512 KB gossip-size cap even after protobuf framing.
-    const big = 'y'.repeat(700 * 1024);
+    // One literal above the 10 MB cap is guaranteed to trip the pre-mutation guard.
+    const big = 'y'.repeat(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
     const quads = [
       {
         subject: 'urn:swm:hi:alice',
@@ -118,10 +118,10 @@ describe('A-2: SHARE 512 KB gossip-size boundary', () => {
     } catch (e) {
       caught = e as Error;
     }
-    expect(caught, 'share() should reject a 700 KB payload with a size-limit error').not.toBeNull();
-    // Spec text from dkg-publisher.ts: "SWM message too large (<KB> KB, limit 512 KB)."
+    expect(caught, 'share() should reject an oversized payload with a size-limit error').not.toBeNull();
+    // Spec text from dkg-publisher.ts: "SWM message too large (<KB> KB, limit 10 MB)."
     expect(caught!.message).toMatch(/SWM message too large/);
-    expect(caught!.message).toMatch(/limit\s+512\s*KB/);
+    expect(caught!.message).toMatch(/limit\s+10\s*MB/);
     // Operator-actionable guidance: split into multiple share() calls.
     expect(caught!.message.toLowerCase()).toMatch(/split|multiple share/);
   });
@@ -130,7 +130,7 @@ describe('A-2: SHARE 512 KB gossip-size boundary', () => {
     const cgId = freshCgId('bnd-atomic');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Atomic', description: '' });
 
-    const big = 'z'.repeat(600 * 1024);
+    const big = 'z'.repeat(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
     const quads = [
       {
         subject: 'urn:swm:atomic:bob',

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -338,7 +338,7 @@ Respect these when producing writes — they're enforced at the node and produce
 
 - **Reorganizing assertions.** There is no rename-assertion or move-between-sub-graphs endpoint. To reorganize, create a new assertion (with `subGraphName?` for a different partition), copy the triples over via `/write`, then `/discard` the original. A new assertion starts a fresh lifecycle record in `_meta`.
 - **Reserved subject IRIs.** Subjects matching `urn:dkg:file:*` or `urn:dkg:extraction:*` are reserved for internal file/extraction metadata and are rejected at write time. Use a different subject IRI.
-- **SWM gossip size cap (512 KB).** A single promote or SWM write must fit in one 512 KB gossip message. Split large assertions by root entity before promoting — use the `entities` parameter on `/promote` to promote subsets.
+- **SWM gossip size cap (10 MB).** A single promote or SWM write must fit in one 10 MB gossip message. Split larger assertions by root entity before promoting — use the `entities` parameter on `/promote` to promote subsets.
 - **SWM entity ownership (first-writer-wins).** The first peer to write a root entity in SWM becomes its owner; other peers' promotes or writes against that same root entity are rejected with an ownership error. Partition work by agent-owned root entities to avoid conflicts.
 - **Blank nodes are auto-skolemized.** Any `_:b0`-style blank nodes you submit are deterministically rewritten to UUID-backed URIs before storage, so IDs stay stable across sync and on-chain anchoring. Prefer explicit IRIs in production data.
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -16,6 +16,12 @@ export const PROTOCOL_STORAGE_ACK = '/dkg/10.0.0/storage-ack';
 
 export const DHT_PROTOCOL = '/dkg/kad/1.0.0';
 
+/** Maximum application payload size allowed for one DKG GossipSub message (10 MB). */
+export const DKG_GOSSIP_MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
+
+/** Allows GossipSub RPC framing around one max-sized application payload. */
+export const DKG_GOSSIP_MAX_RPC_BYTES = DKG_GOSSIP_MAX_MESSAGE_BYTES + 256 * 1024;
+
 // ── V10 GossipSub Topics ───────────────────────────────────────────────
 
 export function contextGraphSharedMemoryTopic(contextGraphId: string): string {

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -17,7 +17,7 @@ import { generateKeyPair, privateKeyFromRaw } from '@libp2p/crypto/keys';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
 import type { ConnectionTransport, DKGNodeConfig } from './types.js';
-import { DHT_PROTOCOL } from './constants.js';
+import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -164,6 +164,8 @@ export class DKGNode {
         emitSelf: false,
         allowPublishToZeroTopicPeers: true,
         floodPublish: true,
+        maxInboundDataLength: DKG_GOSSIP_MAX_RPC_BYTES,
+        maxOutboundBufferSize: DKG_GOSSIP_MAX_RPC_BYTES,
         D: 4,
         Dlo: 2,
         Dhi: 8,

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -18,6 +18,8 @@ import {
   contextGraphSessionsTopic,
   contextGraphSessionTopic,
   networkPeersTopic,
+  DKG_GOSSIP_MAX_MESSAGE_BYTES,
+  DKG_GOSSIP_MAX_RPC_BYTES,
   contextGraphDataUri,
   contextGraphMetaUri,
   contextGraphPrivateUri,
@@ -94,6 +96,11 @@ describe('V10 GossipSub topics', () => {
 
   it('network peers topic', () => {
     expect(networkPeersTopic()).toBe('dkg/network/peers');
+  });
+
+  it('allows one 10 MB DKG gossip application payload', () => {
+    expect(DKG_GOSSIP_MAX_MESSAGE_BYTES).toBe(10 * 1024 * 1024);
+    expect(DKG_GOSSIP_MAX_RPC_BYTES).toBeGreaterThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
   });
 });
 

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, type Ed25519Keypair, computePublishACKDigest, computePublishPublisherDigest } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, contextGraphDataUri, contextGraphMetaUri, contextGraphAssertionUri, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, type Ed25519Keypair, computePublishACKDigest, computePublishPublisherDigest } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import type { Publisher, PublishOptions, PublishResult, KAManifestEntry, PhaseCallback } from './publisher.js';
 import { autoPartition } from './auto-partition.js';
@@ -99,6 +99,16 @@ function publisherAddressFromUal(ual: string | undefined): string | undefined {
   if (!ual?.startsWith(prefix)) return undefined;
   const segments = ual.slice(prefix.length).split('/');
   return coercePublisherAddress(segments[1]);
+}
+
+function formatBytesAsKb(bytes: number): string {
+  return `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+function formatGossipLimit(bytes: number): string {
+  const mb = 1024 * 1024;
+  if (bytes % mb === 0) return `${bytes / mb} MB`;
+  return formatBytesAsKb(bytes);
 }
 
 function recoverCompactMessageSigner(
@@ -734,10 +744,9 @@ export class DKGPublisher implements Publisher {
       subGraphName: options.subGraphName,
     });
 
-    const MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024; // 512 KB
-    if (message.length > MAX_GOSSIP_MESSAGE_SIZE) {
+    if (message.length > DKG_GOSSIP_MAX_MESSAGE_BYTES) {
       throw new Error(
-        `SWM message too large (${(message.length / 1024).toFixed(0)} KB, limit ${MAX_GOSSIP_MESSAGE_SIZE / 1024} KB). ` +
+        `SWM message too large (${formatBytesAsKb(message.length)}, limit ${formatGossipLimit(DKG_GOSSIP_MAX_MESSAGE_BYTES)}). ` +
         `Split large writes into multiple share() calls partitioned by root entity.`,
       );
     }
@@ -2702,10 +2711,9 @@ export class DKGPublisher implements Publisher {
         subGraphName: opts.subGraphName,
       });
 
-      const MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024;
-      if (encoded.length > MAX_GOSSIP_MESSAGE_SIZE) {
+      if (encoded.length > DKG_GOSSIP_MAX_MESSAGE_BYTES) {
         throw new Error(
-          `Promoted assertion too large for gossip (${(encoded.length / 1024).toFixed(0)} KB, limit ${MAX_GOSSIP_MESSAGE_SIZE / 1024} KB). ` +
+          `Promoted assertion too large for gossip (${formatBytesAsKb(encoded.length)}, limit ${formatGossipLimit(DKG_GOSSIP_MAX_MESSAGE_BYTES)}). ` +
           `Promote fewer entities per call.`,
         );
       }

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter } from '@origintrail-official/dkg-chain';
 import {
+  DKG_GOSSIP_MAX_MESSAGE_BYTES,
   TypedEventBus,
   generateEd25519Keypair,
   contextGraphAssertionUri,
@@ -16,6 +17,7 @@ const CG_ID = 'test-assertion-cg';
 const SWM_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
 const AGENT = '0x1234567890abcdef1234567890abcdef12345678';
 const AGENT_B = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const PEER = '12D3KooWPromoteBoundary';
 const ASSERTION_NAME = 'my-assertion';
 
 const TRIPLES = [
@@ -23,6 +25,25 @@ const TRIPLES = [
   { subject: 'urn:test:entity:alice', predicate: 'http://schema.org/age', object: '"30"' },
   { subject: 'urn:test:entity:bob', predicate: 'http://schema.org/name', object: '"Bob"' },
 ];
+
+function largePayloadQuads(prefix: string, bytes: number): Quad[] {
+  const chunkBytes = 16 * 1024;
+  const quads: Quad[] = [];
+  let remaining = bytes;
+  let index = 0;
+  while (remaining > 0) {
+    const size = Math.min(chunkBytes, remaining);
+    quads.push({
+      subject: `urn:test:entity:${prefix}:${index}`,
+      predicate: 'http://schema.org/description',
+      object: `"${'x'.repeat(size)}"`,
+      graph: '',
+    });
+    remaining -= size;
+    index += 1;
+  }
+  return quads;
+}
 
 describe('Working Memory Assertion Lifecycle', () => {
   let store: OxigraphStore;
@@ -90,6 +111,42 @@ describe('Working Memory Assertion Lifecycle', () => {
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
       expect(swmResult.bindings.length).toBe(3);
+    }
+  });
+
+  it('promote accepts a payload above the old 512 KB cap and below 10 MB', async () => {
+    await publisher.assertionCreate(CG_ID, 'large-promote', AGENT);
+    const quads = largePayloadQuads('large-promote', 2 * 1024 * 1024);
+    await publisher.assertionWrite(CG_ID, 'large-promote', AGENT, quads);
+
+    const result = await publisher.assertionPromote(CG_ID, 'large-promote', AGENT, {
+      publisherPeerId: PEER,
+    });
+
+    expect(result.promotedCount).toBe(quads.length);
+    expect(result.gossipMessage).toBeInstanceOf(Uint8Array);
+    expect(result.gossipMessage!.length).toBeGreaterThan(512 * 1024);
+    expect(result.gossipMessage!.length).toBeLessThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
+  });
+
+  it('promote rejects payloads above 10 MB before mutating WM or SWM', async () => {
+    await publisher.assertionCreate(CG_ID, 'too-large-promote', AGENT);
+    const quads = largePayloadQuads('too-large-promote', DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
+    await publisher.assertionWrite(CG_ID, 'too-large-promote', AGENT, quads);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, 'too-large-promote', AGENT, { publisherPeerId: PEER }),
+    ).rejects.toThrow(/Promoted assertion too large for gossip.*10\s*MB/i);
+
+    const assertionQuads = await publisher.assertionQuery(CG_ID, 'too-large-promote', AGENT);
+    expect(assertionQuads.length).toBe(quads.length);
+
+    const swmResult = await store.query(
+      `SELECT ?o WHERE { GRAPH <${SWM_GRAPH}> { <urn:test:entity:too-large-promote:0> <http://schema.org/description> ?o } }`,
+    );
+    expect(swmResult.type).toBe('bindings');
+    if (swmResult.type === 'bindings') {
+      expect(swmResult.bindings.length).toBe(0);
     }
   });
 

--- a/packages/publisher/test/share-batching.test.ts
+++ b/packages/publisher/test/share-batching.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { DKG_GOSSIP_MAX_MESSAGE_BYTES } from '@origintrail-official/dkg-core';
 import { batchAssetsByEstimatedBytes, DEFAULT_MAX_SHARE_BATCH_BYTES, groupAssetsByRootEntity } from '../src/share-batching.js';
 
 describe('share batching helpers', () => {
@@ -19,9 +20,9 @@ describe('share batching helpers', () => {
     ]);
   });
 
-  it('uses a conservative default below the 512KB SWM gossip cap', () => {
+  it('uses a conservative default below the SWM gossip cap', () => {
     expect(DEFAULT_MAX_SHARE_BATCH_BYTES).toBe(450 * 1024);
-    expect(DEFAULT_MAX_SHARE_BATCH_BYTES).toBeLessThan(512 * 1024);
+    expect(DEFAULT_MAX_SHARE_BATCH_BYTES).toBeLessThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
   });
 
   it('splits grouped assets when batch byte estimate exceeds threshold', () => {

--- a/packages/publisher/test/share-size-boundary-extra.test.ts
+++ b/packages/publisher/test/share-size-boundary-extra.test.ts
@@ -3,15 +3,15 @@
  *
  * Audit findings covered:
  *
- *   P-4 (HIGH) — 512 KB SHARE auto-batch boundary.
- *                `packages/publisher/src/dkg-publisher.ts` hard-codes
- *                `MAX_GOSSIP_MESSAGE_SIZE = 512 * 1024`. The existing
+ *   P-4 (HIGH) — 10 MB SHARE gossip boundary.
+ *                `packages/publisher/src/dkg-publisher.ts` enforces
+ *                `DKG_GOSSIP_MAX_MESSAGE_BYTES`. The existing
  *                suite never sends a payload near that limit, so a
  *                silent change to the cap (or a regression that stops
  *                measuring the encoded protobuf length) would not be
  *                detected. These tests pin both sides of the boundary:
- *                  • a payload JUST UNDER 512 KB must succeed; and
- *                  • a payload JUST OVER 512 KB must fail with a clear,
+ *                  • a multi-MB payload below 10 MB must succeed; and
+ *                  • a payload just over 10 MB must fail with a clear,
  *                    caller-actionable error that mentions the limit.
  *
  * Per QA policy: do NOT modify production code or spec docs. If the
@@ -20,7 +20,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import { NoChainAdapter } from '@origintrail-official/dkg-chain';
-import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import { DKG_GOSSIP_MAX_MESSAGE_BYTES, TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
 import { DKGPublisher } from '../src/index.js';
 
 const CG = 'boundary-test-cg';
@@ -33,7 +33,7 @@ function q(s: string, p: string, o: string): Quad {
 /**
  * Build a single quad whose UTF-8 N-Quad serialization is approximately
  * `targetBytes` bytes. We pad the literal object so the encoded
- * WorkspacePublishRequest lands just under or just over 512 KB depending
+ * WorkspacePublishRequest lands below or above the cap depending
  * on `targetBytes`.
  *
  * Using a single root entity keeps manifest overhead constant so the
@@ -50,6 +50,20 @@ function buildQuadWithPayload(bytes: number): Quad {
   return q('urn:test:boundary:root', 'http://schema.org/description', `"${padding}"`);
 }
 
+function buildQuadsWithTotalPayload(bytes: number): Quad[] {
+  const chunkBytes = 16 * 1024;
+  const quads: Quad[] = [];
+  let remaining = bytes;
+  let index = 0;
+  while (remaining > 0) {
+    const size = Math.min(chunkBytes, remaining);
+    quads.push(q(`urn:test:boundary:root:${index}`, 'http://schema.org/description', `"${'x'.repeat(size)}"`));
+    remaining -= size;
+    index += 1;
+  }
+  return quads;
+}
+
 function makePublisher(store: OxigraphStore, eventBus: TypedEventBus): Promise<DKGPublisher> {
   return (async () => {
     const keypair = await generateEd25519Keypair();
@@ -62,7 +76,7 @@ function makePublisher(store: OxigraphStore, eventBus: TypedEventBus): Promise<D
   })();
 }
 
-describe('P-4: SWM share() 512 KB gossip-message boundary', () => {
+describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
   let store: OxigraphStore;
   let eventBus: TypedEventBus;
   let publisher: DKGPublisher;
@@ -73,12 +87,12 @@ describe('P-4: SWM share() 512 KB gossip-message boundary', () => {
     publisher = await makePublisher(store, eventBus);
   });
 
-  it('accepts a payload just under the 512 KB cap and returns an encoded message', async () => {
-    // Target 500 KB of literal payload → total encoded protobuf
-    // message will be a few KB larger but still < 512 KB.
-    const under = buildQuadWithPayload(500 * 1024);
+  it('accepts a multi-MB payload below the 10 MB cap and returns an encoded message', async () => {
+    // Many modest literals match the large-context-graph shape without
+    // stressing storage's single-literal formatter.
+    const under = buildQuadsWithTotalPayload(2 * 1024 * 1024);
 
-    const result = await publisher.share(CG, [under], { publisherPeerId: PEER });
+    const result = await publisher.share(CG, under, { publisherPeerId: PEER });
 
     expect(result).toBeDefined();
     // The encoded message is the protobuf payload the agent would gossip.
@@ -86,14 +100,13 @@ describe('P-4: SWM share() 512 KB gossip-message boundary', () => {
     // without this check the size-limit codepath would be untested.
     expect(result.message).toBeDefined();
     expect(result.message).toBeInstanceOf(Uint8Array);
-    expect(result.message.length).toBeLessThanOrEqual(512 * 1024);
-    expect(result.message.length).toBeGreaterThan(400 * 1024); // sanity: did we actually build big
+    expect(result.message.length).toBeLessThanOrEqual(DKG_GOSSIP_MAX_MESSAGE_BYTES);
+    expect(result.message.length).toBeGreaterThan(1024 * 1024); // sanity: did we actually build big
   });
 
-  it('rejects a payload just over the 512 KB cap with a clear, actionable error', async () => {
-    // Target 600 KB of literal payload — well over the 512 KB cap so
-    // there is no ambiguity about which branch the encoder exits on.
-    const over = buildQuadWithPayload(600 * 1024);
+  it('rejects a payload just over the 10 MB cap with a clear, actionable error', async () => {
+    // Well over the 10 MB cap so there is no ambiguity about the exit path.
+    const over = buildQuadWithPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
 
     let thrown: unknown;
     try {
@@ -109,23 +122,23 @@ describe('P-4: SWM share() 512 KB gossip-message boundary', () => {
     // without attaching a debugger. We also assert the remediation
     // guidance (split by root entity) per spec §04.
     expect(msg).toMatch(/too large/i);
-    expect(msg).toMatch(/512\s*KB/);
+    expect(msg).toMatch(/10\s*MB/);
     expect(msg).toMatch(/split/i);
   });
 
-  it('the cap is exactly 512 KB — a just-over payload fails, a just-under payload passes', async () => {
-    // Pin the constant. If someone reduces the cap to, say, 256 KB
-    // without updating the guidance in the error or the spec, BOTH
+  it('the cap is 10 MB — an oversized payload fails, a multi-MB payload passes', async () => {
+    // Pin the constant. If someone reduces the cap without updating
+    // the guidance in the error or the spec, BOTH
     // halves of this test flip status and the regression is noisy.
-    const justUnder = buildQuadWithPayload(480 * 1024);
-    const justOver = buildQuadWithPayload(560 * 1024);
+    const justUnder = buildQuadsWithTotalPayload(2 * 1024 * 1024);
+    const justOver = buildQuadWithPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 512 * 1024);
 
-    const ok = await publisher.share(CG, [justUnder], { publisherPeerId: PEER });
+    const ok = await publisher.share(CG, justUnder, { publisherPeerId: PEER });
     expect(ok).toBeDefined();
-    expect(ok.message.length).toBeLessThan(512 * 1024);
+    expect(ok.message.length).toBeLessThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
 
     await expect(
       publisher.share(CG, [justOver], { publisherPeerId: PEER }),
-    ).rejects.toThrow(/too large.*512\s*KB/i);
+    ).rejects.toThrow(/too large.*10\s*MB/i);
   });
 });


### PR DESCRIPTION
﻿## Summary

- Raise the DKG GossipSub application payload cap from 512 KB to 10 MB for SWM share and assertion promote paths.
- Configure libp2p gossipsub inbound/outbound buffers with RPC framing headroom for one max-sized DKG payload.
- Update boundary coverage and operator guidance so the reported multi-MB promotion case is accepted while >10 MB payloads still fail before mutation.

## Related

- Related to #428

## Files changed

| File | What |
|------|------|
| `packages/core/src/constants.ts` | Adds shared DKG gossip payload and RPC buffer size constants. |
| `packages/core/src/node.ts` | Applies the RPC-sized limit to gossipsub inbound data and outbound buffering. |
| `packages/publisher/src/dkg-publisher.ts` | Reuses the 10 MB cap in share and assertion promote pre-mutation guards. |
| `packages/publisher/test/draft-lifecycle.test.ts` | Covers promote success above the old 512 KB cap and atomic rejection above 10 MB. |
| `packages/publisher/test/share-size-boundary-extra.test.ts` | Updates share boundary coverage for the 10 MB cap. |
| `packages/publisher/test/share-batching.test.ts` | Keeps batching default conservative while comparing it to the new shared cap. |
| `packages/agent/test/swm-10mb-boundary-extra.test.ts` | Renames and updates the agent-layer SWM boundary test. |
| `packages/agent/scripts/ci-shard-agent.mjs` | Updates the CI shard map for the renamed agent test. |
| `packages/core/test/v10-constants.test.ts` | Pins the new core gossip size constants. |
| `packages/cli/skills/dkg-node/SKILL.md` | Updates operator guidance from 512 KB to 10 MB. |

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-publisher build`
- [x] `pnpm --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-random-sampling --filter @origintrail-official/dkg-agent build`
- [x] `pnpm --filter @origintrail-official/dkg-core test -- test/v10-constants.test.ts`
- [x] `pnpm exec vitest run packages/publisher/test/share-batching.test.ts packages/publisher/test/share-size-boundary-extra.test.ts --config %TEMP%/vitest-dkg-nohardhat.config.ts`
- [x] `pnpm --filter @origintrail-official/dkg-publisher test -- test/draft-lifecycle.test.ts`
- [x] `pnpm --filter @origintrail-official/dkg-agent test -- test/swm-10mb-boundary-extra.test.ts`
- [x] `git diff --check`
