### PR TITLE
refactor(publisher): extract buildScopedMinimalMeta shared by both publish paths (#1269)

### DIFF
--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -31,6 +31,7 @@ import {
   SWM_CURRENT_ASSERTION_PRED,
   VM_CURRENT_ASSERTION_PRED,
   toHex,
+  buildScopedMinimalMeta,
   resolveUalByBatchId,
   promoteUpdatedKaToPerCgId,
   restateLabelGraphForUpdate,
@@ -1609,50 +1610,10 @@ export class DKGPublisher implements Publisher {
           //   - `dkg:materializedVersion` is stamped below.
           // The RS prover and the backfill route are read-both, so old
           // wholesale-copied partitions keep working.
-          const DKG_ONT = 'http://dkg.io/ontology/';
-          const XSD_INT = 'http://www.w3.org/2001/XMLSchema#integer';
           const partitionKaId = publishResult.onChainResult!.kaId ?? publishResult.onChainResult!.batchId;
-          const minimalMeta: Quad[] = [
-            { subject: ual, predicate: `${DKG_ONT}batchId`, object: `"${partitionKaId}"^^<${XSD_INT}>`, graph: ctxMetaGraph },
-            { subject: ual, predicate: `${DKG_ONT}merkleRoot`, object: `"${toHex(publishResult.merkleRoot)}"`, graph: ctxMetaGraph },
-          ];
-          const seenPartitionRoots = new Set<string>();
-          const seenPartitionPrivRoots = new Set<string>();
-          // Codex review "multi-root-access" (restateKaPartition parity):
-          // MULTI-root publishes additionally re-emit the legacy
-          // `<ual>/<tokenId>` token rows so the root↔privateMerkleRoot
-          // pairing stays recoverable; single-root keeps the full collapse.
-          const partitionMultiRoot =
-            new Set(publishResult.kaManifest.map((ka) => ka.rootEntity)).size > 1;
-          for (const ka of publishResult.kaManifest) {
-            if (!seenPartitionRoots.has(ka.rootEntity)) {
-              seenPartitionRoots.add(ka.rootEntity);
-              // RFC ka-metadata-trim Phase 2: single member row (the §10.1
-              // dual-write was collapsed back to `dkg:rootEntity`; readers
-              // stay read-both for dual-written replica rows).
-              minimalMeta.push(
-                { subject: ual, predicate: DKG_ROOT_ENTITY_LEGACY, object: ka.rootEntity, graph: ctxMetaGraph },
-              );
-            }
-            if (ka.privateMerkleRoot && ka.privateMerkleRoot.length > 0) {
-              const privHex = toHex(ka.privateMerkleRoot);
-              if (!seenPartitionPrivRoots.has(privHex)) {
-                seenPartitionPrivRoots.add(privHex);
-                minimalMeta.push({ subject: ual, predicate: `${DKG_ONT}privateMerkleRoot`, object: `"${privHex}"`, graph: ctxMetaGraph });
-              }
-            }
-            if (partitionMultiRoot) {
-              const kaUri = `${ual}/${ka.tokenId}`;
-              minimalMeta.push(
-                { subject: kaUri, predicate: DKG_ROOT_ENTITY_LEGACY, object: ka.rootEntity, graph: ctxMetaGraph },
-                { subject: kaUri, predicate: `${DKG_ONT}partOf`, object: ual, graph: ctxMetaGraph },
-              );
-              if (ka.privateMerkleRoot && ka.privateMerkleRoot.length > 0) {
-                minimalMeta.push({ subject: kaUri, predicate: `${DKG_ONT}privateMerkleRoot`, object: `"${toHex(ka.privateMerkleRoot)}"`, graph: ctxMetaGraph });
-              }
-            }
-          }
-          await this.store.insert(minimalMeta);
+          await this.store.insert(
+            buildScopedMinimalMeta(ual, partitionKaId, publishResult.merkleRoot, publishResult.kaManifest, ctxMetaGraph),
+          );
         }
 
         // Stamp the publish version so a later update can compare against it
@@ -3239,54 +3200,13 @@ export class DKGPublisher implements Publisher {
         );
       }
 
-      // Meta: the minimal shape downstream readers need — `dkg:batchId`
-      // (UAL resolution), `dkg:merkleRoot`, and the collapsed `dkg:rootEntity`
-      // (+ `dkg:privateMerkleRoot`) member rows on the UAL subject. The RS
-      // extractor's read-both UNION resolves all roots from the collapsed shape,
-      // but MULTI-root publishes ALSO re-emit the legacy `<ual>/<tokenId>` token
-      // rows so the root↔privateMerkleRoot pairing stays joinable on the shared
-      // token subject — the AccessHandler keys private bags per member root and
-      // a collapse-only multi-root KC makes non-first bags unreachable. Single
-      // root keeps the full collapse (no pairing needed). Mirrors the SWM block
-      // in `publishFromSharedMemory` and the canonical `generateKCMetadata`
-      // writer; see test/multi-root-token-rows.test.ts for the exact contract.
-      const DKG_ONT = 'http://dkg.io/ontology/';
-      const XSD_INT = 'http://www.w3.org/2001/XMLSchema#integer';
-      const minimalMeta: Quad[] = [
-        { subject: ual, predicate: `${DKG_ONT}batchId`, object: `"${partitionKaId}"^^<${XSD_INT}>`, graph: ctxMetaGraph },
-        { subject: ual, predicate: `${DKG_ONT}merkleRoot`, object: `"${toHex(merkleRoot)}"`, graph: ctxMetaGraph },
-      ];
-      const partitionMultiRoot =
-        new Set(manifestEntries.map((ka) => ka.rootEntity)).size > 1;
-      const seenRoots = new Set<string>();
-      const seenPrivRoots = new Set<string>();
-      for (const ka of manifestEntries) {
-        if (!seenRoots.has(ka.rootEntity)) {
-          seenRoots.add(ka.rootEntity);
-          minimalMeta.push({ subject: ual, predicate: DKG_ROOT_ENTITY_LEGACY, object: ka.rootEntity, graph: ctxMetaGraph });
-        }
-        if (ka.privateMerkleRoot && ka.privateMerkleRoot.length > 0) {
-          const privHex = toHex(ka.privateMerkleRoot);
-          if (!seenPrivRoots.has(privHex)) {
-            seenPrivRoots.add(privHex);
-            minimalMeta.push({ subject: ual, predicate: `${DKG_ONT}privateMerkleRoot`, object: `"${privHex}"`, graph: ctxMetaGraph });
-          }
-        }
-        // MULTI-root only: re-emit the `<ual>/<tokenId>` token rows so each member
-        // root carries its OWN privateMerkleRoot on a shared subject (recoverable
-        // pairing). Not deduped — every token keeps its pairing row.
-        if (partitionMultiRoot) {
-          const kaUri = `${ual}/${ka.tokenId}`;
-          minimalMeta.push(
-            { subject: kaUri, predicate: DKG_ROOT_ENTITY_LEGACY, object: ka.rootEntity, graph: ctxMetaGraph },
-            { subject: kaUri, predicate: `${DKG_ONT}partOf`, object: ual, graph: ctxMetaGraph },
-          );
-          if (ka.privateMerkleRoot && ka.privateMerkleRoot.length > 0) {
-            minimalMeta.push({ subject: kaUri, predicate: `${DKG_ONT}privateMerkleRoot`, object: `"${toHex(ka.privateMerkleRoot)}"`, graph: ctxMetaGraph });
-          }
-        }
-      }
-      await this.store.insert(minimalMeta);
+      // Promote the minimal scoped-meta rows the RS prover + access handler read.
+      // Single source of truth across both publish paths — see
+      // `buildScopedMinimalMeta` (it documents the collapsed shape + the
+      // multi-root `<ual>/<tokenId>` pairing rows the AccessHandler needs).
+      await this.store.insert(
+        buildScopedMinimalMeta(ual, partitionKaId, merkleRoot, manifestEntries, ctxMetaGraph),
+      );
       await writeMaterializedVersion(this.store, ctxMetaGraph, ual, publishVersion);
       this.log.info(ctx, `RS scoped-promote: promoted ${ual} → context graph ${targetCgId} (kaId=${partitionKaId})`);
     });

