### PR TITLE
fix(publisher): enforce byteSize floor on public UPDATE ACKs (#1283)

### DIFF
--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -874,6 +874,14 @@ export class StorageACKHandler {
     // it trusts the claimed root (member post-decrypt verification + the
     // on-chain revert are the integrity backstop) but still independently
     // confirms the CG is curated before signing an opaque ACK.
+    //
+    // #1283: byteSize floor for PUBLIC updates. The public inline / SWM branches
+    // below set this to the attested updated-payload size; it is enforced
+    // against the signed `newByteSize` after parsing. Curated/encrypted updates
+    // keep their own catalog-parity check and the core can't see the private
+    // payload, so they leave it null.
+    let publicUpdateByteSizeFloor: bigint | null = null;
+    let publicUpdateFloorBasis = '';
     if (intent.isEncryptedPayload === true) {
       const swmGraphIdForCuration = intent.swmGraphId && intent.swmGraphId.length > 0
         ? intent.swmGraphId
@@ -1015,6 +1023,13 @@ export class StorageACKHandler {
           `computed=${ethers.hexlify(recomputedRoot).slice(0, 18)}... (${parsed.length} triples) — refusing to ACK`,
         );
       }
+      // #1283: public inline update — the core received the EXACT serialized
+      // payload, so require the signed newByteSize to cover its full byte length
+      // (mirrors the public-publish floor). Without this a publisher can ship a
+      // correct new root while under-declaring newByteSize to underpay the
+      // on-chain storage-growth charge.
+      publicUpdateByteSizeFloor = BigInt(intent.stagingQuads.length);
+      publicUpdateFloorBasis = 'exact inline payload bytes';
     } else {
       // Fallback: data should already be in SWM (publishFromSharedMemory
       // remap / SWM-resolution path). Reuse the publish branch's SWM
@@ -1036,6 +1051,17 @@ export class StorageACKHandler {
           `local=${ethers.hexlify(recomputedRoot).slice(0, 18)}... (${swmQuads.length} triples in SWM)`,
         );
       }
+      // #1283: public SWM-fallback update — the original serialization isn't
+      // byte-reconstructable, so use the serialization-independent lower bound
+      // Σ(UTF-8 byteLength(s,p,o)) (mirrors the public-publish SWM floor).
+      publicUpdateByteSizeFloor = 0n;
+      for (const q of swmQuads) {
+        publicUpdateByteSizeFloor +=
+          BigInt(Buffer.byteLength(q.subject, 'utf8')) +
+          BigInt(Buffer.byteLength(q.predicate, 'utf8')) +
+          BigInt(Buffer.byteLength(q.object, 'utf8'));
+      }
+      publicUpdateFloorBasis = 'Σ UTF-8 term bytes (lower bound)';
     }
 
     // Derive the bigint digest inputs. Fail loud on non-numeric / non-
@@ -1067,6 +1093,22 @@ export class StorageACKHandler {
     const newByteSize = typeof intent.newByteSize === 'number'
       ? BigInt(intent.newByteSize)
       : BigInt(intent.newByteSize.low >>> 0) | (BigInt(intent.newByteSize.high >>> 0) << 32n);
+
+    // #1283: enforce the PUBLIC-update byteSize floor before signing. Mirrors
+    // the public-publish BYTESIZE_UNDERCLAIM gate. Nothing on-chain can see the
+    // content, and the contract only charges growth when newByteSize >
+    // currentByteSize (KnowledgeAssetsLifecycle._executeUpdateCore), so an
+    // under-declared newByteSize would let a publisher grow real public storage
+    // for free. Curated updates already enforce catalog byteSize parity above.
+    if (publicUpdateByteSizeFloor !== null && newByteSize < publicUpdateByteSizeFloor) {
+      return this.encodeDecline(
+        cgId,
+        STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM,
+        `public UPDATE ACK byteSize under-claim: publisher claims newByteSize=${newByteSize} ` +
+        `but the attested updated content requires at least ${publicUpdateByteSizeFloor} UTF-8 bytes ` +
+        `(${publicUpdateFloorBasis}). Refusing to sign an under-priced footprint.`,
+      );
+    }
     const newTokenAmount = intent.newTokenAmount && intent.newTokenAmount.length > 0
       ? BigInt(intent.newTokenAmount)
       : 0n;

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -263,6 +263,197 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
     expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
   });
 
