### PR TITLE
chore(npm): keep metadata check focused

### DIFF
--- a/scripts/check-npm-metadata.mjs
+++ b/scripts/check-npm-metadata.mjs
@@ -9,14 +9,6 @@ const FORBIDDEN_PATTERNS = [
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGES_DIR = path.join(ROOT_DIR, 'packages');
-const LOCKFILE_PATH = path.join(ROOT_DIR, 'pnpm-lock.yaml');
-const BETTER_SQLITE3_PACKAGE = 'better-sqlite3';
-// Exact pin is tied to verified Node ABI v137 macOS arm64 prebuild availability.
-const EXPECTED_BETTER_SQLITE3_VERSION = '12.11.1';
-const PACKAGES_EXPECTED_TO_USE_BETTER_SQLITE3 = new Set([
-  '@origintrail-official/dkg',
-  '@origintrail-official/dkg-node-ui',
-]);
 
 function firstMatchSample(value) {
   const normalized = String(value).replace(/\s+/g, ' ').trim();
@@ -46,90 +38,6 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function inspectPackageBetterSqlite3(pkg, packageJsonPath) {
-  const violations = [];
-  const dependencyRange = pkg.dependencies?.[BETTER_SQLITE3_PACKAGE];
-  const optionalRange = pkg.optionalDependencies?.[BETTER_SQLITE3_PACKAGE];
-  const relativePackageJson = path.relative(ROOT_DIR, packageJsonPath);
-  const expectedPackage = PACKAGES_EXPECTED_TO_USE_BETTER_SQLITE3.has(pkg.name);
-
-  if (expectedPackage && dependencyRange === undefined) {
-    violations.push({
-      packageName: pkg.name,
-      location: `${relativePackageJson}#dependencies.${BETTER_SQLITE3_PACKAGE}`,
-      sample: '<missing>',
-      expected: EXPECTED_BETTER_SQLITE3_VERSION,
-    });
-  }
-
-  const productionRanges = [
-    { field: 'dependencies', value: dependencyRange },
-    { field: 'optionalDependencies', value: optionalRange },
-  ];
-
-  for (const entry of productionRanges) {
-    if (entry.value === undefined) continue;
-    if (entry.value !== EXPECTED_BETTER_SQLITE3_VERSION) {
-      violations.push({
-        packageName: pkg.name,
-        location: `${relativePackageJson}#${entry.field}.${BETTER_SQLITE3_PACKAGE}`,
-        sample: entry.value,
-        expected: EXPECTED_BETTER_SQLITE3_VERSION,
-      });
-    }
-  }
-
-  return violations;
-}
-
-function collectBetterSqlite3LockfileViolations() {
-  if (!fs.existsSync(LOCKFILE_PATH)) {
-    return [{
-      packageName: 'workspace',
-      location: 'pnpm-lock.yaml',
-      sample: '<missing>',
-      expected: `contains ${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION}`,
-    }];
-  }
-
-  const lockfile = fs.readFileSync(LOCKFILE_PATH, 'utf8');
-  const violations = [];
-  const lockfilePackagePattern = new RegExp(
-    `^\\s{2}${escapeRegExp(BETTER_SQLITE3_PACKAGE)}@([^:\\s(]+)(?:\\([^)]*\\))?:`,
-    'gm',
-  );
-  const resolvedVersions = new Set();
-
-  for (const match of lockfile.matchAll(lockfilePackagePattern)) {
-    resolvedVersions.add(match[1]);
-  }
-
-  if (!resolvedVersions.has(EXPECTED_BETTER_SQLITE3_VERSION)) {
-    violations.push({
-      packageName: 'workspace',
-      location: 'pnpm-lock.yaml',
-      sample: `${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION} not found`,
-      expected: `${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION}`,
-    });
-  }
-
-  for (const version of [...resolvedVersions].sort()) {
-    if (version === EXPECTED_BETTER_SQLITE3_VERSION) continue;
-    violations.push({
-      packageName: 'workspace',
-      location: 'pnpm-lock.yaml',
-      sample: `${BETTER_SQLITE3_PACKAGE}@${version}`,
-      expected: `only ${BETTER_SQLITE3_PACKAGE}@${EXPECTED_BETTER_SQLITE3_VERSION}`,
-    });
-  }
-
-  return violations;
-}
-
 function collectViolations() {
   const violations = [];
   const packageDirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true });
@@ -143,8 +51,6 @@ function collectViolations() {
 
     const pkg = readJson(packageJsonPath);
     if (pkg.private) continue;
-
-    violations.push(...inspectPackageBetterSqlite3(pkg, packageJsonPath));
 
     const repository =
       typeof pkg.repository === 'string'
@@ -181,23 +87,18 @@ function collectViolations() {
     }
   }
 
-  violations.push(...collectBetterSqlite3LockfileViolations());
-
   return violations;
 }
 
 const violations = collectViolations();
 
 if (violations.length > 0) {
-  console.error('Found npm package metadata, README, or native dependency policy violations:\n');
+  console.error('Found stale v9 npm metadata/readme references:\n');
   for (const violation of violations) {
     console.error(`- ${violation.packageName}: ${violation.location}`);
     console.error(`  ${violation.sample}`);
-    if (violation.expected) {
-      console.error(`  expected: ${violation.expected}`);
-    }
   }
   process.exit(1);
 }
 
-console.log('NPM metadata check passed: no stale v9 references and better-sqlite3 is pinned to a Node 24-capable build.');
+console.log('NPM metadata check passed: no stale v9 references in publishable packages.');


### PR DESCRIPTION
## Summary

- Follow-up to #1318 review feedback: remove the package-specific `better-sqlite3` metadata/lockfile guard from `scripts/check-npm-metadata.mjs`.
- Keep the actual working package fix from #1318: CLI and Node UI still resolve exact `better-sqlite3@12.11.1` through package manifests and lockfile.
- Restore `pnpm check:npm-metadata` to its original scope: stale v9 package metadata and README references.

## Related

- Follow-up to #1318
- Addresses review thread: https://github.com/OriginTrail/dkg/pull/1318#discussion_r3467687270
- Related to #1315

## Files changed

| File | What |
|------|------|
| `scripts/check-npm-metadata.mjs` | Removes the bespoke SQLite dependency policy and restores the checker output/scope to stale v9 metadata/README validation only. |

## Test plan

- [x] `pnpm check:npm-metadata`
- [x] CLI native smoke: `better-sqlite3` in-memory DB query returned `42`
- [x] Node UI native smoke: `better-sqlite3` in-memory DB query returned `43`
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/vector-store-extra.test.ts` - 18 passed
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/db.test.ts` - 83 passed

## Notes

This PR intentionally does not change the selected package version. `better-sqlite3@12.11.1` is still the current npm version checked during this follow-up and declares Node 24 support. Switching SQLite packages would be a larger storage migration and is not needed to address the review comment.