### PR TITLE
Clarify wallet semantics and add operational signer fallback resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ The three memory layers — see [The three memory layers](#the-three-memory-laye
 
 An authenticated identity on a node. Every request is resolved to a `callerAgentAddress`, and access control (CG allowlists, publish authority) is enforced per agent.
 
+### Wallet roles
+
+DKG keeps wallet naming intentionally close to existing CLI output:
+
+- **Admin wallet** — operator authority key for profile/key management and operator actions (for example `dkg set-ask`).
+- **Operational wallets** — node EVM wallets used for transactions. The first wallet is the **primary operational wallet** (default tx signer for non-publish flows like random-sampling / staking / PCA admin actions).
+- **Operational wallet publish pool** — the same operational wallets when used for publish/update txs. The node can select from this pool (for example, round-robin with on-chain authorization checks).
+
+This keeps one stable mental model: admin wallet = operator authority, operational wallets = tx signers, publish pool = operational wallets in publishing context.
+
 ---
 
 ## API authentication

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ An authenticated identity on a node. Every request is resolved to a `callerAgent
 
 DKG keeps wallet naming intentionally close to existing CLI output:
 
-- **Admin wallet** — operator authority key for profile/key management and operator actions (for example `dkg set-ask`).
+- **Admin wallet** — operator authority key for profile/key management and operator-authority actions.
 - **Operational wallets** — node EVM wallets used for transactions. The first wallet is the **primary operational wallet** (default tx signer for non-publish flows like random-sampling / staking / PCA admin actions).
 - **Operational wallet publish pool** — the same operational wallets when used for publish/update txs. The node can select from this pool (for example, round-robin with on-chain authorization checks).
 

--- a/docs/setup/JOIN_TESTNET.md
+++ b/docs/setup/JOIN_TESTNET.md
@@ -549,7 +549,7 @@ All three paths generate an Ed25519 master key on first run, saved to your `data
 
 - **Stable PeerId** — other agents can always find you at the same address
 - **Consistent profile** — your published agent profile is tied to a fixed identity
-- **Stable EVM wallets** — the CLI auto-generates operational wallets on first run (saved to `wallets.json`); OpenClaw/ElizaOS use an explicit private key from your env config. Either way, addresses stay the same across restarts
+- **Stable EVM wallets** — the CLI auto-generates one admin wallet plus operational wallets on first run (saved to `wallets.json`). The admin wallet is for operator/profile actions; operational wallets are node tx signers (the first is the primary default signer, and the full set is used as the publish wallet pool). OpenClaw/ElizaOS use an explicit private key from your env config. Either way, addresses stay the same across restarts
 
 Without a `dataDir`, a fresh ephemeral identity is generated every time (useful for tests only).
 

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -258,6 +258,7 @@ export class EVMChainAdapter implements ChainAdapter {
   private readonly adminSigner?: Wallet;
   private signerIndex = 0;
   private signerSelectionQueue: Promise<void> = Promise.resolve();
+  private readonly busyOperationalSigners = new Set<string>();
   private readonly hubAddress: string;
   private contracts: ContractCache;
   private initialized = false;
@@ -371,6 +372,84 @@ export class EVMChainAdapter implements ChainAdapter {
     const s = this.signerPool[this.signerIndex % this.signerPool.length];
     this.signerIndex++;
     return s;
+  }
+
+  private async signerHasNativeFunds(signer: Wallet): Promise<boolean> {
+    try {
+      const bal = await this.provider.getBalance(signer.address);
+      return bal > 0n;
+    } catch {
+      // If balance probing fails (flaky RPC), do not hard-fail signer selection.
+      return true;
+    }
+  }
+
+  private async withOperationalSigner<T>(
+    action: (signer: Wallet) => Promise<T>,
+    options: { requireNativeFunds?: boolean; maxWaitMs?: number } = {},
+  ): Promise<T> {
+    const requireNativeFunds = options.requireNativeFunds ?? true;
+    const maxWaitMs = options.maxWaitMs ?? 5000;
+    const startedAt = Date.now();
+
+    let selectedSigner: Wallet | undefined;
+    while (!selectedSigner) {
+      const previousSelection = this.signerSelectionQueue;
+      let releaseSelection!: () => void;
+      this.signerSelectionQueue = new Promise<void>((resolve) => { releaseSelection = resolve; });
+      await previousSelection;
+      try {
+        const start = this.signerIndex % this.signerPool.length;
+        const candidates: Array<{ idx: number; signer: Wallet }> = [];
+        for (let i = 0; i < this.signerPool.length; i += 1) {
+          const idx = (start + i) % this.signerPool.length;
+          const signer = this.signerPool[idx];
+          if (this.busyOperationalSigners.has(signer.address.toLowerCase())) continue;
+          candidates.push({ idx, signer });
+        }
+
+        if (candidates.length > 0) {
+          if (!requireNativeFunds) {
+            const picked = candidates[0];
+            this.signerIndex = picked.idx + 1;
+            selectedSigner = picked.signer;
+          } else {
+            for (const candidate of candidates) {
+              if (await this.signerHasNativeFunds(candidate.signer)) {
+                this.signerIndex = candidate.idx + 1;
+                selectedSigner = candidate.signer;
+                break;
+              }
+            }
+            if (!selectedSigner && Date.now() - startedAt >= maxWaitMs) {
+              throw new Error(
+                'No available operational wallet with native gas funds. ' +
+                'Fund at least one operational wallet, or wait for an in-flight transaction to finish.',
+              );
+            }
+          }
+        } else if (Date.now() - startedAt >= maxWaitMs) {
+          throw new Error(
+            'All operational wallets are currently busy with in-flight transactions. ' +
+            'Retry once one signer becomes available.',
+          );
+        }
+      } finally {
+        releaseSelection();
+      }
+
+      if (!selectedSigner) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+
+    const signerKey = selectedSigner.address.toLowerCase();
+    this.busyOperationalSigners.add(signerKey);
+    try {
+      return await action(selectedSigner);
+    } finally {
+      this.busyOperationalSigners.delete(signerKey);
+    }
   }
 
   private findSignerByAddress(address: string): Wallet | undefined {
@@ -843,39 +922,40 @@ export class EVMChainAdapter implements ChainAdapter {
   async batchMintKnowledgeAssets(params: BatchMintParams): Promise<BatchMintResult> {
     await this.init();
     this.requireV9();
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const ka = this.contracts.knowledgeAssets!.connect(signer) as Contract;
+      const kaAddress = await ka.getAddress();
 
-    const ka = this.contracts.knowledgeAssets!;
-    const kaAddress = await ka.getAddress();
-
-    if (this.contracts.token && params.tokenAmount > 0n) {
-      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, kaAddress);
-      if (currentAllowance < params.tokenAmount) {
-        const approveTx = await this.contracts.token.approve(kaAddress, ethers.MaxUint256);
-        await approveTx.wait();
+      if (this.contracts.token && params.tokenAmount > 0n) {
+        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
+        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, kaAddress);
+        if (currentAllowance < params.tokenAmount) {
+          const approveTx = await tokenWithSigner.approve(kaAddress, ethers.MaxUint256);
+          await approveTx.wait();
+        }
       }
-    }
 
-    const identityIds = params.receiverSignatures.map((s) => s.identityId);
-    const rValues = params.receiverSignatures.map((s) => ethers.hexlify(s.r));
-    const vsValues = params.receiverSignatures.map((s) => ethers.hexlify(s.vs));
+      const identityIds = params.receiverSignatures.map((s) => s.identityId);
+      const rValues = params.receiverSignatures.map((s) => ethers.hexlify(s.r));
+      const vsValues = params.receiverSignatures.map((s) => ethers.hexlify(s.vs));
 
-    const tx = await ka.batchMintKnowledgeAssets(
-      params.publisherNodeIdentityId,
-      ethers.hexlify(params.merkleRoot),
-      params.startKAId,
-      params.endKAId,
-      params.publicByteSize,
-      params.epochs,
-      params.tokenAmount,
-      ethers.ZeroAddress, // paymaster
-      ethers.hexlify(params.publisherSignature.r),
-      ethers.hexlify(params.publisherSignature.vs),
-      identityIds,
-      rValues,
-      vsValues,
-    );
-
-    const receipt = await tx.wait();
+      const tx = await ka.batchMintKnowledgeAssets(
+        params.publisherNodeIdentityId,
+        ethers.hexlify(params.merkleRoot),
+        params.startKAId,
+        params.endKAId,
+        params.publicByteSize,
+        params.epochs,
+        params.tokenAmount,
+        ethers.ZeroAddress, // paymaster
+        ethers.hexlify(params.publisherSignature.r),
+        ethers.hexlify(params.publisherSignature.vs),
+        identityIds,
+        rValues,
+        vsValues,
+      );
+      return tx.wait();
+    });
 
     let batchId = 0n;
     for (const log of receipt.logs) {
@@ -1119,26 +1199,27 @@ export class EVMChainAdapter implements ChainAdapter {
   async extendStorage(params: ExtendStorageParams): Promise<TxResult> {
     await this.init();
     this.requireV9();
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const ka = this.contracts.knowledgeAssets!.connect(signer) as Contract;
 
-    const ka = this.contracts.knowledgeAssets!;
-
-    if (this.contracts.token && params.tokenAmount > 0n) {
-      const kaAddress = await ka.getAddress();
-      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, kaAddress);
-      if (currentAllowance < params.tokenAmount) {
-        const approveTx = await this.contracts.token.approve(kaAddress, ethers.MaxUint256);
-        await approveTx.wait();
+      if (this.contracts.token && params.tokenAmount > 0n) {
+        const kaAddress = await ka.getAddress();
+        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
+        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, kaAddress);
+        if (currentAllowance < params.tokenAmount) {
+          const approveTx = await tokenWithSigner.approve(kaAddress, ethers.MaxUint256);
+          await approveTx.wait();
+        }
       }
-    }
 
-    const tx = await ka.extendStorage(
-      params.batchId,
-      params.additionalEpochs,
-      params.tokenAmount,
-      ethers.ZeroAddress,
-    );
-
-    const receipt = await tx.wait();
+      const tx = await ka.extendStorage(
+        params.batchId,
+        params.additionalEpochs,
+        params.tokenAmount,
+        ethers.ZeroAddress,
+      );
+      return tx.wait();
+    });
 
     return {
       hash: receipt.hash,
@@ -2261,19 +2342,23 @@ export class EVMChainAdapter implements ChainAdapter {
     // Approving the NFT here would still leave the inner `stakingV10.stake`
     // call short on allowance and revert. Mirror the pattern used in
     // `ensureProfile` / `scripts/devnet.sh`.
-    if (this.contracts.token && amount > 0n) {
-      const stakingV10Addr: string = await this.contracts.hub.getContractAddress('StakingV10');
-      if (stakingV10Addr === ethers.ZeroAddress) {
-        throw new Error('StakingV10 not registered in Hub — V10 staking unavailable');
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const stakingNftWithSigner = nft.connect(signer) as Contract;
+      if (this.contracts.token && amount > 0n) {
+        const stakingV10Addr: string = await this.contracts.hub.getContractAddress('StakingV10');
+        if (stakingV10Addr === ethers.ZeroAddress) {
+          throw new Error('StakingV10 not registered in Hub — V10 staking unavailable');
+        }
+        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
+        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, stakingV10Addr);
+        if (currentAllowance < amount) {
+          await (await tokenWithSigner.approve(stakingV10Addr, ethers.MaxUint256)).wait();
+        }
       }
-      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, stakingV10Addr);
-      if (currentAllowance < amount) {
-        await (await this.contracts.token.approve(stakingV10Addr, ethers.MaxUint256)).wait();
-      }
-    }
 
-    const tx = await nft.createConviction(identityId, amount, lockTier);
-    const receipt = await tx.wait();
+      const tx = await stakingNftWithSigner.createConviction(identityId, amount, lockTier);
+      return tx.wait();
+    });
 
     return {
       hash: receipt.hash,
@@ -2300,18 +2385,22 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     const pca = this.contracts.publishingConvictionAccount;
-    const pcaAddress = await pca.getAddress();
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const pcaWithSigner = pca.connect(signer) as Contract;
+      const pcaAddress = await pcaWithSigner.getAddress();
 
-    if (this.contracts.token && amount > 0n) {
-      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, pcaAddress);
-      if (currentAllowance < amount) {
-        const approveTx = await this.contracts.token.approve(pcaAddress, ethers.MaxUint256);
-        await approveTx.wait();
+      if (this.contracts.token && amount > 0n) {
+        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
+        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, pcaAddress);
+        if (currentAllowance < amount) {
+          const approveTx = await tokenWithSigner.approve(pcaAddress, ethers.MaxUint256);
+          await approveTx.wait();
+        }
       }
-    }
 
-    const tx = await pca.createAccount(amount, lockEpochs);
-    const receipt = await tx.wait();
+      const tx = await pcaWithSigner.createAccount(amount, lockEpochs);
+      return tx.wait();
+    });
 
     let accountId = 0n;
     for (const log of receipt.logs) {
@@ -2343,18 +2432,22 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     const pca = this.contracts.publishingConvictionAccount;
-    const pcaAddress = await pca.getAddress();
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const pcaWithSigner = pca.connect(signer) as Contract;
+      const pcaAddress = await pcaWithSigner.getAddress();
 
-    if (this.contracts.token && amount > 0n) {
-      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, pcaAddress);
-      if (currentAllowance < amount) {
-        const approveTx = await this.contracts.token.approve(pcaAddress, ethers.MaxUint256);
-        await approveTx.wait();
+      if (this.contracts.token && amount > 0n) {
+        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
+        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, pcaAddress);
+        if (currentAllowance < amount) {
+          const approveTx = await tokenWithSigner.approve(pcaAddress, ethers.MaxUint256);
+          await approveTx.wait();
+        }
       }
-    }
 
