### PR TITLE
fix(rs): prune expired KAs from per-CG sampling list + pin ACK byteSize to content

### DIFF
--- a/packages/chain/abi/ContextGraphStorage.json
+++ b/packages/chain/abi/ContextGraphStorage.json
@@ -468,7 +468,7 @@
         "type": "uint256"
       }
     ],
-    "name": "KnowledgeAssetRegisteredToContextGraph",
+    "name": "KnowledgeAssetPrunedFromSamplingList",
     "type": "event"
   },
   {
@@ -487,7 +487,7 @@
         "type": "uint256"
       }
     ],
-    "name": "KnowledgeAssetUnlistedFromContextGraph",
+    "name": "KnowledgeAssetRegisteredToContextGraph",
     "type": "event"
   },
   {
@@ -1457,7 +1457,7 @@
         "type": "uint256"
       }
     ],
-    "name": "swapRemoveKnowledgeAssetAt",
+    "name": "swapRemoveSamplingKnowledgeAssetAt",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/chain/abi/ContextGraphStorage.json
+++ b/packages/chain/abi/ContextGraphStorage.json
@@ -1117,6 +1117,49 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getSamplingKaAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getSamplingKaCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "hub",
     "outputs": [

--- a/packages/chain/abi/ContextGraphStorage.json
+++ b/packages/chain/abi/ContextGraphStorage.json
@@ -254,6 +254,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "OnlyRandomSampling",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "TokenTransferFailed",
     "type": "error"
@@ -458,6 +469,25 @@
       }
     ],
     "name": "KnowledgeAssetRegisteredToContextGraph",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      }
+    ],
+    "name": "KnowledgeAssetUnlistedFromContextGraph",
     "type": "event"
   },
   {
@@ -1364,6 +1394,29 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedKaId",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapRemoveKnowledgeAssetAt",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/chain/abi/RandomSampling.json
+++ b/packages/chain/abi/RandomSampling.json
@@ -457,6 +457,35 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "cgId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxScan",
+        "type": "uint256"
+      }
+    ],
+    "name": "pruneExpiredKnowledgeAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "removed",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "randomSamplingStorage",
     "outputs": [

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -191,11 +191,15 @@ const PINNED_DIGESTS: Record<string, string> = {
   ContextGraphs:                '54583e20167c37f4356247cb6bc657b0dccf6f17f99a3267427674a35a151bcf',
   // Repinned: decoupled sampling list (10.0.6). Adds getSamplingKaCount/At
   // (the compacted per-CG list the within-CG draw + keeper use) alongside the
-  // RandomSampling-gated `swapRemoveKnowledgeAssetAt` pruning primitive (now
-  // targeting that sampling list) + its `KnowledgeAssetUnlistedFromContextGraph`
+  // RandomSampling-gated `swapRemoveSamplingKnowledgeAssetAt` pruning primitive
+  // (targets that sampling list) + its `KnowledgeAssetPrunedFromSamplingList`
   // event and `OnlyRandomSampling` error. `_contextGraphKAList` stays append-only
   // as the reconciler's registration ordinal; `kaToContextGraph` is left intact.
-  ContextGraphStorage:          '707942bc9d23f7e6159bae63d40a2c2b711335f4796a96fe375c000cae0dd527',
+  ContextGraphStorage:          '7d106670764438acd8d54875b77a279b3fb73484933e3bc76124730a008a0c96',
+  // RandomSampling — resolved by the chain adapter (challenge creation + runtime
+  // error decoding), so its ABI surface is pinned too. Carries the permissionless
+  // keeper `pruneExpiredKnowledgeAssets` added in #1268.
+  RandomSampling:               '22b0f5b837e03f061826026abbd09a747acdc2c269b32eb43d354ae06c719b43',
   // Identity / staking — consulted on every publish.
   Hub:                          '36976cc71bb87963b8b715791b32e4eb6b7bb85c712998afd6184221289a506b',
   Identity:                     'ca39efe9bd9ec4fd8ae67dccdf9eb888bf91232341c3a56216624477620ff4d8',

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -189,7 +189,11 @@ const PINNED_DIGESTS: Record<string, string> = {
   // rename (getContextGraphKCCount/At/List → getContextGraphKaCount/At/List).
   // Digests recomputed post-merge from the combined ABI.
   ContextGraphs:                '54583e20167c37f4356247cb6bc657b0dccf6f17f99a3267427674a35a151bcf',
-  ContextGraphStorage:          '29f1746bf6d82dfea40eb0365c9a664994c56b63c4a98d99962cd9b61c1df37a',
+  // Repinned: added the RandomSampling-gated `swapRemoveKnowledgeAssetAt`
+  // pruning primitive + its `KnowledgeAssetUnlistedFromContextGraph` event and
+  // `OnlyRandomSampling` error (lets the keeper drop expired KAs from the
+  // per-CG sampling list; `kaToContextGraph` is left intact). Contract → 10.0.5.
+  ContextGraphStorage:          'b5630c6bb97e533d8b725084c2d48e50f25ae955f36f476589e76bb5c96a1470',
   // Identity / staking — consulted on every publish.
   Hub:                          '36976cc71bb87963b8b715791b32e4eb6b7bb85c712998afd6184221289a506b',
   Identity:                     'ca39efe9bd9ec4fd8ae67dccdf9eb888bf91232341c3a56216624477620ff4d8',

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -189,11 +189,13 @@ const PINNED_DIGESTS: Record<string, string> = {
   // rename (getContextGraphKCCount/At/List → getContextGraphKaCount/At/List).
   // Digests recomputed post-merge from the combined ABI.
   ContextGraphs:                '54583e20167c37f4356247cb6bc657b0dccf6f17f99a3267427674a35a151bcf',
-  // Repinned: added the RandomSampling-gated `swapRemoveKnowledgeAssetAt`
-  // pruning primitive + its `KnowledgeAssetUnlistedFromContextGraph` event and
-  // `OnlyRandomSampling` error (lets the keeper drop expired KAs from the
-  // per-CG sampling list; `kaToContextGraph` is left intact). Contract → 10.0.5.
-  ContextGraphStorage:          'b5630c6bb97e533d8b725084c2d48e50f25ae955f36f476589e76bb5c96a1470',
+  // Repinned: decoupled sampling list (10.0.6). Adds getSamplingKaCount/At
+  // (the compacted per-CG list the within-CG draw + keeper use) alongside the
+  // RandomSampling-gated `swapRemoveKnowledgeAssetAt` pruning primitive (now
+  // targeting that sampling list) + its `KnowledgeAssetUnlistedFromContextGraph`
+  // event and `OnlyRandomSampling` error. `_contextGraphKAList` stays append-only
+  // as the reconciler's registration ordinal; `kaToContextGraph` is left intact.
+  ContextGraphStorage:          '707942bc9d23f7e6159bae63d40a2c2b711335f4796a96fe375c000cae0dd527',
   // Identity / staking — consulted on every publish.
   Hub:                          '36976cc71bb87963b8b715791b32e4eb6b7bb85c712998afd6184221289a506b',
   Identity:                     'ca39efe9bd9ec4fd8ae67dccdf9eb888bf91232341c3a56216624477620ff4d8',

--- a/packages/core/src/proto/storage-ack.ts
+++ b/packages/core/src/proto/storage-ack.ts
@@ -97,6 +97,17 @@ export const STORAGE_ACK_DECLINE_CODES = {
    * with a corrected commitment.
    */
   CATALOG_ROOT_MISMATCH: 'CATALOG_ROOT_MISMATCH',
+  /**
+   * The publisher claimed a `publicByteSize` below the lower bound the core
+   * derives from the actual public quads it would attest to. `byteSize` is
+   * signed into the ACK digest and prices the publish on-chain
+   * (`ask · byteSize · epochs`); the contract can't see the content, so a core
+   * MUST refuse to sign an under-stated footprint — otherwise the on-chain cost
+   * can be driven toward zero (e.g. `byteSize = 1` for real content) regardless
+   * of the ask. Permanent (a content/economic-shape lie); the publisher MUST
+   * republish with a `byteSize` that reflects the real content.
+   */
+  BYTESIZE_UNDERCLAIM: 'BYTESIZE_UNDERCLAIM',
 } as const;
 
 export type StorageACKDeclineCode =

--- a/packages/evm-module/abi/ContextGraphStorage.json
+++ b/packages/evm-module/abi/ContextGraphStorage.json
@@ -465,6 +465,25 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      }
+    ],
+    "name": "KnowledgeAssetUnlistedFromContextGraph",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "custodian",
         "type": "address"
@@ -1364,6 +1383,29 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedKaId",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapRemoveKnowledgeAssetAt",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/evm-module/abi/ContextGraphStorage.json
+++ b/packages/evm-module/abi/ContextGraphStorage.json
@@ -254,6 +254,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "OnlyRandomSampling",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "TokenTransferFailed",
     "type": "error"

--- a/packages/evm-module/abi/ContextGraphStorage.json
+++ b/packages/evm-module/abi/ContextGraphStorage.json
@@ -468,7 +468,7 @@
         "type": "uint256"
       }
     ],
-    "name": "KnowledgeAssetRegisteredToContextGraph",
+    "name": "KnowledgeAssetPrunedFromSamplingList",
     "type": "event"
   },
   {
@@ -487,7 +487,7 @@
         "type": "uint256"
       }
     ],
-    "name": "KnowledgeAssetUnlistedFromContextGraph",
+    "name": "KnowledgeAssetRegisteredToContextGraph",
     "type": "event"
   },
   {
@@ -1457,7 +1457,7 @@
         "type": "uint256"
       }
     ],
