### PR TITLE
refactor(node-ui/pca): consolidate the PCA coverage model into a shared resolver (#1344)

### DIFF
--- a/packages/node-ui/src/ui/components/Pca/HealthChip.tsx
+++ b/packages/node-ui/src/ui/components/Pca/HealthChip.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
-import type { PcaSnapshot } from '../../api.js';
+// #1355 V2 — health derivation lives in the domain module `pca/health.ts`; this
+// presentation file re-exports it for back-compat (existing `components/Pca` importers).
+import {
+  type PcaHealthState,
+  PCA_CAP_NEAR_THRESHOLD,
+  PCA_EXPIRING_SOON_SECONDS,
+  healthForSnapshot,
+} from '../../pca/health.js';
 
-/**
- * The health states a PCA can be in (S1/S3 `HealthChip`). Each maps to a
- * DISTINCT glyph (not colour-only) and a text label that is NEVER dropped — the
- * label is the accessible name, the glyph is decorative (`aria-hidden`).
- */
-export type PcaHealthState =
-  | 'healthy'
-  | 'expiring'
-  | 'expired'
-  | 'insolvent'
-  | 'swept'
-  | 'cap-near';
+export { type PcaHealthState, PCA_CAP_NEAR_THRESHOLD, PCA_EXPIRING_SOON_SECONDS, healthForSnapshot };
 
 interface HealthMeta {
   glyph: string;
@@ -64,35 +60,6 @@ export const HEALTH_CHIP_META: Record<PcaHealthState, HealthMeta> = {
     hint: 'Approaching the 100 approved-publishing-wallet cap.',
   },
 };
-
-/** Approved-wallet count at which a PCA is flagged "Cap near 100". */
-export const PCA_CAP_NEAR_THRESHOLD = 90;
-/** Window (seconds) before expiry at which a PCA is flagged "Expiring soon" (7 days). */
-export const PCA_EXPIRING_SOON_SECONDS = 7 * 24 * 60 * 60;
-
-/**
- * The SINGLE source of truth for deriving a PCA's `HealthChip` state from its
- * snapshot — used by S1/S3/S5 so the derivation can't drift across screens.
- * Precedence (highest first), per the lead's contract:
- *   expired → swept → cap-near → expiring → healthy.
- *
- * `insolvent` is intentionally NOT derived in P0: accurate insolvency needs the
- * current-epoch `remainingAllowance` (GAP-4/5 extended snapshot), which the P0
- * snapshot doesn't carry — asserting it from P0 data would be a false claim
- * (invariant #9). The `insolvent` STATE still exists for the P2 budget widget.
- */
-export function healthForSnapshot(
-  snapshot: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount'>,
-  nowSec: number = Math.floor(Date.now() / 1000),
-): PcaHealthState {
-  const { expiresAtTimestamp, fullySwept, agentCount } = snapshot;
-  const hasExpiry = typeof expiresAtTimestamp === 'number' && expiresAtTimestamp > 0;
-  if (hasExpiry && nowSec >= expiresAtTimestamp) return 'expired';
-  if (fullySwept) return 'swept';
-  if (typeof agentCount === 'number' && agentCount >= PCA_CAP_NEAR_THRESHOLD) return 'cap-near';
-  if (hasExpiry && expiresAtTimestamp - nowSec <= PCA_EXPIRING_SOON_SECONDS) return 'expiring';
-  return 'healthy';
-}
 
 /**
  * A status pill for a PCA's health. The text label always renders (the

--- a/packages/node-ui/src/ui/components/Pca/HealthChip.tsx
+++ b/packages/node-ui/src/ui/components/Pca/HealthChip.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 // #1355 V2 — health derivation lives in the domain module `pca/health.ts`; this
-// presentation file re-exports it for back-compat (existing `components/Pca` importers).
-import {
-  type PcaHealthState,
-  PCA_CAP_NEAR_THRESHOLD,
-  PCA_EXPIRING_SOON_SECONDS,
-  healthForSnapshot,
-} from '../../pca/health.js';
-
-export { type PcaHealthState, PCA_CAP_NEAR_THRESHOLD, PCA_EXPIRING_SOON_SECONDS, healthForSnapshot };
+// presentation file only consumes `PcaHealthState` for its pill (every other consumer
+// imports the derivation directly from `pca/health.js`, so no re-export here).
+import { type PcaHealthState } from '../../pca/health.js';
 
 interface HealthMeta {
   glyph: string;

--- a/packages/node-ui/src/ui/components/Pca/index.ts
+++ b/packages/node-ui/src/ui/components/Pca/index.ts
@@ -10,13 +10,9 @@ export {
   isTestnetChain,
 } from './format.js';
 export { HealthChip, HEALTH_CHIP_META } from './HealthChip.js';
-// #1355 V2 — health derivation is sourced from the domain module (not the chip).
-export {
-  healthForSnapshot,
-  PCA_CAP_NEAR_THRESHOLD,
-  PCA_EXPIRING_SOON_SECONDS,
-  type PcaHealthState,
-} from '../../pca/health.js';
+// #1355 V2 — health derivation (healthForSnapshot / PcaHealthState / the threshold
+// constants) is imported DIRECTLY from the domain module `pca/health.js` by every
+// consumer, so the barrel no longer re-exports it.
 export { WalletRow, type WalletRowTone } from './WalletRow.js';
 export { AddressCrux, DEFAULT_ADDRESS_CRUX_NOTE } from './AddressCrux.js';
 export {

--- a/packages/node-ui/src/ui/components/Pca/index.ts
+++ b/packages/node-ui/src/ui/components/Pca/index.ts
@@ -9,14 +9,14 @@ export {
   nativeGasSymbol,
   isTestnetChain,
 } from './format.js';
+export { HealthChip, HEALTH_CHIP_META } from './HealthChip.js';
+// #1355 V2 — health derivation is sourced from the domain module (not the chip).
 export {
-  HealthChip,
-  HEALTH_CHIP_META,
   healthForSnapshot,
   PCA_CAP_NEAR_THRESHOLD,
   PCA_EXPIRING_SOON_SECONDS,
   type PcaHealthState,
-} from './HealthChip.js';
+} from '../../pca/health.js';
 export { WalletRow, type WalletRowTone } from './WalletRow.js';
 export { AddressCrux, DEFAULT_ADDRESS_CRUX_NOTE } from './AddressCrux.js';
 export {

--- a/packages/node-ui/src/ui/hooks/usePcaAlerts.ts
+++ b/packages/node-ui/src/ui/hooks/usePcaAlerts.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { usePcaOverview } from './usePcaOverview.js';
-import { PCA_CAP_NEAR_THRESHOLD, PCA_EXPIRING_SOON_SECONDS } from '../components/Pca/HealthChip.js';
+import { PCA_CAP_NEAR_THRESHOLD, PCA_EXPIRING_SOON_SECONDS } from '../pca/health.js';
 
 export type PcaAlertKind = 'expired' | 'expiring' | 'swept' | 'cap-near' | 'fallthrough';
 

--- a/packages/node-ui/src/ui/hooks/usePcaOverview.ts
+++ b/packages/node-ui/src/ui/hooks/usePcaOverview.ts
@@ -7,7 +7,7 @@ import {
 } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
 import { healthForSnapshot, type PcaHealthState } from '../components/Pca/HealthChip.js';
-import { bigGt0 } from '../pca/coverage.js';
+import { normalizeProbeRegistered, isPcaSpendable } from '../pca/coverage.js';
 
 /** Per-(node wallet) registration probe against one account. `null` = couldn't determine. */
 export interface PcaWalletProbe {
@@ -94,13 +94,10 @@ async function resolveAccount(accountId: string, wallets: string[]): Promise<Res
   const walletProbes: PcaWalletProbe[] = await Promise.all(
     wallets.map((wallet) =>
       fetchPca(accountId, wallet)
-        // S2/#9 — adapterSupported===false (the adapter couldn't answer) is null
-        // (couldn't determine), NOT not-registered → probesInconclusive (H2 path),
-        // excluded from approvedCount, never a false "0 approved".
-        .then((s): PcaWalletProbe => ({
-          wallet,
-          registered: s.probedKey?.adapterSupported === false ? null : (s.probedKey?.registered ?? null),
-        }))
+        // S2/#9 (via shared normalizeProbeRegistered, #1344) — adapterSupported===false
+        // (the adapter couldn't answer) → null (couldn't determine), NOT not-registered
+        // → probesInconclusive (H2 path), excluded from approvedCount.
+        .then((s): PcaWalletProbe => ({ wallet, registered: normalizeProbeRegistered(s.probedKey) }))
         .catch((): PcaWalletProbe => ({ wallet, registered: null })),
     ),
   );
@@ -266,11 +263,9 @@ export function usePcaOverview(intervalMs = 30_000): PcaOverview {
     let best: number | null = null;
     for (const a of accounts) {
       if (!a.snapshot || a.approvedCount <= 0) continue;
-      if (a.health === 'expired' || a.health === 'swept') continue;
-      // U2 — exclude a zero-budget PCA so the dashboard/settings don't advertise a
-      // discount S5 treats as not-covering. Matches usePublishEligibility's coarse
-      // proxy (NOT remainingAllowance — that's P2/#1349); full consolidation #1344.
-      if (!(bigGt0(a.snapshot.topUpBuffer) || bigGt0(a.snapshot.baseEpochAllowance))) continue;
+      // U2 (via shared isPcaSpendable, #1344) — exclude expired/swept + zero-budget so
+      // the dashboard/settings don't advertise a discount S5 treats as not-covering.
+      if (!isPcaSpendable(a.snapshot)) continue;
       const bps = a.snapshot.discountBps;
       if (typeof bps === 'number' && (best == null || bps > best)) best = bps;
     }

--- a/packages/node-ui/src/ui/hooks/usePcaOverview.ts
+++ b/packages/node-ui/src/ui/hooks/usePcaOverview.ts
@@ -94,10 +94,11 @@ async function resolveAccount(accountId: string, wallets: string[]): Promise<Res
   const walletProbes: PcaWalletProbe[] = await Promise.all(
     wallets.map((wallet) =>
       fetchPca(accountId, wallet)
-        // S2/#9 (via shared classifyCoverage, #1344) — adapterSupported===false (the
-        // adapter couldn't answer) → registered null (couldn't determine), NOT
-        // not-registered → probesInconclusive (H2 path), excluded from approvedCount.
-        .then((s): PcaWalletProbe => ({ wallet, registered: classifyCoverage(s, s.probedKey).registered }))
+        // S2/#9 (via shared classifyCoverage, #1344 — reads s.probedKey) —
+        // adapterSupported===false (the adapter couldn't answer) → registered null
+        // (couldn't determine), NOT not-registered → probesInconclusive (H2 path),
+        // excluded from approvedCount (which counts registered === true, not 'covers').
+        .then((s): PcaWalletProbe => ({ wallet, registered: classifyCoverage(s).registered }))
         .catch((): PcaWalletProbe => ({ wallet, registered: null })),
     ),
   );

--- a/packages/node-ui/src/ui/hooks/usePcaOverview.ts
+++ b/packages/node-ui/src/ui/hooks/usePcaOverview.ts
@@ -6,7 +6,7 @@ import {
   type PcaSnapshot,
 } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
-import { healthForSnapshot, type PcaHealthState } from '../components/Pca/HealthChip.js';
+import { healthForSnapshot, type PcaHealthState } from '../pca/health.js';
 import { normalizeProbeRegistered, isPcaSpendable } from '../pca/coverage.js';
 
 /** Per-(node wallet) registration probe against one account. `null` = couldn't determine. */

--- a/packages/node-ui/src/ui/hooks/usePcaOverview.ts
+++ b/packages/node-ui/src/ui/hooks/usePcaOverview.ts
@@ -7,7 +7,7 @@ import {
 } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
 import { healthForSnapshot, type PcaHealthState } from '../pca/health.js';
-import { normalizeProbeRegistered, isPcaSpendable } from '../pca/coverage.js';
+import { classifyCoverage, isPcaSpendable } from '../pca/coverage.js';
 
 /** Per-(node wallet) registration probe against one account. `null` = couldn't determine. */
 export interface PcaWalletProbe {
@@ -94,10 +94,10 @@ async function resolveAccount(accountId: string, wallets: string[]): Promise<Res
   const walletProbes: PcaWalletProbe[] = await Promise.all(
     wallets.map((wallet) =>
       fetchPca(accountId, wallet)
-        // S2/#9 (via shared normalizeProbeRegistered, #1344) — adapterSupported===false
-        // (the adapter couldn't answer) → null (couldn't determine), NOT not-registered
-        // → probesInconclusive (H2 path), excluded from approvedCount.
-        .then((s): PcaWalletProbe => ({ wallet, registered: normalizeProbeRegistered(s.probedKey) }))
+        // S2/#9 (via shared classifyCoverage, #1344) — adapterSupported===false (the
+        // adapter couldn't answer) → registered null (couldn't determine), NOT
+        // not-registered → probesInconclusive (H2 path), excluded from approvedCount.
+        .then((s): PcaWalletProbe => ({ wallet, registered: classifyCoverage(s, s.probedKey).registered }))
         .catch((): PcaWalletProbe => ({ wallet, registered: null })),
     ),
   );

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 import { useFetch } from '../hooks.js';
 import { fetchWalletsBalances, fetchPca, fetchContextGraphs, fetchCurrentAgent } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
-import { healthForSnapshot } from '../components/Pca/HealthChip.js';
 import { canonicalAgentDid } from '../lib/contextGraphSidebar.js';
-import { bigGt0, isPcaSpendable } from '../pca/coverage.js';
+import { normalizeProbeRegistered, isPcaSpendable, isPcaDead, hasPcaBudget } from '../pca/coverage.js';
 import type { PcaVerdict } from '../components/Pca/EligibilityVerdictBanner.js';
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
@@ -116,30 +115,26 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
             // not-registered. Distinguish them: a failed probe is inconclusive (→
             // neutral verdict), never a definitive fall-through DANGER at spend time.
             if (snap === null) { probeError = true; continue; }
-            // S2/#9 — the adapter COULDN'T answer (capability gap) is "couldn't read",
-            // NOT a confirmed not-registered. Funnel it into the inconclusive channel
-            // (→ neutral verdict), never a definitive fall-through DANGER. (Kept inline,
-            // NOT via normalizeProbeRegistered: S5's `!registered` below treats an
-            // undefined registered as a plain skip, whereas overview/S6 treat it as
-            // inconclusive — preserving S5's exact semantics keeps this byte-identical.)
-            if (snap.probedKey?.adapterSupported === false) { probeError = true; continue; }
-            if (!snap.probedKey?.registered) continue;
-            // #1344 — coarse P0 spendability via the shared isPcaSpendable (was inlined;
-            // see the reverted-L2 capstone finding). NOT remainingAllowance (P2/#1349).
+            // S2/#9 — registration via the shared normalizer (#1344): adapter gap OR an
+            // undefined registered → inconclusive ("couldn't determine" → neutral verdict,
+            // never a definitive DANGER); a confirmed not-registered → skip.
+            const reg = normalizeProbeRegistered(snap.probedKey);
+            if (reg === null) { probeError = true; continue; }
+            if (reg === false) continue;
+            // reg === true — coarse P0 spendability (NOT remainingAllowance, P2/#1349).
             if (isPcaSpendable(snap)) {
               cover = { accountId: id, discountBps: snap.discountBps };
               break;
             }
             // Registered here but the account can't cover — break down (dead vs
-            // out-of-budget) so the copy distinguishes "approved-but-dead" from "no PCA"
-            // (#3) and the reasons name the cause. Two INDEPENDENT checks (a dead AND
-            // zero-budget account sets both, matching the pre-refactor behavior).
-            const h = healthForSnapshot(snap);
-            if (h === 'expired' || h === 'swept') {
+            // out-of-budget) from the SAME shared predicates, so the copy distinguishes
+            // "approved-but-dead" from "no PCA" (#3) and the reasons name the cause. Two
+            // INDEPENDENT checks (a dead AND zero-budget account sets both).
+            if (isPcaDead(snap)) {
               sawExpired = true;
               if (!deadAccountId) deadAccountId = id;
             }
-            if (!(bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance))) sawInsolvent = true;
+            if (!hasPcaBudget(snap)) sawInsolvent = true;
           }
           return {
             wallet: w,

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -3,7 +3,7 @@ import { useFetch } from '../hooks.js';
 import { fetchWalletsBalances, fetchPca, fetchContextGraphs, fetchCurrentAgent } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
 import { canonicalAgentDid } from '../lib/contextGraphSidebar.js';
-import { normalizeProbeRegistered, isPcaSpendable, isPcaDead, hasPcaBudget } from '../pca/coverage.js';
+import { classifyCoverage } from '../pca/coverage.js';
 import type { PcaVerdict } from '../components/Pca/EligibilityVerdictBanner.js';
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
@@ -115,26 +115,30 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
             // not-registered. Distinguish them: a failed probe is inconclusive (→
             // neutral verdict), never a definitive fall-through DANGER at spend time.
             if (snap === null) { probeError = true; continue; }
-            // S2/#9 — registration via the shared normalizer (#1344): adapter gap OR an
-            // undefined registered → inconclusive ("couldn't determine" → neutral verdict,
-            // never a definitive DANGER); a confirmed not-registered → skip.
-            const reg = normalizeProbeRegistered(snap.probedKey);
-            if (reg === null) { probeError = true; continue; }
-            if (reg === false) continue;
-            // reg === true — coarse P0 spendability (NOT remainingAllowance, P2/#1349).
-            if (isPcaSpendable(snap)) {
+            // #1344 round-2 — ONE canonical classification (registration + coarse-P0
+            // spendability) instead of bundling the leaf predicates here. Behavior is
+            // byte-identical to the prior 4-helper form. Coarse P0, NOT remainingAllowance
+            // (P2/#1349).
+            const c = classifyCoverage(snap, snap.probedKey);
+            // S2/#9 — adapter gap OR an undefined registered → inconclusive ("couldn't
+            // determine" → neutral verdict, never a definitive DANGER); a confirmed
+            // not-registered → skip.
+            if (c.inconclusive) { probeError = true; continue; }
+            if (c.registered === false) continue;
+            // registered here — coarse spendability decides coverage.
+            if (c.covers) {
               cover = { accountId: id, discountBps: snap.discountBps };
               break;
             }
             // Registered here but the account can't cover — break down (dead vs
-            // out-of-budget) from the SAME shared predicates, so the copy distinguishes
+            // out-of-budget) from the SAME classification, so the copy distinguishes
             // "approved-but-dead" from "no PCA" (#3) and the reasons name the cause. Two
             // INDEPENDENT checks (a dead AND zero-budget account sets both).
-            if (isPcaDead(snap)) {
+            if (c.dead) {
               sawExpired = true;
               if (!deadAccountId) deadAccountId = id;
             }
-            if (!hasPcaBudget(snap)) sawInsolvent = true;
+            if (!c.hasBudget) sawInsolvent = true;
           }
           return {
             wallet: w,

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -4,7 +4,7 @@ import { fetchWalletsBalances, fetchPca, fetchContextGraphs, fetchCurrentAgent }
 import { usePcaStore } from '../stores/pca.js';
 import { healthForSnapshot } from '../components/Pca/HealthChip.js';
 import { canonicalAgentDid } from '../lib/contextGraphSidebar.js';
-import { bigGt0 } from '../pca/coverage.js';
+import { bigGt0, isPcaSpendable } from '../pca/coverage.js';
 import type { PcaVerdict } from '../components/Pca/EligibilityVerdictBanner.js';
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
@@ -118,31 +118,28 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
             if (snap === null) { probeError = true; continue; }
             // S2/#9 — the adapter COULDN'T answer (capability gap) is "couldn't read",
             // NOT a confirmed not-registered. Funnel it into the inconclusive channel
-            // (→ neutral verdict), never a definitive fall-through DANGER.
+            // (→ neutral verdict), never a definitive fall-through DANGER. (Kept inline,
+            // NOT via normalizeProbeRegistered: S5's `!registered` below treats an
+            // undefined registered as a plain skip, whereas overview/S6 treat it as
+            // inconclusive — preserving S5's exact semantics keeps this byte-identical.)
             if (snap.probedKey?.adapterSupported === false) { probeError = true; continue; }
             if (!snap.probedKey?.registered) continue;
-            const h = healthForSnapshot(snap);
-            // reverted L2 — see capstone finding. INTENTIONAL coarse P0 solvency
-            // proxy: a funded PCA holds its per-epoch budget in `baseEpochAllowance`
-            // (the cap), and `topUpBuffer` is only the EXTRA above that cap — 0 on a
-            // fresh, un-topped-up account. A topUpBuffer-only check therefore
-            // false-DANGERed every approved+funded PCA (live capstone: PCA #2, 5
-            // agents approved, chip showed "out of budget"). So ANY budget capacity
-            // ⇒ GREEN-eligible (a prediction, #9 "pending confirmation"); swept/
-            // expired are excluded SEPARATELY by the health check below; precise
-            // mid-epoch remaining is P2 via the extended snapshot's `remainingAllowance`.
-            const solvent = bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance);
-            if (h !== 'expired' && h !== 'swept' && solvent) {
+            // #1344 — coarse P0 spendability via the shared isPcaSpendable (was inlined;
+            // see the reverted-L2 capstone finding). NOT remainingAllowance (P2/#1349).
+            if (isPcaSpendable(snap)) {
               cover = { accountId: id, discountBps: snap.discountBps };
               break;
             }
-            // Registered here but the account can't cover (swept/expired) — remember
-            // it so the copy distinguishes "approved-but-dead" from "no PCA" (#3).
+            // Registered here but the account can't cover — break down (dead vs
+            // out-of-budget) so the copy distinguishes "approved-but-dead" from "no PCA"
+            // (#3) and the reasons name the cause. Two INDEPENDENT checks (a dead AND
+            // zero-budget account sets both, matching the pre-refactor behavior).
+            const h = healthForSnapshot(snap);
             if (h === 'expired' || h === 'swept') {
               sawExpired = true;
               if (!deadAccountId) deadAccountId = id;
             }
-            if (!solvent) sawInsolvent = true;
+            if (!(bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance))) sawInsolvent = true;
           }
           return {
             wallet: w,

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -115,25 +115,25 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
             // not-registered. Distinguish them: a failed probe is inconclusive (→
             // neutral verdict), never a definitive fall-through DANGER at spend time.
             if (snap === null) { probeError = true; continue; }
-            // #1344 round-2 — ONE canonical classification (registration + coarse-P0
-            // spendability) instead of bundling the leaf predicates here. Behavior is
-            // byte-identical to the prior 4-helper form. Coarse P0, NOT remainingAllowance
-            // (P2/#1349).
-            const c = classifyCoverage(snap, snap.probedKey);
+            // #1344 round-3 — ONE canonical classification; switch on its `outcome`
+            // discriminant (coarse P0, NOT remainingAllowance, P2/#1349). The probe is
+            // read from snap.probedKey internally. Behavior is byte-identical to the
+            // prior 5-field form.
+            const c = classifyCoverage(snap);
             // S2/#9 — adapter gap OR an undefined registered → inconclusive ("couldn't
             // determine" → neutral verdict, never a definitive DANGER); a confirmed
             // not-registered → skip.
-            if (c.inconclusive) { probeError = true; continue; }
-            if (c.registered === false) continue;
-            // registered here — coarse spendability decides coverage.
-            if (c.covers) {
+            if (c.outcome === 'inconclusive') { probeError = true; continue; }
+            if (c.outcome === 'unregistered') continue;
+            if (c.outcome === 'covers') {
               cover = { accountId: id, discountBps: snap.discountBps };
-              break;
+              break; // breaks the tracked-id FOR loop (not a switch) — covered, stop probing.
             }
-            // Registered here but the account can't cover — break down (dead vs
-            // out-of-budget) from the SAME classification, so the copy distinguishes
-            // "approved-but-dead" from "no PCA" (#3) and the reasons name the cause. Two
-            // INDEPENDENT checks (a dead AND zero-budget account sets both).
+            // c.outcome === 'uncovered' — registered here but the account can't cover.
+            // Break down (dead vs out-of-budget) from the SAME classification's reason
+            // facets, so the copy distinguishes "approved-but-dead" from "no PCA" (#3)
+            // and the reasons name the cause. Two INDEPENDENT checks (a dead AND
+            // zero-budget account sets both).
             if (c.dead) {
               sawExpired = true;
               if (!deadAccountId) deadAccountId = id;

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -17,10 +17,10 @@ import {
   HealthChip,
   WalletRow,
   AddressCrux,
-  healthForSnapshot,
   formatWeiToTrac,
   formatRelativeExpiry,
 } from '../../components/Pca/index.js';
+import { healthForSnapshot } from '../../pca/health.js';
 import { StatStrip } from '../../components/ContextGraphPrimitives.js';
 import { ApproveWalletsModal } from './ApproveWalletsModal.js';
 

--- a/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
@@ -3,7 +3,7 @@ import { useFetch } from '../../hooks.js';
 import { fetchWalletsBalances, fetchPca, describePcaError } from '../../api.js';
 import { formatEth, formatEthTooltip } from '../../lib/formatEth.js';
 import { usePcaStore } from '../../stores/pca.js';
-import { bigGt0 } from '../../pca/coverage.js';
+import { coverageForProbe } from '../../pca/coverage.js';
 import { PcaModalShell } from './PcaModalShell.js';
 import {
   WalletRow,
@@ -11,7 +11,6 @@ import {
   useCopy,
   nativeGasSymbol,
   isTestnetChain,
-  healthForSnapshot,
 } from '../../components/Pca/index.js';
 
 // Testnet faucets for the native gas token (testnet-only CTA — §6.2). Only
@@ -76,19 +75,11 @@ export function GetSponsoredPanel({ onClose }: { onClose: () => void }) {
         wallets.map((w) =>
           fetchPca(id, w)
             .then((snap): ProbeRow => {
-              // S2/#9 — adapterSupported===false (couldn't answer) → null (neutral
-              // "unknown" row), NOT a confirmed not-approved; all-unsupported falls
-              // into the wholesale "retry" path, never a danger row.
-              const registered =
-                snap.probedKey?.adapterSupported === false ? null : (snap.probedKey?.registered ?? null);
-              // N1: mirror S5's cover predicate so S6 "Ready" == S5 GREEN — a
-              // registered wallet only covers when the PCA is spendable.
-              const h = healthForSnapshot(snap);
-              const covers =
-                registered === true &&
-                h !== 'expired' &&
-                h !== 'swept' &&
-                (bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance));
+              // #1344 — shared classifier: S2 adapterSupported===false → null (neutral
+              // "unknown" row, not a false not-approved; all-unsupported → wholesale
+              // "retry") + N1 covers = registered AND the PCA is spendable (S6 "Ready"
+              // == S5 GREEN).
+              const { registered, covers } = coverageForProbe(snap, snap.probedKey);
               return { wallet: w, registered, covers };
             })
             .catch((): ProbeRow => ({ wallet: w, registered: null, covers: false })),

--- a/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
@@ -75,12 +75,12 @@ export function GetSponsoredPanel({ onClose }: { onClose: () => void }) {
         wallets.map((w) =>
           fetchPca(id, w)
             .then((snap): ProbeRow => {
-              // #1344 — single canonical classifier: S2 adapterSupported===false → null
-              // (neutral "unknown" row, not a false not-approved; all-unsupported →
-              // wholesale "retry") + N1 covers = registered AND the PCA is spendable
-              // (S6 "Ready" == S5 GREEN).
-              const { registered, covers } = classifyCoverage(snap, snap.probedKey);
-              return { wallet: w, registered, covers };
+              // #1344 — single canonical classifier (reads snap.probedKey): S2
+              // adapterSupported===false → registered null (neutral "unknown" row, not a
+              // false not-approved; all-unsupported → wholesale "retry") + N1 covers =
+              // outcome 'covers' (registered AND the PCA is spendable; S6 "Ready" == S5 GREEN).
+              const c = classifyCoverage(snap);
+              return { wallet: w, registered: c.registered, covers: c.outcome === 'covers' };
             })
             .catch((): ProbeRow => ({ wallet: w, registered: null, covers: false })),
         ),

--- a/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
@@ -3,7 +3,7 @@ import { useFetch } from '../../hooks.js';
 import { fetchWalletsBalances, fetchPca, describePcaError } from '../../api.js';
 import { formatEth, formatEthTooltip } from '../../lib/formatEth.js';
 import { usePcaStore } from '../../stores/pca.js';
-import { coverageForProbe } from '../../pca/coverage.js';
+import { classifyCoverage } from '../../pca/coverage.js';
 import { PcaModalShell } from './PcaModalShell.js';
 import {
   WalletRow,
@@ -75,11 +75,11 @@ export function GetSponsoredPanel({ onClose }: { onClose: () => void }) {
         wallets.map((w) =>
           fetchPca(id, w)
             .then((snap): ProbeRow => {
-              // #1344 — shared classifier: S2 adapterSupported===false → null (neutral
-              // "unknown" row, not a false not-approved; all-unsupported → wholesale
-              // "retry") + N1 covers = registered AND the PCA is spendable (S6 "Ready"
-              // == S5 GREEN).
-              const { registered, covers } = coverageForProbe(snap, snap.probedKey);
+              // #1344 — single canonical classifier: S2 adapterSupported===false → null
+              // (neutral "unknown" row, not a false not-approved; all-unsupported →
+              // wholesale "retry") + N1 covers = registered AND the PCA is spendable
+              // (S6 "Ready" == S5 GREEN).
+              const { registered, covers } = classifyCoverage(snap, snap.probedKey);
               return { wallet: w, registered, covers };
             })
             .catch((): ProbeRow => ({ wallet: w, registered: null, covers: false })),

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -5,7 +5,7 @@
 // the previously-inlined copies. NOT the precise mid-epoch `remainingAllowance`
 // check — that's the P2 extended snapshot (#1349).
 
-import { healthForSnapshot } from '../components/Pca/HealthChip.js';
+import { healthForSnapshot } from './health.js';
 import type { PcaSnapshot, PcaProbedKey } from '../api.js';
 
 /** True when a wei decimal-string is a positive amount (> 0). Tolerant of

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -5,7 +5,7 @@
 // the previously-inlined copies. NOT the precise mid-epoch `remainingAllowance`
 // check — that's the P2 extended snapshot (#1349).
 
-import { healthForSnapshot } from './health.js';
+import { isPcaExpired } from './health.js';
 import type { PcaSnapshot, PcaProbedKey } from '../api.js';
 
 /** True when a wei decimal-string is a positive amount (> 0). Tolerant of
@@ -19,13 +19,19 @@ export function bigGt0(wei: string | undefined): boolean {
   }
 }
 
-/** The account can't cover a publish because it's expired or fully swept. */
+/**
+ * The account can't cover a publish because it's expired or fully swept. Built from
+ * the shared `isPcaExpired` liveness primitive (NOT the full health taxonomy) so
+ * spendability doesn't depend on cap-near/expiring/agentCount. Byte-identical to the
+ * old `healthForSnapshot`-derived form: `health==='expired' ⟺ isPcaExpired`, and
+ * `health==='swept' ⟺ !isPcaExpired && fullySwept` (swept is checked after expired),
+ * so `expired || swept = isPcaExpired || fullySwept`.
+ */
 export function isPcaDead(
-  snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount'>,
+  snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept'>,
   nowSec?: number,
 ): boolean {
-  const h = healthForSnapshot(snap, nowSec);
-  return h === 'expired' || h === 'swept';
+  return isPcaExpired(snap, nowSec) || !!snap.fullySwept;
 }
 
 /** The account has budget capacity (top-up buffer OR per-epoch allowance). The coarse
@@ -40,7 +46,7 @@ export function hasPcaBudget(snap: Pick<PcaSnapshot, 'topUpBuffer' | 'baseEpochA
  * eligibility breakdown (dead vs out-of-budget) reuses the SAME rules.
  */
 export function isPcaSpendable(
-  snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount' | 'topUpBuffer' | 'baseEpochAllowance'>,
+  snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'topUpBuffer' | 'baseEpochAllowance'>,
   nowSec?: number,
 ): boolean {
   return !isPcaDead(snap, nowSec) && hasPcaBudget(snap);

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -19,18 +19,31 @@ export function bigGt0(wei: string | undefined): boolean {
   }
 }
 
+/** The account can't cover a publish because it's expired or fully swept. */
+export function isPcaDead(
+  snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount'>,
+  nowSec?: number,
+): boolean {
+  const h = healthForSnapshot(snap, nowSec);
+  return h === 'expired' || h === 'swept';
+}
+
+/** The account has budget capacity (top-up buffer OR per-epoch allowance). The coarse
+ *  P0 proxy — NOT the precise mid-epoch `remainingAllowance` (that's P2/#1349). */
+export function hasPcaBudget(snap: Pick<PcaSnapshot, 'topUpBuffer' | 'baseEpochAllowance'>): boolean {
+  return bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance);
+}
+
 /**
- * The coarse P0 spendability proxy: a PCA can cover a publish only if it is NOT
- * expired/swept AND has budget capacity (top-up buffer OR per-epoch allowance).
- * Mirrors usePublishEligibility's cover check exactly. (Precise mid-epoch remaining
- * is P2/#1349 — do NOT use `remainingAllowance` here.)
+ * The coarse P0 spendability proxy: a PCA can cover a publish only if it is NOT dead
+ * (expired/swept) AND has budget. Composed from the two predicates above so the
+ * eligibility breakdown (dead vs out-of-budget) reuses the SAME rules.
  */
 export function isPcaSpendable(
   snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount' | 'topUpBuffer' | 'baseEpochAllowance'>,
   nowSec?: number,
 ): boolean {
-  const h = healthForSnapshot(snap, nowSec);
-  return h !== 'expired' && h !== 'swept' && (bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance));
+  return !isPcaDead(snap, nowSec) && hasPcaBudget(snap);
 }
 
 /**

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -1,7 +1,12 @@
-// Shared PCA coverage primitives (a step toward the full coverage-resolver
-// consolidation tracked in #1344). Pure helpers — no behavior change vs the
-// previously-inlined copies in usePublishEligibility / GetSponsoredPanel /
-// usePcaOverview.
+// Shared PCA coverage primitives (#1344 — ends the coverage-drift class that
+// recurred across C1/O4/Q2/S2/U2/V3). PURE leaf rules consumed by every surface
+// (usePublishEligibility / usePcaOverview / GetSponsoredPanel); each surface keeps
+// its own iteration / aggregation / verdict logic. Behavior is byte-identical to
+// the previously-inlined copies. NOT the precise mid-epoch `remainingAllowance`
+// check — that's the P2 extended snapshot (#1349).
+
+import { healthForSnapshot } from '../components/Pca/HealthChip.js';
+import type { PcaSnapshot, PcaProbedKey } from '../api.js';
 
 /** True when a wei decimal-string is a positive amount (> 0). Tolerant of
  *  undefined / non-numeric (→ false). */
@@ -12,4 +17,47 @@ export function bigGt0(wei: string | undefined): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * The coarse P0 spendability proxy: a PCA can cover a publish only if it is NOT
+ * expired/swept AND has budget capacity (top-up buffer OR per-epoch allowance).
+ * Mirrors usePublishEligibility's cover check exactly. (Precise mid-epoch remaining
+ * is P2/#1349 — do NOT use `remainingAllowance` here.)
+ */
+export function isPcaSpendable(
+  snap: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount' | 'topUpBuffer' | 'baseEpochAllowance'>,
+  nowSec?: number,
+): boolean {
+  const h = healthForSnapshot(snap, nowSec);
+  return h !== 'expired' && h !== 'swept' && (bigGt0(snap.topUpBuffer) || bigGt0(snap.baseEpochAllowance));
+}
+
+/**
+ * Normalize a probe's registration (the S2 rule): `adapterSupported === false` (the
+ * chain adapter couldn't answer) is "couldn't determine" → `null`, NOT a confirmed
+ * not-registered. Otherwise `registered ?? null`.
+ */
+export function normalizeProbeRegistered(probedKey: PcaProbedKey | undefined): boolean | null {
+  if (probedKey?.adapterSupported === false) return null;
+  return probedKey?.registered ?? null;
+}
+
+/**
+ * Per-(snapshot, probe) coverage classification:
+ *  - `registered` — normalized (null = couldn't determine).
+ *  - `inconclusive` — the probe couldn't be read (registered === null).
+ *  - `covers` — the wallet is registered HERE AND the account is spendable.
+ */
+export function coverageForProbe(
+  snap: PcaSnapshot,
+  probedKey: PcaProbedKey | undefined,
+  nowSec?: number,
+): { registered: boolean | null; inconclusive: boolean; covers: boolean } {
+  const registered = normalizeProbeRegistered(probedKey);
+  return {
+    registered,
+    inconclusive: registered === null,
+    covers: registered === true && isPcaSpendable(snap, nowSec),
+  };
 }

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -57,20 +57,39 @@ export function normalizeProbeRegistered(probedKey: PcaProbedKey | undefined): b
 }
 
 /**
- * Per-(snapshot, probe) coverage classification:
- *  - `registered` — normalized (null = couldn't determine).
- *  - `inconclusive` — the probe couldn't be read (registered === null).
- *  - `covers` — the wallet is registered HERE AND the account is spendable.
+ * The single canonical (snapshot, probe) coverage classification. Every surface
+ * (S5 `usePublishEligibility`, S6 `GetSponsoredPanel`, `usePcaOverview`) runs THIS
+ * one call instead of bundling the leaf predicates itself — so coverage can't
+ * re-diverge across screens. Composed from the building blocks above (which stay
+ * exported: `usePcaOverview` still needs `isPcaSpendable` for its account-level
+ * `bestCoveringDiscountBps` filter, where there's no probe).
  */
-export function coverageForProbe(
+export interface PcaCoverageResult {
+  /** Normalized registration (the S2 rule). `null` = couldn't determine. */
+  registered: boolean | null;
+  /** The probe couldn't be read (`registered === null`) → neutral, never DANGER (#9). */
+  inconclusive: boolean;
+  /** The wallet is registered HERE AND the account is spendable (not dead, has budget). */
+  covers: boolean;
+  /** The account is expired or fully swept (`isPcaDead`). */
+  dead: boolean;
+  /** The account has budget capacity (`hasPcaBudget`). */
+  hasBudget: boolean;
+}
+
+export function classifyCoverage(
   snap: PcaSnapshot,
   probedKey: PcaProbedKey | undefined,
   nowSec?: number,
-): { registered: boolean | null; inconclusive: boolean; covers: boolean } {
+): PcaCoverageResult {
   const registered = normalizeProbeRegistered(probedKey);
+  const dead = isPcaDead(snap, nowSec);
+  const hasBudget = hasPcaBudget(snap);
   return {
     registered,
     inconclusive: registered === null,
-    covers: registered === true && isPcaSpendable(snap, nowSec),
+    covers: registered === true && !dead && hasBudget,
+    dead,
+    hasBudget,
   };
 }

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -57,14 +57,23 @@ export function normalizeProbeRegistered(probedKey: PcaProbedKey | undefined): b
 }
 
 /**
- * The canonical coverage decision for a probed snapshot — the discriminant every
- * surface switches on, so none has to recombine the bool soup itself:
+ * The canonical coverage decision for a probed snapshot — a DISCRIMINATED UNION on
+ * `outcome`, so each surface switches on ONE field and TS enforces which facets are
+ * meaningful (a caller can't read `dead`/`hasBudget` on a probe that never resolved):
  *  - `inconclusive` — the probe couldn't be read → neutral, never DANGER (#9).
  *  - `unregistered` — confirmed NOT an approved publishing wallet here.
  *  - `covers`       — registered HERE AND the account is spendable (not dead, has budget).
- *  - `uncovered`    — registered HERE but the account can't cover (dead and/or no budget).
+ *  - `uncovered`    — registered HERE but the account can't cover; `dead`/`hasBudget`
+ *                     are the reason facets, carried ONLY on this variant.
  */
-export type PcaCoverageOutcome = 'inconclusive' | 'unregistered' | 'covers' | 'uncovered';
+export type PcaCoverageResult =
+  | { outcome: 'inconclusive'; registered: null }
+  | { outcome: 'unregistered'; registered: false }
+  | { outcome: 'covers'; registered: true }
+  | { outcome: 'uncovered'; registered: true; dead: boolean; hasBudget: boolean };
+
+/** The discriminant of {@link PcaCoverageResult}. */
+export type PcaCoverageOutcome = PcaCoverageResult['outcome'];
 
 /**
  * The single canonical coverage classification. Every surface (S5
@@ -72,34 +81,17 @@ export type PcaCoverageOutcome = 'inconclusive' | 'unregistered' | 'covers' | 'u
  * call and switches on `outcome` instead of bundling the leaf predicates itself —
  * so coverage can't re-diverge across screens. The probe is read from
  * `snap.probedKey` (no separate param — a split snapshot/probe pair can't be
- * mismatched). `dead`/`hasBudget` are the reason facets behind `'uncovered'` (S5's
- * breakdown sets sawExpired/sawInsolvent from them INDEPENDENTLY). Composed from
- * the building blocks above, which stay exported: `usePcaOverview` still needs
+ * mismatched). The `dead`/`hasBudget` reason facets are carried ONLY on `'uncovered'`,
+ * where S5's breakdown sets sawExpired/sawInsolvent from them INDEPENDENTLY. Composed
+ * from the building blocks above, which stay exported: `usePcaOverview` still needs
  * `isPcaSpendable` for its account-level `bestCoveringDiscountBps` filter (no probe).
  */
-export interface PcaCoverageResult {
-  /** The canonical coverage decision. */
-  outcome: PcaCoverageOutcome;
-  /** Normalized registration (the S2 rule). `null` = couldn't determine. Overview's
-   *  approvedCount counts `registered === true` (registered wallets, not covering ones). */
-  registered: boolean | null;
-  /** Reason facet — the account is expired or fully swept (`isPcaDead`). */
-  dead: boolean;
-  /** Reason facet — the account has budget capacity (`hasPcaBudget`). */
-  hasBudget: boolean;
-}
-
 export function classifyCoverage(snap: PcaSnapshot, nowSec?: number): PcaCoverageResult {
   const registered = normalizeProbeRegistered(snap.probedKey);
+  if (registered === null) return { outcome: 'inconclusive', registered: null };
+  if (registered === false) return { outcome: 'unregistered', registered: false };
   const dead = isPcaDead(snap, nowSec);
   const hasBudget = hasPcaBudget(snap);
-  const outcome: PcaCoverageOutcome =
-    registered === null
-      ? 'inconclusive'
-      : registered === false
-        ? 'unregistered'
-        : !dead && hasBudget
-          ? 'covers'
-          : 'uncovered';
-  return { outcome, registered, dead, hasBudget };
+  if (!dead && hasBudget) return { outcome: 'covers', registered: true };
+  return { outcome: 'uncovered', registered: true, dead, hasBudget };
 }

--- a/packages/node-ui/src/ui/pca/coverage.ts
+++ b/packages/node-ui/src/ui/pca/coverage.ts
@@ -57,39 +57,49 @@ export function normalizeProbeRegistered(probedKey: PcaProbedKey | undefined): b
 }
 
 /**
- * The single canonical (snapshot, probe) coverage classification. Every surface
- * (S5 `usePublishEligibility`, S6 `GetSponsoredPanel`, `usePcaOverview`) runs THIS
- * one call instead of bundling the leaf predicates itself — so coverage can't
- * re-diverge across screens. Composed from the building blocks above (which stay
- * exported: `usePcaOverview` still needs `isPcaSpendable` for its account-level
- * `bestCoveringDiscountBps` filter, where there's no probe).
+ * The canonical coverage decision for a probed snapshot — the discriminant every
+ * surface switches on, so none has to recombine the bool soup itself:
+ *  - `inconclusive` — the probe couldn't be read → neutral, never DANGER (#9).
+ *  - `unregistered` — confirmed NOT an approved publishing wallet here.
+ *  - `covers`       — registered HERE AND the account is spendable (not dead, has budget).
+ *  - `uncovered`    — registered HERE but the account can't cover (dead and/or no budget).
+ */
+export type PcaCoverageOutcome = 'inconclusive' | 'unregistered' | 'covers' | 'uncovered';
+
+/**
+ * The single canonical coverage classification. Every surface (S5
+ * `usePublishEligibility`, S6 `GetSponsoredPanel`, `usePcaOverview`) runs THIS one
+ * call and switches on `outcome` instead of bundling the leaf predicates itself —
+ * so coverage can't re-diverge across screens. The probe is read from
+ * `snap.probedKey` (no separate param — a split snapshot/probe pair can't be
+ * mismatched). `dead`/`hasBudget` are the reason facets behind `'uncovered'` (S5's
+ * breakdown sets sawExpired/sawInsolvent from them INDEPENDENTLY). Composed from
+ * the building blocks above, which stay exported: `usePcaOverview` still needs
+ * `isPcaSpendable` for its account-level `bestCoveringDiscountBps` filter (no probe).
  */
 export interface PcaCoverageResult {
-  /** Normalized registration (the S2 rule). `null` = couldn't determine. */
+  /** The canonical coverage decision. */
+  outcome: PcaCoverageOutcome;
+  /** Normalized registration (the S2 rule). `null` = couldn't determine. Overview's
+   *  approvedCount counts `registered === true` (registered wallets, not covering ones). */
   registered: boolean | null;
-  /** The probe couldn't be read (`registered === null`) → neutral, never DANGER (#9). */
-  inconclusive: boolean;
-  /** The wallet is registered HERE AND the account is spendable (not dead, has budget). */
-  covers: boolean;
-  /** The account is expired or fully swept (`isPcaDead`). */
+  /** Reason facet — the account is expired or fully swept (`isPcaDead`). */
   dead: boolean;
-  /** The account has budget capacity (`hasPcaBudget`). */
+  /** Reason facet — the account has budget capacity (`hasPcaBudget`). */
   hasBudget: boolean;
 }
 
-export function classifyCoverage(
-  snap: PcaSnapshot,
-  probedKey: PcaProbedKey | undefined,
-  nowSec?: number,
-): PcaCoverageResult {
-  const registered = normalizeProbeRegistered(probedKey);
+export function classifyCoverage(snap: PcaSnapshot, nowSec?: number): PcaCoverageResult {
+  const registered = normalizeProbeRegistered(snap.probedKey);
   const dead = isPcaDead(snap, nowSec);
   const hasBudget = hasPcaBudget(snap);
-  return {
-    registered,
-    inconclusive: registered === null,
-    covers: registered === true && !dead && hasBudget,
-    dead,
-    hasBudget,
-  };
+  const outcome: PcaCoverageOutcome =
+    registered === null
+      ? 'inconclusive'
+      : registered === false
+        ? 'unregistered'
+        : !dead && hasBudget
+          ? 'covers'
+          : 'uncovered';
+  return { outcome, registered, dead, hasBudget };
 }

--- a/packages/node-ui/src/ui/pca/health.ts
+++ b/packages/node-ui/src/ui/pca/health.ts
@@ -1,0 +1,46 @@
+// PCA health derivation — DOMAIN module (#1355 V2). Lifted out of the presentation
+// HealthChip.tsx so domain code (coverage.ts, the hooks) doesn't import a React
+// component file (layer inversion). HealthChip.tsx re-imports these for its pill.
+import type { PcaSnapshot } from '../api.js';
+
+/**
+ * The health states a PCA can be in (S1/S3 `HealthChip`). Each maps to a DISTINCT
+ * glyph (not colour-only) and a text label that is NEVER dropped — the label is the
+ * accessible name, the glyph is decorative (`aria-hidden`).
+ */
+export type PcaHealthState =
+  | 'healthy'
+  | 'expiring'
+  | 'expired'
+  | 'insolvent'
+  | 'swept'
+  | 'cap-near';
+
+/** Approved-wallet count at which a PCA is flagged "Cap near 100". */
+export const PCA_CAP_NEAR_THRESHOLD = 90;
+/** Window (seconds) before expiry at which a PCA is flagged "Expiring soon" (7 days). */
+export const PCA_EXPIRING_SOON_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * The SINGLE source of truth for deriving a PCA's `HealthChip` state from its
+ * snapshot — used by S1/S3/S5 so the derivation can't drift across screens.
+ * Precedence (highest first), per the lead's contract:
+ *   expired → swept → cap-near → expiring → healthy.
+ *
+ * `insolvent` is intentionally NOT derived in P0: accurate insolvency needs the
+ * current-epoch `remainingAllowance` (GAP-4/5 extended snapshot), which the P0
+ * snapshot doesn't carry — asserting it from P0 data would be a false claim
+ * (invariant #9). The `insolvent` STATE still exists for the P2 budget widget.
+ */
+export function healthForSnapshot(
+  snapshot: Pick<PcaSnapshot, 'expiresAtTimestamp' | 'fullySwept' | 'agentCount'>,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): PcaHealthState {
+  const { expiresAtTimestamp, fullySwept, agentCount } = snapshot;
+  const hasExpiry = typeof expiresAtTimestamp === 'number' && expiresAtTimestamp > 0;
+  if (hasExpiry && nowSec >= expiresAtTimestamp) return 'expired';
+  if (fullySwept) return 'swept';
+  if (typeof agentCount === 'number' && agentCount >= PCA_CAP_NEAR_THRESHOLD) return 'cap-near';
+  if (hasExpiry && expiresAtTimestamp - nowSec <= PCA_EXPIRING_SOON_SECONDS) return 'expiring';
+  return 'healthy';
+}

--- a/packages/node-ui/src/ui/pca/health.ts
+++ b/packages/node-ui/src/ui/pca/health.ts
@@ -22,6 +22,20 @@ export const PCA_CAP_NEAR_THRESHOLD = 90;
 export const PCA_EXPIRING_SOON_SECONDS = 7 * 24 * 60 * 60;
 
 /**
+ * The SINGLE expiry (liveness) source — the one check `healthForSnapshot`'s
+ * `'expired'` state and coverage's `isPcaDead` both consume, so coverage liveness
+ * doesn't have to drag in the whole health taxonomy. `expiresAtTimestamp` 0 / absent
+ * means "no lock period" → never expired.
+ */
+export function isPcaExpired(
+  snap: Pick<PcaSnapshot, 'expiresAtTimestamp'>,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): boolean {
+  const { expiresAtTimestamp } = snap;
+  return typeof expiresAtTimestamp === 'number' && expiresAtTimestamp > 0 && nowSec >= expiresAtTimestamp;
+}
+
+/**
  * The SINGLE source of truth for deriving a PCA's `HealthChip` state from its
  * snapshot — used by S1/S3/S5 so the derivation can't drift across screens.
  * Precedence (highest first), per the lead's contract:
@@ -38,7 +52,7 @@ export function healthForSnapshot(
 ): PcaHealthState {
   const { expiresAtTimestamp, fullySwept, agentCount } = snapshot;
   const hasExpiry = typeof expiresAtTimestamp === 'number' && expiresAtTimestamp > 0;
-  if (hasExpiry && nowSec >= expiresAtTimestamp) return 'expired';
+  if (isPcaExpired(snapshot, nowSec)) return 'expired';
   if (fullySwept) return 'swept';
   if (typeof agentCount === 'number' && agentCount >= PCA_CAP_NEAR_THRESHOLD) return 'cap-near';
   if (hasExpiry && expiresAtTimestamp - nowSec <= PCA_EXPIRING_SOON_SECONDS) return 'expiring';

--- a/packages/node-ui/test/pca-components.test.ts
+++ b/packages/node-ui/test/pca-components.test.ts
@@ -11,10 +11,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   HealthChip,
   HEALTH_CHIP_META,
-  healthForSnapshot,
-  PCA_CAP_NEAR_THRESHOLD,
-  PCA_EXPIRING_SOON_SECONDS,
-  type PcaHealthState,
   WalletRow,
   AddressCrux,
   DiscountTierLadder,
@@ -24,6 +20,12 @@ import {
   EligibilityVerdictBanner,
   SponsorshipHandshake,
 } from '../src/ui/components/Pca/index.js';
+import {
+  healthForSnapshot,
+  PCA_CAP_NEAR_THRESHOLD,
+  PCA_EXPIRING_SOON_SECONDS,
+  type PcaHealthState,
+} from '../src/ui/pca/health.js';
 import { EmptyState } from '../src/ui/components/ContextGraphPrimitives.js';
 
 async function render(node: React.ReactElement): Promise<{

--- a/packages/node-ui/test/pca-components.test.ts
+++ b/packages/node-ui/test/pca-components.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../src/ui/components/Pca/index.js';
 import {
   healthForSnapshot,
+  isPcaExpired,
   PCA_CAP_NEAR_THRESHOLD,
   PCA_EXPIRING_SOON_SECONDS,
   type PcaHealthState,
@@ -153,6 +154,24 @@ describe('healthForSnapshot (single source of truth for S1/S3/S5)', () => {
 
   it('treats a missing/zero expiry as "no expiry data" (never expired/expiring)', () => {
     expect(healthForSnapshot({ ...base, expiresAtTimestamp: 0 }, NOW)).toBe('healthy');
+  });
+});
+
+describe('isPcaExpired (shared liveness primitive — single expiry source, #1344 C-live)', () => {
+  const NOW = 1_000_000;
+  it('expired exactly at and past the boundary; not before', () => {
+    expect(isPcaExpired({ expiresAtTimestamp: NOW }, NOW)).toBe(true); // boundary counts as expired
+    expect(isPcaExpired({ expiresAtTimestamp: NOW - 1 }, NOW)).toBe(true);
+    expect(isPcaExpired({ expiresAtTimestamp: NOW + 1 }, NOW)).toBe(false);
+  });
+  it('treats 0 / absent expiry as "no lock period" → never expired', () => {
+    expect(isPcaExpired({ expiresAtTimestamp: 0 }, NOW)).toBe(false);
+    expect(isPcaExpired({ expiresAtTimestamp: undefined as unknown as number }, NOW)).toBe(false);
+  });
+  it('is exactly healthForSnapshot’s expired discriminant', () => {
+    // The two stay lockstep: expired-state ⟺ isPcaExpired (the C-live contract).
+    expect(healthForSnapshot({ expiresAtTimestamp: NOW, fullySwept: false, agentCount: 1 }, NOW)).toBe('expired');
+    expect(isPcaExpired({ expiresAtTimestamp: NOW }, NOW)).toBe(true);
   });
 });
 

--- a/packages/node-ui/test/pca-coverage-parity.test.ts
+++ b/packages/node-ui/test/pca-coverage-parity.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment happy-dom
+//
+// #1344 cross-consumer PARITY (anti-drift) — the three coverage surfaces now
+// share `src/ui/pca/coverage.ts` (the leaf rules that drifted across
+// C1/O4/Q2/S2/U2/V3). This feeds ONE fixture (a PCA snapshot + a per-wallet
+// probe) through `coverageForProbe` and asserts all three surfaces classify the
+// SAME fixture identically — covers / registered-but-uncovered / inconclusive —
+// so they can't re-diverge. Each surface keeps its own aggregation; this pins
+// only their agreement on the shared leaf coverage:
+//   - S5 `PublishEligibilityChip` (usePublishEligibility) → the chip verdict,
+//   - S6 `GetSponsoredPanel`       → the per-wallet approval-check outcome,
+//   - `usePcaOverview`             → registered / approvedCount / covered / bestBps.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchWalletsBalances: vi.fn(),
+  fetchPca: vi.fn(),
+  fetchContextGraphs: vi.fn(),
+  fetchCurrentAgent: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', async (orig) => {
+  const actual = await orig<typeof import('../src/ui/api.js')>();
+  return {
+    ...actual,
+    fetchWalletsBalances: mocks.fetchWalletsBalances,
+    fetchPca: mocks.fetchPca,
+    fetchContextGraphs: mocks.fetchContextGraphs,
+    fetchCurrentAgent: mocks.fetchCurrentAgent,
+  };
+});
+
+const { PublishEligibilityChip } = await import('../src/ui/pages/conviction/PublishEligibilityChip.js');
+const { GetSponsoredPanel } = await import('../src/ui/pages/conviction/GetSponsoredPanel.js');
+const { usePcaOverview } = await import('../src/ui/hooks/usePcaOverview.js');
+const { usePcaStore } = await import('../src/ui/stores/pca.js');
+const { makePcaSnapshot } = await import('../src/ui/mocks/pca.js');
+const { coverageForProbe } = await import('../src/ui/pca/coverage.js');
+import type { PcaOverview } from '../src/ui/hooks/usePcaOverview.js';
+import type { PcaSnapshot, PcaProbedKey } from '../src/ui/api.js';
+
+const W0 = '0x71D4000000000000000000000000000000009Ac2';
+const ACCOUNT = '7';
+
+// ── shared harness helpers (mirrors the consumer tests) ──────────────────────
+async function render(node: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { container, unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+async function waitForText(c: HTMLElement, text: string) {
+  const started = Date.now(); let last = '';
+  while (Date.now() - started < 1500) {
+    last = c.textContent ?? '';
+    if (last.includes(text)) return;
+    await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+  }
+  throw new Error(`Timed out waiting for "${text}" in "${last}"`);
+}
+function setInputValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+// usePcaOverview is a shared-poller hook — drive it through a Harness capturing
+// its latest return, exactly like pca-overview-hook.test.ts.
+let latestOverview: PcaOverview | null = null;
+function OverviewHarness() {
+  latestOverview = usePcaOverview(0); // intervalMs 0 → load once
+  return null;
+}
+async function renderOverview() {
+  latestOverview = null;
+  const handle = await render(React.createElement(OverviewHarness));
+  for (let i = 0; i < 80 && (latestOverview == null || latestOverview.loading); i++) {
+    await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+  }
+  return handle;
+}
+
+// Wire the per-surface fetchers to ONE fixture: the account snapshot for the
+// bare call, the snapshot + probe for a per-wallet call. Wallet is gas+TRAC
+// funded so S5's verdict is coverage-driven (not a gas/TRAC fall-through).
+function wire(snap: PcaSnapshot, probe: PcaProbedKey) {
+  mocks.fetchWalletsBalances.mockResolvedValue({
+    wallets: [W0],
+    balances: [{ address: W0, eth: '0.1', trac: '100', symbol: 'TRAC' }],
+    chainId: '84532',
+    rpcUrl: null,
+  });
+  mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+    key ? { ...snap, probedKey: { ...probe } } : snap,
+  );
+}
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  localStorage.clear();
+  vi.clearAllMocks();
+  latestOverview = null;
+  usePcaStore.setState({ trackedIds: [ACCOUNT], createPending: null });
+  // S5 owner-publish escrow caveat off (not under test here).
+  mocks.fetchContextGraphs.mockResolvedValue({ contextGraphs: [] });
+  mocks.fetchCurrentAgent.mockResolvedValue({ agentDid: 'did:dkg:agent:0x' + '9'.repeat(40) });
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+const FUTURE = Math.floor(Date.now() / 1000) + 60 * 86_400;
+
+describe('#1344 coverage parity — S5 / S6 / overview agree via the shared resolver', () => {
+  it('registered + spendable → ALL THREE say "covers"', async () => {
+    const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
+    const probe: PcaProbedKey = { key: W0, registered: true };
+    wire(snap, probe);
+    const expected = coverageForProbe(snap, probe);
+    expect(expected).toEqual({ registered: true, inconclusive: false, covers: true });
+
+    // overview
+    const ov = await renderOverview();
+    const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
+    expect(a.walletProbes[0]?.registered).toBe(true);
+    expect(a.approvedCount).toBe(1);
+    expect(a.probesInconclusive).toBe(false);
+    expect(latestOverview!.covered).toBe(true);
+    expect(latestOverview!.bestCoveringDiscountBps).toBe(snap.discountBps);
+    await ov.unmount();
+
+    // S5 chip → eligible
+    const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(s5.container, 'Funded by PCA #' + ACCOUNT);
+    expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeTruthy();
+    await s5.unmount();
+
+    // S6 panel → covers → Ready
+    const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
+    await waitForText(s6.container, 'Track your approval');
+    setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await act(async () => {
+      (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await waitForText(s6.container, 'Ready');
+    await s6.unmount();
+  });
+
+  it('adapterSupported:false → ALL THREE say "inconclusive" (never a confirmed not-approved/DANGER)', async () => {
+    const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
+    const probe: PcaProbedKey = { key: W0, registered: false, adapterSupported: false };
+    wire(snap, probe);
+    const expected = coverageForProbe(snap, probe);
+    expect(expected).toEqual({ registered: null, inconclusive: true, covers: false });
+
+    // overview → inconclusive, not 0-approved-confirmed, not covered
+    const ov = await renderOverview();
+    const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
+    expect(a.walletProbes[0]?.registered).toBeNull();
+    expect(a.approvedCount).toBe(0);
+    expect(a.probesInconclusive).toBe(true);
+    expect(latestOverview!.covered).toBe(false);
+    await ov.unmount();
+
+    // S5 chip → unknown (neutral), NOT danger
+    const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(s5.container, 'PCA status unknown');
+    expect(s5.container.querySelector('[data-verdict="unknown"]')).toBeTruthy();
+    expect(s5.container.querySelector('[data-verdict="fallthrough-no-funds"]')).toBeNull();
+    expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeNull();
+    await s5.unmount();
+
+    // S6 panel → neutral row, never "not approved", never Ready
+    const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
+    await waitForText(s6.container, 'Track your approval');
+    setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await act(async () => {
+      (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    // All probed wallets inconclusive (adapterSupported:false) → S6 reports a
+    // wholesale "couldn't determine" (never a false "not approved"/"0 of N",
+    // never Ready) — the inconclusive outcome, consistent with S5 + overview.
+    await waitForText(s6.container, 'the chain lookup failed');
+    expect(s6.container.textContent).not.toContain('Ready');
+    expect(s6.container.textContent).not.toContain('0 of 1');
+    await s6.unmount();
+  });
+
+  it('zero-budget approved → ALL THREE say "registered but NONE covers"', async () => {
+    const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE, topUpBuffer: '0', topUpBufferTrac: '0', baseEpochAllowance: '0' });
+    const probe: PcaProbedKey = { key: W0, registered: true };
+    wire(snap, probe);
+    const expected = coverageForProbe(snap, probe);
+    expect(expected).toEqual({ registered: true, inconclusive: false, covers: false });
+
+    // overview → registered (approvedCount 1) but NOT covered, no advertised discount
+    const ov = await renderOverview();
+    const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
+    expect(a.walletProbes[0]?.registered).toBe(true);
+    expect(a.approvedCount).toBe(1);
+    expect(a.probesInconclusive).toBe(false);
+    expect(latestOverview!.covered).toBe(false);
+    expect(latestOverview!.bestCoveringDiscountBps).toBeNull();
+    await ov.unmount();
+
+    // S5 chip → fall-through (no discount), NOT eligible (covers:false); wallet has
+    // TRAC so it's amber, not danger.
+    const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(s5.container, 'No PCA discount');
+    expect(s5.container.querySelector('[data-verdict="fallthrough"]')).toBeTruthy();
+    expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeNull();
+    await s5.unmount();
+
+    // S6 panel → registered counted, but NOT Ready (the account can't cover)
+    const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
+    await waitForText(s6.container, 'Track your approval');
+    setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await act(async () => {
+      (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await waitForText(s6.container, 'Approved on PCA #' + ACCOUNT);
+    expect(s6.container.textContent).not.toContain('Ready');
+    await s6.unmount();
+  });
+});

--- a/packages/node-ui/test/pca-coverage-parity.test.ts
+++ b/packages/node-ui/test/pca-coverage-parity.test.ts
@@ -119,8 +119,8 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
     const probe: PcaProbedKey = { key: W0, registered: true };
     wire(snap, probe);
-    const expected = classifyCoverage(snap, probe);
-    expect(expected).toEqual({ registered: true, inconclusive: false, covers: true, dead: false, hasBudget: true });
+    const expected = classifyCoverage({ ...snap, probedKey: probe });
+    expect(expected).toEqual({ outcome: 'covers', registered: true, dead: false, hasBudget: true });
 
     // overview
     const ov = await renderOverview();
@@ -155,8 +155,8 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
     const probe: PcaProbedKey = { key: W0, registered: false, adapterSupported: false };
     wire(snap, probe);
-    const expected = classifyCoverage(snap, probe);
-    expect(expected).toEqual({ registered: null, inconclusive: true, covers: false, dead: false, hasBudget: true });
+    const expected = classifyCoverage({ ...snap, probedKey: probe });
+    expect(expected).toEqual({ outcome: 'inconclusive', registered: null, dead: false, hasBudget: true });
 
     // overview → inconclusive, not 0-approved-confirmed, not covered
     const ov = await renderOverview();
@@ -197,8 +197,8 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE, topUpBuffer: '0', topUpBufferTrac: '0', baseEpochAllowance: '0' });
     const probe: PcaProbedKey = { key: W0, registered: true };
     wire(snap, probe);
-    const expected = classifyCoverage(snap, probe);
-    expect(expected).toEqual({ registered: true, inconclusive: false, covers: false, dead: false, hasBudget: false });
+    const expected = classifyCoverage({ ...snap, probedKey: probe });
+    expect(expected).toEqual({ outcome: 'uncovered', registered: true, dead: false, hasBudget: false });
 
     // overview → registered (approvedCount 1) but NOT covered, no advertised discount
     const ov = await renderOverview();

--- a/packages/node-ui/test/pca-coverage-parity.test.ts
+++ b/packages/node-ui/test/pca-coverage-parity.test.ts
@@ -120,7 +120,7 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const probe: PcaProbedKey = { key: W0, registered: true };
     wire(snap, probe);
     const expected = classifyCoverage({ ...snap, probedKey: probe });
-    expect(expected).toEqual({ outcome: 'covers', registered: true, dead: false, hasBudget: true });
+    expect(expected).toEqual({ outcome: 'covers', registered: true });
 
     // overview
     const ov = await renderOverview();
@@ -156,7 +156,7 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const probe: PcaProbedKey = { key: W0, registered: false, adapterSupported: false };
     wire(snap, probe);
     const expected = classifyCoverage({ ...snap, probedKey: probe });
-    expect(expected).toEqual({ outcome: 'inconclusive', registered: null, dead: false, hasBudget: true });
+    expect(expected).toEqual({ outcome: 'inconclusive', registered: null });
 
     // overview → inconclusive, not 0-approved-confirmed, not covered
     const ov = await renderOverview();

--- a/packages/node-ui/test/pca-coverage-parity.test.ts
+++ b/packages/node-ui/test/pca-coverage-parity.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment happy-dom
 //
-// #1344 cross-consumer PARITY (anti-drift) — the three coverage surfaces now
-// share `src/ui/pca/coverage.ts` (the leaf rules that drifted across
-// C1/O4/Q2/S2/U2/V3). This feeds ONE fixture (a PCA snapshot + a per-wallet
+// #1344 cross-consumer PARITY (anti-drift), TABLE-DRIVEN — the three coverage
+// surfaces share `src/ui/pca/coverage.ts` (the leaf rules that drifted across
+// C1/O4/Q2/S2/U2/V3). Each row feeds ONE fixture (a PCA snapshot + a per-wallet
 // probe) through the SINGLE `classifyCoverage` and asserts all three surfaces
-// classify the SAME fixture identically — covers / registered-but-uncovered /
-// inconclusive — so they can't re-diverge. Each surface keeps its own aggregation; this pins
-// only their agreement on the shared leaf coverage:
+// classify it identically — covers / inconclusive / registered-but-uncovered —
+// so they can't re-diverge. One driver, one row per scenario (adding a case is a
+// table row, not a copied render block). Surfaces pinned:
 //   - S5 `PublishEligibilityChip` (usePublishEligibility) → the chip verdict,
 //   - S6 `GetSponsoredPanel`       → the per-wallet approval-check outcome,
 //   - `usePcaOverview`             → registered / approvedCount / covered / bestBps.
@@ -113,122 +113,115 @@ beforeEach(() => {
 afterEach(() => { document.body.innerHTML = ''; });
 
 const FUTURE = Math.floor(Date.now() / 1000) + 60 * 86_400;
+const PAST = Math.floor(Date.now() / 1000) - 86_400;
 
-describe('#1344 coverage parity — S5 / S6 / overview agree via the shared resolver', () => {
-  it('registered + spendable → ALL THREE say "covers"', async () => {
-    const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
-    const probe: PcaProbedKey = { key: W0, registered: true };
-    wire(snap, probe);
-    const expected = classifyCoverage({ ...snap, probedKey: probe });
-    expect(expected).toEqual({ outcome: 'covers', registered: true });
+interface Scenario {
+  name: string;
+  snapOver: Record<string, unknown>;
+  probe: PcaProbedKey;
+  /** The shared-resolver oracle result the 3 surfaces must agree with. */
+  expected: ReturnType<typeof classifyCoverage>;
+  overview: { registered: boolean | null; approvedCount: number; inconclusive: boolean; covered: boolean; bestBps: 'discount' | null };
+  s5Verdict: 'eligible' | 'fallthrough' | 'unknown';
+  s5Wait: string;
+  s6: { wait: string; ready: boolean; notText?: string[] };
+}
 
-    // overview
-    const ov = await renderOverview();
-    const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
-    expect(a.walletProbes[0]?.registered).toBe(true);
-    expect(a.approvedCount).toBe(1);
-    expect(a.probesInconclusive).toBe(false);
-    expect(latestOverview!.covered).toBe(true);
-    expect(latestOverview!.bestCoveringDiscountBps).toBe(snap.discountBps);
-    await ov.unmount();
+const SCENARIOS: Scenario[] = [
+  {
+    name: 'registered + spendable → covers',
+    snapOver: { expiresAtTimestamp: FUTURE },
+    probe: { key: W0, registered: true },
+    expected: { outcome: 'covers', registered: true },
+    overview: { registered: true, approvedCount: 1, inconclusive: false, covered: true, bestBps: 'discount' },
+    s5Verdict: 'eligible',
+    s5Wait: 'Funded by PCA #' + ACCOUNT,
+    s6: { wait: 'Ready', ready: true },
+  },
+  {
+    name: 'adapterSupported:false → inconclusive (never a confirmed not-approved/DANGER)',
+    snapOver: { expiresAtTimestamp: FUTURE },
+    probe: { key: W0, registered: false, adapterSupported: false },
+    expected: { outcome: 'inconclusive', registered: null },
+    overview: { registered: null, approvedCount: 0, inconclusive: true, covered: false, bestBps: null },
+    s5Verdict: 'unknown',
+    s5Wait: 'PCA status unknown',
+    // All-inconclusive → S6 reports a wholesale "couldn't determine" (never a false
+    // "not approved"/"0 of N", never Ready) — still the inconclusive outcome.
+    s6: { wait: 'the chain lookup failed', ready: false, notText: ['0 of 1'] },
+  },
+  {
+    name: 'zero-budget approved → uncovered (hasBudget:false)',
+    snapOver: { expiresAtTimestamp: FUTURE, topUpBuffer: '0', topUpBufferTrac: '0', baseEpochAllowance: '0' },
+    probe: { key: W0, registered: true },
+    expected: { outcome: 'uncovered', registered: true, dead: false, hasBudget: false },
+    overview: { registered: true, approvedCount: 1, inconclusive: false, covered: false, bestBps: null },
+    s5Verdict: 'fallthrough', // wallet has TRAC → amber, not danger
+    s5Wait: 'No PCA discount',
+    s6: { wait: 'Approved on PCA #' + ACCOUNT, ready: false },
+  },
+  {
+    name: 'expired approved → uncovered (dead:true)',
+    snapOver: { expiresAtTimestamp: PAST },
+    probe: { key: W0, registered: true },
+    expected: { outcome: 'uncovered', registered: true, dead: true, hasBudget: true },
+    overview: { registered: true, approvedCount: 1, inconclusive: false, covered: false, bestBps: null },
+    s5Verdict: 'fallthrough',
+    s5Wait: 'No PCA discount',
+    s6: { wait: 'publishes won’t get the discount', ready: false },
+  },
+  {
+    name: 'swept approved → uncovered (dead:true)',
+    snapOver: { fullySwept: true, expiresAtTimestamp: FUTURE },
+    probe: { key: W0, registered: true },
+    expected: { outcome: 'uncovered', registered: true, dead: true, hasBudget: true },
+    overview: { registered: true, approvedCount: 1, inconclusive: false, covered: false, bestBps: null },
+    s5Verdict: 'fallthrough',
+    s5Wait: 'No PCA discount',
+    s6: { wait: 'publishes won’t get the discount', ready: false },
+  },
+];
 
-    // S5 chip → eligible
-    const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
-    await waitForText(s5.container, 'Funded by PCA #' + ACCOUNT);
-    expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeTruthy();
-    await s5.unmount();
+describe('#1344 coverage parity (table-driven) — S5 / S6 / overview agree via classifyCoverage', () => {
+  for (const s of SCENARIOS) {
+    it(`all surfaces agree: ${s.name}`, async () => {
+      const snap = makePcaSnapshot({ accountId: ACCOUNT, ...s.snapOver });
+      wire(snap, s.probe);
 
-    // S6 panel → covers → Ready
-    const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
-    await waitForText(s6.container, 'Track your approval');
-    setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
-    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
-    await act(async () => {
-      (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
-        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      // 0. the shared-resolver oracle — the single source the 3 surfaces consume.
+      expect(classifyCoverage({ ...snap, probedKey: s.probe })).toEqual(s.expected);
+
+      // 1. usePcaOverview
+      const ov = await renderOverview();
+      const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
+      expect(a.walletProbes[0]?.registered).toBe(s.overview.registered);
+      expect(a.approvedCount).toBe(s.overview.approvedCount);
+      expect(a.probesInconclusive).toBe(s.overview.inconclusive);
+      expect(latestOverview!.covered).toBe(s.overview.covered);
+      expect(latestOverview!.bestCoveringDiscountBps).toBe(s.overview.bestBps === 'discount' ? snap.discountBps : null);
+      await ov.unmount();
+
+      // 2. S5 chip (PublishEligibilityChip)
+      const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+      await waitForText(s5.container, s.s5Wait);
+      expect(s5.container.querySelector(`[data-verdict="${s.s5Verdict}"]`)).toBeTruthy();
+      if (s.s5Verdict !== 'eligible') expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeNull();
+      await s5.unmount();
+
+      // 3. S6 panel (GetSponsoredPanel) — run the approval check
+      const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
+      await waitForText(s6.container, 'Track your approval');
+      setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
+      await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+      await act(async () => {
+        (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
+          .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      await waitForText(s6.container, s.s6.wait);
+      if (s.s6.ready) expect(s6.container.textContent).toContain('Ready');
+      else expect(s6.container.textContent).not.toContain('Ready');
+      for (const nt of s.s6.notText ?? []) expect(s6.container.textContent).not.toContain(nt);
+      await s6.unmount();
     });
-    await waitForText(s6.container, 'Ready');
-    await s6.unmount();
-  });
-
-  it('adapterSupported:false → ALL THREE say "inconclusive" (never a confirmed not-approved/DANGER)', async () => {
-    const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
-    const probe: PcaProbedKey = { key: W0, registered: false, adapterSupported: false };
-    wire(snap, probe);
-    const expected = classifyCoverage({ ...snap, probedKey: probe });
-    expect(expected).toEqual({ outcome: 'inconclusive', registered: null });
-
-    // overview → inconclusive, not 0-approved-confirmed, not covered
-    const ov = await renderOverview();
-    const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
-    expect(a.walletProbes[0]?.registered).toBeNull();
-    expect(a.approvedCount).toBe(0);
-    expect(a.probesInconclusive).toBe(true);
-    expect(latestOverview!.covered).toBe(false);
-    await ov.unmount();
-
-    // S5 chip → unknown (neutral), NOT danger
-    const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
-    await waitForText(s5.container, 'PCA status unknown');
-    expect(s5.container.querySelector('[data-verdict="unknown"]')).toBeTruthy();
-    expect(s5.container.querySelector('[data-verdict="fallthrough-no-funds"]')).toBeNull();
-    expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeNull();
-    await s5.unmount();
-
-    // S6 panel → neutral row, never "not approved", never Ready
-    const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
-    await waitForText(s6.container, 'Track your approval');
-    setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
-    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
-    await act(async () => {
-      (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
-        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    // All probed wallets inconclusive (adapterSupported:false) → S6 reports a
-    // wholesale "couldn't determine" (never a false "not approved"/"0 of N",
-    // never Ready) — the inconclusive outcome, consistent with S5 + overview.
-    await waitForText(s6.container, 'the chain lookup failed');
-    expect(s6.container.textContent).not.toContain('Ready');
-    expect(s6.container.textContent).not.toContain('0 of 1');
-    await s6.unmount();
-  });
-
-  it('zero-budget approved → ALL THREE say "registered but NONE covers"', async () => {
-    const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE, topUpBuffer: '0', topUpBufferTrac: '0', baseEpochAllowance: '0' });
-    const probe: PcaProbedKey = { key: W0, registered: true };
-    wire(snap, probe);
-    const expected = classifyCoverage({ ...snap, probedKey: probe });
-    expect(expected).toEqual({ outcome: 'uncovered', registered: true, dead: false, hasBudget: false });
-
-    // overview → registered (approvedCount 1) but NOT covered, no advertised discount
-    const ov = await renderOverview();
-    const a = latestOverview!.accounts.find((x) => x.accountId === ACCOUNT)!;
-    expect(a.walletProbes[0]?.registered).toBe(true);
-    expect(a.approvedCount).toBe(1);
-    expect(a.probesInconclusive).toBe(false);
-    expect(latestOverview!.covered).toBe(false);
-    expect(latestOverview!.bestCoveringDiscountBps).toBeNull();
-    await ov.unmount();
-
-    // S5 chip → fall-through (no discount), NOT eligible (covers:false); wallet has
-    // TRAC so it's amber, not danger.
-    const s5 = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
-    await waitForText(s5.container, 'No PCA discount');
-    expect(s5.container.querySelector('[data-verdict="fallthrough"]')).toBeTruthy();
-    expect(s5.container.querySelector('[data-verdict="eligible"]')).toBeNull();
-    await s5.unmount();
-
-    // S6 panel → registered counted, but NOT Ready (the account can't cover)
-    const s6 = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
-    await waitForText(s6.container, 'Track your approval');
-    setInputValue(s6.container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement, ACCOUNT);
-    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
-    await act(async () => {
-      (Array.from(s6.container.querySelectorAll('button')).find((b) => b.textContent === 'Check approval')!)
-        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    await waitForText(s6.container, 'Approved on PCA #' + ACCOUNT);
-    expect(s6.container.textContent).not.toContain('Ready');
-    await s6.unmount();
-  });
+  }
 });

--- a/packages/node-ui/test/pca-coverage-parity.test.ts
+++ b/packages/node-ui/test/pca-coverage-parity.test.ts
@@ -3,9 +3,9 @@
 // #1344 cross-consumer PARITY (anti-drift) — the three coverage surfaces now
 // share `src/ui/pca/coverage.ts` (the leaf rules that drifted across
 // C1/O4/Q2/S2/U2/V3). This feeds ONE fixture (a PCA snapshot + a per-wallet
-// probe) through `coverageForProbe` and asserts all three surfaces classify the
-// SAME fixture identically — covers / registered-but-uncovered / inconclusive —
-// so they can't re-diverge. Each surface keeps its own aggregation; this pins
+// probe) through the SINGLE `classifyCoverage` and asserts all three surfaces
+// classify the SAME fixture identically — covers / registered-but-uncovered /
+// inconclusive — so they can't re-diverge. Each surface keeps its own aggregation; this pins
 // only their agreement on the shared leaf coverage:
 //   - S5 `PublishEligibilityChip` (usePublishEligibility) → the chip verdict,
 //   - S6 `GetSponsoredPanel`       → the per-wallet approval-check outcome,
@@ -38,7 +38,7 @@ const { GetSponsoredPanel } = await import('../src/ui/pages/conviction/GetSponso
 const { usePcaOverview } = await import('../src/ui/hooks/usePcaOverview.js');
 const { usePcaStore } = await import('../src/ui/stores/pca.js');
 const { makePcaSnapshot } = await import('../src/ui/mocks/pca.js');
-const { coverageForProbe } = await import('../src/ui/pca/coverage.js');
+const { classifyCoverage } = await import('../src/ui/pca/coverage.js');
 import type { PcaOverview } from '../src/ui/hooks/usePcaOverview.js';
 import type { PcaSnapshot, PcaProbedKey } from '../src/ui/api.js';
 
@@ -119,8 +119,8 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
     const probe: PcaProbedKey = { key: W0, registered: true };
     wire(snap, probe);
-    const expected = coverageForProbe(snap, probe);
-    expect(expected).toEqual({ registered: true, inconclusive: false, covers: true });
+    const expected = classifyCoverage(snap, probe);
+    expect(expected).toEqual({ registered: true, inconclusive: false, covers: true, dead: false, hasBudget: true });
 
     // overview
     const ov = await renderOverview();
@@ -155,8 +155,8 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE });
     const probe: PcaProbedKey = { key: W0, registered: false, adapterSupported: false };
     wire(snap, probe);
-    const expected = coverageForProbe(snap, probe);
-    expect(expected).toEqual({ registered: null, inconclusive: true, covers: false });
+    const expected = classifyCoverage(snap, probe);
+    expect(expected).toEqual({ registered: null, inconclusive: true, covers: false, dead: false, hasBudget: true });
 
     // overview → inconclusive, not 0-approved-confirmed, not covered
     const ov = await renderOverview();
@@ -197,8 +197,8 @@ describe('#1344 coverage parity — S5 / S6 / overview agree via the shared reso
     const snap = makePcaSnapshot({ accountId: ACCOUNT, expiresAtTimestamp: FUTURE, topUpBuffer: '0', topUpBufferTrac: '0', baseEpochAllowance: '0' });
     const probe: PcaProbedKey = { key: W0, registered: true };
     wire(snap, probe);
-    const expected = coverageForProbe(snap, probe);
-    expect(expected).toEqual({ registered: true, inconclusive: false, covers: false });
+    const expected = classifyCoverage(snap, probe);
+    expect(expected).toEqual({ registered: true, inconclusive: false, covers: false, dead: false, hasBudget: false });
 
     // overview → registered (approvedCount 1) but NOT covered, no advertised discount
     const ov = await renderOverview();

--- a/packages/node-ui/test/pca-coverage.test.ts
+++ b/packages/node-ui/test/pca-coverage.test.ts
@@ -79,6 +79,21 @@ describe('classifyCoverage (discriminated union — facets ONLY on uncovered)', 
     );
     expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: false, hasBudget: false });
   });
+  // C1 — `dead` and `hasBudget` are INDEPENDENT reason facets. An account that is
+  // BOTH expired (or swept) AND out-of-budget must set BOTH (dead:true, hasBudget:false),
+  // not just one — the reviewer's independence lock (each facet has its own `if`).
+  it('registered + expired + zero-budget → uncovered with BOTH facets (dead:true, hasBudget:false)', () => {
+    const c = classifyCoverage(
+      makePcaSnapshot({ expiresAtTimestamp: PAST, topUpBuffer: '0', baseEpochAllowance: '0', probedKey: { key: '0x', registered: true } }),
+    );
+    expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: true, hasBudget: false });
+  });
+  it('registered + swept + zero-budget → uncovered with BOTH facets (dead:true, hasBudget:false)', () => {
+    const c = classifyCoverage(
+      makePcaSnapshot({ fullySwept: true, expiresAtTimestamp: FUTURE, topUpBuffer: '0', baseEpochAllowance: '0', probedKey: { key: '0x', registered: true } }),
+    );
+    expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: true, hasBudget: false });
+  });
   it('registered:false → { outcome: unregistered, registered: false }', () => {
     const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: false } }));
     expect(c).toEqual({ outcome: 'unregistered', registered: false });

--- a/packages/node-ui/test/pca-coverage.test.ts
+++ b/packages/node-ui/test/pca-coverage.test.ts
@@ -64,31 +64,31 @@ describe('normalizeProbeRegistered', () => {
   });
 });
 
-describe('classifyCoverage', () => {
-  it('registered + spendable → outcome covers (single-input; reads snap.probedKey)', () => {
+describe('classifyCoverage (discriminated union — facets ONLY on uncovered)', () => {
+  it('registered + spendable → { outcome: covers, registered: true } (no dead/hasBudget facets)', () => {
     const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: true } }));
-    expect(c).toEqual({ outcome: 'covers', registered: true, dead: false, hasBudget: true });
+    expect(c).toEqual({ outcome: 'covers', registered: true });
   });
-  it('registered + expired → outcome uncovered, dead:true (the reviewer’s example facet)', () => {
+  it('registered + expired → uncovered, dead:true (the reviewer’s example facet)', () => {
     const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: PAST, probedKey: { key: '0x', registered: true } }));
     expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: true, hasBudget: true });
   });
-  it('registered + zero-budget → outcome uncovered, hasBudget:false (dead+zero-budget reason facet)', () => {
+  it('registered + zero-budget → uncovered, hasBudget:false', () => {
     const c = classifyCoverage(
       makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: true } }),
     );
     expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: false, hasBudget: false });
   });
-  it('registered:false → outcome unregistered', () => {
+  it('registered:false → { outcome: unregistered, registered: false }', () => {
     const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: false } }));
-    expect(c).toEqual({ outcome: 'unregistered', registered: false, dead: false, hasBudget: true });
+    expect(c).toEqual({ outcome: 'unregistered', registered: false });
   });
