### PR TITLE
fix(setup): eagerly create node wallets in openclaw/hermes/mcp setup (#1306)

### DIFF
--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -761,7 +761,12 @@ export async function runHermesSetup(
     try {
       await deps.loadOpWallets(dkgConfigHome);
     } catch (err: any) {
-      warnings.push(`Could not pre-create wallets (${err?.message ?? String(err)}); the daemon will generate them on first start.`);
+      // Informational only — emit via console.warn (NOT the status-bearing
+      // `warnings` array) so a best-effort, daemon-recoverable wallet
+      // pre-creation failure does not flip an otherwise-clean setup to
+      // `degraded`. Matches openclaw (`warn()`)/mcp and the `--network ignored`
+      // precedent above.
+      console.warn(`[hermes-setup] Could not pre-create wallets (${err?.message ?? String(err)}); the daemon will generate them on first start.`);
     }
   }
 

--- a/packages/adapter-hermes/src/setup.ts
+++ b/packages/adapter-hermes/src/setup.ts
@@ -656,7 +656,25 @@ function rewriteActiveProviderLine(raw: string, newProvider: string): string | n
  * (`setup-entrypoint-contract.md` §9 sketch) doesn't change between
  * S2 → S3 → S4.
  */
-export async function runHermesSetup(req: HermesSetupRequest): Promise<HermesSetupResult> {
+/**
+ * Injected runtime deps for Hermes setup. Separate from the user-facing
+ * request so the adapter stays free of a `@origintrail-official/dkg-agent`
+ * dependency: the cli layer (which has dkg-agent) provides `loadOpWallets`.
+ */
+export interface RunHermesSetupDeps {
+  /**
+   * Eagerly create the node's operational wallets (generate-if-absent) after
+   * the config bootstrap and before the daemon starts, so faucet funding and
+   * manual mainnet funding have wallets even if the daemon never fully boots
+   * (issue #1306). Best-effort; omitted in unit tests / when not provided.
+   */
+  loadOpWallets?: (dir: string) => Promise<unknown>;
+}
+
+export async function runHermesSetup(
+  req: HermesSetupRequest,
+  deps: RunHermesSetupDeps = {},
+): Promise<HermesSetupResult> {
   const cliOptions = setupRequestToCliOptions(req);
   const setupOptions = toSetupOptions(cliOptions);
   const profile = resolveHermesProfile(setupOptions);
@@ -730,6 +748,21 @@ export async function runHermesSetup(req: HermesSetupRequest): Promise<HermesSet
     }
   } else if (dryRun) {
     console.log('[hermes-setup] [dry-run] Would bootstrap ~/.dkg/config.json if missing');
+  }
+
+  // Eagerly ensure the node's wallets exist BEFORE the daemon starts (issue
+  // #1306) — matching `dkg init` — so faucet funding (testnet) and manual
+  // mainnet funding have wallets even if the daemon never fully boots. Runs
+  // regardless of `--no-fund` and of `dkgConfigExists` (an existing-config node
+  // may still lack wallets). Best-effort; the daemon's boot-time loadOpWallets
+  // is an idempotent fallback. `loadOpWallets` is injected by the cli layer so
+  // the adapter stays dkg-agent-free.
+  if (!dryRun && deps.loadOpWallets) {
+    try {
+      await deps.loadOpWallets(dkgConfigHome);
+    } catch (err: any) {
+      warnings.push(`Could not pre-create wallets (${err?.message ?? String(err)}); the daemon will generate them on first start.`);
+    }
   }
 
   // Step 3: start daemon.
@@ -836,8 +869,11 @@ export async function runHermesSetup(req: HermesSetupRequest): Promise<HermesSet
  * unchanged; on `result.ok === false` we throw so existing tests that
  * `await expect(runSetup(...)).rejects.toThrow(...)` still pass.
  */
-export async function runSetup(options: HermesCliOptions = {}): Promise<void> {
-  const result = await runHermesSetup(cliOptionsToSetupRequest(options));
+export async function runSetup(
+  options: HermesCliOptions = {},
+  deps: RunHermesSetupDeps = {},
+): Promise<void> {
+  const result = await runHermesSetup(cliOptionsToSetupRequest(options), deps);
   if (!result.ok) {
     throw new Error(result.errors.join('\n'));
   }

--- a/packages/adapter-hermes/test/hermes-adapter.part-07.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.part-07.test.ts
@@ -78,6 +78,42 @@ describe('Hermes profile setup helpers', () => {
     expect(readFileSync(join(dkgHome, 'config.yaml'), 'utf-8')).toBe(yamlBefore);
   });
 
+  // issue #1306 — eager wallet creation. The injected `loadOpWallets` hook
+  // fires after config bootstrap and before daemon start, even with --no-fund
+  // (mainnet has no faucet but the node still needs wallets), and is skipped
+  // under --dry-run. Existing tests omit the hook, so they are unaffected.
+  it('#1306: eagerly creates wallets via the injected hook (even --no-fund), skipped on --dry-run', async () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const dkgHome = mkdtempSync(join(tmpdir(), 'dkg-home-1306-'));
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const oldDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    try {
+      const loadOpWallets = vi.fn(async () => ({
+        adminWallet: { address: '0xAAAA', privateKey: '0x0' },
+        wallets: [],
+      }));
+
+      await runSetup({ hermesHome, verify: false, start: false, fund: false }, { loadOpWallets });
+      expect(loadOpWallets).toHaveBeenCalledTimes(1);
+      expect(loadOpWallets.mock.calls[0][0]).toBe(dkgHome);
+
+      loadOpWallets.mockClear();
+      await runSetup({ hermesHome, verify: false, start: false, fund: false, dryRun: true }, { loadOpWallets });
+      expect(loadOpWallets).not.toHaveBeenCalled();
+    } finally {
+      if (oldDkgHome === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = oldDkgHome;
+      rmSync(hermesHome, { recursive: true, force: true });
+      rmSync(dkgHome, { recursive: true, force: true });
+    }
+  });
+
   // issue #960 — positive control for the test above: a genuinely fresh DKG
   // home (no config.json AND no config.yaml) DOES get bootstrapped, and the
   // written config adopts the `oxigraph-server` store default. This proves the

--- a/packages/adapter-hermes/test/hermes-adapter.part-07.test.ts
+++ b/packages/adapter-hermes/test/hermes-adapter.part-07.test.ts
@@ -24,6 +24,7 @@ import {
   runDisconnect,
   runReconnect,
   resolveHermesProfile,
+  runHermesSetup,
   runSetup,
   runUninstall,
   runVerify,
@@ -106,6 +107,39 @@ describe('Hermes profile setup helpers', () => {
       loadOpWallets.mockClear();
       await runSetup({ hermesHome, verify: false, start: false, fund: false, dryRun: true }, { loadOpWallets });
       expect(loadOpWallets).not.toHaveBeenCalled();
+    } finally {
+      if (oldDkgHome === undefined) delete process.env.DKG_HOME;
+      else process.env.DKG_HOME = oldDkgHome;
+      rmSync(hermesHome, { recursive: true, force: true });
+      rmSync(dkgHome, { recursive: true, force: true });
+    }
+  });
+
+  // issue #1306 — a failing wallet pre-creation is best-effort and must NOT push
+  // into the status-bearing `warnings[]` (which would flip the integration to
+  // `degraded` in the daemon-UI). It goes to console.warn instead. Call
+  // runHermesSetup directly to observe `result.warnings`.
+  it('#1306: a failing loadOpWallets does not flip setup to degraded (console.warn channel)', async () => {
+    const hermesHome = mkdtempSync(join(tmpdir(), 'hermes-profile-'));
+    const dkgHome = mkdtempSync(join(tmpdir(), 'dkg-home-1306f-'));
+    vi.stubGlobal('fetch', async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const oldDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    try {
+      const loadOpWallets = vi.fn(async () => { throw new Error('boom'); });
+      const result = await runHermesSetup(
+        { hermesHome, verify: false, start: false, fund: false },
+        { loadOpWallets },
+      );
+      expect(loadOpWallets).toHaveBeenCalledTimes(1);
+      // The wallet failure must NOT appear in the status-bearing warnings/errors.
+      expect(result.warnings.join('\n')).not.toContain('pre-create wallets');
+      expect(result.errors.join('\n')).not.toContain('pre-create wallets');
     } finally {
       if (oldDkgHome === undefined) delete process.env.DKG_HOME;
       else process.env.DKG_HOME = oldDkgHome;

--- a/packages/adapter-openclaw/src/setup.ts
+++ b/packages/adapter-openclaw/src/setup.ts
@@ -1640,7 +1640,23 @@ export function verifyMemorySlotInvariants(configPath?: string): void {
 // Main entry point
 // ---------------------------------------------------------------------------
 
-export async function runSetup(options: SetupOptions): Promise<void> {
+/**
+ * Injected runtime deps for `runSetup`. Kept separate from the user-facing
+ * `SetupOptions` so the adapter stays free of a `@origintrail-official/dkg-agent`
+ * dependency: the cli layer (which has dkg-agent) provides `loadOpWallets`.
+ */
+export interface RunSetupDeps {
+  /**
+   * Eagerly create the node's operational wallets (generate-if-absent) after
+   * the config write and before the daemon starts, so faucet funding and
+   * manual mainnet funding have wallets even if the daemon never fully boots
+   * (issue #1306). Best-effort; omitted by callers where the daemon is already
+   * running (the node-UI route) or in unit tests.
+   */
+  loadOpWallets?: (dir: string) => Promise<unknown>;
+}
+
+export async function runSetup(options: SetupOptions, deps: RunSetupDeps = {}): Promise<void> {
   const dryRun = options.dryRun ?? false;
   const shouldVerify = options.verify !== false;
   const shouldStart = options.start !== false;
@@ -1724,6 +1740,21 @@ export async function runSetup(options: SetupOptions): Promise<void> {
     } catch { /* use pre-merge values */ }
   } else if (network) {
     log(`[dry-run] Would write ${join(dkgDir(), 'config.json')} (${network.networkName}, port ${apiPort})`);
+  }
+
+  // Eagerly ensure the node's wallets exist BEFORE the daemon starts (issue
+  // #1306) — matching `dkg init` — so faucet funding (testnet) and manual
+  // mainnet funding have wallets to target even if the daemon never fully
+  // boots. Runs regardless of `--no-fund` (mainnet has no faucet but still
+  // needs wallets). Best-effort; the daemon's boot-time loadOpWallets is an
+  // idempotent fallback. `loadOpWallets` is injected by the cli layer so the
+  // adapter stays dkg-agent-free.
+  if (!dryRun && deps.loadOpWallets) {
+    try {
+      await deps.loadOpWallets(dkgDir());
+    } catch (err: any) {
+      warn(`Could not pre-create wallets (${err?.message ?? String(err)}); the daemon will generate them on first start.`);
+    }
   }
 
   // Step 4: Preflight ~/.openclaw/openclaw.json BEFORE the daemon spins up

--- a/packages/adapter-openclaw/test/setup.part-26.test.ts
+++ b/packages/adapter-openclaw/test/setup.part-26.test.ts
@@ -462,4 +462,32 @@ describe('runSetup Step 5 — faucet funding', () => {
     }
   });
 
+  it('#1306: eagerly creates wallets via the injected hook (even --no-fund), skipped on --dry-run', async () => {
+    const env = setupFaucetEnv();
+    try {
+      // --no-fund must STILL create wallets (mainnet has no faucet but the node
+      // needs wallets for manual funding + publishing). Called with the home dir.
+      const loadOpWallets = vi.fn(async () => ({
+        adminWallet: { address: '0xAAAA', privateKey: '0x0' },
+        wallets: [],
+      }));
+      await runSetup(
+        { workspace: env.workspace, network: 'testnet', start: false, verify: false, fund: false },
+        { loadOpWallets },
+      );
+      expect(loadOpWallets).toHaveBeenCalledTimes(1);
+      expect(loadOpWallets.mock.calls[0][0]).toBe(env.dkgHome);
+
+      // --dry-run must NOT create wallets.
+      loadOpWallets.mockClear();
+      await runSetup(
+        { workspace: env.workspace, network: 'testnet', start: false, verify: false, dryRun: true },
+        { loadOpWallets },
+      );
+      expect(loadOpWallets).not.toHaveBeenCalled();
+    } finally {
+      env.restore();
+    }
+  });
+
 });

--- a/packages/adapter-openclaw/test/setup.part-26.test.ts
+++ b/packages/adapter-openclaw/test/setup.part-26.test.ts
@@ -490,4 +490,48 @@ describe('runSetup Step 5 — faucet funding', () => {
     }
   });
 
+  it('#1306: a failing loadOpWallets is best-effort — setup still completes', async () => {
+    const env = setupFaucetEnv();
+    try {
+      const loadOpWallets = vi.fn(async () => { throw new Error('boom'); });
+      // Wallet pre-creation is best-effort; a throw must NOT abort setup.
+      await expect(
+        runSetup(
+          { workspace: env.workspace, network: 'testnet', start: false, verify: false, fund: false },
+          { loadOpWallets },
+        ),
+      ).resolves.toBeUndefined();
+      expect(loadOpWallets).toHaveBeenCalledTimes(1);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('#1306: eager-created wallets feed the faucet (pre-creation runs before funding)', async () => {
+    const env = setupFaucetEnv();
+    // Remove the pre-seeded wallets so ONLY the hook can provide them — proves
+    // the hook writes wallets.json BEFORE the funding step reads it.
+    rmSync(join(env.dkgHome, 'wallets.json'));
+    try {
+      const loadOpWallets = vi.fn(async (dir: string) => {
+        const cfg = {
+          adminWallet: { address: '0xADMIN', privateKey: '0x0' },
+          wallets: [{ address: '0xOP1', privateKey: '0x0' }],
+        };
+        writeFileSync(join(dir, 'wallets.json'), JSON.stringify(cfg));
+        return cfg;
+      });
+      await runSetup(
+        { workspace: env.workspace, network: 'testnet', start: false, verify: false },
+        { loadOpWallets },
+      );
+      // The faucet now finds the eager-created wallets and funds them.
+      expect(requestFaucetFunding).toHaveBeenCalledTimes(1);
+      const [, , addresses] = vi.mocked(requestFaucetFunding).mock.calls[0];
+      expect(addresses).toEqual(['0xADMIN', '0xOP1']);
+    } finally {
+      env.restore();
+    }
+  });
+
 });

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -191,6 +191,14 @@ mcpCmd
       console.error(`  Reason: ${err?.message ?? err}`);
       process.exit(1);
     }
+    let agentExports: typeof import('@origintrail-official/dkg-agent');
+    try {
+      agentExports = await import('@origintrail-official/dkg-agent');
+    } catch (err: any) {
+      console.error('\n[dkg mcp setup] Wallet primitive (dkg-agent) is not available.');
+      console.error(`  Reason: ${err?.message ?? err}`);
+      process.exit(1);
+    }
 
     const { mcpSetupAction } = await import('../mcp-setup.js');
     try {
@@ -200,6 +208,7 @@ mcpCmd
         startDaemon: openclawSetupExports.startDaemon,
         readWalletsWithRetry: openclawSetupExports.readWalletsWithRetry,
         logManualFundingInstructions: openclawSetupExports.logManualFundingInstructions,
+        loadOpWallets: agentExports.loadOpWallets,
         requestFaucetFunding: coreExports.requestFaucetFunding,
         findDkgMonorepoRoot: coreExports.findDkgMonorepoRoot,
         resolveDkgConfigHome: coreExports.resolveDkgConfigHome,

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -191,15 +191,6 @@ mcpCmd
       console.error(`  Reason: ${err?.message ?? err}`);
       process.exit(1);
     }
-    let agentExports: typeof import('@origintrail-official/dkg-agent');
-    try {
-      agentExports = await import('@origintrail-official/dkg-agent');
-    } catch (err: any) {
-      console.error('\n[dkg mcp setup] Wallet primitive (dkg-agent) is not available.');
-      console.error(`  Reason: ${err?.message ?? err}`);
-      process.exit(1);
-    }
-
     const { mcpSetupAction } = await import('../mcp-setup.js');
     try {
       await mcpSetupAction(opts, {
@@ -208,7 +199,15 @@ mcpCmd
         startDaemon: openclawSetupExports.startDaemon,
         readWalletsWithRetry: openclawSetupExports.readWalletsWithRetry,
         logManualFundingInstructions: openclawSetupExports.logManualFundingInstructions,
-        loadOpWallets: agentExports.loadOpWallets,
+        // Lazy + best-effort (parity with openclaw/hermes): dkg-agent is
+        // imported only inside the non-dry-run wallet step, so `--print-only`
+        // / `--dry-run` never require it, and an import failure degrades to a
+        // warning (mcpSetupAction wraps the call in try/catch) instead of
+        // aborting setup.
+        loadOpWallets: async (dir: string) => {
+          const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
+          return loadOpWallets(dir);
+        },
         requestFaucetFunding: coreExports.requestFaucetFunding,
         findDkgMonorepoRoot: coreExports.findDkgMonorepoRoot,
         resolveDkgConfigHome: coreExports.resolveDkgConfigHome,

--- a/packages/cli/src/hermes-setup.ts
+++ b/packages/cli/src/hermes-setup.ts
@@ -54,7 +54,10 @@ export interface NormalizedHermesSetupOptions {
 }
 
 export interface HermesSetupActionDeps {
-  runSetup: (opts: NormalizedHermesSetupOptions) => Promise<void>;
+  runSetup: (
+    opts: NormalizedHermesSetupOptions,
+    runDeps?: { loadOpWallets?: (dir: string) => Promise<unknown> },
+  ) => Promise<void>;
 }
 
 function trimmed(value: unknown): string | undefined {
@@ -111,8 +114,19 @@ export async function hermesSetupAction(
   deps: HermesSetupActionDeps,
 ): Promise<void> {
   await assertSelectableNetwork(opts.network);
-  await deps.runSetup({
-    ...normalizeHermesSetupOptions(opts),
-    nodeSkillContent: loadBundledDkgNodeSkill(),
-  });
+  // Inject the wallet creator from the cli layer (which has dkg-agent) so the
+  // adapter eagerly creates wallets before the daemon starts (issue #1306)
+  // without the adapter package depending on dkg-agent.
+  await deps.runSetup(
+    {
+      ...normalizeHermesSetupOptions(opts),
+      nodeSkillContent: loadBundledDkgNodeSkill(),
+    },
+    {
+      loadOpWallets: async (dir: string) => {
+        const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
+        return loadOpWallets(dir);
+      },
+    },
+  );
 }

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -172,6 +172,13 @@ export interface McpSetupActionDeps {
   startDaemon: typeof import('@origintrail-official/dkg-adapter-openclaw').startDaemon;
   readWalletsWithRetry: typeof import('@origintrail-official/dkg-adapter-openclaw').readWalletsWithRetry;
   logManualFundingInstructions: typeof import('@origintrail-official/dkg-adapter-openclaw').logManualFundingInstructions;
+  /**
+   * Eagerly creates the node's operational wallets (generate-if-absent)
+   * before the daemon starts, so faucet funding (testnet) and manual mainnet
+   * funding have wallets to target even if the daemon never fully boots.
+   * Idempotent. From `@origintrail-official/dkg-agent`; injectable for tests.
+   */
+  loadOpWallets: typeof import('@origintrail-official/dkg-agent').loadOpWallets;
   /** Faucet primitive from `@origintrail-official/dkg-core`. */
   requestFaucetFunding: typeof import('@origintrail-official/dkg-core').requestFaucetFunding;
   /**
@@ -1891,6 +1898,20 @@ export async function mcpSetupAction(
     } catch (err: any) {
       console.error(`[setup] Failed to load network config: ${err?.message ?? err}`);
       throw err;
+    }
+  }
+
+  // Ensure the node's wallets exist BEFORE starting the daemon — matching
+  // `dkg init` — so faucet funding (testnet) and manual mainnet funding have
+  // wallets to target even if the daemon never fully boots. Runs OUTSIDE the
+  // config-write skip-gate above (an existing node can still lack wallets) and
+  // regardless of `--no-fund` (mainnet has no faucet but still needs wallets).
+  // Best-effort; the daemon's boot-time loadOpWallets is an idempotent fallback.
+  if (!dryRun) {
+    try {
+      await deps.loadOpWallets(dkgDirPath);
+    } catch (err: any) {
+      console.warn(`[setup] Could not pre-create wallets (${err?.message ?? err}); the daemon will generate them on first start.`);
     }
   }
 

--- a/packages/cli/src/openclaw-setup.ts
+++ b/packages/cli/src/openclaw-setup.ts
@@ -38,5 +38,13 @@ export async function openclawSetupAction(
   deps: OpenClawSetupActionDeps,
 ): Promise<void> {
   await assertSelectableNetwork(opts.network);
-  await deps.runSetup(opts);
+  // Inject the wallet creator from the cli layer (which has dkg-agent) so the
+  // adapter eagerly creates wallets before the daemon starts (issue #1306)
+  // without the adapter package depending on dkg-agent.
+  await deps.runSetup(opts, {
+    loadOpWallets: async (dir: string) => {
+      const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
+      return loadOpWallets(dir);
+    },
+  });
 }

--- a/packages/cli/test/hermes-setup-cli-args.test.ts
+++ b/packages/cli/test/hermes-setup-cli-args.test.ts
@@ -59,6 +59,23 @@ describe('hermesSetupAction', () => {
     });
   });
 
+  it('#1306: injects a loadOpWallets hook into runSetup (eager wallet creation)', async () => {
+    const runSetupArgs: any[] = [];
+    const runSetup = async (...args: unknown[]) => { runSetupArgs.push(args); };
+
+    await hermesSetupAction(
+      { verify: false, start: false, dryRun: true },
+      makeCommand(),
+      { runSetup: runSetup as any },
+    );
+
+    expect(runSetupArgs).toHaveLength(1);
+    // The 2nd arg is the injected runtime deps; loadOpWallets must be wired so
+    // the adapter can eagerly create wallets before the daemon starts.
+    const [, runDeps] = runSetupArgs[0] as [unknown, { loadOpWallets?: unknown }];
+    expect(typeof runDeps?.loadOpWallets).toBe('function');
+  });
+
   it('defaults verify/start/fund to true and dryRun/preserveProvider to false', () => {
     expect(normalizeHermesSetupOptions({})).toEqual({
       profile: undefined,

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -226,6 +226,14 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       faucet: { url: 'http://faucet.test', mode: 'testnet' },
     }) as any);
     const readWalletsWithRetry = recorder(async () => ['0xadmin', '0xtest1', '0xtest2', '0xtest3']);
+    // Eager wallet creation (issue #1306). Idempotent generate-if-absent;
+    // mcpSetupAction ignores the return value (the faucet re-reads from disk),
+    // so a minimal stub suffices. Tests assert it's called on a non-dry-run
+    // setup and skipped under --dry-run.
+    const loadOpWallets = recorder(async () => ({
+      adminWallet: { address: '0xadmin', privateKey: '0x0' },
+      wallets: [{ address: '0xtest1', privateKey: '0x0' }],
+    }) as any);
     const requestFaucetFunding = recorder(async () => ({
       success: true,
       fundedWallets: ['0xadmin', '0xtest1', '0xtest2', '0xtest3'],
@@ -263,6 +271,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       ensureDkgNodeConfig,
       startDaemon,
       readWalletsWithRetry,
+      loadOpWallets,
       requestFaucetFunding,
       logManualFundingInstructions,
       findDkgMonorepoRoot,
@@ -475,6 +484,22 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     expect((deps.requestFaucetFunding as any).calls).toEqual([]);
     expect(existsSync(join(tmpHome, '.dkg', 'config.json'))).toBe(false);
     expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(false);
+  });
+
+  it('#1306: eagerly creates wallets even with --no-fund, and skips under --dry-run', async () => {
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+
+    // --no-fund must STILL create wallets (mainnet has no faucet but the node
+    // needs wallets for manual funding + publishing). Called with the home dir.
+    const deps = makeDeps();
+    await mcpSetupAction({ fund: false, verify: false }, deps);
+    expect((deps.loadOpWallets as any).calls).toHaveLength(1);
+    expect((deps.loadOpWallets as any).calls[0][0]).toBe(join(tmpHome, '.dkg'));
+
+    // --dry-run must NOT create wallets.
+    const dryDeps = makeDeps();
+    await mcpSetupAction({ dryRun: true }, dryDeps);
+    expect((dryDeps.loadOpWallets as any).calls).toEqual([]);
   });
 
   it('honours --print-only: short-circuits before any other step', async () => {

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -502,6 +502,21 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     expect((dryDeps.loadOpWallets as any).calls).toEqual([]);
   });
 
+  it('#1306: a failing loadOpWallets is best-effort — setup continues', async () => {
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+    const deps = makeDeps({
+      loadOpWallets: recorder(async () => { throw new Error('boom'); }),
+    });
+
+    // A throwing wallet pre-create must NOT abort setup — the daemon still
+    // starts and clients still register.
+    await mcpSetupAction({ fund: false, verify: false }, deps);
+
+    expect((deps.loadOpWallets as any).calls).toHaveLength(1);
+    expect((deps.startDaemon as any).calls).toHaveLength(1);
+    expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
+  });
+
   it('honours --print-only: short-circuits before any other step', async () => {
     const deps = makeDeps();
     const stdoutSpy = captureWrites(process.stdout, 'write');

--- a/packages/cli/test/openclaw-setup-cli-args.test.ts
+++ b/packages/cli/test/openclaw-setup-cli-args.test.ts
@@ -87,4 +87,17 @@ describe('openclawSetupAction — --no-fund/--fund flag threading', () => {
       openclawSetupAction({ dryRun: true }, makeCommand('default'), { runSetup: runSetup as any }),
     ).rejects.toThrow('adapter blew up');
   });
+
+  it('#1306: injects a loadOpWallets hook into runSetup (eager wallet creation)', async () => {
+    const runSetupArgs: any[] = [];
+    const runSetup = async (...args: any[]) => { runSetupArgs.push(args); };
+
+    await openclawSetupAction({ dryRun: true }, makeCommand('default'), { runSetup: runSetup as any });
+
+    expect(runSetupArgs).toHaveLength(1);
+    // The 2nd arg is the injected runtime deps; loadOpWallets must be wired so
+    // the adapter can eagerly create wallets before the daemon starts.
+    const [, runDeps] = runSetupArgs[0];
+    expect(typeof runDeps?.loadOpWallets).toBe('function');
+  });
 });


### PR DESCRIPTION
Fixes #1306.

## Problem

`dkg openclaw setup` / `dkg hermes setup` / `dkg mcp setup` write `config.json` but **never create the node's wallets** — they rely on the daemon creating them at boot (`packages/cli/src/daemon/lifecycle.ts:1112`). The faucet's `readWalletsWithRetry` only *reads* `wallets.json`. So when the daemon doesn't fully boot (a crash before that line, or `--no-start`), no wallets exist and funding finds nothing.

This matters most on **mainnet** — now the default network. Mainnet configs ship **no faucet**, yet the node still needs wallets (for the operator's manual TRAC/gas funding and for publishing). `dkg init` already avoids the gap by eagerly creating wallets (`packages/cli/src/commands/init.ts`); this PR brings the three other setup flows to parity.

## Fix

Each flow now calls `loadOpWallets(home)` **after writing config and before starting the daemon**, on every non-dry-run setup (regardless of `--no-fund`). `loadOpWallets` is generate-if-absent + idempotent, so the daemon's boot-time call remains a harmless fallback (loads the same `wallets.json`/`wallets.key`, no key rotation).

### Why injection (not an import)
`loadOpWallets` lives in `@origintrail-official/dkg-agent`, which the openclaw/hermes adapter packages **intentionally don't depend on** (the faucet was extracted to core in #386 to keep adapters agent-free; `dkg-agent → dkg-core` is one-way, so a core helper would be circular). The **cli action layer** (which has dkg-agent) injects it as an optional hook into `runSetup`/`runHermesSetup`; **MCP** adds it to its existing deps-injection. **No new package dependencies; adapters stay agent-free.**

## Scope — wallets only (verified)

`dkg init` eager-creates *only* `config.json` + `wallets.json`/`wallets.key`. The node/agent identity `agent-keystore.json` is a `DKGAgent` method (`packages/agent/src/dkg-agent-registry.ts:1312`) and `auth.token` is daemon-written — both are created by the **daemon on first boot** for `dkg init`+`dkg start` *and* the adapter flows alike. So wallets are the only init-vs-adapter asymmetry. (Eager node-identity creation would be a new, riskier change affecting `dkg init` too — out of scope; possible follow-up.)

## Files

- **MCP:** `packages/cli/src/mcp-setup.ts` (deps member + call), `packages/cli/src/commands/mcp.ts` (dynamic-import + wire dep).
- **OpenClaw:** `packages/adapter-openclaw/src/setup.ts` (`RunSetupDeps` + call), `packages/cli/src/openclaw-setup.ts` (provide hook).
- **Hermes:** `packages/adapter-hermes/src/setup.ts` (`RunHermesSetupDeps` + call), `packages/cli/src/hermes-setup.ts` (provide hook).

## Test plan

- Per-flow unit tests assert the hook fires on a non-dry-run setup (**including `--no-fund`**) and is skipped under `--dry-run`. Existing tests omit the hook → unaffected (graceful degradation; no dkg-agent mocking needed).
- Full openclaw suite green (1137 passed). Hermes new test green.
- **E2E:** `dkg openclaw setup --no-start --no-fund` on a throwaway `DKG_HOME` (default `mainnet-gnosis`) → `wallets.json` **and** `wallets.key` created with the daemon never started; a subsequent `dkg start` loads the same wallets (no rotation).
- Pre-existing/env-only test reds (not introduced here): the Hermes `python3`-not-on-PATH provider test; load/timing flakes under concurrent full-suite runs (pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)