### PR TITLE
docs: sync Pre-Mainnet Bounty page to main (Hub + honeypot addresses)

### DIFF
--- a/docs/active-now/dkg-v10-premainnet-bounty.md
+++ b/docs/active-now/dkg-v10-premainnet-bounty.md
@@ -114,9 +114,13 @@ Open to anyone — independent researchers, audit firms, AI-augmented teams. No 
 
 ## Codebase
 
-Code under audit: [`packages/evm-module` @ `1f4fa01b`](https://github.com/OriginTrail/dkg/tree/1f4fa01b41c689d641943a59b2bc3d7336ba2f1e/packages/evm-module)
+Code under audit: [packages/evm-module @ 36d9daeb](https://github.com/OriginTrail/dkg/tree/36d9daebee47ea0886a13e0d3b587f9ba512dc45/packages/evm-module)
 
-Commit `1f4fa01b41c689d641943a59b2bc3d7336ba2f1e` (OriginTrail/dkg `main`, 2026-06-09) — the frozen RC the honeypot is deployed from.
+Commit **`36d9daebee47ea0886a13e0d3b587f9ba512dc45`** (OriginTrail/dkg `main`, 2026-06-10) — the frozen RC the honeypot is deployed from.\
+\
+Pre mainnet deployment Hub contract address on Base Mainnet: [0x26146f51e31a95c075228a34cfc696f09e4c36c3](https://basescan.org/address/0x26146f51e31a95c075228a34cfc696f09e4c36c3)\
+\
+Token honeypot contract address: [0x27ff0e72552d7df824f0b561442f3a91a8f9e47e](https://basescan.org/address/0x27ff0e72552d7df824f0b561442f3a91a8f9e47e)
 
 ## Path to mainnet
 


### PR DESCRIPTION
## Why

We're about to repoint GitBook (docs.origintrail.io) to sync from `main` instead of the `codex/dkg-v10-docs-pr119` branch, so `main` becomes the single source of truth for the docs.

The only blocker: the **live Pre-Mainnet Bug Bounty page** was edited through GitBook and those edits landed only on the codex sync branch, never on `main`. If we switched the sync without this, the live page would **regress and lose**:

- Base Mainnet **Hub** contract: `0x26146f51e31a95c075228a34cfc696f09e4c36c3`
- Token **honeypot** contract: `0x27ff0e72552d7df824f0b561442f3a91a8f9e47e`
- the updated frozen audit commit (`1f4fa01b`, Jun 9 → `36d9daeb`, Jun 10)

Those are the actual addresses researchers target, so this just brings `main` up to parity with what's already live before we flip the sync branch.

## What

Ports the `## Codebase` section of `docs/active-now/dkg-v10-premainnet-bounty.md` from the live (codex) version onto `main`. No other changes.

After this merges, `main` is a clean superset of the live docs and GitBook can safely sync from `main` (direction: GitHub → GitBook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)