### PR TITLE
feat(cli): per-node auto-update channel (decouple testnet from latest)

### DIFF
--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -19,9 +19,11 @@
     "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13"
   },
   "autoUpdate": {
-    "enabled": false,
+    "enabled": true,
     "repo": "OriginTrail/dkg",
     "branch": "main",
-    "checkIntervalMinutes": 5
+    "checkIntervalMinutes": 5,
+    "channel": "mainnet",
+    "allowPrerelease": false
   }
 }

--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -19,7 +19,7 @@
     "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13"
   },
   "autoUpdate": {
-    "enabled": true,
+    "enabled": false,
     "repo": "OriginTrail/dkg",
     "branch": "main",
     "checkIntervalMinutes": 5

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -21,9 +21,11 @@
     "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f"
   },
   "autoUpdate": {
-    "enabled": false,
+    "enabled": true,
     "repo": "OriginTrail/dkg",
     "branch": "main",
-    "checkIntervalMinutes": 5
+    "checkIntervalMinutes": 5,
+    "channel": "mainnet",
+    "allowPrerelease": false
   }
 }

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -21,7 +21,7 @@
     "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f"
   },
   "autoUpdate": {
-    "enabled": true,
+    "enabled": false,
     "repo": "OriginTrail/dkg",
     "branch": "main",
     "checkIntervalMinutes": 5

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -20,7 +20,7 @@
     "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F"
   },
   "autoUpdate": {
-    "enabled": true,
+    "enabled": false,
     "repo": "OriginTrail/dkg",
     "branch": "main",
     "checkIntervalMinutes": 5

--- a/network/mainnet-neuroweb.json
+++ b/network/mainnet-neuroweb.json
@@ -20,9 +20,11 @@
     "hubAddress": "0x0957e25BD33034948abc28204ddA54b6E1142D6F"
   },
   "autoUpdate": {
-    "enabled": false,
+    "enabled": true,
     "repo": "OriginTrail/dkg",
     "branch": "main",
-    "checkIntervalMinutes": 5
+    "checkIntervalMinutes": 5,
+    "channel": "mainnet",
+    "allowPrerelease": false
   }
 }

--- a/network/testnet.json
+++ b/network/testnet.json
@@ -15,7 +15,8 @@
     "enabled": true,
     "repo": "OriginTrail/dkg",
     "branch": "main",
