### PR TITLE
feat(rfc49): cut the curated UPDATE path over to the catalog model

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1462,8 +1462,12 @@ export class PublishMethods extends DKGAgentBase {
     // never duplicated, then append exactly the fresh projection. The graph
     // is cosmetic — `partitionCatalogQuads` matches on subject (the CG DID)
     // and the catalog root excludes the graph term — so we stamp the canonical
-    // CG-DID data graph for clarity. Public updates skip this entirely and stay
-    // byte-for-byte identical to today (no floor, no hook).
+    // CG-DID data graph for clarity. Public updates skip this block entirely (no
+    // floor, no hook) and are unchanged on a HEALTHY chain. NB: update() now
+    // resolves the access policy unconditionally (~:1442), exactly as the publish
+    // path always has — so under a DEGRADED / stale policy probe a public update
+    // fails closed (throws) consistently with publish, where the OLD update path
+    // would have proceeded. Fail-closed, never a leak; see PR #1208 notes.
     let updateQuads = quads;
     if (isCuratedUpdate) {
       const cgDid = contextGraphDataUri(contextGraphId);
@@ -1488,7 +1492,7 @@ export class PublishMethods extends DKGAgentBase {
       v10UpdateACKProvider,
       // Curated → wire the single-blob AEAD hook so the producer's
       // `useEncryptedInlineUpdate` gate fires (catalog commit + member
-      // encryption). Public → `undefined`, byte-identical to today.
+      // encryption). Public → `undefined` (no catalog); unchanged on a healthy chain.
       encryptInlinePayload: updateEncryptInlinePayload,
     });
     this.log.info(ctx, `Update complete — status=${result.status}`);

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1432,13 +1432,9 @@ export class PublishMethods extends DKGAgentBase {
     // resolver returns a function for a curated CG (accessPolicy=curated) and
     // `undefined` for a public CG, so the function's truthiness IS the curated
     // gate — exactly what the producer keys `useEncryptedInlineUpdate` off of.
-    // No separate accessPolicy read is needed. The chunked emitter is
-    // deliberately NOT resolved: the producer's update() never invokes it
-    // (single-blob v1 only — no publishOperationId in the update path), and
-    // `_resolveEncryptInlineChunked` THROWS for a curated CG with no workspace-
-    // gossip signer, which would tank an otherwise-valid single-blob update.
-    // The 4th arg mirrors publish: the target on-chain cgId so the AEAD key
-    // derives from the canonical id consumers verify against.
+    // No separate accessPolicy read is needed. The 4th arg mirrors publish: the
+    // target on-chain cgId so the AEAD key derives from the canonical id
+    // consumers verify against.
     const updateEncryptInlinePayload = await this._resolveEncryptInlinePayload(
       contextGraphId,
       undefined,
@@ -1446,6 +1442,24 @@ export class PublishMethods extends DKGAgentBase {
       updateOnChainId ?? undefined,
     );
     const isCuratedUpdate = typeof updateEncryptInlinePayload === 'function';
+
+    // ALSO resolve the chunked SWM emitter — the MEMBER-DISTRIBUTION path. A
+    // curated update must actively fan the updated private payload out to CG
+    // members (OT-RFC-49: cores hold zero ciphertext, members hold it), exactly
+    // as curated publish does — otherwise members silently fall behind a
+    // committed update. The producer prefers this side-effecting chunked emitter
+    // over the pure single-blob hook. Like publish, it THROWS for a curated CG
+    // with no workspace-gossip signer (cores reject unsigned chunked envelopes):
+    // fail-closed — you cannot update a curated CG you cannot distribute to
+    // members. Public CGs → `undefined` (no-op), unchanged.
+    const updateEncryptInlineChunked = isCuratedUpdate
+      ? await this._resolveEncryptInlineChunked(
+          contextGraphId,
+          undefined,
+          undefined,
+          updateOnChainId ?? undefined,
+        )
+      : undefined;
 
     // A2: USER DECISION (a) — deterministic floor RE-PROJECTION (not read-and-
     // merge). For a curated update, the public `_catalog` floor MUST be in the
@@ -1491,9 +1505,12 @@ export class PublishMethods extends DKGAgentBase {
       precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
       v10UpdateACKProvider,
       // Curated → wire the single-blob AEAD hook so the producer's
-      // `useEncryptedInlineUpdate` gate fires (catalog commit + member
-      // encryption). Public → `undefined` (no catalog); unchanged on a healthy chain.
+      // `useEncryptedInlineUpdate` gate fires (catalog commit). Public →
+      // `undefined` (no catalog); unchanged on a healthy chain.
       encryptInlinePayload: updateEncryptInlinePayload,
+      // Curated → the chunked emitter the producer prefers to fan the updated
+      // private payload out to CG members (member distribution). Public → undefined.
+      encryptInlineChunked: updateEncryptInlineChunked,
     });
     this.log.info(ctx, `Update complete — status=${result.status}`);
 

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -96,6 +96,7 @@ import {
   SUBSCRIPTION_SOURCES,
   pickNetworkTunables,
   sharedMemoryReadBothFilter,
+  partitionCatalogQuads,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -1424,9 +1425,60 @@ export class PublishMethods extends DKGAgentBase {
     // could not be resolved (the provider re-resolves the digest cgId from
     // the adapter regardless, so the digest TARGET stays chain-truth).
     const v10UpdateACKProvider = this.createV10UpdateACKProvider(updateOnChainId ?? contextGraphId);
+
+    // OT-RFC-49 / WS-D — curated-UPDATE discrimination + floor re-projection.
+    // A1: resolve the single-blob curated AEAD hook the SAME way the publish
+    // path does (dkg-agent-publish.ts:1257 _resolveEncryptInlinePayload). The
+    // resolver returns a function for a curated CG (accessPolicy=curated) and
+    // `undefined` for a public CG, so the function's truthiness IS the curated
+    // gate — exactly what the producer keys `useEncryptedInlineUpdate` off of.
+    // No separate accessPolicy read is needed. The chunked emitter is
+    // deliberately NOT resolved: the producer's update() never invokes it
+    // (single-blob v1 only — no publishOperationId in the update path), and
+    // `_resolveEncryptInlineChunked` THROWS for a curated CG with no workspace-
+    // gossip signer, which would tank an otherwise-valid single-blob update.
+    // The 4th arg mirrors publish: the target on-chain cgId so the AEAD key
+    // derives from the canonical id consumers verify against.
+    const updateEncryptInlinePayload = await this._resolveEncryptInlinePayload(
+      contextGraphId,
+      undefined,
+      undefined,
+      updateOnChainId ?? undefined,
+    );
+    const isCuratedUpdate = typeof updateEncryptInlinePayload === 'function';
+
+    // A2: USER DECISION (a) — deterministic floor RE-PROJECTION (not read-and-
+    // merge). For a curated update, the public `_catalog` floor MUST be in the
+    // quads handed to the publisher so `partitionCatalogQuads` can lift it back
+    // out, commit a non-zero `newCatalogRoot`, and satisfy the on-chain
+    // `CuratedCGRequiresCatalogCommitment` gate — even for a metadata-only
+    // update (Open Decision #2: every curated update re-commits the floor).
+    // The update analogue of `_ensureCuratedCatalogInSwm` (3606): build the
+    // floor via the SAME `buildPublicProjection({ ual: cgDid, accessPolicy:
+    // 'private' })` so the committed catalog is byte-identical across publish
+    // and update. STRIP-THEN-APPEND: drop any catalog quads the caller's
+    // payload already carries (the from-SWM `publishFromFinalizedAssertion`
+    // path at 3213 can re-load a previously-injected floor) so the floor is
+    // never duplicated, then append exactly the fresh projection. The graph
+    // is cosmetic — `partitionCatalogQuads` matches on subject (the CG DID)
+    // and the catalog root excludes the graph term — so we stamp the canonical
+    // CG-DID data graph for clarity. Public updates skip this entirely and stay
+    // byte-for-byte identical to today (no floor, no hook).
+    let updateQuads = quads;
+    if (isCuratedUpdate) {
+      const cgDid = contextGraphDataUri(contextGraphId);
+      const { otherQuads: nonCatalogQuads } = partitionCatalogQuads(quads, cgDid);
+      const catalogFloor = buildPublicProjection({
+        ual: cgDid,
+        accessPolicy: 'private',
+        graph: cgDid,
+      });
+      updateQuads = [...nonCatalogQuads, ...catalogFloor];
+    }
+
     const result = await this.publisher.update(kaId, {
       contextGraphId,
-      quads,
+      quads: updateQuads,
       privateQuads,
       publisherPeerId: this.node.peerId.toString(),
       publishContextGraphId: updateOnChainId ?? undefined,
@@ -1434,6 +1486,10 @@ export class PublishMethods extends DKGAgentBase {
       onPhase,
       precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
       v10UpdateACKProvider,
+      // Curated → wire the single-blob AEAD hook so the producer's
+      // `useEncryptedInlineUpdate` gate fires (catalog commit + member
+      // encryption). Public → `undefined`, byte-identical to today.
+      encryptInlinePayload: updateEncryptInlinePayload,
     });
     this.log.info(ctx, `Update complete — status=${result.status}`);
 

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1642,6 +1642,13 @@ export class DKGAgent extends DKGAgentBase {
       newMerkleLeafCount: number;
       newCatalogRoot?: Uint8Array;
       newCatalogLeafCount?: number;
+      // OT-RFC-49 / WS-D — `true` for a curated update (the producer sets it
+      // from `useEncryptedInlineUpdate`). Forwarded into `collectUpdate` so it
+      // stamps `UpdateIntent.isEncryptedPayload`, gating the cores' inline-
+      // catalog rebuild/verify/persist path. Undefined for public updates,
+      // which stay byte-for-byte as today. Mirrors the publish closure passing
+      // `isEncryptedPayload` into `collect`.
+      isEncryptedPayload?: boolean;
       stagingQuads?: Uint8Array;
       swmGraphId?: string;
       subGraphName?: string;
@@ -1710,6 +1717,9 @@ export class DKGAgent extends DKGAgentBase {
         swmGraphId: params.swmGraphId,
         subGraphName: params.subGraphName,
         stagingQuads: params.stagingQuads,
+        // OT-RFC-49 / WS-D — stamp `UpdateIntent.isEncryptedPayload` for a
+        // curated update so cores rebuild/verify/persist the inline catalog.
+        isEncryptedPayload: params.isEncryptedPayload,
       });
       return result.acks;
     };

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1646,8 +1646,8 @@ export class DKGAgent extends DKGAgentBase {
       // from `useEncryptedInlineUpdate`). Forwarded into `collectUpdate` so it
       // stamps `UpdateIntent.isEncryptedPayload`, gating the cores' inline-
       // catalog rebuild/verify/persist path. Undefined for public updates,
-      // which stay byte-for-byte as today. Mirrors the publish closure passing
-      // `isEncryptedPayload` into `collect`.
+      // which carry no catalog (unchanged on a healthy chain). Mirrors the publish
+      // closure passing `isEncryptedPayload` into `collect`.
       isEncryptedPayload?: boolean;
       stagingQuads?: Uint8Array;
       swmGraphId?: string;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -158,3 +158,11 @@ export * from './source-worker.js';
 export * from './source-registry.js';
 export * from './generic-sql-source.js';
 export { KaNumberAllocator, type KaAllocation } from './allocator.js';
+// OT-RFC-49 WS-D — the curated public `_catalog` floor builder. Exported on the
+// public surface so off-band tooling (e.g. the devnet update-seal helper) can
+// re-inject the SAME deterministic floor the producer's curated update() does,
+// without deep-importing the compiled `dist/` module.
+export {
+  buildPublicProjection,
+  type PublicProjectionInput,
+} from './context-graph-public-projection.js';

--- a/packages/agent/test/rfc49-catalog-parity.e2e.test.ts
+++ b/packages/agent/test/rfc49-catalog-parity.e2e.test.ts
@@ -35,8 +35,27 @@ import { DKGAgent } from '../src/index.js';
 import {
   extractCatalogLeavesFromStore,
 } from '@origintrail-official/dkg-random-sampling';
-import { computeCatalogRoot, contextGraphCatalogUri } from '@origintrail-official/dkg-core';
-import { ethers } from 'ethers';
+import {
+  computeCatalogRoot,
+  contextGraphCatalogUri,
+  contextGraphDataUri,
+  partitionCatalogQuads,
+  buildUpdateAuthorAttestationTypedData,
+  AUTHOR_SCHEME_VERSION_V1,
+  type PrecomputedUpdateAttestation,
+} from '@origintrail-official/dkg-core';
+// The curated-UPDATE leg signs its precomputedUpdateAttestation over the SAME
+// floor-injected quads the producer's update() recomputes from, so it imports
+// the exact floor builder the feature uses (deterministic from the CG DID) plus
+// the matching V10 merkle/partition helpers.
+import { buildPublicProjection } from '../src/context-graph-public-projection.js';
+import {
+  autoPartition,
+  computeFlatKCRootV10,
+  computePrivateRootV10,
+} from '../../publisher/src/index.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { ethers, Wallet } from 'ethers';
 import {
   spawnHardhatEnv, killHardhat, setMinimumRequiredSignatures, HARDHAT_KEYS, type HardhatContext,
 } from '../../chain/test/hardhat-harness.js';
@@ -62,6 +81,60 @@ function numericCgIdFromCatalogGraph(graphUri: string): bigint | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Build a `precomputedUpdateAttestation` for a curated UPDATE.
+ *
+ * A V10 update requires a caller-supplied attestation over the NEW merkle root
+ * (the agent's `update()` never auto-mints one). For a CURATED CG the producer's
+ * `update()` RE-INJECTS the deterministic public `_catalog` floor into the
+ * payload BEFORE computing the on-chain merkle (dkg-agent-publish.ts: the
+ * `isCuratedUpdate` branch — `partitionCatalogQuads` + `buildPublicProjection`
+ * → `[...nonCatalog, ...floor]`), then hard-checks
+ * `precomputedUpdateAttestation.expectedNewMerkleRoot === kcMerkleRoot`. So this
+ * seal MUST commit to the merkle over the POST-floor-injection quads — we mirror
+ * the producer's injection here with the SAME builder (deterministic floor) so
+ * the two roots agree by construction. Graph term and order are irrelevant: the
+ * V10 triple hash excludes the graph and the tree sorts+dedupes its leaves.
+ */
+async function buildCuratedUpdateSeal(opts: {
+  kaId: bigint;
+  contextGraphId: string;
+  newQuads: Quad[];
+  author: Wallet;
+  provider: ethers.JsonRpcProvider;
+  kav10Address: string;
+}): Promise<PrecomputedUpdateAttestation> {
+  const cgDid = contextGraphDataUri(opts.contextGraphId);
+  // Mirror dkg-agent-publish.ts update()'s curated floor injection EXACTLY.
+  const { otherQuads: nonCatalogQuads } = partitionCatalogQuads(opts.newQuads, cgDid);
+  const catalogFloor = buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: cgDid });
+  const injected: Quad[] = [...nonCatalogQuads, ...catalogFloor];
+
+  // Mirror publisher.update()'s merkle recompute (skolemize === autoPartition,
+  // computeFlatKCRootV10 over the flattened public quads + per-entity private
+  // roots). The UPDATE leg below ships no private quads, so privateRoots is [].
+  const kaMap = autoPartition(injected);
+  const allPublic = [...kaMap.values()].flat();
+  const newMerkleRoot = computeFlatKCRootV10(allPublic, []);
+
+  const chainId = await opts.provider.getNetwork().then((n) => n.chainId);
+  const td = buildUpdateAuthorAttestationTypedData({
+    chainId: BigInt(chainId),
+    kav10Address: opts.kav10Address,
+    kaId: opts.kaId,
+    newMerkleRoot,
+    authorAddress: opts.author.address,
+  });
+  const sigHex = await opts.author.signTypedData(td.domain, td.types, td.message);
+  const sig = ethers.Signature.from(sigHex);
+  return {
+    expectedNewMerkleRoot: newMerkleRoot,
+    authorAddress: opts.author.address,
+    signature: { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) },
+    schemeVersion: AUTHOR_SCHEME_VERSION_V1,
+  };
 }
 
 describe('OT-RFC-49 WS-D — catalog producer↔extractor↔chain parity', () => {
@@ -176,5 +249,89 @@ describe('OT-RFC-49 WS-D — catalog producer↔extractor↔chain parity', () =>
       'the rebuilt root must not change when a post-publish stamp lands',
     ).toBe(onChainRootHex);
     expect(rebuiltAfter.leafCount).toBe(onChainLeafCount);
+  }, 180_000);
+
+  it('curated UPDATE re-commits the catalog (root non-zero, == publish baseline) and a remote core re-hosts it', async () => {
+    const CG = 'rfc49-parity-update';
+    await publisher.createContextGraph({ id: CG, name: 'RFC49 Parity Update', accessPolicy: 1, callerAgentAddress: curator });
+    await publisher.registerContextGraph(CG, { callerAgentAddress: curator });
+
+    const name = 'shipment-upd';
+    // ── initial curated publish (the baseline) ──
+    await publisher.assertion.create(CG, name);
+    await publisher.assertion.write(CG, name, [
+      { subject: 'urn:acme:shipment/SH-99', predicate: 'urn:acme:product', object: '"P-1"' },
+    ]);
+    await publisher.assertion.finalize(CG, name);
+    await publisher.assertion.promote(CG, name);
+    const pub: any = await publisher.publishFromFinalizedAssertion(CG, name);
+    expect(pub.status).toBe('confirmed');
+    const kaId: bigint = pub.kaId;
+
+    const chain: any = (publisher as any).chain;
+    const baselineRoot = ethers.hexlify(await chain.getCatalogRoot(kaId));
+    const baselineLeafCount: number = await chain.getCatalogLeafCount(kaId);
+    expect(baselineRoot).not.toBe(ethers.ZeroHash);
+    expect(baselineLeafCount).toBeGreaterThan(0);
+
+    // ── the curated UPDATE ──
+    // Re-finalizing a PUBLISHED assertion is structurally impossible: the seal
+    // is keyed by the assertion URI, and neither `discard` (clears the
+    // number-based WM-layer URI) nor `create` (clears the lifecycle URN) touches
+    // it, so re-finalize hits `already finalized with a different merkleRoot`.
+    // So we drive the on-chain UPDATE primitive directly — the SAME primitive
+    // `publishFromFinalizedAssertion`'s update branch delegates to — by calling
+    // `publisher.update(kaId, ...)` with new content + a `precomputedUpdateAttestation`.
+    // This exercises the identical curated WS-D feature code (the `isCuratedUpdate`
+    // floor re-projection in dkg-agent-publish.ts update()): the producer re-injects
+    // the public `_catalog` floor, ships it inline, commits a NON-ZERO catalog root,
+    // and the update CONFIRMS. BEFORE this feature a curated update shipped a zero
+    // catalog root and REVERTED with `CuratedCGRequiresCatalogCommitment`.
+    //
+    // The attestation is signed by the KA's ORIGINAL author (the operational key
+    // that published the baseline) over the POST-floor-injection merkle — see
+    // `buildCuratedUpdateSeal`.
+    const author = new Wallet(HARDHAT_KEYS.CORE_OP, ctx.provider);
+    expect(
+      author.address.toLowerCase(),
+      'the baseline publish was authored by the publisher operational key (CORE_OP)',
+    ).toBe(String(pub.seal.authorAddress).toLowerCase());
+
+    const newQuads: Quad[] = [
+      { subject: 'urn:acme:shipment/SH-99', predicate: 'urn:acme:product', object: '"P-1"', graph: '' },
+      { subject: 'urn:acme:shipment/SH-99', predicate: 'urn:acme:status', object: '"delivered"', graph: '' },
+    ];
+    const precomputedUpdateAttestation = await buildCuratedUpdateSeal({
+      kaId,
+      contextGraphId: CG,
+      newQuads,
+      author,
+      provider: ctx.provider,
+      kav10Address: await chain.getKnowledgeAssetsLifecycleAddress(),
+    });
+
+    const upd: any = await publisher.update(kaId, CG, newQuads, [], { precomputedUpdateAttestation });
+    expect(upd.status, 'curated update must CONFIRM (no CuratedCGRequiresCatalogCommitment revert)').toBe('confirmed');
+    // The update targets — and re-confirms — the SAME on-chain KA as the publish.
+    expect(upd.kaId).toBe(kaId);
+
+    // ── on-chain: catalog still committed, non-zero, EQUALS the publish baseline. ──
+    // The catalog is the stable public floor — a curated update RE-COMMITS the
+    // same root (that's what satisfies the on-chain gate); it does NOT rotate.
+    const afterRoot = ethers.hexlify(await chain.getCatalogRoot(kaId));
+    const afterLeafCount: number = await chain.getCatalogLeafCount(kaId);
+    expect(afterRoot).not.toBe(ethers.ZeroHash);
+    expect(afterRoot, 'curated update re-commits the stable floor (== baseline, not rotated)').toBe(baselineRoot);
+    expect(afterLeafCount).toBe(baselineLeafCount);
+
+    // ── the REMOTE core re-hosts the updated catalog; rebuilt == on-chain. ──
+    // The update ACK supplied by ackCore drove its updateHandler to rebuild +
+    // verify + REPLACE-persist `<cg>/_catalog`, so an updated curated KA is
+    // genuinely provable (it was inert before WS-D).
+    const cgId: bigint = await chain.getKAContextGraphId(kaId);
+    const ackStore: any = (ackCore as any).store;
+    const rebuilt = computeCatalogRoot(await extractCatalogLeavesFromStore({ store: ackStore, contextGraphId: cgId }));
+    expect(ethers.hexlify(rebuilt.root), 'remote core re-hosts the updated catalog; rebuilt must equal on-chain').toBe(afterRoot);
+    expect(rebuilt.leafCount).toBe(afterLeafCount);
   }, 180_000);
 });

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3372,12 +3372,28 @@ export class DKGPublisher implements Publisher {
     let effectiveUpdateByteSize = updateByteSize;
     if (useEncryptedInlineUpdate) {
       // MEMBER-SIDE ENCRYPTION STAYS. AEAD-encrypt the private (non-catalog)
-      // data for CG members via the single-blob hook; OT-RFC-49 stripped the
-      // ciphertext from the on-chain commitment, the core ACK, and pricing, so
-      // the returned ciphertext root/bytes are intentionally DISCARDED here.
-      // (Chunked curated UPDATEs are out of v1 scope — single-blob only.)
+      // data and DISTRIBUTE it to CG members — via the chunked SWM fan-out when
+      // wired (PREFERRED; the single-blob hook is pure and does NOT distribute),
+      // mirroring curated publish (:2134-2155). OT-RFC-49 stripped the ciphertext
+      // from the on-chain commitment, the core ACK, and pricing, so the returned
+      // ciphertext root/bytes are intentionally DISCARDED — the gossip side
+      // effect (members receive the updated payload) is the point.
       const plaintextBytes = new TextEncoder().encode(encryptableUpdateNquadsStr);
-      await options.encryptInlinePayload!(plaintextBytes);
+      if (typeof options.encryptInlineChunked === 'function') {
+        // batchId = V10 KC merkleRoot (member-side per-chunk persistence key);
+        // the op id is the per-operation AEAD nonce domain — the update path has
+        // none of its own, so derive a session-scoped, content-unique one.
+        const updateOperationId = `${this.sessionId}-upd-${ethers.hexlify(kcMerkleRoot).slice(2, 18)}`;
+        await options.encryptInlineChunked({
+          plaintextNquads: plaintextBytes,
+          batchId: kcMerkleRoot,
+          publishOperationId: updateOperationId,
+        });
+      } else {
+        // No chunked emitter (single-blob fallback): the hook is pure and does
+        // NOT distribute, so members rely on SWM convergence in this case.
+        await options.encryptInlinePayload!(plaintextBytes);
+      }
       if (useCuratedUpdate) {
         // The ACK wire payload is the PUBLIC catalog N-quads (plaintext —
         // public by design). Cores rebuild the catalog root from these bytes,

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -3312,6 +3312,112 @@ export class DKGPublisher implements Publisher {
       .join('\n');
     const updateByteSize = BigInt(new TextEncoder().encode(updateNquadsStr).length);
 
+    // OT-RFC-49 / WS-D (update) — mirror the curated PUBLISH producer
+    // (dkg-publisher.ts:2030-2169). A value-adding curated update commits the
+    // PUBLIC `_catalog` Merkle root (NOT the stripped ciphertext root). Partition
+    // the catalog leaf-set out of the update's skolemized quads, compute the
+    // commitment ONCE from the committed leaves (post-publish stamps stripped via
+    // `catalogCommittedLeaves`), serialize them to the byte-identical plain
+    // N-Triples (no graph term — same expression as the publish path at
+    // 2059-2064), and price the update off that catalog footprint. The PRIVATE
+    // (non-catalog) data stays AEAD-encrypted for CG MEMBERS only; the catalog is
+    // public and rides inline as `stagingQuads` so cores can rebuild/verify it.
+    // Identity-based partition: the only catalog subject is this CG's canonical
+    // DID, so a forged `rdf:type dkg:PrivateContextGraph` cannot route a user
+    // entity into the plaintext `_catalog`.
+    const { catalogQuads: updateCatalogQuads, otherQuads: updateOtherQuads } =
+      partitionCatalogQuads(allSkolemizedQuads, contextGraphDataUri(contextGraphId));
+    // Non-catalog plaintext fed to the MEMBER encryptor (graph term retained,
+    // mirror 2031-2038). No-op for public updates / curated updates with no
+    // catalog entry (then encryptableUpdateNquadsStr === updateNquadsStr).
+    const encryptableUpdateNquadsStr = updateCatalogQuads.length === 0
+      ? updateNquadsStr
+      : updateOtherQuads
+          .map(
+            (q) =>
+              `<${q.subject}> <${q.predicate}> ${q.object.startsWith('"') ? q.object : `<${q.object}>`} <${q.graph}> .`,
+          )
+          .join('\n');
+    // Committed catalog commitment — derived from the SAME source as the
+    // serialized bytes and the on-chain root so byteSize and the commitment
+    // cannot desync across pricing, ACK digest, and chain tx. undefined for
+    // public updates and any curated update with no catalog entry.
+    const committedUpdateCatalogLeaves = catalogCommittedLeaves(updateCatalogQuads);
+    const updateCatalogCommitment = committedUpdateCatalogLeaves.length > 0
+      ? computeCatalogRoot(committedUpdateCatalogLeaves)
+      : undefined;
+    // Plain N-Triples (no graph term — byte-identical to publish 2059-2064) so
+    // the core's `parseSimpleNQuads` → `catalogCommittedLeaves` → `computeCatalogRoot`
+    // rebuild reproduces the identical leaf hashes (`hashTripleV10` excludes graph).
+    const updateCatalogNquadsStr = committedUpdateCatalogLeaves
+      .map(
+        (t) =>
+          `<${t.subject}> <${t.predicate}> ${t.object.startsWith('"') ? t.object : `<${t.object}>`} .`,
+      )
+      .join('\n');
+    const updateCatalogByteSize = BigInt(new TextEncoder().encode(updateCatalogNquadsStr).length);
+    // A curated update is identified by a wired `encryptInlinePayload` hook
+    // (DKGAgent resolves this from accessPolicy === curated — wired in the
+    // agent half) AND a non-zero catalog commitment (mirror 2125/2131). When
+    // the hook is absent this is a PUBLIC update and EVERY new path below is a
+    // no-op: zero catalog, full-quads stagingQuads, newByteSize=updateByteSize.
+    const useEncryptedInlineUpdate = typeof options.encryptInlinePayload === 'function';
+    const useCuratedUpdate = useEncryptedInlineUpdate && updateCatalogCommitment !== undefined;
+    // Select the inline staging payload + the byteSize that gets priced/signed.
+    // Curated update → the PUBLIC catalog N-quads + the catalog footprint
+    // (THE BYTESIZE TRAP, §3: the core's parity check is vs `newByteSize`, which
+    // we therefore set to `updateCatalogByteSize`). Public update → unchanged:
+    // full update quads inline (when no private roots are mixed in) + updateByteSize.
+    let updateStagingQuads: Uint8Array | undefined;
+    let effectiveUpdateByteSize = updateByteSize;
+    if (useEncryptedInlineUpdate) {
+      // MEMBER-SIDE ENCRYPTION STAYS. AEAD-encrypt the private (non-catalog)
+      // data for CG members via the single-blob hook; OT-RFC-49 stripped the
+      // ciphertext from the on-chain commitment, the core ACK, and pricing, so
+      // the returned ciphertext root/bytes are intentionally DISCARDED here.
+      // (Chunked curated UPDATEs are out of v1 scope — single-blob only.)
+      const plaintextBytes = new TextEncoder().encode(encryptableUpdateNquadsStr);
+      await options.encryptInlinePayload!(plaintextBytes);
+      if (useCuratedUpdate) {
+        // The ACK wire payload is the PUBLIC catalog N-quads (plaintext —
+        // public by design). Cores rebuild the catalog root from these bytes,
+        // verify == the claimed `newCatalogRoot`, persist to `<cg>/_catalog`,
+        // and sign. byteSize == the catalog footprint, from the SAME leaf-set.
+        updateStagingQuads = new TextEncoder().encode(updateCatalogNquadsStr);
+        effectiveUpdateByteSize = updateCatalogByteSize;
+      } else {
+        // Curated update with no catalog entry — nothing public to commit/serve.
+        // Carry a zero catalog commitment; leave staging empty.
+        updateStagingQuads = undefined;
+        effectiveUpdateByteSize = updateByteSize;
+      }
+    } else {
+      // PUBLIC update — unchanged from the prior behaviour: send the full
+      // update N-quads inline so peers recompute `newMerkleRoot`, unless private
+      // roots are mixed in (then the peer can't recompute and we omit staging).
+      updateStagingQuads = updatePrivateRoots.length === 0
+        ? new TextEncoder().encode(updateNquadsStr)
+        : undefined;
+      effectiveUpdateByteSize = updateByteSize;
+    }
+    // B6 — deferred PUBLIC `_catalog` persist. Structurally identical to the
+    // publish path's `persistCatalogEntry` (2079-2092): CLEAR/REPLACE by subject
+    // so repeated updates never accumulate stale catalog triples. Invoked ONLY
+    // from the confirmed-chain-success branch below — never on local-only,
+    // tentative, early-return/definitive-error, or `!txResult.success` paths, so
+    // a failed update never exposes a public catalog entry whose verifiable
+    // memory never landed. Stricter than publish: also gated on `useCuratedUpdate`
+    // because in `update()` ANY `_catalog` write is new behaviour.
+    const persistUpdateCatalogEntry = async (): Promise<void> => {
+      if (!useCuratedUpdate || updateCatalogQuads.length === 0) return;
+      const catalogGraph = contextGraphCatalogUri(contextGraphId);
+      const catalogSubjects = new Set(updateCatalogQuads.map((q) => q.subject));
+      for (const subject of catalogSubjects) {
+        await this.store.deleteByPattern({ graph: catalogGraph, subject });
+      }
+      await this.store.insert(updateCatalogQuads.map((q) => ({ ...q, graph: catalogGraph })));
+    };
+
     if (!options.precomputedUpdateAttestation) {
       throw new Error(
         'Update rejected: on-chain update requires precomputedUpdateAttestation. ' +
@@ -3438,7 +3544,11 @@ export class DKGPublisher implements Publisher {
         // params below), keeping the signed digest and the tx aligned.
         const digestFields = await getFields.call(this.chain, {
           kaId,
-          newByteSize: updateByteSize,
+          // THE BYTESIZE TRAP (§3): price off the catalog footprint for a curated
+          // update so the floored `newTokenAmount` (pinned into the tx via
+          // `boundUpdateTokenAmount` AND signed into the ACK digest) matches the
+          // catalog-priced ACK. Public updates keep `updateByteSize`.
+          newByteSize: effectiveUpdateByteSize,
           mintAmount: 0n,
           burnTokenIds: [],
         });
@@ -3451,23 +3561,30 @@ export class DKGPublisher implements Publisher {
           contextGraphId: digestFields.contextGraphId.toString(),
           preUpdateMerkleRootCount: digestFields.preUpdateMerkleRootCount,
           newMerkleRoot: kcMerkleRoot,
-          newByteSize: updateByteSize,
+          // THE BYTESIZE TRAP (§3): the core's curated-update parity check is vs
+          // `newByteSize` (no `publicByteSize` on UpdateIntent), so this MUST be
+          // the catalog footprint for a curated update. Public update: unchanged.
+          newByteSize: effectiveUpdateByteSize,
           newTokenAmount: digestFields.newTokenAmount,
           mintAmount: digestFields.mintAmount,
           burnTokenIds: digestFields.burnTokenIds,
           newMerkleLeafCount: kcMerkleLeafCount,
-          // Peers recompute newMerkleRoot from the updated quads. Send the
-          // same serialized public N-Quads the byte-size was computed over
-          // so the peer's `computeFlatKCRoot(parsed, [])` matches the
-          // publisher's. Only valid when there are NO private merkle roots
-          // mixed into `kcMerkleRoot` — otherwise the peer (which can't see
-          // the private roots) would recompute a different root and decline.
-          // In that case we omit stagingQuads and the peer falls back to
-          // verifying against its SWM copy (same limitation as the publish
-          // plaintext-inline path).
-          stagingQuads: updatePrivateRoots.length === 0
-            ? new TextEncoder().encode(updateNquadsStr)
-            : undefined,
+          // OT-RFC-49 / WS-D — curated commitment rides the UpdateIntent so the
+          // core can rebuild/verify the public catalog. Gated on `useCuratedUpdate`
+          // (NOT merely a non-empty commitment) so a PUBLIC update that happens to
+          // carry a CG-DID-subject quad never ships a non-zero root (which would
+          // trip the on-chain `PublicCGCannotHaveCatalogCommitment` gate).
+          newCatalogRoot: useCuratedUpdate ? updateCatalogCommitment!.root : undefined,
+          newCatalogLeafCount: useCuratedUpdate ? updateCatalogCommitment!.leafCount : undefined,
+          // Curated → cores gate the inline-catalog rebuild/verify/persist path
+          // on this flag (mirror the publish closure passing isEncryptedPayload).
+          isEncryptedPayload: useEncryptedInlineUpdate ? true : undefined,
+          // For a curated update the inline ACK payload is the PUBLIC catalog
+          // N-quads (`updateStagingQuads` == the catalog bytes). For a public
+          // update it stays the full update N-quads (when no private roots are
+          // mixed in) so peers can recompute `newMerkleRoot`; otherwise the peer
+          // falls back to verifying against its SWM copy. Selected above.
+          stagingQuads: updateStagingQuads,
           swmGraphId: contextGraphId,
         });
         this.log.info(
@@ -3485,8 +3602,17 @@ export class DKGPublisher implements Publisher {
           txResult = await this.chain.updateKnowledgeCollectionV10({
             kaId,
             newMerkleRoot: kcMerkleRoot,
-            newByteSize: updateByteSize,
+            // THE BYTESIZE TRAP (§3): the tx byteSize MUST equal the value signed
+            // into the ACK digest + priced via getUpdateAckDigestFields — the
+            // catalog footprint for a curated update, `updateByteSize` otherwise.
+            newByteSize: effectiveUpdateByteSize,
             newMerkleLeafCount: kcMerkleLeafCount,
+            // OT-RFC-49 / WS-D — carry the SAME catalog commitment the ACK digest
+            // bound + the on-chain gate expects. Gated on `useCuratedUpdate` so a
+            // public update submits bytes32(0)/0 (the contract's
+            // `PublicCGCannotHaveCatalogCommitment` gate enforces this too).
+            newCatalogRoot: useCuratedUpdate ? updateCatalogCommitment!.root : undefined,
+            newCatalogLeafCount: useCuratedUpdate ? updateCatalogCommitment!.leafCount : undefined,
             mintAmount: 0,
             // Pin the tx's newTokenAmount to the floored value the ACK
             // collector already had the peers sign (resolved via
@@ -3603,6 +3729,13 @@ export class DKGPublisher implements Publisher {
       txIndex: txResult.txIndex ?? 0,
     };
     await storeUpdatedQuads(updateVersion);
+
+    // B6 — the on-chain update has confirmed and the verifiable-memory quads are
+    // committed: REPLACE-persist the rotated PUBLIC `_catalog` here, inside the
+    // confirmed-success branch ONLY (no-op unless `useCuratedUpdate`), so a
+    // failed/tentative update never exposes a public catalog entry. Mirrors the
+    // publish path's deferred `persistCatalogEntry` invocation (2989).
+    await persistUpdateCatalogEntry();
 
     const ual = await this.resolveKaUal(kaId);
 

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -131,7 +131,7 @@ export type V10UpdateACKProvider = (params: {
    * OT-RFC-49 / WS-D — set `true` for a curated update so the agent closure
    * forwards it into `collectUpdate`, stamping `UpdateIntent.isEncryptedPayload`.
    * Cores gate the inline-catalog rebuild/verify/persist path on this flag.
-   * Omitted (undefined) for public updates — they stay byte-for-byte as today.
+   * Omitted (undefined) for public updates — no catalog; unchanged on a healthy chain.
    */
   isEncryptedPayload?: boolean;
   /** Updated KC quads (N-Quads) so peers can recompute newMerkleRoot. */

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -127,6 +127,13 @@ export type V10UpdateACKProvider = (params: {
   newMerkleLeafCount: number;
   newCatalogRoot?: Uint8Array;
   newCatalogLeafCount?: number;
+  /**
+   * OT-RFC-49 / WS-D — set `true` for a curated update so the agent closure
+   * forwards it into `collectUpdate`, stamping `UpdateIntent.isEncryptedPayload`.
+   * Cores gate the inline-catalog rebuild/verify/persist path on this flag.
+   * Omitted (undefined) for public updates — they stay byte-for-byte as today.
+   */
+  isEncryptedPayload?: boolean;
   /** Updated KC quads (N-Quads) so peers can recompute newMerkleRoot. */
   stagingQuads?: Uint8Array;
   /** Source SWM graph id (defaults to contextGraphId). */

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -840,6 +840,105 @@ export class StorageACKHandler {
           `UpdateIntent.isEncryptedPayload=true rejected for cg=${cgId}: local curation oracle reports ${curationVerdict === false ? 'PUBLIC (not curated)' : 'UNKNOWN'}; the encrypted-payload path is curated-only`,
         );
       }
+      // OT-RFC-49 WS-D (update): if this curated update carries a public
+      // `_catalog` commitment, INDEPENDENTLY rebuild + verify it and REPLACE-
+      // persist `<cg>/_catalog` — the SAME guarantee the publish handler gives.
+      // The PRIVATE newMerkleRoot stays trusted (the core can't decrypt it),
+      // but the catalog is public and verifiable, so a curated update can no
+      // longer obtain a signed ACK for a catalog root that doesn't match the
+      // data, and cores re-host the rotated catalog so sampling can prove it.
+      // A 32-zero-byte newCatalogRoot = no commitment (the on-chain gate
+      // rejects a zero-root value-adding curated update), so we only ADD the
+      // verification where a commitment is present — legacy/no-op flows intact.
+      if (
+        intent.newCatalogRoot &&
+        intent.newCatalogRoot.length === 32 &&
+        intent.newCatalogRoot.some((b) => b !== 0)
+      ) {
+        const MAX_CATALOG_BYTES = 4 * 1024 * 1024;
+        if (!intent.stagingQuads || intent.stagingQuads.length === 0) {
+          return this.encodeDecline(
+            cgId,
+            STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH,
+            'curated UPDATE ACK requires the public catalog N-quads inline (empty stagingQuads)',
+          );
+        }
+        if (intent.stagingQuads.length > MAX_CATALOG_BYTES) {
+          throw new Error(
+            `curated UPDATE catalog stagingQuads payload (${intent.stagingQuads.length} bytes) exceeds ` +
+            `${MAX_CATALOG_BYTES} byte limit — rejecting request`,
+          );
+        }
+        // byteSize parity: a curated update prices off the catalog footprint, so
+        // the inline catalog bytes MUST equal the claimed `newByteSize`. NOTE:
+        // UpdateIntent has NO `publicByteSize` (unlike PublishIntent) — parity is
+        // vs `newByteSize`, which the producer sets to the catalog byte count.
+        const claimedNewByteSize = typeof intent.newByteSize === 'number'
+          ? intent.newByteSize
+          : Number(
+              BigInt(intent.newByteSize.low >>> 0) |
+                (BigInt(intent.newByteSize.high >>> 0) << 32n),
+            );
+        if (intent.stagingQuads.length !== claimedNewByteSize) {
+          return this.encodeDecline(
+            cgId,
+            STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH,
+            `curated UPDATE ACK byteSize mismatch: inline catalog is ${intent.stagingQuads.length} bytes ` +
+            `but publisher claims newByteSize=${claimedNewByteSize}. For curated updates newByteSize MUST ` +
+            `equal the catalog N-quads byte count.`,
+          );
+        }
+        const claimedCatalogLeafCount = intent.newCatalogLeafCount ?? 0;
+        if (claimedCatalogLeafCount <= 0) {
+          return this.encodeDecline(
+            cgId,
+            STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH,
+            `curated UPDATE ACK requires a positive newCatalogLeafCount; got ${claimedCatalogLeafCount}`,
+          );
+        }
+        // Rebuild over the SHARED committed-leaf definition (post-publish stamps
+        // stripped) so the rebuilt root is byte-identical to the producer's
+        // committed root AND the prover's later rebuild. DECLINE on disagreement.
+        const parsedCatalog = parseSimpleNQuads(
+          new TextDecoder().decode(intent.stagingQuads),
+        );
+        const committedLeaves = catalogCommittedLeaves(parsedCatalog);
+        if (committedLeaves.length === 0) {
+          return this.encodeDecline(
+            cgId,
+            STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH,
+            'curated UPDATE ACK: inline catalog parsed to zero committed leaves',
+          );
+        }
+        const rebuilt = computeCatalogRoot(committedLeaves);
+        if (rebuilt.leafCount !== claimedCatalogLeafCount) {
+          return this.encodeDecline(
+            cgId,
+            STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH,
+            `curated UPDATE ACK leaf-count mismatch: rebuilt ${rebuilt.leafCount} catalog leaves ` +
+            `but publisher claims ${claimedCatalogLeafCount}`,
+          );
+        }
+        if (!bytesEqual(rebuilt.root, intent.newCatalogRoot)) {
+          return this.encodeDecline(
+            cgId,
+            STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH,
+            `curated UPDATE ACK root mismatch: rebuilt catalog root=${ethers.hexlify(rebuilt.root).slice(0, 18)}... ` +
+            `does not match publisher claim=${ethers.hexlify(intent.newCatalogRoot).slice(0, 18)}...`,
+          );
+        }
+        // Root verified — REPLACE-persist the updated public catalog to
+        // `<cg>/_catalog` so this core serves + later proves the rotated root.
+        const catalogGraph = contextGraphCatalogUri(cgId);
+        assertSafeIri(catalogGraph);
+        const catalogSubjects = new Set(parsedCatalog.map((q) => q.subject));
+        for (const subject of catalogSubjects) {
+          await this.store.deleteByPattern({ graph: catalogGraph, subject });
+        }
+        await this.store.insert(
+          parsedCatalog.map((q) => ({ ...q, graph: catalogGraph })),
+        );
+      }
       // Encrypted updates trust the publisher's claimed newMerkleRoot —
       // no recompute. Fall through to the digest sign below.
     } else if (intent.stagingQuads && intent.stagingQuads.length > 0) {

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -9,6 +9,7 @@ import {
   encodeUpdateIntent,
   decodeStorageACK,
   computeUpdateACKDigest,
+  computeCatalogRoot,
   isStorageACKDecline,
   STORAGE_ACK_DECLINE_CODES,
   PROTOCOL_STORAGE_UPDATE_ACK,
@@ -94,6 +95,126 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
       BigInt(newMerkleLeafCount),
     );
   }
+
+  // OT-RFC-49 WS-D — curated UPDATE catalog ACK. A curated update ships the
+  // PUBLIC `_catalog` N-quads inline; the core REBUILDS the catalog root and
+  // DECLINEs CATALOG_ROOT_MISMATCH on disagreement — the PRIVATE newMerkleRoot
+  // stays trusted (the core holds no plaintext). byteSize parity is vs
+  // `newByteSize` (UpdateIntent has NO publicByteSize, unlike PublishIntent),
+  // which the producer sets to the catalog footprint.
+  describe('isEncryptedPayload (curated catalog ACK path — OT-RFC-49 WS-D)', () => {
+    const cgDid = `did:dkg:context-graph:${contextGraphId}`;
+    const catalogTriples = [
+      { subject: cgDid, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'http://www.w3.org/ns/dcat#Dataset' },
+      { subject: cgDid, predicate: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', object: 'https://dkg.network/ontology#PrivateContextGraph' },
+      { subject: cgDid, predicate: 'http://purl.org/dc/terms/identifier', object: `"${cgDid}"` },
+    ];
+    const catalogNquads = catalogTriples
+      .map((t) => `<${t.subject}> <${t.predicate}> ${t.object.startsWith('"') ? t.object : `<${t.object}>`} .`)
+      .join('\n');
+    const catalogBytes = new TextEncoder().encode(catalogNquads);
+    const expectedCatalog = computeCatalogRoot(catalogTriples);
+    const catalogRoot = expectedCatalog.root;
+    const catalogLeafCount = expectedCatalog.leafCount;
+    // The PRIVATE flat-KC root the core cannot recompute — trusted + signed verbatim.
+    const claimedPrivateRoot = ethers.getBytes(ethers.keccak256(ethers.toUtf8Bytes('curated-update-private-root')));
+
+    function curatedUpdateIntent(overrides: Record<string, unknown> = {}): Uint8Array {
+      return encodeUpdateIntent({
+        kaId: kaId.toString(),
+        contextGraphId,
+        preUpdateMerkleRootCount: Number(preUpdateMerkleRootCount),
+        newMerkleRoot: claimedPrivateRoot,
+        newByteSize: catalogBytes.length, // byteSize = catalog footprint (the trap)
+        newTokenAmount: newTokenAmount.toString(),
+        mintAmount: Number(mintAmount),
+        burnTokenIds: burnTokenIds.map((b) => b.toString()),
+        newMerkleLeafCount,
+        publisherPeerId: 'curator-edge',
+        stagingQuads: catalogBytes,
+        isEncryptedPayload: true,
+        newCatalogRoot: catalogRoot,
+        newCatalogLeafCount: catalogLeafCount,
+        ...overrides,
+      });
+    }
+
+    function curatedDigest(): Uint8Array {
+      return computeUpdateACKDigest(
+        TEST_CHAIN_ID,
+        TEST_KAV10_ADDR,
+        cgIdBigInt,
+        kaId,
+        preUpdateMerkleRootCount,
+        claimedPrivateRoot,
+        BigInt(catalogBytes.length),
+        newTokenAmount,
+        mintAmount,
+        burnTokenIds,
+        BigInt(newMerkleLeafCount),
+        catalogRoot,
+        BigInt(catalogLeafCount),
+      );
+    }
+
+    function makeHandler(wallet: ethers.Wallet, store = new OxigraphStore()) {
+      return new StorageACKHandler(store as any, makeConfig(wallet, 42n), new TypedEventBus() as any);
+    }
+
+    it('rebuilds + verifies the catalog root, persists <cg>/_catalog, and signs the catalog ACK digest', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const store = new OxigraphStore();
+      const handler = makeHandler(wallet, store);
+
+      const ack = decodeStorageACK(await handler.updateHandler(curatedUpdateIntent(), fakePeerId));
+      expect(isStorageACKDecline(ack)).toBe(false);
+
+      // The ACK carries the trusted PRIVATE merkleRoot (the core never recomputes it).
+      const decodedRoot = ack.merkleRoot instanceof Uint8Array ? ack.merkleRoot : new Uint8Array(ack.merkleRoot);
+      expect(Buffer.from(decodedRoot).equals(Buffer.from(claimedPrivateRoot))).toBe(true);
+
+      // The digest is signed over the CATALOG commitment (not opaque ciphertext).
+      const recovered = ethers.recoverAddress(ethers.hashMessage(curatedDigest()), {
+        r: ethers.hexlify(ack.coreNodeSignatureR instanceof Uint8Array ? ack.coreNodeSignatureR : new Uint8Array(ack.coreNodeSignatureR)),
+        yParityAndS: ethers.hexlify(ack.coreNodeSignatureVS instanceof Uint8Array ? ack.coreNodeSignatureVS : new Uint8Array(ack.coreNodeSignatureVS)),
+      });
+      expect(recovered.toLowerCase()).toBe(wallet.address.toLowerCase());
+
+      // The verified public catalog is REPLACE-persisted to `<cg>/_catalog`.
+      const persisted = await store.query(`SELECT ?s WHERE { GRAPH <${cgDid}/_catalog> { ?s ?p ?o } } LIMIT 1`);
+      expect(persisted.type).toBe('bindings');
+      if (persisted.type === 'bindings') expect(persisted.bindings.length).toBeGreaterThan(0);
+    });
+
+    it('DECLINEs CATALOG_ROOT_MISMATCH when the rebuilt root != the claimed newCatalogRoot', async () => {
+      const handler = makeHandler(ethers.Wallet.createRandom());
+      const wrongRoot = ethers.getBytes(ethers.keccak256(ethers.toUtf8Bytes('wrong-catalog-root')));
+      const ack = decodeStorageACK(await handler.updateHandler(curatedUpdateIntent({ newCatalogRoot: wrongRoot }), fakePeerId));
+      expect(isStorageACKDecline(ack)).toBe(true);
+      expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH);
+    });
+
+    it('DECLINEs CATALOG_ROOT_MISMATCH on byteSize fraud (newByteSize != inline catalog bytes)', async () => {
+      const handler = makeHandler(ethers.Wallet.createRandom());
+      const ack = decodeStorageACK(await handler.updateHandler(curatedUpdateIntent({ newByteSize: catalogBytes.length + 100 }), fakePeerId));
+      expect(isStorageACKDecline(ack)).toBe(true);
+      expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH);
+    });
+
+    it('DECLINEs CATALOG_ROOT_MISMATCH when the inline catalog stagingQuads is missing', async () => {
+      const handler = makeHandler(ethers.Wallet.createRandom());
+      const ack = decodeStorageACK(await handler.updateHandler(curatedUpdateIntent({ stagingQuads: undefined, newByteSize: 0 }), fakePeerId));
+      expect(isStorageACKDecline(ack)).toBe(true);
+      expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.CATALOG_ROOT_MISMATCH);
+    });
+
+    it('leaves a non-curated (public) update untouched — no catalog gate, MERKLE recompute path', async () => {
+      // Regression guard: isEncryptedPayload=false skips the curated block entirely.
+      const handler = makeHandler(ethers.Wallet.createRandom());
+      const ack = decodeStorageACK(await handler.updateHandler(buildIntent(), fakePeerId));
+      expect(isStorageACKDecline(ack)).toBe(false);
+    });
+  });
 
   it('peer signs computeUpdateACKDigest and the signature recovers to the operational key', async () => {
     const wallet = ethers.Wallet.createRandom();

--- a/scripts/devnet-test-rfc49-catalog-sampling.sh
+++ b/scripts/devnet-test-rfc49-catalog-sampling.sh
@@ -26,10 +26,17 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+export REPO_ROOT
 # shellcheck source=devnet-publish-helpers.sh
 source "$SCRIPT_DIR/devnet-publish-helpers.sh"
 
 DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+# Owner-sealed POST /api/update helpers (build_update_body / ka_owner_key) —
+# used by the curated-UPDATE leg (section 9b). Sourced AFTER DEVNET_DIR is set
+# because the helper asserts on it.
+NUM_NODES="${NUM_NODES:-6}"
+# shellcheck source=devnet-update-helpers.sh
+source "$SCRIPT_DIR/devnet-update-helpers.sh"
 API_PORT_BASE="${API_PORT_BASE:-9201}"
 HARDHAT_PORT="${HARDHAT_PORT:-8545}"
 CONTRACTS_JSON="$REPO_ROOT/packages/evm-module/deployments/localhost_contracts.json"
@@ -334,6 +341,104 @@ done
 [ "$RS_OK" -eq 1 ] || fail "no core submitted a random-sampling proof within the window (the curated KC's _catalog was not proven)"
 
 # ---------------------------------------------------------------------------
+# 9b. CURATED UPDATE (OT-RFC-49 WS-D): update the confirmed curated KA with new
+#     data and prove the catalog stays committed + re-hosted + provable.
+#
+#   A curated UPDATE re-commits the deterministic public `_catalog` floor: the
+#   producer's update() re-injects the floor, ships it inline, the cores rebuild
+#   + REPLACE-persist `<cg>/_catalog`, and the on-chain catalog commitment is set
+#   so the update CONFIRMS (before this feature a curated update shipped a ZERO
+#   catalog root and REVERTED with CuratedCGRequiresCatalogCommitment). The
+#   catalog is the STABLE public floor — the update RE-COMMITS THE SAME ROOT, it
+#   does NOT rotate — so we assert root non-zero AND == the publish baseline.
+#
+#   Driven via POST /api/update with an owner-sealed precomputedUpdateAttestation
+#   (build_update_body --curated). Re-finalize is NOT usable: the seal is keyed
+#   by the assertion URI and neither discard nor re-create clears it, so a 2nd
+#   wm/finalize of changed content hits "already finalized with a different
+#   merkleRoot". /api/update is the on-chain UPDATE primitive the daemon exposes.
+# ---------------------------------------------------------------------------
+log "── CURATED UPDATE path (POST /api/update, owner-sealed, floor re-injected) ──"
+UPD_QUADS=$(STAMP="$STAMP" PRIV_SUBJ="$PRIV_SUBJ" node -e '
+const stamp=process.env.STAMP, subj=process.env.PRIV_SUBJ;
+console.log(JSON.stringify([
+  { subject: subj, predicate: "http://schema.org/name", object: `"Alice Private ${stamp} — UPDATED value, still padded out to keep the encrypted member payload chunking through the LU-11 ciphertext substrate on this devnet update"`, graph: "" },
+  { subject: subj, predicate: "http://schema.org/email", object: `"alice-${stamp}@example.org"`, graph: "" },
+  { subject: subj, predicate: "http://schema.org/role", object: `"private-member-data, UPDATED — padded so the encrypted member payload reliably produces at least one LU-11 ciphertext chunk on this devnet update"`, graph: "" },
+  { subject: subj, predicate: "http://schema.org/jobTitle", object: "\"Lead (added on update)\"", graph: "" }
+]))')
+
+# build_update_body resolves the KA owner key (ownerOf), injects the curated
+# `_catalog` floor (6th arg = LOCAL cg id), seals, and emits the /api/update body.
+UPD_BODY=$(REPO_ROOT="$REPO_ROOT" DEVNET_DIR="$DEVNET_DIR" NUM_NODES="$NUM_NODES" \
+  build_update_body "$EDGE_CURATOR" "$KA_ID" "$CG_ID" "$UPD_QUADS" "[]" "$CG_ID") \
+  || fail "could not build curated update body (seal/owner-key resolution failed)"
+UPD_RESP=$(api_call "$EDGE_CURATOR" POST /api/update "$UPD_BODY")
+log "POST /api/update: $UPD_RESP"
+UPD_STATUS=$(printf '%s' "$UPD_RESP" | jq_field ".status")
+UPD_KA=$(printf '%s' "$UPD_RESP" | jq_field ".kaId")
+[ "$UPD_STATUS" = "confirmed" ] || fail "curated update status=$UPD_STATUS (expected confirmed — CuratedCGRequiresCatalogCommitment regression?): $UPD_RESP"
+[ "$UPD_KA" = "$KA_ID" ] || fail "curated update kaId=$UPD_KA != publish kaId=$KA_ID (update did not target the same KA)"
+pass "curated update confirmed and targets the SAME KA (kaId=$UPD_KA)"
+
+# ── on-chain: catalog still committed, non-zero, EQUALS the publish baseline. ──
+UPD_CHAIN=$(cd "$REPO_ROOT/packages/evm-module" && \
+  RPC_URL="http://127.0.0.1:$HARDHAT_PORT" CONTRACTS_JSON="$CONTRACTS_JSON" ABI_DIR="$ABI_DIR" KA_ID="$KA_ID" node -e '
+const {ethers}=require("ethers");const fs=require("fs");const path=require("path");
+(async()=>{
+  const provider=new ethers.JsonRpcProvider(process.env.RPC_URL);
+  const c=JSON.parse(fs.readFileSync(process.env.CONTRACTS_JSON,"utf8")).contracts;
+  const addr=c.DKGKnowledgeAssets?.evmAddress||c.DKGKnowledgeAssets?.address;
+  const abi=JSON.parse(fs.readFileSync(path.join(process.env.ABI_DIR,"DKGKnowledgeAssets.json"),"utf8"));
+  const k=new ethers.Contract(addr,abi,provider);
+  console.log(JSON.stringify({root:await k.getCatalogRoot(BigInt(process.env.KA_ID)),count:(await k.getCatalogLeafCount(BigInt(process.env.KA_ID))).toString()}));
+})().catch(e=>{console.error(e?.message||e);process.exit(1)});
+') || fail "post-update on-chain getCatalogRoot read failed"
+UPD_ROOT=$(printf '%s' "$UPD_CHAIN" | jq_field ".root")
+UPD_COUNT=$(printf '%s' "$UPD_CHAIN" | jq_field ".count")
+log "post-update on-chain catalogRoot=$UPD_ROOT catalogLeafCount=$UPD_COUNT (baseline root=$CAT_ROOT count=$CAT_COUNT)"
+[ "$UPD_ROOT" != "$ZERO" ] || fail "post-update catalogRoot is ZERO — the curated update dropped the catalog commitment"
+[ "$UPD_ROOT" = "$CAT_ROOT" ] || fail "post-update catalogRoot=$UPD_ROOT != publish baseline=$CAT_ROOT — the stable floor must RE-COMMIT, not rotate"
+[ "$UPD_COUNT" = "$CAT_COUNT" ] || fail "post-update catalogLeafCount=$UPD_COUNT != baseline=$CAT_COUNT"
+pass "curated update RE-COMMITTED the stable catalog floor (root non-zero, == baseline, leafCount=$UPD_COUNT)"
+
+# ── stripped/host-mode cores RE-HOST the updated `_catalog`. ──
+# The update ACK drives each core's updateHandler to rebuild + verify +
+# REPLACE-persist `<cg>/_catalog`. Poll until it lands (same propagation race
+# as the publish path's section 7).
+log "waiting for the updated _catalog to (re-)propagate to the stripped cores (up to 3 min)…"
+for i in $(seq 1 60); do
+  holders=0
+  for n in "${STRIPPED_CORES[@]}"; do c=$(catalog_count "$n"); [ "${c:-0}" -ge 1 ] 2>/dev/null && holders=$((holders+1)); done
+  [ "$holders" -ge 1 ] && { log "  updated catalog present on $holders/${#STRIPPED_CORES[@]} stripped cores"; break; }
+  [ "$i" -eq 1 ] || [ $((i % 10)) -eq 0 ] && log "  …updated catalog on $holders/${#STRIPPED_CORES[@]} cores after $((i*3))s"
+  sleep 3
+done
+UPD_CAT_HOLDERS=0
+for n in "${STRIPPED_CORES[@]}"; do cat=$(catalog_count "$n"); [ "${cat:-0}" -ge 1 ] 2>/dev/null && UPD_CAT_HOLDERS=$((UPD_CAT_HOLDERS+1)); done
+[ "$UPD_CAT_HOLDERS" -ge 1 ] || fail "no stripped core re-hosts the updated public _catalog after the update"
+pass "$UPD_CAT_HOLDERS/${#STRIPPED_CORES[@]} stripped cores re-host the updated public _catalog"
+
+# ── a core submits a random-sampling proof against the UPDATED catalog. ──
+log "driving random sampling against the updated catalog — submittedCount per core:"
+RSU0=()
+for n in "${STRIPPED_CORES[@]}" "$BASELINE_CORE"; do RSU0[$n]=$(rs_submitted "$n"); log "  core$n=${RSU0[$n]:-?}"; done
+RSU_OK=0
+for round in $(seq 1 12); do
+  hardhat_mine 250
+  sleep 8
+  for n in "${STRIPPED_CORES[@]}" "$BASELINE_CORE"; do
+    now=$(rs_submitted "$n")
+    if [ -n "$now" ] && [ -n "${RSU0[$n]}" ] && [ "$now" -gt "${RSU0[$n]}" ] 2>/dev/null; then
+      pass "core$n submitted a random-sampling proof after the update (submittedCount ${RSU0[$n]}→$now) — proving the UPDATED _catalog"
+      RSU_OK=1; break 2
+    fi
+  done
+  log "  round $round: no new post-update proof yet…"
+done
+[ "$RSU_OK" -eq 1 ] || fail "no core submitted a random-sampling proof against the updated catalog within the window"
+
+# ---------------------------------------------------------------------------
 # 10. FROM-SWM SHORTCUT (OT-RFC-49 catalog auto-injection): a curated publish via
 #     the RAW /api/shared-memory/write + /api/shared-memory/publish path (NO
 #     assertion finalize) must ALSO get the `_catalog` injected → confirmed ACK +
@@ -389,5 +494,6 @@ log "  • curated publish → on-chain catalog commitment (root=$CAT_ROOT, leav
 log "  • stripped cores ${STRIPPED_CORES[*]}: ZERO private ciphertext, hold the _catalog"
 log "  • ${BASELINE_SUMMARY:-baseline core: (not evaluated)}"
 log "  • a core proved the public _catalog in random sampling"
+log "  • curated UPDATE (POST /api/update): re-committed the stable catalog floor (root==baseline, leaves=${UPD_COUNT:-?}), cores re-host it, a core proved the updated catalog"
 log "  • FROM-SWM shortcut (raw write+publish, no finalize): catalog auto-injected (leafCount=$SC_COUNT), cores hold it — and the finalize path above stayed intact (leafCount=$CAT_COUNT)"
 log "============================================================"

--- a/scripts/devnet-test-rfc49-catalog-sampling.sh
+++ b/scripts/devnet-test-rfc49-catalog-sampling.sh
@@ -438,6 +438,29 @@ for round in $(seq 1 12); do
 done
 [ "$RSU_OK" -eq 1 ] || fail "no core submitted a random-sampling proof against the updated catalog within the window"
 
+# ── MEMBER converges to the UPDATED private payload (OT-RFC-49 member distribution). ──
+# The curated update now DISTRIBUTES the updated payload: the producer emits the
+# LU-11 ciphertext chunk and the curator persists it (vs the OLD encrypt-then-
+# discard, which delivered NOTHING and left members permanently stale). This is
+# the NON-VACUOUS proof: unlike the catalog re-host (the floor is stable, so cores
+# already held it from publish), the member must end up holding the UPDATED value.
+# NOTE: a live gossip-push to an ALREADY-CONNECTED member is the known M2-a
+# converge race (issue #1205 — affects ALL SWM updates, not curated-update-
+# specific); the SUPPORTED catch-up is converge-on-reconnect. So restart the
+# member to exercise the converge path, then assert it holds the UPDATED value.
+log "restarting member edge$EDGE_MEMBER to exercise SWM converge to the UPDATED payload…"
+"$REPO_ROOT/scripts/devnet.sh" restart-node "$EDGE_MEMBER" >/dev/null 2>&1 || true
+for _ in $(seq 1 90); do curl -sf --max-time 1 -o /dev/null "http://127.0.0.1:$(node_port "$EDGE_MEMBER")/api/status" 2>/dev/null && break; sleep 1; done
+MEMBER_GOT_UPDATE=0
+for i in $(seq 1 40); do
+  got=$(api_call "$EDGE_MEMBER" POST /api/query "$(S="$PRIV_SUBJ" node -e 'console.log(JSON.stringify({sparql:`SELECT (COUNT(*) AS ?c) WHERE { GRAPH ?g { <${process.env.S}> ?p ?o . FILTER(CONTAINS(STR(?o), "UPDATED")) } }`}))')" | _count_from_query)
+  [ "${got:-0}" -ge 1 ] 2>/dev/null && { MEMBER_GOT_UPDATE=1; break; }
+  { [ "$i" -eq 1 ] || [ $((i % 10)) -eq 0 ]; } && log "  …member converging — still on pre-update value after $((i*3))s"
+  sleep 3
+done
+[ "$MEMBER_GOT_UPDATE" -ge 1 ] || fail "member edge$EDGE_MEMBER did NOT converge to the UPDATED private payload after reconnect — the curated update did not DISTRIBUTE to members (Option B regression)"
+pass "member edge$EDGE_MEMBER converged to the UPDATED private payload — the curated update DISTRIBUTES to members (producer emit + curator-held + converge-on-reconnect)"
+
 # ---------------------------------------------------------------------------
 # 10. FROM-SWM SHORTCUT (OT-RFC-49 catalog auto-injection): a curated publish via
 #     the RAW /api/shared-memory/write + /api/shared-memory/publish path (NO

--- a/scripts/devnet-update-helpers.sh
+++ b/scripts/devnet-update-helpers.sh
@@ -49,15 +49,21 @@ sys.exit(1)
 PY
 }
 
-# Args: node_num kaId contextGraphId quads_json_array_string [private_quads_json_array_string]
+# Args: node_num kaId contextGraphId quads_json_array_string [private_quads_json_array_string] [curated_context_graph_id]
+# When the 6th arg is set, the seal injects the OT-RFC-49 public `_catalog`
+# floor (curated CG) so expectedNewMerkleRoot matches the producer's
+# post-injection recompute. Pass the LOCAL context-graph id (== `cg`).
 build_update_body() {
-  local node=$1 kc=$2 cg=$3 quads_json=$4 private_quads_json="${5:-[]}" key seal owner_line seal_args
+  local node=$1 kc=$2 cg=$3 quads_json=$4 private_quads_json="${5:-[]}" curated_cg="${6:-}" key seal owner_line seal_args
   owner_line=$(ka_owner_key "$kc") || return 1
   key="${owner_line##*$'\t'}"
   [ -z "$key" ] && return 1
   seal_args=(--key "$key" --ka-id "$kc" --quads-json "$quads_json")
   if [ "$private_quads_json" != "[]" ] && [ -n "$private_quads_json" ]; then
     seal_args+=(--private-quads-json "$private_quads_json")
+  fi
+  if [ -n "$curated_cg" ]; then
+    seal_args+=(--curated "$curated_cg")
   fi
   seal=$($UPDATE_SEAL "${seal_args[@]}") || return 1
   python3 -c "

--- a/scripts/devnet-update-seal.mjs
+++ b/scripts/devnet-update-seal.mjs
@@ -38,16 +38,14 @@ const {
   partitionCatalogQuads,
   contextGraphDataUri,
 } = req('@origintrail-official/dkg-core');
-// OT-RFC-49 WS-D — the curated public `_catalog` floor builder. Not on the
-// agent package's public surface, so deep-import the compiled module. A curated
-// UPDATE re-injects this deterministic floor into the payload BEFORE the
-// on-chain merkle is computed (mirrors dkg-agent-publish.ts update()'s
-// isCuratedUpdate branch), and the producer hard-checks
-// precomputedUpdateAttestation.expectedNewMerkleRoot against the floor-injected
-// recompute — so a curated update seal MUST commit to the SAME injection.
-const { buildPublicProjection } = req(
-  path.join(REPO_ROOT, 'packages/agent/dist/context-graph-public-projection.js'),
-);
+// OT-RFC-49 WS-D — the curated public `_catalog` floor builder, imported from
+// the agent package's public surface. A curated UPDATE re-injects this
+// deterministic floor into the payload BEFORE the on-chain merkle is computed
+// (mirrors dkg-agent-publish.ts update()'s isCuratedUpdate branch), and the
+// producer hard-checks precomputedUpdateAttestation.expectedNewMerkleRoot
+// against the floor-injected recompute — so a curated update seal MUST commit
+// to the SAME injection.
+const { buildPublicProjection } = req('@origintrail-official/dkg-agent');
 
 function out(o) {
   process.stdout.write(JSON.stringify(o, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)) + '\n');

--- a/scripts/devnet-update-seal.mjs
+++ b/scripts/devnet-update-seal.mjs
@@ -35,7 +35,19 @@ const {
 const {
   buildUpdateAuthorAttestationTypedData,
   AUTHOR_SCHEME_VERSION_V1,
+  partitionCatalogQuads,
+  contextGraphDataUri,
 } = req('@origintrail-official/dkg-core');
+// OT-RFC-49 WS-D — the curated public `_catalog` floor builder. Not on the
+// agent package's public surface, so deep-import the compiled module. A curated
+// UPDATE re-injects this deterministic floor into the payload BEFORE the
+// on-chain merkle is computed (mirrors dkg-agent-publish.ts update()'s
+// isCuratedUpdate branch), and the producer hard-checks
+// precomputedUpdateAttestation.expectedNewMerkleRoot against the floor-injected
+// recompute — so a curated update seal MUST commit to the SAME injection.
+const { buildPublicProjection } = req(
+  path.join(REPO_ROOT, 'packages/agent/dist/context-graph-public-projection.js'),
+);
 
 function out(o) {
   process.stdout.write(JSON.stringify(o, (_k, v) => (typeof v === 'bigint' ? v.toString() : v)) + '\n');
@@ -45,8 +57,18 @@ function toHex32(bytes) {
   return ethers.hexlify(bytes);
 }
 
-async function buildUpdateSeal({ kaId, quads, privateQuads, author, kav10Address, provider }) {
-  const kaMap = autoPartition(quads);
+async function buildUpdateSeal({ kaId, quads, privateQuads, author, kav10Address, provider, curatedContextGraphId }) {
+  // OT-RFC-49 WS-D — for a CURATED CG, re-inject the deterministic public
+  // `_catalog` floor exactly as the producer's update() does, so the seal
+  // commits to the merkle the publisher will recompute post-injection.
+  let sealQuads = quads;
+  if (curatedContextGraphId) {
+    const cgDid = contextGraphDataUri(curatedContextGraphId);
+    const { otherQuads } = partitionCatalogQuads(quads, cgDid);
+    const floor = buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: cgDid });
+    sealQuads = [...otherQuads, ...floor];
+  }
+  const kaMap = autoPartition(sealQuads);
   const allPublic = [...kaMap.values()].flat();
   const privateRoots = [];
   for (const rootEntity of kaMap.keys()) {
@@ -86,12 +108,17 @@ async function main() {
   let kaId = null;
   let quadsJson = null;
   let privateQuadsJson = null;
+  let curatedContextGraphId = null;
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--key') key = argv[++i];
     else if (argv[i] === '--ka-id') kaId = argv[++i];
     else if (argv[i] === '--quads-json') quadsJson = argv[++i];
     else if (argv[i] === '--private-quads-json') privateQuadsJson = argv[++i];
+    // OT-RFC-49 WS-D — for a curated CG, the seal must inject the public
+    // `_catalog` floor. Pass the LOCAL context-graph id (the same value
+    // POST /api/update carries as `contextGraphId`).
+    else if (argv[i] === '--curated') curatedContextGraphId = argv[++i];
   }
   if (!key || kaId == null || !quadsJson) {
     out({ ok: false, error: 'usage: --key 0x.. --ka-id <id> --quads-json <json-array>' });
@@ -141,6 +168,7 @@ async function main() {
       author,
       kav10Address: kav10,
       provider,
+      curatedContextGraphId,
     });
     out({ ok: true, precomputedUpdateAttestation: seal });
   } catch (e) {


### PR DESCRIPTION
> **Draft — code is review-ready; the test layer (unit/e2e/devnet) is in progress** (see "Remaining"). Opening early so review can start on the design + code in parallel.

## What & why
The RFC-49 cutover landed the **publish** path on the catalog model but left the curated **UPDATE** path behind. Today a value-adding curated update ships a zero catalog root → reverts on-chain `CuratedCGRequiresCatalogCommitment`, and where it doesn't revert, cores never re-host (or verify) the updated `_catalog`, so an updated curated KA can't be sampled. This PR closes the **off-chain producer/host/verify** half (the on-chain gates, proto/`UpdateIntent` fields, chain adapter, and ACK digest were already done in the cutover).

## Design — mirror the publish golden path
- **Producer** (`dkg-publisher.ts` `update()`): build the public `_catalog` via `partitionCatalogQuads → catalogCommittedLeaves → computeCatalogRoot` (serialization byte-identical to publish), price `newByteSize` off the **catalog footprint**, ship it inline as `stagingQuads`, set `newCatalogRoot`/`LeafCount` on the ACK + chain tx, and REPLACE-persist `<cg>/_catalog` **only on confirmed chain success**.
- **Agent** (`dkg-agent-publish.ts`, `dkg-agent.ts`): resolve `accessPolicy` on update + wire the curated `encryptInlinePayload` hook (covers `agent.update()` and `publishFromFinalizedAssertion`), **floor-source** the catalog via `buildPublicProjection` (re-project — design decision), and thread `isEncryptedPayload` through the update ACK closure.
- **Handler** (`storage-ack-handler.ts` `updateHandler`): independently **rebuild + verify** the catalog root, enforce **byteSize parity vs `newByteSize`** (UpdateIntent has no `publicByteSize` — the one deliberate divergence from the publish handler), and REPLACE-persist `<cg>/_catalog` **before signing**. Gated on a non-zero `newCatalogRoot`.

Every new path is gated on curated discrimination (`useCuratedUpdate` / `isEncryptedPayload` + non-zero catalog); **public updates carry no catalog and are unchanged on a healthy chain** (see "Merge-review note" below).

## Decisions baked in
- **Re-project the floor** for the direct-update catalog source (deterministic, matches `_ensureCuratedCatalogInSwm`).
- **Every curated update re-commits the catalog** (a zero root reverts on-chain — so even metadata-only curated updates re-ship the current floor).
- **Single-blob v1** — chunked (LU-11) curated updates deferred to a follow-up.

### Behavior note (important for reviewers)
The catalog is the **stable public floor** (a deterministic function of the CG DID). So a curated update **re-commits the same root** — that's what satisfies the on-chain gate and lets cores re-host/verify it; it does **not** rotate to a new root. Consequence of the floor-reprojection decision: `agent.update()` can't carry richer per-update public catalog metadata (a conscious trade-off; "read-existing + merge" is the alternative if we want that later).

## Validation so far
- Build green (publisher + agent).
- **Publisher unit suite: 1163 pass, 0 regression.**
- Adversarial parity check: `parityHolds`, byteSize trap handled (all 3 producer sites + handler), no public-update regression.

## Remaining (in progress)
- **Unit**: `updateHandler` curated catalog ACK happy-path + the `CATALOG_ROOT_MISMATCH` declines (root / leafCount / byteSize / missing); producer sets catalog on a curated update.
- **e2e**: `rfc49-catalog-parity` curated-UPDATE leg — assert catalog root non-zero **and equals the publish baseline** (not "rotated"); harness must sign the update attestation over **post-floor-injection** quads.
- **devnet**: `rfc49-catalog-sampling` curated-UPDATE leg — cores re-host the updated `_catalog` + a core proves it via random sampling (the real end-to-end proof; this scenario has **zero** devnet coverage today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