-  it('adapterSupported:false → outcome inconclusive, never covers', () => {
+  it('adapterSupported:false → { outcome: inconclusive, registered: null }', () => {
     const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: false, adapterSupported: false } }));
-    expect(c).toEqual({ outcome: 'inconclusive', registered: null, dead: false, hasBudget: true });
+    expect(c).toEqual({ outcome: 'inconclusive', registered: null });
   });
-  it('missing probedKey → outcome inconclusive', () => {
+  it('missing probedKey → { outcome: inconclusive, registered: null }', () => {
     const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }));
-    expect(c).toEqual({ outcome: 'inconclusive', registered: null, dead: false, hasBudget: true });
+    expect(c).toEqual({ outcome: 'inconclusive', registered: null });
   });
 });

--- a/packages/node-ui/test/pca-coverage.test.ts
+++ b/packages/node-ui/test/pca-coverage.test.ts
@@ -5,7 +5,7 @@
 // pins the extracted pure functions so the surfaces can't re-diverge.
 
 import { describe, expect, it } from 'vitest';
-import { bigGt0, isPcaSpendable, normalizeProbeRegistered, coverageForProbe } from '../src/ui/pca/coverage.js';
+import { bigGt0, isPcaSpendable, normalizeProbeRegistered, classifyCoverage } from '../src/ui/pca/coverage.js';
 import { makePcaSnapshot } from '../src/ui/mocks/pca.js';
 
 const FUTURE = Math.floor(Date.now() / 1000) + 60 * 86_400;
