### PR TITLE
feat(mcp): dkg_get_entity_sources — verifiable provenance for addressed reads

### DIFF
--- a/packages/mcp-dkg/README.md
+++ b/packages/mcp-dkg/README.md
@@ -138,7 +138,7 @@ autoShare: true
 
 `.dkg/` is gitignored repo-wide so this file stays local to each operator. The `tokenFile` path is resolved relative to the YAML; default of `~/.dkg/auth.token` matches what `dkg start` writes on first boot.
 
-## Tool surface (30 tools)
+## Tool surface (31 tools)
 
 All tools are available the moment `dkg mcp setup` registers the MCP with your client. They group into seven categories tracking how a session typically uses memory: check health, discover the graph, set it up, drive the knowledge-asset lifecycle (create → write → finalize → share → publish), recall from it, query it, and message other agents.
 
@@ -157,6 +157,7 @@ All tools are available the moment `dkg mcp setup` registers the MCP with your c
 | `dkg_list_context_graphs` | List all context graphs (called "projects" in the DKG node UI) this node knows about. Returns id, display name, role (curator / participant), and layer. The first call most agents make when joining a workspace. |
 | `dkg_sub_graph_list` | List the sub-graphs inside a context graph (e.g. `code`, `github`, `decisions`, `tasks`, `meta`, `chat`) with entity counts. Use to figure out what kind of knowledge a CG exposes before querying. |
 | `dkg_get_entity` | All triples where the given URI is the subject, plus a 1-hop inbound-edges neighbourhood. Equivalent to the entity detail page in the Node UI. Use to understand a specific decision, task, file, or PR end-to-end. |
+| `dkg_get_entity_sources` | An entity's facts, each tagged with the Knowledge Asset (author + KA number) that asserted it, so you can cite/verify provenance. Reads one tier — verifiable-memory by default (published/on-chain), or shared-working-memory (pre-publish draft). Facts in non-per-KA graphs are disclosed by count. |
 | `dkg_list_activity` | Recent activity across all sub-graphs, newest first. Mirrors the "Recent activity" feed on the project overview page: decisions, tasks, PRs, chat turns. Use to catch up at the start of a session. |
 | `dkg_get_agent` | Look up an agent by URI (or display name) and return its profile card: framework, operator, wallet address, joined-at, reputation, plus everything that agent has authored in the project. |
 
@@ -293,8 +294,8 @@ Per-turn state is kept in `~/.cache/dkg-mcp/sessions/*.json`; safe to delete at 
 
 | File | Purpose |
 |---|---|
