### PR TITLE
feat(staking): MigrationCreditRecovery — node-independent migration-credit recovery

### DIFF
--- a/packages/evm-module/abi/MigrationCreditRecovery.json
+++ b/packages/evm-module/abi/MigrationCreditRecovery.json
@@ -1,0 +1,164 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "hubAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "msg",
+        "type": "string"
+      }
+    ],
+    "name": "UnauthorizedAccess",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddressHub",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "staker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      }
+    ],
+    "name": "MigrationCreditWithdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "convictionStorage",
+    "outputs": [
+      {
+        "internalType": "contract ConvictionStakingStorage",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hub",
+    "outputs": [
+      {
+        "internalType": "contract Hub",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_status",
+        "type": "bool"
+      }
+    ],
+    "name": "setStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "status",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      }
+    ],
+    "name": "withdrawMigrationCredit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawMigrationCreditAll",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/evm-module/contracts/MigrationCreditRecovery.sol
+++ b/packages/evm-module/contracts/MigrationCreditRecovery.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {ConvictionStakingStorage} from "./storage/ConvictionStakingStorage.sol";
+import {ContractStatus} from "./abstract/ContractStatus.sol";
+import {IInitializable} from "./interfaces/IInitializable.sol";
+import {INamed} from "./interfaces/INamed.sol";
+import {IVersioned} from "./interfaces/IVersioned.sol";
+
+/**
+ * @title MigrationCreditRecovery
+ * @notice Standalone, node-INDEPENDENT recovery path for V8→V10 migration
+ *         credit. Lets a delegator (or operator) reclaim their UNALLOCATED
+ *         migration credit straight to their wallet, with no node, no V10
+ *         profile, and no position involved.
+ *
+ * @dev WHY A SEPARATE CONTRACT.
+ *      The admin V8→V10 drain writes per-wallet `migrationCredit` on
+ *      `ConvictionStakingStorage` (CSS), backed 1:1 by TRAC moved into the CSS
+ *      vault. Until now the ONLY sink for that credit was
+ *      `DKGStakingConvictionNFT.allocate` → `StakingV10.allocateFromCredit`,
+ *      whose first statement reverts `ProfileDoesNotExist` when the target node
+ *      has no V10 profile. On a freshly-deployed chain with zero profiles
+ *      (e.g. NeuroWeb immediately post-cutover) that strands every migrant's
+ *      credit — neither allocatable (no profile to allocate against) nor
+ *      withdrawable (no position can have been created), recoverable only via
+ *      the Hub-owner god-key.
+ *
+ *      We cannot add this function to an existing contract without breaking the
+ *      "same contract set on every chain" invariant:
+ *        - `StakingV10` is already within ~500 bytes of the 24,576-byte EIP-170
+ *          limit, so it has no room.
+ *        - `DKGStakingConvictionNFT` is a plain (non-proxy) ERC-721; redeploying
+ *          it on a live chain would orphan every existing position NFT and reset
+ *          the tokenId counter.
+ *        - `ConvictionStakingStorage` is THE vault + position store; redeploying
+ *          it would destroy all staking state.
+ *      A brand-new, stateless contract sidesteps all three: it is deployed and
+ *      Hub-registered identically on EVERY chain (Base, Gnosis, NeuroWeb),
+ *      leaving the live contracts untouched.
+ *
+ *      WHY IT WORKS ON ALREADY-LIVE CHAINS WITHOUT REDEPLOYING CSS.
+ *      CSS's `spendMigrationCredit` and `transferStake` are `onlyContracts`,
+ *      which checks `hub.isContract(msg.sender)` against the LIVE Hub registry
+ *      at call time. Once this contract is registered in the Hub, the existing
+ *      deployed CSS admits it — no CSS/wrapper redeploy needed. This is the
+ *      exact same gate `StakingV10` already uses to call `transferStake` in
+ *      `withdraw`, so the trust model is unchanged.
+ *
+ *      SAFETY.
+ *      The contract holds no funds and has no admin surface. Each entry point
+ *      forwards `msg.sender` as the credit owner and follows checks-effects-
+ *      interactions: `spendMigrationCredit` (which reverts on `amount == 0` or
+ *      `amount > migrationCredit[msg.sender]`) debits FIRST, then `transferStake`
+ *      moves exactly `amount` TRAC out of the vault to the caller. TRAC has no
+ *      transfer hooks, so there is no reentrancy vector and no need for a guard
+ *      (matching the house convention). A caller can therefore only ever move
+ *      their own credit, in an amount they actually hold — it cannot be used to
+ *      drain the vault. Unallocated credit has no position / node-stake / score
+ *      / sharding-table state, so this is a pure ledger debit + vault outflow
+ *      with no downstream accounting to disturb. It does not weaken the
+ *      economic model: a tier-0 `allocate → withdraw` already cashed credit out
+ *      fully once a profile existed; this only removes the node-existence
+ *      precondition.
+ */
+contract MigrationCreditRecovery is INamed, IVersioned, ContractStatus, IInitializable {
+    string private constant _NAME = "MigrationCreditRecovery";
+    string private constant _VERSION = "1.0.0";
+
+    ConvictionStakingStorage public convictionStorage;
+
+    error ZeroAmount();
+
+    /// @notice Emitted when a delegator/operator reclaims unallocated migration
+    ///         credit straight to their wallet. Reconciliation: a wallet's
+    ///         outstanding credit = Σ(`MigrationStarted` + `OperatorFeeMigrated`)
+    ///         − Σ(`Allocated.amount`) − Σ(`MigrationCreditWithdrawn.amount`).
+    /// @param staker The wallet whose credit was refunded.
+    /// @param amount TRAC refunded out of the CSS vault.
+    event MigrationCreditWithdrawn(address indexed staker, uint96 amount);
+
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address hubAddress) ContractStatus(hubAddress) {}
+
+    /// @dev Wires the single Hub-registered dependency (CSS). Called by the Hub
+    ///      via `forwardCall` at deploy time, so `msg.sender == hub` → `onlyHub`.
+    function initialize() external onlyHub {
+        convictionStorage = ConvictionStakingStorage(hub.getContractAddress("ConvictionStakingStorage"));
+    }
+
+    function name() external pure virtual override returns (string memory) {
+        return _NAME;
+    }
+
+    function version() external pure virtual override returns (string memory) {
+        return _VERSION;
+    }
+
+    /// @notice Reclaim `amount` of the caller's unallocated migration credit
+    ///         directly to their wallet. Repeatable; pass
+    ///         `convictionStorage.migrationCredit(msg.sender)` (or use
+    ///         `withdrawMigrationCreditAll`) to drain it fully. No node, no
+    ///         profile, no position required.
+    /// @param amount TRAC amount of credit to refund; must be > 0 and <= the
+    ///        caller's current `migrationCredit`.
+    function withdrawMigrationCredit(uint96 amount) external {
+        if (amount == 0) revert ZeroAmount();
+        ConvictionStakingStorage cs = convictionStorage;
+        cs.spendMigrationCredit(msg.sender, amount);
+        cs.transferStake(msg.sender, amount);
+        emit MigrationCreditWithdrawn(msg.sender, amount);
+    }
+
+    /// @notice Convenience: reclaim the caller's ENTIRE remaining migration
+    ///         credit in one call. Reverts `ZeroAmount` if the caller holds no
+    ///         credit. No race — only the owner can spend their own credit and
+    ///         the admin drain can only ADD to it, so the read-then-spend is
+    ///         safe.
+    /// @return amount TRAC refunded (the caller's full credit at call time).
+    function withdrawMigrationCreditAll() external returns (uint96 amount) {
+        ConvictionStakingStorage cs = convictionStorage;
+        amount = cs.migrationCredit(msg.sender);
+        if (amount == 0) revert ZeroAmount();
+        cs.spendMigrationCredit(msg.sender, amount);
+        cs.transferStake(msg.sender, amount);
+        emit MigrationCreditWithdrawn(msg.sender, amount);
+    }
+}