+  // #1283 — PUBLIC-update byteSize floor. The pre-fix updateHandler verified
+  // only the new Merkle root and signed the publisher-supplied `newByteSize`
+  // with NO floor, so a publisher could ship a correct new root while
+  // under-declaring `newByteSize` (e.g. 1) to underpay the on-chain
+  // storage-growth charge (the contract only charges when newByteSize >
+  // currentByteSize). The fix mirrors the public-PUBLISH floor into the two
+  // public-update branches. The discriminator that makes these tests prove the
+  // *floor* (not the merkle gate, which runs first): keep `newMerkleRoot`
+  // CORRECT and assert the SPECIFIC BYTESIZE_UNDERCLAIM decline code.
+  describe('#1283 public-update byteSize floor', () => {
+    function makeHandler(wallet: ethers.Wallet, store = new OxigraphStore()) {
+      return new StorageACKHandler(store as any, makeConfig(wallet, 42n), new TypedEventBus() as any);
+    }
+
+    // INLINE public update: CORRECT root, overridable newByteSize.
+    function publicInlineUpdateIntent(overrides: Record<string, unknown> = {}): Uint8Array {
+      return encodeUpdateIntent({
+        kaId: kaId.toString(),
+        contextGraphId,
+        preUpdateMerkleRootCount: Number(preUpdateMerkleRootCount),
+        newMerkleRoot, // correct: computeFlatKCRoot(updatedQuads, [])
+        newByteSize: Number(newByteSize),
+        newTokenAmount: newTokenAmount.toString(),
+        mintAmount: Number(mintAmount),
+        burnTokenIds: burnTokenIds.map((b) => b.toString()),
+        newMerkleLeafCount,
+        publisherPeerId: 'publisher-0',
+        stagingQuads,
+        ...overrides,
+      });
+    }
+
+    it('(a) INLINE under-claim → BYTESIZE_UNDERCLAIM decline (correct root, newByteSize=1)', async () => {
+      // Correct new root passes the MERKLE gate (which runs FIRST), so a decline
+      // here can only come from the new byteSize floor. Pre-fix this signed a
+      // valid ACK (no floor existed); the fix turns it into a typed decline.
+      const handler = makeHandler(ethers.Wallet.createRandom());
+      const decoded = decodeStorageACK(
+        await handler.updateHandler(publicInlineUpdateIntent({ newByteSize: 1 }), fakePeerId),
+      );
+      expect(isStorageACKDecline(decoded)).toBe(true);
+      expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM);
+      expect(decoded.declineMessage).toContain('under-claim');
+      // And it is NOT a signed ACK: the signature fields are empty on a decline.
+      const r = decoded.coreNodeSignatureR instanceof Uint8Array
+        ? decoded.coreNodeSignatureR : new Uint8Array(decoded.coreNodeSignatureR);
+      expect(r.length).toBe(0);
+    });
+
+    it('(b) positive control — INLINE newByteSize == stagingQuads.length → VALID signed ACK', async () => {
+      // The floor is `newByteSize < floor`, so equality is accepted. Prove a
+      // REAL ACK by recovering the signer over the exact 13-field update digest.
+      const wallet = ethers.Wallet.createRandom();
+      const handler = makeHandler(wallet);
+      const decoded = decodeStorageACK(
+        await handler.updateHandler(publicInlineUpdateIntent({ newByteSize: Number(newByteSize) }), fakePeerId),
+      );
+      expect(isStorageACKDecline(decoded)).toBe(false);
+
+      const decodedRoot = decoded.merkleRoot instanceof Uint8Array
+        ? decoded.merkleRoot : new Uint8Array(decoded.merkleRoot);
+      expect(Buffer.from(decodedRoot).equals(Buffer.from(newMerkleRoot))).toBe(true);
+
+      const recovered = ethers.recoverAddress(ethers.hashMessage(expectedDigest()), {
+        r: ethers.hexlify(decoded.coreNodeSignatureR instanceof Uint8Array
+          ? decoded.coreNodeSignatureR : new Uint8Array(decoded.coreNodeSignatureR)),
+        yParityAndS: ethers.hexlify(decoded.coreNodeSignatureVS instanceof Uint8Array
+          ? decoded.coreNodeSignatureVS : new Uint8Array(decoded.coreNodeSignatureVS)),
+      });
+      expect(recovered.toLowerCase()).toBe(wallet.address.toLowerCase());
+    });
+
+    it('(b2) positive control — INLINE newByteSize ABOVE the floor → VALID signed ACK', async () => {
+      const wallet = ethers.Wallet.createRandom();
+      const handler = makeHandler(wallet);
+      const decoded = decodeStorageACK(
+        await handler.updateHandler(
+          publicInlineUpdateIntent({ newByteSize: Number(newByteSize) + 1000 }),
+          fakePeerId,
+        ),
+      );
+      expect(isStorageACKDecline(decoded)).toBe(false);
+      // Digest binds the (larger) claimed newByteSize, recovers to the signer.
+      const digestAbove = computeUpdateACKDigest(
+        TEST_CHAIN_ID,
+        TEST_KAV10_ADDR,
+        cgIdBigInt,
+        kaId,
+        preUpdateMerkleRootCount,
+        newMerkleRoot,
+        newByteSize + 1000n,
+        newTokenAmount,
+        mintAmount,
+        burnTokenIds,
+        BigInt(newMerkleLeafCount),
+      );
+      const recovered = ethers.recoverAddress(ethers.hashMessage(digestAbove), {
+        r: ethers.hexlify(decoded.coreNodeSignatureR instanceof Uint8Array
+          ? decoded.coreNodeSignatureR : new Uint8Array(decoded.coreNodeSignatureR)),
+        yParityAndS: ethers.hexlify(decoded.coreNodeSignatureVS instanceof Uint8Array
+          ? decoded.coreNodeSignatureVS : new Uint8Array(decoded.coreNodeSignatureVS)),
+      });
+      expect(recovered.toLowerCase()).toBe(wallet.address.toLowerCase());
+    });
+
+    it('(c) SWM-fallback under-claim → BYTESIZE_UNDERCLAIM decline (no stagingQuads, correct root, newByteSize=1)', async () => {
+      // No inline payload: the data lives in SWM at `<cg>/_shared_memory` (the
+      // legacy read-both bucket the loadSWMQuads CONSTRUCT reads). The recompute
+      // matches `newMerkleRoot`, so the MERKLE gate passes and only the new
+      // Σ(UTF-8 term bytes) floor can decline.
+      const store = new OxigraphStore();
+      const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+      await store.insert(updatedQuads.map((q) => ({ ...q, graph: swmGraph })));
+      const handler = makeHandler(ethers.Wallet.createRandom(), store);
+
+      const swmIntent = encodeUpdateIntent({
+        kaId: kaId.toString(),
+        contextGraphId,
+        preUpdateMerkleRootCount: Number(preUpdateMerkleRootCount),
+        newMerkleRoot, // correct: recompute over the SWM quads matches this
+        newByteSize: 1,
+        newTokenAmount: newTokenAmount.toString(),
+        mintAmount: Number(mintAmount),
+        burnTokenIds: burnTokenIds.map((b) => b.toString()),
+        newMerkleLeafCount,
+        publisherPeerId: 'publisher-0',
+        // no stagingQuads → SWM-fallback branch
+      });
+
+      const decoded = decodeStorageACK(await handler.updateHandler(swmIntent, fakePeerId));
+      expect(isStorageACKDecline(decoded)).toBe(true);
+      expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.BYTESIZE_UNDERCLAIM);
+      expect(decoded.declineMessage).toContain('under-claim');
+    });
+
+    it('(c2) SWM-fallback positive control — newByteSize at the Σ UTF-8 term-byte floor → VALID signed ACK', async () => {
+      // The serialization-independent SWM floor is Σ(UTF-8 byteLength(s,p,o));
+      // claiming exactly that floor is accepted (gate is `< floor`).
+      const store = new OxigraphStore();
+      const swmGraph = `did:dkg:context-graph:${contextGraphId}/_shared_memory`;
+      await store.insert(updatedQuads.map((q) => ({ ...q, graph: swmGraph })));
+      const wallet = ethers.Wallet.createRandom();
+      const handler = makeHandler(wallet, store);
+
+      const swmFloor = updatedQuads.reduce(
+        (acc, q) =>
+          acc +
+          Buffer.byteLength(q.subject, 'utf8') +
+          Buffer.byteLength(q.predicate, 'utf8') +
+          Buffer.byteLength(q.object, 'utf8'),
+        0,
+      );
+
+      const swmIntent = encodeUpdateIntent({
+        kaId: kaId.toString(),
+        contextGraphId,
+        preUpdateMerkleRootCount: Number(preUpdateMerkleRootCount),
+        newMerkleRoot,
+        newByteSize: swmFloor,
+        newTokenAmount: newTokenAmount.toString(),
+        mintAmount: Number(mintAmount),
+        burnTokenIds: burnTokenIds.map((b) => b.toString()),
+        newMerkleLeafCount,
+        publisherPeerId: 'publisher-0',
+      });
+
+      const decoded = decodeStorageACK(await handler.updateHandler(swmIntent, fakePeerId));
+      expect(isStorageACKDecline(decoded)).toBe(false);
+      const digestSwm = computeUpdateACKDigest(
+        TEST_CHAIN_ID,
+        TEST_KAV10_ADDR,
+        cgIdBigInt,
+        kaId,
+        preUpdateMerkleRootCount,
+        newMerkleRoot,
+        BigInt(swmFloor),
+        newTokenAmount,
+        mintAmount,
+        burnTokenIds,
+        BigInt(newMerkleLeafCount),
+      );
+      const recovered = ethers.recoverAddress(ethers.hashMessage(digestSwm), {
+        r: ethers.hexlify(decoded.coreNodeSignatureR instanceof Uint8Array
+          ? decoded.coreNodeSignatureR : new Uint8Array(decoded.coreNodeSignatureR)),
+        yParityAndS: ethers.hexlify(decoded.coreNodeSignatureVS instanceof Uint8Array
+          ? decoded.coreNodeSignatureVS : new Uint8Array(decoded.coreNodeSignatureVS)),
+      });
+      expect(recovered.toLowerCase()).toBe(wallet.address.toLowerCase());
+    });
+  });
+
   it('collectUpdate reaches a 3-of-4 quorum, recovering each signer against the update digest', async () => {
     const coreWallets = [
       ethers.Wallet.createRandom(),


### PR DESCRIPTION
Closes #1283.

## Problem
Public KA **update** ACKs verify the new Merkle root but signed the publisher-supplied `newByteSize` into the UPDATE ACK digest with **no floor**. So a publisher could submit a *correct* new root while under-declaring `newByteSize` (e.g. `1`) — and since the contract charges storage growth only `if (p.newByteSize > currentByteSize)` (`KnowledgeAssetsLifecycle._executeUpdateCore`) and nothing on-chain can see the content, the publisher grows real public storage that cores must host while paying ~nothing.

The public **publish** path (`BYTESIZE_UNDERCLAIM` floor) and the **curated update** path (inline-catalog byteSize parity) already guard this. Public **update** was the only gap.

## Fix
Mirror the public-publish floor into both public-update branches, enforced before signing:
- **inline** (`stagingQuads` present): `newByteSize >= stagingQuads.length` (the core has the exact serialized payload).
- **SWM fallback**: `newByteSize >= Σ UTF-8 byteLength(subject,predicate,object)` (serialization-independent lower bound).

`DECLINE` with `BYTESIZE_UNDERCLAIM` otherwise. Curated/encrypted updates (`isEncryptedPayload === true`) leave the floor null and keep their own catalog parity check — unaffected.

## Tests
6 new `storage-update-ack.test.ts` cases:
- **Inline under-claim → decline**: correct `newMerkleRoot`, `newByteSize = 1` → `BYTESIZE_UNDERCLAIM`.
- **Inline positive controls**: `newByteSize == stagingQuads.length` and above → valid signed ACK (signer recovered over the exact 13-field `computeUpdateACKDigest`).
- **SWM-fallback under-claim → decline** + **positive control** at the Σ-term-byte floor.

The under-claim/positive-control pairs are the *same* intent differing only in `newByteSize`, isolating the new floor as the sole cause (the merkle gate runs first and stays satisfied). 125 ACK-handler tests green (`storage-update-ack` + `storage-ack-handler` + `v10-ack-edge-cases` + `v10-protocol-operations`), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)