### PR TITLE
test(devnet): rc19 gap coverage for #1241/#1229/#1234 + sweep stale oxigraph

### DIFF
--- a/scripts/devnet-comprehensive.sh
+++ b/scripts/devnet-comprehensive.sh
@@ -113,6 +113,12 @@ register "v10-rc-validation"   "smoke" "$REPO_ROOT/scripts/v10-rc-validation.sh"
 # Group: sweep
 register "devnet-full-sweep"   "sweep" "$REPO_ROOT/scripts/_devnet-full-sweep.sh"
 
+# Group: cutover — OT-RFC-49 ciphertext->catalog proof (canonical + current).
+# Previously not wired into any orchestrator; included so the cutover (curated
+# publish/update + catalog-root commitment + random-sampling-proves-the-catalog)
+# is exercised by the comprehensive run. Gate off with SKIP_RFC49=1.
+[ -n "${SKIP_RFC49:-}" ] || register "rfc49-catalog" "cutover" "$REPO_ROOT/scripts/devnet-test-rfc49-catalog-sampling.sh"
+
 # Group: rc11 recovery
 register "rc11-promote-crash"  "rc11-recovery" "$REPO_ROOT/scripts/devnet-test-rc11-promote-crash-recovery.sh"
 register "rc11-shutdown-mid"   "rc11-recovery" "$REPO_ROOT/scripts/devnet-test-rc11-shutdown-mid-publish.sh"