--- a/packages/publisher/src/metadata.ts
+++ b/packages/publisher/src/metadata.ts
@@ -356,6 +356,69 @@ function intLit(val: number | bigint): string {
   return `"${val}"^^<${XSD}integer>`;
 }
 
+/**
+ * Canonical builder for the "minimal scoped meta" rows the RS prover + access
+ * handler read off a scoped context-graph meta graph: `dkg:batchId` (the UAL
+ * resolution edge) + `dkg:merkleRoot`, the collapsed `dkg:rootEntity`
+ * (+ `dkg:privateMerkleRoot`) member rows on the UAL subject, and — for
+ * MULTI-root KCs only — the `<ual>/<tokenId>` `rootEntity`/`partOf`/
+ * `privateMerkleRoot` pairing rows so each member root↔privateMerkleRoot stays
+ * joinable on its own token subject (single-root keeps the full collapse).
+ *
+ * Single source of truth for the two PUBLISH paths that promote a confirmed KC
+ * into a scoped meta graph: `DKGPublisher.publishFromSharedMemory` (the SWM
+ * path) and `DKGPublisher.promoteConfirmedKCToScopedGraph` (the one-shot
+ * `publish()` RS promotion, #1266). Output is byte-identical to the inline blocks
+ * those two previously carried.
+ *
+ * `restateKaPartition` below writes the SAME shape but from a different data
+ * model — per-root Maps + POSITIONAL `<ual>/<n>` token labels + a DELETE/INSERT
+ * restate — so it intentionally does NOT call this builder. Keep the two shapes
+ * in sync (see the note in `restateKaPartition`).
+ */
+export function buildScopedMinimalMeta(
+  ual: string,
+  kaId: bigint,
+  merkleRoot: Uint8Array,
+  manifestEntries: ReadonlyArray<{ rootEntity: string; tokenId: bigint; privateMerkleRoot?: Uint8Array }>,
+  metaGraph: string,
+): Quad[] {
+  const out: Quad[] = [
+    mq(ual, `${DKG}batchId`, intLit(kaId), metaGraph),
+    mq(ual, `${DKG}merkleRoot`, lit(toHex(merkleRoot)), metaGraph),
+  ];
+  const multiRoot = new Set(manifestEntries.map((ka) => ka.rootEntity)).size > 1;
+  const seenRoots = new Set<string>();
+  const seenPrivRoots = new Set<string>();
+  for (const ka of manifestEntries) {
+    if (!seenRoots.has(ka.rootEntity)) {
+      seenRoots.add(ka.rootEntity);
+      out.push(...entityMemberQuads(ual, ka.rootEntity, metaGraph));
+    }
+    if (ka.privateMerkleRoot && ka.privateMerkleRoot.length > 0) {
+      const privHex = toHex(ka.privateMerkleRoot);
+      if (!seenPrivRoots.has(privHex)) {
+        seenPrivRoots.add(privHex);
+        out.push(mq(ual, `${DKG}privateMerkleRoot`, lit(privHex), metaGraph));
+      }
+    }
+    // MULTI-root only: re-emit the `<ual>/<tokenId>` token rows so each member
+    // root carries its OWN privateMerkleRoot on a shared subject (recoverable
+    // pairing). Not deduped — every token keeps its pairing row.
+    if (multiRoot) {
+      const kaUri = `${ual}/${ka.tokenId}`;
+      out.push(
+        ...entityMemberQuads(kaUri, ka.rootEntity, metaGraph),
+        mq(kaUri, `${DKG}partOf`, ual, metaGraph),
+      );
+      if (ka.privateMerkleRoot && ka.privateMerkleRoot.length > 0) {
+        out.push(mq(kaUri, `${DKG}privateMerkleRoot`, lit(toHex(ka.privateMerkleRoot)), metaGraph));
+      }
+    }
+  }
+  return out;
+}
+
 function dateLit(d: Date): string {
   return `"${d.toISOString()}"^^<${XSD}dateTime>`;
 }
