### PR TITLE
docs: restore the general (website/app) bug bounty page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
 
 * [OriginTrail DKG V10 Pre-Mainnet Bug Bounty](active-now/dkg-v10-premainnet-bounty.md)
 * [DKG V10 Bounty Program](active-now/dkg-v10-bounty.md)
+* [General Bug Bounty](active-now/general-bug-bounty.md)
 
 ## How DKG Works
 

--- a/docs/active-now/general-bug-bounty.md
+++ b/docs/active-now/general-bug-bounty.md
@@ -1,0 +1,78 @@
+---
+icon: file-invoice-dollar
+---
+
+# General bug bounty
+
+To ensure the **security and proper functioning of our websites and applications,** Trace Labs has launched a dedicated bounty program. Each submission will be evaluated based on its severity and will correspond to a specific bounty reward.
+
+## Vulnerability categories and rewards
+
+* **Minor bug:** 50 TRAC
+* **Medium bug:** 250 TRAC
+* **Serious bug:** 500 TRAC
+* **Critical bug:** 1000 TRAC
+
+## Bug bounty rules
+
+1. **Severity assessment:** The severity of each bug will be determined solely at the discretion of Trace Labs, based on both the likelihood and impact of the bug. All reward decisions are final.
+2. **Submission process:** Please send your bug reports to [**bounty@origin-trail.com**](mailto:bounty@origin-trail.com) with the subject "WEBSITE/APP BUG BOUNTY." Upon receipt, we will evaluate the severity of the bug and contact you with further information. Submissions through other channels (e.g., social media) will not be accepted.
+
+## Security vulnerabilities
+
+* SQL injection.
+* Cross-site scripting (XSS).
+* Cross-site request forgery (CSRF).
+* Remote code execution (RCE).
+* Insecure configurations in web servers, databases, and application frameworks.
+* Session hijacking and clickjacking.
+* Sensitive data exposure.
+* Unauthorized access to user accounts.
+* Bypassing authentication mechanisms.
+* Credentials exposure.
+* Logic bypasses.
+
+## Example submission template
+
+```
+**Title:** [Short description of the vulnerability]
+
+**Description:**
+[A detailed description of the vulnerability, including what it is and how it can be exploited]
+
+**Steps to Reproduce:**
+1. [First step]
+2. [Second step]
+3. [Further steps as necessary]
+
+**Proof of Concept:**
+[Include any screenshots, videos, or code snippets]
+
+**Impact:**
+[Explain the potential impact of the vulnerability]
+
+**Suggested Fix:**
+[Provide recommendations for how to fix the issue]
+
+**Additional Information:**
+[Any other information that might be relevant]
+
+```
+
+### Important restrictions
+
+Please ensure you do not harm any live contracts on public networks while testing; otherwise, you will not be eligible for a bug bounty.
+
+Leaking any vulnerability of the smart contracts on social media platforms or public channels will result in the cancellation of the bounty and might also invite legal action.
+
+### Legal notice
+
+We cannot issue rewards to individuals on sanctions lists or who reside in countries on sanctions lists. Depending on your country of residency and citizenship, you are responsible for any tax implications. Your local law may also impose additional restrictions.
+
+This is a discretionary rewards program. We can cancel the program at any time, and the decision to pay a reward is entirely at Trace Labs' discretion.
+
+Your testing must not violate any law or disrupt or compromise any data that is not your own.
+
+{% hint style="warning" %}
+To avoid potential conflicts of interest, we will not grant rewards to Trace Labs employees, employees who have left Trace Labs within the last 2 years, and contractors.&#x20;
+{% endhint %}


### PR DESCRIPTION
## Summary
Restores the **General Bug Bounty** (website/app) page, which went missing from the published docs (docs.origintrail.io) after the V10 GitBook migration. Flagged by @branimir.rakic in **#bounty** — the inbound "WEBSITE/APP BUG BOUNTY" tickets reference this page, so it needs to be live again.

## Changes
- Add `docs/active-now/general-bug-bounty.md` — ported **verbatim** from the old docs repo (`OriginTrail/dkg-docs` → `contribute-to-the-dkg/bounties-and-rewards/general-bug-bounty/README.md`).
- Link it under **Active Now** in `docs/SUMMARY.md`.

## What the page covers
Reward tiers (50 / 250 / 500 / 1000 TRAC), the submission process (email **bounty@origin-trail.com** with subject "WEBSITE/APP BUG BOUNTY"), vulnerability categories, rules, an example submission template, important restrictions, and the legal notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
