### PR TITLE
test: devnet/e2e coverage for rc.17 additions (subscription cap/clear/list + #1004 auto-finalize)

### DIFF
--- a/packages/node-ui/e2e/helpers/devnet-publish.ts
+++ b/packages/node-ui/e2e/helpers/devnet-publish.ts
@@ -215,6 +215,14 @@ export async function createWmAssertion(opts: {
   name: string;
   quads: PublishQuads[];
   promote?: boolean;
+  /**
+   * Finalize the WM assertion at create time. Defaults to `true` for
+   * back-compat with every existing caller. Pass `false` to exercise the
+   * rc.17 #1004 path where `promote` auto-finalizes a FULL promote — i.e. the
+   * real Node UI journey (write → Promote All → Publish-to-VM) with no explicit
+   * finalize step.
+   */
+  finalize?: boolean;
   subGraphName?: string;
   nodeNum?: number;
 }): Promise<{ ok: boolean; status: number; body: string }> {
@@ -225,7 +233,7 @@ export async function createWmAssertion(opts: {
       contextGraphId: opts.contextGraphId,
       name: opts.name,
       quads: opts.quads,
-      finalize: true,
+      finalize: opts.finalize ?? true,
       promote: opts.promote ?? false,
       ...(opts.subGraphName ? { subGraphName: opts.subGraphName } : {}),
     }),

--- a/packages/node-ui/e2e/specs/devnet/messaging-ownership-extended.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/messaging-ownership-extended.devnet.spec.ts
@@ -57,20 +57,28 @@ test.describe('Ownership transfer + delegated KA update (API)', () => {
     expect(list.ok).toBe(true);
   });
 
-  test('KA update endpoint accepts quads after WM→VM pipeline', async () => {
+  test('KA update without a precomputed attestation is rejected (not silently accepted)', async () => {
     const cgs = await listContextGraphs(1);
     requireDevnetPrecondition(test, cgs.length === 0, 'No CGs');
     const cgId = cgs[0]!.id;
-    await runWmSwmVmPipeline({ contextGraphId: cgId });
+    const { kaId } = await runWmSwmVmPipeline({ contextGraphId: cgId });
     const stamp = Date.now();
     const res = await devnetApiFetch('/api/update', {
       method: 'POST',
       body: JSON.stringify({
         contextGraphId: cgId,
+        kaId,
         quads: buildTestQuads(cgId, stamp, `Delegated update ${stamp}`),
       }),
     });
-    expect([200, 400, 422]).toContain(res.status);
+    // On-chain KA update is gated behind a signed UpdateAuthorAttestation. A bare
+    // quads update with no `precomputedUpdateAttestation` MUST be rejected — the
+    // previous `expect([200,400,422]).toContain(res.status)` would have passed
+    // even if the attestation enforcement regressed to ACCEPT un-attested updates.
+    // Mirror the tightened sibling in wm-swm-vm-lifecycle.devnet.spec.ts.
+    expect(res.ok).toBe(false);
+    const body = await res.text();
+    expect(body).toMatch(/precomputedUpdateAttestation|attestation/i);
   });
 
   test('second agent registration succeeds on devnet node2', async () => {

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
@@ -18,6 +18,7 @@ import {
   promoteAssertion,
   publishToVm,
 } from '../../helpers/devnet-publish.js';
+import { withSwmLock } from '../../helpers/swm-lock.js';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -97,6 +98,12 @@ test.describe('WM → SWM → VM API pipeline', () => {
     // the exact thing #1004 fixed — was never exercised end-to-end on the V10
     // chain. (The selective-promote-does-NOT-auto-finalize negative is unit-
     // covered in packages/agent/test/e2e-memory-layers.test.ts.)
+    // Hold the SWM lock across create→promote→publish so a concurrent worker's
+    // conviction-baseline clearAfter:true can't wipe shared memory between this
+    // test's promote and publish (nondeterministic #1004-lane failure at
+    // PW_WORKERS>1). runWmSwmVmPipeline() is already lock-wrapped; this manual
+    // finalize:false path must be too.
+    await withSwmLock(async () => {
     const stamp = Date.now();
     const name = `e2e-autofinalize-${stamp}`;
     const label = `AutoFinalize ${stamp}`;
@@ -119,6 +126,7 @@ test.describe('WM → SWM → VM API pipeline', () => {
     expect(vm.httpStatus, 'auto-finalize publish should be a clean 200, not a 207 partial').toBe(200);
     expect(vm.kaId, 'auto-finalize publish returned 2xx but no numeric kaId').toMatch(/^\d+$/);
     expect(BigInt(vm.kaId!), 'kaId is 0 — auto-finalize publish did not mint on-chain').toBeGreaterThan(0n);
+    });
   });
 });
 

--- a/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
+++ b/packages/node-ui/e2e/specs/devnet/wm-swm-vm-lifecycle.devnet.spec.ts
@@ -16,6 +16,7 @@ import {
   createWmAssertion,
   buildTestQuads,
   promoteAssertion,
+  publishToVm,
 } from '../../helpers/devnet-publish.js';
 
 test.describe.configure({ mode: 'serial' });
@@ -86,6 +87,38 @@ test.describe('WM → SWM → VM API pipeline', () => {
     // on-chain mint (kaId > 0) is the contract — a 0 here is a real regression,
     // not an expected outcome.
     expect(BigInt(result.kaId!), 'kaId is 0 — publish did not mint on-chain (tentative downgrade)').toBeGreaterThan(0n);
+  });
+
+  test('#1004: a FULL promote auto-finalizes an UNFINALIZED WM assertion (no explicit finalize)', async () => {
+    // The canonical Node UI journey: write WITHOUT an explicit finalize → Promote
+    // All → Publish-to-VM. rc.17 #1004 makes a FULL promote auto-finalize the WM
+    // assertion, so this flow mints on-chain with no finalize step. Every OTHER
+    // pipeline helper finalizes at create time (finalize:true), so this path —
+    // the exact thing #1004 fixed — was never exercised end-to-end on the V10
+    // chain. (The selective-promote-does-NOT-auto-finalize negative is unit-
+    // covered in packages/agent/test/e2e-memory-layers.test.ts.)
+    const stamp = Date.now();
+    const name = `e2e-autofinalize-${stamp}`;
+    const label = `AutoFinalize ${stamp}`;
+    const quads = buildTestQuads(run.cgId!, stamp, label);
+
+    const wm = await createWmAssertion({
+      contextGraphId: run.cgId!,
+      name,
+      quads,
+      finalize: false, // <-- the whole point: NO explicit finalize
+    });
+    expect(wm.ok, `WM create (finalize:false) failed: ${wm.status} ${wm.body}`).toBe(true);
+
+    // FULL promote (no entities subset) must auto-finalize the unfinalized draft.
+    const promote = await promoteAssertion({ contextGraphId: run.cgId!, assertionName: name });
+    expect(promote.ok, `auto-finalize promote failed: ${promote.status} ${await promote.text()}`).toBe(true);
+
+    // Publish must mint a CONFIRMED on-chain kaId — no "assertion is not finalized".
+    const vm = await publishToVm({ contextGraphId: run.cgId!, assertionName: name });
+    expect(vm.httpStatus, 'auto-finalize publish should be a clean 200, not a 207 partial').toBe(200);
+    expect(vm.kaId, 'auto-finalize publish returned 2xx but no numeric kaId').toMatch(/^\d+$/);
+    expect(BigInt(vm.kaId!), 'kaId is 0 — auto-finalize publish did not mint on-chain').toBeGreaterThan(0n);
   });
 });
 

--- a/scripts/_devnet-full-sweep.sh
+++ b/scripts/_devnet-full-sweep.sh
@@ -29,15 +29,18 @@ SCRIPTS=(
   "cli-invite"
   "reject-flow"
   "random-sampling"
-  # DESTRUCTIVE — keep LAST. These clear a node's context-graph subscriptions
-  # (DELETE /api/context-graph/subscriptions) and restart it, which drops its
-  # devnet-test SWM hosting and breaks the publish ACK quorum for any publish
-  # test that runs after. They re-subscribe the standard CGs on cleanup, but
-  # ordering them last avoids the race entirely. subscription-clear runs on
-  # node 1; subscription-cap on node 2 (so neither restarts the same node).
-  "subscription-clear"
-  "subscription-cap"
 )
+
+# DESTRUCTIVE subscription tests are OPT-IN (SUBSCRIPTION_TESTS=1) — NOT in the
+# default sweep. They DELETE a node's context-graph subscriptions and restart it;
+# against a REUSED operator devnet that silently drops pre-existing subscriptions
+# (subscription-cap now snapshots + restores its node's cap, but subscription-clear
+# wipes the active subscription set, which the sweep can't restore). When enabled
+# they run LAST, on disjoint nodes (clear→node1, cap→node2) so neither restarts
+# the other's node and the publish ACK quorum is left intact for earlier scripts.
+if [ "${SUBSCRIPTION_TESTS:-0}" = "1" ]; then
+  SCRIPTS+=("subscription-clear" "subscription-cap")
+fi
 
 # soak-rs is intentionally NOT in the default list — it's 30+ minutes and
 # only meaningful as a separate long-running test. Add SOAK=1 to include.

--- a/scripts/_devnet-full-sweep.sh
+++ b/scripts/_devnet-full-sweep.sh
@@ -29,6 +29,14 @@ SCRIPTS=(
   "cli-invite"
   "reject-flow"
   "random-sampling"
+  # DESTRUCTIVE — keep LAST. These clear a node's context-graph subscriptions
+  # (DELETE /api/context-graph/subscriptions) and restart it, which drops its
+  # devnet-test SWM hosting and breaks the publish ACK quorum for any publish
+  # test that runs after. They re-subscribe the standard CGs on cleanup, but
+  # ordering them last avoids the race entirely. subscription-clear runs on
+  # node 1; subscription-cap on node 2 (so neither restarts the same node).
+  "subscription-clear"
+  "subscription-cap"
 )
 
 # soak-rs is intentionally NOT in the default list — it's 30+ minutes and

--- a/scripts/devnet-test-subscription-cap.sh
+++ b/scripts/devnet-test-subscription-cap.sh
@@ -50,6 +50,13 @@ get_count() { curl -s -H "$AUTH" "$API/api/context-graph/subscriptions" | jq_fie
 cleanup() {
   patch_cap remove
   curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null 2>&1 || true
+  # RESTORE the node's standard devnet CGs (this test cleared them) so the publish
+  # ACK quorum isn't left broken for anything that runs after.
+  for cg in devnet-test devnet-isolation; do
+    curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+      -d "{\"contextGraphId\":\"$cg\",\"includeSharedMemory\":true}" \
+      "$API/api/context-graph/subscribe" >/dev/null 2>&1 || true
+  done
 }
 trap cleanup EXIT
 
@@ -100,14 +107,21 @@ log "seeded; active user subs before cap = ${PRE:-?}"
 echo "--- 1. cap=$CAP rehydration ---"
 patch_cap "$CAP"
 restart_and_wait || bad "node $NODE_NUM did not come back after restart (cap=$CAP)"
-read -r X1 Y1 <<<"$(rehydrate_xy)"
-if [ "${X1:-}" = "$CAP" ] && [ "${Y1:-0}" -gt "$CAP" ] 2>/dev/null; then
-  ok "rehydrate ACTIVATED exactly $CAP of $Y1 persisted (cap enforced; $((Y1-CAP)) dormant)"
+# The cap applies to NON-HOSTED user rows; coreHosted CGs (e.g. a devnet-test the
+# node hosts) are always restored and counted in X too — so the invariant is
+# (activated − hosted) == CAP, not X == CAP.
+RLINE=$(latest_rehydrate_line)
+X1=$(printf '%s' "$RLINE" | sed -E 's/.*Rehydrated ([0-9]+) of.*/\1/')
+H1=$(printf '%s' "$RLINE" | sed -nE 's/.*; ([0-9]+) hosted always restored.*/\1/p'); H1=${H1:-0}
+N1=$(printf '%s' "$RLINE" | sed -nE 's/.*\(([0-9]+) non-hosted left dormant.*/\1/p'); N1=${N1:-0}
+ACTIVATED_USER=$(( ${X1:-0} - H1 ))
+if [ "$ACTIVATED_USER" = "$CAP" ] && [ "$N1" -gt 0 ] 2>/dev/null; then
+  ok "cap enforced: $CAP non-hosted user subs activated, $N1 left dormant ($H1 hosted exempt)"
 else
-  bad "expected 'Rehydrated $CAP of >$CAP', got X=${X1:-?} Y=${Y1:-?} (line: $(latest_rehydrate_line | sed 's/.*\[DKGAgent\] //'))"
+  bad "expected $CAP non-hosted activated + dormancy, got activated_user=$ACTIVATED_USER dormant=$N1 hosted=$H1 (line: ${RLINE##*[DKGAgent] })"
 fi
-if latest_rehydrate_line | grep -qE "non-hosted left dormant — over the $CAP activation cap"; then
-  ok "boot log records the dormant note"
+if printf '%s' "$RLINE" | grep -qE "non-hosted left dormant — over the $CAP activation cap"; then
+  ok "boot log records the dormant note at cap=$CAP"
 else
   bad "rehydrate log missing the 'left dormant — over the $CAP activation cap' note"
 fi

--- a/scripts/devnet-test-subscription-cap.sh
+++ b/scripts/devnet-test-subscription-cap.sh
@@ -46,9 +46,12 @@ log()  { echo "[sub-cap] $*"; }
 jq_field() { python3 -c "import sys,json;d=json.load(sys.stdin);print($1)" 2>/dev/null || echo ""; }
 get_count() { curl -s -H "$AUTH" "$API/api/context-graph/subscriptions" | jq_field "d['count']"; }
 
-# Restore a clean config + cap on any exit so the node isn't left capped.
+# Restore the node's ORIGINAL cap on any exit (the smoke mutates it through
+# several values) instead of always deleting it — otherwise running this on a
+# devnet with a non-default cap would permanently rewrite node config and change
+# behaviour outside the test. ORIG_CAP is snapshotted before the first patch_cap.
 cleanup() {
-  patch_cap remove
+  patch_cap "${ORIG_CAP:-remove}"
   curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null 2>&1 || true
   # RESTORE the node's standard devnet CGs (this test cleared them) so the publish
   # ACK quorum isn't left broken for anything that runs after.
@@ -58,6 +61,9 @@ cleanup() {
       "$API/api/context-graph/subscribe" >/dev/null 2>&1 || true
   done
 }
+# Snapshot the node's ORIGINAL cap (number, or "remove" if unset) before any
+# mutation, so cleanup restores exactly what was there.
+ORIG_CAP=$(CFG_PATH="$CFG" node -e "try{const c=JSON.parse(require('fs').readFileSync(process.env.CFG_PATH,'utf8'));const v=c.maxRehydratedContextGraphSubscriptions;console.log(v===undefined?'remove':v);}catch(e){console.log('remove');}" 2>/dev/null || echo remove)
 trap cleanup EXIT
 
 patch_cap() {  # $1 = integer value | "remove"  (env vars MUST precede `node`)
@@ -106,7 +112,12 @@ log "seeded; active user subs before cap = ${PRE:-?}"
 # --- 1. cap=2 → exactly 2 ACTIVATED at rehydrate; dormant note logged --------
 echo "--- 1. cap=$CAP rehydration ---"
 patch_cap "$CAP"
-restart_and_wait || bad "node $NODE_NUM did not come back after restart (cap=$CAP)"
+# Gate ALL post-restart assertions on the restart actually succeeding: a failed
+# restart leaves the OLD process + a stale daemon.log, so reading
+# latest_rehydrate_line() / the responsiveness probes would false-green.
+if ! restart_and_wait; then
+  bad "node $NODE_NUM did not come back after restart (cap=$CAP) — skipping cap-enforcement + responsiveness checks"
+else
 # The cap applies to NON-HOSTED user rows; coreHosted CGs (e.g. a devnet-test the
 # node hosts) are always restored and counted in X too — so the invariant is
 # (activated − hosted) == CAP, not X == CAP.
@@ -138,13 +149,18 @@ if python3 -c "import sys;sys.exit(0 if ($T1-$T0)<3.0 else 1)"; then
 else
   bad "store-backed routes slow on boot (${ELAPSED}s) — possible store contention"
 fi
+fi  # end: cap=$CAP restart-success guard
 
 # --- 3. invalid cap → warning + default 64 (all rehydrated) ------------------
 echo "--- 3. invalid cap → warning + default ---"
 for badval in -1 0.5; do
   patch_cap "$badval"
+  PRE_LINES=$(wc -l < "$DAEMON_LOG" 2>/dev/null || echo 0)
   restart_and_wait || { bad "node did not return after restart (cap=$badval)"; continue; }
-  if grep -E "Ignoring invalid maxRehydratedContextGraphSubscriptions=$badval" "$DAEMON_LOG" >/dev/null 2>&1; then
+  # Grep ONLY the lines appended by THIS restart — the daemon.log is append-only
+  # across restarts, so scanning the whole file could match a warning from an
+  # earlier run even if the current boot stopped emitting it (false green).
+  if tail -n +$((PRE_LINES + 1)) "$DAEMON_LOG" 2>/dev/null | grep -E "Ignoring invalid maxRehydratedContextGraphSubscriptions=$badval" >/dev/null 2>&1; then
     ok "cap=$badval → 'Ignoring invalid …' warning logged"
   else
     bad "cap=$badval → no invalid-cap warning in daemon.log"
@@ -160,13 +176,16 @@ done
 # --- 4. cap=0 → no cap (all rehydrated) --------------------------------------
 echo "--- 4. cap=0 → no cap ---"
 patch_cap 0
-restart_and_wait || bad "node did not return after restart (cap=0)"
+if ! restart_and_wait; then
+  bad "node did not return after restart (cap=0) — skipping cap=0 rehydration check"
+else
 read -r X4 Y4 <<<"$(rehydrate_xy)"
 if [ -n "${X4:-}" ] && [ "${X4:-}" = "${Y4:-}" ]; then
   ok "cap=0 disables the cap (all $Y4 user subs rehydrated)"
 else
   bad "cap=0 → expected all rehydrated, got X=${X4:-?} Y=${Y4:-?}"
 fi
+fi  # end: cap=0 restart-success guard
 
 # --- Summary -----------------------------------------------------------------
 echo ""

--- a/scripts/devnet-test-subscription-cap.sh
+++ b/scripts/devnet-test-subscription-cap.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# rc.17 devnet test — context-graph subscription rehydration CAP + dormancy (#997/#1012).
+#
+# On boot, rehydrateContextGraphSubscriptions ACTIVATES at most
+# maxRehydratedContextGraphSubscriptions user subscriptions (default 64; 0 = no
+# cap). Rows beyond the cap stay PERSISTED but dormant; AGENTS/ONTOLOGY system
+# CGs and coreHosted graphs are exempt. This is the #997 anti-wedge measure: a
+# large stale backlog otherwise fans out store work and starves authenticated
+# routes on boot.
+#
+# Runs on node 2 (not node 1, the relay) so restarts don't disrupt the rest of
+# the devnet. Patches node2/config.json + `devnet.sh restart-node 2` to apply a
+# cap, since the cap only takes effect at rehydrate (boot).
+#
+# Preconditions: ./scripts/devnet.sh start N  (N >= 2; auth enabled)
+#
+# Asserts:
+#   1. cap=2 → exactly 2 user subs ACTIVE; 'Rehydrated 2 of <total>' + dormant note logged.
+#   2. node boots RESPONSIVE under the backlog (status + list answer fast — the wedge guard).
+#   3. invalid cap (-1, 0.5) → 'Ignoring invalid …' warning + default 64 (all active).
+#   4. cap=0 → no cap (all subs active).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+NODE_NUM="${DEVNET_TEST_NODE:-2}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+API_PORT=$((API_PORT_BASE + NODE_NUM - 1))
+API="http://127.0.0.1:${API_PORT}"
+NODE_DIR="$DEVNET_DIR/node${NODE_NUM}"
+CFG="$NODE_DIR/config.json"
+DAEMON_LOG="$NODE_DIR/daemon.log"
+SEED_N="${SEED_N:-8}"     # > cap so some rows are left dormant
+CAP=2
+TS=$(date +%s)
+
+AUTH_TOKEN=$(grep -v '^#' "$NODE_DIR/auth.token" 2>/dev/null | head -1 || echo "")
+AUTH="Authorization: Bearer $AUTH_TOKEN"
+
+PASS=0; FAIL=0; declare -a FAILURES
+ok()   { PASS=$((PASS+1)); echo "  PASS: $*"; }
+bad()  { FAIL=$((FAIL+1)); FAILURES+=("$*"); echo "  FAIL: $*"; }
+log()  { echo "[sub-cap] $*"; }
+jq_field() { python3 -c "import sys,json;d=json.load(sys.stdin);print($1)" 2>/dev/null || echo ""; }
+get_count() { curl -s -H "$AUTH" "$API/api/context-graph/subscriptions" | jq_field "d['count']"; }
+
+# Restore a clean config + cap on any exit so the node isn't left capped.
+cleanup() {
+  patch_cap remove
+  curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+patch_cap() {  # $1 = integer value | "remove"  (env vars MUST precede `node`)
+  CAP_VAL="$1" CFG_PATH="$CFG" node -e "
+    const fs=require('fs'); const p=process.env.CFG_PATH;
+    const c=JSON.parse(fs.readFileSync(p,'utf8'));
+    const v=process.env.CAP_VAL;
+    if (v==='remove') delete c.maxRehydratedContextGraphSubscriptions;
+    else c.maxRehydratedContextGraphSubscriptions = Number(v);
+    fs.writeFileSync(p, JSON.stringify(c,null,2));
+  "
+}
+
+restart_and_wait() {
+  ( cd "$REPO_ROOT" && ./scripts/devnet.sh restart-node "$NODE_NUM" ) >/dev/null 2>&1
+  for _ in $(seq 1 60); do curl -s "$API/api/status" >/dev/null 2>&1 && { sleep 2; return 0; }; sleep 1; done
+  return 1
+}
+
+latest_rehydrate_line() { grep -E "Rehydrated [0-9]+ of [0-9]+ persisted context-graph" "$DAEMON_LOG" 2>/dev/null | tail -1; }
+# Parse "Rehydrated X of Y …" → echoes "X Y" (X=activated, Y=persisted backlog).
+# The GET count is polluted by CGs the node live-discovers from gossip AFTER
+# rehydrate, so the boot log is the deterministic cap signal, not GET.
+rehydrate_xy() { latest_rehydrate_line | sed -E 's/.*Rehydrated ([0-9]+) of ([0-9]+).*/\1 \2/'; }
+
+# --- Preconditions -----------------------------------------------------------
+[ -f "$DEVNET_DIR/hardhat.pid" ] || { echo "devnet not running — ./scripts/devnet.sh start N"; exit 1; }
+curl -s "$API/api/status" >/dev/null || { echo "node $NODE_NUM API :$API_PORT not responding"; exit 1; }
+[ -n "$AUTH_TOKEN" ] || { echo "no admin token at $NODE_DIR/auth.token"; exit 1; }
+log "node $NODE_NUM API :$API_PORT, seeding $SEED_N subs, cap=$CAP"
+
+# --- Seed a clean backlog of SEED_N user subscriptions -----------------------
+curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null 2>&1 || true
+for i in $(seq 1 "$SEED_N"); do
+  CG="did:dkg:context-graph:subcap-${TS}-${i}"
+  curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+    -d "{\"contextGraphId\":\"$CG\",\"includeSharedMemory\":false}" \
+    "$API/api/context-graph/subscribe" >/dev/null
+done
+sleep 1
+PRE=$(get_count)
+log "seeded; active user subs before cap = ${PRE:-?}"
+[ "${PRE:-0}" -ge "$SEED_N" ] && ok "seeded $SEED_N user subscriptions (active=$PRE, uncapped)" \
+  || bad "expected ≥$SEED_N seeded subs, active=$PRE"
+
+# --- 1. cap=2 → exactly 2 ACTIVATED at rehydrate; dormant note logged --------
+echo "--- 1. cap=$CAP rehydration ---"
+patch_cap "$CAP"
+restart_and_wait || bad "node $NODE_NUM did not come back after restart (cap=$CAP)"
+read -r X1 Y1 <<<"$(rehydrate_xy)"
+if [ "${X1:-}" = "$CAP" ] && [ "${Y1:-0}" -gt "$CAP" ] 2>/dev/null; then
+  ok "rehydrate ACTIVATED exactly $CAP of $Y1 persisted (cap enforced; $((Y1-CAP)) dormant)"
+else
+  bad "expected 'Rehydrated $CAP of >$CAP', got X=${X1:-?} Y=${Y1:-?} (line: $(latest_rehydrate_line | sed 's/.*\[DKGAgent\] //'))"
+fi
+if latest_rehydrate_line | grep -qE "non-hosted left dormant — over the $CAP activation cap"; then
+  ok "boot log records the dormant note"
+else
+  bad "rehydrate log missing the 'left dormant — over the $CAP activation cap' note"
+fi
+
+# --- 2. boot responsive under the backlog (the #997 wedge guard) -------------
+echo "--- 2. boot responsive under backlog ---"
+T0=$(python3 -c 'import time;print(time.time())')
+curl -s -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null
+curl -s "$API/api/status" >/dev/null
+T1=$(python3 -c 'import time;print(time.time())')
+ELAPSED=$(python3 -c "print(f'{$T1-$T0:.2f}')")
+if python3 -c "import sys;sys.exit(0 if ($T1-$T0)<3.0 else 1)"; then
+  ok "status + subscriptions answered in ${ELAPSED}s (not starved by the dormant backlog)"
+else
+  bad "store-backed routes slow on boot (${ELAPSED}s) — possible store contention"
+fi
+
+# --- 3. invalid cap → warning + default 64 (all rehydrated) ------------------
+echo "--- 3. invalid cap → warning + default ---"
+for badval in -1 0.5; do
+  patch_cap "$badval"
+  restart_and_wait || { bad "node did not return after restart (cap=$badval)"; continue; }
+  if grep -E "Ignoring invalid maxRehydratedContextGraphSubscriptions=$badval" "$DAEMON_LOG" >/dev/null 2>&1; then
+    ok "cap=$badval → 'Ignoring invalid …' warning logged"
+  else
+    bad "cap=$badval → no invalid-cap warning in daemon.log"
+  fi
+  read -r X3 Y3 <<<"$(rehydrate_xy)"
+  if [ -n "${X3:-}" ] && [ "${X3:-}" = "${Y3:-}" ]; then
+    ok "cap=$badval → default 64 applied (all $Y3 rehydrated, none dormant)"
+  else
+    bad "cap=$badval → expected all rehydrated under default, got X=${X3:-?} Y=${Y3:-?}"
+  fi
+done
+
+# --- 4. cap=0 → no cap (all rehydrated) --------------------------------------
+echo "--- 4. cap=0 → no cap ---"
+patch_cap 0
+restart_and_wait || bad "node did not return after restart (cap=0)"
+read -r X4 Y4 <<<"$(rehydrate_xy)"
+if [ -n "${X4:-}" ] && [ "${X4:-}" = "${Y4:-}" ]; then
+  ok "cap=0 disables the cap (all $Y4 user subs rehydrated)"
+else
+  bad "cap=0 → expected all rehydrated, got X=${X4:-?} Y=${Y4:-?}"
+fi
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+echo "=== subscription-cap: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  for f in "${FAILURES[@]}"; do echo "  ✗ $f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/devnet-test-subscription-clear.sh
+++ b/scripts/devnet-test-subscription-clear.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# rc.17 devnet test — context-graph subscription bulk clear/list API (#997/#1012/#1020).
+#
+# Exercises the operator-recovery HTTP surface added in rc.17:
+#   GET    /api/context-graph/subscriptions   → { count, subscriptions:[{contextGraphId,subscribed,synced,coreHosted}] }
+#   DELETE /api/context-graph/subscriptions   → { cleared:N }
+# Both are node-admin-only (the auth.token Bearer); agent-scoped / unknown
+# tokens get 403. The list excludes the always-on AGENTS/ONTOLOGY system CGs;
+# the clear wipes the user-subscription backlog WITHOUT deafening the node to
+# control-plane gossip (system CGs preserved), and leaves no subscribed:false
+# ghosts behind.
+#
+# Preconditions:
+#   ./scripts/devnet.sh start N   (node 1 up; auth enabled → node1/auth.token exists)
+#
+# Asserts:
+#   1. GET (admin) lists our seeded user subs and EXCLUDES system CGs (agents/ontology).
+#   2. GET with no token / a bogus token → 403 (auth gate).
+#   3. DELETE (admin) → 200 { cleared:N } with N == the seeded user subs.
+#   4. Re-GET → seeded CGs gone (no ghosts), count back to baseline.
+#   5. daemon.log records "Cleared … system context graphs preserved" (control plane kept).
+#   6. The node stays functional post-clear (re-subscribe works).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+NODE_NUM="${DEVNET_TEST_NODE:-1}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+API_PORT=$((API_PORT_BASE + NODE_NUM - 1))
+API="http://127.0.0.1:${API_PORT}"
+NODE_DIR="$DEVNET_DIR/node${NODE_NUM}"
+DAEMON_LOG="$NODE_DIR/daemon.log"
+
+AUTH_TOKEN=$(grep -v '^#' "$NODE_DIR/auth.token" 2>/dev/null | head -1 || echo "")
+AUTH="Authorization: Bearer $AUTH_TOKEN"
+TS=$(date +%s)
+
+PASS=0; FAIL=0; declare -a FAILURES
+ok()   { PASS=$((PASS+1)); echo "  PASS: $*"; }
+bad()  { FAIL=$((FAIL+1)); FAILURES+=("$*"); echo "  FAIL: $*"; }
+log()  { echo "[sub-clear] $*"; }
+
+# JSON field extractor (python3, matches the other probes).
+jq_field() { python3 -c "import sys,json;d=json.load(sys.stdin);print($1)" 2>/dev/null || echo ""; }
+
+# --- Preconditions -----------------------------------------------------------
+[ -f "$DEVNET_DIR/hardhat.pid" ] || { echo "devnet not running — ./scripts/devnet.sh start N"; exit 1; }
+curl -s "$API/api/status" >/dev/null || { echo "node $NODE_NUM API :$API_PORT not responding"; exit 1; }
+[ -n "$AUTH_TOKEN" ] || { echo "no admin token at $NODE_DIR/auth.token (auth must be enabled)"; exit 1; }
+log "node $NODE_NUM API :$API_PORT, admin token ${AUTH_TOKEN:0:8}…"
+
+# --- Baseline ----------------------------------------------------------------
+BASE_GET=$(curl -s -H "$AUTH" "$API/api/context-graph/subscriptions")
+BASE_COUNT=$(printf '%s' "$BASE_GET" | jq_field "d['count']")
+[ -n "$BASE_COUNT" ] || bad "baseline GET returned no count (got: ${BASE_GET:0:120})"
+log "baseline subscribed user CGs: ${BASE_COUNT:-?}"
+
+# --- Seed 3 user subscriptions ----------------------------------------------
+declare -a SEED
+for i in 1 2 3; do
+  CG="did:dkg:context-graph:subclear-${TS}-${i}"
+  SEED+=("$CG")
+  RESP=$(curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+    -d "{\"contextGraphId\":\"$CG\",\"includeSharedMemory\":false}" \
+    "$API/api/context-graph/subscribe")
+  SUBBED=$(printf '%s' "$RESP" | jq_field "d.get('subscribed','')")
+  [ -n "$SUBBED" ] || log "  subscribe $CG → ${RESP:0:140}"
+done
+sleep 1
+
+# --- 1. GET lists our user subs, excludes system CGs -------------------------
+echo "--- 1. GET /api/context-graph/subscriptions (admin) ---"
+G1=$(curl -s -H "$AUTH" "$API/api/context-graph/subscriptions")
+IDS=$(printf '%s' "$G1" | python3 -c "import sys,json;print('\n'.join(s['contextGraphId'] for s in json.load(sys.stdin).get('subscriptions',[])))" 2>/dev/null || echo "")
+COUNT1=$(printf '%s' "$G1" | jq_field "d['count']")
+seen=0; for cg in "${SEED[@]}"; do printf '%s\n' "$IDS" | grep -qxF "$cg" && seen=$((seen+1)); done
+[ "$seen" -eq 3 ] && ok "all 3 seeded user subs listed (count=$COUNT1)" || bad "expected 3 seeded subs listed, saw $seen (ids: $(printf '%s' "$IDS" | tr '\n' ' '))"
+if printf '%s\n' "$IDS" | grep -qxE 'agents|ontology'; then
+  bad "system CG (agents/ontology) leaked into the subscriptions list"
+else
+  ok "system CGs (agents/ontology) correctly EXCLUDED from the list"
+fi
+
+# --- 2. Auth gate: the node-wide subscription view requires auth --------------
+# A missing / unrecognized token is rejected 401 by the daemon's global auth
+# guard BEFORE the route runs. The route's own 403 is the finer-grained case of
+# a VALID but agent-scoped token reaching it (an agent can't enumerate/clear the
+# node-wide backlog) — that distinction is unit-covered in #1012 (agent.test.ts
+# + the route handler); minting an agent token here would mean reading the agent
+# keystore, out of scope for a devnet smoke.
+echo "--- 2. auth gate (endpoint requires auth) ---"
+CODE_NONE=$(curl -s -o /dev/null -w '%{http_code}' "$API/api/context-graph/subscriptions")
+[ "$CODE_NONE" = "401" ] && ok "no token → 401 (auth required)" || bad "no token → expected 401, got $CODE_NONE"
+CODE_BOGUS=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer not-a-real-token-$TS" "$API/api/context-graph/subscriptions")
+[ "$CODE_BOGUS" = "401" ] && ok "unrecognized token → 401" || bad "unrecognized token → expected 401, got $CODE_BOGUS"
+
+# --- 3. DELETE clears the user backlog ---------------------------------------
+echo "--- 3. DELETE /api/context-graph/subscriptions (admin) ---"
+BASELINE_LINES=$([ -s "$DAEMON_LOG" ] && wc -l < "$DAEMON_LOG" | tr -d ' ' || echo 0)
+DEL=$(curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions")
+CLEARED=$(printf '%s' "$DEL" | jq_field "d.get('cleared','')")
+if [ -n "$CLEARED" ] && [ "$CLEARED" -ge 3 ] 2>/dev/null; then
+  ok "DELETE → cleared=$CLEARED (≥ our 3 seeded subs)"
+else
+  bad "DELETE → expected cleared≥3, got: ${DEL:0:160}"
+fi
+
+# --- 4. Re-GET: ghosts gone, count back to baseline --------------------------
+echo "--- 4. re-GET (ghosts gone) ---"
+G2=$(curl -s -H "$AUTH" "$API/api/context-graph/subscriptions")
+IDS2=$(printf '%s' "$G2" | python3 -c "import sys,json;print('\n'.join(s['contextGraphId'] for s in json.load(sys.stdin).get('subscriptions',[])))" 2>/dev/null || echo "")
+COUNT2=$(printf '%s' "$G2" | jq_field "d['count']")
+ghost=0; for cg in "${SEED[@]}"; do printf '%s\n' "$IDS2" | grep -qxF "$cg" && ghost=$((ghost+1)); done
+[ "$ghost" -eq 0 ] && ok "no seeded CG survives the clear (no subscribed:false ghosts)" || bad "$ghost seeded CG(s) still listed after clear"
+[ "${COUNT2:-99}" -le "${BASE_COUNT:-0}" ] && ok "count back to ≤ baseline ($COUNT2 ≤ $BASE_COUNT)" || bad "count $COUNT2 did not return to baseline $BASE_COUNT"
+
+# --- 5. system context graphs preserved (control-plane gossip intact) --------
+echo "--- 5. system CGs preserved ---"
+if tail -n +"$((BASELINE_LINES + 1))" "$DAEMON_LOG" 2>/dev/null | grep -qiE "system context graphs preserved"; then
+  ok "daemon.log: clear preserved system context graphs"
+else
+  bad "no 'system context graphs preserved' line after DELETE (check $DAEMON_LOG)"
+fi
+
+# --- 6. node functional post-clear (re-subscribe works) ----------------------
+echo "--- 6. node functional post-clear ---"
+RECG="did:dkg:context-graph:subclear-${TS}-rejoin"
+RE=$(curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  -d "{\"contextGraphId\":\"$RECG\",\"includeSharedMemory\":false}" "$API/api/context-graph/subscribe")
+G3=$(curl -s -H "$AUTH" "$API/api/context-graph/subscriptions" | python3 -c "import sys,json;print('\n'.join(s['contextGraphId'] for s in json.load(sys.stdin).get('subscriptions',[])))" 2>/dev/null || echo "")
+printf '%s\n' "$G3" | grep -qxF "$RECG" && ok "re-subscribe after clear works (node not wedged)" || bad "re-subscribe after clear failed (resp: ${RE:0:140})"
+
+# Cleanup: clear the rejoin sub so reruns start clean.
+curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null 2>&1 || true
+
+# --- Summary -----------------------------------------------------------------
+echo ""
+echo "=== subscription-clear: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+  for f in "${FAILURES[@]}"; do echo "  ✗ $f"; done
+  exit 1
+fi
+exit 0

--- a/scripts/devnet-test-subscription-clear.sh
+++ b/scripts/devnet-test-subscription-clear.sh
@@ -132,8 +132,15 @@ RE=$(curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' \
 G3=$(curl -s -H "$AUTH" "$API/api/context-graph/subscriptions" | python3 -c "import sys,json;print('\n'.join(s['contextGraphId'] for s in json.load(sys.stdin).get('subscriptions',[])))" 2>/dev/null || echo "")
 printf '%s\n' "$G3" | grep -qxF "$RECG" && ok "re-subscribe after clear works (node not wedged)" || bad "re-subscribe after clear failed (resp: ${RE:0:140})"
 
-# Cleanup: clear the rejoin sub so reruns start clean.
+# Cleanup: clear our test subs, then RESTORE the node's standard devnet CGs so
+# this destructive test doesn't leave node $NODE_NUM without its devnet-test SWM
+# hosting (the publish ACK quorum depends on it).
 curl -s -X DELETE -H "$AUTH" "$API/api/context-graph/subscriptions" >/dev/null 2>&1 || true
+for cg in devnet-test devnet-isolation; do
+  curl -s -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+    -d "{\"contextGraphId\":\"$cg\",\"includeSharedMemory\":true}" \
+    "$API/api/context-graph/subscribe" >/dev/null 2>&1 || true
+done
 
 # --- Summary -----------------------------------------------------------------
 echo ""


### PR DESCRIPTION
Closes the biggest **devnet/e2e coverage gaps for rc.17**, found by auditing all 99 devnet/agent/node-ui test files against the rc.16→rc.17 change surface. Two of rc.17's riskiest additions had **zero** end-to-end coverage; a third was actively **masked** by a test helper.

## New devnet tests (shell)
- **`scripts/devnet-test-subscription-clear.sh`** — the brand-new `GET`/`DELETE /api/context-graph/subscriptions` recovery API (#997/#1012). Asserts: admin token lists active user subs and EXCLUDES the AGENTS/ONTOLOGY system CGs; unauthenticated → 401; `DELETE` → `{cleared:N}`; re-GET shows no `subscribed:false` ghosts; daemon.log confirms system context graphs are preserved (control-plane gossip intact); node stays functional (re-subscribe) post-clear. **9/9 green.**
- **`scripts/devnet-test-subscription-cap.sh`** — the rehydration cap + dormancy (#997/#1012). Patches `maxRehydratedContextGraphSubscriptions` + `restart-node`, then asserts the deterministic `Rehydrated X of Y` boot log: `cap=2` activates exactly 2 (rest dormant + the dormant note); invalid caps (`-1`, `0.5`) log `Ignoring invalid …` and fall back to the default 64; `cap=0` disables; and the node boots responsive under the backlog (the #997 wedge guard). Asserts on the boot log, not GET count, which is polluted by CGs the node live-discovers after rehydrate. **9/9 green.**

## #1004 auto-finalize (un-masked a helper)
`createWmAssertion` hard-coded `finalize:true`, so every devnet/e2e pipeline finalized BEFORE promote — the #1004 auto-finalize-on-full-promote path (the real Node UI journey: write → Promote All → Publish-to-VM with **no explicit finalize**) was never exercised end-to-end on the V10 chain.
- `e2e/helpers/devnet-publish.ts`: parameterize `createWmAssertion` with `finalize` (default `true`).
- `wm-swm-vm-lifecycle.devnet.spec.ts`: new test creates with `finalize:false` → full promote (auto-finalizes) → `publishToVm`, asserting a clean 200 + a confirmed on-chain `kaId>0`. **Full lifecycle spec 7/7 green** on a fresh 4-node devnet.

## Validated
All against a real 4-node devnet (oxigraph-server backend on nodes 1-2). More rc.17 coverage (multi-component blank-node guard, Hermes/OpenClaw 504 attribution route test, stale-test fixes) is in progress on follow-up commits. #1011 (oxigraph-worker timeout) is already unit-covered; #1007 (oversized-promote 413) needs a >10MB payload and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)