### PR TITLE
docs: restore the general (website/app) bug bounty page [GitBook-sync branch]

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
 
 * [OriginTrail DKG V10 Pre-Mainnet Bug Bounty](active-now/dkg-v10-premainnet-bounty.md)
 * [DKG V10 Bounty Program](active-now/dkg-v10-bounty.md)
+* [General Bug Bounty](active-now/general-bug-bounty.md)
 
 ## How DKG Works
 

--- a/docs/active-now/general-bug-bounty.md
+++ b/docs/active-now/general-bug-bounty.md
@@ -1,0 +1,78 @@
+---
+icon: file-invoice-dollar
+---
+
+# General bug bounty
+
+To ensure the **security and proper functioning of our websites and applications,** Trace Labs has launched a dedicated bounty program. Each submission will be evaluated based on its severity and will correspond to a specific bounty reward.
+
+## Vulnerability categories and rewards
+
+* **Minor bug:** 50 TRAC
+* **Medium bug:** 250 TRAC
+* **Serious bug:** 500 TRAC
+* **Critical bug:** 1000 TRAC
+
+## Bug bounty rules
+
+1. **Severity assessment:** The severity of each bug will be determined solely at the discretion of Trace Labs, based on both the likelihood and impact of the bug. All reward decisions are final.
+2. **Submission process:** Please send your bug reports to [**bounty@origin-trail.com**](mailto:bounty@origin-trail.com) with the subject "WEBSITE/APP BUG BOUNTY." Upon receipt, we will evaluate the severity of the bug and contact you with further information. Submissions through other channels (e.g., social media) will not be accepted.
+
+## Security vulnerabilities
+
+* SQL injection.
+* Cross-site scripting (XSS).
+* Cross-site request forgery (CSRF).
+* Remote code execution (RCE).
+* Insecure configurations in web servers, databases, and application frameworks.
+* Session hijacking and clickjacking.
+* Sensitive data exposure.
+* Unauthorized access to user accounts.
+* Bypassing authentication mechanisms.
+* Credentials exposure.
+* Logic bypasses.
+
+## Example submission template
+
+```
+**Title:** [Short description of the vulnerability]
+
+**Description:**
+[A detailed description of the vulnerability, including what it is and how it can be exploited]
+
+**Steps to Reproduce:**
+1. [First step]
+2. [Second step]
+3. [Further steps as necessary]
+
+**Proof of Concept:**
+[Include any screenshots, videos, or code snippets]
+
+**Impact:**
+[Explain the potential impact of the vulnerability]
+
+**Suggested Fix:**
+[Provide recommendations for how to fix the issue]
+
+**Additional Information:**
+[Any other information that might be relevant]
+
+```
+
+### Important restrictions
+
+Please ensure you do not harm any live contracts on public networks while testing; otherwise, you will not be eligible for a bug bounty.
+
+Leaking any vulnerability of the smart contracts on social media platforms or public channels will result in the cancellation of the bounty and might also invite legal action.
+
+### Legal notice
+
+We cannot issue rewards to individuals on sanctions lists or who reside in countries on sanctions lists. Depending on your country of residency and citizenship, you are responsible for any tax implications. Your local law may also impose additional restrictions.
+
+This is a discretionary rewards program. We can cancel the program at any time, and the decision to pay a reward is entirely at Trace Labs' discretion.
+
+Your testing must not violate any law or disrupt or compromise any data that is not your own.
+
+{% hint style="warning" %}
+To avoid potential conflicts of interest, we will not grant rewards to Trace Labs employees, employees who have left Trace Labs within the last 2 years, and contractors.&#x20;
+{% endhint %}


### PR DESCRIPTION
## Summary
Adds the **General Bug Bounty** (always-on, website/app) page to the **GitBook-synced docs branch** so it actually publishes to docs.origintrail.io.

The earlier PR (#1197) added this page to `main`, but the live GitBook space syncs from **`codex/dkg-v10-docs-pr119`** (it carries the `GITBOOK-*` commits; PR #1120 published the Pre-Mainnet tab via this branch), not `main` — so the page never appeared. This PR targets the correct branch.

## Changes
- Add `docs/active-now/general-bug-bounty.md` — ported verbatim from `OriginTrail/dkg-docs` (`contribute-to-the-dkg/bounties-and-rewards/general-bug-bounty/README.md`).
- Link it under **Active Now** in `docs/SUMMARY.md`.

Once merged, GitBook publishes it at `…/active-now/general-bug-bounty`. Requested by @branimir.rakic in #bounty (the inbound "WEBSITE/APP BUG BOUNTY" tickets reference this page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