--- a/packages/evm-module/contracts/MigrationCreditRecovery.sol
+++ b/packages/evm-module/contracts/MigrationCreditRecovery.sol
@@ -109,6 +109,10 @@ contract MigrationCreditRecovery is INamed, IVersioned, ContractStatus, IInitial
         ConvictionStakingStorage cs = convictionStorage;
         cs.spendMigrationCredit(msg.sender, amount);
         cs.transferStake(msg.sender, amount);
+        // CSS is a trusted Hub-registered contract (no untrusted callback) and the
+        // credit debit committed before the transfer, so emitting after the calls
+        // is safe — slither reentrancy-events false positive.
+        // slither-disable-next-line reentrancy-events
         emit MigrationCreditWithdrawn(msg.sender, amount);
     }
 
@@ -124,6 +128,10 @@ contract MigrationCreditRecovery is INamed, IVersioned, ContractStatus, IInitial
         if (amount == 0) revert ZeroAmount();
         cs.spendMigrationCredit(msg.sender, amount);
         cs.transferStake(msg.sender, amount);
+        // CSS is a trusted Hub-registered contract (no untrusted callback) and the
+        // credit debit committed before the transfer, so emitting after the calls
+        // is safe — slither reentrancy-events false positive.
+        // slither-disable-next-line reentrancy-events
         emit MigrationCreditWithdrawn(msg.sender, amount);
     }
 }

