### PR TITLE
fix(daemon): attribute custodial-agent authorship on create + finalize

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -251,9 +251,10 @@ function layerStatus(hist: Record<string, unknown>, layer: "wm" | "swm" | "vm"):
   );
 }
 
-function resolveFinalizeOptions(
+export function resolveFinalizeOptions(
   raw: Record<string, any>,
   res: RequestContext["res"],
+  tokenAgentAddress?: string,
 ): Record<string, unknown> | null {
   const {
     subGraphName,
@@ -300,9 +301,24 @@ function resolveFinalizeOptions(
     jsonResponse(res, 400, { error: '"schemeVersion" must be a positive integer when supplied' });
     return null;
   }
+  // Token attribution — parity with /api/shared-memory/publish (memory.ts).
+  // An agent-scoped bearer token attributes authorship to that agent when the
+  // body specified neither an explicit `authorAgentAddress` nor a pre-signed
+  // attestation. Callers pass `agent.resolveAgentByToken(requestToken)`, which
+  // returns `undefined` for node-level / admin tokens — so those do NOT
+  // auto-attribute, preserving the "publisher signs as itself" default.
+  // Without this, the create + finalize routes ignored the token and a custodial
+  // agent's publish was sealed under the node's own signer instead of the agent
+  // (the on-chain author came out as the node's operational wallet).
+  const effectiveAuthorAgentAddress =
+    typeof authorAgentAddress === "string"
+      ? authorAgentAddress
+      : resolvedPreSignedAttestation == null
+        ? tokenAgentAddress
+        : undefined;
   return {
     ...(subGraphName ? { subGraphName } : {}),
-    ...(typeof authorAgentAddress === "string" ? { authorAgentAddress } : {}),
+    ...(typeof effectiveAuthorAgentAddress === "string" ? { authorAgentAddress: effectiveAuthorAgentAddress } : {}),
     ...(resolvedPreSignedAttestation ? { preSignedAuthorAttestation: resolvedPreSignedAttestation } : {}),
     ...(schemeVersion != null ? { schemeVersion } : {}),
     ...(layer === "swm" ? { layer } : {}),
@@ -726,7 +742,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       });
     }
     const finalizeOptions = shouldFinalize
-      ? resolveFinalizeOptions({ subGraphName, authorAgentAddress, preSignedAuthorAttestation, schemeVersion }, res)
+      ? resolveFinalizeOptions(
+          { subGraphName, authorAgentAddress, preSignedAuthorAttestation, schemeVersion },
+          res,
+          writePreflightCallerAgentAddress,
+        )
       : {};
     if (finalizeOptions === null) return;
     const resolvedAuthorAgentAddress =
@@ -744,7 +764,16 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       } catch {
         /* treat a failed lookup as "does not exist yet" */
       }
-      const assertionUri = await agent.assertion.create(resolvedContextGraphId, name, { subGraphName });
+      // OT-RFC-43 §F2 — the kaId is stamped (in the author's namespace) at
+      // create. It MUST match the author the seal is later finalized under, or
+      // finalize throws KaIdNamespaceMismatch. So stamp under the same resolved
+      // author the finalize uses: the body author, else the token's agent (else
+      // undefined → the daemon's default agent for node/admin tokens).
+      const createAuthorAgentAddress = resolvedAuthorAgentAddress ?? writePreflightCallerAgentAddress;
+      const assertionUri = await agent.assertion.create(resolvedContextGraphId, name, {
+        subGraphName,
+        ...(createAuthorAgentAddress ? { agentAddress: createAuthorAgentAddress } : {}),
+      });
       const result: Record<string, unknown> = { name, assertionUri, alreadyExists, status: "draft-open" };
       emitMemoryGraphChanged?.({ contextGraphId: resolvedContextGraphId, layers: ["wm"], subGraphName, operation: "assertion_created", source: "api", counts: { triples: 0 } });
       recordActivityAndNotify(ctx, { contextGraphId: resolvedContextGraphId, kind: "created", actorAgentAddress: resolvedAuthorAgentAddress ?? requestAgentAddress, subGraphName });
