### PR TITLE
Add mainnet network config values

### DIFF
--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,6 +1,7 @@
 {
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Base mainnet",
   "networkName": "DKG V10 Base Mainnet",
+  "genesisId": "base-mainnet",
   "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
   "genesisVersion": 1,
   "relays": [

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,10 +1,11 @@
 {
-  "_status": "pre-deployment: hubAddress must be set after V10 contracts are deployed on Base",
+  "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
   "chain": {
     "name": "base",
     "type": "evm",
     "chainId": "base:8453",
-    "rpcUrl": "https://mainnet.base.org"
+    "rpcUrl": "https://mainnet.base.org",
+    "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13"
   },
   "autoUpdate": {
     "enabled": true,

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,14 +1,25 @@
 {
+  "networkName": "DKG V10 Mainnet",
   "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
-  "chain": {
-    "name": "base",
-    "type": "evm",
-    "chainId": "base:8453",
-    "rpcUrl": "https://mainnet.base.org",
-    "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13"
-  },
+  "genesisVersion": 1,
+  "relays": [
+    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
+    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
+    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
+    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
+  ],
+  "defaultContextGraphs": [],
+  "defaultNodeRole": "edge",
   "autoUpdate": {
     "enabled": true,
-    "branch": "main"
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
+    "checkIntervalMinutes": 5
+  },
+  "chain": {
+    "type": "evm",
+    "rpcUrl": "https://mainnet.base.org",
+    "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13",
+    "chainId": "base:8453"
   }
 }

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,25 +1,14 @@
 {
-  "networkName": "DKG V10 Mainnet",
-  "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
-  "genesisVersion": 1,
-  "relays": [
-    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
-    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
-    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
-    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
-  ],
-  "defaultContextGraphs": [],
-  "defaultNodeRole": "edge",
+  "_status": "pre-deployment: distinct mainnet genesis networkId and relay peer IDs must be set before enabling Base mainnet",
+  "chain": {
+    "name": "base",
+    "type": "evm",
+    "chainId": "base:8453",
+    "rpcUrl": "https://mainnet.base.org",
+    "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13"
+  },
   "autoUpdate": {
     "enabled": true,
-    "repo": "OriginTrail/dkg",
-    "branch": "main",
-    "checkIntervalMinutes": 5
-  },
-  "chain": {
-    "type": "evm",
-    "rpcUrl": "https://mainnet.base.org",
-    "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13",
-    "chainId": "base:8453"
+    "branch": "main"
   }
 }

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,5 +1,16 @@
 {
-  "_status": "pre-deployment: distinct mainnet genesis networkId and relay peer IDs must be set before enabling Base mainnet",
+  "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Base mainnet",
+  "networkName": "DKG V10 Mainnet",
+  "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
+  "genesisVersion": 1,
+  "relays": [
+    "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",
+    "/ip4/178.105.105.102/tcp/9090/p2p/PEER_ID_LUNARIS",
+    "/ip4/178.156.214.4/tcp/9090/p2p/PEER_ID_ORIONIS",
+    "/ip4/178.105.111.185/tcp/9090/p2p/PEER_ID_KEPLER"
+  ],
+  "defaultContextGraphs": [],
+  "defaultNodeRole": "edge",
   "chain": {
     "name": "base",
     "type": "evm",
@@ -9,6 +20,8 @@
   },
   "autoUpdate": {
     "enabled": true,
-    "branch": "main"
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
+    "checkIntervalMinutes": 5
   }
 }

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,5 +1,5 @@
 {
-  "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Base mainnet",
+  "_status": "pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet",
   "networkName": "DKG V10 Base Mainnet",
   "genesisId": "base-mainnet",
   "networkId": "562ea760dbe27fb4233d58dfc958bbddf844b82596ec3d51dff98718e6bf61ca",

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,6 +1,6 @@
 {
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Base mainnet",
-  "networkName": "DKG V10 Mainnet",
+  "networkName": "DKG V10 Base Mainnet",
   "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
   "genesisVersion": 1,
   "relays": [

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -2,7 +2,7 @@
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Base mainnet",
   "networkName": "DKG V10 Base Mainnet",
   "genesisId": "base-mainnet",
-  "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
+  "networkId": "562ea760dbe27fb4233d58dfc958bbddf844b82596ec3d51dff98718e6bf61ca",
   "genesisVersion": 1,
   "relays": [
     "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,6 +1,7 @@
 {
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Gnosis mainnet",
   "networkName": "DKG V10 Gnosis Mainnet",
+  "genesisId": "gnosis-mainnet",
   "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
   "genesisVersion": 1,
   "relays": [

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,14 +1,25 @@
 {
+  "networkName": "DKG V10 Mainnet",
   "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
-  "chain": {
-    "name": "gnosis",
-    "type": "evm",
-    "chainId": "gnosis:100",
-    "rpcUrl": "https://rpc.gnosischain.com",
-    "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f"
-  },
+  "genesisVersion": 1,
+  "relays": [
+    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
+    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
+    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
+    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
+  ],
+  "defaultContextGraphs": [],
+  "defaultNodeRole": "edge",
   "autoUpdate": {
     "enabled": true,
-    "branch": "main"
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
+    "checkIntervalMinutes": 5
+  },
+  "chain": {
+    "type": "evm",
+    "rpcUrl": "https://rpc.gnosischain.com",
+    "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f",
+    "chainId": "gnosis:100"
   }
 }

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,5 +1,16 @@
 {
-  "_status": "pre-deployment: distinct mainnet genesis networkId and relay peer IDs must be set before enabling Gnosis mainnet",
+  "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Gnosis mainnet",
+  "networkName": "DKG V10 Mainnet",
+  "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
+  "genesisVersion": 1,
+  "relays": [
+    "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",
+    "/ip4/178.105.105.102/tcp/9090/p2p/PEER_ID_LUNARIS",
+    "/ip4/178.156.214.4/tcp/9090/p2p/PEER_ID_ORIONIS",
+    "/ip4/178.105.111.185/tcp/9090/p2p/PEER_ID_KEPLER"
+  ],
+  "defaultContextGraphs": [],
+  "defaultNodeRole": "edge",
   "chain": {
     "name": "gnosis",
     "type": "evm",
@@ -9,6 +20,8 @@
   },
   "autoUpdate": {
     "enabled": true,
-    "branch": "main"
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
+    "checkIntervalMinutes": 5
   }
 }

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,10 +1,11 @@
 {
-  "_status": "pre-deployment: hubAddress must be set after V10 contracts are deployed on Gnosis",
+  "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
   "chain": {
     "name": "gnosis",
     "type": "evm",
     "chainId": "gnosis:100",
-    "rpcUrl": "https://rpc.gnosischain.com"
+    "rpcUrl": "https://rpc.gnosischain.com",
+    "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f"
   },
   "autoUpdate": {
     "enabled": true,

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,6 +1,6 @@
 {
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Gnosis mainnet",
-  "networkName": "DKG V10 Mainnet",
+  "networkName": "DKG V10 Gnosis Mainnet",
   "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
   "genesisVersion": 1,
   "relays": [

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -2,7 +2,7 @@
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Gnosis mainnet",
   "networkName": "DKG V10 Gnosis Mainnet",
   "genesisId": "gnosis-mainnet",
-  "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
+  "networkId": "e08a9fb72a648ec2eb2fd9c152ded90a8ad67bb56f27df4781d9bb7e261fb7a7",
   "genesisVersion": 1,
   "relays": [
     "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,5 +1,5 @@
 {
-  "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling Gnosis mainnet",
+  "_status": "pre-deployment: replace PEER_ID_* relay values before enabling Gnosis mainnet",
   "networkName": "DKG V10 Gnosis Mainnet",
   "genesisId": "gnosis-mainnet",
   "networkId": "e08a9fb72a648ec2eb2fd9c152ded90a8ad67bb56f27df4781d9bb7e261fb7a7",

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,25 +1,14 @@
 {
-  "networkName": "DKG V10 Mainnet",
-  "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
-  "genesisVersion": 1,
-  "relays": [
-    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
-    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
-    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
-    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
-  ],
-  "defaultContextGraphs": [],
-  "defaultNodeRole": "edge",
+  "_status": "pre-deployment: distinct mainnet genesis networkId and relay peer IDs must be set before enabling Gnosis mainnet",
+  "chain": {
+    "name": "gnosis",
+    "type": "evm",
+    "chainId": "gnosis:100",
+    "rpcUrl": "https://rpc.gnosischain.com",
+    "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f"
+  },
   "autoUpdate": {
     "enabled": true,
-    "repo": "OriginTrail/dkg",
-    "branch": "main",
-    "checkIntervalMinutes": 5
-  },
-  "chain": {
-    "type": "evm",
-    "rpcUrl": "https://rpc.gnosischain.com",
-    "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f",
-    "chainId": "gnosis:100"
+    "branch": "main"
   }
 }

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,25 +1,14 @@
 {
-  "networkName": "DKG V10 Mainnet",
-  "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
-  "genesisVersion": 1,
-  "relays": [
-    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
-    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
-    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
-    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
-  ],
-  "defaultContextGraphs": [],
-  "defaultNodeRole": "edge",
+  "_status": "pre-deployment: distinct mainnet genesis networkId and relay peer IDs must be set before enabling NeuroWeb mainnet",
+  "chain": {
+    "name": "neuroweb",
+    "type": "evm",
+    "chainId": "neuroweb:2043",
+    "rpcUrl": "https://astrosat-parachain-rpc.origin-trail.network",
+    "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F"
+  },
   "autoUpdate": {
     "enabled": true,
-    "repo": "OriginTrail/dkg",
-    "branch": "main",
-    "checkIntervalMinutes": 5
-  },
-  "chain": {
-    "type": "evm",
-    "rpcUrl": "https://astrosat-parachain-rpc.origin-trail.network",
-    "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F",
-    "chainId": "neuroweb:2043"
+    "branch": "main"
   }
 }

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,5 +1,5 @@
 {
-  "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling NeuroWeb mainnet",
+  "_status": "pre-deployment: replace PEER_ID_* relay values before enabling NeuroWeb mainnet",
   "networkName": "DKG V10 NeuroWeb Mainnet",
   "genesisId": "neuroweb-mainnet",
   "networkId": "83698bd2a305d6261169bfe96dd7c2f8aa9d24bee92150eee949a9a89bb68729",

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,10 +1,11 @@
 {
-  "_status": "pre-deployment: hubAddress must be set after V10 contracts are deployed on NeuroWeb",
+  "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
   "chain": {
     "name": "neuroweb",
     "type": "evm",
     "chainId": "neuroweb:2043",
-    "rpcUrl": "https://astrosat-parachain-rpc.origin-trail.network"
+    "rpcUrl": "https://astrosat-parachain-rpc.origin-trail.network",
+    "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F"
   },
   "autoUpdate": {
     "enabled": true,

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,6 +1,6 @@
 {
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling NeuroWeb mainnet",
-  "networkName": "DKG V10 Mainnet",
+  "networkName": "DKG V10 NeuroWeb Mainnet",
   "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
   "genesisVersion": 1,
   "relays": [

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,5 +1,16 @@
 {
-  "_status": "pre-deployment: distinct mainnet genesis networkId and relay peer IDs must be set before enabling NeuroWeb mainnet",
+  "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling NeuroWeb mainnet",
+  "networkName": "DKG V10 Mainnet",
+  "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
+  "genesisVersion": 1,
+  "relays": [
+    "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",
+    "/ip4/178.105.105.102/tcp/9090/p2p/PEER_ID_LUNARIS",
+    "/ip4/178.156.214.4/tcp/9090/p2p/PEER_ID_ORIONIS",
+    "/ip4/178.105.111.185/tcp/9090/p2p/PEER_ID_KEPLER"
+  ],
+  "defaultContextGraphs": [],
+  "defaultNodeRole": "edge",
   "chain": {
     "name": "neuroweb",
     "type": "evm",
@@ -9,6 +20,8 @@
   },
   "autoUpdate": {
     "enabled": true,
-    "branch": "main"
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
+    "checkIntervalMinutes": 5
   }
 }

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -2,7 +2,7 @@
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling NeuroWeb mainnet",
   "networkName": "DKG V10 NeuroWeb Mainnet",
   "genesisId": "neuroweb-mainnet",
-  "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
+  "networkId": "83698bd2a305d6261169bfe96dd7c2f8aa9d24bee92150eee949a9a89bb68729",
   "genesisVersion": 1,
   "relays": [
     "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,6 +1,7 @@
 {
   "_status": "pre-deployment: replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_* relay values before enabling NeuroWeb mainnet",
   "networkName": "DKG V10 NeuroWeb Mainnet",
+  "genesisId": "neuroweb-mainnet",
   "networkId": "PLACEHOLDER_MAINNET_NETWORK_ID",
   "genesisVersion": 1,
   "relays": [

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -1,14 +1,25 @@
 {
+  "networkName": "DKG V10 Mainnet",
   "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
-  "chain": {
-    "name": "neuroweb",
-    "type": "evm",
-    "chainId": "neuroweb:2043",
-    "rpcUrl": "https://astrosat-parachain-rpc.origin-trail.network",
-    "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F"
-  },
+  "genesisVersion": 1,
+  "relays": [
+    "/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M",
+    "/ip4/157.180.37.169/tcp/9090/p2p/12D3KooWAbLiM6Xy2TfXtFpUrXqttnTSuctW8Lo1mkauaijsNrWw",
+    "/ip4/178.156.252.147/tcp/9090/p2p/12D3KooWPyTpqBBtU1AvzSsd5rWXCQzFcGtG44qDmeYenWcpzsge",
+    "/ip4/49.12.4.64/tcp/9090/p2p/12D3KooWJqhnnfouiNRUyJBEREpuKtV4A448LUbS6JiVCe8Q82bZ"
+  ],
+  "defaultContextGraphs": [],
+  "defaultNodeRole": "edge",
   "autoUpdate": {
     "enabled": true,
-    "branch": "main"
+    "repo": "OriginTrail/dkg",
+    "branch": "main",
+    "checkIntervalMinutes": 5
+  },
+  "chain": {
+    "type": "evm",
+    "rpcUrl": "https://astrosat-parachain-rpc.origin-trail.network",
+    "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F",
+    "chainId": "neuroweb:2043"
   }
 }

--- a/network/testnet.json
+++ b/network/testnet.json
@@ -1,5 +1,6 @@
 {
   "networkName": "DKG V10 Testnet",
+  "genesisId": "base-testnet",
   "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
   "genesisVersion": 1,
   "relays": [

--- a/network/testnet.json
+++ b/network/testnet.json
@@ -1,5 +1,5 @@
 {
-  "networkName": "DKG V10 Testnet",
+  "networkName": "DKG V10 Base Testnet",
   "genesisId": "base-testnet",
   "networkId": "7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b",
   "genesisVersion": 1,

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -824,6 +824,8 @@ export type ReplicationEventSink = (event: ReplicationEvent) => void;
 
 export interface DKGAgentConfig {
   name: string;
+  /** Selected genesis document. Defaults to the compatibility Base testnet genesis. */
+  genesisId?: string;
   /**
    * public-projection enable flag. When set, a private CG's confirmed VM
    * publishes emit/refresh a verifiable public projection (the floor: existence,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -544,8 +544,10 @@ export class DKGAgent extends DKGAgentBase {
     const eventBus = new TypedEventBus();
     const keypair = wallet.keypair;
 
+    const genesisId = config.genesisId;
+
     // Load genesis knowledge into the store (idempotent)
-    await DKGAgent.loadGenesis(store);
+    await DKGAgent.loadGenesis(store, genesisId);
 
     const port = config.listenPort ?? 0;
     const host = config.listenHost ?? '0.0.0.0';
@@ -751,7 +753,7 @@ export class DKGAgent extends DKGAgentBase {
   }
 
   async networkId(): Promise<string> {
-    return computeNetworkId();
+    return computeNetworkId(this.config.genesisId);
   }
 
   get peerId(): string {
@@ -1359,7 +1361,7 @@ export class DKGAgent extends DKGAgentBase {
    * Loads genesis knowledge into the triple store if not already present.
    * Creates the system context graph graphs and inserts the genesis quads.
    */
-  private static async loadGenesis(store: TripleStore): Promise<void> {
+  private static async loadGenesis(store: TripleStore, genesisId?: string): Promise<void> {
     const gm = new GraphManager(store);
 
     // Ensure system context graphs exist
@@ -1367,13 +1369,20 @@ export class DKGAgent extends DKGAgentBase {
     await gm.ensureContextGraph(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
 
     // Check if genesis is already loaded by looking for the network definition
+    const genesisQuads = getGenesisQuads(genesisId);
+    const networkDefinition = genesisQuads.find(
+      q => q.predicate === DKG_ONTOLOGY.DKG_GENESIS_VERSION && q.graph === '',
+    );
+    if (!networkDefinition) {
+      throw new Error(`Genesis ${genesisId ?? 'default'} is missing its network definition`);
+    }
+
     const result = await store.query(
-      `SELECT ?v WHERE { <did:dkg:network:v9-testnet> <https://dkg.network/ontology#genesisVersion> ?v } LIMIT 1`,
+      `SELECT ?v WHERE { <${networkDefinition.subject}> <https://dkg.network/ontology#genesisVersion> ?v } LIMIT 1`,
     );
     if (result.type === 'bindings' && result.bindings.length > 0) return;
 
     // Insert genesis quads
-    const genesisQuads = getGenesisQuads();
     const quads: Quad[] = genesisQuads.map(gq => ({
       subject: gq.subject,
       predicate: gq.predicate,

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1377,10 +1377,25 @@ export class DKGAgent extends DKGAgentBase {
       throw new Error(`Genesis ${genesisId ?? 'default'} is missing its network definition`);
     }
 
-    const result = await store.query(
-      `SELECT ?v WHERE { <${networkDefinition.subject}> <https://dkg.network/ontology#genesisVersion> ?v } LIMIT 1`,
+    const existingGenesis = await store.query(
+      `SELECT ?network WHERE {
+        ?network <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DKG_NETWORK}> .
+        ?network <${DKG_ONTOLOGY.DKG_GENESIS_VERSION}> ?v .
+      }`,
     );
-    if (result.type === 'bindings' && result.bindings.length > 0) return;
+    if (existingGenesis.type === 'bindings') {
+      const existingSubjects = existingGenesis.bindings
+        .map((binding: any) => String(binding.network?.value ?? binding.network).replace(/^<|>$/g, ''));
+      const foreignSubjects = existingSubjects.filter(subject => subject !== networkDefinition.subject);
+      if (foreignSubjects.length > 0) {
+        throw new Error(
+          `Triple store contains a different genesis (${foreignSubjects.join(', ')}) than selected ` +
+          `${networkDefinition.subject}. Start with an empty DKG home or run the network reset/migration ` +
+          `before switching genesis.`,
+        );
+      }
+      if (existingSubjects.includes(networkDefinition.subject)) return;
+    }
 
     // Insert genesis quads
     const quads: Quad[] = genesisQuads.map(gq => ({

--- a/packages/agent/test/agent.part-10.test.ts
+++ b/packages/agent/test/agent.part-10.test.ts
@@ -93,6 +93,23 @@ describe('Genesis Knowledge', () => {
       await agent.stop().catch(() => {});
     });
 
+    it('rejects switching an existing store to a different genesis', async () => {
+      const store = new OxigraphStore();
+      const defaultAgent = await DKGAgent.create({
+        name: 'DefaultGenesisStore',
+        store,
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+      await defaultAgent.stop().catch(() => {});
+
+      await expect(DKGAgent.create({
+        name: 'ForeignGenesisStore',
+        genesisId: 'gnosis-mainnet',
+        store,
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      })).rejects.toThrow(/contains a different genesis/);
+    });
+
 
     it('genesis loading is idempotent', async () => {
       const store = new OxigraphStore();

--- a/packages/agent/test/agent.part-10.test.ts
+++ b/packages/agent/test/agent.part-10.test.ts
@@ -63,6 +63,36 @@ describe('Genesis Knowledge', () => {
       await agent.stop().catch(() => {});
     });
 
+    it('loads the selected genesis into store and reports its network id', async () => {
+      const store = new OxigraphStore();
+      const agent = await DKGAgent.create({
+        name: 'SelectedGenesisTest',
+        genesisId: 'gnosis-mainnet',
+        store,
+        chainAdapter: createEVMAdapter(HARDHAT_KEYS.CORE_OP),
+      });
+
+      const selectedGenesis = await store.query(
+        `SELECT ?v WHERE { <did:dkg:network:gnosis-mainnet> <https://dkg.network/ontology#genesisVersion> ?v }`,
+      );
+      expect(selectedGenesis.type).toBe('bindings');
+      if (selectedGenesis.type === 'bindings') {
+        expect(selectedGenesis.bindings.length).toBe(1);
+      }
+
+      const defaultGenesis = await store.query(
+        `SELECT ?v WHERE { <did:dkg:network:v9-testnet> <https://dkg.network/ontology#genesisVersion> ?v }`,
+      );
+      expect(defaultGenesis.type).toBe('bindings');
+      if (defaultGenesis.type === 'bindings') {
+        expect(defaultGenesis.bindings.length).toBe(0);
+      }
+
+      expect(await agent.networkId()).toBe(await computeNetworkId('gnosis-mainnet'));
+
+      await agent.stop().catch(() => {});
+    });
+
 
     it('genesis loading is idempotent', async () => {
       const store = new OxigraphStore();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,7 +23,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, validateNetworkConfigReadiness,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo, classifyMonorepoInit, sharedHomeInitGate,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -196,6 +196,11 @@ program
     await ensureDkgDir();
     const existing = await loadConfig();
     const network = await loadNetworkConfig();
+    const readiness = validateNetworkConfigReadiness(network);
+    if (!readiness.ok) {
+      for (const message of readiness.messages) console.error(message);
+      process.exit(1);
+    }
     const rl = createInterface({ input: process.stdin, output: process.stdout });
     const ask = (q: string, def?: string): Promise<string> =>
       new Promise(resolve => {

--- a/packages/cli/src/commands/node-ops.ts
+++ b/packages/cli/src/commands/node-ops.ts
@@ -22,7 +22,7 @@ import {
   loadConfig, saveConfig, configExists, configPath,
   readPid, readApiPort, isProcessRunning, dkgDir, logPath, ensureDkgDir, removeApiPort,
   apiPortPath,
-  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig,
+  loadNetworkConfig, loadProjectConfig, resolveAutoUpdateConfig, resolveAutoUpdateSource, resolveChainConfig, resolveReadyChainConfig,
   releasesDir, activeSlot, swapSlot,
   slotEntryPoint, isStandaloneInstall, repoDir, isDkgMonorepo,
   resolveContextGraphs, resolveNetworkDefaultContextGraphs,
@@ -236,7 +236,7 @@ program
         process.exit(1);
       }
 
-      const chainResolved = resolveChainConfig(config, network);
+      const chainResolved = resolveReadyChainConfig(config, network);
       const rpcUrl = chainResolved?.rpcUrl;
       const hubAddress = chainResolved?.hubAddress;
       if (!rpcUrl || !hubAddress) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -743,6 +743,33 @@ export function resolveNetworkDefaultContextGraphs(network: NetworkConfig | null
   return network?.defaultContextGraphs ?? [];
 }
 
+type NetworkReadinessValidation =
+  | { ok: true; messages: [] }
+  | { ok: false; messages: string[] };
+
+type NetworkReadinessInput = Partial<Pick<NetworkConfig, '_status' | 'networkName' | 'relays'>>;
+
+export function validateNetworkConfigReadiness(
+  network: NetworkReadinessInput | null | undefined,
+): NetworkReadinessValidation {
+  const networkName = network?.networkName ?? 'selected network';
+  const messages: string[] = [];
+  if (network?._status?.toLowerCase().startsWith('pre-deployment')) {
+    messages.push(
+      `FATAL: network config ${networkName} is marked ${network._status}.`,
+    );
+  }
+  const placeholderRelays = network?.relays?.filter(relay => relay.includes('/p2p/PEER_ID_')) ?? [];
+  if (placeholderRelays.length > 0) {
+    messages.push(
+      `FATAL: network config ${networkName} contains placeholder relay peer IDs: ${placeholderRelays.join(', ')}`,
+    );
+    messages.push('Replace pre-deployment relay PeerIDs before selecting this network.');
+  }
+  if (messages.length > 0) return { ok: false, messages };
+  return { ok: true, messages: [] };
+}
+
 /** Resolve shared memory TTL from config, accepting both V10 and legacy keys. */
 export function resolveSharedMemoryTtlMs(config: DkgConfig): number | undefined {
   return config.sharedMemoryTtlMs ?? config.workspaceTtlMs;
@@ -1018,7 +1045,7 @@ export function resolveAutoUpdateSource(
  */
 export function resolveChainConfig(
   config: Pick<DkgConfig, 'chain'> | null | undefined,
-  network: Pick<NetworkConfig, 'chain'> | null | undefined,
+  network: (Pick<NetworkConfig, 'chain'> & NetworkReadinessInput) | null | undefined,
 ): ResolvedChainConfig | undefined {
   const cfg = config?.chain;
   const net = network?.chain;
@@ -1039,6 +1066,11 @@ export function resolveChainConfig(
     if (cfg.chainId !== undefined) mockMerged.chainId = cfg.chainId;
     if (cfg.mockIdentityId !== undefined) mockMerged.mockIdentityId = cfg.mockIdentityId;
     return mockMerged;
+  }
+
+  const readiness = validateNetworkConfigReadiness(network);
+  if (!readiness.ok) {
+    throw new Error(readiness.messages.join('\n'));
   }
 
   const merged: ResolvedChainConfig = {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -770,6 +770,15 @@ export function validateNetworkConfigReadiness(
   return { ok: true, messages: [] };
 }
 
+export function assertNetworkConfigReadiness(
+  network: NetworkReadinessInput | null | undefined,
+): void {
+  const readiness = validateNetworkConfigReadiness(network);
+  if (!readiness.ok) {
+    throw new Error(readiness.messages.join('\n'));
+  }
+}
+
 /** Resolve shared memory TTL from config, accepting both V10 and legacy keys. */
 export function resolveSharedMemoryTtlMs(config: DkgConfig): number | undefined {
   return config.sharedMemoryTtlMs ?? config.workspaceTtlMs;
@@ -1042,10 +1051,13 @@ export function resolveAutoUpdateSource(
  * The return type is `Partial<ChainConfig>` because either source may be
  * partial; consumers that need both `rpcUrl` and `hubAddress` (lifecycle,
  * publisher-runner) MUST guard for those fields before passing to the agent.
+ *
+ * This is a raw field-merge helper. Call {@link resolveReadyChainConfig} at
+ * CLI/daemon activation boundaries that must reject pre-deployment networks.
  */
 export function resolveChainConfig(
   config: Pick<DkgConfig, 'chain'> | null | undefined,
-  network: (Pick<NetworkConfig, 'chain'> & NetworkReadinessInput) | null | undefined,
+  network: Pick<NetworkConfig, 'chain'> | null | undefined,
 ): ResolvedChainConfig | undefined {
   const cfg = config?.chain;
   const net = network?.chain;
@@ -1066,11 +1078,6 @@ export function resolveChainConfig(
     if (cfg.chainId !== undefined) mockMerged.chainId = cfg.chainId;
     if (cfg.mockIdentityId !== undefined) mockMerged.mockIdentityId = cfg.mockIdentityId;
     return mockMerged;
-  }
-
-  const readiness = validateNetworkConfigReadiness(network);
-  if (!readiness.ok) {
-    throw new Error(readiness.messages.join('\n'));
   }
 
   const merged: ResolvedChainConfig = {
@@ -1101,6 +1108,16 @@ export function resolveChainConfig(
   if (cgRegistryScanPageSize !== undefined) merged.cgRegistryScanPageSize = cgRegistryScanPageSize;
   if (cfg?.mockIdentityId !== undefined) merged.mockIdentityId = cfg.mockIdentityId;
   return merged;
+}
+
+export function resolveReadyChainConfig(
+  config: Pick<DkgConfig, 'chain'> | null | undefined,
+  network: (Pick<NetworkConfig, 'chain'> & NetworkReadinessInput) | null | undefined,
+): ResolvedChainConfig | undefined {
+  if (config?.chain?.type !== 'mock') {
+    assertNetworkConfigReadiness(network);
+  }
+  return resolveChainConfig(config, network);
 }
 
 /**

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -100,6 +100,7 @@ export type ResolvedAutoUpdateConfig = AutoUpdateConfig & {
 };
 
 export interface NetworkConfig {
+  _status?: string;
   networkName: string;
   genesisId: string;
   networkId: string;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -101,6 +101,7 @@ export type ResolvedAutoUpdateConfig = AutoUpdateConfig & {
 
 export interface NetworkConfig {
   networkName: string;
+  genesisId: string;
   networkId: string;
   genesisVersion: number;
   relays: string[];

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1247,6 +1247,7 @@ export async function runDaemonInner(
   const agent = await DKGAgent.create({
     kaNumberAllocator,
     name: config.name,
+    genesisId: network?.genesisId,
     framework: "DKG",
     listenPort: config.listenPort,
     dataDir: dkgDir(),

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -125,6 +125,7 @@ import {
   slotEntryPoint,
   CLI_NPM_PACKAGE,
   exitOnStoreConfigErrors,
+  validateNetworkConfigReadiness,
 } from '../config.js';
 import { createPublicSnapshotStore, createPublisherControlFromStore, startPublisherRuntimeIfEnabled, type PublisherRuntime } from '../publisher-runner.js';
 import { createCatchupRunner, type CatchupJobResult, type CatchupRunner } from '../catchup-runner.js';
@@ -736,20 +737,8 @@ export async function validateStartupGenesis(
   network: Pick<NetworkConfig, '_status' | 'genesisId' | 'networkId' | 'networkName' | 'relays'> | null | undefined,
 ): Promise<StartupGenesisValidation> {
   const networkId = await computeNetworkId(network?.genesisId);
-  const networkName = network?.networkName ?? 'selected network';
-  const messages: string[] = [];
-  if (network?._status?.toLowerCase().startsWith('pre-deployment')) {
-    messages.push(
-      `FATAL: network config ${networkName} is marked ${network._status}.`,
-    );
-  }
-  const placeholderRelays = network?.relays?.filter(relay => relay.includes('/p2p/PEER_ID_')) ?? [];
-  if (placeholderRelays.length > 0) {
-    messages.push(
-      `FATAL: network config ${networkName} contains placeholder relay peer IDs: ${placeholderRelays.join(', ')}`,
-    );
-    messages.push('Replace pre-deployment relay PeerIDs before selecting this network.');
-  }
+  const readiness = validateNetworkConfigReadiness(network);
+  const messages = readiness.ok ? [] : [...readiness.messages];
   if (network?.networkId && network.networkId !== networkId) {
     messages.push(
       `FATAL: genesis mismatch! Expected networkId ${network.networkId.slice(0, 16)}... but computed ${networkId.slice(0, 16)}...`,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -733,8 +733,10 @@ type StartupGenesisValidation =
   | { ok: true; networkId: string }
   | { ok: false; networkId: string; messages: string[] };
 
+type StartupGenesisValidationInput = Partial<Pick<NetworkConfig, '_status' | 'genesisId' | 'networkId' | 'networkName' | 'relays'>>;
+
 export async function validateStartupGenesis(
-  network: Pick<NetworkConfig, '_status' | 'genesisId' | 'networkId' | 'networkName' | 'relays'> | null | undefined,
+  network: StartupGenesisValidationInput | null | undefined,
 ): Promise<StartupGenesisValidation> {
   const networkId = await computeNetworkId(network?.genesisId);
   const readiness = validateNetworkConfigReadiness(network);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -742,7 +742,7 @@ export async function validateStartupGenesis(
       networkId,
       messages: [
         `FATAL: genesis mismatch! Expected networkId ${network.networkId.slice(0, 16)}... but computed ${networkId.slice(0, 16)}...`,
-        `This node's genesis does not match network/testnet.json. Rebuild or update the repo.`,
+        `This node's genesis does not match ${network.networkName}. Rebuild or update the selected network config.`,
       ],
     };
   }

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -733,19 +733,32 @@ type StartupGenesisValidation =
   | { ok: false; networkId: string; messages: string[] };
 
 export async function validateStartupGenesis(
-  network: Pick<NetworkConfig, 'genesisId' | 'networkId' | 'networkName'> | null | undefined,
+  network: Pick<NetworkConfig, '_status' | 'genesisId' | 'networkId' | 'networkName' | 'relays'> | null | undefined,
 ): Promise<StartupGenesisValidation> {
   const networkId = await computeNetworkId(network?.genesisId);
-  if (network?.networkId && network.networkId !== networkId) {
-    return {
-      ok: false,
-      networkId,
-      messages: [
-        `FATAL: genesis mismatch! Expected networkId ${network.networkId.slice(0, 16)}... but computed ${networkId.slice(0, 16)}...`,
-        `This node's genesis does not match ${network.networkName}. Rebuild or update the selected network config.`,
-      ],
-    };
+  const networkName = network?.networkName ?? 'selected network';
+  const messages: string[] = [];
+  if (network?._status?.toLowerCase().startsWith('pre-deployment')) {
+    messages.push(
+      `FATAL: network config ${networkName} is marked ${network._status}.`,
+    );
   }
+  const placeholderRelays = network?.relays?.filter(relay => relay.includes('/p2p/PEER_ID_')) ?? [];
+  if (placeholderRelays.length > 0) {
+    messages.push(
+      `FATAL: network config ${networkName} contains placeholder relay peer IDs: ${placeholderRelays.join(', ')}`,
+    );
+    messages.push('Replace pre-deployment relay PeerIDs before selecting this network.');
+  }
+  if (network?.networkId && network.networkId !== networkId) {
+    messages.push(
+      `FATAL: genesis mismatch! Expected networkId ${network.networkId.slice(0, 16)}... but computed ${networkId.slice(0, 16)}...`,
+    );
+    messages.push(
+      `This node's genesis does not match ${network.networkName}. Rebuild or update the selected network config.`,
+    );
+  }
+  if (messages.length > 0) return { ok: false, networkId, messages };
   return { ok: true, networkId };
 }
 
@@ -891,6 +904,12 @@ export async function runDaemonInner(
   }
 
   const network = await loadNetworkConfig();
+  const genesisValidation = await validateStartupGenesis(network);
+  const networkId = genesisValidation.networkId;
+  if (!genesisValidation.ok) {
+    for (const message of genesisValidation.messages) log(message);
+    process.exit(1);
+  }
   const syncContextGraphs = [
     ...new Set([
       ...resolveContextGraphs(config),
@@ -1413,17 +1432,11 @@ export async function runDaemonInner(
   let promoteWorkerLifecycle: PromoteWorkerDaemonLifecycle | null = null;
   let shuttingDown = false;
 
-  const genesisValidation = await validateStartupGenesis(network);
-  const networkId = genesisValidation.networkId;
   const publisherControl = createPublisherControlFromStore(
     agent.store,
     createPublicSnapshotStore(dkgDir(), config),
   );
   log(`Network: ${networkId.slice(0, 16)}...`);
-  if (!genesisValidation.ok) {
-    for (const message of genesisValidation.messages) log(message);
-    process.exit(1);
-  }
   if (network) {
     log(
       `Network config: ${network.networkName} (genesis v${network.genesisVersion})`,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -101,6 +101,7 @@ import {
   ensureDkgDir,
   TELEMETRY_ENDPOINTS,
   type DkgConfig,
+  type NetworkConfig,
   type AutoUpdateConfig,
   type LocalAgentIntegrationCapabilities,
   type LocalAgentIntegrationConfig,
@@ -725,6 +726,27 @@ export function startPromoteWorkerDaemonLifecycle(input: {
     stop,
     getSupervisor: () => promoteWorkerSupervisor,
   };
+}
+
+type StartupGenesisValidation =
+  | { ok: true; networkId: string }
+  | { ok: false; networkId: string; messages: string[] };
+
+export async function validateStartupGenesis(
+  network: Pick<NetworkConfig, 'genesisId' | 'networkId' | 'networkName'> | null | undefined,
+): Promise<StartupGenesisValidation> {
+  const networkId = await computeNetworkId(network?.genesisId);
+  if (network?.networkId && network.networkId !== networkId) {
+    return {
+      ok: false,
+      networkId,
+      messages: [
+        `FATAL: genesis mismatch! Expected networkId ${network.networkId.slice(0, 16)}... but computed ${networkId.slice(0, 16)}...`,
+        `This node's genesis does not match network/testnet.json. Rebuild or update the repo.`,
+      ],
+    };
+  }
+  return { ok: true, networkId };
 }
 
 export async function runDaemon(foreground: boolean): Promise<void> {
@@ -1390,19 +1412,15 @@ export async function runDaemonInner(
   let promoteWorkerLifecycle: PromoteWorkerDaemonLifecycle | null = null;
   let shuttingDown = false;
 
-  const networkId = await computeNetworkId();
+  const genesisValidation = await validateStartupGenesis(network);
+  const networkId = genesisValidation.networkId;
   const publisherControl = createPublisherControlFromStore(
     agent.store,
     createPublicSnapshotStore(dkgDir(), config),
   );
   log(`Network: ${networkId.slice(0, 16)}...`);
-  if (network?.networkId && network.networkId !== networkId) {
-    log(
-      `FATAL: genesis mismatch! Expected networkId ${network.networkId.slice(0, 16)}... but computed ${networkId.slice(0, 16)}...`,
-    );
-    log(
-      `This node's genesis does not match network/testnet.json. Rebuild or update the repo.`,
-    );
+  if (!genesisValidation.ok) {
+    for (const message of genesisValidation.messages) log(message);
     process.exit(1);
   }
   if (network) {

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -616,7 +616,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     const circuitAddrs = agent.multiaddrs.filter((a) =>
       a.includes("/p2p-circuit/"),
     );
-    const networkId = await computeNetworkId();
+    const networkId = await computeNetworkId(network?.genesisId);
     const chainConf = resolveChainConfig(config, network);
     const rpcEndpointCount = chainConf?.rpcUrl
       ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -4,7 +4,7 @@ import { EVMChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain
 import { TypedEventBus, type Ed25519Keypair } from '@origintrail-official/dkg-core';
 import { ACKCollector, AsyncLiftRunner, DKGPublisher, FileWorkspacePublicSnapshotStore, TripleStoreAsyncLiftPublisher, wrapAsRpcPreconditionIfApplicable, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
-import { loadNetworkConfig, resolveChainConfig, type DkgConfig } from './config.js';
+import { loadNetworkConfig, resolveReadyChainConfig, type DkgConfig } from './config.js';
 import { loadPublisherWallets } from './publisher-wallets.js';
 
 export interface PublisherRuntime {
@@ -121,7 +121,7 @@ export async function createPublisherRuntime(args: {
   // expects. If either required field is missing, pass undefined and let
   // the runtime fall back to NoChainAdapter (publisher won't have on-chain
   // finality but still functions).
-  const merged = resolveChainConfig(args.config, network);
+  const merged = resolveReadyChainConfig(args.config, network);
   const chainBase = merged?.rpcUrl && merged?.hubAddress
     ? { rpcUrl: merged.rpcUrl, rpcUrls: merged.rpcUrls, hubAddress: merged.hubAddress, tokenAddress: merged.tokenAddress, chainId: merged.chainId }
     : undefined;

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -172,6 +172,7 @@ describe('loadNetworkConfig', () => {
       {
         name: 'mainnet-base',
         networkName: 'DKG V10 Base Mainnet',
+        genesisId: 'base-mainnet',
         chainName: 'base',
         chainId: 'base:8453',
         rpcUrl: 'https://mainnet.base.org',
@@ -180,6 +181,7 @@ describe('loadNetworkConfig', () => {
       {
         name: 'mainnet-gnosis',
         networkName: 'DKG V10 Gnosis Mainnet',
+        genesisId: 'gnosis-mainnet',
         chainName: 'gnosis',
         chainId: 'gnosis:100',
         rpcUrl: 'https://rpc.gnosischain.com',
@@ -188,6 +190,7 @@ describe('loadNetworkConfig', () => {
       {
         name: 'mainnet-neuroweb',
         networkName: 'DKG V10 NeuroWeb Mainnet',
+        genesisId: 'neuroweb-mainnet',
         chainName: 'neuroweb',
         chainId: 'neuroweb:2043',
         rpcUrl: 'https://astrosat-parachain-rpc.origin-trail.network',
@@ -212,6 +215,7 @@ describe('loadNetworkConfig', () => {
         autoUpdate: cfg.autoUpdate,
       }).toEqual(sharedMainnetPrep);
       expect(cfg.networkName).toBe(expected.networkName);
+      expect(cfg.genesisId).toBe(expected.genesisId);
       for (const relay of cfg.relays) {
         expect(relay).toMatch(/^\/ip4\/178\./);
         expect(relay).toMatch(/\/p2p\/PEER_ID_/);

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -143,6 +143,61 @@ describe('loadNetworkConfig', () => {
     expect(config.networkName).toMatch(/testnet/i);
   });
 
+  it('loads mainnet configs with complete network defaults and expected chain hubs', async () => {
+    const { _resetNetworkConfigCache } = await import('../src/config.js');
+    const networkId = '7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b';
+    const mainnets = [
+      {
+        name: 'mainnet-base',
+        chainId: 'base:8453',
+        rpcUrl: 'https://mainnet.base.org',
+        hubAddress: '0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13',
+      },
+      {
+        name: 'mainnet-gnosis',
+        chainId: 'gnosis:100',
+        rpcUrl: 'https://rpc.gnosischain.com',
+        hubAddress: '0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f',
+      },
+      {
+        name: 'mainnet-neuroweb',
+        chainId: 'neuroweb:2043',
+        rpcUrl: 'https://astrosat-parachain-rpc.origin-trail.network',
+        hubAddress: '0x0957e25BD33034948abc28204ddA54b6E1142D6F',
+      },
+    ];
+
+    for (const expected of mainnets) {
+      _resetNetworkConfigCache();
+      const config = await loadNetworkConfig(expected.name);
+      expect(config).not.toBeNull();
+      const cfg = config!;
+      expect((cfg as any)._status).toBeUndefined();
+      expect(cfg.networkName).toBe('DKG V10 Mainnet');
+      expect(cfg.networkId).toBe(networkId);
+      expect(cfg.genesisVersion).toBe(1);
+      expect(cfg.defaultNodeRole).toBe('edge');
+      expect(Array.isArray(cfg.relays)).toBe(true);
+      expect(cfg.relays.length).toBeGreaterThan(0);
+      for (const relay of cfg.relays) {
+        expect(relay).toMatch(/^\/ip4\/\d+\.\d+\.\d+\.\d+\/tcp\/\d+\/p2p\/12D3KooW/);
+        expect(relay).not.toMatch(/PLACEHOLDER|PEER_ID/);
+      }
+      expect(cfg.autoUpdate).toMatchObject({
+        enabled: true,
+        repo: 'OriginTrail/dkg',
+        branch: 'main',
+        checkIntervalMinutes: 5,
+      });
+      expect(cfg.chain).toEqual({
+        type: 'evm',
+        rpcUrl: expected.rpcUrl,
+        hubAddress: expected.hubAddress,
+        chainId: expected.chainId,
+      });
+    }
+  });
+
   it('returns null when network config file does not exist', async () => {
     const { _resetNetworkConfigCache } = await import('../src/config.js');
     _resetNetworkConfigCache();

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -27,6 +27,7 @@ import {
   resolveAutoUpdateSource,
   resolveApprovalPolicy,
   resolveChainConfig,
+  resolveReadyChainConfig,
 } from '../src/config.js';
 
 describe('classifyMonorepoInit (dkg init monorepo home guard — issue #960)', () => {
@@ -569,8 +570,19 @@ describe('resolveChainConfig (field-level merge)', () => {
     });
   });
 
-  it('refuses to resolve chain defaults from a pre-deployment network', () => {
-    expect(() => resolveChainConfig({}, {
+  it('keeps raw chain merging side-effect-free for pre-deployment network metadata', () => {
+    const merged = resolveChainConfig({}, {
+      _status: 'pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet',
+      networkName: 'DKG V10 Base Mainnet',
+      relays: ['/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS'],
+      chain: fullNetworkChain,
+    });
+
+    expect(merged?.hubAddress).toBe(fullNetworkChain.hubAddress);
+  });
+
+  it('refuses ready chain resolution from a pre-deployment network', () => {
+    expect(() => resolveReadyChainConfig({}, {
       _status: 'pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet',
       networkName: 'DKG V10 Base Mainnet',
       relays: ['/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS'],

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -141,6 +141,7 @@ describe('loadNetworkConfig', () => {
       return;
     }
     expect(config.networkName).toMatch(/testnet/i);
+    expect((config as any).genesisId).toBe('base-testnet');
   });
 
   it('loads mainnet prep configs without activating testnet genesis or relays', async () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -143,8 +143,31 @@ describe('loadNetworkConfig', () => {
     expect(config.networkName).toMatch(/testnet/i);
   });
 
-  it('keeps mainnet chain targets as placeholders until distinct genesis and relays exist', async () => {
+  it('loads mainnet prep configs without activating testnet genesis or relays', async () => {
     const { _resetNetworkConfigCache } = await import('../src/config.js');
+    const testnetNetworkId = '7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b';
+    const sharedMainnetPrep = {
+      networkName: 'DKG V10 Mainnet',
+      networkId: 'PLACEHOLDER_MAINNET_NETWORK_ID',
+      genesisVersion: 1,
+      relays: [
+        '/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS',
+        '/ip4/178.105.105.102/tcp/9090/p2p/PEER_ID_LUNARIS',
+        '/ip4/178.156.214.4/tcp/9090/p2p/PEER_ID_ORIONIS',
+        '/ip4/178.105.111.185/tcp/9090/p2p/PEER_ID_KEPLER',
+      ],
+      defaultContextGraphs: [],
+      defaultNodeRole: 'edge',
+      autoUpdate: {
+        enabled: true,
+        repo: 'OriginTrail/dkg',
+        branch: 'main',
+        checkIntervalMinutes: 5,
+      },
+    };
+    _resetNetworkConfigCache();
+    const testnetConfig = await loadNetworkConfig('testnet');
+    const testnetRelays = testnetConfig?.relays ?? [];
     const mainnets = [
       {
         name: 'mainnet-base',
@@ -174,17 +197,22 @@ describe('loadNetworkConfig', () => {
       const config = await loadNetworkConfig(expected.name);
       expect(config).not.toBeNull();
       const cfg = config! as any;
-      expect(cfg._status).toMatch(/distinct mainnet genesis networkId and relay peer IDs/);
-      expect(cfg.networkName).toBeUndefined();
-      expect(cfg.networkId).toBeUndefined();
-      expect(cfg.genesisVersion).toBeUndefined();
-      expect(cfg.relays).toBeUndefined();
-      expect(cfg.defaultNodeRole).toBeUndefined();
-      expect(cfg.defaultContextGraphs).toBeUndefined();
-      expect(cfg.autoUpdate).toEqual({
-        enabled: true,
-        branch: 'main',
-      });
+      expect(cfg._status).toMatch(/replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_\*/);
+      expect(cfg.networkId).not.toBe(testnetNetworkId);
+      expect(cfg.relays).not.toEqual(testnetRelays);
+      expect({
+        networkName: cfg.networkName,
+        networkId: cfg.networkId,
+        genesisVersion: cfg.genesisVersion,
+        relays: cfg.relays,
+        defaultContextGraphs: cfg.defaultContextGraphs,
+        defaultNodeRole: cfg.defaultNodeRole,
+        autoUpdate: cfg.autoUpdate,
+      }).toEqual(sharedMainnetPrep);
+      for (const relay of cfg.relays) {
+        expect(relay).toMatch(/^\/ip4\/178\./);
+        expect(relay).toMatch(/\/p2p\/PEER_ID_/);
+      }
       expect(cfg.chain).toEqual({
         name: expected.chainName,
         type: 'evm',

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -204,7 +204,8 @@ describe('loadNetworkConfig', () => {
       const config = await loadNetworkConfig(expected.name);
       expect(config).not.toBeNull();
       const cfg = config! as any;
-      expect(cfg._status).toMatch(/replace PLACEHOLDER_MAINNET_NETWORK_ID and PEER_ID_\*/);
+      expect(cfg._status).toMatch(/pre-deployment: replace PEER_ID_\* relay values before enabling/);
+      expect(cfg._status).not.toContain('PLACEHOLDER_MAINNET_NETWORK_ID');
       expect(cfg.networkId).not.toBe(testnetNetworkId);
       expect(cfg.relays).not.toEqual(testnetRelays);
       expect({

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { dkgAuthTokenPath } from '@origintrail-official/dkg-core';
+import { computeNetworkId } from '../../core/src/genesis.js';
 import {
   loadNetworkConfig,
   loadConfig,
@@ -149,7 +150,6 @@ describe('loadNetworkConfig', () => {
     const { _resetNetworkConfigCache } = await import('../src/config.js');
     const testnetNetworkId = '7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b';
     const sharedMainnetPrep = {
-      networkId: 'PLACEHOLDER_MAINNET_NETWORK_ID',
       genesisVersion: 1,
       relays: [
         '/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS',
@@ -208,7 +208,6 @@ describe('loadNetworkConfig', () => {
       expect(cfg.networkId).not.toBe(testnetNetworkId);
       expect(cfg.relays).not.toEqual(testnetRelays);
       expect({
-        networkId: cfg.networkId,
         genesisVersion: cfg.genesisVersion,
         relays: cfg.relays,
         defaultContextGraphs: cfg.defaultContextGraphs,
@@ -217,6 +216,7 @@ describe('loadNetworkConfig', () => {
       }).toEqual(sharedMainnetPrep);
       expect(cfg.networkName).toBe(expected.networkName);
       expect(cfg.genesisId).toBe(expected.genesisId);
+      expect(cfg.networkId).toBe(await computeNetworkId(expected.genesisId));
       for (const relay of cfg.relays) {
         expect(relay).toMatch(/^\/ip4\/178\./);
         expect(relay).toMatch(/\/p2p\/PEER_ID_/);

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -147,7 +147,6 @@ describe('loadNetworkConfig', () => {
     const { _resetNetworkConfigCache } = await import('../src/config.js');
     const testnetNetworkId = '7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b';
     const sharedMainnetPrep = {
-      networkName: 'DKG V10 Mainnet',
       networkId: 'PLACEHOLDER_MAINNET_NETWORK_ID',
       genesisVersion: 1,
       relays: [
@@ -171,6 +170,7 @@ describe('loadNetworkConfig', () => {
     const mainnets = [
       {
         name: 'mainnet-base',
+        networkName: 'DKG V10 Base Mainnet',
         chainName: 'base',
         chainId: 'base:8453',
         rpcUrl: 'https://mainnet.base.org',
@@ -178,6 +178,7 @@ describe('loadNetworkConfig', () => {
       },
       {
         name: 'mainnet-gnosis',
+        networkName: 'DKG V10 Gnosis Mainnet',
         chainName: 'gnosis',
         chainId: 'gnosis:100',
         rpcUrl: 'https://rpc.gnosischain.com',
@@ -185,6 +186,7 @@ describe('loadNetworkConfig', () => {
       },
       {
         name: 'mainnet-neuroweb',
+        networkName: 'DKG V10 NeuroWeb Mainnet',
         chainName: 'neuroweb',
         chainId: 'neuroweb:2043',
         rpcUrl: 'https://astrosat-parachain-rpc.origin-trail.network',
@@ -201,7 +203,6 @@ describe('loadNetworkConfig', () => {
       expect(cfg.networkId).not.toBe(testnetNetworkId);
       expect(cfg.relays).not.toEqual(testnetRelays);
       expect({
-        networkName: cfg.networkName,
         networkId: cfg.networkId,
         genesisVersion: cfg.genesisVersion,
         relays: cfg.relays,
@@ -209,6 +210,7 @@ describe('loadNetworkConfig', () => {
         defaultNodeRole: cfg.defaultNodeRole,
         autoUpdate: cfg.autoUpdate,
       }).toEqual(sharedMainnetPrep);
+      expect(cfg.networkName).toBe(expected.networkName);
       for (const relay of cfg.relays) {
         expect(relay).toMatch(/^\/ip4\/178\./);
         expect(relay).toMatch(/\/p2p\/PEER_ID_/);

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -143,24 +143,26 @@ describe('loadNetworkConfig', () => {
     expect(config.networkName).toMatch(/testnet/i);
   });
 
-  it('loads mainnet configs with complete network defaults and expected chain hubs', async () => {
+  it('keeps mainnet chain targets as placeholders until distinct genesis and relays exist', async () => {
     const { _resetNetworkConfigCache } = await import('../src/config.js');
-    const networkId = '7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b';
     const mainnets = [
       {
         name: 'mainnet-base',
+        chainName: 'base',
         chainId: 'base:8453',
         rpcUrl: 'https://mainnet.base.org',
         hubAddress: '0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13',
       },
       {
         name: 'mainnet-gnosis',
+        chainName: 'gnosis',
         chainId: 'gnosis:100',
         rpcUrl: 'https://rpc.gnosischain.com',
         hubAddress: '0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f',
       },
       {
         name: 'mainnet-neuroweb',
+        chainName: 'neuroweb',
         chainId: 'neuroweb:2043',
         rpcUrl: 'https://astrosat-parachain-rpc.origin-trail.network',
         hubAddress: '0x0957e25BD33034948abc28204ddA54b6E1142D6F',
@@ -171,29 +173,24 @@ describe('loadNetworkConfig', () => {
       _resetNetworkConfigCache();
       const config = await loadNetworkConfig(expected.name);
       expect(config).not.toBeNull();
-      const cfg = config!;
-      expect((cfg as any)._status).toBeUndefined();
-      expect(cfg.networkName).toBe('DKG V10 Mainnet');
-      expect(cfg.networkId).toBe(networkId);
-      expect(cfg.genesisVersion).toBe(1);
-      expect(cfg.defaultNodeRole).toBe('edge');
-      expect(Array.isArray(cfg.relays)).toBe(true);
-      expect(cfg.relays.length).toBeGreaterThan(0);
-      for (const relay of cfg.relays) {
-        expect(relay).toMatch(/^\/ip4\/\d+\.\d+\.\d+\.\d+\/tcp\/\d+\/p2p\/12D3KooW/);
-        expect(relay).not.toMatch(/PLACEHOLDER|PEER_ID/);
-      }
-      expect(cfg.autoUpdate).toMatchObject({
+      const cfg = config! as any;
+      expect(cfg._status).toMatch(/distinct mainnet genesis networkId and relay peer IDs/);
+      expect(cfg.networkName).toBeUndefined();
+      expect(cfg.networkId).toBeUndefined();
+      expect(cfg.genesisVersion).toBeUndefined();
+      expect(cfg.relays).toBeUndefined();
+      expect(cfg.defaultNodeRole).toBeUndefined();
+      expect(cfg.defaultContextGraphs).toBeUndefined();
+      expect(cfg.autoUpdate).toEqual({
         enabled: true,
-        repo: 'OriginTrail/dkg',
         branch: 'main',
-        checkIntervalMinutes: 5,
       });
       expect(cfg.chain).toEqual({
+        name: expected.chainName,
         type: 'evm',
+        chainId: expected.chainId,
         rpcUrl: expected.rpcUrl,
         hubAddress: expected.hubAddress,
-        chainId: expected.chainId,
       });
     }
   });

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -174,6 +174,7 @@ describe('loadNetworkConfig', () => {
         name: 'mainnet-base',
         networkName: 'DKG V10 Base Mainnet',
         genesisId: 'base-mainnet',
+        networkId: '562ea760dbe27fb4233d58dfc958bbddf844b82596ec3d51dff98718e6bf61ca',
         chainName: 'base',
         chainId: 'base:8453',
         rpcUrl: 'https://mainnet.base.org',
@@ -183,6 +184,7 @@ describe('loadNetworkConfig', () => {
         name: 'mainnet-gnosis',
         networkName: 'DKG V10 Gnosis Mainnet',
         genesisId: 'gnosis-mainnet',
+        networkId: 'e08a9fb72a648ec2eb2fd9c152ded90a8ad67bb56f27df4781d9bb7e261fb7a7',
         chainName: 'gnosis',
         chainId: 'gnosis:100',
         rpcUrl: 'https://rpc.gnosischain.com',
@@ -192,6 +194,7 @@ describe('loadNetworkConfig', () => {
         name: 'mainnet-neuroweb',
         networkName: 'DKG V10 NeuroWeb Mainnet',
         genesisId: 'neuroweb-mainnet',
+        networkId: '83698bd2a305d6261169bfe96dd7c2f8aa9d24bee92150eee949a9a89bb68729',
         chainName: 'neuroweb',
         chainId: 'neuroweb:2043',
         rpcUrl: 'https://astrosat-parachain-rpc.origin-trail.network',
@@ -217,7 +220,8 @@ describe('loadNetworkConfig', () => {
       }).toEqual(sharedMainnetPrep);
       expect(cfg.networkName).toBe(expected.networkName);
       expect(cfg.genesisId).toBe(expected.genesisId);
-      expect(cfg.networkId).toBe(await computeNetworkId(expected.genesisId));
+      expect(cfg.networkId).toBe(expected.networkId);
+      expect(await computeNetworkId(expected.genesisId)).toBe(expected.networkId);
       for (const relay of cfg.relays) {
         expect(relay).toMatch(/^\/ip4\/178\./);
         expect(relay).toMatch(/\/p2p\/PEER_ID_/);

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -569,6 +569,15 @@ describe('resolveChainConfig (field-level merge)', () => {
     });
   });
 
+  it('refuses to resolve chain defaults from a pre-deployment network', () => {
+    expect(() => resolveChainConfig({}, {
+      _status: 'pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet',
+      networkName: 'DKG V10 Base Mainnet',
+      relays: ['/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS'],
+      chain: fullNetworkChain,
+    })).toThrow(/pre-deployment/);
+  });
+
   it('overrides only the fields the operator set, inheriting the rest from network', () => {
     // Operator wants their private RPC but should inherit hub + chainId.
     const merged = resolveChainConfig(

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -140,8 +140,9 @@ describe('loadNetworkConfig', () => {
       expect(config).toBeNull();
       return;
     }
-    expect(config.networkName).toMatch(/testnet/i);
+    expect(config.networkName).toBe('DKG V10 Base Testnet');
     expect((config as any).genesisId).toBe('base-testnet');
+    expect(config.networkId).toBe('7449c543ff04a550b2dafa999fe8ee577a00b212023bb4d4244e8d58a4792c7b');
   });
 
   it('loads mainnet prep configs without activating testnet genesis or relays', async () => {

--- a/packages/cli/test/daemon-lifecycle.test.ts
+++ b/packages/cli/test/daemon-lifecycle.test.ts
@@ -41,6 +41,27 @@ describe('daemon startup genesis validation', () => {
       ],
     });
   });
+
+  it('rejects pre-deployment configs with placeholder relay peer ids', async () => {
+    const networkId = await computeNetworkId('base-mainnet');
+
+    const result = await validateStartupGenesis({
+      networkName: 'DKG V10 Base Mainnet',
+      genesisId: 'base-mainnet',
+      networkId,
+      _status: 'pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet',
+      relays: ['/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS'],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.networkId).toBe(networkId);
+    if (!result.ok) {
+      expect(result.messages).toContain(
+        'FATAL: network config DKG V10 Base Mainnet is marked pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet.',
+      );
+      expect(result.messages.some(message => message.includes('PEER_ID_SOLARIS'))).toBe(true);
+    }
+  });
 });
 
 async function writeWorkspaceTsconfig(tsconfigPath: string): Promise<void> {

--- a/packages/cli/test/daemon-lifecycle.test.ts
+++ b/packages/cli/test/daemon-lifecycle.test.ts
@@ -5,11 +5,25 @@ import { spawn } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { computeNetworkId } from '../../core/src/genesis.js';
+import { validateStartupGenesis } from '../src/daemon.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..', '..');
 const cliSource = join(__dirname, '..', 'src', 'cli.ts');
 const tsxLoader = join(repoRoot, 'node_modules', 'tsx', 'dist', 'loader.mjs');
+
+describe('daemon startup genesis validation', () => {
+  it('continues when the selected network genesis id matches its network id', async () => {
+    const networkId = await computeNetworkId('gnosis-mainnet');
+
+    await expect(validateStartupGenesis({
+      networkName: 'DKG V10 Gnosis Mainnet',
+      genesisId: 'gnosis-mainnet',
+      networkId,
+    })).resolves.toEqual({ ok: true, networkId });
+  });
+});
 
 async function writeWorkspaceTsconfig(tsconfigPath: string): Promise<void> {
   const packagesDir = join(repoRoot, 'packages');

--- a/packages/cli/test/daemon-lifecycle.test.ts
+++ b/packages/cli/test/daemon-lifecycle.test.ts
@@ -23,6 +23,24 @@ describe('daemon startup genesis validation', () => {
       networkId,
     })).resolves.toEqual({ ok: true, networkId });
   });
+
+  it('reports the selected overlay when the selected genesis id mismatches its network id', async () => {
+    const staleNetworkId = await computeNetworkId('base-mainnet');
+    const selectedNetworkId = await computeNetworkId('neuroweb-mainnet');
+
+    await expect(validateStartupGenesis({
+      networkName: 'DKG V10 NeuroWeb Mainnet',
+      genesisId: 'neuroweb-mainnet',
+      networkId: staleNetworkId,
+    })).resolves.toEqual({
+      ok: false,
+      networkId: selectedNetworkId,
+      messages: [
+        `FATAL: genesis mismatch! Expected networkId ${staleNetworkId.slice(0, 16)}... but computed ${selectedNetworkId.slice(0, 16)}...`,
+        `This node's genesis does not match DKG V10 NeuroWeb Mainnet. Rebuild or update the selected network config.`,
+      ],
+    });
+  });
 });
 
 async function writeWorkspaceTsconfig(tsconfigPath: string): Promise<void> {

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -6,6 +6,7 @@ import { computeNetworkId } from '../../core/src/genesis.js';
 
 const mocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
+  loadOpWallets: vi.fn(),
   loadNetworkConfig: vi.fn(),
 }));
 
@@ -14,7 +15,7 @@ vi.mock('@origintrail-official/dkg-agent', async importOriginal => {
   return {
     ...actual,
     DKGAgent: { create: mocks.agentCreate },
-    loadOpWallets: vi.fn(),
+    loadOpWallets: mocks.loadOpWallets,
     KaNumberAllocator: class KaNumberAllocator {},
   };
 });
@@ -39,6 +40,7 @@ describe('daemon startup network validation', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    vi.clearAllMocks();
     process.stdout.write = stdoutWrite;
     process.stderr.write = stderrWrite;
     process.removeAllListeners('uncaughtException');
@@ -96,5 +98,39 @@ describe('daemon startup network validation', () => {
     expect(stdoutSpy.mock.calls.map(call => String(call[0])).join('')).toContain(
       'FATAL: network config DKG V10 Base Mainnet is marked pre-deployment',
     );
+  });
+
+  it('passes the selected network genesis id into agent creation', async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-genesis-startup-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+
+    const networkId = await computeNetworkId('gnosis-mainnet');
+    mocks.loadNetworkConfig.mockResolvedValue({
+      networkName: 'DKG V10 Gnosis Mainnet',
+      genesisId: 'gnosis-mainnet',
+      networkId,
+      genesisVersion: 1,
+      relays: [],
+      defaultNodeRole: 'edge',
+    });
+    mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
+    mocks.agentCreate.mockRejectedValue(new Error('after-agent-create'));
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await expect(runDaemonInner(true, {
+      name: 'genesis-startup-test',
+      listenPort: 0,
+      nodeRole: 'edge',
+    } as any, Date.now())).rejects.toThrow('after-agent-create');
+
+    expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
+    expect(mocks.agentCreate.mock.calls[0]?.[0]).toMatchObject({
+      genesisId: 'gnosis-mainnet',
+    });
   });
 });

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -9,11 +9,15 @@ const mocks = vi.hoisted(() => ({
   loadNetworkConfig: vi.fn(),
 }));
 
-vi.mock('@origintrail-official/dkg-agent', () => ({
-  DKGAgent: { create: mocks.agentCreate },
-  loadOpWallets: vi.fn(),
-  KaNumberAllocator: class KaNumberAllocator {},
-}));
+vi.mock('@origintrail-official/dkg-agent', async importOriginal => {
+  const actual = await importOriginal<typeof import('@origintrail-official/dkg-agent')>();
+  return {
+    ...actual,
+    DKGAgent: { create: mocks.agentCreate },
+    loadOpWallets: vi.fn(),
+    KaNumberAllocator: class KaNumberAllocator {},
+  };
+});
 
 vi.mock('../src/config.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/config.js')>();
@@ -28,13 +32,23 @@ const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
 describe('daemon startup network validation', () => {
   let tempHome: string | undefined;
   let originalDkgHome: string | undefined;
-  let stdoutWrite: typeof process.stdout.write;
-  let stderrWrite: typeof process.stderr.write;
+  let stdoutWrite: typeof process.stdout.write = process.stdout.write;
+  let stderrWrite: typeof process.stderr.write = process.stderr.write;
+  let uncaughtExceptionListeners: NodeJS.UncaughtExceptionListener[] = [];
+  let unhandledRejectionListeners: NodeJS.UnhandledRejectionListener[] = [];
 
   afterEach(async () => {
     vi.restoreAllMocks();
     process.stdout.write = stdoutWrite;
     process.stderr.write = stderrWrite;
+    process.removeAllListeners('uncaughtException');
+    for (const listener of uncaughtExceptionListeners) {
+      process.on('uncaughtException', listener);
+    }
+    process.removeAllListeners('unhandledRejection');
+    for (const listener of unhandledRejectionListeners) {
+      process.on('unhandledRejection', listener);
+    }
     if (originalDkgHome === undefined) {
       delete process.env.DKG_HOME;
     } else {
@@ -50,6 +64,8 @@ describe('daemon startup network validation', () => {
     process.env.DKG_HOME = tempHome;
     stdoutWrite = process.stdout.write;
     stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
 
     const networkId = await computeNetworkId('base-mainnet');
     mocks.loadNetworkConfig.mockResolvedValue({

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { computeNetworkId } from '../../core/src/genesis.js';
+
+const mocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  loadNetworkConfig: vi.fn(),
+}));
+
+vi.mock('@origintrail-official/dkg-agent', () => ({
+  DKGAgent: { create: mocks.agentCreate },
+  loadOpWallets: vi.fn(),
+  KaNumberAllocator: class KaNumberAllocator {},
+}));
+
+vi.mock('../src/config.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/config.js')>();
+  return {
+    ...actual,
+    loadNetworkConfig: mocks.loadNetworkConfig,
+  };
+});
+
+const { runDaemonInner } = await import('../src/daemon/lifecycle.js');
+
+describe('daemon startup network validation', () => {
+  let tempHome: string | undefined;
+  let originalDkgHome: string | undefined;
+  let stdoutWrite: typeof process.stdout.write;
+  let stderrWrite: typeof process.stderr.write;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+    if (originalDkgHome === undefined) {
+      delete process.env.DKG_HOME;
+    } else {
+      process.env.DKG_HOME = originalDkgHome;
+    }
+    if (tempHome) await rm(tempHome, { recursive: true, force: true });
+    tempHome = undefined;
+  });
+
+  it('exits before agent creation when the selected network is pre-deployment', async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-predeployment-startup-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+
+    const networkId = await computeNetworkId('base-mainnet');
+    mocks.loadNetworkConfig.mockResolvedValue({
+      _status: 'pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet',
+      networkName: 'DKG V10 Base Mainnet',
+      genesisId: 'base-mainnet',
+      networkId,
+      genesisVersion: 1,
+      relays: ['/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS'],
+      defaultNodeRole: 'edge',
+    });
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: string | number | null) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+    await expect(runDaemonInner(true, {
+      name: 'predeployment-startup-test',
+      listenPort: 0,
+      nodeRole: 'edge',
+    } as any, Date.now())).rejects.toThrow('process.exit:1');
+
+    expect(mocks.agentCreate).not.toHaveBeenCalled();
+    expect(stdoutSpy.mock.calls.map(call => String(call[0])).join('')).toContain(
+      'FATAL: network config DKG V10 Base Mainnet is marked pre-deployment',
+    );
+  });
+});

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -20,7 +20,13 @@
  *     'RPC health probe failed' error, and never echoes an RPC URL.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { computeNetworkId } from '../../core/src/genesis.js';
 import { getSharedContext } from '../../chain/test/evm-test-context.js';
+import { loadNetworkConfig } from '../src/config.js';
+import { handleStatusRoutes } from '../src/daemon/routes/status.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
 import { startLiveDaemon, stopLiveDaemon, authHeaders, type LiveDaemon } from './helpers/live-daemon.js';
 
 // A port nothing listens on — connecting to it is a REAL refused connection.
@@ -89,6 +95,55 @@ describe('/api/status + /api/chain/rpc-health (real daemon, real chain)', () => 
     expect(typeof body.blockNumber).toBe('number');
     for (const probe of body.rpcs) {
       expect(probe).not.toHaveProperty('rpcUrl');
+    }
+  });
+});
+
+describe('/api/status selected overlay details', () => {
+  it('returns the network id and name for the selected overlay genesis', async () => {
+    const network = await loadNetworkConfig('mainnet-gnosis');
+    expect(network).not.toBeNull();
+
+    const server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      await handleStatusRoutes({
+        req,
+        res,
+        path: url.pathname,
+        url,
+        network,
+        config: {
+          name: 'status-selected-overlay-test',
+          nodeRole: 'edge',
+          chain: { type: 'mock' },
+        },
+        startedAt: Date.now(),
+        agent: {
+          peerId: 'peer-status-test',
+          multiaddrs: [],
+          node: {
+            libp2p: { getConnections: () => [] },
+            getRelayStats: () => null,
+          },
+          publisher: { getIdentityId: () => 0n },
+        },
+        nodeVersion: '0.0.0-test',
+        nodeCommit: '',
+      } as unknown as RequestContext);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const address = server.address() as AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${address.port}/api/status`);
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      const selectedNetworkId = await computeNetworkId('gnosis-mainnet');
+
+      expect(body.networkId).toBe(selectedNetworkId.slice(0, 16));
+      expect(body.networkName).toBe('DKG V10 Gnosis Mainnet');
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
     }
   });
 });

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -195,8 +195,37 @@ export async function computeNetworkId(genesisId: string = DEFAULT_GENESIS_ID): 
   return hex;
 }
 
-export function getGenesisRaw(): string {
-  return GENESIS_TRIG;
+function buildGenesisRaw(network: GenesisNetworkDefinition): string {
+  const systemContextGraphLines = network.systemContextGraphs
+    .map((graph, index) => {
+      const terminator = index === network.systemContextGraphs.length - 1 ? '.' : ';';
+      return `    dkg:systemContextGraphs <${graph}> ${terminator}`;
+    })
+    .join('\n');
+
+  return `\
+@prefix dkg:     <https://dkg.network/ontology#> .
+@prefix erc8004: <https://eips.ethereum.org/erc-8004#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix schema:  <https://schema.org/> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<${network.subject}>
+    a dkg:Network ;
+    schema:name "${network.name}" ;
+    dkg:genesisVersion "1"^^xsd:integer ;
+    dkg:createdAt "${network.createdAt}"^^xsd:dateTime ;
+${systemContextGraphLines}
+`;
+}
+
+export function getGenesisRaw(genesisId: string = DEFAULT_GENESIS_ID): string {
+  if (genesisId === DEFAULT_GENESIS_ID) {
+    return GENESIS_TRIG;
+  }
+  return buildGenesisRaw(getGenesisNetwork(genesisId));
 }
 
 export const SYSTEM_CONTEXT_GRAPHS = {

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -30,6 +30,18 @@ const GENESIS_NETWORKS = {
     createdAt: '2026-06-20T00:00:00Z',
     systemContextGraphs: [GENESIS_AGENTS_GRAPH, GENESIS_ONTOLOGY_GRAPH],
   },
+  'gnosis-mainnet': {
+    subject: 'did:dkg:network:gnosis-mainnet',
+    name: 'DKG V10 Gnosis Mainnet',
+    createdAt: '2026-06-20T00:00:00Z',
+    systemContextGraphs: [GENESIS_AGENTS_GRAPH, GENESIS_ONTOLOGY_GRAPH],
+  },
+  'neuroweb-mainnet': {
+    subject: 'did:dkg:network:neuroweb-mainnet',
+    name: 'DKG V10 NeuroWeb Mainnet',
+    createdAt: '2026-06-20T00:00:00Z',
+    systemContextGraphs: [GENESIS_AGENTS_GRAPH, GENESIS_ONTOLOGY_GRAPH],
+  },
 } satisfies Record<string, GenesisNetworkDefinition>;
 
 export type GenesisId = keyof typeof GENESIS_NETWORKS;

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -6,6 +6,34 @@
  * the networkId, ensuring only nodes with identical genesis can peer.
  */
 
+const GENESIS_AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+const GENESIS_ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
+const DEFAULT_GENESIS_ID = 'base-testnet';
+
+interface GenesisNetworkDefinition {
+  subject: string;
+  name: string;
+  createdAt: string;
+  systemContextGraphs: readonly string[];
+}
+
+const GENESIS_NETWORKS = {
+  'base-testnet': {
+    subject: 'did:dkg:network:v9-testnet',
+    name: 'DKG V9 Testnet',
+    createdAt: '2026-02-24T00:00:00Z',
+    systemContextGraphs: [GENESIS_AGENTS_GRAPH, GENESIS_ONTOLOGY_GRAPH],
+  },
+  'base-mainnet': {
+    subject: 'did:dkg:network:base-mainnet',
+    name: 'DKG V10 Base Mainnet',
+    createdAt: '2026-06-20T00:00:00Z',
+    systemContextGraphs: [GENESIS_AGENTS_GRAPH, GENESIS_ONTOLOGY_GRAPH],
+  },
+} satisfies Record<string, GenesisNetworkDefinition>;
+
+export type GenesisId = keyof typeof GENESIS_NETWORKS;
+
 const GENESIS_TRIG = `\
 @prefix dkg:     <https://dkg.network/ontology#> .
 @prefix erc8004: <https://eips.ethereum.org/erc-8004#> .
@@ -23,9 +51,6 @@ const GENESIS_TRIG = `\
     dkg:systemContextGraphs <did:dkg:context-graph:agents> ;
     dkg:systemContextGraphs <did:dkg:context-graph:ontology> .
 `;
-
-const GENESIS_AGENTS_GRAPH = 'did:dkg:context-graph:agents';
-const GENESIS_ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
 
 export interface GenesisQuad {
   subject: string;
@@ -48,19 +73,29 @@ function q(graph: string, s: string, p: string, o: string): GenesisQuad {
   return { subject: s, predicate: p, object: o, graph };
 }
 
-function buildGenesisQuads(): GenesisQuad[] {
+function getGenesisNetwork(genesisId: string): GenesisNetworkDefinition {
+  const network = GENESIS_NETWORKS[genesisId as GenesisId];
+  if (!network) {
+    throw new Error(`Unknown genesisId: ${genesisId}`);
+  }
+  return network;
+}
+
+function buildGenesisQuads(genesisId: string): GenesisQuad[] {
   const quads: GenesisQuad[] = [];
   const DEFAULT = '';
   const AG = GENESIS_AGENTS_GRAPH;
   const OG = GENESIS_ONTOLOGY_GRAPH;
+  const network = getGenesisNetwork(genesisId);
 
   // --- Default graph: network definition ---
-  quads.push(q(DEFAULT, 'did:dkg:network:v9-testnet', `${RDF}type`, `${DKG}Network`));
-  quads.push(q(DEFAULT, 'did:dkg:network:v9-testnet', `${SCHEMA}name`, '"DKG V9 Testnet"'));
-  quads.push(q(DEFAULT, 'did:dkg:network:v9-testnet', `${DKG}genesisVersion`, '"1"'));
-  quads.push(q(DEFAULT, 'did:dkg:network:v9-testnet', `${DKG}createdAt`, '"2026-02-24T00:00:00Z"'));
-  quads.push(q(DEFAULT, 'did:dkg:network:v9-testnet', `${DKG}systemContextGraphs`, `did:dkg:context-graph:agents`));
-  quads.push(q(DEFAULT, 'did:dkg:network:v9-testnet', `${DKG}systemContextGraphs`, `did:dkg:context-graph:ontology`));
+  quads.push(q(DEFAULT, network.subject, `${RDF}type`, `${DKG}Network`));
+  quads.push(q(DEFAULT, network.subject, `${SCHEMA}name`, `"${network.name}"`));
+  quads.push(q(DEFAULT, network.subject, `${DKG}genesisVersion`, '"1"'));
+  quads.push(q(DEFAULT, network.subject, `${DKG}createdAt`, `"${network.createdAt}"`));
+  for (const graph of network.systemContextGraphs) {
+    quads.push(q(DEFAULT, network.subject, `${DKG}systemContextGraphs`, graph));
+  }
 
   // --- Agents contextGraph definition ---
   quads.push(q(AG, 'did:dkg:context-graph:agents', `${RDF}type`, `${DKG}ContextGraph`));
@@ -107,22 +142,25 @@ function buildGenesisQuads(): GenesisQuad[] {
   return quads;
 }
 
-let _cachedQuads: GenesisQuad[] | null = null;
-let _cachedNetworkId: string | null = null;
+const _cachedQuads = new Map<string, GenesisQuad[]>();
+const _cachedNetworkIds = new Map<string, string>();
 
-export function getGenesisQuads(): GenesisQuad[] {
-  if (!_cachedQuads) {
-    _cachedQuads = buildGenesisQuads();
+export function getGenesisQuads(genesisId: string = DEFAULT_GENESIS_ID): GenesisQuad[] {
+  const cached = _cachedQuads.get(genesisId);
+  if (cached) {
+    return cached;
   }
-  return _cachedQuads;
+  const quads = buildGenesisQuads(genesisId);
+  _cachedQuads.set(genesisId, quads);
+  return quads;
 }
 
 /**
  * Canonical representation of genesis for hashing.
  * Sorted N-Quads lines to ensure deterministic output.
  */
-function canonicalGenesisString(): string {
-  const quads = getGenesisQuads();
+function canonicalGenesisString(genesisId: string): string {
+  const quads = getGenesisQuads(genesisId);
   const lines = quads.map(q => {
     const s = q.subject.startsWith('"') ? q.subject : `<${q.subject}>`;
     const p = `<${q.predicate}>`;
@@ -133,14 +171,15 @@ function canonicalGenesisString(): string {
   return lines.sort().join('\n');
 }
 
-export async function computeNetworkId(): Promise<string> {
-  if (_cachedNetworkId) return _cachedNetworkId;
+export async function computeNetworkId(genesisId: string = DEFAULT_GENESIS_ID): Promise<string> {
+  const cached = _cachedNetworkIds.get(genesisId);
+  if (cached) return cached;
 
-  const data = new TextEncoder().encode(canonicalGenesisString());
+  const data = new TextEncoder().encode(canonicalGenesisString(genesisId));
   const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
   const hashArray = new Uint8Array(hashBuffer);
   const hex = Array.from(hashArray).map(b => b.toString(16).padStart(2, '0')).join('');
-  _cachedNetworkId = hex;
+  _cachedNetworkIds.set(genesisId, hex);
   return hex;
 }
 

--- a/packages/core/src/genesis.ts
+++ b/packages/core/src/genesis.ts
@@ -46,24 +46,6 @@ const GENESIS_NETWORKS = {
 
 export type GenesisId = keyof typeof GENESIS_NETWORKS;
 
-const GENESIS_TRIG = `\
-@prefix dkg:     <https://dkg.network/ontology#> .
-@prefix erc8004: <https://eips.ethereum.org/erc-8004#> .
-@prefix prov:    <http://www.w3.org/ns/prov#> .
-@prefix schema:  <https://schema.org/> .
-@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
-
-<did:dkg:network:v9-testnet>
-    a dkg:Network ;
-    schema:name "DKG V9 Testnet" ;
-    dkg:genesisVersion "1"^^xsd:integer ;
-    dkg:createdAt "2026-02-24T00:00:00Z"^^xsd:dateTime ;
-    dkg:systemContextGraphs <did:dkg:context-graph:agents> ;
-    dkg:systemContextGraphs <did:dkg:context-graph:ontology> .
-`;
-
 export interface GenesisQuad {
   subject: string;
   predicate: string;
@@ -222,9 +204,6 @@ ${systemContextGraphLines}
 }
 
 export function getGenesisRaw(genesisId: string = DEFAULT_GENESIS_ID): string {
-  if (genesisId === DEFAULT_GENESIS_ID) {
-    return GENESIS_TRIG;
-  }
   return buildGenesisRaw(getGenesisNetwork(genesisId));
 }
 

--- a/packages/core/test/genesis.test.ts
+++ b/packages/core/test/genesis.test.ts
@@ -78,6 +78,35 @@ describe('getGenesisQuads', () => {
     });
   });
 
+  it('selects distinct mainnet genesis documents by Genesis ID', async () => {
+    const mainnetGenesis = [
+      { genesisId: 'base-mainnet', subject: 'did:dkg:network:base-mainnet', name: '"DKG V10 Base Mainnet"' },
+      { genesisId: 'gnosis-mainnet', subject: 'did:dkg:network:gnosis-mainnet', name: '"DKG V10 Gnosis Mainnet"' },
+      { genesisId: 'neuroweb-mainnet', subject: 'did:dkg:network:neuroweb-mainnet', name: '"DKG V10 NeuroWeb Mainnet"' },
+    ];
+    const networkIds: string[] = [];
+
+    for (const { genesisId, subject, name } of mainnetGenesis) {
+      const quads = getGenesisQuads(genesisId);
+      expect(quads).toContainEqual({
+        subject,
+        predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+        object: name,
+        graph: '',
+      });
+      expect(quads).toContainEqual({
+        subject,
+        predicate: DKG_ONTOLOGY.DKG_CREATED_AT,
+        object: '"2026-06-20T00:00:00Z"',
+        graph: '',
+      });
+      networkIds.push(await computeNetworkId(genesisId));
+    }
+
+    expect(new Set(networkIds).size).toBe(mainnetGenesis.length);
+    expect(networkIds).not.toContain(await computeNetworkId('base-testnet'));
+  });
+
   it('genesis content integrity check — hash detects any modification', () => {
     const raw = getGenesisRaw();
     const hash = sha256(new TextEncoder().encode(raw));

--- a/packages/core/test/genesis.test.ts
+++ b/packages/core/test/genesis.test.ts
@@ -68,6 +68,16 @@ describe('getGenesisQuads', () => {
     expect(a).toEqual(b);
   });
 
+  it('selects Base mainnet genesis data by Genesis ID', () => {
+    const quads = getGenesisQuads('base-mainnet');
+    expect(quads).toContainEqual({
+      subject: 'did:dkg:network:base-mainnet',
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_NETWORK,
+      graph: '',
+    });
+  });
+
   it('genesis content integrity check — hash detects any modification', () => {
     const raw = getGenesisRaw();
     const hash = sha256(new TextEncoder().encode(raw));

--- a/packages/core/test/genesis.test.ts
+++ b/packages/core/test/genesis.test.ts
@@ -143,6 +143,13 @@ describe('getGenesisRaw', () => {
     expect(raw).toContain('did:dkg:context-graph:agents');
     expect(raw).toContain('did:dkg:context-graph:ontology');
   });
+
+  it('returns selected mainnet Genesis Data as TriG', () => {
+    const raw = getGenesisRaw('gnosis-mainnet');
+    expect(raw).toContain('<did:dkg:network:gnosis-mainnet>');
+    expect(raw).toContain('schema:name "DKG V10 Gnosis Mainnet"');
+    expect(raw).toContain('dkg:createdAt "2026-06-20T00:00:00Z"^^xsd:dateTime');
+  });
 });
 
 describe('SYSTEM_CONTEXT_GRAPHS', () => {


### PR DESCRIPTION
Summary:
- Add the genesis-derived DKG networkId to Base, Gnosis, and NeuroWeb mainnet configs.
- Add Hub addresses from /Users/zvonimir/projects/protocol/dkg-evm-module/deployments/*_mainnet_contracts.json.
- Remove stale pre-deployment status markers.

Validation:
- jq . network/mainnet-base.json network/mainnet-gnosis.json network/mainnet-neuroweb.json
- node assertion comparing each config hubAddress to the source deployment artifact
- git diff --check

Note:
- pnpm --dir packages/cli exec vitest run test/config.test.ts could not run because vitest is not installed in this worktree.