### PR TITLE
Make staking NFT claim permissionless

### DIFF
--- a/packages/evm-module/abi/StakingV10.json
+++ b/packages/evm-module/abi/StakingV10.json
@@ -471,11 +471,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "staker",
-        "type": "address"
-      },
-      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -92,10 +92,11 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     //           points and events.
     //         * L8 — `identityId != 0` guard added on mint paths so
     //           ambiguous "zero-node" mints fail fast at the wrapper.
-    //         * 10.0.3 — operator-fee migration: added
-    //           `adminDrainOperatorFeesBatch` + `OperatorFeeMigrated`; bumped so
-    //           the breaking migration ABI is detectable via `version()`.
-    string private constant _VERSION = "10.0.3";
+    // 10.0.3 — operator-fee migration: added
+    //          `adminDrainOperatorFeesBatch` + `OperatorFeeMigrated`; bumped so
+    //          the breaking migration ABI is detectable via `version()`.
+    // 10.0.4 — `claim` is permissionless; owner remains the reward beneficiary.
+    string private constant _VERSION = "10.0.4";
 
     // ========================================================================
     // Constants

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -32,7 +32,7 @@ import {HubLib} from "./libraries/HubLib.sol";
  *
  * @dev V10 split-contract architecture. This contract is a dumb ERC-721
  *      ownership receipt: it mints/burns tokens, validates ownership on
- *      mutating calls, and forwards every business action to `StakingV10`.
+ *      stake-moving calls, and forwards every business action to `StakingV10`.
  *      All stake / withdrawal / reward / migration logic lives in
  *      `StakingV10`, gated by `onlyConvictionNFT` so only this wrapper can
  *      invoke it. TRAC never touches this contract: users approve
@@ -358,12 +358,12 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     // state machine, V8 migration) lives in `StakingV10`, which is gated by
     // `onlyConvictionNFT` so only this contract can invoke it. Each wrapper:
     //
-    //   1. Validates ownership (`ownerOf == msg.sender`) on mutating calls.
+    //   1. Validates ownership (`ownerOf == msg.sender`) on stake-moving calls;
+    //      claim is permissionless but resolves the current owner as beneficiary.
     //   2. For mint paths, fails fast on `lockTier` via `_convictionMultiplier`.
     //   3. Mints / burns the ERC-721 token as needed.
-    //   4. Forwards to the matching `StakingV10` method with `msg.sender`
-    //      passed explicitly as the `staker` argument (StakingV10 never
-    //      trusts `tx.origin`).
+    //   4. Forwards to the matching `StakingV10` method with the staker
+    //      passed explicitly (`msg.sender` for owner actions, ownerOf for claim).
     //   5. Emits a wrapper-layer mirror event for NFT-contract watchers —
     //      the authoritative event for off-chain accounting comes from the
     //      `StakingV10` / `ConvictionStakingStorage` layer.
@@ -498,8 +498,9 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
         // CEI ordering — the receipt NFT is dropped BEFORE the CSS
         // teardown + TRAC payout run, so the on-chain ownership claim
         // ends before any external token movement. ownerOf-gated
-        // re-entry paths on this contract (claim / withdraw / relock /
-        // redelegate) revert at the entry ownership check.
+        // re-entry paths on this contract (withdraw / relock / redelegate)
+        // revert at the entry ownership check; claim reverts at ownerOf
+        // because the receipt is already burned.
         // StakingV10.withdraw gates on the CSS position (`pos.identityId
         // == 0`), not NFT existence, so the teardown is unaffected.
         _burn(tokenId);
@@ -511,10 +512,10 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
 
     /// @notice Walk unclaimed epochs for the position, accumulate reward,
     ///         and bank it into the `ConvictionStakingStorage` rewards
