### PR TITLE
test(publisher,query): regression guards for #373 (adapter signing) and #1185 (view+subGraphName read)

### DIFF
--- a/packages/publisher/test/issue-373-adapter-backed-signer.test.ts
+++ b/packages/publisher/test/issue-373-adapter-backed-signer.test.ts
@@ -24,11 +24,13 @@ const TEST_KEY = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78
 // carries NO local publisher private key on the publisher itself.
 class AdapterOnlySigningChain {
   readonly chainId = 'mock:31337';
+  lastSignAddress?: string; // capture the address the publisher forwards
   constructor(private readonly wallet: ethers.Wallet) {}
   isV10Ready(): boolean {
     return true;
   }
-  async signMessageAs(_address: string, messageHash: Uint8Array): Promise<{ r: Uint8Array; vs: Uint8Array }> {
+  async signMessageAs(address: string, messageHash: Uint8Array): Promise<{ r: Uint8Array; vs: Uint8Array }> {
+    this.lastSignAddress = address;
     const sig = ethers.Signature.from(await this.wallet.signMessage(messageHash));
     return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
   }
@@ -37,9 +39,10 @@ class AdapterOnlySigningChain {
 describe('GH #373 — adapter-backed publisher signing', () => {
   it('getPublisherSigner falls back to a chainAdapter-sourced signer when no local key is set', async () => {
     const wallet = new ethers.Wallet(TEST_KEY);
+    const chain = new AdapterOnlySigningChain(wallet);
     const publisher = new DKGPublisher({
       store: new OxigraphStore(),
-      chain: new AdapterOnlySigningChain(wallet) as unknown as ChainAdapter,
+      chain: chain as unknown as ChainAdapter,
       eventBus: new TypedEventBus(),
       keypair: await generateEd25519Keypair(),
       publisherNodeIdentityId: 1n,
@@ -58,5 +61,10 @@ describe('GH #373 — adapter-backed publisher signing', () => {
     const msg = ethers.toUtf8Bytes('gh-373-adapter-signing');
     const sig = await signer!.signMessage(msg);
     expect(ethers.verifyMessage(msg, sig).toLowerCase()).toBe(wallet.address.toLowerCase());
+
+    // getPublisherSigner must forward the SELECTED publisher address to the adapter
+    // (a regression passing `undefined` / `this.publisherAddress` / a pool address
+    // could still produce a valid sig here but fail against the real address-keyed adapter).
+    expect(chain.lastSignAddress?.toLowerCase()).toBe(wallet.address.toLowerCase());
   });
 });

--- a/packages/publisher/test/issue-373-adapter-backed-signer.test.ts
+++ b/packages/publisher/test/issue-373-adapter-backed-signer.test.ts
@@ -1,0 +1,62 @@
+/**
+ * GH #373 — DKGPublisher must support adapter-backed signing.
+ *
+ * When no local publisher private key is configured but the ChainAdapter
+ * exposes `signMessageAs`, `getPublisherSigner` must fall back to a
+ * 'chainAdapter'-sourced signer (rather than returning undefined / forcing a
+ * local key). Fix: `packages/publisher/src/dkg-publisher.ts` `getPublisherSigner`
+ * — reverting that fallback branch makes this test go red.
+ *
+ * This drives the fallback directly (the publish-path tests in
+ * publisher-no-random-wallet.test.ts use a precomputed seal + mock ACK, so they
+ * do not exercise this branch).
+ */
+import { describe, it, expect } from 'vitest';
+import { DKGPublisher } from '../src/dkg-publisher.js';
+import { OxigraphStore } from '@origintrail-official/dkg-storage';
+import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
+import type { ChainAdapter } from '@origintrail-official/dkg-chain';
+import { ethers } from 'ethers';
+
+const TEST_KEY = '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d';
+
+// Minimal adapter that signs via `signMessageAs` (the adapter-backed path) and
+// carries NO local publisher private key on the publisher itself.
+class AdapterOnlySigningChain {
+  readonly chainId = 'mock:31337';
+  constructor(private readonly wallet: ethers.Wallet) {}
+  isV10Ready(): boolean {
+    return true;
+  }
+  async signMessageAs(_address: string, messageHash: Uint8Array): Promise<{ r: Uint8Array; vs: Uint8Array }> {
+    const sig = ethers.Signature.from(await this.wallet.signMessage(messageHash));
+    return { r: ethers.getBytes(sig.r), vs: ethers.getBytes(sig.yParityAndS) };
+  }
+}
+
+describe('GH #373 — adapter-backed publisher signing', () => {
+  it('getPublisherSigner falls back to a chainAdapter-sourced signer when no local key is set', async () => {
+    const wallet = new ethers.Wallet(TEST_KEY);
+    const publisher = new DKGPublisher({
+      store: new OxigraphStore(),
+      chain: new AdapterOnlySigningChain(wallet) as unknown as ChainAdapter,
+      eventBus: new TypedEventBus(),
+      keypair: await generateEd25519Keypair(),
+      publisherNodeIdentityId: 1n,
+    });
+
+    // `getPublisherSigner` is private — exercise the fallback directly.
+    const signer = await (publisher as unknown as {
+      getPublisherSigner(a: string): Promise<{ source: string; signMessage(m: Uint8Array): Promise<string> } | undefined>;
+    }).getPublisherSigner(wallet.address);
+
+    // Pre-fix: this branch was absent and the call returned `undefined`.
+    expect(signer).toBeDefined();
+    expect(signer!.source).toBe('chainAdapter');
+
+    // The returned signer signs through the adapter and recovers to the address.
+    const msg = ethers.toUtf8Bytes('gh-373-adapter-signing');
+    const sig = await signer!.signMessage(msg);
+    expect(ethers.verifyMessage(msg, sig).toLowerCase()).toBe(wallet.address.toLowerCase());
+  });
+});

--- a/packages/query/test/issue-1185-view-subgraph-read.test.ts
+++ b/packages/query/test/issue-1185-view-subgraph-read.test.ts
@@ -1,0 +1,57 @@
+/**
+ * GH #1185 — sub-graph data must be readable when `view` is combined with
+ * `subGraphName`.
+ *
+ * Pre-fix, a `view=shared-working-memory` + `subGraphName` read returned 0 rows
+ * (or was rejected with "subGraphName cannot be combined with view-based
+ * routing"). The fix (`packages/query/src/dkg-query-engine.ts` —
+ * `resolveViewGraphs` / the view-routing path) threads `subGraphName` into the
+ * view-scoped SWM graph so the read targets `<cg>/<sub>/_shared_memory`
+ * (landed under #184 / #675; covers #1185's exact symptom).
+ *
+ * Reverting the subGraphName threading routes the read back to the ROOT
+ * `<cg>/_shared_memory` and this test goes red.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { contextGraphSharedMemoryUri, type GetView } from '@origintrail-official/dkg-core';
+import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+
+const CG_ID = 'dkg-v10-dev';
+const SUB = 'code';
+const ROOT_SWM = contextGraphSharedMemoryUri(CG_ID); // did:dkg:context-graph:<cg>/_shared_memory
+const SUB_SWM = contextGraphSharedMemoryUri(CG_ID, SUB); // did:dkg:context-graph:<cg>/code/_shared_memory
+
+function q(s: string, p: string, o: string, g: string): Quad {
+  return { subject: s, predicate: p, object: o, graph: g };
+}
+
+describe('GH #1185 — shared-working-memory view + subGraphName read', () => {
+  let store: OxigraphStore;
+  let engine: DKGQueryEngine;
+
+  beforeEach(async () => {
+    store = new OxigraphStore();
+    engine = new DKGQueryEngine(store);
+    // Distinct rows in the ROOT SWM and the sub-graph SWM so we can prove the
+    // read targets the sub-graph graph, not the root bucket.
+    await store.insert([
+      q('urn:swm:root', 'http://ex.org/name', '"RootShare"', ROOT_SWM),
+      q('urn:swm:code', 'http://ex.org/name', '"CodeShare"', SUB_SWM),
+    ]);
+  });
+
+  it('reads the sub-graph SWM (not the root SWM) when view=shared-working-memory + subGraphName are combined', async () => {
+    const result = await engine.query(
+      'SELECT ?s ?name WHERE { ?s <http://ex.org/name> ?name }',
+      { contextGraphId: CG_ID, view: 'shared-working-memory' as GetView, subGraphName: SUB },
+    );
+
+    // Pre-fix: 0 rows / rejected / the root bucket. Fix routes to <cg>/code/_shared_memory.
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0]['name']).toBe('"CodeShare"');
+    const subjects = result.bindings.map((b) => b['s']);
+    expect(subjects).toContain('urn:swm:code');
+    expect(subjects).not.toContain('urn:swm:root'); // isolation from the root SWM bucket
+  });
+});

--- a/packages/query/test/issue-1185-view-subgraph-read.test.ts
+++ b/packages/query/test/issue-1185-view-subgraph-read.test.ts
@@ -19,8 +19,13 @@ import { DKGQueryEngine } from '../src/dkg-query-engine.js';
 
 const CG_ID = 'dkg-v10-dev';
 const SUB = 'code';
+const ADDR = '0x000000000000000000000000000000000000abcd';
 const ROOT_SWM = contextGraphSharedMemoryUri(CG_ID); // did:dkg:context-graph:<cg>/_shared_memory
 const SUB_SWM = contextGraphSharedMemoryUri(CG_ID, SUB); // did:dkg:context-graph:<cg>/code/_shared_memory
+// Per-KA SWM graphs live under the …/_shared_memory/{addr}/{number} prefix; the SWM view
+// discovers them via the (subGraphName-prefixed) `graphPrefixes`, separately from the bare bucket.
+const ROOT_SWM_PERKA = `${ROOT_SWM}/${ADDR}/1`;
+const SUB_SWM_PERKA = `${SUB_SWM}/${ADDR}/1`;
 
 function q(s: string, p: string, o: string, g: string): Quad {
   return { subject: s, predicate: p, object: o, graph: g };
@@ -33,25 +38,29 @@ describe('GH #1185 — shared-working-memory view + subGraphName read', () => {
   beforeEach(async () => {
     store = new OxigraphStore();
     engine = new DKGQueryEngine(store);
-    // Distinct rows in the ROOT SWM and the sub-graph SWM so we can prove the
-    // read targets the sub-graph graph, not the root bucket.
+    // Distinct rows in the ROOT vs sub-graph SWM, in BOTH the bare bucket (resolveViewGraphs
+    // `graphs`) and a per-KA graph (resolveViewGraphs `graphPrefixes` discovery), so the test
+    // guards subGraphName threading into *both* — a regression dropping it from either is caught.
     await store.insert([
       q('urn:swm:root', 'http://ex.org/name', '"RootShare"', ROOT_SWM),
       q('urn:swm:code', 'http://ex.org/name', '"CodeShare"', SUB_SWM),
+      q('urn:swm:rootperka', 'http://ex.org/name', '"RootPerKa"', ROOT_SWM_PERKA),
+      q('urn:swm:codeperka', 'http://ex.org/name', '"CodePerKa"', SUB_SWM_PERKA),
     ]);
   });
 
-  it('reads the sub-graph SWM (not the root SWM) when view=shared-working-memory + subGraphName are combined', async () => {
+  it('reads the sub-graph SWM (bare + per-KA) and excludes the root SWM when view + subGraphName are combined', async () => {
     const result = await engine.query(
       'SELECT ?s ?name WHERE { ?s <http://ex.org/name> ?name }',
       { contextGraphId: CG_ID, view: 'shared-working-memory' as GetView, subGraphName: SUB },
     );
 
-    // Pre-fix: 0 rows / rejected / the root bucket. Fix routes to <cg>/code/_shared_memory.
-    expect(result.bindings).toHaveLength(1);
-    expect(result.bindings[0]['name']).toBe('"CodeShare"');
     const subjects = result.bindings.map((b) => b['s']);
-    expect(subjects).toContain('urn:swm:code');
-    expect(subjects).not.toContain('urn:swm:root'); // isolation from the root SWM bucket
+    // Pre-fix: 0 rows / rejected / the root bucket. Fix routes to <cg>/code/_shared_memory.
+    expect(subjects).toContain('urn:swm:code'); // bare sub-graph SWM (`graphs`)
+    expect(subjects).toContain('urn:swm:codeperka'); // per-KA sub-graph SWM (`graphPrefixes`)
+    // Isolation: neither root bucket nor root per-KA leaks into the sub-graph view.
+    expect(subjects).not.toContain('urn:swm:root');
+    expect(subjects).not.toContain('urn:swm:rootperka');
   });
 });


### PR DESCRIPTION
Adds the missing regression guards for two already-merged fixes (#373, #1185) so they can't silently regress — each is **proven red if the fix is reverted**.

### #373 — adapter-backed publisher signing
`DKGPublisher.getPublisherSigner` falls back to a `chainAdapter`-sourced signer when no local publisher key is configured (fix: commit `f210e125a`). The existing `publisher-no-random-wallet.test.ts` publish tests use a precomputed seal + mock ACK, so they **pass even with the fallback removed** — they don't guard it. New test drives the fallback directly; disabling the branch returns `undefined` → red.

### #1185 — `view` + `subGraphName` read
A `view=shared-working-memory` + `subGraphName` read must target `<cg>/<sub>/_shared_memory`, not the root bucket (fix: `d7a055dea`, landed under #184/#675; existing sub-graph tests use `subGraphName` *without* a `view`, so this exact combination was uncovered). New test inserts distinct root vs sub-graph SWM rows and asserts the read returns only the sub-graph row; dropping the `subGraphName` threading reads the root bucket → red.

Both verified red-on-revert locally. Run in CI: `tornado-publisher` (1209 passing) + Bura "Query tests" (281 passing). Test-only; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
