### PR TITLE
chore(release): bump to 10.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version bump → `10.0.1`

Bumps `version` to `10.0.1` across the root umbrella and all 18 packages — **19 `package.json` files, version field only**, mirroring the `10.0.0` release-bump (`0de5f259f`, also exactly 19/19). No dependency, lockfile, or source changes.

### Merge order
🔸 **Merge this last**, after the other in-flight PRs land. It only touches `version` fields, so it should stay conflict-free with feature PRs.

> ℹ️ This summary is refreshed as more PRs merge before this one lands. Last updated against `origin/main` @ #1324.

### Context
- `v10.0.0` is now tagged + released (baseline at [`539fa0109`](https://github.com/OriginTrail/dkg/releases/tag/v10.0.0) — the commit npm `10.0.0` was actually published from).
- `10.0.1` is a **patch**. The post-launch set since `v10.0.0`, grouped:
  - **Contracts** — already live on **Base**, **Gnosis**, and **NeuroWeb** mainnet: boost-expiry reward boundary (#1297), MigrationCreditRecovery (#1300), permissionless `StakingV10.claimFor` (#1303).
  - **Publish & chain reliability** — funded operational-wallet selection for SWM→VM publish (#1327), multi-RPC failover enabled by default (#1329), agent-token authorship binding (#1324), context-graph policy provenance (#1313).
  - **Publisher / storage / daemon robustness** — private-CG catalog root collision (#1311), oversized RDF-literal guard (#1323), write-route 4xx/503 hardening (#1319), StorageACK decline logging (#1316).
  - **Setup & install** — macOS·Node-24 global-install fix (#1318), network-selection setup UX (#1304), eager wallet creation (#1310), MCP testnet faucet funding (#1312).
  - **Docs & housekeeping** — staking-migration + profile-registration runbooks and V10 doc cleanup (#1301, #1321, #1325), mainnet deploy registries (#1305), npm-metadata check + agent-docs removal (#1320, #1326).

### Release steps after merge (manual — npm enforces 2FA; the NPM Publish workflow is disabled)
1. Tag `v10.0.1` (signed annotated tag — triggers `release.yml` to build the GitHub release + MarkItDown assets).
2. `pnpm install --frozen-lockfile && pnpm build && pnpm -r publish --tag latest` with OTP.
3. Move the channel dist-tags by hand: `npm dist-tag add @origintrail-official/dkg@10.0.1 mainnet` and `… testnet` (otherwise no node auto-updates — per #1295). The `mainnet` channel covers **Base, Gnosis, and NeuroWeb**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