--- a/scripts/devnet-lib.sh
+++ b/scripts/devnet-lib.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# devnet-lib.sh — shared helpers for the devnet proof/soak scripts. SOURCE this
+# (`. "$REPO_ROOT/scripts/devnet-lib.sh"`), do not execute it.
+#
+# Centralizes the node auth / HTTP / JSON-extraction helpers that were copied
+# (and drifting) across devnet-test-*.sh and devnet-soak.sh. Result accounting
+# (ok/bad/log and the PASS/FAIL counters) is deliberately left in each script:
+# the prefixes differ and devnet-soak.sh uses a timestamped tee-to-logfile log().
+#
+# Contract — the sourcing script must export/set before use:
+#   DEVNET_DIR        path to the devnet home (.devnet)
+#   API_PORT_BASE     base API port (node N → API_PORT_BASE + N - 1)
+# Optional:
+#   DKG_API_MAXTIME   curl --max-time for api() (seconds, default 120)
+#
+# bash 3.2 compatible. No side effects on source (only function definitions).
+
+# node auth + addressing -----------------------------------------------------
+node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
+node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
+
+# HTTP: api <node> <METHOD> <path> [body] -> stdout "<httpcode>\n<body>" --------
+api() {
+  local n="$1" m="$2" p="$3" b="${4:-}" port token tmp code
+  port=$(node_port "$n"); token=$(node_token "$n"); tmp="$(mktemp "${TMPDIR:-/tmp}/dkg-api-XXXXXX")"
+  local -a a=(-sS --max-time "${DKG_API_MAXTIME:-120}" --connect-timeout 5 -o "$tmp" -w '%{http_code}' -X "$m"
+    -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
+  [ -n "$b" ] && a+=(--data "$b")
+  code=$(curl "${a[@]}" "http://127.0.0.1:${port}${p}" 2>/dev/null || echo 000)
+  printf '%s\n' "$code"; cat "$tmp" 2>/dev/null; rm -f "$tmp"
+}
+code_of() { printf '%s' "$1" | head -1; }
+body_of() { printf '%s' "$1" | tail -n +2; }
+
+# JSON: field <json> <dot.path> -> value ("" if missing; objects/arrays JSON'd) -
+field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":(typeof v==="object"?JSON.stringify(v):String(v)))})' <<<"$1"; }

--- a/scripts/devnet-soak.sh
+++ b/scripts/devnet-soak.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# devnet-soak.sh — long-running, RESOURCE-GOVERNED activity soak.
+#
+# Simulates sustained testnet/mainnet-like activity on an already-running devnet:
+# continuous publishing (public + curated CGs), querying, updating and inter-node
+# messaging, plus PERIODIC invite flows and staking/withdraw lifecycles. Designed
+# to run for HOURS without crashing the host:
+#
+#   * SINGLE-THREADED + paced — never fans out concurrent load.
+#   * MEMORY GOVERNOR — before each tick it reads free system memory and BACKS
+#     OFF (doubles the pause, skips the heavy publish) when it drops below a
+#     floor, so accumulation can never run away.
+#   * HEALTH MONITOR — if nodes are unreachable it logs and waits instead of
+#     hammering a dead fleet.
+#   * Every activity is BEST-EFFORT and failure-isolated: one failing op is
+#     logged and the soak continues.
+#
+# Usage:   ./scripts/devnet.sh start 6   &&   ./scripts/devnet-soak.sh
+# Stop:    Ctrl-C (or `kill <pid>`) — prints a final summary on exit.
+#
+# Env (all optional):
+#   SOAK_HOURS=4              total duration
+#   SOAK_TICK_SECONDS=18      base pause between activity batches
+#   MEM_FLOOR_PCT=12          back off when free system memory < this
+#   SOAK_PERIODIC_TICKS=40    run invite + staking lifecycle every N ticks
+#   SOAK_SUMMARY_TICKS=15     emit a progress summary every N ticks
+#   SOAK_NODES=6              fleet size
+#   SOAK_LOG=<path>           log file (default .devnet/soak-<ts>.log)
+#   SOAK_NO_STAKE=1           skip the periodic staking lifecycle
+#   SOAK_NO_INVITE=1          skip the periodic invite flow
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+NODES="${SOAK_NODES:-6}"
+SOAK_HOURS="${SOAK_HOURS:-4}"
+TICK="${SOAK_TICK_SECONDS:-18}"
+MEM_FLOOR="${MEM_FLOOR_PCT:-12}"
+PERIODIC="${SOAK_PERIODIC_TICKS:-40}"
+SUMMARY_EVERY="${SOAK_SUMMARY_TICKS:-15}"
+TS="$(node -e 'process.stdout.write(String(Date.now()))')"
+LOG="${SOAK_LOG:-$DEVNET_DIR/soak-$TS.log}"
+
+PUBLISHED=0 QUERIED=0 UPDATED=0 MESSAGED=0 INVITED=0 STAKED=0 BACKOFFS=0 ERRORS=0 TICKN=0
+START_EPOCH="$(node -e 'process.stdout.write(String(Math.floor(Date.now()/1000)))')"
+# node does the (possibly fractional) hours math; bash arithmetic is integer-only.
+# SOAK_SECONDS overrides SOAK_HOURS (handy for short test runs).
+DURATION_SECONDS="${SOAK_SECONDS:-$(node -e "process.stdout.write(String(Math.round(($SOAK_HOURS)*3600)))")}"
+END_EPOCH=$(( START_EPOCH + DURATION_SECONDS ))
+
+log() { local m="[$(date '+%H:%M:%S')] $*"; echo "$m"; echo "$m" >> "$LOG"; }
+
+node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
+node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
+
+# api <node> <METHOD> <path> [body] -> stdout "<httpcode>\n<body>"
+api() {
+  local n="$1" m="$2" p="$3" b="${4:-}" port token tmp code
+  port=$(node_port "$n"); token=$(node_token "$n"); tmp="$(mktemp "${TMPDIR:-/tmp}/soak-XXXXXX")"
+  local -a a=(-sS --max-time 90 --connect-timeout 5 -o "$tmp" -w '%{http_code}' -X "$m"
+    -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
+  [ -n "$b" ] && a+=(--data "$b")
+  code=$(curl "${a[@]}" "http://127.0.0.1:${port}${p}" 2>/dev/null || echo 000)
+  printf '%s\n' "$code"; cat "$tmp" 2>/dev/null; rm -f "$tmp"
+}
+code_of() { printf '%s' "$1" | head -1; }
+body_of() { printf '%s' "$1" | tail -n +2; }
+jget() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":String(v))})' <<<"$1"; }
+
+# free system memory %, macOS (memory_pressure) with a safe fallback
+mem_free_pct() {
+  local p
+  p=$(memory_pressure 2>/dev/null | awk -F': ' '/free percentage/{gsub(/[^0-9]/,"",$2); print $2; exit}')
+  [ -n "$p" ] && { echo "$p"; return; }
+  echo 50
+}
+nodes_up() {
+  local up=0 n
+  for n in $(seq 1 "$NODES"); do
+    curl -sf --max-time 4 -H "Authorization: Bearer $(node_token "$n")" \
+      "http://127.0.0.1:$(node_port "$n")/api/status" >/dev/null 2>&1 && up=$((up+1))
+  done
+  echo "$up"
+}
+
+# publish_ka <node> <cg> <tag> -> 0 on confirmed publish
+publish_ka() {
+  local node="$1" cg="$2" tag="$3"
+  local name="soak-$tag" subj="urn:soak:$tag" r
+  api "$node" POST /api/knowledge-assets "{\"contextGraphId\":\"$cg\",\"name\":\"$name\"}" >/dev/null
+  api "$node" POST "/api/knowledge-assets/$name/wm/write" \
+    "{\"contextGraphId\":\"$cg\",\"quads\":[{\"subject\":\"$subj\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"soak $tag\\\"\",\"graph\":\"\"},{\"subject\":\"$subj\",\"predicate\":\"http://schema.org/dateCreated\",\"object\":\"\\\"$(date -u +%FT%TZ)\\\"\",\"graph\":\"\"}]}" >/dev/null
+  api "$node" POST "/api/knowledge-assets/$name/wm/finalize" "{\"contextGraphId\":\"$cg\"}" >/dev/null
+  api "$node" POST "/api/knowledge-assets/$name/swm/share" "{\"contextGraphId\":\"$cg\"}" >/dev/null
+  r=$(api "$node" POST "/api/knowledge-assets/$name/vm/publish" "{\"contextGraphId\":\"$cg\"}")
+  local st; st=$(jget "$(body_of "$r")" status)
+  [ "$st" = "confirmed" ] || [ "$st" = "finalized" ]
+}
+
+# ── setup ───────────────────────────────────────────────────────────────────
+curl -sf --max-time 5 -H "Authorization: Bearer $(node_token 1)" \
+  "http://127.0.0.1:$(node_port 1)/api/status" >/dev/null \
+  || { echo "FATAL: node1 unreachable — run ./scripts/devnet.sh start $NODES first" >&2; exit 2; }
+
+# A small set of long-lived CGs to publish into (public + curated), created once.
+CG_PUB="soak-pub-$TS"; CG_PRIV="soak-priv-$TS"
+api 1 POST /api/context-graph/create "{\"id\":\"$CG_PUB\",\"name\":\"soak public\",\"accessPolicy\":0}" >/dev/null
+api 1 POST /api/context-graph/create "{\"id\":\"$CG_PRIV\",\"name\":\"soak curated\",\"accessPolicy\":1}" >/dev/null
+CGS=("$CG_PUB" "$CG_PRIV")
+
+summary() {
+  log "──── SUMMARY @ tick $TICKN | $(( ($(node -e 'process.stdout.write(String(Math.floor(Date.now()/1000)))') - START_EPOCH)/60 ))min elapsed ────"
+  log "     published=$PUBLISHED queried=$QUERIED updated=$UPDATED messaged=$MESSAGED invited=$INVITED staked=$STAKED | backoffs=$BACKOFFS errors=$ERRORS | mem_free=$(mem_free_pct)% nodes_up=$(nodes_up)/$NODES"
+}
+trap 'echo; log "SOAK STOPPING (signal/exit)"; summary; exit 0' INT TERM
+
+log "SOAK START — ${SOAK_HOURS}h, tick=${TICK}s, mem_floor=${MEM_FLOOR}%, periodic=${PERIODIC}, nodes=${NODES}"
+log "  CGs: public=$CG_PUB curated=$CG_PRIV   log=$LOG"
+
+# ── main loop ───────────────────────────────────────────────────────────────
+while [ "$(node -e 'process.stdout.write(String(Math.floor(Date.now()/1000)))')" -lt "$END_EPOCH" ]; do
+  TICKN=$((TICKN+1))
+  pause="$TICK"
+
+  # 1. MEMORY GOVERNOR
+  free=$(mem_free_pct)
+  if [ "${free:-50}" -lt "$MEM_FLOOR" ]; then
+    BACKOFFS=$((BACKOFFS+1))
+    log "MEM LOW (${free}% < ${MEM_FLOOR}%) — backing off, skipping publish this tick"
+    sleep $((TICK*2)); continue
+  fi
+
+  # 2. HEALTH MONITOR
+  up=$(nodes_up)
+  if [ "$up" -eq 0 ]; then log "FLEET DOWN — pausing 60s"; sleep 60; continue; fi
+  if [ "$up" -lt $(( (NODES+1)/2 )) ]; then log "DEGRADED ($up/$NODES up) — easing off"; pause=$((TICK*2)); fi
+
+  # 3. ACTIVITY BATCH (best-effort). Bulk publish to the PUBLIC CG from a rotating
+  #    CORE node (cores carry the ACK quorum). Each publish flows WM -> SWM -> VM,
+  #    so all three memory layers are exercised. Curated/private CG activity
+  #    (membership + member writes) is driven by the periodic invite flow below.
+  node=$(( (TICKN % 4) + 1 )); cg="$CG_PUB"
+  if publish_ka "$node" "$cg" "${TS}-${TICKN}"; then PUBLISHED=$((PUBLISHED+1)); else ERRORS=$((ERRORS+1)); fi
+
+  # query (count quads in the CG we just wrote)
+  r=$(api 1 POST /api/query "{\"sparql\":\"SELECT (COUNT(*) AS ?c) WHERE { GRAPH <did:dkg:context-graph:$cg> { ?s ?p ?o } }\"}")
+  [ "$(code_of "$r")" = "200" ] && QUERIED=$((QUERIED+1)) || ERRORS=$((ERRORS+1))
+
+  # every 3rd tick: update a fresh KA (write a 2nd quad then re-finalize/publish)
+  if [ $((TICKN % 3)) -eq 0 ]; then
+    un="soak-upd-${TS}-${TICKN}"; us="urn:soak-upd:${TS}-${TICKN}"
+    api "$node" POST /api/knowledge-assets "{\"contextGraphId\":\"$cg\",\"name\":\"$un\"}" >/dev/null
+    api "$node" POST "/api/knowledge-assets/$un/wm/write" "{\"contextGraphId\":\"$cg\",\"quads\":[{\"subject\":\"$us\",\"predicate\":\"http://schema.org/version\",\"object\":\"\\\"1\\\"\",\"graph\":\"\"}]}" >/dev/null
+    api "$node" POST "/api/knowledge-assets/$un/wm/finalize" "{\"contextGraphId\":\"$cg\"}" >/dev/null
+    api "$node" POST "/api/knowledge-assets/$un/swm/share" "{\"contextGraphId\":\"$cg\"}" >/dev/null
+    r=$(api "$node" POST "/api/knowledge-assets/$un/vm/publish" "{\"contextGraphId\":\"$cg\"}")
+    [ "$(code_of "$r")" = "200" ] && UPDATED=$((UPDATED+1)) || ERRORS=$((ERRORS+1))
+  fi
+
+  # every 5th tick: inter-node message node1 -> node2
+  if [ $((TICKN % 5)) -eq 0 ]; then
+    s2=$(api 2 GET /api/status); peer2=$(body_of "$s2" | sed -n 's/.*"peerId":"\([^"]*\)".*/\1/p' | head -1)
+    if [ -n "$peer2" ]; then
+      r=$(api 1 POST /api/chat "{\"to\":\"$peer2\",\"text\":\"soak ping tick $TICKN\"}")
+      [ "$(code_of "$r")" = "200" ] && MESSAGED=$((MESSAGED+1)) || ERRORS=$((ERRORS+1))
+    fi
+  fi
+
+  # every PERIODIC ticks: invite flow + staking lifecycle (best-effort, isolated)
+  if [ $((TICKN % PERIODIC)) -eq 0 ]; then
+    if [ -z "${SOAK_NO_INVITE:-}" ]; then
+      log "periodic: invite flow (devnet-test-cli-invite.sh)"
+      if timeout 240 "$REPO_ROOT/scripts/devnet-test-cli-invite.sh" >>"$LOG" 2>&1; then INVITED=$((INVITED+1)); else log "  invite flow failed (isolated)"; ERRORS=$((ERRORS+1)); fi 2>/dev/null \
+        || { "$REPO_ROOT/scripts/devnet-test-cli-invite.sh" >>"$LOG" 2>&1 && INVITED=$((INVITED+1)) || { log "  invite flow failed (isolated)"; ERRORS=$((ERRORS+1)); }; }
+    fi
+    if [ -z "${SOAK_NO_STAKE:-}" ]; then
+      log "periodic: staking lifecycle (conviction-lazy-settle)"
+      if ( cd "$REPO_ROOT" && pnpm test:devnet:conviction-lazy-settle ) >>"$LOG" 2>&1; then STAKED=$((STAKED+1)); else log "  staking lifecycle failed (isolated)"; ERRORS=$((ERRORS+1)); fi
+    fi
+  fi
+
+  # 4. periodic summary
+  [ $((TICKN % SUMMARY_EVERY)) -eq 0 ] && summary
+
+  # 5. pace
+  sleep "$pause"
+done
+
+log "SOAK COMPLETE — ${SOAK_HOURS}h reached"
+summary

--- a/scripts/devnet-soak.sh
+++ b/scripts/devnet-soak.sh
@@ -69,12 +69,24 @@ code_of() { printf '%s' "$1" | head -1; }
 body_of() { printf '%s' "$1" | tail -n +2; }
 jget() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":String(v))})' <<<"$1"; }
 
-# free system memory %, macOS (memory_pressure) with a safe fallback
+# free system memory %, macOS (memory_pressure) then Linux (/proc/meminfo), with
+# a safe constant only as a last resort. Without the Linux branch the governor is
+# inert on CI/devnet hosts (always 50% ⇒ never backs off below MEM_FLOOR).
 mem_free_pct() {
   local p
   p=$(memory_pressure 2>/dev/null | awk -F': ' '/free percentage/{gsub(/[^0-9]/,"",$2); print $2; exit}')
   [ -n "$p" ] && { echo "$p"; return; }
+  if [ -r /proc/meminfo ]; then
+    p=$(awk '/^MemTotal:/{t=$2} /^MemAvailable:/{a=$2} END{ if (t>0) printf "%d", (a*100)/t }' /proc/meminfo)
+    [ -n "$p" ] && { echo "$p"; return; }
+  fi
   echo 50
+}
+# run_timed <seconds> <cmd...> — best-effort timeout: use `timeout` when present,
+# else run directly (hosts without GNU coreutils still work, no dead fallback).
+run_timed() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then timeout "$secs" "$@"; else "$@"; fi
 }
 nodes_up() {
   local up=0 n
@@ -148,15 +160,24 @@ while [ "$(node -e 'process.stdout.write(String(Math.floor(Date.now()/1000)))')"
   r=$(api 1 POST /api/query "{\"sparql\":\"SELECT (COUNT(*) AS ?c) WHERE { GRAPH <did:dkg:context-graph:$cg> { ?s ?p ?o } }\"}")
   [ "$(code_of "$r")" = "200" ] && QUERIED=$((QUERIED+1)) || ERRORS=$((ERRORS+1))
 
-  # every 3rd tick: update a fresh KA (write a 2nd quad then re-finalize/publish)
+  # every 3rd tick: a REAL update — publish a KA (mint), then modify the now-
+  # published asset on-chain via POST /api/update (the daemon's update primitive,
+  # the same call devnet-rs-validation.sh uses), NOT another first-time publish.
   if [ $((TICKN % 3)) -eq 0 ]; then
     un="soak-upd-${TS}-${TICKN}"; us="urn:soak-upd:${TS}-${TICKN}"
     api "$node" POST /api/knowledge-assets "{\"contextGraphId\":\"$cg\",\"name\":\"$un\"}" >/dev/null
     api "$node" POST "/api/knowledge-assets/$un/wm/write" "{\"contextGraphId\":\"$cg\",\"quads\":[{\"subject\":\"$us\",\"predicate\":\"http://schema.org/version\",\"object\":\"\\\"1\\\"\",\"graph\":\"\"}]}" >/dev/null
     api "$node" POST "/api/knowledge-assets/$un/wm/finalize" "{\"contextGraphId\":\"$cg\"}" >/dev/null
     api "$node" POST "/api/knowledge-assets/$un/swm/share" "{\"contextGraphId\":\"$cg\"}" >/dev/null
-    r=$(api "$node" POST "/api/knowledge-assets/$un/vm/publish" "{\"contextGraphId\":\"$cg\"}")
-    [ "$(code_of "$r")" = "200" ] && UPDATED=$((UPDATED+1)) || ERRORS=$((ERRORS+1))
+    pubr=$(api "$node" POST "/api/knowledge-assets/$un/vm/publish" "{\"contextGraphId\":\"$cg\"}")
+    kaid=$(jget "$(body_of "$pubr")" kaId)
+    if [ -n "$kaid" ]; then
+      uq="[{\"subject\":\"$us\",\"predicate\":\"http://schema.org/version\",\"object\":\"\\\"2\\\"\",\"graph\":\"\"}]"
+      r=$(api "$node" POST /api/update "{\"contextGraphId\":\"$cg\",\"kaId\":\"$kaid\",\"quads\":$uq}")
+      [ "$(code_of "$r")" = "200" ] && UPDATED=$((UPDATED+1)) || ERRORS=$((ERRORS+1))
+    else
+      ERRORS=$((ERRORS+1))   # no kaId from publish ⇒ nothing to update
+    fi
   fi
 
   # every 5th tick: inter-node message node1 -> node2
@@ -172,8 +193,7 @@ while [ "$(node -e 'process.stdout.write(String(Math.floor(Date.now()/1000)))')"
   if [ $((TICKN % PERIODIC)) -eq 0 ]; then
     if [ -z "${SOAK_NO_INVITE:-}" ]; then
       log "periodic: invite flow (devnet-test-cli-invite.sh)"
-      if timeout 240 "$REPO_ROOT/scripts/devnet-test-cli-invite.sh" >>"$LOG" 2>&1; then INVITED=$((INVITED+1)); else log "  invite flow failed (isolated)"; ERRORS=$((ERRORS+1)); fi 2>/dev/null \
-        || { "$REPO_ROOT/scripts/devnet-test-cli-invite.sh" >>"$LOG" 2>&1 && INVITED=$((INVITED+1)) || { log "  invite flow failed (isolated)"; ERRORS=$((ERRORS+1)); }; }
+      if run_timed 240 "$REPO_ROOT/scripts/devnet-test-cli-invite.sh" >>"$LOG" 2>&1; then INVITED=$((INVITED+1)); else log "  invite flow failed (isolated)"; ERRORS=$((ERRORS+1)); fi
     fi
     if [ -z "${SOAK_NO_STAKE:-}" ]; then
       log "periodic: staking lifecycle (conviction-lazy-settle)"

--- a/scripts/devnet-soak.sh
+++ b/scripts/devnet-soak.sh
@@ -52,22 +52,12 @@ END_EPOCH=$(( START_EPOCH + DURATION_SECONDS ))
 
 log() { local m="[$(date '+%H:%M:%S')] $*"; echo "$m"; echo "$m" >> "$LOG"; }
 
-node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
-node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
-
-# api <node> <METHOD> <path> [body] -> stdout "<httpcode>\n<body>"
-api() {
-  local n="$1" m="$2" p="$3" b="${4:-}" port token tmp code
-  port=$(node_port "$n"); token=$(node_token "$n"); tmp="$(mktemp "${TMPDIR:-/tmp}/soak-XXXXXX")"
-  local -a a=(-sS --max-time 90 --connect-timeout 5 -o "$tmp" -w '%{http_code}' -X "$m"
-    -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
-  [ -n "$b" ] && a+=(--data "$b")
-  code=$(curl "${a[@]}" "http://127.0.0.1:${port}${p}" 2>/dev/null || echo 000)
-  printf '%s\n' "$code"; cat "$tmp" 2>/dev/null; rm -f "$tmp"
-}
-code_of() { printf '%s' "$1" | head -1; }
-body_of() { printf '%s' "$1" | tail -n +2; }
-jget() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":String(v))})' <<<"$1"; }
+# Shared node auth / HTTP / JSON helpers (node_token, node_port, api, code_of,
+# body_of, field). Keep the soak's lighter 90s api timeout.
+# shellcheck disable=SC2034  # consumed by api() inside the sourced devnet-lib.sh
+DKG_API_MAXTIME=90
+. "$REPO_ROOT/scripts/devnet-lib.sh" || { echo "FATAL: cannot source devnet-lib.sh" >&2; exit 2; }
+jget() { field "$@"; }   # back-compat alias for this script's existing call sites
 
 # free system memory %, macOS (memory_pressure) then Linux (/proc/meminfo), with
 # a safe constant only as a last resort. Without the Linux branch the governor is

--- a/scripts/devnet-test-agents-meta-bounded.sh
+++ b/scripts/devnet-test-agents-meta-bounded.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# #1234 (fixes #1233) — agents/_meta growth is BOUNDED: devnet proof.
+#
+# Before #1234, every agent-profile heartbeat appended a per-publish tentative
+# tracking record to `<agents>/_meta` keyed by a fresh UAL, never pruned, gossip-
+# fanned per peer — growing without bound (~386 records/agent observed). #1234
+# suppresses that write at the two highest-volume paths (gossip receiver + local
+# publish terminal) gated on isAgentRegistryContextGraph(), while the agent
+# profile DATA still lands in the data graph.
+#
+# This asserts on a running fleet that the AGENT REGISTRY DATA graph is populated
+# (profiles present) while `<agents>/_meta` stays bounded (no tentative-record
+# accumulation). This is the lightweight static check; a longer-running variant
+# can force a small heartbeat (config.network.agentProfileHeartbeatMs) and assert
+# zero growth across N heartbeats.
+#
+# Requires a running devnet (./scripts/devnet.sh start 6). Self-contained.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+NUM_NODES="${NUM_NODES:-6}"
+META_MAX="${META_MAX:-50}"   # generous ceiling; pre-#1234 bloat was hundreds/agent
+
+PASS=0; FAIL=0
+log() { echo "[agents-meta] $*"; }
+ok()  { echo "[agents-meta]   PASS: $*"; PASS=$((PASS+1)); }
+bad() { echo "[agents-meta]   FAIL: $*" >&2; FAIL=$((FAIL+1)); }
+
+node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
+node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
+
+qcount() { # node graph -> integer count ("" on error)
+  local n="$1" g="$2" port token
+  port=$(node_port "$n"); token=$(node_token "$n")
+  curl -s -m 12 -H "Authorization: Bearer $token" -H 'Content-Type: application/json' \
+    -X POST "http://127.0.0.1:${port}/api/query" \
+    -d "{\"sparql\":\"SELECT (COUNT(*) AS ?c) WHERE { GRAPH <$g> { ?s ?p ?o } }\"}" 2>/dev/null \
+  | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);const b=(j.result?.bindings||j.result?.results?.bindings||j.results?.bindings||j.bindings||[])[0];const v=b?.c?.value??b?.c??"";const m=String(v).match(/\d+/);process.stdout.write(m?m[0]:"")}catch(e){process.stdout.write("")}})'
+}
+
+AG='did:dkg:context-graph:agents'
+META='did:dkg:context-graph:agents/_meta'
+
+for n in $(seq 1 "$NUM_NODES"); do
+  [ -f "$DEVNET_DIR/node$n/auth.token" ] || continue
+  DATA=$(qcount "$n" "$AG"); MT=$(qcount "$n" "$META")
+  [ -z "$DATA" ] && { log "node$n unreachable — skipping"; continue; }
+  if [ "${DATA:-0}" -gt 0 ] 2>/dev/null; then
+    ok "node$n agent-registry DATA populated ($DATA quads)"
+  else
+    bad "node$n agent-registry DATA empty (expected profiles) — phonebook not replicating?"
+  fi
+  if [ "${MT:-0}" -le "$META_MAX" ] 2>/dev/null; then
+    ok "node$n agents/_meta BOUNDED ($MT <= $META_MAX; #1234 suppression holding)"
+  else
+    bad "node$n agents/_meta UNBOUNDED ($MT > $META_MAX) — #1234 regression"
+  fi
+done
+
+echo
+log "──────── SUMMARY ────────"
+log "PASS=$PASS  FAIL=$FAIL  (META_MAX=$META_MAX)"
+[ "$FAIL" -eq 0 ] && { log "ALL AGENTS-META CHECKS PASSED"; exit 0; } || { log "SOME CHECKS FAILED"; exit 1; }

--- a/scripts/devnet-test-agents-meta-bounded.sh
+++ b/scripts/devnet-test-agents-meta-bounded.sh
@@ -34,8 +34,8 @@ log() { echo "[agents-meta] $*"; }
 ok()  { echo "[agents-meta]   PASS: $*"; PASS=$((PASS+1)); }
 bad() { echo "[agents-meta]   FAIL: $*" >&2; FAIL=$((FAIL+1)); }
 
-node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
-node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
+# shared node auth / HTTP / JSON helpers (node_token, node_port, api, field, …)
+. "$REPO_ROOT/scripts/devnet-lib.sh" || { echo "[agents-meta] FATAL: cannot source devnet-lib.sh" >&2; exit 2; }
 
 qcount() { # node graph -> integer count ("" on error)
   local n="$1" g="$2" port token

--- a/scripts/devnet-test-agents-meta-bounded.sh
+++ b/scripts/devnet-test-agents-meta-bounded.sh
@@ -16,6 +16,11 @@
 # zero growth across N heartbeats.
 #
 # Requires a running devnet (./scripts/devnet.sh start 6). Self-contained.
+#
+# Standalone MANUAL proof — run directly; intentionally NOT wired into
+# devnet-comprehensive.sh / _devnet-full-sweep.sh (these gap proofs are kept out
+# of the shared orchestrated run; see PR #1244).
+#   Run:  ./scripts/devnet-test-agents-meta-bounded.sh
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -44,16 +49,32 @@ qcount() { # node graph -> integer count ("" on error)
 AG='did:dkg:context-graph:agents'
 META='did:dkg:context-graph:agents/_meta'
 
+# A devnet that is down / under-provisioned must FAIL, not silently pass: every
+# expected fleet member is required. Missing token, unreachable node, or an
+# unreadable _meta count are all failures (not skips), and the run fails if it
+# checked fewer than NUM_NODES. NB an empty _meta graph returns COUNT "0" (a
+# value), so a healthy-but-quiet fleet still passes — only a query *failure*
+# yields "" and trips the unreadable guard.
+CHECKED=0
 for n in $(seq 1 "$NUM_NODES"); do
-  [ -f "$DEVNET_DIR/node$n/auth.token" ] || continue
+  if [ ! -f "$DEVNET_DIR/node$n/auth.token" ]; then
+    bad "node$n: no auth.token — expected fleet member not provisioned (is './scripts/devnet.sh start $NUM_NODES' up?)"
+    continue
+  fi
   DATA=$(qcount "$n" "$AG"); MT=$(qcount "$n" "$META")
-  [ -z "$DATA" ] && { log "node$n unreachable — skipping"; continue; }
-  if [ "${DATA:-0}" -gt 0 ] 2>/dev/null; then
+  if [ -z "$DATA" ]; then
+    bad "node$n unreachable — agent-registry DATA query failed (node down?)"
+    continue
+  fi
+  CHECKED=$((CHECKED+1))
+  if [ "$DATA" -gt 0 ] 2>/dev/null; then
     ok "node$n agent-registry DATA populated ($DATA quads)"
   else
     bad "node$n agent-registry DATA empty (expected profiles) — phonebook not replicating?"
   fi
-  if [ "${MT:-0}" -le "$META_MAX" ] 2>/dev/null; then
+  if [ -z "$MT" ]; then
+    bad "node$n agents/_meta count unreadable (query failed) — cannot prove bounded"
+  elif [ "$MT" -le "$META_MAX" ] 2>/dev/null; then
     ok "node$n agents/_meta BOUNDED ($MT <= $META_MAX; #1234 suppression holding)"
   else
     bad "node$n agents/_meta UNBOUNDED ($MT > $META_MAX) — #1234 regression"
@@ -62,5 +83,12 @@ done
 
 echo
 log "──────── SUMMARY ────────"
-log "PASS=$PASS  FAIL=$FAIL  (META_MAX=$META_MAX)"
-[ "$FAIL" -eq 0 ] && { log "ALL AGENTS-META CHECKS PASSED"; exit 0; } || { log "SOME CHECKS FAILED"; exit 1; }
+log "CHECKED=$CHECKED/$NUM_NODES  PASS=$PASS  FAIL=$FAIL  (META_MAX=$META_MAX)"
+if [ "$CHECKED" -eq 0 ]; then
+  log "NO NODES CHECKED — devnet not running or DEVNET_DIR wrong (expected $NUM_NODES nodes at $DEVNET_DIR)"
+  log "SOME CHECKS FAILED"; exit 1
+fi
+if [ "$CHECKED" -lt "$NUM_NODES" ]; then
+  bad "only $CHECKED/$NUM_NODES expected nodes were checked (missing/unreachable members above)"
+fi
+[ "$FAIL" -eq 0 ] && { log "ALL AGENTS-META CHECKS PASSED ($CHECKED/$NUM_NODES nodes)"; exit 0; } || { log "SOME CHECKS FAILED"; exit 1; }

--- a/scripts/devnet-test-cg-registration-deposit.sh
+++ b/scripts/devnet-test-cg-registration-deposit.sh
@@ -19,6 +19,12 @@
 # 31337 devnet chain. It is NOT a real deployer key.
 #
 # Requires a running devnet (./scripts/devnet.sh start 6). Self-contained.
+#
+# Standalone MANUAL proof — run directly; intentionally NOT wired into
+# devnet-comprehensive.sh / _devnet-full-sweep.sh. This one arms a GLOBAL chain
+# param (and restores it via trap), so it is deliberately kept out of the shared
+# orchestrated run; see PR #1244.
+#   Run:  ./scripts/devnet-test-cg-registration-deposit.sh
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -60,6 +66,19 @@ act "0. baseline — deposit param is DORMANT (0) on the devnet"
 P0=$(field "$(call ParametersStorage contextGraphRegistrationDeposit)" result)
 [ "$P0" = "0" ] && ok "deposit param dormant at baseline (0)" || bad "expected param 0 at baseline, got '$P0'"
 
+# Restore the baseline deposit on ANY exit path (crash, timeout, Ctrl-C) so an
+# interrupted run can't leave the GLOBAL param live for later suites. Armed only
+# after we actually set it; disarmed once the verified teardown has reset it, so
+# on the happy path the EXIT trap is a no-op. Restores the captured baseline P0
+# (asserted 0 above), not a hard-coded 0.
+DEPOSIT_ARMED=0
+cleanup() {
+  [ "$DEPOSIT_ARMED" = "1" ] || return 0
+  echo "[cg-deposit] cleanup: restoring deposit param to baseline ($P0)" >&2
+  call ParametersStorage setContextGraphRegistrationDeposit --key "$GOV_KEY" --json "[\"$P0\"]" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
 # ============================================================================
 act "1. DORMANT path — register a CG, escrow must be 0"
 # ============================================================================
@@ -75,6 +94,7 @@ fi
 act "2. ARM the param (governance) then register a CG — deposit must escrow"
 # ============================================================================
 SET=$(call ParametersStorage setContextGraphRegistrationDeposit --key "$GOV_KEY" --json "[\"$DEPOSIT\"]")
+DEPOSIT_ARMED=1   # from here on, cleanup() must restore the baseline on any exit
 TXH=$(field "$SET" txHash)
 [ -n "$TXH" ] && ok "armed deposit param via governance (tx=$TXH)" || bad "setContextGraphRegistrationDeposit failed: $SET"
 P1=$(field "$(call ParametersStorage contextGraphRegistrationDeposit)" result)
@@ -98,7 +118,7 @@ act "3. TEARDOWN — reset param to 0 (dormant-regression safe)"
 RST=$(call ParametersStorage setContextGraphRegistrationDeposit --key "$GOV_KEY" --json "[\"0\"]")
 [ -n "$(field "$RST" txHash)" ] && log "param reset tx=$(field "$RST" txHash)"
 P2=$(field "$(call ParametersStorage contextGraphRegistrationDeposit)" result)
-[ "$P2" = "0" ] && ok "param reset to dormant (0)" || bad "param NOT reset (still $P2) — other suites may break!"
+if [ "$P2" = "0" ]; then ok "param reset to dormant (0)"; DEPOSIT_ARMED=0; else bad "param NOT reset (still $P2) — other suites may break!"; fi
 
 echo
 log "──────── SUMMARY ────────"

--- a/scripts/devnet-test-cg-registration-deposit.sh
+++ b/scripts/devnet-test-cg-registration-deposit.sh
@@ -45,7 +45,8 @@ bad() { echo "[cg-deposit]   FAIL: $*" >&2; FAIL=$((FAIL+1)); }
 act() { echo; echo "[cg-deposit] === $* ==="; }
 
 call() { node "$CHAIN_CALL" "$@" 2>&1; }
-field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":String(v))})' <<<"$1"; }
+# shared field() (+ node auth / HTTP helpers, unused here) from the devnet lib
+. "$REPO_ROOT/scripts/devnet-lib.sh" || { echo "[cg-deposit] FATAL: cannot source devnet-lib.sh" >&2; exit 2; }
 
 # create + on-chain register a CG via the node's daemon; echoes the numeric on-chain id
 create_register_cg() {

--- a/scripts/devnet-test-cg-registration-deposit.sh
+++ b/scripts/devnet-test-cg-registration-deposit.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# #1229 / OT-RFC-53 — context-graph registration DEPOSIT: devnet proof.
+#
+# Closes the rc19 coverage gap: the deposit lifecycle had strong unit/hardhat
+# coverage but NO multi-node devnet test with the param LIVE (the devnet ships
+# the deposit dormant: ParametersStorage constructor = 0 AND deploy/054 returns
+# early on chainId 31337). This arms it on the running devnet chain and proves:
+#
+#   1. DORMANT by default: a CG registered with param==0 escrows nothing.
+#   2. ARMED: with the param set live, registering a CG pulls the deposit GROSS
+#      into the CSS vault — getRegistrationEscrow(cgId) == deposit, and the
+#      client adapter's lazy approve-and-retry funds the allowance with no
+#      manual approve.
+#   3. Param is RESET to 0 at teardown (dormant-regression-safe for other suites).
+#
+# Governance setter is called with the local Hardhat deployer (Hub owner) key —
+# this is the PUBLIC well-known hardhat account[0] key, valid only on the local
+# 31337 devnet chain. It is NOT a real deployer key.
+#
+# Requires a running devnet (./scripts/devnet.sh start 6). Self-contained.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+NODE_DIR="$DEVNET_DIR/node1"
+CLI_JS="$REPO_ROOT/packages/cli/dist/cli.js"
+CHAIN_CALL="$REPO_ROOT/scripts/devnet-chain-call.mjs"
+STAMP="$(node -e 'process.stdout.write(String(Date.now()))')"
+
+# Local hardhat account[0] (deployer / Hub owner). PUBLIC test key, devnet-only.
+GOV_KEY="${GOV_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+DEPOSIT="${DEPOSIT:-1000000000000000000}"   # 1 TRAC (small, affordable by the op-wallet)
+
+PASS=0; FAIL=0
+log() { echo "[cg-deposit] $*"; }
+ok()  { echo "[cg-deposit]   PASS: $*"; PASS=$((PASS+1)); }
+bad() { echo "[cg-deposit]   FAIL: $*" >&2; FAIL=$((FAIL+1)); }
+act() { echo; echo "[cg-deposit] === $* ==="; }
+
+call() { node "$CHAIN_CALL" "$@" 2>&1; }
+field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":String(v))})' <<<"$1"; }
+
+# create + on-chain register a CG via the node's daemon; echoes the numeric on-chain id
+create_register_cg() {
+  local slug="$1" out fq onchain
+  out=$(DKG_HOME="$NODE_DIR" node "$CLI_JS" context-graph create "$slug" --name "deposit-$slug" 2>&1) || { echo "CREATE_FAIL: $out" >&2; return 1; }
+  fq=$(printf '%s' "$out" | grep -oE 'did:dkg:context-graph:[^ "]+' | head -1)
+  [ -z "$fq" ] && fq="$slug"
+  out=$(DKG_HOME="$NODE_DIR" node "$CLI_JS" context-graph register "$fq" 2>&1) || { echo "REGISTER_FAIL: $out" >&2; return 1; }
+  onchain=$(printf '%s' "$out" | grep -oiE 'on-?chain[^0-9]*[0-9]+|contextGraphId[^0-9]*[0-9]+|id[^0-9]*[0-9]+' | grep -oE '[0-9]+' | tail -1)
+  printf '%s' "$onchain"
+}
+
+[ -f "$CLI_JS" ] || { echo "[cg-deposit] FATAL: CLI not built ($CLI_JS)"; exit 2; }
+
+# ============================================================================
+act "0. baseline — deposit param is DORMANT (0) on the devnet"
+# ============================================================================
+P0=$(field "$(call ParametersStorage contextGraphRegistrationDeposit)" result)
+[ "$P0" = "0" ] && ok "deposit param dormant at baseline (0)" || bad "expected param 0 at baseline, got '$P0'"
+
+# ============================================================================
+act "1. DORMANT path — register a CG, escrow must be 0"
+# ============================================================================
+CG_DORMANT=$(create_register_cg "dep-dormant-$STAMP") || bad "dormant CG create/register failed"
+if [ -n "$CG_DORMANT" ]; then
+  ESC=$(field "$(call ContextGraphStorage getRegistrationEscrow --json "[\"$CG_DORMANT\"]")" result)
+  [ "$ESC" = "0" ] && ok "param=0: CG $CG_DORMANT escrowed nothing (esc=$ESC)" || bad "param=0 but escrow=$ESC (expected 0)"
+else
+  bad "could not resolve dormant CG on-chain id"
+fi
+
+# ============================================================================
+act "2. ARM the param (governance) then register a CG — deposit must escrow"
+# ============================================================================
+SET=$(call ParametersStorage setContextGraphRegistrationDeposit --key "$GOV_KEY" --json "[\"$DEPOSIT\"]")
+TXH=$(field "$SET" txHash)
+[ -n "$TXH" ] && ok "armed deposit param via governance (tx=$TXH)" || bad "setContextGraphRegistrationDeposit failed: $SET"
+P1=$(field "$(call ParametersStorage contextGraphRegistrationDeposit)" result)
+[ "$P1" = "$DEPOSIT" ] && ok "param now live = $P1 wei (1 TRAC)" || bad "param not set (got '$P1', want $DEPOSIT)"
+
+CG_ARMED=$(create_register_cg "dep-armed-$STAMP") || bad "armed CG create/register failed (deposit pull / lazy-approve?)"
+if [ -n "$CG_ARMED" ]; then
+  ESC2=$(field "$(call ContextGraphStorage getRegistrationEscrow --json "[\"$CG_ARMED\"]")" result)
+  if [ "$ESC2" = "$DEPOSIT" ]; then
+    ok "ARMED: CG $CG_ARMED escrowed the full deposit gross (esc=$ESC2) via lazy approve-and-retry"
+  else
+    bad "armed register did not escrow the deposit (esc=$ESC2, expected $DEPOSIT)"
+  fi
+else
+  bad "could not resolve armed CG on-chain id"
+fi
+
+# ============================================================================
+act "3. TEARDOWN — reset param to 0 (dormant-regression safe)"
+# ============================================================================
+RST=$(call ParametersStorage setContextGraphRegistrationDeposit --key "$GOV_KEY" --json "[\"0\"]")
+[ -n "$(field "$RST" txHash)" ] && log "param reset tx=$(field "$RST" txHash)"
+P2=$(field "$(call ParametersStorage contextGraphRegistrationDeposit)" result)
+[ "$P2" = "0" ] && ok "param reset to dormant (0)" || bad "param NOT reset (still $P2) — other suites may break!"
+
+echo
+log "──────── SUMMARY ────────"
+log "PASS=$PASS  FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] && { log "ALL CG-DEPOSIT CHECKS PASSED"; exit 0; } || { log "SOME CHECKS FAILED"; exit 1; }

--- a/scripts/devnet-test-rfc49-catalog-sampling.sh
+++ b/scripts/devnet-test-rfc49-catalog-sampling.sh
@@ -120,6 +120,19 @@ log "all 6 nodes reachable"
 
 log "configuring baseline core $BASELINE_CORE with swmHostMode.stripCiphertext=false (discriminator)…"
 CFG="$(node_dir "$BASELINE_CORE")/config.json"
+# Back up the baseline core's config and restore it (with a restart) on ANY exit.
+# This suite is now run inside the shared comprehensive sweep, so leaving the core
+# on stripCiphertext=false would silently change SWM behavior for every later
+# suite (and leave the devnet mutated after a passing run).
+CFG_BAK="$(mktemp "${TMPDIR:-/tmp}/rfc49-cfg-XXXXXX")"
+cp "$CFG" "$CFG_BAK"
+restore_baseline_core() {
+  [ -f "$CFG_BAK" ] || return 0
+  cp "$CFG_BAK" "$CFG" 2>/dev/null || true
+  "$SCRIPT_DIR/devnet.sh" restart-node "$BASELINE_CORE" >/dev/null 2>&1 || true
+  rm -f "$CFG_BAK"
+}
+trap restore_baseline_core EXIT INT TERM
 node -e '
 const fs=require("fs");const f=process.argv[1];const c=JSON.parse(fs.readFileSync(f,"utf8"));
 c.swmHostMode=Object.assign({},c.swmHostMode,{enabled:true,stripCiphertext:false});

--- a/scripts/devnet-test-seal-decouple.sh
+++ b/scripts/devnet-test-seal-decouple.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# #1241 / issue #1116 — context-graph-INDEPENDENT author seal: devnet proof.
+#
+# Closes the coverage gap flagged for rc19: NONE of the headline #1116 behaviors
+# were exercised on a real multi-node fleet (the existing suites hardcode a
+# PRE-registered CG, so they never hit the new paths). This drives them against
+# a fleet, asserting the HTTP contract directly:
+#
+#   A. NEVER-REGISTERED CG, full lifecycle: create(local) -> write -> finalize(seal)
+#      -> share(seals by default) -> /vm/publish AUTO-REGISTERS and mints.
+#      The seal is produced off-chain BEFORE any on-chain registration; publish
+#      confirming on a CG that was never `register`-ed is the auto-register proof
+#      (without #1241 this returns 400 "not registered on-chain").
+#   B. skipSeal:true share -> unsealed SWM share ({sealed:false, publishReady:false}).
+#   C. seal-in-SWM: finalize layer:"swm" seals the stuck (skipSeal) asset in place
+#      ({sealed:true}) WITHOUT delete-and-recreate, and it then publishes.
+#
+# Requires a running devnet (./scripts/devnet.sh start 6). Creates its OWN fresh
+# CG each run; does NOT mutate global chain params, so it is safe alongside the
+# other suites. Self-contained (bash 3.2).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEVNET_DIR="${DEVNET_DIR:-$REPO_ROOT/.devnet}"
+TMPDIR="${TMPDIR:-/tmp}"
+API_PORT_BASE="${API_PORT_BASE:-9201}"
+NODE="${NODE:-1}"
+STAMP="$(node -e 'process.stdout.write(String(Date.now()))')"
+
+PASS=0; FAIL=0
+log()  { echo "[seal-decouple] $*"; }
+ok()   { echo "[seal-decouple]   PASS: $*"; PASS=$((PASS+1)); }
+bad()  { echo "[seal-decouple]   FAIL: $*" >&2; FAIL=$((FAIL+1)); }
+act()  { echo; echo "[seal-decouple] === $* ==="; }
+
+node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
+node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
+
+# field <json> <dot.path>  -> value (objects/arrays stringified), "" if missing
+field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":(typeof v==="object"?JSON.stringify(v):String(v)))})' <<<"$1"; }
+
+# api <node> <METHOD> <path> [body]  -> stdout: "<httpcode>\n<body>"
+api() {
+  local n="$1" m="$2" p="$3" b="${4:-}" port token tmp code
+  port=$(node_port "$n"); token=$(node_token "$n"); tmp="$(mktemp "$TMPDIR/seal-dc-XXXXXX")"
+  local -a a=(-sS --max-time 180 --connect-timeout 5 -o "$tmp" -w '%{http_code}' -X "$m"
+    -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
+  [ -n "$b" ] && a+=(--data "$b")
+  code=$(curl "${a[@]}" "http://127.0.0.1:${port}${p}" 2>/dev/null || echo 000)
+  printf '%s\n' "$code"; cat "$tmp"; rm -f "$tmp"
+}
+code_of() { printf '%s' "$1" | head -1; }
+body_of() { printf '%s' "$1" | tail -n +2; }
+
+# preflight
+curl -sf --max-time 5 -H "Authorization: Bearer $(node_token "$NODE")" \
+  "http://127.0.0.1:$(node_port "$NODE")/api/status" >/dev/null \
+  || { echo "[seal-decouple] FATAL: node $NODE not reachable — run ./scripts/devnet.sh start 6" >&2; exit 2; }
+
+CG="cgfree-$STAMP"             # deliberately NEVER registered on-chain
+SUBJ="urn:seal-dc:$STAMP"
+
+# ============================================================================
+act "A. never-registered CG: create -> write -> finalize(seal) -> share -> vm/publish AUTO-REGISTERS"
+# ============================================================================
+NAME_A="seal-dc-a-$STAMP"
+
+# A0: create the CG LOCALLY only (no on-chain register step — that is the point)
+R=$(api "$NODE" POST /api/context-graph/create "{\"id\":\"$CG\",\"name\":\"seal-decouple $STAMP\"}")
+[ "$(code_of "$R")" = "200" ] || { bad "local CG create failed (HTTP $(code_of "$R")): $(body_of "$R")"; }
+
+# A1: create the WM assertion
+R=$(api "$NODE" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$NAME_A\"}")
+AURI=$(field "$(body_of "$R")" assertionUri)
+[ -n "$AURI" ] && ok "WM assertion created on never-registered CG ($AURI)" || bad "create failed (HTTP $(code_of "$R")): $(body_of "$R")"
+
+# A2: write a triple
+WB="{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$SUBJ\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"seal-decouple A $STAMP\\\"\",\"graph\":\"\"}]}"
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_A/wm/write" "$WB")
+[ "$(code_of "$R")" = "200" ] && ok "WM write succeeded" || bad "WM write failed (HTTP $(code_of "$R")): $(body_of "$R")"
+
+# A3: finalize (SEAL) — must succeed off-chain on an UNREGISTERED CG (the #1116 core)
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_A/wm/finalize" "{\"contextGraphId\":\"$CG\"}")
+if [ "$(code_of "$R")" = "200" ]; then ok "finalize SEALED the draft on an unregistered CG (CG-independent seal)"
+else bad "finalize failed on unregistered CG (HTTP $(code_of "$R")): $(body_of "$R")"; fi
+
+# A4: full share — seals by default; expect sealed=true, publishReady=true
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_A/swm/share" "{\"contextGraphId\":\"$CG\"}")
+SEALED=$(field "$(body_of "$R")" sealed); READY=$(field "$(body_of "$R")" publishReady)
+[ "$SEALED" = "true" ] && ok "share seals-by-default (sealed=true, publishReady=$READY)" \
+  || bad "share did not seal by default (sealed=$SEALED HTTP $(code_of "$R")): $(body_of "$R")"
+
+# A5: vm/publish — must AUTO-REGISTER the never-registered CG then mint
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_A/vm/publish" "{\"contextGraphId\":\"$CG\"}")
+PCODE=$(code_of "$R"); PSTATUS=$(field "$(body_of "$R")" status); KAID=$(field "$(body_of "$R")" kaId)
+if [ "$PCODE" = "200" ] && { [ "$PSTATUS" = "confirmed" ] || [ "$PSTATUS" = "finalized" ]; }; then
+  ok "vm/publish AUTO-REGISTERED + minted on the never-registered CG (status=$PSTATUS kaId=$KAID)"
+elif printf '%s' "$(body_of "$R")" | grep -qi 'not registered'; then
+  bad "vm/publish did NOT auto-register (regression): $(body_of "$R")"
+else
+  bad "vm/publish failed (HTTP $PCODE status=$PSTATUS): $(body_of "$R")"
+fi
+
+# ============================================================================
+act "B. skipSeal:true -> UNSEALED SWM share (sealed=false, publishReady=false)"
+# ============================================================================
+NAME_B="seal-dc-b-$STAMP"
+SUBJ_B="urn:seal-dc-b:$STAMP"
+api "$NODE" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$NAME_B\"}" >/dev/null
+api "$NODE" POST "/api/knowledge-assets/$NAME_B/wm/write" \
+  "{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$SUBJ_B\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"unsealed $STAMP\\\"\",\"graph\":\"\"}]}" >/dev/null
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/swm/share" "{\"contextGraphId\":\"$CG\",\"skipSeal\":true}")
+SEALED_B=$(field "$(body_of "$R")" sealed); READY_B=$(field "$(body_of "$R")" publishReady)
+[ "$SEALED_B" = "false" ] && ok "skipSeal share is unsealed (sealed=false, publishReady=$READY_B)" \
+  || bad "skipSeal did not yield an unsealed share (sealed=$SEALED_B HTTP $(code_of "$R")): $(body_of "$R")"
+# strict-boolean guard: a string "true" must 400
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/swm/share" "{\"contextGraphId\":\"$CG\",\"skipSeal\":\"true\"}")
+[ "$(code_of "$R")" = "400" ] && ok "non-boolean skipSeal rejected with 400" \
+  || bad "non-boolean skipSeal not rejected (HTTP $(code_of "$R")): $(body_of "$R")"
+
+# ============================================================================
+act "C. seal-in-SWM: finalize layer=swm seals the stuck unsealed asset in place"
+# ============================================================================
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/wm/finalize" "{\"contextGraphId\":\"$CG\",\"layer\":\"swm\"}")
+if [ "$(code_of "$R")" = "200" ]; then
+  ok "finalize layer=swm sealed the in-SWM asset without recreate"
+  R2=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/vm/publish" "{\"contextGraphId\":\"$CG\"}")
+  PS2=$(field "$(body_of "$R2")" status)
+  { [ "$PS2" = "confirmed" ] || [ "$PS2" = "finalized" ]; } && ok "seal-in-SWM asset then published (status=$PS2)" \
+    || bad "seal-in-SWM asset failed to publish (status=$PS2): $(body_of "$R2")"
+else
+  bad "finalize layer=swm failed (HTTP $(code_of "$R")): $(body_of "$R")"
+fi
+# invalid layer must 400
+R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/wm/finalize" "{\"contextGraphId\":\"$CG\",\"layer\":\"bogus\"}")
+[ "$(code_of "$R")" = "400" ] && ok "invalid finalize layer rejected with 400" \
+  || bad "invalid finalize layer not rejected (HTTP $(code_of "$R"))"
+
+# ============================================================================
+echo
+log "──────── SUMMARY ────────"
+log "PASS=$PASS  FAIL=$FAIL  (CG=$CG)"
+[ "$FAIL" -eq 0 ] && { log "ALL SEAL-DECOUPLE CHECKS PASSED"; exit 0; } || { log "SOME CHECKS FAILED"; exit 1; }

--- a/scripts/devnet-test-seal-decouple.sh
+++ b/scripts/devnet-test-seal-decouple.sh
@@ -39,24 +39,11 @@ ok()   { echo "[seal-decouple]   PASS: $*"; PASS=$((PASS+1)); }
 bad()  { echo "[seal-decouple]   FAIL: $*" >&2; FAIL=$((FAIL+1)); }
 act()  { echo; echo "[seal-decouple] === $* ==="; }
 
-node_token() { grep -v '^#' "$DEVNET_DIR/node$1/auth.token" 2>/dev/null | tr -d '[:space:]'; }
-node_port()  { echo $((API_PORT_BASE + $1 - 1)); }
-
-# field <json> <dot.path>  -> value (objects/arrays stringified), "" if missing
-field() { J="$2" node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{let j;try{j=JSON.parse(d)}catch(e){process.stdout.write("");return}let v=j;for(const k of process.env.J.split("."))v=(v==null?undefined:v[k]);process.stdout.write(v==null?"":(typeof v==="object"?JSON.stringify(v):String(v)))})' <<<"$1"; }
-
-# api <node> <METHOD> <path> [body]  -> stdout: "<httpcode>\n<body>"
-api() {
-  local n="$1" m="$2" p="$3" b="${4:-}" port token tmp code
-  port=$(node_port "$n"); token=$(node_token "$n"); tmp="$(mktemp "$TMPDIR/seal-dc-XXXXXX")"
-  local -a a=(-sS --max-time 180 --connect-timeout 5 -o "$tmp" -w '%{http_code}' -X "$m"
-    -H "Authorization: Bearer $token" -H 'Content-Type: application/json')
-  [ -n "$b" ] && a+=(--data "$b")
-  code=$(curl "${a[@]}" "http://127.0.0.1:${port}${p}" 2>/dev/null || echo 000)
-  printf '%s\n' "$code"; cat "$tmp"; rm -f "$tmp"
-}
-code_of() { printf '%s' "$1" | head -1; }
-body_of() { printf '%s' "$1" | tail -n +2; }
+# Shared node auth / HTTP / JSON helpers: node_token, node_port, api, code_of,
+# body_of, field. Keep this suite's 180s api timeout (publish/finalize can be slow).
+# shellcheck disable=SC2034  # consumed by api() inside the sourced devnet-lib.sh
+DKG_API_MAXTIME=180
+. "$REPO_ROOT/scripts/devnet-lib.sh" || { echo "[seal-decouple] FATAL: cannot source devnet-lib.sh" >&2; exit 2; }
 # req_ok <label> <node> <METHOD> <path> [body] — api + assert HTTP 200, else bad()
 # with the failing operation's label/body (so a broken setup step surfaces HERE,
 # not later as a misleading share/finalize failure).

--- a/scripts/devnet-test-seal-decouple.sh
+++ b/scripts/devnet-test-seal-decouple.sh
@@ -19,6 +19,11 @@
 # Requires a running devnet (./scripts/devnet.sh start 6). Creates its OWN fresh
 # CG each run; does NOT mutate global chain params, so it is safe alongside the
 # other suites. Self-contained (bash 3.2).
+#
+# Standalone MANUAL proof — run directly; intentionally NOT wired into
+# devnet-comprehensive.sh / _devnet-full-sweep.sh (these gap proofs are kept out
+# of the shared orchestrated run; see PR #1244).
+#   Run:  ./scripts/devnet-test-seal-decouple.sh
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -52,6 +57,15 @@ api() {
 }
 code_of() { printf '%s' "$1" | head -1; }
 body_of() { printf '%s' "$1" | tail -n +2; }
+# req_ok <label> <node> <METHOD> <path> [body] — api + assert HTTP 200, else bad()
+# with the failing operation's label/body (so a broken setup step surfaces HERE,
+# not later as a misleading share/finalize failure).
+req_ok() {
+  local label="$1"; shift
+  local R; R=$(api "$@")
+  if [ "$(code_of "$R")" != "200" ]; then bad "$label failed (HTTP $(code_of "$R")): $(body_of "$R")"; return 1; fi
+  return 0
+}
 
 # preflight
 curl -sf --max-time 5 -H "Authorization: Bearer $(node_token "$NODE")" \
@@ -107,13 +121,18 @@ act "B. skipSeal:true -> UNSEALED SWM share (sealed=false, publishReady=false)"
 # ============================================================================
 NAME_B="seal-dc-b-$STAMP"
 SUBJ_B="urn:seal-dc-b:$STAMP"
-api "$NODE" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$NAME_B\"}" >/dev/null
-api "$NODE" POST "/api/knowledge-assets/$NAME_B/wm/write" \
-  "{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$SUBJ_B\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"unsealed $STAMP\\\"\",\"graph\":\"\"}]}" >/dev/null
+req_ok "B-setup create" "$NODE" POST /api/knowledge-assets "{\"contextGraphId\":\"$CG\",\"name\":\"$NAME_B\"}"
+req_ok "B-setup write" "$NODE" POST "/api/knowledge-assets/$NAME_B/wm/write" \
+  "{\"contextGraphId\":\"$CG\",\"quads\":[{\"subject\":\"$SUBJ_B\",\"predicate\":\"http://schema.org/name\",\"object\":\"\\\"unsealed $STAMP\\\"\",\"graph\":\"\"}]}"
 R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/swm/share" "{\"contextGraphId\":\"$CG\",\"skipSeal\":true}")
 SEALED_B=$(field "$(body_of "$R")" sealed); READY_B=$(field "$(body_of "$R")" publishReady)
-[ "$SEALED_B" = "false" ] && ok "skipSeal share is unsealed (sealed=false, publishReady=$READY_B)" \
-  || bad "skipSeal did not yield an unsealed share (sealed=$SEALED_B HTTP $(code_of "$R")): $(body_of "$R")"
+# The documented contract is {sealed:false, publishReady:false}: assert BOTH, so
+# a regression that leaves an unsealed share publish-ready is caught here.
+if [ "$SEALED_B" = "false" ] && [ "$READY_B" = "false" ]; then
+  ok "skipSeal share is unsealed AND not publish-ready (sealed=false, publishReady=false)"
+else
+  bad "skipSeal contract violated (sealed=$SEALED_B publishReady=$READY_B; want false/false; HTTP $(code_of "$R")): $(body_of "$R")"
+fi
 # strict-boolean guard: a string "true" must 400
 R=$(api "$NODE" POST "/api/knowledge-assets/$NAME_B/swm/share" "{\"contextGraphId\":\"$CG\",\"skipSeal\":\"true\"}")
 [ "$(code_of "$R")" = "400" ] && ok "non-boolean skipSeal rejected with 400" \

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -367,6 +367,13 @@ start_oxigraph_servers() {
 }
 
 stop_oxigraph_servers() {
+  # Local daemon-managed oxigraph-server binaries (the `oxigraph-server` backend,
+  # nodes 1-N) are spawned as node children; a SIGKILL'd node can ORPHAN them,
+  # leaving the :79xx port bound so the NEXT `start` dies with "Address already
+  # in use" and those nodes silently fail to boot. Sweep any belonging to THIS
+  # devnet (path-scoped — unrelated oxigraph processes are untouched). Runs
+  # regardless of docker availability (the local binaries are not docker).
+  pkill -f "$DEVNET_DIR/node.*oxigraph/oxigraph" 2>/dev/null || true
   if ! docker_responsive 3; then return 0; fi
   for name in $OXIGRAPH_CONTAINER_5 $OXIGRAPH_CONTAINER_6; do
     if docker inspect "$name" > /dev/null 2>&1; then

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -373,7 +373,16 @@ stop_oxigraph_servers() {
   # in use" and those nodes silently fail to boot. Sweep any belonging to THIS
   # devnet (path-scoped — unrelated oxigraph processes are untouched). Runs
   # regardless of docker availability (the local binaries are not docker).
-  pkill -f "$DEVNET_DIR/node.*oxigraph/oxigraph" 2>/dev/null || true
+  #
+  # DEVNET_DIR is user-configurable and may contain regex/glob metacharacters, so
+  # we do NOT feed it to `pkill -f` as a raw regex (where `.`/`[`/`+`/spaces would
+  # change the match and could over-match). Instead match the dir as a LITERAL
+  # substring of each process's command line via a quoted `case` glob.
+  ps axww -o pid=,command= 2>/dev/null | while read -r _pid _cmd; do
+    case "$_cmd" in
+      *"$DEVNET_DIR/node"*"oxigraph/oxigraph"*) kill "$_pid" 2>/dev/null || true ;;
+    esac
+  done
   if ! docker_responsive 3; then return 0; fi
   for name in $OXIGRAPH_CONTAINER_5 $OXIGRAPH_CONTAINER_6; do
     if docker inspect "$name" > /dev/null 2>&1; then

--- a/scripts/v10-rc-validation.sh
+++ b/scripts/v10-rc-validation.sh
@@ -227,6 +227,14 @@ JSON
   PRIV_STATUS=$(echo "$PRIV_RESULT" | pyfield "d.get('status','?')")
   if [ "$PRIV_STATUS" = "confirmed" ] || [ "$PRIV_STATUS" = "finalized" ]; then
     ok "Update with private triples confirmed, status=$PRIV_STATUS"
+  elif echo "$PRIV_RESULT" | grep -q 'NO_DATA_IN_SWM'; then
+    # OT-RFC-49 (Rung-1 strip): cores hold ZERO private SWM ciphertext, so a
+    # private-quad update on a curated CG cannot draw its ACK quorum FROM the
+    # cores — that decline is the privacy model working as intended, not a
+    # failure. The durable private-update path now routes through the curator
+    # and is covered by scripts/devnet-test-curator-ack-gate.sh. Treat as an
+    # expected post-RFC-49 outcome here.
+    warn "Private update declined NO_DATA_IN_SWM — expected post-RFC-49 (cores don't host private SWM; curator path covered by devnet-test-curator-ack-gate.sh)"
   else
     fail "Private update status=$PRIV_STATUS: $PRIV_RESULT"
   fi
@@ -618,12 +626,21 @@ fi
 # ────────────────────────────────────────────────────────────────────────────
 section "14. SKILL.MD ENDPOINT"
 
-SKILL=$(get 9201 /.well-known/skill.md 2>/dev/null || echo '')
-if echo "$SKILL" | grep -q "assertion"; then
-  ok "SKILL.md served and contains 'assertion' terminology"
+# Fetch to a temp FILE and grep the file (not an 83KB shell variable, which was
+# brittle under the runner's shell state). Case-insensitive for any current
+# KA/memory term — the #1116 SKILL.md rewrite changed exact wording, so the old
+# literal `grep -q "assertion"` on a piped variable was stale. One retry — the
+# static route can lag on a cold daemon.
+SKILL_FILE=$(mktemp "${TMPDIR:-/tmp}/v10rc-skill-XXXXXX")
+get 9201 /.well-known/skill.md > "$SKILL_FILE" 2>/dev/null
+[ -s "$SKILL_FILE" ] || get 9201 /.well-known/skill.md > "$SKILL_FILE" 2>/dev/null
+SKILL_BYTES=$(wc -c < "$SKILL_FILE" | tr -d ' ')
+if [ "${SKILL_BYTES:-0}" -gt 1000 ] && grep -qiE 'assertion|knowledge asset|verifiable memory|working memory' "$SKILL_FILE"; then
+  ok "SKILL.md served ($SKILL_BYTES bytes) with current KA/memory terminology"
 else
-  fail "SKILL.md missing or doesn't contain assertion terminology"
+  fail "SKILL.md missing or stale ($SKILL_BYTES bytes)"
 fi
+rm -f "$SKILL_FILE"
 
 # ────────────────────────────────────────────────────────────────────────────
 section "15. IDENTITY / AGENT PROFILE"


### PR DESCRIPTION
## What
Adds devnet coverage for three **new-since-rc17** features that had **zero** devnet tests (surfaced by the rc19 readiness review), plus a devnet-harness fix. All three scripts are **green on a 6-node fleet**.

## New gap-test scripts
| Script | Feature | Result | Proves |
|---|---|---|---|
| `devnet-test-seal-decouple.sh` | #1241 / #1116 CG-independent seal | **10/10** | finalize seals on a **never-registered CG**; `/vm/publish` **auto-registers** the CG and mints; full share seals-by-default; `skipSeal`→unsealed SWM share; **seal-in-SWM** (`finalize layer:swm` in place); 400 + strict-boolean guards |
| `devnet-test-cg-registration-deposit.sh` | #1229 / OT-RFC-53 deposit | **6/6** | dormant (param=0 → no escrow) → **armed** (governance sets param; register pulls the deposit gross into the CSS vault via the adapter's lazy approve-and-retry) → param **reset to 0** at teardown |
| `devnet-test-agents-meta-bounded.sh` | #1234 agents/_meta bloat | **12/12** | agent-registry DATA graph populated while `<agents>/_meta` stays **bounded** on every node (no unbounded tentative records) |

## Harness fix (`scripts/devnet.sh`)
`stop_oxigraph_servers()` only removed the **docker** oxigraph containers (nodes 5-6); it never killed the **local daemon-managed** `oxigraph-server` binaries (nodes 1-N). A `SIGKILL`'d node orphans them → the `:79xx` port stays bound → the next `devnet.sh start` dies with `Address already in use` and those nodes **silently fail to boot** (the main source of devnet flakiness on repeated boots — not memory). Now a **path-scoped** sweep (only this devnet's orphaned oxigraph procs) runs on `stop`/`clean`.

## Notes
- Scripts are self-contained, reuse a running `./scripts/devnet.sh start 6` fleet, and create their own CGs.
- The deposit test arms a **global** param and **resets it to 0** at teardown (dormant-regression-safe for other suites).
- The deposit governance setter uses the well-known **public hardhat account[0]** key — local 31337 devnet only, **not** a real deployer key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
