### PR TITLE
Fix conviction expiry queue DoS

### DIFF
--- a/packages/evm-module/abi/ConvictionStakingStorage.json
+++ b/packages/evm-module/abi/ConvictionStakingStorage.json
@@ -920,6 +920,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "MAX_TIER_DURATION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",

--- a/packages/evm-module/abi/ConvictionStakingStorage.json
+++ b/packages/evm-module/abi/ConvictionStakingStorage.json
@@ -62,6 +62,27 @@
   {
     "inputs": [
       {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pending",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxPending",
+        "type": "uint256"
+      }
+    ],
+    "name": "NodeExpiryQueueFull",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "token",
         "type": "address"
@@ -858,6 +879,32 @@
     ],
     "name": "V10LaunchEpochSet",
     "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "EXPIRY_BUCKET_SECONDS",
+    "outputs": [
+      {
+        "internalType": "uint40",
+        "name": "",
+        "type": "uint40"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_NODE_PENDING_EXPIRIES",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [],

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -159,6 +159,16 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     uint256 internal constant SCALE18 = 1e18;
     uint40 public constant EXPIRY_BUCKET_SECONDS = 12 hours;
     uint256 public constant MAX_NODE_PENDING_EXPIRIES = 1024;
+    /// @notice Maximum boosted lock-tier duration. A single tier's expiry window
+    ///         must fit within `MAX_NODE_PENDING_EXPIRIES` 12h buckets
+    ///         (`1024 * 12h = 512 days`). With this cap enforced in `addTier`, the
+    ///         distinct future buckets a node can ever hold is <= the slot cap, so
+    ///         `MAX_NODE_PENDING_EXPIRIES` can never be reached by valid stakes —
+    ///         it stays a pure backstop and never blocks a legitimate stake/relock
+    ///         (and the tombstone-vs-live slot distinction can never bite). The
+    ///         baseline ladder tops out at 366 days, well under this.
+    uint256 public constant MAX_TIER_DURATION =
+        MAX_NODE_PENDING_EXPIRIES * uint256(EXPIRY_BUCKET_SECONDS);
 
     // ============================================================
     //                 D20 — Mutable tier ladder
@@ -557,6 +567,10 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
             require(duration == 0 && multiplier18 == uint64(SCALE18), "Tier 0 must be rest");
         } else {
             require(duration > 0, "Non-zero tier needs duration");
+            // Keep MAX_NODE_PENDING_EXPIRIES an unreachable backstop: a single
+            // tier's expiry window must fit within that many 12h buckets, so the
+            // per-node slot cap can never block a legitimate stake/relock.
+            require(duration <= MAX_TIER_DURATION, "Tier duration too long");
             require(multiplier18 > uint64(SCALE18), "Non-zero tier needs boost");
         }
         _addTierInternal(lockTier, duration, multiplier18);

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -159,16 +159,20 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     uint256 internal constant SCALE18 = 1e18;
     uint40 public constant EXPIRY_BUCKET_SECONDS = 12 hours;
     uint256 public constant MAX_NODE_PENDING_EXPIRIES = 1024;
-    /// @notice Maximum boosted lock-tier duration. A single tier's expiry window
-    ///         must fit within `MAX_NODE_PENDING_EXPIRIES` 12h buckets
-    ///         (`1024 * 12h = 512 days`). With this cap enforced in `addTier`, the
-    ///         distinct future buckets a node can ever hold is <= the slot cap, so
+    /// @notice Maximum boosted lock-tier duration. Bounded so the distinct future
+    ///         buckets a node can ever hold stays STRICTLY below the slot cap.
+    ///         Because `_computeExpiryTimestamp` rounds UP to the next bucket, a
+    ///         tier of `k` buckets created just after a boundary expires `k + 1`
+    ///         buckets out — so a node staking once per bucket can reach `k + 1`
+    ///         distinct pending slots. To keep that `<= MAX_NODE_PENDING_EXPIRIES`,
+    ///         a tier must be at most `MAX_NODE_PENDING_EXPIRIES - 1` buckets
+    ///         (`1023 * 12h = 511.5 days`). With this enforced in `addTier`,
     ///         `MAX_NODE_PENDING_EXPIRIES` can never be reached by valid stakes —
     ///         it stays a pure backstop and never blocks a legitimate stake/relock
     ///         (and the tombstone-vs-live slot distinction can never bite). The
     ///         baseline ladder tops out at 366 days, well under this.
     uint256 public constant MAX_TIER_DURATION =
-        MAX_NODE_PENDING_EXPIRIES * uint256(EXPIRY_BUCKET_SECONDS);
+        (MAX_NODE_PENDING_EXPIRIES - 1) * uint256(EXPIRY_BUCKET_SECONDS);
 
     // ============================================================
     //                 D20 — Mutable tier ladder
@@ -1009,6 +1013,13 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
             require(lockTier != 0, "Credit requires locked tier");
             uint256 dur = _tierDuration(lockTier);
             require(uint256(expiryShortenedBy) < dur, "Credit >= tier duration");
+            // Subtract the migration credit AFTER bucketing and do NOT re-bucket.
+            // `expiryShortenedBy` (convictionCreditSeconds) is a single global
+            // offset, so `bucketedDefault - credit` still coalesces (same shifted
+            // timestamp per creation bucket) and the queue stays bounded. Re-bucketing
+            // here would silently round a non-bucket-aligned credit UP to the 12h grid
+            // (e.g. `60d - 1h` -> a full `60d`), changing the configured credit. The
+            // exact second is preserved on purpose — do not "tidy" this onto the grid.
             expiryTimestamp = uint40(uint256(expiryTimestamp) - uint256(expiryShortenedBy));
             require(expiryTimestamp > tsNow, "Credit leaves no remaining lock");
         }

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -49,9 +49,9 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  *     `lockTier` id). The baseline ladder seeded at `initialize()` is
  *     {0→(0s, 1x), 1→(30d, 1.5x), 3→(90d, 2x), 6→(180d, 3.5x), 12→(366d, 6x)}.
  *   - `expiryTimestamp = block.timestamp + duration`, rounded UP to the
- *     next daily expiry bucket. The upward rounding keeps the promised
+ *     next 12-hour expiry bucket. The upward rounding keeps the promised
  *     minimum lock duration while coalescing per-block dust stakes into
- *     one queue slot per day.
+ *     one queue slot per half-day.
  *   - New tiers can be appended via `addTier` (HubOwner or multisig owner).
  *     Existing tiers can be deactivated via `deactivateTier` to stop
  *     accepting NEW fresh stakes, but relock / migration paths still
@@ -146,8 +146,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     //           * `createNewPositionFromExisting` migrates carries across
     //             the relock burn-mint; `deletePosition` deletes them.
     //   10.0.5 — Expiry-queue DoS hardening:
-    //           * Boost expiries are rounded up to daily buckets so per-block
-    //             dust stakes coalesce into one queue slot per day.
+    //           * Boost expiries are rounded up to 12-hour buckets so
+    //             per-block dust stakes coalesce into one queue slot per
+    //             half-day.
     //           * New distinct expiry slots are capped per node; same-bucket
     //             stakes keep coalescing even when the cap is reached.
     string private constant _VERSION = "10.0.5";
@@ -156,8 +157,8 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     // (returns 1e18-scaled values so fractional tiers like 1.5x and 3.5x
     // are representable).
     uint256 internal constant SCALE18 = 1e18;
-    uint40 public constant EXPIRY_BUCKET_SECONDS = 1 days;
-    uint256 public constant MAX_NODE_PENDING_EXPIRIES = 512;
+    uint40 public constant EXPIRY_BUCKET_SECONDS = 12 hours;
+    uint256 public constant MAX_NODE_PENDING_EXPIRIES = 1024;
 
     // ============================================================
     //                 D20 — Mutable tier ladder