-    ///         bucket. Updates `lastClaimedEpoch`.
+    ///         bucket. Updates `lastClaimedEpoch`. Any caller may trigger
+    ///         settlement; the current NFT owner remains the beneficiary.
     function claim(uint256 tokenId) external {
-        if (ownerOf(tokenId) != msg.sender) revert NotPositionOwner();
-        stakingV10.claim(msg.sender, tokenId);
+        stakingV10.claim(ownerOf(tokenId), tokenId);
         // No wrapper-layer event — `StakingV10.claim` emits `RewardsClaimed`
         // with the amount already. The NFT layer does not duplicate reward
         // accounting events.

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -518,9 +518,9 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     ///         rewards are not routed to the caller.
     function claim(uint256 tokenId) external {
         // `ownerOf` is intentionally used as the live-token guard: it reverts
-        // for nonexistent or burned token IDs. `StakingV10.claim` ignores the
-        // address argument; reward attribution is tokenId-keyed.
-        stakingV10.claim(ownerOf(tokenId), tokenId);
+        // for nonexistent or burned token IDs.
+        ownerOf(tokenId);
+        stakingV10.claim(tokenId);
         // No wrapper-layer event — `StakingV10.claim` emits `RewardsClaimed`
         // with the amount already. The NFT layer does not duplicate reward
         // accounting events.

--- a/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
+++ b/packages/evm-module/contracts/DKGStakingConvictionNFT.sol
@@ -360,11 +360,12 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     // `onlyConvictionNFT` so only this contract can invoke it. Each wrapper:
     //
     //   1. Validates ownership (`ownerOf == msg.sender`) on stake-moving calls;
-    //      claim is permissionless but resolves the current owner as beneficiary.
+    //      claim is permissionless and rewards compound into the tokenId-keyed
+    //      NFT position.
     //   2. For mint paths, fails fast on `lockTier` via `_convictionMultiplier`.
     //   3. Mints / burns the ERC-721 token as needed.
     //   4. Forwards to the matching `StakingV10` method with the staker
-    //      passed explicitly (`msg.sender` for owner actions, ownerOf for claim).
+    //      passed explicitly for owner actions.
     //   5. Emits a wrapper-layer mirror event for NFT-contract watchers —
     //      the authoritative event for off-chain accounting comes from the
     //      `StakingV10` / `ConvictionStakingStorage` layer.
@@ -512,10 +513,13 @@ contract DKGStakingConvictionNFT is IVersioned, ContractStatus, IInitializable, 
     }
 
     /// @notice Walk unclaimed epochs for the position, accumulate reward,
-    ///         and bank it into the `ConvictionStakingStorage` rewards
-    ///         bucket. Updates `lastClaimedEpoch`. Any caller may trigger
-    ///         settlement; the current NFT owner remains the beneficiary.
+    ///         and compound it into the tokenId-keyed staking position.
+    ///         Updates `lastClaimedEpoch`. Any caller may trigger settlement;
+    ///         rewards are not routed to the caller.
     function claim(uint256 tokenId) external {
+        // `ownerOf` is intentionally used as the live-token guard: it reverts
+        // for nonexistent or burned token IDs. `StakingV10.claim` ignores the
+        // address argument; reward attribution is tokenId-keyed.
         stakingV10.claim(ownerOf(tokenId), tokenId);
         // No wrapper-layer event — `StakingV10.claim` emits `RewardsClaimed`
         // with the amount already. The NFT layer does not duplicate reward

--- a/packages/evm-module/contracts/StakingV10.sol
+++ b/packages/evm-module/contracts/StakingV10.sol
@@ -716,11 +716,7 @@ contract StakingV10 is INamed, IVersioned, ContractStatus, IInitializable {
      *        4. `cs.setLastClaimedEpoch(tokenId, toEpoch)` — advance cursor.
      *      No StakingStorage writes.
      */
-    function claim(
-        address staker,
-        uint256 tokenId
-    ) external onlyConvictionNFT {
-        staker;
+    function claim(uint256 tokenId) external onlyConvictionNFT {
         _claim(tokenId);
     }
 

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1325,7 +1325,7 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await mintAndApprove(accounts[0], amount);
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
       await expect(
-        StakingV10Contract.connect(accounts[0]).claim(accounts[0].address, 0),
+        StakingV10Contract.connect(accounts[0]).claim(0),
       ).to.be.revertedWithCustomError(StakingV10Contract, 'OnlyConvictionNFT');
     });
 

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -2580,6 +2580,13 @@ describe('@unit DKGStakingConvictionNFT', () => {
     });
   });
 
+  describe('version()', () => {
+    it('reports the permissionless-claim wrapper version while StakingV10 stays stable', async () => {
+      expect(await NFT.version()).to.equal('10.0.4');
+      expect(await StakingV10Contract.version()).to.equal('10.0.4');
+    });
+  });
+
   // ------------------------------------------------------------
   // CCO-8 — Code-review follow-ups (L1 / L2 / L8 / M5).
   // ------------------------------------------------------------

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1345,6 +1345,27 @@ describe('@unit DKGStakingConvictionNFT', () => {
       expect(posAfter.lastClaimedEpoch).to.equal(posBefore.lastClaimedEpoch);
     });
 