--- a/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
+++ b/packages/evm-module/contracts/storage/ConvictionStakingStorage.sol
@@ -383,11 +383,16 @@ contract ConvictionStakingStorage is INamed, IVersioned, Guardian {
     // ============================================================
     // Migrated-but-unallocated TRAC, per delegator. Backed 1:1 by TRAC
     // physically held in THIS contract (moved here by the drain worker via
-    // StakingStorage.transferStake). The only sink is `spendMigrationCredit`
-    // (driven by DKGStakingConvictionNFT.allocate) — credit is NEVER
-    // withdrawable to a wallet. Lives here (durable storage), not on the
-    // wrapper (logic), so a wrapper redeploy mid-migration cannot strand the
-    // already-moved TRAC.
+    // StakingStorage.transferStake). The only ledger mutator is
+    // `spendMigrationCredit`, driven by TWO sinks:
+    // `StakingV10.allocateFromCredit` (spend into a position) AND
+    // `MigrationCreditRecovery.withdrawMigrationCredit` (refund straight to the
+    // wallet via `transferStake`). The latter is a standalone Hub-registered
+    // contract — the node-independent recovery sink for a chain with no V10
+    // profile yet; it passes this contract's `onlyContracts` gate at call time,
+    // so it works against an already-deployed CSS with no redeploy. Lives
+    // here (durable storage), not on the wrapper (logic), so a wrapper redeploy
+    // mid-migration cannot strand the already-moved TRAC.
     mapping(address => uint96) public migrationCredit;
     // Lock-shortening (seconds) applied to ANY tier-6/12 migration allocation
     // (universal — no per-staker eligibility distinction). Set

--- a/packages/evm-module/deploy/active/055a_deploy_migration_credit_recovery.ts
+++ b/packages/evm-module/deploy/active/055a_deploy_migration_credit_recovery.ts
@@ -1,0 +1,25 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+
+/**
+ * V10 — deploys `MigrationCreditRecovery`, the standalone node-independent
+ * recovery path for V8→V10 migration credit.
+ *
+ * It only depends on the Hub and `ConvictionStakingStorage` (the credit ledger
+ * + TRAC vault). Being Hub-registered is what lets it pass CSS's
+ * `onlyContracts` gate, so it can call `spendMigrationCredit` + `transferStake`
+ * on the EXISTING deployed CSS — no CSS or NFT-wrapper redeploy required. This
+ * is the same contract on every chain (Base, Gnosis, NeuroWeb); on chains that
+ * are already live it is an additive deploy + one Hub registration.
+ *
+ * Included in the `v10` deploy tag so the prod cutover pulls it.
+ */
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  await hre.helpers.deploy({
+    newContractName: 'MigrationCreditRecovery',
+  });
+};
+
+export default func;
+func.tags = ['MigrationCreditRecovery', 'v10'];
+func.dependencies = ['Hub', 'ConvictionStakingStorage'];

