### PR TITLE
fix(mcp): trigger testnet faucet funding via the shared orchestrator (no /api/status probe)

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -10,9 +10,6 @@ import { ethers } from 'ethers';
 import { resolveRpcUrls } from '@origintrail-official/dkg-chain';
 import {
   dkgAuthTokenPath,
-  FAUCET_WALLETS_PER_REQUEST,
-  getFundableWalletAddresses,
-  requestFaucetFunding,
   resolveDkgConfigHome,
   toErrorMessage,
   hasErrorCode,

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -197,8 +197,6 @@ mcpCmd
         loadNetworkConfig: openclawSetupExports.loadNetworkConfig,
         ensureDkgNodeConfig: coreExports.ensureDkgNodeConfig,
         startDaemon: openclawSetupExports.startDaemon,
-        readWalletsWithRetry: openclawSetupExports.readWalletsWithRetry,
-        logManualFundingInstructions: openclawSetupExports.logManualFundingInstructions,
         // Lazy + best-effort (parity with openclaw/hermes): dkg-agent is
         // imported only inside the non-dry-run wallet step, so `--print-only`
         // / `--dry-run` never require it, and an import failure degrades to a
@@ -208,7 +206,11 @@ mcpCmd
           const { loadOpWallets } = await import('@origintrail-official/dkg-agent');
           return loadOpWallets(dir);
         },
