### PR TITLE
Guard repeated relay flaps

### DIFF
--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -21,7 +21,7 @@ import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
 import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
 import { readRelayReservations, readConnectionStreams } from './relay-internal-shapes.js';
-import { RelayFlapGuard, parseCircuitRelayPeerIds } from './relay-flap-guard.js';
+import { RelayFlapGuard, parseCircuitRelayPeerIds, buildRelayFlapConnectionGater } from './relay-flap-guard.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -1416,41 +1416,14 @@ export class DKGNode {
   }
 
   private createRelayFlapConnectionGater(): ConnectionGater {
-    const short = (id: string) => id.slice(-8);
     const ts = () => new Date().toISOString();
-    const denyRelayedPath = (
-      direction: 'inbound' | 'outbound',
-      relayPeerId: string,
-      remotePeerId: string,
-      addr?: string,
-    ): boolean => {
-      const result = this.relayFlapGuard.checkRelayedConnection({
-        relayPeerId,
-        remotePeerId,
-      });
-      if (!result.deny) return false;
-
-      if (result.shouldLog) {
-        const remainingSeconds = Math.ceil((result.quarantineMsRemaining ?? 0) / 1000);
-        console.warn(
-          `[${ts()}] Relay flap guard: denying ${direction} relayed connection ` +
-          `remote=${short(remotePeerId)} relay=${short(relayPeerId)} ` +
-          `quarantineRemaining=${remainingSeconds}s${addr ? ` addr=${addr}` : ''}`,
-        );
-      }
-      return true;
-    };
-
-    return {
-      denyInboundRelayedConnection: (relay, remotePeer) =>
-        denyRelayedPath('inbound', relay.toString(), remotePeer.toString()),
-      denyDialMultiaddr: (multiaddr) => {
-        const addr = multiaddr.toString();
-        const parsed = parseCircuitRelayPeerIds(addr);
-        if (!parsed?.remotePeerId) return false;
-        return denyRelayedPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr);
-      },
-    };
+    // The gater hooks live in a pure builder (relay-flap-guard.ts) so the wiring
+    // is unit-tested (relay-flap-guard.test.ts) — a hook arg-shape or plumbing
+    // regression fails a test instead of silently leaving the guard inert.
+    return buildRelayFlapConnectionGater(
+      this.relayFlapGuard,
+      (message) => console.warn(`[${ts()}] ${message}`),
+    ) as ConnectionGater;
   }
 
   /**

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -13,6 +13,7 @@ import { circuitRelayTransport } from '@libp2p/circuit-relay-v2';
 import { circuitRelayServer } from '@libp2p/circuit-relay-v2';
 import { dcutr } from '@libp2p/dcutr';
 import { autoNAT } from '@libp2p/autonat';
+import type { ConnectionGater } from '@libp2p/interface';
 import { generateKeyPair, privateKeyFromRaw } from '@libp2p/crypto/keys';
 import { peerIdFromString, peerIdFromPrivateKey } from '@libp2p/peer-id';
 import { ed25519GetPublicKey } from './crypto/ed25519.js';
@@ -20,6 +21,7 @@ import type { ConnectionTransport, DKGNodeConfig } from './types.js';
 import { DHT_PROTOCOL, DKG_GOSSIP_MAX_RPC_BYTES } from './constants.js';
 import { RelayMetricsAdapter, RELAY_V2_STOP_CODEC } from './libp2p-metrics-adapter.js';
 import { readRelayReservations, readConnectionStreams } from './relay-internal-shapes.js';
+import { RelayFlapGuard, parseCircuitRelayPeerIds } from './relay-flap-guard.js';
 
 export interface DKGServices extends Record<string, unknown> {
   dht: KadDHT;
@@ -482,6 +484,7 @@ export class DKGNode {
   private readonly config: DKGNodeConfig;
   /** Peers currently connected only via relay (candidates for DCUtR upgrade). */
   private readonly relayedPeers = new Set<string>();
+  private readonly relayFlapGuard = new RelayFlapGuard();
   private relayWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
   private relayTargets: RelayTarget[] = [];
   private relayWatchdogConsecutiveFailures = 0;
