### PR TITLE
fix(cli): honor configured network selector

### DIFF
--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -137,7 +137,9 @@ export interface DaemonStatusResponse {
   name: string;
   peerId: string;
   nodeRole?: string;
+  networkConfig?: string;
   networkId?: string;
+  networkName?: string | null;
   uptimeMs: number;
   connectedPeers: number;
   relayConnected: boolean;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -195,7 +195,7 @@ program
 
     await ensureDkgDir();
     const existing = await loadConfig();
-    const network = await loadNetworkConfig();
+    const network = await loadNetworkConfig(existing.networkConfig);
     const readiness = validateNetworkConfigReadiness(network);
     if (!readiness.ok) {
       for (const message of readiness.messages) console.error(message);

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -277,6 +277,7 @@ program
       const uptime = formatUptime(s.uptimeMs);
       console.log(`  Node:      ${s.name}`);
       console.log(`  Role:      ${s.nodeRole ?? 'edge'}`);
+      if (s.networkConfig) console.log(`  Config:    ${s.networkConfig}`);
       console.log(`  Network:   ${s.networkId ?? '—'}`);
       console.log(`  PeerId:    ${s.peerId}`);
       console.log(`  Uptime:    ${uptime}`);

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -123,7 +123,7 @@ program
   .option('--no-verify-tag', 'Skip signed-tag verification for version/tag updates')
   .action(async (versionOrRef: string | undefined, opts: ActionOpts) => {
     const config = await loadConfig();
-    const net = await loadNetworkConfig();
+    const net = await loadNetworkConfig(config.networkConfig);
     // Resolve field-by-field across local/network/project so defaults flow
     // through even when the local config omits repo/branch.
     const au = resolveAutoUpdateConfig(config, net) ?? (() => {

--- a/packages/cli/src/commands/node-ops.ts
+++ b/packages/cli/src/commands/node-ops.ts
@@ -132,7 +132,7 @@ program
   .action(async () => {
     try {
       const config = await loadConfig();
-      const network = await loadNetworkConfig();
+      const network = await loadNetworkConfig(config.networkConfig);
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
 
@@ -227,7 +227,7 @@ program
   .action(async (amount: string, opts: ActionOpts) => {
     try {
       const config = await loadConfig();
-      const network = await loadNetworkConfig();
+      const network = await loadNetworkConfig(config.networkConfig);
       const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
       const opWallets = await loadOpWallets(dkgDir());
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -377,6 +377,11 @@ export interface GraphSetIndexConfig {
 
 export interface DkgConfig {
   name: string;
+  /**
+   * Selects which bundled network/<name>.json overlay this node should use.
+   * When omitted, runtime falls back to project.json#defaultNetwork.
+   */
+  networkConfig?: string;
   relay?: string;
   apiPort: number;
   /** Host to bind the API server (default '127.0.0.1', use '0.0.0.0' for external access). */
@@ -1123,7 +1128,7 @@ export function resolveReadyChainConfig(
 /**
  * Load a network config from network/<name>.json.
  *
- * @param network - Network name (e.g. 'testnet', 'mainnet'). Defaults to
+ * @param network - Network name (e.g. 'testnet', 'mainnet-base'). Defaults to
  *   the `defaultNetwork` value from project.json.
  *
  * Candidate paths (tried in order):
@@ -1136,7 +1141,7 @@ export function resolveReadyChainConfig(
  * without requiring a rebuild of the CLI package.
  */
 export async function loadNetworkConfig(network?: string): Promise<NetworkConfig | null> {
-  const name = network ?? loadProjectConfig().defaultNetwork;
+  const name = network?.trim() || loadProjectConfig().defaultNetwork;
   if (_networkConfig && _networkConfigName === name) return _networkConfig;
   try {
     const file = `${name}.json`;
@@ -1153,6 +1158,10 @@ export async function loadNetworkConfig(network?: string): Promise<NetworkConfig
   } catch {
     return null;
   }
+}
+
+export function resolveNetworkConfigName(config?: Pick<DkgConfig, 'networkConfig'> | null): string {
+  return config?.networkConfig?.trim() || loadProjectConfig().defaultNetwork;
 }
 
 export function dkgDir(): string {

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -895,7 +895,12 @@ export async function runDaemonInner(
     log(`[dkg-build-info] WARNING: failed to emit startup telemetry: ${String(err)}`);
   }
 
-  const network = await loadNetworkConfig();
+  const selectedNetworkConfig = config.networkConfig?.trim();
+  const network = await loadNetworkConfig(selectedNetworkConfig);
+  if (selectedNetworkConfig && !network) {
+    log(`FATAL: network config "${selectedNetworkConfig}" was not found (expected network/${selectedNetworkConfig}.json).`);
+    process.exit(1);
+  }
   const genesisValidation = await validateStartupGenesis(network);
   const networkId = genesisValidation.networkId;
   if (!genesisValidation.ok) {

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -94,6 +94,7 @@ import {
   type LocalAgentIntegrationTransport,
   resolveContextGraphs,
   resolveNetworkDefaultContextGraphs,
+  resolveNetworkConfigName,
   resolveSharedMemoryTtlMs,
   repoDir,
   releasesDir,
@@ -617,7 +618,7 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
     const circuitAddrs = agent.multiaddrs.filter((a) =>
       a.includes("/p2p-circuit/"),
     );
-    const networkId = await computeNetworkId(network?.genesisId);
+    const networkId = network?.networkId ?? await computeNetworkId(network?.genesisId);
     const chainConf = resolveChainConfig(config, network);
     const rpcEndpointCount = chainConf?.rpcUrl
       ? resolveRpcUrls(chainConf.rpcUrl, chainConf.rpcUrls).length
@@ -660,7 +661,8 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
       installMode: detectInstallMode(),
       peerId: agent.peerId,
       nodeRole: config.nodeRole ?? "edge",
-      networkId: networkId.slice(0, 16),
+      networkConfig: resolveNetworkConfigName(config),
+      networkId,
       networkName: network?.networkName ?? null,
       storeBackend: config.store?.backend ?? "oxigraph-worker",
       // External backend visibility (RFC 120 / plan PR 1 item 3). For

--- a/packages/cli/src/migration.ts
+++ b/packages/cli/src/migration.ts
@@ -69,7 +69,7 @@ export const _migrationIo = {
   execFileSync: execFileSync as (...args: any[]) => any,
   repoDir: repoDir as () => string | null,
   loadConfig: loadConfig as () => Promise<any>,
-  loadNetworkConfig: loadNetworkConfig as () => Promise<any>,
+  loadNetworkConfig: loadNetworkConfig as (network?: string) => Promise<any>,
   swapSlot: swapSlot as (slot: 'a' | 'b') => Promise<void>,
 };
 
@@ -102,7 +102,7 @@ export async function migrateToBlueGreen(
   }
 
   const config = await loadConfig().catch(() => ({} as any));
-  const network = await loadNetworkConfig().catch(() => undefined);
+  const network = await loadNetworkConfig(config?.networkConfig).catch(() => undefined);
   const gitEnv = gitCommandEnv(config?.autoUpdate ?? network?.autoUpdate);
   const localRepo = repoDir();
   const hasLocalRepo = Boolean(localRepo && existsSync(join(localRepo, '.git')));

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -112,7 +112,7 @@ export async function createPublisherRuntime(args: {
     throw new Error('No publisher wallets configured. Use `dkg publisher wallet add <privateKey>` first.');
   }
 
-  const network = await loadNetworkConfig();
+  const network = await loadNetworkConfig(args.config.networkConfig);
   const keypair = await loadOrCreateAgentWallet(args.dataDir);
   const store = await createPublisherStore(args.dataDir, args.config);
   const publicSnapshotStore = createPublicSnapshotStore(args.dataDir, args.config);

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -24,6 +24,7 @@ import {
   classifyMonorepoInit,
   sharedHomeInitGate,
   repoDir,
+  resolveNetworkConfigName,
   resolveAutoUpdateSource,
   resolveApprovalPolicy,
   resolveChainConfig,
@@ -403,6 +404,25 @@ describe('localAgentIntegrations config round-trip', () => {
     await writeFile(join(tempDir, 'config.yaml'), 'nodeRole: core\n', 'utf8');
 
     expect(readNodeRoleFromConfigSync()).toBe('edge');
+  });
+
+  it('round-trips networkConfig through saveConfig/loadConfig (network selector)', async () => {
+    await saveConfig({
+      name: 'test-node',
+      networkConfig: 'mainnet-base',
+      apiPort: 9200,
+      listenPort: 0,
+      nodeRole: 'core',
+    });
+
+    const loaded = await loadConfig();
+    expect(loaded.networkConfig).toBe('mainnet-base');
+    expect(resolveNetworkConfigName(loaded)).toBe('mainnet-base');
+  });
+
+  it('falls back to project default network when networkConfig is unset or blank', () => {
+    expect(resolveNetworkConfigName({})).toBe('testnet');
+    expect(resolveNetworkConfigName({ networkConfig: '   ' })).toBe('testnet');
   });
 
   it('round-trips relayServerCapacity through saveConfig/loadConfig (operator override)', async () => {

--- a/packages/cli/test/daemon-startup-validation.test.ts
+++ b/packages/cli/test/daemon-startup-validation.test.ts
@@ -90,13 +90,48 @@ describe('daemon startup network validation', () => {
 
     await expect(runDaemonInner(true, {
       name: 'predeployment-startup-test',
+      networkConfig: 'mainnet-base',
       listenPort: 0,
       nodeRole: 'edge',
     } as any, Date.now())).rejects.toThrow('process.exit:1');
 
+    expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('mainnet-base');
     expect(mocks.agentCreate).not.toHaveBeenCalled();
     expect(stdoutSpy.mock.calls.map(call => String(call[0])).join('')).toContain(
       'FATAL: network config DKG V10 Base Mainnet is marked pre-deployment',
+    );
+  });
+
+  it('exits before agent creation when config.networkConfig does not resolve', async () => {
+    tempHome = await mkdtemp(join(tmpdir(), 'dkg-missing-network-startup-'));
+    originalDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = tempHome;
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+    uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
+    unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
+
+    mocks.loadNetworkConfig.mockResolvedValue(null);
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    vi
+      .spyOn(process, 'exit')
+      .mockImplementation(((code?: string | number | null) => {
+        throw new Error(`process.exit:${code}`);
+      }) as never);
+
+    await expect(runDaemonInner(true, {
+      name: 'missing-network-startup-test',
+      networkConfig: 'missing-mainnet',
+      listenPort: 0,
+      nodeRole: 'edge',
+    } as any, Date.now())).rejects.toThrow('process.exit:1');
+
+    expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('missing-mainnet');
+    expect(mocks.agentCreate).not.toHaveBeenCalled();
+    expect(stdoutSpy.mock.calls.map(call => String(call[0])).join('')).toContain(
+      'FATAL: network config "missing-mainnet" was not found',
     );
   });
 
@@ -109,13 +144,11 @@ describe('daemon startup network validation', () => {
     uncaughtExceptionListeners = process.listeners('uncaughtException') as NodeJS.UncaughtExceptionListener[];
     unhandledRejectionListeners = process.listeners('unhandledRejection') as NodeJS.UnhandledRejectionListener[];
 
-    const networkId = await computeNetworkId('gnosis-mainnet');
     mocks.loadNetworkConfig.mockResolvedValue({
       networkName: 'DKG V10 Gnosis Mainnet',
       genesisId: 'gnosis-mainnet',
-      networkId,
       genesisVersion: 1,
-      relays: [],
+      relays: ['/ip4/178.104.54.178/tcp/9090/p2p/12D3KooWSmU3owJvB9sFw8uApDgKrv2VBMecsGGvgAc4Gq6hB57M'],
       defaultNodeRole: 'edge',
     });
     mocks.loadOpWallets.mockResolvedValue({ adminWallet: undefined, wallets: [] });
@@ -124,10 +157,12 @@ describe('daemon startup network validation', () => {
 
     await expect(runDaemonInner(true, {
       name: 'genesis-startup-test',
+      networkConfig: 'mainnet-gnosis',
       listenPort: 0,
       nodeRole: 'edge',
     } as any, Date.now())).rejects.toThrow('after-agent-create');
 
+    expect(mocks.loadNetworkConfig).toHaveBeenCalledWith('mainnet-gnosis');
     expect(mocks.agentCreate).toHaveBeenCalledTimes(1);
     expect(mocks.agentCreate.mock.calls[0]?.[0]).toMatchObject({
       genesisId: 'gnosis-mainnet',

--- a/packages/cli/test/migration.test.ts
+++ b/packages/cli/test/migration.test.ts
@@ -194,6 +194,20 @@ describe('migrateToBlueGreen', () => {
     expect(existsSync(join(dkgHome, 'wallets.json'))).toBe(true);
   });
 
+  it('loads migration network defaults from config.networkConfig', async () => {
+    let selectedNetwork: string | undefined;
+    _migrationIo.loadConfig = async () => ({ networkConfig: 'mainnet-base' });
+    _migrationIo.loadNetworkConfig = async (network?: string) => {
+      selectedNetwork = network;
+      return undefined;
+    };
+
+    const log = makeLog();
+    await migrateToBlueGreen(log.fn);
+
+    expect(selectedNetwork).toBe('mainnet-base');
+  });
+
   it('logs migration progress', async () => {
     const log = makeLog();
     await migrateToBlueGreen(log.fn);

--- a/packages/cli/test/publisher-wallets.test.ts
+++ b/packages/cli/test/publisher-wallets.test.ts
@@ -140,6 +140,27 @@ describe('publisher wallets', () => {
     ).rejects.toThrow('dkg publisher wallet add <privateKey>');
   });
 
+  it('resolves publisher chain defaults from config.networkConfig', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
+    const wallet = ethers.Wallet.createRandom();
+    await addPublisherWallet(dataDir, wallet.privateKey);
+
+    await expect(
+      createPublisherRuntime({
+        dataDir,
+        config: {
+          name: 'test-node',
+          networkConfig: 'mainnet-base',
+          apiPort: 9200,
+          listenPort: 0,
+          nodeRole: 'edge',
+          contextGraphs: [],
+          store: { backend: 'oxigraph' },
+        },
+      }),
+    ).rejects.toThrow(/DKG V10 Base Mainnet is marked pre-deployment/);
+  });
+
   it('bootstraps publisher runtime from an existing agent store', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
     const wallet = ethers.Wallet.createRandom();

--- a/packages/cli/test/status-route-rpc.test.ts
+++ b/packages/cli/test/status-route-rpc.test.ts
@@ -114,6 +114,7 @@ describe('/api/status selected overlay details', () => {
         network,
         config: {
           name: 'status-selected-overlay-test',
+          networkConfig: 'mainnet-gnosis',
           nodeRole: 'edge',
           chain: { type: 'mock' },
         },
@@ -144,7 +145,8 @@ describe('/api/status selected overlay details', () => {
       const body: any = await res.json();
       const selectedNetworkId = await computeNetworkId('gnosis-mainnet');
 
-      expect(body.networkId).toBe(selectedNetworkId.slice(0, 16));
+      expect(body.networkConfig).toBe('mainnet-gnosis');
+      expect(body.networkId).toBe(selectedNetworkId);
       expect(body.networkName).toBe('DKG V10 Gnosis Mainnet');
     } finally {
       await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));


### PR DESCRIPTION
## Summary

Fix daemon/runtime network selection so npm/source operators can select a bundled network overlay via `config.json`:

- add `networkConfig?: string` to `DkgConfig`
- load `network/<config.networkConfig>.json` during daemon startup
- fail startup when an explicit selector does not resolve
- thread the selector through config-aware runtime paths:
  - init
  - update
  - wallet
  - set-ask
  - migration
  - publisher runtime
- expose `networkConfig`, `networkName`, and the full selected `networkId` in `/api/status`

This prevents nodes configured with `networkConfig: "mainnet-base"` from silently falling back to `project.json#defaultNetwork` (`testnet`).

## Testing

- `pnpm --filter @origintrail-official/dkg exec vitest test/config.test.ts test/daemon-startup-validation.test.ts test/migration.test.ts test/publisher-wallets.test.ts`
- `pnpm --filter @origintrail-official/dkg exec vitest test/status-route-rpc.test.ts -t "selected overlay"`
- `git diff --check`

## Notes

Full live status-route coverage is currently blocked by a stale built `dist` package graph where `@origintrail-official/dkg-publisher` does not export `buildDeterministicTokenRows`.