@@ -786,6 +849,10 @@ async function _restateKaPartitionLocked(opts: {
   //    re-emit the legacy `<ual>/<n>` token rows (insertion = manifest order,
   //    matching the pre-trim tokenIdx mint) so the root↔privateMerkleRoot
   //    pairing stays recoverable; single-root keeps the full collapse.
+  //    SAME SHAPE as `buildScopedMinimalMeta` (the publish-path builder) but
+  //    NOT shared: this path works from per-root Maps with POSITIONAL token
+  //    labels and a DELETE/INSERT restate, vs. the builder's manifest + minted
+  //    `ka.tokenId`. Keep the two shapes in sync if either changes.
   const metaQuads: Quad[] = [];
   const partitionMultiRoot = payloadByRoot.size > 1;
   let partitionTokenIdx = 1;

--- a/packages/publisher/test/multi-root-token-rows.test.ts
+++ b/packages/publisher/test/multi-root-token-rows.test.ts
@@ -29,6 +29,7 @@ import {
   generateKCMetadata,
   restateKaPartition,
   restateLabelGraphForUpdate,
+  buildScopedMinimalMeta,
   toHex,
   type KAMetadata,
 } from '../src/metadata.js';
@@ -232,5 +233,60 @@ describe('restate writers — conditional collapse', () => {
     rows = await metaQuadsOf(store, META);
     expect(tokenRows(rows)).toEqual([]);
     expect(rows).toContainEqual({ subject: UAL, predicate: `${DKG_NS}rootEntity`, object: ROOT_A, graph: META });
+  });
+});
+
+describe('buildScopedMinimalMeta — shared scoped-meta builder for the two publish paths', () => {
+  const KA_ID = 42n;
+  const MR = new Uint8Array(32).fill(7);
+  const XSD_INT = 'http://www.w3.org/2001/XMLSchema#integer';
+  const SCOPED = `did:dkg:context-graph:${CG}/context/9/_meta`;
+
+  it('single-root: resolution edges + collapsed member rows, NO token subjects', () => {
+    const q = buildScopedMinimalMeta(
+      UAL, KA_ID, MR,
+      [{ rootEntity: ROOT_A, tokenId: 1n, privateMerkleRoot: PRIV_A }],
+      SCOPED,
+    );
+    expect(q).toContainEqual({ subject: UAL, predicate: `${DKG_NS}batchId`, object: `"42"^^<${XSD_INT}>`, graph: SCOPED });
+    expect(q).toContainEqual({ subject: UAL, predicate: `${DKG_NS}merkleRoot`, object: `"${toHex(MR)}"`, graph: SCOPED });
+    expect(q).toContainEqual({ subject: UAL, predicate: `${DKG_NS}rootEntity`, object: ROOT_A, graph: SCOPED });
+    expect(q).toContainEqual({ subject: UAL, predicate: `${DKG_NS}privateMerkleRoot`, object: `"${toHex(PRIV_A)}"`, graph: SCOPED });
+    // single-root keeps the full collapse — no `<ual>/<tokenId>` subjects.
+    expect(q.filter((x) => x.subject.startsWith(`${UAL}/`))).toEqual([]);
+  });
+
+  it('multi-root: collapsed rows for both + per-token root↔private pairing rows', () => {
+    const q = buildScopedMinimalMeta(
+      UAL, KA_ID, MR,
+      [
+        { rootEntity: ROOT_A, tokenId: 1n, privateMerkleRoot: PRIV_A },
+        { rootEntity: ROOT_B, tokenId: 2n, privateMerkleRoot: PRIV_B },
+      ],
+      SCOPED,
+    );
+    expect(q).toContainEqual({ subject: UAL, predicate: `${DKG_NS}rootEntity`, object: ROOT_A, graph: SCOPED });
+    expect(q).toContainEqual({ subject: UAL, predicate: `${DKG_NS}rootEntity`, object: ROOT_B, graph: SCOPED });
+    for (const [n, root, priv] of [['1', ROOT_A, PRIV_A], ['2', ROOT_B, PRIV_B]] as const) {
+      expect(q).toContainEqual({ subject: `${UAL}/${n}`, predicate: `${DKG_NS}rootEntity`, object: root, graph: SCOPED });
+      expect(q).toContainEqual({ subject: `${UAL}/${n}`, predicate: `${DKG_NS}partOf`, object: UAL, graph: SCOPED });
+      expect(q).toContainEqual({ subject: `${UAL}/${n}`, predicate: `${DKG_NS}privateMerkleRoot`, object: `"${toHex(priv)}"`, graph: SCOPED });
+    }
+  });
+
+  it('dedupes the collapsed privateMerkleRoot but keeps each token pairing row', () => {
+    // two DISTINCT roots sharing ONE private root: collapsed `<ual>` priv row is
+    // deduped to one; each `<ual>/<tokenId>` keeps its own (so the pairing holds).
+    const q = buildScopedMinimalMeta(
+      UAL, KA_ID, MR,
+      [
+        { rootEntity: ROOT_A, tokenId: 1n, privateMerkleRoot: PRIV_A },
+        { rootEntity: ROOT_B, tokenId: 2n, privateMerkleRoot: PRIV_A },
+      ],
+      SCOPED,
+    );
+    expect(q.filter((x) => x.subject === UAL && x.predicate === `${DKG_NS}privateMerkleRoot`)).toHaveLength(1);
+    expect(q).toContainEqual({ subject: `${UAL}/1`, predicate: `${DKG_NS}privateMerkleRoot`, object: `"${toHex(PRIV_A)}"`, graph: SCOPED });
+    expect(q).toContainEqual({ subject: `${UAL}/2`, predicate: `${DKG_NS}privateMerkleRoot`, object: `"${toHex(PRIV_A)}"`, graph: SCOPED });
   });
 });


