### PR TITLE
fix(profile-storage): guard single-fee underflow in active operator-fee getters

### DIFF
--- a/packages/evm-module/contracts/storage/ProfileStorage.sol
+++ b/packages/evm-module/contracts/storage/ProfileStorage.sol
@@ -13,7 +13,7 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     // (RFC 04 v0.3 / Issue #461). New mapping reads on existing keys return
     // false for the new field. Multiaddrs were briefly added on a prior
     // revision but are deliberately not stored on Profile (RFC 04 §5.2).
-    string private constant _VERSION = "10.0.2";
+    string private constant _VERSION = "10.0.3";
 
     event ProfileCreated(uint72 indexed identityId, string nodeName, bytes nodeId, uint16 initialOperatorFee);
     event ProfileDeleted(uint72 indexed identityId, bytes nodeId);
@@ -234,17 +234,20 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     }
 
     function getActiveOperatorFee(uint72 identityId) external view returns (ProfileLib.OperatorFee memory) {
-        if (profiles[identityId].operatorFees.length == 0) {
+        ProfileLib.OperatorFee[] storage fees = profiles[identityId].operatorFees;
+        uint256 length = fees.length;
+        if (length == 0) {
             return ProfileLib.OperatorFee({feePercentage: 0, effectiveDate: 0});
         }
 
-        if (
-            block.timestamp >
-            profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 1].effectiveDate
-        ) {
-            return profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 1];
+        // A single fee is always the active one. This guards the `length - 2`
+        // underflow below when exactly one (not-yet-effective) fee exists —
+        // e.g. right after profile creation, where the initial fee's
+        // effectiveDate == block.timestamp falls into the else branch.
+        if (length == 1 || block.timestamp > fees[length - 1].effectiveDate) {
+            return fees[length - 1];
         } else {
-            return profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 2];
+            return fees[length - 2];
         }
     }
 
@@ -268,17 +271,20 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     }
 
     function getActiveOperatorFeePercentage(uint72 identityId) public view returns (uint16) {
-        if (profiles[identityId].operatorFees.length == 0) {
+        ProfileLib.OperatorFee[] storage fees = profiles[identityId].operatorFees;
+        uint256 length = fees.length;
+        if (length == 0) {
             return 0;
         }
 
-        if (
-            block.timestamp >
-            profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 1].effectiveDate
-        ) {
-            return profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 1].feePercentage;
+        // A single fee is always the active one. This guards the `length - 2`
+        // underflow below when exactly one (not-yet-effective) fee exists —
+        // e.g. right after profile creation, where the initial fee's
+        // effectiveDate == block.timestamp falls into the else branch.
+        if (length == 1 || block.timestamp > fees[length - 1].effectiveDate) {
+            return fees[length - 1].feePercentage;
         } else {
-            return profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 2].feePercentage;
+            return fees[length - 2].feePercentage;
         }
     }
 

--- a/packages/evm-module/contracts/storage/ProfileStorage.sol
+++ b/packages/evm-module/contracts/storage/ProfileStorage.sol
@@ -13,7 +13,11 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     // (RFC 04 v0.3 / Issue #461). New mapping reads on existing keys return
     // false for the new field. Multiaddrs were briefly added on a prior
     // revision but are deliberately not stored on Profile (RFC 04 §5.2).
-    string private constant _VERSION = "10.0.3";
+    // 10.0.3 -> 10.0.4: active-fee getters (fee / percentage / effective-date)
+    // centralized in `_activeOperatorFee`, fixing the `operatorFees[length - 2]`
+    // underflow panic on the single-not-yet-effective-fee state (the effective-date
+    // getter still had it).
+    string private constant _VERSION = "10.0.4";
 
     event ProfileCreated(uint72 indexed identityId, string nodeName, bytes nodeId, uint16 initialOperatorFee);
     event ProfileDeleted(uint72 indexed identityId, bytes nodeId);
@@ -233,22 +237,27 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
         return _safeGetLatestOperatorFee(identityId);
     }
 
