### PR TITLE
feat(daemon): HTTP admission control — cap concurrent in-flight requests

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -570,6 +570,17 @@ export interface DkgConfig {
   /** HTTP rate limiting settings. */
   rateLimit?: { requestsPerMinute?: number; exempt?: string[] };
   /**
+   * Max concurrent in-flight HTTP requests before the daemon sheds load with
+   * 503 (admission control, IP-agnostic). `<= 0` disables. Overridden by the
+   * `DKG_MAX_INFLIGHT` env var. Defaults to 64.
+   */
+  maxInFlightRequests?: number;
+  /**
+   * Max simultaneous TCP connections the HTTP server will accept. Overridden by
+   * the `DKG_MAX_CONNECTIONS` env var. Defaults to 256.
+   */
+  maxConnections?: number;
+  /**
    * V10 Random Sampling prover (core-only). When the node is `core`
    * AND has an on-chain identity, the agent automatically schedules
    * `RandomSamplingProver.tick()` on `tickIntervalMs`. Edge nodes

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1290,23 +1290,49 @@ function parseIntOrNull(value: string | undefined): number | null {
  * `DKG_MAX_INFLIGHT=abc` or an empty string yields the documented default, not
  * `NaN`/`0`.
  *
- * Pass `allowZero` when non-positive is a meaningful value (e.g. "disable the
- * cap"): then ANY integer is accepted, so `<= 0` (incl. `-1`) flows through to
+ * Pass `allowNonPositive` when `<= 0` is a meaningful value (e.g. "disable the
+ * cap"): then ANY integer is accepted, so `0` or a negative flows through to
  * disable rather than falling back to the default. Without it the minimum
- * accepted value is 1.
+ * accepted value is 1. (Named for what it does — it admits negatives too, not
+ * just zero.)
  */
 export function resolveIntSetting(
   envValue: string | undefined,
   configValue: number | undefined,
   fallback: number,
-  opts: { allowZero?: boolean } = {},
+  opts: { allowNonPositive?: boolean } = {},
 ): number {
   const accepts = (n: number | null | undefined): n is number =>
-    typeof n === 'number' && Number.isInteger(n) && (opts.allowZero === true || n >= 1);
+    typeof n === 'number' && Number.isInteger(n) && (opts.allowNonPositive === true || n >= 1);
   const fromEnv = parseIntOrNull(envValue);
   if (accepts(fromEnv)) return fromEnv;
   if (accepts(configValue)) return configValue;
   return fallback;
+}
+
+/** Minimal shape of the bits of `http.Server` that {@link applyServerLimits} sets. */
+export interface ServerLimitsTarget {
+  maxConnections: number;
+  headersTimeout: number;
+}
+
+/**
+ * Resolve and APPLY the socket-level limits to an HTTP server: `maxConnections`
+ * (cap simultaneous sockets) and `headersTimeout` (kill slow-header
+ * connections). `requestTimeout` is intentionally left at the Node default so
+ * legitimately long publishes / SPARQL queries aren't truncated. Extracted from
+ * the daemon so the resolution precedence AND the assignment are unit-testable.
+ */
+export function applyServerLimits(
+  server: ServerLimitsTarget,
+  opts: {
+    maxConnectionsEnv?: string;
+    maxConnectionsConfig?: number;
+    headersTimeoutEnv?: string;
+  },
+): void {
+  server.maxConnections = resolveIntSetting(opts.maxConnectionsEnv, opts.maxConnectionsConfig, 256);
+  server.headersTimeout = resolveIntSetting(opts.headersTimeoutEnv, undefined, 60_000);
 }
 
 /**

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1276,11 +1276,15 @@ function parseIntOrNull(value: string | undefined): number | null {
 
 /**
  * Resolve an integer setting from an env var (highest precedence), then a
- * config value, then a fallback. Malformed / empty / out-of-range inputs are
- * IGNORED (fall through) rather than silently disabling the setting — a typo
- * like `DKG_MAX_INFLIGHT=abc` or an empty string yields the documented default,
- * not `NaN`/`0`. Pass `allowZero` when 0 is a meaningful value (e.g. "disable
- * the cap"); otherwise the minimum accepted value is 1.
+ * config value, then a fallback. Malformed / empty / NaN inputs are IGNORED
+ * (fall through) rather than silently disabling the setting — a typo like
+ * `DKG_MAX_INFLIGHT=abc` or an empty string yields the documented default, not
+ * `NaN`/`0`.
+ *
+ * Pass `allowZero` when non-positive is a meaningful value (e.g. "disable the
+ * cap"): then ANY integer is accepted, so `<= 0` (incl. `-1`) flows through to
+ * disable rather than falling back to the default. Without it the minimum
+ * accepted value is 1.
  */
 export function resolveIntSetting(
   envValue: string | undefined,
@@ -1288,16 +1292,11 @@ export function resolveIntSetting(
   fallback: number,
   opts: { allowZero?: boolean } = {},
 ): number {
-  const min = opts.allowZero ? 0 : 1;
+  const accepts = (n: number | null | undefined): n is number =>
+    typeof n === 'number' && Number.isInteger(n) && (opts.allowZero === true || n >= 1);
   const fromEnv = parseIntOrNull(envValue);
-  if (fromEnv !== null && fromEnv >= min) return fromEnv;
-  if (
-    typeof configValue === 'number' &&
-    Number.isInteger(configValue) &&
-    configValue >= min
-  ) {
-    return configValue;
-  }
+  if (accepts(fromEnv)) return fromEnv;
+  if (accepts(configValue)) return configValue;
   return fallback;
 }
 
@@ -1306,6 +1305,7 @@ const ADMISSION_EXEMPT_PATHS: ReadonlySet<string> = new Set([
   '/api/status',
   '/api/chain/rpc-health',
   '/.well-known/skill.md',
+  '/.well-known/skill-importer.md',
 ]);
 
 /**

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1220,6 +1220,47 @@ export class HttpRateLimiter {
   }
 }
 
+/**
+ * Bounds the number of HTTP requests being processed concurrently by the
+ * daemon, independent of client IP. This is admission control, not rate
+ * limiting: the single-process daemon funnels every request onto one event
+ * loop (and, on the embedded store backend, one Oxigraph worker thread), so a
+ * burst of concurrent in-flight requests — including local/loopback traffic
+ * that bypasses {@link HttpRateLimiter} — can pile pending work onto the heap
+ * and stall the node. When the cap is reached, callers should shed load with a
+ * 503 + Retry-After rather than queue unboundedly.
+ *
+ * `tryAcquire()` must be paired with exactly one `release()` in a `finally`.
+ */
+export class InFlightLimiter {
+  private _inFlight = 0;
+  private readonly _max: number;
+
+  constructor(max: number) {
+    // A non-positive cap disables the limiter (always admits).
+    this._max = Number.isFinite(max) && max > 0 ? Math.floor(max) : 0;
+  }
+
+  get inFlight(): number {
+    return this._inFlight;
+  }
+
+  get max(): number {
+    return this._max;
+  }
+
+  /** Returns true and reserves a slot, or false if at capacity (shed load). */
+  tryAcquire(): boolean {
+    if (this._max > 0 && this._inFlight >= this._max) return false;
+    this._inFlight += 1;
+    return true;
+  }
+
+  release(): void {
+    if (this._inFlight > 0) this._inFlight -= 1;
+  }
+}
+
 export function isLoopbackClientIp(ip: string): boolean {
   const normalized = ip.trim().toLowerCase();
   if (normalized === '::1') return true;

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1261,6 +1261,94 @@ export class InFlightLimiter {
   }
 }
 
+/**
+ * Parse a base-10 integer from an env-style string. Returns null for
+ * `undefined`, empty/whitespace, or any non-integer text — so malformed input
+ * falls through to the next source instead of becoming `NaN`/`0`.
+ */
+function parseIntOrNull(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const t = value.trim();
+  if (t === '' || !/^-?\d+$/.test(t)) return null;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve an integer setting from an env var (highest precedence), then a
+ * config value, then a fallback. Malformed / empty / out-of-range inputs are
+ * IGNORED (fall through) rather than silently disabling the setting — a typo
+ * like `DKG_MAX_INFLIGHT=abc` or an empty string yields the documented default,
+ * not `NaN`/`0`. Pass `allowZero` when 0 is a meaningful value (e.g. "disable
+ * the cap"); otherwise the minimum accepted value is 1.
+ */
+export function resolveIntSetting(
+  envValue: string | undefined,
+  configValue: number | undefined,
+  fallback: number,
+  opts: { allowZero?: boolean } = {},
+): number {
+  const min = opts.allowZero ? 0 : 1;
+  const fromEnv = parseIntOrNull(envValue);
+  if (fromEnv !== null && fromEnv >= min) return fromEnv;
+  if (
+    typeof configValue === 'number' &&
+    Number.isInteger(configValue) &&
+    configValue >= min
+  ) {
+    return configValue;
+  }
+  return fallback;
+}
+
+/** Cheap liveness/health paths kept answerable even under admission saturation. */
+const ADMISSION_EXEMPT_PATHS: ReadonlySet<string> = new Set([
+  '/api/status',
+  '/api/chain/rpc-health',
+  '/.well-known/skill.md',
+]);
+
+/**
+ * Apply concurrency admission control to one request. CORS preflight (OPTIONS)
+ * and a small set of cheap health/liveness paths are exempt so monitoring,
+ * `dkg status`, doctor, and MCP setup probes keep working even when the daemon
+ * is shedding load. On rejection it writes a `503` + `Retry-After` (with CORS
+ * headers so browsers surface it). Returns whether the request is admitted plus
+ * a `release` disposer the caller MUST call exactly once in a `finally` — it is
+ * idempotent and a no-op for exempt or rejected requests, so a slot is only ever
+ * released by its own owner.
+ */
+export function admitRequest(
+  limiter: InFlightLimiter,
+  method: string | undefined,
+  pathname: string,
+  res: ServerResponse,
+  corsOrigin: string | null,
+): { admitted: boolean; release: () => void } {
+  const noop = () => {};
+  if (method === 'OPTIONS' || ADMISSION_EXEMPT_PATHS.has(pathname)) {
+    return { admitted: true, release: noop };
+  }
+  if (!limiter.tryAcquire()) {
+    res.writeHead(503, {
+      'Content-Type': 'application/json',
+      'Retry-After': '1',
+      ...corsHeaders(corsOrigin),
+    });
+    res.end(JSON.stringify({ error: 'Server busy, retry shortly' }));
+    return { admitted: false, release: noop };
+  }
+  let released = false;
+  return {
+    admitted: true,
+    release: () => {
+      if (released) return;
+      released = true;
+      limiter.release();
+    },
+  };
+}
+
 export function isLoopbackClientIp(ip: string): boolean {
   const normalized = ip.trim().toLowerCase();
   if (normalized === '::1') return true;

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1336,14 +1336,18 @@ export function applyServerLimits(
 }
 
 /**
- * Paths exempt from concurrency admission control. Two reasons to exempt:
- *  - cheap liveness/health paths that must stay answerable under load
- *    (monitoring, `dkg status`, doctor, MCP setup probes);
- *  - long-lived streaming connections (`/api/events` SSE) that would otherwise
- *    hold an in-flight slot for the connection's entire lifetime, so a few open
- *    dashboard tabs could exhaust the pool and shed all real work.
+ * Cheap GET/HEAD paths exempt from concurrency admission control — liveness /
+ * health / manifest handlers that must stay answerable under load (monitoring,
+ * `dkg status`, doctor, MCP setup probes), plus the long-lived `/api/events`
+ * SSE stream (which must NOT hold an in-flight slot for the connection's whole
+ * lifetime, or a few open dashboard tabs would exhaust the pool).
+ *
+ * NOTE: this is one of several HTTP path-category tables in the daemon (see
+ * `auth.ts` public paths, `isLoopbackRateLimitExemptPath`, and the default
+ * rate-limit exempt list in `lifecycle.ts`). Centralizing them behind one
+ * source of truth is a worthwhile follow-up; kept local here for now.
  */
-const ADMISSION_EXEMPT_PATHS: ReadonlySet<string> = new Set([
+const ADMISSION_EXEMPT_GET_PATHS: ReadonlySet<string> = new Set([
   '/api/status',
   '/api/chain/rpc-health',
   '/api/events',
@@ -1352,14 +1356,31 @@ const ADMISSION_EXEMPT_PATHS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Apply concurrency admission control to one request. CORS preflight (OPTIONS)
- * and a small set of cheap health/liveness paths are exempt so monitoring,
- * `dkg status`, doctor, and MCP setup probes keep working even when the daemon
- * is shedding load. On rejection it writes a `503` + `Retry-After` (with CORS
- * headers so browsers surface it). Returns whether the request is admitted plus
- * a `release` disposer the caller MUST call exactly once in a `finally` — it is
- * idempotent and a no-op for exempt or rejected requests, so a slot is only ever
- * released by its own owner.
+ * Whether a request bypasses admission control. METHOD-AWARE on purpose: only
+ * `OPTIONS` (CORS preflight, any path) and safe `GET`/`HEAD` reads of the cheap
+ * liveness/doc/SSE paths bypass. A `POST`/`PUT`/etc. to those same paths is NOT
+ * exempt — it falls through to the router/route-plugins and so must still take
+ * a slot, otherwise a buggy/authenticated local client could run real work
+ * outside the cap via e.g. `POST /api/status`.
+ */
+export function isAdmissionExempt(method: string | undefined, pathname: string): boolean {
+  if (method === 'OPTIONS') return true;
+  if ((method === 'GET' || method === 'HEAD') && ADMISSION_EXEMPT_GET_PATHS.has(pathname)) return true;
+  return false;
+}
+
+/**
+ * Apply concurrency admission control to one request. Exempt requests (see
+ * {@link isAdmissionExempt}) always pass and take no slot. Otherwise a slot is
+ * reserved; on capacity it writes `503` + `Retry-After` (with CORS headers so
+ * browsers surface it) and returns `{ admitted: false }`.
+ *
+ * Ownership model: the slot is released automatically when the RESPONSE
+ * completes (`res` `close`), NOT when the request handler returns — route
+ * plugins and SSE can return with the response still streaming, and releasing
+ * on handler return would free the slot mid-stream and let that work run
+ * outside the cap. The release is registered here so callers cannot get it
+ * wrong; they only need to honor `admitted`.
  */
 export function admitRequest(
   limiter: InFlightLimiter,
@@ -1367,10 +1388,9 @@ export function admitRequest(
   pathname: string,
   res: ServerResponse,
   corsOrigin: string | null,
-): { admitted: boolean; release: () => void } {
-  const noop = () => {};
-  if (method === 'OPTIONS' || ADMISSION_EXEMPT_PATHS.has(pathname)) {
-    return { admitted: true, release: noop };
+): { admitted: boolean } {
+  if (isAdmissionExempt(method, pathname)) {
+    return { admitted: true };
   }
   if (!limiter.tryAcquire()) {
     res.writeHead(503, {
@@ -1379,17 +1399,16 @@ export function admitRequest(
       ...corsHeaders(corsOrigin),
     });
     res.end(JSON.stringify({ error: 'Server busy, retry shortly' }));
-    return { admitted: false, release: noop };
+    return { admitted: false };
   }
+  // Release exactly once, when the response completes (finish or abort).
   let released = false;
-  return {
-    admitted: true,
-    release: () => {
-      if (released) return;
-      released = true;
-      limiter.release();
-    },
-  };
+  res.once('close', () => {
+    if (released) return;
+    released = true;
+    limiter.release();
+  });
+  return { admitted: true };
 }
 
 export function isLoopbackClientIp(ip: string): boolean {

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -1234,6 +1234,7 @@ export class HttpRateLimiter {
  */
 export class InFlightLimiter {
   private _inFlight = 0;
+  private _rejectedTotal = 0;
   private readonly _max: number;
 
   constructor(max: number) {
@@ -1249,9 +1250,17 @@ export class InFlightLimiter {
     return this._max;
   }
 
+  /** Monotonic count of requests shed (tryAcquire returned false) — for metrics/logging. */
+  get rejectedTotal(): number {
+    return this._rejectedTotal;
+  }
+
   /** Returns true and reserves a slot, or false if at capacity (shed load). */
   tryAcquire(): boolean {
-    if (this._max > 0 && this._inFlight >= this._max) return false;
+    if (this._max > 0 && this._inFlight >= this._max) {
+      this._rejectedTotal += 1;
+      return false;
+    }
     this._inFlight += 1;
     return true;
   }
@@ -1300,10 +1309,18 @@ export function resolveIntSetting(
   return fallback;
 }
 
-/** Cheap liveness/health paths kept answerable even under admission saturation. */
+/**
+ * Paths exempt from concurrency admission control. Two reasons to exempt:
+ *  - cheap liveness/health paths that must stay answerable under load
+ *    (monitoring, `dkg status`, doctor, MCP setup probes);
+ *  - long-lived streaming connections (`/api/events` SSE) that would otherwise
+ *    hold an in-flight slot for the connection's entire lifetime, so a few open
+ *    dashboard tabs could exhaust the pool and shed all real work.
+ */
 const ADMISSION_EXEMPT_PATHS: ReadonlySet<string> = new Set([
   '/api/status',
   '/api/chain/rpc-health',
+  '/api/events',
   '/.well-known/skill.md',
   '/.well-known/skill-importer.md',
 ]);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -2732,13 +2732,8 @@ export async function runDaemonInner(
         }
         return;
       }
-      // Release the slot when the RESPONSE actually completes, not when this
-      // handler returns. Route plugins (and SSE) can send headers and return
-      // with the response still open while they keep streaming; releasing on
-      // handler return would free the slot mid-stream and let streaming work
-      // run outside the cap. `close` fires once per response (on finish or
-      // abort), so the slot is held for the response's true lifetime.
-      res.once('close', gate.release);
+      // (admitRequest registers slot release on the response's `close` event —
+      // covers streaming/plugin responses; nothing to release here.)
 
       // CORS preflight
       if (req.method === "OPTIONS") {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -238,6 +238,7 @@ import {
   resolveCorsOrigin,
   corsHeaders,
   HttpRateLimiter,
+  InFlightLimiter,
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
@@ -2672,10 +2673,21 @@ export async function runDaemonInner(
       "/.well-known/skill.md",
     ],
   );
+
+  // Admission control: cap concurrent in-flight requests so a burst (including
+  // loopback traffic, which bypasses the per-IP rate limiter) can't pile
+  // unbounded pending work onto the single event loop / store worker thread.
+  // IP-agnostic on purpose — local agents legitimately burst, so we shed by
+  // concurrency (503 + Retry-After) rather than by per-minute rate. Tunable via
+  // DKG_MAX_INFLIGHT (<=0 disables); default 64.
+  const maxInFlight = Number(process.env.DKG_MAX_INFLIGHT ?? config.maxInFlightRequests ?? 64);
+  const inFlightLimiter = new InFlightLimiter(maxInFlight);
+
   let corsAllowed: CorsAllowlist = "*";
   daemonState.catchupRunner = createCatchupRunner(agent);
 
   const server = createServer(async (req, res) => {
+    let admitted = false;
     try {
       const reqUrl = new URL(req.url ?? "/", `http://${req.headers.host}`);
 
@@ -2691,6 +2703,16 @@ export async function runDaemonInner(
         res.end(JSON.stringify({ error: 'Too many requests' }));
         return;
       }
+
+      // Admission control — shed load when too many requests are already in
+      // flight. Applied to ALL traffic (not bypassed for loopback), so it also
+      // bounds local agents that the per-IP rate limiter intentionally exempts.
+      if (!inFlightLimiter.tryAcquire()) {
+        res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '1', ...corsHeaders(reqCorsOrigin) });
+        res.end(JSON.stringify({ error: 'Server busy, retry shortly' }));
+        return;
+      }
+      admitted = true;
 
       // CORS preflight
       if (req.method === "OPTIONS") {
@@ -2877,8 +2899,20 @@ export async function runDaemonInner(
         enrichEvmError(err);
         jsonResponse(res, 500, { error: err.message });
       }
+    } finally {
+      if (admitted) inFlightLimiter.release();
     }
   });
+
+  // Bound simultaneous sockets and slow-header connections so a flood of
+  // clients can't exhaust file descriptors or park half-open connections.
+  // requestTimeout is left at the Node default so legitimately long publishes /
+  // SPARQL queries aren't truncated. Tunable via DKG_MAX_CONNECTIONS.
+  server.maxConnections = Math.max(
+    1,
+    Number(process.env.DKG_MAX_CONNECTIONS ?? config.maxConnections ?? 256),
+  );
+  server.headersTimeout = Number(process.env.DKG_HEADERS_TIMEOUT_MS ?? 60_000);
 
   const apiPort = config.apiPort || 0;
   const apiHost = config.apiHost || "127.0.0.1";

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -241,6 +241,7 @@ import {
   InFlightLimiter,
   admitRequest,
   resolveIntSetting,
+  applyServerLimits,
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
@@ -2687,7 +2688,7 @@ export async function runDaemonInner(
     process.env.DKG_MAX_INFLIGHT,
     config.maxInFlightRequests,
     64,
-    { allowZero: true },
+    { allowNonPositive: true },
   );
   const inFlightLimiter = new InFlightLimiter(maxInFlight);
   // Throttle the "shedding" warning so a sustained burst can't spam the log,
@@ -2699,7 +2700,6 @@ export async function runDaemonInner(
   daemonState.catchupRunner = createCatchupRunner(agent);
 
   const server = createServer(async (req, res) => {
-    let releaseSlot: (() => void) | undefined;
     try {
       const reqUrl = new URL(req.url ?? "/", `http://${req.headers.host}`);
 
@@ -2732,7 +2732,13 @@ export async function runDaemonInner(
         }
         return;
       }
-      releaseSlot = gate.release;
+      // Release the slot when the RESPONSE actually completes, not when this
+      // handler returns. Route plugins (and SSE) can send headers and return
+      // with the response still open while they keep streaming; releasing on
+      // handler return would free the slot mid-stream and let streaming work
+      // run outside the cap. `close` fires once per response (on finish or
+      // abort), so the slot is held for the response's true lifetime.
+      res.once('close', gate.release);
 
       // CORS preflight
       if (req.method === "OPTIONS") {
@@ -2919,27 +2925,21 @@ export async function runDaemonInner(
         enrichEvmError(err);
         jsonResponse(res, 500, { error: err.message });
       }
-    } finally {
-      releaseSlot?.();
     }
+    // Note: the admission slot is released on the response's `close` event
+    // (registered above), not in a finally here — see the comment at acquire.
   });
 
   // Bound simultaneous sockets and slow-header connections so a flood of
   // clients can't exhaust file descriptors or park half-open connections.
-  // requestTimeout is left at the Node default so legitimately long publishes /
-  // SPARQL queries aren't truncated. Malformed/empty env or config values fall
-  // back to the defaults rather than becoming NaN. Tunable via
-  // DKG_MAX_CONNECTIONS / DKG_HEADERS_TIMEOUT_MS.
-  server.maxConnections = resolveIntSetting(
-    process.env.DKG_MAX_CONNECTIONS,
-    config.maxConnections,
-    256,
-  );
-  server.headersTimeout = resolveIntSetting(
-    process.env.DKG_HEADERS_TIMEOUT_MS,
-    undefined,
-    60_000,
-  );
+  // Resolution + assignment live in applyServerLimits (unit-tested); tunable via
+  // DKG_MAX_CONNECTIONS / DKG_HEADERS_TIMEOUT_MS, with malformed/empty values
+  // falling back to defaults rather than becoming NaN.
+  applyServerLimits(server, {
+    maxConnectionsEnv: process.env.DKG_MAX_CONNECTIONS,
+    maxConnectionsConfig: config.maxConnections,
+    headersTimeoutEnv: process.env.DKG_HEADERS_TIMEOUT_MS,
+  });
 
   const apiPort = config.apiPort || 0;
   const apiHost = config.apiHost || "127.0.0.1";

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -239,6 +239,8 @@ import {
   corsHeaders,
   HttpRateLimiter,
   InFlightLimiter,
+  admitRequest,
+  resolveIntSetting,
   isLoopbackClientIp,
   isLoopbackRateLimitExemptPath,
   shouldBypassRateLimitForLoopbackTraffic,
@@ -2679,15 +2681,21 @@ export async function runDaemonInner(
   // unbounded pending work onto the single event loop / store worker thread.
   // IP-agnostic on purpose — local agents legitimately burst, so we shed by
   // concurrency (503 + Retry-After) rather than by per-minute rate. Tunable via
-  // DKG_MAX_INFLIGHT (<=0 disables); default 64.
-  const maxInFlight = Number(process.env.DKG_MAX_INFLIGHT ?? config.maxInFlightRequests ?? 64);
+  // DKG_MAX_INFLIGHT (explicit 0 disables); default 64. Malformed/empty values
+  // fall back to the default instead of silently disabling the cap.
+  const maxInFlight = resolveIntSetting(
+    process.env.DKG_MAX_INFLIGHT,
+    config.maxInFlightRequests,
+    64,
+    { allowZero: true },
+  );
   const inFlightLimiter = new InFlightLimiter(maxInFlight);
 
   let corsAllowed: CorsAllowlist = "*";
   daemonState.catchupRunner = createCatchupRunner(agent);
 
   const server = createServer(async (req, res) => {
-    let admitted = false;
+    let releaseSlot: (() => void) | undefined;
     try {
       const reqUrl = new URL(req.url ?? "/", `http://${req.headers.host}`);
 
@@ -2704,15 +2712,14 @@ export async function runDaemonInner(
         return;
       }
 
-      // Admission control — shed load when too many requests are already in
-      // flight. Applied to ALL traffic (not bypassed for loopback), so it also
-      // bounds local agents that the per-IP rate limiter intentionally exempts.
-      if (!inFlightLimiter.tryAcquire()) {
-        res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '1', ...corsHeaders(reqCorsOrigin) });
-        res.end(JSON.stringify({ error: 'Server busy, retry shortly' }));
-        return;
-      }
-      admitted = true;
+      // Admission control — shed load (503 + Retry-After) when too many
+      // requests are already in flight. Applied to ALL traffic (not bypassed
+      // for loopback) so it also bounds local agents the per-IP rate limiter
+      // exempts; OPTIONS preflight and cheap health/liveness paths are exempt
+      // inside admitRequest so monitoring stays answerable under saturation.
+      const gate = admitRequest(inFlightLimiter, req.method, reqUrl.pathname, res, reqCorsOrigin);
+      if (!gate.admitted) return;
+      releaseSlot = gate.release;
 
       // CORS preflight
       if (req.method === "OPTIONS") {
@@ -2900,19 +2907,26 @@ export async function runDaemonInner(
         jsonResponse(res, 500, { error: err.message });
       }
     } finally {
-      if (admitted) inFlightLimiter.release();
+      releaseSlot?.();
     }
   });
 
   // Bound simultaneous sockets and slow-header connections so a flood of
   // clients can't exhaust file descriptors or park half-open connections.
   // requestTimeout is left at the Node default so legitimately long publishes /
-  // SPARQL queries aren't truncated. Tunable via DKG_MAX_CONNECTIONS.
-  server.maxConnections = Math.max(
-    1,
-    Number(process.env.DKG_MAX_CONNECTIONS ?? config.maxConnections ?? 256),
+  // SPARQL queries aren't truncated. Malformed/empty env or config values fall
+  // back to the defaults rather than becoming NaN. Tunable via
+  // DKG_MAX_CONNECTIONS / DKG_HEADERS_TIMEOUT_MS.
+  server.maxConnections = resolveIntSetting(
+    process.env.DKG_MAX_CONNECTIONS,
+    config.maxConnections,
+    256,
   );
-  server.headersTimeout = Number(process.env.DKG_HEADERS_TIMEOUT_MS ?? 60_000);
+  server.headersTimeout = resolveIntSetting(
+    process.env.DKG_HEADERS_TIMEOUT_MS,
+    undefined,
+    60_000,
+  );
 
   const apiPort = config.apiPort || 0;
   const apiHost = config.apiHost || "127.0.0.1";

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -2690,6 +2690,10 @@ export async function runDaemonInner(
     { allowZero: true },
   );
   const inFlightLimiter = new InFlightLimiter(maxInFlight);
+  // Throttle the "shedding" warning so a sustained burst can't spam the log,
+  // while still letting operators see the limiter is active (per review).
+  let lastShedLogAt = 0;
+  const SHED_LOG_THROTTLE_MS = 10_000;
 
   let corsAllowed: CorsAllowlist = "*";
   daemonState.catchupRunner = createCatchupRunner(agent);
@@ -2718,7 +2722,16 @@ export async function runDaemonInner(
       // exempts; OPTIONS preflight and cheap health/liveness paths are exempt
       // inside admitRequest so monitoring stays answerable under saturation.
       const gate = admitRequest(inFlightLimiter, req.method, reqUrl.pathname, res, reqCorsOrigin);
-      if (!gate.admitted) return;
+      if (!gate.admitted) {
+        const nowMs = Date.now();
+        if (nowMs - lastShedLogAt >= SHED_LOG_THROTTLE_MS) {
+          lastShedLogAt = nowMs;
+          log(
+            `admission-control: shedding requests (503) — inFlight=${inFlightLimiter.inFlight}/${inFlightLimiter.max} rejectedTotal=${inFlightLimiter.rejectedTotal}`,
+          );
+        }
+        return;
+      }
       releaseSlot = gate.release;
 
       // CORS preflight

--- a/packages/cli/test/daemon-http-inflight-cap.test.ts
+++ b/packages/cli/test/daemon-http-inflight-cap.test.ts
@@ -15,7 +15,13 @@ describe('daemon admission control (real node, maxInFlightRequests=1)', () => {
   let daemon: LiveDaemon | undefined;
 
   beforeAll(async () => {
-    daemon = await startLiveDaemon({ authEnabled: true, extraConfig: { maxInFlightRequests: 1 } });
+    // Pin the cap via ENV (which takes precedence over config) so the test is
+    // hermetic — an ambient DKG_MAX_INFLIGHT in CI/dev can't override it.
+    daemon = await startLiveDaemon({
+      authEnabled: true,
+      extraConfig: { maxInFlightRequests: 1 },
+      env: { DKG_MAX_INFLIGHT: '1' },
+    });
   }, 90_000);
 
   afterAll(async () => {

--- a/packages/cli/test/daemon-http-inflight-cap.test.ts
+++ b/packages/cli/test/daemon-http-inflight-cap.test.ts
@@ -44,6 +44,9 @@ describe('daemon admission control (real node, maxInFlightRequests=1)', () => {
     const shed = results.filter((r) => r.status === 503);
     const ok = results.filter((r) => r.status === 200);
 
+    // Every result must be an EXPECTED status — never a network error (0) or an
+    // unexpected 4xx/5xx that would otherwise hide behind the >=1/>=1 counts.
+    expect(results.every((r) => r.status === 200 || r.status === 503)).toBe(true);
     expect(ok.length).toBeGreaterThan(0); // at least one admitted
     expect(shed.length).toBeGreaterThan(0); // cap enforced under concurrent load
     expect(shed.every((r) => r.retryAfter === '1')).toBe(true); // Retry-After present on every 503
@@ -53,10 +56,16 @@ describe('daemon admission control (real node, maxInFlightRequests=1)', () => {
     expect(recovered.status).toBe(200);
   }, 60_000);
 
-  it('never sheds the exempt liveness path (/api/status) under saturation', async () => {
+  it('keeps the exempt liveness path (/api/status) answerable even while saturated', async () => {
     const d = daemon!;
-    // Saturate with non-exempt query work (not awaited yet)...
-    const burst = Promise.all(Array.from({ length: 40 }, () => selectQuery(d).catch(() => null)));
+    // Saturate with non-exempt query work; capture the burst results so we can
+    // PROVE the daemon was actually over capacity (>=1 shed) while the status
+    // probes ran — otherwise "status stayed 200" would be vacuous.
+    const burst = Promise.all(
+      Array.from({ length: 40 }, () =>
+        selectQuery(d).then((r) => r.status).catch(() => 0),
+      ),
+    );
     // ...while hammering the exempt status endpoint, which must always answer 200.
     const statuses = await Promise.all(
       Array.from({ length: 12 }, () =>
@@ -65,7 +74,10 @@ describe('daemon admission control (real node, maxInFlightRequests=1)', () => {
           .catch(() => 0),
       ),
     );
-    await burst;
-    expect(statuses.every((s) => s === 200)).toBe(true);
+    const burstStatuses = await burst;
+
+    expect(statuses.every((s) => s === 200)).toBe(true); // exempt path never shed
+    expect(burstStatuses.filter((s) => s === 503).length).toBeGreaterThan(0); // saturation really happened
+    expect(burstStatuses.every((s) => s === 200 || s === 503)).toBe(true); // no unexpected failures
   }, 60_000);
 });

--- a/packages/cli/test/daemon-http-inflight-cap.test.ts
+++ b/packages/cli/test/daemon-http-inflight-cap.test.ts
@@ -10,6 +10,14 @@ import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from '.
  * This is the end-to-end counterpart to the unit tests in
  * http-admission-control.test.ts: it would fail if the limiter were never wired
  * into createServer, wired after an early return, or never released.
+ *
+ * Saturation is created with a 50-request burst against cap=1 rather than a
+ * single held-open request. That is statistically deterministic — 50 concurrent
+ * requests cannot all serialize through one slot without overlap — and avoids a
+ * brittle blocking fixture (the daemon admits before the route reads the body,
+ * so an unfinished-body "hold" does not reliably pin the slot). The precise
+ * one-in/one-shed/release semantics are covered deterministically by the unit
+ * tests; here we prove the wiring end-to-end.
  */
 describe('daemon admission control (real node, maxInFlightRequests=1)', () => {
   let daemon: LiveDaemon | undefined;

--- a/packages/cli/test/daemon-http-inflight-cap.test.ts
+++ b/packages/cli/test/daemon-http-inflight-cap.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from './helpers/live-daemon.js';
+
+/**
+ * Real-node admission-control test. Boots an actual daemon with the in-flight
+ * cap pinned to 1 (via config) and verifies, against the LIVE HTTP request
+ * path, that it sheds concurrent over-capacity load with 503 + Retry-After,
+ * keeps the exempt liveness path answerable, and recovers once slots free.
+ *
+ * This is the end-to-end counterpart to the unit tests in
+ * http-admission-control.test.ts: it would fail if the limiter were never wired
+ * into createServer, wired after an early return, or never released.
+ */
+describe('daemon admission control (real node, maxInFlightRequests=1)', () => {
+  let daemon: LiveDaemon | undefined;
+
+  beforeAll(async () => {
+    daemon = await startLiveDaemon({ authEnabled: true, extraConfig: { maxInFlightRequests: 1 } });
+  }, 90_000);
+
+  afterAll(async () => {
+    await stopLiveDaemon(daemon);
+  }, 30_000);
+
+  // Non-exempt endpoint that awaits the store, so concurrent calls overlap and
+  // contend for the single in-flight slot.
+  function selectQuery(d: LiveDaemon): Promise<Response> {
+    return fetch(`${d.base}/api/query`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(d) },
+      body: JSON.stringify({ sparql: 'SELECT * WHERE { ?s ?p ?o } LIMIT 1' }),
+    });
+  }
+
+  it('sheds concurrent over-capacity requests with 503 + Retry-After, then recovers', async () => {
+    const d = daemon!;
+    const results = await Promise.all(
+      Array.from({ length: 50 }, () =>
+        selectQuery(d)
+          .then((r) => ({ status: r.status, retryAfter: r.headers.get('retry-after') }))
+          .catch(() => ({ status: 0, retryAfter: null as string | null })),
+      ),
+    );
+    const shed = results.filter((r) => r.status === 503);
+    const ok = results.filter((r) => r.status === 200);
+
+    expect(ok.length).toBeGreaterThan(0); // at least one admitted
+    expect(shed.length).toBeGreaterThan(0); // cap enforced under concurrent load
+    expect(shed.every((r) => r.retryAfter === '1')).toBe(true); // Retry-After present on every 503
+
+    // Slots are released after each handler completes → a fresh request succeeds.
+    const recovered = await selectQuery(d);
+    expect(recovered.status).toBe(200);
+  }, 60_000);
+
+  it('never sheds the exempt liveness path (/api/status) under saturation', async () => {
+    const d = daemon!;
+    // Saturate with non-exempt query work (not awaited yet)...
+    const burst = Promise.all(Array.from({ length: 40 }, () => selectQuery(d).catch(() => null)));
+    // ...while hammering the exempt status endpoint, which must always answer 200.
+    const statuses = await Promise.all(
+      Array.from({ length: 12 }, () =>
+        fetch(`${d.base}/api/status`, { headers: authHeaders(d) })
+          .then((r) => r.status)
+          .catch(() => 0),
+      ),
+    );
+    await burst;
+    expect(statuses.every((s) => s === 200)).toBe(true);
+  }, 60_000);
+});

--- a/packages/cli/test/helpers/live-daemon.ts
+++ b/packages/cli/test/helpers/live-daemon.ts
@@ -56,6 +56,12 @@ export interface StartDaemonOpts {
   /** Extra keys merged into config.json (e.g. preset contextGraphs). */
   extraConfig?: Record<string, unknown>;
   readyTimeoutMs?: number;
+  /**
+   * Extra env vars for the daemon process. A value of `undefined` DELETES an
+   * inherited var — use this to make a test hermetic against ambient env (e.g.
+   * pin `DKG_MAX_INFLIGHT` instead of inheriting the developer/CI value).
+   */
+  env?: Record<string, string | undefined>;
 }
 
 /** Boot a real edge daemon against the shared Hardhat node and wait for readiness. */
@@ -97,14 +103,19 @@ export async function startLiveDaemon(opts: StartDaemonOpts = {}): Promise<LiveD
     { mode: 0o600 },
   );
 
+  const childEnv: Record<string, string | undefined> = {
+    ...process.env,
+    DKG_HOME: home,
+    DKG_API_PORT: String(apiPort),
+    DKG_NO_BLUE_GREEN: '1',
+    DKG_DISABLE_TELEMETRY: '1',
+    ...(opts.env ?? {}),
+  };
+  // Drop keys explicitly cleared via `env: { KEY: undefined }` so a test can
+  // remove an inherited var (spawn would otherwise pass it through).
+  for (const k of Object.keys(childEnv)) if (childEnv[k] === undefined) delete childEnv[k];
   const child = spawn('node', [CLI_ENTRY, 'daemon-worker'], {
-    env: {
-      ...process.env,
-      DKG_HOME: home,
-      DKG_API_PORT: String(apiPort),
-      DKG_NO_BLUE_GREEN: '1',
-      DKG_DISABLE_TELEMETRY: '1',
-    },
+    env: childEnv,
     stdio: 'ignore',
   });
 

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -48,6 +48,19 @@ describe('InFlightLimiter — concurrency admission control', () => {
       for (let i = 0; i < 1000; i++) expect(limiter.tryAcquire()).toBe(true);
     }
   });
+
+  it('counts rejectedTotal on shed only (for metrics/logging)', () => {
+    const limiter = new InFlightLimiter(1);
+    expect(limiter.rejectedTotal).toBe(0);
+    expect(limiter.tryAcquire()).toBe(true); // admitted — not counted
+    expect(limiter.rejectedTotal).toBe(0);
+    expect(limiter.tryAcquire()).toBe(false); // shed
+    expect(limiter.tryAcquire()).toBe(false); // shed
+    expect(limiter.rejectedTotal).toBe(2);
+    limiter.release();
+    expect(limiter.tryAcquire()).toBe(true); // admitted again — still 2
+    expect(limiter.rejectedTotal).toBe(2);
+  });
 });
 
 describe('resolveIntSetting — env/config/fallback parsing', () => {
@@ -118,7 +131,7 @@ describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => 
     expect(g3.admitted).toBe(true); // recovered
   });
 
-  it('exempts OPTIONS preflight and cheap health paths even at capacity', () => {
+  it('exempts OPTIONS, cheap health paths, and the long-lived SSE stream even at capacity', () => {
     const limiter = new InFlightLimiter(1);
     expect(limiter.tryAcquire()).toBe(true); // saturate
 
@@ -126,6 +139,7 @@ describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => 
       ['OPTIONS', '/api/context-graphs'],
       ['GET', '/api/status'],
       ['GET', '/api/chain/rpc-health'],
+      ['GET', '/api/events'], // SSE — must not hold a slot for the connection lifetime
       ['GET', '/.well-known/skill.md'],
       ['GET', '/.well-known/skill-importer.md'],
     ] as const) {
@@ -136,5 +150,6 @@ describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => 
       gate.release(); // no-op for exempt requests
     }
     expect(limiter.inFlight).toBe(1); // untouched by exempt traffic
+    expect(limiter.rejectedTotal).toBe(0); // exempt traffic is never counted as shed
   });
 });

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -1,22 +1,37 @@
 import { describe, expect, it } from 'vitest';
-import { InFlightLimiter } from '../src/daemon/http-utils.js';
+import type { ServerResponse } from 'node:http';
+import { InFlightLimiter, admitRequest, resolveIntSetting } from '../src/daemon/http-utils.js';
+
+/** Minimal ServerResponse stand-in capturing writeHead/end for assertions. */
+function mockRes() {
+  const r = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: '',
+    writeHead(code: number, headers?: Record<string, string>) {
+      r.statusCode = code;
+      if (headers) Object.assign(r.headers, headers);
+      return r;
+    },
+    end(chunk?: string) {
+      if (chunk) r.body += chunk;
+      return r;
+    },
+  };
+  return r as unknown as ServerResponse & { statusCode: number; headers: Record<string, string>; body: string };
+}
 
 describe('InFlightLimiter — concurrency admission control', () => {
   it('admits up to the cap then sheds, and recovers on release', () => {
     const limiter = new InFlightLimiter(2);
     expect(limiter.max).toBe(2);
-
-    expect(limiter.tryAcquire()).toBe(true); // 1
-    expect(limiter.tryAcquire()).toBe(true); // 2
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.tryAcquire()).toBe(true);
     expect(limiter.inFlight).toBe(2);
-
     expect(limiter.tryAcquire()).toBe(false); // at capacity -> shed
-    expect(limiter.inFlight).toBe(2);
-
     limiter.release();
     expect(limiter.inFlight).toBe(1);
     expect(limiter.tryAcquire()).toBe(true); // slot freed
-    expect(limiter.inFlight).toBe(2);
   });
 
   it('release() never underflows below zero', () => {
@@ -24,8 +39,6 @@ describe('InFlightLimiter — concurrency admission control', () => {
     limiter.release();
     limiter.release();
     expect(limiter.inFlight).toBe(0);
-    expect(limiter.tryAcquire()).toBe(true);
-    expect(limiter.inFlight).toBe(1);
   });
 
   it('treats a non-positive or non-finite cap as disabled (always admits)', () => {
@@ -33,15 +46,82 @@ describe('InFlightLimiter — concurrency admission control', () => {
       const limiter = new InFlightLimiter(max);
       expect(limiter.max).toBe(0);
       for (let i = 0; i < 1000; i++) expect(limiter.tryAcquire()).toBe(true);
-      expect(limiter.inFlight).toBe(1000);
     }
   });
+});
 
-  it('floors fractional caps', () => {
-    const limiter = new InFlightLimiter(2.9);
-    expect(limiter.max).toBe(2);
-    expect(limiter.tryAcquire()).toBe(true);
-    expect(limiter.tryAcquire()).toBe(true);
-    expect(limiter.tryAcquire()).toBe(false);
+describe('resolveIntSetting — env/config/fallback parsing', () => {
+  it('prefers a valid env value, then config, then fallback', () => {
+    expect(resolveIntSetting('128', 200, 64)).toBe(128);
+    expect(resolveIntSetting(undefined, 200, 64)).toBe(200);
+    expect(resolveIntSetting(undefined, undefined, 64)).toBe(64);
+  });
+
+  it('falls back (not NaN/0) on malformed or empty env — the reported bug', () => {
+    expect(resolveIntSetting('abc', undefined, 64)).toBe(64); // typo
+    expect(resolveIntSetting('', undefined, 64)).toBe(64); // empty string
+    expect(resolveIntSetting('  ', undefined, 64)).toBe(64); // whitespace
+    expect(resolveIntSetting('64x', undefined, 64)).toBe(64); // trailing junk
+    expect(resolveIntSetting('abc', 200, 64)).toBe(200); // invalid env -> config
+  });
+
+  it('honors allowZero only when set, and rejects negatives/fractions', () => {
+    expect(resolveIntSetting('0', undefined, 64)).toBe(64); // 0 rejected (min 1)
+    expect(resolveIntSetting('0', undefined, 64, { allowZero: true })).toBe(0); // explicit disable
+    expect(resolveIntSetting('-5', undefined, 64, { allowZero: true })).toBe(64); // negative -> default
+    expect(resolveIntSetting(undefined, 2.5, 64)).toBe(64); // fractional config ignored
+  });
+});
+
+describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => {
+  it('admits, consumes a slot, and the disposer frees exactly that slot (idempotent)', () => {
+    const limiter = new InFlightLimiter(1);
+    const g1 = admitRequest(limiter, 'GET', '/api/context-graphs', mockRes(), null);
+    expect(g1.admitted).toBe(true);
+    expect(limiter.inFlight).toBe(1);
+    g1.release();
+    expect(limiter.inFlight).toBe(0);
+    g1.release(); // idempotent — does not double-free
+    expect(limiter.inFlight).toBe(0);
+  });
+
+  it('sheds an over-capacity request with 503 + Retry-After and preserves CORS', () => {
+    const limiter = new InFlightLimiter(1);
+    const g1 = admitRequest(limiter, 'GET', '/api/context-graphs', mockRes(), null);
+    expect(g1.admitted).toBe(true);
+
+    const res = mockRes();
+    const g2 = admitRequest(limiter, 'GET', '/api/context-graphs', res, 'https://app.example');
+    expect(g2.admitted).toBe(false);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('1');
+    expect(res.headers['Access-Control-Allow-Origin']).toBe('https://app.example');
+    expect(res.body).toContain('busy');
+
+    // A rejected request's disposer must not touch the slot held by g1.
+    g2.release();
+    expect(limiter.inFlight).toBe(1);
+
+    g1.release();
+    const g3 = admitRequest(limiter, 'GET', '/api/context-graphs', mockRes(), null);
+    expect(g3.admitted).toBe(true); // recovered
+  });
+
+  it('exempts OPTIONS preflight and cheap health paths even at capacity', () => {
+    const limiter = new InFlightLimiter(1);
+    expect(limiter.tryAcquire()).toBe(true); // saturate
+
+    for (const [method, path] of [
+      ['OPTIONS', '/api/context-graphs'],
+      ['GET', '/api/status'],
+      ['GET', '/api/chain/rpc-health'],
+    ] as const) {
+      const res = mockRes();
+      const gate = admitRequest(limiter, method, path, res, null);
+      expect(gate.admitted).toBe(true); // never shed
+      expect(res.statusCode).toBe(0); // nothing written
+      gate.release(); // no-op for exempt requests
+    }
+    expect(limiter.inFlight).toBe(1); // untouched by exempt traffic
   });
 });

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ServerResponse } from 'node:http';
-import { InFlightLimiter, admitRequest, resolveIntSetting } from '../src/daemon/http-utils.js';
+import { InFlightLimiter, admitRequest, resolveIntSetting, applyServerLimits } from '../src/daemon/http-utils.js';
 
 /** Minimal ServerResponse stand-in capturing writeHead/end for assertions. */
 function mockRes() {
@@ -78,22 +78,40 @@ describe('resolveIntSetting — env/config/fallback parsing', () => {
     expect(resolveIntSetting('abc', 200, 64)).toBe(200); // invalid env -> config
   });
 
-  it('without allowZero, rejects non-positive (min 1) and fractions', () => {
+  it('without allowNonPositive, rejects non-positive (min 1) and fractions', () => {
     expect(resolveIntSetting('0', undefined, 64)).toBe(64); // 0 rejected (min 1)
     expect(resolveIntSetting('-5', undefined, 64)).toBe(64); // negative rejected
     expect(resolveIntSetting(undefined, 2.5, 64)).toBe(64); // fractional config ignored
     expect(resolveIntSetting(undefined, 0, 64)).toBe(64); // config 0 rejected
   });
 
-  it('with allowZero, any <=0 flows through to disable (does NOT fall back to default)', () => {
+  it('with allowNonPositive, any <=0 flows through to disable (does NOT fall back to default)', () => {
     // Contract: "<= 0 disables". A typo must still fall back, but an explicit
     // 0 or negative is an intentional disable, not garbage.
-    expect(resolveIntSetting('0', undefined, 64, { allowZero: true })).toBe(0);
-    expect(resolveIntSetting('-1', undefined, 64, { allowZero: true })).toBe(-1);
-    expect(resolveIntSetting(undefined, -3, 64, { allowZero: true })).toBe(-3); // via config
-    expect(resolveIntSetting('abc', undefined, 64, { allowZero: true })).toBe(64); // still falls back
+    expect(resolveIntSetting('0', undefined, 64, { allowNonPositive: true })).toBe(0);
+    expect(resolveIntSetting('-1', undefined, 64, { allowNonPositive: true })).toBe(-1);
+    expect(resolveIntSetting(undefined, -3, 64, { allowNonPositive: true })).toBe(-3); // via config
+    expect(resolveIntSetting('abc', undefined, 64, { allowNonPositive: true })).toBe(64); // still falls back
     // And the resolved value disables the limiter end-to-end:
-    expect(new InFlightLimiter(resolveIntSetting('-1', undefined, 64, { allowZero: true })).max).toBe(0);
+    expect(new InFlightLimiter(resolveIntSetting('-1', undefined, 64, { allowNonPositive: true })).max).toBe(0);
+  });
+});
+
+describe('applyServerLimits — socket-level controls applied to the server', () => {
+  it('resolves env > config > default and assigns to the server object', () => {
+    const s = { maxConnections: 0, headersTimeout: 0 };
+
+    applyServerLimits(s, { maxConnectionsEnv: '500', maxConnectionsConfig: 256, headersTimeoutEnv: undefined });
+    expect(s.maxConnections).toBe(500); // env wins
+    expect(s.headersTimeout).toBe(60_000); // default
+
+    applyServerLimits(s, { maxConnectionsEnv: 'abc', maxConnectionsConfig: 300, headersTimeoutEnv: '5000' });
+    expect(s.maxConnections).toBe(300); // malformed env → config
+    expect(s.headersTimeout).toBe(5000); // env honored
+
+    applyServerLimits(s, {});
+    expect(s.maxConnections).toBe(256); // all defaults
+    expect(s.headersTimeout).toBe(60_000);
   });
 });
 

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it } from 'vitest';
 import type { ServerResponse } from 'node:http';
 import { InFlightLimiter, admitRequest, resolveIntSetting, applyServerLimits } from '../src/daemon/http-utils.js';
 
-/** Minimal ServerResponse stand-in capturing writeHead/end for assertions. */
-function mockRes() {
+/**
+ * Minimal ServerResponse stand-in capturing writeHead/end and supporting the
+ * single `once('close', ...)` listener admitRequest registers for slot release.
+ * `emitClose()` simulates the response completing.
+ */
+type MockRes = ServerResponse & {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  emitClose(): void;
+};
+function mockRes(): MockRes {
+  let closeCb: (() => void) | undefined;
   const r = {
     statusCode: 0,
     headers: {} as Record<string, string>,
@@ -17,8 +28,15 @@ function mockRes() {
       if (chunk) r.body += chunk;
       return r;
     },
+    once(event: string, cb: () => void) {
+      if (event === 'close') closeCb = cb;
+      return r;
+    },
+    emitClose() {
+      closeCb?.();
+    },
   };
-  return r as unknown as ServerResponse & { statusCode: number; headers: Record<string, string>; body: string };
+  return r as unknown as MockRes;
 }
 
 describe('InFlightLimiter — concurrency admission control', () => {
@@ -115,47 +133,49 @@ describe('applyServerLimits — socket-level controls applied to the server', ()
   });
 });
 
-describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => {
-  it('admits, consumes a slot, and the disposer frees exactly that slot (idempotent)', () => {
+describe('admitRequest — wiring (503/Retry-After/CORS/exempt) + release on response close', () => {
+  it('admits, consumes a slot, and releases it exactly once when the response closes', () => {
     const limiter = new InFlightLimiter(1);
-    const g1 = admitRequest(limiter, 'GET', '/api/context-graphs', mockRes(), null);
-    expect(g1.admitted).toBe(true);
+    const res = mockRes();
+    const gate = admitRequest(limiter, 'POST', '/api/query', res, null);
+    expect(gate.admitted).toBe(true);
     expect(limiter.inFlight).toBe(1);
-    g1.release();
+    res.emitClose(); // response completes → slot released
     expect(limiter.inFlight).toBe(0);
-    g1.release(); // idempotent — does not double-free
+    res.emitClose(); // idempotent — does not double-free
     expect(limiter.inFlight).toBe(0);
   });
 
   it('sheds an over-capacity request with 503 + Retry-After and preserves CORS', () => {
     const limiter = new InFlightLimiter(1);
-    const g1 = admitRequest(limiter, 'GET', '/api/context-graphs', mockRes(), null);
-    expect(g1.admitted).toBe(true);
+    const held = mockRes();
+    expect(admitRequest(limiter, 'POST', '/api/query', held, null).admitted).toBe(true);
 
     const res = mockRes();
-    const g2 = admitRequest(limiter, 'GET', '/api/context-graphs', res, 'https://app.example');
+    const g2 = admitRequest(limiter, 'POST', '/api/query', res, 'https://app.example');
     expect(g2.admitted).toBe(false);
     expect(res.statusCode).toBe(503);
     expect(res.headers['Retry-After']).toBe('1');
     expect(res.headers['Access-Control-Allow-Origin']).toBe('https://app.example');
     expect(res.body).toContain('busy');
 
-    // A rejected request's disposer must not touch the slot held by g1.
-    g2.release();
+    // The rejected request took no slot and registered no close listener, so
+    // closing its (already-sent) response must not touch the held slot.
+    res.emitClose();
     expect(limiter.inFlight).toBe(1);
 
-    g1.release();
-    const g3 = admitRequest(limiter, 'GET', '/api/context-graphs', mockRes(), null);
-    expect(g3.admitted).toBe(true); // recovered
+    held.emitClose(); // held response completes → slot freed
+    expect(admitRequest(limiter, 'POST', '/api/query', mockRes(), null).admitted).toBe(true); // recovered
   });
 
-  it('exempts OPTIONS, cheap health paths, and the long-lived SSE stream even at capacity', () => {
+  it('exempts OPTIONS (any path) and GET/HEAD liveness/doc/SSE paths even at capacity', () => {
     const limiter = new InFlightLimiter(1);
     expect(limiter.tryAcquire()).toBe(true); // saturate
 
     for (const [method, path] of [
-      ['OPTIONS', '/api/context-graphs'],
+      ['OPTIONS', '/api/query'], // preflight, any path
       ['GET', '/api/status'],
+      ['HEAD', '/api/status'],
       ['GET', '/api/chain/rpc-health'],
       ['GET', '/api/events'], // SSE — must not hold a slot for the connection lifetime
       ['GET', '/.well-known/skill.md'],
@@ -165,9 +185,24 @@ describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => 
       const gate = admitRequest(limiter, method, path, res, null);
       expect(gate.admitted).toBe(true); // never shed
       expect(res.statusCode).toBe(0); // nothing written
-      gate.release(); // no-op for exempt requests
     }
     expect(limiter.inFlight).toBe(1); // untouched by exempt traffic
     expect(limiter.rejectedTotal).toBe(0); // exempt traffic is never counted as shed
+  });
+
+  it('is method-aware: a non-GET/HEAD to an exempt path is NOT exempt (would run work outside the cap)', () => {
+    const limiter = new InFlightLimiter(1);
+    const held = mockRes();
+    expect(admitRequest(limiter, 'GET', '/api/status', held, null).admitted).toBe(true); // exempt → no slot
+    expect(limiter.inFlight).toBe(0); // GET /api/status took no slot
+
+    // POST to the same liveness path is subject to the cap. With the slot free
+    // it's admitted (and takes a slot); once saturated it is shed.
+    const post1 = mockRes();
+    expect(admitRequest(limiter, 'POST', '/api/status', post1, null).admitted).toBe(true);
+    expect(limiter.inFlight).toBe(1);
+    const post2 = mockRes();
+    expect(admitRequest(limiter, 'POST', '/api/status', post2, null).admitted).toBe(false);
+    expect(post2.statusCode).toBe(503);
   });
 });

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -65,11 +65,22 @@ describe('resolveIntSetting — env/config/fallback parsing', () => {
     expect(resolveIntSetting('abc', 200, 64)).toBe(200); // invalid env -> config
   });
 
-  it('honors allowZero only when set, and rejects negatives/fractions', () => {
+  it('without allowZero, rejects non-positive (min 1) and fractions', () => {
     expect(resolveIntSetting('0', undefined, 64)).toBe(64); // 0 rejected (min 1)
-    expect(resolveIntSetting('0', undefined, 64, { allowZero: true })).toBe(0); // explicit disable
-    expect(resolveIntSetting('-5', undefined, 64, { allowZero: true })).toBe(64); // negative -> default
+    expect(resolveIntSetting('-5', undefined, 64)).toBe(64); // negative rejected
     expect(resolveIntSetting(undefined, 2.5, 64)).toBe(64); // fractional config ignored
+    expect(resolveIntSetting(undefined, 0, 64)).toBe(64); // config 0 rejected
+  });
+
+  it('with allowZero, any <=0 flows through to disable (does NOT fall back to default)', () => {
+    // Contract: "<= 0 disables". A typo must still fall back, but an explicit
+    // 0 or negative is an intentional disable, not garbage.
+    expect(resolveIntSetting('0', undefined, 64, { allowZero: true })).toBe(0);
+    expect(resolveIntSetting('-1', undefined, 64, { allowZero: true })).toBe(-1);
+    expect(resolveIntSetting(undefined, -3, 64, { allowZero: true })).toBe(-3); // via config
+    expect(resolveIntSetting('abc', undefined, 64, { allowZero: true })).toBe(64); // still falls back
+    // And the resolved value disables the limiter end-to-end:
+    expect(new InFlightLimiter(resolveIntSetting('-1', undefined, 64, { allowZero: true })).max).toBe(0);
   });
 });
 
@@ -115,6 +126,8 @@ describe('admitRequest — wiring (503/Retry-After/CORS/exempt/release)', () => 
       ['OPTIONS', '/api/context-graphs'],
       ['GET', '/api/status'],
       ['GET', '/api/chain/rpc-health'],
+      ['GET', '/.well-known/skill.md'],
+      ['GET', '/.well-known/skill-importer.md'],
     ] as const) {
       const res = mockRes();
       const gate = admitRequest(limiter, method, path, res, null);

--- a/packages/cli/test/http-admission-control.test.ts
+++ b/packages/cli/test/http-admission-control.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { InFlightLimiter } from '../src/daemon/http-utils.js';
+
+describe('InFlightLimiter — concurrency admission control', () => {
+  it('admits up to the cap then sheds, and recovers on release', () => {
+    const limiter = new InFlightLimiter(2);
+    expect(limiter.max).toBe(2);
+
+    expect(limiter.tryAcquire()).toBe(true); // 1
+    expect(limiter.tryAcquire()).toBe(true); // 2
+    expect(limiter.inFlight).toBe(2);
+
+    expect(limiter.tryAcquire()).toBe(false); // at capacity -> shed
+    expect(limiter.inFlight).toBe(2);
+
+    limiter.release();
+    expect(limiter.inFlight).toBe(1);
+    expect(limiter.tryAcquire()).toBe(true); // slot freed
+    expect(limiter.inFlight).toBe(2);
+  });
+
+  it('release() never underflows below zero', () => {
+    const limiter = new InFlightLimiter(4);
+    limiter.release();
+    limiter.release();
+    expect(limiter.inFlight).toBe(0);
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.inFlight).toBe(1);
+  });
+
+  it('treats a non-positive or non-finite cap as disabled (always admits)', () => {
+    for (const max of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const limiter = new InFlightLimiter(max);
+      expect(limiter.max).toBe(0);
+      for (let i = 0; i < 1000; i++) expect(limiter.tryAcquire()).toBe(true);
+      expect(limiter.inFlight).toBe(1000);
+    }
+  });
+
+  it('floors fractional caps', () => {
+    const limiter = new InFlightLimiter(2.9);
+    expect(limiter.max).toBe(2);
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.tryAcquire()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The daemon runs everything in one Node process: every HTTP request shares one event loop, and on the default-ish `oxigraph-worker` store backend they also serialize through a single worker thread. Today there is **no concurrency cap** on the HTTP server, and **all `/api/*` + `/ui/*` loopback traffic bypasses the per-IP rate limiter** ([`http-utils.ts` `isLoopbackRateLimitExemptPath`](https://github.com/OriginTrail/dkg/blob/main/packages/cli/src/daemon/http-utils.ts)).

Net effect: a handful of local agents/integrations polling the API (e.g. `/api/operations` or `/api/query` on a tight loop) can pile unbounded pending work onto the heap and make the daemon unresponsive — no exotic scale required. This came out of a scalability review of `main` as the highest-proximity node-local bottleneck.

## Fix

- **`InFlightLimiter`** (new, mirrors `HttpRateLimiter`): caps concurrent in-flight requests; excess is shed with **`503` + `Retry-After`** instead of queueing unboundedly.
- Applied to **all** traffic — *not* bypassed for loopback — so it bounds local agents that the rate limiter intentionally exempts. Crucially it does **not** rate-limit their legitimate bursts: rate-limiting (req/min) is the wrong tool for trusted local traffic; concurrency admission control is the right one.
- Bound simultaneous sockets (`server.maxConnections`) and slow-header connections (`server.headersTimeout`).
- `requestTimeout` deliberately left at the Node default so legitimately long publishes / SPARQL queries aren't truncated.

## Tunables (all optional, safe defaults)

| Knob | Env | Config | Default |
|---|---|---|---|
| Max concurrent in-flight requests (`<=0` disables) | `DKG_MAX_INFLIGHT` | `maxInFlightRequests` | 64 |
| Max simultaneous TCP connections | `DKG_MAX_CONNECTIONS` | `maxConnections` | 256 |
| Slow-header timeout (ms) | `DKG_HEADERS_TIMEOUT_MS` | — | 60000 |

## Testing

- New unit test `packages/cli/test/http-admission-control.test.ts` (4 cases: cap+shed+recover, no underflow, disabled when `<=0`/non-finite, floors fractional caps) — green.
- `tsc` build of `packages/cli` (+ workspace deps) passes.

## Risk

Low. The default cap of 64 concurrent in-flight requests is well above normal dashboard + agent traffic; it only sheds under genuine overload, and is fully tunable/disable-able. The handler change is a `try/finally` wrap plus one early-return `503` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)