### PR TITLE
Release v10.0.0-rc.19 — version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/openclaw.plugin.json
+++ b/packages/adapter-openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "adapter-openclaw",
   "name": "DKG Node UI Bridge",
-  "version": "10.0.0-rc.2",
+  "version": "10.0.0-rc.19",
   "description": "Connects a local OpenClaw agent to a DKG V10 node for node-backed chat, memory, and agent-network capabilities.",
   "kind": "memory",
   "channels": ["dkg-ui"],

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/src/index.ts
+++ b/packages/random-sampling/src/index.ts
@@ -18,7 +18,7 @@
  * registered.
  */
 
-export const RANDOM_SAMPLING_PACKAGE_VERSION = '10.0.0-rc.2';
+export const RANDOM_SAMPLING_PACKAGE_VERSION = '10.0.0-rc.19';
 
 export {
   extractV10KCFromStore,

--- a/packages/random-sampling/test/skeleton.test.ts
+++ b/packages/random-sampling/test/skeleton.test.ts
@@ -3,6 +3,6 @@ import { RANDOM_SAMPLING_PACKAGE_VERSION } from '../src/index.js';
 
 describe('@origintrail-official/dkg-random-sampling — skeleton', () => {
   it('exposes a version constant matching the rest of the workspace', () => {
-    expect(RANDOM_SAMPLING_PACKAGE_VERSION).toBe('10.0.0-rc.2');
+    expect(RANDOM_SAMPLING_PACKAGE_VERSION).toBe('10.0.0-rc.19');
   });
 });

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.18",
+  "version": "10.0.0-rc.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## rc19 release — version bump

Version-bump PR for **v10.0.0-rc.19**. Cuts from current `main` (`525004a04`). Single commit: `10.0.0-rc.18 → 10.0.0-rc.19` across all 19 workspace `package.json` (16 public validated == rc.19 for the npm-publish gate). No code or lockfile changes.

> **Scope: version only.** Unlike rc18, this PR does not touch contract addresses — any testnet/mainnet contract redeploy + address update is handled separately.

### What rc19 contains (already merged to `main` since rc18)
**Anti-spam / security**
- OT-RFC-53 context-graph registration deposit — per-CG 100 TRAC anti-spam escrow, bounty #2 mitigation (#1229)
- Private imported-artifact read authorization (#1237)

**Scalability**
- Scalable weighted-CG RandomSampling — Fenwick-BIT O(log) draw + settle hooks (#1226)

**Observability**
- Daemon admission-control stats on `/api/status` + reusable load probe (#1230)

**Mainnet prep & stability**
- V10 mainnet network-config values (#1238); mainnet blockers #1124/#787/#306 (#1239); P0 / high pre-mainnet issues (#1228, #1132)
- Seal/SWM decouple + #1116 follow-ups (#1241, #1242)
- Sync/SWM stability: ack-quorum regressions (#1236), connect-flap (#1227), responder row-list race & defaults (#1232, #1224); agents/_meta bloat (#1234, #1233); raw TooLowAllowance recovery (#1223)

### After merge (release process — for reference, not part of this PR)
Tag `v10.0.0-rc.19` → `npm-publish` (reviewer-gated) → GitHub release → update testnet nodes + validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
