### PR TITLE
fix(agent/sync): cache aborted owner's completed row snapshot (fix sync-responder CI flake on main)

### DIFF
--- a/packages/agent/src/sync/responder/graph-plan.ts
+++ b/packages/agent/src/sync/responder/graph-plan.ts
@@ -216,8 +216,15 @@ export function createResponderSyncRowListMemo(
 
       const load = loadRows()
         .then((rows) => {
+          // The owner's snapshot load (`readRowsAcrossGraphs` et al.) is NOT
+          // abort-aware — it carries no signal, so a settled `rows` here is the
+          // COMPLETE snapshot regardless of whether the owner's stream aborted
+          // mid-wait. Cache it unconditionally so a later same-session request
+          // (which coalesces on this `key`) reuses it instead of re-querying the
+          // store. The owner's own abort still surfaces at the `throwIfAborted`
+          // below, after `await load`, so the aborted request still rejects; it
+          // just no longer discards the snapshot it already paid to build.
           const value = [...rows];
-          throwIfAborted(options?.signal);
           storeCached(key, value);
           return value;
         })

--- a/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
+++ b/packages/agent/test/sync-responder-concurrent-interleaving.test.ts
@@ -838,7 +838,14 @@ describe('sync responder pagination interleaving', () => {
     expect(loads).toBe(2);
   });
 
-  it('does not retain a durable row snapshot when the serving request aborts before build completion', async () => {
+  it('retains the completed snapshot for reuse when the serving request aborts mid-build', async () => {
+    // The owner's row load is not abort-aware, so a settled snapshot is the
+    // COMPLETE result even if the owner's stream aborted while it was loading.
+    // The aborted owner must still reject, but the snapshot it already paid to
+    // build must be cached so a later same-session request reuses it instead of
+    // issuing a second, redundant store query (regression: PR #1142 discarded it,
+    // breaking sync-responder-protection's "keeps row-list cache-miss owners
+    // counted until the shared snapshot settles" on the CI ordering).
     const memo = createResponderSyncRowListMemo(10_000, 1);
     const snapshot = deferred<readonly {
       s: string;
@@ -847,8 +854,13 @@ describe('sync responder pagination interleaving', () => {
       g: string;
     }[]>();
     const controller = new AbortController();
+    let loads = 0;
+    const loadRows = () => {
+      loads += 1;
+      return snapshot.promise;
+    };
 
-    const first = memo.get('durable:aborted', () => snapshot.promise, { signal: controller.signal });
+    const first = memo.get('durable:aborted', loadRows, { signal: controller.signal });
     controller.abort(new Error('request aborted'));
     snapshot.resolve([{
       s: 'urn:memo:row',
@@ -857,13 +869,16 @@ describe('sync responder pagination interleaving', () => {
       g: 'urn:memo:graph',
     }]);
 
+    // The aborting owner still rejects (its stream is gone).
     await expect(first).rejects.toThrow('request aborted');
-    await expect(memo.get('durable:fresh', async () => [{
-      s: 'urn:memo:row',
-      p: `${DKG_NS}label`,
-      o: '"fresh"',
-      g: 'urn:memo:graph',
-    }])).resolves.toHaveLength(1);
+
+    // A later same-session reader reuses the cached snapshot — no second load.
+    await expect(
+      memo.get('durable:aborted', () => {
+        throw new Error('snapshot must be reused, not re-loaded');
+      }, { requireExisting: true }),
+    ).resolves.toHaveLength(1);
+    expect(loads).toBe(1);
   });
 
   it('releases completed durable row snapshots after the completion grace window', async () => {
@@ -881,7 +896,7 @@ describe('sync responder pagination interleaving', () => {
     memo.release('durable:complete', { graceMs: 10 });
 
     await expect(memo.get('durable:blocked', async () => [row])).rejects.toThrow(
-      'Too many active durable data sync session snapshots',
+      SyncRowSnapshotLimitError,
     );
 
     vi.advanceTimersByTime(11);


### PR DESCRIPTION
## What's broken
`main` CI is **currently red** on the `Tornado: agent [5/8/9/10]` shards: `packages/agent/test/sync-responder-protection.test.ts` → "keeps row-list cache-miss owners counted until the shared snapshot settles" fails **deterministically** at line 388 (`expect(queryCalls).toBe(1)` → got `2`).

## Who introduced it
- The **regression** was introduced by **PR #1227 "Codex/sync connect flap fix"** — commit `1db1247f2` *"Reduce sync reconnect snapshot churn"* by **Viktor Pelle** (merged 2026-06-18 20:45). `main` went red minutes later (run `27788711871`, 20:54).
- The **test** that catches it was added earlier by **PR #1142** (Jurij89) — #1142 is *not* the cause.

## Root cause
`#1227` added a `throwIfAborted(options.signal)` **inside** the row-list memo's load `.then`, **before** `storeCached` (`graph-plan.ts`, `createResponderSyncRowListMemo`). Every memo `loadRows` is **abort-unaware** (no signal threaded through `readRowsAcrossGraphs` / `readDurableMetaRows` / the SWM + durable-delta loaders), so when the `.then` runs the snapshot is always **complete** — but the guard **discarded** it whenever the owning request's stream had aborted mid-wait.

It's **deterministic, not a timing race**: per-peer responder concurrency is 1, so a same-session reconnect (`later`) queues behind the aborted owner (`first`) and only reaches the memo *after* `first` settles. By then the abort-guard skipped `storeCached`, `cached` is empty and `inflight` is gone → `later` issues a **second, redundant** store query (the opposite of "reduce churn"). `refresh` is not involved (`prepareResponderSession` gives `later` `refresh=false`, same session token).

## Fix
Drop the in-`.then` abort guard so the completed snapshot is cached unconditionally (matching the sibling graph-list / subgraph-name memos). The owner's own abort still surfaces at the **post-`await load`** `throwIfAborted`, so the aborted request still rejects — it just no longer throws away the snapshot it already paid to build.

```diff
       const load = loadRows()
         .then((rows) => {
+          // loadRows is abort-unaware → a settled `rows` is the COMPLETE snapshot.
+          // Cache it so a later same-session request reuses it; the owner's abort
+          // still surfaces at the post-await throwIfAborted below.
           const value = [...rows];
-          throwIfAborted(options?.signal);
           storeCached(key, value);
           return value;
         })
```

## Tests
- **Rewrote** the interleaving test (added by #1142) that *encoded* the discarding behavior → now asserts the corrected invariant: the completed snapshot is **retained + reused** (`requireExisting`), with a load counter proving **no second load**. Fails before this change, passes after.
- **Fixed** a separate stale assertion in the grace-window test that pointed at the pre-`SyncRowSnapshotLimitError` message (it also fails on clean `main`).

## Verification
- `sync-responder-protection.test.ts` + `sync-responder-concurrent-interleaving.test.ts`: **40/40 pass** (10× deterministic).
- #1227-touched files (protection + interleaving + churn): **53/53 pass**.
- The one remaining unrelated red in the broad sync suite (`swm-snapshot-sync` snapshot-ordering) is **pre-existing on clean `main`**, untouched here.

> Minor, no test exercises it: a *cache-full* aborted owner now rejects with `SyncRowSnapshotLimitError` (from `storeCached`) instead of the abort error — harmless (its stream is already gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)