### PR TITLE
Mainnet release PR: bump to 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0-rc.19",
+  "version": "10.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## First production / mainnet release version bump

Bumps **`10.0.0-rc.19` → `10.0.0`** across all 19 workspace `package.json` files:
- **16 public packages** — must all equal the release tag for the `npm-publish.yml` version-validation gate (fail-closed; a single mismatch aborts the publish).
- **3 private** (`dkg-v10` root, `dkg-evm-module`, `dkg-network-sim`) — bumped for lockstep; skipped by the publish gate.

Only the top-level `version` field changes in each file (one line each, 19 insertions / 19 deletions). Internal deps use `workspace:*`, so no dependency ranges change and `pnpm-lock.yaml` is untouched — same mechanism as the prior `chore(release): bump to …` commits.

### Release intent
- npm publish for `10.0.0` will be done **manually** for this first production cut (`pnpm -r publish --tag latest`), so a stable `10.0.0` lands on the `latest` dist-tag.
- When the `v10.0.0` tag is eventually pushed, create it as a **signed, annotated** tag (`git tag -s v10.0.0 <commit>`) so the GitHub Release workflow accepts it.

### Out of scope
- Network preset un-gating (mainnet relay peer-IDs / `_status`) — handled separately; NeuroWeb still pending as of this branch.
- Contract deployment + staking migration — separate runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)