### PR TITLE
test(devnet): fix pre-existing v10-core-flows reds (bootstrap + test bugs)

### DIFF
--- a/devnet/v10-core-flows/automated.test.ts
+++ b/devnet/v10-core-flows/automated.test.ts
@@ -382,7 +382,11 @@ describe('1. chained sign-at-creation assertion lifecycle', () => {
     let r = await postJson(NODE1_API, '/api/knowledge-assets', { contextGraphId: CONTEXT_GRAPH, name: assertionName }, state.node1Token);
     // KA create returns 201 (resource created) vs the legacy route's 200.
     expect(r.status, `create: ${JSON.stringify(r.body)}`).toBe(201);
-    expect(r.body.assertionUri).toContain(assertionName);
+    // The create response identifies the assertion by `name`; `assertionUri` is
+    // the canonical WM storage URI (`…/_working_memory/<author>/<number>`),
+    // which is author/number-keyed by design and does NOT embed the human name.
+    expect(r.body.name).toBe(assertionName);
+    expect(r.body.assertionUri, `assertionUri: ${r.body.assertionUri}`).toMatch(/\/_working_memory\//);
 
     const quads = [
       { subject: 'urn:test:lifecycle:s1', predicate: 'http://schema.org/name', object: '"Sign-at-creation lifecycle test"', graph: '' },
@@ -452,6 +456,7 @@ describe('2. failed publish does not leak triples into verifiable-memory (RC11 /
       `edge publish returned status='tentative' — pre-PR2 silent downgrade ` +
       `(would re-enable verifiable-memory leak via tentative graph aliasing)`,
     ).not.toBe('tentative');
+    const edgePublishStatus = r.body?.status;
 
     // CORE ASSERTION (RC11 / PR2): regardless of on-chain outcome, the
     // edge publish's triples MUST NOT appear in the
@@ -494,15 +499,24 @@ describe('2. failed publish does not leak triples into verifiable-memory (RC11 /
       if (attempt < VM_POLL_ATTEMPTS - 1) await sleep(VM_POLL_INTERVAL_MS);
     }
     expect(lastVmStatus, `vm query: ${JSON.stringify(lastVmBody)}`).toBe(200);
-    expect(
-      leakSeen,
-      `PR2 invariant violated: edge publish leaked ${lastVmBindings.length} row(s) into ` +
-      `view=verifiable-memory for ${subject} after up to ` +
-      `${VM_POLL_ATTEMPTS * VM_POLL_INTERVAL_MS}ms of polling — the on-chain catch is still ` +
-      `writing tentative quads to a graph that the VM view aliases. ` +
-      `Re-check dkg-publisher.ts catch block and dkg-query-engine.ts ` +
-      `verifiable-memory branch.`,
-    ).toBe(false);
+    // RFC-38: an edge publish (identityId=0) MAY legitimately reach `confirmed`
+    // when peer cores supply storage ACKs — and a CONFIRMED publish's triples
+    // appearing in verifiable-memory is CORRECT, not a leak. The PR2 regression
+    // this guards is the silent `tentative` downgrade (asserted above) writing
+    // into a VM-aliased graph on a publish that did NOT confirm. So only enforce
+    // the zero-rows invariant when the publish did not confirm; otherwise the
+    // rows are the expected, on-chain-attributed result.
+    if (edgePublishStatus !== 'confirmed') {
+      expect(
+        leakSeen,
+        `PR2 invariant violated: a NON-confirmed edge publish (status=${edgePublishStatus}) leaked ` +
+        `${lastVmBindings.length} row(s) into view=verifiable-memory for ${subject} after up to ` +
+        `${VM_POLL_ATTEMPTS * VM_POLL_INTERVAL_MS}ms of polling — the on-chain catch is still ` +
+        `writing tentative quads to a graph that the VM view aliases. ` +
+        `Re-check dkg-publisher.ts catch block and dkg-query-engine.ts ` +
+        `verifiable-memory branch.`,
+      ).toBe(false);
+    }
   }, 90_000);
 });
 
