### PR TITLE
test(devnet): addressed-read provenance e2e for dkg_get_entity_sources

### DIFF
--- a/devnet/v10-core-flows/automated.test.ts
+++ b/devnet/v10-core-flows/automated.test.ts
@@ -461,7 +461,11 @@ describe('2. failed publish does not leak triples into verifiable-memory (RC11 /
       );
       lastVmStatus = vmQuery.status;
       lastVmBody = vmQuery.body;
-      lastVmBindings = vmQuery.body?.bindings ?? vmQuery.body?.results?.bindings ?? [];
+      // The daemon wraps results as { result: { bindings } } — read
+      // `body.result.bindings`. (Was `body.bindings`/`body.results.bindings`,
+      // both undefined here, so this leak guard silently saw zero rows and
+      // could never actually catch a verifiable-memory leak.)
+      lastVmBindings = vmQuery.body?.result?.bindings ?? [];
       if (lastVmBindings.length > 0) {
         leakSeen = true;
         break;
@@ -733,4 +737,79 @@ describe('4. operator-fee accrual + withdrawal', () => {
     const queuedAfter = await state.css.getOperatorFeeWithdrawalRequest(identityId);
     expect(queuedAfter.amount).toBe(0n);
   }, 600_000);
+});
+
+// ───────── 5. Addressed-read provenance (dkg_get_entity_sources, PR #1253) ─────────
+//
+// The `dkg_get_entity_sources` MCP tool answers "what is known about entity X,
+// and which Knowledge Asset asserted each fact?" — it reads
+// `SELECT ?p ?o ?g WHERE { GRAPH ?g { <X> ?p ?o } }` scoped to verifiable-memory
+// and parses the per-KA source graph `…/_verifiable_memory/{author}/{number}`
+// into the on-chain UAL identity a consumer cites/verifies against. The tool's
+// parsing/rendering is unit-tested with synthetic graphs; what ONLY a live
+// devnet can prove is that a REAL publish actually materialises that exact
+// per-KA source graph — i.e. the provenance handle the tool hands back resolves
+// to the publish's true on-chain (author, number).
+//
+// This pins that engine-layer contract end-to-end: publish an entity from a
+// core, read it back via the addressed-read shape, and assert the source graph
+// encodes the SAME (author, number) packed into the returned on-chain kaId
+// (reservedKaId = (uint160(author) << 96) | uint96(number) — the derivation the
+// publisher itself uses to build the VM graph URI, see dkg-publisher.ts:1553).
+describe('5. addressed-read provenance resolves to the per-KA verifiable-memory source', () => {
+  it("a published entity's facts carry a _verifiable_memory/{author}/{number} source matching its on-chain kaId", async () => {
+    const name = `core-flows-prov-${Date.now().toString(36)}`;
+    const subject = `urn:test:core-flows:${name}`; // fullPublish writes quads about this subject
+    const pub = await fullPublish(NODE1_API, state.node1Token, name);
+
+    // Reproduce the publisher's kaId → VM-graph derivation (dkg-publisher.ts:1553).
+    const kaId = BigInt(pub.kaId);
+    const author = '0x' + (kaId >> 96n).toString(16).padStart(40, '0');
+    const number = (kaId & ((1n << 96n) - 1n)).toString();
+    const expectedSource = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verifiable_memory/${author}/${number}`;
+
+    // Addressed read: project the source graph per fact — the exact shape the
+    // tool issues. The daemon wraps results as { result: { bindings } }, so read
+    // `body.result.bindings` (NOT top-level `body.bindings`). Poll briefly so
+    // post-confirmation VM materialisation has time to land.
+    const val = (x: unknown): string =>
+      typeof x === 'string' ? x : ((x as { value?: string })?.value ?? '');
+    let bindings: Array<Record<string, unknown>> = [];
+    for (let attempt = 0; attempt < 15; attempt++) {
+      const r = await postJson(
+        NODE1_API,
+        '/api/query',
+        {
+          sparql: `SELECT ?p ?o ?g WHERE { GRAPH ?g { <${subject}> ?p ?o } }`,
+          contextGraphId: CONTEXT_GRAPH,
+          view: 'verifiable-memory',
+        },
+        state.node1Token,
+      );
+      bindings = r.body?.result?.bindings ?? [];
+      if (bindings.length > 0) break;
+      await sleep(1000);
+    }
+    expect(bindings.length, `no verifiable-memory rows for ${subject} after polling`).toBeGreaterThan(0);
+
+    const sources = [...new Set(bindings.map((b) => val(b.g)))];
+
+    // (1) The correct per-KA source IS present — the handle a consumer cites
+    // resolves to THIS publish's on-chain (author, number).
+    expect(
+      sources.map((s) => s.toLowerCase()),
+      `expected per-KA source ${expectedSource}; got [${sources.join(', ')}]`,
+    ).toContain(expectedSource.toLowerCase());
+
+    // (2) No per-KA-shaped source carries a DIFFERENT (author, number) — i.e.
+    // attribution is never fabricated/mismatched against the on-chain identity.
+    // (Root / per-collection graphs that don't match the per-KA shape are the
+    // tool's "disclosed, non-citable" rows and are intentionally skipped here.)
+    for (const s of sources) {
+      const m = s.match(/\/_verifiable_memory\/([^/]+)\/([^/]+)$/);
+      if (!m) continue;
+      expect(m[1].toLowerCase(), `source ${s}: author != on-chain ${author}`).toBe(author.toLowerCase());
+      expect(m[2], `source ${s}: kaNumber != on-chain ${number}`).toBe(number);
+    }
+  }, 120_000);
 });

--- a/devnet/v10-core-flows/automated.test.ts
+++ b/devnet/v10-core-flows/automated.test.ts
@@ -204,6 +204,27 @@ function postJson(api: string, path: string, body: unknown, token: string): Prom
   });
 }
 
+/**
+ * Parse SPARQL SELECT bindings out of a daemon /api/query response, accepting the
+ * known wrapper shapes and THROWING on an unrecognised 200 — so a future wrapper
+ * regression can never masquerade as "zero rows". Callers must only pass a 200
+ * body; a non-200 (still warming up) has no bindings to read. (otReviewAgent #1258.)
+ */
+function queryBindings(body: any): Array<Record<string, unknown>> {
+  const b =
+    body?.result?.bindings ??   // current daemon shape: { result: { bindings } }
+    body?.results?.bindings ??  // SPARQL 1.1 JSON results shape
+    body?.bindings;             // legacy flat shape
+  if (!Array.isArray(b)) {
+    throw new Error(
+      `unrecognised /api/query response shape (no result.bindings / results.bindings / bindings array): ${
+        typeof body === 'string' ? body.slice(0, 300) : JSON.stringify(body).slice(0, 300)
+      }`,
+    );
+  }
+  return b as Array<Record<string, unknown>>;
+}
+
 function openSseAndCollect(
   api: string,
   token: string,
@@ -461,11 +482,11 @@ describe('2. failed publish does not leak triples into verifiable-memory (RC11 /
       );
       lastVmStatus = vmQuery.status;
       lastVmBody = vmQuery.body;
-      // The daemon wraps results as { result: { bindings } } — read
-      // `body.result.bindings`. (Was `body.bindings`/`body.results.bindings`,
-      // both undefined here, so this leak guard silently saw zero rows and
-      // could never actually catch a verifiable-memory leak.)
-      lastVmBindings = vmQuery.body?.result?.bindings ?? [];
+      // Parse via the shared helper, which THROWS on an unrecognised 200 shape
+      // rather than coercing to [] — otherwise a wrapper regression silently
+      // re-becomes "zero rows" and this leak guard passes open. A non-200 (still
+      // warming up) legitimately has no bindings to read. (otReviewAgent #1258.)
+      lastVmBindings = vmQuery.status === 200 ? queryBindings(vmQuery.body) : [];
       if (lastVmBindings.length > 0) {
         leakSeen = true;
         break;
@@ -766,12 +787,33 @@ describe('5. addressed-read provenance resolves to the per-KA verifiable-memory 
     const kaId = BigInt(pub.kaId);
     const author = '0x' + (kaId >> 96n).toString(16).padStart(40, '0');
     const number = (kaId & ((1n << 96n) - 1n)).toString();
+
+    // Break the circularity (otReviewAgent #1258): pub.kaId comes from the daemon's
+    // own publish response, and the VM graph is materialised from that same value —
+    // so a publisher bug that returned AND materialised the same WRONG id would slip
+    // past a check that only compares the graph to pub.kaId. Anchor to chain truth:
+    // the KA-storage NFT's ownerOf(kaId) REVERTS for a non-existent token and
+    // otherwise returns the address packed into the id (OT-RFC-43:
+    // kaId = (uint160(author) << 96) | uint96(number)). So a forged id either
+    // reverts here or fails owner == author — independently of what the daemon said.
+    const dkgKaAddr: string = await state.hub.getAssetStorageAddress('DKGKnowledgeAssets');
+    const dkgKa = new ethers.Contract(
+      dkgKaAddr,
+      ['function ownerOf(uint256) view returns (address)'],
+      state.provider,
+    );
+    const onChainOwner: string = await dkgKa.ownerOf(kaId); // reverts if kaId is not a real minted KA
+    expect(
+      onChainOwner.toLowerCase(),
+      `kaId ${pub.kaId}: on-chain owner ${onChainOwner} != author packed into the id (${author}) — daemon reported an id that does not match chain truth`,
+    ).toBe(author.toLowerCase());
+
     const expectedSource = `did:dkg:context-graph:${CONTEXT_GRAPH}/_verifiable_memory/${author}/${number}`;
 
     // Addressed read: project the source graph per fact — the exact shape the
-    // tool issues. The daemon wraps results as { result: { bindings } }, so read
-    // `body.result.bindings` (NOT top-level `body.bindings`). Poll briefly so
-    // post-confirmation VM materialisation has time to land.
+    // tool issues. Parse via the shared queryBindings helper (throws on an
+    // unrecognised 200 shape). Poll briefly so post-confirmation VM
+    // materialisation has time to land.
     const val = (x: unknown): string =>
       typeof x === 'string' ? x : ((x as { value?: string })?.value ?? '');
     let bindings: Array<Record<string, unknown>> = [];
@@ -786,7 +828,7 @@ describe('5. addressed-read provenance resolves to the per-KA verifiable-memory 
         },
         state.node1Token,
       );
-      bindings = r.body?.result?.bindings ?? [];
+      bindings = r.status === 200 ? queryBindings(r.body) : [];
       if (bindings.length > 0) break;
       await sleep(1000);
     }


### PR DESCRIPTION
Follow-up to #1253. That PR shipped `dkg_get_entity_sources` with **hermetic** coverage only (engine + tool unit tests over *synthetic* named graphs). This adds the one assertion only a **live devnet** can make.

## The gap

The tool's whole contract is: a published entity's facts come back tagged with the per-KA source graph `…/_verifiable_memory/{author}/{number}`, which it parses into the on-chain UAL identity to cite/verify. The unit tests hand-place those graphs — they can't prove a **real publish** actually materialises that exact graph layout. If the publish/finalization path ever changed the VM graph shape, every unit test would stay green while the tool silently returned wrong/empty provenance.

## What this test does (release-gate, `v10-core-flows`)

1. Publishes an entity from a core (`fullPublish` → on-chain `kaId`).
2. Reads it back via the tool's **exact** shape: `SELECT ?p ?o ?g WHERE { GRAPH ?g { <X> ?p ?o } }`, `view: verifiable-memory`.
3. Asserts the returned source graph encodes the **same `(author, number)`** packed into the on-chain `kaId` — reproducing the publisher's own derivation (`reservedKaId = (uint160(author) << 96) | uint96(number)`, see `dkg-publisher.ts:1553`).
4. Asserts no per-KA source carries a **mismatched** identity (no fabricated attribution).

So it pins the full chain end-to-end: real publish → on-chain id → VM materialization → addressed-read source → matches the UAL.

## Drive-by fix (same file)

The RC11/PR2 **failed-publish leak guard** read `body.bindings` / `body.results.bindings`, but the daemon returns `{ result: { bindings } }` — both were `undefined`, so the guard saw **zero rows unconditionally** and could never actually catch a verifiable-memory leak. Corrected to `body.result.bindings`. (Happy to split this out if you'd prefer.)

## Scope / running

- Lives in the **operator/nightly devnet suite** (`pnpm test:devnet:v10-core-flows`), not per-PR CI — these need `./scripts/devnet.sh start 6` + bootstrap.
- Validated locally to **transform + register** (vitest collects all 6 tests; only the documented `delegators.json` precondition fails off-devnet). Full execution needs a running 6-node devnet — I couldn't boot one here, so a devnet run to confirm green is the one thing left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)