### PR TITLE
fix(rs): heal cgId-race-stranded KCs into the scoped graphs the prover reads

### DIFF
--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -483,6 +483,18 @@ export function createListContextGraphsCacheInvalidatingStore(
     countQuads(graphUri) {
       return innerStore.countQuads(graphUri);
     },
+    // Defined iff the inner store supports it, so the capability propagates
+    // truthfully up the decorator chain (callers gate on `typeof store.update
+    // === 'function'`). A server-side UPDATE can create/drop named graphs and
+    // mutate projected content, so it invalidates the listGraphs cache and
+    // marks the projection dirty just like insert/delete.
+    update: innerStore.update
+      ? (sparql: string) => invalidateAfterMutation(
+        () => innerStore.update!(sparql),
+        () => true,
+        () => markProjectionDirty?.(),
+      )
+      : undefined,
     flush: innerStore.flush ? () => innerStore.flush!() : undefined,
     close() {
       return innerStore.close();

--- a/packages/agent/src/dkg-agent-context-graph.ts
+++ b/packages/agent/src/dkg-agent-context-graph.ts
@@ -1398,6 +1398,14 @@ export class ContextGraphMethods extends DKGAgentBase {
       subject: contextGraphUri,
       predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS,
     });
+    // Single-valued binding guard (RS heal): the on-chain id is immutable, so
+    // clear any prior value before insert — the cgId resolver / heal read this
+    // and must never see a multi-valued (LIMIT-1-nondeterministic) binding.
+    await this.store.deleteByPattern({
+      graph: ontologyGraph,
+      subject: contextGraphUri,
+      predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+    });
     await this.store.insert([
       { subject: contextGraphUri, predicate: DKG_ONTOLOGY.DKG_REGISTRATION_STATUS, object: `"registered"`, graph: cgMetaGraph },
       { subject: contextGraphUri, predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`, object: `"${onChainId}"`, graph: ontologyGraph },

--- a/packages/agent/src/dkg-agent-swm-host.ts
+++ b/packages/agent/src/dkg-agent-swm-host.ts
@@ -36,6 +36,7 @@ import {
   Logger, createOperationContext, sparqlString, isSafeIri, assertSafeIri,
   TrustLevel,
   TRUST_LEVEL_PREDICATE,
+  LEGACY_TRUST_LEVEL_PREDICATE,
   buildTrustLevelQuads,
   isTrustLevelQuad,
   buildAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, type AuthorAttestationTypedData,
@@ -121,6 +122,8 @@ import {
   type WorkspaceAgentRecipientResolverInput,
   type WorkspaceSenderKeyEncryptInput,
   type SharedMemoryPublicSnapshotStorageConfig, type WorkspacePublicSnapshotStore,
+  readMaterializedVersion, shouldApplyMaterialization, writeMaterializedVersion, withMaterializationLock,
+  type MaterializedVersion,
 } from '@origintrail-official/dkg-publisher';
 import { ethers } from 'ethers';
 import { join } from 'node:path';
@@ -401,6 +404,24 @@ const HOST_MODE_PUBLISH_POLICY_MAX_CACHE_AGE_MS = 5_000;
 function normalizeHostModeReconcileBatchSize(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_HOST_MODE_RECONCILE_BATCH_SIZE;
   return Math.max(1, Math.floor(value));
+}
+
+/**
+ * Strip surrounding quotes from a SPARQL SELECT binding value — mirrors
+ * `ka-extractor.ts:stripQuotes` verbatim so the RS-heal resolves the SAME
+ * `?ual`/`?root` strings the prover does. IRIs come back bare from both store
+ * adapters (oxigraph/sparql-http), so this is a no-op for them; it only peels
+ * the `"..."` / `"value"^^<dt>` literal wrappers some result formats apply.
+ */
+function stripBindingQuotes(v: string): string {
+  if (v.startsWith('"') && v.endsWith('"')) {
+    return v.slice(1, -1);
+  }
+  const ix = v.indexOf('"^^');
+  if (v.startsWith('"') && ix !== -1) {
+    return v.slice(1, ix);
+  }
+  return v;
 }
 
 export class SwmHostModeMethods extends DKGAgentBase {
@@ -2491,6 +2512,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
       // Member subscriptions AND Phase D core-hosted public CGs get swept.
       if ((!sub.subscribed && !sub.coreHosted) || !sub.onChainId) continue;
       void this.reconcileCoalescer.trigger(localCgId);
+      // RS heal: relocate any legacy-stranded KC into the scoped graphs the
+      // prover reads (the sweep is the safety net for a missed live nudge).
+      void this.healStrandedScopedKCs(localCgId, sub);
     }
   }
 
@@ -2573,6 +2597,9 @@ export class SwmHostModeMethods extends DKGAgentBase {
           if (bound) {
             this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> bound + reconcile pre-subscribed "${lcg}"`);
             if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(lcg);
+            // RS heal immediately so a live KARegistered doesn't wait ~60s for
+            // the periodic sweep to relocate the stranded KC.
+            void this.healStrandedScopedKCs(lcg, sub);
             return lcg;
           }
         }
@@ -2586,6 +2613,8 @@ export class SwmHostModeMethods extends DKGAgentBase {
     if (!sub?.subscribed && !sub?.coreHosted) return null;
     this.log.info(ctx, `Phase B: KACG nudge cg=${onChainId} ka=${kaId} -> reconcile "${localCgId}"`);
     if (this.reconcileCoalescer) void this.reconcileCoalescer.trigger(localCgId);
+    // RS heal immediately on the already-bound path too.
+    void this.healStrandedScopedKCs(localCgId, sub);
     return localCgId;
   }
 
@@ -2665,6 +2694,170 @@ export class SwmHostModeMethods extends DKGAgentBase {
       this.log.warn(
         createOperationContext('system'),
         `VM reconcile for "${localCgId}" failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * RELOCATE stranded legacy-label KCs into the SCOPED per-onChainId graphs
+   * the Random Sampling prover reads.
+   *
+   * The bug: when a KC is finalized BEFORE its on-chain cgId is locally
+   * resolvable, finalization falls back to writing it into the LEGACY label
+   * graphs (`<cg>/_meta` + `<cg>` root data) instead of the scoped
+   * `<cg>/context/<onChainId>/_meta` + `.../context/<onChainId>` graphs. The
+   * RS prover (`extractV10KCFromStore`) only reads the scoped graphs, so such
+   * a KC reports `kc-not-synced` forever even though the node holds it.
+   *
+   * This COPIES (never moves/deletes) the legacy KC into the scoped graphs so
+   * the prover can find it, while leaving the label-graph view intact.
+   *
+   * CONTENT-BINDING RULE: the data/meta copies go through
+   * `this.store.update(INSERT…WHERE)` so the terms NEVER leave the store. A
+   * `query()`/CONSTRUCT → `insert(quads)` round-trip would double backslashes
+   * in escape-bearing literals and change the leaf bytes the on-chain
+   * `challengeRoot` was committed over, making the proof permanently
+   * unprovable. The projection (root + `.well-known/genid/` descendants,
+   * minus post-publish trustLevel stamps) mirrors `ka-extractor.ts` exactly.
+   *
+   * Idempotent + version-guarded so a re-run is a no-op and a later stale
+   * writer cannot clobber. NEVER calls `isAlreadyConfirmed` — that read-both
+   * guard is the permanence mechanism that made the legacy promotion stick.
+   */
+  async healStrandedScopedKCs(this: DKGAgent, localCgId: string, sub: ContextGraphSub): Promise<void> {
+    try {
+      if (!sub.onChainId) return;
+      // Server-side byte-safe copy is the ONLY safe relocation mechanism; if the
+      // backend can't do SPARQL UPDATE we bail rather than risk a lossy JS round-trip.
+      const storeUpdate = this.store.update;
+      if (typeof storeUpdate !== 'function') return;
+      const update = (sparql: string): Promise<void> => storeUpdate.call(this.store, sparql);
+
+      const DKG = 'http://dkg.io/ontology/';
+      const legacyMeta = contextGraphMetaUri(localCgId);
+      const scopedMeta = contextGraphMetaUri(localCgId, sub.onChainId);
+      const rootData = contextGraphDataUri(localCgId);
+      const scopedData = contextGraphDataUri(localCgId, sub.onChainId);
+
+      // 2a ASK-guard: is there at least one legacy-only KC (batchId present in
+      // legacy meta, absent in scoped meta)? In steady state this is one ASK per
+      // bound CG and returns false once healed.
+      const askGuard = await this.store.query(
+        `ASK {
+           GRAPH <${legacyMeta}> { ?ual <${DKG}batchId> ?b }
+           FILTER NOT EXISTS { GRAPH <${scopedMeta}> { ?ual <${DKG}batchId> ?b } }
+         }`,
+      );
+      if (askGuard.type !== 'boolean' || !askGuard.value) return;
+
+      // 2b: enumerate the stranded UALs.
+      const stranded = await this.store.query(
+        `SELECT ?ual ?b WHERE {
+           GRAPH <${legacyMeta}> { ?ual <${DKG}batchId> ?b }
+           FILTER NOT EXISTS { GRAPH <${scopedMeta}> { ?ual <${DKG}batchId> ?b } }
+         }`,
+      );
+      if (stranded.type !== 'bindings') return;
+
+      for (const row of stranded.bindings) {
+        // Bindings come back stripped to bare values by the store adapters
+        // (oxigraph/sparql-http both emit IRIs unwrapped); strip + validate
+        // exactly as the extractor does for its `ual`.
+        const ual = stripBindingQuotes(row['ual'] ?? '');
+        if (!ual || !isSafeIri(ual)) continue;
+        try {
+          await withMaterializationLock(scopedMeta, ual, async () => {
+            const version = await readMaterializedVersion(this.store, legacyMeta, ual);
+            if (version === null) return; // not safely stampable — skip
+            if (!(await shouldApplyMaterialization(this.store, scopedMeta, ual, version))) return; // idempotent
+
+            assertSafeIri(ual);
+
+            // Resolve roots from legacy meta with the extractor's read-both UNION.
+            const rootsRes = await this.store.query(
+              `SELECT ?root WHERE {
+                 GRAPH <${legacyMeta}> {
+                   { ?ka <${DKG}partOf> <${ual}> ; <${DKG}rootEntity> ?root . }
+                   UNION
+                   { <${ual}> <${DKG}rootEntity> ?root . }
+                 }
+               }`,
+            );
+            if (rootsRes.type !== 'bindings') return;
+            const roots: string[] = [];
+            const seen = new Set<string>();
+            for (const r of rootsRes.bindings) {
+              const root = stripBindingQuotes(r['root'] ?? '');
+              if (root && !seen.has(root) && isSafeIri(root)) {
+                seen.add(root);
+                roots.push(root);
+              }
+            }
+            if (roots.length === 0) return;
+
+            // CRASH-PARTIAL GUARD (all-or-nothing across roots): the extractor
+            // roots a concatenation over EVERY root, so if ANY root's legacy
+            // data is missing locally this is a Factor-B sync gap, not a
+            // relocation. Write NOTHING — must NOT trade kc-not-synced for
+            // KCDataMissingError. ASK each root first.
+            for (const root of roots) {
+              const present = await this.store.query(
+                `ASK {
+                   GRAPH <${rootData}> {
+                     ?s ?p ?o .
+                     FILTER(?s = <${root}> || STRSTARTS(STR(?s), "${root}/.well-known/genid/"))
+                   }
+                 }`,
+              );
+              if (present.type !== 'boolean' || !present.value) return;
+            }
+
+            // DATA copy (per root) — MANDATORY server-side, byte-safe. Skip the
+            // post-publish trustLevel stamps so the recomputed leaf set stays
+            // bit-identical with the on-chain merkleLeafCount.
+            for (const root of roots) {
+              await update(
+                `INSERT { GRAPH <${scopedData}> { ?s ?p ?o } } WHERE {
+                   GRAPH <${rootData}> {
+                     ?s ?p ?o .
+                     FILTER(?s = <${root}> || STRSTARTS(STR(?s), "${root}/.well-known/genid/"))
+                     FILTER(?p != <${TRUST_LEVEL_PREDICATE}> && ?p != <${LEGACY_TRUST_LEVEL_PREDICATE}>)
+                   }
+                 }`,
+              );
+            }
+
+            // META copy — server-side. Carries the `<ual>` subject (batchId
+            // discriminator) + the `<ual>/<tokenId>` token rows
+            // (rootEntity/privateMerkleRoot).
+            await update(
+              `INSERT { GRAPH <${scopedMeta}> { ?s ?p ?o } } WHERE {
+                 GRAPH <${legacyMeta}> {
+                   ?s ?p ?o .
+                   FILTER(?s = <${ual}> || STRSTARTS(STR(?s), "${ual}/"))
+                 }
+               }`,
+            );
+
+            // Stamp so a later stale writer can't clobber.
+            await writeMaterializedVersion(this.store, scopedMeta, ual, version);
+
+            this.log.info(
+              createOperationContext('system'),
+              `RS heal: relocated stranded legacy KC ${ual} -> scoped cg=${sub.onChainId} (${roots.length} root(s))`,
+            );
+          });
+        } catch (err) {
+          this.log.warn(
+            createOperationContext('system'),
+            `RS heal: relocate failed for ${ual} (cg=${sub.onChainId}): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    } catch (err) {
+      this.log.warn(
+        createOperationContext('system'),
+        `RS heal sweep for "${localCgId}" failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1184,6 +1184,14 @@ export class DKGAgent extends DKGAgentBase {
       // the in-memory subscribedContextGraphs map).
       const cgUri = contextGraphDataGraphUri(p.name);
       const ontoGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+      // Single-valued binding guard (RS heal): on-chain id is immutable; clear
+      // any prior value so the cgId resolver / heal never read a multi-valued
+      // (LIMIT-1-nondeterministic) binding.
+      await this.store.deleteByPattern({
+        graph: ontoGraph,
+        subject: cgUri,
+        predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+      });
       await this.store.insert([{
         subject: cgUri,
         predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -54,6 +54,11 @@ export class FinalizationHandler {
   private readonly markContextGraphMetaDirtyFromQuads: MarkContextGraphMetaDirtyFromQuads | undefined;
   private readonly log = new Logger('FinalizationHandler');
   private readonly processedUals = new Set<string>();
+  // Forward-prevention for the cgId-resolution race (RS heal): chain-authoritative
+  // kaId(batchId)->cgId bindings, cached POSITIVE-ONLY. A 0/miss is NEVER cached —
+  // caching a miss for a KC finalized before its on-chain KA->CG binding lands
+  // would pin it to the legacy `/_meta` fallback forever, re-opening the race.
+  private readonly chainCgIdByBatchId = new Map<string, string>();
 
   constructor(
     store: TripleStore,
@@ -114,15 +119,45 @@ export class FinalizationHandler {
       // the id locally when the wire is empty; resolver failures or
       // not-on-chain CGs fall back to legacy behavior unchanged.
       let ctxGraphId = msg.targetContextGraphId || undefined;
-      if (!ctxGraphId && this.resolveContextGraphOnChainId) {
-        try {
-          const resolved = await this.resolveContextGraphOnChainId(contextGraphId);
-          if (resolved !== null && resolved !== undefined && String(resolved).length > 0) {
-            ctxGraphId = String(resolved);
-            this.log.info(ctx, `Finalization: gossip omitted targetContextGraphId; resolved locally to ${ctxGraphId} (defensive lookup)`);
+      if (!ctxGraphId) {
+        // Forward-prevention (RS cgId-race): resolve from CHAIN TRUTH first.
+        // `getKAContextGraphId(batchId)` is authoritative and immune to the
+        // local ontology-binding lag that strands KCs in legacy `/_meta` — the
+        // root cause the heal-sweep exists to repair. Caching POSITIVE results
+        // only (never a 0/miss) keeps a finalization that races ahead of its
+        // on-chain KA->CG binding from being pinned to legacy forever.
+        let batchIdForResolve = 0n;
+        try { batchIdForResolve = protoToBigInt(msg.batchId); } catch { batchIdForResolve = 0n; }
+        const cacheKey = batchIdForResolve > 0n ? batchIdForResolve.toString() : '';
+        if (cacheKey && this.chainCgIdByBatchId.has(cacheKey)) {
+          ctxGraphId = this.chainCgIdByBatchId.get(cacheKey);
+        } else if (
+          cacheKey && this.chain && this.chain.chainId !== 'none'
+          && typeof this.chain.getKAContextGraphId === 'function'
+        ) {
+          try {
+            const boundCg = await this.chain.getKAContextGraphId(batchIdForResolve);
+            if (boundCg !== null && boundCg !== undefined && BigInt(boundCg) > 0n) {
+              ctxGraphId = boundCg.toString();
+              this.chainCgIdByBatchId.set(cacheKey, ctxGraphId); // POSITIVE-only
+              this.log.info(ctx, `Finalization: resolved cgId from chain truth getKAContextGraphId(${batchIdForResolve})=${ctxGraphId}`);
+            }
+          } catch (err) {
+            this.log.info(ctx, `Finalization: chain getKAContextGraphId(${batchIdForResolve}) failed (RPC lag?), falling back to local resolve: ${err instanceof Error ? err.message : String(err)}`);
           }
-        } catch (err) {
-          this.log.warn(ctx, `Finalization: defensive on-chain CG id lookup failed for ${contextGraphId}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        // Local name-based resolver — the existing belt-and-braces for rolling
+        // upgrades when the chain method is absent/lagging.
+        if (!ctxGraphId && this.resolveContextGraphOnChainId) {
+          try {
+            const resolved = await this.resolveContextGraphOnChainId(contextGraphId);
+            if (resolved !== null && resolved !== undefined && String(resolved).length > 0) {
+              ctxGraphId = String(resolved);
+              this.log.info(ctx, `Finalization: gossip omitted targetContextGraphId; resolved locally to ${ctxGraphId} (defensive lookup)`);
+            }
+          } catch (err) {
+            this.log.warn(ctx, `Finalization: defensive on-chain CG id lookup failed for ${contextGraphId}: ${err instanceof Error ? err.message : String(err)}`);
+          }
         }
       }
 

--- a/packages/agent/test/finalization-handler-chain-truth.test.ts
+++ b/packages/agent/test/finalization-handler-chain-truth.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { encodeFinalizationMessage, type FinalizationMessageMsg } from '@origintrail-official/dkg-core';
+import { FinalizationHandler } from '../src/finalization-handler.js';
+
+/**
+ * Regression for STEP 0 (RS cgId-race forward-prevention): when the gossip
+ * envelope omits `targetContextGraphId`, `handleFinalizationMessage` resolves
+ * the on-chain CG id from CHAIN TRUTH first (`chain.getKAContextGraphId(batchId)`)
+ * — authoritative and immune to the local ontology-binding lag that strands KCs
+ * in legacy `_meta`. Two contracts must hold:
+ *   1. A positive chain resolve routes finalization to the SCOPED
+ *      `<cg>/context/<id>/_meta` graph the RS prover reads.
+ *   2. A 0/miss is NOT cached (POSITIVE-only cache): a finalization that races
+ *      ahead of its on-chain KA→CG binding must re-query the chain next time,
+ *      not get pinned to legacy forever. A positive result IS cached.
+ *
+ * Technique (mirrors finalization-handler-defensive-cg-id.test.ts): capture the
+ * SPARQL the handler issues, seed a `dkg:status "confirmed"` sentinel in the
+ * expected meta graph so the dedup ASK short-circuits, and assert which graph
+ * URI got probed.
+ */
+
+const CONTEXT_GRAPH = 'cg-chain-truth';
+const UAL = 'did:dkg:evm:31337/0xABC/1';
+const BATCH_ID = 7;
+const CHAIN_CG_ID = '5';
+const LEGACY_META = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
+const SCOPED_META = `did:dkg:context-graph:${CONTEXT_GRAPH}/context/${CHAIN_CG_ID}/_meta`;
+
+function makeMsg(overrides?: Partial<FinalizationMessageMsg>): FinalizationMessageMsg {
+  return {
+    ual: UAL,
+    contextGraphId: CONTEXT_GRAPH,
+    kcMerkleRoot: new Uint8Array(32),
+    txHash: '0x' + 'ab'.repeat(32),
+    blockNumber: 100,
+    batchId: BATCH_ID,
+    startKAId: 1,
+    endKAId: 2,
+    publisherAddress: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    rootEntities: ['urn:test:entity'],
+    timestampMs: Date.now(),
+    operationId: 'op-chain-truth-test',
+    ...overrides,
+  };
+}
+
+function captureQueries(store: OxigraphStore): string[] {
+  const captured: string[] = [];
+  const orig = store.query.bind(store);
+  store.query = (async (sparql: string, ...rest: unknown[]) => {
+    captured.push(sparql);
+    return (orig as (s: string, ...r: unknown[]) => unknown)(sparql, ...rest);
+  }) as typeof store.query;
+  return captured;
+}
+
+const queriedGraph = (captured: string[], graphUri: string): boolean =>
+  captured.some((q) => q.includes(`<${graphUri}>`));
+
+async function seedConfirmedAt(store: OxigraphStore, metaGraph: string): Promise<void> {
+  await store.insert([{
+    subject: UAL, predicate: 'http://dkg.io/ontology/status', object: '"confirmed"', graph: metaGraph,
+  }]);
+}
+
+/** Minimal ChainAdapter stub exposing only what STEP 0 touches, returning a scripted sequence. */
+type ChainArg = ConstructorParameters<typeof FinalizationHandler>[1];
+function chainStub(sequence: Array<bigint | number | null>): { chain: ChainArg; calls: bigint[] } {
+  const calls: bigint[] = [];
+  let i = 0;
+  const stub = {
+    chainId: 'hardhat',
+    getKAContextGraphId: async (batchId: bigint) => {
+      calls.push(batchId);
+      const v = sequence[Math.min(i, sequence.length - 1)];
+      i += 1;
+      return v;
+    },
+  };
+  return { chain: stub as unknown as ChainArg, calls };
+}
+
+describe('FinalizationHandler STEP 0 — chain-truth cgId resolution', () => {
+  let store: OxigraphStore;
+  let captured: string[];
+
+  beforeEach(() => {
+    store = new OxigraphStore();
+    captured = captureQueries(store);
+  });
+
+  it('routes to the scoped graph on a positive chain-truth resolve (no targetContextGraphId)', async () => {
+    await seedConfirmedAt(store, SCOPED_META);
+    const { chain, calls } = chainStub([5n]);
+    const handler = new FinalizationHandler(store, chain, undefined, undefined);
+
+    await handler.handleFinalizationMessage(encodeFinalizationMessage(makeMsg()), CONTEXT_GRAPH);
+
+    expect(calls).toEqual([BigInt(BATCH_ID)]);
+    expect(queriedGraph(captured, SCOPED_META)).toBe(true);
+  });
+
+  it('does NOT cache a 0/miss (re-queries the chain), but DOES cache a positive', async () => {
+    // Both candidate graphs carry the sentinel so every call short-circuits at
+    // the dedup ASK regardless of which graph it resolves to.
+    await seedConfirmedAt(store, LEGACY_META);
+    await seedConfirmedAt(store, SCOPED_META);
+    const { chain, calls } = chainStub([0n, 5n]); // miss, then positive (then stays positive)
+    const handler = new FinalizationHandler(store, chain, undefined, undefined);
+
+    // Call 1 — chain returns 0 → unresolved → legacy probe; the miss is NOT cached.
+    await handler.handleFinalizationMessage(
+      encodeFinalizationMessage(makeMsg({ txHash: '0x' + '11'.repeat(32) })), CONTEXT_GRAPH,
+    );
+    expect(calls).toHaveLength(1);
+
+    // Call 2 — same batchId, fresh txHash. If the 0 had been cached, the chain
+    // would NOT be re-queried and we'd be pinned to legacy. It must re-query and
+    // now resolve to the scoped graph.
+    const mark = captured.length;
+    await handler.handleFinalizationMessage(
+      encodeFinalizationMessage(makeMsg({ txHash: '0x' + '22'.repeat(32) })), CONTEXT_GRAPH,
+    );
+    expect(calls).toHaveLength(2); // re-queried — miss was NOT cached
+    expect(queriedGraph(captured.slice(mark), SCOPED_META)).toBe(true);
+
+    // Call 3 — the positive (5) is now cached: the chain must NOT be re-queried.
+    await handler.handleFinalizationMessage(
+      encodeFinalizationMessage(makeMsg({ txHash: '0x' + '33'.repeat(32) })), CONTEXT_GRAPH,
+    );
+    expect(calls).toHaveLength(2); // still 2 — positive WAS cached
+  });
+});

--- a/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-decorated.test.ts
@@ -1,0 +1,143 @@
+/**
+ * RS-heal — runs through the PRODUCTION store decorator stack.
+ *
+ * Regression for the review finding: `healStrandedScopedKCs` bails unless
+ * `this.store.update` is a function, but the agent's store is NOT a bare
+ * adapter. `createTripleStore` wraps it in `SharedMemoryLiteralBlobStore` /
+ * `GraphSetIndexStore`, and `DKGAgent.create` wraps THAT in
+ * `createListContextGraphsCacheInvalidatingStore`. If any layer fails to
+ * forward the (optional) `update` method, `this.store.update` is `undefined`
+ * in every normal daemon config → the guard silently returns → the heal never
+ * runs and RS stays stuck. The bare-adapter gate tests cannot see this.
+ *
+ * This builds the store the way production does (factory + agent wrapper) and
+ * proves: (1) `update` propagates to the top of the stack; (2) the heal
+ * actually RELOCATES through it (byte-exact root equality — if `update` were
+ * dropped the guard would no-op and scoped would stay empty); (3) the wrapper's
+ * cache-invalidation + the GraphSetIndex refresh fire so the new scoped graph
+ * is enumerable.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTripleStore, type TripleStore, type Quad } from '@origintrail-official/dkg-storage';
+import { V10MerkleTree, contextGraphDataUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
+import { extractV10KCFromStore } from '@origintrail-official/dkg-random-sampling';
+import { writeMaterializedVersion } from '@origintrail-official/dkg-publisher';
+import { SwmHostModeMethods } from '../src/dkg-agent-swm-host.js';
+import { createListContextGraphsCacheInvalidatingStore } from '../src/dkg-agent-base.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
+const CONTEXT_GRAPH_ON_CHAIN_ID = 'https://dkg.network/ontology#ContextGraphOnChainId';
+
+const ESCAPE_BEARING_VALUE = 'line1\nline2\\x';
+const ROOT = 'urn:entity:strand-root';
+const GENID = `${ROOT}/.well-known/genid/blank-1`;
+const KA_ID = 42n;
+
+function publicTriples(): { subject: string; predicate: string; object: string }[] {
+  return [
+    { subject: ROOT, predicate: 'urn:p:name', object: '"strand"' },
+    { subject: ROOT, predicate: 'urn:p:payload', object: `"${ESCAPE_BEARING_VALUE.replace(/\\/g, '\\\\').replace(/\n/g, '\\n')}"` },
+    { subject: ROOT, predicate: 'urn:p:has', object: GENID },
+    { subject: GENID, predicate: 'urn:p:value', object: '"42"' },
+  ];
+}
+function metaQuads(ual: string, metaGraph: string): Quad[] {
+  return [
+    { subject: ual, predicate: `${RDF}type`, object: `${DKG}KnowledgeCollection`, graph: metaGraph },
+    { subject: ual, predicate: `${DKG}batchId`, object: `"${KA_ID}"^^<${XSD}integer>`, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${DKG}partOf`, object: ual, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${DKG}rootEntity`, object: ROOT, graph: metaGraph },
+  ];
+}
+
+describe('healStrandedScopedKCs — through the production store decorator stack', () => {
+  let store: TripleStore;
+  let invalidateCount: number;
+
+  const TEST_CG = 'stranded-cg';
+  const TEST_ONCHAIN = '7';
+  const TEST_UAL = 'did:dkg:hardhat:31337/0xpub/42';
+  const CTRL_CG = 'control-cg';
+  const CTRL_ONCHAIN = '8';
+  const CTRL_UAL = 'did:dkg:hardhat:31337/0xctrl/42';
+
+  beforeEach(async () => {
+    invalidateCount = 0;
+    // Production wrapping: createTripleStore (→ GraphSetIndexStore) then the
+    // agent's listContextGraphs cache-invalidating wrapper (DKGAgent.create).
+    const inner = await createTripleStore({ backend: 'oxigraph', graphSetIndex: true });
+    store = createListContextGraphsCacheInvalidatingStore(
+      inner,
+      () => { invalidateCount += 1; },
+      () => undefined,
+    );
+
+    const seedOntology = (cg: string, onChainId: string): Promise<void> => store.insert([{
+      subject: `did:dkg:context-graph:${cg}`, predicate: CONTEXT_GRAPH_ON_CHAIN_ID,
+      object: `"${onChainId}"`, graph: ONTOLOGY_GRAPH,
+    }]);
+
+    await seedOntology(CTRL_CG, CTRL_ONCHAIN);
+    await store.insert([
+      ...metaQuads(CTRL_UAL, contextGraphMetaUri(CTRL_CG, CTRL_ONCHAIN)),
+      ...publicTriples().map((t) => ({ ...t, graph: contextGraphDataUri(CTRL_CG, CTRL_ONCHAIN) })),
+    ]);
+
+    await seedOntology(TEST_CG, TEST_ONCHAIN);
+    const legacyMeta = contextGraphMetaUri(TEST_CG);
+    await store.insert([
+      ...metaQuads(TEST_UAL, legacyMeta),
+      ...publicTriples().map((t) => ({ ...t, graph: contextGraphDataUri(TEST_CG) })),
+    ]);
+    await writeMaterializedVersion(store, legacyMeta, TEST_UAL, { blockNumber: 100, txIndex: 0 });
+  });
+
+  async function runHeal(localCgId: string, onChainId: string): Promise<void> {
+    await SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      { store, log: { info: () => undefined, warn: () => undefined, error: () => undefined } } as never,
+      localCgId,
+      { subscribed: true, synced: true, onChainId } as never,
+    );
+  }
+
+  it('exposes update() at the top of the decorator stack (capability propagation)', () => {
+    expect(typeof store.update).toBe('function');
+  });
+
+  it('relocates the stranded KC through the full stack (heal does NOT silently no-op)', async () => {
+    const ctrl = await extractV10KCFromStore(store, BigInt(CTRL_ONCHAIN), KA_ID);
+    const expectedRoot = new V10MerkleTree(ctrl.leaves).root;
+    await expect(extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID)).rejects.toBeTruthy();
+
+    // Seed the GraphSetIndex BEFORE the heal so we can prove the update-path
+    // refresh registers the newly-created scoped graph (not just a lazy scan).
+    const graphsBefore = await store.listGraphs();
+    expect(graphsBefore).not.toContain(contextGraphMetaUri(TEST_CG, TEST_ONCHAIN));
+    const invalidatesBefore = invalidateCount;
+
+    await runHeal(TEST_CG, TEST_ONCHAIN);
+
+    // (1) byte-exact relocation through the stack — if update() were dropped by
+    // any layer, the heal's guard would no-op and this would reject/empty.
+    const healed = await extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID);
+    expect(new V10MerkleTree(healed.leaves).root).toEqual(expectedRoot);
+
+    // (2) the cache-invalidating wrapper's update() ran (graph-creating mutation).
+    expect(invalidateCount).toBeGreaterThan(invalidatesBefore);
+
+    // (3) GraphSetIndexStore.update() refreshed the index — the new scoped
+    //     graph is now enumerable.
+    const graphsAfter = await store.listGraphs();
+    expect(graphsAfter).toContain(contextGraphMetaUri(TEST_CG, TEST_ONCHAIN));
+    expect(graphsAfter).toContain(contextGraphDataUri(TEST_CG, TEST_ONCHAIN));
+
+    // copies, never moves.
+    const legacyStill = await store.query(
+      `ASK { GRAPH <${contextGraphMetaUri(TEST_CG)}> { <${TEST_UAL}> <${DKG}batchId> "${KA_ID}"^^<${XSD}integer> } }`,
+    );
+    expect(legacyStill.type === 'boolean' && legacyStill.value).toBe(true);
+  });
+});

--- a/packages/agent/test/rs-heal-stranded-kc-http.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc-http.test.ts
@@ -1,0 +1,164 @@
+/**
+ * RS-heal content-binding gate — over the SPARQL-HTTP adapter (the DEVNET backend).
+ *
+ * The embedded-OxigraphStore gate (`rs-heal-stranded-kc.test.ts`) proves the
+ * heal's copy fidelity on the in-process wasm store. But devnet daemons run
+ * `backend: "oxigraph-server"`, which routes through the `sparql-http` adapter
+ * — a DIFFERENT serialization path (HTTP + W3C SPARQL JSON / N-Quads on the
+ * wire). The heal's `store.update(INSERT…WHERE)` mandate exists precisely so
+ * the relocated terms never round-trip through THAT adapter's JS
+ * serialization; this test exercises that path end-to-end against a real
+ * oxigraph engine fronted by an HTTP SPARQL endpoint (the SAME helper
+ * `sparql-http.test.ts` uses), seeding + healing + extracting ALL over
+ * `SparqlHttpStore`.
+ *
+ * LOAD-BEARING ASSERTION (same shape as the wasm gate): a CONTROL CG seeded by
+ * a single direct `store.insert` of the SAME raw triples DIRECTLY into its
+ * SCOPED graphs yields `expectedRoot`. After the heal relocates the legacy
+ * strand, the recomputed root over the now-populated scoped graphs must EQUAL
+ * `expectedRoot` — plus a STRLEN==13 genuineness check (the escape-bearing
+ * literal really is a single-byte newline + single backslash on the server).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { SparqlHttpStore, type Quad } from '@origintrail-official/dkg-storage';
+import { V10MerkleTree, contextGraphDataUri, contextGraphMetaUri } from '@origintrail-official/dkg-core';
+import { extractV10KCFromStore } from '@origintrail-official/dkg-random-sampling';
+import { writeMaterializedVersion } from '@origintrail-official/dkg-publisher';
+import { SwmHostModeMethods } from '../src/dkg-agent-swm-host.js';
+import { startOxigraphSparqlEndpoint, type OxigraphSparqlEndpoint } from '../../storage/test/helpers/oxigraph-sparql-endpoint.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
+const CONTEXT_GRAPH_ON_CHAIN_ID = 'https://dkg.network/ontology#ContextGraphOnChainId';
+
+// Escape-bearing value: a raw backslash AND a raw newline. .length === 13.
+const ESCAPE_BEARING_VALUE = 'line1\nline2\\x';
+const ROOT = 'urn:entity:strand-root';
+const GENID = `${ROOT}/.well-known/genid/blank-1`;
+const KA_ID = 42n;
+
+function publicTriples(): { subject: string; predicate: string; object: string }[] {
+  return [
+    { subject: ROOT, predicate: 'urn:p:name', object: '"strand"' },
+    { subject: ROOT, predicate: 'urn:p:payload', object: `"${ESCAPE_BEARING_VALUE.replace(/\\/g, '\\\\').replace(/\n/g, '\\n')}"` },
+    { subject: ROOT, predicate: 'urn:p:has', object: GENID },
+    { subject: GENID, predicate: 'urn:p:value', object: '"42"' },
+  ];
+}
+
+function metaQuads(ual: string, metaGraph: string): Quad[] {
+  return [
+    { subject: ual, predicate: `${RDF}type`, object: `${DKG}KnowledgeCollection`, graph: metaGraph },
+    { subject: ual, predicate: `${DKG}batchId`, object: `"${KA_ID}"^^<${XSD}integer>`, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${RDF}type`, object: `${DKG}KnowledgeAsset`, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${DKG}partOf`, object: ual, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${DKG}rootEntity`, object: ROOT, graph: metaGraph },
+  ];
+}
+
+describe('healStrandedScopedKCs — content-binding gate over SPARQL-HTTP', () => {
+  let endpoint: OxigraphSparqlEndpoint;
+  let store: SparqlHttpStore;
+
+  const TEST_CG = 'stranded-cg';
+  const TEST_ONCHAIN = '7';
+  const TEST_UAL = 'did:dkg:hardhat:31337/0xpub/42';
+  const CTRL_CG = 'control-cg';
+  const CTRL_ONCHAIN = '8';
+  const CTRL_UAL = 'did:dkg:hardhat:31337/0xctrl/42';
+
+  beforeAll(async () => {
+    endpoint = await startOxigraphSparqlEndpoint();
+    store = new SparqlHttpStore({
+      queryEndpoint: endpoint.queryEndpoint,
+      updateEndpoint: endpoint.updateEndpoint,
+    });
+  });
+
+  afterAll(async () => {
+    await endpoint.close();
+  });
+
+  // The extractor maps cgId → local CG name via the ontology graph
+  // (resolveContextGraphNameFromOnChainId); without this binding it reports
+  // KCNotFound. The heal itself takes the name+onChainId directly, but the
+  // assertions go through extractV10KCFromStore which needs it.
+  async function seedOntology(localCgId: string, onChainId: string): Promise<void> {
+    await store.insert([{
+      subject: `did:dkg:context-graph:${localCgId}`,
+      predicate: CONTEXT_GRAPH_ON_CHAIN_ID,
+      object: `"${onChainId}"`,
+      graph: ONTOLOGY_GRAPH,
+    }]);
+  }
+
+  beforeEach(async () => {
+    await store.update('DROP ALL');
+
+    // CONTROL: same raw triples DIRECTLY into the SCOPED graphs.
+    await seedOntology(CTRL_CG, CTRL_ONCHAIN);
+    await store.insert([
+      ...metaQuads(CTRL_UAL, contextGraphMetaUri(CTRL_CG, CTRL_ONCHAIN)),
+      ...publicTriples().map((t) => ({ ...t, graph: contextGraphDataUri(CTRL_CG, CTRL_ONCHAIN) })),
+    ]);
+
+    // TEST: stranded in the LEGACY label graphs; SCOPED graphs EMPTY.
+    await seedOntology(TEST_CG, TEST_ONCHAIN);
+    const legacyMeta = contextGraphMetaUri(TEST_CG);
+    await store.insert([
+      ...metaQuads(TEST_UAL, legacyMeta),
+      ...publicTriples().map((t) => ({ ...t, graph: contextGraphDataUri(TEST_CG) })),
+    ]);
+    await writeMaterializedVersion(store, legacyMeta, TEST_UAL, { blockNumber: 100, txIndex: 0 });
+  });
+
+  async function runHeal(localCgId: string, onChainId: string): Promise<void> {
+    await SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+      { store, log: { info: () => undefined, warn: () => undefined, error: () => undefined } } as never,
+      localCgId,
+      { subscribed: true, synced: true, onChainId } as never,
+    );
+  }
+
+  it('relocates a stranded legacy KC into scoped graphs byte-exactly over HTTP (ROOT EQUALITY)', async () => {
+    const ctrl = await extractV10KCFromStore(store, BigInt(CTRL_ONCHAIN), KA_ID);
+    const expectedRoot = new V10MerkleTree(ctrl.leaves).root;
+
+    // Before the heal the prover cannot find the stranded KC (scoped is empty).
+    await expect(extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID)).rejects.toBeTruthy();
+
+    await runHeal(TEST_CG, TEST_ONCHAIN);
+
+    const healed = await extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID);
+    expect(new V10MerkleTree(healed.leaves).root).toEqual(expectedRoot);
+
+    // Genuineness: the server stored a single-byte newline + single backslash.
+    const scopedData = contextGraphDataUri(TEST_CG, TEST_ONCHAIN);
+    const lenRes = await store.query(
+      `SELECT (STRLEN(?o) AS ?len) WHERE { GRAPH <${scopedData}> { <${ROOT}> <urn:p:payload> ?o } }`,
+    );
+    const lenStr = lenRes.type === 'bindings' ? (lenRes.bindings[0]?.['len'] ?? '') : '';
+    expect(/^"?(\d+)/.exec(lenStr)?.[1]).toBe(String(ESCAPE_BEARING_VALUE.length)); // 13
+
+    // COPIES, never moves: the legacy label graph still resolves the KC.
+    const legacyStill = await store.query(
+      `ASK { GRAPH <${contextGraphMetaUri(TEST_CG)}> { <${TEST_UAL}> <${DKG}batchId> "${KA_ID}"^^<${XSD}integer> } }`,
+    );
+    expect(legacyStill.type === 'boolean' && legacyStill.value).toBe(true);
+  });
+
+  it('is a version-equal no-op on a second run over HTTP (root stays stable)', async () => {
+    await runHeal(TEST_CG, TEST_ONCHAIN);
+    const first = await extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID);
+    const firstRoot = new V10MerkleTree(first.leaves).root;
+
+    await runHeal(TEST_CG, TEST_ONCHAIN);
+    const second = await extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID);
+    expect(new V10MerkleTree(second.leaves).root).toEqual(firstRoot);
+
+    const ctrl = await extractV10KCFromStore(store, BigInt(CTRL_ONCHAIN), KA_ID);
+    expect(firstRoot).toEqual(new V10MerkleTree(ctrl.leaves).root);
+  });
+});

--- a/packages/agent/test/rs-heal-stranded-kc.test.ts
+++ b/packages/agent/test/rs-heal-stranded-kc.test.ts
@@ -1,0 +1,278 @@
+/**
+ * RS-heal content-binding GATE.
+ *
+ * The bug: a KC finalized BEFORE its on-chain cgId is locally resolvable lands
+ * in the LEGACY label graphs (`<cg>/_meta` + `<cg>` root data) instead of the
+ * SCOPED `<cg>/context/<onChainId>/_meta` + `.../context/<onChainId>` graphs the
+ * Random Sampling prover (`extractV10KCFromStore`) reads — so it reports
+ * `kc-not-synced` forever even though the node holds it.
+ *
+ * `healStrandedScopedKCs` RELOCATES (copies, never moves/deletes) such stranded
+ * KCs legacy→scoped. The ABSOLUTE rule: the copy must be a server-side
+ * `store.update(INSERT…WHERE)` so terms never leave the store. A
+ * `query()`/CONSTRUCT → `insert(quads)` round-trip doubles backslashes in
+ * escape-bearing literals and changes the leaf bytes the on-chain
+ * `challengeRoot` was committed over — making the proof permanently unprovable.
+ *
+ * THE LOAD-BEARING ASSERTION (Approach B): a CONTROL CG is seeded by a single
+ * direct `store.insert` of the SAME raw triples DIRECTLY into its SCOPED graphs.
+ * `expected = extract(control).leaves → V10MerkleTree.root`. After the heal,
+ * `actual = extract(test).leaves → V10MerkleTree.root`. Both flow through the
+ * identical `extractV10KCFromStore` recipe, so oxigraph's literal-normalization
+ * cancels and the test isolates COPY FIDELITY. Root equality is what proves
+ * byte-stability survived the relocation — NOT merely "the batchId edge exists".
+ *
+ * The seed includes an escape-bearing literal (raw backslash + raw newline); an
+ * ASCII-only seed false-passes this gate. We assert (via STRLEN) that the stored
+ * value really is a single-byte newline + single backslash, and a NEGATIVE
+ * CONTROL (escapes-stripped object) must produce a DIFFERENT V10 root — proving
+ * the root is byte-sensitive and the equality check isn't trivially always-true.
+ *
+ * NOTE on the RED-flip: on the embedded OxigraphStore the forbidden
+ * `query()`/CONSTRUCT → `insert(quads)` round-trip is LOSSLESS (its insert
+ * decodes N-Triples escapes symmetrically with `termToString`'s re-encode), so
+ * flipping the heal to that path does NOT corrupt and the gate stays green. The
+ * `store.update(INSERT…WHERE)` mandate is correctness-by-construction here and a
+ * hard requirement on NON-symmetric backends (e.g. sparql-http). The negative
+ * control below is the honest substitute that proves byte-sensitivity.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  V10MerkleTree,
+  contextGraphDataUri,
+  contextGraphMetaUri,
+} from '@origintrail-official/dkg-core';
+import { extractV10KCFromStore } from '@origintrail-official/dkg-random-sampling';
+import { writeMaterializedVersion } from '@origintrail-official/dkg-publisher';
+import { SwmHostModeMethods } from '../src/dkg-agent-swm-host.js';
+
+const DKG = 'http://dkg.io/ontology/';
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+const RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
+const CONTEXT_GRAPH_ON_CHAIN_ID = 'https://dkg.network/ontology#ContextGraphOnChainId';
+
+// CRITICAL: an escape-bearing literal — value carries BOTH a raw backslash and
+// a raw newline. This is the byte-pattern a lossy query→insert(quads)
+// round-trip corrupts (double-backslash). An ASCII-only seed would false-pass.
+const ESCAPE_BEARING_VALUE = 'line1\nline2\\x';
+const ROOT = 'urn:entity:strand-root';
+const GENID = `${ROOT}/.well-known/genid/blank-1`;
+const KA_ID = 42n;
+
+/** Public data triples of the stranded KC. One object carries the escape literal. */
+function publicTriples(): { subject: string; predicate: string; object: string }[] {
+  return [
+    { subject: ROOT, predicate: 'urn:p:name', object: '"strand"' },
+    // escape-bearing object — N-Triples-escaped on the wire (raw \n -> \\n, raw \ -> \\\\).
+    { subject: ROOT, predicate: 'urn:p:payload', object: `"${ESCAPE_BEARING_VALUE.replace(/\\/g, '\\\\').replace(/\n/g, '\\n')}"` },
+    { subject: ROOT, predicate: 'urn:p:has', object: GENID },
+    { subject: GENID, predicate: 'urn:p:value', object: '"42"' },
+  ];
+}
+
+/** Meta rows for a KC (UAL + token row carrying rootEntity), graph-parameterised. */
+function metaQuads(ual: string, metaGraph: string): Quad[] {
+  return [
+    { subject: ual, predicate: `${RDF}type`, object: `${DKG}KnowledgeCollection`, graph: metaGraph },
+    { subject: ual, predicate: `${DKG}batchId`, object: `"${KA_ID}"^^<${XSD}integer>`, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${RDF}type`, object: `${DKG}KnowledgeAsset`, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${DKG}partOf`, object: ual, graph: metaGraph },
+    { subject: `${ual}/1`, predicate: `${DKG}rootEntity`, object: ROOT, graph: metaGraph },
+  ];
+}
+
+async function seedOntology(store: OxigraphStore, localCgId: string, onChainId: string): Promise<void> {
+  await store.insert([
+    {
+      subject: `did:dkg:context-graph:${localCgId}`,
+      predicate: CONTEXT_GRAPH_ON_CHAIN_ID,
+      object: `"${onChainId}"`,
+      graph: ONTOLOGY_GRAPH,
+    },
+  ]);
+}
+
+/** Minimal `this` for the heal — only what the method body touches. */
+function makeAgentLike(store: OxigraphStore): unknown {
+  return {
+    store,
+    log: { info: () => undefined, warn: () => undefined, error: () => undefined },
+  };
+}
+
+async function runHeal(store: OxigraphStore, localCgId: string, onChainId: string): Promise<void> {
+  await SwmHostModeMethods.prototype.healStrandedScopedKCs.call(
+    makeAgentLike(store) as never,
+    localCgId,
+    { subscribed: true, synced: true, onChainId } as never,
+  );
+}
+
+async function scopedTripleCount(store: OxigraphStore, localCgId: string, onChainId: string): Promise<number> {
+  const dataG = contextGraphDataUri(localCgId, onChainId);
+  const metaG = contextGraphMetaUri(localCgId, onChainId);
+  const res = await store.query(
+    `SELECT (COUNT(*) AS ?c) WHERE {
+       { GRAPH <${dataG}> { ?s ?p ?o } } UNION { GRAPH <${metaG}> { ?s ?p ?o } }
+     }`,
+  );
+  if (res.type !== 'bindings') return 0;
+  const raw = res.bindings[0]?.['c'] ?? '0';
+  const m = /^"?(\d+)/.exec(raw);
+  return m ? Number(m[1]) : 0;
+}
+
+describe('healStrandedScopedKCs — content-binding gate', () => {
+  let store: OxigraphStore;
+
+  const TEST_CG = 'stranded-cg';
+  const TEST_ONCHAIN = '7';
+  const TEST_UAL = 'did:dkg:hardhat:31337/0xpub/42';
+
+  const CTRL_CG = 'control-cg';
+  const CTRL_ONCHAIN = '8';
+  const CTRL_UAL = 'did:dkg:hardhat:31337/0xctrl/42';
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+
+    // ── CONTROL CG: same raw triples inserted DIRECTLY into the SCOPED graphs
+    //    (single store.insert, never a copy — independence is load-bearing).
+    await seedOntology(store, CTRL_CG, CTRL_ONCHAIN);
+    const ctrlScopedMeta = contextGraphMetaUri(CTRL_CG, CTRL_ONCHAIN);
+    const ctrlScopedData = contextGraphDataUri(CTRL_CG, CTRL_ONCHAIN);
+    await store.insert([
+      ...metaQuads(CTRL_UAL, ctrlScopedMeta),
+      ...publicTriples().map((t) => ({ ...t, graph: ctrlScopedData })),
+    ]);
+
+    // ── TEST CG: stranded in the LEGACY label graphs; SCOPED graphs EMPTY.
+    await seedOntology(store, TEST_CG, TEST_ONCHAIN);
+    const legacyMeta = contextGraphMetaUri(TEST_CG);
+    const legacyData = contextGraphDataUri(TEST_CG);
+    await store.insert([
+      ...metaQuads(TEST_UAL, legacyMeta),
+      ...publicTriples().map((t) => ({ ...t, graph: legacyData })),
+    ]);
+    // A confirmed KC carries a materialized version stamp in legacy meta — the
+    // heal requires it (null version => not safely stampable => skip).
+    await writeMaterializedVersion(store, legacyMeta, TEST_UAL, { blockNumber: 100, txIndex: 0 });
+  });
+
+  it('relocates a stranded legacy KC into scoped graphs with byte-stable leaves (ROOT EQUALITY)', async () => {
+    // Pre-record the challengeRoot from the SAME triples, before the legacy→scoped
+    // copy — via the control CG, which holds them directly in its scoped graphs.
+    const ctrl = await extractV10KCFromStore(store, BigInt(CTRL_ONCHAIN), KA_ID);
+    const expectedRoot = new V10MerkleTree(ctrl.leaves).root;
+
+    // Before the heal the prover cannot find the stranded KC (scoped is empty).
+    await expect(extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID)).rejects.toBeTruthy();
+
+    await runHeal(store, TEST_CG, TEST_ONCHAIN);
+
+    // THE LOAD-BEARING ASSERTION: recomputed leaf-root over the now-populated
+    // scoped graphs EQUALS the pre-recorded challengeRoot. Root equality (not
+    // "the edge exists") is what proves byte-stability survived the copy.
+    const healed = await extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID);
+    const actualRoot = new V10MerkleTree(healed.leaves).root;
+    expect(actualRoot).toEqual(expectedRoot);
+
+    // Sanity: the escape-bearing literal survived intact (no double-backslash).
+    const payload = healed.triples.find((t) => t.predicate === 'urn:p:payload');
+    expect(payload).toBeTruthy();
+    // The extracted object is the N-Triples-escaped form of the original value.
+    expect(payload!.object).toContain('\\n');
+    expect(payload!.object).not.toContain('\\\\n'); // a corrupt copy would over-escape
+
+    // Prove the seed is GENUINELY escape-bearing: the stored value in the SCOPED
+    // data graph is a single-byte newline + single backslash (STRLEN == raw
+    // length 13). A double-escaped corrupt copy would report a larger length.
+    const scopedData = contextGraphDataUri(TEST_CG, TEST_ONCHAIN);
+    const lenRes = await store.query(
+      `SELECT (STRLEN(?o) AS ?len) WHERE {
+         GRAPH <${scopedData}> { <${ROOT}> <urn:p:payload> ?o }
+       }`,
+    );
+    expect(lenRes.type).toBe('bindings');
+    const lenStr = lenRes.type === 'bindings' ? (lenRes.bindings[0]?.['len'] ?? '') : '';
+    expect(/^"?(\d+)/.exec(lenStr)?.[1]).toBe(String(ESCAPE_BEARING_VALUE.length)); // 13
+
+    // (i) the scoped /_meta now has the dkg:batchId edge.
+    const scopedMeta = contextGraphMetaUri(TEST_CG, TEST_ONCHAIN);
+    const batchEdge = await store.query(
+      `ASK { GRAPH <${scopedMeta}> { <${TEST_UAL}> <${DKG}batchId> "${KA_ID}"^^<${XSD}integer> } }`,
+    );
+    expect(batchEdge.type === 'boolean' && batchEdge.value).toBe(true);
+
+    // (ii) the heal COPIES, never moves/deletes — the label graph still resolves it.
+    const legacyMeta = contextGraphMetaUri(TEST_CG);
+    const legacyStill = await store.query(
+      `ASK { GRAPH <${legacyMeta}> { <${TEST_UAL}> <${DKG}batchId> "${KA_ID}"^^<${XSD}integer> } }`,
+    );
+    expect(legacyStill.type === 'boolean' && legacyStill.value).toBe(true);
+  });
+
+  it('is a version-equal no-op on a second run (no duplication / no throw)', async () => {
+    await runHeal(store, TEST_CG, TEST_ONCHAIN);
+    const countAfterFirst = await scopedTripleCount(store, TEST_CG, TEST_ONCHAIN);
+    expect(countAfterFirst).toBeGreaterThan(0);
+
+    // Second run: the ASK-guard short-circuits (scoped now has batchId), so the
+    // scoped triple count is UNCHANGED — no re-copy, no duplication, no throw.
+    await runHeal(store, TEST_CG, TEST_ONCHAIN);
+    const countAfterSecond = await scopedTripleCount(store, TEST_CG, TEST_ONCHAIN);
+    expect(countAfterSecond).toBe(countAfterFirst);
+
+    // And the prover still extracts a stable root.
+    const ctrl = await extractV10KCFromStore(store, BigInt(CTRL_ONCHAIN), KA_ID);
+    const healed = await extractV10KCFromStore(store, BigInt(TEST_ONCHAIN), KA_ID);
+    expect(new V10MerkleTree(healed.leaves).root).toEqual(new V10MerkleTree(ctrl.leaves).root);
+  });
+
+  it('writes NOTHING when the legacy root data is absent (crash-partial guard)', async () => {
+    // Re-seed a CG whose LEGACY META resolves a root but whose LEGACY ROOT DATA
+    // has NO triples under that root — a Factor-B sync gap, NOT a relocation.
+    const GAP_CG = 'gap-cg';
+    const GAP_ONCHAIN = '9';
+    const GAP_UAL = 'did:dkg:hardhat:31337/0xgap/42';
+    await seedOntology(store, GAP_CG, GAP_ONCHAIN);
+    const gapLegacyMeta = contextGraphMetaUri(GAP_CG);
+    await store.insert(metaQuads(GAP_UAL, gapLegacyMeta));
+    await writeMaterializedVersion(store, gapLegacyMeta, GAP_UAL, { blockNumber: 100, txIndex: 0 });
+    // NB: no legacy ROOT DATA seeded for ROOT.
+
+    await runHeal(store, GAP_CG, GAP_ONCHAIN);
+
+    // The crash-partial guard must trade NOTHING: scoped graphs stay empty so we
+    // never turn kc-not-synced into KCDataMissingError.
+    expect(await scopedTripleCount(store, GAP_CG, GAP_ONCHAIN)).toBe(0);
+  });
+
+  it('negative control: a byte-different escape literal yields a DIFFERENT root (root is byte-sensitive)', async () => {
+    // Seed a SECOND control whose only difference is the escape-bearing object:
+    // its escapes are STRIPPED (real newline removed). If the V10 root were NOT
+    // byte-sensitive, this would still equal the escape-bearing root and the
+    // load-bearing equality assertion would be vacuous. It must DIFFER.
+    const NEG_CG = 'neg-control-cg';
+    const NEG_ONCHAIN = '11';
+    const NEG_UAL = 'did:dkg:hardhat:31337/0xneg/42';
+    await seedOntology(store, NEG_CG, NEG_ONCHAIN);
+    const negScopedMeta = contextGraphMetaUri(NEG_CG, NEG_ONCHAIN);
+    const negScopedData = contextGraphDataUri(NEG_CG, NEG_ONCHAIN);
+    const negTriples = publicTriples().map((t) =>
+      t.predicate === 'urn:p:payload'
+        ? { ...t, object: '"line1line2x"' } // escapes stripped — byte-different
+        : t,
+    );
+    await store.insert([
+      ...metaQuads(NEG_UAL, negScopedMeta),
+      ...negTriples.map((t) => ({ ...t, graph: negScopedData })),
+    ]);
+
+    const ctrl = await extractV10KCFromStore(store, BigInt(CTRL_ONCHAIN), KA_ID);
+    const neg = await extractV10KCFromStore(store, BigInt(NEG_ONCHAIN), KA_ID);
+    expect(new V10MerkleTree(neg.leaves).root).not.toEqual(new V10MerkleTree(ctrl.leaves).root);
+  });
+});