-    function getActiveOperatorFee(uint72 identityId) external view returns (ProfileLib.OperatorFee memory) {
+    /// @dev The currently-active operator fee. Centralizes the `length - 2`
+    ///      underflow guard so every active-fee getter (fee / percentage /
+    ///      effective-date) shares ONE implementation. A single fee is always
+    ///      active; with more than one, the latest applies once its effectiveDate
+    ///      has passed (strict `>`), otherwise the prior fee. The `length == 1`
+    ///      guard also covers the createProfile case where the initial fee's
+    ///      effectiveDate == block.timestamp would otherwise hit `length - 2`.
+    function _activeOperatorFee(uint72 identityId) internal view returns (ProfileLib.OperatorFee memory) {
         ProfileLib.OperatorFee[] storage fees = profiles[identityId].operatorFees;
         uint256 length = fees.length;
         if (length == 0) {
             return ProfileLib.OperatorFee({feePercentage: 0, effectiveDate: 0});
         }
-
-        // A single fee is always the active one. This guards the `length - 2`
-        // underflow below when exactly one (not-yet-effective) fee exists —
-        // e.g. right after profile creation, where the initial fee's
-        // effectiveDate == block.timestamp falls into the else branch.
         if (length == 1 || block.timestamp > fees[length - 1].effectiveDate) {
             return fees[length - 1];
-        } else {
-            return fees[length - 2];
         }
+        return fees[length - 2];
+    }
+
+    function getActiveOperatorFee(uint72 identityId) external view returns (ProfileLib.OperatorFee memory) {
+        return _activeOperatorFee(identityId);
     }
 
     function getOperatorFeePercentageByIndex(uint72 identityId, uint256 index) external view returns (uint16) {
@@ -271,21 +280,7 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     }
 
     function getActiveOperatorFeePercentage(uint72 identityId) public view returns (uint16) {
-        ProfileLib.OperatorFee[] storage fees = profiles[identityId].operatorFees;
-        uint256 length = fees.length;
-        if (length == 0) {
-            return 0;
-        }
-
-        // A single fee is always the active one. This guards the `length - 2`
-        // underflow below when exactly one (not-yet-effective) fee exists —
-        // e.g. right after profile creation, where the initial fee's
-        // effectiveDate == block.timestamp falls into the else branch.
-        if (length == 1 || block.timestamp > fees[length - 1].effectiveDate) {
-            return fees[length - 1].feePercentage;
-        } else {
-            return fees[length - 2].feePercentage;
-        }
+        return _activeOperatorFee(identityId).feePercentage;
     }
 
     function getOperatorFeeEffectiveDateByIndex(uint72 identityId, uint256 index) external view returns (uint256) {
@@ -311,18 +306,7 @@ contract ProfileStorage is INamed, IVersioned, HubDependent {
     }
 
     function getActiveOperatorFeeEffectiveDate(uint72 identityId) external view returns (uint256) {
-        if (profiles[identityId].operatorFees.length == 0) {
-            return 0;
-        }
-
-        if (
-            block.timestamp >
-            profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 1].effectiveDate
-        ) {
-            return profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 1].effectiveDate;
-        } else {
-            return profiles[identityId].operatorFees[profiles[identityId].operatorFees.length - 2].effectiveDate;
-        }
+        return _activeOperatorFee(identityId).effectiveDate;
     }
 
     function isOperatorFeeChangePending(uint72 identityId) external view returns (bool) {

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -1,5 +1,5 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
-import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { loadFixture, time } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
 import hre from 'hardhat';
 
@@ -804,6 +804,47 @@ describe('@unit Profile contract', function () {
       expect(ask).to.equal(0n);
       expect(opFees.length).to.equal(1);
       expect(relayCapable).to.equal(true);
+    });
+  });
+
+  // ProfileStorage 10.0.3 — getActiveOperatorFee / getActiveOperatorFeePercentage
+  // used to read operatorFees[length - 2] whenever the latest fee was not yet
+  // effective. With a single fee (length == 1) that is `operatorFees[-1]`, a uint
+  // underflow → out-of-bounds panic → DoS on the active-fee getters.
+  describe('getActiveOperatorFee* — single-fee length-2 underflow regression', () => {
+    it('returns the sole fee right after createProfile (initial fee effectiveDate == now)', async () => {
+      // createProfile seeds operatorFees[0] at effectiveDate == block.timestamp;
+      // reading the active fee in the same block hits `block.timestamp > effectiveDate == false`.
+      await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+
+      expect(await ProfileStorage.getActiveOperatorFeePercentage(identityId1)).to.equal(1000);
+      expect((await ProfileStorage.getActiveOperatorFee(identityId1)).feePercentage).to.equal(1000);
+    });
+
+    it('returns the sole fee when the single fee is not yet effective (the exact underflow trigger)', async () => {
+      await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+      const future = (await time.latest()) + 100_000;
+      // accounts[0] is registered as a Hub contract in the fixture, so it passes onlyContracts.
+      // Replace the single fee with a not-yet-effective one (length stays 1, effectiveDate in the future).
+      await ProfileStorage.connect(accounts[0]).setOperatorFees(identityId1, [
+        { feePercentage: 1500, effectiveDate: future },
+      ]);
+
+      // Pre-10.0.3 this reverted (operatorFees[length - 2] = operatorFees[-1]); now returns the sole fee.
+      expect(await ProfileStorage.getActiveOperatorFeePercentage(identityId1)).to.equal(1500);
+      expect((await ProfileStorage.getActiveOperatorFee(identityId1)).feePercentage).to.equal(1500);
+    });
+
+    it('still returns the older active fee when a second fee is pending (length >= 2 path intact)', async () => {
+      await Profile.createProfile(accounts[1].address, [], 'Node 1', nodeId1, 1000);
+      const future = (await time.latest()) + 100_000;
+      // operatorFees = [ (1000 @ now, active), (2000 @ future, pending) ].
+      await ProfileStorage.connect(accounts[0]).addOperatorFee(identityId1, 2000, future);
+
+      // The pending fee is not active yet → active fee stays operatorFees[length - 2] = 1000
+      // (proves the fix did not regress the genuine length >= 2 else-branch).
+      expect(await ProfileStorage.getActiveOperatorFeePercentage(identityId1)).to.equal(1000);
+      expect((await ProfileStorage.getActiveOperatorFee(identityId1)).feePercentage).to.equal(1000);
     });
   });
 });

