### PR TITLE
fix: guard oversized RDF literals

### DIFF
--- a/packages/agent/src/dkg-agent-publish.ts
+++ b/packages/agent/src/dkg-agent-publish.ts
@@ -97,6 +97,7 @@ import {
   pickNetworkTunables,
   sharedMemoryReadBothFilter,
   partitionCatalogQuads,
+  assertQuadLiteralsMutf8Safe,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
 import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
@@ -418,6 +419,11 @@ export type ResolveCuratedChainKeyContextOptions = {
 function normalizeOptionalContextGraphId(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function rejectOversizedRdfLiterals(quads: Quad[] | undefined, label: string): void {
+  if (!quads || quads.length === 0) return;
+  assertQuadLiteralsMutf8Safe(quads, { label });
 }
 
 export class PublishMethods extends DKGAgentBase {
@@ -989,6 +995,8 @@ export class PublishMethods extends DKGAgentBase {
     if (publicQuads.length === 0 && privateQuads.length === 0) {
       throw new InvalidContentError('Content must include at least one public or private payload');
     }
+    rejectOversizedRdfLiterals(publicQuads, 'publishAsync.publicQuads');
+    rejectOversizedRdfLiterals(privateQuads, 'publishAsync.privateQuads');
 
     const partitioned = partitionPublishAsyncQuads(publicQuads, privateQuads);
     const gossipSigner = opts?.localOnly ? null : await this.resolveWorkspaceGossipSigningAgent(contextGraphId);
@@ -1285,6 +1293,8 @@ export class PublishMethods extends DKGAgentBase {
     const ctx = opts?.operationCtx ?? createOperationContext('publish');
     const onPhase = opts?.onPhase;
     this.log.info(ctx, `Starting publish to context graph "${contextGraphId}" with ${quads.length} triples`);
+    rejectOversizedRdfLiterals(quads, 'agent.publish.quads');
+    rejectOversizedRdfLiterals(privateQuads, 'agent.publish.privateQuads');
 
     const isSystem = contextGraphId === SYSTEM_CONTEXT_GRAPHS.AGENTS || contextGraphId === SYSTEM_CONTEXT_GRAPHS.ONTOLOGY;
     if (!isSystem && !this.subscribedContextGraphs.has(contextGraphId)) {
@@ -1519,6 +1529,8 @@ export class PublishMethods extends DKGAgentBase {
     const ctx = opts?.operationCtx ?? createOperationContext('update');
     const onPhase = opts?.onPhase;
     this.log.info(ctx, `Starting update of kaId=${kaId} in context graph "${contextGraphId}" with ${quads.length} triples`);
+    rejectOversizedRdfLiterals(quads, 'agent.update.quads');
+    rejectOversizedRdfLiterals(privateQuads, 'agent.update.privateQuads');
     // GH #842: thread the on-chain cgId so the publisher can promote the update
     // payload into the per-cgId partition the RS prover reads. Without it,
     // updated KAs stay unprovable (data-corrupted / leaf-count-mismatch).

--- a/packages/agent/test/publish-literal-size.test.ts
+++ b/packages/agent/test/publish-literal-size.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PublishMethods } from '../src/dkg-agent-publish.js';
+import type { Quad } from '@origintrail-official/dkg-storage';
+
+const OVERSIZED_TEXT_QUAD: Quad = {
+  subject: 'http://example.org/root',
+  predicate: 'http://schema.org/text',
+  object: `"${'x'.repeat(60_000)}"`,
+  graph: 'http://example.org/graph',
+};
+
+describe('agent publish literal size validation', () => {
+  it('rejects publishAsync private quads before workspace staging', async () => {
+    const agentStub = {
+      contextGraphExists: vi.fn(async () => true),
+    };
+
+    await expect(
+      PublishMethods.prototype.publishAsync.call(
+        agentStub as never,
+        'computer-history',
+        {
+          publicQuads: [],
+          privateQuads: [OVERSIZED_TEXT_QUAD],
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      actualBytes: 60_002,
+      maxBytes: 60_000,
+      predicate: 'http://schema.org/text',
+    });
+  });
+
+  it('rejects direct publish quads before chain or publisher work', async () => {
+    const agentStub = {
+      log: { info: vi.fn() },
+    };
+
+    await expect(
+      PublishMethods.prototype._publish.call(
+        agentStub as never,
+        'computer-history',
+        [OVERSIZED_TEXT_QUAD],
+      ),
+    ).rejects.toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      actualBytes: 60_002,
+      maxBytes: 60_000,
+      predicate: 'http://schema.org/text',
+    });
+  });
+});

--- a/packages/agent/test/swm-10mb-boundary-extra.test.ts
+++ b/packages/agent/test/swm-10mb-boundary-extra.test.ts
@@ -40,6 +40,25 @@ function freshCgId(prefix: string): string {
   return `${prefix}-${ethers.hexlify(ethers.randomBytes(4)).slice(2)}`;
 }
 
+function buildChunkedDescriptionQuads(prefix: string, bytes: number, fill: string) {
+  const chunkBytes = 16 * 1024;
+  const quads = [];
+  let remaining = bytes;
+  let index = 0;
+  while (remaining > 0) {
+    const size = Math.min(chunkBytes, remaining);
+    quads.push({
+      subject: `urn:swm:${prefix}:e${index}`,
+      predicate: 'http://schema.org/description',
+      object: `"${fill.repeat(size)}"`,
+      graph: '',
+    });
+    remaining -= size;
+    index += 1;
+  }
+  return quads;
+}
+
 beforeAll(async () => {
   _fileSnapshot = await takeSnapshot();
   const { hubAddress } = getSharedContext();
@@ -103,16 +122,9 @@ describe('A-2: SHARE 10 MB gossip-size boundary', () => {
     const cgId = freshCgId('bnd-hi');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Hi', description: '' });
 
-    // One literal above the 10 MB cap is guaranteed to trip the pre-mutation guard.
-    const big = 'y'.repeat(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
-    const quads = [
-      {
-        subject: 'urn:swm:hi:alice',
-        predicate: 'http://schema.org/description',
-        object: `"${big}"`,
-        graph: '',
-      },
-    ];
+    // Many individually-safe literals exercise the aggregate gossip-message
+    // boundary without tripping the stricter per-literal Blazegraph guard.
+    const quads = buildChunkedDescriptionQuads('hi', DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024, 'y');
 
     let caught: Error | null = null;
     try {
@@ -132,22 +144,14 @@ describe('A-2: SHARE 10 MB gossip-size boundary', () => {
     const cgId = freshCgId('bnd-atomic');
     await nodeA!.createContextGraph({ id: cgId, name: 'Boundary Atomic', description: '' });
 
-    const big = 'z'.repeat(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
-    const quads = [
-      {
-        subject: 'urn:swm:atomic:bob',
-        predicate: 'http://schema.org/description',
-        object: `"${big}"`,
-        graph: '',
-      },
-    ];
+    const quads = buildChunkedDescriptionQuads('atomic', DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024, 'z');
 
     await expect(nodeA!.share(cgId, quads)).rejects.toThrow(/SWM message too large/);
 
     // SWM view for this CG must be empty for the attempted subject: the
     // oversized share must not have half-written into the store.
     const qr = await nodeA!.query(
-      `SELECT ?o WHERE { <urn:swm:atomic:bob> <http://schema.org/description> ?o }`,
+      `SELECT ?o WHERE { <urn:swm:atomic:e0> <http://schema.org/description> ?o }`,
       { contextGraphId: cgId, view: 'shared-working-memory' },
     );
     expect(

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       "test/sync-requester-bailout.test.ts",
       "test/swm-catchup-peer-selection.test.ts",
       "test/swm-fanout-peer-selection.test.ts",
+      "test/publish-literal-size.test.ts",
     ],
     testTimeout: 60_000,
     maxWorkers: 1,

--- a/packages/cli/src/daemon/http-utils.ts
+++ b/packages/cli/src/daemon/http-utils.ts
@@ -7,6 +7,8 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   PayloadTooLargeError,
+  assertQuadLiteralsMutf8Safe,
+  isOversizedRdfLiteralError,
   validateContextGraphId,
   validateSubGraphName,
   isSafeIri,
@@ -67,6 +69,26 @@ export function payloadTooLargeResponseBody(err: unknown): Record<string, unknow
   return body;
 }
 
+export function oversizedRdfLiteralResponseBody(err: unknown): Record<string, unknown> {
+  const shaped = (err && typeof err === 'object') ? err as Record<string, unknown> : {};
+  const message = err instanceof Error ? err.message : String(err ?? 'Oversized RDF literal');
+  const body: Record<string, unknown> = {
+    error: message,
+    code: 'OVERSIZED_RDF_LITERAL',
+  };
+  const maxBytes = shaped.maxBytes;
+  if (typeof maxBytes === 'number') body.limitBytes = maxBytes;
+  const actualBytes = shaped.actualBytes;
+  if (typeof actualBytes === 'number') body.actualBytes = actualBytes;
+  const subject = shaped.subject;
+  if (typeof subject === 'string') body.subject = subject;
+  const predicate = shaped.predicate;
+  if (typeof predicate === 'string') body.predicate = predicate;
+  const graph = shaped.graph;
+  if (typeof graph === 'string') body.graph = graph;
+  return body;
+}
+
 export async function resolveNameToPeerId(
   agent: DKGAgent,
   nameOrId: string,
@@ -118,6 +140,21 @@ export function isWritableQuad(value: unknown): boolean {
     typeof v.object === "string" &&
     (v.graph === undefined || typeof v.graph === "string")
   );
+}
+
+export function validateWritableQuadLiteralSizes(
+  label: string,
+  quads: Array<{ subject: string; predicate: string; object: string; graph?: string }>,
+): { ok: true } | { ok: false; body: Record<string, unknown> } {
+  try {
+    assertQuadLiteralsMutf8Safe(quads, { label });
+    return { ok: true };
+  } catch (err) {
+    if (isOversizedRdfLiteralError(err)) {
+      return { ok: false, body: oversizedRdfLiteralResponseBody(err) };
+    }
+    throw err;
+  }
 }
 
 /**
@@ -182,7 +219,7 @@ export function respondIfReconcileUnavailable(res: ServerResponse, e: any): bool
 
 export function parsePublishRequestBody(
   body: string,
-): { ok: true; value: PublishRequestBody } | { ok: false; error: string } {
+): { ok: true; value: PublishRequestBody } | { ok: false; error: string; body?: Record<string, unknown> } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(body);
@@ -218,6 +255,10 @@ export function parsePublishRequestBody(
   }
   const quadObjectError = validateQuadObjectTerms("quads", quads);
   if (quadObjectError) return { ok: false, error: quadObjectError };
+  const quadSize = validateWritableQuadLiteralSizes("quads", quads);
+  if (!quadSize.ok) {
+    return { ok: false, error: String(quadSize.body.error ?? 'Oversized RDF literal'), body: quadSize.body };
+  }
 
   if (
     privateQuads !== undefined &&
@@ -231,6 +272,10 @@ export function parsePublishRequestBody(
   if (privateQuads !== undefined) {
     const privateQuadObjectError = validateQuadObjectTerms("privateQuads", privateQuads);
     if (privateQuadObjectError) return { ok: false, error: privateQuadObjectError };
+    const privateQuadSize = validateWritableQuadLiteralSizes("privateQuads", privateQuads);
+    if (!privateQuadSize.ok) {
+      return { ok: false, error: String(privateQuadSize.body.error ?? 'Oversized RDF literal'), body: privateQuadSize.body };
+    }
   }
 
   if (
@@ -1024,6 +1069,12 @@ export interface ImportFileExtractionPayload {
   pipelineUsed: string | null;
   mdIntermediateHash?: string;
   error?: string;
+  code?: string;
+  limitBytes?: number;
+  actualBytes?: number;
+  subject?: string;
+  predicate?: string;
+  graph?: string;
   // #1101: when status === "skipped", explain WHY extraction was skipped so
   // callers don't have to guess (the dominant cause is an unrecognized
   // content type with no registered converter).
@@ -1050,6 +1101,12 @@ export function buildImportFileResponse(args: {
         ? { mdIntermediateHash: args.extraction.mdIntermediateHash }
         : {}),
       ...(args.extraction.error ? { error: args.extraction.error } : {}),
+      ...(args.extraction.code ? { code: args.extraction.code } : {}),
+      ...(args.extraction.limitBytes != null ? { limitBytes: args.extraction.limitBytes } : {}),
+      ...(args.extraction.actualBytes != null ? { actualBytes: args.extraction.actualBytes } : {}),
+      ...(args.extraction.subject ? { subject: args.extraction.subject } : {}),
+      ...(args.extraction.predicate ? { predicate: args.extraction.predicate } : {}),
+      ...(args.extraction.graph ? { graph: args.extraction.graph } : {}),
       ...(args.extraction.skipReason ? { skipReason: args.extraction.skipReason } : {}),
     },
   };

--- a/packages/cli/src/daemon/routes/agent-chat.ts
+++ b/packages/cli/src/daemon/routes/agent-chat.ts
@@ -191,6 +191,7 @@ import {
   isPublishQuad,
   parsePublishRequestBody,
   jsonResponse,
+  oversizedRdfLiteralResponseBody,
   safeDecodeURIComponent,
   safeParseJson,
   validateOptionalSubGraphName,
@@ -1051,6 +1052,9 @@ export async function handleAgentChatRoutes(ctx: RequestContext): Promise<void> 
       // those to 422 (Unprocessable Entity) so the API surfaces a proper 4xx
       // instead of letting it bubble to the generic 500 handler.
       const message = err instanceof Error ? err.message : String(err);
+      if ((err as any)?.code === "OVERSIZED_RDF_LITERAL") {
+        return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(err));
+      }
       if (message.includes('precomputedUpdateAttestation')) {
         return jsonResponse(res, 422, { error: message });
       }

--- a/packages/cli/src/daemon/routes/epcis.ts
+++ b/packages/cli/src/daemon/routes/epcis.ts
@@ -191,6 +191,7 @@ import {
   isPublishQuad,
   parsePublishRequestBody,
   jsonResponse,
+  oversizedRdfLiteralResponseBody,
   safeDecodeURIComponent,
   safeParseJson,
   validateOptionalSubGraphName,
@@ -567,6 +568,9 @@ export async function handleEpcisRoutes(ctx: RequestContext): Promise<void> {
           error: "InvalidContent",
           message: err instanceof Error ? err.message : String(err),
         });
+      }
+      if (code === "OVERSIZED_RDF_LITERAL") {
+        return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(err));
       }
       return jsonResponse(res, 503, {
         error: "EnqueueFailed",

--- a/packages/cli/src/daemon/routes/knowledge-assets-import.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets-import.ts
@@ -24,6 +24,7 @@ import {
   assertionLifecycleUri,
   validateAssertionName,
   PayloadTooLargeError,
+  assertQuadLiteralsMutf8Safe,
   IMPORTED_ARTIFACT_MAX_PAGE_BYTES,
   isDkgContentHash,
   verifyDkgContentHash,
@@ -40,6 +41,7 @@ import {
   validateRequiredContextGraphId,
   normalizeContextGraphIdOrUri,
   resolveRequiredWriteContextGraphId,
+  oversizedRdfLiteralResponseBody,
   SMALL_BODY_BYTES,
   MAX_UPLOAD_BYTES,
   type ImportFileExtractionPayload,
@@ -959,6 +961,12 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
       error: string,
       tripleCount: number,
       failedPipelineUsed: string | null = pipelineUsed,
+      details: Partial<
+        Pick<
+          ImportFileExtractionPayload,
+          "code" | "limitBytes" | "actualBytes" | "subject" | "predicate" | "graph"
+        >
+      > = {},
     ) => {
       const failedRecord = recordFailedExtraction(
         error,
@@ -973,6 +981,7 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
           ? { mdIntermediateHash: failedRecord.mdIntermediateHash }
           : {}),
         error,
+        ...details,
       });
     };
     const previousExtractionStatusRecord = getExtractionStatusRecord(
@@ -1397,6 +1406,28 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
           graph: skippedMetaGraph,
         });
       }
+      try {
+        assertQuadLiteralsMutf8Safe(skippedMetaQuads, {
+          label: 'import-file.skippedMetaQuads',
+        });
+      } catch (err: any) {
+        if (err?.code === "OVERSIZED_RDF_LITERAL") {
+          const oversizedBody = oversizedRdfLiteralResponseBody(err);
+          return respondWithFailedExtraction(
+            400,
+            String(oversizedBody.error ?? err.message),
+            0,
+            null,
+            oversizedBody as Partial<
+              Pick<
+                ImportFileExtractionPayload,
+                "code" | "limitBytes" | "actualBytes" | "subject" | "predicate" | "graph"
+              >
+            >,
+          );
+        }
+        throw err;
+      }
 
       let skippedMetaCleanupSucceeded = false;
       let skippedDataDropSucceeded = false;
@@ -1807,6 +1838,28 @@ export async function handleKaImportFile(ctx: RequestContext, name: string): Pro
         object: JSON.stringify(uploadedFilename),
         graph: metaGraph,
       });
+    }
+    try {
+      assertQuadLiteralsMutf8Safe([...dataGraphQuads, ...metaQuads], {
+        label: 'import-file.quads',
+      });
+    } catch (err: any) {
+      if (err?.code === "OVERSIZED_RDF_LITERAL") {
+        const oversizedBody = oversizedRdfLiteralResponseBody(err);
+        return respondWithFailedExtraction(
+          400,
+          String(oversizedBody.error ?? err.message),
+          triples.length,
+          pipelineUsed,
+          oversizedBody as Partial<
+            Pick<
+              ImportFileExtractionPayload,
+              "code" | "limitBytes" | "actualBytes" | "subject" | "predicate" | "graph"
+            >
+          >,
+        );
+      }
+      throw err;
     }
 
     // Round 14 Bug 42: lock acquisition moved to the top of the

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -28,6 +28,7 @@ import type { RequestContext } from "./context.js";
 import {
   isPayloadTooLargeError,
   jsonResponse,
+  oversizedRdfLiteralResponseBody,
   payloadTooLargeResponseBody,
   readBody,
   safeParseJson,
@@ -38,6 +39,7 @@ import {
   isWritableQuad,
   validateQuadObjectTerms,
   respondIfReconcileUnavailable,
+  validateWritableQuadLiteralSizes,
   normalizeContextGraphIdOrUri,
   resolveRequiredWriteContextGraphId,
 } from "../http-utils.js";
@@ -122,6 +124,10 @@ const FINALIZE_ONLY_CREATE_FIELDS = [
  * publish path, which never down-classified them).
  */
 function respondAssertionError(res: RequestContext["res"], e: any): void {
+  if (e?.code === "OVERSIZED_RDF_LITERAL") {
+    jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));
+    return;
+  }
   if (isPayloadTooLargeError(e)) {
     jsonResponse(res, 413, payloadTooLargeResponseBody(e));
     return;
@@ -583,7 +589,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
   if (method === "POST" && path === `${PREFIX}/publish`) {
     const rawBody = await readBody(req);
     const parsed = parsePublishRequestBody(rawBody);
-    if (!parsed.ok) return jsonResponse(res, 400, { error: parsed.error });
+    if (!parsed.ok) return jsonResponse(res, 400, parsed.body ?? { error: parsed.error });
     const raw = JSON.parse(rawBody) as Record<string, unknown>;
     const {
       contextGraphId,
@@ -655,6 +661,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (isPayloadTooLargeError(e)) {
         return jsonResponse(res, 413, payloadTooLargeResponseBody(e));
       }
+      if (e?.code === "OVERSIZED_RDF_LITERAL") {
+        return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));
+      }
       // Transient KA-number-floor reconcile failure (rate-limited RPC) -> 503.
       if (respondIfReconcileUnavailable(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
@@ -724,6 +733,13 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     // author attestation and reserves the on-chain identity, so it requires the
     // CG to be registered). OT-RFC-43 §10.5.5.
     const hasQuads = Array.isArray(quads) && quads.length > 0;
+    if (hasQuads) {
+      if (!quads.every(isWritableQuad)) {
+        return jsonResponse(res, 400, { error: '"quads" must be an array of { subject, predicate, object } objects (graph optional); string-shaped quads are not accepted' });
+      }
+      const literalSize = validateWritableQuadLiteralSizes("quads", quads);
+      if (!literalSize.ok) return jsonResponse(res, 400, literalSize.body);
+    }
     const shouldFinalize = hasQuads && finalize !== false;
     // #1116 D5: the create ROUTE stays a primitive — create+write+seal, with
     // opt-in share (this preserves the "create stops at a sealed WM draft"
@@ -858,6 +874,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       if (errors.length > 0) return jsonResponse(res, 207, { created: true, ...result, errors });
       return jsonResponse(res, 201, result);
     } catch (e: any) {
+      if (e?.code === "OVERSIZED_RDF_LITERAL") {
+        return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(e));
+      }
       // Transient KA-number-floor reconcile failure (rate-limited RPC) -> 503.
       if (respondIfReconcileUnavailable(res, e)) return;
       return jsonResponse(res, 500, { error: e?.message ?? String(e) });
@@ -1018,6 +1037,8 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         // literal nor an absolute IRI before they reach (and crash) the parser.
         const wmObjErr = validateQuadObjectTerms("quads", parsed.quads);
         if (wmObjErr) return jsonResponse(res, 400, { error: wmObjErr });
+        const literalSize = validateWritableQuadLiteralSizes("quads", parsed.quads);
+        if (!literalSize.ok) return jsonResponse(res, 400, literalSize.body);
         // A bare write to a name that was never created used to fall through to
         // the legacy `/assertion/{addr}/{name}` graph and produce a KA that is
         // permanently 404 in the descriptor API (no `_meta` lifecycle record,

--- a/packages/cli/src/daemon/routes/memory.ts
+++ b/packages/cli/src/daemon/routes/memory.ts
@@ -199,6 +199,8 @@ import {
   isPublishQuad,
   isWritableQuad,
   validateQuadObjectTerms,
+  validateWritableQuadLiteralSizes,
+  oversizedRdfLiteralResponseBody,
   parsePublishRequestBody,
   jsonResponse,
   safeDecodeURIComponent,
@@ -665,6 +667,8 @@ export async function handleMemoryRoutes(ctx: RequestContext): Promise<void> {
         };
       });
 
+      const literalSize = validateWritableQuadLiteralSizes("quads", normalized);
+      if (!literalSize.ok) return jsonResponse(res, 400, literalSize.body);
       await agent.store.insert(normalized);
       return jsonResponse(res, 200, {
         ok: true,
@@ -1654,6 +1658,8 @@ WHERE {
       const objErr = validateQuadObjectTerms("quads", quads);
       if (objErr) return jsonResponse(res, 400, { error: objErr });
     }
+    const literalSize = validateWritableQuadLiteralSizes("quads", quads);
+    if (!literalSize.ok) return jsonResponse(res, 400, literalSize.body);
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
       contextGraphId,
@@ -2235,6 +2241,8 @@ WHERE {
       const objErr = validateQuadObjectTerms("quads", quads);
       if (objErr) return jsonResponse(res, 400, { error: objErr });
     }
+    const literalSize = validateWritableQuadLiteralSizes("quads", quads);
+    if (!literalSize.ok) return jsonResponse(res, 400, literalSize.body);
     const resolvedContextGraphId = await resolveRequiredWriteContextGraphId(
       agent,
       contextGraphId,
@@ -2430,6 +2438,9 @@ WHERE {
       });
     }
 
+    const literalSize = validateWritableQuadLiteralSizes("quads", quads);
+    if (!literalSize.ok) return jsonResponse(res, 400, literalSize.body);
+
     // 5. Write to target layer
     try {
       if (targetLayer === 'swm') {
@@ -2455,6 +2466,9 @@ WHERE {
         await agent.store.insert(quads);
       }
     } catch (err: any) {
+      if (err?.code === "OVERSIZED_RDF_LITERAL") {
+        return jsonResponse(res, 400, oversizedRdfLiteralResponseBody(err));
+      }
       return jsonResponse(res, 500, { error: `Failed to write turn to ${targetLayer}: ${err.message}` });
     }
     emitMemoryGraphChanged?.({

--- a/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
+++ b/packages/cli/src/daemon/routes/shared-assertion-helpers.ts
@@ -18,11 +18,13 @@ import {
   ImportedArtifactMetadataError,
   isDkgContentHash,
   resolveImportedArtifactMetadata,
+  assertRdfLiteralMutf8Safe,
 } from '@origintrail-official/dkg-core';
 import { type PromoteJob, type PromoteJobState } from '@origintrail-official/dkg-publisher';
 import { daemonState } from '../state.js';
 import {
   jsonResponse,
+  oversizedRdfLiteralResponseBody,
   safeDecodeURIComponent,
   normalizeContextGraphIdOrUri,
   isValidContextGraphId,
@@ -285,6 +287,11 @@ export function normalizeSemanticQuads(raw: unknown): Array<{ subject: string; p
     } else {
       normalizedObject = rdfLiteral(object);
     }
+    assertRdfLiteralMutf8Safe(normalizedObject, {
+      label: `semanticQuads[${index}].object`,
+      subject,
+      predicate,
+    });
     return { subject, predicate, object: normalizedObject };
   });
 }
@@ -491,6 +498,10 @@ export async function isPublicOpenContextGraph(
 export function handleImportArtifactRouteError(res: ServerResponse, err: unknown): boolean {
   if (err instanceof ImportArtifactRouteError) {
     jsonResponse(res, err.statusCode, { error: err.message });
+    return true;
+  }
+  if ((err as { code?: string })?.code === 'OVERSIZED_RDF_LITERAL') {
+    jsonResponse(res, 400, oversizedRdfLiteralResponseBody(err));
     return true;
   }
   const message = err instanceof Error ? err.message : String(err);

--- a/packages/cli/test/epcis-route-readiness.test.ts
+++ b/packages/cli/test/epcis-route-readiness.test.ts
@@ -223,6 +223,42 @@ describe('EPCIS async capture publisher readiness', () => {
     ]);
   });
 
+  it('maps oversized RDF literal publishAsync failures to structured 400 responses', async () => {
+    const oversized = Object.assign(
+      new Error('RDF literal exceeds safe MUTF-8 byte limit'),
+      {
+        code: 'OVERSIZED_RDF_LITERAL',
+        maxBytes: 60_000,
+        actualBytes: 60_002,
+        predicate: 'http://schema.org/text',
+      },
+    );
+    const ctx = createContext({
+      req: createRequest({ epcisDocument: VALID_OBJECT_EVENT_DOC }),
+      agent: {
+        publishAsync: async () => {
+          throw oversized;
+        },
+      } as unknown as RequestContext['agent'],
+      publisherRuntime: {
+        walletIds: ['0xpublisher'],
+        runner: {},
+        publisher: {},
+        stop: async () => {},
+      } as unknown as RequestContext['publisherRuntime'],
+    });
+
+    await handleEpcisRoutes(ctx);
+
+    expect(ctx.res.statusCode).toBe(400);
+    expect(responseBody(ctx)).toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      limitBytes: 60_000,
+      actualBytes: 60_002,
+      predicate: 'http://schema.org/text',
+    });
+  });
+
   it('returns 400 InvalidContent when neither body nor config supplies a contextGraphId', async () => {
     const ctx = createContext({
       req: createRequest({ epcisDocument: VALID_OBJECT_EVENT_DOC }),

--- a/packages/cli/test/http-literal-size-validation.test.ts
+++ b/packages/cli/test/http-literal-size-validation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildImportFileResponse,
+  parsePublishRequestBody,
+  validateWritableQuadLiteralSizes,
+} from '../src/daemon/http-utils.js';
+
+const OVERSIZED_LITERAL = `"${'x'.repeat(60_000)}"`;
+
+describe('HTTP RDF literal size validation', () => {
+  it('returns structured parse failure for oversized direct publish literals', () => {
+    const parsed = parsePublishRequestBody(JSON.stringify({
+      contextGraphId: 'literal-size-cg',
+      quads: [{
+        subject: 'http://example.org/s',
+        predicate: 'http://schema.org/text',
+        object: OVERSIZED_LITERAL,
+        graph: 'http://example.org/g',
+      }],
+    }));
+
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.body).toMatchObject({
+        code: 'OVERSIZED_RDF_LITERAL',
+        actualBytes: 60_002,
+        limitBytes: 60_000,
+        predicate: 'http://schema.org/text',
+      });
+    }
+  });
+
+  it('returns structured validation failure for writable route quads', () => {
+    const result = validateWritableQuadLiteralSizes('quads', [{
+      subject: 'http://example.org/s',
+      predicate: 'http://schema.org/text',
+      object: OVERSIZED_LITERAL,
+    }]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.body).toMatchObject({
+        code: 'OVERSIZED_RDF_LITERAL',
+        actualBytes: 60_002,
+        limitBytes: 60_000,
+      });
+    }
+  });
+
+  it('preserves oversized literal fields in import-file extraction responses', () => {
+    expect(buildImportFileResponse({
+      assertionUri: 'http://example.org/assertion',
+      fileHash: '0xabc',
+      detectedContentType: 'text/markdown',
+      extraction: {
+        status: 'failed',
+        tripleCount: 1,
+        pipelineUsed: 'markdown',
+        error: 'RDF literal exceeds safe MUTF-8 byte limit',
+        code: 'OVERSIZED_RDF_LITERAL',
+        actualBytes: 60_002,
+        limitBytes: 60_000,
+        predicate: 'http://schema.org/text',
+      },
+    }).extraction).toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      actualBytes: 60_002,
+      limitBytes: 60_000,
+      predicate: 'http://schema.org/text',
+    });
+  });
+});

--- a/packages/cli/test/issue-306-787-write-quad-validation.test.ts
+++ b/packages/cli/test/issue-306-787-write-quad-validation.test.ts
@@ -23,6 +23,7 @@ import { startLiveDaemon, stopLiveDaemon, postJson, type LiveDaemon } from './he
 
 let daemon: LiveDaemon | undefined;
 const CG = 'wq-validation-cg';
+const OVERSIZED_LITERAL = `"${'x'.repeat(60_000)}"`;
 
 beforeAll(async () => {
   daemon = await startLiveDaemon({ authEnabled: true });
@@ -52,6 +53,16 @@ describe('GH #787 — POST /api/shared-memory/write quad-shape validation', () =
     });
     expect(status, JSON.stringify(body)).toBe(200);
   });
+
+  it('returns 400 for oversized RDF literals before SWM write', async () => {
+    const { status, body } = await postJson(daemon!, '/api/shared-memory/write', {
+      contextGraphId: CG,
+      quads: [{ subject: 'urn:wq:oversized-swm', predicate: 'http://schema.org/text', object: OVERSIZED_LITERAL }],
+    });
+    expect(status, JSON.stringify(body)).toBe(400);
+    expect(body.code).toBe('OVERSIZED_RDF_LITERAL');
+    expect(body.actualBytes).toBeGreaterThan(60_000);
+  });
 });
 
 describe('GH #306 — POST /api/knowledge-assets/{name}/wm/write quad-shape validation', () => {
@@ -73,6 +84,18 @@ describe('GH #306 — POST /api/knowledge-assets/{name}/wm/write quad-shape vali
       contextGraphId: CG, quads: [{ subject: 'urn:wq:s306', predicate: 'http://schema.org/name', object: '"ok306"' }],
     });
     expect(status, JSON.stringify(body)).toBe(200);
+  });
+
+  it('returns 400 for oversized RDF literals before WM write', async () => {
+    const created = await postJson(daemon!, '/api/knowledge-assets', { contextGraphId: CG, name: 'ka-306-oversized' });
+    expect(created.status).toBeLessThan(300);
+    const { status, body } = await postJson(daemon!, '/api/knowledge-assets/ka-306-oversized/wm/write', {
+      contextGraphId: CG,
+      quads: [{ subject: 'urn:wq:oversized-wm', predicate: 'http://schema.org/text', object: OVERSIZED_LITERAL }],
+    });
+    expect(status, JSON.stringify(body)).toBe(400);
+    expect(body.code).toBe('OVERSIZED_RDF_LITERAL');
+    expect(body.actualBytes).toBeGreaterThan(60_000);
   });
 });
 

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -64,6 +64,8 @@ export default defineConfig({
           'test/blazegraph-integration.test.ts',
           // #761 — context graph write-target validation (from main).
           'test/context-graph-write-path-validation.test.ts',
+          'test/http-literal-size-validation.test.ts',
+          'test/epcis-route-readiness.test.ts',
           // Notifications-pane redesign (A3) — assertion_activity emitter
           // helper. Pure logic + a tmp SQLite DashboardDB, no hardhat.
           'test/activity-notification.test.ts',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,19 @@ export {
   assertSafeRdfTerm,
 } from './sparql-safe.js';
 export {
+  JAVA_WRITE_UTF_MAX_BYTES,
+  DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
+  OVERSIZED_RDF_LITERAL_ERROR_CODE,
+  OversizedRdfLiteralError,
+  javaModifiedUtf8ByteLength,
+  rdfLiteralTermMutf8ByteLength,
+  isOversizedRdfLiteralError,
+  assertRdfLiteralMutf8Safe,
+  assertQuadLiteralsMutf8Safe,
+  type RdfLiteralSizeContext,
+  type QuadLiteralLike,
+} from './rdf-literal-size.js';
+export {
   DKGError,
   DKGUserError,
   DKGInternalError,

--- a/packages/core/src/rdf-literal-size.ts
+++ b/packages/core/src/rdf-literal-size.ts
@@ -1,0 +1,143 @@
+import { DKGUserError } from './errors.js';
+
+export const JAVA_WRITE_UTF_MAX_BYTES = 65_535;
+export const DKG_RDF_LITERAL_SAFE_MUTF8_BYTES = 60_000;
+export const OVERSIZED_RDF_LITERAL_ERROR_CODE = 'OVERSIZED_RDF_LITERAL';
+
+export interface RdfLiteralSizeContext {
+  readonly label?: string;
+  readonly subject?: string;
+  readonly predicate?: string;
+  readonly graph?: string;
+  readonly maxBytes?: number;
+}
+
+export interface QuadLiteralLike {
+  readonly subject: string;
+  readonly predicate: string;
+  readonly object: string;
+  readonly graph?: string;
+}
+
+export class OversizedRdfLiteralError extends DKGUserError {
+  readonly code = OVERSIZED_RDF_LITERAL_ERROR_CODE;
+  readonly actualBytes: number;
+  readonly maxBytes: number;
+  readonly subject?: string;
+  readonly predicate?: string;
+  readonly graph?: string;
+  readonly label?: string;
+
+  constructor(args: {
+    actualBytes: number;
+    maxBytes: number;
+    label?: string;
+    subject?: string;
+    predicate?: string;
+    graph?: string;
+  }) {
+    const location = describeLiteralLocation(args);
+    super(
+      `RDF literal${location} is ${args.actualBytes} Java MUTF-8 bytes, ` +
+      `which exceeds the Blazegraph-compatible safe limit of ${args.maxBytes} bytes. ` +
+      `Split large text into ordered chunks below the limit, or store the body externally ` +
+      `and publish only its URI, hash, summary, and metadata.`,
+    );
+    this.name = 'OversizedRdfLiteralError';
+    this.actualBytes = args.actualBytes;
+    this.maxBytes = args.maxBytes;
+    this.label = args.label;
+    this.subject = args.subject;
+    this.predicate = args.predicate;
+    this.graph = args.graph;
+  }
+}
+
+function describeLiteralLocation(args: {
+  label?: string;
+  subject?: string;
+  predicate?: string;
+  graph?: string;
+}): string {
+  const parts: string[] = [];
+  if (args.label) parts.push(args.label);
+  if (args.subject) parts.push(`subject=${truncateForMessage(args.subject)}`);
+  if (args.predicate) parts.push(`predicate=${truncateForMessage(args.predicate)}`);
+  if (args.graph) parts.push(`graph=${truncateForMessage(args.graph)}`);
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}
+
+function truncateForMessage(value: string): string {
+  return value.length <= 120 ? value : `${value.slice(0, 117)}...`;
+}
+
+/**
+ * Java Modified UTF-8 byte length using Java's UTF-16 code-unit rules.
+ *
+ * This intentionally differs from standard UTF-8:
+ * - U+0000 is 2 bytes.
+ * - U+0001 through U+007F are 1 byte.
+ * - U+0080 through U+07FF are 2 bytes.
+ * - All other UTF-16 code units, including surrogate halves, are 3 bytes.
+ */
+export function javaModifiedUtf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0) {
+      bytes += 2;
+    } else if (code <= 0x7f) {
+      bytes += 1;
+    } else if (code <= 0x07ff) {
+      bytes += 2;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+export function rdfLiteralTermMutf8ByteLength(term: string): number | undefined {
+  if (!term.startsWith('"')) return undefined;
+  return javaModifiedUtf8ByteLength(term);
+}
+
+export function isOversizedRdfLiteralError(err: unknown): err is OversizedRdfLiteralError {
+  if (err instanceof OversizedRdfLiteralError) return true;
+  if (!err || typeof err !== 'object') return false;
+  return (err as { code?: unknown }).code === OVERSIZED_RDF_LITERAL_ERROR_CODE;
+}
+
+export function assertRdfLiteralMutf8Safe(
+  term: string,
+  options: RdfLiteralSizeContext = {},
+): void {
+  const actualBytes = rdfLiteralTermMutf8ByteLength(term);
+  if (actualBytes === undefined) return;
+  const maxBytes = options.maxBytes ?? DKG_RDF_LITERAL_SAFE_MUTF8_BYTES;
+  if (actualBytes <= maxBytes) return;
+  throw new OversizedRdfLiteralError({
+    actualBytes,
+    maxBytes,
+    label: options.label,
+    subject: options.subject,
+    predicate: options.predicate,
+    graph: options.graph,
+  });
+}
+
+export function assertQuadLiteralsMutf8Safe(
+  quads: readonly QuadLiteralLike[],
+  options: Pick<RdfLiteralSizeContext, 'label' | 'maxBytes'> = {},
+): void {
+  for (let i = 0; i < quads.length; i++) {
+    const q = quads[i];
+    assertRdfLiteralMutf8Safe(q.object, {
+      maxBytes: options.maxBytes,
+      label: options.label ? `${options.label}[${i}].object` : `quads[${i}].object`,
+      subject: q.subject,
+      predicate: q.predicate,
+      graph: q.graph,
+    });
+  }
+}

--- a/packages/core/test/rdf-literal-size.test.ts
+++ b/packages/core/test/rdf-literal-size.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
+  OVERSIZED_RDF_LITERAL_ERROR_CODE,
+  assertQuadLiteralsMutf8Safe,
+  assertRdfLiteralMutf8Safe,
+  javaModifiedUtf8ByteLength,
+  rdfLiteralTermMutf8ByteLength,
+} from '../src/rdf-literal-size.js';
+
+describe('rdf literal Java MUTF-8 sizing', () => {
+  it('counts Java Modified UTF-8 byte length by UTF-16 code unit', () => {
+    expect(javaModifiedUtf8ByteLength('abc')).toBe(3);
+    expect(javaModifiedUtf8ByteLength('\u0000')).toBe(2);
+    expect(javaModifiedUtf8ByteLength('\u007f')).toBe(1);
+    expect(javaModifiedUtf8ByteLength('\u0080')).toBe(2);
+    expect(javaModifiedUtf8ByteLength('\u07ff')).toBe(2);
+    expect(javaModifiedUtf8ByteLength('\u0800')).toBe(3);
+    expect(javaModifiedUtf8ByteLength('😀')).toBe(6);
+    expect(javaModifiedUtf8ByteLength('\ud800')).toBe(3);
+    expect(javaModifiedUtf8ByteLength('\udc00')).toBe(3);
+  });
+
+  it('sizes serialized RDF literal object terms and ignores non-literals', () => {
+    expect(rdfLiteralTermMutf8ByteLength('"abc"')).toBe(5);
+    expect(rdfLiteralTermMutf8ByteLength('"abc"@en')).toBe(8);
+    const typed = '"1"^^<http://www.w3.org/2001/XMLSchema#integer>';
+    expect(rdfLiteralTermMutf8ByteLength(typed)).toBe(javaModifiedUtf8ByteLength(typed));
+    expect(rdfLiteralTermMutf8ByteLength('http://example.org/not-a-literal')).toBeUndefined();
+  });
+
+  it('allows literals at the conservative safe boundary', () => {
+    const body = 'x'.repeat(DKG_RDF_LITERAL_SAFE_MUTF8_BYTES - 2);
+    expect(() => assertRdfLiteralMutf8Safe(`"${body}"`)).not.toThrow();
+  });
+
+  it('rejects literals above the conservative safe boundary with diagnostics', () => {
+    const body = 'x'.repeat(DKG_RDF_LITERAL_SAFE_MUTF8_BYTES - 1);
+    expect(() =>
+      assertRdfLiteralMutf8Safe(`"${body}"`, {
+        label: 'test.literal',
+        subject: 'http://example.org/s',
+        predicate: 'http://schema.org/text',
+      }),
+    ).toThrow(/Blazegraph-compatible safe limit/);
+
+    try {
+      assertRdfLiteralMutf8Safe(`"${body}"`, {
+        subject: 'http://example.org/s',
+        predicate: 'http://schema.org/text',
+      });
+    } catch (err) {
+      expect(err).toMatchObject({
+        code: OVERSIZED_RDF_LITERAL_ERROR_CODE,
+        actualBytes: DKG_RDF_LITERAL_SAFE_MUTF8_BYTES + 1,
+        maxBytes: DKG_RDF_LITERAL_SAFE_MUTF8_BYTES,
+        subject: 'http://example.org/s',
+        predicate: 'http://schema.org/text',
+      });
+    }
+  });
+
+  it('validates quad arrays and reports the offending quad', () => {
+    const oversized = `"${'x'.repeat(DKG_RDF_LITERAL_SAFE_MUTF8_BYTES - 1)}"`;
+    expect(() =>
+      assertQuadLiteralsMutf8Safe([
+        { subject: 'http://example.org/safe', predicate: 'http://schema.org/name', object: '"ok"' },
+        { subject: 'http://example.org/bad', predicate: 'http://schema.org/text', object: oversized },
+      ], { label: 'publish.quads' }),
+    ).toThrow(/publish\.quads\[1\]\.object/);
+  });
+});

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2,7 +2,7 @@ import type { Quad, TripleStore } from '@origintrail-official/dkg-storage';
 import type { ChainAdapter, OnChainPublishResult, AddBatchToContextGraphParams } from '@origintrail-official/dkg-chain';
 import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
-import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
+import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
 import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
@@ -408,6 +408,10 @@ function rejectReservedSubjectPrefixes(quads: Quad[]): void {
 function rejectUserAuthoredProtocolMetadata(quads: Quad[]): void {
   rejectReservedSubjectPrefixes(quads);
   assertNoUserAuthoredTrustLevelQuads(quads);
+}
+
+function rejectOversizedRdfLiterals(quads: Quad[], label: string): void {
+  assertQuadLiteralsMutf8Safe(quads, { label });
 }
 
 async function stampTrustLevel(
@@ -1070,6 +1074,7 @@ export class DKGPublisher implements Publisher {
     // reserved-namespace violation cannot be masked by a lock timeout
     // or subject-level validation error downstream.
     rejectUserAuthoredProtocolMetadata(quads);
+    rejectOversizedRdfLiterals(quads, 'share.quads');
     const subjects = [...new Set(quads.map(q => q.subject))];
     const lockPrefix = options.subGraphName ? `${contextGraphId}\0${options.subGraphName}` : contextGraphId;
     const lockKeys = subjects.map(s => `${lockPrefix}\0${s}`);
@@ -1359,6 +1364,7 @@ export class DKGPublisher implements Publisher {
     // violation with a StaleWriteError). Short-circuit per
     // `19_MARKDOWN_CONTENT_TYPE.md §10.2`.
     rejectUserAuthoredProtocolMetadata(quads);
+    rejectOversizedRdfLiterals(quads, 'conditionalShare.quads');
     for (const cond of options.conditions) {
       assertSafeIri(cond.subject);
       assertSafeIri(cond.predicate);
@@ -1990,6 +1996,8 @@ export class DKGPublisher implements Publisher {
       rejectUserAuthoredProtocolMetadata(quads);
       if (privateQuads.length > 0) rejectUserAuthoredProtocolMetadata(privateQuads);
     }
+    rejectOversizedRdfLiterals(quads, 'publish.quads');
+    if (privateQuads.length > 0) rejectOversizedRdfLiterals(privateQuads, 'publish.privateQuads');
     const ctx: OperationContext = operationCtx ?? createOperationContext('publish');
     const effectiveAccessPolicy = accessPolicy ?? (privateQuads.length > 0 ? 'ownerOnly' : 'public');
     const normalizedAllowedPeers = [...new Set((allowedPeers ?? []).map((p) => p.trim()).filter(Boolean))];
@@ -3457,6 +3465,8 @@ export class DKGPublisher implements Publisher {
       rejectUserAuthoredProtocolMetadata(quads);
       if (privateQuads.length > 0) rejectUserAuthoredProtocolMetadata(privateQuads);
     }
+    rejectOversizedRdfLiterals(quads, 'update.quads');
+    if (privateQuads.length > 0) rejectOversizedRdfLiterals(privateQuads, 'update.privateQuads');
     const ctx: OperationContext = operationCtx ?? createOperationContext('publish');
     let publisherContextGraphId: bigint | undefined;
     try {
@@ -5344,6 +5354,7 @@ export class DKGPublisher implements Publisher {
     // Round 9 Bug 25: reject user-authored quads whose subject is in a
     // protocol-reserved URN namespace. See RESERVED_SUBJECT_PREFIXES above.
     rejectUserAuthoredProtocolMetadata(quads);
+    rejectOversizedRdfLiterals(quads, 'assertionWrite.quads');
     await this.store.insert(quads);
   }
 

--- a/packages/publisher/test/async-lift-workspace.test.ts
+++ b/packages/publisher/test/async-lift-workspace.test.ts
@@ -440,21 +440,25 @@ describe('async lift workspace resolution', () => {
     expect(resolved.publisherPeerId).toBe('legacy-peer');
   });
 
-  it('does not duplicate large public literals into metadata', async () => {
-    const marker = 'large-public-literal-marker';
-    const largeValue = `${marker}-${'x'.repeat(512 * 1024)}`;
+  it('does not duplicate large public payload content into metadata', async () => {
+    const marker = 'large-public-payload-marker';
+    const chunk = 'x'.repeat(16 * 1024);
+    const largePayloadQuads = Array.from({ length: 32 }, (_, index) => ({
+      subject: ENTITY,
+      predicate: 'http://schema.org/name',
+      object: JSON.stringify(`${marker}-${index}-${chunk}`),
+      graph: '',
+    }));
 
-    await publisher.share(CONTEXT_GRAPH, [
-      { subject: ENTITY, predicate: 'http://schema.org/name', object: JSON.stringify(largeValue), graph: '' },
-    ], { publisherPeerId: 'peer1' });
+    await publisher.share(CONTEXT_GRAPH, largePayloadQuads, { publisherPeerId: 'peer1' });
 
     const swmGraph = graphManager.sharedMemoryUri(CONTEXT_GRAPH);
     const swmResult = await store.query(
-      `SELECT ?o WHERE { GRAPH <${swmGraph}> { <${ENTITY}> <http://schema.org/name> ?o } } LIMIT 1`,
+      `SELECT ?o WHERE { GRAPH <${swmGraph}> { <${ENTITY}> <http://schema.org/name> ?o } }`,
     );
     expect(swmResult.type).toBe('bindings');
     if (swmResult.type === 'bindings') {
-      expect(swmResult.bindings[0]?.['o']).toContain(marker);
+      expect(JSON.stringify(swmResult.bindings)).toContain(marker);
     }
 
     const metaGraph = graphManager.sharedMemoryMetaUri(CONTEXT_GRAPH);

--- a/packages/publisher/test/dkg-publisher-compat.test.ts
+++ b/packages/publisher/test/dkg-publisher-compat.test.ts
@@ -35,4 +35,35 @@ describe('DKGPublisher compatibility aliases', () => {
 
     expect(publisher.autoPartition(quads)).toEqual(publisher.skolemizeByEntity(quads));
   });
+
+  it('rejects oversized RDF literals at shared-memory producer boundary', async () => {
+    const publisher = await makePublisher();
+    const oversized = `"${'x'.repeat(60_000)}"`;
+
+    await expect(
+      publisher.share('test', [
+        q('urn:compat:oversized', 'http://schema.org/text', oversized),
+      ], { publisherPeerId: 'test-peer' }),
+    ).rejects.toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      actualBytes: 60_002,
+    });
+  });
+
+  it('rejects oversized private literals before publish canonicalization', async () => {
+    const publisher = await makePublisher();
+    const oversized = `"${'x'.repeat(60_000)}"`;
+
+    await expect(
+      publisher.publish({
+        contextGraphId: 'test',
+        publisherPeerId: 'test-peer',
+        quads: [q('urn:compat:root', 'http://schema.org/name', '"ok"')],
+        privateQuads: [q('urn:compat:root', 'http://schema.org/text', oversized)],
+      }),
+    ).rejects.toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      actualBytes: 60_002,
+    });
+  });
 });

--- a/packages/publisher/test/share-size-boundary-extra.test.ts
+++ b/packages/publisher/test/share-size-boundary-extra.test.ts
@@ -30,26 +30,6 @@ function q(s: string, p: string, o: string): Quad {
   return { subject: s, predicate: p, object: o, graph: '' };
 }
 
-/**
- * Build a single quad whose UTF-8 N-Quad serialization is approximately
- * `targetBytes` bytes. We pad the literal object so the encoded
- * WorkspacePublishRequest lands below or above the cap depending
- * on `targetBytes`.
- *
- * Using a single root entity keeps manifest overhead constant so the
- * dominant size contribution is the nquads string. autoPartition groups
- * by root — a single subject maps to a single KA.
- */
-function buildQuadWithPayload(bytes: number): Quad {
-  // subject/predicate/fixed N-Quad framing adds ~120 bytes of overhead.
-  // Subtract that from the target so the rendered N-Quad approximates
-  // `bytes`. We pad with a single ASCII char so 1 char == 1 byte.
-  const overhead = 140;
-  const padLen = Math.max(0, bytes - overhead);
-  const padding = 'x'.repeat(padLen);
-  return q('urn:test:boundary:root', 'http://schema.org/description', `"${padding}"`);
-}
-
 function buildQuadsWithTotalPayload(bytes: number): Quad[] {
   const chunkBytes = 16 * 1024;
   const quads: Quad[] = [];
@@ -106,11 +86,13 @@ describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
 
   it('rejects a payload just over the 10 MB cap with a clear, actionable error', async () => {
     // Well over the 10 MB cap so there is no ambiguity about the exit path.
-    const over = buildQuadWithPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
+    // Use many Blazegraph-safe literals so this exercises the aggregate
+    // gossip-message boundary rather than the per-literal safety guard.
+    const over = buildQuadsWithTotalPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 1024 * 1024);
 
     let thrown: unknown;
     try {
-      await publisher.share(CG, [over], { publisherPeerId: PEER });
+      await publisher.share(CG, over, { publisherPeerId: PEER });
     } catch (err) {
       thrown = err;
     }
@@ -131,14 +113,14 @@ describe('P-4: SWM share() 10 MB gossip-message boundary', () => {
     // the guidance in the error or the spec, BOTH
     // halves of this test flip status and the regression is noisy.
     const justUnder = buildQuadsWithTotalPayload(2 * 1024 * 1024);
-    const justOver = buildQuadWithPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 512 * 1024);
+    const justOver = buildQuadsWithTotalPayload(DKG_GOSSIP_MAX_MESSAGE_BYTES + 512 * 1024);
 
     const ok = await publisher.share(CG, justUnder, { publisherPeerId: PEER });
     expect(ok).toBeDefined();
     expect(ok.message.length).toBeLessThan(DKG_GOSSIP_MAX_MESSAGE_BYTES);
 
     await expect(
-      publisher.share(CG, [justOver], { publisherPeerId: PEER }),
+      publisher.share(CG, justOver, { publisherPeerId: PEER }),
     ).rejects.toThrow(/too large.*10\s*MB/i);
   });
 });

--- a/packages/storage/src/adapters/blazegraph.ts
+++ b/packages/storage/src/adapters/blazegraph.ts
@@ -10,6 +10,7 @@ import type {
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
 import { buildBlankNodeSafeDelete } from './sparql-http.js';
+import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 
 /**
  * BlazegraphStore — TripleStore adapter backed by a remote Blazegraph
@@ -34,8 +35,11 @@ export class BlazegraphStore implements TripleStore {
 
   async insert(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
-    const safe = rejectOversizedLiterals(quads, BLAZEGRAPH_MUTF8_LIMIT);
-    const nquads = safe.map(quadToNQuad).join('\n') + '\n';
+    assertQuadLiteralsMutf8Safe(quads, {
+      maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+      label: 'BlazegraphStore.insert',
+    });
+    const nquads = quads.map(quadToNQuad).join('\n') + '\n';
     const res = await fetch(this.url, {
       method: 'POST',
       headers: { 'Content-Type': 'text/x-nquads' },

--- a/packages/storage/src/adapters/sparql-http.ts
+++ b/packages/storage/src/adapters/sparql-http.ts
@@ -31,6 +31,7 @@ import type {
   AskResult,
 } from '../triple-store.js';
 import { registerTripleStoreAdapter } from '../triple-store.js';
+import { assertQuadLiteralsMutf8Safe, JAVA_WRITE_UTF_MAX_BYTES } from '@origintrail-official/dkg-core';
 import { createHash } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 
@@ -223,6 +224,10 @@ export class SparqlHttpStore implements TripleStore {
 
   async insert(quads: DKGQuad[]): Promise<void> {
     if (quads.length === 0) return;
+    assertQuadLiteralsMutf8Safe(quads, {
+      maxBytes: JAVA_WRITE_UTF_MAX_BYTES,
+      label: 'SparqlHttpStore.insert',
+    });
     const byGraph = new Map<string, DKGQuad[]>();
     for (const q of quads) {
       const g = q.graph || '';

--- a/packages/storage/src/private-store.ts
+++ b/packages/storage/src/private-store.ts
@@ -1,4 +1,5 @@
 import {
+  assertRdfLiteralMutf8Safe,
   assertSafeIri,
   assertSafeRdfTerm,
   escapeSparqlLiteral,
@@ -266,11 +267,19 @@ export class PrivateContentStore {
 
     const graphUri = this.privateStagingGraph(contextGraphId, shareOperationId, subGraphName);
     const subject = privateStageSubject(contextGraphId, shareOperationId, rootEntity, subGraphName);
+    const predicate = 'http://dkg.io/ontology/privateStagedQuads';
+    const stagedPayload = JSON.stringify(JSON.stringify(quads.map((q) => ({ ...q, graph: '' }))));
+    assertRdfLiteralMutf8Safe(stagedPayload, {
+      label: 'PrivateContentStore.storePrivateTriplesForOperation',
+      subject,
+      predicate,
+      graph: graphUri,
+    });
     await this.store.deleteByPattern({ graph: graphUri, subject });
     await this.store.insert([{
       subject,
-      predicate: 'http://dkg.io/ontology/privateStagedQuads',
-      object: JSON.stringify(JSON.stringify(quads.map((q) => ({ ...q, graph: '' })))),
+      predicate,
+      object: stagedPayload,
       graph: graphUri,
     }]);
   }

--- a/packages/storage/test/blazegraph.unit.test.ts
+++ b/packages/storage/test/blazegraph.unit.test.ts
@@ -296,7 +296,7 @@ describe('BlazegraphStore (mocked HTTP)', () => {
     await expect(s.insert([
       { subject: 'http://s1', predicate: 'http://p', object: '"small"', graph: 'http://g' },
       { subject: 'http://s2', predicate: 'http://p', object: oversized, graph: 'http://g' },
-    ])).rejects.toThrow(/MUTF-8 limit/);
+    ])).rejects.toMatchObject({ code: 'OVERSIZED_RDF_LITERAL' });
     expect(fetchCalls).toHaveLength(0);
   });
 

--- a/packages/storage/test/sparql-http.test.ts
+++ b/packages/storage/test/sparql-http.test.ts
@@ -102,6 +102,19 @@ describe('SparqlHttpStore (test server)', () => {
     expect(insertedQuads.some(q => q.includes('INSERT'))).toBe(true);
   });
 
+  it('rejects RDF literals above the Java MUTF-8 hard limit before update POST', async () => {
+    insertedQuads.length = 0;
+    await expect(store.insert([{
+      subject: 'http://ex.org/s',
+      predicate: 'http://schema.org/text',
+      object: `"${'x'.repeat(70_000)}"`,
+      graph: 'http://ex.org/g',
+    }])).rejects.toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+    });
+    expect(insertedQuads).toHaveLength(0);
+  });
+
   it('query SELECT sends query to query endpoint and parses bindings', async () => {
     const result = await store.query(
       'SELECT ?name WHERE { GRAPH <http://ex.org/g1> { <http://ex.org/alice> <http://schema.org/name> ?name } }',

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -590,6 +590,27 @@ describe('PrivateContentStore', () => {
     expect((await ps.getPrivateTriples('cg-stage', entity)).map((quad) => quad.object)).toEqual(['"pending"']);
   });
 
+  it('rejects oversized aggregate operation-staged private payloads before replacing existing staged data', async () => {
+    const entity = 'did:dkg:agent:AsyncPrivateOversized';
+    const prior: Quad[] = [
+      { subject: entity, predicate: 'http://ex.org/secret', object: '"prior"', graph: '' },
+    ];
+    const oversizedAggregate: Quad[] = [
+      { subject: entity, predicate: 'http://ex.org/a', object: `"${'a'.repeat(35_000)}"`, graph: '' },
+      { subject: entity, predicate: 'http://ex.org/b', object: `"${'b'.repeat(35_000)}"`, graph: '' },
+    ];
+
+    await ps.storePrivateTriplesForOperation('cg-stage', 'op-oversized', entity, prior);
+
+    await expect(
+      ps.storePrivateTriplesForOperation('cg-stage', 'op-oversized', entity, oversizedAggregate),
+    ).rejects.toMatchObject({
+      code: 'OVERSIZED_RDF_LITERAL',
+      predicate: 'http://dkg.io/ontology/privateStagedQuads',
+    });
+    expect(await ps.getPrivateTriplesForOperation('cg-stage', 'op-oversized', entity)).toEqual(prior);
+  });
+
   it('hasPrivateTriples returns false before any data is stored', () => {
     expect(ps.hasPrivateTriples('unknown-cg', 'urn:x')).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Add a shared Java Modified UTF-8 RDF literal size guard with a conservative 60,000-byte producer limit.
- Apply oversized-literal validation at CLI, agent, publisher, semantic/import, private async staging, and Blazegraph/SPARQL storage boundaries.
- Return structured `OVERSIZED_RDF_LITERAL` 400 responses where oversized literals are caller-correctable input.

## Related issue
Blazegraph-backed peers reject/sync-retry graphs containing oversized RDF literals, including the reported `schema.org/text` literal in the `0x599BF63E.../computer-history` graph.

## Validation
- `pnpm --filter @origintrail-official/dkg-core exec vitest run test/rdf-literal-size.test.ts`
- `pnpm --filter @origintrail-official/dkg-storage exec vitest run test/blazegraph.unit.test.ts test/sparql-http.test.ts test/storage.test.ts -t PrivateContentStore|Blazegraph|SparqlHttp`
- `pnpm --dir packages/publisher exec vitest run --config vitest.unit.config.ts test/dkg-publisher-compat.test.ts`
- `pnpm --dir packages/cli exec vitest run --config vitest.unit.config.ts test/http-literal-size-validation.test.ts test/epcis-route-readiness.test.ts`
- `pnpm --dir packages/agent exec vitest run --config vitest.unit.config.ts test/publish-literal-size.test.ts`
- `pnpm --filter @origintrail-official/dkg-core run build`
- `pnpm --filter @origintrail-official/dkg-storage run build`
- `pnpm --filter @origintrail-official/dkg-publisher run build`
- `pnpm --filter @origintrail-official/dkg-agent run build`
- `pnpm --filter @origintrail-official/dkg run build`
- `git diff --check`

## Notes
- Live daemon route test `test/issue-306-787-write-quad-validation.test.ts` could not reach assertions in this Windows worktree because the live daemon helper exited early with code 0.
- Live Blazegraph ingest/sync validation still needs a Blazegraph-backed endpoint or peer environment.
- This PR prevents new poisoned publishes; already-published poisoned data still needs a source rewrite/removal/chunking/externalization step.