-    "checkIntervalMinutes": 5
+    "checkIntervalMinutes": 5,
+    "channel": "testnet"
   },
   "chainResetMarker": "v10-rc12-ka-rename-2026-06-01",
   "chain": {

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -396,6 +396,10 @@ function pruneNetworkPinnedDefaults(
   if (existing.autoUpdate && typeof existing.autoUpdate === 'object' && network.autoUpdate) {
     for (const key of Object.keys(existing.autoUpdate)) {
       if (key === 'enabled') continue;
+      // Never strip an explicit `channel` pin, even when it equals the current
+      // network default — it's a deliberate cohort lock whose whole point is to
+      // survive a later change to that default.
+      if (key === 'channel') continue;
       if (existing.autoUpdate[key] === (network.autoUpdate as any)[key]) {
         delete existing.autoUpdate[key];
       }

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -167,6 +167,14 @@ export interface DaemonStatusResponse {
     max: number;
     rejectedTotal: number;
   };
+  // Auto-update status (surfaced by /api/status). Optional — daemons may omit.
+  // `updateAvailable` is null until the first check completes;
+  // `updateChannelTargetMissing` is true when a pinned auto-update channel has
+  // no acceptable target (tag unpublished / prerelease rejected / non-semver).
+  updateAvailable?: boolean | null;
+  updateChannelTargetMissing?: boolean;
+  latestVersion?: string | null;
+  latestCommit?: string | null;
 }
 
 export interface ApiClientConnectOptions {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -331,8 +331,12 @@ program
         //  - `buildTimeoutMs`: per-step overrides for slow ARM64 hosts
         //  - `sshCommand`: custom GIT_SSH_COMMAND (jump hosts, non-default
         //    port, custom IdentityFile, etc.)
+        //  - `channel`: per-node npm dist-tag pin (e.g. a "staging"/"qa"
+        //    cohort) overriding the network default — must survive a rerun
+        //    or the per-node channel guarantee silently breaks.
         ...(existing.autoUpdate?.buildTimeoutMs ? { buildTimeoutMs: existing.autoUpdate.buildTimeoutMs } : {}),
         ...(existing.autoUpdate?.sshCommand ? { sshCommand: existing.autoUpdate.sshCommand } : {}),
+        ...(existing.autoUpdate?.channel ? { channel: existing.autoUpdate.channel } : {}),
       } as AutoUpdateConfig;
     }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -104,6 +104,69 @@ import {
   runForegroundSupervisor,
 } from '../cli-supervisor.js';
 
+/**
+ * Pure builder for the `autoUpdate` block `dkg init` persists. Extracted from
+ * the interactive wizard so it is unit-testable — the decline path (must write
+ * `{ enabled: false }`, NOT fall through to the enabled network default) and
+ * channel/advanced-field preservation across reruns have each regressed before.
+ * The wizard gathers `answers` interactively and passes them in.
+ */
+export function buildInitAutoUpdate(opts: {
+  enableAutoUpdate: boolean;
+  existingAutoUpdate: AutoUpdateConfig | undefined;
+  networkAutoUpdate?: {
+    repo?: string;
+    branch?: string;
+    allowPrerelease?: boolean;
+    sshKeyPath?: string;
+    checkIntervalMinutes?: number;
+  };
+  projRepo: string;
+  projDefaultBranch: string;
+  answers?: {
+    repo: string;
+    branch: string;
+    allowPrerelease: boolean;
+    sshKeyPath: string;
+    interval: number;
+  };
+}): AutoUpdateConfig {
+  const { enableAutoUpdate, existingAutoUpdate, networkAutoUpdate, projRepo, projDefaultBranch, answers } = opts;
+  if (!enableAutoUpdate) {
+    // Explicit decline: persist `enabled: false` so resolveAutoUpdateConfig
+    // does NOT fall through to the enabled network default. Keep any existing
+    // advanced fields (channel, etc.) — the operator only toggled auto-apply.
+    return existingAutoUpdate
+      ? { ...existingAutoUpdate, enabled: false }
+      : { enabled: false };
+  }
+  const a = answers ?? { repo: '', branch: '', allowPrerelease: true, sshKeyPath: '', interval: NaN };
+  // Effective upstream defaults — what the node would use with nothing
+  // persisted. We persist a field only when it differs, so future changes to
+  // the shipped network/project config propagate without a config rewrite.
+  const effectiveRepo = networkAutoUpdate?.repo ?? projRepo;
+  const effectiveBranch = networkAutoUpdate?.branch ?? projDefaultBranch;
+  const effectiveAllowPrerelease = networkAutoUpdate?.allowPrerelease ?? true;
+  const effectiveSshKeyPath = networkAutoUpdate?.sshKeyPath ?? '';
+  const effectiveInterval = networkAutoUpdate?.checkIntervalMinutes ?? 30;
+  return {
+    enabled: true,
+    // OT-RFC-41 Bundle B1d: explicit npm source for fresh installs.
+    source: 'npm' as const,
+    ...(a.repo && a.repo !== effectiveRepo ? { repo: a.repo } : {}),
+    ...(a.branch && a.branch !== effectiveBranch ? { branch: a.branch } : {}),
+    ...(a.allowPrerelease !== effectiveAllowPrerelease ? { allowPrerelease: a.allowPrerelease } : {}),
+    ...(a.sshKeyPath && a.sshKeyPath !== effectiveSshKeyPath ? { sshKeyPath: a.sshKeyPath } : {}),
+    ...(Number.isFinite(a.interval) && a.interval !== effectiveInterval ? { checkIntervalMinutes: a.interval } : {}),
+    // Preserve advanced fields the wizard does not prompt for so a rerun
+    // doesn't silently revert operator tuning: build timeouts, custom SSH
+    // command, and the per-node `channel` cohort pin.
+    ...(existingAutoUpdate?.buildTimeoutMs ? { buildTimeoutMs: existingAutoUpdate.buildTimeoutMs } : {}),
+    ...(existingAutoUpdate?.sshCommand ? { sshCommand: existingAutoUpdate.sshCommand } : {}),
+    ...(existingAutoUpdate?.channel ? { channel: existingAutoUpdate.channel } : {}),
+  } as AutoUpdateConfig;
+}
+
 export function registerInitCommand(program: Command): void {
 // ─── dkg init ────────────────────────────────────────────────────────
 
@@ -281,21 +344,19 @@ program
       autoUpdateDefault ? 'y' : 'n',
     )).toLowerCase() === 'y';
 
-    let autoUpdate = existing.autoUpdate;
+    const proj = loadProjectConfig();
+    // Gather answers interactively only when enabling; the pure
+    // `buildInitAutoUpdate` (above) does the persist decision for both paths so
+    // it is unit-tested. Prompt defaults show existing value, else the upstream
+    // (network → project) default.
+    let autoUpdateAnswers:
+      | { repo: string; branch: string; allowPrerelease: boolean; sshKeyPath: string; interval: number }
+      | undefined;
     if (enableAutoUpdate) {
-      // Effective upstream defaults — what the node would use if nothing were
-      // persisted in ~/.dkg/config.json. Network config beats project.json.
-      // We persist a field only when it differs from the upstream default, so
-      // future changes to the shipped network or project config propagate on
-      // the next daemon run without requiring a config rewrite. Without this
-      // guard, every accepted-default ends up pinned in the custom config
-      // forever.
-      const proj = loadProjectConfig();
       const effectiveRepo = network?.autoUpdate?.repo ?? proj.repo;
       const effectiveBranch = network?.autoUpdate?.branch ?? proj.defaultBranch;
       const effectiveAllowPrerelease = network?.autoUpdate?.allowPrerelease ?? true;
       const effectiveSshKeyPath = network?.autoUpdate?.sshKeyPath ?? '';
-      // Keep this in sync with `resolveAutoUpdateConfig` in config.ts.
       const effectiveInterval = network?.autoUpdate?.checkIntervalMinutes ?? 30;
 
       const defaultRepo = existing.autoUpdate?.repo ?? effectiveRepo;
@@ -313,32 +374,16 @@ program
       const sshKeyPath = (await ask('SSH private key path (optional; blank uses agent/default SSH config)', defaultSshKeyPath)).trim();
       const interval = parseInt(await ask('Check interval (minutes)', String(defaultInterval)), 10);
 
-      autoUpdate = {
-        enabled: true,
-        // OT-RFC-41 Bundle B1d: explicit source. Under rc.12+, fresh
-        // installs always use the npm path (Edge: install -g; Core:
-        // slot install). The legacy 'auto'/'git' values still parse
-        // (rc.11 nodes carrying them upgrade-in-place) but the
-        // daemon dispatches them as 'npm' under §5 PR 5.
-        source: 'npm' as const,
-        ...(repo && repo !== effectiveRepo ? { repo } : {}),
-        ...(branch && branch !== effectiveBranch ? { branch } : {}),
-        ...(allowPrerelease !== effectiveAllowPrerelease ? { allowPrerelease } : {}),
-        ...(sshKeyPath && sshKeyPath !== effectiveSshKeyPath ? { sshKeyPath } : {}),
-        ...(Number.isFinite(interval) && interval !== effectiveInterval ? { checkIntervalMinutes: interval } : {}),
-        // Preserve advanced fields the wizard does not prompt for so a
-        // rerun of `dkg init` doesn't silently revert operator tuning:
-        //  - `buildTimeoutMs`: per-step overrides for slow ARM64 hosts
-        //  - `sshCommand`: custom GIT_SSH_COMMAND (jump hosts, non-default
-        //    port, custom IdentityFile, etc.)
-        //  - `channel`: per-node npm dist-tag pin (e.g. a "staging"/"qa"
-        //    cohort) overriding the network default — must survive a rerun
-        //    or the per-node channel guarantee silently breaks.
-        ...(existing.autoUpdate?.buildTimeoutMs ? { buildTimeoutMs: existing.autoUpdate.buildTimeoutMs } : {}),
-        ...(existing.autoUpdate?.sshCommand ? { sshCommand: existing.autoUpdate.sshCommand } : {}),
-        ...(existing.autoUpdate?.channel ? { channel: existing.autoUpdate.channel } : {}),
-      } as AutoUpdateConfig;
+      autoUpdateAnswers = { repo, branch, allowPrerelease, sshKeyPath, interval };
     }
+    const autoUpdate = buildInitAutoUpdate({
+      enableAutoUpdate,
+      existingAutoUpdate: existing.autoUpdate,
+      networkAutoUpdate: network?.autoUpdate,
+      projRepo: proj.repo,
+      projDefaultBranch: proj.defaultBranch,
+      answers: autoUpdateAnswers,
+    });
 
     // Chain configuration. Field-merge: existing config wins per-field over
     // network defaults so an operator who's only customised RPC keeps that
@@ -382,7 +427,12 @@ program
       apiPort,
       nodeRole,
       contextGraphs,
-      autoUpdate: enableAutoUpdate ? autoUpdate : existing.autoUpdate,
+      // `autoUpdate` already holds the correct value for BOTH branches: the
+      // fully-built block when enabled, or `{ enabled: false }` (preserving
+      // existing advanced fields) when declined. The old ternary here re-read
+      // `existing.autoUpdate` on decline, silently discarding the persisted
+      // disable — so a fresh-config operator who said "no" still auto-updated.
+      autoUpdate,
       chain: chainSection ?? existing.chain,
       auth: { enabled: enableAuth, tokens: existing.auth?.tokens },
       // Persist the chosen backend. `storeBlock === null` from the

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -134,6 +134,7 @@ program
         branch: proj.defaultBranch,
         allowPrerelease: true,
         checkIntervalMinutes: 30,
+        channel: config.autoUpdate?.channel ?? net?.autoUpdate?.channel,
         source: undefined as 'auto' | 'npm' | 'git' | undefined,
       };
     })();
