### PR TITLE
Tune sync responder backpressure defaults

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -400,13 +400,21 @@ import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
-const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, Promise<SyncPageResult>>>();
+type InFlightSyncPageFetch = {
+  promise: Promise<SyncPageResult>;
+  controller: AbortController;
+  waiters: number;
+};
+
+const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, InFlightSyncPageFetch>>();
 
 function syncPageFetchCoalescingKey(params: {
   remotePeerId: string;
   contextGraphId: string;
   includeSharedMemory: boolean;
   phase: SyncPhase;
+  graphUri: string;
+  deadline: number;
   snapshotRef?: string;
   sinceBatchId?: string;
   recovery?: boolean;
@@ -416,13 +424,15 @@ function syncPageFetchCoalescingKey(params: {
     params.contextGraphId,
     params.includeSharedMemory,
     params.phase,
+    params.graphUri,
+    params.deadline,
     params.snapshotRef ?? null,
     params.sinceBatchId ?? null,
     params.recovery === true,
   ]);
 }
 
-function inFlightSyncPageFetchesFor(agent: DKGAgent): Map<string, Promise<SyncPageResult>> {
+function inFlightSyncPageFetchesFor(agent: DKGAgent): Map<string, InFlightSyncPageFetch> {
   let inFlight = inFlightSyncPageFetchesByAgent.get(agent);
   if (!inFlight) {
     inFlight = new Map();
@@ -445,17 +455,39 @@ function asSyncFetchAbortError(reason: unknown): Error {
 }
 
 function waitForSyncPageFetch(
-  promise: Promise<SyncPageResult>,
+  entry: InFlightSyncPageFetch,
   signal: AbortSignal | undefined,
 ): Promise<SyncPageResult> {
-  if (!signal) return promise;
-  if (signal.aborted) return Promise.reject(asSyncFetchAbortError(signal.reason));
+  if (signal?.aborted) return Promise.reject(asSyncFetchAbortError(signal.reason));
+  entry.waiters += 1;
+
   return new Promise<SyncPageResult>((resolve, reject) => {
-    const onAbort = () => reject(asSyncFetchAbortError(signal.reason));
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(resolve, reject).finally(() => {
-      signal.removeEventListener('abort', onAbort);
-    });
+    let settled = false;
+    const release = (options?: { abortSharedIfLast?: boolean; reason?: unknown }) => {
+      if (settled) return;
+      settled = true;
+      if (signal) signal.removeEventListener('abort', onAbort);
+      entry.waiters -= 1;
+      if (entry.waiters === 0 && options?.abortSharedIfLast === true && !entry.controller.signal.aborted) {
+        entry.controller.abort(options.reason);
+      }
+    };
+    const onAbort = () => {
+      release({ abortSharedIfLast: true, reason: signal?.reason });
+      reject(asSyncFetchAbortError(signal?.reason));
+    };
+
+    if (signal) signal.addEventListener('abort', onAbort, { once: true });
+    entry.promise.then(
+      (value) => {
+        release();
+        resolve(value);
+      },
+      (error) => {
+        release();
+        reject(error);
+      },
+    );
   });
 }
 
@@ -2904,6 +2936,8 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       contextGraphId,
       includeSharedMemory,
       phase,
+      graphUri,
+      deadline,
       snapshotRef,
       sinceBatchId,
       recovery,
@@ -2911,12 +2945,28 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const inFlight = inFlightSyncPageFetchesFor(this);
     const existing = inFlight.get(coalescingKey);
     if (existing) {
-      return waitForSyncPageFetch(existing, signal);
+      if (!existing.controller.signal.aborted) {
+        return waitForSyncPageFetch(existing, signal);
+      }
+      inFlight.delete(coalescingKey);
     }
     if (signal?.aborted) {
       return Promise.reject(asSyncFetchAbortError(signal.reason));
     }
 
+    const controller = new AbortController();
+    const abortSharedFetch = (reason: unknown) => {
+      if (!controller.signal.aborted) controller.abort(reason);
+    };
+    const nodeStopSignal = this.node.stopSignal;
+    const onNodeStop = () => abortSharedFetch(nodeStopSignal?.reason);
+    if (nodeStopSignal?.aborted) {
+      abortSharedFetch(nodeStopSignal.reason);
+    } else if (nodeStopSignal) {
+      nodeStopSignal.addEventListener('abort', onNodeStop, { once: true });
+    }
+
+    let entry!: InFlightSyncPageFetch;
     const sharedFetch = fetchSyncPages({
       ctx,
       remotePeerId,
@@ -2934,9 +2984,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       syncPageSize: SYNC_PAGE_SIZE,
       syncDeniedResponse: SYNC_DENIED_RESPONSE,
       // Caller AbortSignals are waiter-scoped below: one duplicate trigger
-      // timing out must not abort the shared fetch for the other waiters. Node
-      // shutdown still aborts the underlying transport through stopSignal.
-      signal: this.node.stopSignal,
+      // timing out must not abort the shared fetch for the other waiters. The
+      // shared fetch itself is cancelled on node shutdown or when every waiter
+      // has detached.
+      signal: controller.signal,
       // Legacy sentinel that older (pre-v10-rc) responders still emit on ACL
       // denial. Recognising it in the requester is what keeps mixed-version
       // catch-up correct: without the second sentinel, a curated-CG denial
@@ -2974,17 +3025,19 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),
     }).finally(() => {
-      if (inFlight.get(coalescingKey) === sharedFetch) {
+      nodeStopSignal?.removeEventListener('abort', onNodeStop);
+      if (inFlight.get(coalescingKey) === entry) {
         inFlight.delete(coalescingKey);
       }
     });
     sharedFetch.catch(() => {
-      // The underlying fetch can outlive all waiter-scoped aborts. Keep late
-      // failures from becoming unhandled while still propagating them to active
-      // waiters through the original promise.
+      // The shared fetch can reject after every waiter has already detached.
+      // Keep that from becoming unhandled while still propagating failures to
+      // active waiters through the original promise.
     });
-    inFlight.set(coalescingKey, sharedFetch);
-    return waitForSyncPageFetch(sharedFetch, signal);
+    entry = { promise: sharedFetch, controller, waiters: 0 };
+    inFlight.set(coalescingKey, entry);
+    return waitForSyncPageFetch(entry, signal);
   }
 
   /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -400,6 +400,64 @@ import { DKGAgentBase } from './dkg-agent-base.js';
 import type { DKGAgent } from './dkg-agent.js';
 
 const DEFAULT_HOST_MODE_RECONCILE_JITTER_RATIO = 0.15;
+const inFlightSyncPageFetchesByAgent = new WeakMap<DKGAgent, Map<string, Promise<SyncPageResult>>>();
+
+function syncPageFetchCoalescingKey(params: {
+  remotePeerId: string;
+  contextGraphId: string;
+  includeSharedMemory: boolean;
+  phase: SyncPhase;
+  snapshotRef?: string;
+  sinceBatchId?: string;
+  recovery?: boolean;
+}): string {
+  return JSON.stringify([
+    params.remotePeerId,
+    params.contextGraphId,
+    params.includeSharedMemory,
+    params.phase,
+    params.snapshotRef ?? null,
+    params.sinceBatchId ?? null,
+    params.recovery === true,
+  ]);
+}
+
+function inFlightSyncPageFetchesFor(agent: DKGAgent): Map<string, Promise<SyncPageResult>> {
+  let inFlight = inFlightSyncPageFetchesByAgent.get(agent);
+  if (!inFlight) {
+    inFlight = new Map();
+    inFlightSyncPageFetchesByAgent.set(agent, inFlight);
+  }
+  return inFlight;
+}
+
+function asSyncFetchAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    if (reason.name === 'AbortError') return reason;
+    const err = new Error(reason.message || 'aborted');
+    err.name = 'AbortError';
+    (err as Error & { cause?: unknown }).cause = reason;
+    return err;
+  }
+  const err = new Error(typeof reason === 'string' ? reason : 'aborted');
+  err.name = 'AbortError';
+  return err;
+}
+
+function waitForSyncPageFetch(
+  promise: Promise<SyncPageResult>,
+  signal: AbortSignal | undefined,
+): Promise<SyncPageResult> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(asSyncFetchAbortError(signal.reason));
+  return new Promise<SyncPageResult>((resolve, reject) => {
+    const onAbort = () => reject(asSyncFetchAbortError(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
 
 function jitteredIntervalMs(intervalMs: number, ratio: number | undefined): number {
   const normalizedRatio =
@@ -2841,7 +2899,25 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // and the request envelope auth mode (R9). Only the recovery driver sets it.
     recovery?: boolean,
   ): Promise<SyncPageResult> {
-    return fetchSyncPages({
+    const coalescingKey = syncPageFetchCoalescingKey({
+      remotePeerId,
+      contextGraphId,
+      includeSharedMemory,
+      phase,
+      snapshotRef,
+      sinceBatchId,
+      recovery,
+    });
+    const inFlight = inFlightSyncPageFetchesFor(this);
+    const existing = inFlight.get(coalescingKey);
+    if (existing) {
+      return waitForSyncPageFetch(existing, signal);
+    }
+    if (signal?.aborted) {
+      return Promise.reject(asSyncFetchAbortError(signal.reason));
+    }
+
+    const sharedFetch = fetchSyncPages({
       ctx,
       remotePeerId,
       contextGraphId,
@@ -2857,7 +2933,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       syncPageRetryAttempts: SYNC_PAGE_RETRY_ATTEMPTS,
       syncPageSize: SYNC_PAGE_SIZE,
       syncDeniedResponse: SYNC_DENIED_RESPONSE,
-      signal,
+      // Caller AbortSignals are waiter-scoped below: one duplicate trigger
+      // timing out must not abort the shared fetch for the other waiters. Node
+      // shutdown still aborts the underlying transport through stopSignal.
+      signal: this.node.stopSignal,
       // Legacy sentinel that older (pre-v10-rc) responders still emit on ACL
       // denial. Recognising it in the requester is what keeps mixed-version
       // catch-up correct: without the second sentinel, a curated-CG denial
@@ -2894,7 +2973,18 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       logWarn: (opCtx, message) => this.log.warn(opCtx, message),
       logInfo: (opCtx, message) => this.log.info(opCtx, message),
       logDebug: (opCtx, message) => this.log.debug(opCtx, message),
+    }).finally(() => {
+      if (inFlight.get(coalescingKey) === sharedFetch) {
+        inFlight.delete(coalescingKey);
+      }
     });
+    sharedFetch.catch(() => {
+      // The underlying fetch can outlive all waiter-scoped aborts. Keep late
+      // failures from becoming unhandled while still propagating them to active
+      // waiters through the original promise.
+    });
+    inFlight.set(coalescingKey, sharedFetch);
+    return waitForSyncPageFetch(sharedFetch, signal);
   }
 
   /**

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -41,6 +41,32 @@ export interface SyncRowListMemo {
   ): Promise<readonly SyncRow[] | null>;
 }
 
+export class SyncRowSnapshotLimitError extends Error {
+  readonly key: string;
+  readonly maxEntries: number;
+  readonly cachedEntries: number;
+  readonly inflightEntries: number;
+  readonly activeEntries: number;
+
+  constructor(params: {
+    key: string;
+    maxEntries: number;
+    cachedEntries: number;
+    inflightEntries: number;
+  }) {
+    const activeEntries = params.cachedEntries + params.inflightEntries;
+    super(
+      `Too many active sync responder session snapshots (key=${params.key}, active=${activeEntries}, max=${params.maxEntries})`,
+    );
+    this.name = 'SyncRowSnapshotLimitError';
+    this.key = params.key;
+    this.maxEntries = params.maxEntries;
+    this.cachedEntries = params.cachedEntries;
+    this.inflightEntries = params.inflightEntries;
+    this.activeEntries = activeEntries;
+  }
+}
+
 interface RowListCache {
   memo: SyncRowListMemo;
   key: string;
@@ -135,7 +161,12 @@ export function createResponderSyncRowListMemo(
     if (value.length === 0) return;
     const replacingExisting = cached.has(key);
     if (!replacingExisting && cached.size >= maxEntries) {
-      throw new Error('Too many active durable data sync session snapshots');
+      throw new SyncRowSnapshotLimitError({
+        key,
+        maxEntries,
+        cachedEntries: cached.size,
+        inflightEntries: inflight.size,
+      });
     }
     deleteCached(key);
     cached.set(key, {
@@ -173,7 +204,12 @@ export function createResponderSyncRowListMemo(
       }
       if (options?.requireExisting) return null;
       if (!cached.has(key) && cached.size + inflight.size >= maxEntries) {
-        throw new Error('Too many active durable data sync session snapshots');
+        throw new SyncRowSnapshotLimitError({
+          key,
+          maxEntries,
+          cachedEntries: cached.size,
+          inflightEntries: inflight.size,
+        });
       }
 
       const load = loadRows()

--- a/packages/agent/src/sync/responder/sync-handler.ts
+++ b/packages/agent/src/sync/responder/sync-handler.ts
@@ -21,6 +21,7 @@ import {
   readSwmDataPage,
   readSwmMetaPage,
   serializeResponderRows,
+  SyncRowSnapshotLimitError,
 } from './graph-plan.js';
 
 const MAX_SYNC_SESSION_TOKENS = 256;
@@ -68,9 +69,12 @@ interface RegisterSyncHandlerParams {
 
 const SYNC_RESPONDER_GLOBAL_CONCURRENCY = 3;
 const SYNC_RESPONDER_PER_PEER_CONCURRENCY = 1;
-const SYNC_RESPONDER_QUEUE_LIMIT = 32;
+const SYNC_RESPONDER_QUEUE_LIMIT = 64;
 const SYNC_RESPONDER_PER_PEER_QUEUE_LIMIT = 4;
 const SYNC_RESPONDER_MAX_QUEUE_WAIT_MS = 10_000;
+export const SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT = 128;
+export const SYNC_RESPONDER_DURABLE_META_SNAPSHOT_LIMIT = 64;
+export const SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT = 64;
 
 class SyncResponderBusyError extends Error {
   constructor(message: string) {
@@ -231,9 +235,18 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
     logDebug,
   } = params;
   const graphListMemo = createResponderGraphListMemo(store);
-  const durableDataRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
-  const durableMetaRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
-  const swmRowsMemo = createResponderSyncRowListMemo(DURABLE_DATA_SYNC_SESSION_TTL_MS);
+  const durableDataRowsMemo = createResponderSyncRowListMemo(
+    DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT,
+  );
+  const durableMetaRowsMemo = createResponderSyncRowListMemo(
+    DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    SYNC_RESPONDER_DURABLE_META_SNAPSHOT_LIMIT,
+  );
+  const swmRowsMemo = createResponderSyncRowListMemo(
+    DURABLE_DATA_SYNC_SESSION_TTL_MS,
+    SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT,
+  );
   const syncSessionTokens = new Map<string, SyncSessionTokenEntry>();
   const subGraphRegistrationMemo = createResponderSubGraphRegistrationMemo(store);
   const swmAdmissionMemo = createResponderSwmAdmissionMemo(store);
@@ -486,6 +499,15 @@ export function registerSyncHandler(params: RegisterSyncHandlerParams): void {
       if (err instanceof SyncResponderBusyError) {
         logDebug(createOperationContext('sync'), `Sync responder busy for "${contextGraphId}" from peer ${peerId} (phase=${phase}): ${err.message}`);
         throw new QuietRetryableHandlerError(err.message);
+      }
+      if (err instanceof SyncRowSnapshotLimitError) {
+        logWarn(
+          createOperationContext('sync'),
+          `Sync responder snapshot limit for "${contextGraphId}" from peer ${peerId} (phase=${phase}, workspace=${isWorkspace}): active=${err.activeEntries}/${err.maxEntries} cached=${err.cachedEntries} inflight=${err.inflightEntries} key=${err.key}`,
+        );
+        throw new QuietRetryableHandlerError(
+          `sync responder snapshot limit exceeded (active=${err.activeEntries}/${err.maxEntries})`,
+        );
       }
       throw err;
     });

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { createOperationContext } from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+import type { SyncPhase } from '../src/sync/auth/request-build.js';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+
+const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const PEER_B = '12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw';
+
+type FetchArgs = {
+  remotePeerId?: string;
+  contextGraphId?: string;
+  includeSharedMemory?: boolean;
+  phase?: SyncPhase;
+  graphUri?: string;
+  deadline?: number;
+  snapshotRef?: string;
+  sinceBatchId?: string;
+  signal?: AbortSignal;
+  recovery?: boolean;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function createAgentWithSend(
+  sendToPeer: (...args: unknown[]) => Promise<Uint8Array>,
+): Promise<DKGAgent> {
+  const agent = await DKGAgent.create({
+    name: 'SyncFetchCoalescing',
+    listenHost: '127.0.0.1',
+    chainAdapter: new MockChainAdapter(),
+  });
+  (agent as any).messenger = { sendToPeer };
+  (agent as any).buildSyncRequest = async () => new Uint8Array([1, 2, 3]);
+  return agent;
+}
+
+function fetchPages(agent: DKGAgent, args: FetchArgs = {}): Promise<SyncPageResult> {
+  return (agent as any).fetchSyncPages(
+    createOperationContext('sync'),
+    args.remotePeerId ?? PEER_A,
+    args.contextGraphId ?? 'coalesced-cg',
+    args.includeSharedMemory ?? false,
+    args.phase ?? 'data',
+    args.graphUri ?? 'did:dkg:context-graph:coalesced-cg',
+    args.deadline ?? Date.now() + 60_000,
+    args.snapshotRef,
+    args.sinceBatchId,
+    args.signal,
+    args.recovery,
+  );
+}
+
+describe('DKGAgent sync fetch coalescing', () => {
+  it('joins concurrent identical fetches onto one sync page sequence', async () => {
+    const response = deferred<Uint8Array>();
+    let sends = 0;
+    const agent = await createAgentWithSend(async () => {
+      sends++;
+      return response.promise;
+    });
+
+    try {
+      const first = fetchPages(agent);
+      await flushMicrotasks();
+      const second = fetchPages(agent);
+      await flushMicrotasks();
+
+      expect(sends).toBe(1);
+      response.resolve(new Uint8Array(0));
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+      expect(firstResult).toBe(secondResult);
+      expect(firstResult.quads).toEqual([]);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('does not coalesce different sync identity keys', async () => {
+    const cases: Array<{ name: string; base: FetchArgs; variant: FetchArgs }> = [
+      { name: 'remotePeerId', base: {}, variant: { remotePeerId: PEER_B } },
+      { name: 'contextGraphId', base: {}, variant: { contextGraphId: 'other-cg', graphUri: 'did:dkg:context-graph:other-cg' } },
+      { name: 'includeSharedMemory', base: {}, variant: { includeSharedMemory: true, graphUri: 'did:dkg:context-graph:coalesced-cg/_shared_memory' } },
+      { name: 'phase', base: {}, variant: { phase: 'meta', graphUri: 'did:dkg:context-graph:coalesced-cg/_meta' } },
+      {
+        name: 'snapshotRef',
+        base: { includeSharedMemory: true, phase: 'snapshot', graphUri: '', snapshotRef: 'snapshot-a' },
+        variant: { includeSharedMemory: true, phase: 'snapshot', graphUri: '', snapshotRef: 'snapshot-b' },
+      },
+      { name: 'sinceBatchId', base: { sinceBatchId: '10' }, variant: { sinceBatchId: '11' } },
+      { name: 'recovery', base: { includeSharedMemory: true, recovery: false }, variant: { includeSharedMemory: true, recovery: true } },
+    ];
+
+    for (const testCase of cases) {
+      const response = deferred<Uint8Array>();
+      let sends = 0;
+      const agent = await createAgentWithSend(async () => {
+        sends++;
+        return response.promise;
+      });
+
+      try {
+        const first = fetchPages(agent, testCase.base);
+        await flushMicrotasks();
+        const second = fetchPages(agent, testCase.variant);
+        await flushMicrotasks();
+
+        expect(sends, testCase.name).toBe(2);
+        response.resolve(new Uint8Array(0));
+        await Promise.all([first, second]);
+      } finally {
+        await agent.stop().catch(() => {});
+      }
+    }
+  });
+
+  it('clears the in-flight entry after success and after failure', async () => {
+    let sends = 0;
+    let failParser = true;
+    const agent = await createAgentWithSend(async () => {
+      sends++;
+      return new TextEncoder().encode('<not-valid-nquads>');
+    });
+    (agent as any).getOrCreateSyncVerifyWorker = () => ({
+      parseAndFilter: async () => {
+        if (failParser) throw new Error('parse failed');
+        return { quads: [], totalQuads: 0 };
+      },
+    });
+
+    try {
+      await expect(fetchPages(agent)).rejects.toThrow('parse failed');
+      expect(sends).toBe(1);
+
+      failParser = false;
+      await expect(fetchPages(agent)).resolves.toMatchObject({ quads: [] });
+      expect(sends).toBe(2);
+
+      await expect(fetchPages(agent)).resolves.toMatchObject({ quads: [] });
+      expect(sends).toBe(3);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('lets one waiter abort without aborting the shared fetch for another waiter', async () => {
+    const response = deferred<Uint8Array>();
+    let sends = 0;
+    const agent = await createAgentWithSend(async () => {
+      sends++;
+      return response.promise;
+    });
+    const abort = new AbortController();
+
+    try {
+      const first = fetchPages(agent);
+      await flushMicrotasks();
+      const second = fetchPages(agent, { signal: abort.signal });
+      await flushMicrotasks();
+      expect(sends).toBe(1);
+
+      abort.abort(new Error('waiter aborted'));
+      await expect(second).rejects.toMatchObject({ name: 'AbortError', message: 'waiter aborted' });
+
+      response.resolve(new Uint8Array(0));
+      await expect(first).resolves.toMatchObject({ quads: [] });
+      expect(sends).toBe(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+});

--- a/packages/agent/test/sync-fetch-coalescing.test.ts
+++ b/packages/agent/test/sync-fetch-coalescing.test.ts
@@ -7,6 +7,7 @@ import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
 
 const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
 const PEER_B = '12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw';
+const DEFAULT_DEADLINE = Date.UTC(2100, 0, 1);
 
 type FetchArgs = {
   remotePeerId?: string;
@@ -58,7 +59,7 @@ function fetchPages(agent: DKGAgent, args: FetchArgs = {}): Promise<SyncPageResu
     args.includeSharedMemory ?? false,
     args.phase ?? 'data',
     args.graphUri ?? 'did:dkg:context-graph:coalesced-cg',
-    args.deadline ?? Date.now() + 60_000,
+    args.deadline ?? DEFAULT_DEADLINE,
     args.snapshotRef,
     args.sinceBatchId,
     args.signal,
@@ -97,6 +98,8 @@ describe('DKGAgent sync fetch coalescing', () => {
       { name: 'contextGraphId', base: {}, variant: { contextGraphId: 'other-cg', graphUri: 'did:dkg:context-graph:other-cg' } },
       { name: 'includeSharedMemory', base: {}, variant: { includeSharedMemory: true, graphUri: 'did:dkg:context-graph:coalesced-cg/_shared_memory' } },
       { name: 'phase', base: {}, variant: { phase: 'meta', graphUri: 'did:dkg:context-graph:coalesced-cg/_meta' } },
+      { name: 'graphUri', base: {}, variant: { graphUri: 'did:dkg:context-graph:coalesced-cg/_alternate' } },
+      { name: 'deadline', base: {}, variant: { deadline: DEFAULT_DEADLINE + 1 } },
       {
         name: 'snapshotRef',
         base: { includeSharedMemory: true, phase: 'snapshot', graphUri: '', snapshotRef: 'snapshot-a' },
@@ -180,6 +183,45 @@ describe('DKGAgent sync fetch coalescing', () => {
       response.resolve(new Uint8Array(0));
       await expect(first).resolves.toMatchObject({ quads: [] });
       expect(sends).toBe(1);
+    } finally {
+      await agent.stop().catch(() => {});
+    }
+  });
+
+  it('aborts the shared fetch when the last waiter aborts', async () => {
+    let sends = 0;
+    let sendSignal: AbortSignal | undefined;
+    const abortObserved = deferred<void>();
+    const agent = await createAgentWithSend(async (...args: unknown[]) => {
+      sends++;
+      const options = args[3] as { signal?: AbortSignal };
+      sendSignal = options.signal;
+      return new Promise<Uint8Array>((_resolve, reject) => {
+        const rejectAbort = () => {
+          abortObserved.resolve();
+          const err = new Error('shared fetch aborted');
+          err.name = 'AbortError';
+          reject(err);
+        };
+        if (options.signal?.aborted) {
+          rejectAbort();
+          return;
+        }
+        options.signal?.addEventListener('abort', rejectAbort, { once: true });
+      });
+    });
+    const abort = new AbortController();
+
+    try {
+      const waiter = fetchPages(agent, { signal: abort.signal });
+      await flushMicrotasks();
+      expect(sends).toBe(1);
+      expect(sendSignal?.aborted).toBe(false);
+
+      abort.abort(new Error('only waiter aborted'));
+      await expect(waiter).rejects.toMatchObject({ name: 'AbortError', message: 'only waiter aborted' });
+      await abortObserved.promise;
+      expect(sendSignal?.aborted).toBe(true);
     } finally {
       await agent.stop().catch(() => {});
     }

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -3,7 +3,13 @@ import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
 import {
   createResponderGraphListMemo,
   createResponderSyncRowListMemo,
+  SyncRowSnapshotLimitError,
 } from '../src/sync/responder/graph-plan.js';
+import {
+  SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT,
+  SYNC_RESPONDER_DURABLE_META_SNAPSHOT_LIMIT,
+  SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT,
+} from '../src/sync/responder/sync-handler.js';
 import {
   DKG_NS,
   lineGraphsFromNquads,
@@ -34,6 +40,12 @@ function deferred<T>() {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+it('keeps responder snapshot defaults above the generic memo fallback', () => {
+  expect(SYNC_RESPONDER_DURABLE_DATA_SNAPSHOT_LIMIT).toBe(128);
+  expect(SYNC_RESPONDER_DURABLE_META_SNAPSHOT_LIMIT).toBe(64);
+  expect(SYNC_RESPONDER_SHARED_MEMORY_SNAPSHOT_LIMIT).toBe(64);
 });
 
 function watchBoundedPageQuery(
@@ -810,8 +822,15 @@ describe('sync responder pagination interleaving', () => {
     await expect(memo.get('durable:session-1', loadRows)).resolves.toHaveLength(1);
     await expect(memo.get('durable:session-2', loadRows)).resolves.toHaveLength(1);
     await expect(memo.get('durable:session-3', loadRows)).rejects.toThrow(
-      'Too many active durable data sync session snapshots',
+      SyncRowSnapshotLimitError,
     );
+    await expect(memo.get('durable:session-3', loadRows)).rejects.toMatchObject({
+      key: 'durable:session-3',
+      maxEntries: 2,
+      cachedEntries: 2,
+      inflightEntries: 0,
+      activeEntries: 2,
+    });
 
     await expect(
       memo.get('durable:session-1', loadRows, { requireExisting: true }),

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       'test/sync-verify-collapsed.test.ts',
       'test/durable-sync-since-threading.test.ts',
       'test/sync-responder-concurrent-interleaving.test.ts',
+      'test/sync-fetch-coalescing.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'test/profile-fix-verify.test.ts',
       'test/sync-verify-collapsed.test.ts',
       'test/durable-sync-since-threading.test.ts',
+      'test/sync-responder-concurrent-interleaving.test.ts',
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -34,8 +34,7 @@ export function isRecoverableSendError(err: unknown): boolean {
     msg.includes('no valid addresses') ||
     (msg.includes('sync responder') &&
       (msg.includes('queue full') ||
-        msg.includes('queue wait exceeded') ||
-        msg.includes('snapshot limit exceeded'))) ||
+        msg.includes('queue wait exceeded'))) ||
     // libp2p dial exhaustion — every known multiaddr for the peer
     // failed in one attempt. Surfaced by `transportManager.dial` and
     // by `dialProtocol` after iterating every relay/transport

--- a/packages/core/src/protocol-router.ts
+++ b/packages/core/src/protocol-router.ts
@@ -32,7 +32,10 @@ export function isRecoverableSendError(err: unknown): boolean {
     msg.includes('epipe') ||
     msg.includes('aborted') ||
     msg.includes('no valid addresses') ||
-    (msg.includes('sync responder') && (msg.includes('queue full') || msg.includes('queue wait exceeded'))) ||
+    (msg.includes('sync responder') &&
+      (msg.includes('queue full') ||
+        msg.includes('queue wait exceeded') ||
+        msg.includes('snapshot limit exceeded'))) ||
     // libp2p dial exhaustion — every known multiaddr for the peer
     // failed in one attempt. Surfaced by `transportManager.dial` and
     // by `dialProtocol` after iterating every relay/transport

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -38,6 +38,7 @@ describe('ProtocolRouter', () => {
       expect(isRecoverableSendError(new Error('sync responder queue full'))).toBe(true);
       expect(isRecoverableSendError(new Error('sync responder peer queue full'))).toBe(true);
       expect(isRecoverableSendError(new Error('sync responder queue wait exceeded'))).toBe(true);
+      expect(isRecoverableSendError(new Error('sync responder snapshot limit exceeded (active=128/128)'))).toBe(true);
     });
 
     // Regression for the May 2026 multi-node soak: libp2p surfaces

--- a/packages/core/test/protocol-router.test.ts
+++ b/packages/core/test/protocol-router.test.ts
@@ -38,7 +38,10 @@ describe('ProtocolRouter', () => {
       expect(isRecoverableSendError(new Error('sync responder queue full'))).toBe(true);
       expect(isRecoverableSendError(new Error('sync responder peer queue full'))).toBe(true);
       expect(isRecoverableSendError(new Error('sync responder queue wait exceeded'))).toBe(true);
-      expect(isRecoverableSendError(new Error('sync responder snapshot limit exceeded (active=128/128)'))).toBe(true);
+    });
+
+    it('does not retry sync snapshot-limit errors with stale request bytes inside ProtocolRouter', () => {
+      expect(isRecoverableSendError(new Error('sync responder snapshot limit exceeded (active=128/128)'))).toBe(false);
     });
 
     // Regression for the May 2026 multi-node soak: libp2p surfaces


### PR DESCRIPTION
## Summary

- Raise sync responder backpressure defaults:
  - durable data snapshot cap: 128
  - durable meta snapshot cap: 64
  - shared-memory snapshot cap: 64
  - responder queue limit: 64
- Convert sync responder snapshot-cap exhaustion into structured retryable sync backpressure with active/cached/inflight/max details.
- Keep snapshot-limit errors non-recoverable inside `ProtocolRouter.send()` so sync retries rebuild fresh auth envelopes/requestIds at the `sendSyncRequest` layer.
- Add requester-side in-flight coalescing around `DKGAgent.fetchSyncPages()` keyed by peer, context graph, SWM/durable mode, phase, snapshot ref, delta watermark, and recovery mode.
- Preserve waiter-scoped cancellation so one duplicate caller aborting does not cancel the shared fetch for other waiters.

## Tests

- `pnpm --filter @origintrail-official/dkg-core exec vitest run test/protocol-router.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts test/sync-fetch-coalescing.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts test/sync-responder-concurrent-interleaving.test.ts test/durable-sync-since-threading.test.ts`
- `pnpm --filter @origintrail-official/dkg-agent build`
- `git diff --check`