-    const tx = await pca.addFunds(accountId, amount);
-    const receipt = await tx.wait();
+      const tx = await pcaWithSigner.addFunds(accountId, amount);
+      return tx.wait();
+    });
 
     return {
       hash: receipt.hash,
@@ -2369,8 +2462,11 @@ export class EVMChainAdapter implements ChainAdapter {
       throw new Error('PublishingConvictionAccount contract not deployed.');
     }
 
-    const tx = await this.contracts.publishingConvictionAccount.extendLock(accountId, additionalEpochs);
-    const receipt = await tx.wait();
+    const pca = this.contracts.publishingConvictionAccount;
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const tx = await (pca.connect(signer) as Contract).extendLock(accountId, additionalEpochs);
+      return tx.wait();
+    });
 
     return {
       hash: receipt.hash,
@@ -2387,8 +2483,11 @@ export class EVMChainAdapter implements ChainAdapter {
     if (!ethers.isAddress(key)) {
       throw new Error(`addPCAAuthorizedKey: ${key} is not a valid EVM address`);
     }
-    const tx = await this.contracts.publishingConvictionAccount.addAuthorizedKey(accountId, key);
-    const receipt = await tx.wait();
+    const pca = this.contracts.publishingConvictionAccount;
+    const receipt = await this.withOperationalSigner(async (signer) => {
+      const tx = await (pca.connect(signer) as Contract).addAuthorizedKey(accountId, key);
+      return tx.wait();
+    });
     return {
       hash: receipt.hash,
       blockNumber: receipt.blockNumber,
@@ -2874,16 +2973,22 @@ export class EVMChainAdapter implements ChainAdapter {
 
   async createChallenge(): Promise<CreateChallengeResult> {
     await this.init();
+    return this.withOperationalSigner(async (signer) => this.withHubStaleRetry(async () => {
+      const identityStorage = await this.resolveContract('IdentityStorage');
+      const identityId: bigint = await identityStorage.getIdentityId(signer.address);
+      if (identityId === 0n) {
+        throw new Error(
+          `Selected operational wallet ${signer.address} has no on-chain identity. ` +
+          'Ensure operational wallets are registered for the node identity.',
+        );
+      }
 
-    const identityStorage = await this.resolveContract('IdentityStorage');
-    const identityId: bigint = await identityStorage.getIdentityId(this.signer.address);
-
-    return this.withHubStaleRetry(async () => {
       const { rs, rss } = await this.getRandomSampling();
+      const rsWithSigner = rs.connect(signer) as Contract;
 
       let receipt: ethers.TransactionReceipt;
       try {
-        const tx = await rs.createChallenge();
+        const tx = await rsWithSigner.createChallenge();
         receipt = await tx.wait();
       } catch (err) {
         this.translateRandomSamplingError(err);
@@ -2932,7 +3037,7 @@ export class EVMChainAdapter implements ChainAdapter {
         challenge,
         contextGraphId,
       };
-    });
+    }));
   }
 
   async submitProof(leaf: Uint8Array | `0x${string}`, merkleProof: Uint8Array[]): Promise<TxResult> {
@@ -2944,12 +3049,13 @@ export class EVMChainAdapter implements ChainAdapter {
     }
     const proofHex = merkleProof.map((p) => ethers.hexlify(p));
 
-    return this.withHubStaleRetry(async () => {
+    return this.withOperationalSigner(async (signer) => this.withHubStaleRetry(async () => {
       const { rs } = await this.getRandomSampling();
+      const rsWithSigner = rs.connect(signer) as Contract;
 
       let receipt: ethers.TransactionReceipt;
       try {
-        const tx = await rs.submitProof(leafHex, proofHex);
+        const tx = await rsWithSigner.submitProof(leafHex, proofHex);
         receipt = await tx.wait();
       } catch (err) {
         this.translateRandomSamplingError(err);
@@ -2960,7 +3066,7 @@ export class EVMChainAdapter implements ChainAdapter {
         blockNumber: receipt.blockNumber,
         success: true,
       };
-    });
+    }));
   }
 
   async getActiveProofPeriodStatus(): Promise<ProofPeriodStatus> {

--- a/packages/chain/src/evm-adapter.ts
+++ b/packages/chain/src/evm-adapter.ts
@@ -413,11 +413,13 @@ export class EVMChainAdapter implements ChainAdapter {
             const picked = candidates[0];
             this.signerIndex = picked.idx + 1;
             selectedSigner = picked.signer;
+            this.busyOperationalSigners.add(selectedSigner.address.toLowerCase());
           } else {
             for (const candidate of candidates) {
               if (await this.signerHasNativeFunds(candidate.signer)) {
                 this.signerIndex = candidate.idx + 1;
                 selectedSigner = candidate.signer;
+                this.busyOperationalSigners.add(selectedSigner.address.toLowerCase());
                 break;
               }
             }
@@ -444,7 +446,6 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     const signerKey = selectedSigner.address.toLowerCase();
-    this.busyOperationalSigners.add(signerKey);
     try {
       return await action(selectedSigner);
     } finally {
@@ -922,40 +923,39 @@ export class EVMChainAdapter implements ChainAdapter {
   async batchMintKnowledgeAssets(params: BatchMintParams): Promise<BatchMintResult> {
     await this.init();
     this.requireV9();
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const ka = this.contracts.knowledgeAssets!.connect(signer) as Contract;
-      const kaAddress = await ka.getAddress();
 
-      if (this.contracts.token && params.tokenAmount > 0n) {
-        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
-        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, kaAddress);
-        if (currentAllowance < params.tokenAmount) {
-          const approveTx = await tokenWithSigner.approve(kaAddress, ethers.MaxUint256);
-          await approveTx.wait();
-        }
+    const ka = this.contracts.knowledgeAssets!;
+    const kaAddress = await ka.getAddress();
+
+    if (this.contracts.token && params.tokenAmount > 0n) {
+      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, kaAddress);
+      if (currentAllowance < params.tokenAmount) {
+        const approveTx = await this.contracts.token.approve(kaAddress, ethers.MaxUint256);
+        await approveTx.wait();
       }
+    }
 
-      const identityIds = params.receiverSignatures.map((s) => s.identityId);
-      const rValues = params.receiverSignatures.map((s) => ethers.hexlify(s.r));
-      const vsValues = params.receiverSignatures.map((s) => ethers.hexlify(s.vs));
+    const identityIds = params.receiverSignatures.map((s) => s.identityId);
+    const rValues = params.receiverSignatures.map((s) => ethers.hexlify(s.r));
+    const vsValues = params.receiverSignatures.map((s) => ethers.hexlify(s.vs));
 
-      const tx = await ka.batchMintKnowledgeAssets(
-        params.publisherNodeIdentityId,
-        ethers.hexlify(params.merkleRoot),
-        params.startKAId,
-        params.endKAId,
-        params.publicByteSize,
-        params.epochs,
-        params.tokenAmount,
-        ethers.ZeroAddress, // paymaster
-        ethers.hexlify(params.publisherSignature.r),
-        ethers.hexlify(params.publisherSignature.vs),
-        identityIds,
-        rValues,
-        vsValues,
-      );
-      return tx.wait();
-    });
+    const tx = await ka.batchMintKnowledgeAssets(
+      params.publisherNodeIdentityId,
+      ethers.hexlify(params.merkleRoot),
+      params.startKAId,
+      params.endKAId,
+      params.publicByteSize,
+      params.epochs,
+      params.tokenAmount,
+      ethers.ZeroAddress, // paymaster
+      ethers.hexlify(params.publisherSignature.r),
+      ethers.hexlify(params.publisherSignature.vs),
+      identityIds,
+      rValues,
+      vsValues,
+    );
+
+    const receipt = await tx.wait();
 
     let batchId = 0n;
     for (const log of receipt.logs) {
@@ -1199,27 +1199,26 @@ export class EVMChainAdapter implements ChainAdapter {
   async extendStorage(params: ExtendStorageParams): Promise<TxResult> {
     await this.init();
     this.requireV9();
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const ka = this.contracts.knowledgeAssets!.connect(signer) as Contract;
 
-      if (this.contracts.token && params.tokenAmount > 0n) {
-        const kaAddress = await ka.getAddress();
-        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
-        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, kaAddress);
-        if (currentAllowance < params.tokenAmount) {
-          const approveTx = await tokenWithSigner.approve(kaAddress, ethers.MaxUint256);
-          await approveTx.wait();
-        }
+    const ka = this.contracts.knowledgeAssets!;
+
+    if (this.contracts.token && params.tokenAmount > 0n) {
+      const kaAddress = await ka.getAddress();
+      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, kaAddress);
+      if (currentAllowance < params.tokenAmount) {
+        const approveTx = await this.contracts.token.approve(kaAddress, ethers.MaxUint256);
+        await approveTx.wait();
       }
+    }
 
-      const tx = await ka.extendStorage(
-        params.batchId,
-        params.additionalEpochs,
-        params.tokenAmount,
-        ethers.ZeroAddress,
-      );
-      return tx.wait();
-    });
+    const tx = await ka.extendStorage(
+      params.batchId,
+      params.additionalEpochs,
+      params.tokenAmount,
+      ethers.ZeroAddress,
+    );
+
+    const receipt = await tx.wait();
 
     return {
       hash: receipt.hash,
@@ -2342,23 +2341,19 @@ export class EVMChainAdapter implements ChainAdapter {
     // Approving the NFT here would still leave the inner `stakingV10.stake`
     // call short on allowance and revert. Mirror the pattern used in
     // `ensureProfile` / `scripts/devnet.sh`.
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const stakingNftWithSigner = nft.connect(signer) as Contract;
-      if (this.contracts.token && amount > 0n) {
-        const stakingV10Addr: string = await this.contracts.hub.getContractAddress('StakingV10');
-        if (stakingV10Addr === ethers.ZeroAddress) {
-          throw new Error('StakingV10 not registered in Hub — V10 staking unavailable');
-        }
-        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
-        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, stakingV10Addr);
-        if (currentAllowance < amount) {
-          await (await tokenWithSigner.approve(stakingV10Addr, ethers.MaxUint256)).wait();
-        }
+    if (this.contracts.token && amount > 0n) {
+      const stakingV10Addr: string = await this.contracts.hub.getContractAddress('StakingV10');
+      if (stakingV10Addr === ethers.ZeroAddress) {
+        throw new Error('StakingV10 not registered in Hub — V10 staking unavailable');
       }
+      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, stakingV10Addr);
+      if (currentAllowance < amount) {
+        await (await this.contracts.token.approve(stakingV10Addr, ethers.MaxUint256)).wait();
+      }
+    }
 
-      const tx = await stakingNftWithSigner.createConviction(identityId, amount, lockTier);
-      return tx.wait();
-    });
+    const tx = await nft.createConviction(identityId, amount, lockTier);
+    const receipt = await tx.wait();
 
     return {
       hash: receipt.hash,
@@ -2385,22 +2380,18 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     const pca = this.contracts.publishingConvictionAccount;
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const pcaWithSigner = pca.connect(signer) as Contract;
-      const pcaAddress = await pcaWithSigner.getAddress();
+    const pcaAddress = await pca.getAddress();
 
-      if (this.contracts.token && amount > 0n) {
-        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
-        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, pcaAddress);
-        if (currentAllowance < amount) {
-          const approveTx = await tokenWithSigner.approve(pcaAddress, ethers.MaxUint256);
-          await approveTx.wait();
-        }
+    if (this.contracts.token && amount > 0n) {
+      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, pcaAddress);
+      if (currentAllowance < amount) {
+        const approveTx = await this.contracts.token.approve(pcaAddress, ethers.MaxUint256);
+        await approveTx.wait();
       }
+    }
 
-      const tx = await pcaWithSigner.createAccount(amount, lockEpochs);
-      return tx.wait();
-    });
+    const tx = await pca.createAccount(amount, lockEpochs);
+    const receipt = await tx.wait();
 
     let accountId = 0n;
     for (const log of receipt.logs) {
@@ -2432,22 +2423,18 @@ export class EVMChainAdapter implements ChainAdapter {
     }
 
     const pca = this.contracts.publishingConvictionAccount;
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const pcaWithSigner = pca.connect(signer) as Contract;
-      const pcaAddress = await pcaWithSigner.getAddress();
+    const pcaAddress = await pca.getAddress();
 
-      if (this.contracts.token && amount > 0n) {
-        const tokenWithSigner = this.contracts.token.connect(signer) as Contract;
-        const currentAllowance: bigint = await tokenWithSigner.allowance(signer.address, pcaAddress);
-        if (currentAllowance < amount) {
-          const approveTx = await tokenWithSigner.approve(pcaAddress, ethers.MaxUint256);
-          await approveTx.wait();
-        }
+    if (this.contracts.token && amount > 0n) {
+      const currentAllowance: bigint = await this.contracts.token.allowance(this.signer.address, pcaAddress);
+      if (currentAllowance < amount) {
+        const approveTx = await this.contracts.token.approve(pcaAddress, ethers.MaxUint256);
+        await approveTx.wait();
       }
+    }
 
-      const tx = await pcaWithSigner.addFunds(accountId, amount);
-      return tx.wait();
-    });
+    const tx = await pca.addFunds(accountId, amount);
+    const receipt = await tx.wait();
 
     return {
       hash: receipt.hash,
@@ -2462,11 +2449,8 @@ export class EVMChainAdapter implements ChainAdapter {
       throw new Error('PublishingConvictionAccount contract not deployed.');
     }
 
-    const pca = this.contracts.publishingConvictionAccount;
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const tx = await (pca.connect(signer) as Contract).extendLock(accountId, additionalEpochs);
-      return tx.wait();
-    });
+    const tx = await this.contracts.publishingConvictionAccount.extendLock(accountId, additionalEpochs);
+    const receipt = await tx.wait();
 
     return {
       hash: receipt.hash,
@@ -2483,11 +2467,8 @@ export class EVMChainAdapter implements ChainAdapter {
     if (!ethers.isAddress(key)) {
       throw new Error(`addPCAAuthorizedKey: ${key} is not a valid EVM address`);
     }
-    const pca = this.contracts.publishingConvictionAccount;
-    const receipt = await this.withOperationalSigner(async (signer) => {
-      const tx = await (pca.connect(signer) as Contract).addAuthorizedKey(accountId, key);
-      return tx.wait();
-    });
+    const tx = await this.contracts.publishingConvictionAccount.addAuthorizedKey(accountId, key);
+    const receipt = await tx.wait();
     return {
       hash: receipt.hash,
       blockNumber: receipt.blockNumber,
@@ -3034,6 +3015,7 @@ export class EVMChainAdapter implements ChainAdapter {
         hash: receipt.hash,
         blockNumber: receipt.blockNumber,
         success: true,
+        publisherAddress: signer.address,
         challenge,
         contextGraphId,
       };
@@ -3065,6 +3047,7 @@ export class EVMChainAdapter implements ChainAdapter {
         hash: receipt.hash,
         blockNumber: receipt.blockNumber,
         success: true,
+        publisherAddress: signer.address,
       };
     }));
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3374,10 +3374,10 @@ program
         console.log('  (missing from legacy wallets.json; add the profile admin key to enable key management)');
       }
 
-      console.log(`\nOperational wallets (${opWallets.wallets.length}):\n`);
+      console.log(`\nOperational wallets (${opWallets.wallets.length}) [publish pool]:\n`);
       for (let i = 0; i < opWallets.wallets.length; i++) {
         const addr = opWallets.wallets[i].address;
-        const label = i === 0 ? '(primary)' : `(pool #${i + 1})`;
+        const label = i === 0 ? '(primary default tx wallet)' : `(publish pool #${i + 1})`;
         console.log(`  ${label} ${addr}`);
         if (provider) {
           try {
@@ -3395,7 +3395,11 @@ program
       console.log(`  File:  ~/.dkg/wallets.json`);
       console.log('\nFund these addresses with ETH (gas) and TRAC (staking/publishing).');
       if (opWallets.adminWallet) {
-        console.log('The admin wallet is used for profile key management. The primary operational wallet is used for staking; all operational wallets are used for publishing.\n');
+        console.log(
+          'The admin wallet is used for profile/key management and operator actions (e.g., set-ask). ' +
+          'The primary operational wallet is the default node tx wallet (sampling/staking/PCA ops); ' +
+          'all operational wallets can be used for publishing.\n',
+        );
       } else {
         console.log('Add the real profile admin key to wallets.json to enable profile key management and operational-wallet repair.\n');
       }
@@ -3410,7 +3414,7 @@ program
 program
   .command('set-ask <amount>')
   .description('Set the node\'s on-chain ask (TRAC per KB·epoch)')
-  .option('--identity <id>', 'Override identity ID (auto-detected from primary wallet by default)')
+  .option('--identity <id>', 'Override identity ID (auto-detected from primary operational wallet by default)')
   .action(async (amount: string, opts: ActionOpts) => {
     try {
       const config = await loadConfig();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3396,7 +3396,7 @@ program
       console.log('\nFund these addresses with ETH (gas) and TRAC (staking/publishing).');
       if (opWallets.adminWallet) {
         console.log(
-          'The admin wallet is used for profile/key management and operator actions (e.g., set-ask). ' +
+          'The admin wallet is used for profile/key management and operator-authority actions. ' +
           'The primary operational wallet is the default node tx wallet (sampling/staking/PCA ops); ' +
           'all operational wallets can be used for publishing.\n',
         );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3442,7 +3442,7 @@ program
       }
 
       const provider = new ethers.JsonRpcProvider(rpcUrl);
-      const wallet = new ethers.Wallet(opWallets.wallets[0].privateKey, provider);
+      const operationalWallets = opWallets.wallets.map((w) => new ethers.Wallet(w.privateKey, provider));
 
       const hub = new ethers.Contract(hubAddress, [
         'function getContractAddress(string) view returns (address)',
@@ -3453,17 +3453,46 @@ program
         'function getIdentityId(address) view returns (uint72)',
       ], provider);
 
-      let identityId: bigint;
+      let wallet: ethers.Wallet | null = null;
+      let identityId: bigint = 0n;
       if (opts.identity) {
         identityId = BigInt(opts.identity);
+        for (const candidate of operationalWallets) {
+          const bal = await provider.getBalance(candidate.address);
+          if (bal > 0n) {
+            wallet = candidate;
+            break;
+          }
+        }
+        wallet ??= operationalWallets[0];
       } else {
-        identityId = await identityStorage.getIdentityId(wallet.address);
-        if (identityId === 0n) {
-          console.error(
-            `No on-chain identity found for primary wallet ${wallet.address}.\n` +
-            'Start the node first ("dkg start") so it creates an on-chain profile, or use --identity <id>.',
-          );
-          process.exit(1);
+        let fallbackIdentity: bigint | null = null;
+        let fallbackWallet: ethers.Wallet | null = null;
+        for (const candidate of operationalWallets) {
+          const candidateIdentity = await identityStorage.getIdentityId(candidate.address);
+          if (candidateIdentity === 0n) continue;
+          if (!fallbackWallet) {
+            fallbackWallet = candidate;
+            fallbackIdentity = candidateIdentity;
+          }
+          const bal = await provider.getBalance(candidate.address);
+          if (bal > 0n) {
+            wallet = candidate;
+            identityId = candidateIdentity;
+            break;
+          }
+        }
+
+        if (!wallet) {
+          if (!fallbackWallet || fallbackIdentity == null) {
+            console.error(
+              'No on-chain identity found for any operational wallet.\n' +
+              'Start the node first ("dkg start") so it creates an on-chain profile, or use --identity <id>.',
+            );
+            process.exit(1);
+          }
+          wallet = fallbackWallet;
+          identityId = fallbackIdentity;
         }
       }
 
@@ -3496,7 +3525,7 @@ program
     } catch (err) {
       if (hasErrorCode(err, 'CALL_EXCEPTION')) {
         console.error(
-          `Transaction reverted. The primary wallet may not be the admin/operational key for this identity.\n` +
+          `Transaction reverted. The selected operational wallet may not be the admin/operational key for this identity.\n` +
           `Use --identity <id> if auto-detection picked the wrong identity.`,
         );
       }

--- a/packages/random-sampling/src/prover.ts
+++ b/packages/random-sampling/src/prover.ts
@@ -293,6 +293,12 @@ export class RandomSamplingProver {
         const created = await this.chain.createChallenge();
         challenge = created.challenge;
         cgId = created.contextGraphId;
+        this.log.info('rs.tick.challenge-created', {
+          kcId: challenge.knowledgeCollectionId.toString(),
+          cgId: cgId.toString(),
+          signer: created.publisherAddress ?? 'unknown',
+          txHash: created.hash,
+        });
       } catch (err) {
         if (err instanceof NoEligibleContextGraphError) {
           this.log.info('rs.tick.no-eligible-cg', {});
@@ -475,6 +481,7 @@ export class RandomSamplingProver {
       cgId: cgId.toString(),
       chunkId: chunkId.toString(),
       txHash: txResult.hash,
+      signer: txResult.publisherAddress ?? 'unknown',
     });
     return { kind: 'submitted', txHash: txResult.hash, kcId, cgId, chunkId };
   }


### PR DESCRIPTION
## Summary
- clarify wallet-role terminology in CLI/docs while preserving existing config/schema names (`adminWallet`, `wallets`)
- update `dkg wallet` / setup docs to explain: admin wallet authority, primary operational default role, and operational publish pool usage
- add funded operational signer fallback for non-publish transaction paths in `EVMChainAdapter`
- make random-sampling txs (`createChallenge`, `submitProof`) use available funded operational signers instead of hard-wired primary-only behavior
- update `dkg set-ask` to pick a funded operational wallet with a valid on-chain identity when available

## Test plan
- [x] `pnpm --filter @origintrail-official/dkg-chain build`
- [x] `pnpm --filter @origintrail-official/dkg build`
- [x] verify no lints in changed files (`packages/chain/src/evm-adapter.ts`, `packages/cli/src/cli.ts`, docs)
- [x] manually inspect diff to confirm backwards-compatible terminology and fallback behavior

Made with [Cursor](https://cursor.com)