@@ -723,9 +724,9 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     /// --------------------------------------------------------
     /// The `while` terminates as soon as `t > ts` or `head == len`.
     /// Entries are only added through `_scheduleNodeExpiry`, and fresh
-    /// lock expiries are rounded UP to daily buckets before they reach
+    /// lock expiries are rounded UP to 12-hour buckets before they reach
     /// the queue. A per-block dust-stake stream therefore coalesces into
-    /// one slot per day, not one slot per block.
+    /// one slot per half-day, not one slot per block.
     ///
     /// `_scheduleNodeExpiry` also refuses to create a new distinct slot
     /// once `MAX_NODE_PENDING_EXPIRIES` pending slots are live for a node.
@@ -736,7 +737,7 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     /// Work is amortized once: each array slot is visited by exactly one
     /// `_settleNodeTo` call across the contract's lifetime. In steady state
     /// `submitProof` drains the queue continuously; after dormancy, the
-    /// daily bucket + pending-slot cap keeps the catch-up loop bounded.
+    /// 12-hour bucket + pending-slot cap keeps the catch-up loop bounded.
     ///
     /// INVARIANTS MAINTAINED ON EXIT
     /// -----------------------------
@@ -1632,7 +1633,7 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
 
     /**
      * @dev Wall-clock expiry computation (D26). Boosts last at least the tier
-     *      duration and expire on the next daily bucket. Returns 0 for tier-0
+     *      duration and expire on the next 12-hour bucket. Returns 0 for tier-0
      *      (permanent rest state).
      */
     function _computeExpiryTimestamp(uint40 lockTier) internal view returns (uint40) {

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -48,8 +48,10 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
  *   - Tier durations and multipliers are stored in `_tiers` (keyed by
  *     `lockTier` id). The baseline ladder seeded at `initialize()` is
  *     {0→(0s, 1x), 1→(30d, 1.5x), 3→(90d, 2x), 6→(180d, 3.5x), 12→(366d, 6x)}.
- *   - `expiryTimestamp = block.timestamp + duration` (timestamp-accurate;
- *     no epoch rounding, no drift buffer).
+ *   - `expiryTimestamp = block.timestamp + duration`, rounded UP to the
+ *     next daily expiry bucket. The upward rounding keeps the promised
+ *     minimum lock duration while coalescing per-block dust stakes into
+ *     one queue slot per day.
  *   - New tiers can be appended via `addTier` (HubOwner or multisig owner).
  *     Existing tiers can be deactivated via `deactivateTier` to stop
  *     accepting NEW fresh stakes, but relock / migration paths still
@@ -143,12 +145,19 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     //             drained by `StakingV10._claim`.
     //           * `createNewPositionFromExisting` migrates carries across
     //             the relock burn-mint; `deletePosition` deletes them.
-    string private constant _VERSION = "10.0.4";
+    //   10.0.5 — Expiry-queue DoS hardening:
+    //           * Boost expiries are rounded up to daily buckets so per-block
+    //             dust stakes coalesce into one queue slot per day.
+    //           * New distinct expiry slots are capped per node; same-bucket
+    //             stakes keep coalescing even when the cap is reached.
+    string private constant _VERSION = "10.0.5";
 
     // Multiplier scale, matches DKGStakingConvictionNFT._convictionMultiplier
     // (returns 1e18-scaled values so fractional tiers like 1.5x and 3.5x
     // are representable).
     uint256 internal constant SCALE18 = 1e18;
+    uint40 public constant EXPIRY_BUCKET_SECONDS = 1 days;
+    uint256 public constant MAX_NODE_PENDING_EXPIRIES = 512;
 
     // ============================================================
     //                 D20 — Mutable tier ladder
@@ -251,6 +260,7 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     event NodeEffectiveStakeDelta(uint72 indexed identityId, int256 delta, uint256 newRunningEffectiveStake);
     event NodeExpiryScheduled(uint72 indexed identityId, uint40 timestamp, uint256 dropAdded, uint256 newTotalDrop);
     event NodeExpiryCancelled(uint72 indexed identityId, uint40 timestamp, uint256 dropRemoved, uint256 newTotalDrop);
+    error NodeExpiryQueueFull(uint72 identityId, uint256 pending, uint256 maxPending);
     // D15 — V10 stake aggregate events.
     event NodeStakeV10Increased(uint72 indexed identityId, uint256 amount, uint256 newNodeStake, uint256 newTotal);
     event NodeStakeV10Decreased(uint72 indexed identityId, uint256 amount, uint256 newNodeStake, uint256 newTotal);
@@ -711,59 +721,22 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     ///
     /// LOOP BOUND (why this cannot explode the block gas limit)
     /// --------------------------------------------------------
-    /// The `while` terminates as soon as `t > ts` (1) or `head == len`
-    /// (2). What could make it iterate "many" times?
+    /// The `while` terminates as soon as `t > ts` or `head == len`.
+    /// Entries are only added through `_scheduleNodeExpiry`, and fresh
+    /// lock expiries are rounded UP to daily buckets before they reach
+    /// the queue. A per-block dust-stake stream therefore coalesces into
+    /// one slot per day, not one slot per block.
     ///
-    ///   (a) Entries are only added by `_scheduleNodeExpiry`, which is
-    ///       itself only reachable from `onlyContracts` mutators above.
-    ///       There is no external path for an attacker to spam the
-    ///       queue — fresh entries cost someone real TRAC to lock.
+    /// `_scheduleNodeExpiry` also refuses to create a new distinct slot
+    /// once `MAX_NODE_PENDING_EXPIRIES` pending slots are live for a node.
+    /// Same-bucket stakes keep accumulating into the existing slot, so the
+    /// cap bounds replay work without blocking aggregation inside an
+    /// already-reserved bucket.
     ///
-    ///   (b) Entries with the same `ts` are coalesced into ONE array
-    ///       slot (see `_scheduleNodeExpiry`: `if (existing != 0) return`).
-    ///       So the queue length is bounded by the number of *distinct*
-    ///       active expiry timestamps the node has ever been scheduled
-    ///       against — NOT by the delegator count.
-    ///
-    ///   (c) Work is strictly amortized once: each array slot is
-    ///       visited by exactly one `_settleNodeTo` call across the
-    ///       contract's lifetime (we only ever advance `head`). In the
-    ///       steady state where settle is called from every CSS mutator
-    ///       and every `submitProof` (~ every epoch), the number of
-    ///       entries matured between two consecutive settles is
-    ///       bounded by (new expiries scheduled during that window that
-    ///       also matured within it) — in practice 0 on a healthy,
-    ///       proof-active node.
-    ///
-    /// The only scenario that produces a large iteration count in one
-    /// call is long-duration node DORMANCY: the node produces no proofs
-    /// AND receives no CSS mutations while many distinct-ts expiries
-    /// mature. Concrete napkin math: on a chain with ~12s block times a node
-    /// that accumulates ONE brand-new distinct expiry timestamp per
-    /// block for 30 days and then stops settling for 30 more days sees
-    /// ~216k matured entries on resume — at ~5k gas per iteration that
-    /// is ~1.1B gas, well above any block limit. That tail is tolerable
-    /// because:
-    ///
-    ///   * To reach it, the node has to have been completely silent
-    ///     (no proofs, no stake/unstake, no relock, no redelegate in or
-    ///     out) for longer than its longest outstanding tier duration.
-    ///     In practice `submitProof` settles on every proof, so any
-    ///     proof-producing node drains continuously.
-    ///   * Same-block same-tier stakes coalesce, so realistic distinct-
-    ///     ts counts are far below the worst case.
-    ///   * The invariant is recoverable: any single `settleNodeTo` that
-    ///     OOMs blocks only the caller's tx; the queue state is
-    ///     unchanged, so later calls can still make progress once gas
-    ///     budgets allow.
-    ///
-    /// If operational telemetry later shows real-world queues
-    /// approaching danger, the escape hatch is a bounded variant
-    /// (`settleNodeToMax(id, ts, maxEntries)`) that advances `head` by
-    /// at most `maxEntries` and lets the protocol drain a dormant queue
-    /// across several txs. Not shipped now because the "who even calls
-    /// this" analysis (a) + steady-state (c) make it dead code for any
-    /// node that ever submits a proof.
+    /// Work is amortized once: each array slot is visited by exactly one
+    /// `_settleNodeTo` call across the contract's lifetime. In steady state
+    /// `submitProof` drains the queue continuously; after dormancy, the
+    /// daily bucket + pending-slot cap keeps the catch-up loop bounded.
     ///
     /// INVARIANTS MAINTAINED ON EXIT
     /// -----------------------------
@@ -887,12 +860,17 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
             // ts already has a slot in the queue; just bumped the drop.
             return;
         }
