### PR TITLE
feat(agent): catalog open-serve + members-only sync auth

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -379,6 +379,7 @@ import {
   deserializeSwmSenderReceiveState,
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
+import { ContextGraphMetaProjection } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 export class DKGAgentBase {
@@ -416,6 +417,7 @@ export class DKGAgentBase {
   protected readonly chain: ChainAdapter;
   /** Shared memory-owned root entities per context graph: entity → creatorPeerId. Used by publisher and shared memory handler. */
   protected readonly workspaceOwnedEntities: Map<string, Map<string, string>>;
+  protected readonly contextGraphMetaProjection: ContextGraphMetaProjection;
   /**
    * OT-RFC-38 / LU-6 Phase B (Codex PR #610 round-2 #2) — highest
    * `nextSeqno` already consumed per (contextGraphId, hostPeerId)
@@ -495,6 +497,8 @@ export class DKGAgentBase {
   protected readonly swmHostModeHandlers = new Map<string, (topic: string, data: Uint8Array, from: string) => void>();
   /** Async lock for the host-mode reconciler so simultaneous calls don't double-subscribe. */
   protected hostModeReconcileInflight?: Promise<void>;
+  /** Rotating cursor for bounded host-mode reconcile sweeps over known context graphs. */
+  protected hostModeReconcileCursor = 0;
   /**
    * OT-RFC-43 A2 — the KA-number allocator, retained on the agent (also
    * forwarded to the publisher as `kaAllocator`). Held here so
@@ -1186,6 +1190,7 @@ export class DKGAgentBase {
     this.wallet = wallet;
     this.node = node;
     this.store = store;
+    this.contextGraphMetaProjection = new ContextGraphMetaProjection(store);
     this.publisher = publisher;
     this.queryEngine = queryEngine;
     this.workspaceOwnedEntities = workspaceOwnedEntities;

--- a/packages/agent/src/dkg-agent-cg-registry.ts
+++ b/packages/agent/src/dkg-agent-cg-registry.ts
@@ -701,20 +701,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) {
       return undefined;
     }
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(
-      `SELECT ?policy WHERE {
-        { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-        UNION
-        { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy } }
-      } LIMIT 1`,
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
-    const raw = result.bindings[0]?.['policy'];
-    if (typeof raw !== 'string') return undefined;
-    const stripped = raw.replace(/^"|"$/g, '');
+    const stripped = (await this.getCgMeta(contextGraphId)).accessPolicy;
     if (stripped === 'public') return 0;
     if (stripped === 'private') return 1;
     return undefined;
@@ -773,19 +760,9 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string[] | null> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?peer WHERE { GRAPH <${cgMetaGraph}> { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?peer } }`,
-      { signal: options.signal },
-    );
-    if (result.type !== 'bindings' || result.bindings.length === 0) {
-      return null;
-    }
-    return result.bindings
-      .map(row => row['peer'])
-      .filter((v): v is string => typeof v === 'string')
-      .map(v => v.replace(/^"|"$/g, ''));
+    void options;
+    const peers = (await this.getCgMeta(contextGraphId)).allowedPeers;
+    return peers.length > 0 ? peers : null;
   }
 
   // ── Sub-Graph Management ───────────────────────────────────────────────
@@ -842,6 +819,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     await gm.ensureSubGraph(contextGraphId, subGraphName);
     await this.store.insert(registrationQuads);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -861,17 +839,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     createdAt?: string;
     description?: string;
   }>> {
-    const { subGraphDiscoverySparql } = await import('@origintrail-official/dkg-publisher');
-    const sparql = subGraphDiscoverySparql(contextGraphId);
-    const result = await this.store.query(sparql);
-    if (result.type !== 'bindings') return [];
-    return result.bindings.map(row => ({
-      uri: row['subGraph'] ?? '',
-      name: stripLiteral(row['name'] ?? ''),
-      createdBy: row['createdBy'] ?? '',
-      createdAt: row['createdAt'] ? stripLiteral(row['createdAt']) : undefined,
-      description: row['description'] ? stripLiteral(row['description']) : undefined,
-    }));
+    return (await this.getCgMeta(contextGraphId)).subGraphs;
   }
 
   /**
@@ -906,7 +874,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
     // Drop assertion graphs under the sub-graph prefix
     const sgPrefix = `did:dkg:context-graph:${contextGraphId}/${subGraphName}/assertion/`;
-    const allGraphs = await this.store.listGraphs();
+    const allGraphs = await listGraphsByPrefix(this.store, sgPrefix);
     for (const g of allGraphs) {
       if (g.startsWith(sgPrefix)) {
         try { await this.store.dropGraph(g); } catch { /* graph may not exist */ }
@@ -916,6 +884,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     // Clear SWM ownership cache for this sub-graph
     const ownershipKey = `${contextGraphId}\0${subGraphName}`;
     this.publisher.clearSubGraphOwnership(ownershipKey);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(
       createOperationContext('system'),
@@ -1006,6 +975,7 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
     }
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     this.subscribeToContextGraph(opts.id);
@@ -1102,4 +1072,10 @@ export class ContextGraphRegistryMethods extends DKGAgentBase {
 
   // ── ENDORSE ─���────────────────────────────────────────────────────────
 
+}
+
+async function listGraphsByPrefix(store: TripleStore, prefix: string): Promise<string[]> {
+  return store.listGraphsByPrefix
+    ? store.listGraphsByPrefix(prefix)
+    : (await store.listGraphs()).filter((graph) => graph.startsWith(prefix));
 }

--- a/packages/agent/src/dkg-agent-cg-resolve.ts
+++ b/packages/agent/src/dkg-agent-cg-resolve.ts
@@ -19,7 +19,7 @@ import {
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
   contextGraphSharedMemoryUri,
   contextGraphVerifiableMemoryUri, contextGraphVerifiableMemoryMetaUri,
-  contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
+  contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri, contextGraphCatalogUri,
   deriveCuratorDidFromCgId,
   MemoryLayer,
   computeACKDigest,
@@ -379,7 +379,73 @@ import {
   deserializePendingSenderKeyEntry,
 } from './dkg-agent-swm-state.js';
 import { DKGAgentBase } from './dkg-agent-base.js';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 import type { DKGAgent } from './dkg-agent.js';
+
+interface ContextGraphListRow {
+  id: string;
+  uri: string;
+  name: string;
+  description?: string;
+  creator?: string;
+  curator?: string;
+  accessPolicy?: string;
+  createdAt?: string;
+  isSystem: boolean;
+  subscribed: boolean;
+  synced: boolean;
+  onChainId?: string;
+  callerInvolved?: boolean;
+}
+
+type InternalContextGraphListRow = ContextGraphListRow & {
+  policyKnown?: boolean;
+};
+
+function listContextGraphsProjectionEnabled(): boolean {
+  const raw = process.env.DKG_LIST_CONTEXT_GRAPHS_PROJECTION?.trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
+function isPrivateContextGraphListRow(accessPolicy?: string): boolean {
+  if (!accessPolicy?.trim()) return false;
+  const t = accessPolicy.trim().replace(/^["']|["']$/g, '').toLowerCase();
+  return t === 'private';
+}
+
+async function applyContextGraphListPrivacy(
+  agent: DKGAgent,
+  rows: InternalContextGraphListRow[],
+  opts?: { callerAgentAddress?: string | null },
+): Promise<ContextGraphListRow[]> {
+  const scopedList = opts !== undefined && Object.prototype.hasOwnProperty.call(opts, 'callerAgentAddress');
+  const visibleRows = scopedList ? rows.filter((r) => r.policyKnown !== false) : rows;
+  let checksum: string | null = null;
+  const rawCaller = opts?.callerAgentAddress?.trim();
+  if (rawCaller && ethers.isAddress(rawCaller)) {
+    try {
+      checksum = ethers.getAddress(rawCaller);
+    } catch {
+      checksum = null;
+    }
+  }
+
+  if (!checksum) {
+    return visibleRows
+      .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy))
+      .map(({ policyKnown: _policyKnown, ...row }) => row);
+  }
+
+  const annotated = await Promise.all(visibleRows.map(async (r) => {
+    const curatorMatch = agent.curatorDidMatchesChecksumAgent(r.curator, checksum);
+    const allowlisted = await agent.callerIsAllowlistedAgentParticipant(r.id, checksum);
+    return { ...r, callerInvolved: curatorMatch || allowlisted };
+  }));
+
+  return annotated
+    .filter((r) => !isPrivateContextGraphListRow(r.accessPolicy) || r.callerInvolved === true)
+    .map(({ policyKnown: _policyKnown, ...row }) => row);
+}
 
 function syncAuthAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
@@ -399,6 +465,59 @@ function throwIfSyncAuthAborted(signal: AbortSignal | undefined): void {
 }
 
 export class ContextGraphResolveMethods extends DKGAgentBase {
+  async getCgMeta(this: DKGAgent, contextGraphId: string): Promise<ContextGraphMetaRecord> {
+    return this.contextGraphMetaProjection.get(contextGraphId);
+  }
+
+  async listContextGraphsFromProjection(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ContextGraphListRow[]> {
+    const candidateIds = new Set(await this.contextGraphMetaProjection.listDeclaredContextGraphIds());
+    for (const [id] of this.subscribedContextGraphs) {
+      candidateIds.add(id);
+    }
+
+    const graphManager = new GraphManager(this.store);
+    for (const id of await graphManager.listContextGraphs()) {
+      candidateIds.add(id);
+    }
+
+    const rows = await Promise.all([...candidateIds].sort().map(async (id): Promise<InternalContextGraphListRow | null> => {
+      if (!id) return null;
+      const sub = this.subscribedContextGraphs.get(id);
+      const meta = await this.getCgMeta(id);
+      const hasProjectionGate = meta.hasAgentGate || meta.hasPeerGate || meta.hasLegacyParticipantGate;
+      const projectedAccessPolicy = meta.accessPolicy ?? (hasProjectionGate ? 'private' : undefined);
+      const policyKnown = meta.declared || projectedAccessPolicy !== undefined;
+
+      if (!meta.declared && !sub?.onChainId && !sub?.pendingMeta) {
+        if (id === SYSTEM_CONTEXT_GRAPHS.AGENTS || id === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY) return null;
+        const hasContent = await this.contextGraphHasLocalContent(id);
+        if (!hasContent) return null;
+      }
+
+      return {
+        id,
+        uri: meta.uri || contextGraphDataUri(id),
+        name: meta.name ?? sub?.name ?? id,
+        description: meta.description,
+        creator: meta.creator,
+        curator: meta.curator,
+        accessPolicy: projectedAccessPolicy,
+        createdAt: meta.createdAt,
+        isSystem: meta.isSystem,
+        subscribed: sub?.subscribed ?? false,
+        synced: sub?.synced ?? false,
+        onChainId: sub?.onChainId ?? meta.onChainId,
+        policyKnown,
+      };
+    }));
+
+    return applyContextGraphListPrivacy(
+      this,
+      rows.filter((row): row is ContextGraphListRow => row !== null),
+      opts,
+    );
+  }
+
   /**
    * Check whether a context graph exists in local storage. Definition triples in
    * ONTOLOGY/_meta count, and storage-backed graph presence also counts so local
@@ -621,6 +740,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
         syncSessionId: typeof parsed.syncSessionId === 'string' ? parsed.syncSessionId : undefined,
         // Phase C: unsigned delta hint. Validated/normalised in the responder.
         sinceBatchId: typeof parsed.sinceBatchId === 'string' ? parsed.sinceBatchId : undefined,
+        // R9 (SECURITY): the unsigned member-recovery marker. This is a STRICT
+        // FIELD ALLOWLIST — anything not copied here is dropped. If `recovery`
+        // were omitted, the responder would never see it, silently fall through
+        // to the fail-open participant/peer path, and the members-only gate
+        // would be dead code. Coerce to a real boolean so a truthy non-bool
+        // can't smuggle through.
+        recovery: parsed.recovery === true ? true : undefined,
       };
     }
 
@@ -740,6 +866,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     snapshotRef?: string,
     sinceBatchId?: string,
     syncSessionId?: string,
+    recovery?: boolean,
   ): Promise<Uint8Array> {
     const isPrivate = await this.isPrivateContextGraph(contextGraphId);
 
@@ -748,7 +875,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     // authenticated request so the remote peer can verify our identity
     // against its allowlist.
     const hasLocalData = this.subscribedContextGraphs.get(contextGraphId)?.synced === true;
-    const needsAuth = isPrivate || !hasLocalData;
+    // the catalog facet is public and served without the
+    // allowlist gate, so an outsider (no CG identity) requests it unauthenticated.
+    // R9: recovery serves plaintext member-to-member and is gated by the strict
+    // members-only authorizer — it MUST be an authenticated (signed) envelope.
+    const needsAuth = recovery || (phase !== 'catalog' && (isPrivate || !hasLocalData));
     const claimedAgentAddress = await this.findLocalAgentForContextGraph(contextGraphId);
     const claimedAgent = claimedAgentAddress ? this.localAgents.get(claimedAgentAddress) : undefined;
     return buildSyncRequestEnvelope({
@@ -767,12 +898,64 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       sinceBatchId: phase === 'data' && !includeSharedMemory ? sinceBatchId : undefined,
       syncSessionId: phase === 'snapshot' ? undefined : syncSessionId,
       needsAuth,
+      // R9: forces the EDGE (member-agent-key) signing path so the responder
+      // recovers the member agent address and matches it against the gate.
+      recovery,
       computeSyncDigest: this.computeSyncDigest.bind(this),
       getIdentityId: () => this.chain.getIdentityId(),
       signMessage: typeof this.chain.signMessage === 'function' ? this.chain.signMessage.bind(this.chain) : undefined,
       claimedAgentAddress: claimedAgentAddress,
       claimedAgentPrivateKey: claimedAgent?.privateKey,
     });
+  }
+
+  /**
+   * fetch a (private) CG's PUBLIC catalog entry from a peer
+   * WITHOUT membership. The responder serves the bounded `_catalog` facet
+   * openly (no allowlist gate); the fetched DCAT dataset record is written to
+   * the local store's `_catalog` graph. Returns the catalog quads received.
+   * The peer serves ONLY `_catalog` — gated content is never returned.
+   */
+  public async fetchPublicCatalog(this: DKGAgent,
+    contextGraphId: string,
+    responderPeerId: string,
+    deadlineMs = 30_000,
+  ): Promise<Quad[]> {
+    const ctx = createOperationContext('sync');
+    const catalogGraph = contextGraphCatalogUri(contextGraphId);
+    const result = await this.fetchSyncPages(
+      ctx, responderPeerId, contextGraphId, false, 'catalog', catalogGraph, Date.now() + deadlineMs,
+    );
+    // SECURITY: this is the UNAUTHENTICATED catalog path — there is no
+    // membership/allowlist gate on what we persist. The generic requester
+    // filter (parseAndFilterNQuads) admits ANY graph under
+    // `did:dkg:context-graph:<cg>/…`, not just `_catalog`, so a malicious
+    // peer could ride the open catalog fetch to inject `_meta`/`_private`/VM
+    // quads into the local store. Re-filter to ONLY the `<cg>/_catalog` graph
+    // before insert and drop everything else.
+    const catalogQuads = result.quads.filter((q) => q.graph === catalogGraph);
+    // Treat partial fetches as NOT done: fetchSyncPages returns
+    // `completed: false` (timed out) with a possibly-truncated page. Inserting
+    // that would corrupt the local `_catalog`, and deleting the checkpoint
+    // would lose the resume cursor. Only persist + delete-checkpoint when the
+    // fetch ran to completion; on partial, keep the checkpoint and persist
+    // nothing.
+    if (result.completed) {
+      // Persist the fetched DCAT dataset record into the local `<cg>/_catalog`
+      // graph and invalidate the meta projection so getCgMeta() /
+      // listContextGraphs() can see the remotely discovered private CG after
+      // this call. The projection read side is disclosure-floor only (rdf:type
+      // / dct:accessRights — CATALOG_META_PREDICATES), so persisting
+      // peer-fetched catalog quads cannot poison the authz-bearing
+      // creator/curator/allowlist fields. Mirrors refreshMetaFromCurator's
+      // persist+invalidate path.
+      if (catalogQuads.length > 0) {
+        await this.store.insert(catalogQuads);
+        this.contextGraphMetaProjection.markDirtyFromQuads(catalogQuads);
+      }
+      this.syncCheckpoints.delete(result.checkpointKey);
+    }
+    return catalogQuads;
   }
 
   computeSyncDigest(this: DKGAgent,
@@ -847,6 +1030,9 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       getAgentGateAddresses: (contextGraphId, lookupOptions) => this.getContextGraphAgentGateAddresses(contextGraphId, lookupOptions),
       getAllowedDelegateePeers: (contextGraphId, lookupOptions) => this.getContextGraphAllowedDelegateePeers(contextGraphId, lookupOptions),
       getAllowedDelegateeKeys: (contextGraphId, lookupOptions) => this.getContextGraphAllowedDelegateeKeys(contextGraphId, lookupOptions),
+      // R9: FRESH `_meta`-only members-only gate for the recovery branch (no
+      // subscription cache). Consulted only when `request.recovery` is set.
+      getMemberRecoveryGate: (contextGraphId, lookupOptions) => this.getMemberRecoveryGate(contextGraphId, lookupOptions),
       refreshMetaFromCurator: (contextGraphId, lookupOptions) => this.refreshMetaFromCurator(contextGraphId, lookupOptions),
       signal: options.signal,
       logWarn: (ctx, message) => this.log.warn(ctx, message),
@@ -1347,6 +1533,13 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     contextGraphId: string,
     options: { signal?: AbortSignal } = {},
   ): Promise<string[] | null> {
+    // the participant set is read from the in-memory meta projection
+    // (getCgMeta), NOT a direct store query — the projection is the only place
+    // that applies revokedAgents filtering, so a store-only read (main's A2
+    // form) would silently re-authorize revoked agents. `options.signal` is
+    // accepted for caller parity with the abort-hardened siblings but the
+    // projection read is in-memory and has no I/O to cancel.
+    void options;
     const merged: string[] = [];
     const seen = new Set<string>();
     const add = (value: string | undefined) => {
@@ -1356,49 +1549,24 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       seen.add(key);
       merged.push(value);
     };
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    const addAgent = (value: string | undefined) => {
+      if (!value || revoked.has(value.toLowerCase())) return;
+      add(value);
+    };
 
     const localAgentParticipants = this.subscribedContextGraphs.get(contextGraphId)?.participantAgents;
     if (localAgentParticipants) {
-      for (const p of localAgentParticipants) add(p);
+      for (const p of localAgentParticipants) addAgent(p);
     }
-
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
 
     // V10 agent model: local allowedAgent entries plus explicit on-chain
     // participantAgent entries both grant local curated access.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
-
+    for (const agent of meta.allowedAgents) addAgent(agent);
+    for (const agent of meta.participantAgents) addAgent(agent);
     // Legacy identity model: participantIdentityIds (numeric IDs as strings)
-    const metaResult = await this.store.query(
-      `SELECT ?identityId WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_IDENTITY_ID}> ?identityId
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (metaResult.type === 'bindings') {
-      for (const row of metaResult.bindings) {
-        const raw = row['identityId'];
-        if (typeof raw === 'string') add(raw.replace(/^"|"$/g, ''));
-      }
-    }
+    for (const identityId of meta.participantIdentityIds) add(identityId);
 
     if (merged.length > 0) return merged;
 
@@ -1585,6 +1753,7 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
       throwIfSyncAuthAborted(options.signal);
       if (metaResult.quads.length > 0) {
         await this.store.insert(metaResult.quads);
+        this.contextGraphMetaProjection.markDirtyFromQuads(metaResult.quads);
         this.syncCheckpoints.delete(metaResult.checkpointKey);
         this.log.info(ctx, `Meta refresh for "${contextGraphId}": ${metaResult.quads.length} triples from curator ${curatorPeerId.slice(-8)}`);
         return true;
@@ -1611,28 +1780,11 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
    * With a valid `callerAgentAddress` option, each row includes `callerInvolved`.
    * With no usable caller wallet, omit that field entirely so callers can infer membership from `curator`.
    */
-  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<Array<{
-    id: string;
-    uri: string;
-    name: string;
-    description?: string;
-    creator?: string;
-    /** Wallet-scoped curator DID (from _meta / ontology), if present. */
-    curator?: string;
-    /** Declared access policy literal, e.g. public / private. */
-    accessPolicy?: string;
-    createdAt?: string;
-    isSystem: boolean;
-    subscribed: boolean;
-    synced: boolean;
-    onChainId?: string;
-    /**
-     * When `callerAgentAddress` is omitted or invalid: property is omitted —
-     * clients fall back to comparing `curator` to identity (listing was not scoped to a caller).
-     * When a valid caller is provided: explicit true/false.
-     */
-    callerInvolved?: boolean;
-  }>> {
+  async listContextGraphs(this: DKGAgent, opts?: { callerAgentAddress?: string | null }): Promise<ContextGraphListRow[]> {
+    if (listContextGraphsProjectionEnabled()) {
+      return this.listContextGraphsFromProjection(opts);
+    }
+
     const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
     const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
     const result = await this.store.query(`
@@ -1827,51 +1979,26 @@ export class ContextGraphResolveMethods extends DKGAgentBase {
     let rows = Array.from(seen.values());
 
     /**
-     * Open CGs replicate `DKG_CREATOR`/name/policy on ONTOLOGY but keep `DKG_CURATOR` in `_meta` only,
-     * so list rows lack `curator` and the sidebar cannot classify "mine" without a Bearer-scoped pass.
-     * Backfill once (parallelised) — also removes duplicate SPARQL in the involvement pass below.
+     * Normalize metadata through the keyed projection before privacy filtering.
+     * Raw discovery can see stale ONTOLOGY and authoritative AGENTS/_meta rows
+     * for the same CG; projection gives private policy precedence.
      */
     rows = await Promise.all(rows.map(async (r) => {
-      if (r.curator?.trim()) return r;
-      const c = await this.getContextGraphCurator(r.id);
-      return c ? { ...r, curator: c } : r;
+      const meta = await this.getCgMeta(r.id);
+      return {
+        ...r,
+        name: meta.name ?? r.name,
+        description: meta.description ?? r.description,
+        creator: meta.creator ?? r.creator,
+        curator: meta.curator ?? r.curator,
+        accessPolicy: meta.accessPolicy ?? r.accessPolicy,
+        createdAt: meta.createdAt ?? r.createdAt,
+        isSystem: meta.isSystem || r.isSystem,
+        onChainId: meta.onChainId ?? r.onChainId,
+      };
     }));
 
-    let checksum: string | null = null;
-    const rawCaller = opts?.callerAgentAddress?.trim();
-    if (rawCaller && ethers.isAddress(rawCaller)) {
-      try {
-        checksum = ethers.getAddress(rawCaller);
-      } catch {
-        checksum = null;
-      }
-    }
-
-    // Privacy filter: curated/private CGs must never leak past the daemon to a non-member
-    // caller. With no caller wallet (Bearer absent), drop all private rows; with a caller,
-    // keep private rows only when they are curator or allowlisted participant.
-    const isPrivateRow = (ap?: string): boolean => {
-      if (!ap?.trim()) return false;
-      const t = ap.trim().replace(/^["']|["']$/g, '').toLowerCase();
-      return t === 'private';
-    };
-
-    if (!checksum) {
-      // Without a caller wallet we still leave `callerInvolved` unset so the UI can use the
-      // curator-vs-identity fallback for OPEN graphs.
-      return rows.filter((r) => !isPrivateRow(r.accessPolicy));
-    }
-
-    const annotated = await Promise.all(rows.map(async (r) => {
-      const curatorMatch = this.curatorDidMatchesChecksumAgent(r.curator, checksum);
-      const allowlisted = await this.callerIsAllowlistedAgentParticipant(r.id, checksum);
-      // `callerInvolved` must reflect ONLY the provided caller wallet.
-      // Using local node identity (`creatorIsSelf`) leaks curated rows to unrelated callers.
-      const involved = curatorMatch || allowlisted;
-      return { ...r, callerInvolved: involved };
-    }));
-
-    return annotated.filter((r) => !isPrivateRow(r.accessPolicy) || r.callerInvolved === true);
+    return applyContextGraphListPrivacy(this, rows, opts);
   }
 
 }

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -652,6 +652,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     );
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(opts.id);
 
     // Force the triple-store flush BEFORE the SQLite caches are written.
@@ -911,6 +912,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CREATOR, object: creatorPeerDid, graph: defGraph },
         { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: curatorDid, graph: cgMetaGraph },
       ]);
+      this.contextGraphMetaProjection.markDirty(id);
       this.log.info(ctx, `Stamped local node as creator contact and address curator for "${id}" (registration-time lazy stamp)`);
       return curatorDid;
     };
@@ -1128,6 +1130,7 @@ export class ContextGraphMethods extends DKGAgentBase {
         await this.store.insert([
           { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         return { onChainId: existingOnChainId, txHash: undefined };
       }
       this.log.warn(
@@ -1300,6 +1303,7 @@ export class ContextGraphMethods extends DKGAgentBase {
             graph: cgMetaGraph,
           },
         ]);
+        this.contextGraphMetaProjection.markDirty(id);
         // Re-fetch participantAgents so the on-chain
         // registration also lists the calling agent (matches
         // what the local agent gate now enforces).
@@ -1400,6 +1404,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       // topic without re-reading the chain event.
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainHash`, object: `"${nameHash}"`, graph: cgMetaGraph },
     ]);
+    this.contextGraphMetaProjection.markDirty(id);
     // We no longer persist `publishAuthorityAccountId` locally even on
     // success (Codex PR #502 round-6 follow-through): with the
     // stored-value fallback gone, nothing reads it. A CG can only
@@ -1526,6 +1531,7 @@ export class ContextGraphMethods extends DKGAgentBase {
     });
 
     await this.store.insert(quadsToInsert);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
 
     // Issue #865 — log a clear warning AFTER the allowlist quad has
     // landed on a CG with an explicit `accessPolicy="public"` triple.
@@ -1689,6 +1695,8 @@ export class ContextGraphMethods extends DKGAgentBase {
 
     await this.store.insert(quadsToInsert);
 
+    this.contextGraphMetaProjection.markDirtyFromQuads(quadsToInsert);
+
     // Issue #865 — companion warning to the peer-invite path above.
     // Allowlist writes on explicit-public CGs are allowed (the
     // publishPolicy=curated + accessPolicy=public combination is a
@@ -1778,6 +1786,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       predicate: DKG_ONTOLOGY.DKG_REVOKED_AGENT,
       object: `"${agentAddress}"`,
     }]);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     this.deleteContextGraphMember(contextGraphId, 'agent', agentAddress);
     this.queueSharedMemoryGossipSubscription(contextGraphId);
     // Drop any cached sender-key send state for this CG so the next
@@ -1855,6 +1864,7 @@ export class ContextGraphMethods extends DKGAgentBase {
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: ontologyGraph },
       { subject: contextGraphUri, predicate: schemaName, object: escaped, graph: cgMetaGraph },
     ]);
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
 
     this.log.info(ctx, `Renamed context graph "${contextGraphId}" to "${trimmed}"`);
   }
@@ -1863,8 +1873,6 @@ export class ContextGraphMethods extends DKGAgentBase {
    * List allowed agents for a context graph.
    */
   async getContextGraphAllowedAgents(this: DKGAgent, contextGraphId: string): Promise<string[]> {
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
     // Subtract `dkg:revokedAgent` tombstones from the allowlist union
     // so a curator who has called `removeAgentFromContextGraph` sees
     // their authoritative view, not the union with peer-sync-replicated
@@ -1873,32 +1881,9 @@ export class ContextGraphMethods extends DKGAgentBase {
     // silently re-include a revoked agent the moment another node's
     // local CG metadata gossiped back (see C1 devnet harness for the
     // reproducer + `removeAgentFromContextGraph` for the write side).
-    const result = await this.store.query(
-      `SELECT ?agent ?revoked WHERE {
-        {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_REVOKED_AGENT}> ?revoked
-          }
-        }
-      }`,
-    );
-    if (result.type !== 'bindings') return [];
-    const allowed: string[] = [];
-    const revoked = new Set<string>();
-    for (const row of result.bindings) {
-      const a = (row as Record<string, string>)['agent'];
-      const r = (row as Record<string, string>)['revoked'];
-      if (typeof a === 'string') {
-        allowed.push(a.replace(/^"|"$/g, ''));
-      }
-      if (typeof r === 'string') {
-        revoked.add(r.replace(/^"|"$/g, '').toLowerCase());
-      }
-    }
+    const meta = await this.getCgMeta(contextGraphId);
+    const allowed = meta.allowedAgents;
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     if (revoked.size === 0) return allowed;
     return allowed.filter((addr) => !revoked.has(addr.toLowerCase()));
   }

--- a/packages/agent/src/dkg-agent-crypto.ts
+++ b/packages/agent/src/dkg-agent-crypto.ts
@@ -432,10 +432,13 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
     const seen = new Set<string>();
     const agents: string[] = [];
     let sawAgentGate = false;
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
     const add = (value: string | undefined) => {
       if (!value || !ethers.isAddress(value)) return;
       const checksum = ethers.getAddress(value);
       const key = checksum.toLowerCase();
+      if (revoked.has(key)) return;
       if (seen.has(key)) return;
       seen.add(key);
       agents.push(checksum);
@@ -447,29 +450,52 @@ export class WorkspaceCryptoMethods extends DKGAgentBase {
       add(agentAddress);
     }
 
-    const contextGraphUri = contextGraphDataGraphUri(contextGraphId);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const result = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-        }
-      }`,
-      { signal: options.signal },
-    );
-    if (result.type === 'bindings') {
-      if (result.bindings.length > 0) sawAgentGate = true;
-      for (const row of result.bindings) {
-        const raw = row['agent'];
-        if (typeof raw === 'string') {
-          add(raw.replace(/^"/, '').replace(/"(@[a-zA-Z-]+|\^\^<[^>]+>)?$/, ''));
-        }
-      }
-    }
+    if (meta.allowedAgents.length > 0 || meta.participantAgents.length > 0) sawAgentGate = true;
+    for (const agent of meta.allowedAgents) add(agent);
+    for (const agent of meta.participantAgents) add(agent);
 
     return sawAgentGate ? agents : null;
+  }
+
+  /**
+   * R9 (SECURITY) — FRESH, `_meta`-only member-recovery gate.
+   *
+   * Resolves `allowedAgents ∪ participantAgents` minus `revokedAgents` from the
+   * CG `_meta` projection (store-backed, write-invalidated), with the
+   * network-influenced `subscribedContextGraphs` subscription cache
+   * DELIBERATELY OMITTED — that cache is poisonable, and folding it in is
+   * exactly what `member-recovery-auth.ts` forbids.
+   *
+   * Unlike {@link getContextGraphAgentGateAddresses} (which feeds the normal
+   * fail-open sync path and DOES fold in the subscription cache), this read is
+   * used ONLY for `request.recovery` and is passed straight to
+   * `isMemberRecoveryAuthorized`, which hard-denies on null/empty. Returns
+   * `null` when the CG has no `_meta` agent gate at all (⇒ hard-deny).
+   */
+  async getMemberRecoveryGate(
+    this: DKGAgent,
+    contextGraphId: string,
+    _options: { signal?: AbortSignal } = {},
+  ): Promise<string[] | null> {
+    const seen = new Set<string>();
+    const agents: string[] = [];
+    const meta = await this.getCgMeta(contextGraphId);
+    if (meta.allowedAgents.length === 0 && meta.participantAgents.length === 0) {
+      return null; // no _meta agent gate ⇒ hard-deny at the recovery gate
+    }
+    const revoked = new Set(meta.revokedAgents.map((addr) => addr.toLowerCase()));
+    const add = (value: string | undefined) => {
+      if (!value || !ethers.isAddress(value)) return;
+      const checksum = ethers.getAddress(value);
+      const key = checksum.toLowerCase();
+      if (revoked.has(key)) return;
+      if (seen.has(key)) return;
+      seen.add(key);
+      agents.push(checksum);
+    };
+    for (const agent of meta.allowedAgents) add(agent);
+    for (const agent of meta.participantAgents) add(agent);
+    return agents;
   }
 
   /**

--- a/packages/agent/src/dkg-agent-helpers.ts
+++ b/packages/agent/src/dkg-agent-helpers.ts
@@ -200,7 +200,7 @@ export function joinDelegationScope(deploymentId: string | undefined, contextGra
 // ── Sync-phase normalisation ──────────────────────────────────────────
 
 export function normalizeSyncPhase(value: unknown): SyncPhase {
-  if (value === 'meta' || value === 'snapshot') return value;
+  if (value === 'meta' || value === 'snapshot' || value === 'catalog') return value;
   return 'data';
 }
 

--- a/packages/agent/src/dkg-agent-ownership.ts
+++ b/packages/agent/src/dkg-agent-ownership.ts
@@ -700,8 +700,6 @@ export class OwnershipMethods extends DKGAgentBase {
   }
 
   async getContextGraphCurator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
     // Multi-curator scenario: peer-to-peer sync of CG `_meta` triples
     // can replicate FOREIGN `dkg:curator` triples onto a node's local
     // store. The original behaviour (`LIMIT 1`) made ownership lookup
@@ -719,21 +717,7 @@ export class OwnershipMethods extends DKGAgentBase {
     // the first curator triple when no local match exists, preserving
     // the legacy "subscriber sees foreign owner" semantics for
     // membership/UI queries against CGs this node did not curate.
-    const curatorResult = await this.store.query(`
-      SELECT ?owner WHERE {
-        GRAPH <${cgMetaGraph}> {
-          <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CURATOR}> ?owner .
-        }
-      }
-    `);
-    if (curatorResult.type !== 'bindings' || curatorResult.bindings.length === 0) {
-      return null;
-    }
-    const owners: string[] = [];
-    for (const b of curatorResult.bindings) {
-      const o = (b as Record<string, string>)['owner'];
-      if (o) owners.push(o);
-    }
+    const owners = (await this.getCgMeta(contextGraphId)).curators;
     if (owners.length === 0) return null;
     if (owners.length === 1) return owners[0];
     const selfDid = `did:dkg:agent:${this.peerId}`;
@@ -817,8 +801,6 @@ export class OwnershipMethods extends DKGAgentBase {
       merged.push(checksumAddress);
     };
 
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const cgMetaGraph = contextGraphMetaUri(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — the on-chain participant-agent list
     // is now the authoritative source for the host-mode envelope
     // authority check on cores (see `resolveOnChainParticipantAgents`
@@ -841,19 +823,13 @@ export class OwnershipMethods extends DKGAgentBase {
     // (those are persisted as PARTICIPANT triples). The merge below
     // is a UNION so any per-CG explicit list survives and just gets
     // augmented with whatever local allowlist exists.
-    const agentResult = await this.store.query(
-      `SELECT ?agent WHERE {
-        GRAPH <${cgMetaGraph}> {
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?agent }
-          UNION
-          { <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?agent }
-        }
-      }`,
-    );
-    if (agentResult.type === 'bindings') {
-      for (const row of agentResult.bindings) {
-        add(row['agent']);
-      }
+    const meta = await this.getCgMeta(contextGraphId);
+    const revoked = new Set(meta.revokedAgents.map((agent) => agent.toLowerCase()));
+    for (const agent of meta.participantAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
+    }
+    for (const agent of meta.allowedAgents) {
+      if (!revoked.has(agent.toLowerCase())) add(agent);
     }
     return merged;
   }
@@ -866,25 +842,7 @@ export class OwnershipMethods extends DKGAgentBase {
    * peers validating via `gossip-publish-handler` see a matching owner.
    */
   async getContextGraphCreator(this: DKGAgent, contextGraphId: string): Promise<string | null> {
-    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
-    const cgMetaGraph = contextGraphMetaGraphUri(contextGraphId);
-    const contextGraphUri = `did:dkg:context-graph:${contextGraphId}`;
-    const result = await this.store.query(`
-      SELECT ?owner WHERE {
-        {
-          GRAPH <${ontologyGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        } UNION {
-          GRAPH <${cgMetaGraph}> {
-            <${contextGraphUri}> <${DKG_ONTOLOGY.DKG_CREATOR}> ?owner .
-          }
-        }
-      }
-      LIMIT 1
-    `);
-    if (result.type !== 'bindings' || result.bindings.length === 0) return null;
-    return (result.bindings[0] as Record<string, string>)['owner'] ?? null;
+    return (await this.getCgMeta(contextGraphId)).creator ?? null;
   }
 
   public async listCclPolicyBindings(this: DKGAgent, opts: {

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -20,6 +20,7 @@ import {
   contextGraphSharedMemoryUri,
   contextGraphVerifiableMemoryUri, contextGraphVerifiableMemoryMetaUri,
   contextGraphDataUri, contextGraphMetaUri, assertionLifecycleUri, contextGraphAssertionUri,
+  contextGraphCatalogUri,
   contextGraphLayerUri,
   deriveCuratorDidFromCgId,
   MemoryLayer,
@@ -149,6 +150,7 @@ import {
   type SignedAgentDelegation,
 } from './auth/agent-delegation.js';
 import { SyncVerifyWorker } from './sync-verify-worker.js';
+import { emitPublicProjection, buildPublicProjection } from './context-graph-public-projection.js';
 import { bindRandomSampling, type RandomSamplingHandle, type RandomSamplingStatus } from './random-sampling-bind.js';
 import { connectToMultiaddr, ensurePeerConnected as ensurePeerConnectedAtom, primeCatchupConnections as primeCatchupConnectionsAtom } from './p2p/peer-connect.js';
 import { Messenger, type SloProtocolStats } from './p2p/messenger.js';
@@ -1287,7 +1289,92 @@ export class PublishMethods extends DKGAgentBase {
     await this.broadcastPublish(contextGraphId, result, ctx);
     onPhase?.('broadcast', 'end');
     this.log.info(ctx, `Publish complete — status=${result.status} kaId=${result.kaId}`);
+
+    // refresh the private CG's public projection now the root
+    // is committed. No-op unless configured; best-effort and error-isolated so
+    // it can never affect the publish just completed.
+    await this.emitPublicProjectionAfterPublish(contextGraphId, result, ctx);
+
     return result;
+  }
+
+  /**
+   * emit/refresh the public projection of a private CG once
+   * its VM publish is confirmed on chain. Binds the private CG into the public
+   * graph as a discoverable, verifiable node (floor: `a dkg:PrivateContextGraph`,
+   * UAL, `dct:accessRights dkg:Private`, `dkg:committedRoot`) while disclosing
+   * nothing beyond chain state (§5.9.1).
+   *
+   * No-op unless `publicProjectionContextGraphId` is configured; skips public
+   * CGs (they are their own public face, handled inside `emitPublicProjection`)
+   * and the discovery CG itself (recursion guard). Fully error-isolated — a
+   * projection failure logs and returns, never affecting the triggering publish.
+   */
+  async emitPublicProjectionAfterPublish(
+    this: DKGAgent,
+    contextGraphId: string,
+    result: PublishResult,
+    ctx: OperationContext,
+  ): Promise<void> {
+    try {
+      const target = this.config.publicProjectionContextGraphId;
+      // Off unless configured; never project the discovery CG into itself.
+      if (!target || contextGraphId === target) return;
+      // Only a confirmed publish has a real on-chain committed root.
+      if (result.status !== 'confirmed' || result.merkleRoot.length !== 32) return;
+      const committedRoot = `0x${Buffer.from(result.merkleRoot).toString('hex')}`;
+
+      await emitPublicProjection(
+        {
+          isPrivateContextGraph: (id) => this.isPrivateContextGraph(id),
+          // B7 — the catalog subject is the context-graph DID
+          // (`did:dkg:context-graph:<id>`), NOT the knowledge-asset UAL
+          // (`result.ual`). Resolving from the CG id makes every publish refresh
+          // the SAME catalog entry (one stable subject per CG) that open-serve
+          // and the in-finalize injection also key off.
+          resolveUal: async (id) => contextGraphDataUri(id),
+          // B8 — persist the projection under the SOURCE CG's `_catalog` graph
+          // (`<source-cg>/_catalog`), the exact graph open-serve reads via
+          // `contextGraphCatalogUri`. The previous TARGET-CG data graph left
+          // outsiders with an empty `<source-cg>/_catalog`.
+          projectionGraph: (id) => contextGraphCatalogUri(id),
+          // buildPublicProjection already stamps each quad's graph from
+          // `projectionGraph` (the source `_catalog`), so the insert lands them
+          // in the right named graph — matching the canonical publisher catalog
+          // persist (dkg-publisher.ts persistCatalogEntry).
+          //
+          // R8 — CLEAR/REPLACE, not append. `committedRoot` changes every
+          // publish, so a bare insert accumulates multiple `dkg:committedRoot`
+          // (and floor) triples for the SAME catalog subject (the CG DID) in
+          // `<source-cg>/_catalog`, leaving open-serve unable to tell which root
+          // is current. Mirror `persistCatalogEntry`: purge the prior rows for
+          // each catalog subject in this graph before inserting the refreshed
+          // entry. `graph` is the callback's third arg (= `contextGraphCatalogUri(id)`,
+          // emitPublicProjection line 225), so delete-graph === insert-graph by
+          // construction; subjects derive from the quads (one stable CG DID),
+          // deleting exactly what we replace. Then invalidate the projection
+          // cache so a cached CG record picks up the new committed root — the
+          // floor predicates (rdf:type / dct:accessRights) are in
+          // CATALOG_META_PREDICATES, so this dirties the right entry.
+          publishProjection: async (_id, quads, graph) => {
+            const subjects = new Set(quads.map((q) => q.subject));
+            for (const subject of subjects) {
+              await this.store.deleteByPattern({ graph, subject });
+            }
+            await this.store.insert(quads);
+            this.contextGraphMetaProjection.markDirtyFromQuads(quads);
+          },
+          log: (level, message) =>
+            level === 'warn' ? this.log.warn(ctx, message) : this.log.info(ctx, message),
+        },
+        contextGraphId,
+        committedRoot,
+      );
+    } catch (err) {
+      // Defense-in-depth: emitPublicProjection already isolates its own errors,
+      // but a bug in target/root resolution must never break a good publish.
+      this.log.warn(ctx, `public projection skipped: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   async update(this: DKGAgent,
@@ -1517,6 +1604,7 @@ export class PublishMethods extends DKGAgentBase {
     ];
 
     await this.store.insert(quads);
+    this.contextGraphMetaProjection.markDirtyFromQuads(quads);
     await gm.ensureContextGraph(contextGraphId);
     await this.store.flush?.();
     this.subscribeToContextGraph(contextGraphId);
@@ -1596,7 +1684,10 @@ export class PublishMethods extends DKGAgentBase {
     const metaGraph = contextGraphMetaUri(contextGraphId);
 
     // 2. Pull the assertion's quads. Refuse to finalize an empty
-    //    assertion — there's nothing to commit.
+    //    assertion — there's nothing to commit. The public DCAT catalog entry
+    //    for a private CG is injected ONLY AFTER this validation (below), so a
+    //    catalog-only assertion (zero user-authored quads) is correctly
+    //    rejected here rather than slipping through on the catalog quad alone.
     const rawQuads = await this.publisher.assertionQuery(
       contextGraphId,
       name,
@@ -1619,14 +1710,38 @@ export class PublishMethods extends DKGAgentBase {
     //     the post-strip set or it commits to a root the publish path
     //     can never recompute. (Round 4 review §8 — "assertionFinalize
     //     hashes WM-only urn:dkg:file: rows".)
-    const quads = rawQuads.filter((q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q));
-    if (quads.length === 0) {
+    const userQuads = rawQuads.filter((q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q));
+    if (userQuads.length === 0) {
       throw new Error(
         `Cannot finalize assertion <${assertionUri}>: every quad has a ` +
           `reserved-namespace subject (urn:dkg:file:* / urn:dkg:extraction:*) ` +
           `which is filtered out before SWM. Add at least one user-authored ` +
           `quad on a non-reserved subject before finalizing.`,
       );
+    }
+
+    // B6 — inject the public DCAT catalog entry for a PRIVATE CG ONLY AFTER the
+    // "≥1 real user-authored quad" contract has been validated against
+    // `userQuads` above, so a catalog-only assertion can never finalize.
+    // The entry rides in the CG's OWN merkle root as a public KA whose subject
+    // is the context-graph DID (`contextGraphDataUri(contextGraphId)` ===
+    // `did:dkg:context-graph:<contextGraphId>`), the SAME subject open-serve
+    // reads from `<source-cg>/_catalog`. Persisted to the WM graph so
+    // promote/reload carry it; the publish-path partition keeps it out of the
+    // ciphertext and routes it to the public `_catalog` sink. The catalog quads
+    // are appended to `quads` (the merkle input) so the root the seal commits
+    // matches the root the publisher recomputes after reloading WM (which then
+    // includes the catalog) — the leaf hash is over (subject, predicate, object)
+    // only, so the placeholder `graph` here does not affect the root.
+    // Idempotent across re-finalize: identical quads dedupe in the WM store.
+    const quads = [...userQuads];
+    if (await this.isPrivateContextGraph(contextGraphId)) {
+      const cgDid = contextGraphDataUri(contextGraphId);
+      // `graph` is a non-empty placeholder only (buildPublicProjection requires
+      // one); assertionWrite re-stamps it with the correct wmGraphUri.
+      const catalogQuads = buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: assertionUri });
+      await this.publisher.assertionWrite(contextGraphId, name, agentAddress, catalogQuads, opts?.subGraphName);
+      quads.push(...catalogQuads);
     }
 
     // 3. Compute merkleRoot using the SAME algorithm the publisher
@@ -2802,7 +2917,7 @@ export class PublishMethods extends DKGAgentBase {
         ${sharedMemoryReadBothFilter(swmGraph)}
       }`;
     }
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.resolveLiftWorkspaceSlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1111,7 +1111,7 @@ export class AgentRegistryMethods extends DKGAgentBase {
     let markedDefaultAddr: string | undefined;
     const needsMigration: AgentKeyRecord[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.agentKeyMigration' });
       if (result.type !== 'bindings') return;
       const strip = (v?: string) => v?.replace(/^"|"$/g, '').replace(/"?\^\^.*$/, '') ?? '';
       for (const row of result.bindings) {

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -386,6 +386,13 @@ import {
 import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
+const DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE = 32;
+
+function normalizeHostModeReconcileBatchSize(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE;
+  return Math.max(1, Math.floor(value));
+}
+
 export class SwmHostModeMethods extends DKGAgentBase {
   /**
    * OT-RFC-38 LU-6 — initialize the on-disk opaque ciphertext store
@@ -786,9 +793,10 @@ export class SwmHostModeMethods extends DKGAgentBase {
 
   /**
    * Periodic reconciler driven by `hostModeReconcilerTimer`. Sweeps
-   * every locally-known CG and ensures host-mode subscription is
-   * in sync. Cheap to call repeatedly because the per-CG
-   * reconciler is idempotent.
+   * a bounded slice of locally-known CGs and ensures host-mode
+   * subscription is in sync. The cursor rotates through the stable
+   * sorted set so large stores converge without each tick touching
+   * every known graph.
    *
    * Serialized via `hostModeReconcileInflight` so an overlap with
    * the cleanup timer (or a manual call from a test) doesn't
@@ -803,9 +811,22 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const inflight = (async () => {
       try {
         const graphManager = new GraphManager(this.store);
-        const knownCgs = await graphManager.listContextGraphs();
-        for (const cgId of knownCgs) {
-          await this.reconcileSwmHostModeSubscription(cgId);
+        const knownCgs = (await graphManager.listContextGraphs()).sort();
+        if (knownCgs.length === 0) {
+          this.hostModeReconcileCursor = 0;
+          return;
+        }
+        const batchSize = normalizeHostModeReconcileBatchSize(this.config.swmHostMode?.reconcileBatchSize);
+        const start = this.hostModeReconcileCursor % knownCgs.length;
+        const count = Math.min(batchSize, knownCgs.length);
+        for (let i = 0; i < count; i++) {
+          const index = (start + i) % knownCgs.length;
+          const cgId = knownCgs[index];
+          try {
+            await this.reconcileSwmHostModeSubscription(cgId);
+          } finally {
+            this.hostModeReconcileCursor = (index + 1) % knownCgs.length;
+          }
         }
       } finally {
         this.hostModeReconcileInflight = undefined;
@@ -1739,7 +1760,7 @@ export class SwmHostModeMethods extends DKGAgentBase {
     const sparql = `SELECT ?o WHERE { ${graphClause} { <${subject}> <${CIPHERTEXT_CHUNK_PREDICATE}> ?o } } LIMIT 1`;
     let result;
     try {
-      result = await this.store.query(sparql);
+      result = await this.store.query(sparql, { source: 'agent.ciphertextChunkCatchup' });
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(ctx, `LU-11 chunk-catchup store query failed cg=${req.contextGraphId} chunkIndex=${req.chunkIndex}: ${reason}`);

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -543,6 +543,9 @@ export class SwmSubstrateMethods extends DKGAgentBase {
   }
 
   async reconcileSharedMemoryGossipSubscription(this: DKGAgent, contextGraphId: string): Promise<void> {
+    // Reconcile is the membership boundary; rebuild this CG's policy view
+    // before deciding whether to keep or drop the SWM subscription.
+    this.contextGraphMetaProjection.markDirty(contextGraphId);
     // OT-RFC-38 / LU-6 Phase B — subscribe on the wire-form (hash) topic.
     // Members compute the hash from their local cleartext id via
     // {@link gossipWireIdFor}; cores hosting CGs they never joined
@@ -812,6 +815,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           getContextGraphOwner: (id) => this.getContextGraphCreator(id),
           subscribeToContextGraph: (id, options) => this.subscribeToContextGraph(id, options),
           hasConfirmedMetaState: (id) => this.hasConfirmedMetaState(id),
+          getCgMeta: (id) => this.getCgMeta(id),
+          markCgMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
           persistContextGraphSubscription: (id) => this.persistContextGraphSubscriptionState(id),
         },
       );
@@ -825,6 +830,8 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         sharedMemoryOwnedEntities: this.workspaceOwnedEntities,
         writeLocks: this.writeLocks,
         localAgentAddresses: () => [...this.localAgents.keys()],
+        contextGraphMetaOracle: (cgId: string) => this.getCgMeta(cgId),
+        markContextGraphMetaDirtyFromQuads: (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
         // OT-RFC-38 / LU-6 Phase B: chain-backed agent-allowlist
         // fallback. Cores hosting curated CGs they are NOT members
         // of have no local meta for the allowlist — without this,
@@ -1508,6 +1515,7 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         // resolve the on-chain id locally so per-cgId promotion still
         // fires and the RS prover sees the KC.
         (cgName: string) => this.getContextGraphOnChainId(cgName),
+        (quads) => { this.contextGraphMetaProjection.markDirtyFromQuads(quads); },
       );
     }
     return this.finalizationHandler;

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -161,6 +161,18 @@ export interface SyncRequestEnvelope {
    * like `phase`/`snapshotRef`), so it's additive and backward-compatible.
    */
   sinceBatchId?: string;
+  /**
+   * R9 (SECURITY) — UNSIGNED member-recovery marker. When set, the responder
+   * authorizes via the strict members-only `isMemberRecoveryAuthorized`
+   * hard-deny gate (a FRESH `_meta` agent-gate read) and MUST NOT fall through
+   * to the weaker participant/peer fallback. Unsigned because it only ever
+   * ESCALATES strictness (an attacker setting it faces the harder gate;
+   * stripping it reverts to the normal path the member already passes), and the
+   * responder decides on the cryptographically RECOVERED signer — never on this
+   * flag or the (forgeable) `requesterAgentAddress` claim. Kept in lockstep with
+   * the duplicate `SyncRequestEnvelope` in `sync/auth/request-build.ts`.
+   */
+  recovery?: boolean;
 }
 
 // ── Public error classes ────────────────────────────────────────────
@@ -781,6 +793,16 @@ export type ReplicationEventSink = (event: ReplicationEvent) => void;
 
 export interface DKGAgentConfig {
   name: string;
+  /**
+   * public-projection target. When set, a private CG's
+   * confirmed VM publishes emit/refresh a verifiable public projection (the
+   * floor: existence, UAL, access class, committed root) into this PUBLIC
+   * context graph, binding the private CG into the public graph as a
+   * discoverable, verifiable node without disclosing its contents. The target
+   * MUST be a public CG (a curated target would encrypt the projection and
+   * also self-recurse). Unset → projections are off.
+   */
+  publicProjectionContextGraphId?: string;
   framework?: string;
   description?: string;
   listenPort?: number;
@@ -965,6 +987,8 @@ export interface DKGAgentConfig {
    *  - `registered`: TTL/byte-cap for on-chain registered CGs (typically larger).
    *  - `pruneIntervalMs`: how often the TTL/cap sweep runs.
    *  - `reconcileIntervalMs`: how often the host-mode subscription reconciler ensures cores are subscribed to all known curated CGs.
+   *  - `reconcileBatchSize`: max known CGs reconciled per tick. Default 32.
+   *  - `reconcileJitterRatio`: startup interval jitter ratio in [0, 1]. Default 0.15.
    */
   swmHostMode?: {
     enabled?: boolean;
@@ -972,6 +996,8 @@ export interface DKGAgentConfig {
     registered?: SwmHostModeStoreLimits;
     pruneIntervalMs?: number;
     reconcileIntervalMs?: number;
+    reconcileBatchSize?: number;
+    reconcileJitterRatio?: number;
     /**
      * OT-RFC-38 / LU-6 Phase B — discovery-beacon rate limits for
      * pre-registration (freemium-tier) ciphertext writes. All three

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1137,6 +1137,7 @@ export class DKGAgent extends DKGAgentBase {
         graph: ontoGraph,
       }]);
 
+      this.contextGraphMetaProjection.markDirty(p.name);
       this.log.info(ctx, `Discovered on-chain context graph "${p.name}" (${p.contextGraphId.slice(0, 16)}…) — auto-subscribed (synced=false)`);
       discovered++;
     }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -43,11 +43,14 @@ export type ResolveContextGraphOnChainId = (
   contextGraphId: string,
 ) => Promise<string | null | undefined>;
 
+export type MarkContextGraphMetaDirtyFromQuads = (quads: readonly Quad[]) => void;
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
   private readonly eventBus: EventBus | undefined;
   private readonly resolveContextGraphOnChainId: ResolveContextGraphOnChainId | undefined;
+  private readonly markContextGraphMetaDirtyFromQuads: MarkContextGraphMetaDirtyFromQuads | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
 
@@ -56,11 +59,13 @@ export class FinalizationHandler {
     chain: ChainAdapter | undefined,
     eventBus?: EventBus,
     resolveContextGraphOnChainId?: ResolveContextGraphOnChainId,
+    markContextGraphMetaDirtyFromQuads?: MarkContextGraphMetaDirtyFromQuads,
   ) {
     this.store = store;
     this.chain = chain;
     this.eventBus = eventBus;
     this.resolveContextGraphOnChainId = resolveContextGraphOnChainId;
+    this.markContextGraphMetaDirtyFromQuads = markContextGraphMetaDirtyFromQuads;
   }
 
   async handleFinalizationMessage(data: Uint8Array, contextGraphId: string): Promise<void> {
@@ -314,7 +319,7 @@ export class FinalizationHandler {
       }
     }`;
 
-    const result = await this.store.query(sparql);
+    const result = await this.store.query(sparql, { source: 'agent.finalization.sharedMemorySlice' });
     return result.type === 'quads' ? result.quads : [];
   }
 
@@ -341,7 +346,7 @@ export class FinalizationHandler {
 
     const roots: Uint8Array[] = [];
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.privateRoots' });
       if (result.type === 'bindings') {
         for (const row of result.bindings) {
           const hex = (row['root'] as string).replace(/^"(.*)".*$/, '$1').replace(/^0x/, '');
@@ -389,7 +394,7 @@ export class FinalizationHandler {
       }
     }`;
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.keepRootCopySignal' });
       if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
       let sawFalse = false;
       for (const row of result.bindings) {
@@ -435,7 +440,7 @@ export class FinalizationHandler {
     } LIMIT 1`;
 
     try {
-      const result = await this.store.query(sparql);
+      const result = await this.store.query(sparql, { source: 'agent.finalization.publisherPeerId' });
       if (result.type === 'bindings' && result.bindings.length > 0) {
         const raw = result.bindings[0]['peerId'] as string;
         const peerId = raw.replace(/^"(.*)".*$/, '$1');
@@ -952,12 +957,14 @@ export class FinalizationHandler {
         } }`,
       );
       if (alreadyRegistered.type !== 'boolean' || !alreadyRegistered.value) {
-        await this.store.insert(generateSubGraphRegistration({
+        const regQuads = generateSubGraphRegistration({
           contextGraphId,
           subGraphName,
           createdBy: publisherAddress || 'finalization-discovery',
           timestamp: new Date(),
-        }));
+        });
+        await this.store.insert(regQuads);
+        this.markContextGraphMetaDirtyFromQuads?.(regQuads);
         this.log.info(ctx, `Finalization: auto-registered sub-graph "${subGraphName}" in context graph "${contextGraphId}"`);
       }
     }

--- a/packages/agent/src/gossip-publish-handler.ts
+++ b/packages/agent/src/gossip-publish-handler.ts
@@ -15,6 +15,7 @@ import {
   type KAMetadata,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
+import type { ContextGraphMetaRecord } from './context-graph-meta-projection.js';
 
 export type GossipPhaseCallback = (phase: string, status: 'start' | 'end') => void;
 
@@ -35,6 +36,8 @@ export interface GossipPublishHandlerCallbacks {
    * callback returned `false`).
    */
   hasConfirmedMetaState?: (id: string) => Promise<boolean>;
+  getCgMeta?: (id: string) => Promise<ContextGraphMetaRecord>;
+  markCgMetaDirtyFromQuads?: (quads: readonly Quad[]) => void;
   persistContextGraphSubscription?: (id: string) => void;
   onPhase?: GossipPhaseCallback;
 }
@@ -250,7 +253,7 @@ export class GossipPublishHandler {
           return;
         }
         const sparql = `SELECT DISTINCT ?s WHERE { GRAPH ?g { ?s ?p ?o } VALUES ?s { ${rootEntities.map(e => `<${e}>`).join(' ')} } FILTER(STRSTARTS(STR(?g), "${dataGraph}/_verifiable_memory/") || STR(?g) = "${dataGraph}") }`;
-        const result = await this.store.query(sparql);
+        const result = await this.store.query(sparql, { source: 'agent.gossipPublishValidation' });
         const existingEntities = new Set<string>(
           result.type === 'bindings' ? result.bindings.map(b => b['s']).filter(Boolean) : [],
         );
@@ -291,6 +294,7 @@ export class GossipPublishHandler {
             timestamp: new Date(),
           });
           await this.store.insert(regQuads);
+          this.callbacks.markCgMetaDirtyFromQuads?.(regQuads);
           this.log.info(ctx, `Auto-registered sub-graph "${subGraphName}" in context graph "${request.contextGraphId}" from gossip`);
         }
       }
@@ -298,6 +302,7 @@ export class GossipPublishHandler {
       phase?.('store', 'start');
       if (normalized.length > 0 && !isReplay) {
         await this.store.insert(normalized);
+        this.callbacks.markCgMetaDirtyFromQuads?.(normalized);
       }
 
       if (request.ual) {
@@ -346,6 +351,7 @@ export class GossipPublishHandler {
         // never trust self-reported on-chain status from gossip messages.
         const metaQuads = generateTentativeMetadata(kcMeta, kaMetadata);
         await this.store.insert(metaQuads);
+        this.callbacks.markCgMetaDirtyFromQuads?.(metaQuads);
         phase?.('store', 'end');
 
         // If the gossip message includes on-chain proof (txHash + blockNumber),
@@ -552,6 +558,11 @@ export class GossipPublishHandler {
   }
 
   private async getContextGraphAllowedPeers(contextGraphId: string): Promise<string[] | null> {
+    if (this.callbacks.getCgMeta) {
+      const peers = (await this.callbacks.getCgMeta(contextGraphId)).allowedPeers;
+      return peers.length > 0 ? peers : null;
+    }
+
     const cgMeta = contextGraphMetaGraphUri(contextGraphId);
     const cgData = contextGraphDataGraphUri(contextGraphId);
     const result = await this.store.query(

--- a/packages/agent/src/swm/member-recovery-auth.ts
+++ b/packages/agent/src/swm/member-recovery-auth.ts
@@ -1,0 +1,43 @@
+import { ethers } from 'ethers';
+
+/**
+ * ACL hard-deny gate (the #1 security item).
+ *
+ * Once recovery serves PLAINTEXT member-to-member, the ACL is the ONLY barrier
+ * between a non-member and a private CG's cleartext. The existing
+ * `authorizePrivateSyncRequest` FAILS OPEN — on a null/failed gate resolve it
+ * widens to a weaker participant/peer check (request-authorize.ts:163-169), so a
+ * transient chain/meta hiccup turns a private CG public. This authorizer is the
+ * member-recovery path's distinct gate and it does the opposite:
+ *
+ *  1. **HARD-DENY on a null/empty gate.** No gate ⇒ deny. Never widen.
+ *  2. **Membership check only** — no participant/peer/node-operator fallback.
+ *
+ * The caller MUST supply a gate resolved from a FRESH authenticated read of the
+ * CG `_meta` (`allowedAgents ∪ participantAgents` minus revoked) — NOT the
+ * network-influenced subscription cache (poisonable; see the adversarial review).
+ * This function only decides membership; sourcing the gate safely is the
+ * caller's responsibility and the other half of the ACL-gate fix.
+ */
+export function isMemberRecoveryAuthorized(
+  requesterAgentAddress: string,
+  agentGate: readonly string[] | null,
+): boolean {
+  // Absent/empty gate → DENY. This is the load-bearing inversion of the fail-open.
+  if (!agentGate || agentGate.length === 0) return false;
+
+  let requester: string;
+  try {
+    requester = ethers.getAddress(requesterAgentAddress).toLowerCase();
+  } catch {
+    return false; // unparseable requester → deny
+  }
+
+  return agentGate.some((entry) => {
+    try {
+      return ethers.getAddress(entry).toLowerCase() === requester;
+    } catch {
+      return false; // ignore malformed gate entries, never widen
+    }
+  });
+}

--- a/packages/agent/src/sync/auth/request-authorize.ts
+++ b/packages/agent/src/sync/auth/request-authorize.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { SyncRequestEnvelope } from './request-build.js';
+import { isMemberRecoveryAuthorized } from '../../swm/member-recovery-auth.js';
 
 interface AuthLookupOptions {
   signal?: AbortSignal;
@@ -42,6 +43,17 @@ interface AuthorizeSyncRequestParams {
    */
   getAllowedDelegateePeers: (contextGraphId: string, options?: AuthLookupOptions) => Promise<Map<string, string[]>>;
   getAllowedDelegateeKeys: (contextGraphId: string, options?: AuthLookupOptions) => Promise<Map<string, string[]>>;
+  /**
+   * R9 (SECURITY) — FRESH, `_meta`-only member-recovery gate. MUST resolve
+   * `allowedAgents ∪ participantAgents` minus `revokedAgents` from a fresh read
+   * of the CG `_meta` projection, and MUST NOT fold in the network-influenced
+   * subscription cache (poisonable — see `member-recovery-auth.ts`). Used ONLY
+   * for `request.recovery`: the gate value is passed straight to
+   * `isMemberRecoveryAuthorized`, which hard-denies on null/empty and never
+   * widens. Distinct from `getAgentGateAddresses` (which DOES fold in the
+   * subscription cache and feeds the normal fail-open path).
+   */
+  getMemberRecoveryGate: (contextGraphId: string, options?: AuthLookupOptions) => Promise<string[] | null>;
   refreshMetaFromCurator: (contextGraphId: string, options?: AuthLookupOptions) => Promise<boolean>;
   signal?: AbortSignal;
   logWarn: (ctx: OperationContext, message: string) => void;
@@ -80,6 +92,7 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
     getAgentGateAddresses,
     getAllowedDelegateePeers,
     getAllowedDelegateeKeys,
+    getMemberRecoveryGate,
     refreshMetaFromCurator,
     signal,
     logWarn,
@@ -158,6 +171,33 @@ export async function authorizePrivateSyncRequest(params: AuthorizeSyncRequestPa
   } else if (!request.requesterAgentAddress || recoveredAddress.toLowerCase() !== request.requesterAgentAddress.toLowerCase()) {
     logWarn(ctx, `Denied sync request for "${request.contextGraphId}": edge signer mismatch (signer=${recoveredAddress} requesterAgentAddress=${request.requesterAgentAddress ?? 'n/a'})`);
     return false;
+  }
+
+  // R9 (SECURITY) — member-recovery branch. Recovery serves PLAINTEXT
+  // member-to-member, so once the crypto prologue above has authenticated the
+  // request (envelope shape, freshness, replay, signer recovery, identity/edge
+  // binding), the ACL is the ONLY barrier left. Swap the normal fail-open
+  // participant/peer resolution for the strict members-only hard-deny gate and
+  // do NOT fall through. The decision is on the cryptographically RECOVERED
+  // `recoveredAddress` — NOT `request.requesterAgentAddress` (a signed but
+  // self-asserted claim any valid signer can set; checking it on the identity
+  // path would be an auth bypass). The gate is a FRESH `_meta`-only read; null/
+  // empty hard-denies and we never widen via `refreshMetaFromCurator`.
+  if (request.recovery) {
+    const recoveryGate = await getMemberRecoveryGate(request.contextGraphId, lookupOptions);
+    throwIfAborted(signal);
+    const recoveryAllowed = isMemberRecoveryAuthorized(recoveredAddress, recoveryGate);
+    logInfo(
+      ctx,
+      `Member-recovery sync auth for "${request.contextGraphId}": signer=${recoveredAddress} identityId=${requesterIdentityId.toString()} gateCount=${recoveryGate?.length ?? 0} allowed=${recoveryAllowed}`,
+    );
+    if (recoveryAllowed) {
+      throwIfAborted(signal);
+      seenRequestIds.set(request.requestId, now);
+    } else {
+      logWarn(ctx, `Denied member-recovery sync request for "${request.contextGraphId}": signer ${recoveredAddress} not in members-only gate (gateCount=${recoveryGate?.length ?? 0})`);
+    }
+    return recoveryAllowed;
   }
 
   let participants = await getParticipants(request.contextGraphId, lookupOptions);

--- a/packages/agent/src/sync/auth/request-build.ts
+++ b/packages/agent/src/sync/auth/request-build.ts
@@ -1,7 +1,15 @@
 import { ethers } from 'ethers';
 
-export type SyncPhase = 'data' | 'meta' | 'snapshot';
+// 'catalog' (§7) — the public facet open-serve: served to ANYONE
+// without the allowlist gate, bounded to exactly the `_catalog` named graph.
+// Backward-compatible: `phase` is not part of the signed digest and only
+// narrows results, so old responders ignore it and new ones honor it.
+export type SyncPhase = 'data' | 'meta' | 'snapshot' | 'catalog';
 
+// NOTE: a structurally-identical `SyncRequestEnvelope` is also declared in
+// `dkg-agent-types.ts` (used by `parseSyncRequest`'s return type and the agent
+// modules). The two MUST be kept in lockstep — adding a field here without
+// mirroring it there silently drops it on the parse/responder path.
 export interface SyncRequestEnvelope {
   contextGraphId: string;
   offset: number;
@@ -31,6 +39,24 @@ export interface SyncRequestEnvelope {
    * full scan; new responders honor it and return a delta.
    */
   sinceBatchId?: string;
+  /**
+   * R9 (SECURITY) — member SWM recovery marker. When set, the recovery path
+   * serves PLAINTEXT member-to-member, so the responder MUST authorize it via
+   * the strict members-only `isMemberRecoveryAuthorized` hard-deny gate (a
+   * FRESH `_meta` agent-gate read, hard-deny on null/empty) and MUST NOT fall
+   * through to the weaker participant/peer fallback in
+   * `authorizePrivateSyncRequest`.
+   *
+   * Deliberately UNSIGNED (rides the envelope after `computeSyncDigest`, like
+   * `phase`/`sinceBatchId`). The rationale differs from those narrowing-only
+   * fields: `recovery` only ever ESCALATES strictness. An attacker who sets it
+   * faces the harder members-only gate; stripping it (MITM on a real member's
+   * request) just reverts to the normal private-sync path the member already
+   * passes. It is auth-safe precisely because the responder decides membership
+   * against the cryptographically RECOVERED signer address — never against this
+   * flag or the (forgeable) `requesterAgentAddress` claim alone.
+   */
+  recovery?: boolean;
 }
 
 interface BuildSyncRequestParams {
@@ -45,6 +71,16 @@ interface BuildSyncRequestParams {
   sinceBatchId?: string;
   syncSessionId?: string;
   needsAuth: boolean;
+  /**
+   * R9 (SECURITY) — member SWM recovery. Forces the JSON auth envelope (never
+   * the public text form) and, critically, forces the EDGE (agent-key) signing
+   * path so the responder-recovered signer == the member agent address. The
+   * responder's members-only gate decides on the RECOVERED signer, so the
+   * recovery request MUST be signed by the member agent's own key (NOT the node
+   * op-key, which would recover to a non-member and be hard-denied). No
+   * delegation is consulted on the recovery path.
+   */
+  recovery?: boolean;
   computeSyncDigest: (
     contextGraphId: string,
     offset: number,
@@ -83,6 +119,7 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     sinceBatchId,
     syncSessionId,
     needsAuth,
+    recovery,
     computeSyncDigest,
     getIdentityId,
     signMessage,
@@ -90,13 +127,28 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
     claimedAgentPrivateKey,
   } = params;
 
+  // R9: recovery serves plaintext member-to-member and is authorized by the
+  // strict members-only gate — it can never ride the unauthenticated public
+  // text form. Private SWM already yields needsAuth=true; assert it rather than
+  // silently downgrade to an envelope no responder will gate as recovery.
+  if (recovery && !needsAuth) {
+    throw new Error(`Cannot build member-recovery sync request for "${contextGraphId}": recovery requires an authenticated envelope`);
+  }
+
   if (!needsAuth) {
     const prefix = includeSharedMemory ? `workspace:${contextGraphId}` : contextGraphId;
     const phaseSuffix = phase === 'meta'
       ? '|meta'
       : phase === 'snapshot'
         ? `|snapshot|${snapshotRef ?? ''}`
-        : '';
+        : phase === 'catalog'
+          // The public `_catalog` facet (§7) is open-served unauthenticated, so
+          // it rides THIS text form. Emit the phase token in parts[3] (same slot
+          // `parsePipeDelimitedSyncRequest` reads) so the phase survives on the
+          // wire and the responder routes to readCatalogPage instead of falling
+          // back to the DEFAULT data phase (which is gated and serves nothing).
+          ? '|catalog'
+          : '';
     // Trailing keyed tokens are additive; old responders ignore the extra parts.
     const sessionSuffix = syncSessionId ? `|session|${syncSessionId}` : '';
     const sinceSuffix = sinceBatchId ? `|since|${sinceBatchId}` : '';
@@ -142,9 +194,29 @@ export async function buildSyncRequestEnvelope(params: BuildSyncRequestParams): 
   // authorization; only narrows the responder's result set).
   if (syncSessionId) request.syncSessionId = syncSessionId;
   if (sinceBatchId) request.sinceBatchId = sinceBatchId;
+  // R9: unsigned recovery marker (only ever escalates strictness — see field
+  // docs). The responder authorizes against the recovered signer, not this flag.
+  if (recovery) request.recovery = true;
 
-  const identityId = await getIdentityId();
-  if (identityId > 0n && typeof signMessage === 'function') {
+  // R9: recovery is authorized against the RECOVERED signer address, which the
+  // responder matches against the members-only agent gate. So a recovery
+  // request MUST be signed by the member agent's OWN key (edge path) — the node
+  // identity op-key would recover to a non-member and be hard-denied. Force the
+  // edge path and require the agent key locally (the recovering node IS the
+  // member, so it holds the key).
+  const identityId = recovery ? 0n : await getIdentityId();
+  if (recovery) {
+    if (!claimedAgentAddress || !claimedAgentPrivateKey) {
+      throw new Error(`Cannot build member-recovery sync request for "${contextGraphId}": missing member agent signing key`);
+    }
+    const wallet = new ethers.Wallet(claimedAgentPrivateKey);
+    const sig = ethers.Signature.from(await wallet.signMessage(digest));
+    request.requesterIdentityId = '0';
+    // requesterAgentAddress was already set above (and bound into the digest);
+    // the responder enforces recoveredAddress === member gate entry.
+    request.requesterSignatureR = ethers.hexlify(sig.r);
+    request.requesterSignatureVS = ethers.hexlify(sig.yParityAndS);
+  } else if (identityId > 0n && typeof signMessage === 'function') {
     const signature = await signMessage(digest);
     request.requesterIdentityId = identityId.toString();
     request.requesterSignatureR = ethers.hexlify(signature.r);

--- a/packages/agent/src/sync/checkpoint/state.ts
+++ b/packages/agent/src/sync/checkpoint/state.ts
@@ -74,6 +74,7 @@ export function getSyncCheckpointKey(
   phase: SyncPhase,
   snapshotRef?: string,
   sinceBatchId?: string,
+  recovery?: boolean,
 ): string {
   const refSuffix = phase === 'snapshot' && snapshotRef ? `|${snapshotRef}` : '';
   // Phase C: `sinceBatchId` changes the responder's result set, so a delta
@@ -82,5 +83,13 @@ export function getSyncCheckpointKey(
   // triples. Scoping the key by `sinceBatchId` keeps each filtered dataset on
   // its own resume cursor; a full sync (no hint) keeps the unscoped key.
   const sinceSuffix = sinceBatchId ? `|since:${sinceBatchId}` : '';
-  return `${remotePeerId}|${contextGraphId}|${includeSharedMemory ? 'swm' : 'durable'}|${phase}${refSuffix}${sinceSuffix}`;
+  // R10: member SWM recovery reuses the same `(peer|cg|swm|phase)` namespace as
+  // background incremental SWM catch-up. A running recovery's mid-stream cursor
+  // (set/dropped per page) would otherwise overwrite or delete the normal
+  // incremental cursor and force background sync to restart from offset 0. Give
+  // recovery its OWN cursor + responder-session scope so it never mutates the
+  // shared incremental-sync cursor. The flag is additive (only set on the
+  // recovery path), so normal sync keeps its unscoped key.
+  const recoverySuffix = recovery ? '|recovery' : '';
+  return `${remotePeerId}|${contextGraphId}|${includeSharedMemory ? 'swm' : 'durable'}|${phase}${refSuffix}${sinceSuffix}${recoverySuffix}`;
 }

--- a/packages/agent/src/sync/requester/page-fetch.ts
+++ b/packages/agent/src/sync/requester/page-fetch.ts
@@ -91,7 +91,15 @@ interface FetchSyncPagesParams {
   debugSyncProgress: boolean;
   protocolSync: string;
   checkpointStore: SyncCheckpointStore;
-  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string) => Promise<Uint8Array>;
+  /**
+   * R9/R10 — member SWM recovery marker. Forks BOTH the checkpoint namespace
+   * (R10: distinct `|recovery` cursor + responder-session scope so it never
+   * mutates the shared incremental-sync cursor) AND the request envelope (R9:
+   * forwarded to `buildSyncRequest` so the responder gates it via the strict
+   * members-only `isMemberRecoveryAuthorized`). Default false ⇒ normal sync.
+   */
+  recovery?: boolean;
+  buildSyncRequest: (contextGraphId: string, offset: number, limit: number, includeSharedMemory: boolean, remotePeerId: string, phase?: SyncPhase, snapshotRef?: string, sinceBatchId?: string, syncSessionId?: string, recovery?: boolean) => Promise<Uint8Array>;
   /**
    * Phase C — optional, gap-safe delta-sync high-water mark. Forwarded to the
    * responder for the durable DATA phase so it returns only KAs with
@@ -177,6 +185,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
     debugSyncProgress,
     protocolSync,
     checkpointStore,
+    recovery,
     buildSyncRequest,
     sinceBatchId,
     parseAndFilter,
@@ -188,7 +197,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
 
   const allQuads: Quad[] = [];
   throwIfAborted(signal);
-  const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId);
+  const checkpointKey = getSyncCheckpointKey(remotePeerId, contextGraphId, includeSharedMemory, phase, snapshotRef, sinceBatchId, recovery);
   let offset = checkpointStore.get(checkpointKey)?.offset ?? 0;
   const usesPageSession = usesResponderSession(includeSharedMemory, phase);
   const sessionStartedAt = Date.now();
@@ -245,7 +254,7 @@ export async function fetchSyncPages(params: FetchSyncPagesParams): Promise<Sync
         // full rationale (codex review on #569 follow-ups #1, #4-#8).
         requestFactory: async () => {
           throwIfAborted(signal);
-          const request = await buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId);
+          const request = await buildSyncRequest(contextGraphId, curOffset, syncPageSize, includeSharedMemory, remotePeerId, phase, snapshotRef, sinceBatchId, syncSessionId, recovery);
           throwIfAborted(signal);
           return request;
         },

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -4,6 +4,7 @@ import {
   assertSafeIri,
   sparqlString,
   validateSubGraphName,
+  contextGraphCatalogUri,
 } from '@origintrail-official/dkg-core';
 import type { TripleStore } from '@origintrail-official/dkg-storage';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
@@ -471,6 +472,28 @@ export async function readDurableDataPage(params: {
       }
       : undefined,
     params.signal,
+  );
+}
+
+/**
+ * read the public catalog facet. STRICTLY bounded to exactly the
+ * `_catalog` named graph (`did:dkg:context-graph:{cg}/_catalog`): it reads that
+ * one graph and nothing else, so the open-serve path cannot leak any gated
+ * quad. This is the only graph the §7 facet open-serve releases without auth.
+ */
+export async function readCatalogPage(params: {
+  store: TripleStore;
+  contextGraphId: string;
+  offset: number;
+  limit: number;
+}): Promise<SyncRow[]> {
+  const catalogGraph = contextGraphCatalogUri(params.contextGraphId);
+  return readPagedRowsAcrossGraphs(
+    params.store,
+    [catalogGraph],
+    params.offset,
+    params.limit,
+    async () => true, // the single graph is already the bound; admit it
   );
 }
 

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -15,6 +15,7 @@ import {
   createResponderSyncRowListMemo,
   createResponderSubGraphRegistrationMemo,
   createResponderSwmAdmissionMemo,
+  readCatalogPage,
   readDurableDataPage,
   readDurableMetaPage,
   readSwmDataPage,
@@ -312,6 +313,18 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
 
     return limiter.run(peerId, signal, async () => {
       throwIfAborted(signal);
+
+      // facet open-serve. The public `_catalog` subgraph (a DCAT
+      // dataset record) is served to ANYONE, with NO allowlist auth, BEFORE the
+      // gate below. Bounded to exactly that one named graph (readCatalogPage), so
+      // no gated quad can leak. This is how outsiders discover a private CG.
+      if (phase === 'catalog') {
+        const rows = await raceAgainstAbort(readCatalogPage({ store, contextGraphId, offset, limit }), signal);
+        const serialized = serializeResponderRows(rows);
+        logDebug(createOperationContext('sync'), `Sync responder catalog facet for "${contextGraphId}": rows=${rows.length}`);
+        return new TextEncoder().encode(serialized ?? '');
+      }
+
       const authStartedAt = Date.now();
       const authorized = await authorizeSyncRequest(request, peerId, { signal });
       const authDurationMs = Date.now() - authStartedAt;

--- a/packages/agent/test/agent.part-13.test.ts
+++ b/packages/agent/test/agent.part-13.test.ts
@@ -73,6 +73,12 @@ describe('Genesis Knowledge', () => {
           object: 'did:dkg:agent:12D3KooWForeignCreatorPeer111111111111111111111111',
         },
       ]);
+      // The raw store.insert/deleteByPattern above forge a foreign-created CG
+      // out-of-band, bypassing the write path that would normally invalidate the
+      // ContextGraphMetaProjection (real sync calls markDirtyFromQuads after
+      // store.insert — see dkg-agent-lifecycle.ts). Invalidate it here so the
+      // projection re-reads the forged creator instead of the stale self-stamp.
+      (agent as any).contextGraphMetaProjection.markDirty('register-foreign-peer-only');
 
       await expect(agent.registerContextGraph('register-foreign-peer-only'))
         .rejects.toThrow(/has no address-scoped curator/);

--- a/packages/agent/test/agent.part-17.test.ts
+++ b/packages/agent/test/agent.part-17.test.ts
@@ -200,6 +200,50 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
     });
 
 
+    it('parseSyncRequest preserves the R9 recovery flag through the JSON allowlist', async () => {
+      const agent = await DKGAgent.create({
+        name: 'ParseRecoveryFlag',
+        listenHost: '127.0.0.1',
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+      try {
+        await agent.start();
+        // The JSON envelope is a STRICT field allowlist on the responder. If
+        // `recovery` is dropped here, the members-only gate becomes dead code
+        // and recovery silently falls through to the fail-open path.
+        const withRecovery = JSON.stringify({
+          contextGraphId: 'cg-rec', offset: 0, limit: 100, includeSharedMemory: true,
+          phase: 'data', targetPeerId: 'T', requesterPeerId: 'R', requestId: 'id1',
+          issuedAtMs: Date.now(), requesterIdentityId: '0',
+          requesterAgentAddress: '0x' + 'a'.repeat(40),
+          requesterSignatureR: '0x00', requesterSignatureVS: '0x00',
+          recovery: true,
+        });
+        const parsed = (agent as any).parseSyncRequest(new TextEncoder().encode(withRecovery));
+        expect(parsed.recovery).toBe(true);
+
+        // Absent / non-true ⇒ undefined (never a truthy non-bool smuggled through).
+        const withoutRecovery = JSON.stringify({
+          contextGraphId: 'cg-rec', offset: 0, limit: 100, includeSharedMemory: true,
+          phase: 'data', targetPeerId: 'T', requesterPeerId: 'R', requestId: 'id2',
+          issuedAtMs: Date.now(), requesterIdentityId: '0',
+        });
+        const parsedNo = (agent as any).parseSyncRequest(new TextEncoder().encode(withoutRecovery));
+        expect(parsedNo.recovery).toBeUndefined();
+
+        const coerced = JSON.stringify({
+          contextGraphId: 'cg-rec', offset: 0, limit: 100, includeSharedMemory: true,
+          phase: 'data', targetPeerId: 'T', requesterPeerId: 'R', requestId: 'id3',
+          issuedAtMs: Date.now(), requesterIdentityId: '0', recovery: 'yes',
+        });
+        const parsedCoerced = (agent as any).parseSyncRequest(new TextEncoder().encode(coerced));
+        expect(parsedCoerced.recovery).toBeUndefined();
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    });
+
+
     it('canReadContextGraph allows locally subscribed private CGs when identityId is 0n', async () => {
       const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
       (chain as any).getIdentityId = async () => 0n;

--- a/packages/agent/test/combined-catalog-baseline.e2e.test.ts
+++ b/packages/agent/test/combined-catalog-baseline.e2e.test.ts
@@ -1,0 +1,109 @@
+/**
+ * combined-model BASELINE (pre-catalog-injection) — curated e2e.
+ *
+ * The first end-to-end curated/private-CG VM publish on the devnet, via the
+ * PRODUCT path (write -> promote -> publishFromFinalizedAssertion). Uses the
+ * pre-staked genesis core nodes for the ACK quorum (lowered to 1), so the
+ * curated `nodeExists` signer check passes.
+ *
+ * Baseline invariant: a private CG publishing N data entities yields a KC of
+ * exactly N KAs. After the catalog injection lands, the SAME publish yields
+ * N+1 KAs (the extra one being the public DCAT catalog KA, subject == CG UAL).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeTestKaNumberAllocator } from './_helpers/ka-allocator.js';
+import { DKGAgent } from '../src/index.js';
+import {
+  spawnHardhatEnv, killHardhat, setMinimumRequiredSignatures, HARDHAT_KEYS, type HardhatContext,
+} from '../../chain/test/hardhat-harness.js';
+
+let ctx: HardhatContext;
+const agents: DKGAgent[] = [];
+
+function chainConfig(opKey: string, adminKey: string) {
+  return { rpcUrl: ctx.rpcUrl, adminPrivateKey: adminKey, operationalKeys: [opKey], hubAddress: ctx.hubAddress, chainId: 'evm:31337' };
+}
+
+// A disk-backed dataDir is REQUIRED for SWM host mode — without it a core cannot
+// store the curated ciphertext chunks and declines the ACK (MISSING_CIPHERTEXT_CHUNKS).
+const mkDataDir = (name: string) => mkdtempSync(join(tmpdir(), `rfc49-${name}-`));
+
+describe('baseline — curated CG product-path publish (pre-catalog)', () => {
+  let publisher: DKGAgent;
+  let curator: string;
+
+  beforeAll(async () => {
+    ctx = await spawnHardhatEnv(8553);
+    await setMinimumRequiredSignatures(ctx.provider, ctx.hubAddress, HARDHAT_KEYS.DEPLOYER, 1);
+
+    // Genesis core nodes are pre-staked. Publisher = CORE_OP (curator/member);
+    // the connected REC1 core holds the curated ciphertext and supplies the ACK.
+    publisher = await DKGAgent.create({
+      kaNumberAllocator: makeTestKaNumberAllocator(), name: 'CatPublisher', nodeRole: 'core', listenPort: 0, skills: [],
+      dataDir: mkDataDir('pub'),
+      chainConfig: chainConfig(HARDHAT_KEYS.CORE_OP, HARDHAT_KEYS.CORE_ADMIN),
+    });
+    const ackCore = await DKGAgent.create({
+      kaNumberAllocator: makeTestKaNumberAllocator(), name: 'CatAckCore', nodeRole: 'core', listenPort: 0, skills: [],
+      dataDir: mkDataDir('ack'),
+      chainConfig: chainConfig(HARDHAT_KEYS.REC1_OP, HARDHAT_KEYS.REC1_ADMIN),
+    });
+    agents.push(publisher, ackCore);
+    await publisher.start(); await ackCore.start();
+    await ackCore.connectTo(publisher.multiaddrs[0]);
+    await new Promise((r) => setTimeout(r, 2000));
+    curator = publisher.defaultAgentAddress ?? publisher.peerId;
+  }, 180_000);
+
+  afterAll(async () => {
+    for (const a of agents) { try { await a.stop(); } catch {} }
+    killHardhat(ctx);
+  });
+
+  it('a private CG publishes via the product path and yields exactly N data KAs', async () => {
+    const CG = 'rfc49-baseline-private';
+    await publisher.createContextGraph({ id: CG, name: 'RFC49 Baseline Private', accessPolicy: 1, callerAgentAddress: curator });
+    await publisher.registerContextGraph(CG, { callerAgentAddress: curator });
+
+    const name = 'shipment';
+    await publisher.assertion.create(CG, name);
+    await publisher.assertion.write(CG, name, [
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"P-9"' },
+    ]);
+    // Explicit finalize = the daemon product path (POST /vm/publish does
+    // assertion.finalize then publishFromFinalizedAssertion). The catalog
+    // injection lives in assertionFinalize; promote then carries the sealed
+    // content (incl. the catalog KA) to SWM for reload.
+    await publisher.assertion.finalize(CG, name);
+    await publisher.assertion.promote(CG, name);
+
+    const pub: any = await publisher.publishFromFinalizedAssertion(CG, name);
+
+    expect(pub.status).toBe('confirmed');
+    // combined model: the private publish now carries the data KA AND
+    // the public DCAT catalog KA (subject = the CG's own UAL), committed in the
+    // CG's own merkle root.
+    expect(pub.kaManifest.length).toBe(2);
+    const roots = pub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
+    expect(roots.some((r: string) => r.includes(CG))).toBe(true); // the catalog KA, keyed on the CG UAL
+
+    // The catalog entry persists PLAINTEXT in the public _catalog graph — a
+    // queryable, standards-compliant DCAT dataset record (NOT encrypted, unlike
+    // the private data which only exists as ciphertext chunks).
+    const cgUal = `did:dkg:context-graph:${CG}`;
+    const catalogGraph = `${cgUal}/_catalog`;
+    const res: any = await (publisher as any).store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${catalogGraph}> { <${cgUal}> ?p ?o } }`,
+    );
+    expect(res.type).toBe('bindings');
+    const triples = res.bindings.map((b: any) => ({ p: b.p, o: b.o }));
+    const types = triples.filter((t: any) => t.p === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type').map((t: any) => t.o);
+    expect(types).toContain('http://www.w3.org/ns/dcat#Dataset');             // standards-compliant DCAT
+    expect(types).toContain('https://dkg.network/ontology#PrivateContextGraph'); // dual-typed
+    const accessRights = triples.find((t: any) => t.p === 'http://purl.org/dc/terms/accessRights');
+    expect(accessRights?.o).toBe('http://publications.europa.eu/resource/authority/access-right/RESTRICTED');
+  });
+});

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { OxigraphStore, GraphManager } from '@origintrail-official/dkg-storage';
+import { OxigraphStore, GraphManager, type Quad } from '@origintrail-official/dkg-storage';
 import {
   encodeFinalizationMessage, type FinalizationMessageMsg, encodePublishRequest, createOperationContext,
   contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -247,8 +247,16 @@ describe('FinalizationHandler', () => {
     const publisherAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
     const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
     const subGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}/${subGraphName}`;
+    const dirtyQuads: Quad[] = [];
+    const localHandler = new FinalizationHandler(
+      store,
+      undefined,
+      undefined,
+      undefined,
+      (quads) => { dirtyQuads.push(...quads); },
+    );
 
-    await (handler as any).promoteSharedMemoryToCanonical(
+    await (localHandler as any).promoteSharedMemoryToCanonical(
       CONTEXT_GRAPH,
       [{ subject: entity, predicate: 'http://schema.org/name', object: '"Alice"', graph: '' }],
       'did:dkg:evm:31337/0xABC/1',
@@ -276,6 +284,16 @@ describe('FinalizationHandler', () => {
     );
     expect(registration.type).toBe('boolean');
     if (registration.type === 'boolean') expect(registration.value).toBe(true);
+    expect(dirtyQuads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          subject: subGraphUri,
+          predicate: 'http://schema.org/name',
+          object: `"${subGraphName}"`,
+          graph: metaGraph,
+        }),
+      ]),
+    );
 
     const canonical = await store.query(
       `ASK { GRAPH <${subGraphUri}> { <${entity}> <http://schema.org/name> ?o } }`,

--- a/packages/agent/test/issue-865-public-cg-allowlist.test.ts
+++ b/packages/agent/test/issue-865-public-cg-allowlist.test.ts
@@ -302,4 +302,25 @@ describe('Issue #865 — public CG + allowlist must not be classified as private
       await agent.stop().catch(() => {});
     }
   });
+
+  it('AGENTS graph private declarations are treated as explicit private policy', async () => {
+    const { agent, store } = await makeAgent();
+    try {
+      const id = 'issue-1138-agents-private';
+      const uri = `did:dkg:context-graph:${id}`;
+      const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+      await store.insert([
+        { subject: uri, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH, graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.SCHEMA_NAME, object: '"Agents Private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_ACCESS_POLICY, object: '"private"', graph: agentsGraph },
+        { subject: uri, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: `did:dkg:agent:${await ownerAddress(agent)}`, graph: agentsGraph },
+      ]);
+
+      expect(await agent.getExplicitAccessPolicy(id)).toBe('private');
+      expect(await agent.isPrivateContextGraph(id)).toBe(true);
+      expect(await agent.readLocalAccessPolicyEnum(id)).toBe(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
 });

--- a/packages/agent/test/request-authorize.test.ts
+++ b/packages/agent/test/request-authorize.test.ts
@@ -58,6 +58,8 @@ interface BuildEnvelopeOptions {
    * envelope with a chain identity.
    */
   requesterAgentAddress?: string;
+  /** R9 — mark the envelope as a member-recovery request. */
+  recovery?: boolean;
 }
 
 async function buildSignedEnvelope(
@@ -84,6 +86,7 @@ async function buildSignedEnvelope(
     requesterSignatureR: ethers.hexlify(sig.r),
     requesterSignatureVS: ethers.hexlify(sig.yParityAndS),
     ...(opts.requesterAgentAddress ? { requesterAgentAddress: opts.requesterAgentAddress } : {}),
+    ...(opts.recovery ? { recovery: true } : {}),
   };
   return { envelope, remotePeerId };
 }
@@ -101,6 +104,8 @@ interface AuthCallParams {
    */
   allowedDelegateePeers?: Map<string, string[]> | Record<string, string[]>;
   allowedDelegateeKeys?: Map<string, string[]> | Record<string, string[]>;
+  /** R9 — fresh `_meta`-only members-only recovery gate (used when envelope.recovery is set). */
+  memberRecoveryGate?: string[] | null;
   verifyIdentity?: (recoveredAddress: string, claimedIdentityId: bigint) => Promise<boolean>;
   signal?: AbortSignal;
 }
@@ -130,6 +135,7 @@ async function callAuth(params: AuthCallParams): Promise<{ allowed: boolean; log
     getAgentGateAddresses: async () => params.agentGateAddresses ?? null,
     getAllowedDelegateePeers: async () => peersMap,
     getAllowedDelegateeKeys: async () => keysMap,
+    getMemberRecoveryGate: async () => params.memberRecoveryGate ?? null,
     refreshMetaFromCurator: async () => false,
     signal: params.signal,
     logWarn: (_c, m) => logs.push(`WARN: ${m}`),
@@ -348,6 +354,7 @@ describe('authorizePrivateSyncRequest — agent-delegation path', () => {
       getAgentGateAddresses: async () => null,
       getAllowedDelegateePeers: async () => new Map<string, string[]>(),
       getAllowedDelegateeKeys: async () => new Map([[agentAddress.toLowerCase(), [nodeOpKey.address.toLowerCase()]]]),
+      getMemberRecoveryGate: async () => null,
       refreshMetaFromCurator: async () => false,
       logWarn: () => {},
       logInfo: () => {},
@@ -385,6 +392,7 @@ describe('authorizePrivateSyncRequest — agent-delegation path', () => {
           ? new Map([[agentAddress.toLowerCase(), [nodeOpKey.address.toLowerCase()]]])
           : new Map<string, string[]>();
       },
+      getMemberRecoveryGate: async () => null,
       refreshMetaFromCurator: async () => {
         refreshed = true;
         return true;
@@ -436,6 +444,10 @@ describe('authorizePrivateSyncRequest — agent-delegation path', () => {
         if (options?.signal) seenSignals.push(options.signal);
         return new Map([[agentAddress.toLowerCase(), [nodeOpKey.address.toLowerCase()]]]);
       },
+      getMemberRecoveryGate: async (_contextGraphId, options) => {
+        if (options?.signal) seenSignals.push(options.signal);
+        return null;
+      },
       refreshMetaFromCurator: async () => false,
       signal: controller.signal,
       logWarn: () => {},
@@ -480,6 +492,7 @@ describe('authorizePrivateSyncRequest — agent-delegation path', () => {
       getAgentGateAddresses: async () => null,
       getAllowedDelegateePeers: async () => new Map<string, string[]>(),
       getAllowedDelegateeKeys: async () => new Map<string, string[]>(),
+      getMemberRecoveryGate: async () => null,
       refreshMetaFromCurator: async () => false,
       signal: controller.signal,
       logWarn: () => {},
@@ -561,5 +574,84 @@ describe('authorizePrivateSyncRequest — agent-delegation path', () => {
       allowedDelegateeKeys: { [agentAddress.toLowerCase()]: [nodeOpKey.address.toLowerCase()] },
     });
     expect(allowed).toBe(true);
+  });
+
+  // R9 (SECURITY) — member-recovery branch. Recovery serves plaintext
+  // member-to-member, so a recovery-flagged envelope MUST be gated by the
+  // strict members-only `isMemberRecoveryAuthorized` on a FRESH `_meta` gate,
+  // hard-denying on null/empty, and MUST NOT fall through to the weaker
+  // participant/peer fallback.
+  describe('member-recovery (request.recovery) branch', () => {
+    it('HARD-DENIES recovery on a null gate even though the participant/peer fallback would allow', async () => {
+      const member = ethers.Wallet.createRandom();
+      const { envelope, remotePeerId } = await buildSignedEnvelope({
+        signer: member,
+        requesterAgentAddress: member.address,
+        recovery: true,
+      });
+      const { allowed } = await callAuth({
+        envelope,
+        remotePeerId,
+        // Fallback would ALLOW (participant + peer both match) — recovery must ignore it.
+        participants: [member.address],
+        allowedPeers: [remotePeerId],
+        memberRecoveryGate: null, // transient/empty fresh gate ⇒ hard-deny
+      });
+      expect(allowed).toBe(false);
+    });
+
+    it('allows recovery when the recovered signer is in the fresh members-only gate', async () => {
+      const member = ethers.Wallet.createRandom();
+      const { envelope, remotePeerId } = await buildSignedEnvelope({
+        signer: member,
+        requesterAgentAddress: member.address,
+        recovery: true,
+      });
+      const { allowed } = await callAuth({
+        envelope,
+        remotePeerId,
+        // Fallback gates intentionally absent — only the members-only gate matters.
+        participants: null,
+        allowedPeers: null,
+        memberRecoveryGate: [member.address],
+      });
+      expect(allowed).toBe(true);
+    });
+
+    it('denies recovery when the recovered signer is NOT in the members-only gate', async () => {
+      const member = ethers.Wallet.createRandom();
+      const other = ethers.Wallet.createRandom();
+      const { envelope, remotePeerId } = await buildSignedEnvelope({
+        signer: member,
+        requesterAgentAddress: member.address,
+        recovery: true,
+      });
+      const { allowed } = await callAuth({
+        envelope,
+        remotePeerId,
+        memberRecoveryGate: [other.address], // member not present
+      });
+      expect(allowed).toBe(false);
+    });
+
+    it('decides on the RECOVERED signer, not a forged requesterAgentAddress claim (identity path)', async () => {
+      // op-key signs, but the envelope CLAIMS a member agent address and a chain
+      // identity. The recovered signer is the op-key (a non-member); recovery
+      // must deny even though `requesterAgentAddress` names a gate member.
+      const member = ethers.Wallet.createRandom();
+      const { envelope, remotePeerId } = await buildSignedEnvelope({
+        signer: nodeOpKey,
+        identityId: '9',
+        requesterAgentAddress: member.address, // forged "on behalf of" a member
+        recovery: true,
+      });
+      const { allowed } = await callAuth({
+        envelope,
+        remotePeerId,
+        verifyIdentity: async () => true, // identity check passes; gate must still deny
+        memberRecoveryGate: [member.address], // member IS in the gate, but signer isn't the member
+      });
+      expect(allowed).toBe(false);
+    });
   });
 });

--- a/packages/agent/test/swm-member-recovery-auth.test.ts
+++ b/packages/agent/test/swm-member-recovery-auth.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { ethers } from 'ethers';
+import { isMemberRecoveryAuthorized } from '../src/swm/member-recovery-auth.js';
+
+const A = ethers.getAddress('0x' + 'a'.repeat(40));
+const B = ethers.getAddress('0x' + 'b'.repeat(40));
+const C = ethers.getAddress('0x' + 'c'.repeat(40));
+
+/**
+ * The members-only ACL gate — the #1 security item. The member-recovery gate HARD-DENIES on a
+ * null/empty gate (the inversion of the fail-open) and never widens.
+ */
+describe('isMemberRecoveryAuthorized', () => {
+  it('HARD-DENIES on a null gate (the #1 fix — no widening to a weaker check)', () => {
+    expect(isMemberRecoveryAuthorized(A, null)).toBe(false);
+  });
+
+  it('HARD-DENIES on an empty gate', () => {
+    expect(isMemberRecoveryAuthorized(A, [])).toBe(false);
+  });
+
+  it('allows an EOA that is in the gate', () => {
+    expect(isMemberRecoveryAuthorized(A, [A, B])).toBe(true);
+  });
+
+  it('denies an EOA that is not in the gate', () => {
+    expect(isMemberRecoveryAuthorized(C, [A, B])).toBe(false);
+  });
+
+  it('is checksum/case-insensitive', () => {
+    expect(isMemberRecoveryAuthorized(A.toLowerCase(), [A.toUpperCase().replace('0X', '0x')])).toBe(true);
+  });
+
+  it('denies (never throws) on a malformed requester or gate entries', () => {
+    expect(isMemberRecoveryAuthorized('not-an-address', [A])).toBe(false);
+    expect(isMemberRecoveryAuthorized(A, ['garbage', A])).toBe(true); // ignores bad entry, still matches A
+    expect(isMemberRecoveryAuthorized(B, ['garbage'])).toBe(false);
+  });
+});

--- a/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
+++ b/packages/agent/test/swm/host-mode-key-canonicalization.test.ts
@@ -28,6 +28,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DKGAgent } from '../../src/index.js';
 import { SwmHostModeStore } from '../../src/swm/host-mode-store.js';
+import { GraphManager } from '@origintrail-official/dkg-storage';
 
 /**
  * Minimal in-memory gossip transport — mirrors the surface the agent
@@ -87,6 +88,9 @@ interface AgentInternals {
   swmHostModeSubscribed: Map<string, string>;
   swmHostModeHandlers: Map<string, unknown>;
   wireIdToLocalCgId: Map<string, string>;
+  config: { swmHostMode?: { reconcileBatchSize?: number } };
+  hostModeReconcileCursor: number;
+  reconcileSwmHostModeSubscription(contextGraphId: string): Promise<void>;
   enqueueHostModePersistence(contextGraphId: string, subscribe: boolean): void;
   awaitHostModePersistence(contextGraphId: string): Promise<void>;
   hostModePersistenceStoreKey(rawCgId: string): string;
@@ -129,6 +133,65 @@ describe('host-mode bookkeeping key canonicalisation', () => {
     await installHostModeStore(core, dataDir);
     return { core, bus };
   }
+
+  it('reconcileHostModeSubscriptions advances a bounded cursor instead of sweeping every CG per tick', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['cursor-cg-d', 'cursor-cg-b', 'cursor-cg-a', 'cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    expect(knownCgs.length).toBeGreaterThanOrEqual(4);
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+    };
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual(knownCgs.slice(0, 2));
+    expect(internals.hostModeReconcileCursor).toBe(2);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([...knownCgs.slice(0, 2), ...knownCgs.slice(2, 4)]);
+    expect(internals.hostModeReconcileCursor).toBe(4 % knownCgs.length);
+  });
+
+  it('reconcileHostModeSubscriptions advances past a failing CG so later CGs are not starved', async () => {
+    const { core } = await makeCore();
+    const internals = core as unknown as AgentInternals;
+    internals.config.swmHostMode = { ...(internals.config.swmHostMode ?? {}), reconcileBatchSize: 2 };
+    const graphManager = new GraphManager(core.store);
+    const cgIds = ['failing-cursor-cg-a', 'failing-cursor-cg-b', 'failing-cursor-cg-c'];
+    for (const cgId of cgIds) {
+      await core.store.insert([{
+        subject: `http://example.org/${cgId}`,
+        predicate: 'http://schema.org/name',
+        object: `"${cgId}"`,
+        graph: graphManager.dataGraphUri(cgId),
+      }]);
+    }
+    const knownCgs = (await graphManager.listContextGraphs()).sort();
+    const calls: string[] = [];
+    internals.reconcileSwmHostModeSubscription = async (contextGraphId: string) => {
+      calls.push(contextGraphId);
+      if (contextGraphId === knownCgs[0]) throw new Error('boom');
+    };
+
+    await expect(core.reconcileHostModeSubscriptions()).rejects.toThrow('boom');
+    expect(calls).toEqual([knownCgs[0]]);
+    expect(internals.hostModeReconcileCursor).toBe(1);
+
+    await core.reconcileHostModeSubscriptions();
+    expect(calls).toEqual([knownCgs[0], knownCgs[1], knownCgs[2]]);
+  });
 
   it('cleartext subscribe followed by wire-hash subscribe for the same CG is idempotent', async () => {
     const { core } = await makeCore();

--- a/packages/agent/test/sync-catalog-p2p.test.ts
+++ b/packages/agent/test/sync-catalog-p2p.test.ts
@@ -1,0 +1,53 @@
+/**
+ * facet open-serve, end-to-end over P2P (no chain/devnet).
+ * An OUTSIDER (non-member) fetches a private CG's public _catalog facet from a
+ * peer and receives the DCAT catalog entry — but never any gated data.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { DKGAgent, MockChainAdapter } from './agent.shared';
+import {
+  DKG_ONTOLOGY, contextGraphCatalogUri, contextGraphDataUri,
+} from '@origintrail-official/dkg-core';
+
+const agents: DKGAgent[] = [];
+afterEach(async () => { for (const a of agents) { try { await a.stop(); } catch {} } agents.length = 0; });
+
+async function mkAgent(name: string, addr: string) {
+  const chain = new MockChainAdapter('mock:31337', addr);
+  const agent = await DKGAgent.create({ name, listenPort: 0, skills: [], chainAdapter: chain });
+  agents.push(agent);
+  await agent.start();
+  return agent;
+}
+
+describe('outsider fetches the _catalog facet over P2P (no membership)', () => {
+  it('serves the catalog to a non-member and never the gated data', async () => {
+    const publisher = await mkAgent('PublisherNode', '0x70997970C51812dc3A010C7d01b50e0d17dc79C8');
+    const outsider = await mkAgent('OutsiderNode', '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC');
+
+    const CG = 'p2p-catalog-cg';
+    const cgUal = contextGraphDataUri(CG);
+    const catalogGraph = contextGraphCatalogUri(CG);
+    const privateGraph = `did:dkg:context-graph:${CG}/_private`;
+
+    // Publisher holds a public catalog entry + gated private data.
+    await (publisher as any).store.insert([
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DCAT_DATASET, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.DCT_ACCESS_RIGHTS, object: DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED, graph: catalogGraph },
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"SECRET-P9"', graph: privateGraph },
+    ]);
+
+    await outsider.connectTo(publisher.multiaddrs[0]);
+    await new Promise((r) => setTimeout(r, 600));
+
+    const quads = await outsider.fetchPublicCatalog(CG, publisher.peerId);
+
+    // The outsider received the DCAT catalog entry...
+    const objs = quads.map((q) => String(q.object));
+    expect(objs).toContain(DKG_ONTOLOGY.DCAT_DATASET);
+    expect(objs).toContain(DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED);
+    // ...and NONE of the gated private data.
+    expect(objs.some((o) => o.includes('SECRET'))).toBe(false);
+  }, 60_000);
+});

--- a/packages/agent/test/sync-catalog-serve.test.ts
+++ b/packages/agent/test/sync-catalog-serve.test.ts
@@ -1,0 +1,61 @@
+/**
+ * facet open-serve bounding. readCatalogPage MUST release only
+ * the public `_catalog` named graph and never any gated quad (private payload,
+ * VM data, or _meta). This is the safety boundary of the open-serve path.
+ */
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import {
+  contextGraphCatalogUri,
+  contextGraphDataUri,
+  contextGraphPrivateGraphUri,
+  contextGraphMetaGraphUri,
+  DKG_ONTOLOGY,
+} from '@origintrail-official/dkg-core';
+import { readCatalogPage } from '../src/sync/responder/graph-plan.js';
+
+describe('readCatalogPage releases ONLY the _catalog graph', () => {
+  it('serves the public DCAT catalog entry and leaks nothing gated', async () => {
+    const store = new OxigraphStore();
+    const CG = 'cat-serve-test';
+    const cgUal = contextGraphDataUri(CG);                 // did:dkg:context-graph:cat-serve-test
+    const catalogGraph = contextGraphCatalogUri(CG);       // …/_catalog
+    const privateGraph = contextGraphPrivateGraphUri(CG);  // …/_private
+    const metaGraph = contextGraphMetaGraphUri(CG);        // …/_meta
+    const vmDataGraph = `did:dkg:context-graph:${CG}/_verifiable_memory/0xabc/0`;
+
+    await store.insert([
+      // public catalog entry (the only thing that may be served)
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DCAT_DATASET, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.RDF_TYPE, object: DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH, graph: catalogGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.DCT_ACCESS_RIGHTS, object: DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED, graph: catalogGraph },
+      // gated content — MUST NOT be served by the open path
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"SECRET-P9"', graph: privateGraph },
+      { subject: 'urn:acme:shipment/SH-42', predicate: 'urn:acme:product', object: '"SECRET-P9"', graph: vmDataGraph },
+      { subject: cgUal, predicate: DKG_ONTOLOGY.DKG_CURATOR, object: 'did:dkg:agent:0xsecret', graph: metaGraph },
+    ]);
+
+    const rows = await readCatalogPage({ store, contextGraphId: CG, offset: 0, limit: 100 });
+
+    expect(rows.length).toBeGreaterThan(0);
+    // EVERY served row is from the _catalog graph
+    expect(rows.every((r) => r.g === catalogGraph)).toBe(true);
+    // the catalog entry IS served
+    expect(rows.some((r) => r.o === DKG_ONTOLOGY.DCAT_DATASET)).toBe(true);
+    expect(rows.some((r) => r.o === DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED)).toBe(true);
+    // NOTHING gated leaks — not private, not VM data, not _meta/curator
+    expect(rows.some((r) => String(r.o).includes('SECRET'))).toBe(false);
+    expect(rows.some((r) => r.g === privateGraph || r.g === vmDataGraph || r.g === metaGraph)).toBe(false);
+    expect(rows.some((r) => r.p === DKG_ONTOLOGY.DKG_CURATOR)).toBe(false);
+  });
+
+  it('returns nothing for a CG with no catalog entry', async () => {
+    const store = new OxigraphStore();
+    const CG = 'no-catalog';
+    await store.insert([
+      { subject: 'urn:x', predicate: 'urn:p', object: '"v"', graph: `did:dkg:context-graph:${CG}/_private` },
+    ]);
+    const rows = await readCatalogPage({ store, contextGraphId: CG, offset: 0, limit: 100 });
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/agent/test/sync-checkpoint-key.test.ts
+++ b/packages/agent/test/sync-checkpoint-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getSyncCheckpointKey } from '../src/sync/checkpoint/state.js';
+import { getSyncCheckpointKey, MemorySyncCheckpointStore } from '../src/sync/checkpoint/state.js';
 
 describe('getSyncCheckpointKey', () => {
   it('keeps an unscoped key when no sinceBatchId is given', () => {
@@ -31,5 +31,36 @@ describe('getSyncCheckpointKey', () => {
     expect(delta7).toBe('peerA|mfacts|durable|data|since:7');
     expect(delta7).not.toBe(full);
     expect(delta7).not.toBe(delta9);
+  });
+
+  // R10 — member SWM recovery must get its OWN cursor namespace so it never
+  // overwrites or deletes the shared incremental-sync cursor.
+  it('scopes the key with a |recovery segment distinct from the normal SWM key', () => {
+    const normal = getSyncCheckpointKey('peerA', 'mfacts', true, 'data');
+    const recovery = getSyncCheckpointKey('peerA', 'mfacts', true, 'data', undefined, undefined, true);
+
+    expect(normal).toBe('peerA|mfacts|swm|data');
+    expect(recovery).toBe('peerA|mfacts|swm|data|recovery');
+    expect(recovery).not.toBe(normal);
+  });
+
+  it('R10 invariant: a recovery run never mutates the shared incremental-sync cursor', () => {
+    const store = new MemorySyncCheckpointStore();
+    const normalKey = getSyncCheckpointKey('peerA', 'mfacts', true, 'data');
+    const recoveryKey = getSyncCheckpointKey('peerA', 'mfacts', true, 'data', undefined, undefined, true);
+
+    // Background incremental sync has advanced its cursor.
+    store.set(normalKey, 42);
+
+    // A recovery run sets and then drops its OWN cursor (mid-stream set, then
+    // the all-or-nothing partial-fetch deleteCheckpoint), as the recovery path
+    // does per page.
+    store.set(recoveryKey, 100);
+    store.delete(recoveryKey);
+
+    // The shared incremental cursor is untouched — incremental sync resumes at
+    // 42, not restarted from 0.
+    expect(store.get(normalKey)?.offset).toBe(42);
+    expect(store.get(recoveryKey)).toBeUndefined();
   });
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -357,6 +357,12 @@ export interface QueryAccessConfig {
   rateLimitPerMinute?: number;
 }
 
+export interface GraphSetIndexConfig {
+  enabled?: boolean;
+  /** Revalidate the named-graph index after this many milliseconds. 0 means every read. */
+  revalidateMs?: number;
+}
+
 export interface DkgConfig {
   name: string;
   relay?: string;
@@ -455,7 +461,7 @@ export interface DkgConfig {
   /** Block explorer URL for TX links (default: derived from chainId). */
   blockExplorerUrl?: string;
   /** Triple store backend override (default: oxigraph-worker with file persistence). */
-  store?: { backend: string; options?: Record<string, unknown> };
+  store?: { backend: string; options?: Record<string, unknown>; graphSetIndex?: boolean | GraphSetIndexConfig };
   /**
    * Cap on how many persisted context-graph subscriptions a node ACTIVATES on
    * boot (gossip + sync). A large stale backlog otherwise fans out store work

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1243,6 +1243,7 @@ export async function runDaemonInner(
     storeConfig: runtimeStore ? {
       backend: runtimeStore.backend,
       options: runtimeStore.options,
+      graphSetIndex: runtimeStore.graphSetIndex,
     } : undefined,
     largeLiteralStorage: runtimeLargeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: runtimeSnapshotStorage,

--- a/packages/cli/src/daemon/oxigraph-managed.ts
+++ b/packages/cli/src/daemon/oxigraph-managed.ts
@@ -49,6 +49,10 @@ export function resolveManagedOxigraphPort(
 interface StoreConfigLike {
   backend?: unknown;
   options?: Record<string, unknown>;
+  graphSetIndex?: boolean | {
+    enabled?: boolean;
+    revalidateMs?: number;
+  };
 }
 
 interface ConfigLike {
@@ -79,6 +83,7 @@ export interface ManagedOxigraphPlan {
   storeConfigTemplate: {
     backend: 'sparql-http';
     options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
   };
   /**
    * largeLiteralStorage to apply when the operator didn't configure one.
@@ -140,16 +145,22 @@ export function planManagedOxigraph(
         }
       : undefined;
 
+  const graphSetIndex = config.store?.graphSetIndex;
+  const storeConfigTemplate: ManagedOxigraphPlan['storeConfigTemplate'] = {
+    backend: 'sparql-http',
+    // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
+    // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
+    options: { managedByDkg: true },
+  };
+  if (graphSetIndex !== undefined) {
+    storeConfigTemplate.graphSetIndex = graphSetIndex;
+  }
+
   return {
     port,
     location,
     cacheDir,
-    storeConfigTemplate: {
-      backend: 'sparql-http',
-      // managedByDkg lets chain-reset wipe DROP ALL on the local RocksDB
-      // we own end-to-end; queryEndpoint/updateEndpoint added at launch.
-      options: { managedByDkg: true },
-    },
+    storeConfigTemplate,
     largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage,
   };
@@ -158,7 +169,11 @@ export function planManagedOxigraph(
 export interface ManagedOxigraphResult {
   handle: OxigraphServerHandle;
   /** Drop-in replacement for `config.store`. */
-  storeConfig: { backend: 'sparql-http'; options: Record<string, unknown> };
+  storeConfig: {
+    backend: 'sparql-http';
+    options: Record<string, unknown>;
+    graphSetIndex?: StoreConfigLike['graphSetIndex'];
+  };
   largeLiteralStorage: { enabled: boolean; thresholdBytes?: number; directory: string };
   /** Set only when the operator enabled the feature (else leave config as-is). */
   sharedMemoryPublicSnapshotStorage?: { enabled: boolean; directory: string };
@@ -206,16 +221,21 @@ export async function startManagedOxigraph(
     io: opts.serverIo,
   });
 
+  const storeConfig: ManagedOxigraphResult['storeConfig'] = {
+    backend: 'sparql-http',
+    options: {
+      ...plan.storeConfigTemplate.options,
+      queryEndpoint: handle.queryEndpoint,
+      updateEndpoint: handle.updateEndpoint,
+    },
+  };
+  if (plan.storeConfigTemplate.graphSetIndex !== undefined) {
+    storeConfig.graphSetIndex = plan.storeConfigTemplate.graphSetIndex;
+  }
+
   return {
     handle,
-    storeConfig: {
-      backend: 'sparql-http',
-      options: {
-        ...plan.storeConfigTemplate.options,
-        queryEndpoint: handle.queryEndpoint,
-        updateEndpoint: handle.updateEndpoint,
-      },
-    },
+    storeConfig,
     largeLiteralStorage: plan.largeLiteralStorage,
     sharedMemoryPublicSnapshotStorage: plan.sharedMemoryPublicSnapshotStorage,
   };

--- a/packages/cli/test/oxigraph-managed.test.ts
+++ b/packages/cli/test/oxigraph-managed.test.ts
@@ -7,6 +7,7 @@
  * loopback endpoints + managedByDkg) without touching disk or processes.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'node:path';
 
 vi.mock('../src/daemon/oxigraph-binary.js', () => ({
   ensureOxigraphBinary: vi.fn(async () => '/cache/oxigraph-v0.5.8'),
@@ -43,12 +44,12 @@ describe('planManagedOxigraph', () => {
     const plan = planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data');
     expect(plan).not.toBeNull();
     expect(plan!.port).toBe(DEFAULT_OXIGRAPH_PORT);
-    expect(plan!.location).toBe('/data/oxigraph-data');
-    expect(plan!.cacheDir).toBe('/data/oxigraph');
+    expect(plan!.location).toBe(join('/data', 'oxigraph-data'));
+    expect(plan!.cacheDir).toBe(join('/data', 'oxigraph'));
     expect(plan!.largeLiteralStorage).toEqual({
       enabled: true,
       thresholdBytes: undefined,
-      directory: '/data/literal-blobs',
+      directory: join('/data', 'literal-blobs'),
     });
     expect(plan!.storeConfigTemplate).toEqual({
       backend: 'sparql-http',
@@ -99,6 +100,19 @@ describe('planManagedOxigraph', () => {
     });
   });
 
+  it('preserves graphSetIndex options through the managed store rewrite plan', () => {
+    const plan = planManagedOxigraph(
+      {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: { enabled: true, revalidateMs: 5_000 },
+        },
+      },
+      '/data',
+    );
+    expect(plan!.storeConfigTemplate.graphSetIndex).toEqual({ enabled: true, revalidateMs: 5_000 });
+  });
+
   it('leaves sharedMemoryPublicSnapshotStorage undefined when disabled/absent', () => {
     expect(
       planManagedOxigraph({ store: { backend: MANAGED_OXIGRAPH_BACKEND } }, '/data')!
@@ -125,7 +139,7 @@ describe('planManagedOxigraph', () => {
     );
     expect(plan!.sharedMemoryPublicSnapshotStorage).toEqual({
       enabled: true,
-      directory: '/data/swm-public-snapshots',
+      directory: join('/data', 'swm-public-snapshots'),
     });
   });
 
@@ -176,6 +190,19 @@ describe('startManagedOxigraph', () => {
         updateEndpoint: `http://127.0.0.1:${DEFAULT_OXIGRAPH_PORT}/update`,
       },
     });
-    expect(result!.largeLiteralStorage.directory).toBe('/data/literal-blobs');
+    expect(result!.largeLiteralStorage.directory).toBe(join('/data', 'literal-blobs'));
+  });
+
+  it('preserves graphSetIndex options when starting the managed store', async () => {
+    const result = await startManagedOxigraph({
+      config: {
+        store: {
+          backend: MANAGED_OXIGRAPH_BACKEND,
+          graphSetIndex: false,
+        },
+      },
+      dataDir: '/data',
+    });
+    expect(result!.storeConfig.graphSetIndex).toBe(false);
   });
 });


### PR DESCRIPTION
Part **4/5** · base: `feat/public-context-graph-projection`.

The serve/auth side: cores serve a private CG's public catalog to outsiders, and member-only operations are authorized strictly.

- **Catalog open-serve** — cores serve the bounded `<cg>/_catalog` subgraph to outsiders with **no allowlist auth** (`readCatalogPage` in graph-plan, the catalog branch in sync-handler, catalog admission in cg-resolve), keyed on the context-graph DID; all gated data stays members-only.
- **Projection-routed meta reads** — access policy / participants / agent-gate resolve through the projection, preserving **revoked-agent filtering** (a store-only read would re-authorize revoked agents); partial projection records fall back per-field to the store.
- **Members-only recovery auth** — a `recovery` flag on the sync request makes the responder enforce a hard-deny members-only gate (`isMemberRecoveryAuthorized`) on the **cryptographically-recovered signer** against a fresh `_meta` gate, instead of the participant/peer fallback.
- Catalog persisted/cleared consistently (peer-fetched catalog persisted + projection invalidated; post-publish emit clear-replaces).

catalog serve/read + auth tests green. Please do not merge before review / out of order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Depends on #1172** — please merge that first.