@@ -527,11 +541,18 @@ describe('3. NFT staking withdraw', () => {
         ?? state.delegators.find((d) => BigInt(d.identityId) === 1n);
       expect(seed, 'no tier-0 delegator seed for createConviction').toBeDefined();
       const seedWallet = new ethers.Wallet(seed!.privateKey, state.provider);
-      const seedNft = new ethers.Contract(state.nft.target, NFT_ABI, seedWallet);
+      // Drive the seed wallet's sequential txs through a NonceManager: this
+      // wallet was already used by the devnet bootstrap, and under automining a
+      // same-wallet approve→createConviction pair races the provider nonce query
+      // (each re-reads getTransactionCount and can see a stale value → "Nonce
+      // too low"). NonceManager assigns nonces locally + monotonically, so the
+      // two txs are strictly ordered regardless of when the chain reflects them.
+      const seedSigner = new ethers.NonceManager(seedWallet);
+      const seedNft = new ethers.Contract(state.nft.target, NFT_ABI, seedSigner);
       const stakeAmount = ethers.parseEther('10000');
       const stakingV10Address = await state.staking.getAddress();
-      const tokenAsSeed = state.token.connect(seedWallet) as ethers.Contract;
-      await tokenAsSeed.approve(stakingV10Address, stakeAmount, { gasLimit: 500_000 });
+      const tokenAsSeed = state.token.connect(seedSigner) as ethers.Contract;
+      await (await tokenAsSeed.approve(stakingV10Address, stakeAmount, { gasLimit: 500_000 })).wait();
       const createTx = await seedNft.createConviction(
         BigInt(seed!.identityId),
         stakeAmount,

--- a/devnet/v10-core-flows/automated.test.ts
+++ b/devnet/v10-core-flows/automated.test.ts
@@ -14,17 +14,20 @@
  *      depend on. (Caught a real bug during devnet validation: standalone
  *      `/finalize` was missing the emit. See FINDINGS.md.)
  *
- *   2. Failed-publish honesty (RC11 / PR2) — runs create+write+finalize
- *      +promote+publish from an edge daemon (no on-chain identity) so the
- *      publisher's chain-submit branch necessarily fails. Asserts the
- *      INVERSE of the old "tentative VM" contract: the publish reports
- *      failure to the caller AND `/api/query?view=verifiable-memory` returns
- *      zero rows for the just-published triples. Pre-RC11 a failed publish
- *      silently wrote its quads into the root data graph and the VM view
- *      aliased that graph into VM, so an external app would observe
- *      "verified" data that the chain had never anchored. PR2 deletes
- *      `generateTentativeMetadata` from the on-chain catch and limits VM
- *      to `_verifiable_memory/*` graphs; this test pins both halves.
+ *   2. Publish/VM honesty (RC11 / PR2) — runs create+write+finalize
+ *      +promote+publish from an edge daemon (no on-chain identity). Post-RFC-38
+ *      that edge publish has TWO legitimate outcomes: it may CONFIRM when peer
+ *      cores supply storage ACKs (attributionId=0 is valid on chain), or it may
+ *      NOT confirm. The honesty rule this test pins: a publish's triples appear
+ *      in `/api/query?view=verifiable-memory` IFF it confirmed on-chain — a
+ *      confirmed publish carries a positive kaId (asserted) and may legitimately
+ *      show in VM, while a non-confirmed publish MUST NOT leak any rows into VM,
+ *      and the caller must never see the silent `tentative` downgrade. Pre-RC11 a
+ *      non-confirmed publish silently wrote its quads into the root data graph
+ *      and the VM view aliased that graph into VM, so an external app would
+ *      observe "verified" data that the chain had never anchored. PR2 deletes
+ *      `generateTentativeMetadata` from the on-chain catch and limits VM to
+ *      `_verifiable_memory/*` graphs; this test pins all three halves.
  *
  *   3. NFT staking withdraw — `DKGStakingConvictionNFT.withdraw(tokenId)`
  *      on an unlocked tier-0 position. Verifies: TRAC delta to staker EOA
@@ -419,9 +422,9 @@ describe('1. chained sign-at-creation assertion lifecycle', () => {
   }, 60_000);
 });
 
-// ─────────────────── 2. Failed-publish honesty (RC11 / PR2) ───────────────────
-describe('2. failed publish does not leak triples into verifiable-memory (RC11 / PR2)', () => {
-  it('edge-node publish fails AND /api/query?view=verifiable-memory returns zero rows for its triples', async () => {
+// ──────────────── 2. Publish/VM honesty (RC11 / PR2) ────────────────
+describe('2. edge publish appears in verifiable-memory iff it confirmed on-chain (RC11 / PR2)', () => {
+  it('a non-confirmed edge publish leaks zero VM rows; a confirmed one carries a positive on-chain kaId', async () => {
     const assertionName = `core-flows-edge-${Date.now().toString(36)}`;
     const subject = `urn:test:edge:rc11:${Date.now().toString(36)}`;
     const witnessLiteral = `"PR2 failed-publish witness ${Date.now().toString(36)}"`;
@@ -457,16 +460,16 @@ describe('2. failed publish does not leak triples into verifiable-memory (RC11 /
       `(would re-enable verifiable-memory leak via tentative graph aliasing)`,
     ).not.toBe('tentative');
     const edgePublishStatus = r.body?.status;
+    const edgePublishKaId = r.body?.kaId;
 
-    // CORE ASSERTION (RC11 / PR2): regardless of on-chain outcome, the
-    // edge publish's triples MUST NOT appear in the
-    // verifiable-memory view on ANY node. Poll node1 (a core) over a few
-    // seconds so any in-flight gossip from the edge has time to land
-    // in the wrong graph — a leak that materialises 1-2s after the
-    // publish call returns would be missed by a single immediate
-    // query. The retry exits early on success (zero rows seen at any
-    // poll); the loop only runs to completion when the query keeps
-    // succeeding with zero rows, which is what we want.
+    // CORE ASSERTION (RC11 / PR2): a NON-confirmed edge publish's triples MUST
+    // NOT appear in the verifiable-memory view on ANY node (the confirmed case
+    // is asserted separately below — those rows are the correct on-chain result).
+    // Poll node1 (a core) over a few seconds so any in-flight gossip from the
+    // edge has time to land in the wrong graph — a leak that materialises 1-2s
+    // after the publish call returns would be missed by a single immediate
+    // query. The retry exits early once rows are seen (a leak in the
+    // non-confirmed case; the expected result in the confirmed case).
     const VM_POLL_ATTEMPTS = 6;
     const VM_POLL_INTERVAL_MS = 500;
     let lastVmStatus = 0;
@@ -516,6 +519,18 @@ describe('2. failed publish does not leak triples into verifiable-memory (RC11 /
         `Re-check dkg-publisher.ts catch block and dkg-query-engine.ts ` +
         `verifiable-memory branch.`,
       ).toBe(false);
+    } else {
+      // CONFIRMED branch: rather than leave this case a no-op (which would only
+      // prove the response was not `tentative` + the query returned 200), assert
+      // POSITIVE on-chain evidence — a real confirmation carries a positive kaId
+      // anchoring it on chain. This is synchronous (read from the publish
+      // response), so it adds no devnet-timing flakiness. A "confirmed" status
+      // with a zero/absent kaId (a fake confirm) fails here.
+      expect(
+        BigInt(edgePublishKaId ?? '0'),
+        `edge publish reported status='confirmed' but kaId='${edgePublishKaId}' is not a positive ` +
+        `on-chain id: ${JSON.stringify(r.body)}`,
+      ).toBeGreaterThan(0n);
     }
   }, 90_000);
 });


### PR DESCRIPTION
Fixes three pre-existing failures in `devnet/v10-core-flows/automated.test.ts`. All predate #1259 (identical at baseline `1bea16c67`) and are **test-harness issues, not product regressions**:

- **test 1** — assert the assertion name via `r.body.name`, not `assertionUri.toContain(name)`. The create response returns the human name in `name`; `assertionUri` is the canonical author/number-keyed WM storage URI (`…/_working_memory/<author>/<number>`) by design and never embedded the name.
- **test 2 (PR2 VM-leak guard)** — only enforce the zero-VM-rows invariant when the edge publish did **not** confirm. RFC-38 permits an edge publish (identityId=0) to reach `confirmed` via peer ACKs, in which case its triples appearing in verifiable-memory is correct — the regression guarded is the silent `tentative` downgrade (still asserted). Removes the run-to-run flakiness.
- **test 3 mint branch** — drive the seed wallet's `approve`→`createConviction` through `ethers.NonceManager`; under automining the back-to-back sends raced the provider nonce (`Nonce too low`) when the bootstrap had already used that wallet.

Verified 6/6 green and stable across repeated runs on a fresh fleet.

**Run prerequisite (worth documenting):** this suite requires `node devnet/_bootstrap/bootstrap.cjs` after `devnet.sh start` (funds delegators, seeds positions + publishes, regenerates `delegators.json`) — surfaced by `loadDelegators()`'s own error message.

---
Found during a comprehensive fresh-fleet devnet pass on merged main. Other findings (separate, pre-existing, NOT in this PR): an RS publisher-path strand that #1259 doesn't heal (publisher's own KC lands legacy without a `materializedVersion` stamp → both chain-reconcile and the heal skip it; confirmed live, manual relocate→proof lands), core-peers degraded-fleet quorum, v10-stress mode-B attribution, edge-update verdaccio infra, and a `devnet.sh` node-stop orphaning oxigraph (data LOCK → cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)