### PR TITLE
feat(core,publisher): public catalog model + publish partition

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// combined-model catalog partition, in core so BOTH the
+// agent (injection side) and the publisher (encryption side) can use it.
+//
+// At publish time a private CG's reloaded quads contain the public DCAT
+// catalog entry (subject = the CG UAL, dual-typed dcat:Dataset +
+// dkg:PrivateContextGraph) alongside the private data. The catalog rides in the
+// CG's own merkle root (verifiability) but must NOT be encrypted: it is routed
+// plaintext to the public sink, while only the data is fed to the curated
+// encryptor. This partition is the seam that separates them.
+
+import { DKG_ONTOLOGY } from './genesis.js';
+
+/** Structural quad — avoids a core→storage dependency. */
+export interface CatalogQuadLike {
+  subject: string;
+  predicate: string;
+  object: string;
+  graph?: string;
+}
+
+/**
+ * Every predicate a catalog entry may carry (floor + recommended + opt-in
+ * tiers). A quad is treated as catalog only if its predicate is in this set AND
+ * its subject is a catalog subject — fail-safe toward privacy.
+ *
+ * NB: `rdf:type` is listed here, but membership is NOT sufficient for a
+ * `rdf:type` quad — its OBJECT must additionally be an allowed catalog class
+ * (see {@link CATALOG_CLASSES}). Otherwise an arbitrary `rdf:type` on the
+ * catalog subject would leak into the public `_catalog` (bug B2).
+ */
+export const CATALOG_PREDICATES: ReadonlySet<string> = new Set<string>([
+  DKG_ONTOLOGY.RDF_TYPE,            // object-gated: only CATALOG_CLASSES go public
+  DKG_ONTOLOGY.DCT_IDENTIFIER,
+  DKG_ONTOLOGY.DCT_ACCESS_RIGHTS,
+  DKG_ONTOLOGY.DCT_PUBLISHER,
+  DKG_ONTOLOGY.DCAT_ACCESS_SERVICE,
+  DKG_ONTOLOGY.DCT_CONFORMS_TO,
+  DKG_ONTOLOGY.DKG_BLINDED_ANCHOR,
+  DKG_ONTOLOGY.DKG_COMMITTED_ROOT, // separate-KA variant; harmless to recognize
+]);
+
+/**
+ * The ONLY `rdf:type` objects allowed into the public catalog partition. Any
+ * other `rdf:type` on the catalog subject is a data/user type assertion and
+ * stays on the private (encrypted) path — fail-safe toward privacy.
+ *
+ * `dcat:Dataset` + `dkg:PrivateContextGraph` are the dual-typed floor every
+ * catalog entry emits (the only types `buildPublicProjection` actually
+ * produces); the remaining DCAT *classes* this ontology defines are included
+ * for forward-compatibility (DCAT models them as separate-subject resources, so
+ * they never appear as a type on the CG subject in practice, but recognizing
+ * them is harmless).
+ */
+export const CATALOG_CLASSES: ReadonlySet<string> = new Set<string>([
+  DKG_ONTOLOGY.DCAT_DATASET,            // floor (interop)
+  DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, // floor (dkg-native, system marker)
+  DKG_ONTOLOGY.DCAT_DISTRIBUTION,
+  DKG_ONTOLOGY.DCAT_DATA_SERVICE,
+  DKG_ONTOLOGY.DCAT_CATALOG,
+]);
+
+export interface CatalogPartition<Q> {
+  /** Public, plaintext, core-servable — excluded from ciphertext, kept in the merkle root. */
+  catalogQuads: Q[];
+  /** Everything else — the existing path (encrypted for a curated CG). */
+  otherQuads: Q[];
+}
+
+/**
+ * Partition publish quads into the public catalog entry and everything else.
+ *
+ * Identity-based, NOT type-marker-based (round-3 SECURITY). The catalog subject
+ * is supplied by the caller as `catalogSubject` — the canonical context-graph
+ * DID (`contextGraphDataUri(contextGraphId)` === `did:dkg:context-graph:<id>`),
+ * the ONLY subject the catalog injection writes to. A quad is catalog iff its
+ * subject IS that exact DID AND its predicate is a catalog predicate AND, for
+ * `rdf:type`, its object is an allowed catalog class ({@link CATALOG_CLASSES}).
+ *
+ * Why the subject is threaded in rather than discovered from a marker quad: the
+ * previous implementation treated ANY subject bearing `rdf:type
+ * dkg:PrivateContextGraph` as a catalog subject. That marker is user-forgeable
+ * and `validatePublishRequest` does not reserve it, so a user could author an
+ * ordinary entity with `rdf:type dkg:PrivateContextGraph` + `dct:*` quads and
+ * have them (a) routed PLAINTEXT into the public `_catalog` (a leak) and (b)
+ * stripped from the encrypted payload. Binding the catalog subject to the
+ * CG-identity the publisher already knows closes that — a forged marker on a
+ * data entity now has a non-matching subject and stays on the encrypted path.
+ *
+ * Fail-safe and defense-in-depth: even on the genuine CG DID, a non-catalog
+ * predicate, or an arbitrary `rdf:type` whose object is not a catalog class,
+ * stays on the encrypted path. Order-preserving and total.
+ *
+ * @param quads          publish quads to partition.
+ * @param catalogSubject the canonical CG DID; pass
+ *   `contextGraphDataUri(contextGraphId)`. When empty/undefined, nothing is
+ *   treated as catalog (every quad goes to `otherQuads` — fail-safe).
+ */
+export function partitionCatalogQuads<Q extends CatalogQuadLike>(
+  quads: readonly Q[],
+  catalogSubject: string,
+): CatalogPartition<Q> {
+  const catalogQuads: Q[] = [];
+  const otherQuads: Q[] = [];
+  for (const q of quads) {
+    const isCatalog =
+      // Identity gate: ONLY the canonical CG DID is a catalog subject — never a
+      // forgeable type marker on a user-authored entity (round-3 SECURITY).
+      catalogSubject.length > 0 &&
+      q.subject === catalogSubject &&
+      CATALOG_PREDICATES.has(q.predicate) &&
+      // Object gate: an `rdf:type` is catalog only if it types the subject as an
+      // allowed catalog class; any other type assertion is private data (B2).
+      (q.predicate !== DKG_ONTOLOGY.RDF_TYPE || CATALOG_CLASSES.has(q.object));
+    if (isCatalog) {
+      catalogQuads.push(q);
+    } else {
+      otherQuads.push(q);
+    }
+  }
+  return { catalogQuads, otherQuads };
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -335,6 +335,18 @@ export function contextGraphSubGraphPrivateUri(contextGraphId: string, subGraphN
   return `did:dkg:context-graph:${contextGraphId}/${subGraphName}/_private`;
 }
 
+/**
+ * the public `_catalog` subgraph of a (private) CG: the
+ * bounded, plaintext, core-servable named graph holding the CG's DCAT catalog
+ * entry. `_`-prefixed, so it cannot collide with a user sub-graph name
+ * (`validateSubGraphName` reserves the prefix). This is the serving / open-serve
+ * boundary; the catalog quads are committed inside the CG's own VM merkle root
+ * (combined model), and the partition routing them here happens at publish time.
+ */
+export function contextGraphCatalogUri(contextGraphId: string): string {
+  return `did:dkg:context-graph:${contextGraphId}/_catalog`;
+}
+
 export function validateContextGraphId(id: string): { valid: boolean; reason?: string } {
   if (!id || id.length === 0) return { valid: false, reason: 'Context graph ID cannot be empty' };
   if (id.length > 256) return { valid: false, reason: 'Context graph ID exceeds 256 characters' };

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -41,6 +41,8 @@ const SCHEMA = 'https://schema.org/';
 const DKG  = 'https://dkg.network/ontology#';
 const ERC8004 = 'https://eips.ethereum.org/erc-8004#';
 const PROV = 'http://www.w3.org/ns/prov#';
+const DCT  = 'http://purl.org/dc/terms/';
+const DCAT = 'http://www.w3.org/ns/dcat#';
 
 function q(graph: string, s: string, p: string, o: string): GenesisQuad {
   return { subject: s, predicate: p, object: o, graph };
@@ -233,6 +235,33 @@ export const DKG_ONTOLOGY = {
   DKG_FACT_RESOLVER_VERSION: `${DKG}factResolverVersion`,
   DKG_FACT_RESOLUTION_MODE: `${DKG}factResolutionMode`,
   DKG_SCOPE_UAL: `${DKG}scopeUal`,
+  // verifiable public catalog entry for a private CG.
+  // The private CG's public face is modeled as a DCAT dataset record (the
+  // "_catalog" subgraph): a standards-compliant catalog entry any DCAT-aware
+  // tool can discover, dual-typed with the dkg: class for native consumers.
+  // Floor = type + identifier + accessRights only; opt-in tiers
+  // (domain/blinded-anchors/aggregates/samples) are added explicitly by the
+  // curator, never by default (the disclosure invariant).
+  DCAT_DATASET: `${DCAT}Dataset`,                        // floor rdf:type (primary, interop)
+  DCAT_DISTRIBUTION: `${DCAT}Distribution`,              // a representation of the dataset
+  DCAT_DATA_SERVICE: `${DCAT}DataService`,               // access/grant endpoint as a service
+  DCAT_CATALOG: `${DCAT}Catalog`,                        // the network-wide public discovery graph
+  DCAT_DISTRIBUTION_PRED: `${DCAT}distribution`,         // dataset -> distribution
+  DCAT_ACCESS_SERVICE: `${DCAT}accessService`,           // recommended: distribution/dataset -> DataService
+  DCAT_ENDPOINT_URL: `${DCAT}endpointURL`,               // DataService -> grant endpoint
+  DCAT_SERVES_DATASET: `${DCAT}servesDataset`,           // DataService -> dataset
+  DCAT_KEYWORD: `${DCAT}keyword`,                        // opt-in T1: keywords
+  DCAT_THEME: `${DCAT}theme`,                            // opt-in T1: coarse category
+  // Standard EU access-right value: "RESTRICTED" = available under conditions
+  // (members / grant), the precise fit for a curated CG.
+  ACCESS_RIGHT_RESTRICTED: 'http://publications.europa.eu/resource/authority/access-right/RESTRICTED',
+  DKG_PRIVATE_CONTEXT_GRAPH: `${DKG}PrivateContextGraph`, // floor rdf:type (dkg-native, dual-typed with dcat:Dataset)
+  DKG_COMMITTED_ROOT: `${DKG}committedRoot`,              // separate-KA model only: links facet KA to the CG's VM root (combined model omits it)
+  DKG_BLINDED_ANCHOR: `${DKG}blindedAnchor`,             // opt-in T2: HMAC(cgSecret, entityId) join key
+  DCT_IDENTIFIER: `${DCT}identifier`,                     // floor: the CG's UAL
+  DCT_ACCESS_RIGHTS: `${DCT}accessRights`,                // floor: -> ACCESS_RIGHT_RESTRICTED
+  DCT_PUBLISHER: `${DCT}publisher`,                       // recommended: controlling identity (MAY be per-CG pseudonym)
+  DCT_CONFORMS_TO: `${DCT}conformsTo`,                    // opt-in T1: ontology/domain
   DKG_VIEW: `${DKG}view`,
   DKG_SNAPSHOT_ID: `${DKG}snapshotId`,
   DKG_RESULT_KIND: `${DKG}resultKind`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './constants.js';
+export * from './catalog.js';
 export { parseDotenvValue } from './dotenv.js';
 export * from './memory-model.js';
 export * from './trust.js';

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4290,10 +4290,24 @@ export class DKGPublisher implements Publisher {
    */
   private async isContextGraphRegistered(contextGraphId: string): Promise<boolean> {
     const cgUri = contextGraphDataUri(contextGraphId);
+    // SECURITY (Codex #1171): registration's `<cgUri> a dkg:ContextGraph` triple is
+    // written ONLY into the system ONTOLOGY data graph (public CGs + every publish)
+    // or the CG's own `_meta` graph (curated CGs) — see createContextGraph `defGraph`
+    // (= isCurated ? cgMeta : ontology) and the publish ontology emitter. It is NEVER
+    // written into a user-authored data/sub-graph. The previous cross-graph
+    // `ASK { GRAPH ?g … }` matched ANY graph, so a publisher could author
+    // `<cgUri> a dkg:ContextGraph` in their own content graph (the rdf:type OBJECT is
+    // not a reserved IRI) and SPOOF registration — making reconstructSharedMemoryOwnership
+    // treat a sub-graph as a registered root and derive the wrong ownership key after
+    // restart. Scope the ASK to exactly the two authoritative graphs.
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const metaGraph = contextGraphMetaUri(contextGraphId);
     const registered = await this.store.query(
-      `ASK { GRAPH ?g {
-        <${assertSafeIri(cgUri)}> a <http://dkg.io/ontology/ContextGraph> .
-      } }`,
+      `ASK {
+        { GRAPH <${assertSafeIri(ontologyGraph)}> { <${assertSafeIri(cgUri)}> a <http://dkg.io/ontology/ContextGraph> . } }
+        UNION
+        { GRAPH <${assertSafeIri(metaGraph)}> { <${assertSafeIri(cgUri)}> a <http://dkg.io/ontology/ContextGraph> . } }
+      }`,
     );
     return registered.type === 'boolean' && registered.value;
   }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2028,6 +2028,21 @@ export class DKGPublisher implements Publisher {
     // without needing per-call flag plumbing. A future commit can drop
     // the LU-5 single-blob callback once chunked is the only path.
     const useChunkedInline = useEncryptedInline && typeof options.encryptInlineChunked === 'function';
+    // A curated publish (encryption enabled) must carry private payload beyond the
+    // public catalog entry. A catalog-only publish — every quad is a catalog entry
+    // on the context-graph's own DID, reachable because that DID namespace is not
+    // reserved — partitions to empty `otherQuads`, leaving `encryptableNquadsStr`
+    // empty. That would otherwise throw an opaque "rejects empty plaintext" deep in
+    // the chunked encryptor (sliceIntoCiphertextChunks). Reject early, with an
+    // actionable message: the catalog entry alone cannot satisfy the required
+    // ciphertext commitment. Public CGs never enter this branch (no encryptor).
+    if (useEncryptedInline && encryptableNquadsStr.length === 0) {
+      throw new Error(
+        `Curated publish for context graph "${contextGraphId}" has no private payload to encrypt — ` +
+        `every quad is a public catalog entry on the context-graph DID. A curated context graph must ` +
+        `publish private content; the catalog entry alone cannot satisfy the required ciphertext commitment.`,
+      );
+    }
     let stagingQuads: Uint8Array | undefined;
     let stagingByteSize = publicByteSize;
     let chunkedCommitment: {

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -7,6 +7,7 @@ import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-sto
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
+import { partitionCatalogQuads, contextGraphCatalogUri } from '@origintrail-official/dkg-core';
 import { RESERVED_SUBJECT_PREFIXES, findReservedSubjectPrefix, isReservedSubject } from './reserved-subjects.js';
 import { skolemize } from './skolemize.js';
 import {
@@ -60,6 +61,20 @@ export {
 };
 
 const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
+}
 
 /**
  * Minimal structural view of the OT-RFC-43 Option-1 KA-number allocator the
@@ -1927,6 +1942,53 @@ export class DKGPublisher implements Publisher {
       )
       .join('\n');
     const publicByteSize = BigInt(new TextEncoder().encode(nquadsStr).length);
+
+    // the public DCAT catalog entry rides in the merkle root
+    // (kcMerkleRoot, above, covers it) but MUST NOT be encrypted: feed only the
+    // non-catalog (private data) quads to the curated encryptor, so
+    // ciphertextChunksRoot commits the private payload only. No-op for public
+    // CGs and any private CG without a catalog entry (catalogQuads empty ⇒
+    // encryptableNquadsStr === nquadsStr).
+    // Identity-based partition: the ONLY catalog subject is this CG's canonical
+    // DID (round-3 SECURITY). A forged `rdf:type dkg:PrivateContextGraph` on a
+    // user entity no longer routes that entity into the plaintext `_catalog`.
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(allSkolemizedQuads, contextGraphDataUri(contextGraphId));
+    const encryptableNquadsStr = catalogQuads.length === 0
+      ? nquadsStr
+      : otherQuads
+          .map(
+            (q) =>
+              `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph}> .`,
+          )
+          .join('\n');
+    // Persist the catalog entry plaintext into the public `_catalog` graph so it
+    // survives the post-publish SWM clear and is queryable/servable (the data
+    // stays encrypted-only). Bounded named graph ⇒ the §7 facet open-serve can
+    // release exactly this and nothing gated.
+    //
+    // B3: this write MUST NOT happen until the publish actually persists. If we
+    // wrote it here (pre-ACK, pre-chain) a failed ACK collection or a reverted
+    // on-chain tx would still leave a public catalog entry exposing a CG whose
+    // verifiable memory never landed. So we only PREPARE the deferred writer
+    // here and invoke it from the exact branches that persist the main publish
+    // result: each intentional-local branch (via `finalizeIntentionalLocalPublish`)
+    // and the confirmed chain-success branch. The chain-failure catch path never
+    // calls it, so a failed publish leaves the `_catalog` graph untouched.
+    const persistCatalogEntry = async (): Promise<void> => {
+      if (catalogQuads.length === 0) return;
+      // Canonical location (shared with projection + open-serve): graph =
+      // contextGraphCatalogUri(contextGraphId) (`<source-cg>/_catalog`), subject =
+      // the context-graph DID. B4: CLEAR/REPLACE — purge any prior catalog
+      // entry for these subjects in this graph before inserting the refreshed
+      // one, so repeated publishes don't accumulate stale catalog triples.
+      const catalogGraph = contextGraphCatalogUri(contextGraphId);
+      const catalogSubjects = new Set(catalogQuads.map((q) => q.subject));
+      for (const subject of catalogSubjects) {
+        await this.store.deleteByPattern({ graph: catalogGraph, subject });
+      }
+      await this.store.insert(catalogQuads.map((q) => ({ ...q, graph: catalogGraph })));
+    };
+
     const merkleRootHex = ethers.hexlify(kcMerkleRoot);
     let publishOperationId = '';
     let ual = '';
@@ -1973,7 +2035,7 @@ export class DKGPublisher implements Publisher {
       ciphertextChunkCount: number;
     } | undefined;
     if (useChunkedInline) {
-      const plaintextBytes = new TextEncoder().encode(nquadsStr);
+      const plaintextBytes = new TextEncoder().encode(encryptableNquadsStr);
       ensurePublishOperationIdentity();
       // batchId = V10 KC merkleRoot. It remains the core-side
       // persistence/sampling key, while publishOperationId is the
@@ -1993,7 +2055,7 @@ export class DKGPublisher implements Publisher {
         ciphertextChunkCount: chunked.ciphertextChunkCount,
       };
     } else if (useEncryptedInline) {
-      const plaintextBytes = new TextEncoder().encode(nquadsStr);
+      const plaintextBytes = new TextEncoder().encode(encryptableNquadsStr);
       const ciphertext = await options.encryptInlinePayload!(plaintextBytes);
       stagingQuads = ciphertext instanceof Uint8Array ? ciphertext : new Uint8Array(ciphertext);
       // For curated CGs the publisher PAYS for ciphertext bytes (cores
@@ -2392,6 +2454,9 @@ export class DKGPublisher implements Publisher {
       this.log.info(ctx, `Storing ${normalizedQuads.length} triples in local store (${reasonLog})`);
       await this.store.insert(normalizedQuads);
       await this.store.insert(tentativeMeta);
+      // B3: only now that the local publish has persisted do we refresh the
+      // public catalog entry (CLEAR/REPLACE — see persistCatalogEntry).
+      await persistCatalogEntry();
     };
 
     // RC11 / PR3: extra intentional-local-only branch for publishes
@@ -2819,6 +2884,12 @@ export class DKGPublisher implements Publisher {
         // (`dkg:authoredBy` bnode + signature quads, spec §9.0.6) is no
         // longer written — zero code readers; the on-chain
         // `KnowledgeBatch.authorAddress` is canonical.
+
+        // B3: the on-chain publish has now confirmed and the verifiable-memory
+        // quads are committed — refresh the public catalog entry here, inside
+        // the success branch, so a failed ACK/chain publish never exposes one
+        // (CLEAR/REPLACE — see persistCatalogEntry).
+        await persistCatalogEntry();
 
         status = 'confirmed';
         onPhase?.('chain:submit', 'end');
@@ -3533,25 +3604,58 @@ export class DKGPublisher implements Publisher {
     const SWM_META_SUFFIX = '/_shared_memory_meta';
     const CG_PREFIX = 'did:dkg:context-graph:';
     try {
-      const contextGraphs = await this.graphManager.listContextGraphs();
+      const allContextGraphs = await listGraphsByPrefix(this.store, CG_PREFIX);
       let total = 0;
 
       // Build list of (ownershipKey, swmMetaGraphUri) pairs: root + sub-graph scoped
       const targets: Array<{ ownershipKey: string; swmMetaGraph: string }> = [];
-      const allGraphs = await this.store.listGraphs();
-      for (const cgId of contextGraphs) {
-        targets.push({ ownershipKey: cgId, swmMetaGraph: this.graphManager.sharedMemoryMetaUri(cgId) });
-
-        // Discover sub-graph SWM meta graphs: did:dkg:context-graph:{cgId}/{sgName}/_shared_memory_meta
-        const sgPrefix = `${CG_PREFIX}${cgId}/`;
-        for (const g of allGraphs) {
-          if (g.startsWith(sgPrefix) && g.endsWith(SWM_META_SUFFIX)) {
-            const middle = g.slice(sgPrefix.length, g.length - SWM_META_SUFFIX.length);
-            if (middle && !middle.includes('/')) {
-              targets.push({ ownershipKey: `${cgId}\0${middle}`, swmMetaGraph: g });
-            }
+      const targetKeys = new Set<string>();
+      const swmMetaGraphs = allContextGraphs
+        .filter((graph) => graph.endsWith(SWM_META_SUFFIX))
+        .map((graph) => ({
+          graph,
+          cgPath: graph.slice(CG_PREFIX.length, graph.length - SWM_META_SUFFIX.length),
+        }))
+        .filter(({ cgPath }) => cgPath.length > 0);
+      for (const { graph, cgPath } of swmMetaGraphs) {
+        // Derive the ownership key from EXPLICIT registration metadata, not a
+        // naive last-slash split. A wallet-scoped root CG id is slash-shaped
+        // (`<addr>/<name>`), so its root-level SWM-meta graph
+        // (`<addr>/<name>/_shared_memory_meta`) is BYTE-IDENTICAL to the
+        // sub-graph SWM-meta graph for root `<addr>`, sub `<name>`
+        // (`<addr>/<name>/_shared_memory_meta`). The last-slash split alone
+        // cannot tell them apart, and the previous code mis-keyed a slash-shaped
+        // root as `<addr>\0<name>` whenever a sub-graph named `<name>` happened
+        // to be registered under `<addr>` — splitting that root's ownership from
+        // the key the write path (`_shareImpl`, plain `contextGraphId`) used.
+        //
+        // Resolution order (must reproduce the write-side `ownershipKey`):
+        //   1. The FULL cgPath is itself a registered root CG → root SWM,
+        //      key = cgPath. Explicit root registration wins the collision; it
+        //      matches the wallet-scoped `<addr>/<name>` convention.
+        //   2. else last-slash split; the trailing segment is registered as a
+        //      sub-graph of the leading part → key = `<root>\0<sub>`.
+        //   3. else → root, key = cgPath.
+        // Identical to the prior behaviour on every non-colliding input
+        // (`42`→root, `42/tasks`→sub, sub-graphs under slash-shaped roots→sub);
+        // only the genuine collision now resolves toward the explicit root.
+        let ownershipKey = cgPath;
+        if (!(await this.isContextGraphRegistered(cgPath))) {
+          const slash = cgPath.lastIndexOf('/');
+          const rootId = slash > 0 ? cgPath.slice(0, slash) : '';
+          const subGraphName = slash > 0 ? cgPath.slice(slash + 1) : '';
+          const isRegisteredSubGraph =
+            rootId.length > 0 &&
+            subGraphName.length > 0 &&
+            !subGraphName.includes('/') &&
+            await this.isSubGraphRegistered(rootId, subGraphName);
+          if (isRegisteredSubGraph) {
+            ownershipKey = `${rootId}\0${subGraphName}`;
           }
         }
+        if (targetKeys.has(ownershipKey)) continue;
+        targetKeys.add(ownershipKey);
+        targets.push({ ownershipKey, swmMetaGraph: graph });
       }
 
       for (const { ownershipKey, swmMetaGraph } of targets) {
@@ -3772,9 +3876,9 @@ export class DKGPublisher implements Publisher {
 
     try {
       const peerToAddress = new Map<string, string | null>();
-      const allGraphs = await this.store.listGraphs();
+      const allGraphs = await listGraphsByPrefix(this.store, CG_PREFIX);
       // GH #748 Codex round 6 (user report): enumerate `_shared_memory_meta`
-      // graphs directly via `store.listGraphs()`. The earlier approach used
+      // graphs directly from the store's context-graph prefix. The earlier approach used
       // `graphManager.listContextGraphs()`, but that helper filters out CG
       // IDs containing a slash (storage/graph-manager.ts:104) to dedupe
       // sub-graph paths — which also excludes legitimate curated CGs of the
@@ -4157,6 +4261,29 @@ export class DKGPublisher implements Publisher {
   }
 
   /**
+   * Is `contextGraphId` declared as a ROOT context graph in local storage?
+   *
+   * Reads the explicit registration triple `<did:dkg:context-graph:<id>> a
+   * dkg:ContextGraph`, which `createContextGraph` writes into the CG's own
+   * `_meta` graph (curated/private CGs) or the ONTOLOGY data graph (public CGs)
+   * — so the ASK is intentionally cross-graph (`GRAPH ?g`) to find it in either
+   * place. The subject-URI shape (`did:dkg:context-graph:<id>`) is identical for
+   * a root and a sub-graph, so the `dkg:ContextGraph` rdf:type is the ONLY thing
+   * that distinguishes a registered root from a registered sub-graph. Used by
+   * `reconstructSharedMemoryOwnership` to disambiguate a slash-shaped root CG id
+   * (`<addr>/<name>`) from a `<root>/<sub-graph>` SWM-meta graph.
+   */
+  private async isContextGraphRegistered(contextGraphId: string): Promise<boolean> {
+    const cgUri = contextGraphDataUri(contextGraphId);
+    const registered = await this.store.query(
+      `ASK { GRAPH ?g {
+        <${assertSafeIri(cgUri)}> a <http://dkg.io/ontology/ContextGraph> .
+      } }`,
+    );
+    return registered.type === 'boolean' && registered.value;
+  }
+
+  /**
    * Throws if `subGraphName` is provided but not registered in the CG's `_meta` graph.
    * Mirrors the registration check in `publish()` for mutation paths that would
    * otherwise create new orphaned sub-graph state.
@@ -4223,8 +4350,7 @@ export class DKGPublisher implements Publisher {
    * graph is intentionally excluded — it is not under the `/` prefix).
    */
   private async swmGraphsUnder(bucketGraph: string): Promise<string[]> {
-    const all = await this.store.listGraphs();
-    return all.filter((g) => g === bucketGraph || g.startsWith(`${bucketGraph}/`));
+    return listGraphFamily(this.store, bucketGraph);
   }
 
   async assertionCreate(

--- a/packages/publisher/src/publish-handler.ts
+++ b/packages/publisher/src/publish-handler.ts
@@ -189,7 +189,7 @@ export class PublishHandler {
       const swmGraph = this.graphManager.sharedMemoryUri(pending.contextGraphId);
       const swmMetaGraph = this.graphManager.sharedMemoryMetaUri(pending.contextGraphId);
       // Uniform layout: span the per-KA …/_shared_memory/{addr}/{number} graphs + the bucket.
-      const swmGraphs = (await this.store.listGraphs()).filter(g => g === swmGraph || g.startsWith(`${swmGraph}/`));
+      const swmGraphs = await listGraphFamily(this.store, swmGraph);
       const rootEntities = new Set(pending.dataQuads.map(q => q.subject));
       for (const rootEntity of rootEntities) {
         for (const g of swmGraphs) {
@@ -573,6 +573,20 @@ export class PublishHandler {
       rejectionReason: reason,
     });
   }
+}
+
+async function listGraphFamily(store: TripleStore, rootGraph: string): Promise<string[]> {
+  const graphs = await listGraphsByPrefix(store, `${rootGraph}/`);
+  if (await store.hasGraph(rootGraph)) {
+    graphs.unshift(rootGraph);
+  }
+  return graphs;
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }
 
 // ── Helpers ──

--- a/packages/publisher/src/workspace-agent-recipients.ts
+++ b/packages/publisher/src/workspace-agent-recipients.ts
@@ -74,6 +74,7 @@ async function getWorkspaceAccessMetadata(
   const cgData = contextGraphDataUri(contextGraphId);
   const cgMeta = contextGraphMetaUri(contextGraphId);
   const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  const agentsGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
   const swmGraph = contextGraphSharedMemoryUri(contextGraphId);
   // Flattened UNION: Blazegraph rejects nested UnionNode inside a
   // GRAPH block that is itself a UNION branch. Semantically identical
@@ -90,6 +91,14 @@ async function getWorkspaceAccessMetadata(
         GRAPH <${cgMeta}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       } UNION {
         GRAPH <${ontologyGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked }
+      } UNION {
+        GRAPH <${agentsGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       } UNION {
         GRAPH <${swmGraph}> { <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy }
       }

--- a/packages/publisher/src/workspace-handler.ts
+++ b/packages/publisher/src/workspace-handler.ts
@@ -47,6 +47,14 @@ export type WorkspaceSenderKeyDecryptor = (
   ctx: OperationContext,
 ) => Promise<Uint8Array>;
 
+export interface ContextGraphMetaOracleRecord {
+  allowedPeers?: readonly string[];
+  allowedAgents?: readonly string[];
+  participantAgents?: readonly string[];
+  revokedAgents?: readonly string[];
+  accessPolicy?: string;
+}
+
 /**
  * Outcome of one `SharedMemoryHandler.handle()` invocation. Added
  * in rc.9 PR-C (codex R3) so the new substrate fan-out receiver
@@ -170,6 +178,10 @@ export class SharedMemoryHandler {
   private readonly sharedMemoryOwnedEntities: Map<string, Map<string, string>> = new Map();
   private readonly writeLocks: Map<string, Promise<void>>;
   private readonly localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+  private readonly contextGraphMetaOracle?: (
+    contextGraphId: string,
+  ) => Promise<ContextGraphMetaOracleRecord | null>;
+  private readonly markContextGraphMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   /**
    * OT-RFC-38 / LU-6 Phase B — chain-backed fallback for the agent
    * allowlist read. Returns the participant-agent EOA set for a
@@ -285,6 +297,10 @@ export class SharedMemoryHandler {
       sharedMemoryOwnedEntities?: Map<string, Map<string, string>>;
       writeLocks?: Map<string, Promise<void>>;
       localAgentAddresses?: () => readonly string[] | Promise<readonly string[]>;
+      contextGraphMetaOracle?: (
+        contextGraphId: string,
+      ) => Promise<ContextGraphMetaOracleRecord | null>;
+      markContextGraphMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
       /**
        * OT-RFC-38 / LU-6 Phase B chain-backed agent-allowlist
        * fallback. See {@link SharedMemoryHandler#chainAgentGateOracle}.
@@ -340,6 +356,8 @@ export class SharedMemoryHandler {
     }
     this.writeLocks = options?.writeLocks ?? new Map();
     this.localAgentAddresses = options?.localAgentAddresses;
+    this.contextGraphMetaOracle = options?.contextGraphMetaOracle;
+    this.markContextGraphMetaDirtyFromQuads = options?.markContextGraphMetaDirtyFromQuads;
     this.chainAgentGateOracle = options?.chainAgentGateOracle;
     this.beaconCuratorOracle = options?.beaconCuratorOracle;
     this.workspaceRecipientPrivateKeys = options?.workspaceRecipientPrivateKeys;
@@ -966,6 +984,7 @@ export class SharedMemoryHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.markContextGraphMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}" from SWM`);
         }
       }
@@ -1448,10 +1467,42 @@ export class SharedMemoryHandler {
   }
 
   /**
+   * Read a single agent-list predicate (allowed / participant / revoked)
+   * for a context graph from the local `_meta` graph. Used as the per-field
+   * store fallback when the (partial) projection did not carry that field.
+   */
+  private async queryMetaAgents(contextGraphId: string, predicate: string): Promise<string[]> {
+    const cgMeta = contextGraphMetaUri(contextGraphId);
+    const cgData = contextGraphDataUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?agent WHERE { GRAPH <${cgMeta}> { <${cgData}> <${predicate}> ?agent } }`,
+    );
+    if (result.type !== 'bindings') return [];
+    return result.bindings
+      .map(row => row['agent'])
+      .filter((v): v is string => typeof v === 'string')
+      .map(stripRdfLiteral);
+  }
+
+  /**
    * Returns the peer allowlist for a context graph, or null if no allowlist
    * is set (open CG — all peers allowed).
    */
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    // The oracle record is intentionally PARTIAL (OT-RFC-49 public
+    // projection): a populated record does NOT imply every gate field
+    // was projected. Short-circuit on the projection ONLY for the
+    // `allowedPeers` field, and ONLY when that field was actually
+    // projected (`!== undefined`). Treating the whole record as a
+    // complete snapshot here would let a projection that carried only
+    // `accessPolicy`/agent fields skip the peer allowlist entirely
+    // (returns null ⇒ "open CG — all peers allowed").
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected?.allowedPeers !== undefined) {
+      const peers = [...new Set(projected.allowedPeers.filter((v): v is string => typeof v === 'string'))];
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaUri(contextGraphId);
     const cgData = contextGraphDataUri(contextGraphId);
     const result = await this.store.query(
@@ -1472,23 +1523,62 @@ export class SharedMemoryHandler {
    * DKG_PARTICIPANT_AGENT metadata.
    */
   private async getContextGraphAgentGateAddresses(contextGraphId: string): Promise<string[] | null> {
-    const cgMeta = contextGraphMetaUri(contextGraphId);
-    const cgData = contextGraphDataUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?agent WHERE { GRAPH <${cgMeta}> {
-        { <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-        UNION
-        { <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-      } }`,
+    // The oracle record is intentionally PARTIAL (OT-RFC-49 public
+    // projection): each gate field is resolved INDEPENDENTLY from the
+    // projection-if-present-else-store, so a projection that carried
+    // only `revokedAgents` (or only `accessPolicy`) cannot silently
+    // discard revocations or skip the allowlist. The allowlist
+    // (allowed + participant) and the revoked tombstone set are
+    // resolved separately and then subtracted — short-circuiting on a
+    // whole truthy record here would let a partial projection fall
+    // back to a *stale store allowlist with no revocation applied*.
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+
+    // Revoked tombstones: prefer the projection when it carried the
+    // field, otherwise read `_meta`. Applied to whichever source the
+    // allowlist comes from, so a projected revocation kicks a store-
+    // resolved member and vice versa.
+    const revoked = new Set<string>(
+      (projected?.revokedAgents !== undefined
+        ? projected.revokedAgents
+        : await this.queryMetaAgents(contextGraphId, DKG_ONTOLOGY.DKG_REVOKED_AGENT)
+      )
+        .filter((v): v is string => typeof v === 'string' && ethers.isAddress(v))
+        .map((v) => v.toLowerCase()),
     );
-    if (result.type === 'bindings' && result.bindings.length > 0) {
-      const agents = result.bindings
-        .map(row => row['agent'])
-        .filter((v): v is string => typeof v === 'string')
-        .map(stripRdfLiteral)
-        .filter((v) => ethers.isAddress(v))
+
+    // Resolve EACH allowlist field (allowed, participant) INDEPENDENTLY:
+    // projection-if-that-specific-field-was-projected, else `_meta` store
+    // fallback for that one field. A partial projection that carried only
+    // `allowedAgents` must NOT suppress the store fallback for
+    // `participantAgents` (and vice versa) — otherwise the gate would be
+    // built from a half-empty allowlist and silently drop legitimate
+    // writers whose membership lives only in the field the oracle omitted.
+    const allowedResolved = projected?.allowedAgents !== undefined
+      ? projected.allowedAgents
+      : await this.queryMetaAgents(contextGraphId, DKG_ONTOLOGY.DKG_ALLOWED_AGENT);
+    const participantResolved = projected?.participantAgents !== undefined
+      ? projected.participantAgents
+      : await this.queryMetaAgents(contextGraphId, DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT);
+
+    // The CG is agent-gated iff EITHER field resolved to any member (from
+    // projection or store). `null` ⇒ not curated (caller falls through);
+    // an empty-but-non-null list ⇒ curated-then-fully-revoked (rejects all).
+    const allowlist: string[] | null =
+      allowedResolved.length > 0 || participantResolved.length > 0
+        ? [...allowedResolved, ...participantResolved]
+        : null;
+
+    if (allowlist !== null) {
+      const agents = allowlist
+        .filter((v): v is string => typeof v === 'string' && ethers.isAddress(v) && !revoked.has(v.toLowerCase()))
         .map((v) => ethers.getAddress(v));
-      return [...new Set(agents)];
+      const unique = [...new Set(agents)];
+      if (unique.length > 0) return unique;
+      // The CG IS agent-gated (an allowlist field was present) but every
+      // member is revoked — return an empty gate (rejects all writers),
+      // NOT null (which the caller reads as "not curated → fall through").
+      if (allowlist.length > 0) return [];
     }
 
     // OT-RFC-38 / LU-6 Phase B: chain-backed fallback when the local
@@ -1550,6 +1640,15 @@ export class SharedMemoryHandler {
   private async contextGraphHasPrivateAccessPolicy(contextGraphId: string): Promise<boolean> {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return false;
+    }
+
+    // Field-specific short-circuit: only when `accessPolicy` was actually
+    // projected (`!== undefined`). The oracle record is PARTIAL, so a
+    // record carrying only agent/peer fields must NOT be read as
+    // "accessPolicy absent ⇒ not private"; fall back to the store.
+    const projected = await this.contextGraphMetaOracle?.(contextGraphId);
+    if (projected?.accessPolicy !== undefined) {
+      return projected.accessPolicy.trim().toLowerCase() === 'private';
     }
 
     const ontologyGraph = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);

--- a/packages/publisher/test/context-graph-registration-scope.test.ts
+++ b/packages/publisher/test/context-graph-registration-scope.test.ts
@@ -1,0 +1,81 @@
+/**
+ * SECURITY (Codex #1171) — `isContextGraphRegistered` must only trust the
+ * AUTHORITATIVE graphs for the `<cgUri> a dkg:ContextGraph` registration triple:
+ * the system ONTOLOGY data graph (public CGs + every publish) or the CG's own
+ * `_meta` graph (curated CGs). The previous cross-graph `ASK { GRAPH ?g … }`
+ * matched ANY graph, so a publisher could author that triple in their own content
+ * graph (the rdf:type OBJECT is not a reserved IRI) and SPOOF registration —
+ * mis-deriving the ownership key in `reconstructSharedMemoryOwnership` after
+ * restart. These tests pin: legit registration in either authoritative graph is
+ * detected; a type triple authored in any other (user) graph is NOT.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DKGPublisher } from '../src/dkg-publisher.js';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  TypedEventBus,
+  generateEd25519Keypair,
+  contextGraphDataUri,
+  contextGraphDataGraphUri,
+  contextGraphMetaUri,
+  SYSTEM_CONTEXT_GRAPHS,
+} from '@origintrail-official/dkg-core';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const CG_TYPE = 'http://dkg.io/ontology/ContextGraph';
+
+describe('isContextGraphRegistered — authoritative-graph scoping (Codex #1171)', () => {
+  let store: OxigraphStore;
+  let isRegistered: (cgId: string) => Promise<boolean>;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    const publisher = new DKGPublisher({
+      store,
+      // isContextGraphRegistered only reads `this.store`; a no-op chain stub is fine.
+      chain: { chainId: 'none' } as unknown as ChainAdapter,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+    });
+    isRegistered = (cgId) =>
+      (publisher as unknown as { isContextGraphRegistered(id: string): Promise<boolean> })
+        .isContextGraphRegistered(cgId);
+  });
+
+  // Write the registration type triple for `cgId` into `graph`.
+  const writeTypeTriple = (cgId: string, graph: string) =>
+    store.insert([{ subject: contextGraphDataUri(cgId), predicate: RDF_TYPE, object: CG_TYPE, graph }]);
+
+  it('unregistered CG ⇒ false', async () => {
+    expect(await isRegistered('0xabc/never-registered')).toBe(false);
+  });
+
+  it('registered in the system ONTOLOGY data graph (public + publish path) ⇒ true', async () => {
+    const cg = '0xabc/public-cg';
+    await writeTypeTriple(cg, contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY));
+    expect(await isRegistered(cg)).toBe(true);
+  });
+
+  it('registered in the CG `_meta` graph (curated create path) ⇒ true', async () => {
+    const cg = '0xabc/curated-cg';
+    await writeTypeTriple(cg, contextGraphMetaUri(cg));
+    expect(await isRegistered(cg)).toBe(true);
+  });
+
+  it('SPOOF: type triple authored in another CG\'s content graph ⇒ false', async () => {
+    const victim = '0xvictim/cg';
+    // an attacker publishes content into THEIR CG and authors the victim's type
+    // triple there — a user data graph, not the authoritative ontology/_meta graph.
+    await writeTypeTriple(victim, contextGraphDataGraphUri('0xattacker/cg'));
+    expect(await isRegistered(victim)).toBe(false);
+  });
+
+  it('SPOOF: type triple authored in the victim CG\'s own data graph ⇒ false', async () => {
+    const victim = '0xvictim2/cg';
+    // the CG's own data graph (named by its DID) carries user-authored content; a
+    // type triple planted there must NOT count as registration.
+    await writeTypeTriple(victim, contextGraphDataUri(victim));
+    expect(await isRegistered(victim)).toBe(false);
+  });
+});

--- a/packages/publisher/test/workspace-agent-recipients.test.ts
+++ b/packages/publisher/test/workspace-agent-recipients.test.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import {
   DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
   WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519,
   computeWorkspaceAgentEncryptionKeyProofPayload,
   computeWorkspaceAgentEncryptionKeyRevocationPayload,
@@ -17,6 +18,7 @@ import { resolveWorkspaceAgentRecipients } from '../src/index.js';
 const CONTEXT_GRAPH_ID = 'workspace-agent-recipient-resolution';
 const DATA_GRAPH = contextGraphDataUri(CONTEXT_GRAPH_ID);
 const META_GRAPH = contextGraphMetaUri(CONTEXT_GRAPH_ID);
+const AGENTS_GRAPH = contextGraphDataUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
 const DKG = 'https://dkg.network/ontology#';
 const DKG_PUBLIC_ENCRYPTION_KEY = `${DKG}publicEncryptionKey`;
 const DKG_ENCRYPTION_KEY_ALGORITHM = `${DKG}encryptionKeyAlgorithm`;
@@ -181,6 +183,32 @@ describe('resolveWorkspaceAgentRecipients', () => {
     expect(resolution.recipients).toHaveLength(1);
     expect(resolution.recipients[0]?.recipientId).toBe(agentUri(wallet.address));
     expect(resolution.recipients[0]?.encryptionKeyAlgorithm).toBe(WORKSPACE_AGENT_ENCRYPTION_KEY_ALGORITHM_X25519);
+  });
+
+  it('resolves AGENTS-graph private declarations through the sender-key recipient path', async () => {
+    const store = new OxigraphStore();
+    const wallet = ethers.Wallet.createRandom();
+    await store.insert([
+      {
+        subject: DATA_GRAPH,
+        predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+        object: '"private"',
+        graph: AGENTS_GRAPH,
+      },
+      {
+        subject: DATA_GRAPH,
+        predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+        object: `"${wallet.address}"`,
+        graph: AGENTS_GRAPH,
+      },
+    ]);
+    await insertAgentEncryptionKey(store, wallet);
+
+    const resolution = await resolveWorkspaceAgentRecipients(store, { contextGraphId: CONTEXT_GRAPH_ID });
+
+    expect(resolution.requiresEncryption).toBe(true);
+    expect(resolution.recipients).toHaveLength(1);
+    expect(resolution.recipients[0]?.agentAddress).toBe(ethers.getAddress(wallet.address));
   });
 
   it('preserves peer-only non-private graphs as legacy plaintext-compatible SWM', async () => {

--- a/packages/publisher/test/workspace-handler-agent-gate.test.ts
+++ b/packages/publisher/test/workspace-handler-agent-gate.test.ts
@@ -205,6 +205,65 @@ describe('SharedMemoryHandler agent-gated gossip', () => {
     await expectStoredName('Private Agent Signed');
   });
 
+  it('rejects signed SWM gossip when the projection oracle tombstones the agent', async () => {
+    const allowed = ethers.Wallet.createRandom();
+    const recipientKey = recipientKeyFor(allowed.address);
+    let recipientLookups = 0;
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [allowed.address],
+      workspaceRecipientPrivateKeys: () => {
+        recipientLookups += 1;
+        return [recipientKey];
+      },
+      contextGraphMetaOracle: async () => ({
+        accessPolicy: 'private',
+        allowedAgents: [allowed.address],
+        revokedAgents: [allowed.address],
+      }),
+    });
+    await insertAgentGate(DKG_ONTOLOGY.DKG_ALLOWED_AGENT, allowed.address);
+
+    const raw = workspaceMessage('Projection Revoked', 'ws-agent-gate-projection-revoked');
+    const encrypted = await encryptWorkspaceMessage(allowed.address, raw, recipientKey);
+    await handler.handle(await signWorkspaceMessage(allowed, encrypted), PEER_ID);
+
+    await expectWorkspaceEmpty();
+    expect(recipientLookups).toBe(0);
+  });
+
+  it('accepts a store-only participant when the partial projection carried allowedAgents but omitted participantAgents', async () => {
+    // OT-RFC-49 partial-projection regression (round-3): the oracle
+    // record is intentionally partial — here it projected `allowedAgents`
+    // (a DIFFERENT, irrelevant agent) but OMITTED `participantAgents`. The
+    // legitimate writer is a participant whose membership lives ONLY in the
+    // local `_meta` store. Each allowlist field must resolve INDEPENDENTLY
+    // (projection-if-present-else-store), so a projected `allowedAgents`
+    // must NOT suppress the store fallback for `participantAgents`. Before
+    // the fix the gate was built from the projected arrays alone, the
+    // participant fell back to `[]`, and this legitimate writer was dropped.
+    const otherAllowed = ethers.Wallet.createRandom();
+    const participant = ethers.Wallet.createRandom();
+    const recipientKey = recipientKeyFor(participant.address);
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      localAgentAddresses: () => [participant.address],
+      workspaceRecipientPrivateKeys: () => [recipientKey],
+      contextGraphMetaOracle: async () => ({
+        accessPolicy: 'private',
+        allowedAgents: [otherAllowed.address],
+        // participantAgents intentionally omitted (partial record)
+      }),
+    });
+    await insertAgentGate(DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT, participant.address);
+
+    const raw = workspaceMessage('Store-Only Participant', 'ws-agent-gate-store-only-participant');
+    const encrypted = await encryptWorkspaceMessage(participant.address, raw, recipientKey);
+    await handler.handle(await signWorkspaceMessage(participant, encrypted), PEER_ID);
+
+    await expectStoredName('Store-Only Participant');
+  });
+
   it.each([
     ['DKG_ALLOWED_AGENT', DKG_ONTOLOGY.DKG_ALLOWED_AGENT],
     ['DKG_PARTICIPANT_AGENT', DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT],

--- a/packages/publisher/test/workspace.test.ts
+++ b/packages/publisher/test/workspace.test.ts
@@ -585,6 +585,107 @@ describe('Workspace: ownership persistence and reconstruction', () => {
     expect(freshOwned.get(CONTEXT_GRAPH)?.get(entity2)).toBe('peerB');
   });
 
+  it('reconstructs ownership for slash-shaped context graph ids from SWM meta graph names', async () => {
+    const curatedContextGraph = `${CONTEXT_GRAPH}/curated`;
+    const curatedEntity = 'urn:test:entity:curated';
+    const swmMetaGraph = `did:dkg:context-graph:${curatedContextGraph}/_shared_memory_meta`;
+    const op = 'urn:test:op:curated';
+    await store.insert([
+      q('urn:test:root-marker', 'http://schema.org/name', '"Root"', WORKSPACE_META_GRAPH),
+      q(curatedEntity, 'http://dkg.io/ontology/workspaceOwner', '"peerCurated"', swmMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', curatedEntity, swmMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerCurated"', swmMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(curatedContextGraph)?.get(curatedEntity)).toBe('peerCurated');
+  });
+
+  it('reconstructs registered sub-graph ownership under the sub-graph key', async () => {
+    const subGraphName = 'registered-sg';
+    const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const subGraphMetaGraph = `${subGraphUri}/_shared_memory_meta`;
+    const entity = 'urn:test:entity:registered-subgraph';
+    const op = 'urn:test:op:registered-subgraph';
+    await store.insert([
+      q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://dkg.io/ontology/SubGraph', `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(subGraphUri, 'http://dkg.io/ontology/createdBy', '"tester"', `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`),
+      q(entity, 'http://dkg.io/ontology/workspaceOwner', '"peerSubGraph"', subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', entity, subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerSubGraph"', subGraphMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(`${CONTEXT_GRAPH}\0${subGraphName}`)?.get(entity)).toBe('peerSubGraph');
+  });
+
+  it('reconstructs registered sub-graph ownership under slash-shaped context graph ids', async () => {
+    const slashContextGraph = `${CONTEXT_GRAPH}/curated`;
+    const subGraphName = 'registered-sg';
+    const subGraphUri = `did:dkg:context-graph:${slashContextGraph}/${subGraphName}`;
+    const subGraphMetaGraph = `${subGraphUri}/_shared_memory_meta`;
+    const entity = 'urn:test:entity:slash-registered-subgraph';
+    const op = 'urn:test:op:slash-registered-subgraph';
+    await store.insert([
+      q(subGraphUri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://dkg.io/ontology/SubGraph', `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(subGraphUri, 'http://schema.org/name', `"${subGraphName}"`, `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(subGraphUri, 'http://dkg.io/ontology/createdBy', '"tester"', `did:dkg:context-graph:${slashContextGraph}/_meta`),
+      q(entity, 'http://dkg.io/ontology/workspaceOwner', '"peerSlashSubGraph"', subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/rootEntity', entity, subGraphMetaGraph),
+      q(op, 'http://dkg.io/ontology/publisherPeerId', '"peerSlashSubGraph"', subGraphMetaGraph),
+    ]);
+
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const keypair = await generateEd25519Keypair();
+    const freshOwned = new Map<string, Map<string, string>>();
+    const freshPublisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store,
+      chain,
+      eventBus: new TypedEventBus(),
+      keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+      sharedMemoryOwnedEntities: freshOwned,
+    });
+
+    const count = await freshPublisher.reconstructWorkspaceOwnership();
+    expect(count).toBe(1);
+    expect(freshOwned.get(`${slashContextGraph}\0${subGraphName}`)?.get(entity)).toBe('peerSlashSubGraph');
+    expect(freshOwned.get(`${slashContextGraph}/${subGraphName}`)?.get(entity)).toBeUndefined();
+  });
+
   it('clears ownership quads on publishFromSharedMemory with clearSharedMemoryAfter', async () => {
     const quads = [q(ENTITY, 'http://schema.org/name', '"Enshrine"')];
     await publisher.share(CONTEXT_GRAPH, quads, { publisherPeerId: 'peer1' });
@@ -661,6 +762,39 @@ describe('SharedMemoryHandler', () => {
       expect(result.bindings[0]['o']).toBe('"Handler Test"');
     }
     expect(workspaceOwned.get(CONTEXT_GRAPH)?.has(ENTITY)).toBe(true);
+  });
+
+  it('notifies context-graph meta invalidation after SWM sub-graph auto-registration', async () => {
+    const dirtyQuads: Quad[] = [];
+    handler = new SharedMemoryHandler(store, new TypedEventBus(), {
+      sharedMemoryOwnedEntities: workspaceOwned,
+      markContextGraphMetaDirtyFromQuads: (quads) => { dirtyQuads.push(...quads); },
+    });
+    const subGraphName = 'tasks';
+    const subGraphGraph = `${DATA_GRAPH}/${subGraphName}`;
+    const nquads = `<${ENTITY}> <http://schema.org/name> "SubGraph Handler Test" <${DATA_GRAPH}> .`;
+    const msg = encodeWorkspacePublishRequest({
+      contextGraphId: CONTEXT_GRAPH,
+      subGraphName,
+      nquads: new TextEncoder().encode(nquads),
+      manifest: [{ rootEntity: ENTITY, privateTripleCount: 0 }],
+      publisherPeerId: '12D3KooWPeer',
+      shareOperationId: 'ws-handler-subgraph-dirty',
+      timestampMs: Date.now(),
+    });
+
+    await handler.handle(msg, '12D3KooWPeer');
+
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphGraph,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: `${DATA_GRAPH}/_meta`,
+        }),
+      ]),
+    );
   });
 
   it('rejects raw workspace gossip when the context graph is agent-gated', async () => {


### PR DESCRIPTION
Part **2/4** · base: `feat/storage-graph-set-index`.

The public catalog data model + publish-time partition for private context graphs.

- **`core`** — the DCAT dataset-record model for a private CG's public catalog entry (`contextGraphCatalogUri`, genesis, constants). Only allowed catalog classes are publicized — an arbitrary `rdf:type` on the catalog subject stays private.
- **`publisher`** — partitions the public catalog out of the private ciphertext; writes it on the **confirmed** publish path (a failed publish exposes nothing) and **replaces** (not appends) on re-publish so stale metadata can't accumulate. Ownership-key derivation is registration-based (no ambiguous last-slash split).

publisher tests green. Please do not merge before review / out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Depends on #1170** — please merge that first.

**Depends on #1170** — please merge that first.
