### PR TITLE
perf(node-ui): memoize polled replication rollups (dashboard query cost)

### DIFF
--- a/packages/cli/test/daemon-http-replication.test.ts
+++ b/packages/cli/test/daemon-http-replication.test.ts
@@ -2,15 +2,21 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from './helpers/live-daemon.js';
 
 /**
- * Real-node test for the dashboard replication rollups. The companion PR wraps
- * DashboardDB.getReplicationSummary / getReplicationPerCg / getReplicationTimeline
- * in a short-TTL memo. These endpoints are served by the live daemon via
- * handleNodeUIRequest + a real DashboardDB, so this boots an actual daemon and
- * exercises the live /api/replication/* HTTP path to prove the memo refactor
- * didn't break the real endpoints and that rapid repeated polls return a stable,
- * well-formed payload (the memo path). Runs in the Bura: cli lane.
+ * Real-node INTEGRATION test for the dashboard replication rollups
+ * (`/api/replication/summary | per-cg | timeline`), served by the live daemon
+ * via handleNodeUIRequest + a real DashboardDB.
+ *
+ * Scope is deliberately narrow: the companion PR wraps those rollups in a
+ * short-TTL memo, and the memo's OBSERVABLE behaviour (cache hit, TTL expiry,
+ * per-window keying, window<=TTL bypass, disable) is proven deterministically in
+ * the unit suite `packages/node-ui/test/replication-cache.test.ts`. The memo is
+ * an internal optimisation and is NOT observable over HTTP, so this test does
+ * not try to assert it. What it DOES guarantee is that the refactor didn't break
+ * the live HTTP surface: the endpoints return well-formed, internally-consistent
+ * payloads and stay correct under the rapid concurrent polling the memo targets.
+ * Runs in the Bura: cli lane.
  */
