### PR TITLE
Codex/sync connect flap fix

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -166,6 +166,9 @@ import {
   createSwmAckQuorum,
   type SwmAckQuorum,
 } from './swm/ack-quorum.js';
+import {
+  type SwmFanoutPeerSelector,
+} from './swm/swm-fanout-peer-selection.js';
 import { SwmHostModeStore, type SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import {
   BEACON_ACCESS_POLICY_CURATED,
@@ -773,6 +776,12 @@ export class DKGAgentBase {
    */
   protected swmAckQuorum?: SwmAckQuorum;
   protected swmAckQuorumTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Active SWM sender-side peer outcome cache. Public CG fan-out uses this
+   * to keep stale/flapping subscriber peers out of the short-term
+   * substrate/ACK set without changing private allowlist semantics.
+   */
+  protected swmFanoutPeerSelector?: SwmFanoutPeerSelector;
   /**
    * Period at which `SwmAckQuorum.tick()` runs. Picked to match
    * RFC-003 §5.2 ("watchdog tick: 5s") — a finer cadence buys

--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -111,6 +111,13 @@ export const GOSSIP_DIAL_TIMEOUT_MS = 10_000;
  * (each of which fires its own connection:open).
  */
 export const CATCHUP_ON_CONNECT_COOLDOWN_MS = 60_000;
+/**
+ * A full libp2p disconnect shorter than this is treated as relay/direct
+ * transport churn, not a meaningful offline gap. Without this grace window,
+ * short circuit-relay flaps reset the catch-up cooldown and every reconnect
+ * can fan out a full sync round.
+ */
+export const SYNC_RECONNECT_FLAP_GRACE_MS = 15_000;
 
 // ── Reconciler / staleness ────────────────────────────────────────────
 /**

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -295,6 +295,7 @@ import {
   GOSSIP_DIAL_COOLDOWN_MS,
   GOSSIP_DIAL_TIMEOUT_MS,
   CATCHUP_ON_CONNECT_COOLDOWN_MS,
+  SYNC_RECONNECT_FLAP_GRACE_MS,
   SYNC_RECONCILER_INTERVAL_MS,
   SYNC_STALENESS_THRESHOLD_MS,
   SYNC_BACKOFF_BASE_MS,
@@ -2057,24 +2058,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         }
       })();
 
-      const now = Date.now();
-      const lastSuccessfulSync = this.lastSuccessfulSyncAt.get(remotePeer);
-      const lastDisconnected = this.lastSyncDisconnectedAt.get(remotePeer) ?? 0;
-      if (
-        lastSuccessfulSync != null &&
-        lastSuccessfulSync > lastDisconnected &&
-        now - lastSuccessfulSync < SYNC_STALENESS_THRESHOLD_MS
-      ) {
-        return;
-      }
-      const last = this.catchupOnConnectAt.get(remotePeer) ?? 0;
-      if (last > lastDisconnected && now - last < CATCHUP_ON_CONNECT_COOLDOWN_MS) return;
-      this.catchupOnConnectAt.set(remotePeer, now);
-      setTimeout(() => {
-        this.trySyncFromPeer(remotePeer).catch((err: unknown) => {
-          handleSyncError(remotePeer, err);
-        });
-      }, 3000);
+      this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
     });
 
     // Remember when the last live connection to a peer is gone. A3 keeps
@@ -2131,11 +2115,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const alreadyConnected = this.node.libp2p.getPeers();
     for (const pid of alreadyConnected) {
       const remotePeer = pid.toString();
-      setTimeout(() => {
-        this.trySyncFromPeer(remotePeer).catch((err: unknown) => {
-          handleSyncError(remotePeer, err);
-        });
-      }, 3000);
+      this.queueSyncFromPeerOnConnect(remotePeer, handleSyncError);
     }
 
     // Start periodic shared memory cleanup
@@ -2397,6 +2377,85 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     this.storageACKRegistrationRetryTimer = null;
   }
 
+  syncOnConnectDisconnectBoundary(this: DKGAgent, remotePeer: string, now = Date.now()): number {
+    const lastDisconnected = this.lastSyncDisconnectedAt.get(remotePeer) ?? 0;
+    if (lastDisconnected === 0) return 0;
+    return now - lastDisconnected >= SYNC_RECONNECT_FLAP_GRACE_MS ? lastDisconnected : 0;
+  }
+
+  queueSyncFromPeerOnConnect(
+    this: DKGAgent,
+    remotePeer: string,
+    handleSyncError: (remotePeer: string, err: unknown) => void,
+    delayMs = 3000,
+  ): boolean {
+    const now = Date.now();
+    const disconnectBoundary = this.syncOnConnectDisconnectBoundary(remotePeer, now);
+    const lastSuccessfulSync = this.lastSuccessfulSyncAt.get(remotePeer);
+    if (
+      lastSuccessfulSync != null &&
+      lastSuccessfulSync > disconnectBoundary &&
+      now - lastSuccessfulSync < SYNC_STALENESS_THRESHOLD_MS
+    ) {
+      return false;
+    }
+
+    const lastQueued = this.catchupOnConnectAt.get(remotePeer) ?? 0;
+    if (lastQueued > disconnectBoundary && now - lastQueued < CATCHUP_ON_CONNECT_COOLDOWN_MS) {
+      return false;
+    }
+
+    const backoff = this.syncReconcilerBackoff.get(remotePeer);
+    if (backoff && now < backoff.nextRetryAt) {
+      return false;
+    }
+
+    this.catchupOnConnectAt.set(remotePeer, now);
+    setTimeout(() => {
+      this.runSyncFromPeerOnConnect(remotePeer, handleSyncError).catch((err: unknown) => {
+        handleSyncError(remotePeer, err);
+      });
+    }, delayMs);
+    return true;
+  }
+
+  async runSyncFromPeerOnConnect(
+    this: DKGAgent,
+    remotePeer: string,
+    handleSyncError: (remotePeer: string, err: unknown) => void,
+  ): Promise<void> {
+    const now = Date.now();
+    const backoff = this.syncReconcilerBackoff.get(remotePeer);
+    if (backoff && now < backoff.nextRetryAt) return;
+
+    const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
+    const lastProgress = this.lastSyncProgressAt.get(remotePeer);
+    const probe = await this.getSyncReconcilerProbe(remotePeer);
+    let syncAccountingClearedBackoff = false;
+    try {
+      const outcome = await this.trySyncFromPeer(remotePeer, () => {
+        syncAccountingClearedBackoff = true;
+      });
+      if (
+        outcome === 'synced' &&
+        !syncAccountingClearedBackoff &&
+        this.lastSuccessfulSyncAt.get(remotePeer) === lastOk &&
+        this.lastSyncProgressAt.get(remotePeer) === lastProgress
+      ) {
+        this.recordSyncReconcilerFailure(remotePeer, probe);
+      }
+    } catch (err: unknown) {
+      if (err instanceof SyncOnConnectPostSyncError) {
+        if (err.backoffEligible) {
+          this.recordSyncReconcilerFailure(remotePeer, probe);
+        }
+      } else {
+        this.recordSyncReconcilerFailure(remotePeer, probe);
+      }
+      handleSyncError(remotePeer, err);
+    }
+  }
+
   /**
    * Pull all triples for the given context graphs from a remote peer and merge
    * them into our local store. Used on peer:connect for initial catch-up,
@@ -2416,6 +2475,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
       getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
+      getSharedMemorySyncContextGraphs: () => this.getSharedMemorySyncContextGraphs(),
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
         contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
@@ -2443,6 +2503,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
         }
       },
     });
+  }
+
+  async getSharedMemorySyncContextGraphs(this: DKGAgent): Promise<string[]> {
+    const eligible: string[] = [];
+    for (const contextGraphId of this.config.syncContextGraphs ?? []) {
+      if (await this.canUseSharedMemoryForContextGraph(contextGraphId)) {
+        eligible.push(contextGraphId);
+      }
+    }
+    return eligible;
   }
 
   /**
@@ -2510,7 +2580,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       const peerId = pid.toString();
       if (this.syncingPeers.has(peerId)) continue;
       const lastOk = this.lastSuccessfulSyncAt.get(peerId);
-      const lastDisconnected = this.lastSyncDisconnectedAt.get(peerId) ?? 0;
+      const lastDisconnected = this.syncOnConnectDisconnectBoundary(peerId, now);
       const lastProgress = this.lastSyncProgressAt.get(peerId);
       const lastSyncCooldown = Math.max(lastOk ?? 0, lastProgress ?? 0);
       const stale = lastSyncCooldown === 0

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -502,6 +502,16 @@ function jitteredIntervalMs(intervalMs: number, ratio: number | undefined): numb
   return Math.max(1, Math.round(intervalMs - delta + Math.random() * delta * 2));
 }
 
+type SharedMemorySyncContextGraphPlan = {
+  publicContextGraphIds: string[];
+  privateRecoverFromCurator: string[];
+  eligibleContextGraphIds: string[];
+};
+
+function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
 export class LifecycleSyncMethods extends DKGAgentBase {
   async start(this: DKGAgent): Promise<void> {
     if (this.started) return;
@@ -2428,22 +2438,37 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     const backoff = this.syncReconcilerBackoff.get(remotePeer);
     if (backoff && now < backoff.nextRetryAt) return;
 
+    const probe = await this.getSyncReconcilerProbe(remotePeer);
+    try {
+      await this.attemptSyncFromPeerWithReconcilerAccounting(remotePeer, probe);
+    } catch (err: unknown) {
+      handleSyncError(remotePeer, err);
+    }
+  }
+
+  async attemptSyncFromPeerWithReconcilerAccounting(
+    this: DKGAgent,
+    remotePeer: string,
+    probe: SyncReconcilerProbe,
+  ): Promise<SyncOnConnectOutcome | 'not-started'> {
     const lastOk = this.lastSuccessfulSyncAt.get(remotePeer);
     const lastProgress = this.lastSyncProgressAt.get(remotePeer);
-    const probe = await this.getSyncReconcilerProbe(remotePeer);
     let syncAccountingClearedBackoff = false;
     try {
       const outcome = await this.trySyncFromPeer(remotePeer, () => {
         syncAccountingClearedBackoff = true;
       });
       if (
-        outcome === 'synced' &&
+        outcome !== 'skipped-no-sync' &&
+        outcome !== 'already-syncing' &&
+        outcome !== 'not-started' &&
         !syncAccountingClearedBackoff &&
         this.lastSuccessfulSyncAt.get(remotePeer) === lastOk &&
         this.lastSyncProgressAt.get(remotePeer) === lastProgress
       ) {
         this.recordSyncReconcilerFailure(remotePeer, probe);
       }
+      return outcome;
     } catch (err: unknown) {
       if (err instanceof SyncOnConnectPostSyncError) {
         if (err.backoffEligible) {
@@ -2452,7 +2477,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       } else {
         this.recordSyncReconcilerFailure(remotePeer, probe);
       }
-      handleSyncError(remotePeer, err);
+      throw err;
     }
   }
 
@@ -2469,13 +2494,26 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     if (!this.started) {
       return 'not-started';
     }
+    const sharedMemorySyncPlans = new Map<string, Promise<SharedMemorySyncContextGraphPlan>>();
+    const getSharedMemorySyncPlan = (peerId: string): Promise<SharedMemorySyncContextGraphPlan> => {
+      let plan = sharedMemorySyncPlans.get(peerId);
+      if (!plan) {
+        plan = this.planSharedMemorySyncContextGraphs(
+          peerId,
+          this.config.syncContextGraphs ?? [],
+          createOperationContext('sync'),
+        );
+        sharedMemorySyncPlans.set(peerId, plan);
+      }
+      return plan;
+    };
     return runSyncOnConnect({
       remotePeer,
       syncingPeers: this.syncingPeers,
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
       getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
-      getSharedMemorySyncContextGraphs: (peerId) => this.getSharedMemorySyncContextGraphs(peerId),
+      getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
         contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
@@ -2486,7 +2524,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       ),
       refreshMetaSyncedFlags: (contextGraphIds) => this.refreshMetaSyncedFlags(contextGraphIds),
       discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
-      syncSharedMemoryFromPeer: (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, { stopOnBackoffWorthyFailure: true }),
+      syncSharedMemoryFromPeer: async (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, {
+        stopOnBackoffWorthyFailure: true,
+        sharedMemorySyncPlan: await getSharedMemorySyncPlan(peerId),
+      }),
       syncSharedMemoryOnConnect: this.config.syncSharedMemoryOnConnect ?? true,
       logInfo: (ctx, message) => this.log.info(ctx, message),
       onPeerSkippedNoSync: (peerId) => {
@@ -2509,20 +2550,134 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
   }
 
-  async getSharedMemorySyncContextGraphs(this: DKGAgent, remotePeerId?: string): Promise<string[]> {
-    const eligible: string[] = [];
-    for (const contextGraphId of this.config.syncContextGraphs ?? []) {
-      if (await this.canUseSharedMemoryForContextGraph(contextGraphId)) {
-        if (remotePeerId && await this.isPrivateContextGraph(contextGraphId)) {
-          const { peerIds, curatorIsLocal } = await this.resolveCuratorPeerIdsForCg(contextGraphId);
-          if (curatorIsLocal || !peerIds.includes(remotePeerId)) {
+  async planSharedMemorySyncContextGraphs(
+    this: DKGAgent,
+    remotePeerId: string | undefined,
+    contextGraphIds: readonly string[],
+    ctx: OperationContext,
+  ): Promise<SharedMemorySyncContextGraphPlan> {
+    // M2 (curator-leader convergence): a PRIVATE CG converges by REPLACE-recovering the
+    // current state from its CURATOR (the authoritative SWM replica), never the
+    // bidirectional mesh union-sync — which corrupts a reconnecting member into {old,new}
+    // AND pollutes the curator back (proven on devnet). PUBLIC CGs keep the union path
+    // (correct for cold-start / empty target).
+    const publicContextGraphIds: string[] = [];
+    const privateRecoverFromCurator: string[] = [];
+    const eligibleContextGraphIds: string[] = [];
+    // Memoized agent-registry lookup: resolve a curator WALLET -> its libp2p peer
+    // via the AGENTS registry (the authoritative agent->peer map), bypassing the
+    // dkg:curator/dkg:creator `_meta` triples — a member that pre-created the CG
+    // self-stamps both, which would otherwise resolve the member AS the curator.
+    let cachedAgents: Array<{ agentAddress?: string; peerId: string }> | undefined;
+    // Resolve EVERY libp2p peer the AGENTS registry advertises for a curator
+    // wallet, not the first match: `findAgents()` is not a unique wallet->peer
+    // map (agent registration is consent-free, so several URIs can share a
+    // wallet, and a restarted curator can linger under a stale peerId). The
+    // caller only needs to know whether the CONNECTING peer is among them, so a
+    // first-match pick could resolve a stale/wrong peer and wrongly defer (or,
+    // for a same-wallet Byzantine advertiser, mis-gate) recovery.
+    const resolveAgentPeers = async (agentAddrLower: string): Promise<string[]> => {
+      if (!cachedAgents) {
+        try {
+          cachedAgents = await this.discovery.findAgents();
+        } catch {
+          cachedAgents = [];
+        }
+      }
+      return cachedAgents
+        .filter((a) => a.agentAddress?.toLowerCase() === agentAddrLower)
+        .map((a) => a.peerId);
+    };
+    let localPeerId: string | undefined;
+    try {
+      localPeerId = this.peerId;
+    } catch {
+      localPeerId = undefined;
+    }
+
+    for (const contextGraphId of contextGraphIds) {
+      if (!(await this.canUseSharedMemoryForContextGraph(contextGraphId))) {
+        this.log.warn(ctx, `Skipping SWM sync for unauthorized or unconfirmed context graph "${contextGraphId}"`);
+        continue;
+      }
+      if (await this.isPrivateContextGraph(contextGraphId)) {
+        if (!remotePeerId) {
+          eligibleContextGraphIds.push(contextGraphId);
+          continue;
+        }
+        // The curator (curator-leader) is the authoritative SWM replica; it never
+        // reverse-syncs a CG it owns. Decide curatorship AND resolve the curator's
+        // peer by the STRUCTURAL curator — the wallet-scoped id prefix `0x<addr>` —
+        // NOT the dkg:curator/dkg:creator triples. A member that locally pre-created
+        // the CG (the rfc38 multi-member onboarding pattern) self-stamps its OWN
+        // wallet as a dkg:curator triple and its OWN peer as dkg:creator, which makes
+        // BOTH isCuratorOf() and resolveCuratorPeerId() resolve the member AS the
+        // curator — so the gate would skip the member's own recovery and it would
+        // silently never converge (a zero-byte-core durability failure). The id
+        // prefix is authoritative; only the node owning that agent is the curator.
+        const structuralCuratorDid = deriveCuratorDidFromCgId(contextGraphId);
+        if (structuralCuratorDid) {
+          const structuralAgent = structuralCuratorDid.slice('did:dkg:agent:'.length).toLowerCase();
+          if ([...this.localAgents.keys()].some((addr) => addr.toLowerCase() === structuralAgent)) {
+            this.log.debug(ctx, `SWM sync: skipping "${contextGraphId}" — local node is the curator (never reverse-syncs a CG it owns)`);
             continue;
           }
+          // Resolve the structural curator's peer via the agent registry. On a
+          // reconnect the registry may not be populated yet, so refresh meta once.
+          let curatorPeers = await resolveAgentPeers(structuralAgent);
+          if (curatorPeers.length === 0) {
+            await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
+            cachedAgents = undefined; // force a fresh registry read after the refresh
+            curatorPeers = await resolveAgentPeers(structuralAgent);
+          }
+          if (curatorPeers.length === 0) {
+            this.log.info(ctx, `SWM recovery skipped for private CG "${contextGraphId.slice(0, 28)}": curator (${structuralAgent.slice(0, 10)}) peer not resolved yet`);
+          } else if (!curatorPeers.includes(remotePeerId)) {
+            this.log.info(ctx, `SWM recovery deferred for private CG "${contextGraphId.slice(0, 28)}": connecting peer ${remotePeerId.slice(0, 12)} is not among the curator's ${curatorPeers.length} registered peer(s)`);
+          } else {
+            this.log.info(ctx, `SWM recovery ENQUEUED for private CG "${contextGraphId.slice(0, 28)}" from curator peer ${remotePeerId.slice(0, 12)}`);
+            privateRecoverFromCurator.push(contextGraphId);
+            eligibleContextGraphIds.push(contextGraphId);
+          }
+          continue;
         }
-        eligible.push(contextGraphId);
+        // Legacy non-wallet-scoped CG (no structural curator): fall back to the
+        // triple-based curator resolution.
+        if (await this.isCuratorOf(contextGraphId)) {
+          this.log.debug(ctx, `SWM sync: skipping "${contextGraphId}" — local node is the curator (never reverse-syncs a CG it owns)`);
+          continue;
+        }
+        let curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
+        if (!curatorPeerId) {
+          await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
+          curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
+        }
+        if (!curatorPeerId) {
+          this.log.info(ctx, `SWM recovery skipped for private CG "${contextGraphId.slice(0, 28)}": curator peerId not resolved`);
+        } else if (localPeerId && curatorPeerId === localPeerId) {
+          this.log.info(ctx, `SWM recovery skipped for private CG "${contextGraphId.slice(0, 28)}": local node resolves AS the curator`);
+        } else if (curatorPeerId !== remotePeerId) {
+          this.log.info(ctx, `SWM recovery deferred for private CG "${contextGraphId.slice(0, 28)}": connecting peer is not the curator`);
+        } else {
+          this.log.info(ctx, `SWM recovery ENQUEUED for private CG "${contextGraphId.slice(0, 28)}" from curator ${curatorPeerId.slice(0, 12)}`);
+          privateRecoverFromCurator.push(contextGraphId);
+          eligibleContextGraphIds.push(contextGraphId);
+        }
+        continue;
       }
+      publicContextGraphIds.push(contextGraphId);
+      eligibleContextGraphIds.push(contextGraphId);
     }
-    return eligible;
+    return { publicContextGraphIds, privateRecoverFromCurator, eligibleContextGraphIds };
+  }
+
+  async getSharedMemorySyncContextGraphs(this: DKGAgent, remotePeerId?: string): Promise<string[]> {
+    const plan = await this.planSharedMemorySyncContextGraphs(
+      remotePeerId,
+      this.config.syncContextGraphs ?? [],
+      createOperationContext('sync'),
+    );
+    return plan.eligibleContextGraphIds;
   }
 
   /**
@@ -2614,43 +2769,15 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       }
       const shortPeer = peerId.slice(-8);
       this.log.info(ctx, `Sync reconciler retrying ${shortPeer} (last success: ${lastOk == null ? 'never' : `${Math.round((now - lastOk) / 1000)}s ago`}${backoff ? `, prior failures: ${backoff.failures}` : ''})`);
-      let syncAccountingClearedBackoff = false;
-      this.trySyncFromPeer(peerId, () => {
-        syncAccountingClearedBackoff = true;
-      })
-        .then((outcome) => {
-          if (outcome === 'skipped-no-sync' || outcome === 'already-syncing' || outcome === 'not-started') {
-            return;
-          }
-          // `onPeerSynced` clears the backoff when a round makes progress or
-          // gets a clean denial. Only useful progress writes the cooldown
-          // marker; denial-only rounds must remain eligible next tick because
-          // a later ACL approval does not emit peer:update/connection:open.
-          // If the attempt resolved without advancing either marker, treat it
-          // as a genuine sync failure so peer backoff grows unless sync
-          // accounting explicitly cleared backoff for this attempt. A peer
-          // that still does not advertise PROTOCOL_SYNC is handled above and
-          // remains eligible on every reconciler tick, so a missed identify
-          // update cannot stretch into a 5/10/20/60-minute delay.
-          if (
-            !syncAccountingClearedBackoff &&
-            this.lastSuccessfulSyncAt.get(peerId) === lastOk &&
-            this.lastSyncProgressAt.get(peerId) === lastProgress
-          ) {
-            this.recordSyncReconcilerFailure(peerId, probe);
-          }
-        })
+      this.attemptSyncFromPeerWithReconcilerAccounting(peerId, probe)
+        .then(() => undefined)
         .catch((err: unknown) => {
           const message = err instanceof Error ? err.message : String(err);
           if (err instanceof SyncOnConnectPostSyncError) {
-            if (err.backoffEligible) {
-              this.recordSyncReconcilerFailure(peerId, probe);
-            }
             const backoffNote = err.backoffEligible ? 'growing peer backoff' : 'retrying without growing peer backoff';
             this.log.warn(ctx, `Sync reconciler post-sync step failed for ${shortPeer}; ${backoffNote}: ${message}`);
             return;
           }
-          this.recordSyncReconcilerFailure(peerId, probe);
           this.log.warn(ctx, `Sync reconciler retry failed for ${shortPeer}: ${message}`);
         });
     }
@@ -3200,106 +3327,17 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async syncSharedMemoryFromPeerDetailed(this: DKGAgent,
     remotePeerId: string,
     contextGraphIds: string[],
-    options?: { stopOnBackoffWorthyFailure?: boolean },
+    options?: {
+      stopOnBackoffWorthyFailure?: boolean;
+      sharedMemorySyncPlan?: SharedMemorySyncContextGraphPlan;
+    },
   ): Promise<SharedMemorySyncResult> {
     const ctx = createOperationContext('sync');
-    // M2 (curator-leader convergence): a PRIVATE CG converges by REPLACE-recovering the
-    // current state from its CURATOR (the authoritative SWM replica), never the
-    // bidirectional mesh union-sync — which corrupts a reconnecting member into {old,new}
-    // AND pollutes the curator back (proven on devnet). PUBLIC CGs keep the union path
-    // (correct for cold-start / empty target).
-    const publicContextGraphIds: string[] = [];
-    const privateRecoverFromCurator: string[] = [];
-    // Memoized agent-registry lookup: resolve a curator WALLET -> its libp2p peer
-    // via the AGENTS registry (the authoritative agent->peer map), bypassing the
-    // dkg:curator/dkg:creator `_meta` triples — a member that pre-created the CG
-    // self-stamps both, which would otherwise resolve the member AS the curator.
-    let cachedAgents: Array<{ agentAddress?: string; peerId: string }> | undefined;
-    // Resolve EVERY libp2p peer the AGENTS registry advertises for a curator
-    // wallet, not the first match: `findAgents()` is not a unique wallet->peer
-    // map (agent registration is consent-free, so several URIs can share a
-    // wallet, and a restarted curator can linger under a stale peerId). The
-    // caller only needs to know whether the CONNECTING peer is among them, so a
-    // first-match pick could resolve a stale/wrong peer and wrongly defer (or,
-    // for a same-wallet Byzantine advertiser, mis-gate) recovery.
-    const resolveAgentPeers = async (agentAddrLower: string): Promise<string[]> => {
-      if (!cachedAgents) {
-        try {
-          cachedAgents = await this.discovery.findAgents();
-        } catch {
-          cachedAgents = [];
-        }
-      }
-      return cachedAgents
-        .filter((a) => a.agentAddress?.toLowerCase() === agentAddrLower)
-        .map((a) => a.peerId);
-    };
-    for (const contextGraphId of contextGraphIds) {
-      if (!(await this.canUseSharedMemoryForContextGraph(contextGraphId))) {
-        this.log.warn(ctx, `Skipping SWM sync for unauthorized or unconfirmed context graph "${contextGraphId}"`);
-        continue;
-      }
-      if (await this.isPrivateContextGraph(contextGraphId)) {
-        // The curator (curator-leader) is the authoritative SWM replica; it never
-        // reverse-syncs a CG it owns. Decide curatorship AND resolve the curator's
-        // peer by the STRUCTURAL curator — the wallet-scoped id prefix `0x<addr>` —
-        // NOT the dkg:curator/dkg:creator triples. A member that locally pre-created
-        // the CG (the rfc38 multi-member onboarding pattern) self-stamps its OWN
-        // wallet as a dkg:curator triple and its OWN peer as dkg:creator, which makes
-        // BOTH isCuratorOf() and resolveCuratorPeerId() resolve the member AS the
-        // curator — so the gate would skip the member's own recovery and it would
-        // silently never converge (a zero-byte-core durability failure). The id
-        // prefix is authoritative; only the node owning that agent is the curator.
-        const structuralCuratorDid = deriveCuratorDidFromCgId(contextGraphId);
-        if (structuralCuratorDid) {
-          const structuralAgent = structuralCuratorDid.slice('did:dkg:agent:'.length).toLowerCase();
-          if ([...this.localAgents.keys()].some((addr) => addr.toLowerCase() === structuralAgent)) {
-            this.log.debug(ctx, `SWM sync: skipping "${contextGraphId}" — local node is the curator (never reverse-syncs a CG it owns)`);
-            continue;
-          }
-          // Resolve the structural curator's peer via the agent registry. On a
-          // reconnect the registry may not be populated yet, so refresh meta once.
-          let curatorPeers = await resolveAgentPeers(structuralAgent);
-          if (curatorPeers.length === 0) {
-            await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
-            cachedAgents = undefined; // force a fresh registry read after the refresh
-            curatorPeers = await resolveAgentPeers(structuralAgent);
-          }
-          if (curatorPeers.length === 0) {
-            this.log.info(ctx, `SWM recovery skipped for private CG "${contextGraphId.slice(0, 28)}": curator (${structuralAgent.slice(0, 10)}) peer not resolved yet`);
-          } else if (!curatorPeers.includes(remotePeerId)) {
-            this.log.info(ctx, `SWM recovery deferred for private CG "${contextGraphId.slice(0, 28)}": connecting peer ${remotePeerId.slice(0, 12)} is not among the curator's ${curatorPeers.length} registered peer(s)`);
-          } else {
-            this.log.info(ctx, `SWM recovery ENQUEUED for private CG "${contextGraphId.slice(0, 28)}" from curator peer ${remotePeerId.slice(0, 12)}`);
-            privateRecoverFromCurator.push(contextGraphId);
-          }
-          continue;
-        }
-        // Legacy non-wallet-scoped CG (no structural curator): fall back to the
-        // triple-based curator resolution.
-        if (await this.isCuratorOf(contextGraphId)) {
-          this.log.debug(ctx, `SWM sync: skipping "${contextGraphId}" — local node is the curator (never reverse-syncs a CG it owns)`);
-          continue;
-        }
-        let curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
-        if (!curatorPeerId) {
-          await this.refreshMetaFromCurator(contextGraphId).catch(() => undefined);
-          curatorPeerId = await this.resolveCuratorPeerId(contextGraphId);
-        }
-        if (!curatorPeerId) {
-          this.log.info(ctx, `SWM recovery skipped for private CG "${contextGraphId.slice(0, 28)}": curator peerId not resolved`);
-        } else if (curatorPeerId === this.peerId) {
-          this.log.info(ctx, `SWM recovery skipped for private CG "${contextGraphId.slice(0, 28)}": local node resolves AS the curator`);
-        } else if (curatorPeerId !== remotePeerId) {
-          this.log.info(ctx, `SWM recovery deferred for private CG "${contextGraphId.slice(0, 28)}": connecting peer is not the curator`);
-        } else {
-          this.log.info(ctx, `SWM recovery ENQUEUED for private CG "${contextGraphId.slice(0, 28)}" from curator ${curatorPeerId.slice(0, 12)}`);
-          privateRecoverFromCurator.push(contextGraphId);
-        }
-        continue;
-      }
-      publicContextGraphIds.push(contextGraphId);
-    }
+    const planned = options?.sharedMemorySyncPlan;
+    const plan = planned && sameStringArray(planned.eligibleContextGraphIds, contextGraphIds)
+      ? planned
+      : await this.planSharedMemorySyncContextGraphs(remotePeerId, contextGraphIds, ctx);
+    const { publicContextGraphIds, privateRecoverFromCurator } = plan;
 
     const subGraphAdmissionByContextGraph = new Map<string, Promise<{ registered: string[]; excluded: string[] }>>();
     const getSubGraphAdmission = (contextGraphId: string) => {

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -3947,6 +3947,10 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     await this.refreshMetaSyncedFlags([contextGraphId]);
 
     if (dataSynced > 0 || sharedMemorySynced > 0) {
+      this.markContextGraphSubscriptionState(contextGraphId, {
+        synced: true,
+        ...(sharedMemorySynced > 0 ? { sharedMemorySynced: true } : {}),
+      });
       this.eventBus.emit(DKGEvent.PROJECT_SYNCED, {
         contextGraphId,
         dataSynced,

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2479,10 +2479,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
         contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
+        undefined,
+        undefined,
+        undefined,
+        { stopOnBackoffWorthyFailure: true },
       ),
       refreshMetaSyncedFlags: (contextGraphIds) => this.refreshMetaSyncedFlags(contextGraphIds),
       discoverContextGraphsFromStore: () => this.discoverContextGraphsFromStore(),
-      syncSharedMemoryFromPeer: (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds),
+      syncSharedMemoryFromPeer: (peerId, contextGraphIds) => this.syncSharedMemoryFromPeerDetailed(peerId, contextGraphIds, { stopOnBackoffWorthyFailure: true }),
       syncSharedMemoryOnConnect: this.config.syncSharedMemoryOnConnect ?? true,
       logInfo: (ctx, message) => this.log.info(ctx, message),
       onPeerSkippedNoSync: (peerId) => {
@@ -2967,6 +2971,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // Phase C — optional gap-safe per-CG delta high-water mark resolver. Backed
     // by a CONTIGUOUS watermark when supplied; omitted ⇒ full scan (default).
     sinceBatchIdFor?: (contextGraphId: string) => string | undefined,
+    options?: { stopOnBackoffWorthyFailure?: boolean },
   ): Promise<DurableSyncResult> {
     const ctx = createOperationContext('sync');
     return runDurableSync({
@@ -2979,6 +2984,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       createContextGraphSyncDeadline: this.createContextGraphSyncDeadline.bind(this),
       fetchSyncPages: this.fetchSyncPages.bind(this),
       sinceBatchIdFor,
+      stopOnBackoffWorthyFailure: options?.stopOnBackoffWorthyFailure,
       processDurableBatchInWorker: this.processDurableBatchInWorker.bind(this),
       storeInsert: (quads) => this.insertSyncedQuadsAndInvalidateListCache(quads),
       deleteCheckpoint: (key) => this.syncCheckpoints.delete(key),
@@ -3194,6 +3200,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
   async syncSharedMemoryFromPeerDetailed(this: DKGAgent,
     remotePeerId: string,
     contextGraphIds: string[],
+    options?: { stopOnBackoffWorthyFailure?: boolean },
   ): Promise<SharedMemorySyncResult> {
     const ctx = createOperationContext('sync');
     // M2 (curator-leader convergence): a PRIVATE CG converges by REPLACE-recovering the
@@ -3327,6 +3334,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
             ),
           getRegisteredSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).registered,
           getExcludedSubGraphNames: async (contextGraphId) => (await getSubGraphAdmission(contextGraphId)).excluded,
+          stopOnBackoffWorthyFailure: options?.stopOnBackoffWorthyFailure,
           ensureContextGraph: async (contextGraphId) => {
             const graphManager = new GraphManager(this.store);
             await graphManager.ensureContextGraph(contextGraphId);
@@ -3372,10 +3380,20 @@ export class LifecycleSyncMethods extends DKGAgentBase {
           summary.completedPhases += 1;
         } else {
           summary.failedPhases += 1;
+          summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
+          if (options?.stopOnBackoffWorthyFailure) {
+            this.log.info(ctx, `Stopping SWM curator-recovery fanout for ${remotePeerId} after "${contextGraphId}" (incomplete recovery)`);
+            break;
+          }
         }
       } catch (err) {
         this.log.warn(ctx, `Curator-recovery for private CG "${contextGraphId}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
         summary.failedPeers += 1;
+        summary.backoffWorthyFailures = (summary.backoffWorthyFailures ?? 0) + 1;
+        if (options?.stopOnBackoffWorthyFailure) {
+          this.log.info(ctx, `Stopping SWM curator-recovery fanout for ${remotePeerId} after "${contextGraphId}" (backoff-worthy failure)`);
+          break;
+        }
       }
     }
 

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -2475,7 +2475,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
       getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
-      getSharedMemorySyncContextGraphs: () => this.getSharedMemorySyncContextGraphs(),
+      getSharedMemorySyncContextGraphs: (peerId) => this.getSharedMemorySyncContextGraphs(peerId),
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
         peerId,
         contextGraphIds ?? [SYSTEM_CONTEXT_GRAPHS.AGENTS, SYSTEM_CONTEXT_GRAPHS.ONTOLOGY, ...(this.config.syncContextGraphs ?? [])],
@@ -2505,10 +2505,16 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     });
   }
 
-  async getSharedMemorySyncContextGraphs(this: DKGAgent): Promise<string[]> {
+  async getSharedMemorySyncContextGraphs(this: DKGAgent, remotePeerId?: string): Promise<string[]> {
     const eligible: string[] = [];
     for (const contextGraphId of this.config.syncContextGraphs ?? []) {
       if (await this.canUseSharedMemoryForContextGraph(contextGraphId)) {
+        if (remotePeerId && await this.isPrivateContextGraph(contextGraphId)) {
+          const { peerIds, curatorIsLocal } = await this.resolveCuratorPeerIdsForCg(contextGraphId);
+          if (curatorIsLocal || !peerIds.includes(remotePeerId)) {
+            continue;
+          }
+        }
         eligible.push(contextGraphId);
       }
     }

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -173,6 +173,7 @@ import {
   createSwmAckQuorum,
   type SwmAckQuorum,
 } from './swm/ack-quorum.js';
+import type { SelectSwmFanoutPeersResult } from './swm/swm-fanout-peer-selection.js';
 import { SwmHostModeStore, type SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import {
   BEACON_ACCESS_POLICY_CURATED,
@@ -516,6 +517,33 @@ export class PublishMethods extends DKGAgentBase {
       };
     }
 
+    let substrateMembers = plan.substrateMembers;
+    let fanoutSelection: SelectSwmFanoutPeersResult | undefined;
+    if (plan.useSubstrate && plan.substrateMembers.length > 0) {
+      fanoutSelection = this.selectSwmFanoutPeersForActiveShare({
+        contextGraphId,
+        candidatePeers: plan.substrateMembers,
+        enumerationSource: plan.enumerationSource,
+      });
+      substrateMembers = fanoutSelection.selectedPeers;
+      if (
+        plan.enumerationSource === 'topic-subscribers'
+        && (
+          substrateMembers.length !== plan.substrateMembers.length
+          || fanoutSelection.skippedRecentPeers.length > 0
+        )
+      ) {
+        this.log.info(
+          ctx,
+          `SWM public fan-out narrowed cgId=${contextGraphId} `
+          + `selected=${substrateMembers.length}/${plan.substrateMembers.length} `
+          + `knownGood=${fanoutSelection.knownGoodPeers.length} `
+          + `unknownProbe=${fanoutSelection.unknownProbedPeers.length} `
+          + `skippedRecent=${fanoutSelection.skippedRecentPeers.length}`,
+        );
+      }
+    }
+
     // rc.9 PR-D codex follow-up #D5 (rebased onto PR-G's G2
     // detach): register the SwmAckQuorum tracker BEFORE
     // substrate + gossip fire so a fast receiver's
@@ -581,14 +609,14 @@ export class PublishMethods extends DKGAgentBase {
     //      check.
     const ackQuorumActive = !!shareOperationId
       && plan.useGossip
-      && plan.substrateMembers.length > 0;
+      && substrateMembers.length > 0;
     let trackedQuorum: SwmAckQuorum | null = null;
     if (ackQuorumActive && shareOperationId) {
       trackedQuorum = this.getOrCreateSwmAckQuorum();
       trackedQuorum.track({
         shareOperationId,
         cgId: contextGraphId,
-        expectedMembers: plan.substrateMembers,
+        expectedMembers: substrateMembers,
         preAckedFromSubstrate: [],
         payload: wireMessage,
         enumerationSource: plan.enumerationSource,
@@ -604,7 +632,7 @@ export class PublishMethods extends DKGAgentBase {
     //   2. (PR-D #D5) Feed substrate-`delivered` peers into
     //      the quorum via onAck so they count toward the same
     //      quorum target as gossip-side acks.
-    if (plan.useSubstrate) {
+    if (plan.useSubstrate && substrateMembers.length > 0) {
       const baseBookkeeper = this.substrateFanoutBookkeeper();
       // PR-J: capture per-peer outcomes for the optional detail
       // line emitted when anything queues/fails/is rejected. Lets
@@ -617,7 +645,7 @@ export class PublishMethods extends DKGAgentBase {
             contextGraphId,
             protocolId: PROTOCOL_SWM_UPDATE,
             payload: wireMessage,
-            members: plan.substrateMembers,
+            members: substrateMembers,
             sendTimeoutMs: DKGAgentBase.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
             substrate: this.messenger,
             bookkeeper: {
@@ -628,6 +656,9 @@ export class PublishMethods extends DKGAgentBase {
                   && record.outcome === 'delivered'
                 ) {
                   trackedQuorum.onAck(shareOperationId, record.peerId);
+                }
+                if (plan.enumerationSource === 'topic-subscribers') {
+                  this.recordSwmFanoutPeerRecord(contextGraphId, record);
                 }
                 if (
                   record.outcome === 'queued'
@@ -649,6 +680,7 @@ export class PublishMethods extends DKGAgentBase {
             ctx,
             `SWM substrate fan-out cgId=${contextGraphId} source=${plan.enumerationSource} `
             + `enumerated=${plan.enumeratedCount} `
+            + `selected=${substrateMembers.length} `
             + `attempted=${substrateResult.attempted} `
             + `delivered=${substrateResult.delivered} rejected=${substrateResult.rejected} `
             + `retryable=${substrateResult.retryable} `
@@ -681,6 +713,13 @@ export class PublishMethods extends DKGAgentBase {
         this.inFlightSubstrateFanOuts.delete(tracked);
       });
       this.inFlightSubstrateFanOuts.add(tracked);
+    } else if (plan.useSubstrate && plan.enumerationSource === 'topic-subscribers') {
+      this.log.info(
+        ctx,
+        `SWM public substrate fan-out skipped cgId=${contextGraphId}: `
+        + `no eligible peers after recent outcome filtering `
+        + `(candidates=${plan.substrateMembers.length})`,
+      );
     }
 
     if (plan.useGossip) {

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -165,6 +165,14 @@ import {
   createSwmAckQuorum,
   type SwmAckQuorum,
 } from './swm/ack-quorum.js';
+import {
+  classifySwmFanoutPeerOutcome,
+  createSwmFanoutPeerSelector,
+  type SelectSwmFanoutPeersInput,
+  type SelectSwmFanoutPeersResult,
+  type SwmFanoutPeerOutcome,
+  type SwmFanoutPeerSelector,
+} from './swm/swm-fanout-peer-selection.js';
 import { SwmHostModeStore, type SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import {
   BEACON_ACCESS_POLICY_CURATED,
@@ -683,7 +691,12 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         );
         return new Uint8Array();
       }
-      this.getOrCreateSwmAckQuorum().onAck(ack.shareOperationId, fromPeerId);
+      const quorum = this.getOrCreateSwmAckQuorum();
+      const record = quorum.inspect(ack.shareOperationId);
+      if (record?.enumerationSource === 'topic-subscribers') {
+        this.recordSwmFanoutPeerOutcome(record.cgId, fromPeerId, 'good');
+      }
+      quorum.onAck(ack.shareOperationId, fromPeerId);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       this.log.warn(
@@ -725,6 +738,38 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     ackPct: number;
   } | undefined {
     return this.swmAckQuorum?.inspect(shareOperationId);
+  }
+
+  getOrCreateSwmFanoutPeerSelector(this: DKGAgent): SwmFanoutPeerSelector {
+    if (!this.swmFanoutPeerSelector) {
+      this.swmFanoutPeerSelector = createSwmFanoutPeerSelector();
+    }
+    return this.swmFanoutPeerSelector;
+  }
+
+  selectSwmFanoutPeersForActiveShare(this: DKGAgent, input: SelectSwmFanoutPeersInput): SelectSwmFanoutPeersResult {
+    return this.getOrCreateSwmFanoutPeerSelector().select(input);
+  }
+
+  recordSwmFanoutPeerOutcome(
+    this: DKGAgent,
+    contextGraphId: string,
+    peerId: string,
+    outcome: SwmFanoutPeerOutcome,
+  ): void {
+    this.getOrCreateSwmFanoutPeerSelector().record(contextGraphId, peerId, outcome);
+  }
+
+  recordSwmFanoutPeerRecord(this: DKGAgent, contextGraphId: string, record: FanOutPeerRecord): void {
+    this.recordSwmFanoutPeerOutcome(
+      contextGraphId,
+      record.peerId,
+      classifySwmFanoutPeerOutcome(record),
+    );
+  }
+
+  getSwmFanoutPeerOutcomeForTests(this: DKGAgent, contextGraphId: string, peerId: string, now?: number): SwmFanoutPeerOutcome | undefined {
+    return this.swmFanoutPeerSelector?.get(contextGraphId, peerId, now);
   }
 
   /**
@@ -1145,9 +1190,35 @@ export class SwmSubstrateMethods extends DKGAgentBase {
       );
       return;
     }
+    const quorumRecord = this.swmAckQuorum?.inspect(shareOperationId);
+    let topUpPeers = dialableMissingPeers;
+    if (quorumRecord?.enumerationSource === 'topic-subscribers') {
+      const selection = this.selectSwmFanoutPeersForActiveShare({
+        contextGraphId: cgId,
+        candidatePeers: dialableMissingPeers,
+        enumerationSource: 'topic-subscribers',
+      });
+      topUpPeers = selection.selectedPeers;
+      if (selection.skippedRecentPeers.length > 0 || topUpPeers.length !== dialableMissingPeers.length) {
+        this.log.info(
+          ctx,
+          `SWM public top-up narrowed cg=${cgId} selected=${topUpPeers.length}/${dialableMissingPeers.length} `
+          + `knownGood=${selection.knownGoodPeers.length} `
+          + `unknownProbe=${selection.unknownProbedPeers.length} `
+          + `skippedRecent=${selection.skippedRecentPeers.length}`,
+        );
+      }
+      if (topUpPeers.length === 0) {
+        this.log.info(
+          ctx,
+          `SWM public top-up skipped for ${shareOperationId} (cg=${cgId}): all ${dialableMissingPeers.length} dialable peer(s) are inside recent negative TTL`,
+        );
+        return;
+      }
+    }
     this.log.info(
       ctx,
-      `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${dialableMissingPeers.length}/${missingPeers.length} dialable peer(s) (cg=${cgId})`,
+      `SWM ack-quorum watchdog firing substrate top-up for ${shareOperationId} to ${topUpPeers.length}/${missingPeers.length} peer(s) (cg=${cgId}, dialable=${dialableMissingPeers.length})`,
     );
     // PR-H bug 1: route per-peer outcomes to the right ack-quorum
     // hook. Pre-PR-H ignored outcomes entirely except for
@@ -1187,13 +1258,16 @@ export class SwmSubstrateMethods extends DKGAgentBase {
     //     publisher) would tighten this further; out of scope
     //     for this PR — see PR #582 comments / follow-up issue.
     let rearmCount = 0;
-    await Promise.allSettled(dialableMissingPeers.map(async (peerId: string) => {
+    await Promise.allSettled(topUpPeers.map(async (peerId: string) => {
       try {
         const sendResult = await this.messenger.sendReliable(peerId, PROTOCOL_SWM_UPDATE, payload, {
           messageId: `swm-topup-${shareOperationId}-${peerId}`,
           timeoutMs: DKGAgentBase.SWM_SUBSTRATE_FANOUT_TIMEOUT_MS,
         });
         const classified = classifySendResult(peerId, sendResult);
+        if (quorumRecord?.enumerationSource === 'topic-subscribers') {
+          this.recordSwmFanoutPeerRecord(cgId, classified);
+        }
         switch (classified.outcome) {
           case 'delivered':
             this.swmAckQuorum?.onAck(shareOperationId, peerId);
@@ -1210,6 +1284,10 @@ export class SwmSubstrateMethods extends DKGAgentBase {
         }
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
+        if (quorumRecord?.enumerationSource === 'topic-subscribers') {
+          this.recordSwmFanoutPeerOutcome(cgId, peerId, 'failed');
+        }
+        this.swmAckQuorum?.dropPeer(shareOperationId, peerId);
         this.log.warn(ctx, `SWM top-up to ${peerId} failed: ${reason}`);
       }
     }));
@@ -1260,7 +1338,13 @@ export class SwmSubstrateMethods extends DKGAgentBase {
           },
           onDeadlineExpired: (e: {
             shareOperationId: string; cgId: string; ackedCount: number; expectedCount: number; ackPct: number;
+            missingPeers: readonly string[]; enumerationSource: 'allowlist' | 'topic-subscribers' | 'none';
           }) => {
+            if (e.enumerationSource === 'topic-subscribers') {
+              for (const peerId of e.missingPeers) {
+                this.recordSwmFanoutPeerOutcome(e.cgId, peerId, 'nonTerminal');
+              }
+            }
             this.log.warn(
               createOperationContext('share', e.shareOperationId),
               `SWM share deadline expired cg=${e.cgId} acked=${e.ackedCount}/${e.expectedCount} (${(e.ackPct * 100).toFixed(1)}%) — offline peers will recover via runSyncOnConnect`,

--- a/packages/agent/src/dkg-agent-swm-substrate.ts
+++ b/packages/agent/src/dkg-agent-swm-substrate.ts
@@ -793,14 +793,15 @@ export class SwmSubstrateMethods extends DKGAgentBase {
    * Add a context graph to runtime sync scope so sync-on-connect includes it.
    * System context graphs are already included by default and are skipped here.
    */
-  public trackSyncContextGraph(this: DKGAgent, contextGraphId: string): void {
+  public trackSyncContextGraph(this: DKGAgent, contextGraphId: string): boolean {
     const systemContextGraphs = new Set<string>(Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]);
-    if (systemContextGraphs.has(contextGraphId)) return;
+    if (systemContextGraphs.has(contextGraphId)) return false;
 
     const syncSet = new Set<string>(this.config.syncContextGraphs ?? []);
-    if (syncSet.has(contextGraphId)) return;
+    if (syncSet.has(contextGraphId)) return false;
     syncSet.add(contextGraphId);
     this.config.syncContextGraphs = [...syncSet];
+    return true;
   }
 
   getOrCreateGossipPublishHandler(this: DKGAgent): GossipPublishHandler {

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -746,6 +746,7 @@ export interface DurableSyncDiagnostics {
   rejectedKcs: number;
   failedPeers: number;
   failedPhases: number;
+  backoffWorthyFailures?: number;
 }
 
 export interface SharedMemorySyncDiagnostics {
@@ -762,6 +763,7 @@ export interface SharedMemorySyncDiagnostics {
   droppedDataTriples: number;
   failedPeers: number;
   failedPhases: number;
+  backoffWorthyFailures?: number;
 }
 
 export interface CatchupSyncDiagnostics {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -987,8 +987,7 @@ export class DKGAgent extends DKGAgentBase {
         // host-only) private CG here would silently undo that operator choice on
         // every discovery scan. Only re-track CGs the node is still a live
         // subscriber of.
-        if (existing.subscribed && await this.isPrivateContextGraph(id)) {
-          this.trackSyncContextGraph(id);
+        if (existing.subscribed && await this.isPrivateContextGraph(id) && this.trackSyncContextGraph(id)) {
           this.log.info(ctx, `Re-tracked already-subscribed private CG "${id.slice(0, 28)}" into the SWM-sync scope on discovery`);
         }
         continue;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -80,6 +80,18 @@ export {
 } from './swm/verify-batch.js';
 export { createCGHostEnumerator, type CGHostEnumerator, type CGHostEnumeratorDeps } from './swm/enumerate-cg-hosts.js';
 export {
+  createSwmCatchupPeerSelector,
+  classifySwmCatchupPeerOutcome,
+  SwmCatchupPeerSelector,
+  SWM_CATCHUP_FALLBACK_PROBE_LIMIT,
+  SWM_CATCHUP_PEER_GOOD_TTL_MS,
+  SWM_CATCHUP_PEER_NEGATIVE_TTL_MS,
+  type SelectSwmCatchupPeersInput,
+  type SelectSwmCatchupPeersResult,
+  type SwmCatchupPeerOutcome,
+  type SwmCatchupPeerSelectorOptions,
+} from './swm/swm-catchup-peer-selection.js';
+export {
   mintMemberAttestation,
   verifyMemberAttestation,
   computeAttestationDigest,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -177,6 +177,17 @@ export {
   type TrackInput,
   type TrackedRecordSnapshot,
 } from './swm/ack-quorum.js';
+export {
+  classifySwmFanoutPeerOutcome,
+  createSwmFanoutPeerSelector,
+  SWM_FANOUT_PEER_GOOD_TTL_MS,
+  SWM_FANOUT_PEER_NEGATIVE_TTL_MS,
+  SWM_FANOUT_UNKNOWN_PROBE_LIMIT,
+  type SelectSwmFanoutPeersInput,
+  type SelectSwmFanoutPeersResult,
+  type SwmFanoutPeerOutcome,
+  type SwmFanoutPeerSelectorOptions,
+} from './swm/swm-fanout-peer-selection.js';
 export * from './source-worker.js';
 export * from './source-registry.js';
 export * from './generic-sql-source.js';

--- a/packages/agent/src/swm/ack-quorum.ts
+++ b/packages/agent/src/swm/ack-quorum.ts
@@ -105,12 +105,15 @@ export interface SwmAckQuorumObservers {
     ackedCount: number;
     expectedCount: number;
     ackPct: number;
+    enumerationSource: CGMemberEnumeration['source'];
   }) => void;
   onWatchdogFired?: (input: {
     shareOperationId: string;
     cgId: string;
     missingCount: number;
     expectedCount: number;
+    missingPeers: readonly string[];
+    enumerationSource: CGMemberEnumeration['source'];
   }) => void;
   onDeadlineExpired?: (input: {
     shareOperationId: string;
@@ -118,6 +121,8 @@ export interface SwmAckQuorumObservers {
     ackedCount: number;
     expectedCount: number;
     ackPct: number;
+    missingPeers: readonly string[];
+    enumerationSource: CGMemberEnumeration['source'];
   }) => void;
 }
 
@@ -329,18 +334,22 @@ export function createSwmAckQuorum(deps: SwmAckQuorumDeps): SwmAckQuorum {
       ackedCount: record.acked.size,
       expectedCount: record.expectedMembers.size,
       ackPct: ackPctOf(record),
+      enumerationSource: record.enumerationSource,
     }));
   }
 
   function expireRecord(record: TrackedRecord): void {
     if (!records.delete(record.shareOperationId)) return;
     deadlineExpiredCount += 1;
+    const missingPeers = [...record.expectedMembers].filter((peerId) => !record.acked.has(peerId));
     safeInvoke(() => observers.onDeadlineExpired?.({
       shareOperationId: record.shareOperationId,
       cgId: record.cgId,
       ackedCount: record.acked.size,
       expectedCount: record.expectedMembers.size,
       ackPct: ackPctOf(record),
+      missingPeers,
+      enumerationSource: record.enumerationSource,
     }));
   }
 
@@ -356,6 +365,8 @@ export function createSwmAckQuorum(deps: SwmAckQuorumDeps): SwmAckQuorum {
       cgId: record.cgId,
       missingCount: missingPeers.length,
       expectedCount: record.expectedMembers.size,
+      missingPeers,
+      enumerationSource: record.enumerationSource,
     }));
     safeInvoke(() => {
       const r = deps.substrateTopUp({

--- a/packages/agent/src/swm/swm-catchup-peer-selection.ts
+++ b/packages/agent/src/swm/swm-catchup-peer-selection.ts
@@ -1,0 +1,198 @@
+export type SwmCatchupPeerOutcome = 'good' | 'empty' | 'denied' | 'unsupported' | 'transportFailed';
+
+export const SWM_CATCHUP_PEER_GOOD_TTL_MS = 10 * 60_000;
+export const SWM_CATCHUP_PEER_NEGATIVE_TTL_MS = 2 * 60_000;
+export const SWM_CATCHUP_FALLBACK_PROBE_LIMIT = 3;
+
+const DEFAULT_MAX_ENTRIES = 4096;
+const KEY_SEPARATOR = '\0';
+
+interface SwmCatchupPeerEntry {
+  outcome: SwmCatchupPeerOutcome;
+  expiresAt: number;
+  updatedAt: number;
+}
+
+export interface SwmCatchupPeerSelectorOptions {
+  goodTtlMs?: number;
+  negativeTtlMs?: number;
+  fallbackProbeLimit?: number;
+  maxEntries?: number;
+}
+
+export interface SelectSwmCatchupPeersInput {
+  contextGraphId: string;
+  candidatePeers: readonly string[];
+  unsupportedPeers?: ReadonlySet<string>;
+  privateCuratorPeerIds?: readonly string[];
+  now?: number;
+  fallbackProbeLimit?: number;
+}
+
+export interface SelectSwmCatchupPeersResult {
+  selectedPeers: string[];
+  skippedUnsupportedPeers: string[];
+  skippedNegativePeers: string[];
+  scopedCandidatePeers: string[];
+}
+
+export class SwmCatchupPeerSelector {
+  private readonly entries = new Map<string, SwmCatchupPeerEntry>();
+  private readonly goodTtlMs: number;
+  private readonly negativeTtlMs: number;
+  private readonly fallbackProbeLimit: number;
+  private readonly maxEntries: number;
+
+  constructor(options: SwmCatchupPeerSelectorOptions = {}) {
+    this.goodTtlMs = options.goodTtlMs ?? SWM_CATCHUP_PEER_GOOD_TTL_MS;
+    this.negativeTtlMs = options.negativeTtlMs ?? SWM_CATCHUP_PEER_NEGATIVE_TTL_MS;
+    this.fallbackProbeLimit = options.fallbackProbeLimit ?? SWM_CATCHUP_FALLBACK_PROBE_LIMIT;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  record(contextGraphId: string, peerId: string, outcome: SwmCatchupPeerOutcome, now = Date.now()): void {
+    const ttl = outcome === 'good' ? this.goodTtlMs : this.negativeTtlMs;
+    if (ttl <= 0) {
+      this.entries.delete(cacheKey(contextGraphId, peerId));
+      return;
+    }
+    this.prune(now);
+    if (this.entries.size >= this.maxEntries) {
+      const oldest = [...this.entries.entries()].sort((a, b) => a[1].updatedAt - b[1].updatedAt)[0]?.[0];
+      if (oldest) this.entries.delete(oldest);
+    }
+    this.entries.set(cacheKey(contextGraphId, peerId), {
+      outcome,
+      expiresAt: now + ttl,
+      updatedAt: now,
+    });
+  }
+
+  get(contextGraphId: string, peerId: string, now = Date.now()): SwmCatchupPeerOutcome | undefined {
+    const key = cacheKey(contextGraphId, peerId);
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.outcome;
+  }
+
+  select(input: SelectSwmCatchupPeersInput): SelectSwmCatchupPeersResult {
+    const now = input.now ?? Date.now();
+    const fallbackProbeLimit = input.fallbackProbeLimit ?? this.fallbackProbeLimit;
+    const unsupportedPeers = input.unsupportedPeers ?? new Set<string>();
+    const scopedCandidatePeers = applyCuratorScope(
+      unique(input.candidatePeers),
+      input.privateCuratorPeerIds,
+    );
+
+    const protocolCandidates: string[] = [];
+    const skippedUnsupportedPeers: string[] = [];
+    for (const peerId of scopedCandidatePeers) {
+      if (unsupportedPeers.has(peerId)) {
+        skippedUnsupportedPeers.push(peerId);
+        continue;
+      }
+      protocolCandidates.push(peerId);
+    }
+
+    const knownGood: string[] = [];
+    const unknown: string[] = [];
+    const negative: string[] = [];
+    for (const peerId of protocolCandidates) {
+      const outcome = this.get(input.contextGraphId, peerId, now);
+      if (outcome === 'good') knownGood.push(peerId);
+      else if (outcome) negative.push(peerId);
+      else unknown.push(peerId);
+    }
+
+    let selectedPeers: string[];
+    if (knownGood.length > 0) {
+      selectedPeers = knownGood;
+    } else if (unknown.length > 0) {
+      selectedPeers = unknown.slice(0, Math.max(0, fallbackProbeLimit));
+    } else {
+      selectedPeers = negative.slice(0, Math.max(0, fallbackProbeLimit));
+    }
+
+    const selected = new Set(selectedPeers);
+    return {
+      selectedPeers,
+      skippedUnsupportedPeers,
+      skippedNegativePeers: negative.filter((peerId) => !selected.has(peerId)),
+      scopedCandidatePeers,
+    };
+  }
+
+  prune(now = Date.now()): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) this.entries.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+export function createSwmCatchupPeerSelector(options?: SwmCatchupPeerSelectorOptions): SwmCatchupPeerSelector {
+  return new SwmCatchupPeerSelector(options);
+}
+
+export function classifySwmCatchupPeerOutcome(input: {
+  insertedTriples?: number;
+  fetchedDataTriples?: number;
+  fetchedMetaTriples?: number;
+  deniedPhases?: number;
+  failedPeers?: number;
+  failedPhases?: number;
+  timedOutPhases?: number;
+  backoffWorthyFailures?: number;
+  errorMessage?: string;
+}): SwmCatchupPeerOutcome {
+  if ((input.insertedTriples ?? 0) > 0 || (input.fetchedDataTriples ?? 0) > 0 || (input.fetchedMetaTriples ?? 0) > 0) {
+    return 'good';
+  }
+  if ((input.deniedPhases ?? 0) > 0 || isDeniedMessage(input.errorMessage)) {
+    return 'denied';
+  }
+  if (
+    input.errorMessage ||
+    (input.failedPeers ?? 0) > 0 ||
+    (input.failedPhases ?? 0) > 0 ||
+    (input.timedOutPhases ?? 0) > 0 ||
+    (input.backoffWorthyFailures ?? 0) > 0
+  ) {
+    return 'transportFailed';
+  }
+  return 'empty';
+}
+
+function cacheKey(contextGraphId: string, peerId: string): string {
+  return `${contextGraphId}${KEY_SEPARATOR}${peerId}`;
+}
+
+function unique(peers: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const peer of peers) {
+    if (!peer || seen.has(peer)) continue;
+    seen.add(peer);
+    out.push(peer);
+  }
+  return out;
+}
+
+function applyCuratorScope(candidatePeers: string[], privateCuratorPeerIds: readonly string[] | undefined): string[] {
+  if (!privateCuratorPeerIds) return candidatePeers;
+  const curatorPeers = new Set(privateCuratorPeerIds);
+  return candidatePeers.filter((peerId) => curatorPeers.has(peerId));
+}
+
+function isDeniedMessage(message: string | undefined): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return lower.includes('denied') || lower.includes('unauthorized') || lower.includes('not authorized');
+}

--- a/packages/agent/src/swm/swm-fanout-peer-selection.ts
+++ b/packages/agent/src/swm/swm-fanout-peer-selection.ts
@@ -1,0 +1,177 @@
+import type { CGMemberEnumeration } from './enumerate-cg-members.js';
+import type { FanOutPeerRecord } from './substrate-fanout.js';
+
+export type SwmFanoutPeerOutcome = 'good' | 'nonTerminal' | 'failed' | 'unsupported';
+
+export const SWM_FANOUT_PEER_GOOD_TTL_MS = 10 * 60_000;
+export const SWM_FANOUT_PEER_NEGATIVE_TTL_MS = 2 * 60_000;
+export const SWM_FANOUT_UNKNOWN_PROBE_LIMIT = 3;
+
+const DEFAULT_MAX_ENTRIES = 4096;
+const KEY_SEPARATOR = '\0';
+
+interface SwmFanoutPeerEntry {
+  outcome: SwmFanoutPeerOutcome;
+  expiresAt: number;
+  updatedAt: number;
+}
+
+export interface SwmFanoutPeerSelectorOptions {
+  goodTtlMs?: number;
+  negativeTtlMs?: number;
+  unknownProbeLimit?: number;
+  maxEntries?: number;
+}
+
+export interface SelectSwmFanoutPeersInput {
+  contextGraphId: string;
+  candidatePeers: readonly string[];
+  enumerationSource: CGMemberEnumeration['source'];
+  now?: number;
+  unknownProbeLimit?: number;
+}
+
+export interface SelectSwmFanoutPeersResult {
+  selectedPeers: string[];
+  knownGoodPeers: string[];
+  unknownProbedPeers: string[];
+  skippedRecentPeers: string[];
+  candidatePeers: string[];
+}
+
+export class SwmFanoutPeerSelector {
+  private readonly entries = new Map<string, SwmFanoutPeerEntry>();
+  private readonly goodTtlMs: number;
+  private readonly negativeTtlMs: number;
+  private readonly unknownProbeLimit: number;
+  private readonly maxEntries: number;
+
+  constructor(options: SwmFanoutPeerSelectorOptions = {}) {
+    this.goodTtlMs = options.goodTtlMs ?? SWM_FANOUT_PEER_GOOD_TTL_MS;
+    this.negativeTtlMs = options.negativeTtlMs ?? SWM_FANOUT_PEER_NEGATIVE_TTL_MS;
+    this.unknownProbeLimit = options.unknownProbeLimit ?? SWM_FANOUT_UNKNOWN_PROBE_LIMIT;
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  record(contextGraphId: string, peerId: string, outcome: SwmFanoutPeerOutcome, now = Date.now()): void {
+    const ttl = outcome === 'good' ? this.goodTtlMs : this.negativeTtlMs;
+    const key = cacheKey(contextGraphId, peerId);
+    if (ttl <= 0) {
+      this.entries.delete(key);
+      return;
+    }
+    this.prune(now);
+    if (this.entries.size >= this.maxEntries) {
+      const oldest = [...this.entries.entries()].sort((a, b) => a[1].updatedAt - b[1].updatedAt)[0]?.[0];
+      if (oldest) this.entries.delete(oldest);
+    }
+    this.entries.set(key, {
+      outcome,
+      expiresAt: now + ttl,
+      updatedAt: now,
+    });
+  }
+
+  get(contextGraphId: string, peerId: string, now = Date.now()): SwmFanoutPeerOutcome | undefined {
+    const key = cacheKey(contextGraphId, peerId);
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.outcome;
+  }
+
+  select(input: SelectSwmFanoutPeersInput): SelectSwmFanoutPeersResult {
+    const candidatePeers = unique(input.candidatePeers);
+    if (input.enumerationSource !== 'topic-subscribers') {
+      return {
+        selectedPeers: candidatePeers,
+        knownGoodPeers: [],
+        unknownProbedPeers: [],
+        skippedRecentPeers: [],
+        candidatePeers,
+      };
+    }
+
+    const now = input.now ?? Date.now();
+    const unknownProbeLimit = Math.max(0, input.unknownProbeLimit ?? this.unknownProbeLimit);
+    const knownGoodPeers: string[] = [];
+    const unknownPeers: string[] = [];
+    const skippedRecentPeers: string[] = [];
+
+    for (const peerId of candidatePeers) {
+      const outcome = this.get(input.contextGraphId, peerId, now);
+      if (outcome === 'good') {
+        knownGoodPeers.push(peerId);
+      } else if (outcome) {
+        skippedRecentPeers.push(peerId);
+      } else {
+        unknownPeers.push(peerId);
+      }
+    }
+
+    const unknownProbedPeers = unknownPeers.slice(0, unknownProbeLimit);
+    return {
+      selectedPeers: [...knownGoodPeers, ...unknownProbedPeers],
+      knownGoodPeers,
+      unknownProbedPeers,
+      skippedRecentPeers,
+      candidatePeers,
+    };
+  }
+
+  prune(now = Date.now()): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) this.entries.delete(key);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+export function createSwmFanoutPeerSelector(options?: SwmFanoutPeerSelectorOptions): SwmFanoutPeerSelector {
+  return new SwmFanoutPeerSelector(options);
+}
+
+export function classifySwmFanoutPeerOutcome(record: Pick<FanOutPeerRecord, 'outcome' | 'error'>): SwmFanoutPeerOutcome {
+  switch (record.outcome) {
+    case 'delivered':
+      return 'good';
+    case 'retryable':
+    case 'queued':
+    case 'inFlight':
+      return 'nonTerminal';
+    case 'rejected':
+    case 'failed':
+      return isUnsupportedMessage(record.error) ? 'unsupported' : 'failed';
+  }
+}
+
+function cacheKey(contextGraphId: string, peerId: string): string {
+  return `${contextGraphId}${KEY_SEPARATOR}${peerId}`;
+}
+
+function unique(peers: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const peer of peers) {
+    if (!peer || seen.has(peer)) continue;
+    seen.add(peer);
+    out.push(peer);
+  }
+  return out;
+}
+
+function isUnsupportedMessage(message: string | undefined): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return lower.includes('unsupported')
+    || lower.includes('protocol negotiation')
+    || lower.includes('protocol not supported')
+    || lower.includes('no protocol')
+    || lower.includes('not support protocol');
+}

--- a/packages/agent/src/sync/error-tags.ts
+++ b/packages/agent/src/sync/error-tags.ts
@@ -35,3 +35,28 @@ export function didSyncPeerRespond(error: unknown): boolean {
 export function isSyncTransportFailure(error: unknown): boolean {
   return Boolean(error && typeof error === 'object' && (error as { syncTransportFailure?: boolean }).syncTransportFailure);
 }
+
+export function isSyncBackoffWorthyError(error: unknown): boolean {
+  if (isSyncTransportFailure(error)) return true;
+
+  const message = error instanceof Error
+    ? error.message.toLowerCase()
+    : String(error).toLowerCase();
+
+  return (
+    message.includes('too many active durable data sync session snapshots') ||
+    (message.includes('sync responder') && (
+      message.includes('queue full') ||
+      message.includes('queue wait exceeded') ||
+      message.includes('snapshot limit exceeded') ||
+      message.includes('busy')
+    )) ||
+    message.includes('stream reset') ||
+    message.includes('connection reset') ||
+    message.includes('econnreset') ||
+    message.includes('etimedout') ||
+    message.includes('send timeout') ||
+    message.includes('operation timed out') ||
+    message.includes('operation was aborted due to timeout')
+  );
+}

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -26,6 +26,7 @@ interface SyncOnConnectContext {
   getPeerProtocols: (peerId: string) => Promise<string[]>;
   knownCorePeerIds: Set<string>;
   getSyncContextGraphs: () => string[];
+  getSharedMemorySyncContextGraphs?: () => string[] | Promise<string[]>;
   syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
   discoverContextGraphsFromStore: () => Promise<number>;
@@ -130,6 +131,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     getPeerProtocols,
     knownCorePeerIds,
     getSyncContextGraphs,
+    getSharedMemorySyncContextGraphs,
     syncFromPeer,
     refreshMetaSyncedFlags,
     discoverContextGraphsFromStore,
@@ -216,7 +218,9 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     }
 
     durableSyncCompleted = true;
-    const wsContextGraphIds = getSyncContextGraphs() ?? [];
+    const wsContextGraphIds = getSharedMemorySyncContextGraphs
+      ? await runNonTransportStep(() => Promise.resolve(getSharedMemorySyncContextGraphs()))
+      : getSyncContextGraphs() ?? [];
     if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
       const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);
       recordSyncAccounting(wsSynced, 'shared');

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -11,6 +11,7 @@ interface SyncProgressSummary {
   failedPeers?: number;
   failedPhases?: number;
   deniedPhases?: number;
+  backoffWorthyFailures?: number;
 }
 
 type SyncFromPeerResult = number | SyncProgressSummary;
@@ -87,7 +88,11 @@ function madeSyncProgress(result: SyncFromPeerResult): boolean {
 
 function hadBackoffWorthyFailure(result: SyncFromPeerResult): boolean {
   if (typeof result === 'number') return false;
-  return (result.failedPeers ?? 0) > 0 || (result.timedOutPhases ?? 0) > 0;
+  return (
+    (result.backoffWorthyFailures ?? 0) > 0 ||
+    (result.failedPeers ?? 0) > 0 ||
+    (result.timedOutPhases ?? 0) > 0
+  );
 }
 
 function hadDeniedPhase(result: SyncFromPeerResult): boolean {
@@ -197,6 +202,10 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     const synced = await syncFromPeer(remotePeer);
     recordSyncAccounting(synced, 'durable');
     logInfo(ctx, `Synced ${insertedTriples(synced)} data triples from peer ${shortPeer}`);
+    if (hadBackoffWorthyFailure(synced)) {
+      logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after durable sync hit backoff-worthy pressure`);
+      return 'synced';
+    }
 
     const syncScope = new Set<string>([
       SYSTEM_CONTEXT_GRAPHS.AGENTS,
@@ -214,6 +223,10 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       const discoverSynced = await syncFromPeer(remotePeer, newlyDiscovered);
       recordSyncAccounting(discoverSynced, 'durable');
       logInfo(ctx, `Synced ${insertedTriples(discoverSynced)} durable triples for newly discovered CG(s) from ${shortPeer}`);
+      if (hadBackoffWorthyFailure(discoverSynced)) {
+        logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG durable sync hit backoff-worthy pressure`);
+        return 'synced';
+      }
       await runNonTransportStep(() => refreshMetaSyncedFlags(newlyDiscovered));
     }
 

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -26,7 +26,7 @@ interface SyncOnConnectContext {
   getPeerProtocols: (peerId: string) => Promise<string[]>;
   knownCorePeerIds: Set<string>;
   getSyncContextGraphs: () => string[];
-  getSharedMemorySyncContextGraphs?: () => string[] | Promise<string[]>;
+  getSharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
   syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
   refreshMetaSyncedFlags: (contextGraphIds: Iterable<string>) => Promise<void>;
   discoverContextGraphsFromStore: () => Promise<number>;
@@ -219,7 +219,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
 
     durableSyncCompleted = true;
     const wsContextGraphIds = getSharedMemorySyncContextGraphs
-      ? await runNonTransportStep(() => Promise.resolve(getSharedMemorySyncContextGraphs()))
+      ? await runNonTransportStep(() => Promise.resolve(getSharedMemorySyncContextGraphs(remotePeer)))
       : getSyncContextGraphs() ?? [];
     if (syncSharedMemoryOnConnect && wsContextGraphIds.length > 0) {
       const wsSynced = await syncSharedMemoryFromPeer(remotePeer, wsContextGraphIds);

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -168,6 +168,17 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       cleanDurableDetailedRound = cleanDurableDetailedRound || cleanDetailedSync(result);
     }
   };
+  const finishSyncAccounting = (): SyncOnConnectOutcome => {
+    const cleanDurableRound = cleanDurableDetailedRound && !sawDurableMetadataOnlyDetailedSync;
+    const clearsPeerBackoff = madeProgress || (!sawBackoffWorthyFailure && (cleanDurableRound || sawDeniedPhase));
+    if (clearsPeerBackoff) {
+      context.onPeerSynced?.(remotePeer, {
+        fresh: !sawBackoffWorthyFailure && !sawDeniedPhase && !sawFailedPhase && cleanDurableRound,
+        progress: madeProgress,
+      });
+    }
+    return 'synced';
+  };
   const runNonTransportStep = async <T>(step: () => Promise<T>): Promise<T> => {
     try {
       return await step();
@@ -204,7 +215,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     logInfo(ctx, `Synced ${insertedTriples(synced)} data triples from peer ${shortPeer}`);
     if (hadBackoffWorthyFailure(synced)) {
       logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after durable sync hit backoff-worthy pressure`);
-      return 'synced';
+      return finishSyncAccounting();
     }
 
     const syncScope = new Set<string>([
@@ -225,7 +236,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       logInfo(ctx, `Synced ${insertedTriples(discoverSynced)} durable triples for newly discovered CG(s) from ${shortPeer}`);
       if (hadBackoffWorthyFailure(discoverSynced)) {
         logInfo(ctx, `Stopping sync-on-connect fanout for peer ${shortPeer} after discovered-CG durable sync hit backoff-worthy pressure`);
-        return 'synced';
+        return finishSyncAccounting();
       }
       await runNonTransportStep(() => refreshMetaSyncedFlags(newlyDiscovered));
     }
@@ -242,15 +253,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       logInfo(ctx, `Skipping shared memory sync from peer ${shortPeer} (syncSharedMemoryOnConnect=false)`);
     }
 
-    const cleanDurableRound = cleanDurableDetailedRound && !sawDurableMetadataOnlyDetailedSync;
-    const clearsPeerBackoff = madeProgress || (!sawBackoffWorthyFailure && (cleanDurableRound || sawDeniedPhase));
-    if (clearsPeerBackoff) {
-      context.onPeerSynced?.(remotePeer, {
-        fresh: !sawBackoffWorthyFailure && !sawDeniedPhase && !sawFailedPhase && cleanDurableRound,
-        progress: madeProgress,
-      });
-    }
-    return 'synced';
+    return finishSyncAccounting();
   } catch (err) {
     if (err instanceof SyncOnConnectPostSyncError) {
       throw err;

--- a/packages/agent/src/sync/requester/durable-sync.ts
+++ b/packages/agent/src/sync/requester/durable-sync.ts
@@ -3,7 +3,7 @@ import { contextGraphDataGraphUri, contextGraphMetaGraphUri } from '@origintrail
 import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { PhaseCallback } from '@origintrail-official/dkg-publisher';
-import { didSyncPeerRespond, isSyncTransportFailure } from '../error-tags.js';
+import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncTransportFailure } from '../error-tags.js';
 import { getSyncCheckpointKey } from '../checkpoint/state.js';
 import type { SyncPageResult } from './page-fetch.js';
 
@@ -25,6 +25,7 @@ export interface DurableSyncSummary {
   rejectedKcs: number;
   failedPeers: number;
   failedPhases: number;
+  backoffWorthyFailures: number;
 }
 
 interface DurableSyncContext {
@@ -61,6 +62,7 @@ interface DurableSyncContext {
    * backed by a CONTIGUOUS watermark. Undefined ⇒ full scan (default today).
    */
   sinceBatchIdFor?: (contextGraphId: string) => string | undefined;
+  stopOnBackoffWorthyFailure?: boolean;
   processDurableBatchInWorker: (dataQuads: Quad[], metaQuads: Quad[], ctx: OperationContext, acceptUnverified: boolean) => Promise<{
     verifiedData: Quad[];
     verifiedMeta: Quad[];
@@ -90,6 +92,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     createContextGraphSyncDeadline,
     fetchSyncPages,
     sinceBatchIdFor,
+    stopOnBackoffWorthyFailure = false,
     processDurableBatchInWorker,
     storeInsert,
     deleteCheckpoint,
@@ -117,6 +120,7 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     rejectedKcs: 0,
     failedPeers: 0,
     failedPhases: 0,
+    backoffWorthyFailures: 0,
   };
 
   const recordPhaseOutcome = (result: SyncPageResult, options: { updateCheckpoint: boolean; countProgress?: boolean }) => {
@@ -139,6 +143,11 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
   };
 
   let peerFailed = false;
+  const shouldStopAfterBackoffWorthyFailure = (contextGraphId: string, reason: string): boolean => {
+    if (!stopOnBackoffWorthyFailure) return false;
+    logInfo(ctx, `Stopping durable sync fanout for ${remotePeerId} after "${contextGraphId}" (${reason})`);
+    return true;
+  };
   for (const [index, pid] of contextGraphIds.entries()) {
     let activePhase: 'fetch' | 'verify' | 'store' | undefined;
     let peerRespondedForContextGraph = false;
@@ -177,6 +186,11 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
           }
         : await fetchSyncPages(ctx, remotePeerId, pid, false, 'meta', metaGraph, deadline);
       if (!skipAgentsMeta) peerRespondedForContextGraph = true;
+      if (metaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
+        recordPhaseOutcome(metaResult, { updateCheckpoint: false });
+        endPhase();
+        break;
+      }
       const dataResult = await fetchSyncPages(ctx, remotePeerId, pid, false, 'data', dataGraph, deadline, undefined, sinceBatchIdFor?.(pid));
       peerRespondedForContextGraph = true;
       endPhase();
@@ -211,6 +225,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       ) {
         recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
         recordPhaseOutcome(dataResult, { updateCheckpoint: updateDataCheckpoint });
+        if ((metaResult.timedOut || dataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
+          break;
+        }
         continue;
       }
 
@@ -229,6 +246,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
       recordPhaseOutcome(metaResult, { updateCheckpoint: updateMetaCheckpoint, countProgress: !metadataOnlyResponse });
       recordPhaseOutcome(dataResult, { updateCheckpoint: updateDataCheckpoint });
       endPhase();
+      if ((metaResult.timedOut || dataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
+        break;
+      }
       const storeDurationMs = Date.now() - storeStartedAt;
 
       if (fetchDurationMs + verifyDurationMs + storeDurationMs > 100) {
@@ -245,6 +265,10 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
     } catch (pidErr) {
       endPhase();
       logWarn(ctx, `Sync for context graph "${pid}" from ${remotePeerId} failed: ${pidErr instanceof Error ? pidErr.message : String(pidErr)}`);
+      const backoffWorthy = isSyncBackoffWorthyError(pidErr);
+      if (backoffWorthy) {
+        summary.backoffWorthyFailures += 1;
+      }
       if ((pidErr as Error & { syncDenied?: boolean }).syncDenied) {
         onAccessDenied?.(pid);
         summary.deniedPhases += 1;
@@ -256,6 +280,9 @@ export async function runDurableSync(context: DurableSyncContext): Promise<Durab
         summary.failedPhases += 1;
       } else {
         peerFailed = true;
+      }
+      if (backoffWorthy && shouldStopAfterBackoffWorthyFailure(pid, 'backoff-worthy failure')) {
+        break;
       }
     }
   }

--- a/packages/agent/src/sync/requester/shared-memory-sync.ts
+++ b/packages/agent/src/sync/requester/shared-memory-sync.ts
@@ -3,7 +3,7 @@ import type { OperationContext } from '@origintrail-official/dkg-core';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { workspacePublicQuadsDigest, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import type { SyncPhase } from '../auth/request-build.js';
-import { didSyncPeerRespond, isSyncTransportFailure } from '../error-tags.js';
+import { didSyncPeerRespond, isSyncBackoffWorthyError, isSyncTransportFailure } from '../error-tags.js';
 import { isSharedMemoryBucketDescendantDataGraph } from '../shared-memory-graphs.js';
 import type { SyncPageResult } from './page-fetch.js';
 
@@ -25,6 +25,7 @@ export interface SharedMemorySyncSummary {
   droppedDataTriples: number;
   failedPeers: number;
   failedPhases: number;
+  backoffWorthyFailures: number;
 }
 
 interface SharedMemorySyncContext {
@@ -62,6 +63,7 @@ interface SharedMemorySyncContext {
   publicSnapshotStore?: WorkspacePublicSnapshotStore;
   getRegisteredSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
   getExcludedSubGraphNames?: (contextGraphId: string) => Promise<readonly string[]>;
+  stopOnBackoffWorthyFailure?: boolean;
   deleteCheckpoint: (key: string) => void;
   setCheckpoint: (key: string, offset: number) => void;
   ensureOwnedMap: (ownershipKey: string) => Map<string, string>;
@@ -83,6 +85,7 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     publicSnapshotStore,
     getRegisteredSubGraphNames,
     getExcludedSubGraphNames,
+    stopOnBackoffWorthyFailure = false,
     deleteCheckpoint,
     setCheckpoint,
     ensureOwnedMap,
@@ -107,11 +110,14 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
     droppedDataTriples: 0,
     failedPeers: 0,
     failedPhases: 0,
+    backoffWorthyFailures: 0,
   };
 
-  const recordPhaseOutcome = (result: SyncPageResult) => {
+  const recordPhaseOutcome = (result: SyncPageResult, options: { updateCheckpoint?: boolean } = {}) => {
+    const updateCheckpoint = options.updateCheckpoint ?? true;
     summary.resumedPhases += result.resumedFromOffset > 0 ? 1 : 0;
     summary.timedOutPhases += result.timedOut ? 1 : 0;
+    if (!updateCheckpoint) return;
     if (result.completed && (result.resumedFromOffset > 0 || result.nextOffset > result.resumedFromOffset)) {
       summary.completedPhases += 1;
     }
@@ -125,6 +131,11 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
   };
 
   let peerFailed = false;
+  const shouldStopAfterBackoffWorthyFailure = (contextGraphId: string, reason: string): boolean => {
+    if (!stopOnBackoffWorthyFailure) return false;
+    logInfo(ctx, `Stopping SWM sync fanout for ${remotePeerId} after "${contextGraphId}" (${reason})`);
+    return true;
+  };
   for (const [index, pid] of contextGraphIds.entries()) {
     let peerRespondedForContextGraph = false;
     try {
@@ -137,6 +148,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       const fetchStartedAt = Date.now();
       const wsMetaResult = await fetchSyncPages(ctx, remotePeerId, pid, true, 'meta', wsMetaGraph, deadline);
       peerRespondedForContextGraph = true;
+      if (wsMetaResult.timedOut && shouldStopAfterBackoffWorthyFailure(pid, 'meta timeout')) {
+        recordPhaseOutcome(wsMetaResult, { updateCheckpoint: false });
+        break;
+      }
       const wsDataResult = await fetchSyncPages(ctx, remotePeerId, pid, true, 'data', wsGraph, deadline);
       peerRespondedForContextGraph = true;
       const fetchDurationMs = Date.now() - fetchStartedAt;
@@ -165,6 +180,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       if (processed.emptyResponses > 0) {
         recordPhaseOutcome(wsMetaResult);
         recordPhaseOutcome(wsDataResult);
+        if ((wsMetaResult.timedOut || wsDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
+          break;
+        }
         continue;
       }
 
@@ -215,6 +233,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
           recordPhaseOutcome(wsDataResult);
           hydrateOwnership();
         }
+        if (snapshotSync.timedOutPhases > 0 && shouldStopAfterBackoffWorthyFailure(pid, 'snapshot timeout')) {
+          break;
+        }
         continue;
       }
 
@@ -233,6 +254,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       }
       recordPhaseOutcome(wsMetaResult);
       recordPhaseOutcome(wsDataResult);
+      if ((wsMetaResult.timedOut || wsDataResult.timedOut) && shouldStopAfterBackoffWorthyFailure(pid, 'phase timeout')) {
+        break;
+      }
 
       hydrateOwnership();
       const storeDurationMs = Date.now() - storeStartedAt;
@@ -246,6 +270,10 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
       }
     } catch (err) {
       logWarn(ctx, `SWM sync for context graph "${pid}" from ${remotePeerId} failed: ${err instanceof Error ? err.message : String(err)}`);
+      const backoffWorthy = isSyncBackoffWorthyError(err);
+      if (backoffWorthy) {
+        summary.backoffWorthyFailures += 1;
+      }
       if ((err as Error & { syncDenied?: boolean }).syncDenied) {
         summary.deniedPhases += 1;
       } else if (
@@ -256,6 +284,9 @@ export async function runSharedMemorySync(context: SharedMemorySyncContext): Pro
         summary.failedPhases += 1;
       } else {
         peerFailed = true;
+      }
+      if (backoffWorthy && shouldStopAfterBackoffWorthyFailure(pid, 'backoff-worthy failure')) {
+        break;
       }
     }
   }

--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -24,6 +24,7 @@ const DKG_BATCH_ID = `${DKG}batchId`;
 const SCHEMA_NAME = 'http://schema.org/name';
 const PROV_GENERATED = 'http://www.w3.org/ns/prov#generated';
 const PROV_USED = 'http://www.w3.org/ns/prov#used';
+const COMPLETED_SYNC_RESPONDER_SESSION_GRACE_MS = 30_000;
 
 export interface GraphListMemo {
   get(options?: { refresh?: boolean; signal?: AbortSignal }): Promise<readonly string[]>;
@@ -39,6 +40,7 @@ export interface SyncRowListMemo {
     loadRows: () => Promise<readonly SyncRow[]>,
     options?: { refresh?: boolean; requireExisting?: boolean; signal?: AbortSignal },
   ): Promise<readonly SyncRow[] | null>;
+  release(key: string, options?: { graceMs?: number }): void;
 }
 
 export class SyncRowSnapshotLimitError extends Error {
@@ -215,6 +217,7 @@ export function createResponderSyncRowListMemo(
       const load = loadRows()
         .then((rows) => {
           const value = [...rows];
+          throwIfAborted(options?.signal);
           storeCached(key, value);
           return value;
         })
@@ -225,6 +228,22 @@ export function createResponderSyncRowListMemo(
       const rows = await load;
       throwIfAborted(options?.signal);
       return [...rows];
+    },
+    release(key, options?: { graceMs?: number }) {
+      const existing = cached.get(key);
+      if (!existing) return;
+      const graceMs = Math.max(0, Math.min(options?.graceMs ?? 0, ttlMs));
+      if (graceMs === 0) {
+        markExpired(key);
+        return;
+      }
+      const cachedAt = Date.now() - (ttlMs - graceMs);
+      clearTimeout(existing.cleanupTimer);
+      cached.set(key, {
+        value: existing.value,
+        cachedAt,
+        cleanupTimer: scheduleCleanup(key, cachedAt),
+      });
     },
   };
 }
@@ -645,7 +664,11 @@ async function readCachedRowsPage(
   if (rows == null) {
     throw new Error(cache.expiredMessage ?? 'Sync session snapshot expired before page completion');
   }
-  return [...rows].slice(safeOffset, safeOffset + safeLimit);
+  const page = [...rows].slice(safeOffset, safeOffset + safeLimit);
+  if (page.length < safeLimit) {
+    cache.memo.release(cache.key, { graceMs: COMPLETED_SYNC_RESPONDER_SESSION_GRACE_MS });
+  }
+  return page;
 }
 
 function asAbortError(reason: unknown): Error {

--- a/packages/agent/test/swm-catchup-peer-selection.test.ts
+++ b/packages/agent/test/swm-catchup-peer-selection.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifySwmCatchupPeerOutcome,
+  createSwmCatchupPeerSelector,
+  SWM_CATCHUP_PEER_NEGATIVE_TTL_MS,
+} from '../src/swm/swm-catchup-peer-selection.js';
+
+describe('SWM catchup peer selection', () => {
+  it('filters peers known not to advertise the current sync protocol', () => {
+    const selector = createSwmCatchupPeerSelector({ fallbackProbeLimit: 3 });
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['legacy-peer', 'current-peer'],
+      unsupportedPeers: new Set(['legacy-peer']),
+      now: 100,
+    });
+
+    expect(result.selectedPeers).toEqual(['current-peer']);
+    expect(result.skippedUnsupportedPeers).toEqual(['legacy-peer']);
+  });
+
+  it('prefers a known-good peer for the context graph over unknown peers', () => {
+    const selector = createSwmCatchupPeerSelector();
+    selector.record('cg', 'peer-b', 'good', 100);
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a', 'peer-b', 'peer-c'],
+      now: 101,
+    });
+
+    expect(result.selectedPeers).toEqual(['peer-b']);
+  });
+
+  it('skips recent empty, denied, and transport-failed peers while an unknown peer exists', () => {
+    const selector = createSwmCatchupPeerSelector({ fallbackProbeLimit: 3 });
+    selector.record('cg', 'empty-peer', 'empty', 100);
+    selector.record('cg', 'denied-peer', 'denied', 100);
+    selector.record('cg', 'failed-peer', 'transportFailed', 100);
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['empty-peer', 'denied-peer', 'failed-peer', 'unknown-peer'],
+      now: 101,
+    });
+
+    expect(result.selectedPeers).toEqual(['unknown-peer']);
+    expect(result.skippedNegativePeers).toEqual(['empty-peer', 'denied-peer', 'failed-peer']);
+  });
+
+  it('keeps cold discovery bounded when no good peer is known', () => {
+    const selector = createSwmCatchupPeerSelector({ fallbackProbeLimit: 2 });
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a', 'peer-b', 'peer-c', 'peer-d'],
+      now: 100,
+    });
+
+    expect(result.selectedPeers).toEqual(['peer-a', 'peer-b']);
+  });
+
+  it('uses resolved curator peers for private context graph catchup', () => {
+    const selector = createSwmCatchupPeerSelector({ fallbackProbeLimit: 3 });
+
+    const result = selector.select({
+      contextGraphId: 'private-cg',
+      candidatePeers: ['unrelated-peer', 'curator-peer', 'other-peer'],
+      privateCuratorPeerIds: ['curator-peer'],
+      now: 100,
+    });
+
+    expect(result.scopedCandidatePeers).toEqual(['curator-peer']);
+    expect(result.selectedPeers).toEqual(['curator-peer']);
+  });
+
+  it('retries a previously skipped peer after the negative TTL expires', () => {
+    const selector = createSwmCatchupPeerSelector();
+    selector.record('cg', 'peer-a', 'empty', 100);
+
+    expect(selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a', 'peer-b'],
+      now: 101,
+    }).selectedPeers).toEqual(['peer-b']);
+
+    expect(selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a'],
+      now: 100 + SWM_CATCHUP_PEER_NEGATIVE_TTL_MS + 1,
+    }).selectedPeers).toEqual(['peer-a']);
+  });
+
+  it('classifies detailed sync outcomes for cache accounting', () => {
+    expect(classifySwmCatchupPeerOutcome({ fetchedDataTriples: 1 })).toBe('good');
+    expect(classifySwmCatchupPeerOutcome({ deniedPhases: 1 })).toBe('denied');
+    expect(classifySwmCatchupPeerOutcome({ failedPeers: 1 })).toBe('transportFailed');
+    expect(classifySwmCatchupPeerOutcome({})).toBe('empty');
+  });
+});

--- a/packages/agent/test/swm-fanout-peer-selection.test.ts
+++ b/packages/agent/test/swm-fanout-peer-selection.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  classifySwmFanoutPeerOutcome,
+  createSwmFanoutPeerSelector,
+  SWM_FANOUT_PEER_NEGATIVE_TTL_MS,
+  type SelectSwmFanoutPeersInput,
+} from '../src/swm/swm-fanout-peer-selection.js';
+import { SwmSubstrateMethods } from '../src/dkg-agent-swm-substrate.js';
+
+describe('active SWM fanout peer selection', () => {
+  it('prefers known-good public peers and bounds unknown probes', () => {
+    const selector = createSwmFanoutPeerSelector({ unknownProbeLimit: 2 });
+    selector.record('cg', 'peer-b', 'good', 100);
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a', 'peer-b', 'peer-c', 'peer-d'],
+      enumerationSource: 'topic-subscribers',
+      now: 101,
+    });
+
+    expect(result.knownGoodPeers).toEqual(['peer-b']);
+    expect(result.unknownProbedPeers).toEqual(['peer-a', 'peer-c']);
+    expect(result.selectedPeers).toEqual(['peer-b', 'peer-a', 'peer-c']);
+  });
+
+  it('excludes recent non-terminal and failed public peers during the negative TTL', () => {
+    const selector = createSwmFanoutPeerSelector({ unknownProbeLimit: 3 });
+    selector.record('cg', 'peer-non-terminal', 'nonTerminal', 100);
+    selector.record('cg', 'peer-failed', 'failed', 100);
+    selector.record('cg', 'peer-unsupported', 'unsupported', 100);
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-non-terminal', 'peer-failed', 'peer-unsupported', 'peer-unknown'],
+      enumerationSource: 'topic-subscribers',
+      now: 101,
+    });
+
+    expect(result.selectedPeers).toEqual(['peer-unknown']);
+    expect(result.skippedRecentPeers).toEqual(['peer-non-terminal', 'peer-failed', 'peer-unsupported']);
+  });
+
+  it('does not fall back to recent negative public peers when no unknown peer exists', () => {
+    const selector = createSwmFanoutPeerSelector({ unknownProbeLimit: 3 });
+    selector.record('cg', 'peer-a', 'nonTerminal', 100);
+
+    const result = selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a'],
+      enumerationSource: 'topic-subscribers',
+      now: 101,
+    });
+
+    expect(result.selectedPeers).toEqual([]);
+    expect(result.skippedRecentPeers).toEqual(['peer-a']);
+  });
+
+  it('retries a skipped public peer after the negative TTL expires', () => {
+    const selector = createSwmFanoutPeerSelector();
+    selector.record('cg', 'peer-a', 'failed', 100);
+
+    expect(selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a'],
+      enumerationSource: 'topic-subscribers',
+      now: 101,
+    }).selectedPeers).toEqual([]);
+
+    expect(selector.select({
+      contextGraphId: 'cg',
+      candidatePeers: ['peer-a'],
+      enumerationSource: 'topic-subscribers',
+      now: 100 + SWM_FANOUT_PEER_NEGATIVE_TTL_MS + 1,
+    }).selectedPeers).toEqual(['peer-a']);
+  });
+
+  it('keeps different context graphs and peers isolated', () => {
+    const selector = createSwmFanoutPeerSelector();
+    selector.record('cg-a', 'peer-a', 'failed', 100);
+
+    expect(selector.select({
+      contextGraphId: 'cg-b',
+      candidatePeers: ['peer-a'],
+      enumerationSource: 'topic-subscribers',
+      now: 101,
+    }).selectedPeers).toEqual(['peer-a']);
+
+    expect(selector.select({
+      contextGraphId: 'cg-a',
+      candidatePeers: ['peer-b'],
+      enumerationSource: 'topic-subscribers',
+      now: 101,
+    }).selectedPeers).toEqual(['peer-b']);
+  });
+
+  it('leaves curated allowlist fanout unchanged', () => {
+    const selector = createSwmFanoutPeerSelector();
+    selector.record('curated-cg', 'offline-allowlist-peer', 'failed', 100);
+
+    const result = selector.select({
+      contextGraphId: 'curated-cg',
+      candidatePeers: ['offline-allowlist-peer', 'online-allowlist-peer'],
+      enumerationSource: 'allowlist',
+      now: 101,
+    });
+
+    expect(result.selectedPeers).toEqual(['offline-allowlist-peer', 'online-allowlist-peer']);
+    expect(result.skippedRecentPeers).toEqual([]);
+  });
+
+  it('classifies active substrate outcomes for selector accounting', () => {
+    expect(classifySwmFanoutPeerOutcome({ outcome: 'delivered', error: '' })).toBe('good');
+    expect(classifySwmFanoutPeerOutcome({ outcome: 'retryable', error: '' })).toBe('nonTerminal');
+    expect(classifySwmFanoutPeerOutcome({ outcome: 'queued', error: '' })).toBe('nonTerminal');
+    expect(classifySwmFanoutPeerOutcome({ outcome: 'inFlight', error: '' })).toBe('nonTerminal');
+    expect(classifySwmFanoutPeerOutcome({ outcome: 'failed', error: 'dial timeout' })).toBe('failed');
+    expect(classifySwmFanoutPeerOutcome({ outcome: 'failed', error: 'protocol not supported' })).toBe('unsupported');
+  });
+
+  it('watchdog top-up records non-terminal outcomes and rearms once', async () => {
+    const recordSwmFanoutPeerRecord = vi.fn();
+    const rearmWatchdog = vi.fn();
+    const selector = createSwmFanoutPeerSelector({ unknownProbeLimit: 3 });
+    const fakeAgent = fakeTopUpAgent({
+      selector,
+      sendReliable: vi.fn(async () => ({
+        delivered: false,
+        queued: true,
+        attempts: 1,
+        messageId: 'm-peer-a',
+        error: 'queued for retry',
+        nextAttemptAtMs: 200,
+      })),
+      recordSwmFanoutPeerRecord,
+      rearmWatchdog,
+    });
+
+    await SwmSubstrateMethods.prototype.swmSubstrateTopUp.call(fakeAgent, {
+      shareOperationId: 'op',
+      cgId: 'cg',
+      payload: new Uint8Array([1]),
+      missingPeers: ['peer-a'],
+    });
+
+    expect(recordSwmFanoutPeerRecord).toHaveBeenCalledWith('cg', expect.objectContaining({
+      peerId: 'peer-a',
+      outcome: 'queued',
+    }));
+    expect(rearmWatchdog).toHaveBeenCalledWith('op');
+  });
+
+  it('watchdog top-up skips a recent non-terminal peer inside TTL', async () => {
+    const sendReliable = vi.fn();
+    const selector = createSwmFanoutPeerSelector({ unknownProbeLimit: 3 });
+    selector.record('cg', 'peer-a', 'nonTerminal', 100);
+    const fakeAgent = fakeTopUpAgent({
+      selector,
+      now: 101,
+      sendReliable,
+    });
+
+    await SwmSubstrateMethods.prototype.swmSubstrateTopUp.call(fakeAgent, {
+      shareOperationId: 'op',
+      cgId: 'cg',
+      payload: new Uint8Array([1]),
+      missingPeers: ['peer-a'],
+    });
+
+    expect(sendReliable).not.toHaveBeenCalled();
+  });
+});
+
+function fakeTopUpAgent(input: {
+  selector: ReturnType<typeof createSwmFanoutPeerSelector>;
+  now?: number;
+  sendReliable: ReturnType<typeof vi.fn>;
+  recordSwmFanoutPeerRecord?: ReturnType<typeof vi.fn>;
+  recordSwmFanoutPeerOutcome?: ReturnType<typeof vi.fn>;
+  rearmWatchdog?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    isPeerDialable: vi.fn(async () => true),
+    messenger: {
+      sendReliable: input.sendReliable,
+    },
+    swmAckQuorum: {
+      inspect: vi.fn(() => ({
+        shareOperationId: 'op',
+        cgId: 'cg',
+        expectedMembers: ['peer-a'],
+        acked: [],
+        ackPct: 0,
+        watchdogFired: true,
+        startedAtMs: 0,
+        watchdogArmedAtMs: 0,
+        watchdogMs: 30_000,
+        deadlineHardMs: 300_000,
+        enumerationSource: 'topic-subscribers',
+      })),
+      onAck: vi.fn(),
+      dropPeer: vi.fn(),
+      rearmWatchdog: input.rearmWatchdog ?? vi.fn(),
+    },
+    selectSwmFanoutPeersForActiveShare: (selectionInput: SelectSwmFanoutPeersInput) => (
+      input.selector.select({ ...selectionInput, now: input.now })
+    ),
+    recordSwmFanoutPeerRecord: input.recordSwmFanoutPeerRecord ?? vi.fn(),
+    recordSwmFanoutPeerOutcome: input.recordSwmFanoutPeerOutcome ?? vi.fn(),
+  };
+}

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { MockChainAdapter } from '@origintrail-official/dkg-chain';
+import { DKGAgent } from '../src/index.js';
+import { CATCHUP_ON_CONNECT_COOLDOWN_MS, SYNC_RECONNECT_FLAP_GRACE_MS } from '../src/dkg-agent-constants.js';
+import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+
+const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => {
+    calls.push(args);
+    return impl(...args);
+  };
+  return Object.assign(fn, { calls });
+}
+
+async function flushTimers(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+async function createUnstartedAgent(name: string): Promise<DKGAgent> {
+  return DKGAgent.create({
+    name,
+    listenHost: '127.0.0.1',
+    chainAdapter: new MockChainAdapter(),
+  });
+}
+
+const noopLog = (_ctx: OperationContext, _message: string) => {};
+
+describe('sync-on-connect churn gates', () => {
+  it('dedupes repeated reconnect scheduling across a short relay flap', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectFlapDedup');
+    const calls: string[] = [];
+    (agent as any).runSyncFromPeerOnConnect = async (peerId: string) => {
+      calls.push(peerId);
+    };
+
+    const handleSyncError = () => undefined;
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, handleSyncError, 0)).toBe(true);
+    const firstQueuedAt = (agent as any).catchupOnConnectAt.get(PEER_A);
+
+    (agent as any).lastSyncDisconnectedAt.set(PEER_A, Date.now() - Math.floor(SYNC_RECONNECT_FLAP_GRACE_MS / 2));
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, handleSyncError, 0)).toBe(false);
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, handleSyncError, 0)).toBe(false);
+    expect((agent as any).catchupOnConnectAt.get(PEER_A)).toBe(firstQueuedAt);
+
+    await flushTimers();
+    expect(calls).toEqual([PEER_A]);
+  });
+
+  it('allows reconnect catch-up after a meaningful offline gap', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectOfflineGap');
+    const calls: string[] = [];
+    (agent as any).runSyncFromPeerOnConnect = async (peerId: string) => {
+      calls.push(peerId);
+    };
+
+    const lastDisconnected = Date.now() - SYNC_RECONNECT_FLAP_GRACE_MS - 100;
+    const beforeDisconnect = lastDisconnected - 1;
+    (agent as any).lastSuccessfulSyncAt.set(PEER_A, beforeDisconnect);
+    (agent as any).catchupOnConnectAt.set(PEER_A, beforeDisconnect);
+    (agent as any).lastSyncDisconnectedAt.set(PEER_A, lastDisconnected);
+
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(true);
+    expect((agent as any).catchupOnConnectAt.get(PEER_A)).toBeGreaterThan(lastDisconnected);
+
+    await flushTimers();
+    expect(calls).toEqual([PEER_A]);
+  });
+
+  it('reconciler still retries stale connected peers', async () => {
+    const agent = await createUnstartedAgent('SyncReconcilerStillRetries');
+    (agent as any).started = true;
+    (agent.node as any).node = {
+      getPeers: () => [{ toString: () => PEER_A }],
+      getConnections: () => [],
+    };
+    (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+    const trySyncFromPeer = recorder(async () => undefined);
+    (agent as any).trySyncFromPeer = trySyncFromPeer;
+
+    await (agent as any).reconcileSyncFromConnectedPeers();
+    await flushTimers();
+
+    expect(trySyncFromPeer.calls).toEqual([[PEER_A, expect.any(Function)]]);
+  });
+
+  it('records backoff after a failed sync round and blocks connection-open rescheduling', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectBackoff');
+    (agent as any).started = true;
+    (agent.node as any).node = {
+      getPeers: () => [{ toString: () => PEER_A }],
+      getConnections: () => [],
+    };
+    (agent as any).getPeerProtocols = async () => [PROTOCOL_SYNC];
+    (agent as any).trySyncFromPeer = async () => 'synced';
+
+    await (agent as any).runSyncFromPeerOnConnect(PEER_A, () => undefined);
+
+    const backoff = (agent as any).syncReconcilerBackoff.get(PEER_A);
+    expect(backoff?.failures).toBe(1);
+    expect(backoff?.nextRetryAt).toBeGreaterThan(Date.now());
+
+    const staleQueuedAt = Date.now() - CATCHUP_ON_CONNECT_COOLDOWN_MS - 1;
+    (agent as any).catchupOnConnectAt.set(PEER_A, staleQueuedAt);
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
+    expect((agent as any).catchupOnConnectAt.get(PEER_A)).toBe(staleQueuedAt);
+  });
+
+  it('skips SWM sync-on-connect fanout when no CG is locally eligible', async () => {
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['unauthorized-cg'],
+      getSharedMemorySyncContextGraphs: () => [],
+      syncFromPeer: async () => 0,
+      refreshMetaSyncedFlags: async () => undefined,
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncSharedMemoryFromPeer.calls).toEqual([]);
+  });
+
+  it('preserves successful SWM sync-on-connect for eligible CGs', async () => {
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['eligible-cg'],
+      getSharedMemorySyncContextGraphs: () => ['eligible-cg'],
+      syncFromPeer: async () => 0,
+      refreshMetaSyncedFlags: async () => undefined,
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['eligible-cg']]]);
+  });
+});

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -7,6 +7,7 @@ import { runSyncOnConnect } from '../src/sync/on-connect/sync-on-connect.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
 
 const PEER_A = '12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M';
+const PEER_B = '12D3KooWRnKxyUg8W3ju7BpxN3e9NAsG1T4d6TuK53LZxD41f3RC';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   const calls: A[] = [];
@@ -31,6 +32,23 @@ async function createUnstartedAgent(name: string): Promise<DKGAgent> {
 }
 
 const noopLog = (_ctx: OperationContext, _message: string) => {};
+
+function emptyDetailedSync(overrides: Record<string, number> = {}) {
+  return {
+    insertedTriples: 0,
+    insertedDataTriples: 0,
+    insertedMetaTriples: 0,
+    metaOnlyResponses: 0,
+    completedPhases: 0,
+    checkpointAdvances: 0,
+    timedOutPhases: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    deniedPhases: 0,
+    backoffWorthyFailures: 0,
+    ...overrides,
+  };
+}
 
 describe('sync-on-connect churn gates', () => {
   it('dedupes repeated reconnect scheduling across a short relay flap', async () => {
@@ -110,6 +128,69 @@ describe('sync-on-connect churn gates', () => {
     (agent as any).catchupOnConnectAt.set(PEER_A, staleQueuedAt);
     expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
     expect((agent as any).catchupOnConnectAt.get(PEER_A)).toBe(staleQueuedAt);
+  });
+
+  it('does not let one peer backoff suppress connection-open sync for another peer', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectBackoffPeerScoped');
+    const calls: string[] = [];
+    (agent as any).syncReconcilerBackoff.set(PEER_A, {
+      failures: 1,
+      nextRetryAt: Date.now() + CATCHUP_ON_CONNECT_COOLDOWN_MS,
+      protocolsKey: null,
+      connectionKey: null,
+    });
+    (agent as any).runSyncFromPeerOnConnect = async (peerId: string) => {
+      calls.push(peerId);
+    };
+
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(false);
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_B, () => undefined, 0)).toBe(true);
+
+    await flushTimers();
+    expect(calls).toEqual([PEER_B]);
+  });
+
+  it('allows connection-open sync after peer backoff cooldown expires', async () => {
+    const agent = await createUnstartedAgent('SyncReconnectBackoffExpiry');
+    const calls: string[] = [];
+    (agent as any).syncReconcilerBackoff.set(PEER_A, {
+      failures: 1,
+      nextRetryAt: Date.now() - 1,
+      protocolsKey: null,
+      connectionKey: null,
+    });
+    (agent as any).runSyncFromPeerOnConnect = async (peerId: string) => {
+      calls.push(peerId);
+    };
+
+    expect((agent as any).queueSyncFromPeerOnConnect(PEER_A, () => undefined, 0)).toBe(true);
+
+    await flushTimers();
+    expect(calls).toEqual([PEER_A]);
+  });
+
+  it('stops post-durable sync-on-connect fanout after backoff-worthy durable pressure', async () => {
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => 0);
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['cg-a'],
+      syncFromPeer: async () => emptyDetailedSync({ failedPeers: 1, backoffWorthyFailures: 1 }),
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(refreshMetaSyncedFlags.calls).toEqual([]);
+    expect(discoverContextGraphsFromStore.calls).toEqual([]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([]);
   });
 
   it('skips SWM sync-on-connect fanout when no CG is locally eligible', async () => {

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -278,18 +278,14 @@ describe('sync-on-connect churn gates', () => {
       contextGraphId !== unconfirmedCg;
     (agent as any).isPrivateContextGraph = async (contextGraphId: string) =>
       contextGraphId.includes('private');
-    (agent as any).resolveCuratorPeerIdsForCg = async (contextGraphId: string) => {
-      if (contextGraphId === privateCg) {
-        return { peerIds: [PEER_A], curatorIsLocal: false, legacyTripleResolved: false };
-      }
-      if (contextGraphId === otherPrivateCg) {
-        return { peerIds: ['other-peer'], curatorIsLocal: false, legacyTripleResolved: false };
-      }
-      if (contextGraphId === localPrivateCg) {
-        return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: false };
-      }
-      return { peerIds: [], curatorIsLocal: false, legacyTripleResolved: false };
+    (agent as any).isCuratorOf = async (contextGraphId: string) =>
+      contextGraphId === localPrivateCg;
+    (agent as any).resolveCuratorPeerId = async (contextGraphId: string) => {
+      if (contextGraphId === privateCg) return PEER_A;
+      if (contextGraphId === otherPrivateCg) return 'other-peer';
+      return undefined;
     };
+    (agent as any).refreshMetaFromCurator = async () => undefined;
 
     expect(await (agent as any).getSharedMemorySyncContextGraphs(PEER_A)).toEqual([
       'public-cg',

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -169,10 +169,74 @@ describe('sync-on-connect churn gates', () => {
     expect(calls).toEqual([PEER_A]);
   });
 
-  it('stops post-durable sync-on-connect fanout after backoff-worthy durable pressure', async () => {
+  it('marks a subscribed context graph synced after SWM-only catchup progress', async () => {
+    const agent = await createUnstartedAgent('SwmOnlyCatchupMarksSynced');
+    const contextGraphId = 'swm-only-catchup-cg';
+    (agent as any).subscribedContextGraphs.set(contextGraphId, {
+      subscribed: true,
+      synced: false,
+      sharedMemorySynced: false,
+    });
+    (agent as any).persistLocalNodeMembership = () => undefined;
+    (agent as any).refreshMetaSyncedFlags = recorder(async () => undefined);
+    (agent as any).waitForSyncProtocol = recorder(async () => true);
+    (agent as any).syncFromPeerDetailed = recorder(async () => ({
+      insertedTriples: 0,
+      fetchedMetaTriples: 0,
+      fetchedDataTriples: 0,
+      insertedMetaTriples: 0,
+      insertedDataTriples: 0,
+      bytesReceived: 0,
+      resumedPhases: 0,
+      timedOutPhases: 0,
+      completedPhases: 0,
+      checkpointAdvances: 0,
+      emptyResponses: 0,
+      metaOnlyResponses: 0,
+      dataRejectedMissingMeta: 0,
+      rejectedKcs: 0,
+      failedPeers: 0,
+      failedPhases: 0,
+      deniedPhases: 0,
+    }));
+    (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => ({
+      insertedTriples: 4,
+      fetchedMetaTriples: 0,
+      fetchedDataTriples: 4,
+      insertedMetaTriples: 0,
+      insertedDataTriples: 4,
+      bytesReceived: 0,
+      resumedPhases: 0,
+      timedOutPhases: 0,
+      completedPhases: 1,
+      checkpointAdvances: 0,
+      emptyResponses: 0,
+      droppedDataTriples: 0,
+      failedPeers: 0,
+      failedPhases: 0,
+      deniedPhases: 0,
+    }));
+
+    const result = await (agent as any).runCatchupOverPeers(
+      contextGraphId,
+      true,
+      [{ toString: () => PEER_A }],
+    );
+
+    expect(result.dataSynced).toBe(0);
+    expect(result.sharedMemorySynced).toBe(4);
+    expect((agent as any).subscribedContextGraphs.get(contextGraphId)).toMatchObject({
+      subscribed: true,
+      synced: true,
+      sharedMemorySynced: true,
+    });
+  });
+
+  it('records progress before stopping post-durable sync-on-connect fanout after backoff-worthy durable pressure', async () => {
     const refreshMetaSyncedFlags = recorder(async () => undefined);
     const discoverContextGraphsFromStore = recorder(async () => 0);
     const syncSharedMemoryFromPeer = recorder(async () => 0);
+    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
 
     const outcome = await runSyncOnConnect({
       remotePeer: PEER_A,
@@ -180,17 +244,75 @@ describe('sync-on-connect churn gates', () => {
       getPeerProtocols: async () => [PROTOCOL_SYNC],
       knownCorePeerIds: new Set(),
       getSyncContextGraphs: () => ['cg-a'],
-      syncFromPeer: async () => emptyDetailedSync({ failedPeers: 1, backoffWorthyFailures: 1 }),
+      syncFromPeer: async () => emptyDetailedSync({
+        insertedTriples: 3,
+        insertedDataTriples: 3,
+        completedPhases: 1,
+        checkpointAdvances: 1,
+        timedOutPhases: 1,
+        backoffWorthyFailures: 1,
+      }),
       refreshMetaSyncedFlags,
       discoverContextGraphsFromStore,
       syncSharedMemoryFromPeer,
       logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => {
+        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+      },
     });
 
     expect(outcome).toBe('synced');
     expect(refreshMetaSyncedFlags.calls).toEqual([]);
     expect(discoverContextGraphsFromStore.calls).toEqual([]);
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
+    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
+  });
+
+  it('records progress before stopping newly discovered CG fanout after durable pressure', async () => {
+    let contextGraphs = ['cg-a'];
+    const refreshMetaSyncedFlags = recorder(async () => undefined);
+    const discoverContextGraphsFromStore = recorder(async () => {
+      contextGraphs = ['cg-a', 'cg-b'];
+      return 1;
+    });
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+    const syncedPeers: Array<{ peerId: string; fresh: boolean; progress?: boolean }> = [];
+    const syncFromPeer = recorder(async (_peerId: string, contextGraphIds?: string[]) => {
+      if (contextGraphIds?.includes('cg-b')) {
+        return emptyDetailedSync({
+          insertedTriples: 4,
+          insertedDataTriples: 4,
+          completedPhases: 1,
+          checkpointAdvances: 1,
+          timedOutPhases: 1,
+          backoffWorthyFailures: 1,
+        });
+      }
+      return emptyDetailedSync();
+    });
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => contextGraphs,
+      syncFromPeer,
+      refreshMetaSyncedFlags,
+      discoverContextGraphsFromStore,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+      onPeerSynced: (peerId, syncOutcome) => {
+        syncedPeers.push({ peerId, fresh: syncOutcome?.fresh ?? false, progress: syncOutcome?.progress });
+      },
+    });
+
+    expect(outcome).toBe('synced');
+    expect(syncFromPeer.calls).toEqual([[PEER_A], [PEER_A, ['cg-b']]]);
+    expect(refreshMetaSyncedFlags.calls).toHaveLength(1);
+    expect(discoverContextGraphsFromStore.calls).toEqual([[]]);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([]);
+    expect(syncedPeers).toEqual([{ peerId: PEER_A, fresh: false, progress: true }]);
   });
 
   it('skips SWM sync-on-connect fanout when no CG is locally eligible', async () => {

--- a/packages/agent/test/sync-on-connect-churn.test.ts
+++ b/packages/agent/test/sync-on-connect-churn.test.ts
@@ -133,6 +133,32 @@ describe('sync-on-connect churn gates', () => {
     expect(syncSharedMemoryFromPeer.calls).toEqual([]);
   });
 
+  it('passes the connecting peer into the SWM sync-scope selector', async () => {
+    const syncSharedMemoryFromPeer = recorder(async () => 0);
+    let selectedForPeer: string | undefined;
+
+    const outcome = await runSyncOnConnect({
+      remotePeer: PEER_A,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_SYNC],
+      knownCorePeerIds: new Set(),
+      getSyncContextGraphs: () => ['eligible-cg'],
+      getSharedMemorySyncContextGraphs: (peerId) => {
+        selectedForPeer = peerId;
+        return ['eligible-cg'];
+      },
+      syncFromPeer: async () => 0,
+      refreshMetaSyncedFlags: async () => undefined,
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(selectedForPeer).toBe(PEER_A);
+    expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['eligible-cg']]]);
+  });
+
   it('preserves successful SWM sync-on-connect for eligible CGs', async () => {
     const syncSharedMemoryFromPeer = recorder(async () => 0);
 
@@ -152,5 +178,47 @@ describe('sync-on-connect churn gates', () => {
 
     expect(outcome).toBe('synced');
     expect(syncSharedMemoryFromPeer.calls).toEqual([[PEER_A, ['eligible-cg']]]);
+  });
+
+  it('filters private SWM sync-on-connect scope to the matching curator peer', async () => {
+    const agent = await createUnstartedAgent('SwmPeerScopedRecovery');
+    const privateCg = 'private-cg';
+    const otherPrivateCg = 'other-private-cg';
+    const localPrivateCg = 'local-private-cg';
+    const unconfirmedCg = 'unconfirmed-cg';
+    (agent as any).config.syncContextGraphs = [
+      'public-cg',
+      privateCg,
+      otherPrivateCg,
+      localPrivateCg,
+      unconfirmedCg,
+    ];
+    (agent as any).canUseSharedMemoryForContextGraph = async (contextGraphId: string) =>
+      contextGraphId !== unconfirmedCg;
+    (agent as any).isPrivateContextGraph = async (contextGraphId: string) =>
+      contextGraphId.includes('private');
+    (agent as any).resolveCuratorPeerIdsForCg = async (contextGraphId: string) => {
+      if (contextGraphId === privateCg) {
+        return { peerIds: [PEER_A], curatorIsLocal: false, legacyTripleResolved: false };
+      }
+      if (contextGraphId === otherPrivateCg) {
+        return { peerIds: ['other-peer'], curatorIsLocal: false, legacyTripleResolved: false };
+      }
+      if (contextGraphId === localPrivateCg) {
+        return { peerIds: [], curatorIsLocal: true, legacyTripleResolved: false };
+      }
+      return { peerIds: [], curatorIsLocal: false, legacyTripleResolved: false };
+    };
+
+    expect(await (agent as any).getSharedMemorySyncContextGraphs(PEER_A)).toEqual([
+      'public-cg',
+      privateCg,
+    ]);
+    expect(await (agent as any).getSharedMemorySyncContextGraphs()).toEqual([
+      'public-cg',
+      privateCg,
+      otherPrivateCg,
+      localPrivateCg,
+    ]);
   });
 });

--- a/packages/agent/test/sync-requester-bailout.test.ts
+++ b/packages/agent/test/sync-requester-bailout.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import type { OperationContext } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+import { runDurableSync } from '../src/sync/requester/durable-sync.js';
+import { runSharedMemorySync } from '../src/sync/requester/shared-memory-sync.js';
+import type { SyncPageResult } from '../src/sync/requester/page-fetch.js';
+import { markSyncTransportFailure } from '../src/sync/error-tags.js';
+
+const ctx = { kind: 'system', id: 'test', startedAt: 0 } as OperationContext;
+const noop = () => {};
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => {
+    calls.push(args);
+    return impl(...args);
+  };
+  return Object.assign(fn, { calls });
+}
+
+function pageResult(
+  contextGraphId: string,
+  phase: string,
+  overrides: Partial<SyncPageResult> = {},
+): SyncPageResult {
+  return {
+    quads: [],
+    bytesReceived: 0,
+    resumedFromOffset: 0,
+    nextOffset: 0,
+    checkpointKey: `${contextGraphId}:${phase}`,
+    completed: true,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+function transportError(message: string): Error {
+  const err = new Error(message);
+  markSyncTransportFailure(err);
+  return err;
+}
+
+function deniedError(): Error & { syncDenied: boolean } {
+  const err = new Error('access denied') as Error & { syncDenied: boolean };
+  err.syncDenied = true;
+  return err;
+}
+
+function durableProcessResult() {
+  return {
+    verifiedData: [] as Quad[],
+    verifiedMeta: [] as Quad[],
+    totalFetchedDataQuads: 0,
+    totalFetchedMetaQuads: 0,
+    rejectedKcs: 0,
+    emptyResponses: 1,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+  };
+}
+
+function sharedMemoryProcessResult() {
+  return {
+    verifiedData: [] as Quad[],
+    verifiedMeta: [] as Quad[],
+    totalFetchedDataQuads: 0,
+    totalFetchedMetaQuads: 0,
+    droppedDataTriples: 0,
+    emptyResponses: 1,
+    entityCreators: [],
+  };
+}
+
+describe('sync requester bailout', () => {
+  it('stops durable context-graph fanout after a backoff-worthy transport failure', async () => {
+    const fetchSyncPages = recorder(async (
+      _ctx: OperationContext,
+      _peer: string,
+      contextGraphId: string,
+      _includeSharedMemory: boolean,
+      phase: 'data' | 'meta',
+    ) => {
+      if (contextGraphId === 'pressured-cg') {
+        throw transportError('Too many active durable data sync session snapshots');
+      }
+      return pageResult(contextGraphId, phase);
+    });
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: ['pressured-cg', 'next-cg'],
+      stopOnBackoffWorthyFailure: true,
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages,
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(summary.failedPeers).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(1);
+    expect(fetchSyncPages.calls).toEqual([
+      [ctx, 'peer-a', 'pressured-cg', false, 'meta', expect.any(String), expect.any(Number)],
+    ]);
+  });
+
+  it('continues durable fanout after an ordinary sync denial', async () => {
+    const fetchSyncPages = recorder(async (
+      _ctx: OperationContext,
+      _peer: string,
+      contextGraphId: string,
+      _includeSharedMemory: boolean,
+      phase: 'data' | 'meta',
+    ) => {
+      if (contextGraphId === 'denied-cg') throw deniedError();
+      return pageResult(contextGraphId, phase);
+    });
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: ['denied-cg', 'next-cg'],
+      stopOnBackoffWorthyFailure: true,
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages,
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(summary.deniedPhases).toBe(1);
+    expect(summary.failedPeers).toBe(0);
+    expect(summary.backoffWorthyFailures).toBe(0);
+    expect(fetchSyncPages.calls).toContainEqual([
+      ctx,
+      'peer-a',
+      'next-cg',
+      false,
+      'data',
+      expect.any(String),
+      expect.any(Number),
+      undefined,
+      undefined,
+    ]);
+  });
+
+  it('stops durable fanout after a sync page timeout', async () => {
+    const setCheckpoint = recorder((_key: string, _offset: number) => {});
+    const fetchSyncPages = recorder(async (
+      _ctx: OperationContext,
+      _peer: string,
+      contextGraphId: string,
+      _includeSharedMemory: boolean,
+      phase: 'data' | 'meta',
+    ) => phase === 'data'
+      ? pageResult(contextGraphId, phase, { completed: false, timedOut: true, nextOffset: 500 })
+      : pageResult(contextGraphId, phase));
+
+    const summary = await runDurableSync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: ['slow-cg', 'next-cg'],
+      stopOnBackoffWorthyFailure: true,
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages,
+      processDurableBatchInWorker: async () => durableProcessResult(),
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint,
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(summary.timedOutPhases).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(0);
+    expect(setCheckpoint.calls).toContainEqual(['slow-cg:data', 500]);
+    expect(fetchSyncPages.calls.some((call) => call[2] === 'next-cg')).toBe(false);
+  });
+
+  it('stops shared-memory context-graph fanout after a backoff-worthy transport failure', async () => {
+    const fetchSyncPages = recorder(async (
+      _ctx: OperationContext,
+      _peer: string,
+      contextGraphId: string,
+      _includeSharedMemory: boolean,
+      phase: 'data' | 'meta',
+    ) => {
+      if (contextGraphId === 'pressured-swm') {
+        throw transportError('sync responder queue full');
+      }
+      return pageResult(contextGraphId, phase);
+    });
+
+    const summary = await runSharedMemorySync({
+      ctx,
+      remotePeerId: 'peer-a',
+      contextGraphIds: ['pressured-swm', 'next-swm'],
+      stopOnBackoffWorthyFailure: true,
+      createContextGraphSyncDeadline: () => Date.now() + 60_000,
+      fetchSyncPages,
+      processSharedMemoryBatch: async () => sharedMemoryProcessResult(),
+      ensureContextGraph: async () => {},
+      storeInsert: async () => {},
+      deleteCheckpoint: () => {},
+      setCheckpoint: () => {},
+      ensureOwnedMap: () => new Map(),
+      logInfo: noop,
+      logWarn: noop,
+      logDebug: noop,
+    });
+
+    expect(summary.failedPeers).toBe(1);
+    expect(summary.backoffWorthyFailures).toBe(1);
+    expect(fetchSyncPages.calls).toEqual([
+      [ctx, 'peer-a', 'pressured-swm', true, 'meta', expect.any(String), expect.any(Number)],
+    ]);
+  });
+});

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -838,6 +838,56 @@ describe('sync responder pagination interleaving', () => {
     expect(loads).toBe(2);
   });
 
+  it('does not retain a durable row snapshot when the serving request aborts before build completion', async () => {
+    const memo = createResponderSyncRowListMemo(10_000, 1);
+    const snapshot = deferred<readonly {
+      s: string;
+      p: string;
+      o: string;
+      g: string;
+    }[]>();
+    const controller = new AbortController();
+
+    const first = memo.get('durable:aborted', () => snapshot.promise, { signal: controller.signal });
+    controller.abort(new Error('request aborted'));
+    snapshot.resolve([{
+      s: 'urn:memo:row',
+      p: `${DKG_NS}label`,
+      o: '"aborted"',
+      g: 'urn:memo:graph',
+    }]);
+
+    await expect(first).rejects.toThrow('request aborted');
+    await expect(memo.get('durable:fresh', async () => [{
+      s: 'urn:memo:row',
+      p: `${DKG_NS}label`,
+      o: '"fresh"',
+      g: 'urn:memo:graph',
+    }])).resolves.toHaveLength(1);
+  });
+
+  it('releases completed durable row snapshots after the completion grace window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const memo = createResponderSyncRowListMemo(10_000, 1);
+    const row = {
+      s: 'urn:memo:row',
+      p: `${DKG_NS}label`,
+      o: '"snapshot"',
+      g: 'urn:memo:graph',
+    };
+
+    await expect(memo.get('durable:complete', async () => [row])).resolves.toHaveLength(1);
+    memo.release('durable:complete', { graceMs: 10 });
+
+    await expect(memo.get('durable:blocked', async () => [row])).rejects.toThrow(
+      'Too many active durable data sync session snapshots',
+    );
+
+    vi.advanceTimersByTime(11);
+    await expect(memo.get('durable:blocked', async () => [row])).resolves.toHaveLength(1);
+  });
+
   it('coalesces concurrent durable row snapshot refreshes', async () => {
     const memo = createResponderSyncRowListMemo();
     const snapshot = deferred<readonly {

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       "test/sync-responder-concurrent-interleaving.test.ts",
       "test/sync-fetch-coalescing.test.ts",
       "test/sync-on-connect-churn.test.ts",
+      "test/sync-requester-bailout.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -1,34 +1,38 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 // generic-sql-source.test.ts uses `import('node:sqlite')`, which is
 // `--experimental-sqlite`-gated on Node 22.5–23.x. The flag is a
 // process-level toggle, so mirror `vitest.config.ts`: switch to the
 // `forks` pool and pass execArgv there. See the long comment in
 // `vitest.config.ts` for the full rationale.
-const SQLITE_EXEC_ARGV = ['--experimental-sqlite', '--no-warnings=ExperimentalWarning'];
+const SQLITE_EXEC_ARGV = [
+  "--experimental-sqlite",
+  "--no-warnings=ExperimentalWarning",
+];
 
 export default defineConfig({
   test: {
     include: [
-      'test/endorse.test.ts',
-      'test/e2e-dht-dial.test.ts',
-      'test/generic-sql-source.test.ts',
-      'test/imported-artifact.test.ts',
-      'test/query-min-trust-alias.test.ts',
-      'test/sync-envelope-cursor.test.ts',
-      'test/swm/host-catchup-sign.test.ts',
-      'test/swm/host-catchup-wire.test.ts',
-      'test/swm/host-mode-store.test.ts',
-      'test/swm/host-mode-key-canonicalization.test.ts',
-      'test/profile-fix-verify.test.ts',
-      'test/sync-verify-collapsed.test.ts',
-      'test/durable-sync-since-threading.test.ts',
-      'test/sync-responder-concurrent-interleaving.test.ts',
-      'test/sync-fetch-coalescing.test.ts',
+      "test/endorse.test.ts",
+      "test/e2e-dht-dial.test.ts",
+      "test/generic-sql-source.test.ts",
+      "test/imported-artifact.test.ts",
+      "test/query-min-trust-alias.test.ts",
+      "test/sync-envelope-cursor.test.ts",
+      "test/swm/host-catchup-sign.test.ts",
+      "test/swm/host-catchup-wire.test.ts",
+      "test/swm/host-mode-store.test.ts",
+      "test/swm/host-mode-key-canonicalization.test.ts",
+      "test/profile-fix-verify.test.ts",
+      "test/sync-verify-collapsed.test.ts",
+      "test/durable-sync-since-threading.test.ts",
+      "test/sync-responder-concurrent-interleaving.test.ts",
+      "test/sync-fetch-coalescing.test.ts",
+      "test/sync-on-connect-churn.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,
-    pool: 'forks',
+    pool: "forks",
     execArgv: SQLITE_EXEC_ARGV,
   },
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       "test/sync-on-connect-churn.test.ts",
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
+      "test/swm-fanout-peer-selection.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       "test/sync-fetch-coalescing.test.ts",
       "test/sync-on-connect-churn.test.ts",
       "test/sync-requester-bailout.test.ts",
+      "test/swm-catchup-peer-selection.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/cli/src/catchup-runner.ts
+++ b/packages/cli/src/catchup-runner.ts
@@ -266,6 +266,10 @@ class WorkerCatchupRunner implements CatchupRunner {
         const [contextGraphId, dataSynced, sharedMemorySynced] = args as [string, number, number];
         await agent.refreshMetaSyncedFlags([contextGraphId]);
         if (dataSynced > 0 || sharedMemorySynced > 0) {
+          agent.markContextGraphSubscriptionState?.(contextGraphId, {
+            synced: true,
+            ...(sharedMemorySynced > 0 ? { sharedMemorySynced: true } : {}),
+          });
           agent.eventBus.emit(DKGEvent.PROJECT_SYNCED, {
             contextGraphId,
             dataSynced,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -898,7 +898,8 @@ WHERE {
     };
     const perCgLegs: PerCgLeg[] = [];
     for (const cgId of cgIds) {
-      if (!(await canUseSharedMemoryForContextGraph(cgId))) {
+      const canUseSharedMemory = await canUseSharedMemoryForContextGraph(cgId);
+      if (!canUseSharedMemory && !includeDurable) {
         perCgLegs.push({
           contextGraphId: cgId,
           perPeer: [],
@@ -922,27 +923,29 @@ WHERE {
           let durable = 0;
           let swmError: string | undefined;
           let durableError: string | undefined;
-          try {
-            const syncResult = await withTimeout(
-              typeof (agent as any).syncSharedMemoryFromPeerDetailed === 'function'
-                ? (agent as any).syncSharedMemoryFromPeerDetailed(candidate, [cgId])
-                : agent.syncSharedMemoryFromPeer(candidate, [cgId]).then(swmCatchupResultFromInserted),
-              PER_PEER_SWM_BUDGET_MS,
-              `SWM catchup from ${candidate} for ${cgId}`,
-            ) as SwmCatchupDetailedResult;
-            swm = Number(syncResult.insertedTriples ?? 0);
-            swmCatchupPeerSelector.record(
-              cgId,
-              candidate,
-              classifySwmCatchupPeerOutcome(swmCatchupOutcomeInput({ ...syncResult, insertedTriples: swm })),
-            );
-          } catch (err: any) {
-            swmError = err?.message ?? String(err);
-            swmCatchupPeerSelector.record(
-              cgId,
-              candidate,
-              classifySwmCatchupPeerOutcome(swmCatchupOutcomeInput({ insertedTriples: 0 }, swmError)),
-            );
+          if (canUseSharedMemory) {
+            try {
+              const syncResult = await withTimeout(
+                typeof (agent as any).syncSharedMemoryFromPeerDetailed === 'function'
+                  ? (agent as any).syncSharedMemoryFromPeerDetailed(candidate, [cgId])
+                  : agent.syncSharedMemoryFromPeer(candidate, [cgId]).then(swmCatchupResultFromInserted),
+                PER_PEER_SWM_BUDGET_MS,
+                `SWM catchup from ${candidate} for ${cgId}`,
+              ) as SwmCatchupDetailedResult;
+              swm = Number(syncResult.insertedTriples ?? 0);
+              swmCatchupPeerSelector.record(
+                cgId,
+                candidate,
+                classifySwmCatchupPeerOutcome(swmCatchupOutcomeInput({ ...syncResult, insertedTriples: swm })),
+              );
+            } catch (err: any) {
+              swmError = err?.message ?? String(err);
+              swmCatchupPeerSelector.record(
+                cgId,
+                candidate,
+                classifySwmCatchupPeerOutcome(swmCatchupOutcomeInput({ insertedTriples: 0 }, swmError)),
+              );
+            }
           }
           if (includeDurable) {
             try {

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -549,6 +549,17 @@ function swmCatchupOutcomeInput(result: SwmCatchupDetailedResult, errorMessage?:
   };
 }
 
+function uniquePeerIds(peerIds: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const peerId of peerIds) {
+    if (!peerId || seen.has(peerId)) continue;
+    seen.add(peerId);
+    out.push(peerId);
+  }
+  return out;
+}
+
 export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
   const {
     req,
@@ -911,19 +922,27 @@ WHERE {
       const baseCandidatePeers = await candidatePeersForContextGraph(cgId);
       const unsupportedPeers = await unsupportedPeersForContextGraph(cgId, baseCandidatePeers);
       const privateCuratorPeerIds = await privateCuratorPeersForContextGraph(cgId);
-      const selectedPeers = swmCatchupPeerSelector.select({
-        contextGraphId: cgId,
-        candidatePeers: baseCandidatePeers,
-        unsupportedPeers,
-        privateCuratorPeerIds,
-      }).selectedPeers;
+      const swmSelectedPeers = canUseSharedMemory
+        ? swmCatchupPeerSelector.select({
+            contextGraphId: cgId,
+            candidatePeers: baseCandidatePeers,
+            unsupportedPeers,
+            privateCuratorPeerIds,
+          }).selectedPeers
+        : [];
+      const durableSelectedPeers = includeDurable
+        ? uniquePeerIds(baseCandidatePeers).filter((peerId) => !unsupportedPeers.has(peerId))
+        : [];
+      const swmSelected = new Set(swmSelectedPeers);
+      const durableSelected = new Set(durableSelectedPeers);
+      const selectedPeers = uniquePeerIds([...swmSelectedPeers, ...durableSelectedPeers]);
       const settled = await Promise.allSettled(
         selectedPeers.map(async (candidate) => {
           let swm = 0;
           let durable = 0;
           let swmError: string | undefined;
           let durableError: string | undefined;
-          if (canUseSharedMemory) {
+          if (swmSelected.has(candidate)) {
             try {
               const syncResult = await withTimeout(
                 typeof (agent as any).syncSharedMemoryFromPeerDetailed === 'function'
@@ -947,7 +966,7 @@ WHERE {
               );
             }
           }
-          if (includeDurable) {
+          if (durableSelected.has(candidate)) {
             try {
               durable = await withTimeout(
                 (agent as any).syncFromPeer?.(candidate, [cgId]) ?? Promise.resolve(0),

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -57,8 +57,13 @@ const daemonRequire = createRequire(import.meta.url);
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { enrichEvmError, MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { DKGAgent, loadOpWallets } from '@origintrail-official/dkg-agent';
-import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, sharedMemoryReadBothFilter, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral, escapeSparqlLiteral } from '@origintrail-official/dkg-core';
+import {
+  DKGAgent,
+  classifySwmCatchupPeerOutcome,
+  createSwmCatchupPeerSelector,
+  loadOpWallets,
+} from '@origintrail-official/dkg-agent';
+import { computeNetworkId, createOperationContext, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, assertSafeRdfTerm, sparqlIri, contextGraphSharedMemoryUri, sharedMemoryReadBothFilter, contextGraphAssertionUri, contextGraphMetaUri, escapeDkgRdfLiteral, escapeSparqlLiteral, PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
 import { skolemizeByEntity, findReservedSubjectPrefix, isSkolemizedUri, type PublishOptions, type PublishResult } from '@origintrail-official/dkg-publisher';
 import type { Quad } from '@origintrail-official/dkg-storage';
 import {
@@ -513,6 +518,37 @@ function decodeReservedKaId(val: unknown): bigint | undefined {
   return n;
 }
 
+const swmCatchupPeerSelector = createSwmCatchupPeerSelector();
+
+type SwmCatchupDetailedResult = {
+  insertedTriples: number;
+  fetchedDataTriples?: number;
+  fetchedMetaTriples?: number;
+  deniedPhases?: number;
+  failedPeers?: number;
+  failedPhases?: number;
+  timedOutPhases?: number;
+  backoffWorthyFailures?: number;
+};
+
+function swmCatchupResultFromInserted(insertedTriples: number): SwmCatchupDetailedResult {
+  return { insertedTriples };
+}
+
+function swmCatchupOutcomeInput(result: SwmCatchupDetailedResult, errorMessage?: string) {
+  return {
+    insertedTriples: result.insertedTriples,
+    fetchedDataTriples: result.fetchedDataTriples,
+    fetchedMetaTriples: result.fetchedMetaTriples,
+    deniedPhases: result.deniedPhases,
+    failedPeers: result.failedPeers,
+    failedPhases: result.failedPhases,
+    timedOutPhases: result.timedOutPhases,
+    backoffWorthyFailures: result.backoffWorthyFailures,
+    errorMessage,
+  };
+}
+
 export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
   const {
     req,
@@ -766,37 +802,67 @@ WHERE {
         );
       });
 
-    // Discover candidate peers. The single-peer mode is opt-in; the
-    // default fan-out mode mirrors what runSyncOnConnect does on every
-    // peer:connect event, but caller-initiated rather than event-driven.
-    //
-    // Codex PR #609 R2 — route through `createCGHostEnumerator` so the
-    // hosting-peer policy stays centralized. Today's Phase-A enumerator
-    // returns all connected peers (minus self); when Phase B lands shard-
-    // aware host selection in LU-6, this call site picks it up for free
-    // instead of needing to be updated in lockstep.
-    let candidatePeers: string[];
-    if (peerIdParam) {
-      candidatePeers = [peerIdParam];
-    } else {
-      const { createCGHostEnumerator } = await import('@origintrail-official/dkg-agent');
-      const enumerator = createCGHostEnumerator({
-        getConnectedPeers: () =>
-          agent.node.libp2p.getConnections().map((c: any) => c.remotePeer.toString()),
-        getSelfPeerId: () => agent.peerId,
-      });
-      // Per-CG enumeration unioned across all requested CGs — phase A's
-      // enumerator returns the same connected-peers set for every cgId,
-      // but unioning keeps us forward-compatible with phase B's per-CG
-      // shard filtering.
-      const unioned = new Set<string>();
-      for (const cgId of cgIds) {
-        for (const p of await enumerator.enumerate(cgId)) unioned.add(p);
+    // Discover candidate peers per CG. The single-peer mode is opt-in; the
+    // default path still starts from the Phase-A host enumerator, then applies
+    // requester-side narrowing: protocol support, private-curator scope, and
+    // recent SWM outcome cache. Unknown state still gets a bounded probe so
+    // cold catchup can discover a new useful peer.
+    const { createCGHostEnumerator } = await import('@origintrail-official/dkg-agent');
+    const connectedPeerIds = () => agent.node.libp2p.getConnections().map((c: any) => c.remotePeer.toString());
+    const enumerator = createCGHostEnumerator({
+      getConnectedPeers: connectedPeerIds,
+      getSelfPeerId: () => agent.peerId,
+    });
+    const protocolChecks = new Map<string, Promise<boolean | undefined>>();
+    const hasCurrentSyncProtocol = (peerId: string): Promise<boolean | undefined> => {
+      let check = protocolChecks.get(peerId);
+      if (!check) {
+        check = Promise.resolve()
+          .then(() => agent.getPeerProtocols(peerId))
+          .then((protocols) => protocols.includes(PROTOCOL_SYNC))
+          .catch(() => undefined);
+        protocolChecks.set(peerId, check);
       }
-      candidatePeers = Array.from(unioned);
-    }
+      return check;
+    };
+    const candidatePeersForContextGraph = async (cgId: string): Promise<string[]> =>
+      peerIdParam ? [peerIdParam] : enumerator.enumerate(cgId);
+    const canUseSharedMemoryForContextGraph = async (cgId: string): Promise<boolean> => {
+      try {
+        return await agent.canUseSharedMemoryForContextGraph(cgId);
+      } catch {
+        return true;
+      }
+    };
+    const unsupportedPeersForContextGraph = async (cgId: string, peers: readonly string[]): Promise<Set<string>> => {
+      const unsupported = new Set<string>();
+      await Promise.all(peers.map(async (peerId) => {
+        const supported = await hasCurrentSyncProtocol(peerId);
+        if (supported === false) {
+          unsupported.add(peerId);
+          swmCatchupPeerSelector.record(cgId, peerId, 'unsupported');
+        }
+      }));
+      return unsupported;
+    };
+    const privateCuratorPeersForContextGraph = async (cgId: string): Promise<string[] | undefined> => {
+      let isPrivate = false;
+      try {
+        isPrivate = await agent.isPrivateContextGraph(cgId);
+      } catch {
+        return undefined;
+      }
+      if (!isPrivate) return undefined;
+      try {
+        const resolved = await agent.resolveCuratorPeerIdsForCg(cgId);
+        if (resolved.curatorIsLocal) return [];
+        return resolved.peerIds.length > 0 ? resolved.peerIds : undefined;
+      } catch {
+        return undefined;
+      }
+    };
 
-    if (candidatePeers.length === 0) {
+    if (!peerIdParam && connectedPeerIds().length === 0) {
       return jsonResponse(res, 200, {
         contextGraphIds: cgIds,
         peersAttempted: 0,
@@ -813,9 +879,9 @@ WHERE {
     // for the others got skipped on the aggregate gate).
     //
     // Now: iterate CGs serially (keeps wire load bounded across many
-    // peers × many CGs), and within each CG parallelize the per-peer
-    // sync exactly like before. Per-peer dial+request is 5-20s on
-    // devnet; serialising peers would compound to N×20s.
+    // peers × many CGs), select a narrowed per-CG peer set, and parallelize
+    // only that set. Per-peer dial+request is 5-20s on devnet; serialising
+    // the selected peers would compound to N×20s.
     type PerPeerLeg = {
       peerId: string;
       insertedTriples: number;
@@ -832,20 +898,51 @@ WHERE {
     };
     const perCgLegs: PerCgLeg[] = [];
     for (const cgId of cgIds) {
+      if (!(await canUseSharedMemoryForContextGraph(cgId))) {
+        perCgLegs.push({
+          contextGraphId: cgId,
+          perPeer: [],
+          insertedTriples: 0,
+          durableInsertedTriples: 0,
+        });
+        continue;
+      }
+      const baseCandidatePeers = await candidatePeersForContextGraph(cgId);
+      const unsupportedPeers = await unsupportedPeersForContextGraph(cgId, baseCandidatePeers);
+      const privateCuratorPeerIds = await privateCuratorPeersForContextGraph(cgId);
+      const selectedPeers = swmCatchupPeerSelector.select({
+        contextGraphId: cgId,
+        candidatePeers: baseCandidatePeers,
+        unsupportedPeers,
+        privateCuratorPeerIds,
+      }).selectedPeers;
       const settled = await Promise.allSettled(
-        candidatePeers.map(async (candidate) => {
+        selectedPeers.map(async (candidate) => {
           let swm = 0;
           let durable = 0;
           let swmError: string | undefined;
           let durableError: string | undefined;
           try {
-            swm = await withTimeout(
-              agent.syncSharedMemoryFromPeer(candidate, [cgId]),
+            const syncResult = await withTimeout(
+              typeof (agent as any).syncSharedMemoryFromPeerDetailed === 'function'
+                ? (agent as any).syncSharedMemoryFromPeerDetailed(candidate, [cgId])
+                : agent.syncSharedMemoryFromPeer(candidate, [cgId]).then(swmCatchupResultFromInserted),
               PER_PEER_SWM_BUDGET_MS,
               `SWM catchup from ${candidate} for ${cgId}`,
+            ) as SwmCatchupDetailedResult;
+            swm = Number(syncResult.insertedTriples ?? 0);
+            swmCatchupPeerSelector.record(
+              cgId,
+              candidate,
+              classifySwmCatchupPeerOutcome(swmCatchupOutcomeInput({ ...syncResult, insertedTriples: swm })),
             );
           } catch (err: any) {
             swmError = err?.message ?? String(err);
+            swmCatchupPeerSelector.record(
+              cgId,
+              candidate,
+              classifySwmCatchupPeerOutcome(swmCatchupOutcomeInput({ insertedTriples: 0 }, swmError)),
+            );
           }
           if (includeDurable) {
             try {
@@ -864,7 +961,7 @@ WHERE {
       const perPeer: PerPeerLeg[] = settled.map((s, idx) => {
         if (s.status === 'fulfilled') {
           return {
-            peerId: candidatePeers[idx],
+            peerId: selectedPeers[idx],
             insertedTriples: s.value.insertedTriples,
             durableInsertedTriples: s.value.durableInsertedTriples,
             ...(s.value.swmError ? { swmError: s.value.swmError } : {}),
@@ -872,7 +969,7 @@ WHERE {
           };
         }
         return {
-          peerId: candidatePeers[idx],
+          peerId: selectedPeers[idx],
           insertedTriples: 0,
           durableInsertedTriples: 0,
           error: s.reason?.message ?? String(s.reason),
@@ -997,7 +1094,7 @@ WHERE {
 
     return jsonResponse(res, 200, {
       contextGraphIds: cgIds,
-      peersAttempted: candidatePeers.length,
+      peersAttempted: perPeerAggregate.size,
       includeDurable,
       totalInsertedTriples: totalInserted,
       totalDurableInsertedTriples: totalDurable,

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -89,4 +89,155 @@ describe('POST /api/shared-memory/catchup durable leg', () => {
       },
     ]);
   });
+
+  it('filters route-selected SWM catchup peers by current protocol and private curator scope', async () => {
+    const cgId = 'private-route-cg';
+    const curatorPeer = 'peer-curator';
+    const nonCuratorPeer = 'peer-non-curator';
+    const legacyPeer = 'peer-legacy';
+    const syncSharedMemoryFromPeerDetailed = vi.fn(async () => ({ insertedTriples: 5 }));
+    const syncFromPeer = vi.fn();
+    const agent = {
+      peerId: 'self-peer',
+      node: {
+        libp2p: {
+          getConnections: () => [curatorPeer, nonCuratorPeer, legacyPeer].map((peerId) => ({
+            remotePeer: { toString: () => peerId },
+          })),
+        },
+      },
+      canUseSharedMemoryForContextGraph: vi.fn(async () => true),
+      getPeerProtocols: vi.fn(async (peerId: string) => (
+        peerId === legacyPeer ? ['/dkg/10.0.1/sync'] : [PROTOCOL_SYNC]
+      )),
+      isPrivateContextGraph: vi.fn(async () => true),
+      resolveCuratorPeerIdsForCg: vi.fn(async () => ({
+        curatorIsLocal: false,
+        peerIds: [curatorPeer],
+      })),
+      syncSharedMemoryFromPeerDetailed,
+      syncFromPeer,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(syncSharedMemoryFromPeerDetailed).toHaveBeenCalledTimes(1);
+    expect(syncSharedMemoryFromPeerDetailed).toHaveBeenCalledWith(curatorPeer, [cgId]);
+    expect(syncFromPeer).not.toHaveBeenCalled();
+
+    const body = JSON.parse(res.body);
+    expect(body.peersAttempted).toBe(1);
+    expect(body.results).toEqual([
+      {
+        peerId: curatorPeer,
+        insertedTriples: 5,
+        durableInsertedTriples: 0,
+      },
+    ]);
+    expect(body.perContextGraph).toEqual([
+      {
+        contextGraphId: cgId,
+        insertedTriples: 5,
+        durableInsertedTriples: 0,
+        perPeer: [
+          {
+            peerId: curatorPeer,
+            insertedTriples: 5,
+            durableInsertedTriples: 0,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('keeps includeDurable independent from the SWM negative outcome cache', async () => {
+    const cgId = 'public-negative-cache-route-cg';
+    const negativePeer = 'peer-negative-cache';
+    const unknownPeer = 'peer-unknown-cache';
+    let connectedPeers = [negativePeer];
+    const syncSharedMemoryFromPeerDetailed = vi.fn(async () => ({ insertedTriples: 0 }));
+    const syncFromPeer = vi.fn(async (peerId: string) => (peerId === negativePeer ? 11 : 13));
+    const agent = {
+      peerId: 'self-peer',
+      node: {
+        libp2p: {
+          getConnections: () => connectedPeers.map((peerId) => ({
+            remotePeer: { toString: () => peerId },
+          })),
+        },
+      },
+      canUseSharedMemoryForContextGraph: vi.fn(async () => true),
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncSharedMemoryFromPeerDetailed,
+      syncFromPeer,
+    };
+
+    const first = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        peerId: negativePeer,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+    await handleMemoryRoutes(first.ctx);
+    expect(first.res.statusCode).toBe(200);
+    expect(syncSharedMemoryFromPeerDetailed).toHaveBeenCalledWith(negativePeer, [cgId]);
+    expect(syncFromPeer).not.toHaveBeenCalled();
+
+    syncSharedMemoryFromPeerDetailed.mockClear();
+    syncFromPeer.mockClear();
+    connectedPeers = [negativePeer, unknownPeer];
+    const second = buildCatchupCtx(
+      {
+        contextGraphId: cgId,
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+    await handleMemoryRoutes(second.ctx);
+
+    expect(second.res.statusCode).toBe(200);
+    expect(syncSharedMemoryFromPeerDetailed).toHaveBeenCalledTimes(1);
+    expect(syncSharedMemoryFromPeerDetailed).toHaveBeenCalledWith(unknownPeer, [cgId]);
+    expect(syncFromPeer.mock.calls.map(([peerId]) => peerId).sort()).toEqual([
+      negativePeer,
+      unknownPeer,
+    ].sort());
+    expect(syncFromPeer).toHaveBeenCalledWith(negativePeer, [cgId]);
+    expect(syncFromPeer).toHaveBeenCalledWith(unknownPeer, [cgId]);
+
+    const body = JSON.parse(second.res.body);
+    expect(body.peersAttempted).toBe(2);
+    expect(body.totalDurableInsertedTriples).toBe(24);
+    expect(body.perContextGraph).toEqual([
+      {
+        contextGraphId: cgId,
+        insertedTriples: 0,
+        durableInsertedTriples: 24,
+        perPeer: expect.arrayContaining([
+          {
+            peerId: negativePeer,
+            insertedTriples: 0,
+            durableInsertedTriples: 11,
+          },
+          {
+            peerId: unknownPeer,
+            insertedTriples: 0,
+            durableInsertedTriples: 13,
+          },
+        ]),
+      },
+    ]);
+  });
 });

--- a/packages/cli/test/shared-memory-catchup-durable.test.ts
+++ b/packages/cli/test/shared-memory-catchup-durable.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PROTOCOL_SYNC } from '@origintrail-official/dkg-core';
+import { handleMemoryRoutes } from '../src/daemon/routes/memory.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+function fakeRes() {
+  const res: any = { statusCode: 0, body: '', headers: {} as Record<string, string>, writableEnded: false };
+  res.writeHead = (status: number, headers?: Record<string, string>) => {
+    res.statusCode = status;
+    if (headers) Object.assign(res.headers, headers);
+  };
+  res.setHeader = (k: string, v: string) => { res.headers[k] = v; };
+  res.end = (body: string) => {
+    res.body = body;
+    res.writableEnded = true;
+  };
+  return res;
+}
+
+function fakeReq(body: unknown) {
+  return {
+    method: 'POST',
+    headers: {},
+    __dkgPrebufferedBody: Buffer.from(JSON.stringify(body)),
+  } as any;
+}
+
+function buildCatchupCtx(body: unknown, agent: Record<string, any>) {
+  const res = fakeRes();
+  const url = new URL('http://127.0.0.1/api/shared-memory/catchup');
+  const ctx = {
+    req: fakeReq(body),
+    res,
+    agent,
+    path: url.pathname,
+    url,
+  } as unknown as RequestContext;
+  return { ctx, res };
+}
+
+describe('POST /api/shared-memory/catchup durable leg', () => {
+  it('still runs includeDurable when SWM is not currently usable for the CG', async () => {
+    const syncSharedMemoryFromPeerDetailed = vi.fn();
+    const syncSharedMemoryFromPeer = vi.fn();
+    const syncFromPeer = vi.fn(async () => 7);
+    const agent = {
+      peerId: 'self-peer',
+      canUseSharedMemoryForContextGraph: vi.fn(async () => false),
+      getPeerProtocols: vi.fn(async () => [PROTOCOL_SYNC]),
+      isPrivateContextGraph: vi.fn(async () => false),
+      syncSharedMemoryFromPeerDetailed,
+      syncSharedMemoryFromPeer,
+      syncFromPeer,
+    };
+    const { ctx, res } = buildCatchupCtx(
+      {
+        contextGraphId: 'review-cg',
+        peerId: 'peer-a',
+        includeDurable: true,
+        hostCatchupFallback: false,
+      },
+      agent,
+    );
+
+    await handleMemoryRoutes(ctx);
+
+    expect(res.statusCode).toBe(200);
+    expect(syncSharedMemoryFromPeerDetailed).not.toHaveBeenCalled();
+    expect(syncSharedMemoryFromPeer).not.toHaveBeenCalled();
+    expect(syncFromPeer).toHaveBeenCalledTimes(1);
+    expect(syncFromPeer).toHaveBeenCalledWith('peer-a', ['review-cg']);
+
+    const body = JSON.parse(res.body);
+    expect(body.totalInsertedTriples).toBe(0);
+    expect(body.totalDurableInsertedTriples).toBe(7);
+    expect(body.peersAttempted).toBe(1);
+    expect(body.perContextGraph).toEqual([
+      {
+        contextGraphId: 'review-cg',
+        insertedTriples: 0,
+        durableInsertedTriples: 7,
+        perPeer: [
+          {
+            peerId: 'peer-a',
+            insertedTriples: 0,
+            durableInsertedTriples: 7,
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
           'test/async-promote-worker.test.ts',
           'test/async-promote-queue-e2e.test.ts',
           'test/import-artifact-routes.test.ts',
+          'test/shared-memory-catchup-durable.test.ts',
           'test/skill-endpoint.test.ts',
           // R6-B — metric COUNT getter TTL memo. Pure logic, no hardhat.
           'test/metrics-queries.test.ts',


### PR DESCRIPTION
## Summary

This PR bounds sync-on-connect fanout during relay/direct reconnect churn and reduces durable sync snapshot pressure.

It keeps sync-on-connect enabled, but stops short disconnect/reconnect flaps from looking like meaningful offline gaps that should trigger a fresh full catch-up round.

## Changes

- Add `SYNC_RECONNECT_FLAP_GRACE_MS` so short disconnects do not reset the sync-on-connect cooldown.
- Centralize connection-open scheduling through `queueSyncFromPeerOnConnect`.
- Respect existing sync reconciler backoff before queueing connection-open sync work.
- Record backoff for failed or no-progress sync-on-connect rounds.
- Keep real offline recovery: reconnects after a meaningful offline gap can still trigger catch-up.
- Make SWM sync-on-connect peer-aware so private CGs are only attempted from matching curator peers.
- Avoid repeated “re-tracked private CG” logging when the CG was already tracked.
- Shorten completed durable responder row snapshot retention after the final page.
- Avoid retaining a durable row snapshot if the serving request aborts before build completion.

## Why

The observed testnet edge node was not holding hundreds of live connections, but relay churn caused repeated short-lived connection events. Each reconnect could schedule durable + SWM sync across many context graphs, and each page had its own bounded retry loop. That created large aggregate retry amplification and responder snapshot pressure.

This PR applies backpressure before sync work fans out, while preserving normal catch-up for peers that were actually offline long enough to need recovery.

## Testing

- `pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/sync-on-connect-churn.test.ts`
  - Pass: 8 tests
- `cd packages/agent && pnpm exec vitest run --config /private/tmp/dkg-agent-responder-vitest.config.ts`
  - Pass: 25 tests
- `pnpm --filter @origintrail-official/dkg-agent build`
  - Pass
- `git diff --check`
  - Pass

## Notes

A live edge-node sample after these changes showed snapshot-limit errors drop to zero in the sampled windows, and SWM sync-on-connect fanout stopped. Connection churn and aggregate retry amplification can still continue at the transport/requester layer, so the next follow-up should add requester-side bailout/backoff inside a failing sync round.