### PR TITLE
Release v10.0.0-rc.18 — Base Sepolia contract redeploy + version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -145,12 +145,12 @@
             "deployed": false
         },
         "RandomSamplingStorage": {
-            "evmAddress": "0x2DB6D9Fd656880f9E435fBA4270575cd1f7c90d1",
-            "version": "10.0.2",
-            "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265750,
-            "deploymentTimestamp": 1780299788277,
+            "evmAddress": "0x49368C5Af425970494d55600EE2A84756c938156",
+            "version": "10.1.0",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983331,
+            "deploymentTimestamp": 1781734952106,
             "deployed": true
         },
         "Staking": {
@@ -190,12 +190,12 @@
             "deployed": false
         },
         "RandomSampling": {
-            "evmAddress": "0x88daA6C2985AF0a5F879AD805F6F92f5079FaC6B",
-            "version": "10.0.4",
-            "gitBranch": "main",
-            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
-            "deploymentBlock": 42661867,
-            "deploymentTimestamp": 1781092026015,
+            "evmAddress": "0xDe7a7A160B7ACa9406c881fB76a35C3A3f58C96f",
+            "version": "10.2.0",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983333,
+            "deploymentTimestamp": 1781734956962,
             "deployed": true
         },
         "KnowledgeAssetsStorage": {
@@ -280,12 +280,12 @@
             "deployed": false
         },
         "DKGPublishingConvictionNFT": {
-            "evmAddress": "0xc3d4A1BD76eB10C99549e4A155A05A93A360678d",
-            "version": "10.0.2",
-            "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265770,
-            "deploymentTimestamp": 1780299831101,
+            "evmAddress": "0x02b0C9840Ff92127B2B2788E1C18AabE0702638A",
+            "version": "10.0.3",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983340,
+            "deploymentTimestamp": 1781734971089,
             "deployed": true
         },
         "StakingV10": {
@@ -307,39 +307,39 @@
             "deployed": true
         },
         "PublishingConvictionStorage": {
-            "evmAddress": "0x1345AEaf6f4DF612D0902efa9366F8AB8b4c7781",
-            "version": "10.0.2",
-            "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265765,
-            "deploymentTimestamp": 1780299821480,
+            "evmAddress": "0xfd95E0eF68606264d0CAd9D6e4D1213B914Dd46d",
+            "version": "10.0.3",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983335,
+            "deploymentTimestamp": 1781734961683,
             "deployed": true
         },
         "PublishingConviction": {
-            "evmAddress": "0x8916820Ba089ca2604978acfE9a5E8f56baf5709",
-            "version": "10.0.2",
-            "gitBranch": "main",
-            "gitCommitHash": "bcfa930d57b90106f9cc95a7f8fe1cd330cd9feb",
-            "deploymentBlock": 42265768,
-            "deploymentTimestamp": 1780299826375,
+            "evmAddress": "0x9Ce0F3F8EA504c4ad7f040DF9c593389daBB0CE0",
+            "version": "10.0.4",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983338,
+            "deploymentTimestamp": 1781734966376,
             "deployed": true
         },
         "DKGKnowledgeAssets": {
-            "evmAddress": "0xe0890228c6D0FA9fd2bB8F563fD9C2DA08F4F43E",
-            "version": "10.0.4",
-            "gitBranch": "main",
-            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
-            "deploymentBlock": 42661860,
-            "deploymentTimestamp": 1781092011081,
+            "evmAddress": "0x061658356662ac675421d936C67bCE96Dd0fa34C",
+            "version": "10.1.0",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983328,
+            "deploymentTimestamp": 1781734947328,
             "deployed": true
         },
         "KnowledgeAssetsLifecycle": {
-            "evmAddress": "0xaC5cCEF95Fd6fCC1A2302bC4c5b770C7bCaB1577",
-            "version": "10.0.5",
-            "gitBranch": "main",
-            "gitCommitHash": "f2ac8caeca411c244020dddf24d36eef436165b9",
-            "deploymentBlock": 42661870,
-            "deploymentTimestamp": 1781092030935,
+            "evmAddress": "0xC3D61e31dC5e13717Cf34Fe16DA885D5d3727a49",
+            "version": "10.1.1",
+            "gitBranch": "release/rc18",
+            "gitCommitHash": "7c83648e539791af3677f16f98105160293ad981",
+            "deploymentBlock": 42983342,
+            "deploymentTimestamp": 1781734975843,
             "deployed": true
         },
         "V8MigrationEligibility": {

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.17",
+  "version": "10.0.0-rc.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## rc18 release — Base Sepolia contract redeploy + version bump

Release-prep PR for **v10.0.0-rc.18** (testnet). Cuts from current `main` (includes #1107). Two commits: contract addresses + version bump.

### Contracts — redeployed to Base Sepolia (`base_sepolia_v10`, chainId 84532)
The 7 V10 contracts changed since rc.17 were redeployed. **Hub unchanged** (`0xC056e67D…09F6`); **22 contracts re-initialized** via `Hub.setAndReinitializeContracts` (7 new + 15 dependents). ACL is `onlyContracts` (Hub-membership), so Hub registration authorizes the new contracts everywhere.

| Contract | Version | Address |
|---|---|---|
| RandomSampling | 10.2.0 | 0xDe7a7A160B7ACa9406c881fB76a35C3A3f58C96f |
| RandomSamplingStorage | 10.1.0 | 0x49368C5Af425970494d55600EE2A84756c938156 |
| KnowledgeAssetsLifecycle | 10.1.1 | 0xC3D61e31dC5e13717Cf34Fe16DA885D5d3727a49 |
| DKGKnowledgeAssets | 10.1.0 | 0x061658356662ac675421d936C67bCE96Dd0fa34C |
| PublishingConviction | 10.0.4 | 0x9Ce0F3F8EA504c4ad7f040DF9c593389daBB0CE0 |
| PublishingConvictionStorage | 10.0.3 | 0xfd95E0eF68606264d0CAd9D6e4D1213B914Dd46d |
| DKGPublishingConvictionNFT | 10.0.3 | 0x02b0C9840Ff92127B2B2788E1C18AabE0702638A |

### Version
`10.0.0-rc.17 → 10.0.0-rc.18` across 19 package.json (16 public validated == rc.18 for the npm-publish gate).

### What rc18 contains (already merged to main)
- RFC-49 "hosting follows access" — full ciphertext→catalog cutover (#1201, #1203, #1208)
- OT-RFC-51 publishing allocation (#1195)
- Proof-of-storage content-binding / Bounty #3 (#1213)
- rc.17 fresh-main QA fixes (#1107)
- daemon HTTP admission control (#1209), node-ui replication memo (#1210)

### After merge
Tag `v10.0.0-rc.18` → `npm-publish` (reviewer-gated) → manual GitHub release → update testnet nodes + validate (publish + RS proof + catalog-sampling).

⚠️ Testnet cutover: the 7 addresses changed — nodes/partners must move to rc18 and re-publish; stale RS challenges drop on re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)