### PR DESCRIPTION
## What

Follow-up to #1266, fixes #1269.

Extracts a single `buildScopedMinimalMeta(...)` helper (in `metadata.ts`) for the "minimal scoped meta" rows the RS prover + access handler read, and calls it from the two publish paths that previously carried **byte-identical inline copies**:

- `publishFromSharedMemory` (the SWM path)
- `promoteConfirmedKCToScopedGraph` (the one-shot `publish()` RS promotion, added in #1266)

This removes the hand-synced duplication `otReviewAgent` flagged on #1266 (https://github.com/OriginTrail/dkg/pull/1266#discussion_r3448171593).

## Scope decision — `restateKaPartition`

`restateKaPartition` (the update path) writes the **same shape** but from a different data model: per-root `Map`s, **positional** `<ual>/<n>` token labels, and a DELETE/INSERT restate — vs. the builder's manifest + minted `ka.tokenId`. It intentionally **does not** share the builder; a cross-reference comment ties the two shapes together. Reconciling restate's positional convention to `ka.tokenId` would change the update-path on-disk token labels — a behavior-sensitive change deliberately left out of this refactor. If we want full convergence, that's a focused follow-up.

## Byte-identical

The builder reuses the canonical `mq` / `intLit` / `lit` / `entityMemberQuads` helpers and emits the exact same quads (same order, same literal forms) the removed inline blocks did. `intLit(kaId)` reproduces the typed-integer `batchId`; `lit(hex)` is equivalent to the raw `"<hex>"` form for hex literals.

## Validation

- new `buildScopedMinimalMeta` unit tests (single-root / multi-root / dedup) in `multi-root-token-rows.test.ts`
- publisher unit suite **110 pass** (incl. the unchanged `restateKaPartition` shape tests)
- `rs-scoped-promotion` **2 pass** (promotion path via the builder)
- `dkg-publisher.test.ts` **36 pass** (both publish paths, real Hardhat chain)
- `tsc --noEmit` clean

Net: −102 lines in `dkg-publisher.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
