### PR TITLE
[codex] Preserve context graph policy provenance

### DIFF
--- a/agent-docs/issue-1309-plan.md
+++ b/agent-docs/issue-1309-plan.md
@@ -1,0 +1,432 @@
+# Issue 1309 Plan: Preserve Derived Same-CG Target Provenance
+
+## Executive Summary
+
+Issue: [OriginTrail/dkg#1309](https://github.com/OriginTrail/dkg/issues/1309)
+
+Publishing a finalized/shared-memory public context graph can fail under slow or rate-limited RPC because the agent loses the distinction between two different meanings of a numeric context graph id:
+
+- explicit caller/remap intent, such as publishing source data into raw on-chain CG `1`
+- internally derived same-CG binding, such as local CG `sports` resolving to its own on-chain id `1`
+
+The current LU-5/LU-11 encryption-policy resolver receives both forms through `publishContextGraphId`. Since it treats any numeric `publishContextGraphId` as an explicit raw remap target, a normal same-CG publish of `sports` can trigger a redundant live policy probe for raw target `1`. If that redundant target probe times out, the publish fails closed even when the source CG policy already proved public.
+
+Selected fix: split policy-resolution target intent from AEAD/ACK/on-chain binding id. Explicit or unproven numeric targets remain policy targets and keep the existing fail-closed raw-slot behavior. Numeric ids become binding-only inputs only when the agent derived or verified them as the source CG's own on-chain id. Verified same-CG ids still bind AEAD, ACK digests, on-chain publish params, and finalization gossip to the numeric id, but they do not force a second raw-target policy decision.
+
+Risk classification: High. The change touches publish encryption policy selection. The implementation must preserve plaintext for chain-confirmed public CGs, encryption for curated/private CGs, and fail-closed behavior for unknown or explicit remap targets.
+
+## Team Findings
+
+### Issue Analyst
+
+- Root cause is provenance loss. The publisher layer already distinguishes `publishContextGraphId` as remap signal from `onChainContextGraphId` as ACK/chain target.
+- The agent encryption resolver collapses them into one positional parameter.
+- Same-CG policy must be source-based: `resolveOnChainAccessPolicyState(contextGraphId)`.
+- Derived numeric ids must still be used for AEAD binding when encryption is required.
+- Explicit numeric remaps must continue to probe the raw on-chain slot and fail closed on unknown target policy.
+
+### Codebase Mapper
+
+Primary code:
+
+- `packages/agent/src/dkg-agent-publish.ts`
+  - `_publish`
+  - `update`
+  - `_resolveCuratedChainKeyContext`
+  - `_resolveEncryptInlinePayload`
+  - `_resolveEncryptInlineChunked`
+  - `publishFromSharedMemory`
+  - `publishFromFinalizedAssertion`
+- `packages/publisher/src/dkg-publisher.ts`
+  - `publishFromSharedMemory` already separates remap `publishContextGraphId` from `onChainContextGraphId`
+
+Important layer distinction:
+
+- Agent SWM wrapper:
+  - `publishContextGraphId` means explicit remap or sub-CG target
+  - `onChainContextGraphId` means ACK/tx target without remap
+- Publisher inner publish:
+  - `publishContextGraphId` means ACK/tx target
+
+### QA/Repro
+
+Best targeted tests:
+
+- `packages/agent/test/encrypt-inline-policy.test.ts`
+- optional supporting checks in `packages/agent/test/swm-public-cg-plaintext.test.ts`
+
+Useful verification commands:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-agent exec vitest run test/encrypt-inline-policy.test.ts test/swm-public-cg-plaintext.test.ts test/dkg-agent-on-chain-policy.test.ts
+```
+
+If publisher code changes:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/v10-remap-wire.test.ts test/storage-ack-handler.test.ts
+```
+
+## Root Cause
+
+Current resolver shape:
+
+```ts
+const targetCgId = publishContextGraphId ?? contextGraphId;
+const explicitRawTarget = publishContextGraphId !== undefined && /^\d+$/.test(targetCgId.trim());
+```
+
+For `contextGraphId = "sports"` and internally derived `onChainId = "1"`:
+
+1. `publishFromSharedMemory` computes `ctxGraphIdStr = undefined`.
+2. It resolves `onChainId = await getContextGraphOnChainId("sports")`, yielding `"1"`.
+3. It calls `_resolveEncryptInlinePayload("sports", ..., "1")`.
+4. It calls `_resolveEncryptInlineChunked("sports", ..., "1")`.
+5. `_resolveCuratedChainKeyContext` sees numeric `publishContextGraphId`.
+6. It treats `"1"` as an explicit raw target and probes target policy separately.
+7. If target live policy probe times out, LU-11 throws:
+
+```text
+source CG "sports" curated=false, target CG "1" curated=unknown
+```
+
+The second target probe is unnecessary for same-CG publishes because the source policy resolver already binds local `sports` to its on-chain slot before trusting policy.
+
+## Behavioral Requirements
+
+- Same-CG public publish:
+  - source `sports` resolves on-chain policy `0`
+  - derived on-chain id `1` must not trigger raw target policy probing
+  - plaintext path must be selected
+
+- Same-CG private publish:
+  - source resolves policy `1`
+  - encryption and chunked LU-11 path must remain active
+  - AEAD must bind to numeric id `1` when available
+
+- Explicit numeric remap:
+  - caller-provided raw target `1` must still be treated as raw on-chain slot
+  - unknown target policy must fail closed
+  - source/target policy mismatch must still throw
+
+- Caller-supplied or provenance-erased numeric target:
+  - must not be downgraded to binding-only unless it is verified against `getContextGraphOnChainId(contextGraphId)`
+  - if verification is unavailable or mismatched, keep the id as an explicit policy target
+
+- Unknown same-CG source policy:
+  - must fail closed unless existing positive local curated signal safely chooses encryption
+
+- No publisher ACK or on-chain semantics should change:
+  - ACK digest target remains numeric on-chain id
+  - on-chain publish target remains numeric on-chain id
+  - finalization gossip still carries the resolved numeric target
+  - remap root-copy behavior remains governed by explicit remap only
+
+## Current Flow
+
+```mermaid
+flowchart TD
+    A["publishFromSharedMemory(contextGraphId=sports)"] --> B["ctxGraphIdStr = undefined"]
+    B --> C["onChainId = getContextGraphOnChainId(sports) = 1"]
+    C --> D["_resolveEncryptInlineChunked(sports, publishContextGraphId=1)"]
+    D --> E["targetCgId = 1"]
+    E --> F["explicitRawTarget = true"]
+    F --> G["probe raw target 1 via readLiveOnChainAccessPolicy"]
+    G --> H{"target probe result"}
+    H -->|timeout/null| I["throw LU-11 unknown policy"]
+    H -->|public| J["probe source sports"]
+    J --> K["select plaintext"]
+```
+
+Problem: `C -> D -> F` treats an internally derived same-CG binding id as an explicit raw remap.
+
+## Desired Flow
+
+```mermaid
+flowchart TD
+    A["publishFromSharedMemory(contextGraphId=sports)"] --> B{"explicit remap/sub-CG?"}
+    B -->|no| C["derivedOnChainId = getContextGraphOnChainId(sports) = 1"]
+    C --> D["policyTarget = source sports"]
+    C --> E["aeadBindingId = 1"]
+    D --> F["resolveOnChainAccessPolicyState(sports)"]
+    F --> G{"source policy"}
+    G -->|public 0| H["plaintext path, no raw target probe"]
+    G -->|private 1| I["encrypted/chunked path bound to aeadBindingId 1"]
+    G -->|unknown| J["fail closed unless local curated signal permits encryption"]
+    B -->|yes| K["explicitPolicyTarget = caller target"]
+    K --> L["numeric target remains raw on-chain slot"]
+    L --> M["existing fail-closed target/mismatch logic"]
+```
+
+## Approaches Considered
+
+### Approach A: Stop Passing Derived On-Chain IDs To The Resolver
+
+Pass `undefined` to `_resolveEncryptInlinePayload` and `_resolveEncryptInlineChunked` when the id was internally derived.
+
+Pros:
+
+- Smallest immediate diff.
+- Prevents redundant raw target policy probe.
+
+Cons:
+
+- Private same-CG publishes would bind AEAD to the local label instead of the canonical numeric id unless another parameter is added.
+- Risks reintroducing prior undecryptable payload behavior when consumers verify/decrypt by numeric on-chain id.
+
+Rejected.
+
+### Approach B: Add Boolean Provenance To Existing `publishContextGraphId`
+
+Keep passing the numeric id, but add an option such as `publishContextGraphIdIsDerived: true`. The resolver would treat target policy as source policy when the flag is true.
+
+Pros:
+
+- Minimal code churn.
+- Preserves AEAD binding id.
+
+Cons:
+
+- Keeps one parameter overloaded with two meanings.
+- Future call sites can still accidentally pass a numeric id without provenance.
+
+Acceptable fallback, but not selected.
+
+### Approach C: Split Explicit Policy Target From Binding ID
+
+Treat the existing fourth resolver argument as explicit policy/remap target only, and add a final options object for binding-only ids:
+
+```ts
+type ResolveCuratedChainKeyContextOptions = {
+  /**
+   * Used only for AEAD associated-data binding. Never used for policy lookup.
+   */
+  aeadBindingContextGraphId?: string;
+};
+```
+
+For normal same-CG publish:
+
+```ts
+_resolveEncryptInlineChunked(contextGraphId, subGraphName, author, undefined, {
+  aeadBindingContextGraphId: onChainId ?? undefined,
+});
+```
+
+For explicit remap:
+
+```ts
+_resolveEncryptInlineChunked(contextGraphId, subGraphName, author, ctxGraphIdStr, {
+  aeadBindingContextGraphId: onChainId ?? ctxGraphIdStr,
+});
+```
+
+Pros:
+
+- Names the two responsibilities directly.
+- Removes numeric-shape inference for internally derived ids.
+- Preserves old explicit remap behavior.
+- Keeps private same-CG AEAD bound to canonical numeric id.
+
+Cons:
+
+- Requires call-site and test updates.
+- Existing helper tests that assert positional call arguments must be updated.
+
+Selected.
+
+## Selected Implementation Plan
+
+1. Update resolver API in `packages/agent/src/dkg-agent-publish.ts`.
+   - Add a local type for resolver options:
+
+```ts
+type ResolveCuratedChainKeyContextOptions = {
+  /**
+   * Binding-only id for AEAD associated data. This value must never affect
+   * plaintext/encrypted policy selection.
+   */
+  aeadBindingContextGraphId?: string;
+};
+```
+
+   - Add optional `options?: ResolveCuratedChainKeyContextOptions` to:
+     - `_resolveCuratedChainKeyContext`
+     - `_resolveEncryptInlinePayload`
+     - `_resolveEncryptInlineChunked`
+   - Interpret the fourth argument as `explicitPolicyTargetContextGraphId`.
+   - Compute:
+
+```ts
+const targetCgId = explicitPolicyTargetContextGraphId ?? contextGraphId;
+const aeadCgId = options?.aeadBindingContextGraphId ?? explicitPolicyTargetContextGraphId ?? contextGraphId;
+```
+
+2. Update agent call sites.
+   - `_publish`:
+     - always distinguish caller-supplied `opts.onChainContextGraphId` from the locally resolved id
+     - if the target id came from `getContextGraphOnChainId(contextGraphId)`, pass no explicit policy target and pass it as `aeadBindingContextGraphId`
+     - if `opts.onChainContextGraphId` is supplied, verify it equals the locally resolved id before treating it as binding-only
+     - if verification is unavailable or mismatched, pass the supplied id as the explicit policy target so existing fail-closed target/mismatch logic remains active
+   - `update`:
+     - pass no explicit policy target
+     - pass `updateOnChainId` as `aeadBindingContextGraphId`
+   - `publishFromSharedMemory`:
+     - pass `ctxGraphIdStr` as explicit target only when explicit remap/sub-CG exists
+     - pass `onChainId` as `aeadBindingContextGraphId`
+   - CLI async publisher encryption factory:
+     - extract `resolveDaemonPublishEncryption` so the async publisher split is directly testable
+     - treat `publishOptions.publishContextGraphId` as binding-only in this path because the async lift resolves it from the source workspace slice before generic `PublishOptions`
+     - document that future explicit async remaps need a separate provenance field instead of reusing this derived value
+
+3. Preserve publisher behavior.
+   - Do not change `DKGPublisher.publishFromSharedMemory` unless tests reveal mismatch.
+   - It already passes:
+     - `publishContextGraphId: ctxGraphIdStr` for remap behavior
+     - `onChainContextGraphId: onChainId` for ACK/tx target
+
+4. Add regression tests in `packages/agent/test/encrypt-inline-policy.test.ts`.
+   - Same-CG public derived numeric binding:
+     - model `sports -> 1` and source policy `0`
+     - call resolver with explicit target `undefined` and `aeadBindingContextGraphId: "1"`
+     - poison `readLiveOnChainAccessPolicy("1")` so a redundant raw-target probe would fail the test
+     - assert raw target `1` is not consulted for policy
+     - expect plaintext path
+   - Explicit numeric remap unknown:
+     - call resolver with explicit target `"1"`
+     - target raw probe unknown
+     - expect fail-closed LU-5/LU-11 error
+   - Explicit numeric remap mismatch:
+     - source public, target private throws the existing mismatch error
+     - source private, target public throws the existing mismatch error
+   - Same-CG private derived numeric binding:
+     - source policy/private signal selects encryption
+     - result must use `aeadCgId: "2"`
+     - poison policy/existence/private lookups for `"2"` to prove the binding id is not authoritative for policy
+   - Update routing tests for `_publish` and add/adjust SWM routing coverage:
+     - same-CG path calls resolver with no explicit target plus binding options
+     - explicit remap path still supplies explicit policy target
+     - caller-supplied `onChainContextGraphId` mismatch stays explicit policy target
+   - Add LU-11 wrapper parity coverage:
+     - LU-11 receives the same explicit-target/options split as LU-5
+     - explicit numeric remap unknown still throws with `LU-11`
+   - Add interface fallout coverage:
+     - update private-helper calls/types in `swm-sender-key-pending-by-agent.test.ts`
+
+5. Add or update async/publisher boundary tests.
+   - Add a focused test for the CLI async `publishEncryptionFactory` split if a suitable existing test can reach it.
+   - Always run publisher remap wire tests to pin ACK/tx target semantics even if publisher code is unchanged.
+
+6. Run verification.
+   - First targeted agent tests.
+   - Then type/build checks if targeted tests pass.
+   - Always run publisher remap wire tests to verify ACK/tx target semantics.
+
+## Adversarial Review Questions
+
+- Can a caller-supplied `onChainContextGraphId` be an implicit remap that now bypasses target policy checks?
+- Does async lift ever carry an explicit remap in `publishOptions.publishContextGraphId`, or is it always derived from source workspace resolution?
+- Do LU-5 and LU-11 remain perfectly aligned after signature changes?
+- Does a private same-CG publish still bind AEAD/chunked encryption to the numeric target id?
+- Does any explicit raw numeric target still use `readLiveOnChainAccessPolicy` and fail closed?
+- Do error messages remain useful enough to diagnose source vs target policy failures?
+
+## Verification Plan
+
+Primary:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-agent exec vitest run test/encrypt-inline-policy.test.ts
+```
+
+Secondary:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-agent exec vitest run test/encrypt-inline-policy.test.ts test/swm-public-cg-plaintext.test.ts test/dkg-agent-on-chain-policy.test.ts
+```
+
+If publisher boundary changes:
+Required publisher boundary check:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/v10-remap-wire.test.ts
+```
+
+Optional if ACK handler behavior is touched:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/storage-ack-handler.test.ts
+```
+
+Build/type check:
+
+```powershell
+pnpm --filter @origintrail-official/dkg-agent run build
+```
+
+## Rollback / Mitigation
+
+The rollback is limited to `packages/agent/src/dkg-agent-publish.ts` and targeted tests. Because publisher ACK/on-chain behavior is intended to remain unchanged, reverting the resolver signature and call-site updates should restore prior behavior.
+
+Operational mitigation remains independent: use a dedicated RPC endpoint instead of public `https://mainnet.base.org` to reduce 429 and timeout frequency.
+
+## Production-Readiness Gate
+
+A staff engineer should approve only if:
+
+- same-CG public derived-id publish no longer performs an explicit raw target policy decision
+- explicit numeric remap remains fail-closed on unknown target
+- same-CG private publish still encrypts and binds to numeric id
+- tests cover both LU-5 and LU-11 paths or prove the shared resolver covers both
+- no ACK/tx/finalization target semantics change
+- caller-supplied or unverified numeric ids do not bypass target policy checks
+
+## Plan Review Status
+
+Adversarial review completed. Required updates applied:
+
+- binding-only ids are limited to agent-derived or verified same-CG provenance
+- caller-supplied `onChainContextGraphId` remains explicit unless verified
+- async publisher runtime is an implementation and verification target
+- option naming changed to `aeadBindingContextGraphId`
+- tests must poison binding-id policy probes to avoid false positives
+- explicit remap mismatch and LU-11 parity coverage are required
+
+## Implementation Review Status
+
+Adversarial implementation review completed with GPT 5.5 xhigh teammates. Findings and fixes:
+
+- Public-source/private-target explicit remaps originally bypassed the mismatch check because the source probe was skipped when the raw target was curated. Fixed by probing the source whenever the raw target policy is known, and added both mismatch-direction tests.
+- The async daemon helper originally attempted to re-resolve the on-chain id, which could reintroduce the same degraded dependency that issue 1309 exposed. Fixed by treating the current async-lift value as binding-only and documenting that future explicit async remaps require a separate provenance field.
+- Update routing did not have direct regression coverage. Added a test proving update passes the derived numeric id as AEAD binding-only while preserving the publisher target.
+- Private same-CG sender-key setup did not directly assert the returned AEAD id. Added coverage that verifies `aeadCgId` uses the resolver binding option.
+- The extracted daemon helper initially used `Pick<DKGAgent, ...>`, which failed TypeScript because the private resolver methods declare `this: DKGAgent`. Fixed by typing the helper parameter as `DKGAgent`.
+
+## Verification Results
+
+Final verification after review fixes:
+
+```powershell
+pnpm exec vitest run --config vitest.config.ts test/encrypt-inline-policy.test.ts
+# packages/agent: 20 passed
+
+pnpm exec vitest run --config vitest.config.ts test/encrypt-inline-policy.test.ts test/swm-public-cg-plaintext.test.ts test/dkg-agent-on-chain-policy.test.ts
+# packages/agent: 73 passed
+
+pnpm exec vitest run --config vitest.config.ts test/swm-sender-key-pending-by-agent.test.ts
+# packages/agent: 26 passed
+
+pnpm exec vitest run test/daemon-publish-encryption-factory.test.ts
+# packages/cli: 1 passed
+
+pnpm --filter @origintrail-official/dkg-agent run build
+# passed
+
+pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/v10-remap-wire.test.ts
+# 3 passed
+
+pnpm --filter @origintrail-official/dkg run build
+# passed
+```
+
+One attempted parallel verification run failed because two agent suites raced the shared Hardhat harness on the same local port/nonce. The same tests passed when rerun sequentially.

--- a/agent-docs/notes/architecture.md
+++ b/agent-docs/notes/architecture.md
@@ -1,0 +1,30 @@
+# Architecture Notes
+
+## Overview
+
+This file records durable architecture knowledge discovered during work in this repository.
+
+## Current Focus
+
+- Issue 1309 concerns DKG agent publish flows, specifically how local context graph IDs and on-chain context graph IDs are passed into LU-5/LU-11 encryption policy resolution.
+
+## Components
+
+- `packages/agent/src/dkg-agent-publish.ts`
+  - `_publish`, `update`, and `publishFromSharedMemory` resolve publisher target ids and feed encryption policy helpers.
+  - `_resolveCuratedChainKeyContext` owns curated/public policy selection and sender-key bootstrap.
+  - `_resolveEncryptInlinePayload` implements LU-5 inline AEAD wrapping.
+  - `_resolveEncryptInlineChunked` implements LU-11 chunked encryption.
+- `packages/cli/src/daemon/lifecycle.ts`
+  - `resolveDaemonPublishEncryption` bridges async publish options to the agent encryption helpers.
+- `packages/publisher/src/dkg-publisher.ts`
+  - Publisher-level SWM remap handling already distinguishes explicit remap target (`publishContextGraphId`) from ACK/tx target (`onChainContextGraphId`).
+
+## Publish Policy Architecture
+
+Policy resolution now separates two concepts:
+
+- Explicit policy target: caller/remap intent that may require raw on-chain target policy probing and fail-closed mismatch checks.
+- AEAD binding context graph id: associated-data id for encrypted payloads/chunks; it must never drive plaintext/encrypted policy selection.
+
+Derived same-CG on-chain ids use the source CG for policy and the numeric on-chain id for AEAD binding. Explicit or unverified numeric targets keep the existing raw-slot fail-closed behavior.

--- a/agent-docs/notes/decisions.md
+++ b/agent-docs/notes/decisions.md
@@ -1,0 +1,25 @@
+# Decisions
+
+## Decision Log
+
+### ADR: Split Publish Policy Target From AEAD Binding ID
+
+Issue: internally derived same-CG numeric ids were passed through the same resolver argument as explicit remap targets, causing redundant raw on-chain policy probes and fail-closed publish failures under RPC degradation.
+
+Decision: treat the resolver's fourth argument as an explicit policy/remap target only, and add `aeadBindingContextGraphId` as a binding-only option.
+
+Rationale:
+
+- Same-CG source policy should be resolved through the normal local/source CG path.
+- Private same-CG publishes still need AEAD associated data bound to the canonical numeric on-chain id.
+- Explicit or unverified numeric remaps must continue to probe raw target policy and fail closed on unknown or mismatch.
+
+Consequence: future call sites must decide whether a numeric id is an explicit policy target or binding-only before calling the resolver.
+
+### ADR: Async Daemon Publish Target Provenance
+
+Issue: the daemon async publisher exposes a generic `publishContextGraphId` after the async lift has already resolved the source workspace target.
+
+Decision: `resolveDaemonPublishEncryption` treats this current async-lift value as binding-only and documents that future explicit async remaps need a separate provenance field.
+
+Rationale: re-resolving or raw-probing this value in the encryption factory can reintroduce the degraded RPC dependency that issue 1309 fixes.

--- a/agent-docs/notes/lessons.md
+++ b/agent-docs/notes/lessons.md
@@ -1,0 +1,15 @@
+# Lessons
+
+## Active Lessons
+
+- Mistake pattern: treating a numeric id as authoritative without preserving whether it was derived internally or supplied as remap intent.
+  Root cause: one positional `string` argument carried both policy target and AEAD binding semantics.
+  Preventive rule: security-sensitive helpers need separate parameters or option fields for separate authorities; tests should poison the invalid authority path.
+
+- Mistake pattern: parallel verification of suites sharing a fixed local Hardhat harness can produce nonce/connection failures unrelated to the code change.
+  Root cause: two test processes raced the same local port/account state.
+  Preventive rule: run Hardhat-backed agent suites sequentially unless the harness is explicitly isolated.
+
+- Mistake pattern: helper extraction around methods with explicit `this: DKGAgent` can fail TypeScript when typed as `Pick<DKGAgent, ...>`.
+  Root cause: method `this` context remains part of the call contract.
+  Preventive rule: type such helpers with the concrete receiver type or wrap calls in a properly typed adapter.

--- a/agent-docs/notes/patterns.md
+++ b/agent-docs/notes/patterns.md
@@ -1,0 +1,8 @@
+# Patterns
+
+## Current Patterns
+
+- Security-sensitive ids should carry provenance in the type/API shape. Avoid overloading one `string` parameter for both policy authority and cryptographic binding.
+- For publish encryption tests, poison the lookup that must not be called. This catches accidental policy probes that would otherwise pass under mocked happy paths.
+- LU-5 and LU-11 resolver changes need parity tests because they share policy selection but diverge at payload/chunk emission.
+- Generated Hardhat deployment artifacts under `packages/evm-module/deployments/localhost*` can appear during tests and should be cleaned before staging.

--- a/agent-docs/notes/pr-history.md
+++ b/agent-docs/notes/pr-history.md
@@ -1,0 +1,20 @@
+# PR History
+
+## Entries
+
+### Issue 1309: Derived Same-CG Policy Provenance
+
+PR: https://github.com/OriginTrail/dkg/pull/1313
+
+Implemented a resolver API split so derived same-CG on-chain ids are binding-only for AEAD while explicit/unverified numeric remaps remain policy targets. Added regression tests for LU-5, LU-11, update routing, SWM routing, sender-key AEAD binding, explicit mismatch directions, and daemon async encryption factory behavior.
+
+Key review fixes:
+
+- source/public vs target/private mismatch now rejects
+- async daemon encryption treats current lift target as binding-only
+- update path now has direct binding-only coverage
+- daemon helper TypeScript receiver type fixed
+
+Verification: focused agent tests, broader agent policy tests, sender-key suite, daemon helper test, publisher remap wire test, agent build, and root CLI build all passed.
+
+Final offline adversarial review: completed after PR creation while the remote reviewer was unavailable. GPT 5.5 xhigh security/provenance, integration/data-flow, and QA/regression lenses found no actionable blockers. Residual non-blocking risks are future explicit async-remap provenance, unavoidable source policy fail-closed behavior under degraded RPC, and chunked AEAD lacking a decrypt round-trip test equivalent to LU-5.

--- a/agent-docs/todo.md
+++ b/agent-docs/todo.md
@@ -1,0 +1,70 @@
+# Active Work
+
+## Issue 1309: Derived On-Chain Context Graph ID Treated As Explicit Remap
+
+Risk: High. The change touches publish encryption-policy selection and must preserve fail-closed behavior for explicit raw remaps.
+
+Status: Complete.
+
+### Plan
+
+- [x] Initialize project memory files.
+- [x] Gather issue context and inspect relevant publish/policy code paths.
+- [x] Coordinate GPT 5.5 xhigh teammate analysis for issue scope, code architecture, and QA/repro strategy.
+- [x] Write detailed implementation plan in `agent-docs/issue-1309-plan.md`.
+- [x] Run adversarial plan review and update the plan.
+- [x] Implement the selected fix with focused tests.
+- [x] Run verification and adversarial implementation review.
+- [x] Apply review fixes if needed.
+- [x] Update project memory with outcomes and lessons.
+- [x] Create a branch, commit, push, and open a PR into `main`.
+
+### Review
+
+Implemented the selected split between explicit policy target and AEAD binding id. Same-CG derived numeric ids now bind AEAD without driving policy lookup, while explicit/unverified numeric remaps keep fail-closed raw target checks. Implementation review found and fixed explicit remap mismatch parity, async daemon provenance, update routing coverage, sender-key binding coverage, and a TypeScript `this`-context issue in the extracted daemon helper.
+
+Verification passed:
+
+- agent encrypt-inline policy: 20 tests
+- agent policy/plaintext/on-chain suite: 73 tests
+- agent SWM sender-key pending suite: 26 tests
+- CLI daemon encryption factory: 1 test
+- publisher v10 remap wire: 3 tests
+- agent build
+- CLI/root build
+
+PR: https://github.com/OriginTrail/dkg/pull/1313
+
+## Final Offline Adversarial Review
+
+Status: Complete.
+
+### Plan
+
+- [x] Run independent GPT 5.5 xhigh review lenses: security/provenance, integration/data-flow, QA/regression.
+- [x] Run main-agent diff audit against `main` and compare implementation to `agent-docs/issue-1309-plan.md`.
+- [x] Re-run targeted verification if the final review touches code or reveals uncertainty.
+- [x] Apply any required fixes, update docs, and push the PR branch.
+- [x] Record final review outcome.
+
+### Outcome
+
+No actionable findings from the final offline adversarial review.
+
+Review lenses:
+
+- Security/provenance: confirmed derived same-CG numeric ids are binding-only while explicit/remap ids still drive policy checks, unknown-target fail-closed behavior, and public/private mismatch rejection.
+- Integration/data-flow: traced `_publish`, `update`, `publishFromSharedMemory`, `publishFromFinalizedAssertion`, daemon async encryption, and publisher boundary semantics against the plan.
+- QA/regression: confirmed regression coverage is sufficient for this fix; targeted tests were rerun by the QA reviewer.
+- Main-agent audit: rechecked async-lift provenance and confirmed current async `publishContextGraphId` is sourced by workspace resolution, while synchronous API remaps still enter as explicit remap targets.
+
+Residual non-blocking risks:
+
+- Future explicit async remaps need a separate provenance field before being enabled.
+- The fix removes the redundant derived-target policy probe, but the necessary source policy probe can still fail closed under real RPC degradation.
+- Chunked AEAD binding is argument-verified; LU-5 has the stronger decrypt round-trip assertion.
+
+Additional verification during final review:
+
+- `packages/agent`: `pnpm exec vitest run --config vitest.config.ts test/encrypt-inline-policy.test.ts` - 20 passed.
+- `packages/cli`: `pnpm exec vitest run test/daemon-publish-encryption-factory.test.ts` - 1 passed.

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -407,6 +407,19 @@ import type { DKGAgent } from './dkg-agent.js';
  */
 export const SEAL_CAPABILITY_GAP_CODE = 'SEAL_CAPABILITY_GAP';
 
+export type ResolveCuratedChainKeyContextOptions = {
+  /**
+   * Binding-only id for AEAD associated data. This value must never affect
+   * plaintext/encrypted policy selection.
+   */
+  aeadBindingContextGraphId?: string;
+};
+
+function normalizeOptionalContextGraphId(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export class PublishMethods extends DKGAgentBase {
   async publishWorkspaceGossip(this: DKGAgent,
     contextGraphId: string,
@@ -1284,7 +1297,27 @@ export class PublishMethods extends DKGAgentBase {
     }
     const v10ACKProvider = this.createV10ACKProvider(contextGraphId);
 
-    const onChainId = opts?.onChainContextGraphId ?? await this.getContextGraphOnChainId(contextGraphId);
+    const suppliedOnChainId = normalizeOptionalContextGraphId(opts?.onChainContextGraphId);
+    let derivedOnChainId: string | undefined;
+    try {
+      derivedOnChainId = normalizeOptionalContextGraphId(await this.getContextGraphOnChainId(contextGraphId));
+    } catch (err) {
+      if (!suppliedOnChainId) throw err;
+      this.log.warn(
+        ctx,
+        `Could not verify caller-supplied on-chain cgId ${suppliedOnChainId} for "${contextGraphId}" ` +
+          `before publish policy resolution; treating it as an explicit target: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+      );
+    }
+    const onChainId = suppliedOnChainId ?? derivedOnChainId;
+    const explicitPublishPolicyTarget = suppliedOnChainId && suppliedOnChainId !== derivedOnChainId
+      ? suppliedOnChainId
+      : undefined;
+    const publishBindingOptions = onChainId
+      ? { aeadBindingContextGraphId: onChainId }
+      : undefined;
 
     // RFC-001 §9.x — sign-at-creation. The publisher refuses on-chain
     // publishes without a `precomputedAttestation`, so the agent
@@ -1339,15 +1372,16 @@ export class PublishMethods extends DKGAgentBase {
     // authorAgentAddress, so we let _resolveEncryptInlinePayload fall back
     // to `defaultAgentAddress ?? peerId`.
     //
-    // Codex PR #608 R2 #12: thread the target on-chain CG id through so
-    // the AEAD key derives from the canonical id consumers will use to
-    // verify/decrypt the published KC. Falls back to the source id when
-    // there's no remap, which is the common case.
+    // Codex PR #608 R2 #12 / GH #1309: keep policy target provenance
+    // separate from the AEAD binding id. Agent-derived same-CG ids bind
+    // AEAD to the canonical on-chain id without being treated as explicit
+    // remaps; caller-supplied mismatches stay explicit policy targets.
     const encryptInlinePayload = await this._resolveEncryptInlinePayload(
       contextGraphId,
       opts?.subGraphName,
       undefined,
-      onChainId ?? undefined,
+      explicitPublishPolicyTarget,
+      publishBindingOptions,
     );
     // OT-RFC-38 LU-11 — also resolve the chunked emitter for curated
     // CGs. When set, the publisher prefers this path: chunks fan out
@@ -1357,7 +1391,8 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       opts?.subGraphName,
       undefined,
-      onChainId ?? undefined,
+      explicitPublishPolicyTarget,
+      publishBindingOptions,
     );
 
     const result = await this.publisher.publish({
@@ -1521,13 +1556,17 @@ export class PublishMethods extends DKGAgentBase {
     // `undefined` for a public CG, so the function's truthiness IS the curated
     // gate — exactly what the producer keys `useEncryptedInlineUpdate` off of.
     // No separate accessPolicy read is needed. The 4th arg mirrors publish: the
-    // target on-chain cgId so the AEAD key derives from the canonical id
-    // consumers verify against.
+    // target on-chain cgId is now binding-only so the AEAD key derives from
+    // the canonical id consumers verify against without reclassifying the
+    // same-CG update as an explicit remap.
     const updateEncryptInlinePayload = await this._resolveEncryptInlinePayload(
       contextGraphId,
       undefined,
       undefined,
-      updateOnChainId ?? undefined,
+      undefined,
+      updateOnChainId
+        ? { aeadBindingContextGraphId: updateOnChainId }
+        : undefined,
     );
     const isCuratedUpdate = typeof updateEncryptInlinePayload === 'function';
 
@@ -1545,7 +1584,10 @@ export class PublishMethods extends DKGAgentBase {
           contextGraphId,
           undefined,
           undefined,
-          updateOnChainId ?? undefined,
+          undefined,
+          updateOnChainId
+            ? { aeadBindingContextGraphId: updateOnChainId }
+            : undefined,
         )
       : undefined;
 
@@ -2819,11 +2861,12 @@ export class PublishMethods extends DKGAgentBase {
     contextGraphId: string,
     subGraphName: string | undefined,
     authorAgentAddress: string | undefined,
-    publishContextGraphId: string | undefined,
+    explicitPolicyTargetContextGraphId: string | undefined,
     logPrefix: string,
+    options?: ResolveCuratedChainKeyContextOptions,
   ): Promise<{ chainKey: Uint8Array; aeadCgId: string; senderAddress: string } | undefined> {
     const ctx = createOperationContext('publish');
-    const targetCgId = publishContextGraphId ?? contextGraphId;
+    const targetCgId = explicitPolicyTargetContextGraphId ?? contextGraphId;
     const probeIsCurated = async (cgId: string, opts?: { rawOnChainSlot?: boolean }): Promise<boolean | null> => {
       // Consume the SHARED tri-state resolver (the same one behind the
       // SWM-gossip gate) so the publish-inline path can never DIVERGE from it,
@@ -2872,12 +2915,12 @@ export class PublishMethods extends DKGAgentBase {
       } catch { /* fall through to the plaintext-inline default */ }
       return false;
     };
-    const explicitRawTarget = publishContextGraphId !== undefined && /^\d+$/.test(targetCgId.trim());
+    const explicitRawTarget = explicitPolicyTargetContextGraphId !== undefined && /^\d+$/.test(targetCgId.trim());
     let sourceIsCurated: boolean | null;
     let targetIsCurated: boolean | null;
     if (targetCgId !== contextGraphId && explicitRawTarget) {
       targetIsCurated = await probeIsCurated(targetCgId, { rawOnChainSlot: true });
-      sourceIsCurated = targetIsCurated ? null : await probeIsCurated(contextGraphId);
+      sourceIsCurated = targetIsCurated == null ? null : await probeIsCurated(contextGraphId);
     } else {
       sourceIsCurated = await probeIsCurated(contextGraphId);
       targetIsCurated = targetCgId === contextGraphId
@@ -2994,7 +3037,7 @@ export class PublishMethods extends DKGAgentBase {
 
     return {
       chainKey: state.chainKey,
-      aeadCgId: publishContextGraphId ?? contextGraphId,
+      aeadCgId: options?.aeadBindingContextGraphId ?? explicitPolicyTargetContextGraphId ?? contextGraphId,
       senderAddress,
     };
   }
@@ -3003,10 +3046,11 @@ export class PublishMethods extends DKGAgentBase {
     contextGraphId: string,
     subGraphName?: string,
     authorAgentAddress?: string,
-    publishContextGraphId?: string,
+    explicitPolicyTargetContextGraphId?: string,
+    options?: ResolveCuratedChainKeyContextOptions,
   ): Promise<((plaintext: Uint8Array) => Promise<Uint8Array>) | undefined> {
     const resolved = await this._resolveCuratedChainKeyContext(
-      contextGraphId, subGraphName, authorAgentAddress, publishContextGraphId, 'LU-5',
+      contextGraphId, subGraphName, authorAgentAddress, explicitPolicyTargetContextGraphId, 'LU-5', options,
     );
     if (!resolved) return undefined;
     const { chainKey, aeadCgId } = resolved;
@@ -3056,7 +3100,8 @@ export class PublishMethods extends DKGAgentBase {
     contextGraphId: string,
     subGraphName?: string,
     authorAgentAddress?: string,
-    publishContextGraphId?: string,
+    explicitPolicyTargetContextGraphId?: string,
+    options?: ResolveCuratedChainKeyContextOptions,
   ): Promise<
     | ((input: { plaintextNquads: Uint8Array; batchId: Uint8Array; publishOperationId: string }) => Promise<{
         ciphertextChunksRoot: Uint8Array;
@@ -3067,7 +3112,7 @@ export class PublishMethods extends DKGAgentBase {
     | undefined
   > {
     const resolved = await this._resolveCuratedChainKeyContext(
-      contextGraphId, subGraphName, authorAgentAddress, publishContextGraphId, 'LU-11',
+      contextGraphId, subGraphName, authorAgentAddress, explicitPolicyTargetContextGraphId, 'LU-11', options,
     );
     if (!resolved) return undefined;
     const { chainKey, aeadCgId } = resolved;
@@ -4132,7 +4177,10 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       options?.subGraphName,
       options?.authorAgentAddress,
-      onChainId ?? undefined,
+      ctxGraphIdStr,
+      onChainId
+        ? { aeadBindingContextGraphId: onChainId }
+        : undefined,
     );
     if (encryptInlinePayload) {
       this.log.info(ctx, `LU-5: curated CG ${contextGraphId} — wrapping inline ACK payload with chain-key AEAD`);
@@ -4147,7 +4195,10 @@ export class PublishMethods extends DKGAgentBase {
       contextGraphId,
       options?.subGraphName,
       options?.authorAgentAddress,
-      onChainId ?? undefined,
+      ctxGraphIdStr,
+      onChainId
+        ? { aeadBindingContextGraphId: onChainId }
+        : undefined,
     );
     if (encryptInlineChunked) {
       this.log.info(ctx, `LU-11: curated CG ${contextGraphId} — chunked path active (per-chunk SWM gossip + V2 ACK)`);

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -14,6 +14,7 @@ import {
   ciphertextChunkStoreSubject,
   CIPHERTEXT_CHUNK_PREDICATE,
   decodeStorageACK,
+  decryptV10PublishPayload,
   encodePublishIntent,
   isStorageACKDecline,
 } from '@origintrail-official/dkg-core';
@@ -91,6 +92,7 @@ async function resolveEncryptInlinePayload(
   agentLike: any,
   contextGraphId: string,
   publishContextGraphId?: string,
+  options?: { aeadBindingContextGraphId?: string },
 ) {
   // RFC-39 / LU-11 refactor extracted the access-policy probe + curated
   // bootstrap into the private helper `_resolveCuratedChainKeyContext`,
@@ -111,6 +113,25 @@ async function resolveEncryptInlinePayload(
     undefined,
     undefined,
     publishContextGraphId,
+    options,
+  );
+}
+
+async function resolveEncryptInlineChunked(
+  agentLike: any,
+  contextGraphId: string,
+  publishContextGraphId?: string,
+  options?: { aeadBindingContextGraphId?: string },
+) {
+  agentLike._resolveCuratedChainKeyContext = (DKGAgent.prototype as any)
+    ._resolveCuratedChainKeyContext;
+  return (DKGAgent.prototype as any)._resolveEncryptInlineChunked.call(
+    agentLike,
+    contextGraphId,
+    undefined,
+    undefined,
+    publishContextGraphId,
+    options,
   );
 }
 
@@ -164,12 +185,95 @@ describe('DKGAgent._resolveEncryptInlinePayload policy lookup', () => {
     expect(agentLike.chain.getContextGraphAccessPolicy.calls).toEqual([]);
   });
 
+  it('keeps an internally derived same-CG numeric binding id out of LU-5 policy lookup (#1309)', async () => {
+    const agentLike = makeAgentLike();
+    agentLike.resolveOnChainAccessPolicyState = recorder(async (cgId: string) => {
+      if (cgId !== 'sports') {
+        throw new Error(`unexpected policy lookup for ${cgId}`);
+      }
+      return 0;
+    });
+    agentLike.readLiveOnChainAccessPolicy = recorder(async (id: string) => {
+      throw new Error(`raw target probe should not run for derived binding id ${id}`);
+    });
+
+    await expect(
+      resolveEncryptInlinePayload(agentLike, 'sports', undefined, {
+        aeadBindingContextGraphId: '1',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(agentLike.resolveOnChainAccessPolicyState.calls[0][0]).toBe('sports');
+    expect(agentLike.readLiveOnChainAccessPolicy.calls).toEqual([]);
+  });
+
+  it('keeps an internally derived same-CG numeric binding id out of LU-11 policy lookup (#1309)', async () => {
+    const agentLike = makeAgentLike();
+    agentLike.resolveOnChainAccessPolicyState = recorder(async (cgId: string) => {
+      if (cgId !== 'sports') {
+        throw new Error(`unexpected policy lookup for ${cgId}`);
+      }
+      return 0;
+    });
+    agentLike.readLiveOnChainAccessPolicy = recorder(async (id: string) => {
+      throw new Error(`raw target probe should not run for derived binding id ${id}`);
+    });
+
+    await expect(
+      resolveEncryptInlineChunked(agentLike, 'sports', undefined, {
+        aeadBindingContextGraphId: '1',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(agentLike.resolveOnChainAccessPolicyState.calls[0][0]).toBe('sports');
+    expect(agentLike.readLiveOnChainAccessPolicy.calls).toEqual([]);
+  });
+
+  it('uses source policy for same-CG private derived bindings before sender-key bootstrap (#1309)', async () => {
+    const agentLike = makeAgentLike();
+    agentLike.resolveOnChainAccessPolicyState = recorder(async (cgId: string) => {
+      if (cgId !== 'private-cg') {
+        throw new Error(`unexpected policy lookup for ${cgId}`);
+      }
+      return 1;
+    });
+    agentLike.readLiveOnChainAccessPolicy = recorder(async (id: string) => {
+      throw new Error(`raw target probe should not run for derived binding id ${id}`);
+    });
+    agentLike.loadSwmSenderKeyState = recorder(async () => undefined);
+    agentLike.getLocalSigningAgentForAddress = recorder(() => null);
+    agentLike.defaultAgentAddress = ethers.Wallet.createRandom().address;
+    agentLike.peerId = 'peer-1';
+
+    await expect(
+      resolveEncryptInlinePayload(agentLike, 'private-cg', undefined, {
+        aeadBindingContextGraphId: '2',
+      }),
+    ).rejects.toThrow(/cannot bootstrap swm-sender-key/);
+
+    expect(agentLike.resolveOnChainAccessPolicyState.calls[0][0]).toBe('private-cg');
+    expect(agentLike.readLiveOnChainAccessPolicy.calls).toEqual([]);
+  });
+
   it('fails closed when a remap target numeric CG policy cannot be resolved', async () => {
     const agentLike = makeAgentLike({
       accessPolicyError: new Error('rpc unavailable'),
     });
 
     await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg', '42')).rejects.toThrow(
+      /target CG "42" curated=unknown/,
+    );
+  });
+
+  it('LU-11 fails closed when a remap target numeric CG policy cannot be resolved', async () => {
+    const agentLike = makeAgentLike({
+      accessPolicyError: new Error('rpc unavailable'),
+    });
+
+    await expect(resolveEncryptInlineChunked(agentLike, 'local-public-cg', '42')).rejects.toThrow(
+      /LU-11: publish access-policy is unknown/,
+    );
+    await expect(resolveEncryptInlineChunked(agentLike, 'local-public-cg', '42')).rejects.toThrow(
       /target CG "42" curated=unknown/,
     );
   });
@@ -188,6 +292,73 @@ describe('DKGAgent._resolveEncryptInlinePayload policy lookup', () => {
     await expect(resolveEncryptInlinePayload(agentLike, 'local-public-cg', '42')).resolves.toBeUndefined();
     expect(agentLike.chain.getContextGraphAccessPolicy.calls.at(-1)).toEqual([42n]);
     expect(contextGraphExists.calls).not.toContainEqual(['42']);
+  });
+
+  it('rejects explicit remap when source is curated and numeric target is public', async () => {
+    const agentLike = makeAgentLike({ accessPolicy: 0 });
+    agentLike.resolveOnChainAccessPolicyState = recorder(async (cgId: string) => {
+      if (cgId === 'private-source') return 1;
+      throw new Error(`unexpected source lookup for ${cgId}`);
+    });
+
+    await expect(resolveEncryptInlinePayload(agentLike, 'private-source', '42')).rejects.toThrow(
+      /remap publish source\/target access-policy mismatch/,
+    );
+  });
+
+  it('rejects explicit remap when source is public and numeric target is curated', async () => {
+    const agentLike = makeAgentLike({ accessPolicy: 1 });
+    agentLike.resolveOnChainAccessPolicyState = recorder(async (cgId: string) => {
+      if (cgId === 'public-source') return 0;
+      throw new Error(`unexpected source lookup for ${cgId}`);
+    });
+
+    await expect(resolveEncryptInlinePayload(agentLike, 'public-source', '42')).rejects.toThrow(
+      /remap publish source\/target access-policy mismatch/,
+    );
+  });
+
+  it('binds LU-5 AEAD to the resolver-returned binding id, not the local source id', async () => {
+    const chainKey = new Uint8Array(32).fill(9);
+    const plaintext = new TextEncoder().encode('<urn:s> <urn:p> "o" <urn:g> .');
+    const agentLike = {
+      _resolveCuratedChainKeyContext: recorder(async () => ({
+        chainKey,
+        aeadCgId: '1',
+        senderAddress: ethers.Wallet.createRandom().address,
+      })),
+    } as any;
+
+    const encryptInlinePayload = await (DKGAgent.prototype as any)._resolveEncryptInlinePayload.call(
+      agentLike,
+      'sports',
+      undefined,
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '1' },
+    );
+    expect(encryptInlinePayload).toBeDefined();
+
+    const encrypted = await encryptInlinePayload(plaintext);
+    const recovered = decryptV10PublishPayload({
+      chainKey,
+      contextGraphId: '1',
+      encryptedPayload: encrypted,
+    });
+    expect(Buffer.from(recovered).equals(Buffer.from(plaintext))).toBe(true);
+    expect(() => decryptV10PublishPayload({
+      chainKey,
+      contextGraphId: 'sports',
+      encryptedPayload: encrypted,
+    })).toThrow();
+    expect(agentLike._resolveCuratedChainKeyContext.calls.at(-1)).toEqual([
+      'sports',
+      undefined,
+      undefined,
+      undefined,
+      'LU-5',
+      { aeadBindingContextGraphId: '1' },
+    ]);
   });
 });
 
@@ -239,13 +410,15 @@ describe('DKGAgent._publish inline encryption routing', () => {
       'local-cg',
       'sg-a',
       undefined,
-      '42',
+      undefined,
+      { aeadBindingContextGraphId: '42' },
     ]);
     expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
       'local-cg',
       'sg-a',
       undefined,
-      '42',
+      undefined,
+      { aeadBindingContextGraphId: '42' },
     ]);
     expect(publisherPublish.calls.at(-1)).toEqual([expect.objectContaining({
       accessPolicy: 'public',
@@ -253,6 +426,213 @@ describe('DKGAgent._publish inline encryption routing', () => {
       encryptInlinePayload,
       encryptInlineChunked,
     })]);
+  });
+
+  it('keeps caller-supplied mismatched onChainContextGraphId as an explicit policy target', async () => {
+    const publisherPublish = recorder(async () => ({
+      status: 'confirmed',
+      kaId: '1',
+    }));
+    const agentLike = {
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      subscribedContextGraphs: new Set(['local-cg']),
+      contextGraphExists: recorder(async () => true),
+      createV10ACKProvider: recorder(() => undefined),
+      getContextGraphOnChainId: recorder(async () => '42'),
+      chain: {},
+      peerId: 'peer-1',
+      publisher: {
+        publish: publisherPublish,
+      },
+      broadcastPublish: recorder(async () => undefined),
+      emitPublicProjectionAfterPublish: recorder(async () => undefined),
+      _resolveEncryptInlinePayload: recorder(async () => undefined),
+      _resolveEncryptInlineChunked: recorder(async () => undefined),
+    } as any;
+
+    await (DKGAgent.prototype as any)._publish.call(
+      agentLike,
+      'local-cg',
+      [{ subject: 's', predicate: 'p', object: 'o', graph: 'g' }],
+      undefined,
+      {
+        onChainContextGraphId: '99',
+      },
+    );
+
+    expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
+      'local-cg',
+      undefined,
+      undefined,
+      '99',
+      { aeadBindingContextGraphId: '99' },
+    ]);
+    expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
+      'local-cg',
+      undefined,
+      undefined,
+      '99',
+      { aeadBindingContextGraphId: '99' },
+    ]);
+    expect(publisherPublish.calls.at(-1)).toEqual([expect.objectContaining({
+      publishContextGraphId: '99',
+    })]);
+  });
+});
+
+describe('DKGAgent.update inline encryption routing', () => {
+  it('passes derived update on-chain id as binding-only while preserving publisher target', async () => {
+    const updateEncryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
+    const updateEncryptInlineChunked = async () => ({
+      ciphertextChunksRoot: new Uint8Array(32),
+      ciphertextChunkCount: 0,
+      totalCiphertextBytes: 0,
+      ciphertextChunks: [],
+    });
+    const publisherUpdate = recorder(async () => ({
+      status: 'confirmed',
+    }));
+    const agentLike = {
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      getContextGraphOnChainId: recorder(async () => '42'),
+      createV10UpdateACKProvider: recorder(() => undefined),
+      node: { peerId: { toString: () => 'peer-1' } },
+      publisher: {
+        update: publisherUpdate,
+      },
+      _resolveEncryptInlinePayload: recorder(async () => updateEncryptInlinePayload),
+      _resolveEncryptInlineChunked: recorder(async () => updateEncryptInlineChunked),
+    } as any;
+
+    await (DKGAgent.prototype as any).update.call(
+      agentLike,
+      123n,
+      'private-cg',
+      [{ subject: 's', predicate: 'p', object: '"o"', graph: 'g' }],
+    );
+
+    expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
+      'private-cg',
+      undefined,
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '42' },
+    ]);
+    expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
+      'private-cg',
+      undefined,
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '42' },
+    ]);
+    expect(publisherUpdate.calls.at(-1)).toEqual([
+      123n,
+      expect.objectContaining({
+        publishContextGraphId: '42',
+        encryptInlinePayload: updateEncryptInlinePayload,
+        encryptInlineChunked: updateEncryptInlineChunked,
+      }),
+    ]);
+  });
+});
+
+describe('DKGAgent.publishFromSharedMemory inline encryption routing', () => {
+  function makeSwmPublishAgentLike(onChainId = '1') {
+    const publisherPublishFromSharedMemory = recorder(async () => ({
+      status: 'tentative',
+      kaId: '1',
+    }));
+    return {
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      getContextGraphOnChainId: recorder(async () => onChainId),
+      createV10ACKProvider: recorder(() => undefined),
+      isPrivateContextGraph: recorder(async () => false),
+      chain: {},
+      _resolveEncryptInlinePayload: recorder(async () => undefined),
+      _resolveEncryptInlineChunked: recorder(async () => undefined),
+      publisher: {
+        publishFromSharedMemory: publisherPublishFromSharedMemory,
+      },
+    } as any;
+  }
+
+  it('passes derived same-CG on-chain id as binding-only and publisher chain target', async () => {
+    const agentLike = makeSwmPublishAgentLike('1');
+
+    await (DKGAgent.prototype as any).publishFromSharedMemory.call(agentLike, 'sports', 'all');
+
+    expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
+      'sports',
+      undefined,
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '1' },
+    ]);
+    expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
+      'sports',
+      undefined,
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '1' },
+    ]);
+    expect(agentLike.publisher.publishFromSharedMemory.calls.at(-1)).toEqual([
+      'sports',
+      'all',
+      expect.objectContaining({
+        publishContextGraphId: undefined,
+        onChainContextGraphId: '1',
+      }),
+    ]);
+  });
+
+  it('passes explicit sub-CG remap id as policy target and binding id', async () => {
+    const agentLike = makeSwmPublishAgentLike('should-not-be-used');
+
+    await (DKGAgent.prototype as any).publishFromSharedMemory.call(
+      agentLike,
+      'sports',
+      'all',
+      { subContextGraphId: '1' },
+    );
+
+    expect(agentLike.getContextGraphOnChainId.calls).toEqual([]);
+    expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
+      'sports',
+      undefined,
+      undefined,
+      '1',
+      { aeadBindingContextGraphId: '1' },
+    ]);
+    expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
+      'sports',
+      undefined,
+      undefined,
+      '1',
+      { aeadBindingContextGraphId: '1' },
+    ]);
+    expect(agentLike.publisher.publishFromSharedMemory.calls.at(-1)).toEqual([
+      'sports',
+      'all',
+      expect.objectContaining({
+        publishContextGraphId: '1',
+        onChainContextGraphId: '1',
+      }),
+    ]);
   });
 });
 
@@ -285,8 +665,23 @@ describe('DKGAgent._resolveEncryptInlineChunked nonce domain', () => {
     } as any;
 
     const encryptInlineChunked = await (DKGAgent.prototype as any)
-      ._resolveEncryptInlineChunked.call(agentLike, '42');
+      ._resolveEncryptInlineChunked.call(
+        agentLike,
+        'sports',
+        undefined,
+        undefined,
+        undefined,
+        { aeadBindingContextGraphId: '42' },
+      );
     expect(encryptInlineChunked).toBeDefined();
+    expect(agentLike._resolveCuratedChainKeyContext.calls.at(-1)).toEqual([
+      'sports',
+      undefined,
+      undefined,
+      undefined,
+      'LU-11',
+      { aeadBindingContextGraphId: '42' },
+    ]);
 
     const batchId = ethers.getBytes(ethers.id('same-merkle-root'));
     const plaintextNquads = new TextEncoder().encode(

--- a/packages/agent/test/swm-sender-key-pending-by-agent.test.ts
+++ b/packages/agent/test/swm-sender-key-pending-by-agent.test.ts
@@ -103,8 +103,9 @@ interface PendingInternals {
     contextGraphId: string,
     subGraphName: string | undefined,
     authorAgentAddress: string | undefined,
-    publishContextGraphId: string | undefined,
+    explicitPolicyTargetContextGraphId: string | undefined,
     logPrefix: string,
+    options?: { aeadBindingContextGraphId?: string },
   ): Promise<{ chainKey: Uint8Array; aeadCgId: string; senderAddress: string } | undefined>;
 }
 
@@ -1342,9 +1343,11 @@ describe('createAndDistributeSwmSenderKeyEpoch: missing-peerId soft success', ()
       sender.agentAddress,
       undefined,
       'LU-5',
+      { aeadBindingContextGraphId: '2' },
     );
 
     expect(resolved?.chainKey).toEqual(chainKey);
+    expect(resolved?.aeadCgId).toBe('2');
     expect(sendCalls).toHaveLength(1);
     expect(sendCalls[0].peerId).toBe(recipientPeerId);
     expect(internals.pendingSenderKeyByAgent.size).toBe(0);

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -773,6 +773,44 @@ export async function runDaemon(foreground: boolean): Promise<void> {
   }
 }
 
+export async function resolveDaemonPublishEncryption(
+  agent: DKGAgent,
+  publishOptions: {
+    contextGraphId: string;
+    subGraphName?: string;
+    publishContextGraphId?: string;
+  },
+): Promise<{
+  encryptInlinePayload: Awaited<ReturnType<DKGAgent['_resolveEncryptInlinePayload']>>;
+  encryptInlineChunked: Awaited<ReturnType<DKGAgent['_resolveEncryptInlineChunked']>>;
+}> {
+  const requestedTarget = publishOptions.publishContextGraphId?.trim();
+  // Async lift resolves this from the source workspace slice before it reaches
+  // generic PublishOptions. Treat it as binding-only; future explicit async
+  // remaps need a separate provenance field.
+  const bindingOptions = requestedTarget
+    ? { aeadBindingContextGraphId: requestedTarget }
+    : undefined;
+  const encryptInlinePayload = await agent._resolveEncryptInlinePayload(
+    publishOptions.contextGraphId,
+    publishOptions.subGraphName,
+    undefined,
+    undefined,
+    bindingOptions,
+  );
+  const encryptInlineChunked = await agent._resolveEncryptInlineChunked(
+    publishOptions.contextGraphId,
+    publishOptions.subGraphName,
+    undefined,
+    undefined,
+    bindingOptions,
+  );
+  return {
+    encryptInlinePayload,
+    encryptInlineChunked,
+  };
+}
+
 export async function runDaemonInner(
   foreground: boolean,
   config: Awaited<ReturnType<typeof loadConfig>>,
@@ -1752,24 +1790,7 @@ export async function runDaemonInner(
               },
               log,
             }),
-            publishEncryptionFactory: async (publishOptions) => {
-              const encryptInlinePayload = await agent._resolveEncryptInlinePayload(
-                publishOptions.contextGraphId,
-                publishOptions.subGraphName,
-                undefined,
-                publishOptions.publishContextGraphId,
-              );
-              const encryptInlineChunked = await agent._resolveEncryptInlineChunked(
-                publishOptions.contextGraphId,
-                publishOptions.subGraphName,
-                undefined,
-                publishOptions.publishContextGraphId,
-              );
-              return {
-                encryptInlinePayload,
-                encryptInlineChunked,
-              };
-            },
+            publishEncryptionFactory: (publishOptions) => resolveDaemonPublishEncryption(agent, publishOptions),
             log,
           });
           publisherRuntime = runtime;

--- a/packages/cli/test/daemon-publish-encryption-factory.test.ts
+++ b/packages/cli/test/daemon-publish-encryption-factory.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDaemonPublishEncryption } from '../src/daemon/lifecycle.js';
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => {
+    calls.push(args);
+    return impl(...args);
+  };
+  return Object.assign(fn, { calls });
+}
+
+describe('daemon publish encryption factory', () => {
+  it('treats async-lift publishContextGraphId as binding-only for LU-5 and LU-11', async () => {
+    const encryptInlinePayload = async (plaintext: Uint8Array) => plaintext;
+    const encryptInlineChunked = async () => ({
+      ciphertextChunksRoot: new Uint8Array(32),
+      ciphertextChunkCount: 0,
+      totalCiphertextBytes: 0,
+      ciphertextChunks: [],
+    });
+    const agentLike = {
+      _resolveEncryptInlinePayload: recorder(async () => encryptInlinePayload),
+      _resolveEncryptInlineChunked: recorder(async () => encryptInlineChunked),
+    } as any;
+
+    const resolved = await resolveDaemonPublishEncryption(agentLike, {
+      contextGraphId: 'sports',
+      subGraphName: 'league',
+      publishContextGraphId: '1',
+    });
+
+    expect(resolved).toEqual({ encryptInlinePayload, encryptInlineChunked });
+    expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
+      'sports',
+      'league',
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '1' },
+    ]);
+    expect(agentLike._resolveEncryptInlineChunked.calls.at(-1)).toEqual([
+      'sports',
+      'league',
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '1' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1309 by preserving the provenance of numeric context graph ids during publish encryption policy resolution.

The agent now separates:

- explicit policy/remap targets, which still drive raw target policy checks and fail closed
- AEAD binding ids, which bind encrypted payloads/chunks to the canonical on-chain context graph id without affecting plaintext/encrypted policy selection

## Root Cause

The LU-5/LU-11 resolver previously accepted one `publishContextGraphId` parameter for both explicit remap intent and internally derived same-CG on-chain ids. A normal same-CG publish such as `sports -> 1` could therefore be mistaken for an explicit raw numeric remap and perform a redundant live policy probe for raw target `1`. Under RPC timeouts/rate limits, that unnecessary probe caused public same-CG publishes to fail closed.

## Changes

- Add `ResolveCuratedChainKeyContextOptions.aeadBindingContextGraphId` and keep policy target intent separate from AEAD binding.
- Update `_publish`, `update`, `publishFromSharedMemory`, LU-5, and LU-11 resolver paths to pass derived same-CG ids as binding-only.
- Preserve explicit/unverified numeric remap behavior, including raw target fail-closed checks and source/target mismatch rejection.
- Extract and test `resolveDaemonPublishEncryption` for async daemon publish encryption routing.
- Add `agent-docs/issue-1309-plan.md` with the detailed plan, team analysis, adversarial review notes, and verification record.

## Verification

- `pnpm exec vitest run --config vitest.config.ts test/encrypt-inline-policy.test.ts` from `packages/agent` - 20 passed
- `pnpm exec vitest run --config vitest.config.ts test/encrypt-inline-policy.test.ts test/swm-public-cg-plaintext.test.ts test/dkg-agent-on-chain-policy.test.ts` from `packages/agent` - 73 passed
- `pnpm exec vitest run --config vitest.config.ts test/swm-sender-key-pending-by-agent.test.ts` from `packages/agent` - 26 passed
- `pnpm exec vitest run test/daemon-publish-encryption-factory.test.ts` from `packages/cli` - 1 passed
- `pnpm --filter @origintrail-official/dkg-agent run build` - passed
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/v10-remap-wire.test.ts` - 3 passed
- `pnpm --filter @origintrail-official/dkg run build` - passed

Note: PR is opened as draft while remote PR review is disabled.