@@ -980,14 +1009,19 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // brand-new or discarded names get created; existing drafts stay append-only.
         const existing = await agent.assertion.history(contextGraphId, name, { subGraphName });
         if (!existing || existing.state === "discarded") {
-          await agent.assertion.create(contextGraphId, name, { subGraphName });
+          // Stamp the kaId under the request token's agent (OT-RFC-43 §F2) so a
+          // later finalize as that agent doesn't hit KaIdNamespaceMismatch.
+          await agent.assertion.create(contextGraphId, name, {
+            subGraphName,
+            ...(writePreflightCallerAgentAddress ? { agentAddress: writePreflightCallerAgentAddress } : {}),
+          });
         }
         await agent.assertion.write(contextGraphId, name, parsed.quads, { subGraphName });
         emitMemoryGraphChanged?.({ contextGraphId, layers: ["wm"], subGraphName, operation: "assertion_written", source: "api", counts: { triples: parsed.quads.length } });
         return jsonResponse(res, 200, { written: parsed.quads.length });
       }
       if (verb === "finalize") {
-        const finalizeOptions = resolveFinalizeOptions(parsed, res);
+        const finalizeOptions = resolveFinalizeOptions(parsed, res, writePreflightCallerAgentAddress);
         if (finalizeOptions === null) return;
         let seal;
         try {

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -789,6 +789,10 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (shouldFinalize) {
         const seal = await agent.assertion.finalize(resolvedContextGraphId, name, finalizeOptions);
         result.merkleRoot = hex(seal.merkleRoot);
+        // Surface the sealed author so clients (and tests) can confirm custodial
+        // attribution on the atomic create+finalize path, mirroring the dedicated
+        // wm/finalize route's response.
+        result.authorAddress = seal.authorAddress;
         result.status = "wm-sealed";
         emitMemoryGraphChanged?.({ contextGraphId: resolvedContextGraphId, layers: ["wm"], subGraphName, operation: "assertion_finalized", source: "api" });
       }
@@ -796,7 +800,14 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       const errors: Array<{ phase: string; error: string }> = [];
       if (alsoShareSwm === true) {
         try {
-          const share = await agent.assertion.promote(resolvedContextGraphId, name, { subGraphName });
+          // Carry the same resolved author into the share. The asset is already
+          // sealed (finalize above), so promote shares the existing seal verbatim
+          // — passing the author keeps the whole atomic flow in one namespace and
+          // covers the seal-on-share path too.
+          const share = await agent.assertion.promote(resolvedContextGraphId, name, {
+            subGraphName,
+            ...(resolvedAuthorAgentAddress ? { authorAgentAddress: resolvedAuthorAgentAddress } : {}),
+          });
           result.swmShared = true;
           result.promotedCount = share.promotedCount;
           result.sealed = share.sealed;

--- a/packages/cli/test/finalize-author-token-attribution.test.ts
+++ b/packages/cli/test/finalize-author-token-attribution.test.ts
@@ -1,0 +1,66 @@
+/**
+ * F1 regression — custodial authorship attribution on the create/finalize path.
+ *
+ * `resolveFinalizeOptions` is the shared author/seal-options resolver for both
+ * the atomic `POST /api/knowledge-assets` (create + auto-finalize) and the
+ * dedicated `POST /api/knowledge-assets/:name/wm/finalize` routes. It must
+ * attribute authorship to the request's agent-scoped bearer token when the body
+ * doesn't carry an explicit author — exactly like `/api/shared-memory/publish`.
+ *
+ * Before the fix it ignored the token, so a custodial agent's create+finalize
+ * sealed under the node's own signer and the on-chain author came out as the
+ * node's operational wallet instead of the agent (surfaced on a devnet run).
+ */
+import { describe, it, expect } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { resolveFinalizeOptions } from '../src/daemon/routes/knowledge-assets.js';
+
+// jsonResponse is only invoked on a validation error — none of these happy-path
+// cases trigger one. Capture any call so an unexpected error surfaces loudly
+// instead of as a silent `null` return.
+function stubRes(): { res: ServerResponse; errors: Array<{ code: number }> } {
+  const errors: Array<{ code: number }> = [];
+  const res = {
+    headersSent: false,
+    statusCode: 0,
+    setHeader() {},
+    writeHead(code: number) {
+      (res as { statusCode: number }).statusCode = code;
+      return res;
+    },
+    end() {
+      errors.push({ code: (res as { statusCode: number }).statusCode });
+    },
+  } as unknown as ServerResponse;
+  return { res, errors };
+}
+
+const TOKEN_AGENT = `0x${'ab'.repeat(20)}`;
+const BODY_AGENT = `0x${'cd'.repeat(20)}`;
+
+describe('resolveFinalizeOptions — token authorship attribution (F1)', () => {
+  it('attributes authorship to the agent-scoped token when the body omits an author', () => {
+    const { res, errors } = stubRes();
+    const out = resolveFinalizeOptions({}, res, TOKEN_AGENT);
+    expect(errors).toEqual([]);
+    expect(out).not.toBeNull();
+    expect((out as Record<string, unknown>).authorAgentAddress).toBe(TOKEN_AGENT);
+  });
+
+  it('lets an explicit body authorAgentAddress win over the token', () => {
+    const { res, errors } = stubRes();
+    const out = resolveFinalizeOptions({ authorAgentAddress: BODY_AGENT }, res, TOKEN_AGENT);
+    expect(errors).toEqual([]);
+    expect((out as Record<string, unknown>).authorAgentAddress).toBe(BODY_AGENT);
+  });
+
+  it('does NOT auto-attribute for a node-level/admin token (undefined agent)', () => {
+    // resolveAgentByToken returns undefined for admin/node tokens → no author
+    // override → publisher signs as itself (pre-fix default preserved).
+    const { res, errors } = stubRes();
+    const out = resolveFinalizeOptions({}, res, undefined);
+    expect(errors).toEqual([]);
+    expect(out).not.toBeNull();
+    expect((out as Record<string, unknown>).authorAgentAddress).toBeUndefined();
+  });
+});

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -326,6 +326,30 @@ describe('/api/knowledge-assets routes (real daemon, real chain)', () => {
       // The fix: stamp + seal are both in the agent's namespace → seal author is
       // the agent, not the node's publisher signer.
       expect(String(fin.body.authorAddress).toLowerCase()).toBe(agentAddress.toLowerCase());
+
+      // ATOMIC path (the create-route callsite this PR changes): create + write +
+      // auto-finalize + share + publish in ONE call, as the agent. This proves
+      // write/finalize/promote/publish all stay in the AGENT's namespace, not just
+      // create — the returned author is the agent, and (when it mints) the kaId is
+      // packed (uint160(author)<<96)|number, so its high 160 bits MUST be the agent.
+      const atomic = await agentPost('/api/knowledge-assets', {
+        contextGraphId: cg,
+        name: 'agent-atomic',
+        quads: [{ subject: 'ex:B', predicate: 'ex:p', object: '"y"' }],
+        finalize: true,
+        alsoShareSwm: true,
+        alsoPublishVm: true,
+      });
+      // authorAddress is stamped at finalize (before any publish tail-error), so
+      // it is always present and must be the agent.
+      expect(String(atomic.body.authorAddress).toLowerCase(), `agent atomic: ${JSON.stringify(atomic.body)}`).toBe(
+        agentAddress.toLowerCase(),
+      );
+      // If it minted on-chain, the minted kaId proves the publish path stayed
+      // agent-scoped (high 160 bits == author == agent).
+      if (atomic.body.kaId != null) {
+        expect(BigInt(atomic.body.kaId) >> 96n).toBe(BigInt(agentAddress));
+      }
     });
   });
 

--- a/packages/cli/test/knowledge-assets-route.test.ts
+++ b/packages/cli/test/knowledge-assets-route.test.ts
@@ -275,6 +275,58 @@ describe('/api/knowledge-assets routes (real daemon, real chain)', () => {
       expect(res.status).toBe(400);
       expect(String(res.body.error)).toContain('preSignedAuthorAttestation.reservedKaId');
     });
+
+    // F1 regression — a custodial agent's bearer token must attribute the seal's
+    // author to that agent (not the node's publisher signer). The on-chain
+    // getLatestMerkleRootAuthor derives from this seal author, so before the fix
+    // a custodial publish recorded the node's operational wallet as author.
+    // (Admin-token "publisher signs as itself" is covered in the unit test
+    // finalize-author-token-attribution.test.ts; here we prove the agent path
+    // end-to-end through the real daemon + real seal.)
+    it('attributes the seal author to the agent-scoped token (F1)', async () => {
+      const reg = await postJson(daemon, '/api/agent/register', {
+        name: `ka-author-agent-${Date.now().toString(36)}`,
+        framework: 'test',
+      });
+      expect(reg.status, `agent register: ${JSON.stringify(reg.body)}`).toBeLessThan(300);
+      const agentAddress = String(reg.body.agentAddress);
+      const agentToken = String(reg.body.authToken);
+      expect(agentAddress).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(agentToken.length).toBeGreaterThan(0);
+
+      // All requests run AS the custodial agent (raw fetch — postJson uses the
+      // node-admin token). The agent authors into its own CG.
+      const agentPost = async (path: string, body: unknown) => {
+        const r = await fetch(`${daemon.base}${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${agentToken}` },
+          body: JSON.stringify(body),
+        });
+        return { status: r.status, body: (await r.json().catch(() => ({}))) as Record<string, any> };
+      };
+
+      const cg = `ka-agent-cg-${Date.now().toString(36)}`;
+      const created = await agentPost('/api/context-graph/create', { id: cg, name: 'Agent CG', accessPolicy: 1 });
+      expect(created.status, `agent CG create: ${JSON.stringify(created.body)}`).toBeLessThan(300);
+      const onchain = await agentPost('/api/context-graph/register', { id: cg, accessPolicy: 1 });
+      expect(onchain.status, `agent CG register: ${JSON.stringify(onchain.body)}`).toBe(200);
+
+      // Create draft → write → finalize, all as the agent. The kaId is stamped
+      // (at create) AND the seal is signed (at finalize) in the SAME agent
+      // namespace, so finalize doesn't throw KaIdNamespaceMismatch and the seal
+      // author is the agent. The finalize route returns the sealed authorAddress.
+      const created2 = await agentPost('/api/knowledge-assets', { contextGraphId: cg, name: 'agent-authored' });
+      expect(created2.status, `agent KA create: ${JSON.stringify(created2.body)}`).toBeLessThan(300);
+      await agentPost('/api/knowledge-assets/agent-authored/wm/write', {
+        contextGraphId: cg,
+        quads: [{ subject: 'ex:A', predicate: 'ex:p', object: '"x"' }],
+      });
+      const fin = await agentPost('/api/knowledge-assets/agent-authored/wm/finalize', { contextGraphId: cg });
+      expect(fin.status, `agent finalize: ${JSON.stringify(fin.body)}`).toBe(200);
+      // The fix: stamp + seal are both in the agent's namespace → seal author is
+      // the agent, not the node's publisher signer.
+      expect(String(fin.body.authorAddress).toLowerCase()).toBe(agentAddress.toLowerCase());
+    });
   });
 
   // ── swm/share ─────────────────────────────────────────────────────