@@ -64,32 +64,32 @@ describe('normalizeProbeRegistered', () => {
   });
 });
 
-describe('coverageForProbe', () => {
-  it('registered + spendable → covers', () => {
-    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: true });
-    expect(c).toEqual({ registered: true, inconclusive: false, covers: true });
+describe('classifyCoverage', () => {
+  it('registered + spendable → covers (full PcaCoverageResult)', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: true });
+    expect(c).toEqual({ registered: true, inconclusive: false, covers: true, dead: false, hasBudget: true });
   });
-  it('registered + expired → registered but does NOT cover', () => {
-    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: PAST }), { key: '0x', registered: true });
-    expect(c).toEqual({ registered: true, inconclusive: false, covers: false });
+  it('registered + expired → registered + dead, does NOT cover', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: PAST }), { key: '0x', registered: true });
+    expect(c).toEqual({ registered: true, inconclusive: false, covers: false, dead: true, hasBudget: true });
   });
-  it('registered + zero-budget → does NOT cover', () => {
-    const c = coverageForProbe(
+  it('registered + zero-budget → hasBudget false, does NOT cover', () => {
+    const c = classifyCoverage(
       makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE }),
       { key: '0x', registered: true },
     );
-    expect(c.covers).toBe(false);
+    expect(c).toEqual({ registered: true, inconclusive: false, covers: false, dead: false, hasBudget: false });
   });
   it('registered:false → not covering, not inconclusive', () => {
-    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false });
-    expect(c).toEqual({ registered: false, inconclusive: false, covers: false });
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false });
+    expect(c).toEqual({ registered: false, inconclusive: false, covers: false, dead: false, hasBudget: true });
   });
   it('adapterSupported:false → inconclusive, never covers', () => {
-    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false, adapterSupported: false });
-    expect(c).toEqual({ registered: null, inconclusive: true, covers: false });
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false, adapterSupported: false });
+    expect(c).toEqual({ registered: null, inconclusive: true, covers: false, dead: false, hasBudget: true });
   });
   it('missing probedKey → inconclusive', () => {
-    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), undefined);
-    expect(c).toEqual({ registered: null, inconclusive: true, covers: false });
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), undefined);
+    expect(c).toEqual({ registered: null, inconclusive: true, covers: false, dead: false, hasBudget: true });
   });
 });

