### PR TITLE
feat(node-ui): live memory graph updates

### DIFF
--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -4402,6 +4402,7 @@ export class DKGAgent {
       this.finalizationHandler = new FinalizationHandler(
         this.store,
         this.chain.chainId === 'none' ? undefined : this.chain,
+        this.eventBus,
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -3,8 +3,9 @@ import {
   contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
   contextGraphDataUri, contextGraphMetaUri,
   contextGraphSubGraphUri, validateSubGraphName,
-  Logger, createOperationContext,
+  DKGEvent, Logger, createOperationContext,
   assertSafeIri, isSafeIri,
+  type EventBus,
   type OperationContext,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
@@ -21,12 +22,14 @@ import { ethers } from 'ethers';
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
+  private readonly eventBus: EventBus | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
 
-  constructor(store: TripleStore, chain: ChainAdapter | undefined) {
+  constructor(store: TripleStore, chain: ChainAdapter | undefined, eventBus?: EventBus) {
     this.store = store;
     this.chain = chain;
+    this.eventBus = eventBus;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -493,6 +496,17 @@ export class FinalizationHandler {
     await this.store.insert(canonicalQuads);
 
     this.log.info(ctx, `Promoted ${canonicalQuads.length} quads from shared memory to canonical for ${ual}`);
+    this.eventBus?.emit(DKGEvent.MEMORY_GRAPH_CHANGED, {
+      contextGraphId,
+      layers: ['swm', 'vm'],
+      subGraphName,
+      operation: 'verified_memory_finalized',
+      source: 'finalization',
+      counts: {
+        roots: rootEntities.length,
+        triples: canonicalQuads.length,
+      },
+    });
   }
 
   private async deleteMetaForRoot(metaGraph: string, rootEntity: string): Promise<void> {

--- a/packages/cli/src/daemon/handle-request.ts
+++ b/packages/cli/src/daemon/handle-request.ts
@@ -318,7 +318,7 @@ import {
   reverseLocalAgentSetupForUi,
   refreshLocalAgentIntegrationFromUi,
 } from './local-agents.js';
-import type { RequestContext } from './routes/context.js';
+import type { MemoryGraphChangedEvent, RequestContext } from './routes/context.js';
 import { handleStatusRoutes } from './routes/status.js';
 import { handleAgentChatRoutes } from './routes/agent-chat.js';
 import { handleOpenclawRoutes } from './routes/openclaw.js';
@@ -361,6 +361,7 @@ export async function handleRequest(
   // server state instead of request headers (SSRF defence).
   apiHost: string,
   apiPortRef: { value: number },
+  emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void,
 ): Promise<void> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
   const path = url.pathname;
@@ -401,6 +402,7 @@ export async function handleRequest(
     path,
     requestToken,
     requestAgentAddress,
+    emitMemoryGraphChanged,
   };
 
   await handleStatusRoutes(ctx);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -323,6 +323,7 @@ import {
 } from './local-agents.js';
 
 import { handleRequest } from './handle-request.js';
+import type { MemoryGraphChangedEvent, MemoryGraphLayer } from './routes/context.js';
 
 /**
  * Resolve the WM agentAddress the daemon hands to `ChatMemoryManager`.
@@ -1125,9 +1126,10 @@ export async function runDaemonInner(
   // Track publishes via KC_PUBLISHED event (covers GossipSub-received publishes)
   agent.eventBus.on(DKGEvent.KC_PUBLISHED, (data: any) => {
     const ctx = createOperationContext("publish");
+    const kcId = data.kcId != null ? String(data.kcId) : undefined;
     tracker.start(ctx, {
       contextGraphId: data.contextGraphId,
-      details: { kcId: data.kcId, source: "gossipsub" },
+      details: { kcId, source: "gossipsub" },
     });
     tracker.complete(ctx, { tripleCount: data.tripleCount });
     try {
@@ -1138,10 +1140,22 @@ export async function runDaemonInner(
         message: `Knowledge collection published${data.contextGraphId ? ` on context graph ${shortId(data.contextGraphId)}` : ""}`,
         source: "dkg",
         meta: JSON.stringify({
-          kcId: data.kcId,
+          kcId,
           contextGraphId: data.contextGraphId,
         }),
       });
+      if (data.contextGraphId) {
+        emitMemoryGraphChanged({
+          contextGraphId: data.contextGraphId,
+          layers: ["vm"],
+          ...(typeof data.subGraphName === "string" ? { subGraphName: data.subGraphName } : {}),
+          operation: "knowledge_collection_published",
+          source: "gossipsub",
+          counts: {
+            triples: typeof data.tripleCount === "number" ? data.tripleCount : undefined,
+          },
+        });
+      }
     } catch {
       /* never crash */
     }
@@ -1155,6 +1169,13 @@ export async function runDaemonInner(
     for (const client of sseClients) {
       try { client.write(msg); } catch { sseClients.delete(client); }
     }
+  }
+  function emitMemoryGraphChanged(event: MemoryGraphChangedEvent) {
+    if (!event.contextGraphId) return;
+    sseBroadcast("memory_graph_changed", {
+      ...event,
+      timestamp: new Date().toISOString(),
+    });
   }
 
   agent.eventBus.on(DKGEvent.JOIN_REQUEST_RECEIVED, (data: any) => {
@@ -1232,6 +1253,43 @@ export async function runDaemonInner(
         dataSynced: data.dataSynced,
         sharedMemorySynced: data.sharedMemorySynced,
       });
+      const layers: MemoryGraphLayer[] = [];
+      if (data.dataSynced) layers.push("vm");
+      if (data.sharedMemorySynced) layers.push("swm");
+      if (data.contextGraphId && layers.length > 0) {
+        emitMemoryGraphChanged({
+          contextGraphId: data.contextGraphId,
+          layers,
+          operation: "project_synced",
+          source: "sync",
+          dataSynced: data.dataSynced,
+          sharedMemorySynced: data.sharedMemorySynced,
+        });
+      }
+    } catch {
+      /* never crash */
+    }
+  });
+
+  agent.eventBus.on(DKGEvent.MEMORY_GRAPH_CHANGED, (data: any) => {
+    try {
+      const layers = Array.isArray(data?.layers)
+        ? data.layers.filter((layer: unknown): layer is MemoryGraphLayer =>
+            layer === "wm" || layer === "swm" || layer === "vm",
+          )
+        : [];
+      if (!data?.contextGraphId || layers.length === 0) return;
+      const counts = data.counts && typeof data.counts === "object"
+        ? data.counts as MemoryGraphChangedEvent["counts"]
+        : undefined;
+      emitMemoryGraphChanged({
+        contextGraphId: String(data.contextGraphId),
+        layers,
+        ...(typeof data.subGraphName === "string" ? { subGraphName: data.subGraphName } : {}),
+        operation: typeof data.operation === "string" ? data.operation : "memory_graph_changed",
+        source: typeof data.source === "string" ? data.source : "event_bus",
+        ...(counts ? { counts } : {}),
+      });
     } catch {
       /* never crash */
     }
@@ -1254,7 +1312,17 @@ export async function runDaemonInner(
       contextGraphId: string,
       quads: any[],
       opts?: { localOnly?: boolean; subGraphName?: string },
-    ) => agent.share(contextGraphId, quads, opts),
+    ) => agent.share(contextGraphId, quads, opts).then((result: any) => {
+      emitMemoryGraphChanged({
+        contextGraphId,
+        layers: ["swm"],
+        subGraphName: opts?.subGraphName,
+        operation: "shared_memory_written",
+        source: opts?.localOnly ? "agent_tool_local" : "agent_tool",
+        counts: { triples: quads.length },
+      });
+      return result;
+    }),
     createAssertion: async (
       contextGraphId: string,
       name: string,
@@ -1286,13 +1354,50 @@ export async function runDaemonInner(
         quads,
         opts?.subGraphName ? { subGraphName: opts.subGraphName } : undefined,
       );
+      emitMemoryGraphChanged({
+        contextGraphId,
+        layers: ["wm"],
+        subGraphName: opts?.subGraphName,
+        operation: "assertion_written",
+        source: "agent_tool",
+        counts: { triples: quads.length },
+      });
       return { written: quads.length };
     },
     publishFromSharedMemory: (
       contextGraphId: string,
       selection: "all" | { rootEntities: string[] },
-      opts?: { clearSharedMemoryAfter?: boolean },
-    ) => agent.publishFromSharedMemory(contextGraphId, selection, opts),
+      opts?: { clearSharedMemoryAfter?: boolean; subGraphName?: string },
+    ) => {
+      const publishOpts = {
+        ...opts,
+        clearSharedMemoryAfter: opts?.clearSharedMemoryAfter ?? false,
+      };
+      return agent.publishFromSharedMemory(contextGraphId, selection, publishOpts).then((result: any) => {
+        const clearAfter = publishOpts.clearSharedMemoryAfter;
+        const publishedSwmCleaned = result?.status === "confirmed";
+        const rootCount = Array.isArray(result?.kaManifest)
+          ? result.kaManifest.length
+          : undefined;
+        const publicTripleCount = Array.isArray(result?.publicQuads)
+          ? result.publicQuads.length
+          : undefined;
+        emitMemoryGraphChanged({
+          contextGraphId,
+          layers: publishedSwmCleaned ? ["swm", "vm"] : ["vm"],
+          subGraphName: opts?.subGraphName,
+          operation: "shared_memory_published",
+          source: "agent_tool",
+          clearSharedMemoryAfter: clearAfter,
+          status: typeof result?.status === "string" ? result.status : undefined,
+          counts: {
+            roots: rootCount,
+            triples: publicTripleCount,
+          },
+        });
+        return result;
+      });
+    },
     createContextGraph: (opts: {
       id: string;
       name: string;
@@ -1642,6 +1747,7 @@ export async function runDaemonInner(
         validTokens,
         apiHost,
         apiPortRef,
+        emitMemoryGraphChanged,
       );
     } catch (err: any) {
       if (res.headersSent || res.writableEnded) return;

--- a/packages/cli/src/daemon/routes/assertion.ts
+++ b/packages/cli/src/daemon/routes/assertion.ts
@@ -358,6 +358,7 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
     path,
     requestToken,
     requestAgentAddress,
+    emitMemoryGraphChanged,
   } = ctx;
 
 
@@ -383,6 +384,14 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         name,
         subGraphName ? { subGraphName } : undefined,
       );
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: ["wm"],
+        subGraphName,
+        operation: "assertion_created",
+        source: "api",
+        counts: { triples: 0 },
+      });
       return jsonResponse(res, 200, { assertionUri });
     } catch (err: any) {
       if (
@@ -427,6 +436,14 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         quads,
         subGraphName ? { subGraphName } : undefined,
       );
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: ["wm"],
+        subGraphName,
+        operation: "assertion_written",
+        source: "api",
+        counts: { triples: quads.length },
+      });
       return jsonResponse(res, 200, { written: quads.length });
     } catch (err: any) {
       if (
@@ -513,6 +530,17 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         assertionName,
         { entities: entities ?? "all", subGraphName },
       );
+      const promotedCount = typeof result?.promotedCount === "number" ? result.promotedCount : undefined;
+      if (promotedCount !== 0) {
+        emitMemoryGraphChanged?.({
+          contextGraphId,
+          layers: ["wm", "swm"],
+          subGraphName,
+          operation: "assertion_promoted",
+          source: "api",
+          counts: { triples: promotedCount },
+        });
+      }
       return jsonResponse(res, 200, result);
     } catch (err: any) {
       if (
@@ -561,6 +589,13 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         subGraphName,
       );
       extractionStatus.delete(assertionUri);
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: ["wm"],
+        subGraphName,
+        operation: "assertion_discarded",
+        source: "api",
+      });
       return jsonResponse(res, 200, { discarded: true });
     } catch (err: any) {
       if (
@@ -1518,6 +1553,14 @@ export async function handleAssertionRoutes(ctx: RequestContext): Promise<void> 
         assertionUri,
         completedRecord,
       );
+      emitMemoryGraphChanged?.({
+        contextGraphId: contextGraphId!,
+        layers: ["wm"],
+        subGraphName,
+        operation: "assertion_imported",
+        source: "api",
+        counts: { triples: triples.length },
+      });
 
       return respondWithImportFileResponse(200, {
         status: "completed",

--- a/packages/cli/src/daemon/routes/context-graph.ts
+++ b/packages/cli/src/daemon/routes/context-graph.ts
@@ -358,6 +358,7 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
     path,
     requestToken,
     requestAgentAddress,
+    emitMemoryGraphChanged,
   } = ctx;
 
 
@@ -598,6 +599,13 @@ export async function handleContextGraphRoutes(ctx: RequestContext): Promise<voi
       });
     try {
       await agent.createSubGraph(contextGraphId, subGraphName);
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: [],
+        subGraphName,
+        operation: "sub_graph_created",
+        source: "api",
+      });
       return jsonResponse(res, 200, { created: subGraphName, contextGraphId });
     } catch (err: any) {
       if (

--- a/packages/cli/src/daemon/routes/context.ts
+++ b/packages/cli/src/daemon/routes/context.ts
@@ -22,6 +22,24 @@ import type { FileStore } from '../../file-store.js';
 import type { VectorStore, EmbeddingProvider } from '../../vector-store.js';
 import type { CatchupTracker } from '../types.js';
 
+export type MemoryGraphLayer = 'wm' | 'swm' | 'vm';
+
+export interface MemoryGraphChangedEvent {
+  contextGraphId: string;
+  layers: MemoryGraphLayer[];
+  subGraphName?: string;
+  operation: string;
+  source?: string;
+  counts?: {
+    triples?: number;
+    roots?: number;
+  };
+  clearSharedMemoryAfter?: boolean;
+  dataSynced?: unknown;
+  sharedMemorySynced?: unknown;
+  status?: string;
+}
+
 export interface RequestContext {
   req: IncomingMessage;
   res: ServerResponse;
@@ -57,4 +75,5 @@ export interface RequestContext {
   path: string;
   requestToken: string | undefined;
   requestAgentAddress: string;
+  emitMemoryGraphChanged?: (event: MemoryGraphChangedEvent) => void;
 }

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -359,6 +359,7 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
     path,
     requestToken,
     requestAgentAddress,
+    emitMemoryGraphChanged,
   } = ctx;
 
 
@@ -517,6 +518,14 @@ WHERE {
         }),
       );
       tracker.complete(ctx, { tripleCount: quads.length });
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: ["swm"],
+        subGraphName,
+        operation: "shared_memory_written",
+        source: localOnly ? "api-local" : "api",
+        counts: { triples: quads.length },
+      });
       return jsonResponse(res, 200, {
         shareOperationId: result?.shareOperationId,
         workspaceOperationId: result?.shareOperationId,
@@ -600,7 +609,28 @@ WHERE {
           chainId ? Number(chainId) : undefined,
         );
       }
-      tracker.complete(ctx, { tripleCount: result.kaManifest?.length ?? 0 });
+      const publicTripleCount = Array.isArray(result.publicQuads)
+        ? result.publicQuads.length
+        : undefined;
+      const rootCount = Array.isArray(result.kaManifest)
+        ? result.kaManifest.length
+        : undefined;
+      tracker.complete(ctx, { tripleCount: publicTripleCount ?? rootCount ?? 0 });
+      const clearSharedMemoryAfter = clearAfter ?? true;
+      const publishedSwmCleaned = result.status === "confirmed";
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: publishedSwmCleaned ? ["swm", "vm"] : ["vm"],
+        subGraphName,
+        operation: "shared_memory_published",
+        source: "api",
+        clearSharedMemoryAfter,
+        status: typeof result.status === "string" ? result.status : undefined,
+        counts: {
+          roots: rootCount,
+          triples: publicTripleCount,
+        },
+      });
       const httpStatus = result.contextGraphError ? 207 : 200;
       return jsonResponse(res, httpStatus, {
         kcId: String(result.kcId),
@@ -648,6 +678,14 @@ WHERE {
         { subGraphName, operationCtx: ctx },
       );
       tracker.complete(ctx, { tripleCount: quads.length });
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: ["swm"],
+        subGraphName,
+        operation: "shared_memory_conditional_written",
+        source: "api-cas",
+        counts: { triples: quads.length },
+      });
       return jsonResponse(res, 200, {
         ok: true,
         shareOperationId: result?.shareOperationId,
@@ -829,6 +867,14 @@ WHERE {
     } catch (err: any) {
       return jsonResponse(res, 500, { error: `Failed to write turn to ${targetLayer}: ${err.message}` });
     }
+    emitMemoryGraphChanged?.({
+      contextGraphId,
+      layers: [targetLayer],
+      subGraphName,
+      operation: "memory_turn_written",
+      source: "memory-turn",
+      counts: { triples: quads.length },
+    });
 
     // 6. Generate embedding (best-effort, non-blocking for response)
     let embeddingId: string | null = null;

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -360,6 +360,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     path,
     requestToken,
     requestAgentAddress,
+    emitMemoryGraphChanged,
   } = ctx;
 
 
@@ -933,6 +934,12 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         batchId: parsedBatchId,
         timeoutMs: timeoutMs ? Number(timeoutMs) : undefined,
         requiredSignatures: validatedRequiredSigs,
+      });
+      emitMemoryGraphChanged?.({
+        contextGraphId,
+        layers: ["vm"],
+        operation: "verified_memory_updated",
+        source: "api",
       });
       return jsonResponse(res, 200, { ...result, batchId: String(batchId) });
     } catch (err) {

--- a/packages/cli/test/memory-graph-events.test.ts
+++ b/packages/cli/test/memory-graph-events.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { handleAssertionRoutes } from '../src/daemon/routes/assertion.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
+import { handleQueryRoutes } from '../src/daemon/routes/query.js';
+
+function createResponse() {
+  const response = {
+    statusCode: 0,
+    headers: undefined as Record<string, string> | undefined,
+    body: '',
+    writableEnded: false,
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(body?: string) {
+      this.body = body ?? '';
+      this.writableEnded = true;
+      return this;
+    },
+  };
+  return response;
+}
+
+function createPostRequest(path: string, body: unknown): RequestContext['req'] {
+  const request = Readable.from([Buffer.from(JSON.stringify(body))]);
+  Object.assign(request, {
+    method: 'POST',
+    url: path,
+    headers: { host: '127.0.0.1' },
+  });
+  return request as RequestContext['req'];
+}
+
+function createTracker(): RequestContext['tracker'] {
+  return {
+    start: vi.fn(),
+    trackPhase: vi.fn((_ctx, _phase, fn: () => Promise<unknown>) => fn()),
+    complete: vi.fn(),
+    fail: vi.fn(),
+    setCost: vi.fn(),
+    setTxHash: vi.fn(),
+  } as unknown as RequestContext['tracker'];
+}
+
+function createContext(path: string, body: unknown, overrides: Partial<RequestContext> = {}): RequestContext {
+  const url = new URL(`http://127.0.0.1${path}`);
+  return {
+    req: createPostRequest(path, body),
+    res: createResponse() as unknown as ServerResponse,
+    agent: {} as RequestContext['agent'],
+    publisherControl: {} as RequestContext['publisherControl'],
+    publisherRuntime: null,
+    config: {} as RequestContext['config'],
+    startedAt: 0,
+    dashDb: {} as RequestContext['dashDb'],
+    opWallets: { adminWallet: { address: '0x0', privateKey: '0x0' }, wallets: [] } as RequestContext['opWallets'],
+    network: null as RequestContext['network'],
+    tracker: createTracker(),
+    memoryManager: {} as RequestContext['memoryManager'],
+    bridgeAuthToken: undefined,
+    nodeVersion: 'test',
+    nodeCommit: 'test',
+    catchupTracker: {} as RequestContext['catchupTracker'],
+    extractionRegistry: {} as RequestContext['extractionRegistry'],
+    fileStore: {} as RequestContext['fileStore'],
+    extractionStatus: new Map(),
+    assertionImportLocks: new Map(),
+    vectorStore: {} as RequestContext['vectorStore'],
+    embeddingProvider: null,
+    validTokens: new Set(),
+    apiHost: '127.0.0.1',
+    apiPortRef: { value: 0 },
+    url,
+    path: url.pathname,
+    requestToken: undefined,
+    requestAgentAddress: '0x0',
+    ...overrides,
+  };
+}
+
+function responseBody(ctx: RequestContext): Record<string, unknown> {
+  return JSON.parse((ctx.res as unknown as { body: string }).body) as Record<string, unknown>;
+}
+
+describe('daemon memory_graph_changed route emissions', () => {
+  it('emits metadata-only SWM refresh events after shared-memory writes', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const share = vi.fn().mockResolvedValue({ shareOperationId: 'op-1' });
+    const ctx = createContext('/api/shared-memory/write', {
+      contextGraphId: 'project-a',
+      subGraphName: 'notes',
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+    }, {
+      agent: { share } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({ contextGraphId: 'project-a', triplesWritten: 1 });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['swm'],
+      subGraphName: 'notes',
+      operation: 'shared_memory_written',
+      source: 'api',
+      counts: { triples: 1 },
+    });
+    expect(emitMemoryGraphChanged.mock.calls[0][0]).not.toHaveProperty('quads');
+    expect(emitMemoryGraphChanged.mock.calls[0][0]).not.toHaveProperty('content');
+  });
+
+  it('emits WM refresh events after assertion writes', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const write = vi.fn().mockResolvedValue(undefined);
+    const ctx = createContext('/api/assertion/draft/write', {
+      contextGraphId: 'project-a',
+      subGraphName: 'notes',
+      quads: [{ subject: 'urn:s', predicate: 'urn:p', object: 'urn:o' }],
+    }, {
+      agent: { assertion: { write } } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleAssertionRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({ written: 1 });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['wm'],
+      subGraphName: 'notes',
+      operation: 'assertion_written',
+      source: 'api',
+      counts: { triples: 1 },
+    });
+  });
+
+  it('emits WM and SWM refresh events after assertion promotion', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const promote = vi.fn().mockResolvedValue({ promotedCount: 2 });
+    const ctx = createContext('/api/assertion/draft/promote', {
+      contextGraphId: 'project-a',
+      subGraphName: 'notes',
+      entities: ['urn:root'],
+    }, {
+      agent: { assertion: { promote } } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleAssertionRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({ promotedCount: 2 });
+    expect(promote).toHaveBeenCalledWith('project-a', 'draft', {
+      entities: ['urn:root'],
+      subGraphName: 'notes',
+    });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['wm', 'swm'],
+      subGraphName: 'notes',
+      operation: 'assertion_promoted',
+      source: 'api',
+      counts: { triples: 2 },
+    });
+  });
+
+  it('does not emit when shared-memory validation fails', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const share = vi.fn();
+    const ctx = createContext('/api/shared-memory/write', {
+      contextGraphId: 'project-a',
+      quads: [],
+    }, {
+      agent: { share } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(400);
+    expect(share).not.toHaveBeenCalled();
+    expect(emitMemoryGraphChanged).not.toHaveBeenCalled();
+  });
+
+  it('emits SWM and VM refresh events after confirmed selective publishes', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const publishFromSharedMemory = vi.fn().mockResolvedValue({
+      kcId: 'kc-1',
+      status: 'confirmed',
+      kaManifest: [{ tokenId: 1n, rootEntity: 'urn:root' }],
+      publicQuads: [
+        { subject: 'urn:root', predicate: 'urn:p1', object: 'urn:o1', graph: 'urn:g' },
+        { subject: 'urn:root', predicate: 'urn:p2', object: 'urn:o2', graph: 'urn:g' },
+      ],
+    });
+    const ctx = createContext('/api/shared-memory/publish', {
+      contextGraphId: 'project-a',
+      subGraphName: 'notes',
+      selection: ['urn:root'],
+      clearAfter: false,
+    }, {
+      agent: { publishFromSharedMemory } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleMemoryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({
+      kcId: 'kc-1',
+      status: 'confirmed',
+      kas: [{ tokenId: '1', rootEntity: 'urn:root' }],
+    });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['swm', 'vm'],
+      subGraphName: 'notes',
+      operation: 'shared_memory_published',
+      source: 'api',
+      clearSharedMemoryAfter: false,
+      status: 'confirmed',
+      counts: { roots: 1, triples: 2 },
+    });
+    expect(ctx.tracker.complete).toHaveBeenCalledWith(expect.anything(), { tripleCount: 2 });
+  });
+
+  it('emits VM refresh events after verified-memory verification', async () => {
+    const emitMemoryGraphChanged = vi.fn();
+    const verify = vi.fn().mockResolvedValue({ verified: true });
+    const ctx = createContext('/api/verify', {
+      contextGraphId: 'project-a',
+      verifiedMemoryId: 'vm-1',
+      batchId: '42',
+    }, {
+      agent: { verify } as unknown as RequestContext['agent'],
+      emitMemoryGraphChanged,
+    });
+
+    await handleQueryRoutes(ctx);
+
+    expect((ctx.res as unknown as { statusCode: number }).statusCode).toBe(200);
+    expect(responseBody(ctx)).toMatchObject({ verified: true, batchId: '42' });
+    expect(verify).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      verifiedMemoryId: 'vm-1',
+      batchId: 42n,
+      timeoutMs: undefined,
+      requiredSignatures: undefined,
+    });
+    expect(emitMemoryGraphChanged).toHaveBeenCalledWith({
+      contextGraphId: 'project-a',
+      layers: ['vm'],
+      operation: 'verified_memory_updated',
+      source: 'api',
+    });
+  });
+});