### PR DESCRIPTION
Custodial-agent publishes were recording the **node's operational wallet** as the on-chain author instead of the **authoring agent**.

## Root cause
A KA's on-chain author is whoever signs the `AuthorAttestation`, and its `kaId` is stamped in that author's namespace at create time (OT-RFC-43 §F2: `reservedKaId = (uint160(author) << 96) | number`). The author binds at **two** points:
1. the **kaId stamp** at `assertion.create`, and
2. the **finalize seal** (`resolveFinalizeOptions` → the signed attestation).

Both resolved the author **only** from an explicit request-body `authorAgentAddress` — they ignored the request's agent-scoped bearer token. `/api/shared-memory/publish` already attributed authorship by token; **create + finalize did not**. So a publish authenticated with a custodial agent's token was stamped *and* sealed under the node's own publisher signer → the on-chain author came out as the node.

## Fix (parity with the publish route)
Thread the token's agent (`agent.resolveAgentByToken(requestToken)`) into **both** author-binding points, consistently:
- `resolveFinalizeOptions` now defaults `authorAgentAddress` to the token's agent when the body specifies neither an explicit author nor a pre-signed attestation;
- the two `assertion.create` calls stamp the `kaId` under that same resolved author.

Because both points share one author, finalize no longer throws `KaIdNamespaceMismatch`. Precedence is unchanged: an explicit body `authorAgentAddress` (or pre-signed attestation) still wins, and **node-level / admin tokens resolve to `undefined` and do NOT auto-attribute** ("publisher signs as itself" — the existing default is preserved).

> Note: a finalize-only change is *not* safe in isolation — it makes the seal attribute to the agent while the kaId is still stamped under the node, which turns an atomic custodial create+finalize into a hard `KaIdNamespaceMismatch`. The two changes must land together (and do, here).

## Tests
- **Unit** (`finalize-author-token-attribution.test.ts`): the token attributes authorship; an explicit body author wins; an admin/node token does not auto-attribute.
- **Real-chain e2e** (`knowledge-assets-route.test.ts`): a custodial agent registers, creates its own CG, and `create → write → finalize` as the agent — the seal's `authorAddress` is the **agent**.
- Full `knowledge-assets` route suite **56/56**; adjacent create/finalize/publish suites (`promote-async-routes`, `1116-share-errors`, `async-promote-queue-e2e`) **49/49**. Admin-token paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
