### PR TITLE
feat(agent): public/meta context-graph projection + catalog open-serve

### DIFF
--- a/packages/agent/src/context-graph-meta-projection.ts
+++ b/packages/agent/src/context-graph-meta-projection.ts
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DKG_ONTOLOGY,
+  SYSTEM_CONTEXT_GRAPHS,
+  assertSafeIri,
+  contextGraphCatalogUri,
+  contextGraphDataGraphUri,
+  contextGraphDataUri,
+  contextGraphMetaGraphUri,
+} from '@origintrail-official/dkg-core';
+import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
+import { strip, stripLiteral } from './dkg-agent-utils.js';
+
+export interface ContextGraphSubGraphMeta {
+  uri: string;
+  name: string;
+  createdBy: string;
+  createdAt?: string;
+  description?: string;
+}
+
+export interface ContextGraphMetaRecord {
+  id: string;
+  uri: string;
+  declared: boolean;
+  isSystem: boolean;
+  name?: string;
+  description?: string;
+  creator?: string;
+  creators: string[];
+  curator?: string;
+  curators: string[];
+  accessPolicy?: string;
+  createdAt?: string;
+  allowedPeers: string[];
+  allowedAgents: string[];
+  participantAgents: string[];
+  participantIdentityIds: string[];
+  revokedAgents: string[];
+  onChainId?: string;
+  subGraphs: ContextGraphSubGraphMeta[];
+  hasAgentGate: boolean;
+  hasPeerGate: boolean;
+  hasLegacyParticipantGate: boolean;
+}
+
+interface ProjectionEntry {
+  value?: ContextGraphMetaRecord;
+  inflight?: Promise<ContextGraphMetaRecord>;
+  dirty: boolean;
+  invalidationVersion: number;
+}
+
+// Source precedence for the scalar "primary" fields (name/description/creator/
+// curator/createdAt/onChainId). A CG's own authoritative graphs override the
+// shared ONTOLOGY graph: a stale value written into ONTOLOGY must not win over a
+// later, authoritative `_meta`/AGENTS row. Higher rank wins; within the same
+// source the first row written stays (matching the previous `??=` behaviour).
+// The `_catalog` graph is the public, possibly peer-fetched face and never sets
+// these scalars, so its rank only matters as a floor below the authoritative
+// graphs.
+const SourceRank = {
+  Ontology: 0,
+  Catalog: 1,
+  Agents: 2,
+  Meta: 3,
+} as const;
+type SourceRank = (typeof SourceRank)[keyof typeof SourceRank];
+
+// Tracks, per scalar field, the rank of the source that last set it, so a
+// higher-precedence source can override and an equal/lower one cannot.
+type PrecedenceTracker = Partial<Record<'name' | 'description' | 'creator' | 'curator' | 'createdAt' | 'onChainId', SourceRank>>;
+
+const DKG_NS = 'https://dkg.network/ontology#';
+const LEGACY_DKG_NS = 'http://dkg.io/ontology/';
+const LEGACY_SCHEMA_NS = 'http://schema.org/';
+const CONTEXT_GRAPH_PREFIX = 'did:dkg:context-graph:';
+
+const SUB_GRAPH_TYPE_URIS = new Set([
+  `${DKG_NS}SubGraph`,
+  `${LEGACY_DKG_NS}SubGraph`,
+]);
+
+const DIRECT_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  DKG_ONTOLOGY.DKG_CREATOR,
+  DKG_ONTOLOGY.DKG_CURATOR,
+  DKG_ONTOLOGY.DKG_CREATED_AT,
+  DKG_ONTOLOGY.DKG_ACCESS_POLICY,
+  DKG_ONTOLOGY.DKG_ALLOWED_PEER,
+  DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT,
+  DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID,
+  DKG_ONTOLOGY.DKG_REVOKED_AGENT,
+  DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
+  DKG_ONTOLOGY.DKG_PUBLISH_POLICY,
+  DKG_ONTOLOGY.DKG_PUBLISH_AUTHORITY_ACCOUNT_ID,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+  `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`,
+]);
+
+// Predicates carried by the public `_catalog` entry (OT-RFC-49 §5.9) that the
+// read projection maps onto the record. The catalog subject is the CG DID
+// (`contextGraphDataUri(id)`), the same subject the `_meta`/ontology/agents
+// facts use, so the catalog graph is loaded by the same `loadContextGraphFacts`
+// path. Only the disclosure-floor predicates that have an authz-free home in the
+// record are mapped: `rdf:type dkg:PrivateContextGraph` (existence + private
+// class) and `dct:accessRights` (RESTRICTED ⇒ private). Recommended/opt-in
+// predicates (`dct:publisher`, `dcat:accessService`, `dct:conformsTo`,
+// `dkg:blindedAnchor`) are intentionally NOT mapped: a `_catalog` graph can be
+// remote-fetched from an untrusted peer, so they must never feed the
+// authorization-bearing creator/curator/allowlist fields.
+const CATALOG_META_PREDICATES = new Set<string>([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.DCT_ACCESS_RIGHTS,
+]);
+
+const SUB_GRAPH_META_PREDICATES = new Set([
+  DKG_ONTOLOGY.RDF_TYPE,
+  DKG_ONTOLOGY.SCHEMA_NAME,
+  `${LEGACY_SCHEMA_NS}name`,
+  DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+  `${LEGACY_SCHEMA_NS}description`,
+  `${DKG_NS}parentContextGraph`,
+  `${LEGACY_DKG_NS}parentContextGraph`,
+  `${DKG_NS}createdBy`,
+  `${LEGACY_DKG_NS}createdBy`,
+  `${DKG_NS}createdAt`,
+  `${LEGACY_DKG_NS}createdAt`,
+  `${DKG_NS}authorizedWriter`,
+  `${LEGACY_DKG_NS}authorizedWriter`,
+]);
+
+export class ContextGraphMetaProjection {
+  private readonly entries = new Map<string, ProjectionEntry>();
+
+  constructor(private readonly store: TripleStore) {}
+
+  async get(contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    const existing = this.entries.get(contextGraphId);
+    if (existing?.value && !existing.dirty) return existing.value;
+    if (existing?.inflight) {
+      if (!existing.dirty) return existing.inflight;
+      await existing.inflight;
+      return this.get(contextGraphId);
+    }
+
+    const entry = existing ?? { dirty: true, invalidationVersion: 0 };
+    const rebuildVersion = entry.invalidationVersion;
+    entry.dirty = false;
+    const inflight = this.rebuild(contextGraphId)
+      .then((record) => {
+        entry.value = record;
+        entry.inflight = undefined;
+        entry.dirty = entry.invalidationVersion !== rebuildVersion;
+        this.entries.set(contextGraphId, entry);
+        return record;
+      })
+      .catch((err) => {
+        entry.inflight = undefined;
+        entry.dirty = true;
+        this.entries.set(contextGraphId, entry);
+        throw err;
+      });
+
+    entry.inflight = inflight;
+    this.entries.set(contextGraphId, entry);
+    return inflight;
+  }
+
+  markDirty(contextGraphId: string): void {
+    const existing = this.entries.get(contextGraphId);
+    if (existing) {
+      existing.dirty = true;
+      existing.invalidationVersion += 1;
+      return;
+    }
+    this.entries.set(contextGraphId, { dirty: true, invalidationVersion: 1 });
+  }
+
+  markAllDirty(): void {
+    for (const entry of this.entries.values()) {
+      entry.dirty = true;
+      entry.invalidationVersion += 1;
+    }
+  }
+
+  markDirtyFromQuads(quads: readonly Quad[]): string[] {
+    const touched = new Set<string>();
+    for (const quad of quads) {
+      const contextGraphId = this.contextGraphIdTouchedByQuad(quad);
+      if (!contextGraphId) continue;
+      touched.add(contextGraphId);
+      this.markDirty(contextGraphId);
+    }
+    return [...touched];
+  }
+
+  async listDeclaredContextGraphIds(): Promise<string[]> {
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+
+    const result = await this.store.query(`
+      SELECT DISTINCT ?ctxGraph WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+          }
+        } UNION {
+          GRAPH ?g {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}> .
+            FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
+            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_meta"))
+          }
+        } UNION {
+          GRAPH ?g {
+            ?ctxGraph <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH}> .
+            FILTER(STRSTARTS(STR(?ctxGraph), "${CONTEXT_GRAPH_PREFIX}"))
+            FILTER(STR(?g) = CONCAT(STR(?ctxGraph), "/_catalog"))
+          }
+        }
+      }
+    `);
+    if (result.type !== 'bindings') return [];
+
+    const ids = new Set<string>();
+    for (const row of result.bindings) {
+      const uri = typeof row['ctxGraph'] === 'string' ? stripTerm(row['ctxGraph']) : '';
+      const id = contextGraphIdFromContextGraphUri(uri);
+      if (id) ids.add(id);
+    }
+    return [...ids].sort();
+  }
+
+  private async rebuild(contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    const uri = contextGraphDataUri(contextGraphId);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    // OT-RFC-49 §5.9: a private CG's public face is its `_catalog` graph (DCAT
+    // dataset record, subject = the CG DID = `uri`). Load it so a CG known only
+    // through its catalog (e.g. fetched from a peer with no local `_meta`) is
+    // visible to getCgMeta()/listContextGraphsFromProjection().
+    const catalogGraph = contextGraphCatalogUri(contextGraphId);
+
+    assertSafeIri(uri);
+    assertSafeIri(ontologyGraph);
+    assertSafeIri(agentsGraph);
+    assertSafeIri(metaGraph);
+    assertSafeIri(catalogGraph);
+
+    const record: ContextGraphMetaRecord = {
+      id: contextGraphId,
+      uri,
+      declared: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      isSystem: (Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId),
+      creators: [],
+      curators: [],
+      allowedPeers: [],
+      allowedAgents: [],
+      participantAgents: [],
+      participantIdentityIds: [],
+      revokedAgents: [],
+      subGraphs: [],
+      hasAgentGate: false,
+      hasPeerGate: false,
+      hasLegacyParticipantGate: false,
+    };
+
+    // Explicit source precedence (authoritative last-wins). ONTOLOGY is the
+    // shared, lowest-trust source; the CG's own AGENTS/`_meta` graphs override
+    // it for the scalar "primary" fields. The load order is irrelevant now that
+    // `applyFact` gates scalar writes on `SourceRank`, but we keep ONTOLOGY
+    // first so its values seed any field the authoritative graphs omit.
+    const sources: Array<{ graphUri: string; rank: SourceRank }> = [
+      { graphUri: ontologyGraph, rank: SourceRank.Ontology },
+      { graphUri: agentsGraph, rank: SourceRank.Agents },
+      { graphUri: metaGraph, rank: SourceRank.Meta },
+      { graphUri: catalogGraph, rank: SourceRank.Catalog },
+    ];
+    const precedence: PrecedenceTracker = {};
+    for (const { graphUri, rank } of sources) {
+      await this.loadContextGraphFacts(graphUri, uri, record, rank, precedence);
+    }
+    record.subGraphs = await this.loadSubGraphs(contextGraphId);
+
+    record.hasAgentGate = record.allowedAgents.length > 0 || record.participantAgents.length > 0;
+    record.hasPeerGate = record.allowedPeers.length > 0;
+    record.hasLegacyParticipantGate = record.participantIdentityIds.length > 0;
+    return record;
+  }
+
+  private async loadContextGraphFacts(graphUri: string, contextGraphUri: string, record: ContextGraphMetaRecord, sourceRank: SourceRank, precedence: PrecedenceTracker): Promise<void> {
+    const result = await this.store.query(
+      `SELECT ?p ?o WHERE {
+        GRAPH <${graphUri}> {
+          <${contextGraphUri}> ?p ?o .
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return;
+
+    for (const row of result.bindings) {
+      const predicate = typeof row['p'] === 'string' ? strip(row['p']) : undefined;
+      const object = typeof row['o'] === 'string' ? stripTerm(row['o']) : undefined;
+      if (!predicate || object === undefined) continue;
+      this.applyFact(record, predicate, object, sourceRank, precedence);
+    }
+  }
+
+  private applyFact(record: ContextGraphMetaRecord, predicate: string, object: string, sourceRank: SourceRank, precedence: PrecedenceTracker): void {
+    switch (predicate) {
+      case DKG_ONTOLOGY.RDF_TYPE:
+        if (object === DKG_ONTOLOGY.DKG_CONTEXT_GRAPH) record.declared = true;
+        if (object === DKG_ONTOLOGY.DKG_SYSTEM_CONTEXT_GRAPH) record.isSystem = true;
+        // OT-RFC-49 §5.9: the `_catalog` entry's native floor type marks the CG
+        // as an existing, discoverable private CG even when no `_meta`/agents
+        // facts are present locally.
+        if (object === DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH) {
+          record.declared = true;
+          applyAccessPolicy(record, 'private');
+        }
+        break;
+      case DKG_ONTOLOGY.DCT_ACCESS_RIGHTS:
+        // The catalog floor value is the RESTRICTED authority IRI (members /
+        // grant), the access class of a private CG. Map it onto the private
+        // policy, preserving the private-wins precedence in applyAccessPolicy.
+        if (object === DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED) {
+          applyAccessPolicy(record, 'private');
+        }
+        break;
+      case DKG_ONTOLOGY.SCHEMA_NAME:
+      case `${LEGACY_SCHEMA_NS}name`:
+        setWithPrecedence(record, precedence, 'name', object, sourceRank);
+        break;
+      case DKG_ONTOLOGY.SCHEMA_DESCRIPTION:
+      case `${LEGACY_SCHEMA_NS}description`:
+        setWithPrecedence(record, precedence, 'description', object, sourceRank);
+        break;
+      case DKG_ONTOLOGY.DKG_CREATOR:
+        pushUnique(record.creators, object);
+        setWithPrecedence(record, precedence, 'creator', object, sourceRank);
+        break;
+      case DKG_ONTOLOGY.DKG_CURATOR:
+        pushUnique(record.curators, object);
+        setWithPrecedence(record, precedence, 'curator', object, sourceRank);
+        break;
+      case DKG_ONTOLOGY.DKG_ACCESS_POLICY:
+        applyAccessPolicy(record, object);
+        break;
+      case DKG_ONTOLOGY.DKG_CREATED_AT:
+        setWithPrecedence(record, precedence, 'createdAt', object, sourceRank);
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_PEER:
+        pushUnique(record.allowedPeers, object);
+        break;
+      case DKG_ONTOLOGY.DKG_ALLOWED_AGENT:
+        pushUnique(record.allowedAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT:
+        pushUnique(record.participantAgents, object);
+        break;
+      case DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID:
+        pushUnique(record.participantIdentityIds, object);
+        break;
+      case DKG_ONTOLOGY.DKG_REVOKED_AGENT:
+        pushUnique(record.revokedAgents, object);
+        break;
+      case `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`:
+        setWithPrecedence(record, precedence, 'onChainId', object, sourceRank);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async loadSubGraphs(contextGraphId: string): Promise<ContextGraphSubGraphMeta[]> {
+    const metaGraph = contextGraphMetaGraphUri(contextGraphId);
+    // The `_meta` graph is shared by the CG and its sub-graphs, so a SubGraph-
+    // shaped subject is not automatically owned by this CG. Bind it to the
+    // emitted `dkg:parentContextGraph <this CG DID>` triple (see
+    // generateSubGraphRegistration) so a stray or other-CG subject that happens
+    // to land in this graph is not surfaced as a member.
+    const parentUri = contextGraphDataUri(contextGraphId);
+    assertSafeIri(parentUri);
+    const result = await this.store.query(
+      `SELECT ?subGraph ?name ?createdBy ?createdAt ?description WHERE {
+        GRAPH <${metaGraph}> {
+          ?subGraph ?typePred ?subGraphType ;
+                    ?parentPred <${parentUri}> ;
+                    ?namePred ?name ;
+                    ?createdByPred ?createdBy .
+          VALUES ?typePred { <${DKG_ONTOLOGY.RDF_TYPE}> }
+          VALUES ?subGraphType { <${DKG_NS}SubGraph> <${LEGACY_DKG_NS}SubGraph> }
+          VALUES ?parentPred { <${DKG_NS}parentContextGraph> <${LEGACY_DKG_NS}parentContextGraph> }
+          VALUES ?namePred { <${DKG_ONTOLOGY.SCHEMA_NAME}> <${LEGACY_SCHEMA_NS}name> }
+          VALUES ?createdByPred { <${DKG_NS}createdBy> <${LEGACY_DKG_NS}createdBy> }
+          OPTIONAL {
+            ?subGraph ?createdAtPred ?createdAt .
+            VALUES ?createdAtPred { <${DKG_NS}createdAt> <${LEGACY_DKG_NS}createdAt> }
+          }
+          OPTIONAL {
+            ?subGraph ?descriptionPred ?description .
+            VALUES ?descriptionPred { <${DKG_ONTOLOGY.SCHEMA_DESCRIPTION}> <${LEGACY_SCHEMA_NS}description> }
+          }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return [];
+
+    const byUri = new Map<string, ContextGraphSubGraphMeta>();
+    for (const row of result.bindings) {
+      const uri = typeof row['subGraph'] === 'string' ? stripTerm(row['subGraph']) : '';
+      if (!uri) continue;
+      const current = byUri.get(uri) ?? {
+        uri,
+        name: row['name'] ? stripTerm(String(row['name'])) : '',
+        createdBy: row['createdBy'] ? stripTerm(String(row['createdBy'])) : '',
+      };
+      if (!current.name && row['name']) current.name = stripTerm(String(row['name']));
+      if (!current.createdBy && row['createdBy']) current.createdBy = stripTerm(String(row['createdBy']));
+      if (!current.createdAt && row['createdAt']) current.createdAt = stripTerm(String(row['createdAt']));
+      if (!current.description && row['description']) current.description = stripTerm(String(row['description']));
+      byUri.set(uri, current);
+    }
+    return [...byUri.values()];
+  }
+
+  private contextGraphIdTouchedByQuad(quad: Quad): string | null {
+    const subject = stripTerm(quad.subject);
+    const predicate = strip(quad.predicate);
+    const object = stripTerm(quad.object);
+    const graph = stripTerm(quad.graph);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaContextGraphId = contextGraphIdFromMetaGraphUri(graph);
+
+    // OT-RFC-49 §5.9: a write into a CG's `_catalog` graph (e.g. publish-time
+    // partition or a peer-fetched catalog) must dirty the projection so a cached
+    // record picks up the new public facts. The catalog subject is the CG DID;
+    // only the predicates the read side maps are invalidation-relevant.
+    const catalogContextGraphId = contextGraphIdFromCatalogGraphUri(graph);
+    if (catalogContextGraphId) {
+      const contextGraphUri = contextGraphDataUri(catalogContextGraphId);
+      if (subject === contextGraphUri && CATALOG_META_PREDICATES.has(predicate)) {
+        return catalogContextGraphId;
+      }
+      return null;
+    }
+
+    if (metaContextGraphId) {
+      const contextGraphUri = contextGraphDataUri(metaContextGraphId);
+      if (subject === contextGraphUri && DIRECT_META_PREDICATES.has(predicate)) {
+        return metaContextGraphId;
+      }
+
+      if (!subject.startsWith(`${contextGraphUri}/`)) return null;
+      if (!SUB_GRAPH_META_PREDICATES.has(predicate)) return null;
+      if (predicate === DKG_ONTOLOGY.RDF_TYPE && !SUB_GRAPH_TYPE_URIS.has(object)) return null;
+      return metaContextGraphId;
+    }
+
+    if ((graph === ontologyGraph || graph === agentsGraph) && DIRECT_META_PREDICATES.has(predicate)) {
+      return contextGraphIdFromContextGraphUri(subject);
+    }
+
+    return null;
+  }
+}
+
+// Set a scalar "primary" field under explicit source precedence: a higher-rank
+// (more authoritative) source overrides whatever a lower-rank source wrote, and
+// within the same rank the first value written wins (mirroring the old `??=`).
+function setWithPrecedence(
+  record: ContextGraphMetaRecord,
+  precedence: PrecedenceTracker,
+  field: 'name' | 'description' | 'creator' | 'curator' | 'createdAt' | 'onChainId',
+  value: string,
+  sourceRank: SourceRank,
+): void {
+  const lastRank = precedence[field];
+  if (lastRank !== undefined && sourceRank <= lastRank) return;
+  record[field] = value;
+  precedence[field] = sourceRank;
+}
+
+function pushUnique(target: string[], value: string): void {
+  const key = value.toLowerCase();
+  if (target.some((existing) => existing.toLowerCase() === key)) return;
+  target.push(value);
+}
+
+function stripTerm(value: string): string {
+  return stripLiteral(strip(value));
+}
+
+function applyAccessPolicy(record: ContextGraphMetaRecord, value: string): void {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'private') {
+    record.accessPolicy = 'private';
+    return;
+  }
+  if (normalized === 'public') {
+    if (record.accessPolicy !== 'private') record.accessPolicy = 'public';
+    return;
+  }
+  record.accessPolicy ??= value;
+}
+
+function contextGraphIdFromContextGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX)) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length);
+  if (!tail) return null;
+  return tail;
+}
+
+function contextGraphIdFromMetaGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX) || !uri.endsWith('/_meta')) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length, -'/_meta'.length);
+  if (!tail) return null;
+  return tail;
+}
+
+function contextGraphIdFromCatalogGraphUri(uri: string): string | null {
+  if (!uri.startsWith(CONTEXT_GRAPH_PREFIX) || !uri.endsWith('/_catalog')) return null;
+  const tail = uri.slice(CONTEXT_GRAPH_PREFIX.length, -'/_catalog'.length);
+  if (!tail) return null;
+  return tail;
+}