--- a/packages/evm-module/test/unit/Profile.test.ts
+++ b/packages/evm-module/test/unit/Profile.test.ts
@@ -807,10 +807,12 @@ describe('@unit Profile contract', function () {
     });
   });
 
-  // ProfileStorage 10.0.3 — getActiveOperatorFee / getActiveOperatorFeePercentage
-  // used to read operatorFees[length - 2] whenever the latest fee was not yet
-  // effective. With a single fee (length == 1) that is `operatorFees[-1]`, a uint
-  // underflow → out-of-bounds panic → DoS on the active-fee getters.
+  // ProfileStorage 10.0.4 — getActiveOperatorFee / getActiveOperatorFeePercentage
+  // / getActiveOperatorFeeEffectiveDate used to read operatorFees[length - 2]
+  // whenever the latest fee was not yet effective. With a single fee (length == 1)
+  // that is `operatorFees[-1]`, a uint underflow → out-of-bounds panic → DoS on the
+  // active-fee getters. All three now route through one `_activeOperatorFee` helper,
+  // so every public active-fee getter is exercised in each case below.
   describe('getActiveOperatorFee* — single-fee length-2 underflow regression', () => {
     it('returns the sole fee right after createProfile (initial fee effectiveDate == now)', async () => {
       // createProfile seeds operatorFees[0] at effectiveDate == block.timestamp;
@@ -819,6 +821,10 @@ describe('@unit Profile contract', function () {
 
       expect(await ProfileStorage.getActiveOperatorFeePercentage(identityId1)).to.equal(1000);
       expect((await ProfileStorage.getActiveOperatorFee(identityId1)).feePercentage).to.equal(1000);
+      // getActiveOperatorFeeEffectiveDate shares the same helper — must not panic.
+      expect(await ProfileStorage.getActiveOperatorFeeEffectiveDate(identityId1)).to.equal(
+        (await ProfileStorage.getActiveOperatorFee(identityId1)).effectiveDate,
+      );
     });
 
     it('returns the sole fee when the single fee is not yet effective (the exact underflow trigger)', async () => {
@@ -830,9 +836,12 @@ describe('@unit Profile contract', function () {
         { feePercentage: 1500, effectiveDate: future },
       ]);
 
-      // Pre-10.0.3 this reverted (operatorFees[length - 2] = operatorFees[-1]); now returns the sole fee.
+      // Pre-fix this reverted (operatorFees[length - 2] = operatorFees[-1]); now returns the sole fee.
       expect(await ProfileStorage.getActiveOperatorFeePercentage(identityId1)).to.equal(1500);
       expect((await ProfileStorage.getActiveOperatorFee(identityId1)).feePercentage).to.equal(1500);
+      // The effective-date getter ALSO panicked on operatorFees[-1] pre-fix (the #1263 🔴);
+      // it now returns the sole not-yet-effective fee's date.
+      expect(await ProfileStorage.getActiveOperatorFeeEffectiveDate(identityId1)).to.equal(future);
     });
 
     it('still returns the older active fee when a second fee is pending (length >= 2 path intact)', async () => {
@@ -845,6 +854,10 @@ describe('@unit Profile contract', function () {
       // (proves the fix did not regress the genuine length >= 2 else-branch).
       expect(await ProfileStorage.getActiveOperatorFeePercentage(identityId1)).to.equal(1000);
       expect((await ProfileStorage.getActiveOperatorFee(identityId1)).feePercentage).to.equal(1000);
+      // Effective-date getter returns the ACTIVE (older) fee's date, not the pending one.
+      expect(await ProfileStorage.getActiveOperatorFeeEffectiveDate(identityId1)).to.equal(
+        (await ProfileStorage.getActiveOperatorFee(identityId1)).effectiveDate,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

`ProfileStorage.getActiveOperatorFee` and `getActiveOperatorFeePercentage` read `operatorFees[length - 2]` whenever the latest fee is not yet effective. When there is exactly one fee (`length == 1`), that is `operatorFees[1 - 2]` — a `uint` underflow → out-of-bounds **panic (0x11)** → DoS on the active operator-fee getters.

### Reachability
- **Right after `createProfile`** — it seeds `operatorFees[0]` at `effectiveDate == block.timestamp`, so `block.timestamp > effectiveDate` is `false` in the same block → `else` branch → `operatorFees[-1]`.
- Any time a single not-yet-effective fee exists.

### Fix
Guard the `else` branch with `length == 1` — a single fee is always the active one. The `length >= 2` pending-fee path is unchanged, and the `>` boundary is preserved, so there is **no reward-split semantics change** (live `StakingV10` reads operator fees via `getOperatorFeePercentageByTimestampReverse`, not these getters).

`ProfileStorage` version bumped `10.0.2 → 10.0.3`.

### Tests
3 regression tests added to `test/unit/Profile.test.ts`:
- sole fee right after `createProfile`,
- single not-yet-effective fee (the exact underflow trigger),
- `length >= 2` pending fee (no-regression on the genuine else-branch).

Verified the 2 trigger tests **fail on the pre-fix code with `panic 0x11`**; full `Profile @unit` suite: **53 passing**.

### Provenance
Surfaced by a multi-model security review (DeepSeek V4 Pro / Grok 4.20 / Gemini 3.1 Pro) and source-verified; two models independently flagged it. Severity: **Medium** (view-function DoS; no fund loss). Note: ProfileStorage is a plain-constructor storage contract, so this lands with a fresh/redeployed ProfileStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