-describe('daemon /api/replication/* (real node, memoized rollups)', () => {
+describe('daemon /api/replication/* (real node, endpoint correctness)', () => {
   let daemon: LiveDaemon | undefined;
 
   beforeAll(async () => {
@@ -26,13 +32,17 @@ describe('daemon /api/replication/* (real node, memoized rollups)', () => {
     return { status: res.status, body: (await res.json().catch(() => null)) as any };
   }
 
-  it('serves well-formed summary, per-cg, and timeline on a live node', async () => {
+  it('serves well-formed, internally-consistent summary / per-cg / timeline', async () => {
     const d = daemon!;
 
     const summary = await getJson(d, '/api/replication/summary');
     expect(summary.status).toBe(200);
     expect(typeof summary.body.totalEvents).toBe('number');
     expect(typeof summary.body.counts).toBe('object');
+    // Internal consistency: totalEvents must equal the sum of the action counts.
+    const countSum = Object.values(summary.body.counts as Record<string, number>)
+      .reduce((s, n) => s + n, 0);
+    expect(summary.body.totalEvents).toBe(countSum);
 
     const perCg = await getJson(d, '/api/replication/per-cg');
     expect(perCg.status).toBe(200);
@@ -43,13 +53,18 @@ describe('daemon /api/replication/* (real node, memoized rollups)', () => {
     expect(Array.isArray(timeline.body.buckets)).toBe(true);
   }, 30_000);
 
-  it('returns stable results across rapid repeated polls (memo path)', async () => {
+  it('stays correct and consistent under rapid concurrent polling', async () => {
+    // The polling pattern the memo optimises: many back-to-back identical reads.
+    // We assert every poll is a well-formed 200 with an identical payload — i.e.
+    // the refactor is concurrency-safe and didn't corrupt results. (The memo's
+    // caching semantics themselves are unit-tested, not asserted here.)
     const d = daemon!;
     const calls = await Promise.all(
       Array.from({ length: 10 }, () => getJson(d, '/api/replication/summary')),
     );
     expect(calls.every((c) => c.status === 200)).toBe(true);
-    const totals = calls.map((c) => c.body.totalEvents);
-    expect(new Set(totals).size).toBe(1); // consistent under the memo
+    expect(calls.every((c) => typeof c.body?.totalEvents === 'number')).toBe(true);
+    const serialized = new Set(calls.map((c) => JSON.stringify(c.body)));
+    expect(serialized.size).toBe(1); // identical payload across all concurrent polls
   }, 30_000);
 });

--- a/packages/cli/test/daemon-http-replication.test.ts
+++ b/packages/cli/test/daemon-http-replication.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from './helpers/live-daemon.js';
+
+/**
+ * Real-node test for the dashboard replication rollups. The companion PR wraps
+ * DashboardDB.getReplicationSummary / getReplicationPerCg / getReplicationTimeline
+ * in a short-TTL memo. These endpoints are served by the live daemon via
+ * handleNodeUIRequest + a real DashboardDB, so this boots an actual daemon and
+ * exercises the live /api/replication/* HTTP path to prove the memo refactor
+ * didn't break the real endpoints and that rapid repeated polls return a stable,
+ * well-formed payload (the memo path). Runs in the Bura: cli lane.
+ */
+describe('daemon /api/replication/* (real node, memoized rollups)', () => {
+  let daemon: LiveDaemon | undefined;
+
+  beforeAll(async () => {
+    daemon = await startLiveDaemon({ authEnabled: true });
+  }, 90_000);
+
+  afterAll(async () => {
+    await stopLiveDaemon(daemon);
+  }, 30_000);
+
+  async function getJson(d: LiveDaemon, path: string): Promise<{ status: number; body: any }> {
+    const res = await fetch(`${d.base}${path}`, { headers: authHeaders(d) });
+    return { status: res.status, body: (await res.json().catch(() => null)) as any };
+  }
+
+  it('serves well-formed summary, per-cg, and timeline on a live node', async () => {
+    const d = daemon!;
+
+    const summary = await getJson(d, '/api/replication/summary');
+    expect(summary.status).toBe(200);
+    expect(typeof summary.body.totalEvents).toBe('number');
+    expect(typeof summary.body.counts).toBe('object');
+
+    const perCg = await getJson(d, '/api/replication/per-cg');
+    expect(perCg.status).toBe(200);
+    expect(Array.isArray(perCg.body.rows)).toBe(true);
+
+    const timeline = await getJson(d, '/api/replication/timeline');
+    expect(timeline.status).toBe(200);
+    expect(Array.isArray(timeline.body.buckets)).toBe(true);
+  }, 30_000);
+
+  it('returns stable results across rapid repeated polls (memo path)', async () => {
+    const d = daemon!;
+    const calls = await Promise.all(
+      Array.from({ length: 10 }, () => getJson(d, '/api/replication/summary')),
+    );
+    expect(calls.every((c) => c.status === 200)).toBe(true);
+    const totals = calls.map((c) => c.body.totalEvents);
+    expect(new Set(totals).size).toBe(1); // consistent under the memo
+  }, 30_000);
+});

--- a/packages/cli/test/daemon-http-replication.test.ts
+++ b/packages/cli/test/daemon-http-replication.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { DashboardDB } from '@origintrail-official/dkg-node-ui';
 import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from './helpers/live-daemon.js';
 
 /**
@@ -6,25 +7,46 @@ import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from '.
  * (`/api/replication/summary | per-cg | timeline`), served by the live daemon
  * via handleNodeUIRequest + a real DashboardDB.
  *
- * Scope is deliberately narrow: the companion PR wraps those rollups in a
- * short-TTL memo, and the memo's OBSERVABLE behaviour (cache hit, TTL expiry,
- * per-window keying, window<=TTL bypass, disable) is proven deterministically in
- * the unit suite `packages/node-ui/test/replication-cache.test.ts`. The memo is
- * an internal optimisation and is NOT observable over HTTP, so this test does
- * not try to assert it. What it DOES guarantee is that the refactor didn't break
- * the live HTTP surface: the endpoints return well-formed, internally-consistent
- * payloads and stay correct under the rapid concurrent polling the memo targets.
- * Runs in the Bura: cli lane.
+ * The memo's OBSERVABLE caching behaviour (hit, TTL expiry, per-window keying,
+ * bypass, disable, defensive-copy) is proven deterministically in the unit suite
+ * `packages/node-ui/test/replication-cache.test.ts`. This test proves the live
+ * HTTP WIRING: with real seeded telemetry it returns NON-EMPTY, internally
+ * consistent payloads, and stays correct under rapid concurrent polling.
+ *
+ * The daemon is started with the memo DISABLED (`DKG_DASHBOARD_CACHE_TTL_MS=0`)
+ * so rows seeded directly into its `node-ui.db` are immediately visible over
+ * HTTP — i.e. we assert non-zero counts, not just empty-payload shape. Runs in
+ * the Bura: cli lane.
  */
-describe('daemon /api/replication/* (real node, endpoint correctness)', () => {
+describe('daemon /api/replication/* (real node, seeded telemetry)', () => {
   let daemon: LiveDaemon | undefined;
+  let prevTtlEnv: string | undefined;
 
   beforeAll(async () => {
+    // Disable the rollup memo in the spawned daemon (inherits process.env via the
+    // helper) so freshly-seeded rows are visible on the very next read.
+    prevTtlEnv = process.env.DKG_DASHBOARD_CACHE_TTL_MS;
+    process.env.DKG_DASHBOARD_CACHE_TTL_MS = '0';
     daemon = await startLiveDaemon({ authEnabled: true });
+
+    // Seed replication telemetry straight into the daemon's node-ui.db (same
+    // file the daemon serves from; dkgDir() === DKG_HOME === daemon.home here).
+    // There is no HTTP route to insert replication_events, so we write directly.
+    const seed = new DashboardDB({ dataDir: daemon.home });
+    try {
+      const now = Date.now();
+      seed.insertReplicationEvent({ ts: now - 10_000, context_graph_id: 'seedcg', action: 'fetch', ual: 'urn:ka:seed', ordinal: 1 });
+      seed.insertReplicationEvent({ ts: now - 5_000, context_graph_id: 'seedcg', action: 'promote', ual: 'urn:ka:seed', ordinal: 1 });
+      seed.insertReplicationEvent({ ts: now - 4_000, context_graph_id: 'seedcg', action: 'promote', ual: 'urn:ka:seed2', ordinal: 2 });
+    } finally {
+      seed.close();
+    }
   }, 90_000);
 
   afterAll(async () => {
     await stopLiveDaemon(daemon);
+    if (prevTtlEnv === undefined) delete process.env.DKG_DASHBOARD_CACHE_TTL_MS;
+    else process.env.DKG_DASHBOARD_CACHE_TTL_MS = prevTtlEnv;
   }, 30_000);
 
   async function getJson(d: LiveDaemon, path: string): Promise<{ status: number; body: any }> {
@@ -32,38 +54,39 @@ describe('daemon /api/replication/* (real node, endpoint correctness)', () => {
     return { status: res.status, body: (await res.json().catch(() => null)) as any };
   }
 
-  it('serves well-formed, internally-consistent summary / per-cg / timeline', async () => {
+  it('exposes the seeded telemetry (non-empty, internally consistent) over HTTP', async () => {
     const d = daemon!;
 
-    const summary = await getJson(d, '/api/replication/summary');
+    const summary = await getJson(d, '/api/replication/summary?periodMs=86400000');
     expect(summary.status).toBe(200);
-    expect(typeof summary.body.totalEvents).toBe('number');
-    expect(typeof summary.body.counts).toBe('object');
-    // Internal consistency: totalEvents must equal the sum of the action counts.
-    const countSum = Object.values(summary.body.counts as Record<string, number>)
-      .reduce((s, n) => s + n, 0);
+    // Non-zero: would still pass with empty payload before seeding, so this is
+    // the assertion that proves the daemon wiring actually surfaces telemetry.
+    expect(summary.body.totalEvents).toBeGreaterThanOrEqual(3);
+    expect(summary.body.counts.promote).toBeGreaterThanOrEqual(2);
+    expect(summary.body.counts.fetch).toBeGreaterThanOrEqual(1);
+    // Internal consistency: totalEvents == sum of action counts.
+    const countSum = Object.values(summary.body.counts as Record<string, number>).reduce((s, n) => s + n, 0);
     expect(summary.body.totalEvents).toBe(countSum);
 
-    const perCg = await getJson(d, '/api/replication/per-cg');
+    const perCg = await getJson(d, '/api/replication/per-cg?periodMs=86400000');
     expect(perCg.status).toBe(200);
     expect(Array.isArray(perCg.body.rows)).toBe(true);
+    expect(perCg.body.rows.some((r: any) => r.context_graph_id === 'seedcg')).toBe(true);
 
-    const timeline = await getJson(d, '/api/replication/timeline');
+    const timeline = await getJson(d, '/api/replication/timeline?periodMs=86400000&bucketMs=3600000');
     expect(timeline.status).toBe(200);
     expect(Array.isArray(timeline.body.buckets)).toBe(true);
+    const timelineTotal = timeline.body.buckets.reduce((s: number, b: any) => s + (b.total ?? 0), 0);
+    expect(timelineTotal).toBeGreaterThanOrEqual(3);
   }, 30_000);
 
   it('stays correct and consistent under rapid concurrent polling', async () => {
-    // The polling pattern the memo optimises: many back-to-back identical reads.
-    // We assert every poll is a well-formed 200 with an identical payload — i.e.
-    // the refactor is concurrency-safe and didn't corrupt results. (The memo's
-    // caching semantics themselves are unit-tested, not asserted here.)
     const d = daemon!;
     const calls = await Promise.all(
-      Array.from({ length: 10 }, () => getJson(d, '/api/replication/summary')),
+      Array.from({ length: 10 }, () => getJson(d, '/api/replication/summary?periodMs=86400000')),
     );
     expect(calls.every((c) => c.status === 200)).toBe(true);
-    expect(calls.every((c) => typeof c.body?.totalEvents === 'number')).toBe(true);
+    expect(calls.every((c) => c.body?.totalEvents >= 3)).toBe(true);
     const serialized = new Set(calls.map((c) => JSON.stringify(c.body)));
     expect(serialized.size).toBe(1); // identical payload across all concurrent polls
   }, 30_000);

--- a/packages/cli/test/daemon-http-replication.test.ts
+++ b/packages/cli/test/daemon-http-replication.test.ts
@@ -44,9 +44,14 @@ describe('daemon /api/replication/* (real node, seeded telemetry)', () => {
   }, 90_000);
 
   afterAll(async () => {
-    await stopLiveDaemon(daemon);
-    if (prevTtlEnv === undefined) delete process.env.DKG_DASHBOARD_CACHE_TTL_MS;
-    else process.env.DKG_DASHBOARD_CACHE_TTL_MS = prevTtlEnv;
+    // Restore the env var even if daemon shutdown throws/times out, so a leaked
+    // TTL=0 can't change caching behaviour for later tests in this worker.
+    try {
+      await stopLiveDaemon(daemon);
+    } finally {
+      if (prevTtlEnv === undefined) delete process.env.DKG_DASHBOARD_CACHE_TTL_MS;
+      else process.env.DKG_DASHBOARD_CACHE_TTL_MS = prevTtlEnv;
+    }
   }, 30_000);
 
   async function getJson(d: LiveDaemon, path: string): Promise<{ status: number; body: any }> {

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -118,6 +118,13 @@ function resolveCacheTtlMs(optValue: number | undefined): number {
   return Number.isFinite(n) ? n : 2000;
 }
 
+/**
+ * A rollup is only memoized when its smallest relevant time window is at least
+ * this many multiples of the TTL — so a cached moving-window result can never
+ * represent a meaningfully different window than the live request.
+ */
+const MEMO_WINDOW_SAFETY_FACTOR = 10;
+
 export class DashboardDB {
   readonly db: Database.Database;
   readonly dataDir: string;
@@ -904,16 +911,22 @@ export class DashboardDB {
   private readonly _memoTtlMs: number;
 
   /**
-   * Memoize a rollup for up to `_memoTtlMs`. `minWindowMs` is the smallest
-   * time window the result depends on; caching is bypassed when it is <= the
-   * TTL, because these rollups are computed over a moving `Date.now()` window —
-   * for a short window, a cached value could otherwise surface events that have
-   * already aged out of the requested window (up to one TTL of staleness) even
-   * with no new writes. Default dashboard windows (1h/24h) are far above the
-   * 2s TTL, so they always cache.
+   * Memoize a rollup for up to `_memoTtlMs`. `minWindowMs` is the smallest time
+   * window the result depends on; caching is bypassed unless that window is
+   * COMFORTABLY larger than the TTL (>= MEMO_WINDOW_SAFETY_FACTOR x). These
+   * rollups are computed over a moving `Date.now()` window, so a cached value
+   * can represent a slightly older window than the live request; requiring a
+   * 10x margin keeps that drift a negligible fraction of the window. A 1x guard
+   * is technically sufficient for `periodMs` (only the window cutoff drives
+   * staleness, not `bucketMs`), but per review (zsculac) we apply the
+   * conservative 10x margin to the smallest relevant window so the cache is used
+   * only where staleness is unambiguously acceptable. Default dashboard windows
+   * (1h/24h) are far above the 2s TTL, so they always cache.
    */
   private memoized<T>(key: string, minWindowMs: number, fn: () => T): T {
-    if (!(this._memoTtlMs > 0) || minWindowMs <= this._memoTtlMs) return fn();
+    if (!(this._memoTtlMs > 0) || minWindowMs <= this._memoTtlMs * MEMO_WINDOW_SAFETY_FACTOR) {
+      return fn();
+    }
     const now = Date.now();
     const hit = this._memo.get(key);
     if (hit && now - hit.at < this._memoTtlMs) return hit.value as T;
@@ -1152,10 +1165,12 @@ export class DashboardDB {
    */
   getReplicationTimeline(opts: { periodMs: number; bucketMs: number; contextGraphId?: string }): ReplicationTimelineBucket[] {
     return this.memoized(
-      // Staleness is driven by the rolling `periodMs` cutoff only; `bucketMs`
-      // controls grouping, not which events fall in/out of the window.
       `replicationTimeline:${opts.periodMs}:${opts.bucketMs}:${opts.contextGraphId ?? ''}`,
-      opts.periodMs,
+      // Staleness is driven by the rolling `periodMs` cutoff; `bucketMs` only
+      // controls grouping. We still pass the smaller of the two so timeline
+      // caching also requires a comfortably-large bucket (conservative, per
+      // review) — fine-grained buckets fall back to a fresh compute.
+      Math.min(opts.periodMs, opts.bucketMs),
       () => this._computeReplicationTimeline(opts),
     );
   }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -912,30 +912,36 @@ export class DashboardDB {
 
   /**
    * Memoize a rollup for up to `_memoTtlMs`. `minWindowMs` is the smallest time
-   * window the result depends on; caching is bypassed unless that window is
-   * COMFORTABLY larger than the TTL (>= MEMO_WINDOW_SAFETY_FACTOR x). These
-   * rollups are computed over a moving `Date.now()` window, so a cached value
-   * can represent a slightly older window than the live request; requiring a
-   * 10x margin keeps that drift a negligible fraction of the window. A 1x guard
-   * is technically sufficient for `periodMs` (only the window cutoff drives
-   * staleness, not `bucketMs`), but per review (zsculac) we apply the
-   * conservative 10x margin to the smallest relevant window so the cache is used
-   * only where staleness is unambiguously acceptable. Default dashboard windows
-   * (1h/24h) are far above the 2s TTL, so they always cache.
+   * window the result depends on; caching is bypassed unless that window is at
+   * least MEMO_WINDOW_SAFETY_FACTOR x the TTL. These rollups are computed over a
+   * moving `Date.now()` window, so a cached value can represent a slightly older
+   * window than the live request; requiring a 10x margin keeps that drift a
+   * negligible fraction of the window. A 1x guard is technically sufficient for
+   * `periodMs` (only the window cutoff drives staleness, not `bucketMs`), but per
+   * review (zsculac) we apply the conservative 10x margin to the smallest
+   * relevant window so the cache is used only where staleness is unambiguously
+   * acceptable. Default dashboard windows (1h/24h) are far above the 2s TTL, so
+   * they always cache.
+   *
+   * Returned values are structuredClone'd so a caller that sorts/pushes/annotates
+   * the summary or rows cannot mutate the cached instance and poison later reads
+   * (these methods previously returned a fresh result object on every call).
    */
   private memoized<T>(key: string, minWindowMs: number, fn: () => T): T {
-    if (!(this._memoTtlMs > 0) || minWindowMs <= this._memoTtlMs * MEMO_WINDOW_SAFETY_FACTOR) {
+    // `< F*ttl` bypasses, so a window of exactly F*ttl IS cached — matching the
+    // ">= 10x cacheable" contract documented above.
+    if (!(this._memoTtlMs > 0) || minWindowMs < this._memoTtlMs * MEMO_WINDOW_SAFETY_FACTOR) {
       return fn();
     }
     const now = Date.now();
     const hit = this._memo.get(key);
-    if (hit && now - hit.at < this._memoTtlMs) return hit.value as T;
+    if (hit && now - hit.at < this._memoTtlMs) return structuredClone(hit.value) as T;
     const value = fn();
     // Bound the map: keys are few in practice, but per-CG timeline variants can
     // accumulate. Entries are short-lived, so a rare full clear is safe.
     if (this._memo.size > 256) this._memo.clear();
     this._memo.set(key, { at: now, value });
-    return value;
+    return structuredClone(value) as T;
   }
 
   // --- Metric snapshots ---

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -876,12 +876,25 @@ export class DashboardDB {
   // synchronously on the daemon's event loop and are polled by the dashboard on
   // a few-second cadence. A short memo collapses repeated identical scans (extra
   // browser tabs, a runaway poller) into one, with no visible staleness on
-  // window-based analytics. Tunable via DKG_DASHBOARD_CACHE_TTL_MS (<=0 disables).
+  // window-based analytics. Tunable via DKG_DASHBOARD_CACHE_TTL_MS (<=0 disables;
+  // malformed/empty falls back to 2000).
   private _memo = new Map<string, { at: number; value: unknown }>();
-  private readonly _memoTtlMs = Number(process.env.DKG_DASHBOARD_CACHE_TTL_MS ?? 2000);
+  private readonly _memoTtlMs = (() => {
+    const raw = Number(process.env.DKG_DASHBOARD_CACHE_TTL_MS);
+    return Number.isFinite(raw) ? raw : 2000;
+  })();
 
-  private memoized<T>(key: string, fn: () => T): T {
-    if (!(this._memoTtlMs > 0)) return fn();
+  /**
+   * Memoize a rollup for up to `_memoTtlMs`. `minWindowMs` is the smallest
+   * time window the result depends on; caching is bypassed when it is <= the
+   * TTL, because these rollups are computed over a moving `Date.now()` window —
+   * for a short window, a cached value could otherwise surface events that have
+   * already aged out of the requested window (up to one TTL of staleness) even
+   * with no new writes. Default dashboard windows (1h/24h) are far above the
+   * 2s TTL, so they always cache.
+   */
+  private memoized<T>(key: string, minWindowMs: number, fn: () => T): T {
+    if (!(this._memoTtlMs > 0) || minWindowMs <= this._memoTtlMs) return fn();
     const now = Date.now();
     const hit = this._memo.get(key);
     if (hit && now - hit.at < this._memoTtlMs) return hit.value as T;
@@ -1030,7 +1043,7 @@ export class DashboardDB {
    *  - raw action counts.
    */
   getReplicationSummary(periodMs = 86_400_000): ReplicationSummary {
-    return this.memoized(`replicationSummary:${periodMs}`, () => this._computeReplicationSummary(periodMs));
+    return this.memoized(`replicationSummary:${periodMs}`, periodMs, () => this._computeReplicationSummary(periodMs));
   }
 
   private _computeReplicationSummary(periodMs: number): ReplicationSummary {
@@ -1092,7 +1105,7 @@ export class DashboardDB {
 
   /** Per-CG rollup of replication activity over the window, newest-active first. */
   getReplicationPerCg(periodMs = 86_400_000): ReplicationPerCgRow[] {
-    return this.memoized(`replicationPerCg:${periodMs}`, () => this._computeReplicationPerCg(periodMs));
+    return this.memoized(`replicationPerCg:${periodMs}`, periodMs, () => this._computeReplicationPerCg(periodMs));
   }
 
   private _computeReplicationPerCg(periodMs: number): ReplicationPerCgRow[] {
@@ -1121,6 +1134,7 @@ export class DashboardDB {
   getReplicationTimeline(opts: { periodMs: number; bucketMs: number; contextGraphId?: string }): ReplicationTimelineBucket[] {
     return this.memoized(
       `replicationTimeline:${opts.periodMs}:${opts.bucketMs}:${opts.contextGraphId ?? ''}`,
+      Math.min(opts.periodMs, opts.bucketMs),
       () => this._computeReplicationTimeline(opts),
     );
   }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -95,6 +95,27 @@ export interface DashboardDBOptions {
   dataDir: string;
   /** Days to retain data before pruning. Default: 14 */
   retentionDays?: number;
+  /**
+   * TTL (ms) for the in-process memo over polled replication rollups. `<= 0`
+   * disables caching. When omitted, falls back to the
+   * `DKG_DASHBOARD_CACHE_TTL_MS` env var, then a 2000ms default.
+   */
+  cacheTtlMs?: number;
+}
+
+/**
+ * Resolve the replication-rollup memo TTL: an explicit option (any finite
+ * number, incl. `<= 0` to disable) wins; otherwise a STRICT parse of
+ * `DKG_DASHBOARD_CACHE_TTL_MS` — empty / malformed falls back to the default so
+ * an empty env var in a deploy file doesn't silently disable the memo; otherwise
+ * 2000ms.
+ */
+function resolveCacheTtlMs(optValue: number | undefined): number {
+  if (typeof optValue === 'number' && Number.isFinite(optValue)) return optValue;
+  const raw = process.env.DKG_DASHBOARD_CACHE_TTL_MS;
+  if (raw === undefined || !/^-?\d+$/.test(raw.trim())) return 2000;
+  const n = Number(raw.trim());
+  return Number.isFinite(n) ? n : 2000;
 }
 
 export class DashboardDB {
@@ -107,6 +128,7 @@ export class DashboardDB {
     this.dataDir = opts.dataDir;
     this.explicitRetentionDays = opts.retentionDays !== undefined;
     this.retentionDays = opts.retentionDays ?? DEFAULT_RETENTION_DAYS;
+    this._memoTtlMs = resolveCacheTtlMs(opts.cacheTtlMs);
     const dbPath = join(opts.dataDir, 'node-ui.db');
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
@@ -876,13 +898,10 @@ export class DashboardDB {
   // synchronously on the daemon's event loop and are polled by the dashboard on
   // a few-second cadence. A short memo collapses repeated identical scans (extra
   // browser tabs, a runaway poller) into one, with no visible staleness on
-  // window-based analytics. Tunable via DKG_DASHBOARD_CACHE_TTL_MS (<=0 disables;
-  // malformed/empty falls back to 2000).
+  // window-based analytics. TTL resolved in the constructor from
+  // `cacheTtlMs` / DKG_DASHBOARD_CACHE_TTL_MS (<=0 disables; default 2000).
   private _memo = new Map<string, { at: number; value: unknown }>();
-  private readonly _memoTtlMs = (() => {
-    const raw = Number(process.env.DKG_DASHBOARD_CACHE_TTL_MS);
-    return Number.isFinite(raw) ? raw : 2000;
-  })();
+  private readonly _memoTtlMs: number;
 
   /**
    * Memoize a rollup for up to `_memoTtlMs`. `minWindowMs` is the smallest
@@ -1133,8 +1152,10 @@ export class DashboardDB {
    */
   getReplicationTimeline(opts: { periodMs: number; bucketMs: number; contextGraphId?: string }): ReplicationTimelineBucket[] {
     return this.memoized(
+      // Staleness is driven by the rolling `periodMs` cutoff only; `bucketMs`
+      // controls grouping, not which events fall in/out of the window.
       `replicationTimeline:${opts.periodMs}:${opts.bucketMs}:${opts.contextGraphId ?? ''}`,
-      Math.min(opts.periodMs, opts.bucketMs),
+      opts.periodMs,
       () => this._computeReplicationTimeline(opts),
     );
   }

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -871,6 +871,28 @@ export class DashboardDB {
     return this._stmts[key];
   }
 
+  // --- Short-TTL memo for polled, scan-heavy read rollups ---
+  // The replication summary/per-cg/timeline endpoints scan `replication_events`
+  // synchronously on the daemon's event loop and are polled by the dashboard on
+  // a few-second cadence. A short memo collapses repeated identical scans (extra
+  // browser tabs, a runaway poller) into one, with no visible staleness on
+  // window-based analytics. Tunable via DKG_DASHBOARD_CACHE_TTL_MS (<=0 disables).
+  private _memo = new Map<string, { at: number; value: unknown }>();
+  private readonly _memoTtlMs = Number(process.env.DKG_DASHBOARD_CACHE_TTL_MS ?? 2000);
+
+  private memoized<T>(key: string, fn: () => T): T {
+    if (!(this._memoTtlMs > 0)) return fn();
+    const now = Date.now();
+    const hit = this._memo.get(key);
+    if (hit && now - hit.at < this._memoTtlMs) return hit.value as T;
+    const value = fn();
+    // Bound the map: keys are few in practice, but per-CG timeline variants can
+    // accumulate. Entries are short-lived, so a rare full clear is safe.
+    if (this._memo.size > 256) this._memo.clear();
+    this._memo.set(key, { at: now, value });
+    return value;
+  }
+
   // --- Metric snapshots ---
 
   insertSnapshot(snap: MetricSnapshotRow): void {
@@ -1008,6 +1030,10 @@ export class DashboardDB {
    *  - raw action counts.
    */
   getReplicationSummary(periodMs = 86_400_000): ReplicationSummary {
+    return this.memoized(`replicationSummary:${periodMs}`, () => this._computeReplicationSummary(periodMs));
+  }
+
+  private _computeReplicationSummary(periodMs: number): ReplicationSummary {
     const cutoff = Date.now() - periodMs;
     const rows = this.db.prepare(
       `SELECT action, COUNT(*) AS n FROM replication_events WHERE ts >= ? GROUP BY action`,
@@ -1066,6 +1092,10 @@ export class DashboardDB {
 
   /** Per-CG rollup of replication activity over the window, newest-active first. */
   getReplicationPerCg(periodMs = 86_400_000): ReplicationPerCgRow[] {
+    return this.memoized(`replicationPerCg:${periodMs}`, () => this._computeReplicationPerCg(periodMs));
+  }
+
+  private _computeReplicationPerCg(periodMs: number): ReplicationPerCgRow[] {
     const cutoff = Date.now() - periodMs;
     return this.db.prepare(`
       SELECT context_graph_id,
@@ -1089,6 +1119,13 @@ export class DashboardDB {
    * is given, the series is scoped to that CG.
    */
   getReplicationTimeline(opts: { periodMs: number; bucketMs: number; contextGraphId?: string }): ReplicationTimelineBucket[] {
+    return this.memoized(
+      `replicationTimeline:${opts.periodMs}:${opts.bucketMs}:${opts.contextGraphId ?? ''}`,
+      () => this._computeReplicationTimeline(opts),
+    );
+  }
+
+  private _computeReplicationTimeline(opts: { periodMs: number; bucketMs: number; contextGraphId?: string }): ReplicationTimelineBucket[] {
     const cutoff = Date.now() - opts.periodMs;
     const bucket = Math.max(1, Math.floor(opts.bucketMs));
     const where = opts.contextGraphId ? 'AND context_graph_id = @cg' : '';

--- a/packages/node-ui/test/replication-cache.test.ts
+++ b/packages/node-ui/test/replication-cache.test.ts
@@ -169,14 +169,22 @@ describe('DashboardDB — cache TTL resolution', () => {
     expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // still cached → default TTL active, not disabled
   });
 
-  it('malformed DKG_DASHBOARD_CACHE_TTL_MS falls back to the default', () => {
+  it('malformed DKG_DASHBOARD_CACHE_TTL_MS falls back to the 2000ms default (not a lax parseInt)', () => {
+    // A lax resolver like `parseInt('64x')` would yield a 64ms TTL, and two
+    // immediate reads can't tell that from 2000ms. Use fake time: advance past a
+    // hypothetical 64ms TTL but well before 2000ms and assert the value is STILL
+    // cached → the TTL really is the default, not a leniently-parsed 64.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const t0 = 1_700_000_000_000;
+    vi.setSystemTime(t0);
     process.env[ENV_KEY] = '64x';
     db = new DashboardDB({ dataDir: dir });
-    const now = Date.now();
-    promote(db, now - 1000, 'cg', 1);
-    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
-    promote(db, now - 500, 'cg', 2);
-    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // cached at default → not disabled
+    promote(db, t0 - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // computed + cached at t0
+
+    promote(db, t0 - 500, 'cg', 2);
+    vi.setSystemTime(t0 + 100); // past a hypothetical 64ms TTL, far below 2000ms
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // still cached → TTL is 2000, not 64
   });
 
   it('the cacheTtlMs option overrides the env var', () => {

--- a/packages/node-ui/test/replication-cache.test.ts
+++ b/packages/node-ui/test/replication-cache.test.ts
@@ -81,13 +81,20 @@ describe('DashboardDB — replication rollup memo', () => {
     expect(db.getReplicationSummary(2 * 60 * 60_000).totalEvents).toBe(2); // distinct key
   });
 
-  it('bypasses the cache when the requested window is <= the TTL (avoids stale-by-window)', () => {
-    db = open(60_000); // TTL 60s, window 10s (<= TTL) → must not cache
+  it('only caches when the window is comfortably (>=10x) larger than the TTL', () => {
+    db = open(60_000); // TTL 60s → caches only when window > 600s (10x)
     const now = Date.now();
     promote(db, now - 1000, 'cg', 1);
-    expect(db.getReplicationSummary(10_000).totalEvents).toBe(1);
+
+    // window 500s (< 10x TTL) → bypass → always fresh
+    expect(db.getReplicationSummary(500_000).totalEvents).toBe(1);
     promote(db, now - 500, 'cg', 2);
-    expect(db.getReplicationSummary(10_000).totalEvents).toBe(2); // not cached → fresh
+    expect(db.getReplicationSummary(500_000).totalEvents).toBe(2);
+
+    // window 700s (> 10x TTL) → cache
+    expect(db.getReplicationSummary(700_000).totalEvents).toBe(2);
+    promote(db, now - 250, 'cg', 3);
+    expect(db.getReplicationSummary(700_000).totalEvents).toBe(2); // cached → 3rd not yet visible
   });
 
   it('memoizes getReplicationPerCg independently and keys it by window', () => {
@@ -101,19 +108,22 @@ describe('DashboardDB — replication rollup memo', () => {
     expect(db.getReplicationPerCg(2 * 3_600_000).length).toBe(2); // different window key → recomputed
   });
 
-  it('timeline cache bypass is driven by periodMs, not bucketMs', () => {
-    db = open(60_000); // 60s TTL
+  it('timeline caching also requires a comfortably-large bucketMs (conservative guard)', () => {
+    db = open(60_000); // 60s TTL → 10x = 600s
     const now = Date.now();
     promote(db, now - 1000, 'cg', 1);
-    // periodMs 1h (> TTL) but bucketMs 10s (<= TTL): with the periodMs-only rule
-    // this CACHES (bucketMs no longer forces a bypass).
-    const big = { periodMs: 3_600_000, bucketMs: 10_000 };
-    expect(timelineTotal(db.getReplicationTimeline(big))).toBe(1);
-    promote(db, now - 500, 'cg', 2);
-    expect(timelineTotal(db.getReplicationTimeline(big))).toBe(1); // cached (periodMs > TTL)
 
-    // A small periodMs (<= TTL) is bypassed → fresh.
-    expect(timelineTotal(db.getReplicationTimeline({ periodMs: 10_000, bucketMs: 1000 }))).toBe(2);
+    // periodMs 24h (>> 10x TTL) but bucketMs 10s (< 10x TTL) → bypass → fresh
+    const fineBuckets = { periodMs: 86_400_000, bucketMs: 10_000 };
+    expect(timelineTotal(db.getReplicationTimeline(fineBuckets))).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(timelineTotal(db.getReplicationTimeline(fineBuckets))).toBe(2); // small bucket → not cached
+
+    // periodMs 24h AND bucketMs 1h (both >> 10x TTL) → cache
+    const coarseBuckets = { periodMs: 86_400_000, bucketMs: 3_600_000 };
+    expect(timelineTotal(db.getReplicationTimeline(coarseBuckets))).toBe(2);
+    promote(db, now - 250, 'cg', 3);
+    expect(timelineTotal(db.getReplicationTimeline(coarseBuckets))).toBe(2); // cached
   });
 });
 

--- a/packages/node-ui/test/replication-cache.test.ts
+++ b/packages/node-ui/test/replication-cache.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DashboardDB } from '../src/db.js';
+
+// The memo TTL is read from the env at construction time, so each test sets it
+// before opening its own DashboardDB.
+const ENV_KEY = 'DKG_DASHBOARD_CACHE_TTL_MS';
+
+let dir: string;
+let db: DashboardDB | undefined;
+let prevEnv: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dkg-repl-cache-'));
+  prevEnv = process.env[ENV_KEY];
+});
+
+afterEach(() => {
+  db?.close();
+  db = undefined;
+  if (prevEnv === undefined) delete process.env[ENV_KEY];
+  else process.env[ENV_KEY] = prevEnv;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function open(ttlMs: number): DashboardDB {
+  process.env[ENV_KEY] = String(ttlMs);
+  return new DashboardDB({ dataDir: dir });
+}
+
+describe('DashboardDB — replication rollup memo', () => {
+  it('serves a cached summary within the TTL (does not re-scan on every poll)', () => {
+    db = open(60_000); // long TTL so the second call is a guaranteed cache hit
+    const now = Date.now();
+    db.insertReplicationEvent({ ts: now - 1000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
+
+    const first = db.getReplicationSummary(3_600_000);
+    expect(first.totalEvents).toBe(1);
+
+    // A new event arrives, but within the TTL the polled value stays cached.
+    db.insertReplicationEvent({ ts: now - 500, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
+    const second = db.getReplicationSummary(3_600_000);
+    expect(second.totalEvents).toBe(1); // cache hit — not yet 2
+  });
+
+  it('reflects fresh data immediately when caching is disabled (TTL <= 0)', () => {
+    db = open(0);
+    const now = Date.now();
+    db.insertReplicationEvent({ ts: now - 1000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
+    db.insertReplicationEvent({ ts: now - 500, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // no cache
+  });
+
+  it('keys the cache by arguments (a different window is not served a stale value)', () => {
+    db = open(60_000);
+    const now = Date.now();
+    // one event inside the 1h window, one only inside the 2h window
+    db.insertReplicationEvent({ ts: now - 30 * 60_000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
+    db.insertReplicationEvent({ ts: now - 90 * 60_000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
+
+    expect(db.getReplicationSummary(60 * 60_000).totalEvents).toBe(1); // 1h window
+    expect(db.getReplicationSummary(2 * 60 * 60_000).totalEvents).toBe(2); // 2h window — distinct key
+  });
+});

--- a/packages/node-ui/test/replication-cache.test.ts
+++ b/packages/node-ui/test/replication-cache.test.ts
@@ -125,6 +125,37 @@ describe('DashboardDB — replication rollup memo', () => {
     promote(db, now - 250, 'cg', 3);
     expect(timelineTotal(db.getReplicationTimeline(coarseBuckets))).toBe(2); // cached
   });
+
+  it('returns a defensive copy — mutating the result does not poison the cache', () => {
+    db = open(60_000);
+    const now = Date.now();
+    promote(db, now - 1000, 'cgA', 1);
+    promote(db, now - 900, 'cgB', 2);
+
+    const rows = db.getReplicationPerCg(3_600_000);
+    expect(rows.length).toBe(2);
+    rows.pop(); // mutate the returned array...
+    (rows as unknown[]).push({ tampered: true });
+    const rows2 = db.getReplicationPerCg(3_600_000); // cache hit within TTL
+    expect(rows2.length).toBe(2); // cached instance untouched
+    expect(rows2.some((r) => (r as { tampered?: boolean }).tampered === true)).toBe(false);
+
+    const summary = db.getReplicationSummary(3_600_000);
+    summary.totalEvents = 999; // mutate the returned object...
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // cached instance untouched
+  });
+
+  it('caches at exactly MEMO_WINDOW_SAFETY_FACTOR x TTL (boundary is inclusive)', () => {
+    db = open(1000); // TTL 1s → 10x boundary = 10_000ms
+    const now = Date.now();
+    promote(db, now - 500, 'cg', 1);
+    // window EXACTLY 10x TTL → cached (matches the ">= 10x cacheable" contract)
+    expect(db.getReplicationSummary(10_000).totalEvents).toBe(1);
+    promote(db, now - 250, 'cg', 2);
+    expect(db.getReplicationSummary(10_000).totalEvents).toBe(1); // cached, still 1
+    // window just under the boundary → bypass → fresh
+    expect(db.getReplicationSummary(9_999).totalEvents).toBe(2);
+  });
 });
 
 describe('DashboardDB — cache TTL resolution', () => {
@@ -156,5 +187,17 @@ describe('DashboardDB — cache TTL resolution', () => {
     expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
     promote(db, now - 500, 'cg', 2);
     expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // option won → no cache
+  });
+
+  it('honors a VALID env value — DKG_DASHBOARD_CACHE_TTL_MS=0 disables (proves env is read, not ignored)', () => {
+    // A resolver that ignored the env and always returned 2000 would pass the
+    // empty/malformed cases above; this proves a real env value takes effect.
+    process.env[ENV_KEY] = '0';
+    db = new DashboardDB({ dataDir: dir });
+    const now = Date.now();
+    promote(db, now - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // env '0' disabled the cache → fresh
   });
 });

--- a/packages/node-ui/test/replication-cache.test.ts
+++ b/packages/node-ui/test/replication-cache.test.ts
@@ -64,4 +64,15 @@ describe('DashboardDB — replication rollup memo', () => {
     expect(db.getReplicationSummary(60 * 60_000).totalEvents).toBe(1); // 1h window
     expect(db.getReplicationSummary(2 * 60 * 60_000).totalEvents).toBe(2); // 2h window — distinct key
   });
+
+  it('bypasses the cache when the requested window is <= the TTL (avoids stale-by-window)', () => {
+    // TTL 60s, window 10s (<= TTL): a cached value could surface events that
+    // have aged out of the 10s window, so caching must be skipped here.
+    db = open(60_000);
+    const now = Date.now();
+    db.insertReplicationEvent({ ts: now - 1000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
+    expect(db.getReplicationSummary(10_000).totalEvents).toBe(1);
+    db.insertReplicationEvent({ ts: now - 500, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
+    expect(db.getReplicationSummary(10_000).totalEvents).toBe(2); // not cached → fresh
+  });
 });

--- a/packages/node-ui/test/replication-cache.test.ts
+++ b/packages/node-ui/test/replication-cache.test.ts
@@ -1,11 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DashboardDB } from '../src/db.js';
+import { DashboardDB, type ReplicationTimelineBucket } from '../src/db.js';
 
-// The memo TTL is read from the env at construction time, so each test sets it
-// before opening its own DashboardDB.
 const ENV_KEY = 'DKG_DASHBOARD_CACHE_TTL_MS';
 
 let dir: string;
@@ -18,6 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   db?.close();
   db = undefined;
   if (prevEnv === undefined) delete process.env[ENV_KEY];
@@ -25,54 +24,127 @@ afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
+// TTL is injected via the constructor option (no global env mutation needed).
 function open(ttlMs: number): DashboardDB {
-  process.env[ENV_KEY] = String(ttlMs);
-  return new DashboardDB({ dataDir: dir });
+  return new DashboardDB({ dataDir: dir, cacheTtlMs: ttlMs });
 }
+
+function promote(d: DashboardDB, ts: number, cg: string, ord: number): void {
+  d.insertReplicationEvent({ ts, context_graph_id: cg, action: 'promote', ual: `urn:ka:${ord}`, ordinal: ord });
+}
+
+const timelineTotal = (buckets: ReplicationTimelineBucket[]): number =>
+  buckets.reduce((s, b) => s + (b.total ?? 0), 0);
 
 describe('DashboardDB — replication rollup memo', () => {
   it('serves a cached summary within the TTL (does not re-scan on every poll)', () => {
-    db = open(60_000); // long TTL so the second call is a guaranteed cache hit
+    db = open(60_000);
     const now = Date.now();
-    db.insertReplicationEvent({ ts: now - 1000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
+    promote(db, now - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
 
-    const first = db.getReplicationSummary(3_600_000);
-    expect(first.totalEvents).toBe(1);
+    promote(db, now - 500, 'cg', 2); // new event, but within TTL the poll stays cached
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
+  });
 
-    // A new event arrives, but within the TTL the polled value stays cached.
-    db.insertReplicationEvent({ ts: now - 500, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
-    const second = db.getReplicationSummary(3_600_000);
-    expect(second.totalEvents).toBe(1); // cache hit — not yet 2
+  it('expires the cache after the TTL — a permanent cache would FAIL this', () => {
+    // Deterministic via faked Date only (leaves real timers/native sqlite alone).
+    vi.useFakeTimers({ toFake: ['Date'] });
+    const t0 = 1_700_000_000_000;
+    vi.setSystemTime(t0);
+    db = open(1000); // 1s TTL, 1h window (> TTL) so caching is active
+    promote(db, t0 - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // computed + cached at t0
+
+    promote(db, t0 - 500, 'cg', 2);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // still within TTL → cached
+
+    vi.setSystemTime(t0 + 1500); // advance past the 1s TTL
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // expired → recomputed
   });
 
   it('reflects fresh data immediately when caching is disabled (TTL <= 0)', () => {
     db = open(0);
     const now = Date.now();
-    db.insertReplicationEvent({ ts: now - 1000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
+    promote(db, now - 1000, 'cg', 1);
     expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
-    db.insertReplicationEvent({ ts: now - 500, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
+    promote(db, now - 500, 'cg', 2);
     expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // no cache
   });
 
-  it('keys the cache by arguments (a different window is not served a stale value)', () => {
+  it('keys the cache by window (a different periodMs is not served a stale value)', () => {
     db = open(60_000);
     const now = Date.now();
-    // one event inside the 1h window, one only inside the 2h window
-    db.insertReplicationEvent({ ts: now - 30 * 60_000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
-    db.insertReplicationEvent({ ts: now - 90 * 60_000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
-
-    expect(db.getReplicationSummary(60 * 60_000).totalEvents).toBe(1); // 1h window
-    expect(db.getReplicationSummary(2 * 60 * 60_000).totalEvents).toBe(2); // 2h window — distinct key
+    promote(db, now - 30 * 60_000, 'cg', 1); // inside 1h
+    promote(db, now - 90 * 60_000, 'cg', 2); // only inside 2h
+    expect(db.getReplicationSummary(60 * 60_000).totalEvents).toBe(1);
+    expect(db.getReplicationSummary(2 * 60 * 60_000).totalEvents).toBe(2); // distinct key
   });
 
   it('bypasses the cache when the requested window is <= the TTL (avoids stale-by-window)', () => {
-    // TTL 60s, window 10s (<= TTL): a cached value could surface events that
-    // have aged out of the 10s window, so caching must be skipped here.
+    db = open(60_000); // TTL 60s, window 10s (<= TTL) → must not cache
+    const now = Date.now();
+    promote(db, now - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(10_000).totalEvents).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(db.getReplicationSummary(10_000).totalEvents).toBe(2); // not cached → fresh
+  });
+
+  it('memoizes getReplicationPerCg independently and keys it by window', () => {
     db = open(60_000);
     const now = Date.now();
-    db.insertReplicationEvent({ ts: now - 1000, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:1', ordinal: 1 });
-    expect(db.getReplicationSummary(10_000).totalEvents).toBe(1);
-    db.insertReplicationEvent({ ts: now - 500, context_graph_id: 'cg', action: 'promote', ual: 'urn:ka:2', ordinal: 2 });
-    expect(db.getReplicationSummary(10_000).totalEvents).toBe(2); // not cached → fresh
+    promote(db, now - 1000, 'cgA', 1);
+    expect(db.getReplicationPerCg(3_600_000).length).toBe(1);
+
+    promote(db, now - 500, 'cgB', 2); // a second CG appears
+    expect(db.getReplicationPerCg(3_600_000).length).toBe(1); // cached within TTL — cgB not yet visible
+    expect(db.getReplicationPerCg(2 * 3_600_000).length).toBe(2); // different window key → recomputed
+  });
+
+  it('timeline cache bypass is driven by periodMs, not bucketMs', () => {
+    db = open(60_000); // 60s TTL
+    const now = Date.now();
+    promote(db, now - 1000, 'cg', 1);
+    // periodMs 1h (> TTL) but bucketMs 10s (<= TTL): with the periodMs-only rule
+    // this CACHES (bucketMs no longer forces a bypass).
+    const big = { periodMs: 3_600_000, bucketMs: 10_000 };
+    expect(timelineTotal(db.getReplicationTimeline(big))).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(timelineTotal(db.getReplicationTimeline(big))).toBe(1); // cached (periodMs > TTL)
+
+    // A small periodMs (<= TTL) is bypassed → fresh.
+    expect(timelineTotal(db.getReplicationTimeline({ periodMs: 10_000, bucketMs: 1000 }))).toBe(2);
+  });
+});
+
+describe('DashboardDB — cache TTL resolution', () => {
+  it('empty DKG_DASHBOARD_CACHE_TTL_MS falls back to the default (does NOT disable) — the reported bug', () => {
+    process.env[ENV_KEY] = '';
+    db = new DashboardDB({ dataDir: dir }); // no option → resolves via env
+    const now = Date.now();
+    promote(db, now - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // still cached → default TTL active, not disabled
+  });
+
+  it('malformed DKG_DASHBOARD_CACHE_TTL_MS falls back to the default', () => {
+    process.env[ENV_KEY] = '64x';
+    db = new DashboardDB({ dataDir: dir });
+    const now = Date.now();
+    promote(db, now - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1); // cached at default → not disabled
+  });
+
+  it('the cacheTtlMs option overrides the env var', () => {
+    process.env[ENV_KEY] = '60000';
+    db = new DashboardDB({ dataDir: dir, cacheTtlMs: 0 }); // option disables, beating env
+    const now = Date.now();
+    promote(db, now - 1000, 'cg', 1);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(1);
+    promote(db, now - 500, 'cg', 2);
+    expect(db.getReplicationSummary(3_600_000).totalEvents).toBe(2); // option won → no cache
   });
 });


### PR DESCRIPTION
## Problem

The dashboard's replication views poll `/api/replication/summary`, `/api/replication/per-cg`, and `/api/replication/timeline`. Each call runs a synchronous `better-sqlite3` scan over the `replication_events` table (GROUP BY rollups + a correlated-subquery latency pairing) **on the daemon's event loop** ([`db.ts`](https://github.com/OriginTrail/dkg/blob/main/packages/node-ui/src/db.ts)). With multiple browser tabs open or a tight poller, the same scan repeats back-to-back on the single thread, adding avoidable event-loop time that compounds with other store work.

Flagged in a scalability review of `main` as part of the "synchronous SQLite reads on the event loop" theme.

## Fix

Wrap the three rollups (`getReplicationSummary` / `getReplicationPerCg` / `getReplicationTimeline`) in a short-TTL memo (default **2s**):

- Repeated identical polls within the TTL return the cached result instead of re-scanning — invisible staleness on window-based analytics (24h windows).
- Cache is **keyed by arguments** (`periodMs` / `bucketMs` / `contextGraphId`), so a different window is never served a stale value.
- Map is **bounded** (rare full clear above 256 entries; entries are short-lived anyway).
- Implementation keeps each public method as a thin wrapper over an unchanged private `_compute*` (verbatim body — no logic/indentation churn).

## Tunable

| Knob | Env | Default |
|---|---|---|
| Memo TTL in ms (`<= 0` disables → per-call scans, original behaviour) | `DKG_DASHBOARD_CACHE_TTL_MS` | 2000 |

## Testing

- New `packages/node-ui/test/replication-cache.test.ts` (3 cases: cache hit within TTL, disabled when `<=0` reflects fresh data, cache keyed by arguments) — green.
- Existing `db.test.ts` replication telemetry suite (10 tests) still passes through the memo.
- `tsc` build of `packages/node-ui` passes.

## Risk

Low. Default 2s staleness on a polled analytics panel is imperceptible; fully disable-able via env. No query logic changed — bodies moved verbatim into private methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)