--- a/packages/node-ui/test/pca-coverage.test.ts
+++ b/packages/node-ui/test/pca-coverage.test.ts
@@ -65,31 +65,30 @@ describe('normalizeProbeRegistered', () => {
 });
 
 describe('classifyCoverage', () => {
-  it('registered + spendable → covers (full PcaCoverageResult)', () => {
-    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: true });
-    expect(c).toEqual({ registered: true, inconclusive: false, covers: true, dead: false, hasBudget: true });
+  it('registered + spendable → outcome covers (single-input; reads snap.probedKey)', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: true } }));
+    expect(c).toEqual({ outcome: 'covers', registered: true, dead: false, hasBudget: true });
   });
-  it('registered + expired → registered + dead, does NOT cover', () => {
-    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: PAST }), { key: '0x', registered: true });
-    expect(c).toEqual({ registered: true, inconclusive: false, covers: false, dead: true, hasBudget: true });
+  it('registered + expired → outcome uncovered, dead:true (the reviewer’s example facet)', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: PAST, probedKey: { key: '0x', registered: true } }));
+    expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: true, hasBudget: true });
   });
-  it('registered + zero-budget → hasBudget false, does NOT cover', () => {
+  it('registered + zero-budget → outcome uncovered, hasBudget:false (dead+zero-budget reason facet)', () => {
     const c = classifyCoverage(
-      makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE }),
-      { key: '0x', registered: true },
+      makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: true } }),
     );
