### PR TITLE
test(evm-module): skip RandomSampling fairness + gas benchmark under coverage (fix coverage CI on main)

### DIFF
--- a/packages/evm-module/test/gas/RandomSampling-bit-gas.test.ts
+++ b/packages/evm-module/test/gas/RandomSampling-bit-gas.test.ts
@@ -19,7 +19,12 @@ import {
 //
 // The tree is left BACKFILL-LOCKED so we can `seed` fake leaves cheaply to grow N;
 // previewChallengeForSeed (the draw) is not gated by the lock, so it still runs.
-describe('@gas RandomSampling BIT draw', () => {
+//
+// Pure gas benchmark — slow under coverage instrumentation and adds no unique
+// contract-line coverage, so skip the whole suite under coverage (same convention
+// as ContextGraphStorage.test.ts's heavy-test skip).
+const skipGasUnderCoverage = process.argv.some((a) => a.includes('coverage'));
+(skipGasUnderCoverage ? describe.skip : describe)('@gas RandomSampling BIT draw', () => {
   const OPEN_POLICY = 1;
   const TEST_KA_BYTE_SIZE = 128n;
   const DOMINANT = 10n ** 18n; // real CG weight dwarfs the fake unit leaves, so the draw lands on it

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1367,7 +1367,12 @@ describe('@unit RandomSampling', () => {
     // active-weight share. Deterministic seed sequence, so this is a fixed
     // pass/fail check, not a flaky statistical one.
     // -----------------------------------------------------------------------
-    it('fairness: draw frequency within ±2pp of weight share (settled state)', async () => {
+    // 5000-draw statistical check: too slow under coverage instrumentation (each
+    // instrumented draw is far slower, so it exceeds the 600s mocha timeout on CI).
+    // It adds no unique contract-line coverage, so skip it under coverage — same
+    // convention as ContextGraphStorage.test.ts's heavy-test skip.
+    const skipFairnessUnderCoverage = process.argv.some((a) => a.includes('coverage'));
+    (skipFairnessUnderCoverage ? it.skip : it)('fairness: draw frequency within ±2pp of weight share (settled state)', async () => {
       const endEpoch = (await Chronos.getCurrentEpoch()) + 100n;
       const sharePct = [50n, 25n, 15n, 7n, 3n]; // sums to 100
       const cgIds: bigint[] = [];


### PR DESCRIPTION
## What's broken
`main`'s **Tornado: Solidity coverage (push safety net)** lane is red: `npx hardhat coverage` exits 1 with **1 failing** test —

```
@unit RandomSampling > Phase 10 — value-weighted challenge generation
  > fairness: draw frequency within ±2pp of weight share (settled state):
    Error: Timeout of 600000ms exceeded.
```

All 781 tests pass locally under coverage (12m); on CI the run takes ~34m and the 5000-draw fairness test tips past the 600s mocha timeout under instrumentation.

## Cause
Introduced by **#1226** (the BIT sampling PR), which added two timing/gas-shaped tests without the coverage guard the repo already uses:
- the **fairness** statistical test (5000 `previewChallengeForSeed` draws), and
- the **`@gas` benchmark** suite.

Under solidity-coverage every draw runs heavily instrumented, so the fairness test blows the timeout. Neither adds unique contract-line coverage (they re-exercise the same paths).

## Fix
Guard both to skip under coverage, matching the existing convention in `ContextGraphStorage.test.ts`:
```ts
const skip = process.argv.some((a) => a.includes('coverage'));
(skip ? it.skip : it)('fairness: …', …)        // RandomSampling.test.ts
(skip ? describe.skip : describe)('@gas …', …)  // RandomSampling-bit-gas.test.ts
```

## Verified
- **Normal `hardhat test`:** both still run + pass (gas 2✓, fairness 1✓).
- **`hardhat coverage`:** both skip (gas suite → `2 pending`, "Coverage skipped for: …"), so no timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)