-    "name": "swapRemoveKnowledgeAssetAt",
+    "name": "swapRemoveSamplingKnowledgeAssetAt",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/evm-module/abi/ContextGraphStorage.json
+++ b/packages/evm-module/abi/ContextGraphStorage.json
@@ -1117,6 +1117,49 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "getSamplingKaAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "kaId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getSamplingKaCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "hub",
     "outputs": [

--- a/packages/evm-module/abi/RandomSampling.json
+++ b/packages/evm-module/abi/RandomSampling.json
@@ -126,19 +126,6 @@
   },
   {
     "inputs": [],
-    "name": "MAX_KA_PRUNE",
-    "outputs": [
-      {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "MAX_KA_RETRIES",
     "outputs": [
       {
@@ -467,6 +454,30 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "cgId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxScan",
+        "type": "uint256"
+      }
+    ],
+    "name": "pruneExpiredKnowledgeAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "removed",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/evm-module/abi/RandomSampling.json
+++ b/packages/evm-module/abi/RandomSampling.json
@@ -465,6 +465,11 @@
       },
       {
         "internalType": "uint256",
+        "name": "startIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "maxScan",
         "type": "uint256"
       }

--- a/packages/evm-module/abi/RandomSampling.json
+++ b/packages/evm-module/abi/RandomSampling.json
@@ -126,6 +126,19 @@
   },
   {
     "inputs": [],
+    "name": "MAX_KA_PRUNE",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "MAX_KA_RETRIES",
     "outputs": [
       {

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -806,16 +806,22 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     ///      gas cleaning dead slots. `swapRemoveKnowledgeAssetAt` preserves
     ///      `kaToContextGraph`, so readers (`getKAContextGraphId`) and the
     ///      double-registration guard stay intact. Gas is bounded by `maxScan`;
-    ///      a large flood is cleared across several calls.
-    /// @param cgId    context graph to clean.
-    /// @param maxScan max list positions to examine this call.
+    ///      a large flood is cleared across several calls. `startIndex` lets a
+    ///      caller target any region — e.g. the expired TAIL of a CG with a long
+    ///      live prefix, which a fixed from-0 scan with a small `maxScan` would
+    ///      never reach. (Reading the list to choose `startIndex` is an off-chain
+    ///      `eth_call`; this on-chain method just acts on the window.)
+    /// @param cgId       context graph to clean.
+    /// @param startIndex first list position to examine (0 = from the head).
+    /// @param maxScan    max list positions to examine this call.
     /// @return removed number of expired KAs swap-popped.
     function pruneExpiredKnowledgeAssets(
         uint256 cgId,
+        uint256 startIndex,
         uint256 maxScan
     ) external returns (uint256 removed) {
         uint256 currentEpoch = chronos.getCurrentEpoch();
-        uint256 i;
+        uint256 i = startIndex;
         for (uint256 scanned; scanned < maxScan; scanned++) {
             uint256 len = contextGraphStorage.getContextGraphKaCount(cgId);
             if (i >= len) break;

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -48,7 +48,12 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     //          submitProof scores the node against min(snapshot, live) (numerator
     //          only; score-per-stake denominator stays live), defeating a
     //          within-period tier-0 flash-stake score-inflation.
-    string private constant _VERSION = "10.5.0";
+    // 10.5.0 — Within-CG draw reads a decoupled compacted sampling list; the
+    //          permissionless keeper `pruneExpiredKnowledgeAssets` compacts it.
+    // 10.6.0 — Sampling reads/keeper retargeted to ContextGraphStorage's
+    //          `_samplingKAList` (getSamplingKaCount/At) so pruning no longer
+    //          mutates the append-only registration ordinal the reconciler reads.
+    string private constant _VERSION = "10.6.0";
     uint256 public constant SCALE18 = 1e18;
 
     /// @notice Maximum number of in-CG resamples when the picker hits an
@@ -682,14 +687,18 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         // Step 2 — pick a challengeable KA inside `chosenCg` (bounded resampling), then a leaf.
         // OT-RFC-49: curated KAs gate on the PUBLIC `_catalog` commitment; a curated KA with
         // `catalogLeafCount == 0` is skipped like an expired KA (cores prove the catalog).
-        uint256 kaCount = contextGraphStorage.getContextGraphKaCount(chosenCg);
+        // Draw from the COMPACTED sampling list, not the append-only registration
+        // list — the keeper prunes expired KAs out of the former, so dead slots
+        // don't accumulate and starve the bounded resample. The `endEpoch` skip
+        // below still guards any expired KA not yet pruned.
+        uint256 kaCount = contextGraphStorage.getSamplingKaCount(chosenCg);
         bool cgIsCurated = contextGraphStorage.getIsCurated(chosenCg);
         bytes32 kaSeed = cgSeed;
         if (kaCount > 0) {
             for (uint8 attempt = 0; attempt < MAX_KA_RETRIES; attempt++) {
                 kaSeed = keccak256(abi.encodePacked(kaSeed, attempt));
                 uint256 idx = uint256(kaSeed) % kaCount;
-                uint256 candidate = contextGraphStorage.getContextGraphKaAt(chosenCg, idx);
+                uint256 candidate = contextGraphStorage.getSamplingKaAt(chosenCg, idx);
                 if (knowledgeAssetStorage.getEndEpoch(candidate) < currentEpoch) continue;
                 if (cgIsCurated && knowledgeAssetStorage.getCatalogLeafCount(candidate) == 0) continue;
                 // Step 3 — leaf draw (curated -> public `_catalog` leaves; public -> flat-KA leaves).
@@ -793,11 +802,12 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     }
 
     /// @notice Permissionless keeper: prune EXPIRED Knowledge Assets from a CG's
-    ///         sampling list. The per-CG list (`_contextGraphKAList`) is
-    ///         append-only with no removal, so expired KAs accumulate as permanent
-    ///         dead slots and can starve the bounded within-CG draw
+    ///         COMPACTED sampling list (`_samplingKAList`). New entries are
+    ///         appended on registration but never removed there, so expired KAs
+    ///         accumulate as dead slots and can starve the bounded within-CG draw
     ///         (`MAX_KA_RETRIES`). Scans up to `maxScan` positions and swap-pops
-    ///         every entry whose `endEpoch < currentEpoch`.
+    ///         every entry whose `endEpoch < currentEpoch`. The append-only
+    ///         registration list the reconciler reads is left untouched.
     /// @dev Commits in its OWN transaction, independently of `createChallenge`
     ///      (whose settle/prune work rolls back on an all-miss revert), so a
     ///      clogged CG is always recoverable. Safe to be permissionless: it can
@@ -823,9 +833,9 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         uint256 currentEpoch = chronos.getCurrentEpoch();
         uint256 i = startIndex;
         for (uint256 scanned; scanned < maxScan; scanned++) {
-            uint256 len = contextGraphStorage.getContextGraphKaCount(cgId);
+            uint256 len = contextGraphStorage.getSamplingKaCount(cgId);
             if (i >= len) break;
-            uint256 ka = contextGraphStorage.getContextGraphKaAt(cgId, i);
+            uint256 ka = contextGraphStorage.getSamplingKaAt(cgId, i);
             if (knowledgeAssetStorage.getEndEpoch(ka) < currentEpoch) {
                 // swap-pops the last element into i, so re-check i (do not advance).
                 contextGraphStorage.swapRemoveKnowledgeAssetAt(cgId, i, ka);

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -58,15 +58,6 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     ///         next one (see {_pickKa}).
     uint8 public constant MAX_KA_RETRIES = 10;
 
-    /// @notice Bound on the lazy self-heal sweep: on a CG miss the production
-    ///         draw probes up to this many random positions in the CG's KA list
-    ///         and swap-pops any EXPIRED entries (see {_pruneExpiredKas}). The
-    ///         append-only KA list otherwise has no removal, so a flood of cheap
-    ///         1-epoch KAs that later expire would be permanent dead slots that
-    ///         exhaust MAX_KA_RETRIES and make the CG's live KAs un-challengeable.
-    ///         Bounded so the extra work on a miss can never blow the gas budget.
-    uint8 public constant MAX_KA_PRUNE = 10;
-
     /// @notice RFC-39 Phase A.5 — bounded retries at the CG selection layer
     ///         when the picked CG has no challengeable KA (all legacy /
     ///         uncommitted curated KAs, or every retry hit an expired KA).
@@ -794,14 +785,6 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
                 revert NoEligibleKnowledgeAsset();
             }
             if (found) return (cg, ka, chunk);
-            // Self-heal: prune EXPIRED KAs from the missed (clogged) CG so a
-            // one-time flood of cheap 1-epoch KAs that later expire can never be
-            // a PERMANENT sampling DoS — the append-only list converges back to
-            // mostly-live over a few draws. Bounded + derived-seed, so it never
-            // changes the draw above (view/full parity holds — only the list
-            // shrinks for future challenges). The missed CG is excluded below,
-            // so pruning it cannot affect any later attempt in this same call.
-            _pruneExpiredKas(cg, keccak256(abi.encodePacked(cgSeed, "kaPrune")), currentEpoch);
             cgWeightTreeStorage.settle(cg); // settle-on-miss (persists only if this call commits)
             exhausted[exhaustedCount++] = cg;
             cgSeed = keccak256(abi.encodePacked(cgSeed, "cgRetry", cgAttempt));
@@ -809,25 +792,40 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
         revert NoEligibleKnowledgeAsset();
     }
 
-    /// @dev Lazy self-heal sweep for a missed CG: probe up to MAX_KA_PRUNE
-    ///      random positions in its KA list and swap-pop any EXPIRED entries —
-    ///      the removal the append-only `_contextGraphKAList` otherwise lacks.
-    ///      Probing on a MISS targets exactly the clogged CGs and cleans them
-    ///      proportionally to the dead-slot density, so a one-time flood of cheap
-    ///      1-epoch KAs that later expire can never be a PERMANENT sampling DoS.
-    ///      Bounded by MAX_KA_PRUNE; the derived seed keeps it independent of the
-    ///      actual draw (no view/full parity impact — the list only shrinks for
-    ///      FUTURE challenges). `swapRemoveKnowledgeAssetAt` is a no-op on a stale
-    ///      index, and the length is re-read each iteration as the list shrinks.
-    function _pruneExpiredKas(uint256 cg, bytes32 seed, uint256 currentEpoch) internal {
-        for (uint8 i = 0; i < MAX_KA_PRUNE; i++) {
-            uint256 len = contextGraphStorage.getContextGraphKaCount(cg);
-            if (len == 0) break;
-            seed = keccak256(abi.encodePacked(seed, i));
-            uint256 idx = uint256(seed) % len;
-            uint256 ka = contextGraphStorage.getContextGraphKaAt(cg, idx);
+    /// @notice Permissionless keeper: prune EXPIRED Knowledge Assets from a CG's
+    ///         sampling list. The per-CG list (`_contextGraphKAList`) is
+    ///         append-only with no removal, so expired KAs accumulate as permanent
+    ///         dead slots and can starve the bounded within-CG draw
+    ///         (`MAX_KA_RETRIES`). Scans up to `maxScan` positions and swap-pops
+    ///         every entry whose `endEpoch < currentEpoch`.
+    /// @dev Commits in its OWN transaction, independently of `createChallenge`
+    ///      (whose settle/prune work rolls back on an all-miss revert), so a
+    ///      clogged CG is always recoverable. Safe to be permissionless: it can
+    ///      ONLY remove already-expired (sampling-ineligible) KAs — never a live
+    ///      one — so there is no griefing vector; a caller merely spends its own
+    ///      gas cleaning dead slots. `swapRemoveKnowledgeAssetAt` preserves
+    ///      `kaToContextGraph`, so readers (`getKAContextGraphId`) and the
+    ///      double-registration guard stay intact. Gas is bounded by `maxScan`;
+    ///      a large flood is cleared across several calls.
+    /// @param cgId    context graph to clean.
+    /// @param maxScan max list positions to examine this call.
+    /// @return removed number of expired KAs swap-popped.
+    function pruneExpiredKnowledgeAssets(
+        uint256 cgId,
+        uint256 maxScan
+    ) external returns (uint256 removed) {
+        uint256 currentEpoch = chronos.getCurrentEpoch();
+        uint256 i;
+        for (uint256 scanned; scanned < maxScan; scanned++) {
+            uint256 len = contextGraphStorage.getContextGraphKaCount(cgId);
+            if (i >= len) break;
+            uint256 ka = contextGraphStorage.getContextGraphKaAt(cgId, i);
             if (knowledgeAssetStorage.getEndEpoch(ka) < currentEpoch) {
-                contextGraphStorage.swapRemoveKnowledgeAssetAt(cg, idx, ka);
+                // swap-pops the last element into i, so re-check i (do not advance).
+                contextGraphStorage.swapRemoveKnowledgeAssetAt(cgId, i, ka);
+                removed++;
+            } else {
+                i++;
             }
         }
     }

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -48,7 +48,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     //          submitProof scores the node against min(snapshot, live) (numerator
     //          only; score-per-stake denominator stays live), defeating a
     //          within-period tier-0 flash-stake score-inflation.
-    string private constant _VERSION = "10.4.0";
+    string private constant _VERSION = "10.5.0";
     uint256 public constant SCALE18 = 1e18;
 
     /// @notice Maximum number of in-CG resamples when the picker hits an
@@ -57,6 +57,15 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     ///         so the node skips the current proof period and retries on the
     ///         next one (see {_pickKa}).
     uint8 public constant MAX_KA_RETRIES = 10;
+
+    /// @notice Bound on the lazy self-heal sweep: on a CG miss the production
+    ///         draw probes up to this many random positions in the CG's KA list
+    ///         and swap-pops any EXPIRED entries (see {_pruneExpiredKas}). The
+    ///         append-only KA list otherwise has no removal, so a flood of cheap
+    ///         1-epoch KAs that later expire would be permanent dead slots that
+    ///         exhaust MAX_KA_RETRIES and make the CG's live KAs un-challengeable.
+    ///         Bounded so the extra work on a miss can never blow the gas budget.
+    uint8 public constant MAX_KA_PRUNE = 10;
 
     /// @notice RFC-39 Phase A.5 — bounded retries at the CG selection layer
     ///         when the picked CG has no challengeable KA (all legacy /
@@ -785,11 +794,42 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
                 revert NoEligibleKnowledgeAsset();
             }
             if (found) return (cg, ka, chunk);
+            // Self-heal: prune EXPIRED KAs from the missed (clogged) CG so a
+            // one-time flood of cheap 1-epoch KAs that later expire can never be
+            // a PERMANENT sampling DoS — the append-only list converges back to
+            // mostly-live over a few draws. Bounded + derived-seed, so it never
+            // changes the draw above (view/full parity holds — only the list
+            // shrinks for future challenges). The missed CG is excluded below,
+            // so pruning it cannot affect any later attempt in this same call.
+            _pruneExpiredKas(cg, keccak256(abi.encodePacked(cgSeed, "kaPrune")), currentEpoch);
             cgWeightTreeStorage.settle(cg); // settle-on-miss (persists only if this call commits)
             exhausted[exhaustedCount++] = cg;
             cgSeed = keccak256(abi.encodePacked(cgSeed, "cgRetry", cgAttempt));
         }
         revert NoEligibleKnowledgeAsset();
+    }
+
+    /// @dev Lazy self-heal sweep for a missed CG: probe up to MAX_KA_PRUNE
+    ///      random positions in its KA list and swap-pop any EXPIRED entries —
+    ///      the removal the append-only `_contextGraphKAList` otherwise lacks.
+    ///      Probing on a MISS targets exactly the clogged CGs and cleans them
+    ///      proportionally to the dead-slot density, so a one-time flood of cheap
+    ///      1-epoch KAs that later expire can never be a PERMANENT sampling DoS.
+    ///      Bounded by MAX_KA_PRUNE; the derived seed keeps it independent of the
+    ///      actual draw (no view/full parity impact — the list only shrinks for
+    ///      FUTURE challenges). `swapRemoveKnowledgeAssetAt` is a no-op on a stale
+    ///      index, and the length is re-read each iteration as the list shrinks.
+    function _pruneExpiredKas(uint256 cg, bytes32 seed, uint256 currentEpoch) internal {
+        for (uint8 i = 0; i < MAX_KA_PRUNE; i++) {
+            uint256 len = contextGraphStorage.getContextGraphKaCount(cg);
+            if (len == 0) break;
+            seed = keccak256(abi.encodePacked(seed, i));
+            uint256 idx = uint256(seed) % len;
+            uint256 ka = contextGraphStorage.getContextGraphKaAt(cg, idx);
+            if (knowledgeAssetStorage.getEndEpoch(ka) < currentEpoch) {
+                contextGraphStorage.swapRemoveKnowledgeAssetAt(cg, idx, ka);
+            }
+        }
     }
 
     // slither-disable-end weak-prng,uninitialized-local,cyclomatic-complexity,incorrect-equality,calls-loop,timestamp

--- a/packages/evm-module/contracts/RandomSampling.sol
+++ b/packages/evm-module/contracts/RandomSampling.sol
@@ -813,7 +813,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
     ///      clogged CG is always recoverable. Safe to be permissionless: it can
     ///      ONLY remove already-expired (sampling-ineligible) KAs — never a live
     ///      one — so there is no griefing vector; a caller merely spends its own
-    ///      gas cleaning dead slots. `swapRemoveKnowledgeAssetAt` preserves
+    ///      gas cleaning dead slots. `swapRemoveSamplingKnowledgeAssetAt` preserves
     ///      `kaToContextGraph`, so readers (`getKAContextGraphId`) and the
     ///      double-registration guard stay intact. Gas is bounded by `maxScan`;
     ///      a large flood is cleared across several calls. `startIndex` lets a
@@ -838,7 +838,7 @@ contract RandomSampling is INamed, IVersioned, ContractStatus, IInitializable {
             uint256 ka = contextGraphStorage.getSamplingKaAt(cgId, i);
             if (knowledgeAssetStorage.getEndEpoch(ka) < currentEpoch) {
                 // swap-pops the last element into i, so re-check i (do not advance).
-                contextGraphStorage.swapRemoveKnowledgeAssetAt(cgId, i, ka);
+                contextGraphStorage.swapRemoveSamplingKnowledgeAssetAt(cgId, i, ka);
                 removed++;
             } else {
                 i++;

--- a/packages/evm-module/contracts/storage/ContextGraphStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphStorage.sol
@@ -45,7 +45,15 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
     //          getContextGraphKaCount/At/List (ABI selector change; no behavior change).
     // 10.0.4 — OT-RFC-53: per-CG registration-escrow accounting (get/set/decrease/
     //          clear) consumed by the deposit pull + admin sweep. ABI surface addition.
-    string private constant _VERSION = "10.0.5";
+    // 10.0.6 — Decoupled sampling list: a SECOND per-CG array (`_samplingKAList`)
+    //          drives random sampling and is the one the keeper compacts, while
+    //          `_contextGraphKAList` stays strictly append-only as the
+    //          registration-ordinal source the off-chain chain-reconciler reads
+    //          (`getContextGraphKaCount/At`). Pruning expired KAs from sampling no
+    //          longer mutates that ordinal, so the reconciler's [watermark, head)
+    //          cursor can never skip a later publish. Adds getSamplingKaCount/At;
+    //          swapRemoveKnowledgeAssetAt now targets the sampling list.
+    string private constant _VERSION = "10.0.6";
 
     // -----------------------------------------------------------------------
     // Bounds on participant list — anti-griefing cap.
@@ -98,8 +106,21 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
     // Public for convenience; zero means "not registered".
     mapping(uint256 kaId => uint256 contextGraphId) public kaToContextGraph;
 
-    // CG -> [KA IDs] forward list for uniform random KA selection within a CG.
+    // CG -> [KA IDs] APPEND-ONLY registration list. This is the per-CG
+    // registration-ordinal source the off-chain chain-reconciler walks as
+    // `[watermark, head)` (head = getContextGraphKaCount) — so it MUST stay
+    // append-only: never reorder, never shrink. Sampling pruning happens on
+    // `_samplingKAList` below, never here.
     mapping(uint256 contextGraphId => uint256[]) private _contextGraphKAList;
+
+    // CG -> [live KA IDs] COMPACTED list that drives within-CG random sampling.
+    // Written alongside `_contextGraphKAList` on registration, but the keeper
+    // (`RandomSampling.pruneExpiredKnowledgeAssets` → `swapRemoveKnowledgeAssetAt`)
+    // swap-pops EXPIRED KAs out of THIS list only. Decoupling the sampling
+    // enumeration from the append-only registration ordinal lets the draw shed
+    // dead slots without corrupting the reconciler cursor. Read via
+    // getSamplingKaCount/At; the two lists diverge over time by design.
+    mapping(uint256 contextGraphId => uint256[]) private _samplingKAList;
 
     // OT-RFC-53 — per-CG registration-deposit escrow (anti-spam). Accounting
     // only: the TRAC itself is custodied in the CSS vault (mirrors
@@ -305,8 +326,11 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
 
     /**
      * @notice Bind a Knowledge Asset to a Context Graph.
-     * @dev Records both the reverse lookup (`kaToContextGraph[kaId] = cgId`)
-     *      and the forward list (`_contextGraphKAList[cgId].push(kaId)`).
+     * @dev Records the reverse lookup (`kaToContextGraph[kaId] = cgId`) and
+     *      appends to BOTH per-CG lists: `_contextGraphKAList` (the append-only
+     *      registration ordinal the reconciler reads) and `_samplingKAList` (the
+     *      compactable sampling enumeration). They start identical; the keeper
+     *      later prunes expired entries from the sampling list only.
      *      Reverts on double registration.
      */
     function registerKnowledgeAssetToContextGraph(
@@ -325,6 +349,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
         }
         kaToContextGraph[kaId] = contextGraphId;
         _contextGraphKAList[contextGraphId].push(kaId);
+        _samplingKAList[contextGraphId].push(kaId);
         emit KnowledgeAssetRegisteredToContextGraph(contextGraphId, kaId);
     }
 
@@ -342,10 +367,12 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
      * @notice Remove a Knowledge Asset from a Context Graph's SAMPLING list by
      *         swap-and-pop.
      * @dev Called only by `RandomSampling.pruneExpiredKnowledgeAssets` (the
-     *      permissionless keeper) to prune EXPIRED KAs, so the otherwise
-     *      append-only list cannot accumulate dead entries into a sampling DoS.
-     *      Removes ONLY from `_contextGraphKAList` (the sampling enumeration) —
-     *      the `kaToContextGraph[kaId]` reverse binding is INTENTIONALLY left
+     *      permissionless keeper) to prune EXPIRED KAs, so the sampling
+     *      enumeration cannot accumulate dead slots into a within-CG sampling DoS.
+     *      Removes ONLY from `_samplingKAList` — the append-only
+     *      `_contextGraphKAList` (the reconciler's registration ordinal) is NOT
+     *      touched, so a later publish can never be skipped by the reconciler's
+     *      cursor. The `kaToContextGraph[kaId]` reverse binding is also left
      *      intact: readers (`getKAContextGraphId`) must still resolve the KA, and
      *      an expired KA can never be re-registered (it cannot be re-published
      *      with the same id), so the double-registration guard stays correct.
@@ -361,7 +388,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
         if (msg.sender != hub.getContractAddress("RandomSampling")) {
             revert OnlyRandomSampling(msg.sender);
         }
-        uint256[] storage list = _contextGraphKAList[contextGraphId];
+        uint256[] storage list = _samplingKAList[contextGraphId];
         uint256 len = list.length;
         if (index >= len || list[index] != expectedKaId) {
             return; // stale / already moved — skip; pruned on a later draw
@@ -409,6 +436,35 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
         uint256[] storage list = _contextGraphKAList[contextGraphId];
         if (index >= list.length) {
             revert KnowledgeAssetsLib.InvalidContextGraphConfig("kaIndex oob");
+        }
+        return list[index];
+    }
+
+    /**
+     * @notice Length of the COMPACTED sampling list (live + not-yet-pruned KAs).
+     * @dev This is the count the within-CG random-sampling draw bounds against
+     *      (`RandomSampling._pickKa`) and the keeper scans. It shrinks as the
+     *      keeper prunes expired KAs — unlike `getContextGraphKaCount`, which is
+     *      the monotonic append-only registration count.
+     */
+    function getSamplingKaCount(
+        uint256 contextGraphId
+    ) external view returns (uint256) {
+        return _samplingKAList[contextGraphId].length;
+    }
+
+    /**
+     * @notice Single KA id at an index within a CG's compacted sampling list.
+     * @dev O(1) accessor for the within-CG draw + the keeper. Reverts
+     *      `InvalidContextGraphConfig("samplingIndex oob")` out of bounds.
+     */
+    function getSamplingKaAt(
+        uint256 contextGraphId,
+        uint256 index
+    ) external view returns (uint256 kaId) {
+        uint256[] storage list = _samplingKAList[contextGraphId];
+        if (index >= list.length) {
+            revert KnowledgeAssetsLib.InvalidContextGraphConfig("samplingIndex oob");
         }
         return list[index];
     }

--- a/packages/evm-module/contracts/storage/ContextGraphStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphStorage.sol
@@ -52,7 +52,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
     //          (`getContextGraphKaCount/At`). Pruning expired KAs from sampling no
     //          longer mutates that ordinal, so the reconciler's [watermark, head)
     //          cursor can never skip a later publish. Adds getSamplingKaCount/At;
-    //          swapRemoveKnowledgeAssetAt now targets the sampling list.
+    //          swapRemoveSamplingKnowledgeAssetAt now targets the sampling list.
     string private constant _VERSION = "10.0.6";
 
     // -----------------------------------------------------------------------
@@ -115,11 +115,20 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
 
     // CG -> [live KA IDs] COMPACTED list that drives within-CG random sampling.
     // Written alongside `_contextGraphKAList` on registration, but the keeper
-    // (`RandomSampling.pruneExpiredKnowledgeAssets` → `swapRemoveKnowledgeAssetAt`)
+    // (`RandomSampling.pruneExpiredKnowledgeAssets` → `swapRemoveSamplingKnowledgeAssetAt`)
     // swap-pops EXPIRED KAs out of THIS list only. Decoupling the sampling
     // enumeration from the append-only registration ordinal lets the draw shed
     // dead slots without corrupting the reconciler cursor. Read via
     // getSamplingKaCount/At; the two lists diverge over time by design.
+    //
+    // POPULATION INVARIANT: `registerKnowledgeAssetToContextGraph` is the SOLE
+    // writer of both arrays and always appends to them together — there is no
+    // setter or migration that writes `_contextGraphKAList` alone. So a CG can
+    // never hold registrations in the append-only list without the matching
+    // sampling entries (the "pre-existing KAs invisible to sampling" state is
+    // unreachable). This is a fresh-design, non-proxy contract deployed empty for
+    // V10 (both lists populate from genesis); should a future deployment ever
+    // need to preserve CG state, the migration MUST seed both arrays together.
     mapping(uint256 contextGraphId => uint256[]) private _samplingKAList;
 
     // OT-RFC-53 — per-CG registration-deposit escrow (anti-spam). Accounting
@@ -353,7 +362,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
         emit KnowledgeAssetRegisteredToContextGraph(contextGraphId, kaId);
     }
 
-    event KnowledgeAssetUnlistedFromContextGraph(uint256 indexed contextGraphId, uint256 indexed kaId);
+    event KnowledgeAssetPrunedFromSamplingList(uint256 indexed contextGraphId, uint256 indexed kaId);
 
     /// @dev The generic swap-pop below can desync the sampling list from
     ///      `kaToContextGraph`, so it is restricted to the RandomSampling
@@ -380,7 +389,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
      *      (a prior swap-pop moved a different KA into `index`) — robust to stale
      *      indices.
      */
-    function swapRemoveKnowledgeAssetAt(
+    function swapRemoveSamplingKnowledgeAssetAt(
         uint256 contextGraphId,
         uint256 index,
         uint256 expectedKaId
@@ -398,7 +407,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
             list[index] = list[last];
         }
         list.pop();
-        emit KnowledgeAssetUnlistedFromContextGraph(contextGraphId, expectedKaId);
+        emit KnowledgeAssetPrunedFromSamplingList(contextGraphId, expectedKaId);
     }
 
     /**

--- a/packages/evm-module/contracts/storage/ContextGraphStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphStorage.sol
@@ -330,26 +330,37 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
 
     event KnowledgeAssetUnlistedFromContextGraph(uint256 indexed contextGraphId, uint256 indexed kaId);
 
+    /// @dev The generic swap-pop below can desync the sampling list from
+    ///      `kaToContextGraph`, so it is restricted to the RandomSampling
+    ///      contract (the sole component that prunes the list, and only for
+    ///      EXPIRED KAs — it checks `endEpoch` before calling). This is stricter
+    ///      than `onlyContracts`: it stops a future/buggy Hub contract from
+    ///      removing a LIVE KA from sampling while it still reports as registered.
+    error OnlyRandomSampling(address caller);
+
     /**
      * @notice Remove a Knowledge Asset from a Context Graph's SAMPLING list by
      *         swap-and-pop.
-     * @dev Used by RandomSampling to lazily prune EXPIRED KAs it encounters
-     *      during a challenge draw, so the otherwise append-only list cannot be
-     *      flooded with permanent dead entries into a sampling DoS. Removes ONLY
-     *      from `_contextGraphKAList` (the sampling enumeration) — the
-     *      `kaToContextGraph[kaId]` reverse binding is INTENTIONALLY left intact:
-     *      readers (`getKAContextGraphId`) must still resolve the KA, and an
-     *      expired KA can never be re-registered (it cannot be re-published with
-     *      the same id), so the double-registration guard stays correct.
+     * @dev Called only by `RandomSampling.pruneExpiredKnowledgeAssets` (the
+     *      permissionless keeper) to prune EXPIRED KAs, so the otherwise
+     *      append-only list cannot accumulate dead entries into a sampling DoS.
+     *      Removes ONLY from `_contextGraphKAList` (the sampling enumeration) —
+     *      the `kaToContextGraph[kaId]` reverse binding is INTENTIONALLY left
+     *      intact: readers (`getKAContextGraphId`) must still resolve the KA, and
+     *      an expired KA can never be re-registered (it cannot be re-published
+     *      with the same id), so the double-registration guard stays correct.
      *      `expectedKaId` makes the call a no-op when the slot no longer holds it
-     *      (a prior swap-pop in the same tx moved a different KA into `index`) —
-     *      robust to stale indices; the entry is simply pruned on a later draw.
+     *      (a prior swap-pop moved a different KA into `index`) — robust to stale
+     *      indices.
      */
     function swapRemoveKnowledgeAssetAt(
         uint256 contextGraphId,
         uint256 index,
         uint256 expectedKaId
-    ) external onlyContracts {
+    ) external {
+        if (msg.sender != hub.getContractAddress("RandomSampling")) {
+            revert OnlyRandomSampling(msg.sender);
+        }
         uint256[] storage list = _contextGraphKAList[contextGraphId];
         uint256 len = list.length;
         if (index >= len || list[index] != expectedKaId) {

--- a/packages/evm-module/contracts/storage/ContextGraphStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphStorage.sol
@@ -45,7 +45,7 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
     //          getContextGraphKaCount/At/List (ABI selector change; no behavior change).
     // 10.0.4 — OT-RFC-53: per-CG registration-escrow accounting (get/set/decrease/
     //          clear) consumed by the deposit pull + admin sweep. ABI surface addition.
-    string private constant _VERSION = "10.0.4";
+    string private constant _VERSION = "10.0.5";
 
     // -----------------------------------------------------------------------
     // Bounds on participant list — anti-griefing cap.
@@ -326,6 +326,41 @@ contract ContextGraphStorage is INamed, IVersioned, Guardian, ERC721Enumerable {
         kaToContextGraph[kaId] = contextGraphId;
         _contextGraphKAList[contextGraphId].push(kaId);
         emit KnowledgeAssetRegisteredToContextGraph(contextGraphId, kaId);
+    }
+
+    event KnowledgeAssetUnlistedFromContextGraph(uint256 indexed contextGraphId, uint256 indexed kaId);
+
+    /**
+     * @notice Remove a Knowledge Asset from a Context Graph's SAMPLING list by
+     *         swap-and-pop.
+     * @dev Used by RandomSampling to lazily prune EXPIRED KAs it encounters
+     *      during a challenge draw, so the otherwise append-only list cannot be
+     *      flooded with permanent dead entries into a sampling DoS. Removes ONLY
+     *      from `_contextGraphKAList` (the sampling enumeration) — the
+     *      `kaToContextGraph[kaId]` reverse binding is INTENTIONALLY left intact:
+     *      readers (`getKAContextGraphId`) must still resolve the KA, and an
+     *      expired KA can never be re-registered (it cannot be re-published with
+     *      the same id), so the double-registration guard stays correct.
+     *      `expectedKaId` makes the call a no-op when the slot no longer holds it
+     *      (a prior swap-pop in the same tx moved a different KA into `index`) —
+     *      robust to stale indices; the entry is simply pruned on a later draw.
+     */
+    function swapRemoveKnowledgeAssetAt(
+        uint256 contextGraphId,
+        uint256 index,
+        uint256 expectedKaId
+    ) external onlyContracts {
+        uint256[] storage list = _contextGraphKAList[contextGraphId];
+        uint256 len = list.length;
+        if (index >= len || list[index] != expectedKaId) {
+            return; // stale / already moved — skip; pruned on a later draw
+        }
+        uint256 last = len - 1;
+        if (index != last) {
+            list[index] = list[last];
+        }
+        list.pop();
+        emit KnowledgeAssetUnlistedFromContextGraph(contextGraphId, expectedKaId);
     }
 
     /**

--- a/packages/evm-module/test/unit/ContextGraphStorage.test.ts
+++ b/packages/evm-module/test/unit/ContextGraphStorage.test.ts
@@ -322,6 +322,21 @@ describe('@unit ContextGraphStorage', () => {
       expect(await StorageContract.getContextGraphKaCount(1)).to.equal(3);
     });
 
+    it('dual-writes both lists: the sampling list mirrors the append-only list on registration', async () => {
+      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 100);
+      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 200);
+      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 300);
+      // Before any prune the two lists are identical (the keeper later diverges
+      // them by swap-popping expired entries from the sampling list only).
+      const count = await StorageContract.getContextGraphKaCount(1);
+      expect(await StorageContract.getSamplingKaCount(1)).to.equal(count);
+      for (let i = 0n; i < count; i++) {
+        expect(await StorageContract.getSamplingKaAt(1, i)).to.equal(
+          await StorageContract.getContextGraphKaAt(1, i),
+        );
+      }
+    });
+
     it('reverts on double registration (KnowledgeAssetAlreadyRegisteredToContextGraph)', async () => {
       await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 100);
       // Create a second CG and try to register the same KA there

--- a/packages/evm-module/test/unit/ContextGraphStorage.test.ts
+++ b/packages/evm-module/test/unit/ContextGraphStorage.test.ts
@@ -354,6 +354,58 @@ describe('@unit ContextGraphStorage', () => {
     });
   });
 
+  describe('swapRemoveKnowledgeAssetAt (lazy expired-KA prune)', () => {
+    beforeEach(async () => {
+      await StorageContract.connect(opSigner).createContextGraph(
+        accounts[0].address, [], 0, 0, 1, ethers.ZeroAddress, 0,
+        ethers.ZeroHash,
+      );
+      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 100);
+      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 200);
+      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 300);
+    });
+
+    it('swap-pops the entry (moves last into the slot) and emits the unlist event', async () => {
+      await expect(
+        StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 0, 100),
+      ).to.emit(StorageContract, 'KnowledgeAssetUnlistedFromContextGraph').withArgs(1, 100);
+      // last (300) swapped into index 0; 100 removed.
+      expect(await StorageContract.getContextGraphKaList(1)).to.deep.equal([300n, 200n]);
+      expect(await StorageContract.getContextGraphKaCount(1)).to.equal(2);
+    });
+
+    it('removing the last element just pops it (no swap)', async () => {
+      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 2, 300);
+      expect(await StorageContract.getContextGraphKaList(1)).to.deep.equal([100n, 200n]);
+    });
+
+    it('PRESERVES the kaToContextGraph binding + dedup after removal from the list', async () => {
+      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 0, 100);
+      // Reverse binding intact: readers (getKAContextGraphId) still resolve it...
+      expect(await StorageContract.kaToContextGraph(100)).to.equal(1);
+      // ...and the double-registration guard still rejects re-adding it.
+      await expect(
+        StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 100),
+      ).to.be.revertedWithCustomError(StorageContract, 'KnowledgeAssetAlreadyRegisteredToContextGraph');
+    });
+
+    it('is a no-op when the slot no longer holds expectedKaId (stale-index guard)', async () => {
+      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 0, 999);
+      expect(await StorageContract.getContextGraphKaList(1)).to.deep.equal([100n, 200n, 300n]);
+    });
+
+    it('is a no-op on an out-of-bounds index', async () => {
+      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 99, 100);
+      expect(await StorageContract.getContextGraphKaCount(1)).to.equal(3);
+    });
+
+    it('reverts when caller is not a Hub contract', async () => {
+      await expect(
+        StorageContract.connect(accounts[5]).swapRemoveKnowledgeAssetAt(1, 0, 100),
+      ).to.be.revertedWithCustomError(HubContract, 'UnauthorizedAccess');
+    });
+  });
+
   // -------------------------------------------------------------------------
   // getContextGraphKaAt — indexed accessor for on-chain consumers
   // -------------------------------------------------------------------------

--- a/packages/evm-module/test/unit/ContextGraphStorage.test.ts
+++ b/packages/evm-module/test/unit/ContextGraphStorage.test.ts
@@ -354,57 +354,10 @@ describe('@unit ContextGraphStorage', () => {
     });
   });
 
-  describe('swapRemoveKnowledgeAssetAt (lazy expired-KA prune)', () => {
-    beforeEach(async () => {
-      await StorageContract.connect(opSigner).createContextGraph(
-        accounts[0].address, [], 0, 0, 1, ethers.ZeroAddress, 0,
-        ethers.ZeroHash,
-      );
-      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 100);
-      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 200);
-      await StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 300);
-    });
-
-    it('swap-pops the entry (moves last into the slot) and emits the unlist event', async () => {
-      await expect(
-        StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 0, 100),
-      ).to.emit(StorageContract, 'KnowledgeAssetUnlistedFromContextGraph').withArgs(1, 100);
-      // last (300) swapped into index 0; 100 removed.
-      expect(await StorageContract.getContextGraphKaList(1)).to.deep.equal([300n, 200n]);
-      expect(await StorageContract.getContextGraphKaCount(1)).to.equal(2);
-    });
-
-    it('removing the last element just pops it (no swap)', async () => {
-      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 2, 300);
-      expect(await StorageContract.getContextGraphKaList(1)).to.deep.equal([100n, 200n]);
-    });
-
-    it('PRESERVES the kaToContextGraph binding + dedup after removal from the list', async () => {
-      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 0, 100);
-      // Reverse binding intact: readers (getKAContextGraphId) still resolve it...
-      expect(await StorageContract.kaToContextGraph(100)).to.equal(1);
-      // ...and the double-registration guard still rejects re-adding it.
-      await expect(
-        StorageContract.connect(opSigner).registerKnowledgeAssetToContextGraph(1, 100),
-      ).to.be.revertedWithCustomError(StorageContract, 'KnowledgeAssetAlreadyRegisteredToContextGraph');
-    });
-
-    it('is a no-op when the slot no longer holds expectedKaId (stale-index guard)', async () => {
-      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 0, 999);
-      expect(await StorageContract.getContextGraphKaList(1)).to.deep.equal([100n, 200n, 300n]);
-    });
-
-    it('is a no-op on an out-of-bounds index', async () => {
-      await StorageContract.connect(opSigner).swapRemoveKnowledgeAssetAt(1, 99, 100);
-      expect(await StorageContract.getContextGraphKaCount(1)).to.equal(3);
-    });
-
-    it('reverts when caller is not a Hub contract', async () => {
-      await expect(
-        StorageContract.connect(accounts[5]).swapRemoveKnowledgeAssetAt(1, 0, 100),
-      ).to.be.revertedWithCustomError(HubContract, 'UnauthorizedAccess');
-    });
-  });
+  // swapRemoveKnowledgeAssetAt is gated to the RandomSampling contract and is
+  // exercised end-to-end (swap-pop mechanics, dedup/binding preservation, the
+  // RandomSampling-only gate) via the RandomSampling keeper test
+  // `pruneExpiredKnowledgeAssets`, where the RandomSampling contract is deployed.
 
   // -------------------------------------------------------------------------
   // getContextGraphKaAt — indexed accessor for on-chain consumers

--- a/packages/evm-module/test/unit/ContextGraphStorage.test.ts
+++ b/packages/evm-module/test/unit/ContextGraphStorage.test.ts
@@ -369,7 +369,7 @@ describe('@unit ContextGraphStorage', () => {
     });
   });
 
-  // swapRemoveKnowledgeAssetAt is gated to the RandomSampling contract and is
+  // swapRemoveSamplingKnowledgeAssetAt is gated to the RandomSampling contract and is
   // exercised end-to-end (swap-pop mechanics, dedup/binding preservation, the
   // RandomSampling-only gate) via the RandomSampling keeper test
   // `pruneExpiredKnowledgeAssets`, where the RandomSampling contract is deployed.

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1308,7 +1308,7 @@ describe('@unit RandomSampling', () => {
         const ka = await createKa(cgId, (await Chronos.getCurrentEpoch()) + 5n);
         // opSigner is a Hub-registered sentinel but NOT the RandomSampling contract.
         await expect(
-          ContextGraphStorage.connect(opSigner).swapRemoveKnowledgeAssetAt(cgId, 0, ka),
+          ContextGraphStorage.connect(opSigner).swapRemoveSamplingKnowledgeAssetAt(cgId, 0, ka),
         ).to.be.revertedWithCustomError(ContextGraphStorage, 'OnlyRandomSampling');
       });
     });

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1151,6 +1151,76 @@ describe('@unit RandomSampling', () => {
     });
 
     // -----------------------------------------------------------------------
+    // Permissionless keeper — prune expired KAs from a CG's sampling list. This
+    // is the committed, non-reverting cleanup path: `createChallenge`'s in-draw
+    // settle work rolls back on an all-miss revert, so a CG clogged with expired
+    // entries needs this keeper (its own tx) to recover. Deterministic — no
+    // internal-seed/createChallenge dependency.
+    // -----------------------------------------------------------------------
+    describe('pruneExpiredKnowledgeAssets (keeper)', () => {
+      it('removes expired KAs, preserves live KAs + the kaToContextGraph binding', async () => {
+        const cgId = await createCG(OPEN_POLICY);
+        const currentEpoch = await Chronos.getCurrentEpoch();
+        const liveEnd = currentEpoch + 100n;
+        const expiredEnd = currentEpoch + 1n;
+
+        // Interleave live/expired: [live1, exp1, live2, exp2, exp3].
+        const live1 = await createKa(cgId, liveEnd);
+        const exp1 = await createKa(cgId, expiredEnd);
+        const live2 = await createKa(cgId, liveEnd);
+        const exp2 = await createKa(cgId, expiredEnd);
+        await createKa(cgId, expiredEnd);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(5n);
+
+        // Advance past the expired endEpoch (live KAs stay live).
+        const epochLength = await Chronos.epochLength();
+        await time.increase(Number(epochLength) * 5);
+        expect(await Chronos.getCurrentEpoch()).to.be.greaterThan(expiredEnd);
+
+        const removed = await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 100n);
+        expect(removed).to.equal(3n);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 100n);
+
+        // Only the 2 live KAs remain.
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(2n);
+        const remaining = new Set<bigint>([
+          await ContextGraphStorage.getContextGraphKaAt(cgId, 0),
+          await ContextGraphStorage.getContextGraphKaAt(cgId, 1),
+        ]);
+        expect(remaining.has(live1)).to.equal(true);
+        expect(remaining.has(live2)).to.equal(true);
+        expect(remaining.has(exp1)).to.equal(false);
+        // Reverse binding for a pruned (expired) KA survives — readers/dedup intact.
+        expect(await ContextGraphStorage.kaToContextGraph(exp2)).to.equal(cgId);
+      });
+
+      it('is bounded by maxScan and clears a large flood across calls', async () => {
+        const cgId = await createCG(OPEN_POLICY);
+        const expiredEnd = (await Chronos.getCurrentEpoch()) + 1n;
+        for (let i = 0; i < 8; i++) await createKa(cgId, expiredEnd);
+        const epochLength = await Chronos.epochLength();
+        await time.increase(Number(epochLength) * 5);
+
+        // maxScan=3 → at most 3 removed this call.
+        expect(await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 3n)).to.equal(3n);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 3n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(5n);
+        // Follow-up clears the rest.
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 100n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(0n);
+      });
+
+      it('the swap-pop primitive is gated to the RandomSampling contract', async () => {
+        const cgId = await createCG(OPEN_POLICY);
+        const ka = await createKa(cgId, (await Chronos.getCurrentEpoch()) + 5n);
+        // opSigner is a Hub-registered sentinel but NOT the RandomSampling contract.
+        await expect(
+          ContextGraphStorage.connect(opSigner).swapRemoveKnowledgeAssetAt(cgId, 0, ka),
+        ).to.be.revertedWithCustomError(ContextGraphStorage, 'OnlyRandomSampling');
+      });
+    });
+
+    // -----------------------------------------------------------------------
     // Test 5 — Distribution regression: 3 public CGs weighted 70/20/10 should
     // be picked at those ratios over many draws. Using the read-only preview
     // helper with per-draw seeds makes this both deterministic and fast.

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1177,9 +1177,9 @@ describe('@unit RandomSampling', () => {
         await time.increase(Number(epochLength) * 5);
         expect(await Chronos.getCurrentEpoch()).to.be.greaterThan(expiredEnd);
 
-        const removed = await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 100n);
+        const removed = await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 0n, 100n);
         expect(removed).to.equal(3n);
-        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 100n);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
 
         // Only the 2 live KAs remain.
         expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(2n);
@@ -1202,12 +1202,31 @@ describe('@unit RandomSampling', () => {
         await time.increase(Number(epochLength) * 5);
 
         // maxScan=3 → at most 3 removed this call.
-        expect(await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 3n)).to.equal(3n);
-        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 3n);
+        expect(await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 0n, 3n)).to.equal(3n);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 3n);
         expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(5n);
         // Follow-up clears the rest.
-        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 100n);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
         expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(0n);
+      });
+
+      it('startIndex reaches the expired tail past a live prefix (live-prefix recoverability)', async () => {
+        const cgId = await createCG(OPEN_POLICY);
+        const currentEpoch = await Chronos.getCurrentEpoch();
+        const liveEnd = currentEpoch + 100n;
+        const expiredEnd = currentEpoch + 1n;
+        for (let i = 0; i < 4; i++) await createKa(cgId, liveEnd); // live prefix
+        for (let i = 0; i < 3; i++) await createKa(cgId, expiredEnd); // expired tail
+        const epochLength = await Chronos.epochLength();
+        await time.increase(Number(epochLength) * 5);
+
+        // A from-0 scan with maxScan below the 4-live prefix removes nothing...
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 3n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(7n);
+        // ...but starting at the tail clears the expired entries.
+        expect(await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 4n, 10n)).to.equal(3n);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 4n, 10n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(4n);
       });
 
       it('the swap-pop primitive is gated to the RandomSampling contract', async () => {

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -265,7 +265,7 @@ describe('@unit RandomSampling', () => {
 
   describe('version()', () => {
     it('Should return correct version', async () => {
-      expect(await RandomSampling.version()).to.equal('10.4.0');
+      expect(await RandomSampling.version()).to.equal('10.5.0');
     });
   });
 

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -1229,6 +1229,45 @@ describe('@unit RandomSampling', () => {
         expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(4n);
       });
 
+      it('recovery path: a clogged CG starves previewChallengeForSeed before pruning, succeeds after', async () => {
+        // The bug this keeper fixes: a bounded within-CG draw starved by expired
+        // dead slots. Prove the actual draw path — not just list mutation.
+        const cgId = await createCG(OPEN_POLICY);
+        const currentEpoch = await Chronos.getCurrentEpoch();
+        const liveKa = await createKa(cgId, currentEpoch + 100n);
+        for (let i = 0; i < 20; i++) await createKa(cgId, currentEpoch + 1n); // expired flood
+        await seedCGValue(cgId, 10_000n, 20n); // keep the single CG weighted across the advance
+        const epochLength = await Chronos.epochLength();
+        await time.increase(Number(epochLength) * 5); // expire the 20 fillers
+
+        // Find a seed whose draw starves on the expired slots (reverts). With
+        // 1 live / 20 expired, P(starve) per seed ≈ (20/21)^10 ≈ 0.61, so a
+        // reverting seed within 50 is a near-certainty (P(miss) ≈ 1e-21).
+        let cloggedSeed: number | undefined;
+        for (let i = 0; i < 50; i++) {
+          try {
+            await RandomSampling.previewChallengeForSeed(testSeed(i));
+          } catch {
+            cloggedSeed = i;
+            break;
+          }
+        }
+        expect(cloggedSeed, 'expected a seed that starves on the expired flood').to.not.equal(undefined);
+        // BEFORE: that seed reverts — the draw is clogged.
+        await expect(
+          RandomSampling.previewChallengeForSeed(testSeed(cloggedSeed!)),
+        ).to.be.revertedWithCustomError(RandomSampling, 'NoEligibleKnowledgeAsset');
+
+        // Prune the expired KAs via the keeper (its own committed tx).
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(1n);
+
+        // AFTER: the SAME seed now resolves to the live KA — the draw recovered.
+        const after = await RandomSampling.previewChallengeForSeed(testSeed(cloggedSeed!));
+        expect(after.cgId).to.equal(cgId);
+        expect(after.kaId).to.equal(liveKa);
+      });
+
       it('the swap-pop primitive is gated to the RandomSampling contract', async () => {
         const cgId = await createCG(OPEN_POLICY);
         const ka = await createKa(cgId, (await Chronos.getCurrentEpoch()) + 5n);

--- a/packages/evm-module/test/unit/RandomSampling.test.ts
+++ b/packages/evm-module/test/unit/RandomSampling.test.ts
@@ -265,7 +265,7 @@ describe('@unit RandomSampling', () => {
 
   describe('version()', () => {
     it('Should return correct version', async () => {
-      expect(await RandomSampling.version()).to.equal('10.5.0');
+      expect(await RandomSampling.version()).to.equal('10.6.0');
     });
   });
 
@@ -1181,17 +1181,20 @@ describe('@unit RandomSampling', () => {
         expect(removed).to.equal(3n);
         await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
 
-        // Only the 2 live KAs remain.
-        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(2n);
+        // Only the 2 live KAs remain IN THE SAMPLING LIST.
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(2n);
         const remaining = new Set<bigint>([
-          await ContextGraphStorage.getContextGraphKaAt(cgId, 0),
-          await ContextGraphStorage.getContextGraphKaAt(cgId, 1),
+          await ContextGraphStorage.getSamplingKaAt(cgId, 0),
+          await ContextGraphStorage.getSamplingKaAt(cgId, 1),
         ]);
         expect(remaining.has(live1)).to.equal(true);
         expect(remaining.has(live2)).to.equal(true);
         expect(remaining.has(exp1)).to.equal(false);
         // Reverse binding for a pruned (expired) KA survives — readers/dedup intact.
         expect(await ContextGraphStorage.kaToContextGraph(exp2)).to.equal(cgId);
+        // Reconciler-safety invariant: the append-only registration list is NOT
+        // mutated by sampling pruning — its count stays at all 5 registered.
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(5n);
       });
 
       it('is bounded by maxScan and clears a large flood across calls', async () => {
@@ -1204,10 +1207,12 @@ describe('@unit RandomSampling', () => {
         // maxScan=3 → at most 3 removed this call.
         expect(await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 0n, 3n)).to.equal(3n);
         await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 3n);
-        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(5n);
-        // Follow-up clears the rest.
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(5n);
+        // Follow-up clears the rest of the SAMPLING list.
         await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
-        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(0n);
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(0n);
+        // The append-only registration list still holds all 8.
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(8n);
       });
 
       it('startIndex reaches the expired tail past a live prefix (live-prefix recoverability)', async () => {
@@ -1222,11 +1227,11 @@ describe('@unit RandomSampling', () => {
 
         // A from-0 scan with maxScan below the 4-live prefix removes nothing...
         await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 3n);
-        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(7n);
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(7n);
         // ...but starting at the tail clears the expired entries.
         expect(await RandomSampling.pruneExpiredKnowledgeAssets.staticCall(cgId, 4n, 10n)).to.equal(3n);
         await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 4n, 10n);
-        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(4n);
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(4n);
       });
 
       it('recovery path: a clogged CG starves previewChallengeForSeed before pruning, succeeds after', async () => {
@@ -1260,12 +1265,42 @@ describe('@unit RandomSampling', () => {
 
         // Prune the expired KAs via the keeper (its own committed tx).
         await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
-        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(1n);
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(1n);
 
         // AFTER: the SAME seed now resolves to the live KA — the draw recovered.
         const after = await RandomSampling.previewChallengeForSeed(testSeed(cloggedSeed!));
         expect(after.cgId).to.equal(cgId);
         expect(after.kaId).to.equal(liveKa);
+      });
+
+      it('reconciler-safety: pruning never rewinds the append-only ordinal, so a later publish is always appended (round-4 regression)', async () => {
+        // The exact failure mode the decoupled sampling list prevents: pruning
+        // must NOT shrink the registration list, or the off-chain reconciler's
+        // [watermark, head) cursor could skip a later publish forever.
+        const cgId = await createCG(OPEN_POLICY);
+        const currentEpoch = await Chronos.getCurrentEpoch();
+        await createKa(cgId, currentEpoch + 1n);
+        await createKa(cgId, currentEpoch + 1n);
+        await createKa(cgId, currentEpoch + 1n);
+        const headBeforePrune = await ContextGraphStorage.getContextGraphKaCount(cgId);
+        expect(headBeforePrune).to.equal(3n);
+
+        const epochLength = await Chronos.epochLength();
+        await time.increase(Number(epochLength) * 5);
+        await RandomSampling.pruneExpiredKnowledgeAssets(cgId, 0n, 100n);
+
+        // Sampling list emptied, but the registration head is UNCHANGED — the
+        // reconciler cursor is not rewound.
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(0n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(headBeforePrune);
+
+        // A later publish appends at the NEXT ordinal (head grows monotonically),
+        // so the reconciler can never skip it — and it is sampling-eligible.
+        const laterKa = await createKa(cgId, currentEpoch + 100n);
+        expect(await ContextGraphStorage.getContextGraphKaCount(cgId)).to.equal(headBeforePrune + 1n);
+        expect(await ContextGraphStorage.getContextGraphKaAt(cgId, headBeforePrune)).to.equal(laterKa);
+        expect(await ContextGraphStorage.getSamplingKaCount(cgId)).to.equal(1n);
+        expect(await ContextGraphStorage.getSamplingKaAt(cgId, 0n)).to.equal(laterKa);
       });
 
       it('the swap-pop primitive is gated to the RandomSampling contract', async () => {
@@ -1482,10 +1517,11 @@ describe('@unit RandomSampling', () => {
           cg,
           currentEpoch,
         );
-        const n = Number(await ContextGraphStorage.getContextGraphKaCount(cg));
+        // The draw reads the SAMPLING list, so the oracle must mirror it.
+        const n = Number(await ContextGraphStorage.getSamplingKaCount(cg));
         const list: bigint[] = [];
         for (let i = 0; i < n; i++) {
-          list.push(await ContextGraphStorage.getContextGraphKaAt(cg, BigInt(i)));
+          list.push(await ContextGraphStorage.getSamplingKaAt(cg, BigInt(i)));
         }
         kaList[cg.toString()] = list;
       }

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -720,6 +720,52 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     ).to.be.revertedWithCustomError(KAV10, 'ZeroEpochs');
   });
 
+  it('extend reverts KnowledgeAssetExpired on an already-expired KA (keeps sampling-prune safe)', async () => {
+    // Safety invariant for RandomSampling's decoupled sampling list: the keeper
+    // prunes a KA once `endEpoch < currentEpoch`, and a pruned KA can never
+    // re-enter the sampling list (the double-registration guard blocks it). If
+    // extend could revive an EXPIRED KA, that KA would be live + paid yet
+    // permanently unsampleable. extend's expiry guard uses the SAME threshold
+    // (`currentEpoch > endEpoch`), so the two are mutually exclusive and the
+    // revive-into-unsampleable path is unreachable. This test pins that guard.
+    const Params = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+    const deposit = ethers.parseEther('2000');
+    await Params.connect(accounts[0]).setContextGraphRegistrationDeposit(deposit);
+    const creator = getDefaultKACreator(accounts);
+    await Token.mint(creator.address, deposit);
+    await Token.connect(creator).approve(await CGFacade.getAddress(), deposit);
+
+    const { cgId, epochs, receivingNodes, publisherIdentityId, receiverIdentityIds } =
+      await setupRegisteredAgentPublish();
+    const reservedKaId = packReservedKaId(creator.address, 1);
+    const p = await buildPublishParams({
+      chainId: DEFAULT_CHAIN_ID,
+      kav10Address: await KAV10.getAddress(),
+      receivingNodes,
+      publisherIdentityId,
+      receiverIdentityIds,
+      author: creator,
+      contextGraphId: cgId,
+      merkleRoot: ethers.keccak256(ethers.toUtf8Bytes('extend-expired')),
+      knowledgeAssetsAmount: 1,
+      byteSize: 1000,
+      epochs,
+      tokenAmount: ethers.parseEther('1000'),
+      isImmutable: false,
+      publishOperationId: 'extend-expired-pub',
+      reservedKaId,
+    });
+    await KAV10.connect(creator).publish(p);
+
+    // Advance past the KA's lifetime so it is expired (and prune-eligible).
+    const epochLength = await Chronos.epochLength();
+    await time.increase(Number(epochLength) * (Number(epochs) + 1));
+
+    await expect(
+      KAV10.connect(creator).extendKnowledgeAssetLifetime(reservedKaId, 1, ethers.parseEther('100')),
+    ).to.be.revertedWithCustomError(KAV10, 'KnowledgeAssetExpired');
+  });
+
   // --------------------------------------------------------------------------
   // OT-RFC-53 — update draws the registration escrow for the delta + pays its fee
   // --------------------------------------------------------------------------

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -642,26 +642,36 @@ export class StorageACKHandler {
     // by the merkle-root check above (computeFlatKCRoot over the SWM quads).
     const verifiedKACount = 1;
 
-    // byteSize pin: the core just recomputed the public merkle root over
-    // `swmQuads`, so it knows the exact triples it is attesting to. The
-    // publisher's claimed `publicByteSize` is signed into the ACK digest and
-    // prices the publish on-chain (`ask · byteSize · epochs`); nothing on-chain
-    // can see the content, so without this an under-claim (e.g. `byteSize = 1`
-    // for real content) drives the cost toward zero regardless of the ask.
-    // Refuse to sign when the claim is below the serialization-INDEPENDENT lower
-    // bound Σ(UTF-8 byteLength(s,p,o)). `publicByteSize` is a UTF-8 BYTE count
-    // (the publisher computes `TextEncoder().encode(nquads).length`), so the
-    // floor MUST be UTF-8 bytes too — JS string `.length` (UTF-16 code units)
-    // would under-count non-ASCII IRIs/literals and let them slip through. Every
-    // valid N-Quads serialization is strictly longer than the bare term bytes (it
-    // adds `<>`, spaces, ` .`, newlines), so an honest publisher
-    // (`publicByteSize == utf8(nquads).length`) never trips this.
-    let byteSizeFloor = 0;
-    for (const q of swmQuads) {
-      byteSizeFloor +=
-        Buffer.byteLength(q.subject, 'utf8') +
-        Buffer.byteLength(q.predicate, 'utf8') +
-        Buffer.byteLength(q.object, 'utf8');
+    // byteSize pin: `publicByteSize` is signed into the ACK digest and prices the
+    // publish on-chain (`ask · byteSize · epochs`); nothing on-chain can see the
+    // content, so without this an under-claim (e.g. `byteSize = 1` for real
+    // content) drives the cost toward zero regardless of the ask. The publisher
+    // computes it as the UTF-8 byte length of the N-Quads serialization
+    // (`TextEncoder().encode(nquads).length`), so the floor is in UTF-8 bytes:
+    //   - INLINE path (`stagingQuads` present): the core received the EXACT
+    //     serialized payload, so require the claim to cover its full byte length
+    //     — anything less omits real serialized bytes (`<>`, separators, graph
+    //     terms, escapes, newlines) the cores must store. This is the tight,
+    //     exact floor (an honest direct publish sets `publicByteSize ==
+    //     stagingQuads.length`; both derive from the same `nquadsStr`).
+    //   - SWM-fallback path: the original serialization isn't reconstructable
+    //     byte-exactly, so fall back to the serialization-INDEPENDENT lower bound
+    //     Σ(UTF-8 byteLength(s,p,o)) (always ≤ the real serialization, so no
+    //     false positives; JS string `.length` would under-count non-ASCII).
+    let byteSizeFloor: number;
+    let floorBasis: string;
+    if (intent.stagingQuads && intent.stagingQuads.length > 0) {
+      byteSizeFloor = intent.stagingQuads.length;
+      floorBasis = 'exact inline payload bytes';
+    } else {
+      byteSizeFloor = 0;
+      for (const q of swmQuads) {
+        byteSizeFloor +=
+          Buffer.byteLength(q.subject, 'utf8') +
+          Buffer.byteLength(q.predicate, 'utf8') +
+          Buffer.byteLength(q.object, 'utf8');
+      }
+      floorBasis = 'Σ UTF-8 term bytes (lower bound)';
     }
     const claimedPublicByteSize = typeof intent.publicByteSize === 'number'
       ? intent.publicByteSize
@@ -671,8 +681,8 @@ export class StorageACKHandler {
         cgId,
         STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM,
         `public ACK byteSize under-claim: publisher claims publicByteSize=${claimedPublicByteSize} ` +
-        `but the ${swmQuads.length} attested triples require at least ${byteSizeFloor} UTF-8 bytes ` +
-        `(Σ term bytes; the N-Quads serialization is strictly larger). Refusing to sign an under-priced footprint.`,
+        `but the attested content requires at least ${byteSizeFloor} UTF-8 bytes ` +
+        `(${floorBasis}). Refusing to sign an under-priced footprint.`,
       );
     }
     const verifiedByteSize = BigInt(claimedPublicByteSize);

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -641,9 +641,35 @@ export class StorageACKHandler {
     // The data integrity that recompute was protecting is already guaranteed
     // by the merkle-root check above (computeFlatKCRoot over the SWM quads).
     const verifiedKACount = 1;
-    const verifiedByteSize = typeof intent.publicByteSize === 'number'
-      ? BigInt(intent.publicByteSize)
-      : BigInt(Number(intent.publicByteSize));
+
+    // byteSize pin: the core just recomputed the public merkle root over
+    // `swmQuads`, so it knows the exact triples it is attesting to. The
+    // publisher's claimed `publicByteSize` is signed into the ACK digest and
+    // prices the publish on-chain (`ask · byteSize · epochs`); nothing on-chain
+    // can see the content, so without this an under-claim (e.g. `byteSize = 1`
+    // for real content) drives the cost toward zero regardless of the ask.
+    // Refuse to sign when the claim is below the serialization-INDEPENDENT lower
+    // bound Σ(|s|+|p|+|o|): every valid N-Quads serialization is strictly longer
+    // than the bare term lengths (it adds `<>`, spaces, ` .`, newlines), so an
+    // honest publisher whose `publicByteSize == nquads.length` never trips this,
+    // while a grossly under-stated footprint is rejected before signing.
+    let byteSizeFloor = 0;
+    for (const q of swmQuads) {
+      byteSizeFloor += q.subject.length + q.predicate.length + q.object.length;
+    }
+    const claimedPublicByteSize = typeof intent.publicByteSize === 'number'
+      ? intent.publicByteSize
+      : Number(intent.publicByteSize);
+    if (!Number.isFinite(claimedPublicByteSize) || claimedPublicByteSize < byteSizeFloor) {
+      return this.encodeDecline(
+        cgId,
+        STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM,
+        `public ACK byteSize under-claim: publisher claims publicByteSize=${claimedPublicByteSize} ` +
+        `but the ${swmQuads.length} attested triples require at least ${byteSizeFloor} bytes ` +
+        `(Σ term lengths; the N-Quads serialization is strictly larger). Refusing to sign an under-priced footprint.`,
+      );
+    }
+    const verifiedByteSize = BigInt(claimedPublicByteSize);
 
     // Derive numeric CG ID the same way the publisher does. Fail loud on
     // non-numeric or non-positive ids — the V10 contract rejects

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -649,13 +649,19 @@ export class StorageACKHandler {
     // can see the content, so without this an under-claim (e.g. `byteSize = 1`
     // for real content) drives the cost toward zero regardless of the ask.
     // Refuse to sign when the claim is below the serialization-INDEPENDENT lower
-    // bound Σ(|s|+|p|+|o|): every valid N-Quads serialization is strictly longer
-    // than the bare term lengths (it adds `<>`, spaces, ` .`, newlines), so an
-    // honest publisher whose `publicByteSize == nquads.length` never trips this,
-    // while a grossly under-stated footprint is rejected before signing.
+    // bound Σ(UTF-8 byteLength(s,p,o)). `publicByteSize` is a UTF-8 BYTE count
+    // (the publisher computes `TextEncoder().encode(nquads).length`), so the
+    // floor MUST be UTF-8 bytes too — JS string `.length` (UTF-16 code units)
+    // would under-count non-ASCII IRIs/literals and let them slip through. Every
+    // valid N-Quads serialization is strictly longer than the bare term bytes (it
+    // adds `<>`, spaces, ` .`, newlines), so an honest publisher
+    // (`publicByteSize == utf8(nquads).length`) never trips this.
     let byteSizeFloor = 0;
     for (const q of swmQuads) {
-      byteSizeFloor += q.subject.length + q.predicate.length + q.object.length;
+      byteSizeFloor +=
+        Buffer.byteLength(q.subject, 'utf8') +
+        Buffer.byteLength(q.predicate, 'utf8') +
+        Buffer.byteLength(q.object, 'utf8');
     }
     const claimedPublicByteSize = typeof intent.publicByteSize === 'number'
       ? intent.publicByteSize
@@ -665,8 +671,8 @@ export class StorageACKHandler {
         cgId,
         STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM,
         `public ACK byteSize under-claim: publisher claims publicByteSize=${claimedPublicByteSize} ` +
-        `but the ${swmQuads.length} attested triples require at least ${byteSizeFloor} bytes ` +
-        `(Σ term lengths; the N-Quads serialization is strictly larger). Refusing to sign an under-priced footprint.`,
+        `but the ${swmQuads.length} attested triples require at least ${byteSizeFloor} UTF-8 bytes ` +
+        `(Σ term bytes; the N-Quads serialization is strictly larger). Refusing to sign an under-priced footprint.`,
       );
     }
     const verifiedByteSize = BigInt(claimedPublicByteSize);

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -658,25 +658,36 @@ export class StorageACKHandler {
     //     byte-exactly, so fall back to the serialization-INDEPENDENT lower bound
     //     Σ(UTF-8 byteLength(s,p,o)) (always ≤ the real serialization, so no
     //     false positives; JS string `.length` would under-count non-ASCII).
-    let byteSizeFloor: number;
+    // `publicByteSize` is a protobuf `uint64` (number | Long on the wire). Parse
+    // it to `bigint` ONCE and keep the floor, the compare, AND the signed ACK
+    // digest value in `bigint` across the full uint64 range — a `Number()` round
+    // would corrupt a value above 2^53 before it is priced/signed.
+    let byteSizeFloor: bigint;
     let floorBasis: string;
     if (intent.stagingQuads && intent.stagingQuads.length > 0) {
-      byteSizeFloor = intent.stagingQuads.length;
+      byteSizeFloor = BigInt(intent.stagingQuads.length);
       floorBasis = 'exact inline payload bytes';
     } else {
-      byteSizeFloor = 0;
+      byteSizeFloor = 0n;
       for (const q of swmQuads) {
         byteSizeFloor +=
-          Buffer.byteLength(q.subject, 'utf8') +
-          Buffer.byteLength(q.predicate, 'utf8') +
-          Buffer.byteLength(q.object, 'utf8');
+          BigInt(Buffer.byteLength(q.subject, 'utf8')) +
+          BigInt(Buffer.byteLength(q.predicate, 'utf8')) +
+          BigInt(Buffer.byteLength(q.object, 'utf8'));
       }
       floorBasis = 'Σ UTF-8 term bytes (lower bound)';
     }
-    const claimedPublicByteSize = typeof intent.publicByteSize === 'number'
-      ? intent.publicByteSize
-      : Number(intent.publicByteSize);
-    if (!Number.isFinite(claimedPublicByteSize) || claimedPublicByteSize < byteSizeFloor) {
+    let claimedPublicByteSize: bigint;
+    try {
+      claimedPublicByteSize = BigInt(
+        typeof intent.publicByteSize === 'number'
+          ? intent.publicByteSize
+          : intent.publicByteSize.toString(),
+      );
+    } catch {
+      claimedPublicByteSize = -1n; // non-integer / unparseable → fails the wire-validity gate
+    }
+    if (claimedPublicByteSize < 0n || claimedPublicByteSize < byteSizeFloor) {
       return this.encodeDecline(
         cgId,
         STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM,
@@ -685,7 +696,7 @@ export class StorageACKHandler {
         `(${floorBasis}). Refusing to sign an under-priced footprint.`,
       );
     }
-    const verifiedByteSize = BigInt(claimedPublicByteSize);
+    const verifiedByteSize = claimedPublicByteSize;
 
     // Derive numeric CG ID the same way the publisher does. Fail loud on
     // non-numeric or non-positive ids — the V10 contract rejects

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -168,6 +168,45 @@ describe('StorageACKHandler', () => {
     expect(isStorageACKDecline(decoded)).toBe(false);
   });
 
+  it('byteSize floor is UTF-8 bytes — a UTF-16 code-unit count is rejected for non-ASCII content', async () => {
+    // `publicByteSize` is a UTF-8 byte count; the floor must be too. With a
+    // non-ASCII IRI, UTF-8 byte length > UTF-16 code-unit length, so a claim at
+    // the (smaller) code-unit sum — which a JS `.length` floor would have wrongly
+    // ACCEPTED — must be declined.
+    const naQuads: Quad[] = [makeQuad('urn:s:日本', 'urn:p', 'urn:o:語')];
+    const naRoot = computeFlatKCRoot(naQuads, []);
+    const naLeafCount = computeFlatKCMerkleLeafCountV10(naQuads, []);
+    const utf8Floor =
+      Buffer.byteLength('urn:s:日本', 'utf8') +
+      Buffer.byteLength('urn:p', 'utf8') +
+      Buffer.byteLength('urn:o:語', 'utf8');
+    const utf16Sum = 'urn:s:日本'.length + 'urn:p'.length + 'urn:o:語'.length;
+    expect(utf8Floor).to.be.greaterThan(utf16Sum); // sanity: non-ASCII makes UTF-8 > UTF-16
+
+    const handler = await createHandler(naQuads);
+    const mk = (publicByteSize: number) =>
+      encodePublishIntent({
+        merkleRoot: naRoot,
+        contextGraphId,
+        publisherPeerId: 'publisher-0',
+        publicByteSize,
+        isPrivate: false,
+        kaCount: 1,
+        rootEntities: ['urn:s:日本'],
+        epochs: 1,
+        tokenAmountStr: '1000',
+        merkleLeafCount: naLeafCount,
+      });
+
+    // Claim at the UTF-16 code-unit sum (< UTF-8 floor) → declined under-claim.
+    const declined = decodeStorageACK(await handler.handler(mk(utf16Sum), fakePeerId));
+    expect(isStorageACKDecline(declined)).toBe(true);
+    expect(declined.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM);
+    // Claim at the UTF-8 floor → accepted.
+    const accepted = decodeStorageACK(await handler.handler(mk(utf8Floor), fakePeerId));
+    expect(isStorageACKDecline(accepted)).toBe(false);
+  });
+
   it('declines (SIGNER_NOT_REGISTERED) when the signer is no longer confirmed registered', async () => {
     // PR #557: this used to throw, which the publisher saw as a libp2p
     // stream reset; now the handler returns a typed decline so the

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -120,6 +120,54 @@ describe('StorageACKHandler', () => {
     expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
   });
 
+  it('declines (BYTESIZE_UNDERCLAIM) when publicByteSize is below the real content lower bound', async () => {
+    // The 3 fixture triples have Σ(|s|+|p|+|o|) = 69, a strict lower bound on
+    // any valid N-Quads serialization. A claim of 1 (the byteSize=1 cost dodge)
+    // must be refused so the on-chain ask actually prices the real footprint.
+    const handler = await createHandler(swmQuads);
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 1,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:entity:1', 'urn:entity:2'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: swmMerkleLeafCount,
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM);
+    expect(decoded.declineMessage).toContain('under-claim');
+  });
+
+  it('signs a public ACK when publicByteSize meets the real content lower bound (boundary)', async () => {
+    // Exactly the Σ term-length floor (69) is accepted — an honest publisher's
+    // `publicByteSize == nquads.length` is always strictly above it.
+    const handler = await createHandler(swmQuads);
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 69,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:entity:1', 'urn:entity:2'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: swmMerkleLeafCount,
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+    expect(isStorageACKDecline(decoded)).toBe(false);
+  });
+
   it('declines (SIGNER_NOT_REGISTERED) when the signer is no longer confirmed registered', async () => {
     // PR #557: this used to throw, which the publisher saw as a libp2p
     // stream reset; now the handler returns a typed decline so the

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -207,6 +207,50 @@ describe('StorageACKHandler', () => {
     expect(isStorageACKDecline(accepted)).toBe(false);
   });
 
+  it('inline path: byteSize floor is the EXACT serialized payload, not just term bytes', async () => {
+    // When the publisher sends the payload inline (stagingQuads), the core has
+    // the exact serialized bytes, so the floor is the full payload length — a
+    // claim at the bare term-byte sum (which the loose lower bound accepted)
+    // under-prices the real serialization (<>, separators, graph term, ` .`).
+    const g = 'did:dkg:context-graph:42';
+    const inlineQuads: Quad[] = [makeQuad('urn:s', 'urn:p', 'urn:o', g)];
+    const nquadsStr = inlineQuads
+      .map((q) => `<${q.subject}> <${q.predicate}> <${q.object}> <${q.graph}> .`)
+      .join('\n');
+    const stagingBytes = new TextEncoder().encode(nquadsStr);
+    const inlineRoot = computeFlatKCRoot(inlineQuads, []);
+    const inlineLeaf = computeFlatKCMerkleLeafCountV10(inlineQuads, []);
+    const termSum =
+      Buffer.byteLength('urn:s', 'utf8') +
+      Buffer.byteLength('urn:p', 'utf8') +
+      Buffer.byteLength('urn:o', 'utf8');
+    expect(stagingBytes.length).to.be.greaterThan(termSum); // serialization overhead exists
+
+    const handler = await createHandler([]); // no SWM data; the payload is inline
+    const mk = (publicByteSize: number) =>
+      encodePublishIntent({
+        merkleRoot: inlineRoot,
+        contextGraphId,
+        publisherPeerId: 'publisher-0',
+        publicByteSize,
+        isPrivate: false,
+        kaCount: 1,
+        rootEntities: ['urn:s'],
+        epochs: 1,
+        tokenAmountStr: '1000',
+        merkleLeafCount: inlineLeaf,
+        stagingQuads: stagingBytes,
+      });
+
+    // Claim at the term-byte sum (omits serialization overhead) → declined.
+    const declined = decodeStorageACK(await handler.handler(mk(termSum), fakePeerId));
+    expect(isStorageACKDecline(declined)).toBe(true);
+    expect(declined.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM);
+    // Claim at the exact serialized byte length → accepted.
+    const ok = decodeStorageACK(await handler.handler(mk(stagingBytes.length), fakePeerId));
+    expect(isStorageACKDecline(ok)).toBe(false);
+  });
+
   it('declines (SIGNER_NOT_REGISTERED) when the signer is no longer confirmed registered', async () => {
     // PR #557: this used to throw, which the publisher saw as a libp2p
     // stream reset; now the handler returns a typed decline so the


### PR DESCRIPTION
Two related robustness fixes to V10 random-sampling KA selection.

## 1. Decouple the sampling list so expired KAs can be pruned (on-chain)

The per-CG KA list is append-only with **no removal**, while the CG-level Fenwick tree self-de-weights via epoch-scoped value. So expired KAs accumulate as permanent dead slots in a CG's sampling list. The within-CG draw is a fixed `MAX_KA_RETRIES` uniform resample that skips expired entries — once dead slots dominate a list, every draw can exhaust the retry budget and the CG's *live* KAs stop being challengeable, with no on-chain recovery.

The list can't simply be pruned in place: the **same list is the append-only registration ordinal the off-chain chain-reconciler walks** as `[watermark, head)` (`head = getContextGraphKaCount`), and it runs for public CGs too. A swap-pop would move an un-reconciled KA below the watermark → permanently skipped from the VM. So the two roles are split into two per-CG arrays:

- `_contextGraphKAList` stays **strictly append-only** — the reconciler's registration ordinal. `getContextGraphKaCount/At` unchanged. Never reordered, never shrunk.
- New `_samplingKAList` (read via `getSamplingKaCount/At`) is the **compacted** list the within-CG draw reads and the keeper compacts. Registration appends to both; pruning swap-pops the **sampling list only**, so the registration ordinal is never rewound and a later publish can never be skipped.
- `ContextGraphStorage.swapRemoveKnowledgeAssetAt(cgId, index, expectedKaId)` — O(1) swap-and-pop on the sampling list. **`kaToContextGraph` left intact** (reverse lookup + double-registration guard keep working; an expired KA can never re-register). `expectedKaId` makes it a no-op on a stale index. **Restricted to the `RandomSampling` contract** (`OnlyRandomSampling`).
- Permissionless keeper `RandomSampling.pruneExpiredKnowledgeAssets(cgId, startIndex, maxScan)` — scans `maxScan` sampling-list positions from `startIndex` and swap-pops every expired KA (`endEpoch < currentEpoch`). **Commits in its own transaction**, independent of `createChallenge` (whose in-draw settle work rolls back on an all-miss revert), so a clogged CG is always recoverable. `startIndex` reaches any region (e.g. an expired tail behind a live prefix). Safe to be permissionless: removes only already-expired (sampling-ineligible) KAs. Bounded by `maxScan`; a large flood clears across calls.
- No new contract, no migration (mainnet is a fresh deploy); the off-chain reconciler + chain adapter are unchanged.
- Versions: `RandomSampling` → 10.6.0, `ContextGraphStorage` → 10.0.6.

## 2. Pin the public ACK byteSize to real content (off-chain)

A core signs the publisher's claimed `publicByteSize` into the ACK digest verbatim; that `byteSize` prices the publish on-chain (`ask · byteSize · epochs`) and nothing on-chain can see the content — so a claim far below the real footprint under-prices the publish regardless of the ask.

The core already recomputes the public merkle root over the quads it attests to, so it knows the exact content. It now **declines to sign** (`BYTESIZE_UNDERCLAIM`) an under-claim:
- **inline path** (`stagingQuads` present): the core has the exact serialized payload, so the floor is its full UTF-8 byte length. An honest direct publish sets `publicByteSize == stagingQuads.length` (both derive from the same `nquadsStr`), so this is exact with no false positives.
- **SWM-fallback path**: the original serialization isn't reconstructable byte-exactly, so the floor is the serialization-independent lower bound `Σ(UTF-8 byteLength(s,p,o))` (always ≤ the real serialization).

## Tests
- **Reconciler-safety regression** (the crux): pruning empties the sampling list but never shrinks the append-only registration count, and a later publish appends at the next ordinal + is sampling-eligible — the exact reconciler-skip scenario, now impossible. The existing `chain-reconcile-e2e` stays green (the adapter still reads the append-only ordinal).
- **Cross-function safety**: extend reverts `KnowledgeAssetExpired` on the same threshold the keeper prunes on → a pruned KA can't be revived into a live-but-unsampleable state.
- `ContextGraphStorage`: registration dual-writes both lists; `getSamplingKa*` mirrors `getContextGraphKa*` before any prune.
- `RandomSampling` keeper regression: prunes expired KAs from the sampling list, **preserves live KAs + the `kaToContextGraph` binding**, honors `maxScan`/`startIndex`, draw-level recovery (clogged CG starves `previewChallengeForSeed`, succeeds after prune), swap-pop `RandomSampling`-gated; **view/full draw-parity oracle** retargeted to the sampling list.
- `storage-ack-handler`: under-claim decline + boundary accept + non-ASCII UTF-8 floor + inline-exact floor.
- Full suites green: `dkg-evm-module` **834**, `dkg-publisher` **1215**, `dkg-chain` **615**, `dkg-core` **1084** — all 0 failing.

## Review feedback addressed
Round 1:
- 🔴 *prune didn't persist on an all-miss revert* → replaced the in-`createChallenge` prune with the committed permissionless keeper above (its own tx; recoverable regardless of draw outcome). The draw path is read-only-pick again, so the hot-path mutation + view/full-parity concerns are also gone.
- 🟡 *generic swap-pop callable by any Hub contract* → narrowed `swapRemoveKnowledgeAssetAt` to the `RandomSampling` contract only (`OnlyRandomSampling`); the expiry invariant lives in that single caller.

Round 2:
- 🔴 *byteSize floor used UTF-16 string length* → now sums `Buffer.byteLength(s/p/o, 'utf8')` to match `publicByteSize` (a UTF-8 byte count); non-ASCII content can no longer under-claim. Non-ASCII regression added.
- 🟡 *keeper had no cursor (live-prefix CGs unrecoverable)* → added `startIndex` so any region is reachable; live-prefix regression added.

Round 3:
- 🔴 *byteSize floor too loose in the inline path* → when `stagingQuads` is present the floor is now the exact payload byte length (term-sum omitted `<>`/separators/graph terms); exact, no false positives. Inline regression added.
- 🔴 *new ABI surface not in `packages/chain/abi`* → refreshed the chain ABIs (SDK/adapter loads these first); ABI pin digest repinned.
- 🟡 *keeper tests didn't prove the recovery path* → added a draw-level regression (clogged CG starves `previewChallengeForSeed`, then succeeds against the live KA after pruning).

Round 4:
- 🔴 *pruning the shared list corrupts the append-only reconciler ordinal* → **redesigned to the decoupled two-list approach in §1** (append-only `_contextGraphKAList` for the reconciler + compacted `_samplingKAList` for the draw). Reconciler-safety + cross-function (extend-expired) regressions added; `chain-reconcile-e2e` stays green.
- 🟡 *`publicByteSize` (uint64) routed through `Number()`* → parsed to `bigint` once; floor/compare/signed-digest stay `bigint`, with a wire-validity gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