@@ -1070,6 +1073,7 @@ export class DKGNode {
       streamMuxers: [yamux()],
       peerDiscovery,
       services,
+      connectionGater: this.createRelayFlapConnectionGater(),
       connectionManager: {
         minConnections: 0,
         // Core Nodes scale this with relayServerCapacity (default
@@ -1411,6 +1415,44 @@ export class DKGNode {
     }
   }
 
+  private createRelayFlapConnectionGater(): ConnectionGater {
+    const short = (id: string) => id.slice(-8);
+    const ts = () => new Date().toISOString();
+    const denyRelayedPath = (
+      direction: 'inbound' | 'outbound',
+      relayPeerId: string,
+      remotePeerId: string,
+      addr?: string,
+    ): boolean => {
+      const result = this.relayFlapGuard.checkRelayedConnection({
+        relayPeerId,
+        remotePeerId,
+      });
+      if (!result.deny) return false;
+
+      if (result.shouldLog) {
+        const remainingSeconds = Math.ceil((result.quarantineMsRemaining ?? 0) / 1000);
+        console.warn(
+          `[${ts()}] Relay flap guard: denying ${direction} relayed connection ` +
+          `remote=${short(remotePeerId)} relay=${short(relayPeerId)} ` +
+          `quarantineRemaining=${remainingSeconds}s${addr ? ` addr=${addr}` : ''}`,
+        );
+      }
+      return true;
+    };
+
+    return {
+      denyInboundRelayedConnection: (relay, remotePeer) =>
+        denyRelayedPath('inbound', relay.toString(), remotePeer.toString()),
+      denyDialMultiaddr: (multiaddr) => {
+        const addr = multiaddr.toString();
+        const parsed = parseCircuitRelayPeerIds(addr);
+        if (!parsed?.remotePeerId) return false;
+        return denyRelayedPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr);
+      },
+    };
+  }
+
   /**
    * Wire up connection:open / connection:close listeners that track transport
    * type (direct vs relayed) and detect DCUtR upgrades from relay to direct.
@@ -1437,6 +1479,7 @@ export class DKGNode {
         const upgraded = this.relayedPeers.has(pid);
         if (upgraded) {
           this.relayedPeers.delete(pid);
+          this.relayFlapGuard.clearRemotePeer(pid);
           console.log(
             `[${ts()}] DCUtR upgrade: ${short(pid)} relayed -> direct ` +
             `dir=${dir} addr=${addr}`,
@@ -1457,7 +1500,7 @@ export class DKGNode {
       const transport: ConnectionTransport = addr.includes('/p2p-circuit') ? 'relayed' : 'direct';
       const durationMs = conn.timeline.close
         ? conn.timeline.close - conn.timeline.open
-        : '?';
+        : null;
 
       // If this was the last connection to the peer, clean up tracking state.
       const remaining = node.getConnections(conn.remotePeer);
@@ -1465,9 +1508,30 @@ export class DKGNode {
         this.relayedPeers.delete(pid);
       }
 
+      if (transport === 'relayed' && durationMs != null) {
+        const relayPath = parseCircuitRelayPeerIds(addr);
+        if (relayPath) {
+          const result = this.relayFlapGuard.recordRelayedClose({
+            relayPeerId: relayPath.relayPeerId,
+            remotePeerId: pid,
+            durationMs,
+          });
+          if (result.enteredQuarantine) {
+            console.warn(
+              `[${ts()}] Relay flap guard: quarantined relayed path ` +
+              `remote=${short(pid)} relay=${short(relayPath.relayPeerId)} ` +
+              `shortCloses=${result.shortCloseCount} ` +
+              `ttl=${Math.ceil((result.quarantineTtlMs ?? 0) / 1000)}s`,
+            );
+          }
+        }
+      } else if (transport === 'direct' && durationMs != null) {
+        this.relayFlapGuard.recordDirectClose({ remotePeerId: pid, durationMs });
+      }
+
       console.log(
         `[${ts()}] Connection closed: ${short(pid)} transport=${transport} ` +
-        `duration=${durationMs}ms addr=${addr}`,
+        `duration=${durationMs ?? '?'}ms addr=${addr}`,
       );
     });
 

--- a/packages/core/src/relay-flap-guard.ts
+++ b/packages/core/src/relay-flap-guard.ts
@@ -139,7 +139,10 @@ export class RelayFlapGuard {
     const key = pairKey(input.relayPeerId, input.remotePeerId);
     const existing = this.pairs.get(key);
     if (input.durationMs >= this.options.shortCloseMs) {
-      if (existing) this.prune(existing, now);
+      if (existing) {
+        this.prune(existing, now);
+        this.evictIfIdle(key, existing, now);
+      }
       return {
         shortClose: false,
         shortCloseCount: existing?.shortCloseTimes.length ?? 0,
@@ -205,11 +208,15 @@ export class RelayFlapGuard {
     now?: number;
   }): RelayFlapDenyResult {
     const now = input.now ?? Date.now();
-    const state = this.pairs.get(pairKey(input.relayPeerId, input.remotePeerId));
+    const key = pairKey(input.relayPeerId, input.remotePeerId);
+    const state = this.pairs.get(key);
     if (!state) return { deny: false, shouldLog: false };
 
     if (state.quarantineUntil <= now) {
+      // Quarantine lapsed — prune stale closes, and if the pair now carries no
+      // useful state, evict it so the map stays bounded on long-lived nodes.
       this.prune(state, now);
+      this.evictIfIdle(key, state, now);
       return { deny: false, shouldLog: false };
     }
 
@@ -266,4 +273,77 @@ export class RelayFlapGuard {
     const cutoff = now - this.options.windowMs;
     state.shortCloseTimes = state.shortCloseTimes.filter((ts) => ts >= cutoff);
   }
+
+  /**
+   * Drop a pair from the tracking map once it carries no useful state — no
+   * in-window short closes AND no active quarantine. Without this the map grows
+   * without bound on long-lived nodes that see many transient relayed peers,
+   * and stale `strikes` would inflate future quarantines via the exponential
+   * backoff. Returns true if the entry was evicted.
+   */
+  private evictIfIdle(key: string, state: RelayFlapPairState, now: number): boolean {
+    if (state.shortCloseTimes.length === 0 && state.quarantineUntil <= now) {
+      this.pairs.delete(key);
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Minimal structural shape of the libp2p ConnectionGater hooks this guard
+ * implements. Kept structural (`{ toString(): string }`) so the gater can be
+ * unit-tested without importing libp2p's PeerId/Multiaddr types — the module
+ * stays a dependency-free, pure state machine.
+ */
+export interface RelayFlapConnectionGater {
+  denyInboundRelayedConnection(relay: { toString(): string }, remotePeer: { toString(): string }): boolean;
+  denyDialMultiaddr(multiaddr: { toString(): string }): boolean;
+}
+
+/**
+ * Build the libp2p connection-gater hooks that enforce a `RelayFlapGuard`.
+ * Extracted as a pure function so the WIRING (not just the guard) is testable:
+ * a regression in the hook arg-shapes or guard plumbing fails a unit test
+ * rather than silently leaving the guard inert in production.
+ *
+ * NOTE on `denyDialMultiaddr`: libp2p (>=3.x / @libp2p/interface 3.x) invokes
+ * this hook with a SINGLE argument — the multiaddr. The remote peer id, when
+ * known, is encoded in that multiaddr as `/p2p/<id>`; `parseCircuitRelayPeerIds`
+ * pulls both the relay and remote ids out of a `/p2p-circuit` address. (Older
+ * libp2p passed `(peerId, multiaddr)` — we are NOT on that shape.)
+ */
+export function buildRelayFlapConnectionGater(
+  guard: RelayFlapGuard,
+  log: (message: string) => void = () => {},
+): RelayFlapConnectionGater {
+  const short = (id: string): string => id.slice(-8);
+  const denyRelayedPath = (
+    direction: 'inbound' | 'outbound',
+    relayPeerId: string,
+    remotePeerId: string,
+    addr?: string,
+  ): boolean => {
+    const result = guard.checkRelayedConnection({ relayPeerId, remotePeerId });
+    if (!result.deny) return false;
+    if (result.shouldLog) {
+      const remainingSeconds = Math.ceil((result.quarantineMsRemaining ?? 0) / 1000);
+      log(
+        `Relay flap guard: denying ${direction} relayed connection ` +
+        `remote=${short(remotePeerId)} relay=${short(relayPeerId)} ` +
+        `quarantineRemaining=${remainingSeconds}s${addr ? ` addr=${addr}` : ''}`,
+      );
+    }
+    return true;
+  };
+  return {
+    denyInboundRelayedConnection: (relay, remotePeer) =>
+      denyRelayedPath('inbound', relay.toString(), remotePeer.toString()),
+    denyDialMultiaddr: (multiaddr) => {
+      const addr = multiaddr.toString();
+      const parsed = parseCircuitRelayPeerIds(addr);
+      if (!parsed?.remotePeerId) return false;
+      return denyRelayedPath('outbound', parsed.relayPeerId, parsed.remotePeerId, addr);
+    },
+  };
 }

--- a/packages/core/src/relay-flap-guard.ts
+++ b/packages/core/src/relay-flap-guard.ts
@@ -1,0 +1,269 @@
+export const RELAY_FLAP_SHORT_CLOSE_MS = 1_000;
+export const RELAY_FLAP_WINDOW_MS = 60_000;
+export const RELAY_FLAP_THRESHOLD = 5;
+export const RELAY_FLAP_BASE_QUARANTINE_MS = 2 * 60_000;
+export const RELAY_FLAP_MAX_QUARANTINE_MS = 10 * 60_000;
+export const RELAY_FLAP_STABLE_CLOSE_MS = 10_000;
+export const RELAY_FLAP_DENY_LOG_INTERVAL_MS = 30_000;
+
+const KEY_SEPARATOR = '\u001f';
+
+export interface RelayPathPeerIds {
+  relayPeerId: string;
+  remotePeerId?: string;
+}
+
+export interface RelayFlapGuardOptions {
+  shortCloseMs?: number;
+  windowMs?: number;
+  threshold?: number;
+  baseQuarantineMs?: number;
+  maxQuarantineMs?: number;
+  stableCloseMs?: number;
+  denyLogIntervalMs?: number;
+}
+
+export interface RelayFlapCloseResult {
+  shortClose: boolean;
+  shortCloseCount: number;
+  enteredQuarantine: boolean;
+  cleared: boolean;
+  quarantineUntil?: number;
+  quarantineTtlMs?: number;
+}
+
+export interface RelayFlapDenyResult {
+  deny: boolean;
+  shouldLog: boolean;
+  quarantineUntil?: number;
+  quarantineMsRemaining?: number;
+}
+
+interface RelayFlapPairState {
+  relayPeerId: string;
+  remotePeerId: string;
+  shortCloseTimes: number[];
+  quarantineUntil: number;
+  strikes: number;
+  lastDenyLogAt?: number;
+}
+
+export interface RelayFlapPairSnapshot {
+  relayPeerId: string;
+  remotePeerId: string;
+  shortCloseCount: number;
+  quarantineUntil: number;
+  strikes: number;
+}
+
+function defaultedOptions(options: RelayFlapGuardOptions): Required<RelayFlapGuardOptions> {
+  return {
+    shortCloseMs: options.shortCloseMs ?? RELAY_FLAP_SHORT_CLOSE_MS,
+    windowMs: options.windowMs ?? RELAY_FLAP_WINDOW_MS,
+    threshold: options.threshold ?? RELAY_FLAP_THRESHOLD,
+    baseQuarantineMs: options.baseQuarantineMs ?? RELAY_FLAP_BASE_QUARANTINE_MS,
+    maxQuarantineMs: options.maxQuarantineMs ?? RELAY_FLAP_MAX_QUARANTINE_MS,
+    stableCloseMs: options.stableCloseMs ?? RELAY_FLAP_STABLE_CLOSE_MS,
+    denyLogIntervalMs: options.denyLogIntervalMs ?? RELAY_FLAP_DENY_LOG_INTERVAL_MS,
+  };
+}
+
+function pairKey(relayPeerId: string, remotePeerId: string): string {
+  return `${relayPeerId}${KEY_SEPARATOR}${remotePeerId}`;
+}
+
+function clampPositiveInteger(value: number, fallback: number): number {
+  return Number.isFinite(value) && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
+export function parseCircuitRelayPeerIds(addr: string): RelayPathPeerIds | null {
+  const parts = addr.split('/').filter(Boolean);
+  const circuitIndex = parts.indexOf('p2p-circuit');
+  if (circuitIndex === -1) return null;
+
+  let relayPeerId: string | undefined;
+  for (let i = circuitIndex - 1; i >= 0; i--) {
+    if (parts[i] === 'p2p' && i + 1 < circuitIndex) {
+      relayPeerId = parts[i + 1];
+      break;
+    }
+  }
+  if (!relayPeerId) return null;
+
+  let remotePeerId: string | undefined;
+  for (let i = circuitIndex + 1; i < parts.length - 1; i++) {
+    if (parts[i] === 'p2p') {
+      remotePeerId = parts[i + 1];
+      break;
+    }
+  }
+
+  return { relayPeerId, remotePeerId };
+}
+
+export class RelayFlapGuard {
+  private readonly options: Required<RelayFlapGuardOptions>;
+  private readonly pairs = new Map<string, RelayFlapPairState>();
+
+  constructor(options: RelayFlapGuardOptions = {}) {
+    const defaults = defaultedOptions(options);
+    this.options = {
+      shortCloseMs: clampPositiveInteger(defaults.shortCloseMs, RELAY_FLAP_SHORT_CLOSE_MS),
+      windowMs: clampPositiveInteger(defaults.windowMs, RELAY_FLAP_WINDOW_MS),
+      threshold: clampPositiveInteger(defaults.threshold, RELAY_FLAP_THRESHOLD),
+      baseQuarantineMs: clampPositiveInteger(defaults.baseQuarantineMs, RELAY_FLAP_BASE_QUARANTINE_MS),
+      maxQuarantineMs: clampPositiveInteger(defaults.maxQuarantineMs, RELAY_FLAP_MAX_QUARANTINE_MS),
+      stableCloseMs: clampPositiveInteger(defaults.stableCloseMs, RELAY_FLAP_STABLE_CLOSE_MS),
+      denyLogIntervalMs: clampPositiveInteger(defaults.denyLogIntervalMs, RELAY_FLAP_DENY_LOG_INTERVAL_MS),
+    };
+  }
+
+  recordRelayedClose(input: {
+    relayPeerId: string;
+    remotePeerId: string;
+    durationMs: number;
+    now?: number;
+  }): RelayFlapCloseResult {
+    const now = input.now ?? Date.now();
+    if (input.durationMs >= this.options.stableCloseMs) {
+      return {
+        shortClose: false,
+        shortCloseCount: 0,
+        enteredQuarantine: false,
+        cleared: this.clearPair(input.relayPeerId, input.remotePeerId),
+      };
+    }
+
+    const key = pairKey(input.relayPeerId, input.remotePeerId);
+    const existing = this.pairs.get(key);
+    if (input.durationMs >= this.options.shortCloseMs) {
+      if (existing) this.prune(existing, now);
+      return {
+        shortClose: false,
+        shortCloseCount: existing?.shortCloseTimes.length ?? 0,
+        enteredQuarantine: false,
+        cleared: false,
+        quarantineUntil: existing?.quarantineUntil,
+      };
+    }
+
+    const state = existing ?? {
+      relayPeerId: input.relayPeerId,
+      remotePeerId: input.remotePeerId,
+      shortCloseTimes: [],
+      quarantineUntil: 0,
+      strikes: 0,
+    };
+    this.pairs.set(key, state);
+    this.prune(state, now);
+    state.shortCloseTimes.push(now);
+
+    if (state.quarantineUntil > now) {
+      return {
+        shortClose: true,
+        shortCloseCount: state.shortCloseTimes.length,
+        enteredQuarantine: false,
+        cleared: false,
+        quarantineUntil: state.quarantineUntil,
+      };
+    }
+
+    if (state.shortCloseTimes.length < this.options.threshold) {
+      return {
+        shortClose: true,
+        shortCloseCount: state.shortCloseTimes.length,
+        enteredQuarantine: false,
+        cleared: false,
+        quarantineUntil: state.quarantineUntil,
+      };
+    }
+
+    state.strikes += 1;
+    const quarantineTtlMs = Math.min(
+      this.options.baseQuarantineMs * Math.pow(2, state.strikes - 1),
+      this.options.maxQuarantineMs,
+    );
+    state.quarantineUntil = now + quarantineTtlMs;
+    state.shortCloseTimes = [];
+    state.lastDenyLogAt = undefined;
+
+    return {
+      shortClose: true,
+      shortCloseCount: this.options.threshold,
+      enteredQuarantine: true,
+      cleared: false,
+      quarantineUntil: state.quarantineUntil,
+      quarantineTtlMs,
+    };
+  }
+
+  checkRelayedConnection(input: {
+    relayPeerId: string;
+    remotePeerId: string;
+    now?: number;
+  }): RelayFlapDenyResult {
+    const now = input.now ?? Date.now();
+    const state = this.pairs.get(pairKey(input.relayPeerId, input.remotePeerId));
+    if (!state) return { deny: false, shouldLog: false };
+
+    if (state.quarantineUntil <= now) {
+      this.prune(state, now);
+      return { deny: false, shouldLog: false };
+    }
+
+    const shouldLog =
+      state.lastDenyLogAt == null ||
+      now - state.lastDenyLogAt >= this.options.denyLogIntervalMs;
+    if (shouldLog) state.lastDenyLogAt = now;
+
+    return {
+      deny: true,
+      shouldLog,
+      quarantineUntil: state.quarantineUntil,
+      quarantineMsRemaining: state.quarantineUntil - now,
+    };
+  }
+
+  clearPair(relayPeerId: string, remotePeerId: string): boolean {
+    return this.pairs.delete(pairKey(relayPeerId, remotePeerId));
+  }
+
+  recordDirectClose(input: {
+    remotePeerId: string;
+    durationMs: number;
+  }): number {
+    if (input.durationMs < this.options.stableCloseMs) return 0;
+    return this.clearRemotePeer(input.remotePeerId);
+  }
+
+  clearRemotePeer(remotePeerId: string): number {
+    let cleared = 0;
+    for (const [key, state] of this.pairs.entries()) {
+      if (state.remotePeerId === remotePeerId) {
+        this.pairs.delete(key);
+        cleared++;
+      }
+    }
+    return cleared;
+  }
+
+  getPairState(relayPeerId: string, remotePeerId: string, now = Date.now()): RelayFlapPairSnapshot | undefined {
+    const state = this.pairs.get(pairKey(relayPeerId, remotePeerId));
+    if (!state) return undefined;
+    this.prune(state, now);
+    return {
+      relayPeerId: state.relayPeerId,
+      remotePeerId: state.remotePeerId,
+      shortCloseCount: state.shortCloseTimes.length,
+      quarantineUntil: state.quarantineUntil,
+      strikes: state.strikes,
+    };
+  }
+
+  private prune(state: RelayFlapPairState, now: number): void {
+    const cutoff = now - this.options.windowMs;
+    state.shortCloseTimes = state.shortCloseTimes.filter((ts) => ts >= cutoff);
+  }
+}

--- a/packages/core/test/relay-flap-guard.test.ts
+++ b/packages/core/test/relay-flap-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RelayFlapGuard, parseCircuitRelayPeerIds } from '../src/relay-flap-guard.js';
+import { RelayFlapGuard, buildRelayFlapConnectionGater, parseCircuitRelayPeerIds } from '../src/relay-flap-guard.js';
 
 const RELAY_A = '12D3KooWRelayA';
 const RELAY_B = '12D3KooWRelayB';
@@ -108,5 +108,67 @@ describe('RelayFlapGuard', () => {
 
     expect(g.recordDirectClose({ remotePeerId: REMOTE_A, durationMs: 50 })).toBe(0);
     expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 30 }).deny).toBe(true);
+  });
+
+  it('does not accumulate short closes that age out of the rolling window', () => {
+    const g = guard();
+    // Two short closes early, then one AFTER the window has fully elapsed. The
+    // first two must be pruned, so the late one is the only in-window close and
+    // never reaches the quarantine threshold (a regression that stops pruning
+    // would let three closes across a >window span trip quarantine).
+    expect(g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 0 }).enteredQuarantine).toBe(false);
+    expect(g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 10 }).enteredQuarantine).toBe(false);
+    const late = g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 1_100 });
+    expect(late.enteredQuarantine).toBe(false);
+    expect(late.shortCloseCount).toBe(1);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 1_100 }).deny).toBe(false);
+  });
+
+  it('evicts idle pairs so the tracking map stays bounded', () => {
+    const g = guard();
+    recordShortBurst(g); // quarantines RELAY_A/REMOTE_A until now=220
+    expect(g.getPairState(RELAY_A, REMOTE_A, 25)).toBeDefined();
+
+    // Once the quarantine lapses, the next check must drop the now-idle entry
+    // (no in-window closes, no active quarantine) — otherwise the map leaks one
+    // entry per relay/remote pair forever on a long-lived node.
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 5_000 }).deny).toBe(false);
+    expect(g.getPairState(RELAY_A, REMOTE_A, 5_000)).toBeUndefined();
+  });
+});
+
+describe('buildRelayFlapConnectionGater (libp2p wiring)', () => {
+  it('denies the quarantined relayed path through the actual gater hook arg-shapes', () => {
+    // Long quarantine so the gater's real-clock checkRelayedConnection() stays
+    // inside the window for the synchronous assertions below.
+    const g = new RelayFlapGuard({
+      shortCloseMs: 100,
+      windowMs: 60_000,
+      threshold: 3,
+      baseQuarantineMs: 60_000,
+      maxQuarantineMs: 60_000,
+      stableCloseMs: 60_000,
+    });
+    const now = Date.now();
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: now + 10 });
+    expect(
+      g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: now + 20 }).enteredQuarantine,
+    ).toBe(true);
+
+    const gater = buildRelayFlapConnectionGater(g);
+
+    // denyDialMultiaddr is SINGLE-ARG in libp2p >=3.x — the peer ids ride in the
+    // /p2p-circuit multiaddr. A regression to a (peerId, multiaddr) shape would
+    // break this assertion (which is what the review comment feared).
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`)).toBe(true);
+    // A different relayed pair is not quarantined → allowed.
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_B}/p2p-circuit/p2p/${REMOTE_B}`)).toBe(false);
+    // A direct (non-circuit) multiaddr is never gated.
+    expect(gater.denyDialMultiaddr(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBe(false);
+
+    // The inbound hook (relay, remotePeer) also denies the quarantined pair.
+    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_A }, { toString: () => REMOTE_A })).toBe(true);
+    expect(gater.denyInboundRelayedConnection({ toString: () => RELAY_B }, { toString: () => REMOTE_B })).toBe(false);
   });
 });