-    expect(c).toEqual({ registered: true, inconclusive: false, covers: false, dead: false, hasBudget: false });
+    expect(c).toEqual({ outcome: 'uncovered', registered: true, dead: false, hasBudget: false });
   });
-  it('registered:false → not covering, not inconclusive', () => {
-    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false });
-    expect(c).toEqual({ registered: false, inconclusive: false, covers: false, dead: false, hasBudget: true });
+  it('registered:false → outcome unregistered', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: false } }));
+    expect(c).toEqual({ outcome: 'unregistered', registered: false, dead: false, hasBudget: true });
   });
-  it('adapterSupported:false → inconclusive, never covers', () => {
-    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false, adapterSupported: false });
-    expect(c).toEqual({ registered: null, inconclusive: true, covers: false, dead: false, hasBudget: true });
+  it('adapterSupported:false → outcome inconclusive, never covers', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE, probedKey: { key: '0x', registered: false, adapterSupported: false } }));
+    expect(c).toEqual({ outcome: 'inconclusive', registered: null, dead: false, hasBudget: true });
   });
-  it('missing probedKey → inconclusive', () => {
-    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), undefined);
-    expect(c).toEqual({ registered: null, inconclusive: true, covers: false, dead: false, hasBudget: true });
+  it('missing probedKey → outcome inconclusive', () => {
+    const c = classifyCoverage(makePcaSnapshot({ expiresAtTimestamp: FUTURE }));
+    expect(c).toEqual({ outcome: 'inconclusive', registered: null, dead: false, hasBudget: true });
   });
 });

