### PR TITLE
fix(random-sampling): bind proof length to tree height — closes PoS forgery (audit F01, Critical)

### DIFF
--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -335,6 +335,25 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         // public proof folds: leaf -> publicRoot -> hashPair(publicRoot, privateDataHash).
         bytes32 leaf = keccak256(content);
 
+        // SECURITY FIX (F01): bind the proof length to the tree height for the
+        // pinned leaf count. Without this, an empty (or too-short) proof folds
+        // too few times and `_verifyV10MerkleProof` returns `leaf == root`, so an
+        // attacker submits the root's OWN preimage as `content` — e.g. the root's
+        // two children, which are PUBLIC for a curated KA (or a public KA with no
+        // private data) — and passes with ZERO stored data. The earlier
+        // content-binding change closed the 32-byte "echo the root as the leaf"
+        // case but NOT this 64-byte "submit the root's preimage" variant.
+        // Requiring a FULL-height proof means a valid submission needs a genuine
+        // merkle-inclusion path; a forged leaf would require a keccak256
+        // second-preimage. Expected length matches the off-chain builder exactly:
+        //   curated (plain `_catalog` tree):               height(leafCount)
+        //   public  (structured hashPair + private sibling): height(leafCount) + 1
+        // (`buildV10CatalogProofMaterial` vs `buildV10ProofMaterial` in dkg-core).
+        uint256 expectedProofLen = _treeHeight(uint256(leafCount)) + (challenge.isCurated ? 0 : 1);
+        if (merkleProof.length != expectedProofLen) {
+            revert MerkleRootMismatchError(bytes32(0), expectedMerkleRoot);
+        }
+
         if (!_verifyV10MerkleProof(expectedMerkleRoot, leaf, challenge.chunkId, merkleProof)) {
             revert MerkleRootMismatchError(bytes32(0), expectedMerkleRoot);
         }
@@ -401,6 +420,20 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
             }
         }
         return h == root;
