### PR TITLE
fix(agent/swm): repair ack-quorum / metaSynced test regressions on main

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -173,7 +173,10 @@ import {
   createSwmAckQuorum,
   type SwmAckQuorum,
 } from './swm/ack-quorum.js';
-import type { SelectSwmFanoutPeersResult } from './swm/swm-fanout-peer-selection.js';
+import {
+  classifySwmFanoutPeerOutcome,
+  type SelectSwmFanoutPeersResult,
+} from './swm/swm-fanout-peer-selection.js';
 import { SwmHostModeStore, type SwmHostModeStoreLimits } from './swm/host-mode-store.js';
 import {
   BEACON_ACCESS_POLICY_CURATED,
@@ -607,16 +610,28 @@ export class PublishMethods extends DKGAgentBase {
     //      we don't pretend we can verify those deliveries.
     //      Cross-peer SWM-inbox SPARQL remains the ground-truth
     //      check.
+    // #1227 regression fix: gate + track on the FULL dialable set
+    // (`plan.substrateMembers`), NOT the churn-selector-narrowed
+    // `substrateMembers` send set. The active-fanout selector only
+    // bounds which peers we ATTEMPT this round (to limit churn); the
+    // ack-quorum's `expectedMembers` must stay the complete
+    // roundtrip-eligible roster so a peer the selector skipped this
+    // round still counts toward quorum once it acks (via gossip or a
+    // later top-up). Narrowing `expectedMembers` to the probe-limited
+    // subset silently dropped real subscribers from the quorum target
+    // — the same class of bug the codex-RED note in
+    // `enumerate-cg-members.ts` (`members` must not shrink
+    // `expectedMembers`) was added to prevent.
     const ackQuorumActive = !!shareOperationId
       && plan.useGossip
-      && substrateMembers.length > 0;
+      && plan.substrateMembers.length > 0;
     let trackedQuorum: SwmAckQuorum | null = null;
     if (ackQuorumActive && shareOperationId) {
       trackedQuorum = this.getOrCreateSwmAckQuorum();
       trackedQuorum.track({
         shareOperationId,
         cgId: contextGraphId,
-        expectedMembers: substrateMembers,
+        expectedMembers: plan.substrateMembers,
         preAckedFromSubstrate: [],
         payload: wireMessage,
         enumerationSource: plan.enumerationSource,
@@ -657,7 +672,22 @@ export class PublishMethods extends DKGAgentBase {
                 ) {
                   trackedQuorum.onAck(shareOperationId, record.peerId);
                 }
-                if (plan.enumerationSource === 'topic-subscribers') {
+                // #1227 regression fix: only feed TERMINAL initial-fanout
+                // outcomes (delivered→good, failed/rejected→failed/
+                // unsupported) into the active-fanout churn selector. A
+                // transient `queued`/`retryable`/`inFlight` outcome
+                // classifies as `nonTerminal` and would be cached with the
+                // negative TTL (2m) — which is longer than the watchdog
+                // interval (30s), so it suppressed the SAME share's first
+                // watchdog top-up of that very peer (the watchdog exists
+                // precisely to retry those queued/transient peers). Cross-
+                // share churn limiting still works: a genuinely failed/
+                // unsupported peer is remembered, and the top-up path
+                // (swmSubstrateTopUp) keeps feeding its own outcomes.
+                if (
+                  plan.enumerationSource === 'topic-subscribers'
+                  && classifySwmFanoutPeerOutcome(record) !== 'nonTerminal'
+                ) {
                   this.recordSwmFanoutPeerRecord(contextGraphId, record);
                 }
                 if (

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -954,9 +954,17 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         (agent.node.libp2p.peerStore as any).get = recorder(async () => ({
           protocols: [PROTOCOL_SYNC],
         } as any));
-        (agent as any).syncFromPeer = recorder(async () => 0);
+        // `runSyncOnConnect` calls `syncFromPeerDetailed` /
+        // `syncSharedMemoryFromPeerDetailed` (the seams `trySyncFromPeer`
+        // wires in), NOT the bare `syncFromPeer` helpers. Stub the real
+        // seams to a clean (zero, no-backoff) result so the durable round
+        // does not trip the "stop on backoff-worthy failure" early-return
+        // (added by `4b50883c6`), which would otherwise skip
+        // `refreshMetaSyncedFlags` and make this assertion pass only
+        // vacuously.
+        (agent as any).syncFromPeerDetailed = recorder(async () => 0);
+        (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => 0);
         (agent as any).discoverContextGraphsFromStore = recorder(async () => 0);
-        (agent as any).syncSharedMemoryFromPeer = recorder(async () => 0);
 
         await (agent as any).trySyncFromPeer(remotePeer.toString());
 
@@ -997,9 +1005,17 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         (agent.node.libp2p.peerStore as any).get = recorder(async () => ({
           protocols: [PROTOCOL_SYNC],
         } as any));
-        (agent as any).syncFromPeer = recorder(async () => 0);
+        // `runSyncOnConnect` calls `syncFromPeerDetailed` /
+        // `syncSharedMemoryFromPeerDetailed` (the seams `trySyncFromPeer`
+        // wires in), NOT the bare `syncFromPeer` helpers. Stub the real
+        // seams to a clean (zero, no-backoff) result so the durable round
+        // does not trip the "stop on backoff-worthy failure" early-return
+        // (added by `4b50883c6`), which would otherwise skip
+        // `refreshMetaSyncedFlags` and leave `metaSynced` false even though
+        // the ontology confirms the CG.
+        (agent as any).syncFromPeerDetailed = recorder(async () => 0);
+        (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => 0);
         (agent as any).discoverContextGraphsFromStore = recorder(async () => 0);
-        (agent as any).syncSharedMemoryFromPeer = recorder(async () => 0);
 
         await (agent as any).trySyncFromPeer(remotePeer.toString());
 

--- a/packages/agent/test/agent.part-16.test.ts
+++ b/packages/agent/test/agent.part-16.test.ts
@@ -6,6 +6,63 @@ function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
   return Object.assign(fn, { calls });
 }
 
+// #1236 🔵: clean (all-zero, no-backoff, made-no-progress) detailed
+// sync summaries shaped to match the production `DurableSyncResult` /
+// `SharedMemorySyncResult` returns of `syncFromPeerDetailed` /
+// `syncSharedMemoryFromPeerDetailed` (see dkg-agent-types.ts and
+// dkg-agent-lifecycle.ts). `runSyncOnConnect` accounts results as
+// `number | SyncProgressSummary`; a bare `0` takes the
+// `typeof result === 'number'` happy-path branch in EVERY accounting
+// helper (madeSyncProgress → true, cleanDetailedSync → true,
+// hadBackoffWorthyFailure → false, metadataOnlySync never reached),
+// so a numeric fixture would mask accounting drift in the
+// object-branch logic. A zero-valued object exercises the real
+// object-branch accounting while preserving the "clean, no-backoff"
+// semantics those stubs intend.
+function cleanDurableSyncResult() {
+  return {
+    insertedTriples: 0,
+    deniedPhases: 0,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 0,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    metaOnlyResponses: 0,
+    dataRejectedMissingMeta: 0,
+    rejectedKcs: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    backoffWorthyFailures: 0,
+  };
+}
+
+function cleanSharedMemorySyncResult() {
+  return {
+    insertedTriples: 0,
+    deniedPhases: 0,
+    fetchedMetaTriples: 0,
+    fetchedDataTriples: 0,
+    insertedMetaTriples: 0,
+    insertedDataTriples: 0,
+    bytesReceived: 0,
+    resumedPhases: 0,
+    timedOutPhases: 0,
+    completedPhases: 0,
+    checkpointAdvances: 0,
+    emptyResponses: 0,
+    droppedDataTriples: 0,
+    failedPeers: 0,
+    failedPhases: 0,
+    backoffWorthyFailures: 0,
+  };
+}
+
 
 
 let _fileSnapshot: string;
@@ -962,8 +1019,20 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         // (added by `4b50883c6`), which would otherwise skip
         // `refreshMetaSyncedFlags` and make this assertion pass only
         // vacuously.
-        (agent as any).syncFromPeerDetailed = recorder(async () => 0);
-        (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => 0);
+        //
+        // #1236 🔵: return a properly-shaped DETAILED summary object
+        // (matching the production `DurableSyncResult` /
+        // `SharedMemorySyncResult` shapes), NOT a bare `0`. A bare
+        // number takes `runSyncOnConnect`'s `typeof result === 'number'`
+        // happy-path branch in EVERY accounting helper
+        // (`madeSyncProgress` → true, `cleanDetailedSync` → true,
+        // `hadBackoffWorthyFailure` → false, `metadataOnlySync` never
+        // reached), so the fixture would mask any accounting drift in
+        // the object-branch logic. A zero-valued object exercises the
+        // real object-branch accounting while preserving the intended
+        // "clean, no-backoff, made-no-progress" semantics.
+        (agent as any).syncFromPeerDetailed = recorder(async () => cleanDurableSyncResult());
+        (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => cleanSharedMemorySyncResult());
         (agent as any).discoverContextGraphsFromStore = recorder(async () => 0);
 
         await (agent as any).trySyncFromPeer(remotePeer.toString());
@@ -1013,8 +1082,13 @@ describe('DKGAgent config — syncContextGraphs and queryAccess warning', () => 
         // (added by `4b50883c6`), which would otherwise skip
         // `refreshMetaSyncedFlags` and leave `metaSynced` false even though
         // the ontology confirms the CG.
-        (agent as any).syncFromPeerDetailed = recorder(async () => 0);
-        (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => 0);
+        //
+        // #1236 🔵: shaped detailed summary objects, not bare `0` (see the
+        // metaSynced-scope-only test above for the full rationale — a
+        // bare number masks accounting drift by taking the number
+        // happy-path in every `runSyncOnConnect` accounting helper).
+        (agent as any).syncFromPeerDetailed = recorder(async () => cleanDurableSyncResult());
+        (agent as any).syncSharedMemoryFromPeerDetailed = recorder(async () => cleanSharedMemorySyncResult());
         (agent as any).discoverContextGraphsFromStore = recorder(async () => 0);
 
         await (agent as any).trySyncFromPeer(remotePeer.toString());

--- a/packages/agent/test/swm-ack-quorum-integration.test.ts
+++ b/packages/agent/test/swm-ack-quorum-integration.test.ts
@@ -1114,4 +1114,178 @@ describe('DKGAgent SwmAckQuorum integration (rc.9 PR-D)', () => {
     expect(statsAfter.completed).toBe(1);
     expect(statsAfter.pending).toBe(1);
   });
+
+  /**
+   * #1236 review 🔴 discriminator (otReviewAgent on the #1227
+   * regression fix). PR #1236 widened the ack-quorum's
+   * `expectedMembers` back to the FULL `plan.substrateMembers`
+   * (not the churn-narrowed initial-push set), but the watchdog
+   * top-up in `swmSubstrateTopUp` was NOT changed: for a public
+   * (`topic-subscribers`) CG it still runs the fan-out selector,
+   * which SKIPS any peer sitting in the selector's negative-TTL
+   * cache. The bot's worry: a quorum-EXPECTED peer that
+   * TERMINALLY FAILED the initial push (→ negative cache) and
+   * does NOT ack via gossip might never be re-attempted by the
+   * watchdog, stalling the quorum until the hard deadline.
+   *
+   * This test constructs EXACTLY that scenario and asserts what
+   * actually happens (empirical, not theoretical):
+   *
+   *   - `Term` rejects the initial push (0x01 sentinel →
+   *     classified `failed` → recorded into the selector's
+   *     negative cache with the 2-min negative TTL). It IS part
+   *     of the full quorum set (`expectedMembers`) and does NOT
+   *     ack via gossip.
+   *   - `Good1` / `Good2` queue on the initial push (NOT terminal
+   *     → NOT cached), then ack via gossip — but 2/3 < the 0.9
+   *     default quorum threshold, so the record stays pending on
+   *     `Term`.
+   *   - The watchdog then fires substrate top-up for the only
+   *     missing peer, `Term`.
+   *
+   * OBSERVED OUTCOME = (b), graceful degradation:
+   *   1. The top-up does NOT re-reach `Term` — the selector
+   *      classifies it as a recent-negative peer and drops it
+   *      from `selectedPeers` (`sendReliable` for the
+   *      `swm-topup-` messageId is never called for `Term`). This
+   *      confirms the bot's mechanism is real: the watchdog DOES
+   *      skip a quorum-expected, negative-cached peer.
+   *   2. BUT the share is NOT permanently stuck: the hard
+   *      deadline reaps the record cleanly via `onDeadlineExpired`
+   *      (`deadlineExpired` ticks, `pending` returns to 0, the
+   *      record is removed). Offline/rejecting peers fall through
+   *      to `runSyncOnConnect` — the documented catch-up safety
+   *      net (ack-quorum.ts §4).
+   *
+   * Why (b) and not (c): the skipped peer here TERMINALLY
+   * rejected the initial push. Re-blasting the identical wire
+   * bytes at it on every 30s watchdog tick would reproduce the
+   * exact churn-amplification soak bug #1227's selector was added
+   * to stop — and would never succeed (a permanent rejection
+   * rejects again). The deadline-reap + sync-on-connect recovery
+   * is the correct terminal for a peer that can't accept the
+   * share. So the 🔴 is a defensible graceful-degradation path,
+   * NOT a correctness bug — no source change is warranted; this
+   * test documents the deadline-resolution contract.
+   */
+  it('#1236 🔴 (b): watchdog top-up skips a terminally-failed, negative-cached quorum-expected peer; deadline reaps it cleanly (graceful degradation)', async () => {
+    const agent = register(await createAgent('AckQuorum1236TerminalSkip'));
+    const gossip = new CapturingGossip();
+    gossip.subscribers = ['12D3KooWTerm', '12D3KooWGood1', '12D3KooWGood2'];
+    (agent as unknown as { gossip: CapturingGossip }).gossip = gossip;
+
+    // Initial fan-out: `Term` returns the 0x01 REJECTED sentinel
+    // (delivered: true at the wire layer, but the receiver
+    // permanently rejected) → classified `failed` →
+    // terminal → fed into the fan-out selector's negative cache.
+    // `Good1` / `Good2` queue (non-terminal → NOT cached) so
+    // they stay pending after the initial push.
+    const { calls, install } = stubMessengerSendReliable((peerId, _proto, msgId) => {
+      const isTopUp = msgId?.startsWith('swm-topup-');
+      if (!isTopUp) {
+        if (peerId === '12D3KooWTerm') {
+          // 0x01 → rejected → classifySwmFanoutPeerOutcome → 'failed'
+          return { delivered: true, response: new Uint8Array([0x01]), attempts: 1, messageId: 'init-term' };
+        }
+        return { delivered: false, queued: true, attempts: 1, messageId: 'q-init', error: 'transient', nextAttemptAtMs: Date.now() + 1000 };
+      }
+      // Any top-up that DOES reach a peer succeeds (so if the
+      // watchdog were to re-reach `Term`, we'd see it).
+      return { delivered: true, response: new Uint8Array(), attempts: 1, messageId: msgId! };
+    });
+    install(agent);
+
+    const { shareOperationId } = await agent.share('cg-1236-terminal-skip', [{
+      subject: 'urn:test:1236', predicate: 'http://schema.org/name', object: '"t1236"', graph: '',
+    }]);
+
+    // The share must have run a public (topic-subscribers)
+    // substrate fan-out — that's the only enumeration source the
+    // selector (and thus the negative cache) applies to. If this
+    // assertion ever flips, the discriminator's preconditions no
+    // longer hold and the outcome below is meaningless.
+    const snap0 = agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId);
+    expect(snap0).toBeDefined();
+    expect([...(snap0?.expectedMembers ?? [])].sort()).toEqual([
+      '12D3KooWGood1', '12D3KooWGood2', '12D3KooWTerm',
+    ]);
+
+    // Precondition 1: the initial fan-out actually attempted all 3
+    // peers (so `Term`'s rejection was observed by the bookkeeper).
+    const initCalls = calls.filter((c) => !c.messageId?.startsWith('swm-topup-') && c.protocolId === PROTOCOL_SWM_UPDATE);
+    expect(initCalls.map((c) => c.peerId).sort()).toEqual([
+      '12D3KooWGood1', '12D3KooWGood2', '12D3KooWTerm',
+    ]);
+
+    // Precondition 2: `Term` landed in the fan-out selector's
+    // negative cache (this is the gate the watchdog top-up
+    // re-applies). `failed` is a negative outcome, so the
+    // selector will skip it inside the 2-min TTL.
+    expect(agent.getSwmFanoutPeerOutcomeForTests('cg-1236-terminal-skip', '12D3KooWTerm')).toBe('failed');
+
+    // `Good1` / `Good2` ack via gossip. 2/3 = 0.67 < 0.9 default
+    // threshold, so the record is still pending on `Term`.
+    const ackHandler = await agent.getOrCreateSwmShareAckHandlerForTests();
+    await ackHandler(encodeSwmShareAck({ shareOperationId, ackPeerId: '12D3KooWGood1' }), '12D3KooWGood1');
+    await ackHandler(encodeSwmShareAck({ shareOperationId, ackPeerId: '12D3KooWGood2' }), '12D3KooWGood2');
+    const snap1 = agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId);
+    expect(snap1).toBeDefined();
+    expect([...(snap1?.acked ?? [])].sort()).toEqual(['12D3KooWGood1', '12D3KooWGood2']);
+    expect(agent.getSwmAckQuorumStats().completed).toBe(0);
+    expect(agent.getSwmAckQuorumStats().pending).toBe(1);
+
+    // Make `Term` dialable for the top-up's `isPeerDialable`
+    // filter so we isolate the negative-cache skip (not a
+    // dialability skip) as the reason the top-up doesn't reach it.
+    // (Short test peer ids resolve via the gossip-subscriber
+    // fast path in `installAllReachableLibp2pStub`; `Term` is in
+    // `gossip.subscribers`, so it's already dialable.)
+
+    // Count top-up calls BEFORE driving the watchdog.
+    const topUpCallsBefore = calls.filter((c) => c.messageId?.startsWith('swm-topup-')).length;
+
+    // Drive the watchdog top-up for the only missing peer (`Term`).
+    // This is the EXACT path the 5s tick → fireWatchdog →
+    // substrateTopUp would take, with `missingPeers` =
+    // expectedMembers ∖ acked = [Term].
+    await agent.invokeSwmSubstrateTopUpForTests({
+      shareOperationId,
+      cgId: 'cg-1236-terminal-skip',
+      payload: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+      missingPeers: ['12D3KooWTerm'],
+    });
+
+    // OBSERVED (1): the top-up did NOT re-reach `Term`. The
+    // selector classified it as a recent-negative peer and
+    // dropped it from `selectedPeers`, so no `swm-topup-`
+    // sendReliable fired for it. This confirms the bot's
+    // mechanism: the watchdog DOES skip a quorum-expected,
+    // negative-cached peer.
+    const topUpCallsAfter = calls.filter((c) => c.messageId?.startsWith('swm-topup-'));
+    expect(topUpCallsAfter.filter((c) => c.peerId === '12D3KooWTerm')).toEqual([]);
+    expect(topUpCallsAfter.length).toBe(topUpCallsBefore);
+
+    // The record is still pending on `Term` (the top-up was a
+    // no-op for it).
+    expect(agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId)).toBeDefined();
+    expect(agent.getSwmAckQuorumStats().pending).toBe(1);
+    expect(agent.getSwmAckQuorumStats().completed).toBe(0);
+
+    // OBSERVED (2): the share is NOT permanently stuck. The hard
+    // deadline reaps the record cleanly via `onDeadlineExpired`.
+    // Advance the quorum clock past `startedAtMs + deadlineHardMs`
+    // (5 min default) and tick — the record is removed,
+    // `deadlineExpired` increments, `pending` returns to 0.
+    const quorum = (agent as unknown as {
+      getOrCreateSwmAckQuorum: () => { tick: (now?: number) => void };
+    }).getOrCreateSwmAckQuorum();
+    quorum.tick(Date.now() + 5 * 60_000 + 1);
+
+    expect(agent.getSwmAckQuorumRecordSnapshotForTests(shareOperationId)).toBeUndefined();
+    const finalStats = agent.getSwmAckQuorumStats();
+    expect(finalStats.pending).toBe(0);
+    expect(finalStats.deadlineExpired).toBe(1);
+    // Never falsely counted as completed.
+    expect(finalStats.completed).toBe(0);
+  });
 });

--- a/packages/agent/test/swm-ack-quorum.test.ts
+++ b/packages/agent/test/swm-ack-quorum.test.ts
@@ -397,7 +397,10 @@ describe('createSwmAckQuorum: tick + watchdog + deadline', () => {
       cgId: 'cg-watch',
       missingCount: 2,
       expectedCount: 4,
+      missingPeers: expect.arrayContaining(['p3', 'p4']),
+      enumerationSource: 'topic-subscribers',
     }]);
+    expect(onWatchdogFired.calls.at(-1)![0].missingPeers).toHaveLength(2);
 
     // Subsequent ticks before deadline must NOT re-fire.
     nowMs += 30_000;
@@ -476,7 +479,10 @@ describe('createSwmAckQuorum: tick + watchdog + deadline', () => {
       ackedCount: 1,
       expectedCount: 3,
       ackPct: 1 / 3,
+      missingPeers: expect.arrayContaining(['p2', 'p3']),
+      enumerationSource: 'allowlist',
     }]);
