### PR TITLE
fix(agent): data sync no longer unions a reconnecting member's shared memory

### DIFF
--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -230,7 +230,7 @@ export function verifySyncedData(
   return { data: verifiedData, meta: verifiedMeta, rejected, logs };
 }
 
-function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
+export function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
   const quads = parseNQuads(text);
   const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}/`;
   // A request is a shared-memory/workspace request iff its OWN graphUri names a

--- a/packages/agent/src/sync-verify-worker-impl.ts
+++ b/packages/agent/src/sync-verify-worker-impl.ts
@@ -233,8 +233,26 @@ export function verifySyncedData(
 function parseAndFilterNQuads(text: string, graphUri: string, contextGraphId: string): SyncParseResult {
   const quads = parseNQuads(text);
   const cgUriPrefix = `did:dkg:context-graph:${contextGraphId}/`;
+  // A request is a shared-memory/workspace request iff its OWN graphUri names a
+  // `_shared_memory` graph (base bucket, per-KA descendant, or `_shared_memory_meta`).
+  // When it is NOT (a durable data/meta sync), reject any quad whose graph names a
+  // `_shared_memory` graph: the responder over-serves the whole `_shared_memory`
+  // subtree under the CG prefix, and a blind `storeInsert` of those quads on the
+  // streaming durable-sync apply UNIONS a reconnecting private-CG member into
+  // {old,new} for single-valued roots. SWM must flow ONLY through the dedicated
+  // SWM-sync / all-or-nothing recovery path (which passes an SWM graphUri here, so
+  // `swmRequest` is true and the base bucket + per-KA subgraphs are kept exactly as
+  // before). This is an EXCLUDE (drops quads), never a per-page REPLACE, so it
+  // cannot truncate a root spanning a page boundary. The literal "/_shared_memory"
+  // matches every SWM URI form and only those (validateSubGraphName forbids a
+  // leading "_" on subgraph names, so no data/meta/context graph can collide).
+  const swmRequest = graphUri.includes('/_shared_memory');
   return {
-    quads: quads.filter((q) => q.graph === graphUri || q.graph.startsWith(cgUriPrefix)),
+    quads: quads.filter(
+      (q) =>
+        q.graph === graphUri ||
+        (q.graph.startsWith(cgUriPrefix) && (swmRequest || !q.graph.includes('/_shared_memory'))),
+    ),
     totalQuads: quads.length,
   };
 }

--- a/packages/agent/test/sync-verify-data-swm-partition.test.ts
+++ b/packages/agent/test/sync-verify-data-swm-partition.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression for the data-sync union-corruption fix (#1191).
+ *
+ * The DATA sync responder over-serves the whole `_shared_memory` subtree under a
+ * CG prefix; a blind streaming-apply insert of those quads UNIONS a reconnecting
+ * private-CG member into {old,new} for single-valued roots. `parseAndFilterNQuads`
+ * now EXCLUDES `_shared_memory` quads from a NON-SWM (durable data/meta) request,
+ * while a shared-memory request stays a NO-OP (the dedicated SWM-sync path keeps
+ * the base bucket + per-KA subgraphs exactly as before).
+ */
+import { describe, it, expect } from 'vitest';
+import { parseAndFilterNQuads } from '../src/sync-verify-worker-impl.js';
+
+const CG = '0xabc/cg';
+const dataGraph = `did:dkg:context-graph:${CG}/context/data`;
+const otherData = `did:dkg:context-graph:${CG}/context/other`;
+const swmBase = `did:dkg:context-graph:${CG}/_shared_memory`;
+const swmPerKa = `did:dkg:context-graph:${CG}/_shared_memory/0xKA/1`;
+
+const nq = (graph: string, s: string) => `<${s}> <urn:p> <urn:o> <${graph}> .`;
+// One quad in each graph kind, all under the CG prefix.
+const input = [
+  nq(dataGraph, 'urn:s1'),
+  nq(otherData, 'urn:s2'),
+  nq(swmBase, 'urn:s3'),
+  nq(swmPerKa, 'urn:s4'),
+].join('\n');
+
+const graphsOf = (text: string, graphUri: string) =>
+  parseAndFilterNQuads(text, graphUri, CG).quads.map((q) => q.graph);
+
+describe('parseAndFilterNQuads — data/SWM partition (#1191 union-corruption guard)', () => {
+  it('a DATA request DROPS _shared_memory quads (no {old,new} union on reconnect)', () => {
+    const result = parseAndFilterNQuads(input, dataGraph, CG);
+    expect(result.totalQuads).toBe(4); // totalQuads reports the pre-filter count
+    const graphs = result.quads.map((q) => q.graph);
+    expect(graphs).toContain(dataGraph); // the request graph is kept
+    expect(graphs).toContain(otherData); // other (non-SWM) data subgraph kept
+    expect(graphs).not.toContain(swmBase); // base _shared_memory dropped
+    expect(graphs).not.toContain(swmPerKa); // per-KA _shared_memory dropped
+  });
+
+  it('a meta DATA request also drops _shared_memory (any non-SWM graphUri)', () => {
+    const metaGraph = `did:dkg:context-graph:${CG}/_meta`;
+    const graphs = graphsOf([...input.split('\n'), nq(metaGraph, 'urn:s5')].join('\n'), metaGraph);
+    expect(graphs).toContain(metaGraph);
+    expect(graphs).not.toContain(swmBase);
+    expect(graphs).not.toContain(swmPerKa);
+  });
+
+  it('a SWM request is a NO-OP — keeps the base bucket AND per-KA _shared_memory subgraphs', () => {
+    const graphs = graphsOf(input, swmBase);
+    expect(graphs).toContain(swmBase); // request graph
+    expect(graphs).toContain(swmPerKa); // per-KA SWM subgraph kept (the no-op invariant)
+  });
+
+  it('a per-KA SWM request keeps both that subgraph and the base bucket (swmRequest=true)', () => {
+    const graphs = graphsOf(input, swmPerKa);
+    expect(graphs).toContain(swmPerKa);
+    expect(graphs).toContain(swmBase);
+  });
+});


### PR DESCRIPTION
## What

Fixes a shared-memory corruption on reconnect: the general **data** sync over-accepted `_shared_memory` quads and blind-inserted them, so a reconnecting member that already held a value `v1` and re-synced a graph now at `v3` ended up holding the **union** `{v1, v3}` instead of `v3`.

## Root cause

`parseAndFilterNQuads` (sync-verify-worker-impl.ts) accepted any quad under the CG URI prefix. For a **data** request that swept in the CG's `_shared_memory` graphs and the data path `storeInsert`-ed them additively (no per-subject REPLACE), unioning stale and fresh state.

## Fix

Graph-gate the filter: a **data** request excludes `_shared_memory` graphs; a `_shared_memory` request is a **no-op** (reduces to the original filter), so per-KA SWM subgraph sync is unchanged. SWM convergence is owned by the SWM sync path (per-subject REPLACE), not the data path.

## Scope / risk

One-file, ~19 lines. No-op for SWM requests (verified: a KA-published value survives reconnect); only data requests change, and only to stop sweeping SWM. Standalone — independent of the recovery/convergence work that consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
