### PR TITLE
Update mainnet relay peer config

### DIFF
--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -1,14 +1,13 @@
 {
-  "_status": "pre-deployment: replace PEER_ID_* relay values before enabling Base mainnet",
   "networkName": "DKG V10 Base Mainnet",
   "genesisId": "base-mainnet",
   "networkId": "562ea760dbe27fb4233d58dfc958bbddf844b82596ec3d51dff98718e6bf61ca",
   "genesisVersion": 1,
   "relays": [
-    "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",
-    "/ip4/178.105.105.102/tcp/9090/p2p/PEER_ID_LUNARIS",
-    "/ip4/178.156.214.4/tcp/9090/p2p/PEER_ID_ORIONIS",
-    "/ip4/178.105.111.185/tcp/9090/p2p/PEER_ID_KEPLER"
+    "/ip4/178.104.98.10/tcp/9090/p2p/12D3KooWFWm8sg6dkitmdBd5Uxaqp3CDRL27mFcM7vEHK92Xapyy",
+    "/ip4/168.119.127.54/tcp/9090/p2p/12D3KooWMasqzRrim48ZJM64UyTfHufDTmSG3n3jqwsS5phz8m91",
+    "/ip4/178.156.237.133/tcp/9090/p2p/12D3KooWDgTunUpkGaE7dYCaDP1CCBT6Dm2HPMXSZhJn2KXYLH15",
+    "/ip4/178.105.211.42/tcp/9090/p2p/12D3KooWCodgXHMwybaEe93rbKgWMfGXQvUb6cpT3VCrjCbbnyEu"
   ],
   "defaultContextGraphs": [],
   "defaultNodeRole": "edge",

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -1,14 +1,15 @@
 {
-  "_status": "pre-deployment: replace PEER_ID_* relay values before enabling Gnosis mainnet",
   "networkName": "DKG V10 Gnosis Mainnet",
   "genesisId": "gnosis-mainnet",
   "networkId": "e08a9fb72a648ec2eb2fd9c152ded90a8ad67bb56f27df4781d9bb7e261fb7a7",
   "genesisVersion": 1,
   "relays": [
-    "/ip4/178.105.87.39/tcp/9090/p2p/PEER_ID_SOLARIS",
-    "/ip4/178.105.105.102/tcp/9090/p2p/PEER_ID_LUNARIS",
-    "/ip4/178.156.214.4/tcp/9090/p2p/PEER_ID_ORIONIS",
-    "/ip4/178.105.111.185/tcp/9090/p2p/PEER_ID_KEPLER"
+    "/ip4/178.104.101.41/tcp/9090/p2p/12D3KooWL9gwurFAVhQguJVs8CpzuSbt2hom9jyNJ5oHdHfyz351",
+    "/ip4/168.119.127.63/tcp/9090/p2p/12D3KooWS8pRJLrDgjqBNGJAjHDF7VoNrE4igbZ2tt9N61u7AUrG",
+    "/ip4/178.156.228.202/tcp/9090/p2p/12D3KooWGEW48Foccg27wPyKv66oUnjeAx46p1mQkWURXw8orCA1",
+    "/ip4/88.198.202.128/tcp/9090/p2p/12D3KooWLwPkoiastt27S2SRPtdx6t8KuFXwcbHovgCkAMfkJcXx",
+    "/ip4/91.98.129.173/tcp/9090/p2p/12D3KooWJth5STEUczjRh2NXqBedRtvrsjrB11172CUZbKGKNPKg",
+    "/ip4/78.47.4.139/tcp/9090/p2p/12D3KooWD2Q9pd6q6qT2hKPuXHRB6TGmGa12xNPyRphb2kTeVMZm"
   ],
   "defaultContextGraphs": [],
   "defaultNodeRole": "edge",


### PR DESCRIPTION
## Summary

- Update Base mainnet relay config with concrete relay multiaddrs
- Update Gnosis mainnet relay config with concrete relay multiaddrs
- Remove pre-deployment `_status` markers now that relay peer IDs are populated

## Testing

- `jq empty network/mainnet-base.json network/mainnet-gnosis.json`
- `git diff --check -- network/mainnet-base.json network/mainnet-gnosis.json`