--- a/packages/agent/src/context-graph-public-projection.ts
+++ b/packages/agent/src/context-graph-public-projection.ts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// the verifiable public projection of a private CG.
+//
+// A private CG holds its data off the network, but it is not invisible to
+// it. Every private CG maintains a small, public, signed RDF *projection*
+// that binds it into the public graph as a verifiable, addressable node —
+// enough for an outsider to discover that it exists, verify claims bound to
+// it, and learn how to ask for access — while disclosing nothing beyond what
+// the chain already exposes.
+//
+// This module is the *write* direction (CG state -> floor quads). It is pure
+// and side-effect-free: the caller publishes the returned quads as an
+// ordinary PUBLIC knowledge asset (signed + anchored, hence tamper-evident).
+// The *read* direction (triples -> ContextGraphMetaRecord) lives in
+// context-graph-meta-projection.ts.
+//
+// The disclosure invariant (§5.9.1): the floor MUST contain only facts
+// already derivable from the on-chain record. This builder enforces it
+// structurally — it accepts only typed floor/recommended/opt-in fields, so
+// it cannot emit a triple the caller did not explicitly supply.
+
+import { createHmac } from 'node:crypto';
+import { DKG_ONTOLOGY, assertSafeIri } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+/** A 32-byte hex string, `0x`-prefixed (an on-chain merkle root). */
+const ROOT_RE = /^0x[0-9a-fA-F]{64}$/;
+
+export interface PublicProjectionInput {
+  /** The CG's UAL / DID — the subject of every projection triple (floor). */
+  ual: string;
+  /**
+   * The CG's access class. A catalog entry is a *private*-CG concept; this
+   * builder refuses any other value (a public CG IS its own public face).
+   */
+  accessPolicy: string;
+  /**
+   * Optional. The on-chain VM merkleRoot, `0x`+64 hex. Used only by the
+   * separate-KA model, where the catalog entry has its own root and needs an
+   * explicit `dkg:committedRoot` back-reference. The combined model commits
+   * the entry inside the CG's own root, so verifiability is intrinsic and this
+   * is omitted.
+   */
+  committedRoot?: string;
+  /** Target graph URI: the public `_catalog` subgraph this entry is written into (floor). */
+  graph: string;
+
+  // ---- Recommended (§5.9.2). Omit for the bare floor. ----
+  /** Controlling identity IRI for `dct:publisher`. MAY be a per-CG pseudonymous key (§9 Q5). */
+  publisher?: string;
+  /** Grant endpoint IRI for `dcat:accessService` — how a consumer requests scoped access. */
+  accessService?: string;
+
+  // ---- Opt-in, disclosure-priced (§5.9.4). Each is a deliberate curator choice. ----
+  /** T1: ontology / domain IRIs the CG conforms to. Discloses the field. */
+  conformsTo?: string[];
+  /**
+   * T2: blinded join keys, each `HMAC-SHA256(cgSecret, canonicalEntityId)`
+   * (see {@link blindedAnchor}). Discloses *how many* shared entities, never
+   * *which*. Matchable only by holders of the CG secret.
+   */
+  blindedAnchors?: string[];
+}
+
+function literal(value: string): string {
+  // Mirror dkg-agent-context-graph.ts's literal convention: quoted object.
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function quad(subject: string, predicate: string, object: string, graph: string): Quad {
+  return { subject, predicate, object, graph };
+}
+
+/**
+ * Build the public catalog-entry quads for a private CG — a DCAT dataset
+ * record (§5.9), the CG's standards-compliant public face.
+ *
+ * Returns the mandatory floor — `a dcat:Dataset, dkg:PrivateContextGraph`
+ * (dual-typed: DCAT for interop, dkg: for native consumers), `dct:identifier`
+ * (UAL), `dct:accessRights …/RESTRICTED` — plus any recommended/opt-in fields
+ * the caller explicitly supplied (including `dkg:committedRoot` iff a
+ * `committedRoot` is passed, for the separate-KA model), and nothing else.
+ *
+ * @throws if `accessPolicy` is not `'private'`, the UAL / graph are missing,
+ *         a supplied `committedRoot` is malformed, or any IRI-bearing input
+ *         (ual, graph, publisher, accessService, conformsTo) contains a
+ *         character that would break a SPARQL `<...>` IRI and let a malformed
+ *         value emit invalid RDF or inject extra triples. The throw is the
+ *         disclosure-invariant guard: a malformed entry must never be
+ *         published as if authoritative.
+ */
+export function buildPublicProjection(input: PublicProjectionInput): Quad[] {
+  if (input.accessPolicy !== 'private') {
+    throw new Error(
+      `public catalog entry is a private-CG concept; refusing accessPolicy='${input.accessPolicy}'`,
+    );
+  }
+  const ual = input.ual?.trim();
+  if (!ual) throw new Error('public catalog entry requires a non-empty UAL');
+  const graph = input.graph?.trim();
+  if (!graph) throw new Error('public catalog entry requires a target graph URI');
+  // These two are serialized as bare IRIs (<ual>, <graph>); a `>`/space/control
+  // char would break the RDF or inject triples. Reject — same guard the
+  // publisher uses before interpolating a value into `<...>`.
+  assertSafeIri(ual);
+  assertSafeIri(graph);
+
+  // --- Mandatory floor (§5.9.3) — a DCAT dataset record ---
+  const quads: Quad[] = [
+    quad(ual, DKG_ONTOLOGY.RDF_TYPE, DKG_ONTOLOGY.DCAT_DATASET, graph),            // interop
+    quad(ual, DKG_ONTOLOGY.RDF_TYPE, DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, graph), // dkg-native
+    quad(ual, DKG_ONTOLOGY.DCT_IDENTIFIER, literal(ual), graph),
+    quad(ual, DKG_ONTOLOGY.DCT_ACCESS_RIGHTS, DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED, graph),
+  ];
+
+  // --- Separate-KA back-reference (combined model omits it) ---
+  if (input.committedRoot !== undefined) {
+    if (!ROOT_RE.test(input.committedRoot)) {
+      throw new Error(`committedRoot, when given, must be 0x + 64 hex; got '${input.committedRoot}'`);
+    }
+    quads.push(quad(ual, DKG_ONTOLOGY.DKG_COMMITTED_ROOT, literal(input.committedRoot), graph));
+  }
+
+  // --- Recommended (§5.9.2) ---
+  // publisher / accessService are serialized as bare IRIs (<publisher>,
+  // <accessService>); validate before emit so a malformed value cannot inject
+  // triples or break the RDF (assertSafeIri throws on unsafe input).
+  if (input.publisher?.trim()) {
+    const publisher = assertSafeIri(input.publisher.trim());
+    quads.push(quad(ual, DKG_ONTOLOGY.DCT_PUBLISHER, publisher, graph));
+  }
+  if (input.accessService?.trim()) {
+    const accessService = assertSafeIri(input.accessService.trim());
+    quads.push(quad(ual, DKG_ONTOLOGY.DCAT_ACCESS_SERVICE, accessService, graph));
+  }
+
+  // --- Opt-in, disclosure-priced (§5.9.4) ---
+  // conformsTo entries are serialized as bare IRIs (<onto>); validate each.
+  for (const onto of input.conformsTo ?? []) {
+    if (onto?.trim()) quads.push(quad(ual, DKG_ONTOLOGY.DCT_CONFORMS_TO, assertSafeIri(onto.trim()), graph));
+  }
+  for (const anchor of input.blindedAnchors ?? []) {
+    if (anchor?.trim()) quads.push(quad(ual, DKG_ONTOLOGY.DKG_BLINDED_ANCHOR, literal(anchor.trim()), graph));
+  }
+
+  return quads;
+}
+
+/**
+ * Compute a blinded entity anchor (§5.9.4 T2): `HMAC-SHA256(cgSecret, id)`,
+ * hex, prefixed `hmac:`. Partners holding `cgSecret` recompute this over the
+ * same canonical entity id to discover overlap; the public sees only opaque
+ * hashes. `canonicalEntityId` MUST already be normalized by the caller (the
+ * normalization scheme is §9 Q10).
+ */
+export function blindedAnchor(cgSecret: Buffer | string, canonicalEntityId: string): string {
+  const key = typeof cgSecret === 'string' ? Buffer.from(cgSecret, 'utf8') : cgSecret;
+  const mac = createHmac('sha256', key).update(canonicalEntityId, 'utf8').digest('hex');
+  return `hmac:${mac}`;
+}
+
+/** Floor predicates, exported so tests / auditors can assert the disclosure invariant. */
+export const PUBLIC_PROJECTION_FLOOR_PREDICATES: readonly string[] = [
+  DKG_ONTOLOGY.RDF_TYPE,        // dcat:Dataset + dkg:PrivateContextGraph (two quads, one predicate)
+  DKG_ONTOLOGY.DCT_IDENTIFIER,
+  DKG_ONTOLOGY.DCT_ACCESS_RIGHTS,
+];
+
+// Combined-model partition (§5.9 / §4): separate the public catalog entry from
+// everything else at publish time. The catalog quads ride in the CG's own
+// merkle root (verifiability) but are routed PLAINTEXT to the public sink and
+// EXCLUDED from the ciphertext fed to the curated encryption emitter. Lives in
+// core so the publisher (encryption side) can use it too; re-exported here for
+// agent-side callers and tests.
+export { CATALOG_PREDICATES, partitionCatalogQuads, type CatalogPartition } from '@origintrail-official/dkg-core';
+
+// ---------------------------------------------------------------------------
+// Orchestration: emit a private CG's projection on VM publish (§5.9.3).
+//
+// The capabilities the agent supplies are injected, so the orchestration —
+// the private-CG short-circuit, resolution order, build, publish, and (load-
+// bearing) error isolation — is unit-testable without a running node.
+// ---------------------------------------------------------------------------
+
+export interface ProjectionEmitDeps {
+  /** True iff the CG is private. Only private CGs get a projection (§5.9). */
+  isPrivateContextGraph(contextGraphId: string): Promise<boolean>;
+  /** Resolve the CG's UAL — the subject of the projection. */
+  resolveUal(contextGraphId: string): Promise<string>;
+  /** The public graph URI the projection KA is published into. */
+  projectionGraph(contextGraphId: string): string;
+  /** Publish the projection quads as a PUBLIC knowledge asset. */
+  publishProjection(contextGraphId: string, quads: Quad[], graph: string): Promise<void>;
+  /** Optional controlling identity for `dct:publisher` (MAY be a per-CG pseudonym). */
+  publisherIdentity?(contextGraphId: string): string | undefined;
+  /** Optional grant endpoint for `dkg:accessService`. */
+  accessService?(contextGraphId: string): string | undefined;
+  log?(level: 'info' | 'warn', message: string): void;
+}
+
+export interface ProjectionEmitResult {
+  emitted: boolean;
+  quads: Quad[];
+  /** Set when emission was attempted but failed; never thrown (see below). */
+  error?: string;
+}
+
+/**
+ * Emit (or refresh) the public projection for a CG after a VM publish commits
+ * `committedRoot` on chain. Public CGs are a no-op (they are their own public
+ * face). For a private CG, builds the floor (plus any recommended fields the
+ * deps surface) and publishes it.
+ *
+ * Error isolation is deliberate and load-bearing: a projection failure MUST
+ * NOT break the VM publish that triggered it, so this never throws — it logs
+ * and returns `{ emitted: false, error }`. The caller treats the projection as
+ * best-effort and the next publish refreshes it.
+ */
+export async function emitPublicProjection(
+  deps: ProjectionEmitDeps,
+  contextGraphId: string,
+  committedRoot: string,
+): Promise<ProjectionEmitResult> {
+  try {
+    if (!(await deps.isPrivateContextGraph(contextGraphId))) {
+      return { emitted: false, quads: [] };
+    }
+    const ual = await deps.resolveUal(contextGraphId);
+    const graph = deps.projectionGraph(contextGraphId);
+    const quads = buildPublicProjection({
+      ual,
+      accessPolicy: 'private',
+      committedRoot,
+      graph,
+      publisher: deps.publisherIdentity?.(contextGraphId),
+      accessService: deps.accessService?.(contextGraphId),
+    });
+    await deps.publishProjection(contextGraphId, quads, graph);
+    deps.log?.('info', `public projection refreshed for ${contextGraphId} @ root ${committedRoot}`);
+    return { emitted: true, quads };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.log?.('warn', `public projection emit failed for ${contextGraphId}: ${message} (publish unaffected)`);
+    return { emitted: false, quads: [], error: message };
+  }
+}

--- a/packages/agent/test/context-graph-discovery.test.ts
+++ b/packages/agent/test/context-graph-discovery.test.ts
@@ -575,6 +575,112 @@ describe('listContextGraphs merge', () => {
     const unauthenticated = await agent.listContextGraphs();
     expect(unauthenticated.find(p => p.id === 'my-curated')).toBeUndefined();
   }, 15000);
+
+  it('listContextGraphs applies the same privacy rules to AGENTS-declared private CGs', async () => {
+    const result = await createTestAgent();
+    agent = result.agent;
+    await agent.start();
+
+    const id = 'agents-declared-private';
+    const myWallet = agent.getDefaultAgentAddress()!;
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+    await result.store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Declared Private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: metaGraph },
+    ]);
+
+    const otherWallet = ethers.Wallet.createRandom().address;
+    expect((await agent.listContextGraphs()).find(p => p.id === id)).toBeUndefined();
+    expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === id)).toBeUndefined();
+    const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === id);
+    expect(visible).toBeDefined();
+    expect(visible?.accessPolicy).toBe('private');
+  }, 15000);
+
+  it('listContextGraphs projection mode preserves AGENTS privacy and root _meta discovery', async () => {
+    const previous = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+    process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = '1';
+    try {
+      const result = await createTestAgent();
+      agent = result.agent;
+      await agent.start();
+
+      const privateId = 'projection-list-agents-private';
+      const gateOnlyId = 'projection-list-gate-only-private';
+      const metaOnlyId = 'projection-list-meta-only';
+      const policyUnknownId = 'projection-list-policy-unknown';
+      const implicitPublicId = 'projection-list-implicit-public';
+      const myWallet = agent.getDefaultAgentAddress()!;
+      const privateUri = contextGraphDataGraphUri(privateId);
+      const gateOnlyUri = contextGraphDataGraphUri(gateOnlyId);
+      const metaOnlyUri = contextGraphDataGraphUri(metaOnlyId);
+      const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      const privateMetaGraph = contextGraphMetaGraphUri(privateId);
+      const gateOnlyMetaGraph = contextGraphMetaGraphUri(gateOnlyId);
+      await result.store.insert([
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Agents Private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${myWallet}`, graph: agentsGraph },
+        { subject: privateUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: privateMetaGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Gate Only Private"', graph: agentsGraph },
+        { subject: gateOnlyUri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: `"${myWallet}"`, graph: gateOnlyMetaGraph },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: metaOnlyUri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Projection Meta Only"', graph: contextGraphMetaGraphUri(metaOnlyId) },
+        { subject: 'urn:projection-list-policy-unknown:root', predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Policy Unknown"', graph: contextGraphSharedMemoryUri(policyUnknownId) },
+      ]);
+      await agent.share(implicitPublicId, [
+        {
+          subject: 'urn:projection-list-implicit-public:root',
+          predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+          object: '"Projection Implicit Public"',
+          graph: '',
+        },
+      ], { callerAgentAddress: myWallet });
+
+      const unscoped = await agent.listContextGraphs();
+      expect(unscoped.find(p => p.id === privateId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect(unscoped.find(p => p.id === metaOnlyId)?.name).toBe('Projection Meta Only');
+      expect((await agent.listContextGraphs({ callerAgentAddress: null })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const otherWallet = ethers.Wallet.createRandom().address;
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === privateId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === gateOnlyId)).toBeUndefined();
+      expect((await agent.listContextGraphs({ callerAgentAddress: otherWallet })).find(p => p.id === policyUnknownId)).toBeUndefined();
+
+      const visible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === privateId);
+      expect(visible).toBeDefined();
+      expect(visible?.accessPolicy).toBe('private');
+      expect(visible?.callerInvolved).toBe(true);
+      const gateVisible = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === gateOnlyId);
+      expect(gateVisible).toBeDefined();
+      expect(gateVisible?.accessPolicy).toBe('private');
+      expect(gateVisible?.callerInvolved).toBe(true);
+      const implicitPublic = (await agent.listContextGraphs({ callerAgentAddress: myWallet })).find(p => p.id === implicitPublicId);
+      expect(implicitPublic).toBeDefined();
+      expect(implicitPublic?.accessPolicy).toBe('public');
+      expect(implicitPublic?.callerInvolved).toBe(true);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION;
+      } else {
+        process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION = previous;
+      }
+    }
+  }, 15000);
 });
 
 describe('discoverContextGraphsFromChain', () => {

--- a/packages/agent/test/context-graph-meta-projection.test.ts
+++ b/packages/agent/test/context-graph-meta-projection.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail-official/dkg-core';
+import { OxigraphStore, type Quad, type TripleStore } from '@origintrail-official/dkg-storage';
+import { generateSubGraphRegistration } from '@origintrail-official/dkg-publisher';
+import { ContextGraphMetaProjection } from '../src/context-graph-meta-projection.js';
+import { DKGAgent } from '../src/dkg-agent.js';
+
+describe('ContextGraphMetaProjection', () => {
+  it('enumerates declared context graph ids from ontology, agents, and root _meta graphs', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const ontologyId = 'projection-list-ontology';
+    const agentsId = 'projection-list-agents';
+    const metaId = '0x0000000000000000000000000000000000000abc/projection-list-meta';
+
+    await store.insert([
+      {
+        subject: contextGraphDataGraphUri(ontologyId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: ontologyGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(agentsId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: agentsGraph,
+      },
+      {
+        subject: contextGraphDataGraphUri(metaId),
+        predicate: DKG_ONTOLOGY.RDF_TYPE,
+        object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+        graph: contextGraphMetaGraphUri(metaId),
+      },
+    ]);
+
+    expect(await projection.listDeclaredContextGraphIds()).toEqual([
+      agentsId,
+      metaId,
+      ontologyId,
+    ].sort());
+  });
+
+  it('loads AGENTS graph policy rows and invalidates allowlist mutations', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = '0x0000000000000000000000000000000000000abc/projection-agents-private';
+    const uri = contextGraphDataGraphUri(id);
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"public"', graph: ontologyGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0x0000000000000000000000000000000000000111', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT, object: '"0x0000000000000000000000000000000000000333"', graph: agentsGraph },
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT, object: '"0x0000000000000000000000000000000000000111"', graph: metaGraph },
+    ]);
+
+    const first = await projection.get(id);
+    expect(first.accessPolicy).toBe('private');
+    expect(first.curator).toBe('did:dkg:agent:0x0000000000000000000000000000000000000111');
+    expect(first.allowedAgents).toEqual(['0x0000000000000000000000000000000000000111']);
+    expect(first.revokedAgents).toEqual(['0x0000000000000000000000000000000000000333']);
+
+    const addedAgent: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.DKG_ALLOWED_AGENT,
+      object: '"0x0000000000000000000000000000000000000222"',
+      graph: metaGraph,
+    };
+    await store.insert([addedAgent]);
+    expect(projection.markDirtyFromQuads([addedAgent])).toEqual([id]);
+
+    const second = await projection.get(id);
+    expect(second.allowedAgents).toHaveLength(2);
+    expect(second.allowedAgents).toEqual(expect.arrayContaining([
+      '0x0000000000000000000000000000000000000111',
+      '0x0000000000000000000000000000000000000222',
+    ]));
+  });
+
+  it('does not dirty policy entries for unrelated tentative KC metadata', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-tentative-no-thrash';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const metaGraph = contextGraphMetaGraphUri(id);
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+    ]);
+
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+    ]);
+
+    const tentativeQuad: Quad = {
+      subject: `did:dkg:assertion:${id}:tentative`,
+      predicate: 'https://dkg.network/ontology#assertionStatus',
+      object: '"TENTATIVE"',
+      graph: metaGraph,
+    };
+    const rootLikeDataQuad: Quad = {
+      subject: uri,
+      predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+      object: '"Not authoritative metadata"',
+      graph: contextGraphDataGraphUri('projection-user-data'),
+    };
+    expect(projection.markDirtyFromQuads([tentativeQuad, rootLikeDataQuad])).toEqual([]);
+    expect((await projection.get(id)).accessPolicy).toBeUndefined();
+
+    projection.markDirty(id);
+    expect((await projection.get(id)).accessPolicy).toBe('private');
+  });
+
+  it('rebuilds for callers that arrive after invalidation during an in-flight rebuild', async () => {
+    let releaseFirstQuery!: () => void;
+    const firstQuery = new Promise<void>((resolve) => { releaseFirstQuery = resolve; });
+    let queryCalls = 0;
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const store = {
+      async query(sparql: string) {
+        queryCalls += 1;
+        const callNumber = queryCalls;
+        if (callNumber === 1) await firstQuery;
+        if (callNumber <= 4) return { type: 'bindings', bindings: [] };
+        if (sparql.includes(`<${agentsGraph}>`)) {
+          return {
+            type: 'bindings',
+            bindings: [{ p: DKG_ONTOLOGY.DKG_ACCESS_POLICY, o: '"private"' }],
+          };
+        }
+        return { type: 'bindings', bindings: [] };
+      },
+    } as unknown as TripleStore;
+    const projection = new ContextGraphMetaProjection(store);
+
+    const first = projection.get('projection-inflight-dirty');
+    projection.markDirty('projection-inflight-dirty');
+    const afterDirty = projection.get('projection-inflight-dirty');
+    releaseFirstQuery();
+
+    expect((await first).accessPolicy).toBeUndefined();
+    expect((await afterDirty).accessPolicy).toBe('private');
+    expect(queryCalls).toBeGreaterThan(4);
+  });
+
+  it('projects sub-graph registrations from the context graph meta graph', async () => {
+    const store = new OxigraphStore();
+    const projection = new ContextGraphMetaProjection(store);
+    const id = 'projection-subgraphs';
+    const uri = contextGraphDataGraphUri(id);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const registration = generateSubGraphRegistration({
+      contextGraphId: id,
+      subGraphName: 'tasks',
+      createdBy: 'projection-test',
+      description: 'Task memory',
+      timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await store.insert([
+      { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+      ...registration,
+    ]);
+    projection.markDirtyFromQuads(registration);
+
+    expect((await projection.get(id)).subGraphs).toEqual([
+      {
+        uri: `${uri}/tasks`,
+        name: 'tasks',
+        createdBy: 'did:dkg:agent:projection-test',
+        createdAt: '2026-01-01T00:00:00Z',
+        description: 'Task memory',
+      },
+    ]);
+  });
+
+  it('filters projected revoked agents from private participant authorization lists', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      subscribedContextGraphs: new Map<string, { participantAgents?: string[] }>([
+        ['projection-agents-private', { participantAgents: [revoked] }],
+      ]),
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        participantIdentityIds: ['identity:legacy'],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getPrivateContextGraphParticipants(this: unknown, contextGraphId: string): Promise<string[] | null>;
+    }).getPrivateContextGraphParticipants.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active, 'identity:legacy']);
+  });
+
+  it('filters projected revoked agents from registration participant agents', async () => {
+    const revoked = '0x0000000000000000000000000000000000000111';
+    const active = '0x0000000000000000000000000000000000000222';
+    const agentLike = {
+      getCgMeta: async () => ({
+        allowedAgents: [revoked, active],
+        participantAgents: [revoked],
+        revokedAgents: [revoked],
+      }),
+    };
+
+    const participants = await (DKGAgent.prototype as unknown as {
+      getContextGraphParticipantAgentAddresses(this: unknown, contextGraphId: string): Promise<string[]>;
+    }).getContextGraphParticipantAgentAddresses.call(agentLike, 'projection-agents-private');
+
+    expect(participants).toEqual([active]);
+  });
+});

--- a/packages/agent/test/context-graph-public-projection.test.ts
+++ b/packages/agent/test/context-graph-public-projection.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import {
+  buildPublicProjection,
+  blindedAnchor,
+  emitPublicProjection,
+  partitionCatalogQuads,
+  CATALOG_PREDICATES,
+  PUBLIC_PROJECTION_FLOOR_PREDICATES,
+  type PublicProjectionInput,
+  type ProjectionEmitDeps,
+} from '../src/context-graph-public-projection.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+const q = (subject: string, predicate: string, object: string, graph = 'g'): Quad => ({ subject, predicate, object, graph });
+
+const UAL = 'did:dkg:otp:2043/0x5cadeface0000000000000000000000000000001/142';
+const ROOT = '0x' + '9f3c2a'.padEnd(64, '0');
+const GRAPH = `${UAL}/_projection`;
+
+const floorInput = (over: Partial<PublicProjectionInput> = {}): PublicProjectionInput => ({
+  ual: UAL,
+  accessPolicy: 'private',
+  graph: GRAPH,
+  ...over,
+});
+
+describe('public catalog entry — mandatory floor (DCAT)', () => {
+  it('emits a dual-typed DCAT dataset record as the bare floor', () => {
+    const quads = buildPublicProjection(floorInput());
+    expect(quads).toHaveLength(4); // rdf:type x2 (dcat:Dataset + dkg:PrivateContextGraph) + identifier + accessRights
+
+    // every floor triple is about the CG's UAL, in the catalog graph
+    for (const q of quads) {
+      expect(q.subject).toBe(UAL);
+      expect(q.graph).toBe(GRAPH);
+    }
+    const types = quads.filter(q => q.predicate === DKG_ONTOLOGY.RDF_TYPE).map(q => q.object);
+    expect(types).toContain(DKG_ONTOLOGY.DCAT_DATASET);            // interop type
+    expect(types).toContain(DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH); // dkg-native type
+    const accessRights = quads.find(q => q.predicate === DKG_ONTOLOGY.DCT_ACCESS_RIGHTS);
+    expect(accessRights?.object).toBe(DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED); // standard EU vocab IRI, bare
+    expect(quads.find(q => q.predicate === DKG_ONTOLOGY.DCT_IDENTIFIER)?.object).toBe(`"${UAL}"`);
+
+    // floor predicate set matches the exported invariant
+    expect([...new Set(quads.map(q => q.predicate))].sort()).toEqual([...PUBLIC_PROJECTION_FLOOR_PREDICATES].sort());
+  });
+
+  it('committedRoot is optional — omitted in the combined model, present + validated in the separate-KA model', () => {
+    expect(buildPublicProjection(floorInput()).some(q => q.predicate === DKG_ONTOLOGY.DKG_COMMITTED_ROOT)).toBe(false);
+    const withRoot = buildPublicProjection(floorInput({ committedRoot: ROOT }));
+    expect(withRoot).toHaveLength(5);
+    expect(withRoot.find(q => q.predicate === DKG_ONTOLOGY.DKG_COMMITTED_ROOT)?.object).toBe(`"${ROOT}"`);
+  });
+});
+
+describe('disclosure invariant — nothing leaks by default', () => {
+  it('the bare floor discloses no domain/schema/scale/entity predicate', () => {
+    const quads = buildPublicProjection(floorInput());
+    const leaky = [
+      DKG_ONTOLOGY.DCT_CONFORMS_TO,
+      DKG_ONTOLOGY.DKG_BLINDED_ANCHOR,
+      DKG_ONTOLOGY.SCHEMA_NAME,
+      DKG_ONTOLOGY.SCHEMA_DESCRIPTION,
+    ];
+    for (const p of leaky) expect(quads.some(q => q.predicate === p)).toBe(false);
+  });
+
+  it('refuses to project a public CG (a public CG is its own public face)', () => {
+    expect(() => buildPublicProjection(floorInput({ accessPolicy: 'public' }))).toThrow(/private-CG concept/);
+  });
+
+  it('refuses a malformed committed root when one is supplied (must be 0x + 64 hex)', () => {
+    expect(() => buildPublicProjection(floorInput({ committedRoot: '0xdead' }))).toThrow(/committedRoot/);
+    expect(() => buildPublicProjection(floorInput({ committedRoot: 'deadbeef' }))).toThrow(/committedRoot/);
+  });
+
+  it('requires UAL and target graph', () => {
+    expect(() => buildPublicProjection(floorInput({ ual: '  ' }))).toThrow(/UAL/);
+    expect(() => buildPublicProjection(floorInput({ graph: '' }))).toThrow(/graph/);
+  });
+});
+
+describe('recommended fields — opt-in, pseudonymizable', () => {
+  it('adds publisher + access service only when supplied', () => {
+    const quads = buildPublicProjection(floorInput({
+      publisher: 'did:dkg:identity:0x7bcgkey',
+      accessService: 'https://grants.example/dkg',
+    }));
+    expect(quads).toHaveLength(6); // 4 floor + publisher + accessService
+    const pub = quads.find(q => q.predicate === DKG_ONTOLOGY.DCT_PUBLISHER);
+    expect(pub?.object).toBe('did:dkg:identity:0x7bcgkey'); // IRI, bare
+    const svc = quads.find(q => q.predicate === DKG_ONTOLOGY.DCAT_ACCESS_SERVICE);
+    expect(svc?.object).toBe('https://grants.example/dkg'); // dcat:accessService -> service IRI, bare
+  });
+});
+
+describe('opt-in tiers — each a deliberate addition', () => {
+  it('T1 conformsTo and T2 blinded anchors appear only when supplied', () => {
+    const quads = buildPublicProjection(floorInput({
+      conformsTo: ['https://gs1.org/voc/EPCIS'],
+      blindedAnchors: ['hmac:9a2f', 'hmac:1b7e'],
+    }));
+    expect(quads.filter(q => q.predicate === DKG_ONTOLOGY.DCT_CONFORMS_TO)).toHaveLength(1);
+    expect(quads.filter(q => q.predicate === DKG_ONTOLOGY.DKG_BLINDED_ANCHOR)).toHaveLength(2);
+  });
+});
+
+describe('T2 — blinded anchor primitive', () => {
+  it('is deterministic for the same secret + entity, and hides the entity', () => {
+    const a1 = blindedAnchor('consortium-secret', 'gtin:09506000134352');
+    const a2 = blindedAnchor('consortium-secret', 'gtin:09506000134352');
+    expect(a1).toBe(a2);
+    expect(a1).toMatch(/^hmac:[0-9a-f]{64}$/);
+    expect(a1).not.toContain('09506000134352'); // entity is not recoverable from the output
+  });
+
+  it('differs across secrets (public cannot match without the secret) and across entities', () => {
+    expect(blindedAnchor('secret-A', 'gtin:1')).not.toBe(blindedAnchor('secret-B', 'gtin:1'));
+    expect(blindedAnchor('secret-A', 'gtin:1')).not.toBe(blindedAnchor('secret-A', 'gtin:2'));
+  });
+});
+
+describe('emit orchestration — on VM publish', () => {
+  interface Published { contextGraphId: string; quads: Quad[]; graph: string; }
+
+  const makeDeps = (over: Partial<ProjectionEmitDeps> & { isPrivate?: boolean } = {}) => {
+    const published: Published[] = [];
+    const logs: Array<{ level: string; message: string }> = [];
+    const deps: ProjectionEmitDeps = {
+      isPrivateContextGraph: async () => over.isPrivate ?? true,
+      resolveUal: async () => UAL,
+      projectionGraph: () => GRAPH,
+      publishProjection: async (contextGraphId, quads, graph) => { published.push({ contextGraphId, quads, graph }); },
+      log: (level, message) => logs.push({ level, message }),
+      ...over,
+    };
+    return { deps, published, logs };
+  };
+
+  it('publishes the catalog entry for a private CG and reports emitted', async () => {
+    const { deps, published } = makeDeps();
+    const res = await emitPublicProjection(deps, 'cg-1', ROOT);
+    expect(res.emitted).toBe(true);
+    expect(published).toHaveLength(1);
+    expect(published[0].graph).toBe(GRAPH);
+    const types = published[0].quads.filter(q => q.predicate === DKG_ONTOLOGY.RDF_TYPE).map(q => q.object);
+    expect(types).toContain(DKG_ONTOLOGY.DCAT_DATASET); // DCAT dataset record
+    const root = published[0].quads.find(q => q.predicate === DKG_ONTOLOGY.DKG_COMMITTED_ROOT);
+    expect(root?.object).toBe(`"${ROOT}"`); // separate-KA model threads committedRoot through
+  });
+
+  it('is a no-op for a public CG (a public CG is its own public face)', async () => {
+    const { deps, published } = makeDeps({ isPrivate: false });
+    const res = await emitPublicProjection(deps, 'cg-pub', ROOT);
+    expect(res.emitted).toBe(false);
+    expect(published).toHaveLength(0);
+  });
+
+  it('threads recommended fields when deps surface them', async () => {
+    const { deps, published } = makeDeps({
+      publisherIdentity: () => 'did:dkg:identity:0xpseudo',
+      accessService: () => 'https://grants.example/dkg',
+    });
+    await emitPublicProjection(deps, 'cg-1', ROOT);
+    const preds = published[0].quads.map(q => q.predicate);
+    expect(preds).toContain(DKG_ONTOLOGY.DCT_PUBLISHER);
+    expect(preds).toContain(DKG_ONTOLOGY.DCAT_ACCESS_SERVICE);
+  });
+
+  it('isolates errors — a publish failure never throws, just logs and reports', async () => {
+    const { deps, logs } = makeDeps({
+      publishProjection: async () => { throw new Error('chain down'); },
+    });
+    const res = await emitPublicProjection(deps, 'cg-1', ROOT);
+    expect(res.emitted).toBe(false);
+    expect(res.error).toMatch(/chain down/);
+    expect(logs.some(l => l.level === 'warn' && /publish unaffected/.test(l.message))).toBe(true);
+  });
+});
+
+describe('combined-model partition — catalog vs everything else (identity-based)', () => {
+  // The catalog subject is the canonical CG DID — the exact subject the
+  // injection writes and the publisher threads in (round-3 SECURITY). NOT a
+  // forgeable type marker.
+  const CG_DID = 'did:dkg:context-graph:acme-supply';
+
+  it('separates the catalog entry from data by CG-DID identity; total + order-preserving', () => {
+    const data = [
+      q('urn:acme:shipment/SH-42', DKG_ONTOLOGY.RDF_TYPE, 'urn:acme:Shipment'), // a data rdf:type — must NOT be catalog
+      q('urn:acme:shipment/SH-42', 'urn:acme:product', '"P-9"'),
+      q('urn:acme:shipment/SH-42', 'urn:acme:quantity', '"500"'),
+    ];
+    const catalog = buildPublicProjection({ ual: CG_DID, accessPolicy: 'private', graph: 'g' }); // dual-typed floor
+    const mixed = [data[0], catalog[0], data[1], catalog[1], data[2], catalog[2], catalog[3]];
+
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(mixed, CG_DID);
+
+    expect(catalogQuads).toHaveLength(catalog.length);
+    expect(otherQuads).toHaveLength(data.length);
+    expect(catalogQuads.length + otherQuads.length).toBe(mixed.length); // total
+    expect(new Set(catalogQuads)).toEqual(new Set(catalog));             // exactly the catalog set
+    expect(catalogQuads.every(c => c.subject === CG_DID)).toBe(true);    // all about the CG DID
+    expect(otherQuads.some(o => o.subject === CG_DID)).toBe(false);      // no data quad leaked in
+    // fail-safe: the data entity's rdf:type stays on the data side
+    expect(otherQuads).toContainEqual(data[0]);
+  });
+
+  it('SECURITY: a forged dkg:PrivateContextGraph type marker on a USER entity never leaks into the public catalog', () => {
+    // Attack: author an ordinary entity that self-types as the CG marker and
+    // carries dct:* quads, hoping to be routed plaintext into `_catalog` and
+    // stripped from the ciphertext. Identity-based partitioning defeats it: the
+    // attacker's subject is not the CG DID, so every quad stays on the
+    // encrypted path.
+    const ATTACKER = 'urn:acme:evil/leak-me';
+    const forged = [
+      q(ATTACKER, DKG_ONTOLOGY.RDF_TYPE, DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH), // forged marker
+      q(ATTACKER, DKG_ONTOLOGY.DCT_IDENTIFIER, '"secret-id"'),
+      q(ATTACKER, DKG_ONTOLOGY.DCT_PUBLISHER, 'urn:acme:who'),
+    ];
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(forged, CG_DID);
+    expect(catalogQuads).toHaveLength(0);       // nothing leaked to the public catalog
+    expect(otherQuads).toEqual(forged);         // all of it stays encrypted
+  });
+
+  it('fail-safe: a non-catalog predicate on the catalog subject stays on the encrypted path', () => {
+    const catalog = buildPublicProjection({ ual: CG_DID, accessPolicy: 'private', graph: 'g' });
+    const leaky = q(CG_DID, 'urn:acme:secret', '"do-not-leak"'); // CG DID subject, non-catalog predicate
+    const { catalogQuads, otherQuads } = partitionCatalogQuads([...catalog, leaky], CG_DID);
+    expect(catalogQuads).toHaveLength(catalog.length);
+    expect(otherQuads).toEqual([leaky]);
+  });
+
+  it('fail-safe: an empty catalog subject treats everything as encrypted (no public leak)', () => {
+    const catalog = buildPublicProjection({ ual: CG_DID, accessPolicy: 'private', graph: 'g' });
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(catalog, '');
+    expect(catalogQuads).toHaveLength(0);
+    expect(otherQuads).toEqual(catalog);
+  });
+
+  it('a private CG with no catalog entry yields all otherQuads (no accidental public leak)', () => {
+    const data = [q('urn:acme:x', 'urn:acme:p', '"v"')];
+    const { catalogQuads, otherQuads } = partitionCatalogQuads(data, CG_DID);
+    expect(catalogQuads).toHaveLength(0);
+    expect(otherQuads).toEqual(data);
+  });
+
+  it('CATALOG_PREDICATES covers every predicate buildPublicProjection can emit', () => {
+    const full = buildPublicProjection({
+      ual: CG_DID, accessPolicy: 'private', graph: 'g', committedRoot: '0x' + 'ab'.repeat(32),
+      publisher: 'did:dkg:identity:0xp', accessService: 'https://grants/x',
+      conformsTo: ['https://gs1.org/voc/EPCIS'], blindedAnchors: ['hmac:9a'],
+    });
+    for (const quad of full) expect(CATALOG_PREDICATES.has(quad.predicate)).toBe(true);
+  });
+});


### PR DESCRIPTION
Part **3/5** · base: `feat/public-catalog-model`.

In-memory projections of context-graph metadata, the read side of the public-projection work.

- **`ContextGraphMetaProjection`** + **`ContextGraphPublicProjection`** — projections of CG metadata kept fresh via `markDirtyFromQuads`, reading the `<cg>/_catalog` graph as a source (DCAT type / access-rights, disclosure-floor predicates only — never authz-bearing fields from an untrusted peer's catalog).
- Backs `getCgMeta()` / `listContextGraphsFromProjection()` so a privately-discovered CG resolves locally.

Self-contained (no facet/recovery imports). projection tests green. Please do not merge before review / out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Depends on #1171** — please merge that first.