--- a/packages/evm-module/test/v10-pool-migration.test.ts
+++ b/packages/evm-module/test/v10-pool-migration.test.ts
@@ -28,6 +28,7 @@ import {
   ConvictionStakingStorage,
   DKGStakingConvictionNFT,
   Hub,
+  MigrationCreditRecovery,
   ParametersStorage,
   Profile,
   StakingStorage,
@@ -53,6 +54,7 @@ type Fixture = {
   accounts: SignerWithAddress[];
   Hub: Hub;
   NFT: DKGStakingConvictionNFT;
+  Recovery: MigrationCreditRecovery;
   StakingV10: StakingV10;
   StakingStorage: StakingStorage;
   ConvictionStakingStorage: ConvictionStakingStorage;
@@ -63,7 +65,12 @@ type Fixture = {
 };
 
 async function deployFixture(): Promise<Fixture> {
-  await hre.deployments.fixture(['DKGStakingConvictionNFT', 'StakingV10', 'Profile']);
+  await hre.deployments.fixture([
+    'DKGStakingConvictionNFT',
+    'StakingV10',
+    'MigrationCreditRecovery',
+    'Profile',
+  ]);
 
   const accounts = await hre.ethers.getSigners();
   const Hub = await hre.ethers.getContract<Hub>('Hub');
@@ -73,6 +80,7 @@ async function deployFixture(): Promise<Fixture> {
     accounts,
     Hub,
     NFT: await hre.ethers.getContract<DKGStakingConvictionNFT>('DKGStakingConvictionNFT'),
+    Recovery: await hre.ethers.getContract<MigrationCreditRecovery>('MigrationCreditRecovery'),
     StakingV10: await hre.ethers.getContract<StakingV10>('StakingV10'),
     StakingStorage: await hre.ethers.getContract<StakingStorage>('StakingStorage'),
     ConvictionStakingStorage: await hre.ethers.getContract<ConvictionStakingStorage>(
@@ -92,6 +100,7 @@ describe('@integration pool & allocate migration', function () {
 
   let accounts: SignerWithAddress[];
   let NFT: DKGStakingConvictionNFT;
+  let Recovery: MigrationCreditRecovery;
   let StakingV10Contract: StakingV10;
   let HubContract: Hub;
   let SS: StakingStorage;
@@ -105,6 +114,7 @@ describe('@integration pool & allocate migration', function () {
       accounts,
       Hub: HubContract,
       NFT,
+      Recovery,
       StakingV10: StakingV10Contract,
       StakingStorage: SS,
       ConvictionStakingStorage: CSS,
@@ -709,6 +719,173 @@ describe('@integration pool & allocate migration', function () {
       await NFT.connect(d).allocate(id, stake, 0); // tier-0 exempt from the active-tier gate
       await NFT.connect(d).withdraw(1n);
       expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + stake);
+    });
+  });
+
+  // ===========================================================================
+  // withdrawMigrationCredit — node-INDEPENDENT recovery (the zero-node escape)
+  //
+  // The tier-0 recovery above still needs a V10 profile to allocate against. On
+  // a freshly-deployed chain with ZERO profiles, `allocate` reverts
+  // ProfileDoesNotExist, so that safety net is unreachable and admin-drained
+  // credit would be frozen to the wallet. These cover the direct credit→wallet
+  // refund that removes the node-existence precondition.
+  // ===========================================================================
+  describe('withdrawMigrationCredit (node-independent recovery)', () => {
+    it('is a standalone Hub-registered contract with its own name/version', async () => {
+      // Registration is what lets it pass CSS's onlyContracts gate; the
+      // behavioural tests below prove the gate admits it (transfers succeed).
+      expect(await Recovery.name()).to.equal('MigrationCreditRecovery');
+      expect(await Recovery.version()).to.equal('1.0.0');
+      expect(await HubContract['isContract(address)'](await Recovery.getAddress())).to.equal(true);
+    });
+
+    // Seed V8 stake on an identityId that was NEVER createProfile'd, then drain
+    // it to credit — the exact post-drain state of a chain with zero V10
+    // profiles. `drainV8ToCredit` reads StakingStorage by (delegator, id) and
+    // does not require a V10 profile, so this is a faithful reproduction.
+    const drainWithoutProfile = async (
+      d: SignerWithAddress,
+      id: number,
+      stake: bigint,
+    ) => {
+      await seedV8Stake(d, id, stake);
+      await NFT.connect(accounts[0]).adminMigrateToCredit(d.address, [id]);
+    };
+
+    it('refunds credit to the wallet when NO profile exists (allocate is impossible)', async () => {
+      const d = accounts[2];
+      const idNoProfile = 1; // never createProfile'd → ProfileStorage has nothing
+      const stake = hre.ethers.parseEther('5000');
+      await drainWithoutProfile(d, idNoProfile, stake);
+
+      // Precondition: the allocate-based recovery is genuinely blocked here.
+      await expect(
+        NFT.connect(d).allocate(idNoProfile, stake, 0),
+      ).to.be.revertedWithCustomError(StakingV10Contract, 'ProfileDoesNotExist');
+
+      const walletBefore = await TokenContract.balanceOf(d.address);
+      const cssBefore = await TokenContract.balanceOf(await CSS.getAddress());
+
+      await expect(Recovery.connect(d).withdrawMigrationCredit(stake))
+        .to.emit(Recovery, 'MigrationCreditWithdrawn')
+        .withArgs(d.address, stake);
+
+      // 1:1 invariant — ledger AND vault both decrement by exactly `amount`.
+      expect(await NFT.migrationCredit(d.address)).to.equal(0n);
+      expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + stake);
+      expect(await TokenContract.balanceOf(await CSS.getAddress())).to.equal(cssBefore - stake);
+    });
+
+    it('withdrawMigrationCreditAll drains the full balance in one call', async () => {
+      const d = accounts[3];
+      const stake = hre.ethers.parseEther('1234');
+      await drainWithoutProfile(d, 1, stake);
+
+      const walletBefore = await TokenContract.balanceOf(d.address);
+      await expect(Recovery.connect(d).withdrawMigrationCreditAll())
+        .to.emit(Recovery, 'MigrationCreditWithdrawn')
+        .withArgs(d.address, stake);
+      expect(await NFT.migrationCredit(d.address)).to.equal(0n);
+      expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + stake);
+    });
+
+    it('supports partial withdrawals — repeatable until the credit is drained', async () => {
+      const d = accounts[2];
+      const stake = hre.ethers.parseEther('900');
+      const part = hre.ethers.parseEther('300');
+      await drainWithoutProfile(d, 1, stake);
+
+      const walletBefore = await TokenContract.balanceOf(d.address);
+      await Recovery.connect(d).withdrawMigrationCredit(part);
+      expect(await NFT.migrationCredit(d.address)).to.equal(stake - part);
+      expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + part);
+
+      // Drain the remainder via the convenience function.
+      await Recovery.connect(d).withdrawMigrationCreditAll();
+      expect(await NFT.migrationCredit(d.address)).to.equal(0n);
+      expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + stake);
+    });
+
+    it('reverts on over-withdraw (more than the credit) and leaves credit intact', async () => {
+      const d = accounts[2];
+      const stake = hre.ethers.parseEther('500');
+      await drainWithoutProfile(d, 1, stake);
+      await expect(
+        Recovery.connect(d).withdrawMigrationCredit(stake + 1n),
+      ).to.be.revertedWith('Amount exceeds credit');
+      expect(await NFT.migrationCredit(d.address)).to.equal(stake);
+    });
+
+    it('reverts ZeroAmount on a zero withdraw and on All with no credit', async () => {
+      const d = accounts[4]; // never credited
+      await expect(
+        Recovery.connect(d).withdrawMigrationCredit(0),
+      ).to.be.revertedWithCustomError(Recovery, 'ZeroAmount');
+      await expect(
+        Recovery.connect(d).withdrawMigrationCreditAll(),
+      ).to.be.revertedWithCustomError(Recovery, 'ZeroAmount');
+    });
+
+    it('is self-scoped — a caller can only ever withdraw their OWN credit', async () => {
+      const a = accounts[2];
+      const b = accounts[3];
+      const stakeA = hre.ethers.parseEther('700');
+      const stakeB = hre.ethers.parseEther('400');
+      await drainWithoutProfile(a, 1, stakeA);
+      await drainWithoutProfile(b, 2, stakeB);
+
+      // A drains all of A's credit; B's is untouched.
+      await Recovery.connect(a).withdrawMigrationCreditAll();
+      expect(await NFT.migrationCredit(a.address)).to.equal(0n);
+      expect(await NFT.migrationCredit(b.address)).to.equal(stakeB);
+
+      // A (now empty) cannot reach into B's credit.
+      await expect(
+        Recovery.connect(a).withdrawMigrationCredit(stakeB),
+      ).to.be.revertedWith('Amount exceeds credit');
+    });
+
+    it('mixed path: allocate part to a real node, then withdraw the remainder', async () => {
+      // The realistic flow — "I converted some into conviction, cash out the
+      // rest." Proves the credit ledger and position accounting stay
+      // independent: the allocation does not consume the withdrawable remainder
+      // and the withdraw does not disturb the live position.
+      const d = accounts[2];
+      const id = await createProfile(1); // a REAL profile so allocate succeeds
+      const stake = hre.ethers.parseEther('1000');
+      const allocated = hre.ethers.parseEther('600');
+      const remainder = stake - allocated;
+      await seedV8Stake(d, id, stake);
+      await NFT.connect(accounts[0]).adminMigrateToCredit(d.address, [id]);
+
+      await NFT.connect(d).allocate(id, allocated, 0); // tier-0 position, tokenId 1
+      expect(await NFT.migrationCredit(d.address)).to.equal(remainder);
+
+      const walletBefore = await TokenContract.balanceOf(d.address);
+      await Recovery.connect(d).withdrawMigrationCreditAll();
+      expect(await NFT.migrationCredit(d.address)).to.equal(0n);
+      expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + remainder);
+
+      // The allocated position is untouched and still independently withdrawable.
+      expect((await CSS.getPosition(1)).raw).to.equal(allocated);
+      await NFT.connect(d).withdraw(1n);
+      expect(await TokenContract.balanceOf(d.address)).to.equal(walletBefore + stake);
+    });
+
+    it('refunds operator-fee credit too (same bucket, still no node required)', async () => {
+      const op = accounts[0]; // createProfile sets accounts[0] as the ADMIN_KEY holder
+      const id = await createProfile(1);
+      const fee = hre.ethers.parseEther('250');
+      await TokenContract.mint(await SS.getAddress(), fee);
+      await SS.connect(accounts[0]).increaseOperatorFeeBalance(id, fee);
+      await NFT.connect(accounts[0]).adminDrainOperatorFeesBatch([id], [op.address]);
+      expect(await NFT.migrationCredit(op.address)).to.equal(fee);
+
+      const before = await TokenContract.balanceOf(op.address);
+      await Recovery.connect(op).withdrawMigrationCreditAll();
+      expect(await NFT.migrationCredit(op.address)).to.equal(0n);
+      expect(await TokenContract.balanceOf(op.address)).to.equal(before + fee);
     });
   });
 


### PR DESCRIPTION
## What & why

Adds **`MigrationCreditRecovery`** — a standalone Hub-registered contract that lets a delegator/operator reclaim their **unallocated** V8→V10 migration credit straight to their wallet, with **no node, profile, or position** required.

**The problem it fixes.** The admin V8→V10 drain writes per-wallet `migrationCredit` (TRAC custodied 1:1 in `ConvictionStakingStorage`). The only sink was `allocate` → `allocateFromCredit`, whose first statement reverts `ProfileDoesNotExist` when the target node has no V10 profile. On a freshly-cut chain with **zero profiles** (e.g. NeuroWeb immediately post-cutover) that **strands every migrant's stake** — neither allocatable (no profile) nor withdrawable (no position can exist) — recoverable only via the Hub-owner god-key.

## Why a new contract (not a method on an existing one)

To keep the **contract set identical on every chain**:
- `StakingV10` is ~500 bytes under the **EIP-170** 24,576-byte limit → no room.
- `DKGStakingConvictionNFT` is a **non-proxy ERC-721** → redeploying it on a live chain orphans every position NFT and resets the tokenId counter.
- `ConvictionStakingStorage` is the **vault + position store** → redeploying destroys all staking state.

A new stateless contract sidesteps all three. The key enabler: CSS's `spendMigrationCredit`/`transferStake` are `onlyContracts`, which checks `hub.isContract(msg.sender)` against the **live Hub registry at call time**. Once registered, the **already-deployed** CSS on Base/Gnosis admits it — **no CSS/wrapper redeploy**. This is the same gate `StakingV10` already uses for `transferStake` in `withdraw`.

**Verified on-chain:** live CSS is `version() == 10.0.6` on **both** Base and Gnosis (same address `0xdc4c66f9…677b1D`), with the `migrationCredit`/`transferStake`/`spendMigrationCredit` ABI present — i.e. the exact surface this contract compiles against. Live TRAC confirmed a standard ERC20 (no hooks/fee-on-transfer) on both chains.

## Changes

- **`contracts/MigrationCreditRecovery.sol`** (v1.0.0) — `withdrawMigrationCredit(uint96)` + `withdrawMigrationCreditAll()`. CEI: `spendMigrationCredit` (reverts on `0` / over-credit) → `transferStake`; `msg.sender` hardwired as the credit owner; holds no funds; no admin surface; emits `MigrationCreditWithdrawn`.
- **`deploy/active/055a_deploy_migration_credit_recovery.ts`** — deploy + Hub-register + initialize (`v10` tag).
- **`ConvictionStakingStorage.sol`** — **comment-only** (documents the second sink). No bytecode/storage change → **CSS is not redeployed**.
- **`StakingV10.sol` / `DKGStakingConvictionNFT.sol`** — **untouched**; the wrapper stays `10.0.3` on every chain.
- **`test/v10-pool-migration.test.ts`** — 9 cases.

## Verification

- **Full evm-module suite: 852 passing, 0 failing** (run on this base, with #1297). `solhint`: 0 errors.
- New tests: registration/name/version; zero-profile e2e (`allocate` reverts `ProfileDoesNotExist`, then recovery pays the exact TRAC); **1:1 invariant** (credit ledger **and** CSS vault both −amount); full/partial/over-withdraw/zero/self-scope; mixed-path (allocate part to a real node, withdraw remainder — independent accounting); operator-fee credit (same bucket).

## Security audit (3 independent adversarial reviewers — no Critical/High/Medium)

- **Access control / reentrancy:** `msg.sender` not spoofable (no `from` param); `onlyContracts` blocks EOAs/unregistered callers from `transferStake`; CEI makes it reentrancy-safe **even under a hypothetical callback token** (re-entry sees the already-debited balance → no double-spend).
- **Accounting / collateralization:** the 1:1 backing invariant **holds, provably** — `migrationCredit` has exactly two writers and every add moves TRAC into CSS first (the `pending`/`feeRequest` terms verified non-double-counting against the V8 withdrawal branches). Credit is "side TRAC" outside every position aggregate, so withdrawing it can't under-collateralize positions/fees/escrow. Double-use vs `allocate` and re-credit idempotency are structurally impossible.
- **System / deploy / economic:** adds one well-behaved member to the `transferStake`-capable set (smaller blast radius than StakingV10). No new economic leak (tier-0 `allocate→withdraw` already permitted cash-out; this only removes the node-existence precondition). Always-on (no `status` gate) is correct for a safety net and matches the "status is set-but-never-read" convention. Fail-safe on misconfig.

## Deploy / operational notes

- **NeuroWeb:** part of the fresh `v10` deploy — `055a` auto-deploys/registers/initializes (deployer key = Hub owner). Removes the hard "onboard-profile-before-drain" ordering requirement.
- **Base / Gnosis (already live):** additive, **not** a plain script run (owner is the multisig): deploy bytecode → multisig `setContractAddress("MigrationCreditRecovery", addr)` → multisig `forwardCall(initialize)` → verify `isContract(addr)` and `convictionStorage()`. Wrapper/CSS/positions untouched.
- **C-01 (pre-existing):** registration rides the Hub 1-of-N multisig; this PR neither creates nor worsens it. At cutover, verify the registered address matches the audited bytecode.
- **Indexers:** index `MigrationCreditWithdrawn`; outstanding credit = Σ(`MigrationStarted`+`OperatorFeeMigrated`) − Σ(`Allocated`) − Σ(`MigrationCreditWithdrawn`). Keep the V8 `getTotalStake()==0` release gate independent of vault balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
