### PR TITLE
chore(agent): relax agent-profile heartbeat 5m → 20m

### DIFF
--- a/packages/agent/src/dkg-agent-constants.ts
+++ b/packages/agent/src/dkg-agent-constants.ts
@@ -201,12 +201,16 @@ export const MESSAGE_OUTBOX_TICK_MS = 30_000;
  * the `agents` Context Graph (PR feat/chain-agents-cg-phonebook).
  *
  * Each heartbeat refreshes the profile's `dkg:multiaddr` triples
- * (current dialable addrs) and `dkg:lastSeen` timestamp, so other
- * peers querying agents-CG see fresh phonebook entries even when
- * direct connections haven't been exchanged recently. Mirrors the
- * `beaconReannounceTimer` (5 min) cadence and the relay reservation
- * lifecycle (~30 min default duration limit), so we publish at least
- * a few times per reservation epoch.
+ * (current dialable addrs) and `dkg:lastSeen` timestamp. This is a
+ * FALLBACK source only: live peer addresses come primarily from
+ * libp2p `peerRouting.findPeer` (signed peer records), and the
+ * agents-CG dial fallback already tolerates entries up to
+ * `AGENT_PROFILE_STALE_THRESHOLD_MS` (24h) old. The cadence therefore
+ * does not need to track the `beaconReannounceTimer` (5 min): at
+ * 20 min we still re-announce at least once per ~30-min relay-
+ * reservation epoch while cutting profile publish + gossip churn ~4x
+ * (the previous 5-min cadence was ~288x more frequent than the 24h
+ * freshness budget it feeds). Complements the agents/_meta growth fix.
  *
  * Tuning: lower for chatty small networks (more responsive but more
  * gossip volume), higher for large meshes (less volume; slower
@@ -214,7 +218,7 @@ export const MESSAGE_OUTBOX_TICK_MS = 30_000;
  * `config.network.agentProfileHeartbeatMs`. Set to `0` to disable
  * (the one-shot startup publish still fires).
  */
-export const AGENT_PROFILE_HEARTBEAT_MS = 5 * 60 * 1000;
+export const AGENT_PROFILE_HEARTBEAT_MS = 20 * 60 * 1000;
 
 /**
  * Staleness threshold for an agents-CG profile read during dial

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -957,7 +957,7 @@ export interface DKGAgentConfig {
    * Cadence at which the daemon re-publishes its own agent profile
    * (PR feat/chain-agents-cg-phonebook). Forwarded straight from
    * `DkgConfig.network.agentProfileHeartbeatMs`. Defaults to
-   * `AGENT_PROFILE_HEARTBEAT_MS` (5 min) when omitted; `0` disables
+   * `AGENT_PROFILE_HEARTBEAT_MS` (20 min) when omitted; `0` disables
    * the timer (the one-shot startup publish still fires).
    */
   agentProfileHeartbeatMs?: number;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -688,7 +688,7 @@ export interface DkgConfig {
     dhtQuerySelfIntervalMs?: number;
     /**
      * Cadence at which the daemon re-publishes its own profile to the
-     * `agents` Context Graph (default 5min — see
+     * `agents` Context Graph (default 20min — see
      * `AGENT_PROFILE_HEARTBEAT_MS`). Set to `0` to disable; the
      * one-shot startup publish still fires.
      *


### PR DESCRIPTION
## What
Relax the default agent-profile heartbeat cadence **5 min → 20 min** (`AGENT_PROFILE_HEARTBEAT_MS`).

## Why
The `agents`-CG profile is only a **dial fallback**, not the primary source:
- Live peer addresses come primarily from libp2p `peerRouting.findPeer` (signed peer records).
- The fallback ignores any profile whose `dkg:lastSeen` is older than `AGENT_PROFILE_STALE_THRESHOLD_MS` (**24h**).
- Encryption keys are derived from the peerId, not the profile.

So the 5-min cadence was ~288× more frequent than the 24h freshness budget it actually feeds. **20 min**:
- still re-announces **~2× per ~30-min relay-reservation epoch** (the original alignment reason),
- stays **72× under** the 24h staleness threshold,
- cuts profile publish + gossip churn **~4×**.

Complements #1234 (which stopped the unbounded `agents/_meta` *storage* growth); this trims the ongoing publish/gossip CPU + network churn.

## Scope
- One constant (`AGENT_PROFILE_HEARTBEAT_MS`, the single source of truth) + two doc comments. No API or behavior change beyond cadence.
- Operators can still override `config.network.agentProfileHeartbeatMs` or set `0` to disable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