--- a/packages/core/test/relay-flap-guard.test.ts
+++ b/packages/core/test/relay-flap-guard.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { RelayFlapGuard, parseCircuitRelayPeerIds } from '../src/relay-flap-guard.js';
+
+const RELAY_A = '12D3KooWRelayA';
+const RELAY_B = '12D3KooWRelayB';
+const REMOTE_A = '12D3KooWRemoteA';
+const REMOTE_B = '12D3KooWRemoteB';
+
+function guard(): RelayFlapGuard {
+  return new RelayFlapGuard({
+    shortCloseMs: 100,
+    windowMs: 1_000,
+    threshold: 3,
+    baseQuarantineMs: 200,
+    maxQuarantineMs: 800,
+    stableCloseMs: 1_000,
+    denyLogIntervalMs: 50,
+  });
+}
+
+function recordShortBurst(g: RelayFlapGuard, relayPeerId = RELAY_A, remotePeerId = REMOTE_A): void {
+  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 0 }).enteredQuarantine).toBe(false);
+  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 10 }).enteredQuarantine).toBe(false);
+  expect(g.recordRelayedClose({ relayPeerId, remotePeerId, durationMs: 50, now: 20 }).enteredQuarantine).toBe(true);
+}
+
+describe('parseCircuitRelayPeerIds', () => {
+  it('extracts relay and remote peer ids from a circuit address', () => {
+    expect(
+      parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit/p2p/${REMOTE_A}`),
+    ).toEqual({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A });
+  });
+
+  it('extracts only the relay peer id from reservation-style circuit addresses', () => {
+    expect(
+      parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${RELAY_A}/p2p-circuit`),
+    ).toEqual({ relayPeerId: RELAY_A, remotePeerId: undefined });
+  });
+
+  it('does not classify direct addresses as relayed paths', () => {
+    expect(parseCircuitRelayPeerIds(`/ip4/1.2.3.4/tcp/9090/p2p/${REMOTE_A}`)).toBeNull();
+  });
+});
+
+describe('RelayFlapGuard', () => {
+  it('quarantines the exact relay/remote pair after repeated short relayed closes', () => {
+    const g = guard();
+    recordShortBurst(g);
+
+    const denied = g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 25 });
+    expect(denied.deny).toBe(true);
+    expect(denied.shouldLog).toBe(true);
+    expect(denied.quarantineMsRemaining).toBe(195);
+
+    const repeatedDenied = g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 30 });
+    expect(repeatedDenied.deny).toBe(true);
+    expect(repeatedDenied.shouldLog).toBe(false);
+  });
+
+  it('does not quarantine below the short-close threshold', () => {
+    const g = guard();
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 0 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 10 });
+
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 20 }).deny).toBe(false);
+    expect(g.getPairState(RELAY_A, REMOTE_A, 20)?.shortCloseCount).toBe(2);
+  });
+
+  it('does not quarantine long-lived relayed closes and clears prior penalty', () => {
+    const g = guard();
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 0 });
+    g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 50, now: 10 });
+
+    const result = g.recordRelayedClose({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, durationMs: 1_000, now: 20 });
+    expect(result.cleared).toBe(true);
+    expect(g.getPairState(RELAY_A, REMOTE_A, 20)).toBeUndefined();
+  });
+
+  it('isolates quarantine by both relay peer and remote peer', () => {
+    const g = guard();
+    recordShortBurst(g, RELAY_A, REMOTE_A);
+
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 30 }).deny).toBe(true);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_B, now: 30 }).deny).toBe(false);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_B, remotePeerId: REMOTE_A, now: 30 }).deny).toBe(false);
+  });
+
+  it('expires quarantine and allows later relayed attempts', () => {
+    const g = guard();
+    recordShortBurst(g);
+
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 219 }).deny).toBe(true);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 221 }).deny).toBe(false);
+  });
+
+  it('clears penalty after a stable direct close from the same remote peer', () => {
+    const g = guard();
+    recordShortBurst(g);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 25 }).deny).toBe(true);
+
+    expect(g.recordDirectClose({ remotePeerId: REMOTE_A, durationMs: 1_000 })).toBe(1);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 30 }).deny).toBe(false);
+  });
+
+  it('does not clear relay penalty for short direct closes', () => {
+    const g = guard();
+    recordShortBurst(g);
+
+    expect(g.recordDirectClose({ remotePeerId: REMOTE_A, durationMs: 50 })).toBe(0);
+    expect(g.checkRelayedConnection({ relayPeerId: RELAY_A, remotePeerId: REMOTE_A, now: 30 }).deny).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a core-level relay flap guard to reduce repeated short-lived relayed connection churn on DKG V10 testnet edge nodes.

The guard tracks short relayed connection closes by exact `(relayPeerId, remotePeerId)` path, quarantines only that pair after repeated flaps, and wires the quarantine into libp2p connection gating for inbound relayed connections and full outbound relayed dial paths. Direct connections are never blocked, relay reservation paths are left alone, and quarantine expires so legitimate relay recovery can still happen.

## Why

Recent testnet checks showed sync/SWM pressure was no longer the main source of churn:

- Small live connection count
- No snapshot-limit or queue-pressure errors
- Churn mostly from repeated short-lived relayed circuits through the same relay/remote pairs

This moves the backpressure lower in the stack so bad relay paths stop repeatedly triggering app-level connection-open handling.

## Changes

- Added `RelayFlapGuard` in `packages/core/src/relay-flap-guard.ts`
- Added parsing for `/p2p-circuit` multiaddrs to identify relay and remote peer IDs
- Wired libp2p `connectionGater` in `packages/core/src/node.ts`
- Quarantines repeated short-lived relayed closes for the exact `(relay, remote)` pair
- Denies inbound relayed connections while the pair is quarantined
- Denies outbound full relay dial paths while the pair is quarantined
- Keeps relay reservation-style addresses allowed
- Clears/decays penalties on stable relayed closes and direct/DCUtR recovery
- Added focused core tests for quarantine behavior, isolation, expiry, and direct-path safety

## Validation

Local focused tests/build:

```bash
pnpm --filter @origintrail-official/dkg-core exec vitest run --config vitest.config.ts test/relay-flap-guard.test.ts
pnpm --filter @origintrail-official/dkg-core build
pnpm --filter @origintrail-official/dkg-agent... build
pnpm --filter @origintrail-official/dkg-agent exec vitest run --config vitest.unit.config.ts test/sync-on-connect-churn.test.ts test/sync-requester-bailout.test.ts
pnpm --filter @origintrail-official/dkg... build