--- a/packages/node-ui/test/pca-coverage.test.ts
+++ b/packages/node-ui/test/pca-coverage.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+//
+// #1344 — exhaustive matrix on the shared coverage leaf rules (the ones that drifted
+// across C1/O4/Q2/S2/U2/V3). The hooks/components keep their own aggregation; this
+// pins the extracted pure functions so the surfaces can't re-diverge.
+
+import { describe, expect, it } from 'vitest';
+import { bigGt0, isPcaSpendable, normalizeProbeRegistered, coverageForProbe } from '../src/ui/pca/coverage.js';
+import { makePcaSnapshot } from '../src/ui/mocks/pca.js';
+
+const FUTURE = Math.floor(Date.now() / 1000) + 60 * 86_400;
+const PAST = Math.floor(Date.now() / 1000) - 86_400;
+
+describe('bigGt0', () => {
+  it('treats positive wei strings as true; everything else false', () => {
+    expect(bigGt0('1')).toBe(true);
+    expect(bigGt0('850000000000000000000')).toBe(true);
+    expect(bigGt0('0')).toBe(false);
+    expect(bigGt0(undefined)).toBe(false);
+    expect(bigGt0('')).toBe(false);
+    expect(bigGt0('not-a-number')).toBe(false);
+  });
+});
+
+describe('isPcaSpendable', () => {
+  it('expired → false', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ expiresAtTimestamp: PAST }))).toBe(false);
+  });
+  it('fully swept → false', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ fullySwept: true }))).toBe(false);
+  });
+  it('zero budget (both 0), not swept/expired → false', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE }))).toBe(false);
+  });
+  it('topUpBuffer-only → true', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ topUpBuffer: '1', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE }))).toBe(true);
+  });
+  it('baseEpochAllowance-only → true (the capstone L2 case)', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '1', expiresAtTimestamp: FUTURE }))).toBe(true);
+  });
+  it('healthy + both budgets → true', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ expiresAtTimestamp: FUTURE }))).toBe(true);
+  });
+  it('expired beats budget (excluded even with budget)', () => {
+    expect(isPcaSpendable(makePcaSnapshot({ expiresAtTimestamp: PAST, topUpBuffer: '1', baseEpochAllowance: '1' }))).toBe(false);
+  });
+});
+
+describe('normalizeProbeRegistered', () => {
+  it('registered true / false pass through', () => {
+    expect(normalizeProbeRegistered({ key: '0x', registered: true })).toBe(true);
+    expect(normalizeProbeRegistered({ key: '0x', registered: false })).toBe(false);
+  });
+  it('adapterSupported:false → null (couldn’t determine), even with registered:false', () => {
+    expect(normalizeProbeRegistered({ key: '0x', registered: false, adapterSupported: false })).toBeNull();
+    expect(normalizeProbeRegistered({ key: '0x', adapterSupported: false })).toBeNull();
+  });
+  it('undefined probedKey / undefined registered → null', () => {
+    expect(normalizeProbeRegistered(undefined)).toBeNull();
+    expect(normalizeProbeRegistered({ key: '0x' })).toBeNull();
+  });
+  it('registered true with adapterSupported true → true', () => {
+    expect(normalizeProbeRegistered({ key: '0x', registered: true, adapterSupported: true })).toBe(true);
+  });
+});
+
+describe('coverageForProbe', () => {
+  it('registered + spendable → covers', () => {
+    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: true });
+    expect(c).toEqual({ registered: true, inconclusive: false, covers: true });
+  });
+  it('registered + expired → registered but does NOT cover', () => {
+    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: PAST }), { key: '0x', registered: true });
+    expect(c).toEqual({ registered: true, inconclusive: false, covers: false });
+  });
+  it('registered + zero-budget → does NOT cover', () => {
+    const c = coverageForProbe(
+      makePcaSnapshot({ topUpBuffer: '0', baseEpochAllowance: '0', expiresAtTimestamp: FUTURE }),
+      { key: '0x', registered: true },
+    );
+    expect(c.covers).toBe(false);
+  });
+  it('registered:false → not covering, not inconclusive', () => {
+    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false });
+    expect(c).toEqual({ registered: false, inconclusive: false, covers: false });
+  });
+  it('adapterSupported:false → inconclusive, never covers', () => {
+    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), { key: '0x', registered: false, adapterSupported: false });
+    expect(c).toEqual({ registered: null, inconclusive: true, covers: false });
+  });
+  it('missing probedKey → inconclusive', () => {
+    const c = coverageForProbe(makePcaSnapshot({ expiresAtTimestamp: FUTURE }), undefined);
+    expect(c).toEqual({ registered: null, inconclusive: true, covers: false });
+  });
+});

