### PR TITLE
Fix private CG catalog root collision

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -106,8 +106,9 @@ import {
   ACKCollector, StorageACKHandler,
   VerifyCollector, VerifyProposalHandler, buildVerificationMetadata,
   resolveWorkspaceAgentRecipients,
-  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
+  computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject,
   canonicalPublishPayload,
+  generatedPrivateCatalogTripleKeys,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,
   subtractFinalizedExactQuads,
@@ -1179,6 +1180,9 @@ export class PublishMethods extends DKGAgentBase {
     const canonical = canonicalPublishPayload(
       subtracted.resolved.quads,
       subtracted.resolved.privateQuads ?? [],
+      (await this.isPrivateContextGraph(request.contextGraphId))
+        ? { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(request.contextGraphId) }
+        : undefined,
     );
 
     // Resolve author: callback → custodial keystore → publisher fallback. User-input pre-validated in publishAsync entry.
@@ -1587,6 +1591,9 @@ export class PublishMethods extends DKGAgentBase {
       operationCtx: ctx,
       onPhase,
       precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
+      trustedNonManifestCatalogTriples: isCuratedUpdate
+        ? generatedPrivateCatalogTripleKeys(contextGraphId)
+        : undefined,
       v10UpdateACKProvider,
       // Curated → wire the single-blob AEAD hook so the producer's
       // `useEncryptedInlineUpdate` gate fires (catalog commit). Public →
@@ -2005,7 +2012,10 @@ export class PublishMethods extends DKGAgentBase {
     // only, so the placeholder `graph` here does not affect the root.
     // Idempotent across re-finalize: identical quads dedupe in the WM store.
     const quads = [...userQuads];
-    if (await this.isPrivateContextGraph(contextGraphId)) {
+    const trustedGeneratedCatalogTriples = (await this.isPrivateContextGraph(contextGraphId))
+      ? generatedPrivateCatalogTripleKeys(contextGraphId)
+      : undefined;
+    if (trustedGeneratedCatalogTriples) {
       const cgDid = contextGraphDataUri(contextGraphId);
       // `graph` is a non-empty placeholder only (buildPublicProjection requires
       // one); assertionWrite re-stamps it with the correct wmGraphUri.
@@ -2067,7 +2077,10 @@ export class PublishMethods extends DKGAgentBase {
     //     instead of bundling everything currently sitting in shared
     //     memory (Round 4 review §9). Now safe by construction — the
     //     guard above guarantees every key passes `isSafeIri`.
-    const rootEntities = allRootEntities;
+    const canonicalForManifest = canonicalPublishPayload(quads, [], {
+      trustedNonManifestCatalogTriples: trustedGeneratedCatalogTriples,
+    });
+    const rootEntities = canonicalForManifest.manifestEntries.map((m) => m.rootEntity);
     if (rootEntities.length === 0) {
       throw new Error(
         `Cannot finalize assertion <${assertionUri}>: skolemizeByEntity produced ` +
@@ -2585,30 +2598,15 @@ export class PublishMethods extends DKGAgentBase {
       );
     }
 
-    const kaMap = skolemizeByEntity(quads);
-    const allSkolemizedQuads = [...kaMap.values()].flat();
-    // Mirror the publisher's per-rootEntity private partition + root
-    // derivation (see `dkg-publisher.ts:1526-1570`). Each public root
-    // entity gets the private quads whose subjects either equal it or
-    // skolemize beneath its `…/.well-known/genid/` namespace; each
-    // such non-empty bag becomes a `computePrivateRootV10` leaf in the
-    // KC merkle. The order MUST follow the publisher's manifest
-    // iteration over `kaMap`, which is the insertion order — same map
-    // we built two lines up.
     const privateQuads = opts?.privateQuads ?? [];
-    const privateRoots: Uint8Array[] = [];
-    for (const rootEntity of kaMap.keys()) {
-      if (privateQuads.length === 0) break;
-      const entityPrivateQuads = privateQuads.filter(
-        (q) =>
-          q.subject === rootEntity ||
-          q.subject.startsWith(rootEntity + '/.well-known/genid/'),
-      );
-      if (entityPrivateQuads.length === 0) continue;
-      const root = computePrivateRoot(entityPrivateQuads);
-      if (root) privateRoots.push(root);
-    }
-    const merkleRoot = computeFlatKCRoot(allSkolemizedQuads, privateRoots);
+    const canonical = canonicalPublishPayload(
+      quads,
+      privateQuads,
+      (await this.isPrivateContextGraph(contextGraphId))
+        ? { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId) }
+        : undefined,
+    );
+    const merkleRoot = canonical.kcMerkleRoot;
 
     const chainId = await this.chain.getEvmChainId();
     const kav10Address = await this.chain.getKnowledgeAssetsLifecycleAddress();
@@ -3930,10 +3928,9 @@ export class PublishMethods extends DKGAgentBase {
    * by the SAME `buildPublicProjection`, so the committed catalog is byte-identical
    * across both paths.
    *
-   * IDEMPOTENT: if the catalog is already in the SWM read scope (finalize path, or
-   * a prior from-SWM publish), it does nothing. Re-injection would in any case
-   * dedupe in the V10 merkle (identical leaves) so `catalogLeafCount` is stable,
-   * but the guard avoids the redundant write entirely.
+    * IDEMPOTENT: repeated insertion dedupes in the store/V10 Merkle path because
+    * the floor is deterministic, so `catalogLeafCount` stays stable across
+    * finalize-path and direct from-SWM publishes.
    *
    * Returns a possibly-extended `selection`: for a `{rootEntities}` publish the
    * CG-DID catalog subject is appended so it is in scope for BOTH the author seal
@@ -3949,19 +3946,12 @@ export class PublishMethods extends DKGAgentBase {
   ): Promise<'all' | { rootEntities: string[] }> {
     const swmGraph = contextGraphSharedMemoryUri(contextGraphId, subGraphName);
     const cgDid = contextGraphDataUri(contextGraphId);
-    const existing = await this.store.query(
-      `CONSTRUCT { <${cgDid}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DCAT_DATASET}> } ` +
-      `WHERE { GRAPH ?g { <${cgDid}> <${DKG_ONTOLOGY.RDF_TYPE}> <${DKG_ONTOLOGY.DCAT_DATASET}> } ${sharedMemoryReadBothFilter(swmGraph)} }`,
+    const catalogQuads = buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: swmGraph });
+    await this.store.insert(catalogQuads);
+    this.log.info(
+      ctx,
+      `OT-RFC-49: ensured ${catalogQuads.length}-quad public _catalog floor in SWM for curated CG ${contextGraphId} (from-SWM publish without finalize)`,
     );
-    const alreadyPresent = existing.type === 'quads' && existing.quads.length > 0;
-    if (!alreadyPresent) {
-      const catalogQuads = buildPublicProjection({ ual: cgDid, accessPolicy: 'private', graph: swmGraph });
-      await this.store.insert(catalogQuads);
-      this.log.info(
-        ctx,
-        `OT-RFC-49: injected ${catalogQuads.length}-quad public _catalog floor into SWM for curated CG ${contextGraphId} (from-SWM publish without finalize)`,
-      );
-    }
     if (selection !== 'all' && !selection.rootEntities.includes(cgDid)) {
       return { rootEntities: [...selection.rootEntities, cgDid] };
     }
@@ -4079,7 +4069,11 @@ export class PublishMethods extends DKGAgentBase {
     // spurious. Returns a possibly-extended selection so the CG-DID catalog
     // subject is in scope for a `{rootEntities}` publish too (the seal-read and
     // the publisher reload scope identically).
-    if (onChainId != null && (await this.isPrivateContextGraph(contextGraphId))) {
+    const hasGeneratedPrivateCatalog = onChainId != null && (await this.isPrivateContextGraph(contextGraphId));
+    const trustedNonManifestCatalogTriples = hasGeneratedPrivateCatalog
+      ? generatedPrivateCatalogTripleKeys(contextGraphId)
+      : undefined;
+    if (hasGeneratedPrivateCatalog) {
       selection = await this._ensureCuratedCatalogInSwm(contextGraphId, selection, options?.subGraphName, ctx);
     }
 
@@ -4165,6 +4159,7 @@ export class PublishMethods extends DKGAgentBase {
       onChainContextGraphId: onChainId,
       contextGraphSignatures: options?.contextGraphSignatures,
       v10ACKProvider,
+      trustedNonManifestCatalogTriples,
       subGraphName: options?.subGraphName,
       publisherNodeIdentityIdOverride: options?.publisherNodeIdentityIdOverride,
       publishEpochs: options?.publishEpochs,

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -1570,8 +1570,9 @@ export class PublishMethods extends DKGAgentBase {
     // path always has — so under a DEGRADED / stale policy probe a public update
     // fails closed (throws) consistently with publish, where the OLD update path
     // would have proceeded. Fail-closed, never a leak; see PR #1208 notes.
+    const shouldInjectCuratedCatalogFloor = isCuratedUpdate && updateOnChainId != null;
     let updateQuads = quads;
-    if (isCuratedUpdate) {
+    if (shouldInjectCuratedCatalogFloor) {
       const cgDid = contextGraphDataUri(contextGraphId);
       const { otherQuads: nonCatalogQuads } = partitionCatalogQuads(quads, cgDid);
       const catalogFloor = buildPublicProjection({
@@ -1591,7 +1592,7 @@ export class PublishMethods extends DKGAgentBase {
       operationCtx: ctx,
       onPhase,
       precomputedUpdateAttestation: opts?.precomputedUpdateAttestation,
-      trustedNonManifestCatalogTriples: isCuratedUpdate
+      trustedNonManifestCatalogTriples: shouldInjectCuratedCatalogFloor
         ? generatedPrivateCatalogTripleKeys(contextGraphId)
         : undefined,
       v10UpdateACKProvider,
@@ -2599,10 +2600,11 @@ export class PublishMethods extends DKGAgentBase {
     }
 
     const privateQuads = opts?.privateQuads ?? [];
+    const trustedCatalogOnChainId = opts?.targetOnChainCgId ?? await this.getContextGraphOnChainId(contextGraphId);
     const canonical = canonicalPublishPayload(
       quads,
       privateQuads,
-      (await this.isPrivateContextGraph(contextGraphId))
+      trustedCatalogOnChainId != null && (await this.isPrivateContextGraph(contextGraphId))
         ? { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId) }
         : undefined,
     );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2024,7 +2024,9 @@ export class DKGAgent extends DKGAgentBase {
           { awaitCuratorAck: opts?.awaitCuratorAck, curatorAckTimeoutMs: opts?.curatorAckTimeoutMs },
           createOperationContext('share'),
         );
-        const trustedNonManifestCatalogTriples = (await agent.isPrivateContextGraph(contextGraphId))
+        const trustedCatalogOnChainContextGraphId = await agent.getContextGraphOnChainId(contextGraphId) ?? undefined;
+        const isPrivateContextGraph = await agent.isPrivateContextGraph(contextGraphId);
+        const trustedNonManifestCatalogTriples = isPrivateContextGraph
           ? generatedPrivateCatalogTripleKeys(contextGraphId)
           : undefined;
         const { promotedCount, gossipMessage, promotedAllRoots } = await agent.publisher.assertionPromote(
@@ -2034,6 +2036,7 @@ export class DKGAgent extends DKGAgentBase {
             publisherPeerId: agent.node.peerId.toString(),
             senderAgentAddress: gossipSigner?.agentAddress,
             trustedNonManifestCatalogTriples,
+            onChainContextGraphId: trustedCatalogOnChainContextGraphId,
             confirmBeforeCommit,
           },
         );

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -94,6 +94,7 @@ import {
   resolveWorkspaceAgentRecipients,
   computeTripleHashV10 as computeTripleHash, computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity, isReservedSubject, computePrivateRootV10 as computePrivateRoot,
   canonicalPublishPayload,
+  generatedPrivateCatalogTripleKeys,
   resolveLiftWorkspaceSlice,
   validateLiftPublishPayload,
   subtractFinalizedExactQuads,
@@ -2023,12 +2024,16 @@ export class DKGAgent extends DKGAgentBase {
           { awaitCuratorAck: opts?.awaitCuratorAck, curatorAckTimeoutMs: opts?.curatorAckTimeoutMs },
           createOperationContext('share'),
         );
+        const trustedNonManifestCatalogTriples = (await agent.isPrivateContextGraph(contextGraphId))
+          ? generatedPrivateCatalogTripleKeys(contextGraphId)
+          : undefined;
         const { promotedCount, gossipMessage, promotedAllRoots } = await agent.publisher.assertionPromote(
           contextGraphId, name, agentAddress,
           {
             ...opts,
             publisherPeerId: agent.node.peerId.toString(),
             senderAgentAddress: gossipSigner?.agentAddress,
+            trustedNonManifestCatalogTriples,
             confirmBeforeCommit,
           },
         );

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -16,8 +16,11 @@ import { GraphManager, type TripleStore, type Quad } from '@origintrail-official
 import { type ChainAdapter, type EventFilter } from '@origintrail-official/dkg-chain';
 import {
   computeFlatKCRootV10 as computeFlatKCRoot, skolemizeByEntity,
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
   generateConfirmedFullMetadata, buildDeterministicTokenRows, compareRootIris, getTentativeStatusQuad,
   generateSubGraphRegistration,
+  splitTrustedGeneratedCatalogRootMap,
   shouldApplyMaterialization, writeMaterializedVersion, withMaterializationLock,
   type MaterializedVersion,
   type KCMetadata, type KAMetadata, type OnChainProvenance,
@@ -192,9 +195,16 @@ export class FinalizationHandler {
 
       if (sharedMemoryQuads.length > 0) {
         const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
-        const merkleMatch = this.verifyMerkleMatch(sharedMemoryQuads, privateRoots, msg.kcMerkleRoot);
+        const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(ctxGraphId);
+        const merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
+          contextGraphId,
+          sharedMemoryQuads,
+          privateRoots,
+          msg.kcMerkleRoot,
+          allowGeneratedCatalogFloor,
+        );
 
-        if (merkleMatch) {
+        if (merkleMatchedQuads) {
           const batchId = protoToBigInt(msg.batchId);
           // PR #845 review #9: derive `txIndex` from the verified receipt
           // (via `verifyOnChain`), NOT from gossip-supplied `msg.txIndex`.
@@ -258,7 +268,7 @@ export class FinalizationHandler {
             // `shouldApplyMaterialization` and `writeMaterializedVersion`.
             const outcome = await this.applyVerifiedFinalization({
               contextGraphId,
-              sharedMemoryQuads,
+              sharedMemoryQuads: merkleMatchedQuads,
               ual: msg.ual,
               rootEntities: msg.rootEntities,
               publisherAddress: msg.publisherAddress,
@@ -377,6 +387,41 @@ export class FinalizationHandler {
   private verifyMerkleMatch(sharedMemoryQuads: Quad[], privateRoots: Uint8Array[], expectedMerkleRoot: Uint8Array): boolean {
     const computedRoot = computeFlatKCRoot(sharedMemoryQuads, privateRoots);
     return ethers.hexlify(computedRoot) === ethers.hexlify(expectedMerkleRoot);
+  }
+
+  private sharedMemoryQuadsMatchingMerkle(
+    contextGraphId: string,
+    sharedMemoryQuads: Quad[],
+    privateRoots: Uint8Array[],
+    expectedMerkleRoot: Uint8Array,
+    allowGeneratedCatalogFloor: boolean,
+  ): Quad[] | null {
+    if (this.verifyMerkleMatch(sharedMemoryQuads, privateRoots, expectedMerkleRoot)) {
+      return sharedMemoryQuads;
+    }
+
+    if (!allowGeneratedCatalogFloor) return null;
+
+    const withGeneratedCatalog = [
+      ...sharedMemoryQuads,
+      ...generatedPrivateCatalogFloorQuads(contextGraphId),
+    ];
+    if (this.verifyMerkleMatch(withGeneratedCatalog, privateRoots, expectedMerkleRoot)) {
+      return withGeneratedCatalog;
+    }
+
+    return null;
+  }
+
+  private async allowsGeneratedCatalogFloor(onChainCgId: string | bigint | undefined): Promise<boolean> {
+    if (onChainCgId === undefined || onChainCgId === null) return false;
+    if (!this.chain || this.chain.chainId === 'none') return false;
+    if (typeof this.chain.getContextGraphAccessPolicy !== 'function') return false;
+    try {
+      return Number(await this.chain.getContextGraphAccessPolicy(BigInt(onChainCgId))) === 1;
+    } catch {
+      return false;
+    }
   }
 
   private async getPrivateRootsFromMeta(contextGraphId: string, rootEntities: string[], subGraphName?: string): Promise<Uint8Array[]> {
@@ -678,7 +723,12 @@ export class FinalizationHandler {
     // KC root and comparing to the chain root. This is the same flat-KC root
     // the gossip path verifies against, so a match is an authoritative
     // merkle verification.
-    const snapshot = await this.findSwmSnapshotForMerkleRoot(contextGraphId, merkleRoot, subGraphName);
+    const snapshot = await this.findSwmSnapshotForMerkleRoot(
+      contextGraphId,
+      merkleRoot,
+      subGraphName,
+      onChainCgId,
+    );
     if (!snapshot) {
       this.log.info(ctx, `Chain-reconcile: no local SWM snapshot matches the published merkleRoot for ${ual}; deferring to sweep retry`);
       return 'no-swm';
@@ -778,10 +828,17 @@ export class FinalizationHandler {
     contextGraphId: string,
     merkleRoot: Uint8Array,
     subGraphName?: string,
+    onChainCgId?: string,
   ): Promise<{ rootEntities: string[]; sharedMemoryQuads: Quad[]; subGraphName?: string } | null> {
+    const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(onChainCgId);
     // Caller knows the exact namespace → search only that one.
     if (subGraphName) {
-      const hit = await this.findSwmSnapshotInNamespace(contextGraphId, merkleRoot, subGraphName);
+      const hit = await this.findSwmSnapshotInNamespace(
+        contextGraphId,
+        merkleRoot,
+        subGraphName,
+        allowGeneratedCatalogFloor,
+      );
       return hit ? { ...hit, subGraphName } : null;
     }
 
@@ -791,7 +848,12 @@ export class FinalizationHandler {
     // forever because its SWM snapshot lives under a sub-graph meta graph,
     // not the root workspace meta. Return the namespace we matched in so the
     // caller promotes into the correct data graph.
-    const rootHit = await this.findSwmSnapshotInNamespace(contextGraphId, merkleRoot, undefined);
+    const rootHit = await this.findSwmSnapshotInNamespace(
+      contextGraphId,
+      merkleRoot,
+      undefined,
+      allowGeneratedCatalogFloor,
+    );
     if (rootHit) return { ...rootHit, subGraphName: undefined };
 
     let subGraphNames: string[] = [];
@@ -799,7 +861,12 @@ export class FinalizationHandler {
       subGraphNames = await new GraphManager(this.store).listSubGraphs(contextGraphId);
     } catch { /* no sub-graphs / store can't enumerate */ }
     for (const sg of subGraphNames) {
-      const hit = await this.findSwmSnapshotInNamespace(contextGraphId, merkleRoot, sg);
+      const hit = await this.findSwmSnapshotInNamespace(
+        contextGraphId,
+        merkleRoot,
+        sg,
+        allowGeneratedCatalogFloor,
+      );
       if (hit) return { ...hit, subGraphName: sg };
     }
     return null;
@@ -814,6 +881,7 @@ export class FinalizationHandler {
     contextGraphId: string,
     merkleRoot: Uint8Array,
     subGraphName?: string,
+    allowGeneratedCatalogFloor = false,
   ): Promise<{ rootEntities: string[]; sharedMemoryQuads: Quad[] } | null> {
     const graphManager = new GraphManager(this.store);
     const wsMetaGraph = subGraphName
@@ -850,8 +918,15 @@ export class FinalizationHandler {
       const sharedMemoryQuads = await this.getSharedMemoryQuadsForRoots(contextGraphId, roots, subGraphName);
       if (sharedMemoryQuads.length === 0) continue;
       const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, roots, subGraphName);
-      if (this.verifyMerkleMatch(sharedMemoryQuads, privateRoots, merkleRoot)) {
-        return { rootEntities: roots, sharedMemoryQuads };
+      const merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
+        contextGraphId,
+        sharedMemoryQuads,
+        privateRoots,
+        merkleRoot,
+        allowGeneratedCatalogFloor,
+      );
+      if (merkleMatchedQuads) {
+        return { rootEntities: roots, sharedMemoryQuads: merkleMatchedQuads };
       }
     }
     return null;
@@ -1094,7 +1169,20 @@ export class FinalizationHandler {
     if (msgRootEntities.length > 0) {
       const msgSet = new Set(msgRootEntities);
       const extraInMsg = msgRootEntities.filter(r => !localRootSet.has(r));
-      const missingInMsg = [...localRootSet].filter(r => !msgSet.has(r));
+      let generatedCatalogRootSet = new Set<string>();
+      try {
+        generatedCatalogRootSet = new Set(
+          splitTrustedGeneratedCatalogRootMap(
+            partitioned,
+            generatedPrivateCatalogTripleKeys(contextGraphId),
+          ).generatedCatalogRootEntities,
+        );
+      } catch {
+        generatedCatalogRootSet = new Set<string>();
+      }
+      const missingInMsg = [...localRootSet].filter(
+        r => !msgSet.has(r) && !generatedCatalogRootSet.has(r),
+      );
       if (extraInMsg.length > 0 || missingInMsg.length > 0) {
         this.log.warn(ctx, `Finalization: root entity set mismatch — extra in msg: [${extraInMsg.join(', ')}], missing: [${missingInMsg.join(', ')}]`);
       }

--- a/packages/agent/src/finalization-handler.ts
+++ b/packages/agent/src/finalization-handler.ts
@@ -49,6 +49,28 @@ export type ResolveContextGraphOnChainId = (
 
 export type MarkContextGraphMetaDirtyFromQuads = (quads: readonly Quad[]) => void;
 
+function stripOptionalLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      const lastQuote = value.lastIndexOf('"');
+      return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
+    }
+  }
+  return value;
+}
+
+function sameBigIntLiteral(left: string | bigint | null | undefined, right: string | bigint | null | undefined): boolean {
+  if (left === undefined || left === null || right === undefined || right === null) return false;
+  try {
+    return BigInt(left) === BigInt(right);
+  } catch {
+    return false;
+  }
+}
+
 export class FinalizationHandler {
   private readonly store: TripleStore;
   private readonly chain: ChainAdapter | undefined;
@@ -195,7 +217,7 @@ export class FinalizationHandler {
 
       if (sharedMemoryQuads.length > 0) {
         const privateRoots = await this.getPrivateRootsFromMeta(contextGraphId, msg.rootEntities, subGraphName);
-        const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(ctxGraphId);
+        const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, ctxGraphId);
         const merkleMatchedQuads = this.sharedMemoryQuadsMatchingMerkle(
           contextGraphId,
           sharedMemoryQuads,
@@ -413,10 +435,64 @@ export class FinalizationHandler {
     return null;
   }
 
-  private async allowsGeneratedCatalogFloor(onChainCgId: string | bigint | undefined): Promise<boolean> {
+  private async storedOnChainContextGraphId(contextGraphId: string): Promise<string | undefined> {
+    const ontologyGraph = contextGraphDataUri('ontology');
+    const contextGraphUri = contextGraphDataUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?id WHERE { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <https://dkg.network/ontology#ContextGraphOnChainId> ?id } } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+    return stripOptionalLiteral(result.bindings[0]?.['id'])?.trim();
+  }
+
+  private async onChainContextGraphMatchesLocalId(
+    contextGraphId: string,
+    onChainCgId: string | bigint | undefined,
+  ): Promise<boolean> {
+    if (onChainCgId === undefined || onChainCgId === null) return false;
+    const normalizedOnChainId = String(onChainCgId).trim();
+    const normalizedContextGraphId = contextGraphId.trim();
+
+    if (/^\d+$/.test(normalizedContextGraphId) && normalizedContextGraphId === normalizedOnChainId) return true;
+
+    const liveNameHashMatches = async (): Promise<boolean> => {
+      if (typeof this.chain?.getContextGraphNameHash !== 'function') return false;
+      try {
+        const nameHash = await this.chain.getContextGraphNameHash(BigInt(normalizedOnChainId));
+        return typeof nameHash === 'string' &&
+          nameHash.toLowerCase() === ethers.keccak256(ethers.toUtf8Bytes(normalizedContextGraphId)).toLowerCase();
+      } catch {
+        return false;
+      }
+    };
+
+    let resolvedOnChainId: string | null | undefined;
+    try {
+      resolvedOnChainId = await this.resolveContextGraphOnChainId?.(contextGraphId);
+    } catch {
+      resolvedOnChainId = undefined;
+    }
+    if (sameBigIntLiteral(resolvedOnChainId, normalizedOnChainId)) {
+      return typeof this.chain?.getContextGraphNameHash === 'function'
+        ? liveNameHashMatches()
+        : true;
+    }
+
+    const storedOnChainId = await this.storedOnChainContextGraphId(contextGraphId);
+    if (sameBigIntLiteral(storedOnChainId, normalizedOnChainId)) {
+      return typeof this.chain?.getContextGraphNameHash === 'function'
+        ? liveNameHashMatches()
+        : true;
+    }
+
+    return liveNameHashMatches();
+  }
+
+  private async allowsGeneratedCatalogFloor(contextGraphId: string, onChainCgId: string | bigint | undefined): Promise<boolean> {
     if (onChainCgId === undefined || onChainCgId === null) return false;
     if (!this.chain || this.chain.chainId === 'none') return false;
     if (typeof this.chain.getContextGraphAccessPolicy !== 'function') return false;
+    if (!await this.onChainContextGraphMatchesLocalId(contextGraphId, onChainCgId)) return false;
     try {
       return Number(await this.chain.getContextGraphAccessPolicy(BigInt(onChainCgId))) === 1;
     } catch {
@@ -830,7 +906,7 @@ export class FinalizationHandler {
     subGraphName?: string,
     onChainCgId?: string,
   ): Promise<{ rootEntities: string[]; sharedMemoryQuads: Quad[]; subGraphName?: string } | null> {
-    const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(onChainCgId);
+    const allowGeneratedCatalogFloor = await this.allowsGeneratedCatalogFloor(contextGraphId, onChainCgId);
     // Caller knows the exact namespace → search only that one.
     if (subGraphName) {
       const hit = await this.findSwmSnapshotInNamespace(

--- a/packages/agent/test/combined-catalog-baseline.e2e.test.ts
+++ b/packages/agent/test/combined-catalog-baseline.e2e.test.ts
@@ -120,5 +120,18 @@ describe('baseline — curated CG product-path publish (pre-catalog)', () => {
     const secondRoots = secondPub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
     expect(secondRoots).toEqual(['urn:acme:shipment/SH-43']);
     expect(secondRoots).not.toContain(cgUal);
+
+    const postSecondCatalog: any = await (publisher as any).store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${catalogGraph}> { <${cgUal}> ?p ?o } }`,
+    );
+    expect(postSecondCatalog.type).toBe('bindings');
+    const postSecondTriples = postSecondCatalog.bindings.map((b: any) => ({ p: b.p, o: b.o }));
+    expect(postSecondTriples.filter((t: any) => t.p === 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type').map((t: any) => t.o))
+      .toEqual(expect.arrayContaining([
+        'http://www.w3.org/ns/dcat#Dataset',
+        'https://dkg.network/ontology#PrivateContextGraph',
+      ]));
+    expect(postSecondTriples.find((t: any) => t.p === 'http://purl.org/dc/terms/accessRights')?.o)
+      .toBe('http://publications.europa.eu/resource/authority/access-right/RESTRICTED');
   });
 });

--- a/packages/agent/test/combined-catalog-baseline.e2e.test.ts
+++ b/packages/agent/test/combined-catalog-baseline.e2e.test.ts
@@ -6,9 +6,9 @@
  * pre-staked genesis core nodes for the ACK quorum (lowered to 1), so the
  * curated `nodeExists` signer check passes.
  *
- * Baseline invariant: a private CG publishing N data entities yields a KC of
- * exactly N KAs. After the catalog injection lands, the SAME publish yields
- * N+1 KAs (the extra one being the public DCAT catalog KA, subject == CG UAL).
+ * Baseline invariant: a private CG publishing N data entities yields a manifest
+ * with exactly N data roots. The public DCAT catalog floor is still committed in
+ * the KC Merkle root and served from `_catalog`, but it is not a user KA root.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync } from 'node:fs';
@@ -75,20 +75,20 @@ describe('baseline — curated CG product-path publish (pre-catalog)', () => {
     ]);
     // Explicit finalize = the daemon product path (POST /vm/publish does
     // assertion.finalize then publishFromFinalizedAssertion). The catalog
-    // injection lives in assertionFinalize; promote then carries the sealed
-    // content (incl. the catalog KA) to SWM for reload.
+    // injection lives in assertionFinalize and is re-injected as generated
+    // catalog material at publish time, without becoming a manifest root.
     await publisher.assertion.finalize(CG, name);
     await publisher.assertion.promote(CG, name);
 
     const pub: any = await publisher.publishFromFinalizedAssertion(CG, name);
 
     expect(pub.status).toBe('confirmed');
-    // combined model: the private publish now carries the data KA AND
-    // the public DCAT catalog KA (subject = the CG's own UAL), committed in the
-    // CG's own merkle root.
-    expect(pub.kaManifest.length).toBe(2);
+    // combined model: the private publish carries only data roots in the KA
+    // manifest. The generated catalog floor is committed in the CG's Merkle root
+    // and public _catalog graph, but not sealed as a Rule-4-colliding root.
+    expect(pub.kaManifest.length).toBe(1);
     const roots = pub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
-    expect(roots.some((r: string) => r.includes(CG))).toBe(true); // the catalog KA, keyed on the CG UAL
+    expect(roots).toEqual(['urn:acme:shipment/SH-42']);
 
     // The catalog entry persists PLAINTEXT in the public _catalog graph — a
     // queryable, standards-compliant DCAT dataset record (NOT encrypted, unlike
@@ -105,5 +105,20 @@ describe('baseline — curated CG product-path publish (pre-catalog)', () => {
     expect(types).toContain('https://dkg.network/ontology#PrivateContextGraph'); // dual-typed
     const accessRights = triples.find((t: any) => t.p === 'http://purl.org/dc/terms/accessRights');
     expect(accessRights?.o).toBe('http://publications.europa.eu/resource/authority/access-right/RESTRICTED');
+
+    const secondName = 'shipment-2';
+    await publisher.assertion.create(CG, secondName);
+    await publisher.assertion.write(CG, secondName, [
+      { subject: 'urn:acme:shipment/SH-43', predicate: 'urn:acme:product', object: '"P-10"' },
+    ]);
+    await publisher.assertion.finalize(CG, secondName);
+    await publisher.assertion.promote(CG, secondName);
+
+    const secondPub: any = await publisher.publishFromFinalizedAssertion(CG, secondName);
+    expect(secondPub.status).toBe('confirmed');
+    expect(secondPub.kaManifest.length).toBe(1);
+    const secondRoots = secondPub.kaManifest.map((m: any) => String(m.rootEntity ?? m.entity ?? m.subject ?? ''));
+    expect(secondRoots).toEqual(['urn:acme:shipment/SH-43']);
+    expect(secondRoots).not.toContain(cgUal);
   });
 });

--- a/packages/agent/test/e2e-memory-layers.test.ts
+++ b/packages/agent/test/e2e-memory-layers.test.ts
@@ -553,6 +553,45 @@ describe('#1116 seal decoupled from CG — full vs skipSeal share, seal-in-SWM',
     expect(pub.seal).toBeDefined();
   }, 30_000);
 
+  it('strips the generated private-CG catalog floor on pre-registration product-path promote', async () => {
+    const agent = await createAgent('PrivateCgCatalogPromoteBot');
+    const cg = `${CG_ID}-private-local`;
+    const callerAgentAddress = agent.defaultAgentAddress ?? agent.peerId;
+    await agent.createContextGraph({
+      id: cg,
+      name: 'Private Local CG Catalog Promote E2E',
+      accessPolicy: 1,
+      callerAgentAddress,
+    });
+    expect(await agent.getContextGraphOnChainId(cg)).toBeNull();
+
+    const name = 'private-local-catalog-promote';
+    await agent.assertion.create(cg, name);
+    await agent.assertion.write(cg, name, [
+      { subject: `${ENTITY_BASE}:plcp`, predicate: 'http://schema.org/name', object: '"Private Local Catalog Promote"' },
+    ]);
+    await agent.assertion.finalize(cg, name);
+
+    const promoted = await agent.assertion.promote(cg, name);
+    expect(promoted.sealed).toBe(true);
+    expect(promoted.publishReady).toBe(true);
+
+    const cgDid = `did:dkg:context-graph:${cg}`;
+    const swmGraph = `${cgDid}/_shared_memory`;
+    const swmMetaGraph = `${cgDid}/_shared_memory_meta`;
+    const swmCatalog = await (agent as any).store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${swmGraph}> { <${cgDid}> ?p ?o } }`,
+    );
+    expect(swmCatalog.type).toBe('bindings');
+    expect(swmCatalog.bindings).toHaveLength(0);
+
+    const swmCatalogOwner = await (agent as any).store.query(
+      `SELECT ?owner WHERE { GRAPH <${swmMetaGraph}> { <${cgDid}> <http://dkg.io/ontology/workspaceOwner> ?owner } }`,
+    );
+    expect(swmCatalogOwner.type).toBe('bindings');
+    expect(swmCatalogOwner.bindings).toHaveLength(0);
+  }, 30_000);
+
   // B3 (#1116 CORE REGRESSION GUARD): the seal is context-graph-INDEPENDENT, so
   // a default FULL share SEALS even when the CG was NEVER registered on-chain —
   // registration is deferred to publish time. This is the claim the existing

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -12,6 +12,7 @@ import {
   generatedPrivateCatalogFloorQuads,
 } from '@origintrail-official/dkg-publisher';
 import { FinalizationHandler } from '../src/finalization-handler.js';
+import { ethers } from 'ethers';
 
 const CONTEXT_GRAPH = 'test-contextGraph';
 
@@ -393,11 +394,16 @@ describe('FinalizationHandler.handleChainReconciledKC (Phase B)', () => {
   }
 
   /** Minimal chain whose getKAContextGraphId binds the KA to the given CG. */
-  function makeBindingChain(boundCg: bigint, accessPolicy = 1): ChainAdapter {
+  function makeBindingChain(
+    boundCg: bigint,
+    accessPolicy = 1,
+    nameHash: string | null = ethers.keccak256(ethers.toUtf8Bytes(CONTEXT_GRAPH)),
+  ): ChainAdapter {
     return {
       chainId: 'evm:31337',
       getKAContextGraphId: async (_kaId: bigint) => boundCg,
       getContextGraphAccessPolicy: async (_contextGraphId: bigint) => accessPolicy,
+      getContextGraphNameHash: async (_contextGraphId: bigint) => nameHash,
     } as unknown as ChainAdapter;
   }
 
@@ -469,6 +475,23 @@ describe('FinalizationHandler.handleChainReconciledKC (Phase B)', () => {
       [],
     );
     const handler = new FinalizationHandler(store, makeBindingChain(42n, 0));
+
+    const outcome = await handler.handleChainReconciledKC(input(merkleRoot), createOperationContext('system'));
+    expect(outcome).toBe('no-swm');
+  });
+
+  it('does not regenerate the private-CG catalog floor when live name hash does not match the local CG', async () => {
+    const store = new OxigraphStore();
+    await seedSwmSnapshot(store);
+    const merkleRoot = computeFlatKCRootV10(
+      [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Reconciled"', graph: '' },
+        ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+      ],
+      [],
+    );
+    const staleNameHash = `0x${'11'.repeat(32)}`;
+    const handler = new FinalizationHandler(store, makeBindingChain(42n, 1, staleNameHash));
 
     const outcome = await handler.handleChainReconciledKC(input(merkleRoot), createOperationContext('system'));
     expect(outcome).toBe('no-swm');

--- a/packages/agent/test/finalization-handler.test.ts
+++ b/packages/agent/test/finalization-handler.test.ts
@@ -7,7 +7,10 @@ import {
   DKG_ROOT_ENTITY_LEGACY,
 } from '@origintrail-official/dkg-core';
 import type { ChainAdapter } from '@origintrail-official/dkg-chain';
-import { computeFlatKCRootV10 } from '@origintrail-official/dkg-publisher';
+import {
+  computeFlatKCRootV10,
+  generatedPrivateCatalogFloorQuads,
+} from '@origintrail-official/dkg-publisher';
 import { FinalizationHandler } from '../src/finalization-handler.js';
 
 const CONTEXT_GRAPH = 'test-contextGraph';
@@ -390,10 +393,11 @@ describe('FinalizationHandler.handleChainReconciledKC (Phase B)', () => {
   }
 
   /** Minimal chain whose getKAContextGraphId binds the KA to the given CG. */
-  function makeBindingChain(boundCg: bigint): ChainAdapter {
+  function makeBindingChain(boundCg: bigint, accessPolicy = 1): ChainAdapter {
     return {
       chainId: 'evm:31337',
       getKAContextGraphId: async (_kaId: bigint) => boundCg,
+      getContextGraphAccessPolicy: async (_contextGraphId: bigint) => accessPolicy,
     } as unknown as ChainAdapter;
   }
 
@@ -422,6 +426,52 @@ describe('FinalizationHandler.handleChainReconciledKC (Phase B)', () => {
       `ASK { GRAPH <${perCgGraph}> { <${ENTITY}> <http://schema.org/name> "Reconciled" } }`,
     );
     expect(promoted.type === 'boolean' && promoted.value).toBe(true);
+  });
+
+  it('chain-reconcile regenerates generated private-CG catalog floor for merkle match without adding it as a root', async () => {
+    const store = new OxigraphStore();
+    await seedSwmSnapshot(store);
+    const catalogFloor = generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH);
+    const merkleRoot = computeFlatKCRootV10(
+      [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Reconciled"', graph: '' },
+        ...catalogFloor,
+      ],
+      [],
+    );
+    const handler = new FinalizationHandler(store, makeBindingChain(42n));
+
+    const outcome = await handler.handleChainReconciledKC(input(merkleRoot), createOperationContext('system'));
+    expect(outcome).toBe('promoted');
+
+    const perCgGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/context/${ON_CHAIN_CG}`;
+    const cgDid = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+    const catalogPromoted = await store.query(
+      `ASK { GRAPH <${perCgGraph}> { <${cgDid}> <http://purl.org/dc/terms/accessRights> <http://publications.europa.eu/resource/authority/access-right/RESTRICTED> } }`,
+    );
+    expect(catalogPromoted.type === 'boolean' && catalogPromoted.value).toBe(true);
+
+    const metaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/context/${ON_CHAIN_CG}/_meta`;
+    const catalogManifestRoot = await store.query(
+      `ASK { GRAPH <${metaGraph}> { ?s <http://dkg.io/ontology/rootEntity> <${cgDid}> } }`,
+    );
+    expect(catalogManifestRoot.type === 'boolean' && catalogManifestRoot.value).toBe(false);
+  });
+
+  it('does not regenerate the private-CG catalog floor for public on-chain access policy', async () => {
+    const store = new OxigraphStore();
+    await seedSwmSnapshot(store);
+    const merkleRoot = computeFlatKCRootV10(
+      [
+        { subject: ENTITY, predicate: 'http://schema.org/name', object: '"Reconciled"', graph: '' },
+        ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+      ],
+      [],
+    );
+    const handler = new FinalizationHandler(store, makeBindingChain(42n, 0));
+
+    const outcome = await handler.handleChainReconciledKC(input(merkleRoot), createOperationContext('system'));
+    expect(outcome).toBe('no-swm');
   });
 
   it('mirrors the keep-root dual-write when the publisher persisted keepRootCopyOnLabel=true', async () => {

--- a/packages/publisher/src/canonical-publish-payload.ts
+++ b/packages/publisher/src/canonical-publish-payload.ts
@@ -6,6 +6,10 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
 import { skolemizeByEntity } from './auto-partition.js';
 import { computeFlatKCRootV10, computePrivateRootV10 } from './merkle.js';
+import {
+  splitTrustedGeneratedCatalogRootMap,
+  type TrustedCatalogTripleKeys,
+} from './catalog-trust.js';
 
 export interface CanonicalManifestEntry {
   readonly rootEntity: string;
@@ -19,16 +23,49 @@ export interface CanonicalPublishPayload {
   readonly privateRoots: Uint8Array[];
   readonly kcMerkleRoot: Uint8Array;
   readonly manifestEntries: ReadonlyArray<CanonicalManifestEntry>;
+  readonly generatedCatalogRootEntities: ReadonlyArray<string>;
+}
+
+export interface CanonicalPublishPayloadOptions {
+  /**
+   * Exact generated public-catalog triples that must ride in the KC Merkle root
+   * but must not become user KA manifest roots. This is intentionally an exact
+   * subject/predicate/object allow-list, not a prefix or predicate bypass.
+   */
+  readonly trustedNonManifestCatalogTriples?: TrustedCatalogTripleKeys;
 }
 
 export function canonicalPublishPayload(
   quads: Quad[],
   privateQuads: Quad[] = [],
+  options?: CanonicalPublishPayloadOptions,
 ): CanonicalPublishPayload {
   const kaMap = skolemizeByEntity(quads);
+  const {
+    contentRootMap,
+    generatedCatalogRootEntities,
+  } = splitTrustedGeneratedCatalogRootMap(
+    kaMap,
+    options?.trustedNonManifestCatalogTriples,
+  );
+  const generatedCatalogRootSet = new Set(generatedCatalogRootEntities);
 
   const manifestEntries: CanonicalManifestEntry[] = [];
-  for (const [rootEntity, publicForRoot] of kaMap) {
+  for (const rootEntity of generatedCatalogRootSet) {
+    const hiddenPrivateQuads = privateQuads.filter(
+      (qq) =>
+        qq.subject === rootEntity ||
+        qq.subject.startsWith(rootEntity + '/.well-known/genid/'),
+    );
+    if (hiddenPrivateQuads.length > 0) {
+      throw new Error(
+        `Generated catalog subject "${rootEntity}" has private triples; ` +
+        'refusing to exclude it from the KA manifest',
+      );
+    }
+  }
+
+  for (const [rootEntity, publicForRoot] of contentRootMap) {
     const entityPrivateQuads = privateQuads.filter(
       (qq) =>
         qq.subject === rootEntity ||
@@ -55,5 +92,6 @@ export function canonicalPublishPayload(
     privateRoots,
     kcMerkleRoot,
     manifestEntries,
+    generatedCatalogRootEntities,
   };
 }

--- a/packages/publisher/src/catalog-trust.ts
+++ b/packages/publisher/src/catalog-trust.ts
@@ -1,0 +1,110 @@
+import { DKG_ONTOLOGY, contextGraphDataUri } from '@origintrail-official/dkg-core';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+export type TrustedCatalogTripleKeys = ReadonlySet<string> | readonly string[] | undefined;
+
+const FIELD_SEPARATOR = '\u0000';
+
+function literal(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function catalogTripleKey(q: Pick<Quad, 'subject' | 'predicate' | 'object'>): string {
+  return `${q.subject}${FIELD_SEPARATOR}${q.predicate}${FIELD_SEPARATOR}${q.object}`;
+}
+
+export function trustedCatalogTripleKeySet(keys: TrustedCatalogTripleKeys): ReadonlySet<string> {
+  if (!keys) return new Set<string>();
+  if (keys instanceof Set) return keys;
+  return new Set(keys);
+}
+
+export function generatedPrivateCatalogFloorQuads(
+  contextGraphId: string,
+  graph = '',
+): Quad[] {
+  const cgDid = contextGraphDataUri(contextGraphId);
+  return [
+    {
+      subject: cgDid,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DCAT_DATASET,
+      graph,
+    },
+    {
+      subject: cgDid,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_PRIVATE_CONTEXT_GRAPH,
+      graph,
+    },
+    {
+      subject: cgDid,
+      predicate: DKG_ONTOLOGY.DCT_IDENTIFIER,
+      object: literal(cgDid),
+      graph,
+    },
+    {
+      subject: cgDid,
+      predicate: DKG_ONTOLOGY.DCT_ACCESS_RIGHTS,
+      object: DKG_ONTOLOGY.ACCESS_RIGHT_RESTRICTED,
+      graph,
+    },
+  ];
+}
+
+export function generatedPrivateCatalogTripleKeys(contextGraphId: string): ReadonlySet<string> {
+  return new Set(generatedPrivateCatalogFloorQuads(contextGraphId).map(catalogTripleKey));
+}
+
+export function assertTrustedCatalogTriplesAreGeneratedFloor(
+  contextGraphId: string,
+  keysInput: TrustedCatalogTripleKeys,
+): void {
+  const keys = trustedCatalogTripleKeySet(keysInput);
+  if (keys.size === 0) return;
+
+  const generated = generatedPrivateCatalogTripleKeys(contextGraphId);
+  const invalid = [...keys].filter((key) => !generated.has(key));
+  if (invalid.length > 0 || keys.size !== generated.size) {
+    throw new Error(
+      `trustedNonManifestCatalogTriples for context graph "${contextGraphId}" ` +
+      'must exactly match the deterministic generated private-CG catalog floor triples',
+    );
+  }
+}
+
+export interface TrustedCatalogRootSplit {
+  readonly contentRootMap: Map<string, Quad[]>;
+  readonly generatedCatalogRootEntities: string[];
+}
+
+export function splitTrustedGeneratedCatalogRootMap(
+  kaMap: ReadonlyMap<string, Quad[]>,
+  trustedKeysInput: TrustedCatalogTripleKeys,
+): TrustedCatalogRootSplit {
+  const trustedKeys = trustedCatalogTripleKeySet(trustedKeysInput);
+  const contentRootMap = new Map<string, Quad[]>();
+  const generatedCatalogRootEntities: string[] = [];
+
+  for (const [rootEntity, publicForRoot] of kaMap) {
+    const trustedCount = publicForRoot.filter((q) => trustedKeys.has(catalogTripleKey(q))).length;
+    if (trustedCount === 0) {
+      contentRootMap.set(rootEntity, publicForRoot);
+      continue;
+    }
+    const publicKeys = new Set(publicForRoot.map(catalogTripleKey));
+    const isCompleteTrustedFloor =
+      publicKeys.size === trustedKeys.size &&
+      [...publicKeys].every((key) => trustedKeys.has(key));
+    if (trustedCount === publicForRoot.length && isCompleteTrustedFloor) {
+      generatedCatalogRootEntities.push(rootEntity);
+      continue;
+    }
+    throw new Error(
+      `Generated catalog subject "${rootEntity}" mixes trusted catalog triples ` +
+      'with non-catalog triples; refusing to hide it from the KA manifest',
+    );
+  }
+
+  return { contentRootMap, generatedCatalogRootEntities };
+}

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
@@ -319,9 +319,11 @@ export type WriteConditionalToWorkspaceOptions = ConditionalShareOptions;
 // public entry points at all (the daemon's direct `store.insert`
 // bypass, which is the other legitimate non-guard path).
 const INTERNAL_ORIGIN_TOKEN = Symbol('dkg-publisher:internal-origin');
+const TRUSTED_CATALOG_ORIGIN_TOKEN = Symbol('dkg-publisher:trusted-catalog-origin');
 
 type InternalPublishOptions = PublishOptions & {
   [INTERNAL_ORIGIN_TOKEN]?: true;
+  [TRUSTED_CATALOG_ORIGIN_TOKEN]?: true;
 };
 
 interface PublisherSigner {
@@ -344,6 +346,32 @@ interface PublisherSigner {
 
 function isInternalOrigin(options: PublishOptions): boolean {
   return (options as InternalPublishOptions)[INTERNAL_ORIGIN_TOKEN] === true;
+}
+
+function isTrustedCatalogInternalOrigin(options: PublishOptions): boolean {
+  return (options as InternalPublishOptions)[TRUSTED_CATALOG_ORIGIN_TOKEN] === true;
+}
+
+function stripOptionalLiteral(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      const lastQuote = value.lastIndexOf('"');
+      return value.slice(1, lastQuote > 0 ? lastQuote : undefined);
+    }
+  }
+  return value;
+}
+
+function sameBigIntLiteral(left: string | bigint | undefined, right: string | bigint | undefined): boolean {
+  if (left === undefined || right === undefined) return false;
+  try {
+    return BigInt(left) === BigInt(right);
+  } catch {
+    return false;
+  }
 }
 
 // Round 14 Bug 41: case-insensitive check against `RESERVED_SUBJECT_PREFIXES`.
@@ -538,6 +566,169 @@ export class DKGPublisher implements Publisher {
 
   setWorkspaceSenderKeyEncryptor(encryptor: WorkspaceSenderKeyEncryptor | undefined): void {
     this.workspaceSenderKeyEncryptor = encryptor;
+  }
+
+  private async storedOnChainContextGraphId(contextGraphId: string): Promise<string | undefined> {
+    const ontologyGraph = contextGraphDataUri('ontology');
+    const contextGraphUri = contextGraphDataUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?id WHERE { GRAPH <${ontologyGraph}> { <${contextGraphUri}> <https://dkg.network/ontology#ContextGraphOnChainId> ?id } } LIMIT 1`,
+    );
+    if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+    return stripOptionalLiteral(result.bindings[0]?.['id'])?.trim();
+  }
+
+  private async onChainContextGraphMatchesLocalId(
+    contextGraphId: string,
+    onChainContextGraphId: bigint | string | undefined,
+  ): Promise<boolean> {
+    if (onChainContextGraphId === undefined || onChainContextGraphId === null) return false;
+    const normalizedOnChainId = String(onChainContextGraphId).trim();
+    const normalizedContextGraphId = contextGraphId.trim();
+
+    if (/^\d+$/.test(normalizedContextGraphId) && normalizedContextGraphId === normalizedOnChainId) return true;
+
+    const liveNameHashMatches = async (): Promise<boolean> => {
+      if (typeof this.chain?.getContextGraphNameHash !== 'function') return false;
+      try {
+        const nameHash = await this.chain.getContextGraphNameHash(BigInt(normalizedOnChainId));
+        return typeof nameHash === 'string' &&
+          nameHash.toLowerCase() === ethers.keccak256(ethers.toUtf8Bytes(normalizedContextGraphId)).toLowerCase();
+      } catch {
+        return false;
+      }
+    };
+
+    const storedOnChainId = await this.storedOnChainContextGraphId(contextGraphId);
+    if (sameBigIntLiteral(storedOnChainId, normalizedOnChainId)) {
+      return typeof this.chain?.getContextGraphNameHash === 'function'
+        ? liveNameHashMatches()
+        : true;
+    }
+
+    return liveNameHashMatches();
+  }
+
+  private async onChainContextGraphIsPrivate(
+    contextGraphId: string,
+    onChainContextGraphId: bigint | string | undefined,
+  ): Promise<boolean> {
+    if (onChainContextGraphId === undefined || onChainContextGraphId === null) return false;
+    if (!this.chain || this.chain.chainId === 'none') return false;
+    if (typeof this.chain.getContextGraphAccessPolicy !== 'function') return false;
+    if (!await this.onChainContextGraphMatchesLocalId(contextGraphId, onChainContextGraphId)) return false;
+    try {
+      return Number(await this.chain.getContextGraphAccessPolicy(BigInt(onChainContextGraphId))) === 1;
+    } catch {
+      return false;
+    }
+  }
+
+  private async localContextGraphHasPrivateAccessSignal(contextGraphId: string): Promise<boolean> {
+    if ((Object.values(SYSTEM_CONTEXT_GRAPHS) as string[]).includes(contextGraphId)) return false;
+
+    const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+    const agentsGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.AGENTS);
+    const cgMeta = contextGraphMetaUri(contextGraphId);
+    const cgData = contextGraphDataUri(contextGraphId);
+    const result = await this.store.query(
+      `SELECT ?policy ?gate WHERE {
+        {
+          GRAPH <${ontologyGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        } UNION {
+          GRAPH <${cgMeta}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ACCESS_POLICY}> ?policy
+          }
+        } UNION {
+          GRAPH <${ontologyGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?gate
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?gate
+          }
+        } UNION {
+          GRAPH <${cgMeta}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_AGENT}> ?gate
+          }
+        } UNION {
+          GRAPH <${ontologyGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?gate
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?gate
+          }
+        } UNION {
+          GRAPH <${cgMeta}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_PARTICIPANT_AGENT}> ?gate
+          }
+        } UNION {
+          GRAPH <${ontologyGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?gate
+          }
+        } UNION {
+          GRAPH <${agentsGraph}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?gate
+          }
+        } UNION {
+          GRAPH <${cgMeta}> {
+            <${cgData}> <${DKG_ONTOLOGY.DKG_ALLOWED_PEER}> ?gate
+          }
+        }
+      }`,
+    );
+    if (result.type !== 'bindings') return false;
+    let hasPrivatePolicy = false;
+    let hasGate = false;
+    for (const row of result.bindings) {
+      const policy = stripOptionalLiteral(row['policy'])?.trim().toLowerCase();
+      if (policy === 'public') return false;
+      if (policy === 'private') hasPrivatePolicy = true;
+      if (stripOptionalLiteral(row['gate'])?.trim()) hasGate = true;
+    }
+    return hasPrivatePolicy || hasGate;
+  }
+
+  private async assertTrustedCatalogTriplesAllowed(params: {
+    contextGraphId: string;
+    trustedNonManifestCatalogTriples: PublishOptions['trustedNonManifestCatalogTriples'];
+    onChainContextGraphId?: bigint | string;
+    internalCatalogOrigin?: boolean;
+    allowLocalPrivateContextGraph?: boolean;
+  }): Promise<void> {
+    const {
+      contextGraphId,
+      trustedNonManifestCatalogTriples,
+      onChainContextGraphId,
+      internalCatalogOrigin = false,
+      allowLocalPrivateContextGraph = false,
+    } = params;
+    assertTrustedCatalogTriplesAreGeneratedFloor(
+      contextGraphId,
+      trustedNonManifestCatalogTriples,
+    );
+
+    if (trustedCatalogTripleKeySet(trustedNonManifestCatalogTriples).size === 0) return;
+    if (internalCatalogOrigin) return;
+    const storedOnChainContextGraphId = await this.storedOnChainContextGraphId(contextGraphId);
+    const effectiveOnChainContextGraphId = onChainContextGraphId ?? storedOnChainContextGraphId;
+    if (
+      allowLocalPrivateContextGraph &&
+      effectiveOnChainContextGraphId === undefined &&
+      await this.localContextGraphHasPrivateAccessSignal(contextGraphId)
+    ) return;
+    if (await this.onChainContextGraphIsPrivate(contextGraphId, effectiveOnChainContextGraphId)) return;
+
+    throw new Error(
+      'trustedNonManifestCatalogTriples is only allowed for internal private context graph catalog floor handling',
+    );
   }
 
   private async resolvePublisherAddress(
@@ -1408,6 +1599,15 @@ export class DKGPublisher implements Publisher {
       );
     }
 
+    const hasTrustedCatalogTriples = trustedCatalogTripleKeySet(
+      options?.trustedNonManifestCatalogTriples,
+    ).size > 0;
+    await this.assertTrustedCatalogTriplesAllowed({
+      contextGraphId,
+      trustedNonManifestCatalogTriples: options?.trustedNonManifestCatalogTriples,
+      onChainContextGraphId: chainCgId,
+    });
+
     this.log.info(ctx, `Publishing ${quads.length} quads from shared memory to ${ctxGraphId ? `context graph ${ctxGraphId}` : 'data graph'}${chainCgId && !ctxGraphId ? ` (on-chain CG ${chainCgId})` : ''}${options?.subGraphName ? ` (sub-graph: ${options.subGraphName})` : ''}`);
     const internalPublishOptions: InternalPublishOptions = {
       contextGraphId,
@@ -1427,6 +1627,7 @@ export class DKGPublisher implements Publisher {
       // OT-RFC-43 A2 — reuse the finalize-stamped kaId (no re-allocate).
       reservedKaId: options?.reservedKaId,
       [INTERNAL_ORIGIN_TOKEN]: true,
+      ...(hasTrustedCatalogTriples ? { [TRUSTED_CATALOG_ORIGIN_TOKEN]: true } : {}),
     };
     let publishResult: PublishResult;
     try {
@@ -1874,10 +2075,12 @@ export class DKGPublisher implements Publisher {
     onPhase?.('prepare:ensureContextGraph', 'end');
 
     onPhase?.('prepare:partition', 'start');
-    assertTrustedCatalogTriplesAreGeneratedFloor(
+    await this.assertTrustedCatalogTriplesAllowed({
       contextGraphId,
-      options.trustedNonManifestCatalogTriples,
-    );
+      trustedNonManifestCatalogTriples: options.trustedNonManifestCatalogTriples,
+      onChainContextGraphId: publisherContextGraphId,
+      internalCatalogOrigin: isTrustedCatalogInternalOrigin(options),
+    });
     const canonical = canonicalPublishPayload(quads, privateQuads, {
       trustedNonManifestCatalogTriples: options.trustedNonManifestCatalogTriples,
     });
@@ -3307,10 +3510,12 @@ export class DKGPublisher implements Publisher {
 
     onPhase?.('prepare', 'start');
     onPhase?.('prepare:partition', 'start');
-    assertTrustedCatalogTriplesAreGeneratedFloor(
+    await this.assertTrustedCatalogTriplesAllowed({
       contextGraphId,
-      options.trustedNonManifestCatalogTriples,
-    );
+      trustedNonManifestCatalogTriples: options.trustedNonManifestCatalogTriples,
+      onChainContextGraphId: publisherContextGraphId,
+      internalCatalogOrigin: isTrustedCatalogInternalOrigin(options),
+    });
     const kaMap = skolemizeByEntity(quads);
     const {
       contentRootMap,
@@ -5359,6 +5564,7 @@ export class DKGPublisher implements Publisher {
       publisherPeerId?: string;
       senderAgentAddress?: string;
       trustedNonManifestCatalogTriples?: PublishOptions['trustedNonManifestCatalogTriples'];
+      onChainContextGraphId?: string | bigint;
       /**
        * Strict curator-ack gate (OT-RFC-49 curator-leader), same contract as
        * `ShareOptions.confirmBeforeCommit`: called after the gossip message is
@@ -5489,10 +5695,12 @@ export class DKGPublisher implements Publisher {
       (q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q),
     );
 
-    assertTrustedCatalogTriplesAreGeneratedFloor(
+    await this.assertTrustedCatalogTriplesAllowed({
       contextGraphId,
-      opts?.trustedNonManifestCatalogTriples,
-    );
+      trustedNonManifestCatalogTriples: opts?.trustedNonManifestCatalogTriples,
+      onChainContextGraphId: opts?.onChainContextGraphId,
+      allowLocalPrivateContextGraph: true,
+    });
     const trustedGeneratedCatalogTriples = trustedCatalogTripleKeySet(
       opts?.trustedNonManifestCatalogTriples,
     );

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -7,6 +7,12 @@ import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-sto
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
+import {
+  assertTrustedCatalogTriplesAreGeneratedFloor,
+  catalogTripleKey,
+  splitTrustedGeneratedCatalogRootMap,
+  trustedCatalogTripleKeySet,
+} from './catalog-trust.js';
 import { partitionCatalogQuads, catalogCommittedLeaves, computeCatalogRoot, contextGraphCatalogUri, isAgentRegistryContextGraph } from '@origintrail-official/dkg-core';
 import { RESERVED_SUBJECT_PREFIXES, findReservedSubjectPrefix, isReservedSubject } from './reserved-subjects.js';
 import { skolemize } from './skolemize.js';
@@ -1245,6 +1251,7 @@ export class DKGPublisher implements Publisher {
       onChainContextGraphId?: string;
       contextGraphSignatures?: Array<{ identityId: bigint; r: Uint8Array; vs: Uint8Array }>;
       v10ACKProvider?: PublishOptions['v10ACKProvider'];
+      trustedNonManifestCatalogTriples?: PublishOptions['trustedNonManifestCatalogTriples'];
       subGraphName?: string;
       /**
        * Per-call override for the on-chain attribution target — see
@@ -1408,6 +1415,7 @@ export class DKGPublisher implements Publisher {
       operationCtx: ctx,
       onPhase: options?.onPhase,
       v10ACKProvider: options?.v10ACKProvider,
+      trustedNonManifestCatalogTriples: options?.trustedNonManifestCatalogTriples,
       publishContextGraphId: chainCgId ?? undefined,
       fromSharedMemory: true,
       subGraphName: options?.subGraphName,
@@ -1866,7 +1874,13 @@ export class DKGPublisher implements Publisher {
     onPhase?.('prepare:ensureContextGraph', 'end');
 
     onPhase?.('prepare:partition', 'start');
-    const canonical = canonicalPublishPayload(quads, privateQuads);
+    assertTrustedCatalogTriplesAreGeneratedFloor(
+      contextGraphId,
+      options.trustedNonManifestCatalogTriples,
+    );
+    const canonical = canonicalPublishPayload(quads, privateQuads, {
+      trustedNonManifestCatalogTriples: options.trustedNonManifestCatalogTriples,
+    });
     onPhase?.('prepare:partition', 'end');
 
     const manifestEntries: KAManifestEntry[] = [];
@@ -1914,7 +1928,15 @@ export class DKGPublisher implements Publisher {
     onPhase?.('prepare:validate', 'start');
     const publishOwnershipKey = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
     const existing = this.ownedEntities.get(publishOwnershipKey) ?? new Set();
-    const validation = validatePublishRequest(allSkolemizedQuads, manifestEntries, contextGraphId, existing);
+    const validation = validatePublishRequest(
+      allSkolemizedQuads,
+      manifestEntries,
+      contextGraphId,
+      existing,
+      {
+        trustedNonManifestCatalogTriples: options.trustedNonManifestCatalogTriples,
+      },
+    );
     if (!validation.valid) {
       throw new Error(`Validation failed: ${validation.errors.join('; ')}`);
     }
@@ -3285,7 +3307,29 @@ export class DKGPublisher implements Publisher {
 
     onPhase?.('prepare', 'start');
     onPhase?.('prepare:partition', 'start');
+    assertTrustedCatalogTriplesAreGeneratedFloor(
+      contextGraphId,
+      options.trustedNonManifestCatalogTriples,
+    );
     const kaMap = skolemizeByEntity(quads);
+    const {
+      contentRootMap,
+      generatedCatalogRootEntities,
+    } = splitTrustedGeneratedCatalogRootMap(
+      kaMap,
+      options.trustedNonManifestCatalogTriples,
+    );
+    for (const rootEntity of generatedCatalogRootEntities) {
+      const hiddenPrivateQuads = privateQuads.filter(
+        (q) => q.subject === rootEntity || q.subject.startsWith(rootEntity + '/.well-known/genid/'),
+      );
+      if (hiddenPrivateQuads.length > 0) {
+        throw new Error(
+          `Generated catalog subject "${rootEntity}" has private triples; ` +
+          'refusing to exclude it from the KA manifest',
+        );
+      }
+    }
     onPhase?.('prepare:partition', 'end');
 
     onPhase?.('prepare:manifest', 'start');
@@ -3293,7 +3337,7 @@ export class DKGPublisher implements Publisher {
     const entityPrivateMap = new Map<string, Quad[]>();
 
     let tokenCounter = 1n;
-    for (const [rootEntity, publicQuads] of kaMap) {
+    for (const [rootEntity] of contentRootMap) {
       const entityPrivateQuads = privateQuads.filter(
         (q) => q.subject === rootEntity || q.subject.startsWith(rootEntity + '/.well-known/genid/'),
       );
@@ -3380,11 +3424,11 @@ export class DKGPublisher implements Publisher {
       // payload. Purging the union (and not just the new roots) is what
       // closes the leak described above.
       const rootsToPurge = new Set<string>(priorRootEntities);
-      for (const [rootEntity] of kaMap) rootsToPurge.add(rootEntity);
+      for (const [rootEntity] of contentRootMap) rootsToPurge.add(rootEntity);
       for (const rootEntity of rootsToPurge) {
         await this.privateStore.deletePrivateTriples(contextGraphId, rootEntity, options.subGraphName);
       }
-      for (const [rootEntity] of kaMap) {
+      for (const [rootEntity] of contentRootMap) {
         const entityPrivateQuads = entityPrivateMap.get(rootEntity) ?? [];
         if (entityPrivateQuads.length > 0) {
           await this.privateStore.storePrivateTriples(contextGraphId, rootEntity, entityPrivateQuads, options.subGraphName);
@@ -3431,7 +3475,7 @@ export class DKGPublisher implements Publisher {
         metaGraph: labelMeta,
         ual: ualForRestate,
         merkleRoot: kcMerkleRoot,
-        payloadByRoot: kaMap,
+        payloadByRoot: contentRootMap,
         privateRootByRoot: updatePrivateRootByRoot,
         version,
       });
@@ -3930,7 +3974,7 @@ export class DKGPublisher implements Publisher {
           ual,
           kaId,
           merkleRoot: kcMerkleRoot,
-          payloadByRoot: kaMap,
+          payloadByRoot: contentRootMap,
           privateRootByRoot,
           version: updateVersion,
         });
@@ -5314,6 +5358,7 @@ export class DKGPublisher implements Publisher {
       subGraphName?: string;
       publisherPeerId?: string;
       senderAgentAddress?: string;
+      trustedNonManifestCatalogTriples?: PublishOptions['trustedNonManifestCatalogTriples'];
       /**
        * Strict curator-ack gate (OT-RFC-49 curator-leader), same contract as
        * `ShareOptions.confirmBeforeCommit`: called after the gossip message is
@@ -5443,6 +5488,22 @@ export class DKGPublisher implements Publisher {
     quadsToPromote = quadsToPromote.filter(
       (q) => !isReservedSubject(q.subject) && !isTrustLevelQuad(q),
     );
+
+    assertTrustedCatalogTriplesAreGeneratedFloor(
+      contextGraphId,
+      opts?.trustedNonManifestCatalogTriples,
+    );
+    const trustedGeneratedCatalogTriples = trustedCatalogTripleKeySet(
+      opts?.trustedNonManifestCatalogTriples,
+    );
+    const trustedGeneratedCatalogQuads = trustedGeneratedCatalogTriples.size > 0
+      ? quadsToPromote.filter((q) => trustedGeneratedCatalogTriples.has(catalogTripleKey(q)))
+      : [];
+    if (trustedGeneratedCatalogQuads.length > 0) {
+      quadsToPromote = quadsToPromote.filter(
+        (q) => !trustedGeneratedCatalogTriples.has(catalogTripleKey(q)),
+      );
+    }
 
     if (opts?.entities && opts.entities !== 'all') {
       const entitySet = new Set(opts.entities);
@@ -5636,7 +5697,9 @@ export class DKGPublisher implements Publisher {
     const effectivePromoteQuads = skippedRoots.size > 0
       ? quadsToPromote.filter(q => !skippedRoots.has(q.subject) && !skippedRoots.has(q.subject.split('/.well-known/genid/')[0]))
       : quadsToPromote;
-    await this.store.delete(effectivePromoteQuads.map((q) => ({ ...q, graph: graphUri })));
+    await this.store.delete(
+      [...effectivePromoteQuads, ...trustedGeneratedCatalogQuads].map((q) => ({ ...q, graph: graphUri })),
+    );
 
     // Update the assertion's memory layer from WM → SWM in _meta
     const assertionMetaGraph = contextGraphMetaUri(contextGraphId);

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -6,7 +6,18 @@ export {
   canonicalPublishPayload,
   type CanonicalPublishPayload,
   type CanonicalManifestEntry,
+  type CanonicalPublishPayloadOptions,
 } from './canonical-publish-payload.js';
+export {
+  assertTrustedCatalogTriplesAreGeneratedFloor,
+  catalogTripleKey,
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
+  splitTrustedGeneratedCatalogRootMap,
+  trustedCatalogTripleKeySet,
+  type TrustedCatalogTripleKeys,
+  type TrustedCatalogRootSplit,
+} from './catalog-trust.js';
 export { resolveLiftWorkspaceSlice } from './workspace-resolution.js';
 export {
   computeTripleHash,

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -1,6 +1,7 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { OnChainPublishResult } from '@origintrail-official/dkg-chain';
 import type { OperationContext } from '@origintrail-official/dkg-core';
+import type { TrustedCatalogTripleKeys } from './catalog-trust.js';
 
 export const DEFAULT_PUBLISH_EPOCHS = 12;
 /** PublishIntent encodes epochs as uint32; reject larger overrides before wire encoding. */
@@ -201,6 +202,12 @@ export interface PublishOptions {
    * this overrides contextGraphId as the ACK domain and on-chain contextGraphId.
    */
   publishContextGraphId?: string;
+  /**
+   * Internal/private-CG catalog path: exact generated catalog triples that ride
+   * in the KC Merkle root but are not user KA manifest roots. Public callers
+   * should not set this for arbitrary metadata.
+   */
+  trustedNonManifestCatalogTriples?: TrustedCatalogTripleKeys;
   /**
    * When true, the data is already in peers' SWM via shared memory gossip.
    * V10 ACK collection will NOT send inline staging quads — core nodes

--- a/packages/publisher/src/validation.ts
+++ b/packages/publisher/src/validation.ts
@@ -1,6 +1,11 @@
 import type { Quad } from '@origintrail-official/dkg-storage';
 import type { KAManifestEntry } from './publisher.js';
 import { isBlankNode, isSkolemizedUri, rootEntityFromSkolemized } from './skolemize.js';
+import {
+  catalogTripleKey,
+  trustedCatalogTripleKeySet,
+  type TrustedCatalogTripleKeys,
+} from './catalog-trust.js';
 
 export interface ValidationResult {
   valid: boolean;
@@ -14,6 +19,11 @@ export interface ValidationOptions {
   upsertableEntities?: Set<string>;
   /** Override the expected named graph URI for Rule 1 (default: `did:dkg:context-graph:{contextGraphId}`). */
   expectedGraph?: string;
+  /**
+   * Exact generated public-catalog triples allowed to be present in nquads
+   * without a manifest root. This is not a generic metadata bypass.
+   */
+  trustedNonManifestCatalogTriples?: TrustedCatalogTripleKeys;
 }
 
 /**
@@ -29,6 +39,9 @@ export function validatePublishRequest(
   const errors: string[] = [];
   const contextGraph = options?.expectedGraph ?? `did:dkg:context-graph:${contextGraphId}`;
   const rootEntities = new Set(manifest.map((m) => m.rootEntity));
+  const trustedCatalogTriples = trustedCatalogTripleKeySet(
+    options?.trustedNonManifestCatalogTriples,
+  );
 
   // Rule 1: Every quad's named graph MUST be the target context graph URI
   // (or the sub-graph URI when expectedGraph is overridden).
@@ -43,6 +56,7 @@ export function validatePublishRequest(
   // Rule 2: Every triple's subject MUST be a rootEntity from the manifest
   // OR a skolemized URI whose prefix matches a rootEntity.
   for (const q of nquads) {
+    if (trustedCatalogTriples.has(catalogTripleKey(q))) continue;
     const s = q.subject;
     if (rootEntities.has(s)) continue;
     if (isSkolemizedUri(s)) {

--- a/packages/publisher/test/canonical-publish-payload.test.ts
+++ b/packages/publisher/test/canonical-publish-payload.test.ts
@@ -10,6 +10,10 @@ import {
   computePrivateRootV10,
 } from '../src/merkle.js';
 import { autoPartition } from '../src/auto-partition.js';
+import {
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
+} from '../src/catalog-trust.js';
 
 const q = (s: string, p: string, o: string) => ({
   subject: s,
@@ -101,5 +105,59 @@ describe('canonicalPublishPayload — shared canonicalization for agent ↔ publ
 
     expect(result.privateRoots).toEqual([]);
     expect(result.manifestEntries[0].privateMerkleRoot).toBeUndefined();
+  });
+
+  it('hashes generated private-CG catalog floor but excludes it from manifest roots', () => {
+    const contextGraphId = 'private-catalog-cg';
+    const content = [
+      q('urn:example:shipment:1', 'http://schema.org/name', '"Shipment 1"'),
+    ];
+    const catalog = generatedPrivateCatalogFloorQuads(contextGraphId);
+    const all = [...content, ...catalog];
+
+    const result = canonicalPublishPayload(all, [], {
+      trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId),
+    });
+    const skolemized = [...autoPartition(all).values()].flat();
+    const expectedMerkle = computeFlatKCRootV10(skolemized, []);
+
+    expect(ethers.hexlify(result.kcMerkleRoot)).toBe(ethers.hexlify(expectedMerkle));
+    expect(result.manifestEntries.map((m) => m.rootEntity)).toEqual(['urn:example:shipment:1']);
+    expect(result.generatedCatalogRootEntities).toEqual([
+      'did:dkg:context-graph:private-catalog-cg',
+    ]);
+    expect(result.skolemizedPublicQuads).toHaveLength(skolemized.length);
+  });
+
+  it('refuses to hide a generated catalog subject that also carries non-catalog triples', () => {
+    const contextGraphId = 'private-catalog-cg';
+    const cgDid = `did:dkg:context-graph:${contextGraphId}`;
+    const catalog = generatedPrivateCatalogFloorQuads(contextGraphId);
+    const mixed = [
+      q('urn:example:shipment:1', 'http://schema.org/name', '"Shipment 1"'),
+      ...catalog,
+      q(cgDid, 'urn:example:secret', '"must stay manifest-visible"'),
+    ];
+
+    expect(() =>
+      canonicalPublishPayload(mixed, [], {
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId),
+      }),
+    ).toThrow(/mixes trusted catalog triples/);
+  });
+
+  it('refuses to hide an incomplete generated catalog floor', () => {
+    const contextGraphId = 'private-catalog-cg';
+    const partialCatalog = generatedPrivateCatalogFloorQuads(contextGraphId).slice(0, 1);
+    const mixed = [
+      q('urn:example:shipment:1', 'http://schema.org/name', '"Shipment 1"'),
+      ...partialCatalog,
+    ];
+
+    expect(() =>
+      canonicalPublishPayload(mixed, [], {
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(contextGraphId),
+      }),
+    ).toThrow(/mixes trusted catalog triples/);
   });
 });

--- a/packages/publisher/test/canonical-publish-payload.test.ts
+++ b/packages/publisher/test/canonical-publish-payload.test.ts
@@ -129,6 +129,22 @@ describe('canonicalPublishPayload — shared canonicalization for agent ↔ publ
     expect(result.skolemizedPublicQuads).toHaveLength(skolemized.length);
   });
 
+  it('keeps generated catalog-looking quads manifest-visible without the trusted floor option', () => {
+    const contextGraphId = 'private-catalog-cg';
+    const content = [
+      q('urn:example:shipment:1', 'http://schema.org/name', '"Shipment 1"'),
+    ];
+    const catalog = generatedPrivateCatalogFloorQuads(contextGraphId);
+
+    const result = canonicalPublishPayload([...content, ...catalog]);
+
+    expect(result.manifestEntries.map((m) => m.rootEntity).sort()).toEqual([
+      'did:dkg:context-graph:private-catalog-cg',
+      'urn:example:shipment:1',
+    ]);
+    expect(result.generatedCatalogRootEntities).toEqual([]);
+  });
+
   it('refuses to hide a generated catalog subject that also carries non-catalog triples', () => {
     const contextGraphId = 'private-catalog-cg';
     const cgDid = `did:dkg:context-graph:${contextGraphId}`;

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -6,13 +6,19 @@ import {
   TypedEventBus,
   generateEd25519Keypair,
   contextGraphAssertionUri,
+  contextGraphDataUri,
   contextGraphMetaUri,
   contextGraphSharedMemoryUri,
   contextGraphLayerUri,
   MemoryLayer,
   assertionLifecycleUri,
 } from '@origintrail-official/dkg-core';
-import { DKGPublisher, AssertionNotPersistedError } from '../src/index.js';
+import {
+  DKGPublisher,
+  AssertionNotPersistedError,
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
+} from '../src/index.js';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 
@@ -182,6 +188,31 @@ describe('Working Memory Assertion Lifecycle', () => {
     if (swmResult.type === 'bindings') {
       expect(swmResult.bindings.length).toBe(3);
     }
+  });
+
+  it('promote strips generated private-CG catalog floor from SWM and WM when trusted', async () => {
+    const name = 'private-catalog-promote';
+    const cgDid = contextGraphDataUri(CG_ID);
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
+      ...generatedPrivateCatalogFloorQuads(CG_ID),
+    ]);
+
+    const result = await publisher.assertionPromote(CG_ID, name, AGENT, {
+      publisherPeerId: PEER,
+      trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
+    });
+
+    expect(result.promotedCount).toBe(1);
+    const swmCatalog = await store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${SWM_GRAPH}> { <${cgDid}> ?p ?o } }`,
+    );
+    expect(swmCatalog.type).toBe('bindings');
+    if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(0);
+
+    const remaining = await publisher.assertionQuery(CG_ID, name, AGENT);
+    expect(remaining).toHaveLength(0);
   });
 
   // Issue #864 — when the assertion data graph is empty but `_meta` says

--- a/packages/publisher/test/draft-lifecycle.test.ts
+++ b/packages/publisher/test/draft-lifecycle.test.ts
@@ -25,6 +25,11 @@ import { createEVMAdapter, getSharedContext, HARDHAT_KEYS } from '../../chain/te
 const CG_ID = 'test-assertion-cg';
 const SWM_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory`;
 const SWM_META_GRAPH = `did:dkg:context-graph:${CG_ID}/_shared_memory_meta`;
+const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
+const AGENTS_GRAPH = 'did:dkg:context-graph:agents';
+const ON_CHAIN_ID_PREDICATE = 'https://dkg.network/ontology#ContextGraphOnChainId';
+const ACCESS_POLICY_PREDICATE = 'https://dkg.network/ontology#accessPolicy';
+const ALLOWED_AGENT_PREDICATE = 'https://dkg.network/ontology#allowedAgent';
 const AGENT = '0x1234567890abcdef1234567890abcdef12345678';
 const AGENT_B = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 const PEER = '12D3KooWPromoteBoundary';
@@ -54,6 +59,42 @@ function largePayloadQuads(prefix: string, bytes: number): Quad[] {
     index += 1;
   }
   return quads;
+}
+
+function onChainIdQuad(id = '1'): Quad {
+  return {
+    subject: contextGraphDataUri(CG_ID),
+    predicate: ON_CHAIN_ID_PREDICATE,
+    object: `"${id}"`,
+    graph: ONTOLOGY_GRAPH,
+  };
+}
+
+function localPrivateContextGraphQuad(): Quad {
+  return {
+    subject: contextGraphDataUri(CG_ID),
+    predicate: ACCESS_POLICY_PREDICATE,
+    object: '"private"',
+    graph: contextGraphMetaUri(CG_ID),
+  };
+}
+
+function agentsPublicContextGraphQuad(): Quad {
+  return {
+    subject: contextGraphDataUri(CG_ID),
+    predicate: ACCESS_POLICY_PREDICATE,
+    object: '"public"',
+    graph: AGENTS_GRAPH,
+  };
+}
+
+function localAllowedAgentQuad(): Quad {
+  return {
+    subject: contextGraphDataUri(CG_ID),
+    predicate: ALLOWED_AGENT_PREDICATE,
+    object: `"${AGENT}"`,
+    graph: contextGraphMetaUri(CG_ID),
+  };
 }
 
 describe('Working Memory Assertion Lifecycle', () => {
@@ -198,6 +239,52 @@ describe('Working Memory Assertion Lifecycle', () => {
       { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
       ...generatedPrivateCatalogFloorQuads(CG_ID),
     ]);
+    await store.insert([onChainIdQuad('1')]);
+    (publisher as any).chain.getContextGraphAccessPolicy = async () => 1;
+    (publisher as any).chain.getContextGraphNameHash = async () => ethers.keccak256(ethers.toUtf8Bytes(CG_ID));
+
+    const result = await publisher.assertionPromote(CG_ID, name, AGENT, {
+      publisherPeerId: PEER,
+      trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
+      onChainContextGraphId: '1',
+    });
+
+    expect(result.promotedCount).toBe(1);
+    const swmCatalog = await store.query(
+      `SELECT ?p ?o WHERE { GRAPH <${SWM_GRAPH}> { <${cgDid}> ?p ?o } }`,
+    );
+    expect(swmCatalog.type).toBe('bindings');
+    if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(0);
+
+    const remaining = await publisher.assertionQuery(CG_ID, name, AGENT);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('rejects generated private-CG catalog floor stripping without private CG proof', async () => {
+    const name = 'private-catalog-promote-reject';
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
+      ...generatedPrivateCatalogFloorQuads(CG_ID),
+    ]);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, name, AGENT, {
+        publisherPeerId: PEER,
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('promote strips finalized private-CG catalog floor for local private CGs before first registration', async () => {
+    const name = 'private-catalog-promote-local-private';
+    const cgDid = contextGraphDataUri(CG_ID);
+    await store.insert([localPrivateContextGraphQuad()]);
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
+      ...generatedPrivateCatalogFloorQuads(CG_ID),
+    ]);
 
     const result = await publisher.assertionPromote(CG_ID, name, AGENT, {
       publisherPeerId: PEER,
@@ -210,9 +297,62 @@ describe('Working Memory Assertion Lifecycle', () => {
     );
     expect(swmCatalog.type).toBe('bindings');
     if (swmCatalog.type === 'bindings') expect(swmCatalog.bindings).toHaveLength(0);
+  });
 
-    const remaining = await publisher.assertionQuery(CG_ID, name, AGENT);
-    expect(remaining).toHaveLength(0);
+  it('rejects generated private-CG catalog floor stripping with a borrowed private on-chain id', async () => {
+    const name = 'private-catalog-promote-borrowed-id';
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
+      ...generatedPrivateCatalogFloorQuads(CG_ID),
+    ]);
+    await store.insert([onChainIdQuad('2')]);
+    (publisher as any).chain.getContextGraphAccessPolicy = async () => 1;
+    (publisher as any).chain.getContextGraphNameHash = async () => null;
+
+    await expect(
+      publisher.assertionPromote(CG_ID, name, AGENT, {
+        publisherPeerId: PEER,
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
+        onChainContextGraphId: '1',
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects local private-CG catalog floor stripping when a stored on-chain id is public', async () => {
+    const name = 'private-catalog-promote-stale-local-policy';
+    await store.insert([localPrivateContextGraphQuad(), onChainIdQuad('1')]);
+    (publisher as any).chain.getContextGraphAccessPolicy = async () => 0;
+    (publisher as any).chain.getContextGraphNameHash = async () => ethers.keccak256(ethers.toUtf8Bytes(CG_ID));
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
+      ...generatedPrivateCatalogFloorQuads(CG_ID),
+    ]);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, name, AGENT, {
+        publisherPeerId: PEER,
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects local catalog floor stripping when agents graph declares the CG public', async () => {
+    const name = 'private-catalog-promote-agents-public';
+    await store.insert([agentsPublicContextGraphQuad(), localAllowedAgentQuad()]);
+    await publisher.assertionCreate(CG_ID, name, AGENT);
+    await publisher.assertionWrite(CG_ID, name, AGENT, [
+      { subject: 'urn:test:entity:catalog-content', predicate: 'http://schema.org/name', object: '"Content"' },
+      ...generatedPrivateCatalogFloorQuads(CG_ID),
+    ]);
+
+    await expect(
+      publisher.assertionPromote(CG_ID, name, AGENT, {
+        publisherPeerId: PEER,
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CG_ID),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
   });
 
   // Issue #864 — when the assertion data graph is empty but `_meta` says

--- a/packages/publisher/test/pure-functions.test.ts
+++ b/packages/publisher/test/pure-functions.test.ts
@@ -11,7 +11,11 @@ import {
   computePrivateRootV10 as computePrivateRoot,
   computeKARootV10 as computeKARoot,
   computeKCRootV10 as computeKCRoot,
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
+  catalogTripleKey,
   validatePublishRequest,
+  assertTrustedCatalogTriplesAreGeneratedFloor,
 } from '../src/index.js';
 import type { ValidationOptions } from '../src/validation.js';
 
@@ -158,6 +162,59 @@ describe('validatePublishRequest', () => {
     const result = validatePublishRequest(quads, manifest, CONTEXT_GRAPH, new Set());
     expect(result.valid).toBe(false);
     expect(result.errors[0]).toContain('Rule 2');
+  });
+
+  it('Rule 2 allows only exact generated private-CG catalog floor triples outside the manifest', () => {
+    const privateCg = 'private-catalog-cg';
+    const contentRoot = 'urn:test:shipment:1';
+    const contentQuad = q(
+      contentRoot,
+      'http://schema.org/name',
+      '"Shipment 1"',
+      `did:dkg:context-graph:${privateCg}`,
+    );
+    const catalog = generatedPrivateCatalogFloorQuads(privateCg);
+    const manifest = [{ tokenId: 1n, rootEntity: contentRoot }];
+
+    const accepted = validatePublishRequest(
+      [contentQuad, ...catalog],
+      manifest,
+      privateCg,
+      new Set(),
+      { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(privateCg) },
+    );
+    expect(accepted.valid).toBe(true);
+
+    const forged = [
+      contentQuad,
+      ...catalog,
+      {
+        subject: `did:dkg:context-graph:${privateCg}`,
+        predicate: 'urn:test:not-generated',
+        object: '"hidden"',
+        graph: '',
+      },
+    ];
+    const rejected = validatePublishRequest(
+      forged,
+      manifest,
+      privateCg,
+      new Set(),
+      { trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(privateCg) },
+    );
+    expect(rejected.valid).toBe(false);
+    expect(rejected.errors.some((e) => e.includes('Rule 2'))).toBe(true);
+  });
+
+  it('refuses partial generated catalog trust sets', () => {
+    const privateCg = 'private-catalog-cg';
+    const partial = new Set([
+      catalogTripleKey(generatedPrivateCatalogFloorQuads(privateCg)[0]),
+    ]);
+
+    expect(() =>
+      assertTrustedCatalogTriplesAreGeneratedFloor(privateCg, partial),
+    ).toThrow(/must exactly match/);
   });
 
   it('fails Rule 3: manifest root with no public triples and not fully private', () => {

--- a/packages/publisher/test/shared-memory-publish-boundary.test.ts
+++ b/packages/publisher/test/shared-memory-publish-boundary.test.ts
@@ -21,6 +21,8 @@ const CONTEXT_GRAPH_URI = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
 const SWM_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory`;
 const SWM_META_GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}/_shared_memory_meta`;
 const PER_KA_SWM_GRAPH = `${SWM_GRAPH}/0x1111111111111111111111111111111111111111/1`;
+const ONTOLOGY_GRAPH = 'did:dkg:context-graph:ontology';
+const ON_CHAIN_ID_PREDICATE = 'https://dkg.network/ontology#ContextGraphOnChainId';
 const WORKSPACE_OWNER_PREDICATE = 'http://dkg.io/ontology/workspaceOwner';
 
 function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
@@ -36,14 +38,34 @@ function q(subject: string, predicate = 'http://schema.org/name', object = '"val
   return { subject, predicate, object, graph };
 }
 
-async function makePublisher() {
+function onChainIdQuad(id = '1'): Quad {
+  return { subject: CONTEXT_GRAPH_URI, predicate: ON_CHAIN_ID_PREDICATE, object: `"${id}"`, graph: ONTOLOGY_GRAPH };
+}
+
+function privatePolicyChain(options: { nameHash?: string | null } = {}) {
+  const chain = new NoChainAdapter() as any;
+  Object.defineProperty(chain, 'chainId', { value: 'mock-private' });
+  Object.defineProperty(chain, 'deploymentId', { value: 'mock-private' });
+  chain.getContextGraphAccessPolicy = async () => 1;
+  if ('nameHash' in options) {
+    chain.getContextGraphNameHash = async () => options.nameHash ?? null;
+  }
+  return chain;
+}
+
+async function makeRealPublisher(chain = new NoChainAdapter()) {
   const store = new OxigraphStore();
   const publisher = new DKGPublisher({
     store,
-    chain: new NoChainAdapter(),
+    chain,
     eventBus: new TypedEventBus(),
     keypair: await generateEd25519Keypair(),
   });
+  return { publisher, store };
+}
+
+async function makePublisher(chain = new NoChainAdapter()) {
+  const { publisher, store } = await makeRealPublisher(chain);
   const publishResult: PublishResult = {
     kaId: 1n,
     ual: 'did:dkg:0x0000000000000000000000000000000000000001/1',
@@ -180,9 +202,10 @@ describe('publishFromSharedMemory multi-root selection (OT-RFC-44 / Design B: on
   });
 
   it('loads selected data root plus generated private-CG catalog root and threads trusted floor', async () => {
-    const { publisher, store, publishSpy } = await makePublisher();
+    const { publisher, store, publishSpy } = await makePublisher(privatePolicyChain());
     const cgDid = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
     await store.insert([
+      onChainIdQuad('1'),
       q('urn:test:root:one'),
       ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH, SWM_GRAPH),
     ]);
@@ -191,6 +214,7 @@ describe('publishFromSharedMemory multi-root selection (OT-RFC-44 / Design B: on
       publisher.publishFromSharedMemory(CONTEXT_GRAPH, {
         rootEntities: ['urn:test:root:one', cgDid],
       }, {
+        onChainContextGraphId: '1',
         trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
       }),
     ).resolves.toMatchObject({ status: 'tentative' });
@@ -206,6 +230,127 @@ describe('publishFromSharedMemory multi-root selection (OT-RFC-44 / Design B: on
         ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
       ]),
     );
+  });
+
+  it('rejects trusted generated catalog floor for public direct publishes', async () => {
+    const { publisher } = await makeRealPublisher();
+
+    await expect(
+      publisher.publish({
+        contextGraphId: CONTEXT_GRAPH,
+        quads: [
+          q('urn:test:root:one', 'http://schema.org/name', '"value"', ''),
+          ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+        ],
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects trusted generated catalog floor when callers set a non-public KA access policy without private CG proof', async () => {
+    const { publisher } = await makeRealPublisher();
+
+    await expect(
+      publisher.publish({
+        contextGraphId: CONTEXT_GRAPH,
+        publisherPeerId: '12D3KooWPublicBypass',
+        accessPolicy: 'ownerOnly',
+        quads: [
+          q('urn:test:root:one', 'http://schema.org/name', '"value"', ''),
+          ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+        ],
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects trusted generated catalog floor with a borrowed private on-chain context graph id', async () => {
+    const { publisher, store } = await makeRealPublisher(privatePolicyChain());
+    await store.insert([onChainIdQuad('2')]);
+
+    await expect(
+      publisher.publish({
+        contextGraphId: CONTEXT_GRAPH,
+        publishContextGraphId: '1',
+        quads: [
+          q('urn:test:root:one', 'http://schema.org/name', '"value"', ''),
+          ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+        ],
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects stale stored on-chain context graph ids when the live name hash no longer matches', async () => {
+    const staleNameHash = `0x${'11'.repeat(32)}`;
+    const { publisher, store } = await makeRealPublisher(privatePolicyChain({ nameHash: staleNameHash }));
+    await store.insert([onChainIdQuad('1')]);
+
+    await expect(
+      publisher.publish({
+        contextGraphId: CONTEXT_GRAPH,
+        publishContextGraphId: '1',
+        quads: [
+          q('urn:test:root:one', 'http://schema.org/name', '"value"', ''),
+          ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+        ],
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects trusted generated catalog floor on update without private CG proof', async () => {
+    const { publisher } = await makeRealPublisher();
+
+    await expect(
+      publisher.update(1n, {
+        contextGraphId: CONTEXT_GRAPH,
+        publisherPeerId: '12D3KooWPublicBypass',
+        accessPolicy: 'ownerOnly',
+        quads: [
+          q('urn:test:root:one', 'http://schema.org/name', '"value"', ''),
+          ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+        ],
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('rejects shared-memory trusted floor with a borrowed private on-chain context graph id', async () => {
+    const { publisher, store } = await makeRealPublisher(privatePolicyChain());
+    const cgDid = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+    await store.insert([
+      onChainIdQuad('2'),
+      q('urn:test:root:one'),
+      ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH, SWM_GRAPH),
+    ]);
+
+    await expect(
+      publisher.publishFromSharedMemory(CONTEXT_GRAPH, {
+        rootEntities: ['urn:test:root:one', cgDid],
+      }, {
+        onChainContextGraphId: '1',
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).rejects.toThrow(/trustedNonManifestCatalogTriples is only allowed/);
+  });
+
+  it('treats generated catalog-looking quads as a normal root without the trusted option', async () => {
+    const { publisher } = await makeRealPublisher();
+
+    const result = await publisher.publish({
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [
+        q('urn:test:root:one', 'http://schema.org/name', '"value"', ''),
+        ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+      ],
+    });
+
+    expect(result.status).toBe('tentative');
+    expect(result.kaManifest.map((m) => m.rootEntity).sort()).toEqual([
+      CONTEXT_GRAPH_URI,
+      'urn:test:root:one',
+    ]);
   });
 
   it('falls back to direct publish when SWM ACKs fail with NO_DATA_IN_SWM', async () => {

--- a/packages/publisher/test/shared-memory-publish-boundary.test.ts
+++ b/packages/publisher/test/shared-memory-publish-boundary.test.ts
@@ -9,7 +9,11 @@ import {
   DKG_ROOT_ENTITY_LEGACY,
 } from '@origintrail-official/dkg-core';
 import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
-import { DKGPublisher } from '../src/index.js';
+import {
+  DKGPublisher,
+  generatedPrivateCatalogFloorQuads,
+  generatedPrivateCatalogTripleKeys,
+} from '../src/index.js';
 import type { PublishResult } from '../src/publisher.js';
 
 const CONTEXT_GRAPH = 'publish-boundary';
@@ -173,6 +177,35 @@ describe('publishFromSharedMemory multi-root selection (OT-RFC-44 / Design B: on
     expect(publishSpy.calls[0][0].quads).toEqual([
       { subject: 'urn:test:root:one', predicate: 'http://schema.org/name', object: '"promoted"', graph: '' },
     ]);
+  });
+
+  it('loads selected data root plus generated private-CG catalog root and threads trusted floor', async () => {
+    const { publisher, store, publishSpy } = await makePublisher();
+    const cgDid = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+    await store.insert([
+      q('urn:test:root:one'),
+      ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH, SWM_GRAPH),
+    ]);
+
+    await expect(
+      publisher.publishFromSharedMemory(CONTEXT_GRAPH, {
+        rootEntities: ['urn:test:root:one', cgDid],
+      }, {
+        trustedNonManifestCatalogTriples: generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+      }),
+    ).resolves.toMatchObject({ status: 'tentative' });
+
+    expect(publishSpy.calls).toHaveLength(1);
+    const publishArgs = publishSpy.calls[0][0];
+    expect(publishArgs.trustedNonManifestCatalogTriples).toEqual(
+      generatedPrivateCatalogTripleKeys(CONTEXT_GRAPH),
+    );
+    expect(publishArgs.quads).toEqual(
+      expect.arrayContaining([
+        { subject: 'urn:test:root:one', predicate: 'http://schema.org/name', object: '"value"', graph: '' },
+        ...generatedPrivateCatalogFloorQuads(CONTEXT_GRAPH),
+      ]),
+    );
   });
 
   it('falls back to direct publish when SWM ACKs fail with NO_DATA_IN_SWM', async () => {


### PR DESCRIPTION
## Summary
- Treat the generated private context graph catalog floor as committed system metadata, not a KA manifest/root entity.
- Add exact generated-catalog trust helpers and use content-root maps for publish, update, promote, finalization, and materialization surfaces.
- Harden `trustedNonManifestCatalogTriples` so generated floor suppression requires internal provenance, an identity-bound on-chain private CG, or a promote-only pre-registration local private proof.
- Align local private proof with agent metadata sources (`ontology`, `agents`, and CG `_meta`) while preserving explicit-public precedence and disabling local fallback once an on-chain id is known.
- Add regressions for the two-KA Rule 4 collision, public trust-option misuse, stale local policy, agents-graph public override, selected-root catalog loading, promote stripping, finalization policy checks, and product-path pre-registration SWM cleanup.

Fixes #1308

## Verification
- `pnpm --filter @origintrail-official/dkg-publisher --filter @origintrail-official/dkg-agent run build`
- `pnpm exec vitest run test/draft-lifecycle.test.ts test/shared-memory-publish-boundary.test.ts test/canonical-publish-payload.test.ts test/pure-functions.test.ts` in `packages/publisher` (106 tests)
- `pnpm exec vitest run test/finalization-handler.test.ts --pool=threads` in `packages/agent` (23 tests)
- `pnpm exec vitest run test/e2e-memory-layers.test.ts --pool=threads -t "strips the generated private-CG catalog floor"` in `packages/agent`
- Earlier full private-CG two-KA e2e passed for `combined-catalog-baseline.e2e.test.ts`; later reruns hit local Hardhat deployment setup flakiness before the test body, so the final pass uses the focused product-path regression above.
- `git diff --check`