-| `src/index.ts` | Stdio MCP server entrypoint. Boots `McpServer` and registers the 30 tools. |
-| `src/tools.ts` | Read tools (`dkg_list_context_graphs`, `dkg_sub_graph_list`, `dkg_query`, `dkg_get_entity`, `dkg_list_activity`, `dkg_get_agent`). |
+| `src/index.ts` | Stdio MCP server entrypoint. Boots `McpServer` and registers the 31 tools. |
+| `src/tools.ts` | Read tools (`dkg_list_context_graphs`, `dkg_sub_graph_list`, `dkg_query`, `dkg_get_entity`, `dkg_get_entity_sources`, `dkg_list_activity`, `dkg_get_agent`). |
 | `src/tools/assertions.ts` | Knowledge-asset lifecycle (`dkg_knowledge_asset_*` × 13: create/write/finalize/share/publish/pull_from/discard/query/history/import_file + import_artifact_resolve/read_markdown + semantic_enrichment_write). |
 | `src/tools/health.ts` | `dkg_status`, `dkg_peer_info`, `dkg_wallet_balances`. |
 | `src/tools/memory-search.ts` | `dkg_memory_search` with WM/SWM/VM fan-out and trust-weighted ranking. |

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -52,22 +52,19 @@ export interface DkgClientOptions {
 const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
 
 export function normalizeContextGraphId(contextGraphIdOrUri: string): string {
-  // Idempotent: strip EVERY leading DID prefix and any trailing slash(es).
-  // Consumers that re-normalize (e.g. the wire scope AND a downstream
-  // provenance anchor) must converge on the same id even for malformed input
-  // like a double-prefixed or trailing-slash value — otherwise the two derive
-  // different context-graph ids and silently disagree.
-  let s = contextGraphIdOrUri.trim();
-  while (s.startsWith(CONTEXT_GRAPH_URI_PREFIX)) {
-    s = s.slice(CONTEXT_GRAPH_URI_PREFIX.length);
-  }
-  // Trim trailing slash(es) with a linear index walk, NOT `/\/+$/`: that
-  // regex is a polynomial-ReDoS on a string of many '/' (replace scans every
-  // start position and the `\/+` backtracks at each), and this id is
-  // caller/config input — CodeQL js/polynomial-redos flags it.
-  let end = s.length;
-  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end -= 1;
-  return s.slice(0, end);
+  // Strip EXACTLY ONE leading DID prefix and trim whitespace — matching the
+  // daemon-side normalizer. Deliberately NOT canonicalising further: the
+  // daemon allows `/` and `:` in context-graph ids, so trailing slashes or a
+  // repeated DID prefix denote DISTINCT valid ids. Collapsing them here (this
+  // helper backs ~all client requests) would silently route reads/writes to a
+  // different project. Consumers needing the daemon's resolved id should call
+  // this once and reuse the result for both the wire scope and any downstream
+  // use (see dkg_get_entity_sources); a malformed id then fails closed rather
+  // than aliasing.
+  const trimmed = contextGraphIdOrUri.trim();
+  return trimmed.startsWith(CONTEXT_GRAPH_URI_PREFIX)
+    ? trimmed.slice(CONTEXT_GRAPH_URI_PREFIX.length)
+    : trimmed;
 }
 
 function optionalContextGraphId(contextGraphIdOrUri: string | undefined): string | undefined {

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -61,7 +61,13 @@ export function normalizeContextGraphId(contextGraphIdOrUri: string): string {
   while (s.startsWith(CONTEXT_GRAPH_URI_PREFIX)) {
     s = s.slice(CONTEXT_GRAPH_URI_PREFIX.length);
   }
-  return s.replace(/\/+$/, '');
+  // Trim trailing slash(es) with a linear index walk, NOT `/\/+$/`: that
+  // regex is a polynomial-ReDoS on a string of many '/' (replace scans every
+  // start position and the `\/+` backtracks at each), and this id is
+  // caller/config input — CodeQL js/polynomial-redos flags it.
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) end -= 1;
+  return s.slice(0, end);
 }
 
 function optionalContextGraphId(contextGraphIdOrUri: string | undefined): string | undefined {

--- a/packages/mcp-dkg/src/client.ts
+++ b/packages/mcp-dkg/src/client.ts
@@ -51,11 +51,17 @@ export interface DkgClientOptions {
 
 const CONTEXT_GRAPH_URI_PREFIX = 'did:dkg:context-graph:';
 
-function normalizeContextGraphId(contextGraphIdOrUri: string): string {
-  const trimmed = contextGraphIdOrUri.trim();
-  return trimmed.startsWith(CONTEXT_GRAPH_URI_PREFIX)
-    ? trimmed.slice(CONTEXT_GRAPH_URI_PREFIX.length)
-    : trimmed;
+export function normalizeContextGraphId(contextGraphIdOrUri: string): string {
+  // Idempotent: strip EVERY leading DID prefix and any trailing slash(es).
+  // Consumers that re-normalize (e.g. the wire scope AND a downstream
+  // provenance anchor) must converge on the same id even for malformed input
+  // like a double-prefixed or trailing-slash value — otherwise the two derive
+  // different context-graph ids and silently disagree.
+  let s = contextGraphIdOrUri.trim();
+  while (s.startsWith(CONTEXT_GRAPH_URI_PREFIX)) {
+    s = s.slice(CONTEXT_GRAPH_URI_PREFIX.length);
+  }
+  return s.replace(/\/+$/, '');
 }
 
 function optionalContextGraphId(contextGraphIdOrUri: string | undefined): string | undefined {

--- a/packages/mcp-dkg/src/sparql.ts
+++ b/packages/mcp-dkg/src/sparql.ts
@@ -98,37 +98,27 @@ const LAYER_SLUG_TO_VIEW: Record<string, EntitySource['memoryLayer']> = {
  * per-author UAL, so it intentionally does NOT match — those facts are
  * disclosed, not attributed.
  *
- * When the caller's context-graph id is known, pass it: a CG id may itself
+ * `cgId` is REQUIRED and the parse is ANCHORED on it: a CG id may itself
  * contain `/` and `_` (validateContextGraphId allows them), so an
  * adversarially-named CG like `evil/_verifiable_memory/0xaa/1` could have a
  * ROOT graph that a greedy, unanchored parse misreads as a per-KA partition and
  * fabricates `KA 0xaa/1`. Anchoring on the known `…:{cgId}/` prefix makes the
  * CG-id portion impossible to reinterpret as layer/addr/number (mirrors
- * node-ui's useSwmAttributions). With no `cgId`, fall back to the greedy form.
+ * node-ui's useSwmAttributions). There is deliberately no unanchored fallback —
+ * that greedy form is the footgun, so callers must supply the known cgId.
  */
-export function parseEntitySource(sourceGraph: string, cgId?: string): EntitySource {
+export function parseEntitySource(sourceGraph: string, cgId: string): EntitySource {
   const src: EntitySource = { sourceGraph };
-  const PER_KA_TAIL = /^(?:.+\/)?(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/;
-  if (cgId !== undefined) {
-    const prefix = `did:dkg:context-graph:${cgId}/`;
-    if (!sourceGraph.startsWith(prefix)) return src;
-    const m = sourceGraph.slice(prefix.length).match(PER_KA_TAIL);
-    if (m) {
-      src.contextGraphId = cgId;
-      src.memoryLayer = LAYER_SLUG_TO_VIEW[m[1]];
-      src.author = m[2];
-      src.kaNumber = m[3];
-    }
-    return src;
-  }
-  const m = sourceGraph.match(
-    /^did:dkg:context-graph:(.+)\/(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/,
-  );
+  const prefix = `did:dkg:context-graph:${cgId}/`;
+  if (!sourceGraph.startsWith(prefix)) return src;
+  const m = sourceGraph
+    .slice(prefix.length)
+    .match(/^(?:.+\/)?(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/);
   if (m) {
-    src.contextGraphId = m[1];
-    src.memoryLayer = LAYER_SLUG_TO_VIEW[m[2]];
-    src.author = m[3];
-    src.kaNumber = m[4];
+    src.contextGraphId = cgId;
+    src.memoryLayer = LAYER_SLUG_TO_VIEW[m[1]];
+    src.author = m[2];
+    src.kaNumber = m[3];
   }
   return src;
 }

--- a/packages/mcp-dkg/src/sparql.ts
+++ b/packages/mcp-dkg/src/sparql.ts
@@ -89,9 +89,38 @@ const LAYER_SLUG_TO_VIEW: Record<string, EntitySource['memoryLayer']> = {
   _verifiable_memory: 'verifiable-memory',
 };
 
-/** Parse a source named-graph URI into a verifiable handle. */
-export function parseEntitySource(sourceGraph: string): EntitySource {
+/**
+ * Parse a source named-graph URI into a verifiable handle.
+ *
+ * Per-KA partition layout: `…:{cg}[/{sub}]/{_layer}/{addr}/{number}` — TWO
+ * trailing segments after the layer slug. A single-segment VM graph such as the
+ * consensus `…/_verifiable_memory/{vmId}` is keyed by a batch id, not a
+ * per-author UAL, so it intentionally does NOT match — those facts are
+ * disclosed, not attributed.
+ *
+ * When the caller's context-graph id is known, pass it: a CG id may itself
+ * contain `/` and `_` (validateContextGraphId allows them), so an
+ * adversarially-named CG like `evil/_verifiable_memory/0xaa/1` could have a
+ * ROOT graph that a greedy, unanchored parse misreads as a per-KA partition and
+ * fabricates `KA 0xaa/1`. Anchoring on the known `…:{cgId}/` prefix makes the
+ * CG-id portion impossible to reinterpret as layer/addr/number (mirrors
+ * node-ui's useSwmAttributions). With no `cgId`, fall back to the greedy form.
+ */
+export function parseEntitySource(sourceGraph: string, cgId?: string): EntitySource {
   const src: EntitySource = { sourceGraph };
+  const PER_KA_TAIL = /^(?:.+\/)?(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/;
+  if (cgId !== undefined) {
+    const prefix = `did:dkg:context-graph:${cgId}/`;
+    if (!sourceGraph.startsWith(prefix)) return src;
+    const m = sourceGraph.slice(prefix.length).match(PER_KA_TAIL);
+    if (m) {
+      src.contextGraphId = cgId;
+      src.memoryLayer = LAYER_SLUG_TO_VIEW[m[1]];
+      src.author = m[2];
+      src.kaNumber = m[3];
+    }
+    return src;
+  }
   const m = sourceGraph.match(
     /^did:dkg:context-graph:(.+)\/(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/,
   );
@@ -104,9 +133,16 @@ export function parseEntitySource(sourceGraph: string): EntitySource {
   return src;
 }
 
-/** Short citation label: `KA <author>/<kaNumber>` for a per-KA source, else the graph. */
+/**
+ * Short citation label. A per-KA source renders as `KA <author>/<number>`;
+ * a shared-working-memory source is a PRE-PUBLISH reserved UAL (not yet on
+ * chain, may still change or be discarded), so it is qualified as a draft so a
+ * per-fact label can't be lifted out of context and cited as on-chain.
+ */
 export function sourceLabel(s: EntitySource): string {
-  return s.author && s.kaNumber ? `KA \`${s.author}/${s.kaNumber}\`` : `\`${s.sourceGraph}\``;
+  if (!(s.author && s.kaNumber)) return `\`${s.sourceGraph}\``;
+  const draft = s.memoryLayer === 'shared-working-memory' ? 'draft ' : '';
+  return `${draft}KA \`${s.author}/${s.kaNumber}\``;
 }
 
 /** Markdown table from SPARQL bindings, with pretty-printed terms. */

--- a/packages/mcp-dkg/src/sparql.ts
+++ b/packages/mcp-dkg/src/sparql.ts
@@ -68,6 +68,47 @@ export function escapeSparqlLiteral(s: string): string {
     .replace(/\t/g, '\\t');
 }
 
+/**
+ * A verifiable source handle parsed from a result row's named graph. The raw
+ * `sourceGraph` is always set; for the uniform per-KA layout
+ * `did:dkg:context-graph:{cg}[/{sub}]/{_layer}/{addr}/{number}` the remaining
+ * fields decode the on-chain UAL identity `(author, kaNumber)` a consumer
+ * cites/verifies against. For any other content graph only `sourceGraph` is set.
+ */
+export interface EntitySource {
+  sourceGraph: string;
+  contextGraphId?: string;
+  memoryLayer?: 'working-memory' | 'shared-working-memory' | 'verifiable-memory';
+  author?: string;
+  kaNumber?: string;
+}
+
+const LAYER_SLUG_TO_VIEW: Record<string, EntitySource['memoryLayer']> = {
+  _working_memory: 'working-memory',
+  _shared_memory: 'shared-working-memory',
+  _verifiable_memory: 'verifiable-memory',
+};
+
+/** Parse a source named-graph URI into a verifiable handle. */
+export function parseEntitySource(sourceGraph: string): EntitySource {
+  const src: EntitySource = { sourceGraph };
+  const m = sourceGraph.match(
+    /^did:dkg:context-graph:(.+)\/(_working_memory|_shared_memory|_verifiable_memory)\/([^/]+)\/([^/]+)$/,
+  );
+  if (m) {
+    src.contextGraphId = m[1];
+    src.memoryLayer = LAYER_SLUG_TO_VIEW[m[2]];
+    src.author = m[3];
+    src.kaNumber = m[4];
+  }
+  return src;
+}
+
+/** Short citation label: `KA <author>/<kaNumber>` for a per-KA source, else the graph. */
+export function sourceLabel(s: EntitySource): string {
+  return s.author && s.kaNumber ? `KA \`${s.author}/${s.kaNumber}\`` : `\`${s.sourceGraph}\``;
+}
+
 /** Markdown table from SPARQL bindings, with pretty-printed terms. */
 export function bindingsToTable(bindings: SparqlBinding[], columns?: string[]): string {
   if (!bindings.length) return '(no results)';

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -16,6 +16,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { DkgClient, ProjectRow } from './client.js';
+import { normalizeContextGraphId } from './client.js';
 import type { DkgConfig } from './config.js';
 import {
   NS,
@@ -380,6 +381,12 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
     async ({ uri, projectId, view, subGraphName }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
+      // The client accepts a full `did:dkg:context-graph:<id>` and normalises it
+      // for the wire query, so the returned graphs are keyed by the bare id.
+      // Anchor parseEntitySource on the SAME normalised id (and scope the query
+      // with it), or a DID-form pid would double-prefix and mark every per-KA
+      // graph unattributed.
+      const cgId = normalizeContextGraphId(pid);
       const safeIri = uri.replace(/^<|>$/g, '');
       // Guard the IRI interpolation: reject anything that could break out of
       // the `<…>` term. (A SPARQL injection here would let a caller widen the
@@ -398,13 +405,13 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
         const result = await client.query({
           sparql: `${PREFIXES}
 SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
-          contextGraphId: pid,
+          contextGraphId: cgId,
           subGraphName,
           view: scopeView,
         });
         const rows = result.bindings ?? [];
         if (!rows.length) {
-          return ok(`No facts found for <${safeIri}> in '${pid}' (view=${scopeView}).`);
+          return ok(`No facts found for <${safeIri}> in '${cgId}' (view=${scopeView}).`);
         }
         // A VM/SWM read binds MORE than per-KA partitions: the root context
         // graph, per-collection `/context/{id}` graphs, and the SWM bucket also
@@ -426,8 +433,8 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
         for (const b of rows) {
           const p = bindingValue(b.p);
           const o = bindingValue(b.o);
-          const src = parseEntitySource(bindingValue(b.g), pid);
-          const key = `${p} ${o}`;
+          const src = parseEntitySource(bindingValue(b.g), cgId);
+          const key = JSON.stringify([p, o]);
           const fact = facts.get(key) ?? { p, o, ka: [] };
           if (src.author && src.kaNumber) {
             if (!fact.ka.some((s) => s.sourceGraph === src.sourceGraph)) fact.ka.push(src);
@@ -440,7 +447,7 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
 
         if (!attributed.length) {
           return ok(
-            `No KA-attributable facts for <${safeIri}> in '${pid}' (view=${scopeView}). ` +
+            `No KA-attributable facts for <${safeIri}> in '${cgId}' (view=${scopeView}). ` +
               `${unattributed.length} fact(s) are present only in non-per-KA graphs ` +
               `(root / reconcile / bucket), which do not encode a citable KA identity.`,
           );

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -376,9 +376,15 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
           .optional()
           .describe('Memory tier to read sources from. Defaults to verifiable-memory (on-chain, citable). working-memory is intentionally not offered: it is private draft state (the engine requires an agent identity to read it) and is not a citable source.'),
         subGraphName: z.string().optional().describe('Limit the read to a single sub-graph'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Max attributed facts to render (default 100). A high-degree or many-publisher entity is truncated deterministically and the remainder disclosed, so the response cannot exhaust agent context.'),
       },
     },
-    async ({ uri, projectId, view, subGraphName }): Promise<ToolResult> => {
+    async ({ uri, projectId, view, subGraphName, limit }): Promise<ToolResult> => {
       const pid = resolveProject(projectId, config);
       if (!pid) return projectErr();
       // The client accepts a full `did:dkg:context-graph:<id>` and normalises it
@@ -433,16 +439,14 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
           ka: EntitySource[];
         }
         const facts = new Map<string, Fact>();
-        const kaSources = new Map<string, EntitySource>();
         for (const b of rows) {
           const p = bindingValue(b.p);
           const o = bindingValue(b.o);
           const src = parseEntitySource(bindingValue(b.g), cgId);
           const key = JSON.stringify([p, o]);
           const fact = facts.get(key) ?? { p, o, ka: [] };
-          if (src.author && src.kaNumber) {
-            if (!fact.ka.some((s) => s.sourceGraph === src.sourceGraph)) fact.ka.push(src);
-            kaSources.set(src.sourceGraph, src);
+          if (src.author && src.kaNumber && !fact.ka.some((s) => s.sourceGraph === src.sourceGraph)) {
+            fact.ka.push(src);
           }
           facts.set(key, fact);
         }
@@ -457,7 +461,16 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
           );
         }
 
-        const factLines = attributed.map(
+        // Deterministic output cap: render at most `limit` attributed facts and
+        // only the sources THEY cite, so a high-degree / many-publisher entity
+        // cannot dump an unbounded MCP response. Remainder disclosed, not dropped.
+        const cap = limit ?? 100;
+        const shown = attributed.slice(0, cap);
+        const truncated = attributed.length - shown.length;
+        const kaSources = new Map<string, EntitySource>();
+        for (const f of shown) for (const s of f.ka) kaSources.set(s.sourceGraph, s);
+
+        const factLines = shown.map(
           (f) => `- **${prettyTerm(f.p)}**: ${prettyTerm(f.o)}  ←  ${f.ka.map((s) => sourceLabel(s)).join(', ')}`,
         );
         const sourceLines = [...kaSources.values()].map(
@@ -484,6 +497,12 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
           sourcesHeader,
           sourceLines.join('\n'),
         ];
+        if (truncated > 0) {
+          parts.push(
+            '',
+            `_${truncated} more attributed fact(s) not shown — raise \`limit\` (currently ${cap})._`,
+          );
+        }
         if (unattributed.length) {
           parts.push(
             '',

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -450,7 +450,15 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
           }
           facts.set(key, fact);
         }
-        const attributed = [...facts.values()].filter((f) => f.ka.length > 0);
+        // Stable ordering BEFORE the cap so truncation is genuinely deterministic
+        // — the SPARQL query has no ORDER BY, so raw row order is backend/
+        // discovery-dependent. Facts sort by (predicate, object); each fact's KA
+        // sources by sourceGraph.
+        const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+        const attributed = [...facts.values()]
+          .filter((f) => f.ka.length > 0)
+          .map((f) => ({ ...f, ka: [...f.ka].sort((x, y) => cmp(x.sourceGraph, y.sourceGraph)) }))
+          .sort((a, b) => cmp(a.p, b.p) || cmp(a.o, b.o));
         const unattributed = [...facts.values()].filter((f) => f.ka.length === 0);
 
         if (!attributed.length) {
@@ -473,9 +481,9 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
         const factLines = shown.map(
           (f) => `- **${prettyTerm(f.p)}**: ${prettyTerm(f.o)}  ←  ${f.ka.map((s) => sourceLabel(s)).join(', ')}`,
         );
-        const sourceLines = [...kaSources.values()].map(
-          (s) => `- ${sourceLabel(s)} (${s.memoryLayer}) — \`${s.sourceGraph}\``,
-        );
+        const sourceLines = [...kaSources.values()]
+          .sort((a, b) => cmp(a.sourceGraph, b.sourceGraph))
+          .map((s) => `- ${sourceLabel(s)} (${s.memoryLayer}) — \`${s.sourceGraph}\``);
         // Verifiable-memory sources are published/on-chain; shared-working-memory
         // sources are pre-publish DRAFT (reserved, not-yet-on-chain) handles —
         // condition the framing so a per-fact line can't be cited as on-chain.

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -25,6 +25,9 @@ import {
   bindingsToParagraphs,
   escapeSparqlLiteral,
   prettyTerm,
+  parseEntitySource,
+  sourceLabel,
+  type EntitySource,
 } from './sparql.js';
 import { EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION } from './tools/context-graph-description.js';
 
@@ -336,6 +339,88 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
         return ok(parts.join('\n'));
       } catch (e) {
         return err(`Failed to describe entity: ${formatError(e)}`);
+      }
+    },
+  );
+
+  // ── dkg_get_entity_sources ──────────────────────────────────────
+  // Verifiable grounding: return an entity's facts each tagged with the
+  // source it came from. This is an ADDRESSED read — the tool owns the query
+  // shape (one entity, a single view, no user solution modifiers), so the
+  // source named graph binds unambiguously and stays scoped to the CG. That
+  // is why provenance is sound here but not for arbitrary `dkg_query` SELECTs
+  // (DISTINCT/LIMIT/UNION/SWM-union all perturb a rewrite of a user query).
+  server.registerTool(
+    'dkg_get_entity_sources',
+    {
+      title: 'Describe Entity with Verifiable Sources',
+      description:
+        'Fetch the facts asserted about an entity, each tagged with the verifiable source it came from — the Knowledge Asset (author + KA number = on-chain UAL identity) you cite or verify against. Use when you need provenance, not just values: "what is known about X, and who asserted each fact?". Reads ONE memory tier (default verifiable-memory — published/on-chain, the citable tier); pass `view` for shared- or working-memory.',
+      inputSchema: {
+        uri: z.string().describe('Entity URI (e.g. urn:dkg:decision:shacl-on-vm-promotion)'),
+        projectId: z
+          .string()
+          .optional()
+          .describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
+        view: z
+          .enum(['working-memory', 'shared-working-memory', 'verifiable-memory'])
+          .optional()
+          .describe('Memory tier to read sources from. Defaults to verifiable-memory (on-chain, citable). A single tier is read — provenance is per-tier, so the WM∪SWM union is intentionally not offered here.'),
+        subGraphName: z.string().optional().describe('Limit the read to a single sub-graph'),
+      },
+    },
+    async ({ uri, projectId, view, subGraphName }): Promise<ToolResult> => {
+      const pid = resolveProject(projectId, config);
+      if (!pid) return projectErr();
+      const safeIri = uri.replace(/^<|>$/g, '');
+      // Guard the IRI interpolation: reject anything that could break out of
+      // the `<…>` term. (A SPARQL injection here would let a caller widen the
+      // query beyond the single entity.)
+      if (!safeIri || /[\s<>"{}\\|^`]/.test(safeIri)) {
+        return err(`Unsafe entity URI: ${uri}`);
+      }
+      const scopeView = view ?? 'verifiable-memory';
+      try {
+        // Tool-owned shape: one entity, GRAPH ?g to bind the source, a single
+        // view (NOT includeSharedMemory — the union path would duplicate), no
+        // DISTINCT/LIMIT/ORDER. The engine constrains ?g to this CG's content
+        // graphs, so no `_meta`/`_private` and no cross-context bleed.
+        const result = await client.query({
+          sparql: `${PREFIXES}
+SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
+          contextGraphId: pid,
+          subGraphName,
+          view: scopeView,
+        });
+        const rows = result.bindings ?? [];
+        if (!rows.length) {
+          return ok(`No facts found for <${safeIri}> in '${pid}' (view=${scopeView}).`);
+        }
+        const sources = new Map<string, EntitySource>();
+        const factLines = rows.map((b) => {
+          const p = prettyTerm(bindingValue(b.p));
+          const o = prettyTerm(bindingValue(b.o));
+          const src = parseEntitySource(bindingValue(b.g));
+          if (!sources.has(src.sourceGraph)) sources.set(src.sourceGraph, src);
+          return `- **${p}**: ${o}  ←  ${sourceLabel(src)}`;
+        });
+        const sourceLines = [...sources.values()].map(
+          (s) => `- ${sourceLabel(s)}${s.memoryLayer ? ` (${s.memoryLayer})` : ''} — \`${s.sourceGraph}\``,
+        );
+        return ok(
+          [
+            `# ${prettyTerm(safeIri)}`,
+            `<${safeIri}>  ·  view=${scopeView}`,
+            '',
+            '## Facts (with sources)',
+            factLines.join('\n'),
+            '',
+            `## Sources (${sources.size} verifiable)`,
+            sourceLines.join('\n'),
+          ].join('\n'),
+        );
+      } catch (e) {
+        return err(`Failed to describe entity sources: ${formatError(e)}`);
       }
     },
   );

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -387,7 +387,11 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
       // with it), or a DID-form pid would double-prefix and mark every per-KA
       // graph unattributed.
       const cgId = normalizeContextGraphId(pid);
-      const safeIri = uri.replace(/^<|>$/g, '');
+      // Unwrap only a MATCHED `<…>` pair. Stripping `<` and `>` independently
+      // would rewrite a mismatched input like `<urn:x` to a different, valid
+      // entity (`urn:x`) and silently query it; leaving the stray delimiter in
+      // place lets the unsafe-char guard below reject it (fail closed).
+      const safeIri = uri.startsWith('<') && uri.endsWith('>') ? uri.slice(1, -1) : uri;
       // Guard the IRI interpolation: reject anything that could break out of
       // the `<…>` term. (A SPARQL injection here would let a caller widen the
       // query beyond the single entity.) Mirrors core's UNSAFE_IRI_CHARS — the

--- a/packages/mcp-dkg/src/tools.ts
+++ b/packages/mcp-dkg/src/tools.ts
@@ -345,17 +345,25 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
 
   // ── dkg_get_entity_sources ──────────────────────────────────────
   // Verifiable grounding: return an entity's facts each tagged with the
-  // source it came from. This is an ADDRESSED read — the tool owns the query
-  // shape (one entity, a single view, no user solution modifiers), so the
-  // source named graph binds unambiguously and stays scoped to the CG. That
-  // is why provenance is sound here but not for arbitrary `dkg_query` SELECTs
-  // (DISTINCT/LIMIT/UNION/SWM-union all perturb a rewrite of a user query).
+  // published Knowledge Asset that asserted it. This is an ADDRESSED read —
+  // the tool owns the query shape (one entity, a single view, no user solution
+  // modifiers), so the source named graph binds and stays scoped to the CG.
+  // That is why provenance is sound here but not for arbitrary `dkg_query`
+  // SELECTs (DISTINCT/LIMIT/UNION/SWM-union/minTrust all perturb a rewrite of
+  // a user query — see the closed #1252).
+  //
+  // A VM/SWM read binds MORE than per-KA partitions (root, per-collection
+  // `/context/{id}`, the SWM bucket), and a fact can live in both a per-KA
+  // partition and the root. Only the per-KA partition encodes a citable KA
+  // identity, so the handler attributes facts to a KA ONLY from those graphs,
+  // collapses the root duplicate, and discloses (not drops) unattributed
+  // facts. working-memory is not offered (private; needs an agent identity).
   server.registerTool(
     'dkg_get_entity_sources',
     {
       title: 'Describe Entity with Verifiable Sources',
       description:
-        'Fetch the facts asserted about an entity, each tagged with the verifiable source it came from — the Knowledge Asset (author + KA number = on-chain UAL identity) you cite or verify against. Use when you need provenance, not just values: "what is known about X, and who asserted each fact?". Reads ONE memory tier (default verifiable-memory — published/on-chain, the citable tier); pass `view` for shared- or working-memory.',
+        'Fetch the facts about an entity, each tagged with the Knowledge Asset that asserted it (author + KA number). With the default verifiable-memory view these are PUBLISHED, on-chain KA identities you can cite or verify; with shared-working-memory they are PRE-PUBLISH DRAFT handles (a reserved, not-yet-on-chain UAL that may still change or be discarded — not citable on chain). Answers "what is known about X, and who asserted each fact?". Reads ONE memory tier. Facts present only in non-per-KA graphs (root / reconcile / bucket) carry no per-KA identity; their count is disclosed, not listed as sources.',
       inputSchema: {
         uri: z.string().describe('Entity URI (e.g. urn:dkg:decision:shacl-on-vm-promotion)'),
         projectId: z
@@ -363,9 +371,9 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
           .optional()
           .describe(`${EXISTING_CONTEXT_GRAPH_ID_DESCRIPTION} Defaults to .dkg/config.yaml.`),
         view: z
-          .enum(['working-memory', 'shared-working-memory', 'verifiable-memory'])
+          .enum(['shared-working-memory', 'verifiable-memory'])
           .optional()
-          .describe('Memory tier to read sources from. Defaults to verifiable-memory (on-chain, citable). A single tier is read — provenance is per-tier, so the WM∪SWM union is intentionally not offered here.'),
+          .describe('Memory tier to read sources from. Defaults to verifiable-memory (on-chain, citable). working-memory is intentionally not offered: it is private draft state (the engine requires an agent identity to read it) and is not a citable source.'),
         subGraphName: z.string().optional().describe('Limit the read to a single sub-graph'),
       },
     },
@@ -375,8 +383,10 @@ SELECT DISTINCT ?s ?p WHERE { ?s ?p <${uri}> } LIMIT 50`,
       const safeIri = uri.replace(/^<|>$/g, '');
       // Guard the IRI interpolation: reject anything that could break out of
       // the `<…>` term. (A SPARQL injection here would let a caller widen the
-      // query beyond the single entity.)
-      if (!safeIri || /[\s<>"{}\\|^`]/.test(safeIri)) {
+      // query beyond the single entity.) Mirrors core's UNSAFE_IRI_CHARS — the
+      // full control-char range (incl. NUL), not just `\s` — so the tool fails
+      // closed cleanly instead of surfacing a raw oxigraph parse error.
+      if (!safeIri || /[<>"{}|\\^\x60\x00-\x20]/.test(safeIri)) {
         return err(`Unsafe entity URI: ${uri}`);
       }
       const scopeView = view ?? 'verifiable-memory';
@@ -396,29 +406,81 @@ SELECT ?p ?o ?g WHERE { GRAPH ?g { <${safeIri}> ?p ?o } }`,
         if (!rows.length) {
           return ok(`No facts found for <${safeIri}> in '${pid}' (view=${scopeView}).`);
         }
-        const sources = new Map<string, EntitySource>();
-        const factLines = rows.map((b) => {
-          const p = prettyTerm(bindingValue(b.p));
-          const o = prettyTerm(bindingValue(b.o));
-          const src = parseEntitySource(bindingValue(b.g));
-          if (!sources.has(src.sourceGraph)) sources.set(src.sourceGraph, src);
-          return `- **${p}**: ${o}  ←  ${sourceLabel(src)}`;
-        });
-        const sourceLines = [...sources.values()].map(
-          (s) => `- ${sourceLabel(s)}${s.memoryLayer ? ` (${s.memoryLayer})` : ''} — \`${s.sourceGraph}\``,
+        // A VM/SWM read binds MORE than per-KA partitions: the root context
+        // graph, per-collection `/context/{id}` graphs, and the SWM bucket also
+        // appear, and a fact can be materialised in BOTH a per-KA partition and
+        // the root. Only the per-KA partition `…/_{layer}/{addr}/{number}`
+        // encodes a citable KA identity. So: group rows by fact (predicate +
+        // object); attribute a fact to a KA ONLY from per-KA sources; collapse
+        // the root duplicate (a fact in a per-KA partition AND the root is one
+        // attributed fact); keep multiple DISTINCT per-KA sources for one fact
+        // (genuine multi-publisher); and DISCLOSE — not silently drop — facts
+        // that have no per-KA source at all.
+        interface Fact {
+          p: string;
+          o: string;
+          ka: EntitySource[];
+        }
+        const facts = new Map<string, Fact>();
+        const kaSources = new Map<string, EntitySource>();
+        for (const b of rows) {
+          const p = bindingValue(b.p);
+          const o = bindingValue(b.o);
+          const src = parseEntitySource(bindingValue(b.g), pid);
+          const key = `${p} ${o}`;
+          const fact = facts.get(key) ?? { p, o, ka: [] };
+          if (src.author && src.kaNumber) {
+            if (!fact.ka.some((s) => s.sourceGraph === src.sourceGraph)) fact.ka.push(src);
+            kaSources.set(src.sourceGraph, src);
+          }
+          facts.set(key, fact);
+        }
+        const attributed = [...facts.values()].filter((f) => f.ka.length > 0);
+        const unattributed = [...facts.values()].filter((f) => f.ka.length === 0);
+
+        if (!attributed.length) {
+          return ok(
+            `No KA-attributable facts for <${safeIri}> in '${pid}' (view=${scopeView}). ` +
+              `${unattributed.length} fact(s) are present only in non-per-KA graphs ` +
+              `(root / reconcile / bucket), which do not encode a citable KA identity.`,
+          );
+        }
+
+        const factLines = attributed.map(
+          (f) => `- **${prettyTerm(f.p)}**: ${prettyTerm(f.o)}  ←  ${f.ka.map((s) => sourceLabel(s)).join(', ')}`,
         );
-        return ok(
-          [
-            `# ${prettyTerm(safeIri)}`,
-            `<${safeIri}>  ·  view=${scopeView}`,
-            '',
-            '## Facts (with sources)',
-            factLines.join('\n'),
-            '',
-            `## Sources (${sources.size} verifiable)`,
-            sourceLines.join('\n'),
-          ].join('\n'),
+        const sourceLines = [...kaSources.values()].map(
+          (s) => `- ${sourceLabel(s)} (${s.memoryLayer}) — \`${s.sourceGraph}\``,
         );
+        // Verifiable-memory sources are published/on-chain; shared-working-memory
+        // sources are pre-publish DRAFT (reserved, not-yet-on-chain) handles —
+        // condition the framing so a per-fact line can't be cited as on-chain.
+        const isVm = scopeView === 'verifiable-memory';
+        const n = kaSources.size;
+        const factsHeader = isVm
+          ? '## Facts (with verifiable KA sources)'
+          : '## Facts (with draft KA sources — shared-working-memory, not yet on-chain)';
+        const sourcesHeader = isVm
+          ? `## Sources (${n} verifiable KA${n === 1 ? '' : 's'})`
+          : `## Sources (${n} draft KA${n === 1 ? '' : 's'} — reserved UAL, not yet on-chain)`;
+        const parts = [
+          `# ${prettyTerm(safeIri)}`,
+          `<${safeIri}>  ·  view=${scopeView}`,
+          '',
+          factsHeader,
+          factLines.join('\n'),
+          '',
+          sourcesHeader,
+          sourceLines.join('\n'),
+        ];
+        if (unattributed.length) {
+          parts.push(
+            '',
+            `_${unattributed.length} additional fact(s) present only in non-per-KA graphs ` +
+              `(root / reconcile / bucket) — no citable KA identity — omitted._`,
+          );
+        }
+        return ok(parts.join('\n'));
       } catch (e) {
         return err(`Failed to describe entity sources: ${formatError(e)}`);
       }

--- a/packages/mcp-dkg/test/drop-sweep.test.ts
+++ b/packages/mcp-dkg/test/drop-sweep.test.ts
@@ -116,8 +116,11 @@ describe('drop-sweep — none of the 10 W2-dropped tools reappear in tools/list'
   // the README's "30 tools" — so the locked count is the full 30-tool surface
   // (previously this guard registered only 6 modules and locked 28, silently
   // under-covering registerChatTools).
-  it('registered surface contains exactly 30 tools (full production surface, post-PR locked count)', () => {
-    expect(server.tools.size).toBe(30);
+  // addressed-read provenance PR: +1 net-new read tool
+  // (dkg_get_entity_sources) — describes an entity's facts each tagged with
+  // the verifiable KA source — taking the surface from 30 → 31.
+  it('registered surface contains exactly 31 tools (full production surface, post-PR locked count)', () => {
+    expect(server.tools.size).toBe(31);
   });
 });
 

--- a/packages/mcp-dkg/test/entity-sources-tool.test.ts
+++ b/packages/mcp-dkg/test/entity-sources-tool.test.ts
@@ -33,10 +33,29 @@ describe('dkg_get_entity_sources', () => {
     const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
     expect(result.isError).toBeFalsy();
     const call = client.queryCalls.at(-1)!;
-    expect(String(call.sparql)).toContain('GRAPH ?g');
+    // Assert the FULL addressed-read shape, not just a `GRAPH ?g` substring —
+    // one entity, projects p/o/g, no widening or extra patterns.
+    expect(String(call.sparql)).toContain('SELECT ?p ?o ?g WHERE { GRAPH ?g { <urn:x:1> ?p ?o } }');
     expect(call.view).toBe('verifiable-memory');
+    expect(call.contextGraphId).toBe('test-cg');
     // Never the WM∪SWM union path (that would duplicate every sourced row).
     expect(call.includeSharedMemory).toBeUndefined();
+  });
+
+  it('normalizes a full-DID project id so per-KA graphs still attribute', async () => {
+    // The client accepts/normalizes `did:dkg:context-graph:<id>`; the anchor
+    // must use the same normalized id or every per-KA graph reads unattributed.
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({ bindings: [{ p: 'http://schema.org/name', o: '"X"', g: VM('0xaa', '7') }] }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', {
+      uri: 'urn:x:1',
+      projectId: 'did:dkg:context-graph:test-cg',
+    });
+    expect(result.content[0].text).toContain('0xaa/7'); // attributed despite DID-form id
+    expect(client.queryCalls.at(-1)!.contextGraphId).toBe('test-cg');
   });
 
   it('attributes facts to KA sources, collapses the root duplicate, and discloses unattributed facts', async () => {
@@ -153,6 +172,20 @@ describe('dkg_get_entity_sources', () => {
     const text = result.content[0].text;
     expect(text).not.toContain('KA `0xaa/1`');
     expect(text).toMatch(/No KA-attributable facts/);
+  });
+
+  it('forwards subGraphName and attributes a sub-graph-scoped per-KA source', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({
+        bindings: [{ p: 'http://schema.org/name', o: '"sub-name"', g: `did:dkg:context-graph:${CG}/decisions/_verifiable_memory/0xaa/7` }],
+      }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1', subGraphName: 'decisions' });
+    expect(client.queryCalls.at(-1)!.subGraphName).toBe('decisions');
+    // The sub-graph segment between cgId and the layer slug still attributes.
+    expect(result.content[0].text).toContain('0xaa/7');
   });
 
   it('rejects an injection-shaped entity URI before querying', async () => {

--- a/packages/mcp-dkg/test/entity-sources-tool.test.ts
+++ b/packages/mcp-dkg/test/entity-sources-tool.test.ts
@@ -33,9 +33,12 @@ describe('dkg_get_entity_sources', () => {
     const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
     expect(result.isError).toBeFalsy();
     const call = client.queryCalls.at(-1)!;
-    // Assert the FULL addressed-read shape, not just a `GRAPH ?g` substring —
-    // one entity, projects p/o/g, no widening or extra patterns.
-    expect(String(call.sparql)).toContain('SELECT ?p ?o ?g WHERE { GRAPH ?g { <urn:x:1> ?p ?o } }');
+    // Assert the FULL addressed-read shape, anchored at the END so nothing can
+    // be appended (a `toContain` would still pass with a trailing LIMIT/ORDER
+    // BY, which would silently break the no-modifiers provenance contract).
+    const sparql = String(call.sparql).trim();
+    expect(sparql.endsWith('SELECT ?p ?o ?g WHERE { GRAPH ?g { <urn:x:1> ?p ?o } }')).toBe(true);
+    expect(sparql).not.toMatch(/\b(LIMIT|OFFSET|ORDER\s+BY|DISTINCT|REDUCED)\b/i);
     expect(call.view).toBe('verifiable-memory');
     expect(call.contextGraphId).toBe('test-cg');
     // Never the WM∪SWM union path (that would duplicate every sourced row).
@@ -194,6 +197,18 @@ describe('dkg_get_entity_sources', () => {
     registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
     const before = client.queryCalls.length;
     const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x> } UNION { ?s ?p ?o' });
+    expect(result.isError).toBe(true);
+    expect(client.queryCalls.length).toBe(before);
+  });
+
+  it('fails closed on a mismatched angle bracket instead of silently re-targeting', async () => {
+    // `<urn:x` must NOT be unwrapped to `urn:x` (a different, valid entity);
+    // only a matched `<…>` pair is stripped, so the stray `<` is rejected.
+    const server = new FakeServer();
+    const client = new FakeClient();
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const before = client.queryCalls.length;
+    const result = await server.call('dkg_get_entity_sources', { uri: '<urn:x' });
     expect(result.isError).toBe(true);
     expect(client.queryCalls.length).toBe(before);
   });

--- a/packages/mcp-dkg/test/entity-sources-tool.test.ts
+++ b/packages/mcp-dkg/test/entity-sources-tool.test.ts
@@ -129,15 +129,16 @@ describe('dkg_get_entity_sources', () => {
     expect(result.content[0].text).toMatch(/No KA-attributable facts/);
   });
 
-  it('caps rendered facts at `limit` and discloses the remainder', async () => {
+  it('caps rendered facts at `limit`, discloses the remainder, and truncates deterministically', async () => {
     const server = new FakeServer();
     const client = new FakeClient({
+      // Rows returned in REVERSE order (p4..p0) to prove the cap selects by a
+      // stable sort, not backend row order.
       query: async () => ({
-        bindings: Array.from({ length: 5 }, (_, i) => ({
-          p: `http://schema.org/p${i}`,
-          o: `"v${i}"`,
-          g: VM('0xaa', String(i)),
-        })),
+        bindings: Array.from({ length: 5 }, (_, i) => {
+          const n = 4 - i;
+          return { p: `http://schema.org/p${n}`, o: `"v${n}"`, g: VM('0xaa', String(n)) };
+        }),
       }),
     });
     registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
@@ -146,6 +147,13 @@ describe('dkg_get_entity_sources', () => {
     // Exactly 2 fact lines rendered (one `←` arrow each), remainder disclosed.
     expect((text.match(/←/g) ?? []).length).toBe(2);
     expect(text).toMatch(/3 more attributed fact\(s\) not shown/);
+    // Deterministic: the two LOWEST by (predicate, object) are shown regardless
+    // of input order — p0/p1, never the late-sorting p2..p4. (prettyTerm strips
+    // the literal quotes, so match the bare value.)
+    expect(text).toContain('schema:p0');
+    expect(text).toContain('schema:p1');
+    expect(text).not.toContain('schema:p2');
+    expect(text).not.toContain('schema:p4');
   });
 
   it('forwards an explicit shared-working-memory view', async () => {

--- a/packages/mcp-dkg/test/entity-sources-tool.test.ts
+++ b/packages/mcp-dkg/test/entity-sources-tool.test.ts
@@ -1,0 +1,70 @@
+/**
+ * `dkg_get_entity_sources` — addressed-read provenance tool.
+ *
+ * The engine contract (scoped `GRAPH ?g` binds the source) is pinned in
+ * packages/query; here we pin the tool surface: it issues the controlled
+ * single-tier `GRAPH ?g` query (never the SWM-union), defaults to the citable
+ * verifiable-memory tier, renders each fact with its KA source, and refuses an
+ * injection-shaped entity URI.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { registerReadTools } from '../src/tools.js';
+import { FakeServer, FakeClient, makeConfig } from './harness.js';
+
+const VM = (addr: string, n: string) => `did:dkg:context-graph:cg/_verifiable_memory/${addr}/${n}`;
+
+describe('dkg_get_entity_sources', () => {
+  it('issues a scoped, single-view GRAPH ?g query and defaults to verifiable-memory', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient();
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
+    expect(result.isError).toBeFalsy();
+    const call = client.queryCalls.at(-1)!;
+    expect(String(call.sparql)).toContain('GRAPH ?g');
+    expect(call.view).toBe('verifiable-memory');
+    // Never the WM∪SWM union path (that would duplicate every sourced row).
+    expect(call.includeSharedMemory).toBeUndefined();
+  });
+
+  it('renders each fact with its KA source and a deduped Sources section', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({
+        bindings: [
+          { p: 'http://schema.org/name', o: '"X-name"', g: VM('0xaa', '7') },
+          { p: 'http://schema.org/color', o: '"X-color"', g: VM('0xbb', '8') },
+        ],
+      }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
+    expect(result.isError).toBeFalsy();
+    const text = result.content[0].text;
+    expect(text).toContain('Facts (with sources)');
+    expect(text).toContain('X-name');
+    expect(text).toContain('0xaa/7');
+    expect(text).toContain('0xbb/8');
+    expect(text).toContain('Sources (2 verifiable)');
+  });
+
+  it('forwards an explicit view', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient();
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    await server.call('dkg_get_entity_sources', { uri: 'urn:x:1', view: 'shared-working-memory' });
+    expect(client.queryCalls.at(-1)!.view).toBe('shared-working-memory');
+  });
+
+  it('rejects an injection-shaped entity URI before querying', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient();
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const before = client.queryCalls.length;
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x> } UNION { ?s ?p ?o' });
+    expect(result.isError).toBe(true);
+    expect(client.queryCalls.length).toBe(before);
+  });
+});

--- a/packages/mcp-dkg/test/entity-sources-tool.test.ts
+++ b/packages/mcp-dkg/test/entity-sources-tool.test.ts
@@ -1,17 +1,28 @@
 /**
  * `dkg_get_entity_sources` — addressed-read provenance tool.
  *
- * The engine contract (scoped `GRAPH ?g` binds the source) is pinned in
- * packages/query; here we pin the tool surface: it issues the controlled
- * single-tier `GRAPH ?g` query (never the SWM-union), defaults to the citable
- * verifiable-memory tier, renders each fact with its KA source, and refuses an
- * injection-shaped entity URI.
+ * The engine contract (scoped `GRAPH ?g` binds the source, but a VM read also
+ * returns root / per-collection graphs) is pinned in packages/query. Here we
+ * pin the tool surface:
+ *   - issues the controlled single-tier `GRAPH ?g` query (never the SWM-union);
+ *   - attributes a fact to a KA ONLY from a per-KA partition;
+ *   - collapses a root/per-KA duplicate and keeps genuine multi-publisher;
+ *   - discloses (does not silently drop) facts with no citable KA;
+ *   - does NOT offer working-memory (needs an agent identity);
+ *   - refuses an injection-shaped entity URI.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { registerReadTools } from '../src/tools.js';
 import { FakeServer, FakeClient, makeConfig } from './harness.js';
 
-const VM = (addr: string, n: string) => `did:dkg:context-graph:cg/_verifiable_memory/${addr}/${n}`;
+// cgId must match makeConfig()'s defaultProject ('test-cg'): the tool anchors
+// parseEntitySource on the resolved project id, so per-KA graphs only attribute
+// when their CG segment equals it.
+const CG = 'test-cg';
+const VM = (addr: string, n: string) => `did:dkg:context-graph:${CG}/_verifiable_memory/${addr}/${n}`;
+const SWM = (addr: string, n: string) => `did:dkg:context-graph:${CG}/_shared_memory/${addr}/${n}`;
+const ROOT = `did:dkg:context-graph:${CG}`;
+const PERCGID = `did:dkg:context-graph:${CG}/context/7`;
 
 describe('dkg_get_entity_sources', () => {
   it('issues a scoped, single-view GRAPH ?g query and defaults to verifiable-memory', async () => {
@@ -28,13 +39,18 @@ describe('dkg_get_entity_sources', () => {
     expect(call.includeSharedMemory).toBeUndefined();
   });
 
-  it('renders each fact with its KA source and a deduped Sources section', async () => {
+  it('attributes facts to KA sources, collapses the root duplicate, and discloses unattributed facts', async () => {
     const server = new FakeServer();
     const client = new FakeClient({
       query: async () => ({
         bindings: [
+          // X-name: in a per-KA partition AND duplicated in the root graph.
           { p: 'http://schema.org/name', o: '"X-name"', g: VM('0xaa', '7') },
+          { p: 'http://schema.org/name', o: '"X-name"', g: ROOT },
+          // X-color: a single per-KA source.
           { p: 'http://schema.org/color', o: '"X-color"', g: VM('0xbb', '8') },
+          // X-shape: only in the per-collection graph → no citable KA.
+          { p: 'http://schema.org/shape', o: '"square"', g: PERCGID },
         ],
       }),
     });
@@ -43,19 +59,100 @@ describe('dkg_get_entity_sources', () => {
     const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
     expect(result.isError).toBeFalsy();
     const text = result.content[0].text;
-    expect(text).toContain('Facts (with sources)');
+
+    // Attributed facts carry their KA; the root duplicate of X-name collapses
+    // (X-name appears once, attributed to the per-KA source).
     expect(text).toContain('X-name');
     expect(text).toContain('0xaa/7');
+    expect(text).toContain('X-color');
     expect(text).toContain('0xbb/8');
-    expect(text).toContain('Sources (2 verifiable)');
+    expect((text.match(/X-name/g) ?? []).length).toBe(1);
+    // Two verifiable KA sources (0xaa/7 + 0xbb/8); the bare root is NOT a
+    // source line (backtick-delimited exact match — the per-KA URIs share the
+    // root as a prefix, so a bare `toContain(ROOT)` would false-positive).
+    expect(text).toContain('Sources (2 verifiable KAs)');
+    expect(text).not.toContain(`\`${ROOT}\``);
+    // The per-collection-only fact is disclosed, not shown as a KA source.
+    expect(text).not.toContain('square');
+    expect(text).toMatch(/1 additional fact/);
   });
 
-  it('forwards an explicit view', async () => {
+  it('keeps genuine multi-publisher attribution (same fact asserted by two KAs)', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({
+        bindings: [
+          { p: 'http://schema.org/name', o: '"shared"', g: VM('0xaa', '1') },
+          { p: 'http://schema.org/name', o: '"shared"', g: VM('0xbb', '2') },
+        ],
+      }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
+    const text = result.content[0].text;
+    expect((text.match(/shared/g) ?? []).length).toBe(1); // one fact line
+    expect(text).toContain('0xaa/1');
+    expect(text).toContain('0xbb/2'); // ...with both KA sources
+    expect(text).toContain('Sources (2 verifiable KAs)');
+  });
+
+  it('reports no KA-attributable facts when only non-per-KA graphs match', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({ bindings: [{ p: 'http://schema.org/name', o: '"only-root"', g: ROOT }] }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1' });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toMatch(/No KA-attributable facts/);
+  });
+
+  it('forwards an explicit shared-working-memory view', async () => {
     const server = new FakeServer();
     const client = new FakeClient();
     registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
     await server.call('dkg_get_entity_sources', { uri: 'urn:x:1', view: 'shared-working-memory' });
     expect(client.queryCalls.at(-1)!.view).toBe('shared-working-memory');
+  });
+
+  it('does not offer working-memory (rejected at the schema)', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient();
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    await expect(
+      server.call('dkg_get_entity_sources', { uri: 'urn:x:1', view: 'working-memory' }),
+    ).rejects.toThrow();
+  });
+
+  it('frames shared-working-memory sources as DRAFT, not on-chain/verifiable', async () => {
+    // SWM per-KA (author, number) is a reserved, pre-mint UAL — not on chain.
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({ bindings: [{ p: 'http://schema.org/name', o: '"draft-name"', g: SWM('0xaa', '3') }] }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1', view: 'shared-working-memory' });
+    const text = result.content[0].text;
+    expect(text).toContain('draft KA');
+    expect(text).toContain('not yet on-chain');
+    // Must NOT assert the verifiable/on-chain framing for a draft tier.
+    expect(text).not.toContain('verifiable KA');
+  });
+
+  it('does not fabricate a KA for an adversarially-named CG whose id embeds a layer tail', async () => {
+    // CG id is valid (validateContextGraphId allows `/` and `_`); its ROOT
+    // graph looks like a per-KA partition to a greedy parser. Anchoring on the
+    // known project id must classify it as unattributed, not "KA 0xaa/1".
+    const evilCg = 'evil/_verifiable_memory/0xaa/1';
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({ bindings: [{ p: 'http://schema.org/name', o: '"x"', g: `did:dkg:context-graph:${evilCg}` }] }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1', projectId: evilCg });
+    const text = result.content[0].text;
+    expect(text).not.toContain('KA `0xaa/1`');
+    expect(text).toMatch(/No KA-attributable facts/);
   });
 
   it('rejects an injection-shaped entity URI before querying', async () => {

--- a/packages/mcp-dkg/test/entity-sources-tool.test.ts
+++ b/packages/mcp-dkg/test/entity-sources-tool.test.ts
@@ -129,6 +129,25 @@ describe('dkg_get_entity_sources', () => {
     expect(result.content[0].text).toMatch(/No KA-attributable facts/);
   });
 
+  it('caps rendered facts at `limit` and discloses the remainder', async () => {
+    const server = new FakeServer();
+    const client = new FakeClient({
+      query: async () => ({
+        bindings: Array.from({ length: 5 }, (_, i) => ({
+          p: `http://schema.org/p${i}`,
+          o: `"v${i}"`,
+          g: VM('0xaa', String(i)),
+        })),
+      }),
+    });
+    registerReadTools(server.asMcpServer(), client.asDkgClient(), makeConfig());
+    const result = await server.call('dkg_get_entity_sources', { uri: 'urn:x:1', limit: 2 });
+    const text = result.content[0].text;
+    // Exactly 2 fact lines rendered (one `←` arrow each), remainder disclosed.
+    expect((text.match(/←/g) ?? []).length).toBe(2);
+    expect(text).toMatch(/3 more attributed fact\(s\) not shown/);
+  });
+
   it('forwards an explicit shared-working-memory view', async () => {
     const server = new FakeServer();
     const client = new FakeClient();

--- a/packages/mcp-dkg/test/normalize-context-graph-id.test.ts
+++ b/packages/mcp-dkg/test/normalize-context-graph-id.test.ts
@@ -1,36 +1,27 @@
 /**
- * `normalizeContextGraphId` must be IDEMPOTENT so a consumer that re-normalizes
- * (the wire scope AND a downstream provenance anchor in dkg_get_entity_sources)
- * converges on the same id even for malformed input. The trailing-slash trim is
- * a linear index walk, not `/\/+$/` — that regex is a polynomial-ReDoS on a
- * string of many '/' (CodeQL js/polynomial-redos), and the id is caller input.
+ * `normalizeContextGraphId` strips EXACTLY ONE leading `did:dkg:context-graph:`
+ * prefix and trims whitespace — matching the daemon. It deliberately does NOT
+ * canonicalise trailing slashes or repeated prefixes: the daemon allows `/` and
+ * `:` in context-graph ids, so those denote DISTINCT valid ids, and this helper
+ * backs ~all client requests. Pinning the contract directly (the round-3 attempt
+ * to make it idempotent silently aliased distinct ids and added a ReDoS).
  */
 import { describe, it, expect } from 'vitest';
 import { normalizeContextGraphId } from '../src/client.js';
 
-describe('normalizeContextGraphId', () => {
+describe('normalizeContextGraphId — single DID-prefix strip, no further canonicalisation', () => {
   it.each([
-    ['test-cg', 'test-cg'],
-    ['did:dkg:context-graph:test-cg', 'test-cg'],
-    ['  did:dkg:context-graph:test-cg  ', 'test-cg'],
-    ['test-cg/', 'test-cg'],
-    ['test-cg///', 'test-cg'],
-    ['did:dkg:context-graph:test-cg/', 'test-cg'],
-    // double-prefixed (the round-2 regression class) collapses fully
-    ['did:dkg:context-graph:did:dkg:context-graph:foo', 'foo'],
-    // sub-graph-bearing ids keep their internal slashes, lose only trailing
-    ['0xowner/proj', '0xowner/proj'],
-    ['0xowner/proj/', '0xowner/proj'],
-  ])('normalizes %j -> %j', (input, expected) => {
+    ['bare id', 'test-cg', 'test-cg'],
+    ['single DID form', 'did:dkg:context-graph:test-cg', 'test-cg'],
+    ['whitespace-padded DID', '  did:dkg:context-graph:test-cg  ', 'test-cg'],
+    ['empty', '', ''],
+    ['sub-graph-bearing id (internal slashes kept)', '0xowner/proj', '0xowner/proj'],
+    // The cases below MUST be preserved, not canonicalised — they are distinct
+    // valid ids the daemon may treat differently:
+    ['trailing slash preserved', 'test-cg/', 'test-cg/'],
+    ['DID form with trailing slash', 'did:dkg:context-graph:test-cg/', 'test-cg/'],
+    ['only ONE prefix stripped', 'did:dkg:context-graph:did:dkg:context-graph:foo', 'did:dkg:context-graph:foo'],
+  ])('%s: %j -> %j', (_label, input, expected) => {
     expect(normalizeContextGraphId(input)).toBe(expected);
-    // Idempotent: normalizing the result again is a no-op.
-    expect(normalizeContextGraphId(normalizeContextGraphId(input))).toBe(expected);
-  });
-
-  it('is linear on a long run of trailing slashes (no ReDoS blowup)', () => {
-    const input = 'cg' + '/'.repeat(100_000) + '';
-    const t0 = Date.now();
-    expect(normalizeContextGraphId(input)).toBe('cg');
-    expect(Date.now() - t0).toBeLessThan(1000);
   });
 });

--- a/packages/mcp-dkg/test/normalize-context-graph-id.test.ts
+++ b/packages/mcp-dkg/test/normalize-context-graph-id.test.ts
@@ -1,0 +1,36 @@
+/**
+ * `normalizeContextGraphId` must be IDEMPOTENT so a consumer that re-normalizes
+ * (the wire scope AND a downstream provenance anchor in dkg_get_entity_sources)
+ * converges on the same id even for malformed input. The trailing-slash trim is
+ * a linear index walk, not `/\/+$/` — that regex is a polynomial-ReDoS on a
+ * string of many '/' (CodeQL js/polynomial-redos), and the id is caller input.
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeContextGraphId } from '../src/client.js';
+
+describe('normalizeContextGraphId', () => {
+  it.each([
+    ['test-cg', 'test-cg'],
+    ['did:dkg:context-graph:test-cg', 'test-cg'],
+    ['  did:dkg:context-graph:test-cg  ', 'test-cg'],
+    ['test-cg/', 'test-cg'],
+    ['test-cg///', 'test-cg'],
+    ['did:dkg:context-graph:test-cg/', 'test-cg'],
+    // double-prefixed (the round-2 regression class) collapses fully
+    ['did:dkg:context-graph:did:dkg:context-graph:foo', 'foo'],
+    // sub-graph-bearing ids keep their internal slashes, lose only trailing
+    ['0xowner/proj', '0xowner/proj'],
+    ['0xowner/proj/', '0xowner/proj'],
+  ])('normalizes %j -> %j', (input, expected) => {
+    expect(normalizeContextGraphId(input)).toBe(expected);
+    // Idempotent: normalizing the result again is a no-op.
+    expect(normalizeContextGraphId(normalizeContextGraphId(input))).toBe(expected);
+  });
+
+  it('is linear on a long run of trailing slashes (no ReDoS blowup)', () => {
+    const input = 'cg' + '/'.repeat(100_000) + '';
+    const t0 = Date.now();
+    expect(normalizeContextGraphId(input)).toBe('cg');
+    expect(Date.now() - t0).toBeLessThan(1000);
+  });
+});

--- a/packages/query/test/entity-source-provenance.test.ts
+++ b/packages/query/test/entity-source-provenance.test.ts
@@ -1,10 +1,15 @@
 /**
  * Addressed-read provenance contract (the `dkg_get_entity_sources` MCP tool
  * depends on this engine behaviour): a context-graph-scoped `GRAPH ?g` query
- * over a single entity binds each fact's source named graph, stays scoped to
- * the CG's content graphs, and excludes `_meta`/`_private` and other context
- * graphs. This is the property that makes addressed-read provenance sound
- * without rewriting arbitrary user SELECTs.
+ * over a single entity binds each fact's source named graph and stays scoped
+ * to the CG (no `_meta`/`_private`, no cross-context bleed).
+ *
+ * Crucially, a verifiable-memory read binds MORE than per-KA partitions — the
+ * root content graph and per-collection `/context/{id}` graphs appear too, and
+ * a fact can be materialised in both a per-KA partition AND the root. Only the
+ * per-KA partition encodes a citable KA identity, so the TOOL (tested in
+ * mcp-dkg) attributes facts to a KA only from those graphs; this test pins the
+ * raw engine reality the tool must handle.
  *
  * Hermetic: in-memory OxigraphStore, zero mocks, zero chain.
  */
@@ -20,13 +25,19 @@ function q(s: string, p: string, o: string, g: string) {
 }
 
 describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => {
-  it('binds each fact to its own KA partition; excludes _meta and other context graphs', async () => {
+  it('binds per-KA, root and per-collection graphs; stays scoped; excludes _meta and other CGs', async () => {
     const store = new OxigraphStore();
     const engine = new DKGQueryEngine(store);
+    const perKaA = 'did:dkg:context-graph:cg-one/_verifiable_memory/0xaa/1';
+    const perKaB = 'did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2';
     await store.insert([
       // Entity X described by TWO different KAs in cg-one (multi-publisher).
-      q(E, NAME, '"X-name"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xaa/1'),
-      q(E, COLOR, '"X-color"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2'),
+      q(E, NAME, '"X-name"', perKaA),
+      q(E, COLOR, '"X-color"', perKaB),
+      // The SAME fact also materialised in the root content graph (read-both).
+      q(E, NAME, '"X-name"', 'did:dkg:context-graph:cg-one'),
+      // A fact only in the per-collection (chain-reconcile) graph.
+      q(E, 'http://schema.org/shape', '"square"', 'did:dkg:context-graph:cg-one/context/7'),
       // A seal row about X in cg-one `_meta` — must NOT surface as a fact.
       q(E, 'http://dkg.io/ontology/authorAddress', '"0xAUTH"', 'did:dkg:context-graph:cg-one/_meta'),
       // The same entity in a DIFFERENT context graph — must NOT bleed in.
@@ -37,21 +48,21 @@ describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => 
       `SELECT ?p ?o ?g WHERE { GRAPH ?g { <${E}> ?p ?o } }`,
       { contextGraphId: 'cg-one', view: 'verifiable-memory' },
     );
-
-    const objects = r.bindings.map((b) => b['o']);
     const graphs = r.bindings.map((b) => b['g']);
+    const objects = r.bindings.map((b) => b['o']);
 
-    // Both content facts present, each tagged with its own KA partition.
-    expect(objects).toEqual(expect.arrayContaining(['"X-name"', '"X-color"']));
-    const nameRow = r.bindings.find((b) => b['o'] === '"X-name"')!;
-    const colorRow = r.bindings.find((b) => b['o'] === '"X-color"')!;
-    expect(nameRow['g']).toBe('did:dkg:context-graph:cg-one/_verifiable_memory/0xaa/1');
-    expect(colorRow['g']).toBe('did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2');
+    // Per-KA sources present, each on its own partition.
+    expect(r.bindings.find((b) => b['o'] === '"X-color"')!['g']).toBe(perKaB);
+    expect(graphs).toContain(perKaA);
+    // Root + per-collection graphs ALSO bind (the reality the tool de-dups /
+    // discloses): the root copy of X-name, and the per-collection-only fact.
+    expect(graphs).toContain('did:dkg:context-graph:cg-one');
+    expect(graphs).toContain('did:dkg:context-graph:cg-one/context/7');
 
-    // The `_meta` seal value is not a fact; no cross-context bleed.
+    // Scoping invariants: no `_meta` seal value, no cross-context bleed.
     expect(objects).not.toContain('"0xAUTH"');
     expect(objects).not.toContain('"X-OTHER-CG"');
-    expect(graphs.every((g) => g.startsWith('did:dkg:context-graph:cg-one/'))).toBe(true);
+    expect(graphs.every((g) => g.startsWith('did:dkg:context-graph:cg-one'))).toBe(true);
     expect(graphs.some((g) => g.includes('_meta'))).toBe(false);
   });
 });

--- a/packages/query/test/entity-source-provenance.test.ts
+++ b/packages/query/test/entity-source-provenance.test.ts
@@ -83,6 +83,10 @@ describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => 
     const engine = new DKGQueryEngine(store);
     await store.insert([
       q(E, NAME, '"swm-draft"', 'did:dkg:context-graph:cg-one/_shared_memory/0xaa/1'),
+      // The bare SWM BUCKET graph (no per-KA segment) — the engine resolves it
+      // too, and the tool discloses such rows as non-per-KA. Cover it so this
+      // test fails if the bucket stops being bound.
+      q(E, 'http://schema.org/note', '"swm-bucket"', 'did:dkg:context-graph:cg-one/_shared_memory'),
       q(E, COLOR, '"vm-published"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2'),
       q(E, 'http://schema.org/shape', '"rooted"', 'did:dkg:context-graph:cg-one'),
     ]);
@@ -91,9 +95,20 @@ describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => 
       { contextGraphId: 'cg-one', view: 'shared-working-memory' },
     );
     const objects = r.bindings.map((b) => b['o']);
-    expect(objects).toContain('"swm-draft"');
+    expect(objects).toContain('"swm-draft"'); // per-KA SWM
+    expect(objects).toContain('"swm-bucket"'); // bare bucket (disclosure path)
     expect(objects).not.toContain('"vm-published"');
     expect(objects).not.toContain('"rooted"');
-    expect(r.bindings.every((b) => b['g'].includes('/_shared_memory/'))).toBe(true);
+    // Every source is within the SWM tier — a per-KA partition OR the bare
+    // bucket — never _verifiable_memory or root.
+    expect(
+      r.bindings.every((b) => {
+        const g = b['g'];
+        return (
+          g === 'did:dkg:context-graph:cg-one/_shared_memory' ||
+          g.startsWith('did:dkg:context-graph:cg-one/_shared_memory/')
+        );
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/query/test/entity-source-provenance.test.ts
+++ b/packages/query/test/entity-source-provenance.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Addressed-read provenance contract (the `dkg_get_entity_sources` MCP tool
+ * depends on this engine behaviour): a context-graph-scoped `GRAPH ?g` query
+ * over a single entity binds each fact's source named graph, stays scoped to
+ * the CG's content graphs, and excludes `_meta`/`_private` and other context
+ * graphs. This is the property that makes addressed-read provenance sound
+ * without rewriting arbitrary user SELECTs.
+ *
+ * Hermetic: in-memory OxigraphStore, zero mocks, zero chain.
+ */
+import { describe, expect, it } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+
+const NAME = 'http://schema.org/name';
+const COLOR = 'http://schema.org/color';
+const E = 'https://example.org/entity/X';
+function q(s: string, p: string, o: string, g: string) {
+  return { subject: s, predicate: p, object: o, graph: g };
+}
+
+describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => {
+  it('binds each fact to its own KA partition; excludes _meta and other context graphs', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      // Entity X described by TWO different KAs in cg-one (multi-publisher).
+      q(E, NAME, '"X-name"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xaa/1'),
+      q(E, COLOR, '"X-color"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2'),
+      // A seal row about X in cg-one `_meta` — must NOT surface as a fact.
+      q(E, 'http://dkg.io/ontology/authorAddress', '"0xAUTH"', 'did:dkg:context-graph:cg-one/_meta'),
+      // The same entity in a DIFFERENT context graph — must NOT bleed in.
+      q(E, NAME, '"X-OTHER-CG"', 'did:dkg:context-graph:cg-two/_verifiable_memory/0xcc/9'),
+    ]);
+
+    const r = await engine.query(
+      `SELECT ?p ?o ?g WHERE { GRAPH ?g { <${E}> ?p ?o } }`,
+      { contextGraphId: 'cg-one', view: 'verifiable-memory' },
+    );
+
+    const objects = r.bindings.map((b) => b['o']);
+    const graphs = r.bindings.map((b) => b['g']);
+
+    // Both content facts present, each tagged with its own KA partition.
+    expect(objects).toEqual(expect.arrayContaining(['"X-name"', '"X-color"']));
+    const nameRow = r.bindings.find((b) => b['o'] === '"X-name"')!;
+    const colorRow = r.bindings.find((b) => b['o'] === '"X-color"')!;
+    expect(nameRow['g']).toBe('did:dkg:context-graph:cg-one/_verifiable_memory/0xaa/1');
+    expect(colorRow['g']).toBe('did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2');
+
+    // The `_meta` seal value is not a fact; no cross-context bleed.
+    expect(objects).not.toContain('"0xAUTH"');
+    expect(objects).not.toContain('"X-OTHER-CG"');
+    expect(graphs.every((g) => g.startsWith('did:dkg:context-graph:cg-one/'))).toBe(true);
+    expect(graphs.some((g) => g.includes('_meta'))).toBe(false);
+  });
+});

--- a/packages/query/test/entity-source-provenance.test.ts
+++ b/packages/query/test/entity-source-provenance.test.ts
@@ -65,4 +65,25 @@ describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => 
     expect(graphs.every((g) => g.startsWith('did:dkg:context-graph:cg-one'))).toBe(true);
     expect(graphs.some((g) => g.includes('_meta'))).toBe(false);
   });
+
+  it('a shared-working-memory read binds only SWM partitions — no _verifiable_memory or root', async () => {
+    // The tool frames SWM sources as DRAFT (not on-chain). That is only safe
+    // because a SWM-view read cannot bleed in published VM / root rows; pin it.
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q(E, NAME, '"swm-draft"', 'did:dkg:context-graph:cg-one/_shared_memory/0xaa/1'),
+      q(E, COLOR, '"vm-published"', 'did:dkg:context-graph:cg-one/_verifiable_memory/0xbb/2'),
+      q(E, 'http://schema.org/shape', '"rooted"', 'did:dkg:context-graph:cg-one'),
+    ]);
+    const r = await engine.query(
+      `SELECT ?o ?g WHERE { GRAPH ?g { <${E}> ?p ?o } }`,
+      { contextGraphId: 'cg-one', view: 'shared-working-memory' },
+    );
+    const objects = r.bindings.map((b) => b['o']);
+    expect(objects).toContain('"swm-draft"');
+    expect(objects).not.toContain('"vm-published"');
+    expect(objects).not.toContain('"rooted"');
+    expect(r.bindings.every((b) => b['g'].includes('/_shared_memory/'))).toBe(true);
+  });
 });

--- a/packages/query/test/entity-source-provenance.test.ts
+++ b/packages/query/test/entity-source-provenance.test.ts
@@ -42,6 +42,10 @@ describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => 
       q(E, 'http://dkg.io/ontology/authorAddress', '"0xAUTH"', 'did:dkg:context-graph:cg-one/_meta'),
       // The same entity in a DIFFERENT context graph — must NOT bleed in.
       q(E, NAME, '"X-OTHER-CG"', 'did:dkg:context-graph:cg-two/_verifiable_memory/0xcc/9'),
+      // PREFIX-COLLISION: a CG whose id shares `cg-one` as a prefix. A naive
+      // `startsWith('…cg-one')` check would let this leak; the CG boundary is
+      // the `/` (or exact root), so it must NOT appear.
+      q(E, NAME, '"X-PREFIX-COLLISION"', 'did:dkg:context-graph:cg-one-extra/_verifiable_memory/0xdd/3'),
     ]);
 
     const r = await engine.query(
@@ -59,10 +63,16 @@ describe('addressed-read provenance — scoped GRAPH ?g over one entity', () => 
     expect(graphs).toContain('did:dkg:context-graph:cg-one');
     expect(graphs).toContain('did:dkg:context-graph:cg-one/context/7');
 
-    // Scoping invariants: no `_meta` seal value, no cross-context bleed.
+    // Scoping invariants: no `_meta` seal value, no cross-context bleed, and no
+    // prefix-collision leak (the CG boundary is the exact root or a `/`).
     expect(objects).not.toContain('"0xAUTH"');
     expect(objects).not.toContain('"X-OTHER-CG"');
-    expect(graphs.every((g) => g.startsWith('did:dkg:context-graph:cg-one'))).toBe(true);
+    expect(objects).not.toContain('"X-PREFIX-COLLISION"');
+    expect(
+      graphs.every(
+        (g) => g === 'did:dkg:context-graph:cg-one' || g.startsWith('did:dkg:context-graph:cg-one/'),
+      ),
+    ).toBe(true);
     expect(graphs.some((g) => g.includes('_meta'))).toBe(false);
   });
 


### PR DESCRIPTION
## What

A read tool that returns an entity's facts **each tagged with the verifiable source it came from** — the Knowledge Asset (`author` + KA number = on-chain UAL identity) you cite or verify against. Answers *"what is known about X, and who asserted each fact?"* — the concrete form of "every answer cites a verifiable source."

```
# urn:dkg:decision:shacl-on-vm-promotion
## Facts (with sources)
- **schema:name**: "SHACL on VM promotion"  ←  KA `0xaa…/7`
- **decisions:status**: "approved"          ←  KA `0xbb…/2`
## Sources (2 verifiable)
- KA `0xaa…/7` (verifiable-memory) — `did:dkg:context-graph:cg/_verifiable_memory/0xaa…/7`
- KA `0xbb…/2` (verifiable-memory) — `did:dkg:context-graph:cg/_verifiable_memory/0xbb…/2`
```

## Why this shape (addressed read, not query-rewriting)

This supersedes #1252, which tried to annotate **arbitrary `dkg_query` SELECTs** with an `includeProvenance` flag that rewrote the user's query (`GRAPH ?g { … }`) and re-entered the engine. Automated review correctly found that the rewrite perturbs nearly every other branch of the query path:

- **DISTINCT/REDUCED** — adding the hidden source column changes the dedup key → duplicate user rows.
- **LIMIT/OFFSET/ORDER BY** — modifiers run over `_meta`/`_private` rows that get dropped post-hoc → fewer/different content rows.
- **UNION** — the non-provenance path falls back to root-graph-only; the rewrite reads per-KA partitions too → extra rows.
- **`includeSharedMemory`** — the WM∪SWM merge path runs two now-identical executions → every row duplicated.
- **`minTrust`** — the trust filter rejects `GRAPH` patterns and fails closed → empty result for trusted queries.
- **unscoped** — without a `contextGraphId` the rewrite scans all named graphs → cross-context exposure.

A repo grep showed those shapes (DISTINCT, LIMIT, SWM-union, aggregates) are exactly what the built-in tools, SKILL.md examples, and adapters actually issue — so the flag would no-op or misbehave for ~all real queries.

**An addressed read sidesteps the entire class:** the tool owns the query shape — one entity, a single memory tier (default `verifiable-memory`, never the union), no user modifiers — so the engine binds the source named graph per fact and constrains it to the CG's content graphs (no `_meta`/`_private`, no cross-context bleed) with **zero engine changes**.

## Scope

- `mcp`: `parseEntitySource` (graph URI → `{author, kaNumber, layer}`) + `sourceLabel`; the `dkg_get_entity_sources` tool (IRI-injection-guarded; tool surface 30 → 31).
- `query` test: pins the scoped `GRAPH ?g` engine contract the tool relies on — binds the per-KA source, excludes `_meta`, no cross-CG bleed (multi-publisher entity).
- `mcp` test: the tool issues the controlled single-view query (never `includeSharedMemory`) and renders facts + deduped sources.
- No engine / daemon / agent changes.

## Testing
query **279** + mcp-dkg **308** green; touched packages typecheck.

## Follow-ups (deliberately out of scope)
- Incoming-edge provenance (who asserted links *to* X).
- Cross-tier sources in one call (would need per-tier queries merged tool-side, not the engine's `includeSharedMemory` union).

🤖 Generated with [Claude Code](https://claude.com/claude-code)