--- a/packages/core/src/event-bus.ts
+++ b/packages/core/src/event-bus.ts
@@ -30,6 +30,7 @@ export const DKGEvent = {
   JOIN_APPROVED: 'join:approved',
   JOIN_REJECTED: 'join:rejected',
   PROJECT_SYNCED: 'project:synced',
+  MEMORY_GRAPH_CHANGED: 'memory-graph:changed',
 } as const;
 
 export type DKGEventType = (typeof DKGEvent)[keyof typeof DKGEvent];

--- a/packages/core/test/event-bus.test.ts
+++ b/packages/core/test/event-bus.test.ts
@@ -97,6 +97,10 @@ describe('TypedEventBus', () => {
     expect(DKGEvent.CONNECTION_UPGRADED).toBe('connection:upgraded');
   });
 
+  it('DKGEvent includes memory graph change notifications', () => {
+    expect(DKGEvent.MEMORY_GRAPH_CHANGED).toBe('memory-graph:changed');
+  });
+
   it('emits connection events through the bus', () => {
     const bus = new TypedEventBus();
     const openTracker = tracker();

--- a/packages/node-ui/src/ui/components/SubGraphBar.tsx
+++ b/packages/node-ui/src/ui/components/SubGraphBar.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { fetchSubGraphs, type SubGraphInfo } from '../api.js';
 import type { ProjectProfile } from '../hooks/useProjectProfile.js';
 import type { MemoryEntity } from '../hooks/useMemoryEntities.js';
+import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 
 export interface SubGraphBadge {
   /** Short label shown inline on the chip, e.g. "2 proposed" */
@@ -78,16 +79,22 @@ export const SubGraphBar: React.FC<SubGraphBarProps> = ({ contextGraphId, profil
   const [subGraphs, setSubGraphs] = React.useState<SubGraphInfo[]>([]);
   const [loading, setLoading] = React.useState(true);
   const badges = React.useMemo(() => computeBadges(entities), [entities]);
+  const requestIdRef = React.useRef(0);
 
-  React.useEffect(() => {
-    let cancelled = false;
+  const loadSubGraphs = React.useCallback(() => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     fetchSubGraphs(contextGraphId)
-      .then(r => { if (!cancelled) setSubGraphs(r.subGraphs ?? []); })
+      .then(r => { if (requestId === requestIdRef.current) setSubGraphs(r.subGraphs ?? []); })
       .catch(() => { /* silent — leave empty */ })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
+      .finally(() => { if (requestId === requestIdRef.current) setLoading(false); });
   }, [contextGraphId]);
+
+  React.useEffect(() => {
+    loadSubGraphs();
+    return () => { requestIdRef.current++; };
+  }, [loadSubGraphs]);
+  useMemoryGraphEvents(contextGraphId, loadSubGraphs);
 
   const merged = React.useMemo(() => {
     // Filter out the `meta` sub-graph since it holds the profile itself, not

--- a/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
+++ b/packages/node-ui/src/ui/hooks/useMemoryEntities.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { authHeaders } from '../api.js';
+import { useMemoryGraphEvents } from './useNodeEvents.js';
 
 export type TrustLevel = 'working' | 'shared' | 'verified';
 
@@ -308,6 +309,8 @@ export function useMemoryEntities(contextGraphId: string): MemoryData {
       if (version === versionRef.current) setLoading(false);
     }
   }, [contextGraphId]);
+
+  useMemoryGraphEvents(contextGraphId, fetchAll);
 
   useEffect(() => { fetchAll(); }, [fetchAll]);
 

--- a/packages/node-ui/src/ui/hooks/useNodeEvents.ts
+++ b/packages/node-ui/src/ui/hooks/useNodeEvents.ts
@@ -1,7 +1,24 @@
-import { useEffect, useRef } from 'react';
-import { authHeaders } from '../api.js';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
-export type NodeEventType = 'join_request' | 'join_approved' | 'join_rejected' | 'project_synced' | 'connected';
+export type MemoryGraphLayer = 'wm' | 'swm' | 'vm';
+
+export interface MemoryGraphChangedData extends Record<string, unknown> {
+  contextGraphId?: string;
+  layers?: MemoryGraphLayer[];
+  layer?: MemoryGraphLayer;
+  subGraphName?: string;
+  operation?: string;
+  source?: string;
+  timestamp?: string;
+}
+
+export type NodeEventType =
+  | 'join_request'
+  | 'join_approved'
+  | 'join_rejected'
+  | 'project_synced'
+  | 'memory_graph_changed'
+  | 'connected';
 
 export interface NodeEvent {
   type: NodeEventType;
@@ -13,6 +30,32 @@ type Listener = (event: NodeEvent) => void;
 const listeners = new Set<Listener>();
 let source: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+export const MEMORY_GRAPH_REFRESH_DEBOUNCE_MS = 350;
+
+function isMemoryGraphLayer(value: unknown): value is MemoryGraphLayer {
+  return value === 'wm' || value === 'swm' || value === 'vm';
+}
+
+export function getMemoryGraphEventLayers(data: Record<string, unknown>): MemoryGraphLayer[] {
+  const layers = data.layers;
+  if (Array.isArray(layers)) {
+    return layers.filter(isMemoryGraphLayer);
+  }
+  return isMemoryGraphLayer(data.layer) ? [data.layer] : [];
+}
+
+export function isMemoryGraphEventRelevant(
+  data: Record<string, unknown>,
+  contextGraphId: string,
+  layers?: MemoryGraphLayer[],
+): boolean {
+  if (!contextGraphId || data.contextGraphId !== contextGraphId) return false;
+  if (!layers || layers.length === 0) return true;
+
+  const eventLayers = getMemoryGraphEventLayers(data);
+  if (eventLayers.length === 0) return true;
+  return layers.some(layer => eventLayers.includes(layer));
+}
 
 function connect() {
   if (source) return;
@@ -34,6 +77,7 @@ function connect() {
   source.addEventListener('join_approved', handleEvent('join_approved'));
   source.addEventListener('join_rejected', handleEvent('join_rejected'));
   source.addEventListener('project_synced', handleEvent('project_synced'));
+  source.addEventListener('memory_graph_changed', handleEvent('memory_graph_changed'));
   source.addEventListener('connected', handleEvent('connected'));
 
   source.onerror = () => {
@@ -72,4 +116,37 @@ export function useNodeEvents(handler: Listener) {
   useEffect(() => {
     return subscribe((event) => handlerRef.current(event));
   }, []);
+}
+
+export function useMemoryGraphEvents(
+  contextGraphId: string,
+  handler: (event: MemoryGraphChangedData) => void,
+  options: { layers?: MemoryGraphLayer[]; debounceMs?: number } = {},
+) {
+  const handlerRef = useRef(handler);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  handlerRef.current = handler;
+
+  const debounceMs = options.debounceMs ?? MEMORY_GRAPH_REFRESH_DEBOUNCE_MS;
+  const layers = useMemo(() => options.layers ?? [], [options.layers?.join('|')]);
+
+  const clearDebounce = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+  }, []);
+
+  useNodeEvents(useCallback((event) => {
+    if (event.type !== 'memory_graph_changed') return;
+    if (!isMemoryGraphEventRelevant(event.data, contextGraphId, layers)) return;
+
+    clearDebounce();
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      handlerRef.current(event.data as MemoryGraphChangedData);
+    }, debounceMs);
+  }, [clearDebounce, contextGraphId, debounceMs, layers]));
+
+  useEffect(() => clearDebounce, [clearDebounce]);
 }

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, lazy, Suspense } from 'react';
 import { useFetch } from '../hooks.js';
 import { executeQuery, listAssertions, promoteAssertion, publishSharedMemory, listSwmEntities, type AssertionInfo, type PublishResult, type SwmRootEntity } from '../api.js';
 import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
+import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 
 const RdfGraph = lazy(() =>
   import('@origintrail-official/dkg-graph-viz/react').then(m => ({ default: m.RdfGraph }))
@@ -128,6 +129,7 @@ export function MemoryLayerView({ layer, contextGraphId }: MemoryLayerViewProps)
     [sparql, contextGraphId, includeShared, graphSuffix, queryView],
     0
   );
+  useMemoryGraphEvents(contextGraphId, refresh, { layers: [layer] });
 
   const runQuery = useCallback(() => {
     const next = draftQuery.trim();
@@ -362,6 +364,7 @@ function AssertionList({ contextGraphId, onPromoted }: { contextGraphId: string;
     [contextGraphId],
     0
   );
+  useMemoryGraphEvents(contextGraphId, refresh, { layers: ['wm'] });
   const [promoting, setPromoting] = useState<string | null>(null);
   const [promoteResult, setPromoteResult] = useState<{ name: string; count: number } | null>(null);
   const [promoteError, setPromoteError] = useState<string | null>(null);
@@ -476,6 +479,7 @@ function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: string;
     [contextGraphId],
     0
   );
+  useMemoryGraphEvents(contextGraphId, refresh, { layers: ['swm'] });
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [publishing, setPublishing] = useState(false);
   const [publishResult, setPublishResult] = useState<PublishResult | null>(null);

--- a/packages/node-ui/test/ui-compat.test.ts
+++ b/packages/node-ui/test/ui-compat.test.ts
@@ -361,6 +361,7 @@ describe('listAssertions query path', () => {
 
 describe('useMemoryEntities hook', () => {
   const hook = readFileSync(resolve(UI_DIR, 'hooks', 'useMemoryEntities.ts'), 'utf-8');
+  const nodeEventsHook = readFileSync(resolve(UI_DIR, 'hooks', 'useNodeEvents.ts'), 'utf-8');
 
   it('exports TrustLevel type with three levels', () => {
     expect(hook).toContain("type TrustLevel = 'working' | 'shared' | 'verified'");
@@ -396,6 +397,11 @@ describe('useMemoryEntities hook', () => {
 
   it('deduplicates triples across layers for graph data', () => {
     expect(hook).toContain('const seen = new Set<string>()');
+  });
+
+  it('subscribes to memory_graph_changed events for live graph refreshes', () => {
+    expect(nodeEventsHook).toContain("'memory_graph_changed'");
+    expect(hook).toContain('useMemoryGraphEvents(contextGraphId, fetchAll)');
   });
 });
 

--- a/packages/node-ui/test/use-memory-entities-live-updates.test.ts
+++ b/packages/node-ui/test/use-memory-entities-live-updates.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { useMemoryEntities } from '../src/ui/hooks/useMemoryEntities.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  readonly listeners = new Map<string, Array<(event: MessageEvent) => void>>();
+  closed = false;
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  emit(type: string, data: Record<string, unknown>) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ data: JSON.stringify(data) } as MessageEvent);
+    }
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+function tripleBinding(subject: string, graph: string) {
+  return {
+    s: { value: subject },
+    p: { value: RDF_TYPE },
+    o: { value: 'http://schema.org/Thing' },
+    g: { value: graph },
+  };
+}
+
+function bindingsForLayer(sparql: string, contextGraphId: string, revision: number) {
+  if (!sparql.includes('/assertion/')) return [];
+  return Array.from({ length: revision }, (_, i) =>
+    tripleBinding(
+      `urn:test:${contextGraphId}:wm-${i + 1}`,
+      `did:dkg:context-graph:${contextGraphId}/notes/assertion/agent/a-${i + 1}`,
+    ),
+  );
+}
+
+function Probe({ contextGraphId }: { contextGraphId: string }) {
+  const memory = useMemoryEntities(contextGraphId);
+  return React.createElement(
+    'div',
+    {
+      id: 'probe',
+      'data-total': String(memory.counts.total),
+      'data-wm': String(memory.counts.wm),
+      'data-loading': String(memory.loading),
+    },
+  );
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('useMemoryEntities live updates', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let revision = 1;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockEventSource.instances = [];
+    (globalThis as any).EventSource = MockEventSource;
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    revision = 1;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { sparql?: string; contextGraphId?: string };
+      const bindings = bindingsForLayer(body.sparql ?? '', body.contextGraphId ?? 'unknown', revision);
+      return {
+        ok: true,
+        json: async () => ({ result: { bindings } }),
+      } as Response;
+    }));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('debounces matching memory_graph_changed events and refreshes graph data', async () => {
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'project-a' }));
+    });
+    await flush();
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('1');
+
+    revision = 2;
+    await act(async () => {
+      MockEventSource.instances[0].emit('memory_graph_changed', {
+        contextGraphId: 'project-a',
+        layers: ['wm'],
+        operation: 'assertion_written',
+        timestamp: new Date().toISOString(),
+      });
+      vi.advanceTimersByTime(349);
+    });
+    expect(fetch).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    await flush();
+
+    expect(fetch).toHaveBeenCalledTimes(6);
+    expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('2');
+  });
+
+  it('ignores memory_graph_changed events for other context graphs', async () => {
+    await act(async () => {
+      root.render(React.createElement(Probe, { contextGraphId: 'project-a' }));
+    });
+    await flush();
+
+    revision = 2;
+    await act(async () => {
+      MockEventSource.instances[0].emit('memory_graph_changed', {
+        contextGraphId: 'project-b',
+        layers: ['wm'],
+        operation: 'assertion_written',
+      });
+      vi.advanceTimersByTime(350);
+    });
+    await flush();
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(container.querySelector('#probe')?.getAttribute('data-wm')).toBe('1');
+  });
+});

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -1929,7 +1929,11 @@ export class DKGPublisher implements Publisher {
       subGraphName: options.subGraphName,
     };
 
-    this.eventBus.emit(DKGEvent.KC_PUBLISHED, result);
+    this.eventBus.emit(DKGEvent.KC_PUBLISHED, {
+      ...result,
+      contextGraphId,
+      tripleCount: allSkolemizedQuads.length,
+    });
     return result;
   }
 

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -334,6 +334,9 @@ export class PublishHandler {
       this.eventBus.emit(DKGEvent.KC_PUBLISHED, {
         ual: request.ual,
         from: fromPeerId,
+        contextGraphId,
+        subGraphName: request.subGraphName || undefined,
+        tripleCount: normalized.length,
       });
 
       const publicByteSize = request.nquads.length;

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -1,7 +1,7 @@
 import type { TripleStore, Quad } from '@origintrail-official/dkg-storage';
 import { GraphManager } from '@origintrail-official/dkg-storage';
 import type { EventBus } from '@origintrail-official/dkg-core';
-import { Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri, DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, contextGraphDataUri, contextGraphMetaUri, DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS } from '@origintrail-official/dkg-core';
 import type { PhaseCallback } from './publisher.js';
 import {
   decodeGossipEnvelope,
@@ -346,6 +346,14 @@ export class SharedMemoryHandler {
       onPhase?.('store', 'end');
       if (applied) {
         this.log.info(ctx, `Stored SWM write ${shareOperationId} (${quads.length} quads)`);
+        this.eventBus.emit(DKGEvent.MEMORY_GRAPH_CHANGED, {
+          contextGraphId,
+          layers: ['swm'],
+          subGraphName,
+          operation: 'shared_memory_gossiped',
+          source: 'gossip',
+          counts: { triples: quads.length },
+        });
       }
     } catch (err) {
       this.log.error(ctx, `SWM handle failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -175,9 +175,9 @@ describe('DKGPublisher', () => {
   });
 
   it('emits KC_PUBLISHED event', async () => {
-    let emitted = false;
-    eventBus.on('kc:published', () => {
-      emitted = true;
+    let emitted: any;
+    eventBus.on('kc:published', (event) => {
+      emitted = event;
     });
 
     await publisher.publish({
@@ -185,7 +185,10 @@ describe('DKGPublisher', () => {
       quads: [q(ENTITY, 'http://schema.org/name', '"Bot"')],
     });
 
-    expect(emitted).toBe(true);
+    expect(emitted).toMatchObject({
+      contextGraphId: CONTEXT_GRAPH,
+      tripleCount: 1,
+    });
   });
 
   it('publishes with confirmed status and onChainResult', async () => {


### PR DESCRIPTION
﻿## Summary

- Adds metadata-only `memory_graph_changed` SSE notifications so open Node UI graph views refresh as WM, SWM, and VM memory state changes.
- Wires Node UI graph data loaders to debounce and refresh on relevant memory graph events without remounting graph renderers or losing active layer/sub-graph/query state.
- Emits memory graph change metadata from daemon routes, sync/publish events, SWM gossip handling, and VM finalization while avoiding raw triples or private WM content in SSE payloads.

## Related

- None

## Implementation notes

- The event contract carries `contextGraphId`, affected `layers`, optional `subGraphName`, operation/source labels, counts, and a daemon timestamp.
- `useMemoryGraphEvents` filters by context graph and optional layer list, then coalesces bursty events with a 350ms debounce before calling existing refresh functions.
- Publish/promotion event layer sets are based on actual storage side effects: promotion refreshes WM and SWM; confirmed SWM publish refreshes SWM and VM; VM verification refreshes VM.
- KC publish and received-publish event payloads now include context graph metadata so the daemon can translate them into VM refresh events.

## Files changed

| File | What |
|------|------|
| `packages/node-ui/src/ui/hooks/useNodeEvents.ts` | Adds typed `memory_graph_changed` SSE support and debounced `useMemoryGraphEvents`. |
| `packages/node-ui/src/ui/hooks/useMemoryEntities.ts` | Refreshes cross-layer project graph data on relevant memory events. |
| `packages/node-ui/src/ui/views/MemoryLayerView.tsx` | Refreshes standalone WM/SWM/VM layer graph tabs and auxiliary lists/panels on layer events. |
| `packages/node-ui/src/ui/components/SubGraphBar.tsx` | Refreshes sub-graph counts when graph memory changes. |
| `packages/cli/src/daemon/lifecycle.ts` | Broadcasts memory graph SSE events and translates sync/KC/event-bus mutations. |
| `packages/cli/src/daemon/routes/*.ts` | Emits metadata-only memory graph events after durable route mutations. |
| `packages/core/src/event-bus.ts` | Adds the shared `MEMORY_GRAPH_CHANGED` event constant. |
| `packages/publisher/src/*.ts` | Emits SWM gossip/KC publish metadata needed for live UI refresh. |
| `packages/agent/src/*.ts` | Emits finalization metadata after SWM is promoted to VM. |
| `packages/*/test/*` | Adds regression coverage for UI refresh, daemon events, event constants, and KC publish metadata. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/use-memory-entities-live-updates.test.ts test/ui-compat.test.ts` - 89 passed, 38 skipped.
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run test/memory-graph-events.test.ts` - 6 passed. The package still prints the existing trailing `The system cannot find the path specified.` message after exit 0.
- [x] `pnpm --filter @origintrail-official/dkg-core exec vitest run test/event-bus.test.ts` - 9 passed.
- [x] `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/dkg-publisher.test.ts` - 36 passed.
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-core run build` - passed.
- [x] `pnpm --filter @origintrail-official/dkg-publisher run build` - passed.
- [x] Browser smoke via Vite at `http://127.0.0.1:5174/ui/`: opened Node UI, selected a project, opened Graph Overview, and confirmed no browser console errors.

## Local PR review

- Ran `.codex` local PR review against `pr-diff.patch` for 5 rounds.
- Fixed all actionable review comments covering SWM publish refresh semantics, publish counts, assertion promotion layer coverage, agent-tool clear defaults, KC publish context metadata, and BigInt-safe notification metadata.
- Final reviewer response: `{"comments":[]}`.

## Risks and follow-ups

- This is an event-driven refresh path, not an incremental graph-delta protocol; large graphs still reload through existing query APIs.
- `pnpm --filter @origintrail-official/dkg-agent run build` still fails on pre-existing unrelated `accessPolicy` typing in `CreateOnChainContextGraphParams`.
- `pnpm --filter @origintrail-official/dkg run build` still fails on pre-existing unrelated `epcis.ts` type mismatches and missing `@iarna/toml` declarations.
