### PR TITLE
fix(#1116): follow-up — DRY clearAssertionSeal + precise auto-register retry test

### DIFF
--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -37,7 +37,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     }
   });
 
-  async function startWith(assertion: Record<string, unknown>) {
+  async function startWith(assertion: Record<string, unknown>, agentOverrides: Record<string, unknown> = {}) {
     const agent = {
       async listContextGraphs() {
         return [{
@@ -53,6 +53,9 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       },
       resolveAgentByToken: () => undefined,
       assertion,
+      // Agent-level methods (e.g. publishFromFinalizedAssertion /
+      // ensureRegisteredForPublish for the vm/publish path) — opt-in per test.
+      ...agentOverrides,
     };
     server = createServer(async (req, res) => {
       const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -247,6 +250,84 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       const res = await post('swm/share-async', { contextGraphId: CG_ID, skipSeal: false });
       expect(res.status).toBe(200);
       expect(res.body.jobId).toBe('job-123');
+    });
+  });
+
+  // #1116 follow-up (reviewer 🟡 #2): the /vm/publish auto-register branch must
+  // complete the register-then-RETRY sequence — publishFromFinalizedAssertion
+  // throws CG_NOT_REGISTERED, the route registers ONCE, then RE-CALLS
+  // publishFromFinalizedAssertion and returns THAT result. The live-daemon test
+  // can only assert "5xx + not 'not registered'", which a regression that
+  // registers then fails-before-retry would still pass. This pins the exact
+  // call order with a fake agent.
+  describe('vm/publish auto-register retry sequence', () => {
+    it('on CG_NOT_REGISTERED: registers ONCE between TWO publish calls and returns the retry result', async () => {
+      const calls: string[] = [];
+      let publishCount = 0;
+
+      await startWith(
+        {}, // no `assertion` methods needed for vm/publish
+        {
+          async publishFromFinalizedAssertion(_cg: string, _name: string, _opts: unknown) {
+            publishCount += 1;
+            calls.push(`publish#${publishCount}`);
+            if (publishCount === 1) {
+              // First attempt: the CG isn't registered on-chain yet.
+              throw Object.assign(
+                new Error(`Context graph "${CG_ID}" is not registered on-chain. Run 'dkg context-graph register' first.`),
+                { code: 'CG_NOT_REGISTERED' },
+              );
+            }
+            // Retry (after register): confirmed publish.
+            return { status: 'confirmed', ual: 'did:dkg:test/1/42', kaId: '42', seal: { authorAddress: '0x00000000000000000000000000000000000000a1' } };
+          },
+          async ensureRegisteredForPublish(_cg: string, _opts: unknown) {
+            calls.push('register');
+            // success — the CG is now registered.
+          },
+        },
+      );
+
+      const res = await post('vm/publish', { contextGraphId: CG_ID });
+
+      // Exact call order: publish (throws) → register (once) → publish (succeeds).
+      expect(calls).toEqual(['publish#1', 'register', 'publish#2']);
+      expect(publishCount).toBe(2);
+      expect(calls.filter((c) => c === 'register').length).toBe(1);
+
+      // The response reflects the SECOND (success) call, NOT the first 409.
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('confirmed');
+      expect(res.body.ual).toBe('did:dkg:test/1/42');
+      expect(String(res.body.error ?? '')).not.toMatch(/not registered on-chain/i);
+    });
+
+    it('if auto-register itself fails, returns 400 and does NOT retry the publish', async () => {
+      const calls: string[] = [];
+      let publishCount = 0;
+
+      await startWith(
+        {},
+        {
+          async publishFromFinalizedAssertion() {
+            publishCount += 1;
+            calls.push(`publish#${publishCount}`);
+            throw Object.assign(new Error(`Context graph "${CG_ID}" is not registered on-chain.`), { code: 'CG_NOT_REGISTERED' });
+          },
+          async ensureRegisteredForPublish() {
+            calls.push('register');
+            throw new Error('insufficient TRAC to register context graph');
+          },
+        },
+      );
+
+      const res = await post('vm/publish', { contextGraphId: CG_ID });
+
+      // Only ONE publish attempt — no retry after a failed register.
+      expect(calls).toEqual(['publish#1', 'register']);
+      expect(publishCount).toBe(1);
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toMatch(/could not be auto-registered on-chain/i);
     });
   });
 });

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4665,12 +4665,16 @@ export class DKGPublisher implements Publisher {
    * lives on a DIFFERENT subject than the lifecycle URN, so the create/discard
    * clean-slates that key on the lifecycle URN don't reach it.
    *
-   * Used by the seal-in-SWM reconstruction (finalize layer="swm") to drop a
-   * STALE seal from a PRIOR lifecycle BEFORE pull-from: pull-from reads
-   * `seal.rootEntities` ahead of the member-row fallback, so a stale seal from a
-   * superseded share (e.g. full {A,C} → recreate → full {A,B}) would otherwise
-   * make it reconstruct the OLD root set. finalize(layer="swm") mints a fresh
-   * seal immediately after, so clearing here loses nothing.
+   * Callers: `assertionDiscard` (drops the seal when a non-published draft is
+   * discarded) and `assertionPullFrom` (re-opens a draft for editing, so the
+   * stale seal must go — it is rebuilt at the next finalize with the same
+   * reservedKaId via assertionCreate's A2 carry-over).
+   *
+   * NOTE (#1116 round 8+): finalize(layer="swm") does NOT pre-clear the seal.
+   * The SWM pull resolves scope from the marker-gated promoted member rows —
+   * never `seal.rootEntities` — and `assertionPullFrom` does its own seal
+   * teardown only AFTER validating a non-empty source, which keeps the operation
+   * atomic-on-failure (a failed pull no longer strands a previously-valid seal).
    */
   async clearAssertionSeal(
     contextGraphId: string,
@@ -5203,12 +5207,11 @@ export class DKGPublisher implements Publisher {
     // "already finalized with a different merkleRoot" and the edit loop was
     // permanently wedged. Pull-from re-opens the draft for editing, so the
     // stale seal MUST go (it is rebuilt — same reservedKaId, preserved by
-    // assertionCreate's A2 carry-over — at the next finalize).
-    for (const sealSubj of new Set([sealSubject, wmGraph])) {
-      for (const pred of Object.values(ASSERTION_SEAL_PREDICATES)) {
-        await this.store.deleteByPattern({ graph: metaGraph, subject: sealSubj, predicate: pred });
-      }
-    }
+    // assertionCreate's A2 carry-over — at the next finalize). Reuse the single
+    // clearAssertionSeal helper so the seal subject/predicate set has one source
+    // of truth (sealSubject == the helper's name-keyed assertion URI; wmGraph is
+    // re-resolved identically).
+    await this.clearAssertionSeal(contextGraphId, name, agentAddress, subGraphName);
     await this.assertionWrite(contextGraphId, name, agentAddress, gathered, subGraphName);
     return { seeded: gathered.length, fromLayer: sourceLayer, entities: entities.length };
   }


### PR DESCRIPTION
## Summary

Two leftover 🟡 review comments from the merged #1241 (#1116 CG-independent seal), addressed as a small follow-up.

- **Stale `clearAssertionSeal` docstring + duplicated seal-deletion (`dkg-publisher.ts`).** The helper's docstring still described the round-7 behavior that round 8/9 reversed (it claimed `finalize(layer:swm)` pre-clears the seal and that pull-from reads `seal.rootEntities` first — the opposite of the current invariant). Corrected it, and `assertionPullFrom` now calls the single `clearAssertionSeal` helper instead of inlining the subject/predicate loop, so the seal subject/predicate set has one source of truth (`sealSubject` == the helper's name-keyed assertion URI; `wmGraph` resolves identically — behavior-equivalent).

- **Loose auto-register route test (`knowledge-assets-route.test.ts`).** The `/vm/publish` auto-register path was only covered by a live-daemon smoke test that accepts any 5xx + an on-chain id — so a regression that auto-registers then fails *before* retrying `publishFromFinalizedAssertion` would still pass. Added a focused fake-agent route test that proves the exact register-then-retry sequence completes.

## Related

- Follow-up to #1241 (issue #1116). Same review thread (otReviewAgent round-12 comments).

## Files changed

| File | What |
|------|------|
| `packages/publisher/src/dkg-publisher.ts` | `assertionPullFrom` reuses the `clearAssertionSeal` helper; helper docstring corrected to the round-8+ invariant (SWM scope from marker-gated member rows, never `seal.rootEntities`; teardown after non-empty-source validation → atomic-on-failure) |
| `packages/cli/test/knowledge-assets-1116-share-errors.test.ts` | New fake-agent test: `publishFromFinalizedAssertion` throws `CG_NOT_REGISTERED` → `ensureRegisteredForPublish` (once, between) → second `publishFromFinalizedAssertion` returns confirmed → 200; plus the converse (register fails → 400, no retry). `startWith` extended (backward-compatibly) to stub agent-level methods |

## Test plan

- [x] `pnpm -C packages/publisher exec vitest run test/assertion-pull-from.test.ts` → 16/16 (exercises the pull-from seal teardown)
- [x] `pnpm -C packages/cli exec vitest run test/knowledge-assets-1116-share-errors.test.ts` → 10/10 (8 prior + 2 new)
- [x] Mutation check: removing the route's retry (`publishFromFinalizedAssertion` after `ensureRegisteredForPublish`) fails the new test
- [x] `pnpm build:packages` clean (20/20); fresh `pnpm -C packages/cli build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)