+    it('rejects a burned token id at the NFT boundary without advancing the replacement cursor', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseEther('1000');
+      await mintAndApprove(accounts[0], amount);
+      await NFT.connect(accounts[0]).createConviction(identityId, amount, 1);
+      await advanceEpochs(2);
+      await NFT.connect(accounts[0]).claim(1);
+
+      const newTokenId = await NFT.connect(accounts[0]).relock.staticCall(1, 12);
+      await NFT.connect(accounts[0]).relock(1, 12);
+      await advanceEpochs(1);
+
+      const posBefore = await ConvictionStakingStorageContract.getPosition(newTokenId);
+      await expect(
+        NFT.connect(accounts[4]).claim(1),
+      ).to.be.revertedWithCustomError(NFT, 'ERC721NonexistentToken').withArgs(1n);
+
+      const posAfter = await ConvictionStakingStorageContract.getPosition(newTokenId);
+      expect(posAfter.lastClaimedEpoch).to.equal(posBefore.lastClaimedEpoch);
+    });
+
     // -----------------------------------------------------------------
     // No-op paths
     // -----------------------------------------------------------------

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1278,6 +1278,24 @@ describe('@unit DKGStakingConvictionNFT', () => {
       expect(vaultBalance).to.be.gte(totalStake);
     };
 
+    const expectNonOwnerMutationGatesAfterClaim = async (
+      tokenId: bigint | number,
+      newIdentityId: number,
+    ) => {
+      const nonOwner = accounts[4];
+
+      await expect(NFT.connect(nonOwner).claim(tokenId)).to.not.be.reverted;
+      await expect(
+        NFT.connect(nonOwner).withdraw(tokenId),
+      ).to.be.revertedWithCustomError(NFT, 'NotPositionOwner');
+      await expect(
+        NFT.connect(nonOwner).relock(tokenId, 3),
+      ).to.be.revertedWithCustomError(NFT, 'NotPositionOwner');
+      await expect(
+        NFT.connect(nonOwner).redelegate(tokenId, newIdentityId),
+      ).to.be.revertedWithCustomError(NFT, 'NotPositionOwner');
+    };
+
     // -----------------------------------------------------------------
     // Revert / gate paths
     // -----------------------------------------------------------------

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1290,6 +1290,17 @@ describe('@unit DKGStakingConvictionNFT', () => {
       await expect(NFT.connect(accounts[4]).claim(1)).to.not.be.reverted;
     });
 
+    it('keeps stake-moving mutations owner-only after a non-owner claim', async () => {
+      const { identityId } = await createProfile();
+      const { identityId: newIdentityId } = await createProfile(accounts[0], accounts[2]);
+      const amount = hre.ethers.parseEther('1000');
+      await mintAndApprove(accounts[0], amount);
+      await NFT.connect(accounts[0]).createConviction(identityId, amount, 1);
+      await advanceEpochs(2);
+
+      await expectNonOwnerMutationGatesAfterClaim(1, newIdentityId);
+    });
+
     it('direct StakingV10.claim call from non-NFT caller reverts via gate', async () => {
       const { identityId } = await createProfile();
       const amount = hre.ethers.parseEther('1000');

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1282,16 +1282,12 @@ describe('@unit DKGStakingConvictionNFT', () => {
     // Revert / gate paths
     // -----------------------------------------------------------------
 
-    it('reverts if not owner (non-owner caller)', async () => {
+    it('allows a non-owner caller to claim an existing staking NFT', async () => {
       const { identityId } = await createProfile();
       const amount = hre.ethers.parseEther('1000');
       await mintAndApprove(accounts[0], amount);
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
-      // `accounts[4]` does not own tokenId 0 — wrapper-layer guard.
-      await expect(NFT.connect(accounts[4]).claim(1)).to.be.revertedWithCustomError(
-        NFT,
-        'NotPositionOwner',
-      );
+      await expect(NFT.connect(accounts[4]).claim(1)).to.not.be.reverted;
     });
 
     it('direct StakingV10.claim call from non-NFT caller reverts via gate', async () => {

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -2221,27 +2221,33 @@ describe('@unit DKGStakingConvictionNFT', () => {
       expect(posAfter.cumulativeRewardsClaimed).to.equal(expectedReward);
     });
 
-    it('Alice cannot claim after transfer (reverts NotPositionOwner)', async () => {
+    it('Alice can trigger claim after transfer for Bob-owned rewards', async () => {
       const { identityId } = await createProfile();
       const amount = hre.ethers.parseEther('1000');
       await mintAndApprove(accounts[0], amount);
       await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
 
-      // Advance + inject so there's actual reward on the table — otherwise
-      // a revert at the ownership gate would be indistinguishable from a
-      // no-op window. This verifies the gate fires BEFORE the walk.
       const creationEpoch = await ChronosContract.getCurrentEpoch();
       await advanceEpochs(1);
       const scorePerStake36 = hre.ethers.parseEther('0.001');
       const nodeScore18 = hre.ethers.parseEther('100');
+      const pool = hre.ethers.parseEther('1000');
       await injectEpochRewardState(
         creationEpoch,
         identityId,
         scorePerStake36,
         nodeScore18,
         nodeScore18,
-        hre.ethers.parseEther('1000'),
+        pool,
       );
+      const expectedReward = computeReward(
+        (amount * SIX_X) / SCALE18,
+        scorePerStake36,
+        pool,
+        nodeScore18,
+        nodeScore18,
+      );
+      await fundVault(expectedReward);
 
       await NFT.connect(accounts[0]).transferFrom(
         accounts[0].address,
@@ -2249,11 +2255,16 @@ describe('@unit DKGStakingConvictionNFT', () => {
         1,
       );
 
-      // Alice no longer owns the NFT — wrapper-layer ownership gate fires.
-      await expect(NFT.connect(accounts[0]).claim(1)).to.be.revertedWithCustomError(
-        NFT,
-        'NotPositionOwner',
-      );
+      const rawBefore = (await ConvictionStakingStorageContract.getPosition(1)).raw;
+      const tx = await NFT.connect(accounts[0]).claim(1);
+      await expect(tx)
+        .to.emit(StakingV10Contract, 'RewardsClaimed')
+        .withArgs(1n, expectedReward);
+
+      expect(await NFT.ownerOf(1)).to.equal(accounts[4].address);
+      const posAfter = await ConvictionStakingStorageContract.getPosition(1);
+      expect(posAfter.raw).to.equal(rawBefore + expectedReward);
+      expect(posAfter.cumulativeRewardsClaimed).to.equal(expectedReward);
     });
 
     it('Alice cannot relock / redelegate / withdraw after transfer', async () => {

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1421,6 +1421,31 @@ describe('@unit DKGStakingConvictionNFT', () => {
       expect(await ConvictionStakingStorageContract.totalStakeV10()).to.equal(totalStakeBefore);
     });
 
+    it('no-op: non-owner zero scorePerStake claim advances lastClaimedEpoch but emits nothing', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseEther('1000');
+      await mintAndApprove(accounts[0], amount);
+      await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
+      await advanceEpochs(1);
+
+      const posBefore = await ConvictionStakingStorageContract.getPosition(1);
+      const nodeStakeBefore = await ConvictionStakingStorageContract.getNodeStakeV10(identityId);
+      const totalStakeBefore = await ConvictionStakingStorageContract.totalStakeV10();
+
+      const tx = await NFT.connect(accounts[4]).claim(1);
+      await expect(tx).to.not.emit(StakingV10Contract, 'RewardsClaimed');
+
+      const posAfter = await ConvictionStakingStorageContract.getPosition(1);
+      const currentEpoch = await ChronosContract.getCurrentEpoch();
+      expect(posAfter.lastClaimedEpoch).to.equal(currentEpoch - 1n);
+      expect(posAfter.lastClaimedEpoch).to.equal(posBefore.lastClaimedEpoch + 1n);
+      expect(posAfter.raw).to.equal(posBefore.raw);
+      expect(posAfter.cumulativeRewardsClaimed).to.equal(posBefore.cumulativeRewardsClaimed);
+      expect(await ConvictionStakingStorageContract.getNodeStakeV10(identityId)).to.equal(nodeStakeBefore);
+      expect(await ConvictionStakingStorageContract.totalStakeV10()).to.equal(totalStakeBefore);
+      expect(await NFT.ownerOf(1)).to.equal(accounts[0].address);
+    });
+
     // -----------------------------------------------------------------
     // Happy paths — reward accumulation
     // -----------------------------------------------------------------

--- a/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGStakingConvictionNFT.test.ts
@@ -1329,6 +1329,22 @@ describe('@unit DKGStakingConvictionNFT', () => {
       ).to.be.revertedWithCustomError(StakingV10Contract, 'OnlyConvictionNFT');
     });
 
+    it('rejects a nonexistent token id at the NFT boundary without advancing a live cursor', async () => {
+      const { identityId } = await createProfile();
+      const amount = hre.ethers.parseEther('1000');
+      await mintAndApprove(accounts[0], amount);
+      await NFT.connect(accounts[0]).createConviction(identityId, amount, 12);
+      await advanceEpochs(1);
+
+      const posBefore = await ConvictionStakingStorageContract.getPosition(1);
+      await expect(
+        NFT.connect(accounts[4]).claim(2),
+      ).to.be.revertedWithCustomError(NFT, 'ERC721NonexistentToken').withArgs(2n);
+
+      const posAfter = await ConvictionStakingStorageContract.getPosition(1);
+      expect(posAfter.lastClaimedEpoch).to.equal(posBefore.lastClaimedEpoch);
+    });
+
     // -----------------------------------------------------------------
     // No-op paths
     // -----------------------------------------------------------------

--- a/packages/evm-module/test/v10-operator-fee-timestamp-binding.test.ts
+++ b/packages/evm-module/test/v10-operator-fee-timestamp-binding.test.ts
@@ -407,6 +407,66 @@ describe('@integration H-5 regression — operator fee bound to epoch timestamp'
   );
 
   // -------------------------------------------------------------------------
+  // Permissionless claim: operator-fee liveness
+  // -------------------------------------------------------------------------
+  it('Permissionless staking NFT claim settles previous epoch before fee update', async function () {
+    const nodeOp = accounts[1];
+    const nodeAdmin = accounts[2];
+    const delegator = accounts[3];
+    const keeper = accounts[4];
+
+    expect(await Chronos.getCurrentEpoch()).to.equal(1n);
+
+    const { identityId } = await createProfile(ProfileContract, {
+      operational: nodeOp,
+      admin: nodeAdmin,
+    });
+
+    await ProfileContract.connect(nodeAdmin).updateOperatorFee(
+      identityId,
+      Number(FEE_OLD),
+    );
+
+    await advanceEpoch(Chronos);
+    const epoch2 = await Chronos.getCurrentEpoch();
+    expect(epoch2).to.equal(2n);
+
+    await Token.mint(delegator.address, RAW);
+    await Token.connect(delegator).approve(
+      await StakingV10Contract.getAddress(),
+      RAW,
+    );
+    await NFT.connect(delegator).createConviction(identityId, RAW, LOCK_EPOCHS);
+    const tokenId = 1n;
+
+    await injectEpochRewards(ctx, identityId, epoch2, RAW);
+
+    await advanceEpoch(Chronos);
+    expect(await Chronos.getCurrentEpoch()).to.equal(3n);
+    expect(await CSS.isOperatorFeeClaimedForEpoch(identityId, epoch2)).to.equal(false);
+
+    await expect(
+      ProfileContract.connect(nodeAdmin).updateOperatorFee(
+        identityId,
+        Number(FEE_HIGH),
+      ),
+    ).to.be.revertedWith(
+      'Cannot update operatorFee if operatorFee has not been calculated and claimed for previous epochs',
+    );
+
+    await NFT.connect(keeper).claim(tokenId);
+
+    expect(await CSS.isOperatorFeeClaimedForEpoch(identityId, epoch2)).to.equal(true);
+
+    await expect(
+      ProfileContract.connect(nodeAdmin).updateOperatorFee(
+        identityId,
+        Number(FEE_HIGH),
+      ),
+    ).to.not.be.reverted;
+  });
+
+  // -------------------------------------------------------------------------
   // Fix 1: StakingKPI.getNetNodeRewards preview parity
   // -------------------------------------------------------------------------
   //


### PR DESCRIPTION
## Summary
- Make `DKGStakingConvictionNFT.claim` permissionless while settling rewards to the current `ownerOf(tokenId)`, not the caller.
- Keep staking NFT mutation operations owner-only after permissionless claims.
- Add regression coverage for transferred NFTs, invalid and burned token IDs, rewardless epochs, and the wrapper version bump.

## Test Plan
- [x] `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts test/v10-operator-fee-timestamp-binding.test.ts`
- [x] `pnpm --dir packages/evm-module exec hardhat test --network hardhat --config hardhat.node.config.ts test/unit/DKGStakingConvictionNFT.test.ts`
