### PR TITLE
fix(daemon): write routes 4xx on malformed quad object + resilient KA-number-floor reconcile

### DIFF
--- a/packages/agent/src/allocator.ts
+++ b/packages/agent/src/allocator.ts
@@ -50,6 +50,67 @@ export interface KaAllocatorChain {
 }
 
 /**
+ * Transient chain/RPC failures (rate-limit, timeout, gateway, network blip) that
+ * a bounded retry can ride out — as opposed to a deterministic error (bad
+ * address, revert) where retrying is pointless. Public free RPCs in particular
+ * answer the node's poll load with 429 "over rate limit" / 408 / 503, and the
+ * one-time-per-author KA-number-floor reconcile read MUST NOT turn one of those
+ * into a hard publish-prep 500.
+ */
+const TRANSIENT_CHAIN_ERROR_RE =
+  /\b(408|425|429|500|502|503|504)\b|too many requests|over rate limit|rate.?limit|timeout|timed out|temporarily|service unavailable|bad gateway|gateway time-?out|network|fetch failed|socket hang|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|SERVER_ERROR|failed to detect network/i;
+
+export function isTransientChainError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return TRANSIENT_CHAIN_ERROR_RE.test(msg);
+}
+
+/**
+ * Thrown when the KA-number-floor reconcile can't reach the chain. Carries a
+ * stable `code` + `retryable` flag so the daemon HTTP layer maps it to a 503
+ * (retry) instead of a blanket 500. Keeps the legacy
+ * "failed to reconcile KA-number floor" message substring so existing matchers
+ * (dkg-agent.ts) keep working.
+ */
+export class KaFloorReconcileError extends Error {
+  readonly code = 'KA_FLOOR_RECONCILE_UNAVAILABLE';
+  readonly retryable: boolean;
+  constructor(author: string, cause: unknown) {
+    super(
+      `OT-RFC-43 A2: failed to reconcile KA-number floor for author ${author}: ` +
+        (cause instanceof Error ? cause.message : String(cause)),
+    );
+    this.name = 'KaFloorReconcileError';
+    this.retryable = isTransientChainError(cause);
+  }
+}
+
+/** Backoff schedule for the reconcile chain-read retry (ms). */
+const RECONCILE_RETRY_DELAYS_MS = [250, 750, 2000];
+
+/**
+ * Read the on-chain max KA-number for an author, retrying transient RPC errors
+ * (the read is idempotent). Deterministic errors throw immediately. Exposed for
+ * unit testing.
+ */
+export async function readMaxKaNumberWithRetry(
+  read: (author: string) => Promise<bigint>,
+  author: string,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+): Promise<bigint> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await read(author);
+    } catch (err) {
+      if (attempt >= RECONCILE_RETRY_DELAYS_MS.length || !isTransientChainError(err)) {
+        throw err;
+      }
+      await sleep(RECONCILE_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+}
+
+/**
  * Reconcile the per-author KA-number floor against the chain (ONCE per author,
  * cached in `reconciled`) then allocate the next number and derive its reserved
  * UAL `did:dkg:{chainId}/{author}/{number}`.
@@ -63,18 +124,21 @@ export async function reconcileAndAllocateKaNumber(
   chain: KaAllocatorChain,
   reconciled: Set<string>,
   author: string,
+  /** Injectable backoff sleep (tests pass a no-op); defaults to real setTimeout. */
+  sleep?: (ms: number) => Promise<void>,
 ): Promise<{ number: bigint; reservedUal: string }> {
   const key = author.toLowerCase();
   if (!reconciled.has(key)) {
     let chainMax = -1n;
     if (typeof chain.getMaxKaNumberForAuthor === 'function') {
+      const read = chain.getMaxKaNumberForAuthor.bind(chain);
       try {
-        chainMax = await chain.getMaxKaNumberForAuthor(author);
+        // Retry transient RPC failures (429/timeout/5xx) before giving up — a
+        // rate-limited public RPC must not hard-fail a publish at the
+        // one-time-per-author floor reconcile (GH issue: KA create 500 on 429).
+        chainMax = await readMaxKaNumberWithRetry(read, author, sleep);
       } catch (err) {
-        throw new Error(
-          `OT-RFC-43 A2: failed to reconcile KA-number floor for author ${author}: ` +
-            (err instanceof Error ? err.message : String(err)),
-        );
+        throw new KaFloorReconcileError(author, err);
       }
     }
     if (chainMax >= 0n) allocator.reconcile(author, chainMax);

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -380,7 +380,7 @@ import {
   isLocalOxigraphConfig,
   sliceIntoCiphertextChunks,
 } from './dkg-agent-helpers.js';
-import { reconcileAndAllocateKaNumber, readMaxKaNumberWithRetry } from './allocator.js';
+import { reconcileAndAllocateKaNumber, readMaxKaNumberWithRetry, isTransientChainError } from './allocator.js';
 import {
   swmSenderStateKey,
   swmReceiverStateKey,
@@ -2352,12 +2352,15 @@ export class PublishMethods extends DKGAgentBase {
           } catch (err) {
             // #1116 (round 11) — CAPABILITY GAP (the chain read to reconcile the
             // KA-number floor failed — a transient/RPC capability problem, not bad input).
+            // PR #1319 review: tag the transient/deterministic verdict so the daemon
+            // HTTP layer (respondIfReconcileUnavailable) only 503s a genuinely
+            // retryable failure — a deterministic revert falls through to its normal mapping.
             throw Object.assign(
               new Error(
                 `OT-RFC-43 A2: failed to reconcile KA-number floor for author ${authorAddress} at finalize: ` +
                   (err instanceof Error ? err.message : String(err)),
               ),
-              { code: SEAL_CAPABILITY_GAP_CODE },
+              { code: SEAL_CAPABILITY_GAP_CODE, retryable: isTransientChainError(err) },
             );
           }
         }
@@ -2683,9 +2686,15 @@ export class PublishMethods extends DKGAgentBase {
             // Retry transient RPC failures (429/timeout/5xx) on the floor read.
             selChainMax = await readMaxKaNumberWithRetry(this.chain.getMaxKaNumberForAuthor.bind(this.chain), authorAddress);
           } catch (err) {
-            throw new Error(
-              `OT-RFC-43 §F2: failed to reconcile KA-number floor for author ${authorAddress} (selection publish): ` +
-                (err instanceof Error ? err.message : String(err)),
+            // PR #1319 review: tag the transient/deterministic verdict (same as the
+            // finalize path) so the daemon only 503s a genuinely retryable failure;
+            // a deterministic revert falls through to its normal mapping.
+            throw Object.assign(
+              new Error(
+                `OT-RFC-43 §F2: failed to reconcile KA-number floor for author ${authorAddress} (selection publish): ` +
+                  (err instanceof Error ? err.message : String(err)),
+              ),
+              { retryable: isTransientChainError(err) },
             );
           }
         }

--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -380,7 +380,7 @@ import {
   isLocalOxigraphConfig,
   sliceIntoCiphertextChunks,
 } from './dkg-agent-helpers.js';
-import { reconcileAndAllocateKaNumber } from './allocator.js';
+import { reconcileAndAllocateKaNumber, readMaxKaNumberWithRetry } from './allocator.js';
 import {
   swmSenderStateKey,
   swmReceiverStateKey,
@@ -2346,7 +2346,9 @@ export class PublishMethods extends DKGAgentBase {
         let chainMax = -1n;
         if (typeof this.chain.getMaxKaNumberForAuthor === 'function') {
           try {
-            chainMax = await this.chain.getMaxKaNumberForAuthor(authorAddress);
+            // Retry transient RPC failures (429/timeout/5xx) on the floor read
+            // so a rate-limited public RPC doesn't hard-fail finalize.
+            chainMax = await readMaxKaNumberWithRetry(this.chain.getMaxKaNumberForAuthor.bind(this.chain), authorAddress);
           } catch (err) {
             // #1116 (round 11) — CAPABILITY GAP (the chain read to reconcile the
             // KA-number floor failed — a transient/RPC capability problem, not bad input).
@@ -2678,7 +2680,8 @@ export class PublishMethods extends DKGAgentBase {
         let selChainMax = -1n;
         if (typeof this.chain.getMaxKaNumberForAuthor === 'function') {
           try {
-            selChainMax = await this.chain.getMaxKaNumberForAuthor(authorAddress);
+            // Retry transient RPC failures (429/timeout/5xx) on the floor read.
+            selChainMax = await readMaxKaNumberWithRetry(this.chain.getMaxKaNumberForAuthor.bind(this.chain), authorAddress);
           } catch (err) {
             throw new Error(
               `OT-RFC-43 §F2: failed to reconcile KA-number floor for author ${authorAddress} (selection publish): ` +

--- a/packages/agent/test/allocator.test.ts
+++ b/packages/agent/test/allocator.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { KaNumberStore } from '@origintrail-official/dkg-core';
-import { KaNumberAllocator } from '../src/allocator.js';
+import {
+  KaNumberAllocator,
+  reconcileAndAllocateKaNumber,
+  readMaxKaNumberWithRetry,
+  isTransientChainError,
+  KaFloorReconcileError,
+} from '../src/allocator.js';
 
 /**
  * OT-RFC-43 Option-1 deterministic KA identity — B2 allocator core.
@@ -313,5 +319,79 @@ describe('KaNumberAllocator — canonical address (codex PR #976 F8)', () => {
     const peeked = alloc.peekKaId(AUTHOR_A);
     const { kaId } = alloc.allocate(AUTHOR_A.toLowerCase());
     expect(peeked).toBe(kaId);
+  });
+});
+
+/**
+ * KA-number-floor reconcile resilience to transient RPC failures.
+ *
+ * Repro: a free public RPC answered the one-time-per-author floor read with
+ * `429 Too Many Requests`, and the reconcile threw a hard error → the daemon
+ * returned HTTP 500 on `POST /api/knowledge-assets` (named-assertion create).
+ * The fix retries transient errors and, if the chain stays unreachable, throws a
+ * typed `KaFloorReconcileError` the HTTP layer maps to a retryable 503.
+ *
+ * `noSleep` is injected so the backoff doesn't actually wait in tests.
+ */
+describe('KA-number-floor reconcile resilience to RPC failures', () => {
+  const noSleep = async () => {};
+
+  it('isTransientChainError: rate-limit/timeout/5xx transient; revert/bad-input not', () => {
+    expect(isTransientChainError(new Error('server response 429 Too Many Requests'))).toBe(true);
+    expect(isTransientChainError(new Error('over rate limit'))).toBe(true);
+    expect(isTransientChainError(new Error('Request timeout on the free tier'))).toBe(true);
+    expect(isTransientChainError(new Error('503 Service Unavailable'))).toBe(true);
+    expect(isTransientChainError(new Error('failed to detect network'))).toBe(true);
+    expect(isTransientChainError(new Error('execution reverted: TooLowBalance'))).toBe(false);
+    expect(isTransientChainError(new Error('KaNumberAllocator: invalid author address'))).toBe(false);
+  });
+
+  it('readMaxKaNumberWithRetry retries a transient error then succeeds', async () => {
+    let calls = 0;
+    const read = async () => {
+      calls += 1;
+      if (calls < 3) throw new Error('server response 429 Too Many Requests');
+      return 41n;
+    };
+    expect(await readMaxKaNumberWithRetry(read, AUTHOR_A, noSleep)).toBe(41n);
+    expect(calls).toBe(3);
+  });
+
+  it('readMaxKaNumberWithRetry does NOT retry a deterministic error', async () => {
+    let calls = 0;
+    const read = async () => { calls += 1; throw new Error('execution reverted'); };
+    await expect(readMaxKaNumberWithRetry(read, AUTHOR_A, noSleep)).rejects.toThrow(/reverted/);
+    expect(calls).toBe(1);
+  });
+
+  it('reconcileAndAllocateKaNumber succeeds after transient retries (no 500 on a 429)', async () => {
+    let calls = 0;
+    const chain = {
+      chainId: 'gnosis:100',
+      getMaxKaNumberForAuthor: async () => {
+        calls += 1;
+        if (calls < 2) throw new Error('over rate limit');
+        return 5n;
+      },
+    };
+    const { number, reservedUal } = await reconcileAndAllocateKaNumber(
+      alloc, chain, new Set<string>(), AUTHOR_A, noSleep,
+    );
+    expect(number).toBe(6n); // floor reconciled to 5 → next allocation is 6
+    expect(reservedUal).toBe(`did:dkg:gnosis:100/${AUTHOR_A.toLowerCase()}/6`);
+  });
+
+  it('reconcileAndAllocateKaNumber throws a typed, retryable KaFloorReconcileError when the chain stays unreachable', async () => {
+    const chain = {
+      chainId: 'gnosis:100',
+      getMaxKaNumberForAuthor: async () => { throw new Error('server response 429 Too Many Requests'); },
+    };
+    const err = await reconcileAndAllocateKaNumber(alloc, chain, new Set<string>(), AUTHOR_A, noSleep)
+      .then(() => null, (e) => e);
+    expect(err).toBeInstanceOf(KaFloorReconcileError);
+    expect(err.code).toBe('KA_FLOOR_RECONCILE_UNAVAILABLE');
+    expect(err.retryable).toBe(true);
+    // keeps the legacy message substring existing matchers rely on
+    expect(String(err.message)).toMatch(/failed to reconcile KA-number floor/);
   });
 });

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -120,9 +120,20 @@ export function isWritableQuad(value: unknown): boolean {
   );
 }
 
-function validatePublishQuadObjectTerms(
+/**
+ * GH #306 / #787 (follow-up) — validate each quad's `object` term is either a
+ * quoted RDF literal (`"…"`) or an absolute IRI. Shared by the publish path AND
+ * the write routes (wm/write, shared-memory/write, conditional-write): the shape
+ * guards ({@link isPublishQuad} / {@link isWritableQuad}) only check the fields
+ * are strings, so an object that is neither a literal nor an IRI (e.g. a bare
+ * word `hello` or a number `123`) slips past them and crashes the RDF parser
+ * with an uncaught "No scheme found in an absolute IRI" → HTTP 500 instead of an
+ * actionable 400. Operates on any `{ object: string }` (PublishQuad or writable
+ * quad alike).
+ */
+export function validateQuadObjectTerms(
   label: string,
-  quads: PublishQuad[],
+  quads: ReadonlyArray<{ object: string }>,
 ): string | null {
   const badIndex = quads.findIndex((q) => {
     const object = q.object.trim();
@@ -168,7 +179,7 @@ export function parsePublishRequestBody(
       error: 'Missing or invalid "quads" (must be a non-empty quad array)',
     };
   }
-  const quadObjectError = validatePublishQuadObjectTerms("quads", quads);
+  const quadObjectError = validateQuadObjectTerms("quads", quads);
   if (quadObjectError) return { ok: false, error: quadObjectError };
 
   if (
@@ -181,7 +192,7 @@ export function parsePublishRequestBody(
     };
   }
   if (privateQuads !== undefined) {
-    const privateQuadObjectError = validatePublishQuadObjectTerms("privateQuads", privateQuads);
+    const privateQuadObjectError = validateQuadObjectTerms("privateQuads", privateQuads);
     if (privateQuadObjectError) return { ok: false, error: privateQuadObjectError };
   }
 

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -145,30 +145,39 @@ export function validateQuadObjectTerms(
 
 /**
  * KA-number-floor reconcile resilience (follow-up to the "KA create 500-on-429"
- * fix). If `e` is the transient reconcile failure — the chain RPC couldn't serve
+ * fix). If `e` is a **transient** reconcile failure — the chain RPC couldn't serve
  * the one-time-per-author floor read (e.g. a 429 after the bounded retry in
  * `allocator.ts` is exhausted) — send a retryable **503** and return true;
  * otherwise return false so the caller falls through to its normal mapping.
- * Matched by `code` OR message so it works for both the typed
- * `KaFloorReconcileError` and the `…at finalize` direct-call wrap, even if
- * re-wrapped on the way up. Used by every route that can trigger the reconcile
- * (named create, one-shot publish, shared-memory publish, and the WM-verb routes
- * via `respondAssertionError`) so they answer consistently instead of 500.
+ *
+ * The transient-vs-deterministic verdict comes from `retryable` (derived from
+ * `isTransientChainError`): the typed `KaFloorReconcileError` carries it, and the
+ * finalize/selection re-wrap sites in `dkg-agent-publish.ts` tag the same marker.
+ * A deterministic failure (`retryable === false`, e.g. a revert) is NOT a 503 —
+ * advertising a retry would be pointless — so it falls through. The legacy
+ * message-text match is honored ONLY when the error explicitly marks itself
+ * retryable, so a bare re-wrapped message can never force a deterministic error
+ * into a retryable 503 (PR #1319 review). Used by every route that can trigger the
+ * reconcile (named create, one-shot publish, shared-memory publish, and the
+ * WM-verb routes via `respondAssertionError`) so they answer consistently.
  */
 export function respondIfReconcileUnavailable(res: ServerResponse, e: any): boolean {
   const msg = e?.message ?? String(e);
-  if (
-    e?.code === "KA_FLOOR_RECONCILE_UNAVAILABLE" ||
-    /failed to reconcile KA-number floor/i.test(msg)
-  ) {
-    jsonResponse(res, 503, {
-      error: msg,
-      code: "KA_FLOOR_RECONCILE_UNAVAILABLE",
-      retryable: e?.retryable !== false,
-    });
-    return true;
+  const isTyped = e?.code === "KA_FLOOR_RECONCILE_UNAVAILABLE";
+  // Message-text fallback (for errors re-wrapped on the way up) is accepted only
+  // when the error explicitly carries a retryable marker — never for a bare
+  // message, which might be hiding a deterministic revert.
+  const isMarkedLegacyTransient =
+    e?.retryable === true && /failed to reconcile KA-number floor/i.test(msg);
+  if ((!isTyped && !isMarkedLegacyTransient) || e?.retryable === false) {
+    return false;
   }
-  return false;
+  jsonResponse(res, 503, {
+    error: msg,
+    code: "KA_FLOOR_RECONCILE_UNAVAILABLE",
+    retryable: true,
+  });
+  return true;
 }
 
 export function parsePublishRequestBody(

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -143,6 +143,34 @@ export function validateQuadObjectTerms(
   return `Invalid "${label}[${badIndex}].object": RDF object must be a quoted literal term or absolute IRI`;
 }
 
+/**
+ * KA-number-floor reconcile resilience (follow-up to the "KA create 500-on-429"
+ * fix). If `e` is the transient reconcile failure — the chain RPC couldn't serve
+ * the one-time-per-author floor read (e.g. a 429 after the bounded retry in
+ * `allocator.ts` is exhausted) — send a retryable **503** and return true;
+ * otherwise return false so the caller falls through to its normal mapping.
+ * Matched by `code` OR message so it works for both the typed
+ * `KaFloorReconcileError` and the `…at finalize` direct-call wrap, even if
+ * re-wrapped on the way up. Used by every route that can trigger the reconcile
+ * (named create, one-shot publish, shared-memory publish, and the WM-verb routes
+ * via `respondAssertionError`) so they answer consistently instead of 500.
+ */
+export function respondIfReconcileUnavailable(res: ServerResponse, e: any): boolean {
+  const msg = e?.message ?? String(e);
+  if (
+    e?.code === "KA_FLOOR_RECONCILE_UNAVAILABLE" ||
+    /failed to reconcile KA-number floor/i.test(msg)
+  ) {
+    jsonResponse(res, 503, {
+      error: msg,
+      code: "KA_FLOOR_RECONCILE_UNAVAILABLE",
+      retryable: e?.retryable !== false,
+    });
+    return true;
+  }
+  return false;
+}
+
 export function parsePublishRequestBody(
   body: string,
 ): { ok: true; value: PublishRequestBody } | { ok: false; error: string } {

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -37,6 +37,7 @@ import {
   parsePublishRequestBody,
   isWritableQuad,
   validateQuadObjectTerms,
+  respondIfReconcileUnavailable,
   normalizeContextGraphIdOrUri,
   resolveRequiredWriteContextGraphId,
 } from "../http-utils.js";
@@ -157,23 +158,10 @@ function respondAssertionError(res: RequestContext["res"], e: any): void {
     });
     return;
   }
-  const msg = e?.message ?? String(e);
   // KA-number-floor reconcile couldn't reach the chain (e.g. a rate-limited RPC
-  // returned 429 on the one-time-per-author read). This is a transient
-  // dependency failure, not a client error — surface a retryable 503 instead of
-  // a blanket 500 so the caller knows to retry. Match by code OR message so it
-  // works even if the error was re-wrapped on the way up.
-  if (
-    e?.code === "KA_FLOOR_RECONCILE_UNAVAILABLE" ||
-    /failed to reconcile KA-number floor/i.test(msg)
-  ) {
-    jsonResponse(res, 503, {
-      error: msg,
-      code: "KA_FLOOR_RECONCILE_UNAVAILABLE",
-      retryable: e?.retryable !== false,
-    });
-    return;
-  }
+  // 429'd the one-time-per-author read) -> retryable 503, not 500.
+  if (respondIfReconcileUnavailable(res, e)) return;
+  const msg = e?.message ?? String(e);
   if (
     e?.name === "ReservedNamespaceError" ||
     msg.includes("not found") ||
@@ -667,6 +655,8 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (isPayloadTooLargeError(e)) {
         return jsonResponse(res, 413, payloadTooLargeResponseBody(e));
       }
+      // Transient KA-number-floor reconcile failure (rate-limited RPC) -> 503.
+      if (respondIfReconcileUnavailable(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
     }
   }
@@ -868,6 +858,8 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (errors.length > 0) return jsonResponse(res, 207, { created: true, ...result, errors });
       return jsonResponse(res, 201, result);
     } catch (e: any) {
+      // Transient KA-number-floor reconcile failure (rate-limited RPC) -> 503.
+      if (respondIfReconcileUnavailable(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
     }
   }

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -36,6 +36,7 @@ import {
   validateRequiredContextGraphId,
   parsePublishRequestBody,
   isWritableQuad,
+  validateQuadObjectTerms,
   normalizeContextGraphIdOrUri,
   resolveRequiredWriteContextGraphId,
 } from "../http-utils.js";
@@ -157,6 +158,22 @@ function respondAssertionError(res: RequestContext["res"], e: any): void {
     return;
   }
   const msg = e?.message ?? String(e);
+  // KA-number-floor reconcile couldn't reach the chain (e.g. a rate-limited RPC
+  // returned 429 on the one-time-per-author read). This is a transient
+  // dependency failure, not a client error — surface a retryable 503 instead of
+  // a blanket 500 so the caller knows to retry. Match by code OR message so it
+  // works even if the error was re-wrapped on the way up.
+  if (
+    e?.code === "KA_FLOOR_RECONCILE_UNAVAILABLE" ||
+    /failed to reconcile KA-number floor/i.test(msg)
+  ) {
+    jsonResponse(res, 503, {
+      error: msg,
+      code: "KA_FLOOR_RECONCILE_UNAVAILABLE",
+      retryable: e?.retryable !== false,
+    });
+    return;
+  }
   if (
     e?.name === "ReservedNamespaceError" ||
     msg.includes("not found") ||
@@ -1005,6 +1022,10 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         if (!parsed.quads.every(isWritableQuad)) {
           return jsonResponse(res, 400, { error: '"quads" must be an array of { subject, predicate, object } objects (graph optional); string-shaped quads are not accepted' });
         }
+        // GH #306/#787 (follow-up) — reject objects that are neither a quoted
+        // literal nor an absolute IRI before they reach (and crash) the parser.
+        const wmObjErr = validateQuadObjectTerms("quads", parsed.quads);
+        if (wmObjErr) return jsonResponse(res, 400, { error: wmObjErr });
         // A bare write to a name that was never created used to fall through to
         // the legacy `/assertion/{addr}/{name}` graph and produce a KA that is
         // permanently 404 in the descriptor API (no `_meta` lifecycle record,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -198,6 +198,7 @@ import {
   resolveNameToPeerId,
   isPublishQuad,
   isWritableQuad,
+  validateQuadObjectTerms,
   parsePublishRequestBody,
   jsonResponse,
   safeDecodeURIComponent,
@@ -1646,6 +1647,13 @@ WHERE {
     // of crashing the SWM write path with a TypeError (HTTP 500).
     if (!Array.isArray(quads) || !quads.every(isWritableQuad))
       return jsonResponse(res, 400, { error: '"quads" must be an array of { subject, predicate, object } objects (graph optional); string-shaped quads are not accepted' });
+    // GH #306/#787 (follow-up) — also reject objects that are neither a quoted
+    // literal nor an absolute IRI; otherwise they slip past the shape guard and
+    // crash the RDF parser ("No scheme found in an absolute IRI") with HTTP 500.
+    {
+      const objErr = validateQuadObjectTerms("quads", quads);
+      if (objErr) return jsonResponse(res, 400, { error: objErr });
+    }
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
       contextGraphId,
@@ -2220,6 +2228,13 @@ WHERE {
     // GH #787 / #306 — reject string-shaped / malformed quads (4xx, not a 500 crash).
     if (!Array.isArray(quads) || !quads.every(isWritableQuad))
       return jsonResponse(res, 400, { error: '"quads" must be an array of { subject, predicate, object } objects (graph optional); string-shaped quads are not accepted' });
+    // GH #306/#787 (follow-up) — also reject objects that are neither a quoted
+    // literal nor an absolute IRI; otherwise they slip past the shape guard and
+    // crash the RDF parser ("No scheme found in an absolute IRI") with HTTP 500.
+    {
+      const objErr = validateQuadObjectTerms("quads", quads);
+      if (objErr) return jsonResponse(res, 400, { error: objErr });
+    }
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
       contextGraphId,

--- a/packages/cli/test/issue-306-787-write-quad-validation.test.ts
+++ b/packages/cli/test/issue-306-787-write-quad-validation.test.ts
@@ -75,3 +75,50 @@ describe('GH #306 — POST /api/knowledge-assets/{name}/wm/write quad-shape vali
     expect(status, JSON.stringify(body)).toBe(200);
   });
 });
+
+/**
+ * GH #306/#787 FOLLOW-UP — a quad whose `object` is neither a quoted literal nor
+ * an absolute IRI (e.g. a bare word `hello`, a number `123`) passes the shape
+ * guard (isWritableQuad checks only that the fields are strings) but then crashes
+ * the RDF parser with an uncaught "No scheme found in an absolute IRI" → HTTP 500.
+ * The fix runs `validateQuadObjectTerms` on the write routes too (it already ran
+ * on publish), so these now return an actionable 400.
+ */
+describe('GH #306/#787 follow-up — malformed object TERM is 4xx, not a 500 parser crash', () => {
+  const badObjectQuad = (s: string) => [
+    { subject: s, predicate: 'http://schema.org/name', object: 'hello' }, // bare word: not a literal, not an IRI
+  ];
+
+  it('/shared-memory/write rejects a bare-word object with 400', async () => {
+    const { status, body } = await postJson(daemon!, '/api/shared-memory/write', {
+      contextGraphId: CG, quads: badObjectQuad('urn:wq:obj1'),
+    });
+    expect(status, JSON.stringify(body)).toBe(400);
+  });
+
+  it('/shared-memory/conditional-write rejects a bare-word object with 400', async () => {
+    const { status, body } = await postJson(daemon!, '/api/shared-memory/conditional-write', {
+      contextGraphId: CG,
+      quads: badObjectQuad('urn:wq:obj2'),
+      conditions: [{ subject: 'urn:wq:obj2', predicate: 'http://schema.org/name', expectedValue: null }],
+    });
+    expect(status, JSON.stringify(body)).toBe(400);
+  });
+
+  it('/knowledge-assets/{name}/wm/write rejects a bare-word object with 400', async () => {
+    const created = await postJson(daemon!, '/api/knowledge-assets', { contextGraphId: CG, name: 'ka-objterm' });
+    expect(created.status, 'KA create precondition').toBeLessThan(300);
+    const { status, body } = await postJson(daemon!, '/api/knowledge-assets/ka-objterm/wm/write', {
+      contextGraphId: CG, quads: badObjectQuad('urn:wq:obj3'),
+    });
+    expect(status, JSON.stringify(body)).toBe(400);
+  });
+
+  it('still accepts an absolute-IRI object (regression)', async () => {
+    const { status, body } = await postJson(daemon!, '/api/shared-memory/write', {
+      contextGraphId: CG,
+      quads: [{ subject: 'urn:wq:obj4', predicate: 'http://schema.org/url', object: 'https://example.org/ok' }],
+    });
+    expect(status, JSON.stringify(body)).toBe(200);
+  });
+});

--- a/packages/cli/test/reconcile-503-mapping.test.ts
+++ b/packages/cli/test/reconcile-503-mapping.test.ts
@@ -8,6 +8,12 @@
  * this pins the status-code mapping. Verified end-to-end on a real Gnosis
  * mainnet node behind a 429-injecting RPC proxy (POST /api/knowledge-assets ->
  * 503, code KA_FLOOR_RECONCILE_UNAVAILABLE, retryable:true).
+ *
+ * PR #1319 review hardening: the 503 mapping is gated on the transient verdict.
+ * Only a genuinely retryable failure becomes a 503 — a DETERMINISTIC reconcile
+ * failure (retryable:false, e.g. a revert) falls through to the caller's normal
+ * mapping, and a bare legacy message with NO retryable marker is never force-mapped
+ * to a retryable 503.
  */
 import { describe, it, expect } from 'vitest';
 import { respondIfReconcileUnavailable } from '../src/daemon/http-utils.js';
@@ -28,7 +34,7 @@ function fakeRes() {
 }
 
 describe('respondIfReconcileUnavailable — reconcile failure -> retryable 503', () => {
-  it('maps a typed KaFloorReconcileError (by code) to a retryable 503', () => {
+  it('maps a typed KaFloorReconcileError (by code, retryable) to a retryable 503', () => {
     const { rec, res } = fakeRes();
     const handled = respondIfReconcileUnavailable(res, {
       code: 'KA_FLOOR_RECONCILE_UNAVAILABLE',
@@ -42,21 +48,67 @@ describe('respondIfReconcileUnavailable — reconcile failure -> retryable 503',
     expect(body.retryable).toBe(true);
   });
 
-  it('maps the legacy message (no code, e.g. the "…at finalize" direct-call wrap) to 503', () => {
+  // PR #1319 review — the core fix: a typed reconcile error that is DETERMINISTIC
+  // (retryable:false, e.g. the floor read reverted rather than rate-limited) must
+  // NOT be advertised as a retryable 503. It falls through so the caller maps it.
+  it('does NOT map a typed but NON-retryable reconcile error (deterministic revert) — falls through', () => {
+    const { rec, res } = fakeRes();
+    const handled = respondIfReconcileUnavailable(res, {
+      code: 'KA_FLOOR_RECONCILE_UNAVAILABLE',
+      message: 'OT-RFC-43 A2: failed to reconcile KA-number floor for author 0xabc: execution reverted',
+      retryable: false,
+    });
+    expect(handled).toBe(false);
+    expect(rec.ended).toBe(false);
+    expect(rec.status).toBe(0);
+  });
+
+  // The finalize/selection re-wrap sites tag `retryable` (from isTransientChainError)
+  // but carry a SEAL_CAPABILITY_GAP / no code — matched via the legacy message ONLY
+  // because they explicitly mark themselves retryable.
+  it('maps a legacy-message re-wrap to 503 when it carries retryable:true', () => {
     const { rec, res } = fakeRes();
     const handled = respondIfReconcileUnavailable(
       res,
-      new Error('OT-RFC-43 A2: failed to reconcile KA-number floor for author 0xabc at finalize: server response 429'),
+      Object.assign(
+        new Error('OT-RFC-43 A2: failed to reconcile KA-number floor for author 0xabc at finalize: server response 429'),
+        { code: 'SEAL_CAPABILITY_GAP', retryable: true },
+      ),
     );
     expect(handled).toBe(true);
     expect(rec.status).toBe(503);
-    expect(JSON.parse(rec.body).code).toBe('KA_FLOOR_RECONCILE_UNAVAILABLE');
+    const body = JSON.parse(rec.body);
+    expect(body.code).toBe('KA_FLOOR_RECONCILE_UNAVAILABLE');
+    expect(body.retryable).toBe(true);
   });
 
-  it('defaults retryable to true when the flag is absent', () => {
+  // PR #1319 review — the mirror of the typed case for the legacy re-wrap path: a
+  // deterministic finalize/selection re-wrap (retryable:false) must fall through.
+  it('does NOT map a legacy-message re-wrap that is retryable:false — falls through', () => {
     const { rec, res } = fakeRes();
-    respondIfReconcileUnavailable(res, new Error('failed to reconcile KA-number floor for author 0xabc: 503'));
-    expect(JSON.parse(rec.body).retryable).toBe(true);
+    const handled = respondIfReconcileUnavailable(
+      res,
+      Object.assign(
+        new Error('OT-RFC-43 §F2: failed to reconcile KA-number floor for author 0xabc (selection publish): execution reverted'),
+        { retryable: false },
+      ),
+    );
+    expect(handled).toBe(false);
+    expect(rec.ended).toBe(false);
+    expect(rec.status).toBe(0);
+  });
+
+  // PR #1319 review — a BARE legacy message with no retryable marker is no longer
+  // force-mapped to a retryable 503 (it could be hiding a deterministic revert).
+  it('does NOT map a bare legacy message with no retryable marker — falls through', () => {
+    const { rec, res } = fakeRes();
+    const handled = respondIfReconcileUnavailable(
+      res,
+      new Error('failed to reconcile KA-number floor for author 0xabc: something'),
+    );
+    expect(handled).toBe(false);
+    expect(rec.ended).toBe(false);
+    expect(rec.status).toBe(0);
   });
 
   it('does NOT respond (returns false) for unrelated errors — caller keeps its own mapping', () => {

--- a/packages/cli/test/reconcile-503-mapping.test.ts
+++ b/packages/cli/test/reconcile-503-mapping.test.ts
@@ -1,0 +1,69 @@
+/**
+ * KA-number-floor reconcile resilience (follow-up to the "KA create 500-on-429"
+ * fix) — the HTTP mapping half. `respondIfReconcileUnavailable` is the shared
+ * helper every reconcile-triggering route uses (named create, one-shot publish,
+ * shared-memory publish, and the WM-verb routes via respondAssertionError) so a
+ * transient KA-number-floor reconcile failure surfaces as a retryable 503 rather
+ * than a blanket 500. The retry half is pinned in packages/agent allocator.test;
+ * this pins the status-code mapping. Verified end-to-end on a real Gnosis
+ * mainnet node behind a 429-injecting RPC proxy (POST /api/knowledge-assets ->
+ * 503, code KA_FLOOR_RECONCILE_UNAVAILABLE, retryable:true).
+ */
+import { describe, it, expect } from 'vitest';
+import { respondIfReconcileUnavailable } from '../src/daemon/http-utils.js';
+
+function fakeRes() {
+  const rec: { status: number; body: string; ended: boolean } = { status: 0, body: '', ended: false };
+  const res = {
+    writeHead(status: number) {
+      rec.status = status;
+      return res;
+    },
+    end(body?: string) {
+      if (typeof body === 'string') rec.body = body;
+      rec.ended = true;
+    },
+  } as any;
+  return { rec, res };
+}
+
+describe('respondIfReconcileUnavailable — reconcile failure -> retryable 503', () => {
+  it('maps a typed KaFloorReconcileError (by code) to a retryable 503', () => {
+    const { rec, res } = fakeRes();
+    const handled = respondIfReconcileUnavailable(res, {
+      code: 'KA_FLOOR_RECONCILE_UNAVAILABLE',
+      message: 'OT-RFC-43 A2: failed to reconcile KA-number floor for author 0xabc: 429',
+      retryable: true,
+    });
+    expect(handled).toBe(true);
+    expect(rec.status).toBe(503);
+    const body = JSON.parse(rec.body);
+    expect(body.code).toBe('KA_FLOOR_RECONCILE_UNAVAILABLE');
+    expect(body.retryable).toBe(true);
+  });
+
+  it('maps the legacy message (no code, e.g. the "…at finalize" direct-call wrap) to 503', () => {
+    const { rec, res } = fakeRes();
+    const handled = respondIfReconcileUnavailable(
+      res,
+      new Error('OT-RFC-43 A2: failed to reconcile KA-number floor for author 0xabc at finalize: server response 429'),
+    );
+    expect(handled).toBe(true);
+    expect(rec.status).toBe(503);
+    expect(JSON.parse(rec.body).code).toBe('KA_FLOOR_RECONCILE_UNAVAILABLE');
+  });
+
+  it('defaults retryable to true when the flag is absent', () => {
+    const { rec, res } = fakeRes();
+    respondIfReconcileUnavailable(res, new Error('failed to reconcile KA-number floor for author 0xabc: 503'));
+    expect(JSON.parse(rec.body).retryable).toBe(true);
+  });
+
+  it('does NOT respond (returns false) for unrelated errors — caller keeps its own mapping', () => {
+    const { rec, res } = fakeRes();
+    const handled = respondIfReconcileUnavailable(res, new Error('execution reverted: TooLowBalance'));
+    expect(handled).toBe(false);
+    expect(rec.ended).toBe(false);
+    expect(rec.status).toBe(0);
+  });
+});

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       ? ['test/daemon-http-behavior-extra.test.ts']
       : [
           'test/api-client.test.ts',
+          'test/reconcile-503-mapping.test.ts',
           'test/config.test.ts',
           'test/status-route-rpc.test.ts',
           'test/memory-graph-events.test.ts',


### PR DESCRIPTION
Two robustness bugs found during **V10 mainnet (Base + Gnosis) publish QA** on an edge node. Neither changes the happy path; both turn an uncaught **HTTP 500** into a correct status.

## #1 — Write routes 500 on a malformed quad `object`
`POST /api/shared-memory/write`, `/api/shared-memory/conditional-write`, and `/api/knowledge-assets/:name/wm/write` returned **HTTP 500** (uncaught RDF parser crash — *"No scheme found in an absolute IRI"*) when a quad's `object` was neither a quoted literal nor an absolute IRI (e.g. a bare word `hello`, a number `123`).

**Root cause:** `isWritableQuad` validates only field *shape* (the fields are strings). The publish path already runs `validatePublishQuadObjectTerms` for the object *term*, but the write routes never did — so a malformed object reached the parser.

**Fix:** generalize + export it as `validateQuadObjectTerms` (operates on any `{ object: string }`) and run it on all three write routes after the shape guard → actionable **400**. Same defect family as #306/#787, an un-covered variant.

## #4 — Named-assertion create 500 when the RPC is rate-limited
`POST /api/knowledge-assets` returned **HTTP 500** (`failed to reconcile KA-number floor … 429 Too Many Requests`) when the chain RPC was rate-limited, because the one-time-per-author KA-number-floor reconcile read was not fault-tolerant.

**Fix:** in `reconcileAndAllocateKaNumber`, retry transient RPC errors (429 / timeout / 5xx / network) with bounded backoff; on persistent failure throw a typed `KaFloorReconcileError` (`code: KA_FLOOR_RECONCILE_UNAVAILABLE`, `retryable`) that the daemon maps to a retryable **503**. Deterministic errors (revert / bad input) still fail fast. The legacy `"failed to reconcile KA-number floor"` message substring is preserved for existing matchers. Retry sleep is injectable for instant tests.

## Tests
- `issue-306-787-write-quad-validation.test.ts` — **+4** object-term cases (bare-word rejected with 400 on all 3 routes; absolute-IRI still accepted). Live daemon, **8/8 green**.
- `allocator.test.ts` — **+5** retry/resilience cases (transient retried then succeeds; deterministic fails fast; typed retryable error on persistent failure). **28/28 green**.
- Full `pnpm build` clean.

Scope note: deliberately does **not** touch the separate Base RPC-config findings (single default RPC; several public RPCs incompatible with the node's `eth_getLogs`) — those are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)