### PR TITLE
Codex/private imported artifact read auth

### DIFF
--- a/packages/agent/src/imported-artifact.ts
+++ b/packages/agent/src/imported-artifact.ts
@@ -418,12 +418,13 @@ async function resolveImportedArtifactReadSubject(
     };
   }
 
+  const requesterProof = hasSelectorBoundRequesterProof(agent, syncReq);
   const ownerAllowed = Boolean(
     syncReq.requesterAgentAddress &&
     isSameAgentAddress(parsedAssertion.assertionAgentAddress, syncReq.requesterAgentAddress) &&
-    hasSelectorBoundRequesterProof(agent, syncReq),
+    requesterProof,
   );
-  if (!ownerAllowed) return null;
+  if (!ownerAllowed && (!syncReq.requesterAgentAddress || !requesterProof || parsedAssertion.legacy)) return null;
   return {
     assertionUri: canonicalImportedAssertionUri(req.contextGraphId, parsedAssertion),
     ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),
@@ -668,6 +669,7 @@ export class ImportedArtifactMethods extends DKGAgentBase {
       if (
         page.offset !== requestedRange.offset ||
         page.hash !== params.hash ||
+        Buffer.byteLength(page.bytesB64, 'base64') > requestedRange.maxBytes ||
         (page.totalBytes != null && page.offset + Buffer.byteLength(page.bytesB64, 'base64') > page.totalBytes) ||
         (page.truncated && (page.nextOffset == null || page.nextOffset <= page.offset))
       ) {

--- a/packages/agent/src/imported-artifact.ts
+++ b/packages/agent/src/imported-artifact.ts
@@ -358,6 +358,24 @@ async function isPublicOpenContextGraph(
   }
 }
 
+async function isContextGraphAuthorizedReadAgent(
+  agent: DKGAgent,
+  contextGraphId: string,
+  requesterAgentAddress: string | undefined,
+): Promise<boolean> {
+  if (!requesterAgentAddress) return false;
+  const [allowedAgents, participantAgents] = await Promise.all([
+    typeof agent.getContextGraphAllowedAgents === 'function'
+      ? agent.getContextGraphAllowedAgents(contextGraphId).catch(() => [] as string[])
+      : Promise.resolve([] as string[]),
+    typeof agent.getContextGraphParticipantAgentAddresses === 'function'
+      ? agent.getContextGraphParticipantAgentAddresses(contextGraphId).catch(() => [] as string[])
+      : Promise.resolve([] as string[]),
+  ]);
+  return [...allowedAgents, ...participantAgents].some((agentAddress) =>
+    isSameAgentAddress(agentAddress, requesterAgentAddress));
+}
+
 function hasSelectorBoundRequesterProof(
   agent: DKGAgent,
   syncReq: SyncRequestEnvelope,
@@ -424,7 +442,20 @@ async function resolveImportedArtifactReadSubject(
     isSameAgentAddress(parsedAssertion.assertionAgentAddress, syncReq.requesterAgentAddress) &&
     requesterProof,
   );
-  if (!ownerAllowed && (!syncReq.requesterAgentAddress || !requesterProof || parsedAssertion.legacy)) return null;
+  if (ownerAllowed) {
+    return {
+      assertionUri: canonicalImportedAssertionUri(req.contextGraphId, parsedAssertion),
+      ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),
+    };
+  }
+
+  if (!syncReq.requesterAgentAddress || !requesterProof || parsedAssertion.legacy) return null;
+  const requesterIsAuthorizedReadAgent = await isContextGraphAuthorizedReadAgent(
+    agent,
+    req.contextGraphId,
+    syncReq.requesterAgentAddress,
+  );
+  if (!requesterIsAuthorizedReadAgent) return null;
   return {
     assertionUri: canonicalImportedAssertionUri(req.contextGraphId, parsedAssertion),
     ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),

--- a/packages/agent/test/imported-artifact.test.ts
+++ b/packages/agent/test/imported-artifact.test.ts
@@ -121,6 +121,8 @@ function fakeAgent(args: {
   queryBindings?: Array<Record<string, unknown>>;
   bytes?: Buffer;
   onChainPolicy?: { accessPolicy?: number; publishPolicy?: number };
+  allowedAgents?: string[];
+  participantAgents?: string[];
 }) {
   const authorizeSyncRequest = vi.fn(async (
     syncReq: SyncRequestEnvelope,
@@ -168,6 +170,8 @@ function fakeAgent(args: {
     getContextGraphOnChainPolicy: args.onChainPolicy
       ? vi.fn(async () => args.onChainPolicy)
       : vi.fn(async () => ({})),
+    getContextGraphAllowedAgents: vi.fn(async () => args.allowedAgents ?? []),
+    getContextGraphParticipantAgentAddresses: vi.fn(async () => args.participantAgents ?? []),
     findLocalAgentForContextGraph: vi.fn(async () => 'did:dkg:agent:owner'),
     sendToPeer: vi.fn(async () => new TextEncoder().encode(JSON.stringify({
       version: 1,
@@ -305,9 +309,9 @@ describe('generic imported artifact peer handler', () => {
     expect(res.hashMismatch).toBe(true);
   });
 
-  it('allows non-owner artifact reads when context graph sync auth and selector-bound requester proof pass', async () => {
+  it('allows non-owner artifact reads when the requester is an authorized CG read agent', async () => {
     const bytes = Buffer.from('abcdef');
-    const agent = fakeAgent({ bytes });
+    const agent = fakeAgent({ bytes, allowedAgents: [otherAgentAddress] });
     const nonOwner = await request({}, {
       requesterAgentAddress: otherAgentAddress,
       signer: otherWallet,
@@ -318,6 +322,24 @@ describe('generic imported artifact peer handler', () => {
     expect(agent.store.query).toHaveBeenCalled();
     expect(res.denied).toBeUndefined();
     expect(res.bytesB64).toBe(bytes.subarray(0, 4).toString('base64'));
+  });
+
+  it('denies non-owner artifact reads on public curators-only CGs without read-agent membership', async () => {
+    const agent = fakeAgent({
+      bytes: Buffer.from('abcdef'),
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 0 },
+    });
+    const nonOwner = await request({}, {
+      requesterAgentAddress: otherAgentAddress,
+      signer: otherWallet,
+    });
+    const res = await invoke(agent, nonOwner);
+
+    expect(agent.authorizeSyncRequest).toHaveBeenCalledTimes(1);
+    expect(agent.getContextGraphAllowedAgents).toHaveBeenCalledWith(contextGraphId);
+    expect(agent.getContextGraphParticipantAgentAddresses).toHaveBeenCalledWith(contextGraphId);
+    expect(agent.store.query).not.toHaveBeenCalled();
+    expect(res.denied).toBe('denied');
   });
 
   it('denies forged owner claims on direct artifact reads without selector-bound owner proof', async () => {

--- a/packages/agent/test/imported-artifact.test.ts
+++ b/packages/agent/test/imported-artifact.test.ts
@@ -305,8 +305,9 @@ describe('generic imported artifact peer handler', () => {
     expect(res.hashMismatch).toBe(true);
   });
 
-  it('denies non-owner artifact reads even when context graph sync auth passes', async () => {
-    const agent = fakeAgent({ bytes: Buffer.from('abcdef') });
+  it('allows non-owner artifact reads when context graph sync auth and selector-bound requester proof pass', async () => {
+    const bytes = Buffer.from('abcdef');
+    const agent = fakeAgent({ bytes });
     const nonOwner = await request({}, {
       requesterAgentAddress: otherAgentAddress,
       signer: otherWallet,
@@ -314,8 +315,9 @@ describe('generic imported artifact peer handler', () => {
     const res = await invoke(agent, nonOwner);
 
     expect(agent.authorizeSyncRequest).toHaveBeenCalledTimes(1);
-    expect(agent.store.query).not.toHaveBeenCalled();
-    expect(res.denied).toBe('denied');
+    expect(agent.store.query).toHaveBeenCalled();
+    expect(res.denied).toBeUndefined();
+    expect(res.bytesB64).toBe(bytes.subarray(0, 4).toString('base64'));
   });
 
   it('denies forged owner claims on direct artifact reads without selector-bound owner proof', async () => {
@@ -676,6 +678,40 @@ describe('generic imported artifact peer handler', () => {
       offset: 1,
       maxBytes: 3,
     }));
+  });
+
+  it('rejects an unverified remote page that exceeds the requested range', async () => {
+    const bytes = Buffer.from('abcdef');
+    const artifactHash = keccakHash(bytes);
+    const agent = {
+      readAssertionArtifact: vi.fn(async () => ({
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'source',
+        hash: artifactHash,
+        offset: 1,
+        totalBytes: bytes.length,
+        nextOffset: bytes.length,
+        truncated: true,
+        bytesB64: bytes.toString('base64'),
+      })),
+    };
+
+    const res = await ImportedArtifactMethods.prototype.fetchAndVerifyAssertionArtifact.call(agent, {
+      contextGraphId,
+      assertionUri,
+      kind: 'source',
+      hash: artifactHash,
+      offset: 1,
+      maxBytes: 3,
+      sourcePeerId: 'peer-local',
+      cache: false,
+    });
+
+    expect(res.response.hashMismatch).toBe(true);
+    expect(res.response.bytesB64).toBeUndefined();
+    expect(res.verifiedBytes).toBeUndefined();
   });
 
   it('serves requested pages for artifacts larger than the cache promotion cap', async () => {

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -490,6 +490,7 @@ export async function handleKaImportArtifactReadMarkdown(ctx: RequestContext): P
       ctx,
       parsed as Record<string, unknown>,
       'Import artifact Markdown can only be read from imported assertions owned by the requesting agent',
+      { allowSharedMemoryFallback: true },
     );
     const maxBytes = normalizeMarkdownReadLimit((parsed as Record<string, unknown>).maxBytes);
     if (!artifact.markdownHash) {

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -55,6 +55,9 @@ import {
   normalizeGeneratedAt,
   normalizeGeneratedBy,
   normalizeMarkdownReadLimit,
+  parseImportedAssertionUri,
+  isSameAgentAddress,
+  isContextGraphAuthorizedReadAgent,
   type ImportedArtifactResolution,
 } from "./shared-assertion-helpers.js";
 import { parseBoundary, parseMultipart, MultipartParseError } from "../../http/multipart.js";
@@ -145,6 +148,7 @@ async function fetchFirstAvailableAssertionArtifact(
   resolved: AssertionArtifactResolution,
   opts: {
     sourcePeerIds: string[];
+    requesterAgentAddress: string;
     offset: number;
     maxBytes: number;
     cache: boolean;
@@ -158,7 +162,7 @@ async function fetchFirstAvailableAssertionArtifact(
       assertionUri: resolved.assertionUri,
       kind: resolved.kind,
       hash: resolved.hash,
-      requestingAgentAddress: resolved.assertionAgentAddress,
+      requestingAgentAddress: opts.requesterAgentAddress,
       offset: opts.offset,
       maxBytes: opts.maxBytes,
       ...(resolved.subGraphName ? { subGraphName: resolved.subGraphName } : {}),
@@ -168,7 +172,8 @@ async function fetchFirstAvailableAssertionArtifact(
     if (remote.verifiedBytes) return { availability: 'verified', remote, sourcePeerId };
     const page = remote.response;
     if (!page.denied && !page.unavailable && !page.hashMismatch && page.bytesB64 != null) {
-      return { availability: 'unverified_page', remote, sourcePeerId };
+      fallback ??= { availability: 'unverified_page', remote, sourcePeerId };
+      continue;
     }
     fallback ??= { availability: 'unavailable', remote, sourcePeerId };
   }
@@ -187,15 +192,22 @@ async function resolveAssertionArtifact(
     throw new ImportArtifactRouteError(400, 'Invalid hash');
   }
 
-  const artifact = await resolveImportedArtifactForRead(
-    ctx,
-    {
-      ...raw,
-      fileHash: undefined,
-    },
-    'Import artifact bytes can only be read from imported assertions owned by the requesting agent',
-    { allowSharedMemoryFallback: true },
-  );
+  let artifact: ImportedArtifactResolution;
+  try {
+    artifact = await resolveImportedArtifactForRead(
+      ctx,
+      {
+        ...raw,
+        fileHash: undefined,
+      },
+      'Import artifact bytes can only be read from imported assertions owned by the requesting agent',
+      { allowSharedMemoryFallback: true },
+    );
+  } catch (err) {
+    const directRemote = await resolveExplicitAuthorizedRemoteArtifact(ctx, raw, kind, requestedHash, err);
+    if (directRemote) return directRemote;
+    throw err;
+  }
 
   const resolvedHash = kind === 'markdown'
     ? artifact.markdownHash
@@ -213,6 +225,58 @@ async function resolveAssertionArtifact(
   };
 }
 
+async function resolveExplicitAuthorizedRemoteArtifact(
+  ctx: RequestContext,
+  raw: Record<string, unknown>,
+  kind: AssertionArtifactKind,
+  requestedHash: string | undefined,
+  cause: unknown,
+): Promise<AssertionArtifactResolution | null> {
+  if (!isMissingImportMetadataError(cause)) return null;
+  if (!requestedHash) return null;
+  if (typeof raw.sourcePeerId !== 'string' || !raw.sourcePeerId.trim()) return null;
+  if (typeof raw.contextGraphId !== 'string' || !raw.contextGraphId.trim()) return null;
+  if (typeof raw.assertionUri !== 'string' || !raw.assertionUri.trim()) return null;
+
+  const contextGraphId = normalizeContextGraphIdOrUri(raw.contextGraphId);
+  const parsedAssertion = parseImportedAssertionUri(raw.assertionUri.trim(), contextGraphId, ctx.requestAgentAddress);
+  if (!parsedAssertion) return null;
+  if (typeof raw.subGraphName === 'string' && raw.subGraphName.trim() !== (parsedAssertion.subGraphName ?? '')) return null;
+  const allowed = isSameAgentAddress(parsedAssertion.assertionAgentAddress, ctx.requestAgentAddress)
+    || await isContextGraphAuthorizedReadAgent(ctx.agent, contextGraphId, ctx.requestAgentAddress);
+  if (!allowed) return null;
+
+  const sourceContentType = kind === 'markdown' ? 'text/markdown' : 'application/octet-stream';
+  return {
+    contextGraphId,
+    assertionUri: contextGraphAssertionUri(
+      contextGraphId,
+      parsedAssertion.assertionAgentAddress,
+      parsedAssertion.assertionName,
+      parsedAssertion.subGraphName,
+    ),
+    assertionName: parsedAssertion.assertionName,
+    assertionAgentAddress: parsedAssertion.assertionAgentAddress,
+    ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),
+    fileHash: requestedHash,
+    sourceFileHash: requestedHash,
+    detectedContentType: sourceContentType,
+    sourceContentType,
+    extractionStatus: 'completed',
+    canReadMarkdown: kind === 'markdown',
+    ...(kind === 'markdown' ? { markdownHash: requestedHash } : {}),
+    kind,
+    hash: requestedHash,
+    contentType: sourceContentType,
+  };
+}
+
+function isMissingImportMetadataError(err: unknown): boolean {
+  return err instanceof ImportArtifactRouteError
+    && err.statusCode === 404
+    && /No completed import metadata found for assertionUri/i.test(err.message);
+}
+
 function importedArtifactReadOwnerGuard(
   ctx: RequestContext,
   message: string,
@@ -221,6 +285,7 @@ function importedArtifactReadOwnerGuard(
     requestAgentAddress: ctx.requestAgentAddress,
     message,
     relaxOnPublicOpenCg: true,
+    relaxOnAuthorizedReadCg: true,
   };
 }
 
@@ -325,6 +390,7 @@ export async function handleKaImportArtifactRead(ctx: RequestContext): Promise<v
     const cache = raw.cache !== false && offset === 0;
     const fetched = await fetchFirstAvailableAssertionArtifact(agent, resolved, {
       sourcePeerIds,
+      requesterAgentAddress: ctx.requestAgentAddress,
       offset,
       maxBytes,
       cache,
@@ -415,7 +481,7 @@ export async function handleKaImportArtifactRead(ctx: RequestContext): Promise<v
 // POST /api/knowledge-assets/import-artifact/read-markdown
 // Read only the Markdown blob tied to a completed imported assertion.
 export async function handleKaImportArtifactReadMarkdown(ctx: RequestContext): Promise<void> {
-  const { req, res, fileStore } = ctx;
+  const { req, res, agent, fileStore } = ctx;
   const body = await readBody(req, SMALL_BODY_BYTES);
   const parsed = safeParseJson(body, res);
   if (!parsed) return;
@@ -434,6 +500,43 @@ export async function handleKaImportArtifactReadMarkdown(ctx: RequestContext): P
     }
     const bytes = await fileStore.get(artifact.markdownHash);
     if (!bytes) {
+      const resolved: AssertionArtifactResolution = {
+        ...artifact,
+        kind: 'markdown',
+        hash: artifact.markdownHash,
+        contentType: 'text/markdown',
+      };
+      const rawSourcePeerId = (parsed as Record<string, unknown>).sourcePeerId;
+      const sourcePeerId = typeof rawSourcePeerId === 'string' && rawSourcePeerId.trim()
+        ? rawSourcePeerId.trim()
+        : undefined;
+      const discoveredPeerIds = await discoverArtifactCandidatePeers(agent, resolved);
+      const sourcePeerIds = orderedArtifactCandidatePeers(sourcePeerId, discoveredPeerIds);
+      const fetched = await fetchFirstAvailableAssertionArtifact(agent, resolved, {
+        sourcePeerIds,
+        requesterAgentAddress: ctx.requestAgentAddress,
+        offset: 0,
+        maxBytes,
+        cache: true,
+      });
+      if (fetched?.availability === 'verified' && fetched.remote.verifiedBytes) {
+        await fileStore.put(fetched.remote.verifiedBytes, 'text/markdown');
+        if (fetched.remote.verifiedBytes.length > maxBytes) {
+          return jsonResponse(res, 413, {
+            error: `Markdown content exceeds maxBytes (${maxBytes})`,
+            artifact,
+            bytes: fetched.remote.verifiedBytes.length,
+          });
+        }
+        return jsonResponse(res, 200, {
+          artifact,
+          markdownHash: artifact.markdownHash,
+          contentType: 'text/markdown',
+          bytes: fetched.remote.verifiedBytes.length,
+          markdown: fetched.remote.verifiedBytes.toString('utf8'),
+          source: { peerId: fetched.sourcePeerId, agentAddress: artifact.assertionAgentAddress },
+        });
+      }
       // Issue #872 — when the owner guard was relaxed (public + open
       // CG, cross-agent request), the missing bytes are the
       // expected outcome: peers replicate the SWM triples for the

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -155,7 +155,8 @@ async function fetchFirstAvailableAssertionArtifact(
   },
 ): Promise<AssertionArtifactRemoteResult | null> {
   if (typeof agent.fetchAndVerifyAssertionArtifact !== 'function') return null;
-  let fallback: AssertionArtifactRemoteResult | null = null;
+  let unverifiedFallback: AssertionArtifactRemoteResult | null = null;
+  let failureFallback: AssertionArtifactRemoteResult | null = null;
   for (const sourcePeerId of opts.sourcePeerIds) {
     const remote = await agent.fetchAndVerifyAssertionArtifact({
       contextGraphId: resolved.contextGraphId,
@@ -172,12 +173,12 @@ async function fetchFirstAvailableAssertionArtifact(
     if (remote.verifiedBytes) return { availability: 'verified', remote, sourcePeerId };
     const page = remote.response;
     if (!page.denied && !page.unavailable && !page.hashMismatch && page.bytesB64 != null) {
-      fallback ??= { availability: 'unverified_page', remote, sourcePeerId };
+      unverifiedFallback ??= { availability: 'unverified_page', remote, sourcePeerId };
       continue;
     }
-    fallback ??= { availability: 'unavailable', remote, sourcePeerId };
+    failureFallback ??= { availability: 'unavailable', remote, sourcePeerId };
   }
-  return fallback;
+  return unverifiedFallback ?? failureFallback;
 }
 
 async function resolveAssertionArtifact(

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -522,7 +522,6 @@ export async function handleKaImportArtifactReadMarkdown(ctx: RequestContext): P
         cache: true,
       });
       if (fetched?.availability === 'verified' && fetched.remote.verifiedBytes) {
-        await fileStore.put(fetched.remote.verifiedBytes, 'text/markdown');
         if (fetched.remote.verifiedBytes.length > maxBytes) {
           return jsonResponse(res, 413, {
             error: `Markdown content exceeds maxBytes (${maxBytes})`,
@@ -530,6 +529,7 @@ export async function handleKaImportArtifactReadMarkdown(ctx: RequestContext): P
             bytes: fetched.remote.verifiedBytes.length,
           });
         }
+        await fileStore.put(fetched.remote.verifiedBytes, 'text/markdown');
         return jsonResponse(res, 200, {
           artifact,
           markdownHash: artifact.markdownHash,

--- a/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
+++ b/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
@@ -682,7 +682,7 @@ export async function resolveImportedArtifact(
       assertionUri,
       ...(parsedAssertion.subGraphName ? { subGraphName: parsedAssertion.subGraphName } : {}),
       ...(requestedFileHash ? { requestedFileHash } : {}),
-      allowSharedMemoryFallback: ownerGuardRelaxed || opts?.allowSharedMemoryFallback,
+      allowSharedMemoryFallback: ownerGuardRelaxed || (opts?.allowSharedMemoryFallback && !parsedAssertion.legacy),
       fallbackDetectedContentType: extractionRecord?.detectedContentType,
       query: (sparql: string) => ctx.agent.store.query(sparql) as Promise<{ type?: string; bindings?: Array<Record<string, unknown>> }>,
     });

--- a/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
+++ b/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
@@ -524,6 +524,11 @@ export async function resolveImportedArtifact(
      * to mutate someone else's imported assertion.
      */
     relaxOnPublicOpenCg?: boolean;
+    /**
+     * Read routes also allow private/curated CG participants to read imported
+     * artifact metadata. Writes intentionally do not set this.
+     */
+    relaxOnAuthorizedReadCg?: boolean;
   },
   opts?: {
     allowSharedMemoryFallback?: boolean;
@@ -577,6 +582,7 @@ export async function resolveImportedArtifact(
   // someone else's imported assertion just because cross-agent READS
   // are allowed.
   const canRelaxGuard = Boolean(ownerGuard?.relaxOnPublicOpenCg);
+  const canRelaxAuthorizedRead = Boolean(ownerGuard?.relaxOnAuthorizedReadCg);
   // Probing the on-chain policy is a no-op for the write path (which
   // never relaxes). Skip it there to keep the diff scoped and avoid
   // adding chain-cache reads to a code path that doesn't need them.
@@ -627,7 +633,14 @@ export async function resolveImportedArtifact(
     // `assertionAgentAddress === requestAgentAddress` so the guard
     // passes) while non-owner cross-agent reads get the same 404
     // they got pre-PR rather than a misleading 200.
-    if (canRelaxGuard && isPublicOpen && !parsedAssertion.legacy) {
+    const isOwner = isSameAgentAddress(
+      parsedAssertion.assertionAgentAddress,
+      ownerGuard.requestAgentAddress,
+    );
+    const isAuthorizedReadAgent = !isOwner && canRelaxAuthorizedRead && !parsedAssertion.legacy
+      ? await isContextGraphAuthorizedReadAgent(ctx.agent, contextGraphId, ownerGuard.requestAgentAddress)
+      : false;
+    if ((canRelaxGuard && isPublicOpen && !parsedAssertion.legacy) || isAuthorizedReadAgent) {
       ownerGuardRelaxed = !isSameAgentAddress(
         parsedAssertion.assertionAgentAddress,
         ownerGuard.requestAgentAddress,
@@ -726,4 +739,23 @@ export async function resolveImportedArtifact(
     canReadMarkdown: markdownAvailableLocally,
     ...(ownerGuardRelaxed ? { ownerGuardRelaxed: true } : {}),
   };
+}
+
+export async function isContextGraphAuthorizedReadAgent(
+  agent: {
+    getContextGraphAllowedAgents?: (contextGraphId: string) => Promise<string[]>;
+    getContextGraphParticipantAgentAddresses?: (contextGraphId: string) => Promise<string[]>;
+  },
+  contextGraphId: string,
+  requestAgentAddress: string,
+): Promise<boolean> {
+  const lists = await Promise.all([
+    typeof agent.getContextGraphAllowedAgents === 'function'
+      ? agent.getContextGraphAllowedAgents(contextGraphId).catch(() => [] as string[])
+      : Promise.resolve([] as string[]),
+    typeof agent.getContextGraphParticipantAgentAddresses === 'function'
+      ? agent.getContextGraphParticipantAgentAddresses(contextGraphId).catch(() => [] as string[])
+      : Promise.resolve([] as string[]),
+  ]);
+  return lists.flat().some((agentAddress) => isSameAgentAddress(agentAddress, requestAgentAddress));
 }

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -1123,6 +1123,68 @@ describe('import artifact daemon routes', () => {
     await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
   });
 
+  it('fetches verified Markdown remotely for an allowlisted private CG member using synced shared-memory metadata', async () => {
+    const bytes = Buffer.from('# Private Synced Metadata Markdown\n');
+    const artifactHash = keccak256ContentHash(bytes);
+    const contextGraphId = 'cg-private-allowlisted-swm-metadata-read';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async () => ({
+      response: {
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'markdown',
+        hash: artifactHash,
+        offset: 0,
+        totalBytes: bytes.length,
+        truncated: false,
+        contentType: 'text/markdown',
+        bytesB64: bytes.toString('base64'),
+      },
+      verifiedBytes: bytes,
+    }));
+    const { agent, queries } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      allowedAgents: ['did:dkg:agent:test'],
+      omitImportMeta: true,
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const read = await post('/api/knowledge-assets/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      sourcePeerId: 'peer-owner',
+      maxBytes: 1024,
+    });
+
+    expect(read.status).toBe(200);
+    expect(read.body).toMatchObject({
+      markdownHash: artifactHash,
+      contentType: 'text/markdown',
+      bytes: bytes.length,
+      markdown: bytes.toString('utf8'),
+      source: { peerId: 'peer-owner', agentAddress: 'did:dkg:agent:source' },
+    });
+    expect(queries.some((sparql) => sparql.includes('SELECT ?sourceFile'))).toBe(true);
+    expect(fetchAndVerifyAssertionArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      sourcePeerId: 'peer-owner',
+      requestingAgentAddress: 'did:dkg:agent:test',
+      cache: true,
+    }));
+    await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
+  });
+
   it('serves a remote artifact page even when the full artifact is not cache-promoted', async () => {
     const bytes = Buffer.from('remote page bytes');
     const artifactHash = sha256Hash(bytes);

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -129,6 +129,8 @@ describe('import artifact daemon routes', () => {
     structuralTripleCount?: string;
     mdIntermediateHash?: string;
     omitImportMeta?: boolean;
+    omitSharedMemoryArtifact?: boolean;
+    allowedAgents?: string[];
     publisherCreateError?: Error;
     publisherWriteError?: Error;
     publisherDiscardError?: Error;
@@ -240,6 +242,12 @@ describe('import artifact daemon routes', () => {
       ...(args.fetchAndVerifyAssertionArtifact
         ? { fetchAndVerifyAssertionArtifact: args.fetchAndVerifyAssertionArtifact }
         : {}),
+      async getContextGraphAllowedAgents(contextGraphId: string) {
+        return contextGraphId === args.contextGraphId ? args.allowedAgents ?? [] : [];
+      },
+      async getContextGraphParticipantAgentAddresses(contextGraphId: string) {
+        return contextGraphId === args.contextGraphId ? args.allowedAgents ?? [] : [];
+      },
       store: {
         async hasGraph() {
           return Boolean(args.targetGraphExists);
@@ -274,6 +282,9 @@ describe('import artifact daemon routes', () => {
             expect(sparql).toContain('GRAPH ?g');
             expect(sparql).toContain(sharedMemoryReadBothFilter(contextGraphSharedMemoryUri(args.contextGraphId)));
             expect(sparql).toContain(`<${args.assertionUri}> <${DKG}sourceFile>`);
+            if (args.omitSharedMemoryArtifact) {
+              return { type: 'bindings', bindings: [] };
+            }
             return {
               type: 'bindings',
               bindings: [{
@@ -921,6 +932,197 @@ describe('import artifact daemon routes', () => {
     expect(fetchAndVerifyAssertionArtifact).toHaveBeenCalledTimes(1);
   });
 
+  it('lets an assertion owner fetch explicit remote bytes before local metadata has replicated', async () => {
+    const bytes = Buffer.from('# Private Owner Remote\n');
+    const artifactHash = keccak256ContentHash(bytes);
+    const contextGraphId = 'cg-private-owner-explicit-remote-read';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:test', assertionName);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async () => ({
+      response: {
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'source',
+        hash: artifactHash,
+        offset: 0,
+        totalBytes: bytes.length,
+        truncated: false,
+        contentType: 'application/x-spoofed',
+        bytesB64: bytes.toString('base64'),
+      },
+      verifiedBytes: bytes,
+    }));
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      omitImportMeta: true,
+      omitSharedMemoryArtifact: true,
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const fetched = await post('/api/knowledge-assets/import-artifact/read', {
+      contextGraphId,
+      assertionUri,
+      kind: 'source',
+      hash: artifactHash,
+      sourcePeerId: 'peer-with-private-blob',
+      maxBytes: 1024,
+    });
+
+    expect(fetched.status).toBe(200);
+    expect(fetched.body).toMatchObject({
+      status: 'fetched',
+      contextGraphId,
+      assertionUri,
+      kind: 'source',
+      hash: artifactHash,
+      contentType: 'application/octet-stream',
+      bytesB64: bytes.toString('base64'),
+      source: { peerId: 'peer-with-private-blob', agentAddress: 'did:dkg:agent:test' },
+    });
+    expect(fetchAndVerifyAssertionArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      contextGraphId,
+      assertionUri,
+      kind: 'source',
+      hash: artifactHash,
+      sourcePeerId: 'peer-with-private-blob',
+      requestingAgentAddress: 'did:dkg:agent:test',
+      cache: true,
+    }));
+    await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
+  });
+
+  it('lets an allowlisted private CG member fetch imported artifact bytes from the owner peer', async () => {
+    const bytes = Buffer.from('# Private Allowlisted Remote\n');
+    const artifactHash = keccak256ContentHash(bytes);
+    const contextGraphId = 'cg-private-allowlisted-byte-read';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async () => ({
+      response: {
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'markdown',
+        hash: artifactHash,
+        offset: 0,
+        totalBytes: bytes.length,
+        truncated: false,
+        contentType: 'text/markdown',
+        bytesB64: bytes.toString('base64'),
+      },
+      verifiedBytes: bytes,
+    }));
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      allowedAgents: ['did:dkg:agent:test'],
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const fetched = await post('/api/knowledge-assets/import-artifact/read', {
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      sourcePeerId: 'peer-owner',
+      maxBytes: 1024,
+    });
+
+    expect(fetched.status).toBe(200);
+    expect(fetched.body).toMatchObject({
+      status: 'fetched',
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      contentType: 'text/markdown',
+      bytesB64: bytes.toString('base64'),
+      source: { peerId: 'peer-owner', agentAddress: 'did:dkg:agent:source' },
+    });
+    expect(fetchAndVerifyAssertionArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      sourcePeerId: 'peer-owner',
+      requestingAgentAddress: 'did:dkg:agent:test',
+      cache: true,
+    }));
+    await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
+  });
+
+  it('fetches verified Markdown remotely for an allowlisted private CG member before returning 404', async () => {
+    const bytes = Buffer.from('# Private Allowlisted Markdown\n');
+    const artifactHash = keccak256ContentHash(bytes);
+    const contextGraphId = 'cg-private-allowlisted-markdown-read';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async () => ({
+      response: {
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'markdown',
+        hash: artifactHash,
+        offset: 0,
+        totalBytes: bytes.length,
+        truncated: false,
+        contentType: 'text/markdown',
+        bytesB64: bytes.toString('base64'),
+      },
+      verifiedBytes: bytes,
+    }));
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      allowedAgents: ['did:dkg:agent:test'],
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const read = await post('/api/knowledge-assets/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      sourcePeerId: 'peer-owner',
+      maxBytes: 1024,
+    });
+
+    expect(read.status).toBe(200);
+    expect(read.body).toMatchObject({
+      markdownHash: artifactHash,
+      contentType: 'text/markdown',
+      bytes: bytes.length,
+      markdown: bytes.toString('utf8'),
+      source: { peerId: 'peer-owner', agentAddress: 'did:dkg:agent:source' },
+    });
+    expect(fetchAndVerifyAssertionArtifact).toHaveBeenCalledWith(expect.objectContaining({
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      sourcePeerId: 'peer-owner',
+      requestingAgentAddress: 'did:dkg:agent:test',
+      cache: true,
+    }));
+    await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
+  });
+
   it('serves a remote artifact page even when the full artifact is not cache-promoted', async () => {
     const bytes = Buffer.from('remote page bytes');
     const artifactHash = sha256Hash(bytes);
@@ -983,7 +1185,7 @@ describe('import artifact daemon routes', () => {
       offset: 1024,
       maxBytes: 4096,
       cache: false,
-      requestingAgentAddress: 'did:dkg:agent:source',
+      requestingAgentAddress: 'did:dkg:agent:test',
     }));
   });
 
@@ -1055,6 +1257,63 @@ describe('import artifact daemon routes', () => {
     expect(fetchAndVerifyAssertionArtifact.mock.calls.map(([params]) => params.sourcePeerId)).toEqual([
       'peer-poisoned',
       'peer-good',
+    ]);
+    await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
+  });
+
+  it('prefers a later verified peer over an earlier unverified remote page', async () => {
+    const bytes = Buffer.from('# Verified Candidate\n');
+    const artifactHash = sha256Hash(bytes);
+    const contextGraphId = 'cg-public-open-discovered-unverified-fallback';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const discoverAssertionArtifactCandidates = vi.fn(async () => ['peer-unverified', 'peer-verified']);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async (params: { sourcePeerId: string }) => ({
+      response: {
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'markdown',
+        hash: artifactHash,
+        offset: 0,
+        totalBytes: bytes.length,
+        truncated: false,
+        contentType: 'text/markdown',
+        bytesB64: bytes.toString('base64'),
+      },
+      ...(params.sourcePeerId === 'peer-verified' ? { verifiedBytes: bytes } : {}),
+    }));
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+      discoverAssertionArtifactCandidates,
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const read = await post('/api/knowledge-assets/import-artifact/read', {
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      maxBytes: 1024,
+    });
+
+    expect(read.status).toBe(200);
+    expect(read.body).toMatchObject({
+      status: 'fetched',
+      hash: artifactHash,
+      bytesB64: bytes.toString('base64'),
+      source: { peerId: 'peer-verified' },
+    });
+    expect(fetchAndVerifyAssertionArtifact.mock.calls.map(([params]) => params.sourcePeerId)).toEqual([
+      'peer-unverified',
+      'peer-verified',
     ]);
     await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
   });

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -1380,6 +1380,84 @@ describe('import artifact daemon routes', () => {
     await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
   });
 
+  it('uses an unverified remote page fallback after an earlier unavailable peer', async () => {
+    const bytes = Buffer.from('late unverified page bytes');
+    const artifactHash = sha256Hash(bytes);
+    const contextGraphId = 'cg-public-open-unavailable-then-unverified';
+    const assertionName = 'large-imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const discoverAssertionArtifactCandidates = vi.fn(async () => ['peer-dead', 'peer-page']);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async (params: { sourcePeerId: string }) => {
+      if (params.sourcePeerId === 'peer-dead') {
+        return {
+          response: {
+            version: 1,
+            contextGraphId,
+            assertionUri,
+            kind: 'markdown',
+            hash: artifactHash,
+            offset: 1024,
+            unavailable: true,
+          },
+        };
+      }
+      return {
+        response: {
+          version: 1,
+          contextGraphId,
+          assertionUri,
+          kind: 'markdown',
+          hash: artifactHash,
+          offset: 1024,
+          totalBytes: 64 * 1024 * 1024 + 1,
+          nextOffset: 1024 + bytes.length,
+          truncated: true,
+          contentType: 'text/markdown',
+          bytesB64: bytes.toString('base64'),
+        },
+      };
+    });
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      onChainPolicy: { accessPolicy: 0, publishPolicy: 1 },
+      discoverAssertionArtifactCandidates,
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const read = await post('/api/knowledge-assets/import-artifact/read', {
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      offset: 1024,
+      maxBytes: 4096,
+      cache: false,
+    });
+
+    expect(read.status).toBe(200);
+    expect(read.body).toMatchObject({
+      status: 'unverified',
+      contextGraphId,
+      assertionUri,
+      kind: 'markdown',
+      hash: artifactHash,
+      offset: 1024,
+      bytesB64: bytes.toString('base64'),
+      source: { peerId: 'peer-page', agentAddress: 'did:dkg:agent:source' },
+      reason: 'Remote page fetched without full-artifact hash verification',
+    });
+    expect(fetchAndVerifyAssertionArtifact.mock.calls.map(([params]) => params.sourcePeerId)).toEqual([
+      'peer-dead',
+      'peer-page',
+    ]);
+  });
+
   it('derives non-owner public + open read metadata from replicated SWM linkage when _meta is absent (#872 devnet)', async () => {
     // Devnet peers receive the promoted SWM assertion triples but do not
     // receive the origin node's CG-root `_meta` rows. The read route should

--- a/packages/cli/test/import-artifact-routes.test.ts
+++ b/packages/cli/test/import-artifact-routes.test.ts
@@ -1185,6 +1185,54 @@ describe('import artifact daemon routes', () => {
     await expect(fileStore.get(artifactHash)).resolves.toEqual(bytes);
   });
 
+  it('does not cache oversized verified remote Markdown when read-markdown returns 413', async () => {
+    const bytes = Buffer.from('# Too Large\n');
+    const artifactHash = keccak256ContentHash(bytes);
+    const contextGraphId = 'cg-private-oversized-markdown-read';
+    const assertionName = 'imported-md';
+    const assertionUri = contextGraphAssertionUri(contextGraphId, 'did:dkg:agent:source', assertionName);
+    const fetchAndVerifyAssertionArtifact = vi.fn(async () => ({
+      response: {
+        version: 1,
+        contextGraphId,
+        assertionUri,
+        kind: 'markdown',
+        hash: artifactHash,
+        offset: 0,
+        totalBytes: bytes.length,
+        truncated: false,
+        contentType: 'text/markdown',
+        bytesB64: bytes.toString('base64'),
+      },
+      verifiedBytes: bytes,
+    }));
+    const { agent } = makeAgent({
+      contextGraphId,
+      assertionName,
+      assertionUri,
+      fileHash: artifactHash,
+      markdownHash: artifactHash,
+      markdownForm: `urn:dkg:file:${artifactHash}`,
+      allowedAgents: ['did:dkg:agent:test'],
+      fetchAndVerifyAssertionArtifact,
+    });
+    await startRoutes({ agent });
+
+    const read = await post('/api/knowledge-assets/import-artifact/read-markdown', {
+      contextGraphId,
+      assertionUri,
+      sourcePeerId: 'peer-owner',
+      maxBytes: bytes.length - 1,
+    });
+
+    expect(read.status).toBe(413);
+    expect(read.body).toMatchObject({
+      error: `Markdown content exceeds maxBytes (${bytes.length - 1})`,
+      bytes: bytes.length,
+    });
+    await expect(fileStore.get(artifactHash)).resolves.toBeNull();
+  });
+
   it('serves a remote artifact page even when the full artifact is not cache-promoted', async () => {
     const bytes = Buffer.from('remote page bytes');
     const artifactHash = sha256Hash(bytes);


### PR DESCRIPTION
## Summary

Fix private imported-artifact Markdown reads for allowlisted/approved context graph members.

## What Changed

- Let `POST /api/knowledge-assets/import-artifact/read-markdown` resolve imported-artifact metadata from synced shared-memory metadata, matching the generic byte-read path.
- Keep legacy ownerless assertion URIs fail-closed so the shared-memory fallback does not turn malformed/cross-agent legacy reads into misleading successes.
- Added a regression test for an allowlisted private CG member fetching verified Markdown from the owner when local `_meta` is absent but synced SWM metadata is present.

## Why

Allowlisted or approved members of private/curated context graphs could sync the graph and assertion but fail to read `.md` content with:

`404 No completed import metadata found for assertionUri`

The reader was authorized, but `read-markdown` only looked for local import metadata and did not use the synced shared-memory metadata fallback before fetching bytes from the owner peer.

## Validation

- `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/import-artifact-routes.test.ts`
  - `44 passed`
- Two-node DKG V10 Testnet matrix on commit `02d36c17`
  - `11/11` passed
  - Evidence: `/tmp/dkg-testnet-fresh-private-read-mqkia5qs/evidence/full-matrix-imported-artifact-02d36c17-mqkjb9hj.json`

Matrix covered:

- private/open allowlisted read: `200`, markdown matched
- private/curated allowlisted read: `200`, markdown matched
- private/curated participant read: `200`, markdown matched
- private/curated add-participant read: `200`, markdown matched
- private/curated approved-join read: `200`, markdown matched
- pending join denied: `403`
- peer-only denied: `403`
- owner-only denied: `403`