--- a/packages/node-ui/test/pca-mocks.test.ts
+++ b/packages/node-ui/test/pca-mocks.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, expect, it } from 'vitest';
 import { PCA_FIXTURES, MOCK_COST_COVERED } from '../src/ui/mocks/pca.js';
-import { healthForSnapshot, convictionDiscountBps } from '../src/ui/components/Pca/index.js';
+import { convictionDiscountBps } from '../src/ui/components/Pca/index.js';
+import { healthForSnapshot } from '../src/ui/pca/health.js';
 
 describe('PCA fixtures', () => {
   it('each fixture derives its intended HealthChip state', () => {

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -211,6 +211,29 @@ describe('PublishEligibilityChip (S5)', () => {
     await unmount();
   });
 
+  // C1 — `dead` and out-of-budget are INDEPENDENT reason facets: an account that
+  // is BOTH expired AND zero-budget must surface BOTH reasons in the popover (the
+  // two independent `if`s in usePublishEligibility fire), not just one.
+  it('C1: an expired AND out-of-budget approved account surfaces BOTH reasons', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('50')); // gas+TRAC → amber fall-through
+    const deadBroke = makePcaSnapshot({
+      expiresAtTimestamp: Math.floor(Date.now() / 1000) - 86_400, // expired
+      topUpBuffer: '0',
+      topUpBufferTrac: '0',
+      baseEpochAllowance: '0', // out of budget
+    });
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...deadBroke, probedKey: { key, registered: true } } : deadBroke,
+    );
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'No PCA discount'); // amber (wallet has TRAC)
+    const why = container.querySelector('.v10-pca-verdict-why') as HTMLButtonElement;
+    await act(async () => { why.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'expired or been fully swept');
+    expect(container.textContent).toContain('out of budget'); // BOTH independent facets surfaced
+    await unmount();
+  });
+
   // #3 — an approved wallet on a swept/expired PCA is uncovered via HEALTH (not
   // solvency), and reads "approved … but swept", never a misleading "no PCA".
   it('an approved wallet on a SWEPT PCA reads "approved … but swept", not "no PCA" (#3)', async () => {

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -149,6 +149,21 @@ describe('PublishEligibilityChip (S5)', () => {
     await unmount();
   });
 
+  // V1/#1344/#9 — routing S5 registration through the shared normalizer means an
+  // OMITTED registered (undefined) is now inconclusive ("couldn't determine"), not a
+  // confirmed not-registered → resolves NEUTRAL, never a DANGER. (Now matches overview/S6.)
+  it('V1 — a probedKey with registered OMITTED resolves NEUTRAL, not DANGER', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('0')); // gas-funded, no TRAC
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...makePcaSnapshot(), probedKey: { key } } : makePcaSnapshot(), // registered OMITTED
+    );
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'PCA status unknown');
+    expect(container.querySelector('[data-verdict="fallthrough-no-funds"]')).toBeNull();
+    expect(container.querySelector('[data-verdict="unknown"]')).toBeTruthy();
+    await unmount();
+  });
+
   // L1 — when wallets are covered by DIFFERENT PCAs, the GREEN chip advertises the
   // MAX covering discount (matching bestCoveringDiscountBps), not covered[0].
   it('GREEN advertises the MAX covering discount across wallets on different PCAs (L1)', async () => {


### PR DESCRIPTION
Consolidates the PCA coverage/inconclusive/spendability model into one shared module so the four surfaces can't drift again. **Closes #1344.**

### Why
PR #1343's review surfaced the same coverage rule re-implemented across `usePublishEligibility`, `usePcaOverview`, `GetSponsoredPanel` (and the bell via the overview), and successive rounds (C1/O4/Q2/S2/U2/V3) kept finding *interactions* between those copies — culminating in V3, two earlier fixes colliding. This extracts the load-bearing leaf rules into one place so a change is made (and tested) once.

### What — a **pure, byte-identical** refactor
Into `src/ui/pca/coverage.ts` (alongside the existing `bigGt0`):
- `isPcaSpendable(snap)` — the coarse P0 proxy: `health !== expired/swept && (bigGt0(topUpBuffer) || bigGt0(baseEpochAllowance))`. **Not** `remainingAllowance` (that's the P2 extended snapshot → #1349).
- `normalizeProbeRegistered(probedKey)` — the S2 rule: `adapterSupported === false` ⇒ `null` ("couldn't determine", not a confirmed not-registered); else `registered ?? null`.
- `coverageForProbe(snap, probedKey)` ⇒ `{ registered, inconclusive, covers }`.

Each surface keeps its **own** iteration / aggregation / verdict — only the leaf rules moved:
- **`usePublishEligibility`** sources the cover decision from `isPcaSpendable`; the verdict logic (gas-aware GREEN, funding-aware fall-through, `balanceUnknown`, mixed-inconclusive→`unknown`) and the dead-vs-out-of-budget breakdown are untouched. (Its `adapterSupported`/`!registered` checks are kept inline on purpose — S5's `!registered` treats *undefined* as a skip while overview/S6 treat it as inconclusive; preserving that keeps the diff strictly byte-identical.)
- **`usePcaOverview`** uses `normalizeProbeRegistered` + the `isPcaSpendable` filter in `bestCoveringDiscountBps`/`covered`.
- **`GetSponsoredPanel`** uses `coverageForProbe`.

### Proof it's behavior-preserving
- **Every existing** `usePublishEligibility` / `usePcaOverview` / `GetSponsoredPanel` / component / bell test passes **unchanged**.
- New `pca-coverage.test.ts` — exhaustive matrix on the pure fns (registered true/false/null, `adapterSupported:false`, expired, swept, zero-budget, topUpBuffer-only, baseEpochAllowance-only).
- New `pca-coverage-parity.test.ts` — **anti-drift**: one shared fixture through the resolver, asserting S5 / S6 / overview classify it identically (registered+spendable → all cover; `adapterSupported:false` → all inconclusive, never a false DANGER; zero-budget approved → registered but none covers).
- Full node-ui suite **1667 passed / 38 skipped / 0 failed**; `tsc --noEmit` clean. Frontend-only — no daemon change.

### Scope
First of the chained sub-PRs into the `feat/pca-node-ui` integration branch (#1343). Out of scope by design: precise mid-epoch `remainingAllowance` (#1349), the api-module split (#1345), and the poller/store extraction (part of the broader #1344 follow-through if pursued) — this PR is the coverage-model consolidation only.
