### PR TITLE
fix(cli): support Node 24 global install

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
     "@origintrail-official/dkg-storage": "workspace:*",
     "@iarna/toml": "^2.2.5",
     "commander": "^13",
-    "better-sqlite3": "^11",
+    "better-sqlite3": "12.11.1",
     "ethers": "^6",
     "js-yaml": "^4.1.1",
     "n3": "^2.0.1",

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -49,6 +49,8 @@ export default defineConfig({
           'test/blazegraph-docker.test.ts',
           'test/store-identity-tag.test.ts',
           'test/publisher-runner-lu11.test.ts',
+          // SQLite-backed vector store. Pure local DB coverage; no hardhat.
+          'test/vector-store-extra.test.ts',
           // Release 2 — managed local Oxigraph server (opt-in). Pure logic
           // + injected fetch/spawn/fs; no network, no real binary.
           'test/oxigraph-binary.test.ts',

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -22,7 +22,7 @@
     "@openuidev/react-lang": "^0.2.3",
     "@origintrail-official/dkg-core": "workspace:*",
     "@origintrail-official/dkg-graph-viz": "workspace:*",
-    "better-sqlite3": "^11",
+    "better-sqlite3": "12.11.1",
     "lucide-react": "^1.14.0",
     "react-dropzone": "^15.0.0",
     "react-markdown": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,8 +357,8 @@ importers:
         specifier: workspace:*
         version: link:../storage
       better-sqlite3:
-        specifier: ^11
-        version: 11.10.0
+        specifier: 12.11.1
+        version: 12.11.1
       commander:
         specifier: ^13
         version: 13.1.0
@@ -719,8 +719,8 @@ importers:
         specifier: workspace:*
         version: link:../graph-viz
       better-sqlite3:
-        specifier: ^11
-        version: 11.10.0
+        specifier: 12.11.1
+        version: 12.11.1
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.4)
@@ -3009,8 +3009,9 @@ packages:
     peerDependencies:
       ajv: 4.11.8 - 8
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bezier-js@6.1.4:
     resolution: {integrity: sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==}
@@ -5296,6 +5297,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.1.2:
@@ -8852,7 +8854,7 @@ snapshots:
       jsonpointer: 5.0.1
       leven: 3.1.0
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/scripts/check-npm-metadata.mjs
+++ b/scripts/check-npm-metadata.mjs
@@ -9,6 +9,14 @@ const FORBIDDEN_PATTERNS = [
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGES_DIR = path.join(ROOT_DIR, 'packages');
+const LOCKFILE_PATH = path.join(ROOT_DIR, 'pnpm-lock.yaml');
+const BETTER_SQLITE3_PACKAGE = 'better-sqlite3';
+// Exact pin is tied to verified Node ABI v137 macOS arm64 prebuild availability.
+const EXPECTED_BETTER_SQLITE3_VERSION = '12.11.1';
+const PACKAGES_EXPECTED_TO_USE_BETTER_SQLITE3 = new Set([
+  '@origintrail-official/dkg',
+  '@origintrail-official/dkg-node-ui',
+]);
 
 function firstMatchSample(value) {
   const normalized = String(value).replace(/\s+/g, ' ').trim();
@@ -38,6 +46,90 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function inspectPackageBetterSqlite3(pkg, packageJsonPath) {
+  const violations = [];
+  const dependencyRange = pkg.dependencies?.[BETTER_SQLITE3_PACKAGE];
+  const optionalRange = pkg.optionalDependencies?.[BETTER_SQLITE3_PACKAGE];
+  const relativePackageJson = path.relative(ROOT_DIR, packageJsonPath);
+  const expectedPackage = PACKAGES_EXPECTED_TO_USE_BETTER_SQLITE3.has(pkg.name);
+
+  if (expectedPackage && dependencyRange === undefined) {
+    violations.push({
+      packageName: pkg.name,
+      location: `${relativePackageJson}#dependencies.${BETTER_SQLITE3_PACKAGE}`,
+      sample: '<missing>',
+      expected: EXPECTED_BETTER_SQLITE3_VERSION,
+    });
+  }
+
+  const productionRanges = [
+    { field: 'dependencies', value: dependencyRange },
+    { field: 'optionalDependencies', value: optionalRange },
+  ];
+
+  for (const entry of productionRanges) {
+    if (entry.value === undefined) continue;
+    if (entry.value !== EXPECTED_BETTER_SQLITE3_VERSION) {
+      violations.push({
+        packageName: pkg.name,
+        location: `${relativePackageJson}#${entry.field}.${BETTER_SQLITE3_PACKAGE}`,
+        sample: entry.value,
+        expected: EXPECTED_BETTER_SQLITE3_VERSION,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function collectBetterSqlite3LockfileViolations() {
+  if (!fs.existsSync(LOCKFILE_PATH)) {
+    return [{
+      packageName: 'workspace',
+      location: 'pnpm-lock.yaml',
+      sample: '<missing>',
+      expected: `contains ${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION}`,
+    }];
+  }
+
+  const lockfile = fs.readFileSync(LOCKFILE_PATH, 'utf8');
+  const violations = [];
+  const lockfilePackagePattern = new RegExp(
+    `^\\s{2}${escapeRegExp(BETTER_SQLITE3_PACKAGE)}@([^:\\s(]+)(?:\\([^)]*\\))?:`,
+    'gm',
+  );
+  const resolvedVersions = new Set();
+
+  for (const match of lockfile.matchAll(lockfilePackagePattern)) {
+    resolvedVersions.add(match[1]);
+  }
+
+  if (!resolvedVersions.has(EXPECTED_BETTER_SQLITE3_VERSION)) {
+    violations.push({
+      packageName: 'workspace',
+      location: 'pnpm-lock.yaml',
+      sample: `${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION} not found`,
+      expected: `${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION}`,
+    });
+  }
+
+  for (const version of [...resolvedVersions].sort()) {
+    if (version === EXPECTED_BETTER_SQLITE3_VERSION) continue;
+    violations.push({
+      packageName: 'workspace',
+      location: 'pnpm-lock.yaml',
+      sample: `${BETTER_SQLITE3_PACKAGE}@${version}`,
+      expected: `only ${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION}`,
+    });
+  }
+
+  return violations;
+}
+
 function collectViolations() {
   const violations = [];
   const packageDirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true });
@@ -51,6 +143,8 @@ function collectViolations() {
 
     const pkg = readJson(packageJsonPath);
     if (pkg.private) continue;
+
+    violations.push(...inspectPackageBetterSqlite3(pkg, packageJsonPath));
 
     const repository =
       typeof pkg.repository === 'string'
@@ -87,18 +181,23 @@ function collectViolations() {
     }
   }
 
+  violations.push(...collectBetterSqlite3LockfileViolations());
+
   return violations;
 }
 
 const violations = collectViolations();
 
 if (violations.length > 0) {
-  console.error('Found stale v9 npm metadata/readme references:\n');
+  console.error('Found npm package metadata, README, or native dependency policy violations:\n');
   for (const violation of violations) {
     console.error(`- ${violation.packageName}: ${violation.location}`);
     console.error(`  ${violation.sample}`);
+    if (violation.expected) {
+      console.error(`  expected: ${violation.expected}`);
+    }
   }
   process.exit(1);
 }
 
-console.log('NPM metadata check passed: no stale v9 references in publishable packages.');
+console.log('NPM metadata check passed: no stale v9 references and better-sqlite3 is pinned to a Node 24-capable build.');


### PR DESCRIPTION
## Summary

Fixes #1315.

- Pins both installable SQLite dependency edges (`@origintrail-official/dkg` and `@origintrail-official/dkg-node-ui`) to exact `better-sqlite3@12.11.1`, which has Node 24 support and the target macOS arm64 Node ABI v137 prebuild.
- Refreshes the lockfile from `better-sqlite3@11.10.0` to `12.11.1`.
- Extends `pnpm check:npm-metadata` so public production dependencies and lockfile resolution cannot drift away from the validated exact native dependency version.
- Adds the SQLite-backed CLI vector-store test to the fast unit config.

## Root Cause

The reported macOS arm64 Node 24 install failure happens before DKG CLI code runs. `better-sqlite3@11.10.0` does not publish a `node-v137-darwin-arm64` prebuild, so `prebuild-install` falls back to `node-gyp rebuild --release`; the Xcode/CLT error is the secondary fallback failure, not the package-level root cause.

## Files Changed

- `packages/cli/package.json` - exact `better-sqlite3@12.11.1` pin.
- `packages/node-ui/package.json` - exact `better-sqlite3@12.11.1` pin.
- `pnpm-lock.yaml` - resolves `better-sqlite3@12.11.1`.
- `scripts/check-npm-metadata.mjs` - enforces the exact production dependency and lockfile policy.
- `packages/cli/vitest.unit.config.ts` - includes the SQLite vector-store suite in the fast unit lane.

## Test Plan

Passed:

- `pnpm install --ignore-scripts`
- CLI dependency-path native load: `better-sqlite3` in-memory DB query succeeded.
- Node UI dependency-path native load: `better-sqlite3` in-memory DB query succeeded.
- `pnpm run build:runtime:packages`
- `pnpm check:npm-metadata`
- `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/db.test.ts`
- `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/vector-store-extra.test.ts`
- `pnpm --filter @origintrail-official/dkg-node-ui run build:ui` (existing Vite export/chunk-size warnings only)
- Packed CLI and Node UI tarballs and verified both package manifests contain `better-sqlite3: 12.11.1`.
- Isolated Windows temp-prefix npm install from patched CLI and Node UI tarballs completed successfully.

Known validation limits:

- Full `pnpm install` with scripts on this Windows machine fails because `@cyfrin/aderyn` postinstall does not support the platform; required native paths were validated directly after `--ignore-scripts`.
- The temp-prefix `dkg.cmd --version` runtime smoke was not valid because other workspace packages resolved from already-published npm `10.0.0`, causing an unrelated internal export mismatch. Before release closure, run a Verdaccio/local-registry smoke that publishes all public workspace packages from this branch, installs `@origintrail-official/dkg`, and runs `dkg --version`, `dkg --help`, and `dkg mcp --help`.
- `pnpm --filter @origintrail-official/dkg run test:unit` still fails on existing Windows/environment-sensitive suites: Hardhat-context-dependent daemon route/event tests, an existing Windows path assertion in `chain-reset-wipe.test.ts`, and oxigraph executable tests.
- macOS arm64 Node `24.11.0` / npm `11.6.4` global install validation remains a release gate before closing the issue.

## Release Notes

This PR updates source manifests but cannot repair already-published npm `10.0.0`. The user-facing fix requires publishing a new patched package version with the CLI and Node UI package graph aligned.