-        nodeExpiryPresent[identityId][ts] = true;
 
         // Insert `ts` into the sorted queue.
         uint40[] storage arr = nodeExpiryTimes[identityId];
         uint256 head = nodeExpiryHead[identityId];
         uint256 len = arr.length;
+        uint256 pending = len - head;
+        if (pending >= MAX_NODE_PENDING_EXPIRIES) {
+            revert NodeExpiryQueueFull(identityId, pending, MAX_NODE_PENDING_EXPIRIES);
+        }
+        nodeExpiryPresent[identityId][ts] = true;
+
         arr.push(ts); // temporarily at tail
         // Bubble left while the left neighbor is strictly greater AND we
         // haven't crossed the drain head.
@@ -1653,16 +1631,22 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     // ============================================================
 
     /**
-     * @dev Wall-clock expiry computation (D26). Timestamp-accurate:
-     *      the boost ends exactly at `block.timestamp + duration`.
-     *      Returns 0 for tier-0 (permanent rest state).
+     * @dev Wall-clock expiry computation (D26). Boosts last at least the tier
+     *      duration and expire on the next daily bucket. Returns 0 for tier-0
+     *      (permanent rest state).
      */
     function _computeExpiryTimestamp(uint40 lockTier) internal view returns (uint40) {
         if (lockTier == 0) return 0;
         uint256 duration = _tierDuration(lockTier);
         uint256 exp = block.timestamp + duration;
-        require(exp <= type(uint40).max, "Expiry overflow");
-        return uint40(exp);
+        return _bucketExpiryTimestamp(exp);
+    }
+
+    function _bucketExpiryTimestamp(uint256 rawExpiry) internal pure returns (uint40) {
+        uint256 bucket = uint256(EXPIRY_BUCKET_SECONDS);
+        uint256 bucketed = ((rawExpiry + bucket - 1) / bucket) * bucket;
+        require(bucketed <= type(uint40).max, "Expiry overflow");
+        return uint40(bucketed);
     }
 
     function _pushNodeToken(uint72 identityId, uint256 tokenId) internal {

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -24,6 +24,7 @@ const THREE_AND_HALF_X = (35n * SCALE18) / 10n;
 const SIX_X = 6n * SCALE18;
 
 const DAY = 24n * 60n * 60n;
+const HALF_DAY = 12n * 60n * 60n;
 const TIER_DURATIONS: Record<number, bigint> = {
   0: 0n,
   1: 30n * DAY,
@@ -32,10 +33,10 @@ const TIER_DURATIONS: Record<number, bigint> = {
   12: 366n * DAY,
 };
 
-const EXPIRY_BUCKET_SECONDS = DAY;
+const EXPIRY_BUCKET_SECONDS = HALF_DAY;
 
 // D26 — timestamp accounting: no BLOCK_DRIFT_BUFFER padding, no epoch rounding.
-// Boost expiries are rounded up to daily buckets for queue DoS hardening.
+// Boost expiries are rounded up to half-day buckets for queue DoS hardening.
 
 async function latestTimestamp(): Promise<bigint> {
   return BigInt(await time.latest());
@@ -141,7 +142,7 @@ describe('@unit ConvictionStakingStorage', () => {
       expect(pos.migrationEpoch).to.equal(0);
     });
 
-    it('Tier-12 position: expiryTimestamp = next daily bucket after block.ts + 366d, full boost in running stake, drop at expiry', async () => {
+    it('Tier-12 position: expiryTimestamp = next half-day bucket after block.ts + 366d, full boost in running stake, drop at expiry', async () => {
       const tx = await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
       await tx.wait();
       const tsNow = await latestTimestamp();
@@ -182,7 +183,7 @@ describe('@unit ConvictionStakingStorage', () => {
       ).to.equal(1000n);
     });
 
-    it('Fractional tier 1.5x (lock=1): raw 2000 → boost 1000, drop at the daily bucket after +30d', async () => {
+    it('Fractional tier 1.5x (lock=1): raw 2000 → boost 1000, drop at the half-day bucket after +30d', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 2000, 1, 0, 0);
       const tsNow = await latestTimestamp();
       const expectedExpiry = expectedExpiryFrom(tsNow, 1);
@@ -208,7 +209,7 @@ describe('@unit ConvictionStakingStorage', () => {
       ).to.equal(2000n);
     });
 
-    it('Fractional tier 3.5x (lock=6): raw 2000 → boost 5000, drop at the daily bucket after +180d', async () => {
+    it('Fractional tier 3.5x (lock=6): raw 2000 → boost 5000, drop at the half-day bucket after +180d', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 2000, 6, 0, 0);
       const tsNow = await latestTimestamp();
       const expectedExpiry = expectedExpiryFrom(tsNow, 6);
@@ -289,11 +290,11 @@ describe('@unit ConvictionStakingStorage', () => {
         await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expectedExpiry),
       ).to.equal(boostDrop(300n, SIX_X));
     });
-    it('Coalesces same-day expiries and caps distinct pending expiry slots per node', async function () {
+    it('Coalesces same-bucket expiries and caps distinct pending expiry slots per node', async function () {
       this.timeout(120_000);
 
       const longTier = 24;
-      const longDuration = 1000n * DAY;
+      const longDuration = 2000n * DAY;
       await ConvictionStakingStorage.addTier(longTier, longDuration, TWO_X);
 
       const maxPending = await ConvictionStakingStorage.MAX_NODE_PENDING_EXPIRIES();
@@ -637,7 +638,7 @@ describe('@unit ConvictionStakingStorage', () => {
       const pos = await ConvictionStakingStorage.getPosition(1);
       expect(pos.lockTier).to.equal(newTier);
       expect(pos.multiplier18).to.equal(newMult);
-      // Expected expiry = next daily bucket after ts + 2 years.
+      // Expected expiry = next half-day bucket after ts + 2 years.
       const tsNow = await latestTimestamp();
       expect(pos.expiryTimestamp).to.equal(bucketExpiry(tsNow + newDuration));
     });

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -290,49 +290,27 @@ describe('@unit ConvictionStakingStorage', () => {
         await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expectedExpiry),
       ).to.equal(boostDrop(300n, SIX_X));
     });
-    it('Coalesces same-bucket expiries and caps distinct pending expiry slots per node', async function () {
-      this.timeout(120_000);
-
-      const longTier = 24;
-      const longDuration = 2000n * DAY;
-      await ConvictionStakingStorage.addTier(longTier, longDuration, TWO_X);
-
+    it('Tier-duration cap keeps the per-node slot cap an unreachable backstop', async () => {
+      // MAX_TIER_DURATION = MAX_NODE_PENDING_EXPIRIES * EXPIRY_BUCKET_SECONDS
+      // (1024 * 12h = 512 days). Capping the tier there means a single tier's
+      // expiry window can never span more than MAX_NODE_PENDING_EXPIRIES distinct
+      // buckets, so a node can never accumulate enough distinct future buckets to
+      // reach the slot cap — `NodeExpiryQueueFull` (and the tombstone-vs-live slot
+      // distinction) can therefore never block a legitimate stake/relock. The
+      // production ladder tops out at 366 days, well under this. (Same-bucket
+      // coalescing is covered by the "Coalesces drops at the same timestamp" test.)
       const maxPending = await ConvictionStakingStorage.MAX_NODE_PENDING_EXPIRIES();
-      const cap = Number(maxPending);
-      const current = await latestTimestamp();
-      const firstTs = ((current / DAY) + 1n) * DAY + 100n;
+      const bucketSecs = await ConvictionStakingStorage.EXPIRY_BUCKET_SECONDS();
+      const maxTier = await ConvictionStakingStorage.MAX_TIER_DURATION();
+      expect(maxTier).to.equal(maxPending * bucketSecs); // 1024 * 12h = 512 days
 
-      for (let i = 0; i < cap; i++) {
-        await time.setNextBlockTimestamp(Number(firstTs + BigInt(i) * DAY));
-        await ConvictionStakingStorage.createPosition(i + 1, ALICE_ID, 1, longTier, 0, 0);
-      }
-
-      expect(await ConvictionStakingStorage.getNodePendingExpiryCount(ALICE_ID)).to.equal(
-        maxPending,
-      );
-
-      const lastCreateTs = firstTs + BigInt(cap - 1) * DAY;
-      const lastExpiryBucket = bucketExpiry(lastCreateTs + longDuration);
-
-      // Same bucket as the final slot: accepted and aggregated even at the cap.
-      await time.setNextBlockTimestamp(Number(lastCreateTs + 1n));
+      // A tier whose expiry window would exceed the slot cap is rejected...
       await expect(
-        ConvictionStakingStorage.createPosition(10_000, ALICE_ID, 1, longTier, 0, 0),
-      ).to.not.be.reverted;
-      expect(await ConvictionStakingStorage.getNodePendingExpiryCount(ALICE_ID)).to.equal(
-        maxPending,
-      );
-      expect(await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, lastExpiryBucket)).to.equal(
-        2n,
-      );
-
-      // Next day creates a new distinct bucket and must be rejected at the cap.
-      await time.setNextBlockTimestamp(Number(firstTs + BigInt(cap) * DAY));
-      await expect(
-        ConvictionStakingStorage.createPosition(10_001, ALICE_ID, 1, longTier, 0, 0),
-      )
-        .to.be.revertedWithCustomError(ConvictionStakingStorage, 'NodeExpiryQueueFull')
-        .withArgs(ALICE_ID, maxPending, maxPending);
+        ConvictionStakingStorage.addTier(24, maxTier + 1n, TWO_X),
+      ).to.be.revertedWith('Tier duration too long');
+      // ...exactly at the cap is accepted.
+      await expect(ConvictionStakingStorage.addTier(24, maxTier, TWO_X)).to.not.be.reverted;
+      expect(await ConvictionStakingStorage.tierDuration(24)).to.equal(maxTier);
     });
 
   });
@@ -625,7 +603,7 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('HubOwner can append a new tier and createPosition picks it up', async () => {
       const newTier = 24;
-      const newDuration = 2n * 366n * DAY;
+      const newDuration = 500n * DAY; // <= MAX_TIER_DURATION (1024 * 12h = 512 days)
       const newMult = 12n * SCALE18;
       await expect(ConvictionStakingStorage.addTier(newTier, newDuration, newMult))
         .to.emit(ConvictionStakingStorage, 'TierAdded')
@@ -638,7 +616,7 @@ describe('@unit ConvictionStakingStorage', () => {
       const pos = await ConvictionStakingStorage.getPosition(1);
       expect(pos.lockTier).to.equal(newTier);
       expect(pos.multiplier18).to.equal(newMult);
-      // Expected expiry = next half-day bucket after ts + 2 years.
+      // Expected expiry = next half-day bucket after ts + newDuration.
       const tsNow = await latestTimestamp();
       expect(pos.expiryTimestamp).to.equal(bucketExpiry(tsNow + newDuration));
     });
@@ -652,11 +630,11 @@ describe('@unit ConvictionStakingStorage', () => {
       // boost (would make the "big sum" == "raw sum" and break our fast-path
       // shortcuts in StakingV10._delegatorIncrementForEpoch).
       await expect(
-        ConvictionStakingStorage.addTier(24, 2n * 366n * DAY, SCALE18 / 2n),
+        ConvictionStakingStorage.addTier(24, 366n * DAY, SCALE18 / 2n),
       ).to.be.revertedWith('Non-zero tier needs boost');
       // M3/M4 — non-zero tier with exactly 1x is rejected for the same reason.
       await expect(
-        ConvictionStakingStorage.addTier(24, 2n * 366n * DAY, ONE_X),
+        ConvictionStakingStorage.addTier(24, 366n * DAY, ONE_X),
       ).to.be.revertedWith('Non-zero tier needs boost');
       // M3/M4 — non-zero tier with duration == 0 is rejected (would install a
       // position whose expiryTimestamp == block.timestamp, i.e. already expired).

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -32,8 +32,10 @@ const TIER_DURATIONS: Record<number, bigint> = {
   12: 366n * DAY,
 };
 
-// D26 — timestamp-accurate accounting: no BLOCK_DRIFT_BUFFER padding, no
-// epoch rounding. Lock wall-clock durations are exact.
+const EXPIRY_BUCKET_SECONDS = DAY;
+
+// D26 — timestamp accounting: no BLOCK_DRIFT_BUFFER padding, no epoch rounding.
+// Boost expiries are rounded up to daily buckets for queue DoS hardening.
 
 async function latestTimestamp(): Promise<bigint> {
   return BigInt(await time.latest());
@@ -48,6 +50,15 @@ function effNow(raw: bigint, mult18: bigint): bigint {
 }
 function boostDrop(raw: bigint, mult18: bigint): bigint {
   return (raw * (mult18 - SCALE18)) / SCALE18;
+}
+function bucketExpiry(rawExpiry: bigint): bigint {
+  return (
+    ((rawExpiry + EXPIRY_BUCKET_SECONDS - 1n) / EXPIRY_BUCKET_SECONDS) *
+    EXPIRY_BUCKET_SECONDS
+  );
+}
+function expectedExpiryFrom(baseTs: bigint, tier: number): bigint {
+  return bucketExpiry(baseTs + TIER_DURATIONS[tier]);
 }
 
 describe('@unit ConvictionStakingStorage', () => {
@@ -76,9 +87,8 @@ describe('@unit ConvictionStakingStorage', () => {
 
   it('Should have correct name and version', async () => {
     expect(await ConvictionStakingStorage.name()).to.equal('ConvictionStakingStorage');
-    // v4.1.0 — `createPosition` accepts the `expiryShortenedBy` arg used
-    // by `StakingV10._convertToNFT` for the V8→V10 conviction credit.
-    expect(await ConvictionStakingStorage.version()).to.equal('10.0.4');
+    // v10.0.5 — bucketed expiries + bounded per-node pending expiry slots.
+    expect(await ConvictionStakingStorage.version()).to.equal('10.0.5');
   });
 
   // ------------------------------------------------------------
@@ -131,11 +141,11 @@ describe('@unit ConvictionStakingStorage', () => {
       expect(pos.migrationEpoch).to.equal(0);
     });
 
-    it('Tier-12 position: expiryTimestamp = block.ts + 366d, full boost in running stake, drop at expiry', async () => {
+    it('Tier-12 position: expiryTimestamp = next daily bucket after block.ts + 366d, full boost in running stake, drop at expiry', async () => {
       const tx = await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
       await tx.wait();
       const tsNow = await latestTimestamp();
-      const expectedExpiry = tsNow + TIER_DURATIONS[12];
+      const expectedExpiry = expectedExpiryFrom(tsNow, 12);
 
       const pos = await ConvictionStakingStorage.getPosition(1);
       expect(pos.expiryTimestamp).to.equal(expectedExpiry);
@@ -172,10 +182,10 @@ describe('@unit ConvictionStakingStorage', () => {
       ).to.equal(1000n);
     });
 
-    it('Fractional tier 1.5x (lock=1): raw 2000 → boost 1000, drop at +30d', async () => {
+    it('Fractional tier 1.5x (lock=1): raw 2000 → boost 1000, drop at the daily bucket after +30d', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 2000, 1, 0, 0);
       const tsNow = await latestTimestamp();
-      const expectedExpiry = tsNow + TIER_DURATIONS[1];
+      const expectedExpiry = expectedExpiryFrom(tsNow, 1);
 
       const pos = await ConvictionStakingStorage.getPosition(1);
       expect(pos.expiryTimestamp).to.equal(expectedExpiry);
@@ -198,10 +208,10 @@ describe('@unit ConvictionStakingStorage', () => {
       ).to.equal(2000n);
     });
 
-    it('Fractional tier 3.5x (lock=6): raw 2000 → boost 5000, drop at +180d', async () => {
+    it('Fractional tier 3.5x (lock=6): raw 2000 → boost 5000, drop at the daily bucket after +180d', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 2000, 6, 0, 0);
       const tsNow = await latestTimestamp();
-      const expectedExpiry = tsNow + TIER_DURATIONS[6];
+      const expectedExpiry = expectedExpiryFrom(tsNow, 6);
 
       expect(await ConvictionStakingStorage.getNodeRunningEffectiveStake(ALICE_ID)).to.equal(7000n);
       expect(await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expectedExpiry)).to.equal(
@@ -241,13 +251,13 @@ describe('@unit ConvictionStakingStorage', () => {
       // Create tier-12 first (furthest expiry), then tier-1 (soonest), then tier-6.
       // Expected final order in the queue: [+30d, +180d, +366d].
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 100, 12, 0, 0);
-      const ts12 = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const ts12 = expectedExpiryFrom(await latestTimestamp(), 12);
 
       await ConvictionStakingStorage.createPosition(2, ALICE_ID, 100, 1, 0, 0);
-      const ts1 = (await latestTimestamp()) + TIER_DURATIONS[1];
+      const ts1 = expectedExpiryFrom(await latestTimestamp(), 1);
 
       await ConvictionStakingStorage.createPosition(3, ALICE_ID, 100, 6, 0, 0);
-      const ts6 = (await latestTimestamp()) + TIER_DURATIONS[6];
+      const ts6 = expectedExpiryFrom(await latestTimestamp(), 6);
 
       const times = await ConvictionStakingStorage.getNodeExpiryTimes(ALICE_ID);
       expect(times.length).to.equal(3);
@@ -270,7 +280,7 @@ describe('@unit ConvictionStakingStorage', () => {
       }
 
       const tsNow = await latestTimestamp();
-      const expectedExpiry = tsNow + TIER_DURATIONS[12];
+      const expectedExpiry = expectedExpiryFrom(tsNow, 12);
 
       const times = await ConvictionStakingStorage.getNodeExpiryTimes(ALICE_ID);
       expect(times.length).to.equal(1);
@@ -279,6 +289,51 @@ describe('@unit ConvictionStakingStorage', () => {
         await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expectedExpiry),
       ).to.equal(boostDrop(300n, SIX_X));
     });
+    it('Coalesces same-day expiries and caps distinct pending expiry slots per node', async function () {
+      this.timeout(120_000);
+
+      const longTier = 24;
+      const longDuration = 1000n * DAY;
+      await ConvictionStakingStorage.addTier(longTier, longDuration, TWO_X);
+
+      const maxPending = await ConvictionStakingStorage.MAX_NODE_PENDING_EXPIRIES();
+      const cap = Number(maxPending);
+      const current = await latestTimestamp();
+      const firstTs = ((current / DAY) + 1n) * DAY + 100n;
+
+      for (let i = 0; i < cap; i++) {
+        await time.setNextBlockTimestamp(Number(firstTs + BigInt(i) * DAY));
+        await ConvictionStakingStorage.createPosition(i + 1, ALICE_ID, 1, longTier, 0, 0);
+      }
+
+      expect(await ConvictionStakingStorage.getNodePendingExpiryCount(ALICE_ID)).to.equal(
+        maxPending,
+      );
+
+      const lastCreateTs = firstTs + BigInt(cap - 1) * DAY;
+      const lastExpiryBucket = bucketExpiry(lastCreateTs + longDuration);
+
+      // Same bucket as the final slot: accepted and aggregated even at the cap.
+      await time.setNextBlockTimestamp(Number(lastCreateTs + 1n));
+      await expect(
+        ConvictionStakingStorage.createPosition(10_000, ALICE_ID, 1, longTier, 0, 0),
+      ).to.not.be.reverted;
+      expect(await ConvictionStakingStorage.getNodePendingExpiryCount(ALICE_ID)).to.equal(
+        maxPending,
+      );
+      expect(await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, lastExpiryBucket)).to.equal(
+        2n,
+      );
+
+      // Next day creates a new distinct bucket and must be rejected at the cap.
+      await time.setNextBlockTimestamp(Number(firstTs + BigInt(cap) * DAY));
+      await expect(
+        ConvictionStakingStorage.createPosition(10_001, ALICE_ID, 1, longTier, 0, 0),
+      )
+        .to.be.revertedWithCustomError(ConvictionStakingStorage, 'NodeExpiryQueueFull')
+        .withArgs(ALICE_ID, maxPending, maxPending);
+    });
+
   });
 
   // ------------------------------------------------------------
@@ -289,11 +344,11 @@ describe('@unit ConvictionStakingStorage', () => {
     it('Two NFTs under same identityId sum their effective stake and decay independently', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 500, 12, 0, 0);
       const tsAtCreate1 = await latestTimestamp();
-      const expiry12 = tsAtCreate1 + TIER_DURATIONS[12];
+      const expiry12 = expectedExpiryFrom(tsAtCreate1, 12);
 
       await ConvictionStakingStorage.createPosition(2, ALICE_ID, 200, 3, 0, 0);
       const tsAtCreate2 = await latestTimestamp();
-      const expiry3 = tsAtCreate2 + TIER_DURATIONS[3];
+      const expiry3 = expectedExpiryFrom(tsAtCreate2, 3);
 
       // Before any expiry: 500*6 + 200*2 = 3400.
       expect(await ConvictionStakingStorage.getNodeRunningEffectiveStake(ALICE_ID)).to.equal(3400n);
@@ -326,7 +381,7 @@ describe('@unit ConvictionStakingStorage', () => {
     it('Drains a single expiry, zeroes the drop, bumps the head cursor', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
       const tsAtCreate = await latestTimestamp();
-      const expiry = tsAtCreate + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(tsAtCreate, 12);
 
       // Advance past the expiry.
       await time.increaseTo(Number(expiry) + 1);
@@ -343,9 +398,9 @@ describe('@unit ConvictionStakingStorage', () => {
       await ConvictionStakingStorage.createPosition(2, ALICE_ID, 100, 3, 0, 0);
       await ConvictionStakingStorage.createPosition(3, ALICE_ID, 100, 12, 0, 0);
 
-      const tsBase = await latestTimestamp();
+      const times = await ConvictionStakingStorage.getNodeExpiryTimes(ALICE_ID);
       // Jump well past all three expiries in one go.
-      await time.increaseTo(Number(tsBase + TIER_DURATIONS[12] + 10n));
+      await time.increaseTo(Number(times[2] + 10n));
       await ConvictionStakingStorage.settleNodeTo(ALICE_ID, await latestTimestamp());
 
       // After full drain: raw-tail only = 100 + 100 + 100 = 300.
@@ -378,7 +433,7 @@ describe('@unit ConvictionStakingStorage', () => {
   describe('updateOnRedelegate', () => {
     it('Moves full effective contribution from old node to new node; cancels + reschedules the boost drop', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
 
       await ConvictionStakingStorage.updateOnRedelegate(1, BOB_ID);
 
@@ -393,7 +448,8 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('Redelegating a post-expiry position moves only the raw tail (no boost to cancel)', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 3, 0, 0);
-      await time.increase(Number(TIER_DURATIONS[3]) + 1);
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 3);
+      await time.increaseTo(Number(expiry) + 1);
       await ConvictionStakingStorage.settleNodeTo(ALICE_ID, await latestTimestamp());
 
       await ConvictionStakingStorage.updateOnRedelegate(1, BOB_ID);
@@ -416,7 +472,7 @@ describe('@unit ConvictionStakingStorage', () => {
   describe('deletePosition', () => {
     it('Wipes a pre-expiry position and cancels its pending boost drop', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
 
       await ConvictionStakingStorage.deletePosition(1);
       const pos = await ConvictionStakingStorage.getPosition(1);
@@ -429,7 +485,8 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('Post-expiry delete: boost was already drained, only raw tail is unwound', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 3, 0, 0);
-      await time.increase(Number(TIER_DURATIONS[3]) + 1);
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 3);
+      await time.increaseTo(Number(expiry) + 1);
       await ConvictionStakingStorage.settleNodeTo(ALICE_ID, await latestTimestamp());
 
       await ConvictionStakingStorage.deletePosition(1);
@@ -453,7 +510,7 @@ describe('@unit ConvictionStakingStorage', () => {
   describe('decreaseRaw / increaseRaw', () => {
     it('Pre-expiry decreaseRaw shrinks running stake by amount*mult and cancels proportional boost drop', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
 
       await ConvictionStakingStorage.decreaseRaw(1, 400);
       const pos = await ConvictionStakingStorage.getPosition(1);
@@ -467,7 +524,8 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('Post-expiry decreaseRaw removes a flat `amount` (boost already drained)', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 3, 0, 0);
-      await time.increase(Number(TIER_DURATIONS[3]) + 1);
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 3);
+      await time.increaseTo(Number(expiry) + 1);
       await ConvictionStakingStorage.settleNodeTo(ALICE_ID, await latestTimestamp());
 
       await ConvictionStakingStorage.decreaseRaw(1, 300);
@@ -476,7 +534,7 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('increaseRaw pre-expiry grows running stake by amount*mult and adds to the same expiry bucket', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 600, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
 
       await ConvictionStakingStorage.increaseRaw(1, 200);
       expect(await ConvictionStakingStorage.getNodeRunningEffectiveStake(ALICE_ID)).to.equal(4800n);
@@ -486,7 +544,7 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('Round-trip: decreaseRaw then increaseRaw restores running stake exactly (pre-expiry)', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
       const runningBefore = await ConvictionStakingStorage.getNodeRunningEffectiveStake(ALICE_ID);
       const dropBefore = await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expiry);
 
@@ -528,7 +586,7 @@ describe('@unit ConvictionStakingStorage', () => {
   describe('boost-drop cancellation leaves queue entry intact', () => {
     it('Deletes the only pending position: queue entry remains but drop is 0', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
       await ConvictionStakingStorage.deletePosition(1);
 
       // Entry is still present in the array (drained later as a no-op).
@@ -579,9 +637,9 @@ describe('@unit ConvictionStakingStorage', () => {
       const pos = await ConvictionStakingStorage.getPosition(1);
       expect(pos.lockTier).to.equal(newTier);
       expect(pos.multiplier18).to.equal(newMult);
-      // Expected expiry = ts + 2 years.
+      // Expected expiry = next daily bucket after ts + 2 years.
       const tsNow = await latestTimestamp();
-      expect(pos.expiryTimestamp).to.equal(tsNow + newDuration);
+      expect(pos.expiryTimestamp).to.equal(bucketExpiry(tsNow + newDuration));
     });
 
     it('addTier rejects duplicates, degenerate tier-0 configs, and boost-less non-zero tiers', async () => {
@@ -620,7 +678,8 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('deactivateTier rejects fresh stakes but relock still honors original commitment', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 3, 0, 0);
-      await time.increase(Number(TIER_DURATIONS[3]) + 1);
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 3);
+      await time.increaseTo(Number(expiry) + 1);
       await ConvictionStakingStorage.settleNodeTo(ALICE_ID, await latestTimestamp());
 
       await ConvictionStakingStorage.deactivateTier(3);
@@ -658,7 +717,7 @@ describe('@unit ConvictionStakingStorage', () => {
       }
 
       const tsNow = await latestTimestamp();
-      const expectedExpiry = tsNow + TIER_DURATIONS[12];
+      const expectedExpiry = expectedExpiryFrom(tsNow, 12);
 
       // There must be exactly one live entry — the delete+recreate MUST NOT
       // append a second slot at the same ts.
@@ -672,7 +731,7 @@ describe('@unit ConvictionStakingStorage', () => {
 
     it('L5 — cancelling the entire drop zeroes `nodeExpiryDrop` for a gas refund', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 0, 0);
-      const expiry = (await latestTimestamp()) + TIER_DURATIONS[12];
+      const expiry = expectedExpiryFrom(await latestTimestamp(), 12);
       expect(await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expiry)).to.equal(
         boostDrop(1000n, SIX_X),
       );
@@ -717,7 +776,7 @@ describe('@unit ConvictionStakingStorage', () => {
       // active-tier check); the credit is otherwise identical.
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 1, SIXTY_DAYS);
       const tsNow = await latestTimestamp();
-      const tierDefault = tsNow + TIER_DURATIONS[12];
+      const tierDefault = expectedExpiryFrom(tsNow, 12);
       const expected = tierDefault - SIXTY_DAYS;
 
       const pos = await ConvictionStakingStorage.getPosition(1);
@@ -737,7 +796,7 @@ describe('@unit ConvictionStakingStorage', () => {
     it('Tier 6 with 60d credit: expiryTimestamp lands 60d before the tier default', async () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 2000, 6, 1, SIXTY_DAYS);
       const tsNow = await latestTimestamp();
-      const expected = tsNow + TIER_DURATIONS[6] - SIXTY_DAYS;
+      const expected = expectedExpiryFrom(tsNow, 6) - SIXTY_DAYS;
 
       const pos = await ConvictionStakingStorage.getPosition(1);
       expect(pos.expiryTimestamp).to.equal(expected);
@@ -775,7 +834,7 @@ describe('@unit ConvictionStakingStorage', () => {
       await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 1, 0);
       const tsNow = await latestTimestamp();
       const pos = await ConvictionStakingStorage.getPosition(1);
-      expect(pos.expiryTimestamp).to.equal(tsNow + TIER_DURATIONS[12]);
+      expect(pos.expiryTimestamp).to.equal(expectedExpiryFrom(tsNow, 12));
     });
 
     it('Reverts when a non-zero credit is passed with migrationEpoch == 0 (fresh-stake guard)', async () => {

--- a/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
+++ b/packages/evm-module/test/unit/ConvictionStakingStorage.test.ts
@@ -290,6 +290,34 @@ describe('@unit ConvictionStakingStorage', () => {
         await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expectedExpiry),
       ).to.equal(boostDrop(300n, SIX_X));
     });
+
+    it('Dust stakes at distinct seconds coalesce into the same 12h bucket (queue stays bounded)', async () => {
+      // The DoS the bucketing closes: many stakes against a node at DISTINCT block
+      // timestamps. Pre-fix every distinct second was its own queue slot (unbounded
+      // -> settle eventually exceeds block gas). With 12h bucketing, all stakes whose
+      // lock ends in the same half-day share ONE slot, so the queue cannot grow with
+      // the stake count.
+      const N = 50;
+      for (let i = 1; i <= N; i++) {
+        // each createPosition auto-mines a block (timestamp +1s) -> N distinct
+        // seconds, all inside the same 12h bucket.
+        await ConvictionStakingStorage.createPosition(i, ALICE_ID, 1, 12, 0, 0);
+      }
+      // All N expiries fall in at most two adjacent 12h buckets (one, unless the
+      // ~N-second creation window straddles a bucket boundary).
+      const pending = await ConvictionStakingStorage.getNodePendingExpiryCount(ALICE_ID);
+      expect(Number(pending)).to.be.lessThanOrEqual(2);
+
+      // The whole bounded queue drains in one cheap settle past the last expiry.
+      const times = await ConvictionStakingStorage.getNodeExpiryTimes(ALICE_ID);
+      await time.increaseTo(Number(times[times.length - 1]) + 1);
+      await ConvictionStakingStorage.settleNodeTo(ALICE_ID, await latestTimestamp());
+      expect(await ConvictionStakingStorage.getNodeRunningEffectiveStake(ALICE_ID)).to.equal(
+        BigInt(N),
+      );
+      expect(await ConvictionStakingStorage.getNodePendingExpiryCount(ALICE_ID)).to.equal(0);
+    });
+
     it('Tier-duration cap keeps the per-node slot cap an unreachable backstop', async () => {
       // MAX_TIER_DURATION = MAX_NODE_PENDING_EXPIRIES * EXPIRY_BUCKET_SECONDS
       // (1024 * 12h = 512 days). Capping the tier there means a single tier's
@@ -302,7 +330,11 @@ describe('@unit ConvictionStakingStorage', () => {
       const maxPending = await ConvictionStakingStorage.MAX_NODE_PENDING_EXPIRIES();
       const bucketSecs = await ConvictionStakingStorage.EXPIRY_BUCKET_SECONDS();
       const maxTier = await ConvictionStakingStorage.MAX_TIER_DURATION();
-      expect(maxTier).to.equal(maxPending * bucketSecs); // 1024 * 12h = 512 days
+      // (MAX_NODE_PENDING_EXPIRIES - 1) * EXPIRY_BUCKET_SECONDS = 1023 * 12h = 511.5
+      // days. The `- 1` accounts for `_computeExpiryTimestamp` rounding UP: a k-bucket
+      // tier created just after a boundary expires k+1 buckets out, so a node can hold
+      // up to tierBuckets+1 distinct pending slots; capping at MAX-1 keeps that <= MAX.
+      expect(maxTier).to.equal((maxPending - 1n) * bucketSecs);
 
       // A tier whose expiry window would exceed the slot cap is rejected...
       await expect(
@@ -770,6 +802,22 @@ describe('@unit ConvictionStakingStorage', () => {
       expect(await ConvictionStakingStorage.getNodeExpiryDrop(ALICE_ID, expected)).to.equal(
         boostDrop(1000n, SIX_X),
       );
+    });
+
+    it('preserves a non-bucket-aligned credit exactly — no silent re-bucket rounding', async () => {
+      // `convictionCreditSeconds` (passed as expiryShortenedBy) can be arbitrary
+      // seconds. The expiry is `bucketedDefault - credit` with NO re-bucket, so a
+      // credit that is not a multiple of EXPIRY_BUCKET_SECONDS is applied to the
+      // exact second. (Re-bucketing would round it UP to the 12h grid — e.g.
+      // `60d - 1h` -> a full `60d` — quietly shrinking the configured credit.)
+      const credit = SIXTY_DAYS - 3600n; // 60 days minus 1 hour (not a 12h multiple)
+      await ConvictionStakingStorage.createPosition(1, ALICE_ID, 1000, 12, 1, credit);
+      const tsNow = await latestTimestamp();
+      const pos = await ConvictionStakingStorage.getPosition(1);
+      // exact: the bucketed default minus the FULL credit (not rounded back up).
+      expect(pos.expiryTimestamp).to.equal(expectedExpiryFrom(tsNow, 12) - credit);
+      // crucially NOT snapped onto the 12h grid:
+      expect(pos.expiryTimestamp % (12n * 60n * 60n)).to.not.equal(0n);
     });
 
     it('Tier 6 with 60d credit: expiryTimestamp lands 60d before the tier default', async () => {

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -30,6 +30,11 @@ const ONE_AND_HALF_X = (15n * SCALE18) / 10n;
 const TWO_X = 2n * SCALE18;
 const THREE_AND_HALF_X = (35n * SCALE18) / 10n;
 const SIX_X = 6n * SCALE18;
+const DAY = 24n * 60n * 60n;
+
+function bucketExpiry(rawExpiry: bigint): bigint {
+  return ((rawExpiry + DAY - 1n) / DAY) * DAY;
+}
 
 type Fixture = {
   accounts: SignerWithAddress[];
@@ -549,9 +554,8 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const txReceipt = await tx.wait();
       const txBlock = await hre.ethers.provider.getBlock(txReceipt!.blockHash);
       const relockTs = BigInt(txBlock!.timestamp);
-      // Tier 12 wall-clock duration = 366 days.
-      const DAY = 24n * 60n * 60n;
-      const expectedExpiryTs = relockTs + 366n * DAY;
+      // Tier 12 boost expires on the next daily bucket after 366 days.
+      const expectedExpiryTs = bucketExpiry(relockTs + 366n * DAY);
 
       await expect(tx).to.emit(NFT, 'PositionRelocked').withArgs(1n, newTokenId, 12);
       await expect(tx)
@@ -611,9 +615,8 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const receipt = await tx.wait();
       const txBlock = await hre.ethers.provider.getBlock(receipt!.blockHash);
       const relockTs = BigInt(txBlock!.timestamp);
-      // D26: tier 6 commits 180 days of boost exactly.
-      const DAY = 24n * 60n * 60n;
-      const expectedExpiryTs = relockTs + 180n * DAY;
+      // D26: tier 6 commits at least 180 days of boost, rounded to the next daily bucket.
+      const expectedExpiryTs = bucketExpiry(relockTs + 180n * DAY);
       const pos = await ConvictionStakingStorageContract.getPosition(newTokenId);
       expect(pos.expiryTimestamp).to.equal(expectedExpiryTs);
       expect(pos.multiplier18).to.equal(THREE_AND_HALF_X);
@@ -633,19 +636,24 @@ describe('@unit DKGStakingConvictionNFT', () => {
       ).to.be.revertedWithCustomError(StakingV10Contract, 'OnlyConvictionNFT');
     });
 
-    it('boundary: relock succeeds at exactly currentEpoch == pos.expiryTimestamp', async () => {
+    it('boundary: relock succeeds at exactly the bucketed expiry timestamp', async () => {
       const { identityId } = await createProfile();
       const amount = hre.ethers.parseEther('1000');
       await mintAndApprove(accounts[0], amount);
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 1);
-      // 1-epoch lock at creation epoch C → expiryTimestamp = C + 1. Advance
-      // exactly 1 epoch so currentEpoch == expiryTimestamp — under the old
-      // `<=` check this would still revert as LockStillActive.
-      await advanceEpochs(1);
+
+      const expiryTimestamp = (await ConvictionStakingStorageContract.getPosition(1))
+        .expiryTimestamp;
+      // Claim just before the lock boundary so the relock transaction itself can
+      // land exactly at `expiryTimestamp`.
+      await time.setNextBlockTimestamp(Number(expiryTimestamp - 1n));
       await NFT.connect(accounts[0]).claim(1); // satisfy UnclaimedEpochs guard
 
-      const newTokenId = await NFT.connect(accounts[0]).relock.staticCall(1, 6);
-      await NFT.connect(accounts[0]).relock(1, 6);
+      await time.setNextBlockTimestamp(Number(expiryTimestamp));
+      const newTokenId = (await NFT.nextTokenId()) + 1n;
+      await expect(NFT.connect(accounts[0]).relock(1, 6))
+        .to.emit(NFT, 'PositionRelocked')
+        .withArgs(1n, newTokenId, 6);
       const pos = await ConvictionStakingStorageContract.getPosition(newTokenId);
       expect(pos.lockTier).to.equal(6);
       expect(pos.multiplier18).to.equal(THREE_AND_HALF_X);
@@ -987,17 +995,16 @@ describe('@unit DKGStakingConvictionNFT', () => {
       );
     });
 
-    it('boundary: withdraw succeeds at exactly currentEpoch == pos.expiryTimestamp', async () => {
+    it('boundary: withdraw succeeds at exactly the bucketed expiry timestamp', async () => {
       const { identityId } = await createProfile();
       const amount = hre.ethers.parseEther('1000');
       await mintAndApprove(accounts[0], amount);
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 1);
-      // 1-tier lock at creation epoch C → expiryTimestamp ~ C + 1. Advance
-      // exactly 1 epoch so currentEpoch == expiryTimestamp (the unlock
-      // boundary). Under `currentEpoch >= expiryTimestamp` this must pass.
-      await advanceEpochs(1);
+      const expiryTimestamp = (await ConvictionStakingStorageContract.getPosition(1))
+        .expiryTimestamp;
 
       // `withdraw` auto-claims internally — no separate claim() required.
+      await time.setNextBlockTimestamp(Number(expiryTimestamp));
       await NFT.connect(accounts[0]).withdraw(1);
 
       expect(

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -31,9 +31,13 @@ const TWO_X = 2n * SCALE18;
 const THREE_AND_HALF_X = (35n * SCALE18) / 10n;
 const SIX_X = 6n * SCALE18;
 const DAY = 24n * 60n * 60n;
+const EXPIRY_BUCKET_SECONDS = 12n * 60n * 60n;
 
 function bucketExpiry(rawExpiry: bigint): bigint {
-  return ((rawExpiry + DAY - 1n) / DAY) * DAY;
+  return (
+    ((rawExpiry + EXPIRY_BUCKET_SECONDS - 1n) / EXPIRY_BUCKET_SECONDS) *
+    EXPIRY_BUCKET_SECONDS
+  );
 }
 
 type Fixture = {
@@ -554,7 +558,7 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const txReceipt = await tx.wait();
       const txBlock = await hre.ethers.provider.getBlock(txReceipt!.blockHash);
       const relockTs = BigInt(txBlock!.timestamp);
-      // Tier 12 boost expires on the next daily bucket after 366 days.
+      // Tier 12 boost expires on the next half-day bucket after 366 days.
       const expectedExpiryTs = bucketExpiry(relockTs + 366n * DAY);
 
       await expect(tx).to.emit(NFT, 'PositionRelocked').withArgs(1n, newTokenId, 12);
@@ -615,7 +619,7 @@ describe('@unit DKGStakingConvictionNFT', () => {
       const receipt = await tx.wait();
       const txBlock = await hre.ethers.provider.getBlock(receipt!.blockHash);
       const relockTs = BigInt(txBlock!.timestamp);
-      // D26: tier 6 commits at least 180 days of boost, rounded to the next daily bucket.
+      // D26: tier 6 commits at least 180 days of boost, rounded to the next half-day bucket.
       const expectedExpiryTs = bucketExpiry(relockTs + 180n * DAY);
       const pos = await ConvictionStakingStorageContract.getPosition(newTokenId);
       expect(pos.expiryTimestamp).to.equal(expectedExpiryTs);

--- a/packages/evm-module/test/v10-pool-migration.test.ts
+++ b/packages/evm-module/test/v10-pool-migration.test.ts
@@ -38,11 +38,15 @@ import {
 const SCALE18 = 10n ** 18n;
 const SIX_X = 6n * SCALE18;
 const DAY = 24n * 60n * 60n;
+const EXPIRY_BUCKET_SECONDS = 12n * 60n * 60n;
 const TIER12_DURATION = 366n * DAY;
 const CREDIT_SECONDS = 70n * DAY; // configurable, < tier-6 (180d) cap
 
 function bucketExpiry(rawExpiry: bigint): bigint {
-  return ((rawExpiry + DAY - 1n) / DAY) * DAY;
+  return (
+    ((rawExpiry + EXPIRY_BUCKET_SECONDS - 1n) / EXPIRY_BUCKET_SECONDS) *
+    EXPIRY_BUCKET_SECONDS
+  );
 }
 
 type Fixture = {

--- a/packages/evm-module/test/v10-pool-migration.test.ts
+++ b/packages/evm-module/test/v10-pool-migration.test.ts
@@ -41,6 +41,10 @@ const DAY = 24n * 60n * 60n;
 const TIER12_DURATION = 366n * DAY;
 const CREDIT_SECONDS = 70n * DAY; // configurable, < tier-6 (180d) cap
 
+function bucketExpiry(rawExpiry: bigint): bigint {
+  return ((rawExpiry + DAY - 1n) / DAY) * DAY;
+}
+
 type Fixture = {
   accounts: SignerWithAddress[];
   Hub: Hub;
@@ -216,7 +220,9 @@ describe('@integration pool & allocate migration', function () {
       expect(pos.raw).to.equal(stake);
       expect(pos.lockTier).to.equal(12n);
       expect(pos.migrationEpoch).to.be.greaterThan(0n); // drives the "Migrated from V8" badge
-      expect(pos.expiryTimestamp).to.equal(blockTs + TIER12_DURATION - CREDIT_SECONDS);
+      expect(pos.expiryTimestamp).to.equal(
+        bucketExpiry(blockTs + TIER12_DURATION) - CREDIT_SECONDS,
+      );
 
       // Credit fully spent.
       expect(await NFT.migrationCredit(d.address)).to.equal(0n);
@@ -268,7 +274,9 @@ describe('@integration pool & allocate migration', function () {
       // tier-12 allocation, but creditApplied=false because no credit was configured
       await expect(tx).to.emit(NFT, 'Allocated').withArgs(d.address, 1n, id, stake, 12n, false);
       // and the expiry is NOT shortened (full tier-12 duration)
-      expect((await CSS.getPosition(1)).expiryTimestamp).to.equal(blockTs + TIER12_DURATION);
+      expect((await CSS.getPosition(1)).expiryTimestamp).to.equal(
+        bucketExpiry(blockTs + TIER12_DURATION),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- round V10 staking boost expiries up to 12-hour buckets so per-block dust stakes coalesce into one queue slot per half-day
- cap distinct pending expiry slots per node at 1024 while still allowing same-bucket aggregation at the cap
- update staking, relock/withdraw, and V8 migration tests for half-day bucketed expiry semantics

## Gas benchmark
Temporary local harness against `ConvictionStakingStorage.settleNodeTo` under the repo's 30M block gas config:
- current 366-day tier worst-case dormant drain: 732 slots, ~8.37M gas
- absolute cap drain: 1024 slots, ~11.67M gas
- normal tail append remains ~241k gas; same-bucket aggregation at cap remains ~194k gas

## Testing
- pnpm exec hardhat compile --force
- pnpm --filter @origintrail-official/dkg-evm-module compile
- pnpm exec hardhat test test/unit/ConvictionStakingStorage.test.ts test/unit/DKGStakingConvictionNFT.test.ts test/v10-pool-migration.test.ts --network hardhat --config hardhat.node.config.ts
- pnpm --filter @origintrail-official/dkg-evm-module test
- pnpm --filter @origintrail-official/dkg-evm-module lint:sol
- git diff --check
