### PR TITLE
Log core StorageACK declines

### DIFF
--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1204,6 +1204,13 @@ export class LifecycleSyncMethods extends DKGAgentBase {
                   `keeping handler active: ${err instanceof Error ? err.message : String(err)}`,
                 );
               },
+              onDecline: (details) => {
+                this.log.warn(
+                  attemptCtx,
+                  `V10 StorageACK declined: code=${details.code} ` +
+                  `cg=${details.contextGraphId} reason=${details.message}`,
+                );
+              },
               // PR5 ACK-provenance — bind to the agent's host-mode
               // bookkeeping so every signed ACK carries which of the
               // four LU-6 Phase B discovery paths brought this CG's

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -56,6 +56,15 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
     expect(combined).toMatch(registerRE);
   });
 
+  it('agent wires core-side StorageACK decline logging', () => {
+    const combined = walk(AGENT_SRC)
+      .map((f) => readFileSync(f, 'utf8'))
+      .join('\n');
+
+    expect(combined).toMatch(/onDecline:\s*\(details\)\s*=>/);
+    expect(combined).toContain('V10 StorageACK declined: code=');
+  });
+
   it('agent source never publishes ACKs on GossipSub', () => {
     // A false-positive here would be any call like
     // `publish('/dkg/10.0.1/storage-ack', ...)` or

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -547,6 +547,17 @@ export class ACKCollector {
     // and follow the legacy retry path below — declines are strictly
     // additive on the wire.
     const declines = new Map<string, { code: string; message: string }>();
+    // ACKs that arrived over the protocol but failed publisher-side validation
+    // are not "no response". Track them separately so QuorumUnmetError can
+    // distinguish transport silence from an ACK the publisher rejected locally
+    // (signature, merkle root, or chain/RPC identity verification).
+    const ackFailures = new Map<string, { reason: string }>();
+    const recordACKFailure = (peerId: string, reason: string): void => {
+      ackFailures.set(peerId, { reason });
+      // A later terminal ACK-validation failure is more actionable than an
+      // earlier transient decline from the same peer.
+      declines.delete(peerId);
+    };
 
     const formatDeclineDetail = (): string => {
       if (declines.size === 0) return '';
@@ -591,6 +602,15 @@ export class ACKCollector {
             protocolSupported: true,
             ...(advertised !== undefined ? { swmHostModeAdvertised: advertised } : {}),
             reason: ack.subscriptionSource ? `ACK:${ack.subscriptionSource}` : 'ACK',
+          };
+        }
+        const ackFailure = ackFailures.get(peerId);
+        if (ackFailure) {
+          return {
+            peerId,
+            dialOk: true,
+            protocolSupported: true,
+            reason: ackFailure.reason,
           };
         }
         const decline = declines.get(peerId);
@@ -653,6 +673,7 @@ export class ACKCollector {
             // prior entry is intentional — operators care most about
             // why the peer ultimately could not ACK.
             declines.set(peerId, { code, message: declineMessage });
+            ackFailures.delete(peerId);
 
             // Transient declines (SWM replication catching up via
             // gossip) can resolve on a retry, so re-send with backoff
@@ -703,11 +724,13 @@ export class ACKCollector {
 
           const recoveredAddress = this.recoverACKSigner(ack, ackDigest);
           if (!recoveredAddress) {
+            recordACKFailure(peerId, 'INVALID_SIGNATURE');
             log(`[ACKCollector] Invalid ACK signature from ${peerId.slice(-8)}`);
             return null;
           }
 
           if (!this.merkleRootsMatch(ack.merkleRoot, merkleRoot)) {
+            recordACKFailure(peerId, 'MERKLE_ROOT_MISMATCH');
             log(`[ACKCollector] Merkle root mismatch from ${peerId.slice(-8)}`);
             return null;
           }
@@ -726,7 +749,8 @@ export class ACKCollector {
           if (this.deps.verifyIdentityDetailed) {
             const verdict = await this.deps.verifyIdentityDetailed(recoveredAddress, identityId);
             if (!verdict.valid) {
-              const reason = verdict.reason ?? 'unknown';
+              const reason = sanitizeDeclineField(verdict.reason ?? 'unknown', MAX_DECLINE_CODE_CHARS) || 'unknown';
+              recordACKFailure(peerId, `ACK_VERIFY:${reason}`);
               log(
                 `[ACKCollector] ACK from ${peerId.slice(-8)} rejected: ${reason}` +
                 ` (signer=${recoveredAddress.slice(0, 10)}..., identity=${identityId})`,
@@ -736,6 +760,7 @@ export class ACKCollector {
           } else if (this.deps.verifyIdentity) {
             const valid = await this.deps.verifyIdentity(recoveredAddress, identityId);
             if (!valid) {
+              recordACKFailure(peerId, 'ACK_VERIFY:key-not-registered');
               log(`[ACKCollector] Signer ${recoveredAddress.slice(0, 10)}... not registered for identity ${identityId} — rejecting ACK from ${peerId.slice(-8)}`);
               return null;
             }
@@ -746,6 +771,7 @@ export class ACKCollector {
           // stale decline would still appear in `storage_ack_insufficient`
           // if quorum fails for unrelated reasons.
           declines.delete(peerId);
+          ackFailures.delete(peerId);
 
           // PR5: capture the peer-reported ACK-provenance source if
           // present. Pre-PR5 cores never set the field; treat any

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -24,6 +24,8 @@ type PeerId = { toString(): string };
 
 const MAX_DECLINE_ENTITY_COUNT = 5;
 const MAX_DECLINE_ENTITY_CHARS = 120;
+const MAX_DECLINE_LOG_CG_ID_CHARS = 160;
+const MAX_DECLINE_LOG_MESSAGE_CHARS = 240;
 
 function compactDeclineText(value: string, maxChars: number): string {
   const compacted = value.replace(/[\u0000-\u001f\u007f]+/g, ' ').replace(/\s+/g, ' ').trim();
@@ -92,6 +94,16 @@ export interface StorageACKHandlerConfig {
    * registered on-chain at signing time.
    */
   onSignerRegistrationLookupFailed?: (err: unknown) => void | Promise<void>;
+  /**
+   * Called whenever the handler returns a typed StorageACK decline. The hook
+   * receives bounded, log-safe text; the wire decline message is encoded
+   * unchanged below so publisher-visible behavior stays stable.
+   */
+  onDecline?: (details: {
+    code: StorageACKDeclineCode;
+    contextGraphId: string;
+    message: string;
+  }) => void | Promise<void>;
   /**
    * Codex PR #608: independent curation oracle. The handler MUST verify a
    * publisher's `isEncryptedPayload=true` claim against the CG's real
@@ -262,6 +274,18 @@ export class StorageACKHandler {
     code: StorageACKDeclineCode,
     message: string,
   ): Uint8Array {
+    if (this.config.onDecline) {
+      const details = {
+        code,
+        contextGraphId: compactDeclineText(cgId, MAX_DECLINE_LOG_CG_ID_CHARS),
+        message: compactDeclineText(message, MAX_DECLINE_LOG_MESSAGE_CHARS),
+      };
+      try {
+        void Promise.resolve(this.config.onDecline(details)).catch(() => undefined);
+      } catch {
+        // Logging must never change ACK wire behavior.
+      }
+    }
     return encodeStorageACK({
       merkleRoot: new Uint8Array(0),
       coreNodeSignatureR: new Uint8Array(0),

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -331,6 +331,56 @@ describe('StorageACKHandler', () => {
     expect(decoded.declineMessage).toContain('urn:entity:1');
   });
 
+  it('calls the decline hook with typed, bounded details when returning a decline', async () => {
+    const onDecline = vi.fn();
+    const handler = await createHandler([], { onDecline });
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:entity:1'],
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
+    expect(onDecline).toHaveBeenCalledOnce();
+    expect(onDecline).toHaveBeenCalledWith({
+      code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+      contextGraphId,
+      message: expect.stringContaining('No data found in SWM'),
+    });
+    const details = onDecline.mock.calls[0]?.[0];
+    expect(details.message.length).toBeLessThanOrEqual(240);
+  });
+
+  it('ignores decline hook failures and preserves the encoded decline', async () => {
+    const handler = await createHandler([], {
+      onDecline: async () => { throw new Error('logger unavailable'); },
+    });
+    const intent = encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 300,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:entity:1'],
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const decoded = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(decoded)).toBe(true);
+    expect(decoded.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
+    expect(decoded.declineMessage).toContain('No data found in SWM');
+  });
+
   it('declines (MERKLE_MISMATCH_IN_SWM) when SWM data does not match the publisher merkle root', async () => {
     const differentQuads = [makeQuad('urn:other', 'urn:p', 'urn:val')];
     const handler = await createHandler(differentQuads);

--- a/packages/publisher/test/storage-update-ack.test.ts
+++ b/packages/publisher/test/storage-update-ack.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-ack-handler.js';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
 import {
@@ -51,7 +51,11 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
 
   const fakePeerId = { toString: () => 'publisher-peer' };
 
-  function makeConfig(wallet: ethers.Wallet, identityId: bigint): StorageACKHandlerConfig {
+  function makeConfig(
+    wallet: ethers.Wallet,
+    identityId: bigint,
+    overrides: Partial<StorageACKHandlerConfig> = {},
+  ): StorageACKHandlerConfig {
     return {
       nodeRole: 'core',
       nodeIdentityId: identityId,
@@ -61,6 +65,7 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       isCgCurated: async () => true,
+      ...overrides,
     };
   }
 
@@ -261,6 +266,39 @@ describe('V10 UPDATE StorageACK — peer handler + collector quorum', () => {
     const ack = decodeStorageACK(await handler.updateHandler(intent, fakePeerId));
     expect(isStorageACKDecline(ack)).toBe(true);
     expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.MERKLE_MISMATCH_IN_SWM);
+  });
+
+  it('calls the decline hook for UPDATE typed declines', async () => {
+    const wallet = ethers.Wallet.createRandom();
+    const onDecline = vi.fn();
+    const handler = new StorageACKHandler(
+      new OxigraphStore() as any,
+      makeConfig(wallet, 42n, { onDecline }),
+      new TypedEventBus() as any,
+    );
+    const intent = encodeUpdateIntent({
+      kaId: kaId.toString(),
+      contextGraphId,
+      preUpdateMerkleRootCount: Number(preUpdateMerkleRootCount),
+      newMerkleRoot,
+      newByteSize: Number(newByteSize),
+      newTokenAmount: newTokenAmount.toString(),
+      mintAmount: Number(mintAmount),
+      burnTokenIds: burnTokenIds.map((b) => b.toString()),
+      newMerkleLeafCount,
+      publisherPeerId: 'publisher-0',
+    });
+
+    const ack = decodeStorageACK(await handler.updateHandler(intent, fakePeerId));
+
+    expect(isStorageACKDecline(ack)).toBe(true);
+    expect(ack.declineCode).toBe(STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM);
+    expect(onDecline).toHaveBeenCalledOnce();
+    expect(onDecline).toHaveBeenCalledWith({
+      code: STORAGE_ACK_DECLINE_CODES.NO_DATA_IN_SWM,
+      contextGraphId,
+      message: expect.stringContaining('UpdateStorageACK: no data found in SWM graph'),
+    });
   });
 
   // #1283 — PUBLIC-update byteSize floor. The pre-fix updateHandler verified

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -369,11 +369,76 @@ describe('ACKCollector identity verification', () => {
     };
     const collector = new ACKCollector(deps);
 
-    await expect(collector.collect(buildCollectParams()))
-      .rejects.toThrow('storage_ack_insufficient');
+    let captured: any;
+    try {
+      await collector.collect(buildCollectParams());
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toContain('storage_ack_insufficient');
+    expect(captured.message).toContain('ACK_VERIFY:rpc-error');
+    expect(captured.peerOutcomes.map((p: { reason?: string }) => p.reason))
+      .toEqual(['ACK_VERIFY:rpc-error', 'ACK_VERIFY:rpc-error', 'ACK_VERIFY:rpc-error']);
     expect(log.calls.some(
       (c: unknown[]) => /rpc-error/.test(c[0] as string),
     )).toBe(true);
+  });
+
+  it('invalid ACK signatures surface as terminal peer outcomes, not no_response', async () => {
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: async (peerId) => {
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: new Uint8Array(32),
+          coreNodeSignatureVS: new Uint8Array(32),
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    let captured: any;
+    try {
+      await collector.collect(buildCollectParams());
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toContain('storage_ack_insufficient');
+    expect(captured.message).toContain('INVALID_SIGNATURE');
+    expect(captured.peerOutcomes.map((p: { reason?: string }) => p.reason))
+      .toEqual(['INVALID_SIGNATURE', 'INVALID_SIGNATURE', 'INVALID_SIGNATURE']);
+  });
+
+  it('ACK merkle mismatches surface as terminal peer outcomes, not no_response', async () => {
+    const wrongRoot = ethers.getBytes(ethers.keccak256(ethers.toUtf8Bytes('wrong-root')));
+    const deps: ACKCollectorDeps = {
+      gossipPublish: noop(),
+      sendP2P: buildSendP2P({ merkleRootOverride: wrongRoot }),
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: noop(),
+    };
+    const collector = new ACKCollector(deps);
+
+    let captured: any;
+    try {
+      await collector.collect(buildCollectParams());
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.message).toContain('storage_ack_insufficient');
+    expect(captured.message).toContain('MERKLE_ROOT_MISMATCH');
+    expect(captured.peerOutcomes.map((p: { reason?: string }) => p.reason))
+      .toEqual(['MERKLE_ROOT_MISMATCH', 'MERKLE_ROOT_MISMATCH', 'MERKLE_ROOT_MISMATCH']);
   });
 
   it('detailed verifier takes precedence over legacy boolean verifier', async () => {


### PR DESCRIPTION
## Summary
- add a core-side `onDecline` hook to `StorageACKHandlerConfig`
- emit warn-level daemon logs for typed StorageACK declines from core nodes
- keep ACK decline wire behavior unchanged and swallow logging hook failures
- cover publish/update decline paths plus agent wiring in focused tests

## Testing
- `pnpm exec vitest run --root packages/publisher --config /private/tmp/dkg-publisher-focused-vitest.config.ts`
- `pnpm exec vitest run --root packages/agent --config /private/tmp/dkg-agent-focused-vitest.config.ts`
- `pnpm --filter @origintrail-official/dkg-publisher exec tsc --noEmit`
- `pnpm --filter @origintrail-official/dkg-agent exec tsc --noEmit`