### PR TITLE
chore(deploy): record testnet StakingV10 10.0.4 redeploy address

### DIFF
--- a/packages/evm-module/deployments/base_sepolia_v10_contracts.json
+++ b/packages/evm-module/deployments/base_sepolia_v10_contracts.json
@@ -262,12 +262,12 @@
             "deployed": true
         },
         "StakingV10": {
-            "evmAddress": "0x583818aACBcCAb8D19ba2A7bC035Eff33F7deD44",
-            "version": "10.0.3",
+            "evmAddress": "0x9bE42B00263383Ae659c3b43f2f0460579aCCeeC",
+            "version": "10.0.4",
             "gitBranch": "main",
-            "gitCommitHash": "a23407de7801c6a7b85203c9cdc147b3402c2ca9",
-            "deploymentBlock": 43146009,
-            "deploymentTimestamp": 1782060308649,
+            "gitCommitHash": "2513b3463df4bdb604dde93a8d95a30bb89ee049",
+            "deploymentBlock": 43181497,
+            "deploymentTimestamp": 1782131284827,
             "deployed": true
         },
         "DKGStakingConvictionNFT": {


### PR DESCRIPTION
Records the Base Sepolia testnet incremental redeploy of **StakingV10 → 10.0.4** (the #1286 best-effort sharding-table admission + `admitNode` + selective insert-catch from #1288).

Only StakingV10 was redeployed; the Hub re-registered it and reinitialized dependents. Verified on-chain:
- `Hub → StakingV10` = `0x9bE42B00263383Ae659c3b43f2f0460579aCCeeC`, `version() == 10.0.4`, `admitNode` present (`admitNode(<in-ring node>)` reverts `NodeAlreadyInShardingTable`)
- `DKGStakingConvictionNFT.stakingV10()` re-cached to the new address
- **State preserved:** 4 sharding nodes, stakes (60k / 50k / 50k), params (minStake 50k · deposit 100 TRAC · withdrawalDelay 60) all unchanged

Diff is a single contract entry (address + version + deploy metadata) — no other contract changed. This keeps the committed registry in sync with the chain so a future deploy from `main` reads the live StakingV10 address instead of the orphaned `0x583818aA…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)