@@ -149,7 +150,7 @@ program
 
       if (opts.check) {
         console.log('Checking NPM registry for updates...');
-        const check = await checkForNpmVersionUpdate(logFn, allowPre);
+        const check = await checkForNpmVersionUpdate(logFn, allowPre, au.channel);
         if (check.status === 'available' && check.version) {
           console.log(`Update available: ${check.version}`);
         } else if (check.status === 'up-to-date') {
@@ -193,7 +194,7 @@ program
       }
       if (!version) {
         console.log('Checking NPM registry for updates...');
-        const check = await checkForNpmVersionUpdate(logFn, allowPre);
+        const check = await checkForNpmVersionUpdate(logFn, allowPre, au.channel);
         if (check.status === 'available' && check.version) {
           version = check.version;
         } else if (check.status === 'up-to-date') {

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -129,10 +129,13 @@ program
     const au = resolveAutoUpdateConfig(config, net) ?? (() => {
       const proj = loadProjectConfig();
       return {
+        // Mirror resolveAutoUpdateConfig precedence for the fields a manual
+        // `dkg update` depends on — auto-apply being disabled must NOT drop the
+        // operator's stable-only (allowPrerelease) intent or channel pin.
         enabled: true,
         repo: proj.repo,
         branch: proj.defaultBranch,
-        allowPrerelease: true,
+        allowPrerelease: config.autoUpdate?.allowPrerelease ?? net?.autoUpdate?.allowPrerelease ?? true,
         checkIntervalMinutes: 30,
         channel: config.autoUpdate?.channel ?? net?.autoUpdate?.channel,
         source: undefined as 'auto' | 'npm' | 'git' | undefined,
@@ -153,6 +156,8 @@ program
         const check = await checkForNpmVersionUpdate(logFn, allowPre, au.channel);
         if (check.status === 'available' && check.version) {
           console.log(`Update available: ${check.version}`);
+        } else if (check.status === 'no-target') {
+          console.log(`No acceptable target for channel "${check.channel}" (tag unpublished, or a pre-release rejected by allowPrerelease=false) — nothing to update to.`);
         } else if (check.status === 'up-to-date') {
           console.log('No updates available.');
         } else {
@@ -197,6 +202,9 @@ program
         const check = await checkForNpmVersionUpdate(logFn, allowPre, au.channel);
         if (check.status === 'available' && check.version) {
           version = check.version;
+        } else if (check.status === 'no-target') {
+          console.log(`No acceptable target for channel "${check.channel}" (tag unpublished, or a pre-release rejected by allowPrerelease=false) — nothing to update to.`);
+          return;
         } else if (check.status === 'up-to-date') {
           console.log('No update needed — already on latest.');
           return;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -44,6 +44,19 @@ export interface AutoUpdateConfig {
   branch?: string;
   /** Allow auto-updating to pre-release versions (e.g. 9.0.5-rc.1). */
   allowPrerelease?: boolean;
+  /**
+   * npm dist-tag this node tracks for auto-updates. When set, the updater
+   * follows ONLY `dist-tags[channel]` (e.g. "testnet", "mainnet", "latest")
+   * instead of the default `max(latest, dev, beta, next)`. This decouples a
+   * cohort from whatever `latest` happens to point at — e.g. testnet nodes
+   * pinned to `channel: "testnet"` keep tracking testnet releases even after
+   * `latest` is repurposed for mainnet. Omit to keep the legacy behaviour.
+   *
+   * Forward-only: a node updates only when the channel's target is a HIGHER
+   * semver than its current version (same gate as the default path), so
+   * re-pointing a tag at a LOWER version is a no-op, not a downgrade.
+   */
+  channel?: string;
   /** Optional SSH private key path for git-based update fetches/clones. */
   sshKeyPath?: string;
   /** Optional raw GIT_SSH_COMMAND override for git-based update fetches/clones. */
@@ -114,6 +127,8 @@ export interface NetworkConfig {
     repo: string;
     branch: string;
     allowPrerelease?: boolean;
+    /** npm dist-tag this network's nodes track — see `AutoUpdateConfig.channel`. */
+    channel?: string;
     sshKeyPath?: string;
     sshCommand?: string;
     checkIntervalMinutes: number;
@@ -1005,6 +1020,7 @@ export function resolveAutoUpdateConfig(
   const sshCommand = cfg?.sshCommand ?? net?.sshCommand;
   const checkIntervalMinutes = cfg?.checkIntervalMinutes ?? net?.checkIntervalMinutes ?? 30;
   const source = cfg?.source ?? net?.source;
+  const channel = cfg?.channel ?? net?.channel;
 
   // Merge build timeouts per-key so operators can override one step (e.g.
   // `contracts` on slow ARM hosts) without re-specifying the rest.
@@ -1030,6 +1046,7 @@ export function resolveAutoUpdateConfig(
     checkIntervalMinutes,
     ...(buildTimeoutMs ? { buildTimeoutMs } : {}),
     ...(source ? { source } : {}),
+    ...(channel ? { channel } : {}),
   };
 }
 

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -294,14 +294,25 @@ export type NpmVersionResult =
   | { version: null; error: true }
   | { version: null; error: false };
 
+// Official semver.org grammar (anchored). Rejects malformed values that a
+// loose shape check would accept (e.g. `10.0.0-alpha..1` — empty prerelease
+// identifier) before they reach `compareSemver` (a non-numeric part makes it
+// return NaN, which is not `<= 0` and would slip the forward-only gate).
+const SEMVER_RE =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+/** True when `v` is a valid semver string. */
+export function isValidSemver(v: string): boolean {
+  return SEMVER_RE.test(v.trim());
+}
+
 /**
- * Minimal semver-shape guard: MAJOR.MINOR.PATCH with optional -prerelease/+build.
- * Used to reject malformed dist-tag values before they reach `compareSemver`
- * (a non-numeric part makes `compareSemver` return NaN, which is not `<= 0` and
- * would slip the forward-only gate, attempting an "update" to garbage).
+ * True when `v` carries a prerelease component (the `-…` segment) — build
+ * metadata (`+…`) is NOT a prerelease, so `1.0.0+mainnet-build.1` is stable
+ * even though it contains a hyphen. Used for the `allowPrerelease` gate.
  */
-export function isLikelySemver(v: string): boolean {
-  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(v.trim());
+export function isPrerelease(v: string): boolean {
+  return v.trim().split("+")[0].includes("-");
 }
 
 export async function resolveLatestNpmVersion(
@@ -337,13 +348,13 @@ export async function resolveLatestNpmVersion(
         );
         return { version: null, error: false };
       }
-      if (!isLikelySemver(pinned)) {
+      if (!isValidSemver(pinned)) {
         log(
           `Auto-update (npm): channel "${channel}" → "${pinned}" is not a valid semver, skipping`,
         );
         return { version: null, error: false };
       }
-      if (!allowPrerelease && pinned.includes("-")) {
+      if (!allowPrerelease && isPrerelease(pinned)) {
         log(
           `Auto-update (npm): channel "${channel}" points at a pre-release and allowPrerelease=false, skipping`,
         );
@@ -354,7 +365,7 @@ export async function resolveLatestNpmVersion(
 
     const stable = tags.latest ?? null;
     if (!allowPrerelease) {
-      if (stable && !stable.includes("-")) return { version: stable };
+      if (stable && !isPrerelease(stable)) return { version: stable };
       log(
         "Auto-update (npm): latest dist-tag is a pre-release and allowPrerelease=false, skipping",
       );
@@ -446,7 +457,7 @@ export async function checkForNpmVersionUpdate(
   // (compareSemver would return NaN, which is not <= 0). The channel path
   // already guards this upstream; this also covers the default tag set
   // without changing its candidate selection.
-  if (!isLikelySemver(result.version)) {
+  if (!isValidSemver(result.version)) {
     log(
       `Auto-update (npm): resolved version "${result.version}" is not valid semver, skipping`,
     );
@@ -470,14 +481,17 @@ export async function checkForNpmVersionUpdate(
  */
 export function deriveUpdateCheckState(
   npmStatus: NpmVersionStatus,
-): { upToDate: boolean; channelTargetMissing: boolean; version?: string } | null {
+): { upToDate: boolean; channelTargetMissing: boolean; latestVersion: string } | null {
   if (npmStatus.status === "error") return null;
   if (npmStatus.status === "no-target")
-    return { upToDate: true, channelTargetMissing: true };
+    return { upToDate: true, channelTargetMissing: true, latestVersion: "" };
   return {
     upToDate: npmStatus.status === "up-to-date",
     channelTargetMissing: false,
-    ...(npmStatus.version ? { version: npmStatus.version } : {}),
+    // Only an "available" result has a newer version to report; clear it on
+    // up-to-date / no-target so `/api/status` never shows a stale latestVersion.
+    latestVersion:
+      npmStatus.status === "available" ? npmStatus.version ?? "" : "",
   };
 }
 

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -294,6 +294,16 @@ export type NpmVersionResult =
   | { version: null; error: true }
   | { version: null; error: false };
 
+/**
+ * Minimal semver-shape guard: MAJOR.MINOR.PATCH with optional -prerelease/+build.
+ * Used to reject malformed dist-tag values before they reach `compareSemver`
+ * (a non-numeric part makes `compareSemver` return NaN, which is not `<= 0` and
+ * would slip the forward-only gate, attempting an "update" to garbage).
+ */
+export function isLikelySemver(v: string): boolean {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(v.trim());
+}
+
 export async function resolveLatestNpmVersion(
   log: (msg: string) => void,
   allowPrerelease = true,
@@ -324,6 +334,12 @@ export async function resolveLatestNpmVersion(
       if (!pinned) {
         log(
           `Auto-update (npm): channel "${channel}" has no published version, skipping`,
+        );
+        return { version: null, error: false };
+      }
+      if (!isLikelySemver(pinned)) {
+        log(
+          `Auto-update (npm): channel "${channel}" → "${pinned}" is not a valid semver, skipping`,
         );
         return { version: null, error: false };
       }
@@ -390,8 +406,10 @@ export function getCurrentCliVersion(): string {
 }
 
 export type NpmVersionStatus = {
-  status: "available" | "up-to-date" | "error";
+  status: "available" | "up-to-date" | "error" | "no-target";
   version?: string;
+  /** Set on "no-target": the pinned channel that has no acceptable version. */
+  channel?: string;
 };
 
 export async function checkForNpmVersionUpdate(
@@ -414,14 +432,53 @@ export async function checkForNpmVersionUpdate(
   }
 
   const result = await resolveLatestNpmVersion(log, allowPrerelease, channel);
-  if (result.version === null)
-    return { status: result.error ? "error" : "up-to-date" };
+  if (result.version === null) {
+    if (result.error) return { status: "error" };
+    // A pinned channel with no acceptable target (tag missing / prerelease
+    // rejected / non-semver) is NOT a clean "up-to-date" — surface it so a
+    // misconfigured or unpublished channel (e.g. mainnet) is visible rather
+    // than silently reported as current.
+    if (channel) return { status: "no-target", channel };
+    return { status: "up-to-date" };
+  }
+
+  // Never trust a non-semver target through the forward-only gate below
+  // (compareSemver would return NaN, which is not <= 0). The channel path
+  // already guards this upstream; this also covers the default tag set
+  // without changing its candidate selection.
+  if (!isLikelySemver(result.version)) {
+    log(
+      `Auto-update (npm): resolved version "${result.version}" is not valid semver, skipping`,
+    );
+    return channel ? { status: "no-target", channel } : { status: "up-to-date" };
+  }
 
   if (result.version === currentVersion) return { status: "up-to-date" };
   if (compareSemver(result.version, currentVersion) <= 0)
     return { status: "up-to-date" };
 
   return { status: "available", version: result.version };
+}
+
+/**
+ * Pure mapping from an {@link NpmVersionStatus} to the daemon's
+ * `lastUpdateCheck` fields. Extracted so the runCheck → /api/status
+ * derivation is unit-testable. The `no-target` case in particular MUST report
+ * `upToDate: true` (there is no update to apply) so `/api/status` does not flip
+ * to `updateAvailable: true`; `channelTargetMissing` carries the distinct
+ * signal. Returns null for `error` — the caller leaves prior state unchanged.
+ */
+export function deriveUpdateCheckState(
+  npmStatus: NpmVersionStatus,
+): { upToDate: boolean; channelTargetMissing: boolean; version?: string } | null {
+  if (npmStatus.status === "error") return null;
+  if (npmStatus.status === "no-target")
+    return { upToDate: true, channelTargetMissing: true };
+  return {
+    upToDate: npmStatus.status === "up-to-date",
+    channelTargetMissing: false,
+    ...(npmStatus.version ? { version: npmStatus.version } : {}),
+  };
 }
 
 /**

--- a/packages/cli/src/daemon/auto-update.ts
+++ b/packages/cli/src/daemon/auto-update.ts
@@ -286,7 +286,8 @@ export async function writePendingUpdateState(
 /**
  * Query the NPM registry for the latest published version of the CLI package.
  * Uses `dist-tags.latest` by default; when `allowPrerelease` is true, also
- * checks `beta` / `next` tags and picks the highest semver.
+ * checks `beta` / `next` tags and picks the highest semver. When `channel`
+ * is set, follows ONLY that dist-tag instead (still honouring `allowPrerelease`).
  */
 export type NpmVersionResult =
   | { version: string; error?: false }
@@ -296,6 +297,7 @@ export type NpmVersionResult =
 export async function resolveLatestNpmVersion(
   log: (msg: string) => void,
   allowPrerelease = true,
+  channel?: string,
 ): Promise<NpmVersionResult> {
   const { fetch } = _autoUpdateIo;
   const url = `https://registry.npmjs.org/${CLI_NPM_PACKAGE}`;
@@ -313,6 +315,26 @@ export async function resolveLatestNpmVersion(
     const data = (await res.json()) as { "dist-tags"?: Record<string, string> };
     const tags = data["dist-tags"];
     if (!tags) return { version: null, error: true };
+
+    // Channel pin: follow ONLY this dist-tag (e.g. "testnet"), ignoring the
+    // default latest/dev/beta/next set. Lets a cohort track its own release
+    // line without being captured by whatever `latest` points at.
+    if (channel) {
+      const pinned = tags[channel] ?? null;
+      if (!pinned) {
+        log(
+          `Auto-update (npm): channel "${channel}" has no published version, skipping`,
+        );
+        return { version: null, error: false };
+      }
+      if (!allowPrerelease && pinned.includes("-")) {
+        log(
+          `Auto-update (npm): channel "${channel}" points at a pre-release and allowPrerelease=false, skipping`,
+        );
+        return { version: null, error: false };
+      }
+      return { version: pinned };
+    }
 
     const stable = tags.latest ?? null;
     if (!allowPrerelease) {
@@ -375,6 +397,7 @@ export type NpmVersionStatus = {
 export async function checkForNpmVersionUpdate(
   log: (msg: string) => void,
   allowPrerelease = true,
+  channel?: string,
 ): Promise<NpmVersionStatus> {
   const { dkgDir, readFile } = _autoUpdateIo;
   const versionFile = join(dkgDir(), ".current-version");
@@ -390,7 +413,7 @@ export async function checkForNpmVersionUpdate(
     return { status: "error" };
   }
 
-  const result = await resolveLatestNpmVersion(log, allowPrerelease);
+  const result = await resolveLatestNpmVersion(log, allowPrerelease, channel);
   if (result.version === null)
     return { status: result.error ? "error" : "up-to-date" };
 

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1887,13 +1887,14 @@ export async function runDaemonInner(
   if (standalone) {
     const checkIntervalMs = (au?.checkIntervalMinutes ?? 30) * 60_000;
     const allowPre = au?.allowPrerelease ?? true;
+    const channel = au?.channel;
 
     log(
-      `Auto-update (npm): ${au ? "enabled" : "disabled — version check only"} (every ${au?.checkIntervalMinutes ?? 30}min)`,
+      `Auto-update (npm): ${au ? "enabled" : "disabled — version check only"}${channel ? ` channel="${channel}"` : ""} (every ${au?.checkIntervalMinutes ?? 30}min)`,
     );
 
     const runCheck = async () => {
-      const npmStatus = await checkForNpmVersionUpdate(log, allowPre);
+      const npmStatus = await checkForNpmVersionUpdate(log, allowPre, channel);
       if (npmStatus.status !== "error") {
         daemonState.lastUpdateCheck.upToDate = npmStatus.status === "up-to-date";
         daemonState.lastUpdateCheck.checkedAt = Date.now();

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -272,6 +272,7 @@ import {
   getCurrentCliVersion,
   type NpmVersionStatus,
   checkForNpmVersionUpdate,
+  deriveUpdateCheckState,
   type UpdateStatus,
   acquireUpdateLock,
   releaseUpdateLock,
@@ -1886,8 +1887,13 @@ export async function runDaemonInner(
 
   if (standalone) {
     const checkIntervalMs = (au?.checkIntervalMinutes ?? 30) * 60_000;
-    const allowPre = au?.allowPrerelease ?? true;
-    const channel = au?.channel;
+    // Even in version-check-only mode (au is null because auto-apply is
+    // disabled) the policy used for the check must reflect the operator's
+    // shipped intent — read allowPrerelease + channel from config/network
+    // rather than hardcoding `true`/none, or a disabled-but-checking node
+    // silently ignores its `allowPrerelease:false` / channel pin.
+    const allowPre = au?.allowPrerelease ?? network?.autoUpdate?.allowPrerelease ?? config.autoUpdate?.allowPrerelease ?? true;
+    const channel = au?.channel ?? network?.autoUpdate?.channel ?? config.autoUpdate?.channel;
 
     log(
       `Auto-update (npm): ${au ? "enabled" : "disabled — version check only"}${channel ? ` channel="${channel}"` : ""} (every ${au?.checkIntervalMinutes ?? 30}min)`,
@@ -1895,11 +1901,17 @@ export async function runDaemonInner(
 
     const runCheck = async () => {
       const npmStatus = await checkForNpmVersionUpdate(log, allowPre, channel);
-      if (npmStatus.status !== "error") {
-        daemonState.lastUpdateCheck.upToDate = npmStatus.status === "up-to-date";
+      const derived = deriveUpdateCheckState(npmStatus);
+      if (derived) {
         daemonState.lastUpdateCheck.checkedAt = Date.now();
-        if (npmStatus.version)
-          daemonState.lastUpdateCheck.latestVersion = npmStatus.version;
+        daemonState.lastUpdateCheck.upToDate = derived.upToDate;
+        daemonState.lastUpdateCheck.channelTargetMissing = derived.channelTargetMissing;
+        if (derived.version)
+          daemonState.lastUpdateCheck.latestVersion = derived.version;
+        if (npmStatus.status === "no-target")
+          log(
+            `Auto-update (npm): WARNING — channel "${npmStatus.channel}" has no acceptable target (tag missing or rejected by allowPrerelease); node will not update until it is published.`,
+          );
       }
       if (npmStatus.status !== "available" || !npmStatus.version) return;
       if (!au) return; // version check only — no auto-apply when polling disabled

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1889,11 +1889,12 @@ export async function runDaemonInner(
     const checkIntervalMs = (au?.checkIntervalMinutes ?? 30) * 60_000;
     // Even in version-check-only mode (au is null because auto-apply is
     // disabled) the policy used for the check must reflect the operator's
-    // shipped intent — read allowPrerelease + channel from config/network
-    // rather than hardcoding `true`/none, or a disabled-but-checking node
-    // silently ignores its `allowPrerelease:false` / channel pin.
-    const allowPre = au?.allowPrerelease ?? network?.autoUpdate?.allowPrerelease ?? config.autoUpdate?.allowPrerelease ?? true;
-    const channel = au?.channel ?? network?.autoUpdate?.channel ?? config.autoUpdate?.channel;
+    // shipped intent, and must mirror resolveAutoUpdateConfig's precedence:
+    // local config BEFORE network default. A disabled node with a local
+    // channel / allowPrerelease pin must observe its own cohort, not the
+    // network's.
+    const allowPre = au?.allowPrerelease ?? config.autoUpdate?.allowPrerelease ?? network?.autoUpdate?.allowPrerelease ?? true;
+    const channel = au?.channel ?? config.autoUpdate?.channel ?? network?.autoUpdate?.channel;
 
     log(
       `Auto-update (npm): ${au ? "enabled" : "disabled — version check only"}${channel ? ` channel="${channel}"` : ""} (every ${au?.checkIntervalMinutes ?? 30}min)`,
@@ -1906,8 +1907,9 @@ export async function runDaemonInner(
         daemonState.lastUpdateCheck.checkedAt = Date.now();
         daemonState.lastUpdateCheck.upToDate = derived.upToDate;
         daemonState.lastUpdateCheck.channelTargetMissing = derived.channelTargetMissing;
-        if (derived.version)
-          daemonState.lastUpdateCheck.latestVersion = derived.version;
+        // Always write (including '') so a prior "available" version does not
+        // linger after the target disappears or the node catches up.
+        daemonState.lastUpdateCheck.latestVersion = derived.latestVersion;
         if (npmStatus.status === "no-target")
           log(
             `Auto-update (npm): WARNING — channel "${npmStatus.channel}" has no acceptable target (tag missing or rejected by allowPrerelease); node will not update until it is published.`,

--- a/packages/cli/src/daemon/routes/status.ts
+++ b/packages/cli/src/daemon/routes/status.ts
@@ -732,6 +732,10 @@ export async function handleStatusRoutes(ctx: RequestContext): Promise<void> {
         : null,
       updateAvailable:
         daemonState.lastUpdateCheck.checkedAt > 0 ? !daemonState.lastUpdateCheck.upToDate : null,
+      // True when this node pins an auto-update channel that has no acceptable
+      // target yet (e.g. the `mainnet` tag is unpublished, or points at a
+      // prerelease under allowPrerelease=false). Distinct from updateAvailable.
+      updateChannelTargetMissing: daemonState.lastUpdateCheck.channelTargetMissing,
       latestCommit: daemonState.lastUpdateCheck.latestCommit || null,
       latestVersion: daemonState.lastUpdateCheck.latestVersion || null,
     });

--- a/packages/cli/src/daemon/state.ts
+++ b/packages/cli/src/daemon/state.ts
@@ -38,6 +38,10 @@ export const daemonState: {
     checkedAt: number;
     latestCommit: string;
     latestVersion: string;
+    /** True when a pinned auto-update channel has no acceptable target
+     *  (tag missing / prerelease rejected / non-semver). Distinct from
+     *  `upToDate` so `/api/status` can show a misconfigured channel. */
+    channelTargetMissing: boolean;
   };
   /** Memoised result of `isStandaloneInstall()` — null = not yet checked. */
   standaloneCache: boolean | null;
@@ -80,6 +84,7 @@ export const daemonState: {
     checkedAt: 0,
     latestCommit: '',
     latestVersion: '',
+    channelTargetMissing: false,
   },
   standaloneCache: null,
   natStatus: 'unknown',

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -1116,18 +1116,29 @@ describe('checkForNpmVersionUpdate tag precedence', () => {
     expect(result.status).toBe('up-to-date');
   });
 
-  it('channel pin no-ops gracefully when the dist-tag does not exist yet', async () => {
+  it('channel pin reports no-target (not up-to-date) when the dist-tag does not exist yet', async () => {
     const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
     fetchImpl = async () => makeRegistryResponse({ latest: '9.5.0' }); // no `testnet`
     const result = await checkForNpmVersionUpdate(() => {}, true, 'testnet');
-    expect(result.status).toBe('up-to-date');
+    // Distinct from up-to-date: an unpublished/misconfigured channel must be
+    // visible, not silently reported as current.
+    expect(result.status).toBe('no-target');
+    expect(result.channel).toBe('testnet');
   });
 
-  it('channel pin honours allowPrerelease=false (skips a prerelease tag)', async () => {
+  it('channel pin reports no-target when allowPrerelease=false rejects a prerelease tag', async () => {
     const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
     fetchImpl = async () => makeRegistryResponse({ testnet: '9.6.0-rc.1' });
     const result = await checkForNpmVersionUpdate(() => {}, false, 'testnet');
-    expect(result.status).toBe('up-to-date');
+    expect(result.status).toBe('no-target');
+    expect(result.channel).toBe('testnet');
+  });
+
+  it('channel pin reports no-target when the tag value is not valid semver', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({ testnet: 'not-a-version' });
+    const result = await checkForNpmVersionUpdate(() => {}, true, 'testnet');
+    expect(result.status).toBe('no-target');
   });
 
   it('channel pin follows a stable tag under allowPrerelease=false', async () => {
@@ -1139,6 +1150,38 @@ describe('checkForNpmVersionUpdate tag precedence', () => {
     const result = await checkForNpmVersionUpdate(() => {}, false, 'mainnet');
     expect(result.status).toBe('available');
     expect(result.version).toBe('10.0.0');
+  });
+
+  it('default path does NOT attempt an update to a non-semver latest', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({ latest: 'garbage' });
+    const result = await checkForNpmVersionUpdate(() => {}, true);
+    expect(result.status).toBe('up-to-date'); // not 'available' on garbage
+  });
+});
+
+describe('deriveUpdateCheckState (runCheck → /api/status mapping)', () => {
+  it('no-target → upToDate:true + channelTargetMissing:true (updateAvailable stays false)', async () => {
+    const { deriveUpdateCheckState } = await import('../src/daemon.js');
+    expect(deriveUpdateCheckState({ status: 'no-target', channel: 'mainnet' }))
+      .toEqual({ upToDate: true, channelTargetMissing: true });
+  });
+
+  it('available → upToDate:false + clears channelTargetMissing + carries version', async () => {
+    const { deriveUpdateCheckState } = await import('../src/daemon.js');
+    expect(deriveUpdateCheckState({ status: 'available', version: '10.1.0' }))
+      .toEqual({ upToDate: false, channelTargetMissing: false, version: '10.1.0' });
+  });
+
+  it('up-to-date → upToDate:true + clears channelTargetMissing', async () => {
+    const { deriveUpdateCheckState } = await import('../src/daemon.js');
+    expect(deriveUpdateCheckState({ status: 'up-to-date' }))
+      .toEqual({ upToDate: true, channelTargetMissing: false });
+  });
+
+  it('error → null (caller leaves prior state untouched)', async () => {
+    const { deriveUpdateCheckState } = await import('../src/daemon.js');
+    expect(deriveUpdateCheckState({ status: 'error' })).toBeNull();
   });
 });
 

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -1141,6 +1141,22 @@ describe('checkForNpmVersionUpdate tag precedence', () => {
     expect(result.status).toBe('no-target');
   });
 
+  it('channel pin rejects a semver-LIKE-but-invalid tag (empty prerelease identifier)', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({ testnet: '10.0.0-alpha..1' });
+    const result = await checkForNpmVersionUpdate(() => {}, true, 'testnet');
+    expect(result.status).toBe('no-target');
+  });
+
+  it('allowPrerelease=false accepts a STABLE version with hyphenated build metadata', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    // The hyphen is in +build metadata, not a prerelease — must NOT be rejected.
+    fetchImpl = async () => makeRegistryResponse({ mainnet: '10.0.0+mainnet-build.1' });
+    const result = await checkForNpmVersionUpdate(() => {}, false, 'mainnet');
+    expect(result.status).toBe('available');
+    expect(result.version).toBe('10.0.0+mainnet-build.1');
+  });
+
   it('channel pin follows a stable tag under allowPrerelease=false', async () => {
     const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
     fetchImpl = async () => makeRegistryResponse({
@@ -1161,22 +1177,22 @@ describe('checkForNpmVersionUpdate tag precedence', () => {
 });
 
 describe('deriveUpdateCheckState (runCheck → /api/status mapping)', () => {
-  it('no-target → upToDate:true + channelTargetMissing:true (updateAvailable stays false)', async () => {
+  it('no-target → upToDate:true + channelTargetMissing:true + cleared latestVersion (updateAvailable stays false)', async () => {
     const { deriveUpdateCheckState } = await import('../src/daemon.js');
     expect(deriveUpdateCheckState({ status: 'no-target', channel: 'mainnet' }))
-      .toEqual({ upToDate: true, channelTargetMissing: true });
+      .toEqual({ upToDate: true, channelTargetMissing: true, latestVersion: '' });
   });
 
-  it('available → upToDate:false + clears channelTargetMissing + carries version', async () => {
+  it('available → upToDate:false + clears channelTargetMissing + carries latestVersion', async () => {
     const { deriveUpdateCheckState } = await import('../src/daemon.js');
     expect(deriveUpdateCheckState({ status: 'available', version: '10.1.0' }))
-      .toEqual({ upToDate: false, channelTargetMissing: false, version: '10.1.0' });
+      .toEqual({ upToDate: false, channelTargetMissing: false, latestVersion: '10.1.0' });
   });
 
-  it('up-to-date → upToDate:true + clears channelTargetMissing', async () => {
+  it('up-to-date → upToDate:true, clears channelTargetMissing AND clears stale latestVersion', async () => {
     const { deriveUpdateCheckState } = await import('../src/daemon.js');
-    expect(deriveUpdateCheckState({ status: 'up-to-date' }))
-      .toEqual({ upToDate: true, channelTargetMissing: false });
+    expect(deriveUpdateCheckState({ status: 'up-to-date', version: 'should-be-ignored' }))
+      .toEqual({ upToDate: true, channelTargetMissing: false, latestVersion: '' });
   });
 
   it('error → null (caller leaves prior state untouched)', async () => {

--- a/packages/cli/test/auto-update.test.ts
+++ b/packages/cli/test/auto-update.test.ts
@@ -1091,6 +1091,55 @@ describe('checkForNpmVersionUpdate tag precedence', () => {
     const result = await checkForNpmVersionUpdate(() => {}, true);
     expect(result.status).toBe('up-to-date');
   });
+
+  // Channel pinning (OT-RFC-41): a node tracks ONE dist-tag and is never
+  // captured by whatever `latest` happens to point at. This is what keeps a
+  // testnet cohort on the `testnet` tag after `latest` is repurposed for mainnet.
+  it('channel pin follows ONLY that dist-tag, ignoring a higher latest', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({
+      latest: '9.5.0',          // another release line — MUST be ignored
+      testnet: '9.0.0-beta.5',  // the pinned channel
+    });
+    const result = await checkForNpmVersionUpdate(() => {}, true, 'testnet');
+    expect(result.status).toBe('available');
+    expect(result.version).toBe('9.0.0-beta.5');
+  });
+
+  it('channel pin is up-to-date when the pinned tag does not advance', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({
+      latest: '9.5.0',
+      testnet: '9.0.0-beta.3', // == current version
+    });
+    const result = await checkForNpmVersionUpdate(() => {}, true, 'testnet');
+    expect(result.status).toBe('up-to-date');
+  });
+
+  it('channel pin no-ops gracefully when the dist-tag does not exist yet', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({ latest: '9.5.0' }); // no `testnet`
+    const result = await checkForNpmVersionUpdate(() => {}, true, 'testnet');
+    expect(result.status).toBe('up-to-date');
+  });
+
+  it('channel pin honours allowPrerelease=false (skips a prerelease tag)', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({ testnet: '9.6.0-rc.1' });
+    const result = await checkForNpmVersionUpdate(() => {}, false, 'testnet');
+    expect(result.status).toBe('up-to-date');
+  });
+
+  it('channel pin follows a stable tag under allowPrerelease=false', async () => {
+    const { checkForNpmVersionUpdate } = await import('../src/daemon.js');
+    fetchImpl = async () => makeRegistryResponse({
+      latest: '9.0.0-beta.9',
+      mainnet: '10.0.0',
+    });
+    const result = await checkForNpmVersionUpdate(() => {}, false, 'mainnet');
+    expect(result.status).toBe('available');
+    expect(result.version).toBe('10.0.0');
+  });
 });
 
 describe('performNpmUpdate', () => {

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -161,8 +161,10 @@ describe('loadNetworkConfig', () => {
       ],
       defaultContextGraphs: [],
       defaultNodeRole: 'edge',
+      // Mainnet auto-update is held OFF until launch (Option Y): testnet keeps
+      // a living channel; mainnet stays frozen so no node chases `latest`.
       autoUpdate: {
-        enabled: true,
+        enabled: false,
         repo: 'OriginTrail/dkg',
         branch: 'main',
         checkIntervalMinutes: 5,

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -161,13 +161,15 @@ describe('loadNetworkConfig', () => {
       ],
       defaultContextGraphs: [],
       defaultNodeRole: 'edge',
-      // Mainnet auto-update is held OFF until launch (Option Y): testnet keeps
-      // a living channel; mainnet stays frozen so no node chases `latest`.
+      // Mainnet tracks a dedicated `mainnet` dist-tag channel (stable-only),
+      // NOT `latest` — so no node ever follows whatever `latest` points at.
       autoUpdate: {
-        enabled: false,
+        enabled: true,
         repo: 'OriginTrail/dkg',
         branch: 'main',
         checkIntervalMinutes: 5,
+        channel: 'mainnet',
+        allowPrerelease: false,
       },
     };
     _resetNetworkConfigCache();

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { buildInitAutoUpdate } from '../src/commands/init.js';
+
+// Guards the `dkg init` auto-update persistence decision. Both the decline
+// path (PR #1295 round 3: must persist { enabled: false }, not fall through to
+// the enabled network default) and channel/advanced-field preservation across
+// reruns (round 1) have regressed before — these pin the behavior.
+describe('buildInitAutoUpdate', () => {
+  const proj = { projRepo: 'OriginTrail/dkg', projDefaultBranch: 'main' };
+  const net = {
+    repo: 'OriginTrail/dkg',
+    branch: 'main',
+    allowPrerelease: true,
+    checkIntervalMinutes: 5,
+  };
+
+  it('decline on a fresh config persists { enabled: false } (so the daemon does NOT re-enable via the network default)', () => {
+    const r = buildInitAutoUpdate({
+      enableAutoUpdate: false,
+      existingAutoUpdate: undefined,
+      networkAutoUpdate: net,
+      ...proj,
+    });
+    expect(r).toEqual({ enabled: false });
+  });
+
+  it('decline disables but preserves existing advanced fields (channel, intervals)', () => {
+    const r = buildInitAutoUpdate({
+      enableAutoUpdate: false,
+      existingAutoUpdate: { enabled: true, channel: 'staging', checkIntervalMinutes: 10 },
+      networkAutoUpdate: net,
+      ...proj,
+    });
+    expect(r.enabled).toBe(false);
+    expect(r.channel).toBe('staging');
+    expect(r.checkIntervalMinutes).toBe(10);
+  });
+
+  it('enable preserves a local channel pin across the rerun', () => {
+    const r = buildInitAutoUpdate({
+      enableAutoUpdate: true,
+      existingAutoUpdate: { enabled: true, channel: 'staging' },
+      networkAutoUpdate: net,
+      ...proj,
+      answers: { repo: '', branch: '', allowPrerelease: true, sshKeyPath: '', interval: 5 },
+    });
+    expect(r.enabled).toBe(true);
+    expect(r.channel).toBe('staging');
+  });
+
+  it('enable persists only fields that differ from the network/project defaults', () => {
+    const r = buildInitAutoUpdate({
+      enableAutoUpdate: true,
+      existingAutoUpdate: undefined,
+      networkAutoUpdate: net,
+      ...proj,
+      // Every answer equals the effective default → nothing extra is pinned.
+      answers: { repo: 'OriginTrail/dkg', branch: 'main', allowPrerelease: true, sshKeyPath: '', interval: 5 },
+    });
+    expect(r).toEqual({ enabled: true, source: 'npm' });
+  });
+
+  it('enable persists a field that DOES differ from the default (e.g. allowPrerelease)', () => {
+    const r = buildInitAutoUpdate({
+      enableAutoUpdate: true,
+      existingAutoUpdate: undefined,
+      networkAutoUpdate: net, // allowPrerelease default = true
+      ...proj,
+      answers: { repo: 'OriginTrail/dkg', branch: 'main', allowPrerelease: false, sshKeyPath: '', interval: 5 },
+    });
+    expect(r).toEqual({ enabled: true, source: 'npm', allowPrerelease: false });
+  });
+});

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, afterAll, beforeEach, describe, expect, it } from
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync } from 'node:fs';
 import { tmpdir, homedir, platform } from 'node:os';
 import { join } from 'node:path';
+import { createServer } from 'node:net';
 import TOML from '@iarna/toml';
 import { mcpSetupAction, type McpSetupActionDeps } from '../src/mcp-setup.js';
 import {
@@ -379,12 +380,24 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
     const deps = makeDeps();
 
-    // No fetch stub: with no `--port`, effectivePort is the CLI default
-    // 9200 — nothing is listening there in CI (the shared Hardhat node
-    // is on 9548, live daemons on 21000+), so the production probe
-    // hits a real closed port and ECONNREFUSEs. That is the genuine
-    // "daemon not reachable" condition, exercised for real.
-    await mcpSetupAction({ start: false, verify: false }, deps);
+    // No fetch stub: the production probe does a real `/api/status`
+    // round-trip. Point it at a GUARANTEED-unused port (bind an ephemeral
+    // port → capture → close) so the connect() ECONNREFUSEs deterministically.
+    // The CLI default 9200 is racy here: under full-suite parallelism a
+    // different test file's daemon can occupy 9200 the instant this probe
+    // runs, making the daemon look "reachable" and firing the faucet. An
+    // ephemeral port (32768+) never collides with test daemons (9200 default
+    // / 21000+ live), so this exercises the genuine "not reachable" path.
+    const closedPort = await new Promise<number>((resolve, reject) => {
+      const srv = createServer();
+      srv.once('error', reject);
+      srv.listen(0, '127.0.0.1', () => {
+        const addr = srv.address();
+        const port = typeof addr === 'object' && addr ? addr.port : 0;
+        srv.close(() => (port ? resolve(port) : reject(new Error('no free port'))));
+      });
+    });
+    await mcpSetupAction({ start: false, verify: false, port: String(closedPort) }, deps);
 
     expect((deps.startDaemon as any).calls).toEqual([]);
     expect((deps.requestFaucetFunding as any).calls).toEqual([]);
@@ -393,7 +406,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     // And the new explicit log line fired (replacing the pre-F14
     // silent omission).
     const logged = (logSpy.calls as any[]).map((c) => c.join(' ')).join('\n');
-    expect(logged).toMatch(/Skipping wallet funding \(daemon not reachable on port 9200\)/);
+    expect(logged).toMatch(new RegExp(`Skipping wallet funding \\(daemon not reachable on port ${closedPort}\\)`));
   });
 
   // F14 (qa-review-round-2): the canonical decoupled-flow test.


### PR DESCRIPTION
## Summary

Adds `autoUpdate.channel` — an npm dist-tag a node tracks for auto-updates — so each network tracks its own release line on the **same npm package**, and **no node depends on what `latest` points at**.

**Why:** the node auto-updater follows `dist-tags.latest` (+ `dev`/`beta`/`next`). Without per-node channels, the moment `latest` becomes mainnet every testnet node auto-updates onto it (junk graphs, surprise upgrades). Dedicated channels decouple `latest` from auto-update entirely.

## Commits
1. **`feat(cli): per-node auto-update channel`** — the `channel` field, threaded through the resolver, `resolveLatestNpmVersion`/`checkForNpmVersionUpdate`, the daemon poll loop, and manual `dkg update`; 5 unit tests.
2. **`test(cli): harden mcp-setup F14 probe`** — a *pre-existing* port-race flake surfaced by this PR's test-scheduling shift (F14 probed the shared default 9200 for an "unreachable" assertion). Now probes a guaranteed-free ephemeral port. Independent — cherry-pickable.
3. **`feat(config): mainnet tracks a dedicated `mainnet` channel`** — see below.

## Final config (symmetric — `latest` fully decoupled)
- `testnet.json` → `channel: "testnet"`
- `mainnet-{base,gnosis,neuroweb}.json` → `channel: "mainnet"`, `allowPrerelease: false` (stable-only), enabled. No-ops until a build is published to the `mainnet` tag — launch-ready with no later enable-flip.
- `latest` is followed by no auto-updating node (free for default `npm install`).

## Resolution semantics
- `channel` set → follow ONLY `dist-tags[channel]` (honours `allowPrerelease`; **forward-only** via the existing `compareSemver` gate; graceful no-op if the tag is absent).
- `channel` unset → unchanged legacy `max(latest, dev, beta, next)`.

## Rollout (manual — NOT performed here)
1. Publish this build to `latest` (existing testnet fleet's last old-logic hop) **and** to the `testnet` tag (target for the now-pinned nodes).
2. ⚠️ Confirm the whole testnet fleet has converged onto this channel-aware build before you stop publishing testnet builds to `latest`. Long-offline nodes (still on old code following `latest`) need a manual `dkg update`.
3. At mainnet launch: publish the mainnet stable build to the `mainnet` tag; mainnet nodes (already `channel:mainnet`, enabled) converge on it. Optionally point `latest`→mainnet for default installs.

## Verification
- Full `Bura: cli` suite green locally; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)