### PR TITLE
fix(agent): bound sync responder page-build cost (#1221 R-7) + memoize admission ASK (R-6)

### DIFF
--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -427,13 +427,17 @@ export async function readDurableDataPage(params: {
   }).sort(compareCodePoint);
 
   let assertionGraphs: Set<string> | null = null;
+  // Per-request memo: the admission walk re-ASKs the same ancestor URIs for
+  // every candidate graph; this collapses ~O(graphs × segments) identical
+  // `isKnownContextGraph` ASKs to ~O(unique-URIs) without changing the result.
+  const isKnownMemo = createIsKnownContextGraphMemo(params.store);
   const isAdmitted = (signal?: AbortSignal) => async (graph: string): Promise<boolean> => {
     if (graph.includes('/assertion/')) {
       assertionGraphs ??= await readAdmittedAssertionGraphs(params.store, params.contextGraphId, signal);
       const assertionGraph = graph.endsWith('/_meta') ? graph.slice(0, -'/_meta'.length) : graph;
       if (!assertionGraphs.has(assertionGraph)) return false;
     }
-    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph, signal));
+    return !(await isDescendantOfKnownChildContextGraph(params.store, cgPrefix, graph, signal, isKnownMemo));
   };
 
   if (params.sinceBatchId == null) {
@@ -638,10 +642,14 @@ async function readAdmittedSwmSubGraphNames(
   signal?: AbortSignal,
 ): Promise<string[]> {
   const cgPrefix = contextGraphDataGraphUri(contextGraphId);
+  // Per-call memo dedupes the per-sub-graph isKnownContextGraph ASKs (same
+  // un-memoized admission storm as the durable-data path; deterministic ASK,
+  // read-only request).
+  const isKnown = createIsKnownContextGraphMemo(store);
   const names: string[] = [];
   for (const name of await readRegisteredSubGraphNames(store, contextGraphId, signal)) {
     const childCgUri = `${cgPrefix}/${name}`;
-    if (await isKnownContextGraph(store, childCgUri, signal)) continue;
+    if (await isKnown(childCgUri, signal)) continue;
     names.push(name);
   }
   return names.sort(compareCodePoint);
@@ -708,25 +716,56 @@ async function isKnownContextGraph(
   return res.type === 'boolean' && res.value;
 }
 
+/**
+ * Resolves `isKnownContextGraph(uri)` and is the SAME deterministic predicate;
+ * a memo just dedupes the redundant ASKs (admission walks the same ancestor
+ * URIs across every candidate graph). The admitted set is provably unchanged.
+ */
+type IsKnownContextGraphResolver = (uri: string, signal?: AbortSignal) => Promise<boolean>;
+
+/**
+ * Per-request memo for {@link isKnownContextGraph}. The admission walk
+ * (`isDescendantOfKnownChildContextGraph`) re-ASKs the same ancestor URIs for
+ * every candidate graph under a shared prefix; on a multi-sub-graph CG a single
+ * page build fires ~O(graphs × segments) identical ASKs. The memo collapses
+ * those to ~O(unique-URIs). Scope is ONE page request: the cache is created per
+ * `readDurableDataPage` call, sync is read-only so the ASK result cannot change
+ * mid-request, and the cached promise is bound to the first caller's signal —
+ * all admission callers within one request share that request's signal, so this
+ * is safe. Do NOT hoist this cache to a cross-request lifetime without reworking
+ * the abort-signal handling.
+ */
+function createIsKnownContextGraphMemo(store: TripleStore): IsKnownContextGraphResolver {
+  const cache = new Map<string, Promise<boolean>>();
+  return (uri, signal) => {
+    const cached = cache.get(uri);
+    if (cached) return cached;
+    const pending = isKnownContextGraph(store, uri, signal);
+    cache.set(uri, pending);
+    return pending;
+  };
+}
+
 async function isDescendantOfKnownChildContextGraph(
   store: TripleStore,
   cgPrefix: string,
   graph: string,
   signal?: AbortSignal,
+  isKnown: IsKnownContextGraphResolver = (uri, sig) => isKnownContextGraph(store, uri, sig),
 ): Promise<boolean> {
   if (graph === cgPrefix || !graph.startsWith(`${cgPrefix}/`)) return false;
   const remainder = graph.slice(cgPrefix.length + 1);
   const segments = remainder.split('/').filter(Boolean);
   if (isParentOwnedReservedGraphSegments(segments)) return false;
-  if (await isKnownContextGraph(store, graph, signal)) return true;
+  if (await isKnown(graph, signal)) return true;
   if (graph.endsWith('/_meta')) {
     const graphOwner = graph.slice(0, -'/_meta'.length);
-    if (await isKnownContextGraph(store, graphOwner, signal)) return true;
+    if (await isKnown(graphOwner, signal)) return true;
   }
   let childUri = cgPrefix;
   for (const segment of segments) {
     childUri = `${childUri}/${segment}`;
-    if (await isKnownContextGraph(store, childUri, signal)) return true;
+    if (await isKnown(childUri, signal)) return true;
   }
   return false;
 }
@@ -791,6 +830,53 @@ async function readRowsAcrossGraphs(
     .map((row) => ({ s: row['s'], p: row['p'], o: row['o'], g: row['g'] }))
     .filter((row) => row.s && row.p && row.o && row.g)
     .sort(compareRows);
+}
+
+/**
+ * Like {@link readRowsAcrossGraphs} but pushes the SWM root-membership filter
+ * into SPARQL instead of materializing every quad and filtering in JS. The
+ * `FILTER` is placed at the WHERE level (after the `GRAPH ?g { ?s ?p ?o }`
+ * block, never inside it) so the store still streams only matching quads while
+ * the page-build cost drops from O(graph) to O(matched). The filter is the
+ * SAME shape already used by the durable-delta path
+ * ({@link durableDeltaWhereClauseForGraphs}): a subject is kept iff it is a
+ * fresh root or a genid descendant of one — byte-identical to the JS predicate
+ * `roots.has(s) || rootPrefixes.some((p) => s.startsWith(p))` with
+ * `rootPrefixes === root + "/.well-known/genid/"`.
+ */
+async function readRowsAcrossGraphsForRoots(
+  store: TripleStore,
+  graphs: readonly string[],
+  roots: ReadonlySet<string>,
+  signal?: AbortSignal,
+): Promise<SyncRow[]> {
+  const graphValuesClause = graphValues(graphs);
+  const rootValuesClause = rootValues(roots);
+  if (!graphValuesClause || !rootValuesClause) return [];
+  const res = await store.query(`
+    SELECT ?g ?s ?p ?o WHERE {
+      VALUES ?g { ${graphValuesClause} }
+      GRAPH ?g { ?s ?p ?o }
+      VALUES ?swmRoot { ${rootValuesClause} }
+      FILTER(sameTerm(?s, ?swmRoot) || STRSTARTS(STR(?s), CONCAT(STR(?swmRoot), "/.well-known/genid/")))
+    }
+  `, { signal });
+  if (res.type !== 'bindings') return [];
+  // The `VALUES ?swmRoot` join can yield a row once per matching root. A genid
+  // subject normally matches exactly one root, but a nested-genid subject could
+  // match two (one root being a genid-prefix of another), so dedupe to keep the
+  // old JS `.filter()` semantics of one row per quad.
+  const seen = new Set<string>();
+  const rows: SyncRow[] = [];
+  for (const binding of res.bindings) {
+    const row = { s: binding['s'], p: binding['p'], o: binding['o'], g: binding['g'] };
+    if (!row.s || !row.p || !row.o || !row.g) continue;
+    const key = `${row.g} ${row.s} ${row.p} ${row.o}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    rows.push(row);
+  }
+  return rows.sort(compareRows);
 }
 
 async function readRowsPageAcrossGraphs(
@@ -901,12 +987,19 @@ async function readFreshSwmDataRows(
     if (!graphSet.has(metaGraph)) continue;
     const roots = await readFreshSwmRoots(store, metaGraph, cutoffIso, signal);
     if (roots.size === 0) continue;
-    const rootPrefixes = [...roots].map((root) => `${root}/.well-known/genid/`);
-    const graphRows = await readRowsAcrossGraphs(store, candidateGraphsFor(graph), signal);
-    rows.push(...graphRows.filter((row) =>
-      roots.has(row.s) || rootPrefixes.some((prefix) => row.s.startsWith(prefix)),
-    ));
+    // Push the root-membership filter into SPARQL (was a full per-graph
+    // materialize + JS filter). Equivalent to the old predicate
+    // `roots.has(s) || rootPrefixes.some((p) => s.startsWith(p))`.
+    const graphRows = await readRowsAcrossGraphsForRoots(
+      store,
+      candidateGraphsFor(graph),
+      roots,
+      signal,
+    );
+    rows.push(...graphRows);
   }
+  // Post-merge sort across the multi-graph union is load-bearing: per-graph
+  // store ordering does not order the union, and pages slice this list.
   return rows.sort(compareRows);
 }
 
@@ -965,6 +1058,15 @@ async function readDurableMetaRows(
     }
   }
 
+  const matchesAssertionName = (subject: string): boolean => {
+    // Equivalent to `assertionNames.some((name) => subject.endsWith('/' + name))`
+    // but O(1): assertion names are single path segments, so the old predicate
+    // matches iff the subject's final segment is a known assertion name.
+    if (!subject.includes('/assertion/')) return false;
+    const lastSegment = subject.slice(subject.lastIndexOf('/') + 1);
+    return assertionNames.has(lastSegment);
+  };
+
   return rows.filter((row) =>
     row.s === cgEntity ||
     registeredSubGraphSubjects.has(row.s) ||
@@ -973,10 +1075,7 @@ async function readDurableMetaRows(
     nonWorkingLifecycles.has(row.s) ||
     assertionGraphs.has(row.s) ||
     eventSubjects.has(row.s) ||
-    (
-      row.s.includes('/assertion/') &&
-      [...assertionNames].some((name) => row.s.endsWith(`/${name}`))
-    ),
+    matchesAssertionName(row.s),
   );
 }
 
@@ -1087,6 +1186,10 @@ function durableDeltaGroupClause(
 
 function graphValues(graphs: readonly string[]): string {
   return dedupeStrings(graphs).map((graph) => `<${assertSafeIri(graph)}>`).join(' ');
+}
+
+function rootValues(roots: ReadonlySet<string>): string {
+  return dedupeStrings([...roots]).map((root) => `<${assertSafeIri(root)}>`).join(' ');
 }
 
 function durableDataRowListCacheKey(scope: string, contextGraphId: string, sinceBatchId: bigint | null): string {

--- a/packages/agent/test/sync-responder-r7-r6-pushdown.test.ts
+++ b/packages/agent/test/sync-responder-r7-r6-pushdown.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  DKG_NS,
+  RDF_TYPE,
+  linesFromNquads,
+  lineGraphsFromNquads,
+  registerTestSyncHandler,
+  subGraphRegistrationQuads,
+  workspaceOpQuads,
+} from './_helpers/sync-responder.js';
+
+/**
+ * R-7 (page-build pushdown) + R-6 (admission ASK memo) regression tests.
+ *
+ * The HARD invariant for both: the responder's emitted row-set must be
+ * BYTE-IDENTICAL to the pre-fix behaviour — the fixes only change HOW the rows
+ * are computed (store-side filter / cached ASK), never WHICH rows are returned
+ * or WHICH graphs are admitted. Any divergence is a sync-correctness break.
+ */
+
+const PUBLISHED = `${DKG_NS}publishedAt`;
+
+function countAskShape(store: OxigraphStore, fragment: string): { count(): number } {
+  const original = store.query.bind(store);
+  let n = 0;
+  store.query = (async (sparql: string) => {
+    const normalized = sparql.replace(/\s+/g, ' ').trim();
+    if (normalized.startsWith('ASK') && normalized.includes(fragment)) n += 1;
+    return original(sparql);
+  }) as OxigraphStore['query'];
+  return { count: () => n };
+}
+
+describe('R-7 swm-data root-filter pushdown — byte-invariance', () => {
+  it('returns EXACTLY the root + genid-descendant rows, dropping unrelated subjects', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'r7-swm-data';
+    const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    const swmMetaGraph = `${swmGraph}_meta`;
+    const dataGraph = `${swmGraph}/0xabc/1`;
+    const now = new Date().toISOString();
+
+    const root = 'urn:root:kept';
+    const genidChild = `${root}/.well-known/genid/0001`;
+    const unrelated = 'urn:root:NOT-fresh';
+    const genidLookalike = 'urn:root:keptX/.well-known/genid/0001'; // prefix is a different root
+
+    const rows: Quad[] = [
+      // fresh op => root admitted by cutoff
+      ...workspaceOpQuads(cgId, 'op-1', root, swmMetaGraph, now),
+      // data rows in the bucket
+      { graph: dataGraph, subject: root, predicate: `${DKG_NS}label`, object: '"root-row"' },
+      { graph: dataGraph, subject: genidChild, predicate: `${DKG_NS}label`, object: '"genid-row"' },
+      { graph: dataGraph, subject: unrelated, predicate: `${DKG_NS}label`, object: '"unrelated-row"' },
+      { graph: dataGraph, subject: genidLookalike, predicate: `${DKG_NS}label`, object: '"lookalike-row"' },
+    ];
+    await store.insert(rows);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 5000 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    const lines = linesFromNquads(out);
+    // EXACTLY the root row + its genid descendant; NOT the unrelated subject and
+    // NOT the look-alike (whose prefix belongs to a different, non-fresh root).
+    expect(out).toContain('"root-row"');
+    expect(out).toContain('"genid-row"');
+    expect(out).not.toContain('"unrelated-row"');
+    expect(out).not.toContain('"lookalike-row"');
+    expect(lines).toHaveLength(2);
+    expect(lineGraphsFromNquads(out)).toEqual(new Set([dataGraph]));
+  });
+
+  it('pushes a FILTER into the snapshot read but adds no ORDER BY / OFFSET / LIMIT', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'r7-swm-data-shape';
+    const swmGraph = `did:dkg:context-graph:${cgId}/_shared_memory`;
+    const swmMetaGraph = `${swmGraph}_meta`;
+    const dataGraph = `${swmGraph}/0xabc/1`;
+    const now = new Date().toISOString();
+    await store.insert([
+      ...workspaceOpQuads(cgId, 'op-1', 'urn:root:a', swmMetaGraph, now),
+      { graph: dataGraph, subject: 'urn:root:a', predicate: `${DKG_NS}label`, object: '"a"' },
+    ]);
+
+    const original = store.query.bind(store);
+    let sawFilteredSnapshotRead = false;
+    store.query = (async (sparql: string) => {
+      const normalized = sparql.replace(/\s+/g, ' ').trim();
+      const isSnapshotRead = /^SELECT \?g \?s \?p \?o WHERE \{/.test(normalized) &&
+        normalized.includes(`VALUES ?g { <${dataGraph}>`) &&
+        normalized.includes('GRAPH ?g { ?s ?p ?o }');
+      if (isSnapshotRead) {
+        sawFilteredSnapshotRead = true;
+        // R-7: the root-filter is pushed in; the snapshot read stays unordered/unpaged.
+        expect(normalized).toContain('FILTER');
+        expect(normalized).toContain('STRSTARTS');
+        expect(normalized).not.toContain('ORDER BY');
+        expect(normalized).not.toContain('OFFSET ');
+        expect(normalized).not.toContain('LIMIT ');
+      }
+      return original(sparql);
+    }) as OxigraphStore['query'];
+
+    await cap_invoke(store, cgId, dataGraph);
+    expect(sawFilteredSnapshotRead).toBe(true);
+  });
+});
+
+async function cap_invoke(store: OxigraphStore, cgId: string, _dataGraph: string) {
+  const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 5000 });
+  return cap.invoke({ contextGraphId: cgId, includeSharedMemory: true, phase: 'data', offset: 0, limit: 5000 });
+}
+
+describe('R-7 durable-meta de-quadratic assertion-name match — byte-invariance', () => {
+  it('keeps trailing-segment assertion-name subjects and drops non-final-segment look-alikes', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'r7-durable-meta';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const metaGraph = `${cgPrefix}/_meta`;
+    const lifecycle = `${cgPrefix}/lifecycle/1`;
+    const assertionName = 'myAssertion';
+    const matchSubject = `${cgPrefix}/assertion/0xabc/${assertionName}`;          // trailing segment == name
+    const nearMissSubject = `${cgPrefix}/assertion/0xabc/${assertionName}/extra`;  // name is NOT the final segment
+
+    await store.insert([
+      // a non-working lifecycle that names `myAssertion`
+      { graph: metaGraph, subject: lifecycle, predicate: `${DKG_NS}memoryLayer`, object: '"VerifiedMemory"' },
+      { graph: metaGraph, subject: lifecycle, predicate: `${DKG_NS}assertionName`, object: `"${assertionName}"` },
+      // the two candidate assertion subjects
+      { graph: metaGraph, subject: matchSubject, predicate: `${DKG_NS}label`, object: '"match"' },
+      { graph: metaGraph, subject: nearMissSubject, predicate: `${DKG_NS}label`, object: '"near-miss"' },
+    ]);
+
+    const cap = registerTestSyncHandler(store, { syncPageSize: 5000 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'meta',
+      offset: 0,
+      limit: 5000,
+    });
+
+    // trailing-segment match kept; non-final-segment look-alike dropped — exactly
+    // the semantics of the old `subject.endsWith('/' + name)` predicate.
+    expect(out).toContain('"match"');
+    expect(out).not.toContain('"near-miss"');
+  });
+});
+
+describe('R-6 isKnownContextGraph admission-ASK memo', () => {
+  it('collapses redundant per-graph/per-segment ASKs to one per unique URI', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'r6-admission';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    // Several data graphs sharing deep prefixes => the un-memoized walk would
+    // re-ASK cg/a, cg/a/b, ... once per sibling graph.
+    const graphs = [
+      `${cgPrefix}/a/b/c/x`,
+      `${cgPrefix}/a/b/c/y`,
+      `${cgPrefix}/a/b/d/z`,
+    ];
+    const rows: Quad[] = [];
+    for (const g of graphs) {
+      rows.push({ graph: g, subject: `${g}#s`, predicate: `${DKG_NS}label`, object: `"row-${g}"` });
+    }
+    await store.insert(rows);
+
+    const probe = countAskShape(store, 'registrationStatus');
+    const cap = registerTestSyncHandler(store, { syncPageSize: 5000 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: false,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+
+    // All graphs admitted (none are known child CGs), and the admission ASKs are
+    // deduped: with N unique candidate URIs walked, the memo issues each ASK once.
+    // The un-memoized code would issue strictly more (shared prefixes re-ASKed
+    // per sibling). We assert the count equals the number of DISTINCT URIs walked.
+    const uniqueWalked = new Set<string>();
+    for (const g of graphs) {
+      const rem = g.slice(cgPrefix.length + 1).split('/');
+      uniqueWalked.add(g);
+      let cur = cgPrefix;
+      for (const seg of rem) { cur = `${cur}/${seg}`; uniqueWalked.add(cur); }
+    }
+    expect(probe.count()).toBe(uniqueWalked.size);
+    // and the rows still come through (admitted set unchanged)
+    expect(out).toContain(`"row-${graphs[0]}"`);
+    expect(out).toContain(`"row-${graphs[2]}"`);
+  });
+});
+
+describe('R-6 SWM-twin admission memo (readAdmittedSwmSubGraphNames)', () => {
+  it('still admits unregistered sub-graphs after memoizing the isKnownContextGraph ASK', async () => {
+    const store = new OxigraphStore();
+    const cgId = 'r6-swm-twin';
+    const cgPrefix = `did:dkg:context-graph:${cgId}`;
+    const subName = 'team';
+    const subSwm = `${cgPrefix}/${subName}/_shared_memory`;
+    const subSwmMeta = `${subSwm}_meta`;
+    const now = new Date().toISOString();
+    await store.insert([
+      ...subGraphRegistrationQuads(cgId, subName),
+      ...workspaceOpQuads(cgId, 'op-1', 'urn:root:t', subSwmMeta, now),
+      { graph: subSwm, subject: 'urn:root:t', predicate: `${DKG_NS}label`, object: '"sub-row"' },
+    ]);
+
+    const cap = registerTestSyncHandler(store, { sharedMemoryTtlMs: 60_000, syncPageSize: 5000 });
+    const out = await cap.invoke({
+      contextGraphId: cgId,
+      includeSharedMemory: true,
+      phase: 'data',
+      offset: 0,
+      limit: 5000,
+    });
+    // the unregistered-as-child sub-graph's SWM is admitted + served
+    expect(out).toContain('"sub-row"');
+  });
+});


### PR DESCRIPTION
## Summary

Residual ~9–10-core oxigraph CPU peg on rc.18 under live multi-peer sync (#1221), after the #1164 (A1–A4) un-peg gate. Root-caused to the **sync responder page-build path**: serving sync pages against an operation-heavy context graph materializes far more of the store than the page actually needs, and oxigraph v0.5.8 (per-query single-threaded MVCC, no global lock, no query-cancel on client abort) saturates one core per concurrent heavy page. Under the requester retry/flap storm those heavy page-builds stack and peg ~9 cores.

This PR bounds the **per-page cost** — the body of the responder work. It is the responder/server half of the fix; the requester/round-count half is **#1224** (complementary — see below).

### R-7 — bound page-build query cost (headline)
- **swm-data:** push the SWM-root membership filter into the SPARQL snapshot read (`readRowsAcrossGraphsForRoots`) instead of materializing every row in the candidate graphs and filtering in JS. The store now returns only the root + its `/.well-known/genid/` descendants. Byte-identical to the prior `roots.has(s) || rootPrefixes.some(p => s.startsWith(p))` predicate.
- **durable-meta:** replace the O(rows × assertionNames) nested `.some()` scan with an O(rows) trailing-segment lookup (`matchesAssertionName`). Byte-equivalent because assertion names cannot contain `/`.

The pushed filter is placed **outside** the `GRAPH ?g { ?s ?p ?o }` block, so the frozen-snapshot read contract (`watchUnorderedSnapshotRead`: no `ORDER BY` / `OFFSET` / `LIMIT`) is preserved — verified by the 23 snapshot-stability contracts in `sync-responder-concurrent-interleaving.test.ts`. The load-bearing post-merge union `sort(compareRows)` is preserved.

### R-6 — memoize admission ASK (adjunct)
Per-request `Map<string, Promise<boolean>>` memo for the `isKnownContextGraph` admission ASK, threaded through `readDurableDataPage` and the SWM-twin `readAdmittedSwmSubGraphNames`. Collapses the offset-0 per-graph / per-segment re-ASK storm to one ASK per unique URI.

**Invariant for both:** the emitted row-set / admitted-graph set is byte-identical to pre-fix behaviour — only *how* the rows are computed changes, never *which*.

## Tests
- New `test/sync-responder-r7-r6-pushdown.test.ts` — byte-invariance for the swm-data root filter (genid-lookalike negative), the FILTER-present / no-`ORDER BY`/`OFFSET`/`LIMIT` shape, the durable-meta near-miss drop, the R-6 ASK-count collapse + SWM-twin admission.
- `test/sync-responder-concurrent-interleaving.test.ts` — 23 snapshot-stability contracts green.
- Full `@origintrail-official/dkg-agent` suite: 1616 pass (1 unrelated P2P-timing flake in `e2e-join.test.ts`).

## Validation status
- ✅ Unit-verified (byte-invariance + snapshot contracts + full suite).
- ⏳ **Live before/after pending** — per `VALIDATION-RUNBOOK-1221.md`, measuring per-source responder page-build `totalMs` on the real operation-heavy store. **Draft until that lands.**

## Relationship to #1224
#1224 (sync responder backpressure defaults + requester-side in-flight coalescing) is the **complementary half**: it bounds the *number* of page requests / flap fanout; this PR bounds the *cost per page*. Together they break the responder feedback loop at both ends.
- **Conflict-free:** #1224's `graph-plan.ts` edits are in the memo/snapshot-limit region (~L41–204); this PR's are in the read functions (L427+). Disjoint — no merge conflict. #1224 edits `sync-responder-concurrent-interleaving.test.ts`; this PR adds a separate test file. They can land in either order.

Refs #1221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