+    }
+
+    /**
+     * @dev `ceil(log2(n))` — the V10 Merkle tree height. The off-chain builder
+     *      pads odd levels by duplicating the last node (`duplicate-last-on-odd`),
+     *      which keeps the height at `ceil(log2(leafCount))` and gives every leaf a
+     *      proof of exactly that many siblings. Returns 0 for `n <= 1`.
+     */
+    function _treeHeight(uint256 n) internal pure returns (uint256 h) {
+        while ((uint256(1) << h) < n) {
+            unchecked {
+                ++h;
+            }
+        }
     }
 
     /**

--- a/packages/evm-module/test/integration/RandomSampling-submitproof-seam.test.ts
+++ b/packages/evm-module/test/integration/RandomSampling-submitproof-seam.test.ts
@@ -58,6 +58,26 @@ const decoyMerkleRoot = ethers.keccak256(
 const catalogContent = ethers.toUtf8Bytes('r3-seam-catalog-content');
 const catalogRoot = ethers.keccak256(catalogContent);
 
+// ── CURATED catalog MULTI-leaf KA (Test G — F01 length binding) ──
+// Two PUBLIC catalog leaves ⇒ a 2-leaf V10MerkleTree (height 1). The honest
+// curated proof is NON-empty (length == height == 1, no private sibling), so this
+// exercises the `isCurated ? height : height+1` branch on the real contract — and
+// proves an empty/too-long proof now reverts. V10MerkleTree sorts leaves ascending
+// before pairing, so root = keccak256(sortedLow ‖ sortedHigh).
+const catalogLeaf0 = ethers.toUtf8Bytes('r3-seam-catalog-2leaf-0');
+const catalogLeaf1 = ethers.toUtf8Bytes('r3-seam-catalog-2leaf-1');
+const _ch0 = ethers.keccak256(catalogLeaf0);
+const _ch1 = ethers.keccak256(catalogLeaf1);
+const catalog2Sorted: [string, string] =
+  BigInt(_ch0) < BigInt(_ch1) ? [_ch0, _ch1] : [_ch1, _ch0];
+const catalog2ContentByHash: Record<string, Uint8Array> = {
+  [_ch0]: catalogLeaf0,
+  [_ch1]: catalogLeaf1,
+};
+const catalog2Root = ethers.keccak256(
+  ethers.concat([catalog2Sorted[0], catalog2Sorted[1]]),
+);
+
 // OT-RFC-49 / WS-B Trap 1 (proof-race, Test C2): a NEW catalog the curated KA
 // rotates to AFTER its challenge is issued. An honest proof built against the
 // PINNED issuance-time catalog (`catalogContent`) must still verify; a proof
@@ -353,6 +373,58 @@ describe('@integration RandomSampling submitProof + multi-store seam (R3)', () =
     return kaId;
   }
 
+  // Like seedCuratedKa but commits a 2-LEAF catalog (count=2) for the multi-leaf
+  // curated proof regression (Test G).
+  async function seedCuratedKaMultiLeaf(cgId: bigint): Promise<bigint> {
+    const currentEpoch = await Chronos.getCurrentEpoch();
+    const endEpoch = currentEpoch + 5n;
+    const receipt = await (
+      await DKGKnowledgeAssets.connect(opSigner).createKnowledgeAsset(
+        opSigner.address,
+        opSigner.address,
+        nextKaId(),
+        'seam-test-curated-2leaf',
+        decoyMerkleRoot,
+        1,
+        TEST_KA_BYTE_SIZE,
+        currentEpoch,
+        endEpoch,
+        0,
+        false,
+        1, // merkleLeafCount (decoy public count; curated path uses the catalog)
+      )
+    ).wait();
+    const iface = DKGKnowledgeAssets.interface;
+    const topic = iface.getEvent('KnowledgeAssetCreated')!.topicHash;
+    const log = receipt!.logs.find((l) => l.topics[0] === topic)!;
+    const kaId = iface.parseLog(
+      log as unknown as { topics: string[]; data: string },
+    )!.args[0] as bigint;
+
+    await (
+      await DKGKnowledgeAssets.connect(opSigner).setCatalogCommitment(
+        kaId,
+        catalog2Root,
+        2, // 2-leaf catalog ⇒ chunkId ∈ {0,1}, honest proof length == height == 1
+      )
+    ).wait();
+    await (
+      await ContextGraphStorage.connect(
+        opSigner,
+      ).registerKnowledgeAssetToContextGraph(cgId, kaId)
+    ).wait();
+    await (
+      await ContextGraphValueStorage.connect(opSigner).addCGValueForEpochRange(
+        cgId,
+        currentEpoch,
+        5n,
+        1_000n,
+      )
+    ).wait();
+    await (await CGWeightTreeStorage.connect(opSigner).settle(cgId)).wait();
+    return kaId;
+  }
+
   async function setupChallengingNode() {
     const node = { operational: accounts[2], admin: accounts[1] };
     const { identityId } = await createProfile(Profile, node);
@@ -631,5 +703,54 @@ describe('@integration RandomSampling submitProof + multi-store seam (R3)', () =
       node.identityId,
     );
     expect(solved.solved).to.equal(true);
+  });
+
+  it('Test G — curated multi-leaf: honest catalog proof verifies; empty/too-long proofs revert (F01 length binding)', async () => {
+    // The existing curated tests use a 1-leaf catalog (height 0 ⇒ empty proof is
+    // legitimately valid). This exercises the multi-leaf curated path on the REAL
+    // contract: a 2-leaf catalog (height 1) where the honest proof is NON-empty,
+    // so the `isCurated ? height : height+1` length split is verified and the
+    // root-preimage / empty-proof forgery surface is closed for curated too.
+    const cgId = await createCuratedCG();
+    await seedCuratedKaMultiLeaf(cgId);
+    const node = await setupChallengingNode();
+
+    await RandomSampling.updateAndGetActiveProofPeriodStartBlock();
+    await RandomSampling.connect(node.operational).createChallenge();
+    const challenge = await RandomSamplingStorage.getNodeChallenge(
+      node.identityId,
+    );
+    expect(challenge.isCurated).to.equal(true);
+    expect(challenge.challengeLeafCount).to.equal(2n);
+    expect(challenge.challengeRoot).to.equal(catalog2Root);
+
+    const chunkId = Number(challenge.chunkId); // 0 or 1
+    const leafHash = catalog2Sorted[chunkId];
+    const content = catalog2ContentByHash[leafHash];
+    const sibling = catalog2Sorted[1 - chunkId];
+
+    // Empty proof: length 0 != expected height(2) == 1 → revert.
+    await expect(
+      RandomSampling.connect(node.operational).submitProof(content, []),
+    ).to.be.reverted;
+    // Too-long proof: length 2 != 1 → revert.
+    await expect(
+      RandomSampling.connect(node.operational).submitProof(content, [
+        sibling,
+        ethers.ZeroHash,
+      ]),
+    ).to.be.reverted;
+    // Still unsolved after the failed attempts.
+    expect(
+      (await RandomSamplingStorage.getNodeChallenge(node.identityId)).solved,
+    ).to.equal(false);
+
+    // Honest curated proof (correct length == 1) verifies and marks solved.
+    await RandomSampling.connect(node.operational).submitProof(content, [
+      sibling,
+    ]);
+    expect(
+      (await RandomSamplingStorage.getNodeChallenge(node.identityId)).solved,
+    ).to.equal(true);
   });
 });

--- a/packages/random-sampling/test/e2e-hardhat-chain.test.ts
+++ b/packages/random-sampling/test/e2e-hardhat-chain.test.ts
@@ -348,10 +348,10 @@ describe('Random Sampling E2E (Hardhat)', () => {
     }
   }, 90_000);
 
-  // Bounty Finding #3 regression — the empty-proof bypass is dead ON-CHAIN.
-  // Uses REC2 (an independent sharded node) so it never disturbs REC1's
-  // honest challenge above.
-  it('reverts the empty-proof bypass on the real RandomSampling.sol (content-binding)', async () => {
+  // Bounty Finding #3 + audit F01 regression — empty-proof AND root-preimage
+  // forgeries are dead ON-CHAIN. Uses REC2 (an independent sharded node) so it
+  // never disturbs REC1's honest challenge above.
+  it('reverts empty-proof + root-preimage forgeries on the real RandomSampling.sol (content-binding + proof-length binding)', async () => {
     const ctx = getSharedContext();
     const attacker = createEVMAdapter(HARDHAT_KEYS.REC2_OP);
     const attackerId = BigInt(ctx.receiverIds[1]!);
@@ -370,6 +370,24 @@ describe('Random Sampling E2E (Hardhat)', () => {
     await expect(
       attacker.submitProof!(ethers.toUtf8Bytes('<urn:x> <urn:y> <urn:z> .'), []),
     ).rejects.toThrow();
+
+    // F01 (root-preimage / proof-length binding): the 32-byte echo above is the
+    // weak variant. The structured root is keccak256(publicRoot ‖ privateDataHash);
+    // this KA is public with NO private data, so privateDataHash is the known
+    // SENTINEL and publicRoot is recomputable from public triples — i.e. the
+    // root's 64-byte PREIMAGE is fully attacker-derivable. Submitting it as
+    // `content` with an EMPTY proof gives keccak256(content) == root, which
+    // pre-fix folded zero times → leaf == root → accepted with ZERO stored data.
+    // The proof-length binding (proof.length == height(leafCount)+1 on the public
+    // path) rejects the empty proof.
+    const { root: rebuilt, publicTree, privateDataHash } = structuredKARootV10(
+      rawLeaves,
+      [],
+    );
+    expect(ethers.hexlify(rebuilt)).toBe(ethers.hexlify(root)); // attacker recomputes R
+    const rootPreimage = ethers.concat([publicTree.root, privateDataHash]); // 64 bytes
+    expect(ethers.keccak256(rootPreimage)).toBe(ethers.hexlify(root)); // valid forgery
+    await expect(attacker.submitProof!(rootPreimage, [])).rejects.toThrow();
 
     // No credit: the challenge stays unsolved after the failed attacks.
     const after = await attacker.getNodeChallenge!(attackerId);


### PR DESCRIPTION
## Audit finding F01 (Critical — proof-of-storage soundness)

The v10.2.0 content-binding fix (#1213) closed the 32-byte *"echo the root as the leaf"* bypass but **not a second variant**. `_verifyV10MerkleProof` loops on `proof.length` with no check that it equals the tree height, so an **empty proof folds zero times and returns `leaf == root`**. The on-chain root is `keccak256(left‖right)` with no leaf/node domain separation, so:

```
content   = left ‖ right            // the root's two children — PUBLIC for a curated KA,
                                     // or a public KA whose privateDataHash is the known sentinel
leaf      = keccak256(content) == root
submitProof(content, [])            // empty proof → leaf == root → ACCEPTED, zero stored data
```

Any registered node forges valid proofs holding **zero data** and siphons the epoch reward pool from honest storage providers (proven by the audit PoC).

## Fix (contract-only, no re-publish)

Require the proof to be exactly tree-height long:

```solidity
uint256 expectedProofLen = _treeHeight(uint256(leafCount)) + (challenge.isCurated ? 0 : 1);
if (merkleProof.length != expectedProofLen) revert MerkleRootMismatchError(bytes32(0), expectedMerkleRoot);
```

- **curated** (plain `_catalog` tree): `height(leafCount)`
- **public** (structured `hashPair(publicRoot, privateDataHash)`): `height(leafCount) + 1` (the one committed `privateDataHash` sibling)

This forces a genuine full-height merkle-inclusion proof; a forged leaf would require a keccak256 second-preimage. It **changes no roots**, so honest proofs (which already carry exactly that many siblings) keep passing — **no off-chain change, no re-publish**. (Leaf/node domain separation is sound additional defense-in-depth but is a breaking re-hash; it can be folded into the planned testnet cutover.)

## Validation

- **Formula ↔ builder parity:** `expectedProofLen` matches the real off-chain builder (`buildV10CatalogProofMaterial` / `buildV10ProofMaterial`) for `leafCount` 1–17, **including the odd / duplicate-last-on-odd shapes** (3, 5, 6, 7, 9, 17) — the off-by-one that would brick honest proving.
- **Real contract, honest path:** `e2e-hardhat-chain` still drives publish→challenge→`submitProof`→`solved=true`.
- **Real contract, forgery:** extended the on-chain bypass regression to submit the actual root preimage (`publicRoot ‖ sentinel`) with an empty proof — the test asserts it *is* a valid preimage of the pinned root, and `submitProof` now reverts.
- evm-module RandomSampling unit suites: **112 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)