-        requestFaucetFunding: coreExports.requestFaucetFunding,
+        // Shared faucet orchestrator — the SAME one openclaw/hermes use.
+        // Replaces the old bespoke `/api/status` reachability probe +
+        // `requestFaucetFunding` path that silently skipped funding on a slow
+        // testnet node.
+        fundWalletsBestEffort: coreExports.fundWalletsBestEffort,
         findDkgMonorepoRoot: coreExports.findDkgMonorepoRoot,
         resolveDkgConfigHome: coreExports.resolveDkgConfigHome,
       });

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -2143,8 +2143,8 @@ export async function mcpSetupAction(
   // are out of scope for setup.
   if (shouldVerify && !dryRun && shouldStart) {
     try {
-      // F26: same hang-bound as the funding-step reachability probe.
-      // A partially-up daemon must not block setup completion.
+      // Bound the health probe with a 2s timeout so a partially-up daemon
+      // (port bound but unresponsive) can't block setup completion.
       const res = await fetch(`http://127.0.0.1:${effectivePort}/api/status`, {
         signal: AbortSignal.timeout(2000),
       });

--- a/packages/cli/src/mcp-setup.ts
+++ b/packages/cli/src/mcp-setup.ts
@@ -170,8 +170,6 @@ export interface McpSetupActionDeps {
    */
   ensureDkgNodeConfig: typeof import('@origintrail-official/dkg-core').ensureDkgNodeConfig;
   startDaemon: typeof import('@origintrail-official/dkg-adapter-openclaw').startDaemon;
-  readWalletsWithRetry: typeof import('@origintrail-official/dkg-adapter-openclaw').readWalletsWithRetry;
-  logManualFundingInstructions: typeof import('@origintrail-official/dkg-adapter-openclaw').logManualFundingInstructions;
   /**
    * Eagerly creates the node's operational wallets (generate-if-absent)
    * before the daemon starts, so faucet funding (testnet) and manual mainnet
@@ -179,8 +177,13 @@ export interface McpSetupActionDeps {
    * Idempotent. From `@origintrail-official/dkg-agent`; injectable for tests.
    */
   loadOpWallets: typeof import('@origintrail-official/dkg-agent').loadOpWallets;
-  /** Faucet primitive from `@origintrail-official/dkg-core`. */
-  requestFaucetFunding: typeof import('@origintrail-official/dkg-core').requestFaucetFunding;
+  /**
+   * Shared best-effort faucet orchestrator — the SAME one openclaw/hermes use.
+   * Reads `wallets.json` (with retry when the daemon was started this run),
+   * gates on `network.faucet.url`, calls the faucet, and logs manual curl
+   * instructions on failure. Non-throwing. From `@origintrail-official/dkg-core`.
+   */
+  fundWalletsBestEffort: typeof import('@origintrail-official/dkg-core').fundWalletsBestEffort;
   /**
    * Walks ancestors looking for a DKG monorepo root. Defaulted to the
    * dkg-core implementation in production; injectable so tests can
@@ -1929,88 +1932,37 @@ export async function mcpSetupAction(
   }
 
   // ── Step 3: optional faucet ───────────────────────────────────────
-  // Reads wallets from `~/.dkg/wallets.json` (written async by the
-  // daemon) with the same 5×1s retry openclaw-setup uses. Faucet
-  // failures log a manual `curl` block and continue — funding is
-  // non-fatal for setup.
+  // Delegates to the SAME shared orchestrator as `dkg openclaw setup` /
+  // `dkg hermes setup` (`fundWalletsBestEffort`) instead of a bespoke
+  // `/api/status` reachability probe. The old probe gated funding on a 2s
+  // `GET /api/status` responding — which routinely times out on a real
+  // testnet node (peers + store make `/api/status` slow), so funding was
+  // silently skipped even though wallets and a faucet existed. The
+  // orchestrator needs only `wallets.json` (eager-created above, issue #1306)
+  // + a `network.faucet.url`; it reads wallets with retry when the daemon was
+  // started this run (so a freshly-flushed wallets.json is picked up), gates
+  // on the faucet, calls it, and logs manual `curl` instructions on failure.
+  // Funding is non-fatal — `fundWalletsBestEffort` never throws, so the outer
+  // try/catch only guards the `loadNetworkConfig` lookup.
   //
-  // F14: the funding decision is decoupled from `shouldStart`. The
-  // pre-fix outer guard `if (shouldFund && !dryRun && shouldStart)`
-  // silently skipped funding whenever `--no-start` was supplied,
-  // even when the daemon was already running from a prior invocation
-  // and a re-run-to-retry-funding was the user's actual goal.
-  // Post-fix flow:
-  //   1. Honour `--no-fund` (explicit opt-out, unchanged).
-  //   2. Honour `--dry-run` (no network calls).
-  //   3. Probe daemon reachability at `/api/status` on
-  //      `effectivePort`. If unreachable, log explicit
-  //      "skipping wallet funding (daemon not reachable on port X)"
-  //      with the reason — replaces the silent omission. If
-  //      reachable, proceed with funding regardless of which
-  //      invocation started the daemon.
+  // The `--no-start + already-running daemon → fund` goal (F14) is preserved:
+  // funding no longer depends on a reachability probe, only on wallets.json
+  // existing — which it does whether the daemon ran this invocation, a prior
+  // one, or the #1306 eager-create produced it.
   if (!shouldFund) {
     console.log('[setup] Skipping wallet funding (--no-fund)');
   } else if (dryRun) {
     console.log('[setup] [dry-run] Would attempt wallet funding');
   } else {
-    let daemonReachable = false;
     try {
-      // F26: bound the probe with AbortSignal.timeout(2000) so a
-      // partially-up daemon (port bound but unresponsive — half-stuck
-      // process or deadlocked startup) doesn't hang setup. The probe
-      // is best-effort; treating timeout as "not reachable" is the
-      // correct fallback because we move on to log the explicit
-      // skip-with-reason message anyway.
-      const probe = await fetch(`http://127.0.0.1:${effectivePort}/api/status`, {
-        signal: AbortSignal.timeout(2000),
+      const network = deps.loadNetworkConfig(setupNetworkConfigName);
+      await deps.fundWalletsBestEffort({
+        network,
+        idempotencySeed: effectiveAgentName,
+        didStartDaemon: shouldStart,
       });
-      daemonReachable = probe.ok;
-    } catch { /* not reachable (or timed out) */ }
-
-    if (!daemonReachable) {
-      console.log(
-        `[setup] Skipping wallet funding (daemon not reachable on port ${effectivePort})`,
-      );
-    } else {
-      try {
-        const network = deps.loadNetworkConfig(setupNetworkConfigName);
-        const faucetUrl = network.faucet?.url;
-        const faucetMode = network.faucet?.mode ?? 'testnet';
-        if (!faucetUrl) {
-          console.log('[setup] No faucet URL configured for this network; skipping wallet funding.');
-        } else {
-          const wallets = await deps.readWalletsWithRetry();
-          if (wallets.length === 0) {
-            console.log('[setup] No wallets to fund yet (daemon may not have flushed wallets.json).');
-          } else {
-            try {
-              const result = await deps.requestFaucetFunding(faucetUrl, faucetMode, wallets, effectiveAgentName);
-              if (result?.success === false) {
-                console.warn(
-                  `[setup] Faucet returned failure${result.error ? ` (${result.error})` : ''}; emitting manual instructions.`,
-                );
-                deps.logManualFundingInstructions(wallets, faucetUrl, faucetMode);
-              } else if (result?.error) {
-                const failedWallets = Array.isArray(result.failedWallets) && result.failedWallets.length
-                  ? result.failedWallets
-                  : wallets;
-                console.warn(`[setup] Faucet partially completed (${result.error}); emitting manual instructions for remaining wallet(s).`);
-                deps.logManualFundingInstructions(failedWallets, faucetUrl, faucetMode);
-              } else {
-                const fundedWalletCount = Array.isArray(result?.fundedWallets) && result.fundedWallets.length
-                  ? result.fundedWallets.length
-                  : wallets.length;
-                console.log(`[setup] Funded ${fundedWalletCount} wallet(s) via testnet faucet.`);
-              }
-            } catch (err: any) {
-              console.warn(`[setup] Faucet call failed (${err?.message ?? err}); emitting manual instructions.`);
-              deps.logManualFundingInstructions(wallets, faucetUrl, faucetMode);
-            }
-          }
-        }
-      } catch (err: any) {
-        console.warn(`[setup] Faucet step skipped: ${err?.message ?? err}`);
-      }
+    } catch (err: any) {
+      console.warn(`[setup] Faucet step skipped: ${err?.message ?? err}`);
     }
   }
 

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -217,7 +217,8 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     // a recorder so tests assert it's invoked with (network, idempotencySeed,
     // didStartDaemon) on a normal setup and skipped under --no-fund / --dry-run.
     // Its internal wallet-read + faucet-call + manual-instructions behavior is
-    // covered by dkg-core's faucet-orchestration tests, not re-asserted here.
+    // covered directly by packages/core/test/faucet-orchestration.test.ts, not
+    // re-asserted here.
     const fundWalletsBestEffort = recorder(async (_opts: any) => {});
     // Phase-2: detectContext defaults to "installed" by returning null
     // from findDkgMonorepoRoot. Tests that exercise the monorepo path
@@ -381,7 +382,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
   // directly — so `--no-start` (daemon not started this run) STILL funds. This
   // also preserves the F14 "re-run-to-retry-funding" goal: funding depends only
   // on wallets.json existing, never on a daemon being reachable.
-  it('funds without any reachability probe even with --no-start (didStartDaemon=false)', async () => {
+  it('funds under --no-start (didStartDaemon=false), unconditional on daemon reachability', async () => {
     mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
     const deps = makeDeps();
 
@@ -494,10 +495,11 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
 
   // Faucet failure handling — manual `curl` instructions on a faucet error or
   // partial success — now lives INSIDE `fundWalletsBestEffort` (the shared
-  // orchestrator) and is covered by dkg-core's faucet-orchestration tests. The
-  // mcp layer only decides whether to invoke it (asserted above), so the former
-  // mcp-level faucet-failure/partial-success tests were removed with the
-  // bespoke inline faucet path.
+  // orchestrator) and is covered directly by
+  // packages/core/test/faucet-orchestration.test.ts. The mcp layer only decides
+  // whether to invoke it (asserted above), so the former mcp-level
+  // faucet-failure/partial-success tests were removed with the bespoke inline
+  // faucet path.
 
   // ── Phase-2: monorepo context detection + --installed/--monorepo flags ──
 

--- a/packages/cli/test/mcp-setup.test.ts
+++ b/packages/cli/test/mcp-setup.test.ts
@@ -1,15 +1,9 @@
-import { afterEach, beforeAll, afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync } from 'node:fs';
 import { tmpdir, homedir, platform } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:net';
 import TOML from '@iarna/toml';
 import { mcpSetupAction, type McpSetupActionDeps } from '../src/mcp-setup.js';
-import {
-  startLiveDaemon,
-  stopLiveDaemon,
-  type LiveDaemon,
-} from './helpers/live-daemon.js';
 
 /**
  * NO MOCKS. `dkg mcp setup` is a pure CLI ORCHESTRATOR over (a) a real
@@ -25,15 +19,15 @@ import {
  *
  * The two genuinely-external boundaries stay injected doubles, on
  * purpose: `startDaemon` (would spawn a 30s daemon per test) and
- * `requestFaucetFunding` (hits a live testnet faucet CI cannot reach —
- * same class as the hermes/openclaw external adapters left mocked).
+ * `fundWalletsBestEffort` (the shared faucet orchestrator — would hit a
+ * live testnet faucet CI cannot reach; same class as the hermes/openclaw
+ * external adapters left mocked).
  *
- * The ONE piece of real daemon behaviour the action performs itself —
- * the `/api/status` reachability probe gating wallet funding (F14/F26)
- * — is exercised against a REAL edge daemon booted via
- * `startLiveDaemon` (see the funding-gate tests): reachable cases point
- * the probe at the live daemon's port; unreachable cases point it at a
- * closed port for a real ECONNREFUSED. No `fetch` stub anywhere.
+ * Wallet funding delegates to that shared orchestrator (parity with
+ * openclaw/hermes). There is no longer a bespoke `/api/status`
+ * reachability probe gating funding, so the suite needs no live daemon
+ * and performs no `fetch` round-trip — the faucet tests just assert
+ * `fundWalletsBestEffort` is (or isn't) invoked with the right args.
  */
 
 /**
@@ -109,20 +103,6 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
   let warnSpy: ReturnType<typeof captureWrites>;
   let errorSpy: ReturnType<typeof captureWrites>;
   let stderrSilencer: ReturnType<typeof captureWrites>;
-
-  // A REAL edge daemon, booted once for this describe. The funding-gate
-  // tests (F14/F26) that need the `/api/status` reachability probe to
-  // return ok point `opts.port` at this daemon's real API port — the
-  // production `fetch(.../api/status)` then does a true round-trip
-  // against it (no fetch stub). `requestFaucetFunding` stays an
-  // injected double (live testnet faucet, unreachable from CI).
-  let liveDaemon: LiveDaemon | undefined;
-  beforeAll(async () => {
-    liveDaemon = await startLiveDaemon({ authEnabled: false });
-  }, 90_000);
-  afterAll(async () => {
-    await stopLiveDaemon(liveDaemon);
-  });
 
   beforeEach(() => {
     tmpHome = mkdtempSync(join(tmpdir(), 'mcp-setup-test-'));
@@ -225,7 +205,6 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       defaultNodeRole: 'edge',
       faucet: { url: 'http://faucet.test', mode: 'testnet' },
     }) as any);
-    const readWalletsWithRetry = recorder(async () => ['0xadmin', '0xtest1', '0xtest2', '0xtest3']);
     // Eager wallet creation (issue #1306). Idempotent generate-if-absent;
     // mcpSetupAction ignores the return value (the faucet re-reads from disk),
     // so a minimal stub suffices. Tests assert it's called on a non-dry-run
@@ -234,11 +213,12 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       adminWallet: { address: '0xadmin', privateKey: '0x0' },
       wallets: [{ address: '0xtest1', privateKey: '0x0' }],
     }) as any);
-    const requestFaucetFunding = recorder(async () => ({
-      success: true,
-      fundedWallets: ['0xadmin', '0xtest1', '0xtest2', '0xtest3'],
-    }) as any);
-    const logManualFundingInstructions = recorder(() => {});
+    // Shared faucet orchestrator — the SAME one openclaw/hermes use. Stubbed as
+    // a recorder so tests assert it's invoked with (network, idempotencySeed,
+    // didStartDaemon) on a normal setup and skipped under --no-fund / --dry-run.
+    // Its internal wallet-read + faucet-call + manual-instructions behavior is
+    // covered by dkg-core's faucet-orchestration tests, not re-asserted here.
+    const fundWalletsBestEffort = recorder(async (_opts: any) => {});
     // Phase-2: detectContext defaults to "installed" by returning null
     // from findDkgMonorepoRoot. Tests that exercise the monorepo path
     // override this dep to return a mock repo root.
@@ -270,10 +250,8 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
       loadNetworkConfig,
       ensureDkgNodeConfig,
       startDaemon,
-      readWalletsWithRetry,
       loadOpWallets,
-      requestFaucetFunding,
-      logManualFundingInstructions,
+      fundWalletsBestEffort,
       findDkgMonorepoRoot,
       resolveDkgConfigHome,
       ...overrides,
@@ -377,100 +355,57 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     expect((deps.startDaemon as any).calls).toEqual([]);
   });
 
-  it('honours --no-start: skips daemon start; faucet path is gated on daemon reachability (F14)', async () => {
-    // Pre-F14, --no-start was conflated with "skip funding" via the
-    // outer `shouldFund && shouldStart` guard. Post-F14 the funding
-    // decision is decoupled: if the daemon is reachable on
-    // effectivePort, funding proceeds regardless of which invocation
-    // started the daemon. This test pins the daemon-not-reachable
-    // path: --no-start with no running daemon → faucet skipped via
-    // the new explicit "daemon not reachable on port X" log line
-    // (NOT the silent omission that pre-F14 produced).
+  it('funds wallets via the shared fundWalletsBestEffort orchestrator (network, seed, didStartDaemon)', async () => {
+    // Wallet funding delegates to the SAME orchestrator openclaw/hermes use
+    // (no bespoke /api/status probe). On a normal setup it fires with the
+    // loaded network, an idempotency seed (the agent name), and
+    // didStartDaemon=true (the daemon was started this run).
     mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
     const deps = makeDeps();
 
-    // No fetch stub: the production probe does a real `/api/status`
-    // round-trip. Point it at a GUARANTEED-unused port (bind an ephemeral
-    // port → capture → close) so the connect() ECONNREFUSEs deterministically.
-    // The CLI default 9200 is racy here: under full-suite parallelism a
-    // different test file's daemon can occupy 9200 the instant this probe
-    // runs, making the daemon look "reachable" and firing the faucet. An
-    // ephemeral port (32768+) never collides with test daemons (9200 default
-    // / 21000+ live), so this exercises the genuine "not reachable" path.
-    const closedPort = await new Promise<number>((resolve, reject) => {
-      const srv = createServer();
-      srv.once('error', reject);
-      srv.listen(0, '127.0.0.1', () => {
-        const addr = srv.address();
-        const port = typeof addr === 'object' && addr ? addr.port : 0;
-        srv.close(() => (port ? resolve(port) : reject(new Error('no free port'))));
-      });
-    });
-    await mcpSetupAction({ start: false, verify: false, port: String(closedPort) }, deps);
+    await mcpSetupAction({ verify: false }, deps);
+
+    const calls = (deps.fundWalletsBestEffort as any).calls;
+    expect(calls).toHaveLength(1);
+    const arg = calls[0][0];
+    expect(arg.network?.faucet?.url).toBe('http://faucet.test');
+    expect(arg.didStartDaemon).toBe(true);
+    expect(typeof arg.idempotencySeed).toBe('string');
+    expect(arg.idempotencySeed.length).toBeGreaterThan(0);
+  });
+
+  // Regression for the testnet-faucet bug (#mcp-testnet-faucet): the old code
+  // gated funding on a 2s `/api/status` reachability probe that routinely timed
+  // out on a real testnet node (peers + store make /api/status slow), silently
+  // skipping funding. fundWalletsBestEffort has NO probe — it reads wallets.json
+  // directly — so `--no-start` (daemon not started this run) STILL funds. This
+  // also preserves the F14 "re-run-to-retry-funding" goal: funding depends only
+  // on wallets.json existing, never on a daemon being reachable.
+  it('funds without any reachability probe even with --no-start (didStartDaemon=false)', async () => {
+    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
+    const deps = makeDeps();
+
+    await mcpSetupAction({ start: false, verify: false }, deps);
 
     expect((deps.startDaemon as any).calls).toEqual([]);
-    expect((deps.requestFaucetFunding as any).calls).toEqual([]);
+    const calls = (deps.fundWalletsBestEffort as any).calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].didStartDaemon).toBe(false);
     // Registration still proceeds — orthogonal axis.
     expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
-    // And the new explicit log line fired (replacing the pre-F14
-    // silent omission).
-    const logged = (logSpy.calls as any[]).map((c) => c.join(' ')).join('\n');
-    expect(logged).toMatch(new RegExp(`Skipping wallet funding \\(daemon not reachable on port ${closedPort}\\)`));
   });
 
-  // F14 (qa-review-round-2): the canonical decoupled-flow test.
-  // --no-start with a daemon already running (e.g. user re-runs to
-  // retry funding after the faucet was down on first run) MUST
-  // proceed with funding — pre-F14 it was silently skipped because
-  // the outer guard required `shouldStart === true`.
-  it('F14: --no-start with daemon already reachable → funding proceeds', async () => {
-    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
-    const deps = makeDeps();
-
-    // Point the probe at the REAL live daemon's API port: the
-    // production `fetch(.../api/status)` does a true round-trip and
-    // gets a real 200, so funding proceeds. No fetch stub.
-    await mcpSetupAction({ start: false, verify: false, port: String(liveDaemon!.apiPort) }, deps);
-
-    expect((deps.startDaemon as any).calls).toEqual([]);
-    // Funding MUST proceed — daemon is reachable, --no-fund was not
-    // supplied. This is the bug F14 fixes.
-    expect((deps.requestFaucetFunding as any).calls).toHaveLength(1);
-    expect((deps.requestFaucetFunding as any).calls[0][2])
-      .toEqual(['0xadmin', '0xtest1', '0xtest2', '0xtest3']);
-  });
-
-  it('F14: --no-fund + --no-start → explicit-skip log (not the unreachable log)', async () => {
-    // The --no-fund explicit-skip path takes precedence over the
-    // daemon-reachability probe — no probe should fire when funding
-    // is explicitly opted out, and the existing
-    // "Skipping wallet funding (--no-fund)" log line stays intact.
-    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
-    const deps = makeDeps();
-
-    // No fetch stub: --no-fund returns before the reachability probe is
-    // ever reached, so no `/api/status` request fires at all. The
-    // assertions below prove that path directly — the funding double is
-    // never called and the --no-fund (not the unreachable) line logs.
-    await mcpSetupAction({ start: false, fund: false, verify: false }, deps);
-
-    expect((deps.requestFaucetFunding as any).calls).toEqual([]);
-    const logged = (logSpy.calls as any[]).map((c) => c.join(' ')).join('\n');
-    expect(logged).toMatch(/Skipping wallet funding \(--no-fund\)/);
-    // The unreachable-path log line MUST NOT fire when --no-fund
-    // short-circuits the funding step.
-    expect(logged).not.toMatch(/daemon not reachable/);
-  });
-
-  it('honours --no-fund: skips the faucet step but starts daemon + registers', async () => {
+  it('honours --no-fund: skips the faucet orchestrator but starts daemon + registers', async () => {
     mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
     const deps = makeDeps();
 
     await mcpSetupAction({ fund: false, verify: false }, deps);
 
     expect((deps.startDaemon as any).calls).toHaveLength(1);
-    expect((deps.requestFaucetFunding as any).calls).toEqual([]);
+    expect((deps.fundWalletsBestEffort as any).calls).toEqual([]);
     expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
+    const logged = (logSpy.calls as any[]).map((c) => c.join(' ')).join('\n');
+    expect(logged).toMatch(/Skipping wallet funding \(--no-fund\)/);
   });
 
   it('honours --dry-run: no filesystem writes, no daemon start, no faucet call', async () => {
@@ -481,7 +416,7 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
 
     expect((deps.ensureDkgNodeConfig as any).calls).toEqual([]);
     expect((deps.startDaemon as any).calls).toEqual([]);
-    expect((deps.requestFaucetFunding as any).calls).toEqual([]);
+    expect((deps.fundWalletsBestEffort as any).calls).toEqual([]);
     expect(existsSync(join(tmpHome, '.dkg', 'config.json'))).toBe(false);
     expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(false);
   });
@@ -557,64 +492,12 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     expect((deps.startDaemon as any).calls[0][0]).toBe(9300);
   });
 
-  it('faucet failure logs manual instructions; setup continues to register clients', async () => {
-    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
-    const deps = makeDeps({
-      requestFaucetFunding: recorder(async () => {
-        throw new Error('faucet 503');
-      }),
-    });
-    // F14 + F26: the funding step probes daemon reachability via
-    // `/api/status` before attempting the faucet call. Point the probe
-    // at the REAL live daemon (a true 200 round-trip) so the funding
-    // step proceeds and the throwing-faucet double is actually reached.
-    await mcpSetupAction({ verify: false, port: String(liveDaemon!.apiPort) }, deps);
-
-    expect((deps.logManualFundingInstructions as any).calls).toHaveLength(1);
-    // Registration still proceeds.
-    expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
-  });
-
-  it('faucet result failures log faucet-provided reasons', async () => {
-    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
-    const deps = makeDeps({
-      requestFaucetFunding: recorder(async () => ({
-        success: false,
-        fundedWallets: [],
-        failedWallets: ['0xadmin', '0xtest1', '0xtest2', '0xtest3'],
-        error: 'Faucet did not fund all wallets: 0xadmin. Faucet reported: cooldown_active: Caller cooldown active until 2026-05-11T19:17:45.000Z',
-      }) as any),
-    });
-    // Reachable probe → real live daemon (true 200), no fetch stub.
-    await mcpSetupAction({ verify: false, port: String(liveDaemon!.apiPort) }, deps);
-
-    expect((deps.logManualFundingInstructions as any).calls).toHaveLength(1);
-    const warned = (warnSpy.calls as any[]).map((c) => c.join(' ')).join('\n');
-    expect(warned).toContain('cooldown_active');
-    expect(warned).toContain('2026-05-11T19:17:45.000Z');
-    expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
-  });
-
-  it('faucet partial success logs manual instructions for remaining wallets only', async () => {
-    mkdirSync(join(tmpHome, '.cursor'), { recursive: true });
-    const deps = makeDeps({
-      requestFaucetFunding: recorder(async () => ({
-        success: true,
-        fundedWallets: ['0xadmin', '0xtest1'],
-        failedWallets: ['0xtest2', '0xtest3'],
-        error: 'Faucet did not fund all wallets: 0xtest2, 0xtest3',
-      }) as any),
-    });
-    // Reachable probe → real live daemon (true 200), no fetch stub.
-    await mcpSetupAction({ verify: false, port: String(liveDaemon!.apiPort) }, deps);
-
-    expect((deps.logManualFundingInstructions as any).calls).toHaveLength(1);
-    expect((deps.logManualFundingInstructions as any).calls[0][0])
-      .toEqual(['0xtest2', '0xtest3']);
-    const warned = (warnSpy.calls as any[]).map((c) => c.join(' ')).join('\n');
-    expect(warned).toMatch(/Faucet partially completed/);
-    expect(existsSync(join(tmpHome, '.cursor', 'mcp.json'))).toBe(true);
-  });
+  // Faucet failure handling — manual `curl` instructions on a faucet error or
+  // partial success — now lives INSIDE `fundWalletsBestEffort` (the shared
+  // orchestrator) and is covered by dkg-core's faucet-orchestration tests. The
+  // mcp layer only decides whether to invoke it (asserted above), so the former
+  // mcp-level faucet-failure/partial-success tests were removed with the
+  // bespoke inline faucet path.
 
   // ── Phase-2: monorepo context detection + --installed/--monorepo flags ──
 
@@ -746,9 +629,9 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     const deps = makeDeps({
       findDkgMonorepoRoot: recorder(() => fakeRepoRoot),
     });
-    // No fetch stub: with start+fund+verify all off the action never
-    // reaches a `/api/status` probe — this test is purely about
-    // client-entry reclassification on the real filesystem.
+    // With start+fund+verify all off the action does no network calls —
+    // this test is purely about client-entry reclassification on the real
+    // filesystem.
     await mcpSetupAction({ start: false, fund: false, verify: false }, deps);
 
     // Post-write, the config now carries the monorepo-form entry —
@@ -1406,9 +1289,9 @@ describe('mcpSetupAction — bundled init + daemon-start + register flow', () =>
     const deps = makeDeps({
       findDkgMonorepoRoot: recorder(() => fakeRepoRoot),
     });
-    // No fetch stub: with start+fund+verify all off the action never
-    // reaches a `/api/status` probe — this test is purely about
-    // client-entry reclassification on the real filesystem.
+    // With start+fund+verify all off the action does no network calls —
+    // this test is purely about client-entry reclassification on the real
+    // filesystem.
     await mcpSetupAction({ start: false, fund: false, verify: false }, deps);
 
     const written = JSON.parse(readFileSync(vscodePath, 'utf-8'));

--- a/packages/core/test/faucet-orchestration.test.ts
+++ b/packages/core/test/faucet-orchestration.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Direct coverage for the shared faucet ORCHESTRATOR (`fundWalletsBestEffort`),
+// which the openclaw/hermes/mcp setup paths all delegate funding to. Only the
+// faucet HTTP primitive (`requestFaucetFunding`) is mocked — `readWallets`
+// (real fs read of DKG_HOME/wallets.json), `getFundableWalletAddresses`, and
+// `logManualFundingInstructions` (real console output) run as production code,
+// so the failure / partial-success / manual-curl branches are exercised for
+// real. `fundWalletsBestEffort` imports `requestFaucetFunding` from
+// `./faucet.js`, so mocking that module intercepts the orchestrator's call.
+vi.mock('../src/faucet.js', async (importActual) => {
+  const actual = await importActual<typeof import('../src/faucet.js')>();
+  return { ...actual, requestFaucetFunding: vi.fn() };
+});
+
+import { fundWalletsBestEffort } from '../src/faucet-orchestration.js';
+import { requestFaucetFunding } from '../src/faucet.js';
+
+const NETWORK = { faucet: { url: 'https://faucet.test/api', mode: 'testnet' } };
+
+describe('fundWalletsBestEffort (shared faucet orchestrator)', () => {
+  let dkgHome: string;
+  let oldDkgHome: string | undefined;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dkgHome = mkdtempSync(join(tmpdir(), 'dkg-faucet-orch-'));
+    oldDkgHome = process.env.DKG_HOME;
+    process.env.DKG_HOME = dkgHome;
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(requestFaucetFunding).mockReset();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    if (oldDkgHome === undefined) delete process.env.DKG_HOME;
+    else process.env.DKG_HOME = oldDkgHome;
+    rmSync(dkgHome, { recursive: true, force: true });
+  });
+
+  function seedWallets() {
+    writeFileSync(
+      join(dkgHome, 'wallets.json'),
+      JSON.stringify({
+        adminWallet: { address: '0xADMIN', privateKey: '0x0' },
+        wallets: [
+          { address: '0xOP1', privateKey: '0x0' },
+          { address: '0xOP2', privateKey: '0x0' },
+        ],
+      }),
+    );
+  }
+  const logged = () => logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+  const warned = () => warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+  // Just the `--data-raw '{"mode":...,"wallets":[...]}'` curl line(s), so wallet
+  // assertions target the manual-funding batch — NOT the unrelated
+  // `Wallets: 0x…` line readWallets() logs for every discovered wallet.
+  const curlWallets = () =>
+    logSpy.mock.calls.map((c) => c.join(' ')).filter((l) => l.includes('--data-raw')).join('\n');
+
+  it('skips (no faucet call) when the network has no faucet configured (e.g. mainnet)', async () => {
+    seedWallets();
+    await fundWalletsBestEffort({ network: {}, didStartDaemon: false });
+    expect(requestFaucetFunding).not.toHaveBeenCalled();
+    expect(logged()).toMatch(/Skipping wallet funding \(no faucet configured/);
+  });
+
+  it('skips (no faucet call) when wallets.json is absent', async () => {
+    // No seedWallets() — readWallets() returns [] (with a warning).
+    await fundWalletsBestEffort({ network: NETWORK, didStartDaemon: false });
+    expect(requestFaucetFunding).not.toHaveBeenCalled();
+    expect(warned()).toMatch(/No wallet addresses available/);
+  });
+
+  it('calls the faucet with the discovered addresses + idempotency seed on full success (no manual curl)', async () => {
+    seedWallets();
+    vi.mocked(requestFaucetFunding).mockResolvedValue({ success: true, funded: ['0.01 ETH', '1000 TRAC'] } as any);
+
+    await fundWalletsBestEffort({ network: NETWORK, idempotencySeed: 'agent-x', didStartDaemon: false });
+
+    expect(requestFaucetFunding).toHaveBeenCalledTimes(1);
+    const [url, mode, addresses, seed] = vi.mocked(requestFaucetFunding).mock.calls[0] as any[];
+    expect(url).toBe('https://faucet.test/api');
+    expect(mode).toBe('testnet');
+    expect(addresses).toEqual(['0xADMIN', '0xOP1', '0xOP2']);
+    expect(seed).toBe('agent-x');
+    expect(logged()).not.toMatch(/To fund wallets manually/);
+  });
+
+  it('logs manual curl instructions (non-fatal) when the faucet throws', async () => {
+    seedWallets();
+    vi.mocked(requestFaucetFunding).mockRejectedValue(new Error('faucet 503'));
+
+    // Best-effort: must never throw.
+    await expect(
+      fundWalletsBestEffort({ network: NETWORK, didStartDaemon: false }),
+    ).resolves.toBeUndefined();
+
+    expect(warned()).toMatch(/Faucet call failed: faucet 503/);
+    expect(logged()).toMatch(/To fund wallets manually/);
+    // All wallets fall back into the manual-curl batch when the call throws.
+    expect(curlWallets()).toContain('0xADMIN');
+    expect(curlWallets()).toContain('0xOP2');
+  });
+
+  it('logs the faucet-provided reason + manual curl for ALL wallets on success:false', async () => {
+    seedWallets();
+    vi.mocked(requestFaucetFunding).mockResolvedValue({
+      success: false,
+      funded: [],
+      error: 'cooldown_active: Caller cooldown active',
+    } as any);
+
+    await fundWalletsBestEffort({ network: NETWORK, didStartDaemon: false });
+
+    expect(warned()).toMatch(/cooldown_active/);
+    expect(logged()).toMatch(/To fund wallets manually/);
+    expect(curlWallets()).toContain('0xADMIN');
+    expect(curlWallets()).toContain('0xOP2');
+  });
+
+  it('logs manual curl for the FAILED wallets only on partial success', async () => {
+    seedWallets();
+    vi.mocked(requestFaucetFunding).mockResolvedValue({
+      success: true,
+      funded: ['0.01 ETH'],
+      failedWallets: ['0xOP2'],
+      error: 'Faucet did not fund all wallets: 0xOP2',
+    } as any);
+
+    await fundWalletsBestEffort({ network: NETWORK, didStartDaemon: false });
+
+    expect(warned()).toMatch(/Faucet partially completed/);
+    expect(logged()).toMatch(/To fund wallets manually/);
+    // Only the FAILED wallet is in the manual-curl batch; the funded ones are not.
+    expect(curlWallets()).toContain('0xOP2');
+    expect(curlWallets()).not.toContain('0xADMIN');
+    expect(curlWallets()).not.toContain('0xOP1');
+  });
+});


### PR DESCRIPTION
## Problem

`dkg mcp setup --network testnet` does not fund the node's wallets, unlike `dkg openclaw setup` / `dkg hermes setup`.

The MCP flow gated funding on a **bespoke 2s `GET /api/status` reachability probe** (`packages/cli/src/mcp-setup.ts`) before calling the faucet. On a real testnet node the status route computes metrics over connected peers + the triple store and routinely takes **>2s**, so the probe timed out, `daemonReachable` was `false`, and funding was silently skipped — `[setup] Skipping wallet funding (daemon not reachable on port …)` — even though wallets and a faucet existed.

openclaw/hermes have **no such probe**: they call the shared `fundWalletsBestEffort` orchestrator, which needs only `wallets.json` (eager-created by #1306) + `network.faucet.url`.

## Fix — use the same orchestrator openclaw/hermes use

- `mcp-setup.ts`: replace the probe + inline `requestFaucetFunding` path with `fundWalletsBestEffort({ network, idempotencySeed, didStartDaemon })`. Swap the `readWalletsWithRetry` / `requestFaucetFunding` / `logManualFundingInstructions` deps for the single `fundWalletsBestEffort` dep; wire it from `coreExports` in `commands/mcp.ts`. (Net −71 lines of bespoke faucet code.)
- The **F14 goal** ("--no-start + already-running daemon → fund") is preserved and strengthened: funding now depends only on `wallets.json` existing, never on a reachability probe. Wallet-read-with-retry + faucet-failure manual instructions now live inside `fundWalletsBestEffort` (covered by dkg-core's faucet-orchestration tests).

## Tests

- Rewrote the mcp faucet tests to assert `fundWalletsBestEffort` is invoked with `(network, idempotencySeed, didStartDaemon)` on a normal setup, **fires even under `--no-start`** (the direct regression guard for this bug), and is skipped under `--no-fund` / `--dry-run`.
- Removed the probe-specific F14/F26 + faucet-failure tests and the **live-daemon fixture that existed solely for the probe round-trip**. Bonus: the whole `mcp-setup` suite now runs without a live daemon — **108/108 pass locally** (previously all skipped when the live daemon couldn't boot).

## Verification

- `mcp-setup.test.ts`: 108/108 pass; cli build clean.
- The live-faucet e2e was intentionally not run (it would consume the per-IP testnet faucet budget for throwaway wallets); the new `--no-start` unit test proves the funding step is now reached (`fundWalletsBestEffort` invoked) where the probe previously skipped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)