+    expect(onDeadlineExpired.calls.at(-1)![0].missingPeers).toHaveLength(2);
   });
 
   it('multiple records advance independently in a single tick', () => {


### PR DESCRIPTION
## What's broken
`main`'s `Tornado: agent` shards are red on **7 tests**:
- `swm-ack-quorum.test.ts` ×2 (watchdog/deadline payloads),
- `swm-ack-quorum-integration.test.ts` ×4 (`share()`, PR-D #D6, PR-H bug 1, PR-H bug 2),
- `agent.part-16.test.ts` ×1 (`metaSynced`).

## Root cause + per-failure decision
**`swm-ack-quorum.test.ts` (×2) — test-update.** PR #1227 (`008d8d1df` "Limit active SWM public fanout churn", Viktor Pelle) intentionally enriched the `onWatchdogFired`/`onDeadlineExpired` payloads with `missingPeers` + `enumerationSource`. The emitted values are correct; the unit `toEqual` expectations just asserted the old subset. Updated them.

**`swm-ack-quorum-integration.test.ts` (×4) — source-fix (`dkg-agent-publish.ts`).** #1227's new fanout selector narrowed the peer set used for the **quorum target** (`track({expectedMembers})` + the `ackQuorumActive` gate) to the probe-limited substrate set, and fed transient (`queued`/`retryable`) outcomes into the selector's negative cache. Since `onAck` drops any peer not in `expectedMembers`, real acks from healthy un-pushed peers were silently discarded (`share()` short a peer; D6 top-up not counted; PR-H watchdog/dropPeer paths starved). Fix: track + gate the quorum on the **full** `plan.substrateMembers` (the narrowed set bounds only what we *attempt* to push, never what counts toward quorum), and only feed **terminal** initial-fan-out outcomes to the selector. The legitimate churn-limiting (narrowed initial push) is preserved.

**`agent.part-16.test.ts` (×1) — test-only; NOT #1227.** Proven by reverting #1227 (still fails). The de-mocked test stubs `syncFromPeer`/`syncSharedMemoryFromPeer`, but `trySyncFromPeer` wires the `*Detailed` variants, so the stubs were no-ops → a real self-dial sync ran, failed, and the early-return skipped `refreshMetaSyncedFlags`. Fixed by stubbing the actual `*Detailed` seams. No sync source touched.

## Why this is the minimal fix
The regressions are at the publish/quorum-target level, so a 38-line `dkg-agent-publish.ts` change fixes all of them **without** changing the substrate fan-out behavior or deleting any of #1227's `swm-fanout-peer-selection` tests.

## Verified
4 affected files = **89 passing** (incl. all 7 originally-red tests + the 9 `swm-fanout-peer-selection` tests #1227 added); the broader substrate suite (`swm-substrate-fanout*`) also green (105 total across the set). `tsc --noEmit` clean.

> This is the last of the three `main` CI failure groups: `sync-responder-protection` (#1232, merged), Solidity coverage (#1235), and this one — all traced to recently-merged PRs (#1227 ×2 + #1226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)