### PR TITLE
Fix PR 1324 follow-up lane handling

### DIFF
--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -447,20 +447,15 @@ function classifyVmPublish(pub: unknown): { httpStatus: 200 | 207 | 502; reason?
   };
 }
 
-// Reject finalized-publish request shapes that don't make sense once the URL
-// name + seal already select the assertion and encode the author (PR #971).
-// The seal commits to the whole assertion content + author, so assertionName /
-// author overrides / partial selection on vm/publish are user errors, not
-// silently-ignored fields.
-function validateFinalizedAssertionPublishRequest(
-  parsed: Record<string, unknown>,
+// Reject finalized-publish fields that don't make sense once the URL name +
+// seal already select the assertion and encode the author (PR #971). The seal
+// commits to the whole assertion content + author, so assertionName / author
+// overrides / partial selection are user errors, not silently-ignored fields.
+function validateFinalizedAssertionPublishShape(
+  source: Record<string, unknown>,
   res: RequestContext["res"],
 ): boolean {
-  const nested = parsed.options && typeof parsed.options === "object" && !Array.isArray(parsed.options)
-    ? parsed.options as Record<string, unknown>
-    : undefined;
-  const assertionName = parsed.assertionName ?? nested?.assertionName;
-  if (assertionName !== undefined) {
+  if (source.assertionName !== undefined) {
     jsonResponse(res, 400, {
       error:
         '"assertionName" is not accepted on /api/knowledge-assets/:name/vm/publish — the URL name selects the assertion.',
@@ -468,10 +463,8 @@ function validateFinalizedAssertionPublishRequest(
     return false;
   }
   const hasAuthorOverride =
-    parsed.authorAgentAddress != null ||
-    parsed.preSignedAuthorAttestation != null ||
-    nested?.authorAgentAddress != null ||
-    nested?.preSignedAuthorAttestation != null;
+    source.authorAgentAddress != null ||
+    source.preSignedAuthorAttestation != null;
   if (hasAuthorOverride) {
     jsonResponse(res, 400, {
       error:
@@ -479,8 +472,7 @@ function validateFinalizedAssertionPublishRequest(
     });
     return false;
   }
-  const selection = parsed.selection ?? nested?.selection;
-  if (selection !== undefined && selection !== "all") {
+  if (source.selection !== undefined && source.selection !== "all") {
     jsonResponse(res, 400, {
       error:
         '"selection" must be omitted or "all" on vm/publish — the seal commits to the entire assertion content.',
@@ -488,6 +480,29 @@ function validateFinalizedAssertionPublishRequest(
     return false;
   }
   return true;
+}
+
+function publishIntegerString(
+  value: unknown,
+  field: string,
+  res: RequestContext["res"],
+  opts: { positive: boolean },
+): string | null {
+  if (typeof value !== "string" && typeof value !== "number") {
+    jsonResponse(res, 400, { error: `"${field}" must be a ${opts.positive ? "positive " : "non-negative "}integer (string or number)` });
+    return null;
+  }
+  if (typeof value === "number" && (!Number.isSafeInteger(value) || (opts.positive ? value <= 0 : value < 0))) {
+    jsonResponse(res, 400, { error: `"${field}" must be a ${opts.positive ? "positive " : "non-negative "}safe integer (string or number)` });
+    return null;
+  }
+  const v = typeof value === "string" ? value.trim() : String(value);
+  const pattern = opts.positive ? /^[1-9]\d*$/ : /^\d+$/;
+  if (!pattern.test(v)) {
+    jsonResponse(res, 400, { error: `"${field}" must be a ${opts.positive ? "positive " : "non-negative "}integer (string or number)` });
+    return null;
+  }
+  return v;
 }
 
 // Validate + normalize the finalized-publish options BEFORE they reach
@@ -508,23 +523,15 @@ function resolveFinalizedPublishOptions(
 
   let resolvedPublisherIdentityOverride: bigint | undefined;
   if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
-    const v = String(publisherNodeIdentityIdOverride);
-    if (!/^\d+$/.test(v)) {
-      jsonResponse(res, 400, {
-        error: '"publisherNodeIdentityIdOverride" must be a non-negative integer (string or number)',
-      });
-      return null;
-    }
+    const v = publishIntegerString(publisherNodeIdentityIdOverride, "publisherNodeIdentityIdOverride", res, { positive: false });
+    if (v === null) return null;
     resolvedPublisherIdentityOverride = BigInt(v);
   }
 
   let resolvedPublishEpochs: number | undefined;
   if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
-    const v = String(rawPublishEpochs).trim();
-    if (!/^[1-9]\d*$/.test(v)) {
-      jsonResponse(res, 400, { error: `"${publishEpochsField}" must be a positive integer (string or number)` });
-      return null;
-    }
+    const v = publishIntegerString(rawPublishEpochs, publishEpochsField, res, { positive: true });
+    if (v === null) return null;
     const n = Number(v);
     if (!Number.isSafeInteger(n)) {
       jsonResponse(res, 400, { error: `"${publishEpochsField}" is too large to safely represent as a JavaScript integer` });
@@ -553,6 +560,26 @@ function resolveFinalizedPublishOptions(
       ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
       : {}),
   };
+}
+
+function resolveInlineVmPublishOptions(
+  ctx: RequestContext,
+  source: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!validateFinalizedAssertionPublishShape(source, ctx.res)) return null;
+  return resolveFinalizedPublishOptions(ctx, source);
+}
+
+function resolveStandaloneVmPublishOptions(
+  ctx: RequestContext,
+  source: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (!validateFinalizedAssertionPublishShape(source, ctx.res)) return null;
+  const raw = source.options;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    if (!validateFinalizedAssertionPublishShape(raw as Record<string, unknown>, ctx.res)) return null;
+  }
+  return resolveFinalizedPublishOptions(ctx, raw);
 }
 
 async function verifyDirectPublishOnChainContextGraphId(
@@ -845,6 +872,13 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
     // request-shape error into orphaned state.
     const alsoPublishVmRequested =
       alsoPublishVm === true || (typeof alsoPublishVm === "object" && alsoPublishVm !== null);
+    const alsoPublishVmOptions = alsoPublishVmRequested
+      ? resolveInlineVmPublishOptions(
+          ctx,
+          typeof alsoPublishVm === "object" && alsoPublishVm !== null ? alsoPublishVm : {},
+        )
+      : {};
+    if (alsoPublishVmOptions === null) return;
     if (!shouldFinalize && (alsoShareSwm === true || alsoPublishVmRequested)) {
       return jsonResponse(res, 400, {
         error: '"alsoShareSwm"/"alsoPublishVm" require a finalized assertion (non-empty "quads" and "finalize" !== false)',
@@ -950,10 +984,9 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       }
       if (alsoPublishVm === true || (typeof alsoPublishVm === "object" && alsoPublishVm !== null)) {
         try {
-          const opts = typeof alsoPublishVm === "object" && alsoPublishVm ? alsoPublishVm : {};
           const pub: any = await agent.publishFromFinalizedAssertion(resolvedContextGraphId, name, {
             subGraphName,
-            ...opts,
+            ...alsoPublishVmOptions,
             ...atomicAuthorLane,
           });
           result.kaId = pub?.kaId;
@@ -1372,8 +1405,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       try {
         // Validate the request shape + normalize options BEFORE the publish (PR
         // #971): this is a standalone request, so a 400 here mutates nothing.
-        if (!validateFinalizedAssertionPublishRequest(parsed, res)) return;
-        const opts = resolveFinalizedPublishOptions(ctx, parsed.options);
+        const opts = resolveStandaloneVmPublishOptions(ctx, parsed);
         if (opts === null) return;
         // #1116: registration moved from seal-time to publish-time, but it must
         // run AFTER the local preconditions, not before — otherwise a doomed

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -380,9 +380,10 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
   // registers then fails-before-retry would still pass. This pins the exact
   // call order with a fake agent.
   describe('vm/publish auto-register retry sequence', () => {
-    it('atomic create+alsoPublishVm passes the token-scoped storage lane into finalized publish', async () => {
+    it('atomic create+alsoPublishVm forces the token-scoped storage lane over caller publish options', async () => {
       const token = 'agent-token-atomic';
       const tokenAgentAddress = `0x${'cd'.repeat(20)}`;
+      const attackerAgentAddress = `0x${'aa'.repeat(20)}`;
       const seenOpts: unknown[] = [];
 
       await startWith(
@@ -424,13 +425,257 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
           graph: '',
         }],
         finalize: true,
-        alsoPublishVm: true,
+        alsoPublishVm: {
+          agentAddress: attackerAgentAddress,
+          clearAfter: false,
+        },
       });
 
       expect(res.status).toBe(201);
       expect(res.body.status).toBe('vm-confirmed');
       expect(seenOpts).toHaveLength(1);
-      expect(seenOpts[0]).toMatchObject({ agentAddress: tokenAgentAddress });
+      expect(seenOpts[0]).toMatchObject({
+        agentAddress: tokenAgentAddress,
+        clearSharedMemoryAfter: false,
+      });
+    });
+
+    it('atomic create+alsoPublishVm strips caller storage-lane overrides on default-lane requests', async () => {
+      const attackerAgentAddress = `0x${'aa'.repeat(20)}`;
+      const seenOpts: Record<string, unknown>[] = [];
+
+      await startWith(
+        {
+          create: async () => 'did:dkg:assertion:atomic-default-publish',
+          write: async () => undefined,
+          finalize: async () => ({
+            assertionUri: 'did:dkg:assertion:atomic-default-publish',
+            merkleRoot: new Uint8Array(32),
+            authorAddress: `0x${'ef'.repeat(20)}`,
+            schemeVersion: 1,
+            chainId: 1n,
+            kav10Address: `0x${'ef'.repeat(20)}`,
+            eip712Digest: `0x${'34'.repeat(32)}`,
+          }),
+        },
+        {
+          async publishFromFinalizedAssertion(_cg: string, _name: string, opts: Record<string, unknown>) {
+            seenOpts.push(opts);
+            return {
+              status: 'confirmed',
+              ual: 'did:dkg:test/1/45',
+              kaId: '45',
+              seal: { authorAddress: `0x${'ef'.repeat(20)}` },
+            };
+          },
+        },
+      );
+
+      const res = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-default-publish',
+        subGraphName: 'real-subgraph',
+        quads: [{
+          subject: 'did:dkg:test:AtomicDefaultPublish',
+          predicate: 'http://schema.org/name',
+          object: '"Atomic default"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          agentAddress: attackerAgentAddress,
+          subGraphName: 'evil-subgraph',
+          epochs: '2',
+          clearAfter: false,
+        },
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.status).toBe('vm-confirmed');
+      expect(seenOpts).toHaveLength(1);
+      expect(seenOpts[0]).toMatchObject({
+        subGraphName: 'real-subgraph',
+        publishEpochs: 2,
+        clearSharedMemoryAfter: false,
+      });
+      expect(Object.prototype.hasOwnProperty.call(seenOpts[0], 'agentAddress')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(seenOpts[0], 'authorAgentAddress')).toBe(false);
+    });
+
+    it('atomic create+alsoPublishVm rejects forbidden finalized-publish shape before mutation', async () => {
+      const createCalls: unknown[] = [];
+
+      await startWith({
+        create: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return 'did:dkg:assertion:should-not-create';
+        },
+        write: async () => undefined,
+        finalize: async () => {
+          throw new Error('finalize should not be called');
+        },
+      });
+
+      const res = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-invalid-publish-shape',
+        quads: [{
+          subject: 'did:dkg:test:InvalidPublishShape',
+          predicate: 'http://schema.org/name',
+          object: '"Invalid shape"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          authorAgentAddress: `0x${'aa'.repeat(20)}`,
+          selection: { rootEntities: ['urn:only-this'] },
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('authorAgentAddress');
+      expect(createCalls).toHaveLength(0);
+    });
+
+    it('atomic create+alsoPublishVm rejects partial selection before mutation', async () => {
+      const createCalls: unknown[] = [];
+
+      await startWith({
+        create: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return 'did:dkg:assertion:should-not-create';
+        },
+        write: async () => undefined,
+        finalize: async () => {
+          throw new Error('finalize should not be called');
+        },
+      });
+
+      const res = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-invalid-publish-selection',
+        quads: [{
+          subject: 'did:dkg:test:InvalidPublishSelection',
+          predicate: 'http://schema.org/name',
+          object: '"Invalid selection"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          selection: { rootEntities: ['urn:only-this'] },
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('selection');
+      expect(createCalls).toHaveLength(0);
+    });
+
+    it('atomic create+alsoPublishVm rejects assertionName before mutation', async () => {
+      const createCalls: unknown[] = [];
+
+      await startWith({
+        create: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return 'did:dkg:assertion:should-not-create';
+        },
+        write: async () => undefined,
+        finalize: async () => {
+          throw new Error('finalize should not be called');
+        },
+      });
+
+      const res = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-invalid-publish-assertion-name',
+        quads: [{
+          subject: 'did:dkg:test:InvalidPublishAssertionName',
+          predicate: 'http://schema.org/name',
+          object: '"Invalid assertionName"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          assertionName: 'other-assertion',
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('assertionName');
+      expect(createCalls).toHaveLength(0);
+    });
+
+    it('atomic create+alsoPublishVm rejects malformed publish controls before mutation', async () => {
+      const createCalls: unknown[] = [];
+
+      await startWith({
+        create: async (...args: unknown[]) => {
+          createCalls.push(args);
+          return 'did:dkg:assertion:should-not-create';
+        },
+        write: async () => undefined,
+        finalize: async () => {
+          throw new Error('finalize should not be called');
+        },
+      });
+
+      const res = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-invalid-publish-controls',
+        quads: [{
+          subject: 'did:dkg:test:InvalidPublishControls',
+          predicate: 'http://schema.org/name',
+          object: '"Invalid controls"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          publishEpochs: [2],
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('publishEpochs');
+      expect(createCalls).toHaveLength(0);
+
+      const identityRes = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-invalid-publish-identity',
+        quads: [{
+          subject: 'did:dkg:test:InvalidPublishIdentity',
+          predicate: 'http://schema.org/name',
+          object: '"Invalid identity"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          publisherNodeIdentityIdOverride: [0],
+        },
+      });
+
+      expect(identityRes.status).toBe(400);
+      expect(String(identityRes.body.error)).toContain('publisherNodeIdentityIdOverride');
+      expect(createCalls).toHaveLength(0);
+
+      const unsafeIdentityRes = await postRoot({
+        contextGraphId: CG_ID,
+        name: 'atomic-unsafe-publish-identity',
+        quads: [{
+          subject: 'did:dkg:test:UnsafePublishIdentity',
+          predicate: 'http://schema.org/name',
+          object: '"Unsafe identity"',
+          graph: '',
+        }],
+        finalize: true,
+        alsoPublishVm: {
+          publisherNodeIdentityIdOverride: Number.MAX_SAFE_INTEGER + 1,
+        },
+      });
+
+      expect(unsafeIdentityRes.status).toBe(400);
+      expect(String(unsafeIdentityRes.body.error)).toContain('publisherNodeIdentityIdOverride');
+      expect(String(unsafeIdentityRes.body.error)).toContain('safe integer');
+      expect(createCalls).toHaveLength(0);
     });
 
     it('passes the token-scoped storage lane into finalized publish calls', async () => {
@@ -460,6 +705,32 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(res.status).toBe(200);
       expect(seenOpts).toHaveLength(1);
       expect(seenOpts[0]).toMatchObject({ agentAddress: tokenAgentAddress });
+    });
+
+    it('standalone vm/publish rejects partial selection before publish', async () => {
+      const publishCalls: unknown[] = [];
+
+      await startWith(
+        {},
+        {
+          async publishFromFinalizedAssertion(_cg: string, _name: string, opts: unknown) {
+            publishCalls.push(opts);
+            return { status: 'confirmed', ual: 'did:dkg:test/1/45', kaId: '45' };
+          },
+        },
+      );
+
+      const cases = [
+        { contextGraphId: CG_ID, selection: { rootEntities: ['urn:only-this'] } },
+        { contextGraphId: CG_ID, options: { selection: { rootEntities: ['urn:only-this'] } } },
+      ];
+
+      for (const body of cases) {
+        const res = await post('vm/publish', body);
+        expect(res.status).toBe(400);
+        expect(String(res.body.error)).toContain('selection');
+      }
+      expect(publishCalls).toHaveLength(0);
     });
 
     it('on CG_NOT_REGISTERED: registers ONCE between TWO publish calls and returns the retry result', async () => {

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
           'test/promote-async-daemon-lifecycle.test.ts',
           'test/async-promote-worker.test.ts',
           'test/async-promote-queue-e2e.test.ts',
+          'test/knowledge-assets-1116-share-errors.test.ts',
           'test/import-artifact-routes.test.ts',
           'test/shared-memory-catchup-durable.test.ts',
           'test/skill-endpoint.test.ts',

--- a/packages/publisher/src/async-promote-queue-impl.ts
+++ b/packages/publisher/src/async-promote-queue-impl.ts
@@ -40,6 +40,7 @@ import {
 import {
   ACTIVE_PROMOTE_STATES,
   DEFAULT_PROMOTE_CONTROL_GRAPH_URI,
+  PROMOTE_ASSERTION_NAME,
   PROMOTE_CONTEXT_GRAPH_ID,
   PROMOTE_PAYLOAD,
   PROMOTE_STATE,
@@ -49,12 +50,23 @@ import {
   expectBindings,
   jobSubject,
   literal,
+  normalizePromoteAgentLane,
   parseJobPayload,
-  requestsShareUniquenessKey,
+  promoteLaneConflictScope,
+  promoteLaneScopesConflict,
   serializeJob,
   uniquenessKey,
   uniquenessLookupKeys,
+  type PromoteUniquenessInput,
 } from './async-promote-queue-utils.js';
+
+type PromoteConflictLookup = {
+  request: PromoteUniquenessInput;
+  lookupQuery:
+    | { kind: 'uniquenessKeys'; keys: string[] }
+    | { kind: 'assertionWildcard' };
+  laneScope: ReturnType<typeof promoteLaneConflictScope>;
+};
 
 export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
   /**
@@ -96,16 +108,17 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
 
   async enqueue(request: PromoteRequest): Promise<string> {
     this.validateRequest(request);
+    const requestSnapshot = this.snapshotRequest(request);
     return this.withMutationLock(async () => {
       await this.ensureGraph();
-      await this.assertNoActiveConflict(request);
+      await this.assertNoActiveConflict(this.conflictLookupForRequest(requestSnapshot));
 
       const now = this.now();
       const jobId = this.idGenerator();
       this.validateJobId(jobId);
       const job: PromoteJob = {
         jobId,
-        request: this.normalizeRequest(request),
+        request: requestSnapshot,
         state: 'queued',
         enqueuedAt: now,
         updatedAt: now,
@@ -172,18 +185,22 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
           `Cannot recover job in state '${job.state}'. Only 'failed' jobs can be recovered.`,
         );
       }
+      const now = this.now();
+      if (await this.abandonIfMissingStorageLane(job, now)) {
+        throw new Error(`Cannot recover job ${jobId}: ${this.missingStorageLaneReason()}`);
+      }
       if (this.requiresManualInspection(job)) {
         throw new Error(
           `Cannot recover job ${jobId}: ${job.reason ?? job.attempt.lastError?.message ?? 'manual inspection required'}`,
         );
       }
-      await this.assertNoActiveConflict(job.request, job.jobId);
+      await this.assertNoActiveConflict(this.conflictLookupForStoredJob(job), job.jobId);
       const recovered: PromoteJob = {
         jobId: job.jobId,
-        request: job.request,
+        request: this.snapshotRequest(job.request),
         state: 'queued',
         enqueuedAt: job.enqueuedAt,
-        updatedAt: this.now(),
+        updatedAt: now,
         attempt: { count: 0, maxRetries: job.attempt.maxRetries },
         // Explicit operator recovery is the right place to upgrade a
         // legacy row to the current persistence format: the operator
@@ -215,9 +232,14 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
         if (j.state === 'failed_retrying' && (j.attempt.nextRetryAt ?? 0) <= now) return true;
         return false;
       });
+      const claimableCandidates: PromoteJob[] = [];
+      for (const candidate of candidates) {
+        if (await this.abandonIfMissingStorageLane(candidate, now)) continue;
+        claimableCandidates.push(candidate);
+      }
 
       const running = await this.list({ state: ['running'] });
-      const eligible = candidates.filter((candidate) =>
+      const eligible = claimableCandidates.filter((candidate) =>
         !running.some((active) => active.jobId !== candidate.jobId && this.jobsShareClaimLane(active, candidate)),
       );
       if (eligible.length === 0) return null;
@@ -377,9 +399,14 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
       const expiresAt = job.lease?.expiresAt ?? 0;
       if (expiresAt > now) continue; // lease still valid; worker is fine
 
-      const conflicting = await this.findActiveConflict(job.request, job.jobId);
+      if (await this.abandonIfMissingStorageLane(job, now)) {
+        abandoned += 1;
+        continue;
+      }
+
+      const conflicting = await this.findActiveConflict(this.conflictLookupForStoredJob(job), job.jobId);
       if (conflicting) {
-        await this.abandonStartupRecovery(
+        await this.abandonForManualInspection(
           job,
           now,
           `recovery conflict: active promote job ${conflicting.jobId} already owns this assertion`,
@@ -401,13 +428,10 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
       // to the manual-recovery path below.
       const formatVersion = job.formatVersion ?? 0;
       const hasRecoverableCommitMarker = formatVersion >= ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION;
-      const missingStorageLaneForAuthorOnlyJob =
-        formatVersion < ASYNC_PROMOTE_QUEUE_FORMAT_VERSION &&
-        job.request.agentAddress === undefined &&
-        job.request.authorAgentAddress !== undefined;
-      if (hasRecoverableCommitMarker && !missingStorageLaneForAuthorOnlyJob && swmInserted === false && promoteStarted !== true) {
+      if (hasRecoverableCommitMarker && swmInserted === false && promoteStarted !== true) {
         const reclaimedJob: PromoteJob = {
           ...job,
+          request: this.snapshotRequest(job.request),
           state: 'queued',
           updatedAt: now,
           reason: undefined,
@@ -431,15 +455,11 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
       // safe to re-run automatically.
       const legacyReason = !hasRecoverableCommitMarker
         ? `legacy promote job (formatVersion=${formatVersion}); needs operator inspection — recovery refuses to reclaim pre-v${ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION} rows that may have started promote without writing a marker`
-        : missingStorageLaneForAuthorOnlyJob
-          ? `missing storage lane for pre-v${ASYNC_PROMOTE_QUEUE_FORMAT_VERSION} author-scoped promote job; needs operator inspection`
         : null;
       const legacyMessage = !hasRecoverableCommitMarker
         ? `Legacy promote job (formatVersion=${formatVersion}) found in recovery; daemon refuses automatic reclaim because pre-v${ASYNC_PROMOTE_QUEUE_MIN_AUTO_RECOVERABLE_FORMAT_VERSION} workers may have entered assertionPromote without recording promoteStarted`
-        : missingStorageLaneForAuthorOnlyJob
-          ? `Pre-v${ASYNC_PROMOTE_QUEUE_FORMAT_VERSION} promote job carries authorAgentAddress without agentAddress; daemon refuses automatic reclaim because it cannot prove the WM storage lane`
         : null;
-      await this.abandonStartupRecovery(
+      await this.abandonForManualInspection(
         job,
         now,
         legacyReason
@@ -486,8 +506,11 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
     if (request.subGraphName !== undefined && typeof request.subGraphName !== 'string') {
       throw new Error('subGraphName must be a string when provided');
     }
-    if (request.agentAddress !== undefined && typeof request.agentAddress !== 'string') {
-      throw new Error('agentAddress must be a string when provided');
+    if (
+      request.agentAddress !== undefined &&
+      (typeof request.agentAddress !== 'string' || normalizePromoteAgentLane(request.agentAddress) === '')
+    ) {
+      throw new Error('agentAddress must be a non-empty string when provided');
     }
     if (request.authorAgentAddress !== undefined && typeof request.authorAgentAddress !== 'string') {
       throw new Error('authorAgentAddress must be a string when provided');
@@ -519,23 +542,24 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
     }
   }
 
-  /** Freeze entity arrays so downstream callers can't mutate the persisted job. */
-  private normalizeRequest(request: PromoteRequest): PromoteRequest {
-    const normalized: PromoteRequest = {
+  /** Snapshot caller-owned input before the first await, preserving the worker-facing storage lane string. */
+  private snapshotRequest(request: PromoteRequest): PromoteRequest {
+    const copied: PromoteRequest = {
       contextGraphId: request.contextGraphId,
       assertionName: request.assertionName,
       entities: request.entities === 'all' ? 'all' : Object.freeze([...request.entities]),
     };
     if (request.subGraphName !== undefined) {
-      normalized.subGraphName = request.subGraphName;
+      copied.subGraphName = request.subGraphName;
     }
-    if (request.agentAddress !== undefined) {
-      normalized.agentAddress = request.agentAddress;
+    const agentAddress = request.agentAddress?.trim();
+    if (agentAddress !== undefined && agentAddress !== '') {
+      copied.agentAddress = agentAddress;
     }
     if (request.authorAgentAddress !== undefined) {
-      normalized.authorAgentAddress = request.authorAgentAddress;
+      copied.authorAgentAddress = request.authorAgentAddress;
     }
-    return normalized;
+    return copied;
   }
 
   private async ensureGraph(): Promise<void> {
@@ -581,49 +605,76 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
   }
 
   private async assertNoActiveConflict(
-    request: Pick<PromoteRequest, 'contextGraphId' | 'subGraphName' | 'assertionName' | 'agentAddress'>,
+    lookup: PromoteConflictLookup,
     excludeJobId?: string,
   ): Promise<void> {
-    const existing = await this.findActiveConflict(request, excludeJobId);
+    const existing = await this.findActiveConflict(lookup, excludeJobId);
     if (existing) {
       throw new PromoteJobConflictError(existing.jobId, {
-        contextGraphId: request.contextGraphId,
-        subGraphName: request.subGraphName,
-        assertionName: request.assertionName,
-        agentAddress: request.agentAddress,
+        contextGraphId: lookup.request.contextGraphId,
+        subGraphName: lookup.request.subGraphName,
+        assertionName: lookup.request.assertionName,
+        agentAddress: lookup.request.agentAddress,
       });
     }
   }
 
   private async findActiveConflict(
-    request: Pick<PromoteRequest, 'contextGraphId' | 'subGraphName' | 'assertionName' | 'agentAddress'>,
+    lookup: PromoteConflictLookup,
     excludeJobId?: string,
   ): Promise<PromoteJob | null> {
-    const keyFilter = uniquenessLookupKeys(request).map((key) => literal(key)).join(', ');
-    const result = await this.store.query(
-      `SELECT ?payload WHERE { GRAPH <${this.graphUri}> { ?job <${PROMOTE_UNIQUENESS_KEY}> ?key ; <${PROMOTE_PAYLOAD}> ?payload . FILTER (?key IN (${keyFilter})) } }`,
-    );
+    const result = lookup.lookupQuery.kind === 'assertionWildcard'
+      ? await this.store.query(
+          `SELECT ?payload WHERE { GRAPH <${this.graphUri}> { ?job <${PROMOTE_CONTEXT_GRAPH_ID}> ${literal(lookup.request.contextGraphId)} ; <${PROMOTE_ASSERTION_NAME}> ${literal(lookup.request.assertionName)} ; <${PROMOTE_PAYLOAD}> ?payload . } }`,
+        )
+      : await this.store.query(
+          `SELECT ?payload WHERE { GRAPH <${this.graphUri}> { ?job <${PROMOTE_UNIQUENESS_KEY}> ?key ; <${PROMOTE_PAYLOAD}> ?payload . FILTER (?key IN (${lookup.lookupQuery.keys.map((key) => literal(key)).join(', ')})) } }`,
+        );
     const rows = expectBindings(result);
     for (const row of rows) {
       const job = parseJobPayload(row['payload']);
       if (job?.jobId === excludeJobId) continue;
-      if (job && ACTIVE_PROMOTE_STATES.includes(job.state) && this.storedJobConflictsWithRequest(job, request)) return job;
+      if (job && ACTIVE_PROMOTE_STATES.includes(job.state) && this.jobConflictsWithRequest(job, lookup)) return job;
     }
     return null;
   }
 
   private jobsShareClaimLane(active: PromoteJob, candidate: PromoteJob): boolean {
-    return requestsShareUniquenessKey(active.request, candidate.request, {
-      missingAgentAddressMatchesAnyLane:
-        this.usesLegacyWildcardLane(active) || this.usesLegacyWildcardLane(candidate),
-    });
+    return promoteLaneScopesConflict(
+      this.laneConflictScopeForStoredJob(active),
+      this.laneConflictScopeForStoredJob(candidate),
+    );
   }
 
-  private storedJobConflictsWithRequest(
-    job: PromoteJob,
-    request: Pick<PromoteRequest, 'contextGraphId' | 'subGraphName' | 'assertionName' | 'agentAddress'>,
-  ): boolean {
-    return requestsShareUniquenessKey(job.request, request, {
+  private conflictLookupForRequest(request: PromoteUniquenessInput): PromoteConflictLookup {
+    return this.buildConflictLookup(request, false);
+  }
+
+  private conflictLookupForStoredJob(job: PromoteJob): PromoteConflictLookup {
+    return this.buildConflictLookup(job.request, this.usesLegacyWildcardLane(job));
+  }
+
+  private buildConflictLookup(request: PromoteUniquenessInput, missingLaneMatchesAnyLane: boolean): PromoteConflictLookup {
+    return {
+      request,
+      lookupQuery: missingLaneMatchesAnyLane
+        ? { kind: 'assertionWildcard' }
+        : { kind: 'uniquenessKeys', keys: uniquenessLookupKeys(request) },
+      laneScope: promoteLaneConflictScope(request, {
+        missingAgentAddressMatchesAnyLane: missingLaneMatchesAnyLane,
+      }),
+    };
+  }
+
+  private jobConflictsWithRequest(job: PromoteJob, lookup: PromoteConflictLookup): boolean {
+    return promoteLaneScopesConflict(
+      this.laneConflictScopeForStoredJob(job),
+      lookup.laneScope,
+    );
+  }
+
+  private laneConflictScopeForStoredJob(job: PromoteJob): ReturnType<typeof promoteLaneConflictScope> {
+    return promoteLaneConflictScope(job.request, {
       missingAgentAddressMatchesAnyLane: this.usesLegacyWildcardLane(job),
     });
   }
@@ -632,7 +683,32 @@ export class TripleStoreAsyncPromoteQueue implements AsyncPromoteQueue {
     return (job.formatVersion ?? 0) < ASYNC_PROMOTE_QUEUE_FORMAT_VERSION && job.request.agentAddress === undefined;
   }
 
-  private async abandonStartupRecovery(
+  private missingStorageLaneForAuthorOnlyJob(job: PromoteJob): boolean {
+    return (job.formatVersion ?? 0) < ASYNC_PROMOTE_QUEUE_FORMAT_VERSION
+      && job.request.agentAddress === undefined
+      && job.request.authorAgentAddress !== undefined;
+  }
+
+  private missingStorageLaneReason(): string {
+    return `missing storage lane for pre-v${ASYNC_PROMOTE_QUEUE_FORMAT_VERSION} author-scoped promote job; needs operator inspection`;
+  }
+
+  private missingStorageLaneMessage(): string {
+    return `Pre-v${ASYNC_PROMOTE_QUEUE_FORMAT_VERSION} promote job carries authorAgentAddress without agentAddress; daemon refuses automatic reclaim because it cannot prove the WM storage lane`;
+  }
+
+  private async abandonIfMissingStorageLane(job: PromoteJob, now: number): Promise<boolean> {
+    if (!this.missingStorageLaneForAuthorOnlyJob(job)) return false;
+    await this.abandonForManualInspection(
+      job,
+      now,
+      this.missingStorageLaneReason(),
+      this.missingStorageLaneMessage(),
+    );
+    return true;
+  }
+
+  private async abandonForManualInspection(
     job: PromoteJob,
     now: number,
     reason: string,

--- a/packages/publisher/src/async-promote-queue-types.ts
+++ b/packages/publisher/src/async-promote-queue-types.ts
@@ -73,7 +73,7 @@ export interface PromoteRequest {
   subGraphName?: string;
   assertionName: string;
   entities: readonly string[] | 'all';
-  /** Storage namespace used to locate the WM draft. */
+  /** Worker-facing storage namespace used to locate the WM draft; conflict keys canonicalize separately. */
   agentAddress?: string;
   /** Signing author used by finalize/seal during promote replay. */
   authorAgentAddress?: string;

--- a/packages/publisher/src/async-promote-queue-utils.ts
+++ b/packages/publisher/src/async-promote-queue-utils.ts
@@ -62,10 +62,23 @@ export function jobSubject(jobId: string): string {
   return `urn:dkg:promote-queue:job:${jobId}`;
 }
 
-type PromoteUniquenessInput = Pick<PromoteRequest, 'contextGraphId' | 'subGraphName' | 'assertionName' | 'agentAddress'>;
+export type PromoteUniquenessInput = Pick<PromoteRequest, 'contextGraphId' | 'subGraphName' | 'assertionName' | 'agentAddress'>;
 
-function normalizedAgentLane(agentAddress?: string): string {
-  return agentAddress?.trim().toLowerCase() ?? '';
+export type PromoteLaneConflictScope = {
+  legacyKey: string;
+  lane: {
+    value: string;
+    missingMatchesAnyLane: boolean;
+  };
+};
+
+/**
+ * Canonical queue lane used for conflict keys. EVM agent lanes are
+ * case-insensitive, but peer/DID-style fallback lanes are not safe to lowercase.
+ */
+export function normalizePromoteAgentLane(agentAddress?: string): string {
+  const lane = agentAddress?.trim() ?? '';
+  return /^0x[0-9a-fA-F]{40}$/.test(lane) ? lane.toLowerCase() : lane;
 }
 
 export function legacyUniquenessKey(request: PromoteUniquenessInput): string {
@@ -76,24 +89,34 @@ export function legacyUniquenessKey(request: PromoteUniquenessInput): string {
 }
 
 export function uniquenessKey(request: PromoteUniquenessInput): string {
-  return `${legacyUniquenessKey(request)}\u001f${normalizedAgentLane(request.agentAddress)}`;
+  return `${legacyUniquenessKey(request)}\u001f${normalizePromoteAgentLane(request.agentAddress)}`;
 }
 
 export function uniquenessLookupKeys(request: PromoteUniquenessInput): string[] {
-  return Array.from(new Set([uniquenessKey(request), legacyUniquenessKey(request)]));
+  const preCanonicalLaneKey = `${legacyUniquenessKey(request)}\u001f${request.agentAddress?.trim().toLowerCase() ?? ''}`;
+  const currentDefaultLaneKey = `${legacyUniquenessKey(request)}\u001f`;
+  return Array.from(new Set([uniquenessKey(request), preCanonicalLaneKey, currentDefaultLaneKey, legacyUniquenessKey(request)]));
 }
 
-export function requestsShareUniquenessKey(
-  a: PromoteUniquenessInput,
-  b: PromoteUniquenessInput,
+export function promoteLaneConflictScope(
+  request: PromoteUniquenessInput,
   opts: { missingAgentAddressMatchesAnyLane?: boolean } = {},
-): boolean {
-  if (legacyUniquenessKey(a) !== legacyUniquenessKey(b)) return false;
-  const aLane = normalizedAgentLane(a.agentAddress);
-  const bLane = normalizedAgentLane(b.agentAddress);
-  return opts.missingAgentAddressMatchesAnyLane
-    ? aLane === '' || bLane === '' || aLane === bLane
-    : aLane === bLane;
+): PromoteLaneConflictScope {
+  const value = normalizePromoteAgentLane(request.agentAddress);
+  return {
+    legacyKey: legacyUniquenessKey(request),
+    lane: {
+      value,
+      missingMatchesAnyLane: value === '' && opts.missingAgentAddressMatchesAnyLane === true,
+    },
+  };
+}
+
+export function promoteLaneScopesConflict(a: PromoteLaneConflictScope, b: PromoteLaneConflictScope): boolean {
+  if (a.legacyKey !== b.legacyKey) return false;
+  return a.lane.value === b.lane.value
+    || a.lane.missingMatchesAnyLane
+    || b.lane.missingMatchesAnyLane;
 }
 
 export function quad(subject: string, predicate: string, object: string, graph: string): Quad {

--- a/packages/publisher/test/async-promote-queue.test.ts
+++ b/packages/publisher/test/async-promote-queue.test.ts
@@ -89,6 +89,11 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     await (createQueue() as unknown as { writeJob(job: PromoteJob): Promise<void> }).writeJob(job);
   }
 
+  async function insertRawStoredJob(job: PromoteJob, key: string): Promise<void> {
+    await store.insert(serializeJob(job, DEFAULT_PROMOTE_CONTROL_GRAPH_URI));
+    await rewriteStoredUniquenessKey(job.jobId, key);
+  }
+
   // ---------------------------------------------------------------------------
   // §3.1 enqueue
   // ---------------------------------------------------------------------------
@@ -135,6 +140,7 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     await expect(queue.enqueue(makeRequest({ assertionName: '' }))).rejects.toThrow(/assertionName/);
     await expect(queue.enqueue(makeRequest({ contextGraphId: '' }))).rejects.toThrow(/contextGraphId/);
     await expect(queue.enqueue(makeRequest({ entities: [] }))).rejects.toThrow(/entities array must not be empty/);
+    await expect(queue.enqueue(makeRequest({ agentAddress: '   ' }))).rejects.toThrow(/agentAddress must be a non-empty string/);
   });
 
   it('3. enqueue() rejects with PromoteJobConflictError when (cgId, subGraphName, assertionName) has an active job', async () => {
@@ -160,21 +166,106 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     const agentAUpper = `0x${'AA'.repeat(20)}`;
     const agentB = `0x${'bb'.repeat(20)}`;
 
-    const first = await queue.enqueue(makeRequest({ agentAddress: agentA }));
+    const first = await queue.enqueue(makeRequest({ agentAddress: `  ${agentAUpper}  ` }));
+    expect((await queue.getStatus(first))?.request.agentAddress).toBe(agentAUpper);
 
     // Same cg/subgraph/name, different storage lane -> independent work.
     const second = await queue.enqueue(makeRequest({ agentAddress: agentB }));
     expect(second).toBe('job-2');
+    expect((await queue.getStatus(second))?.request.agentAddress).toBe(agentB);
 
     // Same lane with different address casing -> same active resource.
-    await expect(queue.enqueue(makeRequest({ agentAddress: agentAUpper }))).rejects.toMatchObject({
+    await expect(queue.enqueue(makeRequest({ agentAddress: agentA }))).rejects.toMatchObject({
       name: 'PromoteJobConflictError',
       existingJobId: first,
+      key: { agentAddress: agentA },
     });
 
     // Default daemon lane is also independent from explicit agent lanes.
     const third = await queue.enqueue(makeRequest());
     expect(third).toBe('job-3');
+
+    const peerLane = '12D3KooWCaseSensitiveLane';
+    const peerLaneJob = await queue.enqueue(makeRequest({
+      assertionName: 'peer-lane',
+      agentAddress: ` ${peerLane} `,
+    }));
+    expect((await queue.getStatus(peerLaneJob))?.request.agentAddress).toBe(peerLane);
+
+    await expect(queue.enqueue(makeRequest({
+      assertionName: 'peer-lane',
+      agentAddress: peerLane,
+    }))).rejects.toMatchObject({
+      name: 'PromoteJobConflictError',
+      existingJobId: peerLaneJob,
+      key: { agentAddress: peerLane },
+    });
+
+    const peerLaneCaseVariant = await queue.enqueue(makeRequest({
+      assertionName: 'peer-lane',
+      agentAddress: peerLane.toLowerCase(),
+    }));
+    expect(peerLaneCaseVariant).toBe('job-5');
+  });
+
+  it('3e. enqueue() still detects active rows stored with the pre-canonical lowercased lane key', async () => {
+    const queue = createQueue();
+    const peerLane = '12D3KooWCaseSensitiveLane';
+    const request = makeRequest({ assertionName: 'old-peer-lane', agentAddress: peerLane });
+    const oldLowercaseKey = `${legacyUniquenessKey(request)}\u001f${peerLane.toLowerCase()}`;
+
+    await insertRawStoredJob({
+      jobId: 'old-key-peer-lane',
+      request,
+      state: 'queued',
+      enqueuedAt: now,
+      updatedAt: now,
+      attempt: { count: 0, maxRetries: 5 },
+      formatVersion: ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
+    }, oldLowercaseKey);
+
+    await expect(queue.enqueue(request)).rejects.toMatchObject({
+      name: 'PromoteJobConflictError',
+      existingJobId: 'old-key-peer-lane',
+      key: { agentAddress: peerLane },
+    });
+  });
+
+  it('3f. enqueue() snapshots caller-owned requests before async conflict checks and persistence', async () => {
+    const queue = createQueue();
+    const agentUpper = `0x${'AA'.repeat(20)}`;
+    const mutatedAgent = `0x${'bb'.repeat(20)}`;
+    const entities = ['urn:entity:original'];
+    const request = makeRequest({
+      assertionName: 'mutable-enqueue-input',
+      agentAddress: agentUpper,
+      entities,
+    });
+
+    const enqueueing = queue.enqueue(request);
+    request.agentAddress = mutatedAgent;
+    entities.push('urn:entity:mutated');
+    const jobId = await enqueueing;
+
+    const job = await queue.getStatus(jobId);
+    expect(job?.request.agentAddress).toBe(agentUpper);
+    expect(job?.request.entities).toEqual(['urn:entity:original']);
+
+    await expect(queue.enqueue(makeRequest({
+      assertionName: 'mutable-enqueue-input',
+      agentAddress: agentUpper,
+      entities: ['urn:entity:replacement'],
+    }))).rejects.toMatchObject({
+      name: 'PromoteJobConflictError',
+      existingJobId: jobId,
+    });
+
+    const independent = await queue.enqueue(makeRequest({
+      assertionName: 'mutable-enqueue-input',
+      agentAddress: mutatedAgent,
+      entities: ['urn:entity:mutated-lane'],
+    }));
+    expect(independent).toBe('job-2');
   });
 
   it('3d. enqueue() treats legacy no-agent active jobs as conflicting with explicit upgraded lanes', async () => {
@@ -397,6 +488,48 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     expect(claimedB?.request.agentAddress).toBe(agentB);
   });
 
+  it('13e. claimNext() preserves the worker-facing storage lane from old queued payloads', async () => {
+    const queue = createQueue();
+    const agentUpper = `0x${'AA'.repeat(20)}`;
+    await insertRawStoredJob({
+      jobId: 'old-mixed-case-lane',
+      request: makeRequest({ agentAddress: agentUpper }),
+      state: 'queued',
+      enqueuedAt: now,
+      updatedAt: now,
+      attempt: { count: 0, maxRetries: 5 },
+      formatVersion: ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
+    }, uniquenessKey(makeRequest({ agentAddress: agentUpper })));
+
+    const claimed = await queue.claimNext('worker-1');
+
+    expect(claimed?.jobId).toBe('old-mixed-case-lane');
+    expect(claimed?.request.agentAddress).toBe(agentUpper);
+    expect((await queue.getStatus('old-mixed-case-lane'))?.request.agentAddress).toBe(agentUpper);
+  });
+
+  it('13f. claimNext() parks pre-v3 author-only rows that have no storage lane', async () => {
+    const queue = createQueue();
+    const legacyAuthorOnly: PromoteJob = {
+      jobId: 'queued-v2-author-only',
+      request: makeRequest({ authorAgentAddress: `0x${'aa'.repeat(20)}` }),
+      state: 'queued',
+      enqueuedAt: now,
+      updatedAt: now,
+      attempt: { count: 0, maxRetries: 5 },
+      formatVersion: 2,
+    };
+    await insertRawStoredJob(legacyAuthorOnly, `${legacyUniquenessKey(legacyAuthorOnly.request)}\u001f`);
+
+    const claimed = await queue.claimNext('worker-1');
+
+    expect(claimed).toBeNull();
+    const parked = await queue.getStatus('queued-v2-author-only');
+    expect(parked?.state).toBe('failed');
+    expect(parked?.reason).toMatch(/missing storage lane/i);
+    expect(parked?.attempt.lastError?.message).toMatch(/cannot prove the WM storage lane/);
+  });
+
   it('13c. claimNext() does not claim an explicit lane while a legacy no-agent job is running', async () => {
     const queue = createQueue();
     const legacyRequest = makeRequest();
@@ -425,6 +558,28 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     );
 
     expect(await queue.claimNext('worker-2')).toBeNull();
+  });
+
+  it('13f. enqueue() treats rewritten legacy no-agent rows as wildcard conflicts', async () => {
+    const queue = createQueue();
+    const legacyRequest = makeRequest();
+    const legacyJobId = await queue.enqueue(legacyRequest);
+    await rewriteStoredJob({
+      ...(await queue.getStatus(legacyJobId))!,
+      formatVersion: 2,
+    });
+    await rewriteStoredUniquenessKey(legacyJobId, legacyUniquenessKey(legacyRequest));
+
+    const claimed = await queue.claimNext('worker-legacy');
+    expect(claimed?.jobId).toBe(legacyJobId);
+    expect(claimed?.formatVersion).toBe(2);
+    expect((await queue.getStatus(legacyJobId))?.request.agentAddress).toBeUndefined();
+    await rewriteStoredUniquenessKey(legacyJobId, `${legacyUniquenessKey(legacyRequest)}\u001f`);
+
+    await expect(queue.enqueue(makeRequest({ agentAddress: `0x${'aa'.repeat(20)}` }))).rejects.toMatchObject({
+      name: 'PromoteJobConflictError',
+      existingJobId: legacyJobId,
+    });
   });
 
   it('13d. claimNext() can claim a current default-lane job and explicit agent-lane job concurrently', async () => {
@@ -720,6 +875,69 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     expect((await queue.getStatus(second))?.state).toBe('queued');
   });
 
+  it('24c. recover(jobId) treats v2 no-agent rows as wildcard conflicts against active explicit lanes', async () => {
+    const queue = createQueue();
+    const failedLegacyJob: PromoteJob = {
+      jobId: 'failed-v2-wildcard',
+      request: makeRequest(),
+      state: 'failed',
+      enqueuedAt: now,
+      updatedAt: now,
+      attempt: { count: 1, maxRetries: 5 },
+      formatVersion: 2,
+    };
+    await insertRawStoredJob(failedLegacyJob, `${legacyUniquenessKey(failedLegacyJob.request)}\u001f`);
+    await insertRawStoredJob({
+      jobId: 'active-explicit-lane',
+      request: makeRequest({ agentAddress: `0x${'aa'.repeat(20)}` }),
+      state: 'queued',
+      enqueuedAt: now + 1,
+      updatedAt: now + 1,
+      attempt: { count: 0, maxRetries: 5 },
+      formatVersion: ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
+    }, uniquenessKey(makeRequest({ agentAddress: `0x${'aa'.repeat(20)}` })));
+
+    await expect(queue.recover('failed-v2-wildcard')).rejects.toMatchObject({
+      name: 'PromoteJobConflictError',
+      existingJobId: 'active-explicit-lane',
+    });
+    expect((await queue.getStatus('failed-v2-wildcard'))?.state).toBe('failed');
+  });
+
+  it('24d. recover(jobId) refuses pre-v3 author-only rows that have no storage lane', async () => {
+    const queue = createQueue();
+    const rows: Array<{ jobId: string; reason: string }> = [
+      { jobId: 'failed-v2-author-only', reason: 'transient old failure' },
+      { jobId: 'failed-v2-author-only-conflict', reason: 'recovery conflict: active promote job already owns this assertion' },
+    ];
+
+    for (const [index, row] of rows.entries()) {
+      const request = makeRequest({
+        assertionName: `legacy-author-only-${index}`,
+        authorAgentAddress: `0x${'aa'.repeat(20)}`,
+      });
+      await insertRawStoredJob({
+        jobId: row.jobId,
+        request,
+        state: 'failed',
+        enqueuedAt: now + index,
+        updatedAt: now + index,
+        reason: row.reason,
+        attempt: { count: 1, maxRetries: 5 },
+        formatVersion: 2,
+      }, `${legacyUniquenessKey(request)}\u001f`);
+    }
+
+    for (const row of rows) {
+      await expect(queue.recover(row.jobId)).rejects.toThrow(/missing storage lane/i);
+      const parked = await queue.getStatus(row.jobId);
+      expect(parked?.state).toBe('failed');
+      expect(parked?.formatVersion).toBe(2);
+      expect(parked?.reason).toMatch(/missing storage lane/i);
+      expect(parked?.attempt.lastError?.message).toMatch(/cannot prove the WM storage lane/);
+    }
+  });
+
   it('25. recoverOnStartup() abandons running jobs whose lease expired AND swmInserted=true (partial-promote ambiguity)', async () => {
     const queue = createQueue({ leaseMs: 10_000 });
     const jobId = await queue.enqueue(makeRequest());
@@ -999,6 +1217,48 @@ describe('TripleStoreAsyncPromoteQueue', () => {
     expect((await queue.getStatus(jobId))?.reason).toMatch(/recovery conflict/i);
     expect((await queue.getStatus('corrupt-duplicate'))?.state).toBe('queued');
     expect(claimed?.state).toBe('running');
+  });
+
+  it('27c. recoverOnStartup() treats v2 no-agent rows as wildcard conflicts against active explicit lanes', async () => {
+    const queue = createQueue({ leaseMs: 10_000 });
+    const jobId = await queue.enqueue(makeRequest());
+    const claimed = await queue.claimNext('worker-legacy');
+    await (queue as unknown as { writeJob(job: PromoteJob): Promise<void> }).writeJob({
+      ...claimed!,
+      request: {
+        contextGraphId: claimed!.request.contextGraphId,
+        subGraphName: claimed!.request.subGraphName,
+        assertionName: claimed!.request.assertionName,
+        entities: claimed!.request.entities,
+      },
+      formatVersion: 2,
+      commitMarker: {
+        promoteStarted: false,
+        swmInserted: false,
+        wmCleaned: false,
+        lifecycleStamped: false,
+        gossiped: false,
+      },
+    });
+    await insertRawStoredJob({
+      jobId: 'active-explicit-during-recovery',
+      request: makeRequest({ agentAddress: `0x${'aa'.repeat(20)}` }),
+      state: 'queued',
+      enqueuedAt: now + 1,
+      updatedAt: now + 1,
+      attempt: { count: 0, maxRetries: 5 },
+      formatVersion: ASYNC_PROMOTE_QUEUE_FORMAT_VERSION,
+    }, uniquenessKey(makeRequest({ agentAddress: `0x${'aa'.repeat(20)}` })));
+
+    advance(60_000);
+    const summary = await queue.recoverOnStartup();
+
+    expect(summary.reclaimed).toBe(0);
+    expect(summary.abandoned).toBe(1);
+    const job = await queue.getStatus(jobId);
+    expect(job?.state).toBe('failed');
+    expect(job?.reason).toMatch(/recovery conflict/i);
+    expect((await queue.getStatus('active-explicit-during-recovery'))?.state).toBe('queued');
   });
 
   it('29. recoverOnStartup() returns counts of {reclaimed, abandoned}', async () => {


### PR DESCRIPTION
## Summary

- Harden atomic `alsoPublishVm` and standalone finalized VM publish validation so forbidden finalized-publish shapes are rejected before side effects, publish controls are allowlisted, malformed integer controls are rejected, and the resolved storage lane is forced at publish time.
- Preserve async promote worker-facing `agentAddress` values in persisted requests while canonicalizing only separate uniqueness/conflict keys, including compatibility lookups for existing key shapes.
- Keep legacy/pre-v3 queue rows conservative by modeling lane conflicts explicitly and parking author-only rows that lack a persisted storage lane from claim, recover, and startup recovery paths.

## Related

- Follow-up to #1324

## Files changed

| File | What |
|------|------|
| `packages/cli/src/daemon/routes/knowledge-assets.ts` | Reuses finalized-publish validation/option normalization for atomic `alsoPublishVm` and standalone VM publish inputs. |
| `packages/cli/test/knowledge-assets-1116-share-errors.test.ts` | Adds fake-agent regressions for lane override stripping, forbidden publish shapes, malformed publish controls, unsafe numeric identity overrides, and standalone partial selection rejection. |
| `packages/cli/vitest.unit.config.ts` | Includes the fake-agent route regression file in the fast unit test lane. |
| `packages/publisher/src/async-promote-queue-impl.ts` | Keeps `writeJob` transparent, snapshots requests at activation boundaries, uses explicit lane conflict scopes, and parks unsafe pre-v3 author-only/no-lane rows. |
| `packages/publisher/src/async-promote-queue-types.ts` | Documents the worker-facing storage-lane contract. |
| `packages/publisher/src/async-promote-queue-utils.ts` | Centralizes lane normalization for conflict keys and explicit lane conflict scope matching. |
| `packages/publisher/test/async-promote-queue.test.ts` | Adds coverage for mixed-case EVM lane preservation, case-sensitive fallback lanes, old persisted keys, mutable enqueue inputs, and legacy no-lane claim/recover/recovery safety. |

## Test plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts` on Windows. Scripts were disabled because `@cyfrin/aderyn` postinstall is unsupported on this platform.
- [x] `pnpm run build:runtime:packages`
- [x] From `packages/publisher`: `pnpm exec vitest run --config vitest.unit.config.ts test/async-promote-queue.test.ts` (64 tests passed)
- [x] From `packages/cli`: `pnpm exec vitest run --config vitest.unit.config.ts test/knowledge-assets-1116-share-errors.test.ts -t "alsoPublishVm|standalone vm/publish"` (7 tests passed, 14 skipped by filter)
- [x] `git diff --check`
- [x] GPT-5.5 adversarial review across queue storage/recovery, CLI validation, and PR hygiene; valid findings were fixed and final re-checks returned no findings.