### PR TITLE
fix lu11 chunked self ack persistence

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -2740,6 +2740,13 @@ export class PublishMethods extends DKGAgentBase {
             object: literal,
             graph: chunksGraph,
           }]);
+          log.debug(
+            ctx,
+            `LU-11: persisted local ciphertext chunk before ACK collection ` +
+            `cgId=${contextGraphId} swmGraphId=${contextGraphId} ` +
+            `batchId=${batchIdHex.slice(0, 18)}... chunkIndex=${i} ` +
+            `graph=${chunksGraph} subject=${subject}`,
+          );
         } catch (err) {
           log.warn(
             ctx,

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -342,6 +342,14 @@ describe('DKGAgent._resolveEncryptInlineChunked nonce domain', () => {
       predicate: CIPHERTEXT_CHUNK_PREDICATE,
       graph: ciphertextChunkStoreGraph(canonicalSwmCgId),
     });
+    expect(agentLike.log.debug).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining(`graph=${ciphertextChunkStoreGraph(canonicalSwmCgId)}`),
+    );
+    expect(agentLike.log.debug).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining(`subject=${ciphertextChunkStoreSubject(batchId, 0)}`),
+    );
 
     const handler = new StorageACKHandler(
       store as any,


### PR DESCRIPTION
## Summary

Follow-up to the merged LU-11 chunked self-ACK fix.

Adds publisher-side diagnostics after a LU-11 chunk is synchronously persisted to the local ciphertext chunk store, so operators can confirm the exact key that the local `StorageACKHandler` should read during self-ACK.

## Changes

- Log successful local LU-11 chunk persistence before ACK collection with:
  - `cgId` / `swmGraphId`
  - `batchId` / merkle root preview
  - `chunkIndex`
  - ciphertext chunk graph URI
  - ciphertext chunk subject URI
- Extend the loopback-free self-ACK regression to assert the debug log contains the expected graph and subject keys.

## Validation

- `pnpm exec vitest run --config /private/tmp/dkg-agent-lu11-rebased-vitest.config.ts`

Result: `packages/agent/test/encrypt-inline-policy.test.ts` passed, `10 tests`.

## Branch

`codex/lu11-self-ack-fix`

Commit: `1a28c768 fix lu11 chunked self ack persistence`