### PR TITLE
feat(query): per-row source provenance on local SELECT (includeProvenance)

### DIFF
--- a/packages/agent/src/dkg-agent-query.ts
+++ b/packages/agent/src/dkg-agent-query.ts
@@ -393,6 +393,14 @@ export class QueryMethods extends DKGAgentBase {
        */
       includeContextGraphPartitions?: boolean;
       /**
+       * Opt-in: return per-row source provenance in `result.provenance`. The
+       * engine binds each row's source named graph (the per-KA partition that
+       * encodes the on-chain UAL identity) and lifts it into a structured
+       * handle. No-op for query shapes that can't carry it (aggregates,
+       * CONSTRUCT/ASK, explicit GRAPH). Adds no access.
+       */
+      includeProvenance?: boolean;
+      /**
        * Opt-in: allow the scoped query to reference the context graph's own
        * `_private` partition (excluded from the scope guard's allow-set by
        * default). Used by the EPCIS events query, whose SPARQL always names
@@ -647,6 +655,7 @@ export class QueryMethods extends DKGAgentBase {
       graphSuffix: opts.graphSuffix,
       includeSharedMemory: opts.includeSharedMemory,
       includeContextGraphPartitions: opts.includeContextGraphPartitions,
+      includeProvenance: opts.includeProvenance,
       includePrivate: opts.includePrivate,
       view: opts.view,
       agentAddress: effectiveWmAddress,

--- a/packages/cli/src/daemon/routes/query.ts
+++ b/packages/cli/src/daemon/routes/query.ts
@@ -405,6 +405,10 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
     const includeSharedMemory =
       parsed.includeSharedMemory ?? parsed.includeWorkspace;
     const includeContextGraphPartitions = parsed.includeContextGraphPartitions === true;
+    // Opt-in per-row source provenance (the verifiable handle each result row
+    // came from). Returned in `result.provenance`; no-op for query shapes that
+    // can't carry it. See DKGQueryEngine `includeProvenance`.
+    const includeProvenance = parsed.includeProvenance === true;
     const view = parsed.view;
     const agentAddress = parsed.agentAddress;
     // the
@@ -586,6 +590,7 @@ export async function handleQueryRoutes(ctx: RequestContext): Promise<void> {
         graphSuffix,
         includeSharedMemory,
         includeContextGraphPartitions,
+        includeProvenance,
         view,
         agentAddress,
         verifiedGraph,

--- a/packages/cli/test/daemon/routes/query.test.ts
+++ b/packages/cli/test/daemon/routes/query.test.ts
@@ -46,6 +46,20 @@ describe('/api/query error mapping (real daemon)', () => {
     expect(status).toBe(200);
   });
 
+  it('accepts includeProvenance on the real route and returns a provenance array (route parse + forward)', async () => {
+    // Proves the daemon parses `includeProvenance` and forwards it through
+    // `agent.query` to the engine (PR review 🟡): a scoped, modifier-free SELECT
+    // comes back 200 with a `provenance` array aligned to the bindings.
+    const { status, body } = await postJson(daemon, '/api/query', {
+      sparql: 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }',
+      contextGraphId: 'all',
+      includeProvenance: true,
+    });
+    expect(status).toBe(200);
+    expect(Array.isArray(body.result.provenance)).toBe(true);
+    expect(body.result.provenance.length).toBe(body.result.bindings.length);
+  });
+
   it('rejects a SPARQL mutation (INSERT/DELETE) with a 4xx, not a 500', async () => {
     // Read endpoint must refuse writes — a real, observable contract that
     // does not depend on any injected error string.

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -19,6 +19,25 @@ export interface SparqlBinding {
 export interface SparqlResult {
   head?: { vars?: string[] };
   bindings: SparqlBinding[];
+  /**
+   * Per-row source provenance, aligned 1:1 with `bindings`. Present only when
+   * the request set `includeProvenance: true` and the query shape supported
+   * it. Each entry is the verifiable handle the row's triple came from.
+   */
+  provenance?: SparqlProvenance[];
+}
+
+export interface SparqlProvenance {
+  /** The named graph the row's triple was read from. */
+  sourceGraph: string;
+  /** Context graph id (may include a `/{sub}` sub-graph segment). */
+  contextGraphId?: string;
+  /** Declared memory layer of the source graph. */
+  memoryLayer?: 'working-memory' | 'shared-working-memory' | 'verifiable-memory';
+  /** Author EVM address — the high half of the on-chain UAL identity. */
+  author?: string;
+  /** Per-author KA number — the low half of the on-chain UAL identity. */
+  kaNumber?: string;
 }
 
 export interface QueryResponse {
@@ -407,6 +426,15 @@ export class DkgClient {
      * server actually honours to avoid documented-yet-failing inputs.
      */
     minTrust?: 'SelfAttested' | 'Endorsed' | 0 | 1;
+    /**
+     * Opt-in: ask the daemon to attach per-row source provenance
+     * (`result.provenance`, aligned 1:1 with `bindings`). Each entry is the
+     * verifiable handle the row came from — for published facts, the per-KA
+     * partition encoding the on-chain UAL identity `(author, kaNumber)`.
+     * No-op for query shapes that can't carry it (aggregates, CONSTRUCT/ASK,
+     * explicit GRAPH).
+     */
+    includeProvenance?: boolean;
   }): Promise<SparqlResult> {
     const body: Record<string, unknown> = { sparql: args.sparql };
     const contextGraphId = optionalContextGraphId(args.contextGraphId);
@@ -419,6 +447,7 @@ export class DkgClient {
     if (args.assertionName) body.assertionName = args.assertionName;
     if (args.agentAddress) body.agentAddress = args.agentAddress;
     if (args.minTrust != null) body.minTrust = args.minTrust;
+    if (args.includeProvenance != null) body.includeProvenance = args.includeProvenance;
 
     const r = await this.request<QueryResponse>('POST', '/api/query', body);
     return r.result ?? { bindings: [] };

--- a/packages/mcp-dkg/src/sparql.ts
+++ b/packages/mcp-dkg/src/sparql.ts
@@ -5,7 +5,7 @@
  *   - Common prefix map used everywhere in the V10 ontology.
  *   - Markdown renderers for SPARQL bindings.
  */
-import type { SparqlBinding } from './client.js';
+import type { SparqlBinding, SparqlProvenance } from './client.js';
 import { bindingValue } from './client.js';
 
 // Re-export so tool code can pull everything it needs from one module.
@@ -78,6 +78,29 @@ export function bindingsToTable(bindings: SparqlBinding[], columns?: string[]): 
     '| ' + cols.map((c) => prettyTerm(bindingValue(row[c]))).join(' | ') + ' |',
   );
   return [header, sep, ...rows].join('\n');
+}
+
+/**
+ * Render the verifiable sources behind a result set as a compact, deduplicated
+ * markdown list. `provenance` is aligned 1:1 with the rows it describes; rows
+ * sharing a source collapse to one entry. Each line cites the on-chain KA
+ * identity `(author/kaNumber)` when the source is a per-KA partition, plus the
+ * raw source graph so the caller can always resolve it.
+ */
+export function renderProvenanceSources(provenance: SparqlProvenance[]): string {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const p of provenance) {
+    if (!p?.sourceGraph || seen.has(p.sourceGraph)) continue;
+    seen.add(p.sourceGraph);
+    const id =
+      p.author && p.kaNumber
+        ? `KA \`${p.author}/${p.kaNumber}\`${p.memoryLayer ? ` (${p.memoryLayer})` : ''}`
+        : p.memoryLayer ?? 'source';
+    lines.push(`- ${id} — \`${p.sourceGraph}\``);
+  }
+  if (!lines.length) return '';
+  return `\n\n**Sources** (verifiable provenance):\n${lines.join('\n')}`;
 }
 
 /** Multi-line markdown summary per binding — better than a wide table for

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -23,6 +23,7 @@ import {
   bindingValue,
   bindingsToTable,
   bindingsToParagraphs,
+  renderProvenanceSources,
   escapeSparqlLiteral,
   prettyTerm,
 } from './sparql.js';
@@ -207,10 +208,14 @@ export function registerReadTools(
           .boolean()
           .optional()
           .describe('When set with view: "working-memory", include SWM in the result set (the legacy `layer: "union"` semantics).'),
+        includeProvenance: z
+          .boolean()
+          .optional()
+          .describe('Attach the verifiable source each result row came from — the source graph plus, for published facts, the on-chain UAL identity (author + KA number) you cite/verify against. Ignored for aggregates, CONSTRUCT/ASK, or queries that already use an explicit GRAPH clause.'),
         limit: z.number().optional().describe('Row cap when rendering to markdown; does NOT modify the query'),
       },
     },
-    async ({ sparql, projectId, subGraphName, view, includeSharedMemory, limit }): Promise<ToolResult> => {
+    async ({ sparql, projectId, subGraphName, view, includeSharedMemory, includeProvenance, limit }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
       const fullSparql = sparql.startsWith('PREFIX') ? sparql : `${PREFIXES}\n${sparql}`;
@@ -221,11 +226,21 @@ export function registerReadTools(
           subGraphName,
           view,
           includeSharedMemory,
+          includeProvenance,
         });
         const all = result.bindings ?? [];
         const capped = typeof limit === 'number' ? all.slice(0, limit) : all;
         const tail = capped.length < all.length ? `\n\n_(showing ${capped.length} of ${all.length} — raise limit to see more)_` : '';
-        return ok(`${bindingsToTable(capped)}${tail}`);
+        // When provenance was requested AND the query shape supported it, list
+        // the verifiable sources behind the shown rows so the caller can cite
+        // each fact. `result.provenance` is aligned 1:1 with `bindings`.
+        const provTail =
+          includeProvenance && result.provenance?.length
+            ? renderProvenanceSources(result.provenance.slice(0, capped.length))
+            : includeProvenance
+              ? '\n\n_(per-row provenance unavailable for this query shape — use a non-aggregate SELECT without an explicit GRAPH clause)_'
+              : '';
+        return ok(`${bindingsToTable(capped)}${tail}${provTail}`);
       } catch (e) {
         return err(`SPARQL failed: ${formatError(e)}`);
       }

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -211,7 +211,7 @@ export function registerReadTools(
         includeProvenance: z
           .boolean()
           .optional()
-          .describe('Attach the verifiable source each result row came from — the source graph plus, for published facts, the on-chain UAL identity (author + KA number) you cite/verify against. Ignored for aggregates, CONSTRUCT/ASK, or queries that already use an explicit GRAPH clause.'),
+          .describe('Attach the verifiable source each result row came from — the source graph plus, for published facts, the on-chain UAL identity (author + KA number) you cite/verify against. Needs a project-scoped plain SELECT; ignored for aggregates, DISTINCT/REDUCED, LIMIT/OFFSET/ORDER BY, CONSTRUCT/ASK, or an explicit GRAPH clause.'),
         limit: z.number().optional().describe('Row cap when rendering to markdown; does NOT modify the query'),
       },
     },
@@ -238,7 +238,7 @@ export function registerReadTools(
           includeProvenance && result.provenance?.length
             ? renderProvenanceSources(result.provenance.slice(0, capped.length))
             : includeProvenance
-              ? '\n\n_(per-row provenance unavailable for this query shape — use a non-aggregate SELECT without an explicit GRAPH clause)_'
+              ? '\n\n_(per-row provenance unavailable for this query shape — needs a project-scoped plain SELECT: no DISTINCT/REDUCED/LIMIT/OFFSET/ORDER BY, aggregates, or explicit GRAPH clause)_'
               : '';
         return ok(`${bindingsToTable(capped)}${tail}${provTail}`);
       } catch (e) {

--- a/packages/mcp-dkg/test/query-provenance-surface.test.ts
+++ b/packages/mcp-dkg/test/query-provenance-surface.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Public-surface coverage for `includeProvenance` (PR review 🟡): the engine
+ * tests prove the behaviour, but the flag must also survive the MCP plumbing —
+ * the real `DkgClient.query` body, the `dkg_query` tool→client forward, and the
+ * tool's rendering of `result.provenance`. Without these, the engine could work
+ * while the public surface silently drops the flag or the rendered handle.
+ */
+import { describe, it, expect } from 'vitest';
+import { DkgClient } from '../src/client.js';
+import { registerReadTools } from '../src/tools.js';
+import { FakeServer, FakeClient, makeConfig } from './harness.js';
+
+const PROV = {
+  sourceGraph: 'did:dkg:context-graph:cg/_verifiable_memory/0xaa/7',
+  contextGraphId: 'cg',
+  memoryLayer: 'verifiable-memory' as const,
+  author: '0xaa',
+  kaNumber: '7',
+};
+
+describe('includeProvenance — MCP public surface', () => {
+  it('DkgClient.query serializes includeProvenance into the /api/query body and returns provenance', async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const client = new DkgClient({
+      config: makeConfig(),
+      fetcher: (async (url, init) => {
+        calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? '{}')) });
+        return new Response(JSON.stringify({ result: { bindings: [{ s: 'urn:x' }], provenance: [PROV] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch,
+    });
+    const res = await client.query({
+      sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
+      contextGraphId: 'cg',
+      includeProvenance: true,
+    });
+    expect(calls[0].url).toContain('/api/query');
+    expect(calls[0].body.includeProvenance).toBe(true);
+    // ...and the provenance the daemon returned survives back to the caller.
+    expect(res.provenance?.[0]?.kaNumber).toBe('7');
+  });
+
+  it('DkgClient.query omits includeProvenance from the body when not requested (back-compat)', async () => {
+    const calls: Array<{ body: Record<string, unknown> }> = [];
+    const client = new DkgClient({
+      config: makeConfig(),
+      fetcher: (async (_url, init) => {
+        calls.push({ body: JSON.parse(String(init?.body ?? '{}')) });
+        return new Response(JSON.stringify({ result: { bindings: [] } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch,
+    });
+    await client.query({ sparql: 'SELECT ?s WHERE { ?s ?p ?o }', contextGraphId: 'cg' });
+    expect('includeProvenance' in calls[0].body).toBe(false);
+  });
+
+  it('dkg_query forwards includeProvenance to the client', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient();
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_query', {
+      sparql: 'SELECT ?s WHERE { ?s ?p ?o }',
+      includeProvenance: true,
+    });
+    expect(result.isError).toBeFalsy();
+    expect(client.queryCalls.at(-1)!.includeProvenance).toBe(true);
+  });
+
+  it('dkg_query renders the verifiable Sources section when the daemon returns provenance', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({ bindings: [{ s: 'urn:x', o: '"V"' }], provenance: [PROV] }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_query', {
+      sparql: 'SELECT ?s ?o WHERE { ?s ?p ?o }',
+      includeProvenance: true,
+    });
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text as string;
+    expect(text).toContain('Sources');
+    expect(text).toContain('0xaa/7');
+  });
+});

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -1,6 +1,6 @@
 import type { TripleStore, Quad, QueryResult as StoreQueryResult } from '@origintrail-official/dkg-storage';
 import { GraphManager } from '@origintrail-official/dkg-storage';
-import type { QueryResult, QueryOptions, QueryEngine } from './query-engine.js';
+import type { QueryResult, QueryOptions, QueryEngine, QueryProvenance } from './query-engine.js';
 import {
   contextGraphDataUri, contextGraphSharedMemoryUri, contextGraphVerifiableMemoryUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer,
   contextGraphSubGraphUri, contextGraphMetaUri, contextGraphSharedMemoryMetaUri, assertionLifecycleUri,
@@ -231,6 +231,23 @@ export class DKGQueryEngine implements QueryEngine {
     const guard = validateReadOnlySparql(sparql);
     if (!guard.safe) {
       throw new Error(`SPARQL rejected: ${guard.reason}`);
+    }
+
+    // ── Per-row source provenance (opt-in) ────────────────────────────
+    // Rewrite a qualifying SELECT to `SELECT … ?<reserved> WHERE { GRAPH
+    // ?<reserved> { <orig> } }` and re-enter WITHOUT the flag, so the
+    // rewritten query flows through the SAME scope guard that constrains
+    // every other `GRAPH ?g` to the allowed graph set (no new access, no
+    // new scoping code). The bound source graph is then lifted out of each
+    // row into `QueryResult.provenance`. Queries that can't carry per-row
+    // provenance (aggregates, CONSTRUCT/ASK, an explicit GRAPH clause) run
+    // normally and return no `provenance`.
+    if (options?.includeProvenance) {
+      const { includeProvenance: _drop, ...rest } = options;
+      const plan = planProvenanceRewrite(sparql);
+      if (!plan) return this.query(sparql, rest);
+      const inner = await this.query(plan.rewritten, rest);
+      return liftProvenance(inner, plan.varName);
     }
 
     // ── V10 view-based routing ────────────────────────────────────────
@@ -2316,6 +2333,137 @@ function findMatchingCloseBrace(sparql: string, openIdx: number): number {
     i++;
   }
   return -1;
+}
+
+// ── Per-row source provenance (opt-in) ──────────────────────────────────
+//
+// The reserved SPARQL variable the provenance rewrite binds the source named
+// graph to. Double-underscored + namespaced so a collision with a user
+// variable is practically impossible; `planProvenanceRewrite` additionally
+// refuses to rewrite any query that already references it.
+const PROVENANCE_VAR = '__dkgSourceGraph';
+
+const PROVENANCE_LAYER_SLUG_TO_VIEW: Record<string, GetView> = {
+  _working_memory: 'working-memory',
+  _shared_memory: 'shared-working-memory',
+  _verifiable_memory: 'verifiable-memory',
+};
+
+/**
+ * Decide whether a query can carry per-row source provenance and, if so,
+ * return the rewritten query plus the variable the source graph binds to.
+ *
+ * Qualifying shape: a single non-aggregate SELECT, with no explicit GRAPH
+ * clause, that does not already use the reserved variable. The rewrite wraps
+ * the WHERE group in `GRAPH ?<reserved> { … }` and adds `?<reserved>` to the
+ * projection (unless it is already `SELECT *`). Returns `null` for every other
+ * shape — the caller then runs the query unchanged with no provenance.
+ */
+function planProvenanceRewrite(sparql: string): { rewritten: string; varName: string } | null {
+  const varName = PROVENANCE_VAR;
+  const varTok = `?${varName}`;
+  // Never rewrite a query that already binds the reserved variable.
+  if (new RegExp(`[?$]${varName}\\b`).test(sparql)) return null;
+
+  const code = stripLiteralsAndComments(sparql);
+
+  // Must be a SELECT, and SELECT must be the query form (not a keyword inside
+  // a CONSTRUCT/ASK/DESCRIBE). Sub-SELECTs (>1 SELECT) are out of scope.
+  const selectMatches = code.match(/\bSELECT\b/gi);
+  if (!selectMatches || selectMatches.length !== 1) return null;
+  const formMatch = code.match(/\b(SELECT|CONSTRUCT|ASK|DESCRIBE)\b/i);
+  if (!formMatch || formMatch[1].toUpperCase() !== 'SELECT') return null;
+
+  // Per-row provenance is meaningless once rows are aggregated/grouped.
+  if (/\bGROUP\s+BY\b/i.test(code)) return null;
+  if (/\b(COUNT|SUM|AVG|MIN|MAX|SAMPLE|GROUP_CONCAT)\s*\(/i.test(code)) return null;
+
+  // An explicit GRAPH clause means the caller is already scoping by graph;
+  // honour it and don't double-wrap.
+  if (hasGraphClause(sparql)) return null;
+
+  const braceStart = findWhereBraceStart(sparql);
+  if (braceStart === -1) return null;
+  const braceEnd = findMatchingCloseBrace(sparql, braceStart);
+  if (braceEnd === -1) return null;
+
+  // Insert the provenance variable into the projection. Prefer just before the
+  // explicit WHERE keyword; fall back to just before the WHERE `{` for the
+  // keyword-less `SELECT ?x { … }` form. `SELECT *` already projects it.
+  const whereTok = findExplicitWhereTokenIdx(sparql);
+  const insertAt = whereTok !== -1 && whereTok < braceStart ? whereTok : braceStart;
+  const head = sparql.slice(0, insertAt);
+  const mid = sparql.slice(insertAt, braceStart + 1);
+  const inner = sparql.slice(braceStart + 1, braceEnd);
+  const tail = sparql.slice(braceEnd);
+
+  const isStar = /\bSELECT\s+(?:DISTINCT\s+|REDUCED\s+)?\*/i.test(stripLiteralsAndComments(head));
+  const projectedHead = isStar ? head : `${head.replace(/\s+$/, '')} ${varTok} `;
+
+  const rewritten = `${projectedHead}${mid} GRAPH ${varTok} { ${inner} } ${tail}`;
+  return { rewritten, varName };
+}
+
+/**
+ * Lift the reserved provenance variable out of every binding row into a
+ * parallel `provenance` array (1:1 with `bindings`), removing it from the
+ * user-facing bindings so the caller's projection is unchanged.
+ *
+ * Rows sourced from a metadata / private partition are dropped: a plain
+ * (non-GRAPH) content SELECT never unions those graphs, so surfacing them
+ * here would CHANGE the result set rather than just annotate it. The
+ * provenance rewrite's `GRAPH ?var` can otherwise bind the CG's `_meta` /
+ * `_shared_memory_meta` / `_private` graphs, which sit in the legacy- and
+ * working-memory-route allow-sets (the verifiable-memory view already
+ * excludes them). Keeping `provenance` equal to "the plain query's rows,
+ * annotated" is the invariant this preserves.
+ */
+function liftProvenance(result: QueryResult, varName: string): QueryResult {
+  const rows = result.bindings ?? [];
+  const bindings: Array<Record<string, string>> = [];
+  const provenance: QueryProvenance[] = [];
+  for (const row of rows) {
+    const { [varName]: src, ...rest } = row;
+    const sourceGraph = typeof src === 'string' ? src : '';
+    if (isNonContentProvenanceGraph(sourceGraph)) continue;
+    bindings.push(rest);
+    provenance.push(buildProvenanceHandle(sourceGraph));
+  }
+  return { ...result, bindings, provenance };
+}
+
+/**
+ * True for a source graph a plain content SELECT would not return: the CG's
+ * `_meta` / `_shared_memory_meta` (last segment ends `_meta`) or `_private`
+ * partitions, including their per-KA and sub-graph variants. Content graphs
+ * (root data, `_verifiable_memory/*`, `_shared_memory/*`, `/context/*`,
+ * sub-graph roots) are kept.
+ */
+function isNonContentProvenanceGraph(graph: string): boolean {
+  if (!graph) return false;
+  const seg = graph.slice(graph.lastIndexOf('/') + 1);
+  return seg === '_private' || seg.endsWith('_meta');
+}
+
+/**
+ * Parse a source named-graph URI into a verifiable handle. Recognises the
+ * uniform per-KA layout
+ * `did:dkg:context-graph:{cg}[/{sub}]/{_layer}/{addr}/{number}` (see
+ * `contextGraphLayerUri`); for any other graph only `sourceGraph` is set.
+ */
+function buildProvenanceHandle(sourceGraph: string | undefined): QueryProvenance {
+  if (!sourceGraph) return { sourceGraph: '' };
+  const handle: QueryProvenance = { sourceGraph };
+  const m = sourceGraph.match(
+    /^did:dkg:context-graph:(.+)\/(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/,
+  );
+  if (m) {
+    handle.contextGraphId = m[1];
+    handle.memoryLayer = PROVENANCE_LAYER_SLUG_TO_VIEW[m[2]];
+    handle.author = m[3];
+    handle.kaNumber = m[4];
+  }
+  return handle;
 }
 
 /**

--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -239,12 +239,18 @@ export class DKGQueryEngine implements QueryEngine {
     // rewritten query flows through the SAME scope guard that constrains
     // every other `GRAPH ?g` to the allowed graph set (no new access, no
     // new scoping code). The bound source graph is then lifted out of each
-    // row into `QueryResult.provenance`. Queries that can't carry per-row
-    // provenance (aggregates, CONSTRUCT/ASK, an explicit GRAPH clause) run
-    // normally and return no `provenance`.
+    // row into `QueryResult.provenance`.
+    //
+    // Gated on `contextGraphId`: the guard that constrains the helper graph
+    // variable runs ONLY for a CG-scoped query. Without it the rewrite would
+    // turn a default-graph SELECT into an unconstrained all-named-graphs scan
+    // (cross-context exposure), so the flag is ignored for unscoped queries.
+    // Queries that can't carry per-row provenance (aggregates, solution
+    // modifiers, CONSTRUCT/ASK, an explicit GRAPH clause) also run normally
+    // and return no `provenance`.
     if (options?.includeProvenance) {
       const { includeProvenance: _drop, ...rest } = options;
-      const plan = planProvenanceRewrite(sparql);
+      const plan = options.contextGraphId ? planProvenanceRewrite(sparql) : null;
       if (!plan) return this.query(sparql, rest);
       const inner = await this.query(plan.rewritten, rest);
       return liftProvenance(inner, plan.varName);
@@ -2378,6 +2384,20 @@ function planProvenanceRewrite(sparql: string): { rewritten: string; varName: st
   if (/\bGROUP\s+BY\b/i.test(code)) return null;
   if (/\b(COUNT|SUM|AVG|MIN|MAX|SAMPLE|GROUP_CONCAT)\s*\(/i.test(code)) return null;
 
+  // Solution modifiers make the rewrite unsound, because it both ADDS a
+  // hidden projection column (the source graph) and DROPS non-content rows
+  // AFTER the engine has applied the modifier:
+  //   - DISTINCT/REDUCED would dedupe over `(…user vars…, sourceGraph)`, so
+  //     stripping the helper var can leave duplicate user rows;
+  //   - LIMIT/OFFSET/ORDER BY run over rows the plain content query never
+  //     sees (the helper var can bind `_meta`/`_private` on legacy/WM routes),
+  //     so a slot can be spent on a metadata row and the content result
+  //     differs from the same query without provenance.
+  // Leave these shapes unrevised — like aggregates — so results are identical
+  // with and without the flag.
+  if (/\b(DISTINCT|REDUCED|LIMIT|OFFSET)\b/i.test(code)) return null;
+  if (/\bORDER\s+BY\b/i.test(code)) return null;
+
   // An explicit GRAPH clause means the caller is already scoping by graph;
   // honour it and don't double-wrap.
   if (hasGraphClause(sparql)) return null;
@@ -2417,6 +2437,11 @@ function planProvenanceRewrite(sparql: string): { rewritten: string; varName: st
  * working-memory-route allow-sets (the verifiable-memory view already
  * excludes them). Keeping `provenance` equal to "the plain query's rows,
  * annotated" is the invariant this preserves.
+ *
+ * Dropping rows AFTER execution is sound only because `planProvenanceRewrite`
+ * refuses any query carrying a solution modifier (DISTINCT/REDUCED/LIMIT/
+ * OFFSET/ORDER BY) — without that guarantee, the engine could apply the
+ * modifier over the to-be-dropped metadata rows and change the content set.
  */
 function liftProvenance(result: QueryResult, varName: string): QueryResult {
   const rows = result.bindings ?? [];

--- a/packages/query/src/query-engine.ts
+++ b/packages/query/src/query-engine.ts
@@ -5,6 +5,38 @@ import { TrustLevel } from '@origintrail-official/dkg-core';
 export interface QueryResult {
   bindings: Array<Record<string, string>>;
   quads?: Quad[];
+  /**
+   * Per-row source provenance, aligned 1:1 with `bindings`. Populated ONLY
+   * when the caller passes `includeProvenance: true` AND the query shape
+   * supports it (a single non-aggregate SELECT with no explicit GRAPH
+   * clause). Each entry pins the named graph the row's triple was read from
+   * — which, for published per-KA partitions, encodes the on-chain UAL
+   * identity `(author, kaNumber)` and is the handle a consumer follows to
+   * the assertion seal / on-chain merkle root to verify the fact.
+   * `undefined` means the caller did not ask, or the query shape could not
+   * carry per-row provenance.
+   */
+  provenance?: QueryProvenance[];
+}
+
+/**
+ * A verifiable source handle for one result row. `sourceGraph` is always the
+ * raw named-graph URI; the remaining fields are a best-effort parse of the
+ * uniform per-KA layout `did:dkg:context-graph:{cg}[/{sub}]/{_layer}/{addr}/{number}`
+ * (see `contextGraphLayerUri`). When the row came from a non-per-KA graph
+ * (e.g. the bare CG data graph), only `sourceGraph` is set.
+ */
+export interface QueryProvenance {
+  /** The named graph the row's triple was read from. */
+  sourceGraph: string;
+  /** Context graph id (may include a `/{sub}` sub-graph segment). */
+  contextGraphId?: string;
+  /** Declared memory layer the source graph belongs to. */
+  memoryLayer?: GetView;
+  /** Author EVM address — the high half of the UAL identity. */
+  author?: string;
+  /** Per-author KA number — the low half of the UAL identity. */
+  kaNumber?: string;
 }
 
 export interface QueryOptions {
@@ -24,6 +56,17 @@ export interface QueryOptions {
    * to their selected graph set unless this is true.
    */
   includeContextGraphPartitions?: boolean;
+  /**
+   * Opt-in: return per-row source provenance in `QueryResult.provenance`.
+   * The engine wraps the query's WHERE pattern in `GRAPH ?<reserved> { … }`,
+   * lets the existing scope guard constrain it to the same allowed graph
+   * set, then lifts the bound source graph out of each row into a structured
+   * handle. Supported for a single non-aggregate SELECT with no explicit
+   * GRAPH clause; otherwise the query runs normally and `provenance` is
+   * `undefined`. Adds no access — `?<reserved>` is constrained to exactly the
+   * graphs the query could already read.
+   */
+  includeProvenance?: boolean;
   /**
    * Opt-in: allow the scoped query to explicitly reference the context
    * graph's own `_private` partition (`<cg>/_private`, or the sub-graph

--- a/packages/query/test/query-provenance.test.ts
+++ b/packages/query/test/query-provenance.test.ts
@@ -179,4 +179,49 @@ describe('includeProvenance — per-row source provenance', () => {
     expect(r.provenance).toBeUndefined();
     expect(r.bindings).toHaveLength(2);
   });
+
+  it('ignores the flag for unscoped queries (no contextGraphId) — no cross-context scan', async () => {
+    // Without a contextGraphId the scope guard does not run, so a GRAPH-var
+    // rewrite would scan ALL named graphs (here: two different CGs). The flag
+    // must no-op and leave the plain default-graph result unchanged.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q('https://example.org/1', NAME, '"FromCgOne"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xaa/1'),
+      q('https://example.org/2', NAME, '"FromCgTwo"', 'did:dkg:context-graph:cg-two/_verifiable_memory/0xbb/2'),
+    ]);
+    const plain = await engine.query(`SELECT ?o WHERE { ?s <${NAME}> ?o }`, {});
+    const prov = await engine.query(`SELECT ?o WHERE { ?s <${NAME}> ?o }`, { includeProvenance: true });
+    expect(prov.provenance).toBeUndefined();
+    expect(prov.bindings).toEqual(plain.bindings);
+  });
+
+  it('no-ops DISTINCT — preserves dedup semantics instead of leaking the source-graph key', async () => {
+    // Same subject in two VM partitions: adding the hidden source column would
+    // make `DISTINCT ?s` return two identical ?s rows after the column is lifted.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q('https://example.org/dup', NAME, '"V"', `did:dkg:context-graph:${CG}/_verifiable_memory/0xaa/1`),
+      q('https://example.org/dup', NAME, '"V"', `did:dkg:context-graph:${CG}/_verifiable_memory/0xbb/2`),
+    ]);
+    const r = await engine.query(`SELECT DISTINCT ?s WHERE { ?s <${NAME}> ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    expect(r.provenance).toBeUndefined();
+    expect(r.bindings).toHaveLength(1);
+  });
+
+  it('no-ops LIMIT — content row count matches the plain query (no slot spent on metadata rows)', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT ?s ?o WHERE { ?s <${NAME}> ?o } LIMIT 1`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    expect(r.provenance).toBeUndefined();
+    expect(r.bindings).toHaveLength(1);
+  });
 });

--- a/packages/query/test/query-provenance.test.ts
+++ b/packages/query/test/query-provenance.test.ts
@@ -1,0 +1,182 @@
+/**
+ * `includeProvenance` — per-row source provenance on the local SELECT path.
+ *
+ * A discovery `SELECT` normally returns triples with no link back to the KA /
+ * publisher they came from (the source named graph is dropped). With
+ * `includeProvenance: true` the engine wraps the query in `GRAPH ?<reserved>`,
+ * lets the existing scope guard constrain it, and lifts the bound source graph
+ * out of each row into `result.provenance` — the handle a consumer follows to
+ * the assertion seal / on-chain merkle root to verify the fact.
+ *
+ * Hermetic: in-memory OxigraphStore, zero mocks, zero chain.
+ */
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+
+const CG = 'prov-cg';
+const ADDR_A = '0xaaa0000000000000000000000000000000000001';
+const ADDR_B = '0xbbb0000000000000000000000000000000000002';
+const NAME = 'http://schema.org/name';
+
+const vmGraphA = `did:dkg:context-graph:${CG}/_verifiable_memory/${ADDR_A}/5`;
+const vmGraphB = `did:dkg:context-graph:${CG}/_verifiable_memory/${ADDR_B}/9`;
+const metaGraph = `did:dkg:context-graph:${CG}/_meta`;
+const assertionUri = `did:dkg:context-graph:${CG}/assertion/${ADDR_A}/myassertion`;
+
+function q(subject: string, predicate: string, object: string, graph: string) {
+  return { subject, predicate, object, graph };
+}
+
+async function fixture() {
+  const store = new OxigraphStore();
+  const engine = new DKGQueryEngine(store);
+  await store.insert([
+    q('https://example.org/a', NAME, '"FromKA_A"', vmGraphA),
+    q('https://example.org/b', NAME, '"FromKA_B"', vmGraphB),
+    // A seal row in `_meta` — must NOT bleed into a content read.
+    q(assertionUri, 'http://dkg.io/ontology/authorAddress', '"0xAUTHOR"', metaGraph),
+  ]);
+  return engine;
+}
+
+describe('includeProvenance — per-row source provenance', () => {
+  it('attaches a parsed UAL-identity handle to each row and keeps bindings clean', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT ?s ?o WHERE { ?s <${NAME}> ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+
+    expect(r.bindings).toHaveLength(2);
+    // The reserved provenance variable must NOT leak into user bindings.
+    for (const row of r.bindings) {
+      expect(Object.keys(row).sort()).toEqual(['o', 's']);
+    }
+    expect(r.provenance).toHaveLength(2);
+
+    // Provenance is aligned 1:1 with bindings; match by row content.
+    const byObject = new Map(
+      r.bindings.map((row, i) => [row['o'], r.provenance![i]]),
+    );
+    const provA = byObject.get('"FromKA_A"')!;
+    expect(provA.sourceGraph).toBe(vmGraphA);
+    expect(provA.contextGraphId).toBe(CG);
+    expect(provA.memoryLayer).toBe('verifiable-memory');
+    expect(provA.author).toBe(ADDR_A);
+    expect(provA.kaNumber).toBe('5');
+
+    const provB = byObject.get('"FromKA_B"')!;
+    expect(provB.author).toBe(ADDR_B);
+    expect(provB.kaNumber).toBe('9');
+  });
+
+  it('does not widen access — the `_meta` seal graph is not unioned into the read', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT ?s ?o WHERE { ?s ?p ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    const objects = r.bindings.map((b) => b['o']);
+    expect(objects).not.toContain('"0xAUTHOR"');
+    for (const p of r.provenance ?? []) {
+      expect(p.sourceGraph).not.toContain('/_meta');
+    }
+  });
+
+  it('does not leak _meta seal rows on the default (no-view) path — content rows only, annotated', async () => {
+    // The default `dkg_query` path omits `view` → legacy routing, whose
+    // GRAPH-variable allow-set includes the CG `_meta` graph. Pre-fix, the
+    // provenance rewrite surfaced the seal rows (authorAddress / merkleRoot)
+    // as content; the lift step must drop them so the result equals the plain
+    // query's rows, just annotated.
+    const engine = await fixture();
+    const r = await engine.query(`SELECT ?s ?o WHERE { ?s ?p ?o }`, {
+      contextGraphId: CG,
+      includeProvenance: true,
+    });
+    const objects = r.bindings.map((b) => b['o']);
+    expect(objects).toContain('"FromKA_A"');
+    expect(objects).toContain('"FromKA_B"');
+    // The _meta seal row must NOT appear (it would, pre-fix).
+    expect(objects).not.toContain('"0xAUTHOR"');
+    expect(r.provenance).toBeDefined();
+    expect(r.provenance!).toHaveLength(r.bindings.length);
+    for (const p of r.provenance!) {
+      expect(p.sourceGraph).not.toContain('_meta');
+      expect(p.sourceGraph.endsWith('/_private')).toBe(false);
+    }
+  });
+
+  it('returns a sourceGraph-only handle for non-per-KA content graphs (per-cgId /context/{id})', async () => {
+    // Chain-reconcile / per-cgId materialisation writes confirmed VM data to
+    // `…/context/{onChainId}` (see GH #1098), which is NOT the per-KA layout.
+    // The handle is honest: sourceGraph is set, identity fields are absent.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    const perCgId = `did:dkg:context-graph:${CG}/context/7`;
+    await store.insert([q('https://example.org/c', NAME, '"FromPerCgId"', perCgId)]);
+    const r = await engine.query(`SELECT ?s ?o WHERE { ?s <${NAME}> ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    const idx = r.bindings.findIndex((b) => b['o'] === '"FromPerCgId"');
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const p = r.provenance![idx];
+    expect(p.sourceGraph).toBe(perCgId);
+    expect(p.author).toBeUndefined();
+    expect(p.kaNumber).toBeUndefined();
+  });
+
+  it('handles SELECT * by stripping the reserved variable from each row', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT * WHERE { ?s <${NAME}> ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    expect(r.bindings).toHaveLength(2);
+    for (const row of r.bindings) {
+      expect(Object.keys(row).some((k) => k.includes('dkgSourceGraph'))).toBe(false);
+    }
+    expect(r.provenance).toHaveLength(2);
+    expect(r.provenance!.every((p) => p.author && p.kaNumber)).toBe(true);
+  });
+
+  it('is a no-op for aggregate queries (per-row provenance is meaningless)', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    expect(r.provenance).toBeUndefined();
+    expect(r.bindings).toHaveLength(1);
+    expect(r.bindings[0]['n']).toContain('2');
+  });
+
+  it('is a no-op when the caller already uses an explicit GRAPH clause', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT ?s ?o ?g WHERE { GRAPH ?g { ?s <${NAME}> ?o } }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+      includeProvenance: true,
+    });
+    // The user's own ?g projection is honoured; no parallel provenance array.
+    expect(r.provenance).toBeUndefined();
+    expect(r.bindings.every((row) => typeof row['g'] === 'string')).toBe(true);
+  });
+
+  it('omits provenance entirely when not requested (back-compat default off)', async () => {
+    const engine = await fixture();
+    const r = await engine.query(`SELECT ?s ?o WHERE { ?s <${NAME}> ?o }`, {
+      contextGraphId: CG,
+      view: 'verifiable-memory',
+    });
+    expect(r.provenance).toBeUndefined();
+    expect(r.bindings).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What & why

A discovery `SELECT` against the DKG drops the **source named graph**, so an LLM/agent gets triples with no link back to the Knowledge Asset that produced them — it can't cite or verify a fact. This is the *"every answer cites a verifiable source"* gap in the verifiable-grounding story.

The source graph **is** recoverable — for published facts it's the per-KA partition `…/_verifiable_memory/{author}/{kaNumber}`, which encodes the on-chain UAL identity — but only via an explicit `GRAPH ?g` projection that the `dkg_query` tool never exposed (and that a consumer would have to understand the partition layout to use).

## Approach

Opt-in `includeProvenance` flag, threaded `dkg_query` → `/api/query` → `agent.query` → engine. On a qualifying SELECT the engine:

1. rewrites `SELECT … WHERE { <body> }` → `SELECT … ?__dkgSourceGraph WHERE { GRAPH ?__dkgSourceGraph { <body> } }` and **re-enters `query()` with the flag stripped**, so the rewritten query flows through the **existing** scope guard that already constrains every `GRAPH ?g` to the allowed graph set — no new scoping code;
2. lifts the bound source graph out of each row into `result.provenance` — a structured handle `{ sourceGraph, contextGraphId, memoryLayer, author, kaNumber }` aligned 1:1 with `bindings`.

The MCP tool renders the deduped verifiable sources behind the shown rows.

## Correctness / security

- **No new access** — `?__dkgSourceGraph` is constrained to exactly the graphs the query could already read; the cross-CG / explicit-`GRAPH` boundaries are untouched (the rewrite is a no-op when the query already has a `GRAPH` clause).
- **Invariant — "the plain query's rows, just annotated."** The legacy and working-memory route allow-sets bind the CG's `_meta` / `_private` graphs to the GRAPH var, so the lift step **drops** metadata/private-partition rows. Without this the default (no-view) path would mix seal rows (authorAddress, merkleRoot) into content results. Pinned by a no-view regression test.
- **No-op** for shapes that can't carry per-row provenance: aggregates / `GROUP BY`, `CONSTRUCT` / `ASK`, sub-SELECTs, or an explicit `GRAPH` clause. **Default off** — existing callers unaffected.

## Scope / limitations

- Local query path only (MCP / daemon / `agent.query`). The cross-node libp2p path still flattens quads→N-Triples — separate follow-up.
- The full `{author, kaNumber}` identity is parsed only for the per-KA partition layout. Rows from the root data graph or the per-cgId `…/context/{id}` materialisation (GH #1098) return `sourceGraph` only (still a resolvable handle) — covered by a test.

## Testing

- `packages/query/test/query-provenance.test.ts` — 8 cases: parsed handle + clean bindings, `SELECT *`, aggregate no-op, explicit-`GRAPH` no-op, back-compat default-off, **no-view `_meta`-leak guard**, per-cgId sourceGraph-only handle, access-not-widened.
- Suites green: query **286**, mcp-dkg **304**, cli query route **3**, agent query **3**. All touched packages typecheck (`turbo build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)