--- a/packages/random-sampling/src/index.ts
+++ b/packages/random-sampling/src/index.ts
@@ -23,6 +23,7 @@ export const RANDOM_SAMPLING_PACKAGE_VERSION = '10.0.0-rc.19';
 export {
   extractV10KCFromStore,
   extractV10KCQuads,
+  POST_PUBLISH_PREDICATES_TO_SKIP,
   KCNotFoundError,
   KCRootEntitiesNotFoundError,
   KCDataMissingError,

--- a/packages/random-sampling/src/ka-extractor.ts
+++ b/packages/random-sampling/src/ka-extractor.ts
@@ -26,7 +26,7 @@ const CG_URI_PREFIX = 'did:dkg:context-graph:';
  * The publisher already refuses user-authored trustLevel triples via
  * `assertNoUserAuthoredTrustLevelQuads`, so excluding them here is safe.
  */
-const POST_PUBLISH_PREDICATES_TO_SKIP: ReadonlySet<string> = new Set([
+export const POST_PUBLISH_PREDICATES_TO_SKIP: ReadonlySet<string> = new Set([
   TRUST_LEVEL_PREDICATE,
   LEGACY_TRUST_LEVEL_PREDICATE,
 ]);

--- a/packages/storage/src/adapters/oxigraph-worker.ts
+++ b/packages/storage/src/adapters/oxigraph-worker.ts
@@ -255,6 +255,9 @@ export class OxigraphWorkerStore implements TripleStore {
   async insert(quads: Quad[]): Promise<void> { return this.call('insert', quads); }
   async delete(quads: Quad[]): Promise<void> { return this.call('delete', quads); }
   async deleteByPattern(pattern: Partial<Quad>): Promise<number> { return this.call('deleteByPattern', pattern); }
+  // Server-side SPARQL UPDATE forwarded to the worker's OxigraphStore (which
+  // implements `update`); same atomic single-message contract as `insert`.
+  async update(sparql: string): Promise<void> { return this.call('update', sparql); }
   async query(sparql: string, options?: TripleStoreQueryOptions): Promise<QueryResult> {
     return this.callWithTimeout<QueryResult>(this.operationTimeoutMs, options?.signal, 'query', sparql);
   }

--- a/packages/storage/src/adapters/oxigraph.ts
+++ b/packages/storage/src/adapters/oxigraph.ts
@@ -301,6 +301,16 @@ export class OxigraphStore implements TripleStore {
     return removed;
   }
 
+  /**
+   * Server-side SPARQL UPDATE — runs inside the embedded oxigraph engine, so
+   * graph-to-graph `INSERT…WHERE` copies keep terms byte-identical (no JS
+   * termToString→parseTerm round-trip). See {@link TripleStore.update}.
+   */
+  async update(sparql: string): Promise<void> {
+    this.store.update(sparql);
+    this.scheduleFlush();
+  }
+
   async countQuads(graphUri?: string): Promise<number> {
     if (graphUri) {
       return this.store.match(

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -305,6 +305,20 @@ export class SparqlHttpStore implements TripleStore {
     return Math.max(0, before - after);
   }
 
+  /**
+   * Server-side SPARQL UPDATE over the SPARQL 1.1 protocol — the endpoint
+   * (oxigraph-server) executes graph-to-graph `INSERT…WHERE` copies internally,
+   * so terms stay byte-identical (no JS round-trip). See {@link TripleStore.update}.
+   */
+  async update(sparql: string): Promise<void> {
+    const res = await this.postUpdate(sparql);
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`SPARQL HTTP update failed (${res.status}): ${text.slice(0, 300)}`);
+    }
+    this.invalidateListGraphsCache();
+  }
+
   async query(sparql: string, options?: SparqlHttpQueryOptions): Promise<QueryResult> {
     const startedAt = this.now();
     throwIfAborted(options?.signal);

--- a/packages/storage/src/graph-set-index-store.ts
+++ b/packages/storage/src/graph-set-index-store.ts
@@ -13,7 +13,7 @@ export type GraphSetMutationSource =
   | 'dropGraph'
   | 'query';
 
-type GraphSetRefreshSource = 'seed' | 'revalidate' | 'deleteByPattern' | 'query';
+type GraphSetRefreshSource = 'seed' | 'revalidate' | 'deleteByPattern' | 'query' | 'update';
 
 export type GraphSetMutationEvent =
   | {
@@ -123,6 +123,25 @@ export class GraphSetIndexStore implements TripleStore {
       }
     }
     return result;
+  }
+
+  async update(sparql: string): Promise<void> {
+    if (typeof this.inner.update !== 'function') {
+      throw new Error('GraphSetIndexStore: inner store does not support update()');
+    }
+    if (!this.enabled) {
+      await this.inner.update(sparql);
+      return;
+    }
+    await this.inner.update(sparql);
+    // A server-side SPARQL UPDATE (e.g. the RS heal's INSERT…WHERE) can create
+    // or drop named graphs that the index must learn about — without this a
+    // freshly-created scoped graph would be absent from listGraphs(). Same
+    // refresh-from-inner handling as an UPDATE routed through query() above.
+    this.bumpMutation();
+    if (this.graphs || this.refreshInFlight) {
+      await this.maintainIndex(() => this.refreshIndex('update'));
+    }
   }
 
   async hasGraph(graphUri: string): Promise<boolean> {

--- a/packages/storage/src/shared-memory-literal-blob-store.ts
+++ b/packages/storage/src/shared-memory-literal-blob-store.ts
@@ -78,6 +78,19 @@ export class SharedMemoryLiteralBlobStore implements TripleStore {
     return removed;
   }
 
+  async update(sparql: string): Promise<void> {
+    if (typeof this.inner.update !== 'function') {
+      throw new Error('SharedMemoryLiteralBlobStore: inner store does not support update()');
+    }
+    // Forward verbatim. A server-side INSERT…WHERE copies whatever terms are
+    // already stored — including any externalized blob-ref placeholders — so
+    // there is nothing to externalize (the blob is shared by content hash and
+    // a copied placeholder rehydrates identically through `query`). Re-running
+    // externalization here is impossible anyway: an arbitrary UPDATE string
+    // carries no quad objects to inspect.
+    return this.inner.update(sparql);
+  }
+
   async query(sparql: string, options?: QueryOptions): Promise<QueryResult> {
     const rewritten = this.rewriteLargeLiteralConstants(sparql);
     if (!rewritten) {

--- a/packages/storage/src/triple-store.ts
+++ b/packages/storage/src/triple-store.ts
@@ -73,6 +73,20 @@ export interface TripleStore {
 
   deleteBySubjectPrefix(graphUri: string, prefix: string): Promise<number>;
 
+  /**
+   * Run a SPARQL UPDATE (e.g. a server-side `INSERT { GRAPH dst {…} } WHERE
+   * { GRAPH src {…} }` graph-to-graph copy) entirely inside the backend, so
+   * terms NEVER get serialized to JS and re-parsed. This is required for any
+   * byte-stable copy: the `insert(quads)` path round-trips object terms through
+   * `termToString`→`parseTerm`, which doubles backslashes for literals bearing
+   * `\`/newline/quote/CR/tab and therefore changes the bytes a content-bound
+   * hash (e.g. RS proof leaves) is computed over. Optional: only the embedded
+   * `oxigraph` and the `oxigraph-server`/`sparql-http` adapters implement it;
+   * callers needing a byte-stable copy MUST guard on its presence and never
+   * fall back to `insert(quads)` for already-stored terms.
+   */
+  update?(sparql: string): Promise<void>;
+
   countQuads(graphUri?: string): Promise<number>;
 
   /**


### PR DESCRIPTION
## What

Fix the Random Sampling `kc-not-synced` bug: a KC finalized **before** its on-chain cgId is locally resolvable lands in the **legacy** label graphs (`<cg>/_meta` + `<cg>`), but the V10 prover (`extractV10KCFromStore`) reads only the **scoped** per-onChainId graphs (`<cg>/context/<id>/_meta` + `.../context/<id>`) — so the node reports `kc-not-synced` forever for a KC it actually holds. This was the symptom behind **0 RS proofs over the comprehensive soak**.

No contract change, no redeploy.

## How

- **STEP 0 — forward-prevention** (`finalization-handler.ts`): resolve cgId from **chain truth** first via `getKAContextGraphId(batchId)`, immune to the local ontology-binding lag that strands KCs. **Positive-only** cache so a finalization racing ahead of its KA→CG binding is never pinned to legacy forever.
- **Heal sweep** (`dkg-agent-swm-host.ts: healStrandedScopedKCs`): **relocate** (copy, never move/delete) stranded legacy KCs into the scoped graphs. The copy is a server-side **`store.update(INSERT…WHERE)`** so terms never leave the store — **byte-exact by construction** across both the wasm and sparql-http adapters. Guards: ASK-guard early-exit, per-KA materialization lock + version idempotency, **crash-partial Factor-B guard** (per-root presence ASK → write NOTHING if any root's legacy data is absent, never trading `kc-not-synced` for `KCDataMissingError`), trust-stamp skip matching the extractor, `isSafeIri`/`assertSafeIri` vs SPARQL injection. Wired into the periodic reconcile sweep (safety net) + both `KARegistered` nudge paths (immediate heal).
- **Storage**: add optional `TripleStore.update(sparql)` + implement on the oxigraph (wasm) and sparql-http (oxigraph-server) adapters — enables the byte-safe copy.
- **STEP 3**: single-valued `OnChainId` binding guards at the two CG-discovery write sites.
- **Export** `POST_PUBLISH_PREDICATES_TO_SKIP` so the heal's projection stays bit-identical with the proven leaf set.

## Why it's byte-safe

Leaf = `hashTripleV10(s,p,o)` = `keccak256("<s> <p> <o> .")`, **graph excluded** — so a legacy→scoped relocation can only break a proof if it changes the s/p/o term strings. Server-side `INSERT…WHERE` keeps terms inside oxigraph (never serialized out/in), so it's byte-exact on **both** adapters. (Empirically the naive `CONSTRUCT→insert(quads)` round-trip is also faithful on the wasm adapter, but server-side is chosen for unconditional exactness — the sparql-http devnet path is otherwise untested by the unit suite.)

## Parity (strand-write ↔ heal-read) — verified

| | Production strand-write (`ctxGraphId` unresolved) | Heal reads |
|---|---|---|
| Meta | `<cg>/_meta` (`<ual> dkg:batchId` + `buildDeterministicTokenRows` partOf/rootEntity) | `contextGraphMetaUri(cg)` = `<cg>/_meta` |
| Data | `graphManager.dataGraphUri(cg)` ≡ `contextGraphDataUri(cg)` ≡ `<cg>` | `contextGraphDataUri(cg)` = `<cg>` |
| Version | `writeMaterializedVersion(<cg>/_meta, …)` | `readMaterializedVersion(<cg>/_meta, …)` |

The strand-write is the **same quads as the scoped-write modulo the graph URI**; scoped KCs prove fine in prod, so the relocated KC proves too.

## Tests

- `rs-heal-stranded-kc.test.ts` (4/4): load-bearing = post-heal scoped extraction root **equals** a control-CG root (both via `extractV10KCFromStore`→`V10MerkleTree`); STRLEN==13 escape-bearing **genuineness** check + **negative control** proving the root is byte-sensitive (the equality isn't vacuous); copy-not-move; version-equal no-op; crash-partial writes nothing.
- Regression: `ka-extractor` 26/26, finalization/cg 126/126. Full chain `tsc` clean.

## ⚠️ Held — NOT soak-validated

STEP 0 makes the race essentially **never** fire on a local hardhat devnet, so a normal "wait for a proof to land" soak is **vacuously green**. The real gate is a **forced-strand soak**: a proof landing for a UAL the heal **relocated** (correlated `RS heal: relocated stranded legacy KC <ual>` log + on-chain proof submission for that UAL) — which is also the only thing that exercises server-side byte-exactness on the **sparql-http** adapter. See `/tmp/rs-rootcause-diagnosis.md`.

## Out of scope — Factor B

The on-chain RS draw has **no hosting filter**: a node can be challenged on a CG it never synced. The heal only relocates KCs the node already holds. Factor B is a separate structural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
