### PR TITLE
feat(pca): P1 — live approved-wallet table (B3), cross-PCA conflict (B10), agent→account discovery (GAP-3)

### DIFF
--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1518,6 +1518,15 @@ export class AgentRegistryMethods extends DKGAgentBase {
     return this.chain.getPublishingConvictionAccountInfo(accountId);
   }
 
+  /** Enumerate registered publishing agents (operational wallets) for a PCA.
+   *  `null` when the adapter lacks the surface (daemon maps null → 503). */
+  async getPublishingConvictionAgents(this: DKGAgent,
+    accountId: bigint,
+  ): Promise<string[] | null> {
+    if (typeof this.chain.getPublishingConvictionAgents !== 'function') return null;
+    return this.chain.getPublishingConvictionAgents(accountId);
+  }
+
   // ---------------------------------------------------------------------------
 
   /**

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1527,6 +1527,17 @@ export class AgentRegistryMethods extends DKGAgentBase {
     return this.chain.getPublishingConvictionAgents(accountId);
   }
 
+  /** Reverse-resolve which PCA a wallet is a registered publishing agent of,
+   *  via the on-chain `agentToAccountId` map. `0n` = not registered on any
+   *  account; `null` = adapter lacks the surface (daemon maps null → 503).
+   *  Chain-scoped DISCOVERY (may surface an account the node does not track);
+   *  callers route the id through coverage classification, never treating
+   *  "registered" as "covered". */
+  async getConvictionAgentAccountId(this: DKGAgent, agent: string): Promise<bigint | null> {
+    if (typeof this.chain.getConvictionAgentAccountId !== 'function') return null;
+    return this.chain.getConvictionAgentAccountId(agent);
+  }
+
   // ---------------------------------------------------------------------------
 
   /**

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1533,9 +1533,13 @@ export class AgentRegistryMethods extends DKGAgentBase {
    *  Chain-scoped DISCOVERY (may surface an account the node does not track);
    *  callers route the id through coverage classification, never treating
    *  "registered" as "covered". */
-  async getConvictionAgentAccountId(this: DKGAgent, agent: string): Promise<bigint | null> {
+  async getConvictionAgentAccountId(
+    this: DKGAgent,
+    agent: string,
+    opts?: { strict?: boolean },
+  ): Promise<bigint | null> {
     if (typeof this.chain.getConvictionAgentAccountId !== 'function') return null;
-    return this.chain.getConvictionAgentAccountId(agent);
+    return this.chain.getConvictionAgentAccountId(agent, opts);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -42,4 +42,19 @@ describe('DKGAgent V10 PCA facade', () => {
     const agent = await makeAgent(new NoChainAdapter());
     expect(agent.supportsPublishingConvictionNft).toBe(false);
   });
+
+  it('getPublishingConvictionAgents delegates to the adapter (checksummed list)', async () => {
+    const owner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', owner.address);
+    const agent = await makeAgent(chain);
+    const created = await agent.createPublishingConvictionAccount(1_000n, 42n);
+    const wallet = ethers.Wallet.createRandom().address;
+    await agent.registerPublishingConvictionAgent(created!.accountId, wallet);
+    expect(await agent.getPublishingConvictionAgents(created!.accountId)).toEqual([ethers.getAddress(wallet)]);
+  });
+
+  it('getPublishingConvictionAgents returns null when the adapter lacks the surface', async () => {
+    const agent = await makeAgent(new NoChainAdapter());
+    expect(await agent.getPublishingConvictionAgents(1n)).toBeNull();
+  });
 });

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -57,4 +57,21 @@ describe('DKGAgent V10 PCA facade', () => {
     const agent = await makeAgent(new NoChainAdapter());
     expect(await agent.getPublishingConvictionAgents(1n)).toBeNull();
   });
+
+  it('getConvictionAgentAccountId delegates: registered wallet → its account id, unregistered → 0n', async () => {
+    const owner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', owner.address);
+    const agent = await makeAgent(chain);
+    const created = await agent.createPublishingConvictionAccount(1_000n, 42n);
+    const wallet = ethers.Wallet.createRandom().address;
+    await agent.registerPublishingConvictionAgent(created!.accountId, wallet);
+    expect(await agent.getConvictionAgentAccountId(wallet)).toBe(created!.accountId);
+    // Unregistered wallet → 0n (the chain "not registered" sentinel), not null.
+    expect(await agent.getConvictionAgentAccountId(ethers.Wallet.createRandom().address)).toBe(0n);
+  });
+
+  it('getConvictionAgentAccountId returns null when the adapter lacks the surface', async () => {
+    const agent = await makeAgent(new NoChainAdapter());
+    expect(await agent.getConvictionAgentAccountId(ethers.Wallet.createRandom().address)).toBeNull();
+  });
 });

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -916,6 +916,14 @@ export interface ChainAdapter {
   getPublishingConvictionAccountInfo?(accountId: bigint): Promise<V10PublishingConvictionAccountInfo | null>;
 
   /**
+   * Enumerate the operational wallets registered as publishing agents on
+   * `accountId` (mirrors `getRegisteredAgents`). Checksummed addresses;
+   * `[]` when the account has none or the NFT is undeployed. Optional —
+   * adapters that omit it surface as "no agent enumeration" (daemon → 503).
+   */
+  getPublishingConvictionAgents?(accountId: bigint): Promise<string[]>;
+
+  /**
    * Sign an arbitrary message hash using the node's primary operational key.
    * Used for self-signing as receiver or context graph participant.
    */

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -872,7 +872,7 @@ export interface ChainAdapter {
    * don't model PCA registration can omit the implementation. The
    * publisher gracefully treats `undefined` as "no PCA path active".
    */
-  getConvictionAgentAccountId?(agent: string): Promise<bigint>;
+  getConvictionAgentAccountId?(agent: string, opts?: { strict?: boolean }): Promise<bigint>;
 
   /**
    * Returns the V10 NFT-backed PCA's `lockDurationEpochs` for the given

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -380,4 +380,33 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       throw err;
     }
   }
+
+  /**
+   * Enumerate every publishing agent (operational wallet) currently
+   * registered to `accountId`, mirroring
+   * `PublishingConvictionStorage.getRegisteredAgents` (surfaced via the
+   * `DKGPublishingConvictionNFT` wrapper). The on-chain view already
+   * returns checksummed addresses; normalize defensively so callers (and
+   * the daemon's approved-wallet table) always get EIP-55 form.
+   *
+   * Returns `[]` when the NFT contract is not deployed, the id is
+   * non-positive, or the chain call reverts (e.g. unknown account). The
+   * daemon route runs its own existence check via
+   * `getPublishingConvictionAccountInfo` first, so once that passes a `[]`
+   * here means "account exists, no agents registered".
+   */
+  async getPublishingConvictionAgents(accountId: bigint): Promise<string[]> {
+    await this.init();
+    if (!this.contracts.dkgPublishingConvictionNFT) return [];
+    if (accountId <= 0n) return [];
+    try {
+      const raw: string[] = await this.readContract(
+        this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getRegisteredAgents', 'getRegisteredAgents', accountId,
+      );
+      return (raw ?? []).map((a) => ethers.getAddress(a));
+    } catch (err: any) {
+      if (err?.code === 'CALL_EXCEPTION') return [];
+      throw err;
+    }
+  }
 }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -34,9 +34,19 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    * deployed on this chain, the address is malformed, or the chain
    * call fails — callers treat the unknown case as "no PCA path".
    */
-  async getConvictionAgentAccountId(agent: string): Promise<bigint> {
+  async getConvictionAgentAccountId(
+    agent: string,
+    opts?: { strict?: boolean },
+  ): Promise<bigint> {
     await this.init();
-    if (!this.contracts.dkgPublishingConvictionNFT) return 0n;
+    if (!this.contracts.dkgPublishingConvictionNFT) {
+      // Selector fail-safe: "no PCA contract on this chain" → "no PCA path"
+      // (0n), so publishing stays on direct-spend. The discovery path (strict)
+      // surfaces it instead, so the daemon answers 503 rather than letting a UI
+      // read "unavailable" as "registered nowhere".
+      if (opts?.strict) throw new PcaUnavailableError();
+      return 0n;
+    }
     if (!ethers.isAddress(agent)) return 0n;
     try {
       const id: bigint = await this.readContract(
@@ -44,7 +54,13 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       );
       return BigInt(id);
     } catch (err: any) {
-      if (err?.code === 'CALL_EXCEPTION') return 0n;
+      // `agentToAccountId` is a plain mapping getter — it returns 0 (NOT a
+      // revert) for an unregistered address, so a CALL_EXCEPTION here is a real
+      // read failure, never a normal "unregistered". The selector fail-safe
+      // masks it as 0n (publish at full price, safe); the discovery path
+      // (strict) rethrows so a transient blip stays inconclusive instead of
+      // flipping a covered wallet to a confirmed "registered nowhere".
+      if (err?.code === 'CALL_EXCEPTION' && !opts?.strict) return 0n;
       throw err;
     }
   }

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -405,24 +405,23 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    * returns checksummed addresses; normalize defensively so callers (and
    * the daemon's approved-wallet table) always get EIP-55 form.
    *
-   * Returns `[]` when the NFT contract is not deployed, the id is
-   * non-positive, or the chain call reverts (e.g. unknown account). The
-   * daemon route runs its own existence check via
-   * `getPublishingConvictionAccountInfo` first, so once that passes a `[]`
-   * here means "account exists, no agents registered".
+   * Discovery-only (no funded-wallet-selector caller), so it does NOT
+   * fail-safe a read error to `[]`: `getRegisteredAgents` is reached only
+   * AFTER the daemon route's existence/capability gate
+   * (`getPublishingConvictionAccountInfo`), so a CALL_EXCEPTION here is a real
+   * read failure (stale binding / RPC), never a "missing account". Surfacing
+   * it lets the route answer 503 — a transient blip must not read as a
+   * confirmed empty list ("no approved wallets"), the same #9 honesty rule as
+   * the strict GAP-3 lookup. A healthy empty read still returns `[]`. The
+   * undeployed / non-positive-id guards are defensive (the route gates both).
    */
   async getPublishingConvictionAgents(accountId: bigint): Promise<string[]> {
     await this.init();
     if (!this.contracts.dkgPublishingConvictionNFT) return [];
     if (accountId <= 0n) return [];
-    try {
-      const raw: string[] = await this.readContract(
-        this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getRegisteredAgents', 'getRegisteredAgents', accountId,
-      );
-      return (raw ?? []).map((a) => ethers.getAddress(a));
-    } catch (err: any) {
-      if (err?.code === 'CALL_EXCEPTION') return [];
-      throw err;
-    }
+    const raw: string[] = await this.readContract(
+      this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getRegisteredAgents', 'getRegisteredAgents', accountId,
+    );
+    return (raw ?? []).map((a) => ethers.getAddress(a));
   }
 }

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -653,6 +653,14 @@ export class MockChainAdapter implements ChainAdapter {
     return acct.agents.has(ethers.getAddress(agent).toLowerCase());
   }
 
+  /** Mirrors `getRegisteredAgents`. Keys are stored lowercased, so
+   *  checksum-normalize on the way out to match the on-chain view. */
+  async getPublishingConvictionAgents(accountId: bigint): Promise<string[]> {
+    const acct = this.convictionAccounts.get(accountId);
+    if (!acct) return [];
+    return [...acct.agents].map((k) => ethers.getAddress(k));
+  }
+
   /** Mirrors `agentToAccountId`; `0n` for unregistered → publisher SDK
    *  stays on direct-spend until an agent is registered. */
   async getConvictionAgentAccountId(agent: string): Promise<bigint> {

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -113,6 +113,22 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
     await expect(mock.registerPublishingConvictionAgent(accountId, agent))
       .rejects.toThrow(/AgentAlreadyRegistered/);
   });
+
+  it('getPublishingConvictionAgents enumerates checksummed addresses and returns [] for missing/empty (B3 parity)', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    expect(await mock.getPublishingConvictionAgents(999n)).toEqual([]); // missing account
+
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+    expect(await mock.getPublishingConvictionAgents(accountId)).toEqual([]); // exists, no agents
+
+    // Mock stores keys lowercased; register a LOWERCASE address and assert the
+    // enumerator checksum-normalizes to match the on-chain address[] view.
+    const checksummed = ethers.getAddress('0x' + 'ab'.repeat(20));
+    await mock.registerPublishingConvictionAgent(accountId, checksummed.toLowerCase());
+    const agents = await mock.getPublishingConvictionAgents(accountId);
+    expect(agents).toEqual([checksummed]);
+    expect(agents[0]).not.toBe(checksummed.toLowerCase()); // EIP-55, not lowercased
+  });
 });
 
 describe('MockChainAdapter — V10 conviction topUp/settle', () => {

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -88,6 +88,27 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(await owner.getConvictionAgentAccountId(agent)).toBe(0n);
   });
 
+  it('getConvictionAgentAccountId strict mode: healthy reads resolve normally; undeployed NFT surfaces (PcaUnavailableError) instead of fail-safe 0n', async () => {
+    const owner = await fundedOwner();
+    const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);
+    const wallet = ethers.Wallet.createRandom().address;
+    await owner.registerPublishingConvictionAgent(accountId, wallet);
+
+    // Healthy read: strict returns the same on-chain truth as the fail-safe path.
+    expect(await owner.getConvictionAgentAccountId(wallet, { strict: true })).toBe(accountId);
+    expect(await owner.getConvictionAgentAccountId(ethers.Wallet.createRandom().address, { strict: true })).toBe(0n);
+
+    // Undeployed NFT: the discovery (strict) path SURFACES it so the daemon can
+    // answer 503 — never a 0n a UI would read as "registered nowhere". init() is
+    // idempotent (`if (this.initialized) return`), so clearing the cached
+    // binding after init holds for the next call.
+    (owner as any).contracts.dkgPublishingConvictionNFT = undefined;
+    await expect(owner.getConvictionAgentAccountId(wallet, { strict: true }))
+      .rejects.toMatchObject({ code: 'PCA_UNAVAILABLE' });
+    // The funded-wallet-selector fail-safe path still returns 0n for the same state.
+    expect(await owner.getConvictionAgentAccountId(wallet)).toBe(0n);
+  });
+
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -88,6 +88,32 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(await owner.getConvictionAgentAccountId(agent)).toBe(0n);
   });
 
+  it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
+    const owner = await fundedOwner();
+    const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);
+    expect(await owner.getPublishingConvictionAgents(accountId)).toEqual([]);
+
+    const a1 = ethers.Wallet.createRandom().address;
+    const a2 = ethers.Wallet.createRandom().address;
+    // Register a1 in lowercased form to prove normalization is input-agnostic.
+    await owner.registerPublishingConvictionAgent(accountId, a1.toLowerCase());
+    await owner.registerPublishingConvictionAgent(accountId, a2);
+
+    const agents = await owner.getPublishingConvictionAgents(accountId);
+    expect(agents).toHaveLength(2);
+    expect(agents).toEqual(expect.arrayContaining([ethers.getAddress(a1), ethers.getAddress(a2)]));
+    // EIP-55 checksummed (the on-chain address[] view), regardless of input case.
+    for (const a of agents) expect(a).toBe(ethers.getAddress(a));
+
+    await owner.deregisterPublishingConvictionAgent(accountId, a1);
+    expect(await owner.getPublishingConvictionAgents(accountId)).toEqual([ethers.getAddress(a2)]);
+  });
+
+  it('getPublishingConvictionAgents returns [] for a nonexistent account', async () => {
+    const owner = await fundedOwner();
+    expect(await owner.getPublishingConvictionAgents(999999n)).toEqual([]);
+  });
+
   it('owner topUpPublishingConvictionAccount + settlePublishingConvictionAccount succeed and topUpBuffer updates', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -70,6 +70,34 @@ function classifyPcaRevert(msg: string): { status: number; error: string } | nul
   return null;
 }
 
+// B10: resolve WHICH account already holds `agentAddr` for an
+// AgentAlreadyRegistered conflict, so the UI can deep-link ("approved on
+// PCA #N — deregister it there first"). Primary: the decoded revert arg —
+// `enrichEvmError` (run on every pcaWrite) sets `err.revert.args` from
+// AgentAlreadyRegistered(agent, existingAccountId). Fallback: some RPCs strip
+// revert data, so resolve via the on-chain reverse map. NEVER throws — a
+// failed lookup must not mask the 409; it just omits `existingAccountId`.
+// Returns the id string only when resolvable and > 0n.
+async function resolveConflictingAccountId(
+  err: any,
+  agentAddr: string,
+  agent: { getConvictionAgentAccountId(agent: string, opts?: { strict?: boolean }): Promise<bigint | null> },
+): Promise<string | undefined> {
+  let existing: bigint | null = null;
+  const rv: any = err?.revert;
+  if (rv?.name === 'AgentAlreadyRegistered') {
+    const raw = rv.args?.existingAccountId ?? rv.args?.[1];
+    if (raw != null) { try { existing = BigInt(raw); } catch { /* unparseable arg */ } }
+  }
+  if (existing == null || existing <= 0n) {
+    try {
+      const viaMap = await agent.getConvictionAgentAccountId(agentAddr);
+      if (viaMap != null && viaMap > 0n) existing = viaMap;
+    } catch { /* reverse-map fallback is best-effort; never mask the 409 */ }
+  }
+  return existing != null && existing > 0n ? existing.toString() : undefined;
+}
+
 function parseAccountId(idStr: string): bigint | null {
   if (!/^\d+$/.test(idStr)) return null;
   try {
@@ -252,26 +280,8 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
       if (revert) {
         const body: Record<string, unknown> = { error: revert.error, accountId: idStr };
         if (revert.error === 'AgentAlreadyRegistered') {
-          // B10: surface WHICH account already holds this wallet so the UI can
-          // deep-link ("approved on PCA #N — deregister it there first").
-          // Primary: the decoded revert arg — `enrichEvmError` (run on every
-          // pcaWrite) sets `err.revert.args` from AgentAlreadyRegistered(agent,
-          // existingAccountId). Fallback: some RPCs strip revert data, so
-          // resolve via the on-chain reverse map. Both are wrapped so a failed
-          // lookup never masks the 409.
-          let existing: bigint | null = null;
-          const rv: any = (err as any)?.revert;
-          if (rv?.name === 'AgentAlreadyRegistered') {
-            const raw = rv.args?.existingAccountId ?? rv.args?.[1];
-            if (raw != null) { try { existing = BigInt(raw); } catch { /* unparseable arg */ } }
-          }
-          if (existing == null || existing <= 0n) {
-            try {
-              const viaMap = await agent.getConvictionAgentAccountId(agentAddr);
-              if (viaMap != null && viaMap > 0n) existing = viaMap;
-            } catch { /* reverse-map fallback is best-effort; never mask the 409 */ }
-          }
-          if (existing != null && existing > 0n) body.existingAccountId = existing.toString();
+          const existingAccountId = await resolveConflictingAccountId(err, agentAddr, agent);
+          if (existingAccountId) body.existingAccountId = existingAccountId;
         }
         return jsonResponse(res, revert.status, body);
       }

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -366,6 +366,36 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     }
   }
 
+  // GET /api/pca/agent/:address — reverse-lookup which PCA a wallet is a
+  // registered publishing agent of (GAP-3, for S5/S6 discovery). Returns the
+  // bare on-chain `agentToAccountId` fact (may be an account this node does
+  // NOT track — that is the point for edge discovery); the UI routes the id
+  // through coverage classification, never treating "registered" as "covered".
+  // Two-segment path: no collision with the generic GET :id, but declared
+  // ahead of it for explicit ordering.
+  if (req.method === 'GET' && /^\/api\/pca\/agent\/[^/]+$/.test(path)) {
+    const addr = decodeURIComponent(path.split('/')[4] ?? '');
+    if (!ethers.isAddress(addr)) {
+      return jsonResponse(res, 400, { error: 'address must be a valid 0x-prefixed EVM address' });
+    }
+    try {
+      const accountId = await agent.getConvictionAgentAccountId(addr);
+      if (accountId === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      return jsonResponse(res, 200, {
+        agent: ethers.getAddress(addr),
+        accountId: accountId > 0n ? accountId.toString() : null,
+      });
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (respondIfChainRpcTransportError(res, err)) return;
+      return jsonResponse(res, 500, {
+        error: `getConvictionAgentAccountId failed: ${msg}`,
+      });
+    }
+  }
+
   // GET /api/pca/:id/agents — enumerate the operational wallets registered
   // as publishing agents on this PCA (B3). Mirrors the GET :id existence
   // check first, so an unknown account is a 404 (not an empty list): a 200

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -366,6 +366,45 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     }
   }
 
+  // GET /api/pca/:id/agents — enumerate the operational wallets registered
+  // as publishing agents on this PCA (B3). Mirrors the GET :id existence
+  // check first, so an unknown account is a 404 (not an empty list): a 200
+  // with `agents: []` means the account EXISTS but has no approved wallets.
+  // Declared before the generic GET :id below (it matches single-segment ids
+  // only, but the explicit ordering keeps the two-segment route unambiguous).
+  if (req.method === 'GET' && /^\/api\/pca\/[^/]+\/agents$/.test(path)) {
+    const idStr = decodeURIComponent(path.split('/')[3] ?? '');
+    const accountId = parseAccountId(idStr);
+    if (accountId === null) {
+      return jsonResponse(res, 400, { error: 'Invalid accountId — must be a non-negative integer' });
+    }
+    try {
+      // Existence gate (mirror GET :id): null = view absent OR account
+      // missing; the facade capability signal disambiguates 503 vs 404.
+      const info = await agent.getPublishingConvictionAccountInfo(accountId);
+      if (info === null) {
+        if (!agent.supportsPublishingConvictionNft) {
+          return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+        }
+        return jsonResponse(res, 404, { error: `Unknown PCA accountId ${idStr}` });
+      }
+      const agents = await agent.getPublishingConvictionAgents(accountId);
+      // getInfo succeeded but the adapter lacks the enumerator → capability gap.
+      if (agents === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      return jsonResponse(res, 200, { accountId: idStr, agents });
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (respondIfChainRpcTransportError(res, err)) return;
+      const revert = classifyPcaRevert(msg);
+      if (revert) return jsonResponse(res, revert.status, { error: revert.error, accountId: idStr });
+      return jsonResponse(res, 500, {
+        error: `getPublishingConvictionAgents failed: ${msg}`,
+      });
+    }
+  }
+
   // GET /api/pca/:id — V10 conviction NFT snapshot. Optional ?key=0x...
   // probes whether that address is a registered agent.
   if (req.method === 'GET' && /^\/api\/pca\/[^/]+$/.test(path)) {

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -482,6 +482,15 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
       if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       if (respondIfChainRpcTransportError(res, err)) return;
+      // A CALL_EXCEPTION here is a real enumerator read failure (the route's
+      // existence gate already ran, so the account exists) → 503 retryable, NOT
+      // a 200 [] the UI would read as a confirmed "no approved wallets" (#9).
+      if (err?.code === 'CALL_EXCEPTION') {
+        return jsonResponse(res, 503, {
+          error: 'PCA agent enumeration temporarily unavailable — chain read failed',
+          code: 'PCA_LOOKUP_READ_FAILED',
+        });
+      }
       const revert = classifyPcaRevert(msg);
       if (revert) return jsonResponse(res, revert.status, { error: revert.error, accountId: idStr });
       return jsonResponse(res, 500, {

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -249,7 +249,32 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
         });
       }
       const revert = classifyPcaRevert(msg);
-      if (revert) return jsonResponse(res, revert.status, { error: revert.error, accountId: idStr });
+      if (revert) {
+        const body: Record<string, unknown> = { error: revert.error, accountId: idStr };
+        if (revert.error === 'AgentAlreadyRegistered') {
+          // B10: surface WHICH account already holds this wallet so the UI can
+          // deep-link ("approved on PCA #N — deregister it there first").
+          // Primary: the decoded revert arg — `enrichEvmError` (run on every
+          // pcaWrite) sets `err.revert.args` from AgentAlreadyRegistered(agent,
+          // existingAccountId). Fallback: some RPCs strip revert data, so
+          // resolve via the on-chain reverse map. Both are wrapped so a failed
+          // lookup never masks the 409.
+          let existing: bigint | null = null;
+          const rv: any = (err as any)?.revert;
+          if (rv?.name === 'AgentAlreadyRegistered') {
+            const raw = rv.args?.existingAccountId ?? rv.args?.[1];
+            if (raw != null) { try { existing = BigInt(raw); } catch { /* unparseable arg */ } }
+          }
+          if (existing == null || existing <= 0n) {
+            try {
+              const viaMap = await agent.getConvictionAgentAccountId(agentAddr);
+              if (viaMap != null && viaMap > 0n) existing = viaMap;
+            } catch { /* reverse-map fallback is best-effort; never mask the 409 */ }
+          }
+          if (existing != null && existing > 0n) body.existingAccountId = existing.toString();
+        }
+        return jsonResponse(res, revert.status, body);
+      }
       return jsonResponse(res, 500, { error: `registerPublishingConvictionAgent failed: ${msg}` });
     }
   }

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -403,8 +403,19 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     if (!ethers.isAddress(addr)) {
       return jsonResponse(res, 400, { error: 'address must be a valid 0x-prefixed EVM address' });
     }
+    // Capability gate (mirror B3 / GET :id): an adapter without the PCA surface
+    // answers 503 — never a 200 a UI would read as "registered nowhere".
+    if (!agent.supportsPublishingConvictionNft) {
+      return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+    }
     try {
-      const accountId = await agent.getConvictionAgentAccountId(addr);
+      // STRICT discovery read: surfaces NFT-undeployed (PcaUnavailableError →
+      // 503) and read failures (CALL_EXCEPTION → 503) instead of the selector's
+      // fail-safe 0n. Otherwise a transient blip would resolve `accountId:null`
+      // = a CONFIRMED "registered nowhere", flipping a covered wallet to a
+      // false-DANGER fall-through in S5 (#9). A 0n from a healthy read is a
+      // genuine "unregistered" → accountId:null.
+      const accountId = await agent.getConvictionAgentAccountId(addr, { strict: true });
       if (accountId === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       return jsonResponse(res, 200, {
         agent: ethers.getAddress(addr),
@@ -415,6 +426,15 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
       if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       if (respondIfChainRpcTransportError(res, err)) return;
+      // A CALL_EXCEPTION on the mapping getter is a real read failure (the
+      // getter never reverts for an unregistered address) → 503 retryable, NOT
+      // a 200 the UI would read as a confirmed "registered nowhere".
+      if (err?.code === 'CALL_EXCEPTION') {
+        return jsonResponse(res, 503, {
+          error: 'PCA agent lookup temporarily unavailable — chain read failed',
+          code: 'PCA_LOOKUP_READ_FAILED',
+        });
+      }
       return jsonResponse(res, 500, {
         error: `getConvictionAgentAccountId failed: ${msg}`,
       });

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -665,22 +665,27 @@ describe('daemon /api/pca V10 caller contract', () => {
   });
 
   // ----- GAP-3: GET /api/pca/agent/:address (which PCA funds a wallet) -----
-  it('GET /api/pca/agent/:address → 200 { agent, accountId } for a registered wallet', async () => {
+  it('GET /api/pca/agent/:address → 200 { agent, accountId } for a registered wallet (strict discovery read)', async () => {
     const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
-    let queried: string | null = null;
+    let queried: { a: string; strict: boolean | undefined } | null = null;
     const agent = {
-      getConvictionAgentAccountId: async (a: string) => { queried = a; return 7n; },
+      supportsPublishingConvictionNft: true,
+      getConvictionAgentAccountId: async (a: string, opts?: { strict?: boolean }) => {
+        queried = { a, strict: opts?.strict };
+        return 7n;
+      },
     };
     const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
     await done;
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ agent: addr, accountId: '7' });
-    expect(queried).toBe(addr);
+    // Discovery route MUST opt into strict so a read failure can't masquerade as "unregistered".
+    expect(queried).toEqual({ a: addr, strict: true });
   });
 
-  it('GET /api/pca/agent/:address → 200 { accountId: null } for an unregistered wallet (0n)', async () => {
+  it('GET /api/pca/agent/:address → 200 { accountId: null } for a genuinely unregistered wallet (0n on a healthy read)', async () => {
     const addr = ethers.getAddress('0x' + 'cd'.repeat(20));
-    const agent = { getConvictionAgentAccountId: async () => 0n };
+    const agent = { supportsPublishingConvictionNft: true, getConvictionAgentAccountId: async () => 0n };
     const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
     await done;
     expect(res.statusCode).toBe(200);
@@ -693,9 +698,57 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(res.statusCode).toBe(400);
   });
 
-  it('GET /api/pca/agent/:address → 503 when the adapter lacks the surface (facade null)', async () => {
+  it('GET /api/pca/agent/:address → 503 (capability gate) when the adapter lacks the PCA surface; lookup not called', async () => {
+    let called = false;
     const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
-    const agent = { getConvictionAgentAccountId: async () => null };
+    const agent = {
+      supportsPublishingConvictionNft: false,
+      getConvictionAgentAccountId: async () => { called = true; return 0n; },
+    };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(called).toBe(false);
+  });
+
+  it('GET /api/pca/agent/:address → 503 when the facade returns null despite capability', async () => {
+    const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
+    const agent = { supportsPublishingConvictionNft: true, getConvictionAgentAccountId: async () => null };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('GET /api/pca/agent/:address → 503 PCA_LOOKUP_READ_FAILED on a CALL_EXCEPTION read failure (NOT 200 null)', async () => {
+    const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getConvictionAgentAccountId: async () => {
+        // The strict path rethrows a CALL_EXCEPTION (a real read failure on the
+        // mapping getter) — the route must NOT collapse it to accountId:null.
+        const err: any = new Error('missing revert data (execution reverted)');
+        err.code = 'CALL_EXCEPTION';
+        throw err;
+      },
+    };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe('PCA_LOOKUP_READ_FAILED');
+    expect(body.accountId).toBeUndefined();
+  });
+
+  it('GET /api/pca/agent/:address → 503 when strict surfaces NFT-undeployed (PcaUnavailableError)', async () => {
+    const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getConvictionAgentAccountId: async () => {
+        const err: any = new Error('DKGPublishingConvictionNFT not deployed on this Hub.');
+        err.code = 'PCA_UNAVAILABLE';
+        throw err;
+      },
+    };
     const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
     await done;
     expect(res.statusCode).toBe(503);
@@ -704,6 +757,7 @@ describe('daemon /api/pca V10 caller contract', () => {
   it('GET /api/pca/agent/:address → 503 on RPC transport exhaustion (sanitized)', async () => {
     const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
     const agent = {
+      supportsPublishingConvictionNft: true,
       getConvictionAgentAccountId: async () => {
         const err: any = new Error(
           'agentToAccountId failed on all configured RPC endpoints (https://rpc.example/v2/SECRETKEY): boom',

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -658,6 +658,27 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(res.body).not.toContain('SECRETKEY');
   });
 
+  it('GET /api/pca/:id/agents → 503 PCA_LOOKUP_READ_FAILED on an enumerator CALL_EXCEPTION (NOT 200 [])', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async () => ({ owner: '0x' + '9'.repeat(40) }),
+      getPublishingConvictionAgents: async () => {
+        // getRegisteredAgents is a plain getter that returns [] for an unknown
+        // account, so a CALL_EXCEPTION is a real read failure — the route must
+        // NOT collapse it to a confirmed 200 [] ("no approved wallets").
+        const err: any = new Error('missing revert data (execution reverted)');
+        err.code = 'CALL_EXCEPTION';
+        throw err;
+      },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/5/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    const body = JSON.parse(res.body);
+    expect(body.code).toBe('PCA_LOOKUP_READ_FAILED');
+    expect(body.agents).toBeUndefined();
+  });
+
   it('GET /api/pca/:id/agents → 400 for a non-numeric id', async () => {
     const { res, done } = runCtx('GET', '/api/pca/not-an-id/agents', {});
     await done;

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -663,4 +663,60 @@ describe('daemon /api/pca V10 caller contract', () => {
     await done;
     expect(res.statusCode).toBe(400);
   });
+
+  // ----- GAP-3: GET /api/pca/agent/:address (which PCA funds a wallet) -----
+  it('GET /api/pca/agent/:address → 200 { agent, accountId } for a registered wallet', async () => {
+    const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
+    let queried: string | null = null;
+    const agent = {
+      getConvictionAgentAccountId: async (a: string) => { queried = a; return 7n; },
+    };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ agent: addr, accountId: '7' });
+    expect(queried).toBe(addr);
+  });
+
+  it('GET /api/pca/agent/:address → 200 { accountId: null } for an unregistered wallet (0n)', async () => {
+    const addr = ethers.getAddress('0x' + 'cd'.repeat(20));
+    const agent = { getConvictionAgentAccountId: async () => 0n };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ agent: addr, accountId: null });
+  });
+
+  it('GET /api/pca/agent/:address → 400 for a malformed address', async () => {
+    const { res, done } = runCtx('GET', '/api/pca/agent/not-an-address', {});
+    await done;
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('GET /api/pca/agent/:address → 503 when the adapter lacks the surface (facade null)', async () => {
+    const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
+    const agent = { getConvictionAgentAccountId: async () => null };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('GET /api/pca/agent/:address → 503 on RPC transport exhaustion (sanitized)', async () => {
+    const addr = ethers.getAddress('0x' + 'ab'.repeat(20));
+    const agent = {
+      getConvictionAgentAccountId: async () => {
+        const err: any = new Error(
+          'agentToAccountId failed on all configured RPC endpoints (https://rpc.example/v2/SECRETKEY): boom',
+        );
+        err.code = 'RPC_ENDPOINTS_EXHAUSTED';
+        err.rpcUrls = ['https://rpc.example/v2/SECRETKEY'];
+        throw err;
+      },
+    };
+    const { res, done } = runCtx('GET', `/api/pca/agent/${addr}`, agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(res.body).not.toContain('SECRETKEY');
+  });
 });

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -719,4 +719,65 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(JSON.parse(res.body).code).toBe('RPC_ENDPOINTS_EXHAUSTED');
     expect(res.body).not.toContain('SECRETKEY');
   });
+
+  // ----- B10: register 409 carries existingAccountId (cross-PCA conflict) -----
+  it('register AgentAlreadyRegistered → 409 with existingAccountId from the decoded revert arg', async () => {
+    const addr = '0x' + '1'.repeat(40);
+    const agent = {
+      registerPublishingConvictionAgent: async () => {
+        const err: any = new Error(`execution reverted: AgentAlreadyRegistered(${addr}, 5)`);
+        // enrichEvmError shape: ethers.Result exposes named + positional access.
+        err.revert = {
+          name: 'AgentAlreadyRegistered',
+          args: Object.assign([addr, 5n], { agent: addr, existingAccountId: 5n }),
+        };
+        throw err;
+      },
+      // Must NOT be consulted when the revert arg is present.
+      getConvictionAgentAccountId: async () => { throw new Error('should not be called'); },
+    };
+    const { res, done } = runCtx('POST', '/api/pca/1/agent', agent, { agent: addr });
+    await done;
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'AgentAlreadyRegistered', accountId: '1', existingAccountId: '5' });
+  });
+
+  it('register AgentAlreadyRegistered with no revert arg → 409 with existingAccountId via reverse-map fallback', async () => {
+    const addr = '0x' + '1'.repeat(40);
+    const agent = {
+      registerPublishingConvictionAgent: async () => {
+        // RPC stripped the revert data — no err.revert, message-only.
+        throw new Error('execution reverted: AgentAlreadyRegistered');
+      },
+      getConvictionAgentAccountId: async (a: string) => { expect(a).toBe(addr); return 7n; },
+    };
+    const { res, done } = runCtx('POST', '/api/pca/1/agent', agent, { agent: addr });
+    await done;
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'AgentAlreadyRegistered', accountId: '1', existingAccountId: '7' });
+  });
+
+  it('register AgentAlreadyRegistered with neither arg nor resolvable map → 409 WITHOUT existingAccountId', async () => {
+    const addr = '0x' + '1'.repeat(40);
+    const agent = {
+      registerPublishingConvictionAgent: async () => { throw new Error('execution reverted: AgentAlreadyRegistered'); },
+      getConvictionAgentAccountId: async () => 0n,
+    };
+    const { res, done } = runCtx('POST', '/api/pca/1/agent', agent, { agent: addr });
+    await done;
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'AgentAlreadyRegistered', accountId: '1' });
+  });
+
+  it('register AgentAlreadyRegistered fallback throwing must NOT mask the 409', async () => {
+    const addr = '0x' + '1'.repeat(40);
+    const agent = {
+      registerPublishingConvictionAgent: async () => { throw new Error('execution reverted: AgentAlreadyRegistered'); },
+      getConvictionAgentAccountId: async () => { throw new Error('reverse-map RPC blip'); },
+    };
+    const { res, done } = runCtx('POST', '/api/pca/1/agent', agent, { agent: addr });
+    await done;
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'AgentAlreadyRegistered', accountId: '1' });
+  });
 });

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -575,4 +575,92 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(probe.registered).toBe(true);
     expect(probe).not.toHaveProperty('authorized');
   });
+
+  // ----- B3: GET /api/pca/:id/agents (live approved publishing-wallet list) -----
+  it('GET /api/pca/:id/agents → 200 with the checksummed agent list', async () => {
+    const a1 = ethers.getAddress('0x' + 'ab'.repeat(20));
+    const a2 = ethers.getAddress('0x' + 'cd'.repeat(20));
+    let enumeratedId: bigint | null = null;
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async () => ({ owner: '0x' + '9'.repeat(40) }),
+      getPublishingConvictionAgents: async (id: bigint) => { enumeratedId = id; return [a1, a2]; },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/5/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ accountId: '5', agents: [a1, a2] });
+    expect(enumeratedId).toBe(5n);
+  });
+
+  it('GET /api/pca/:id/agents → 200 { agents: [] } for an existing account with no agents (NOT 404)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async () => ({ owner: '0x' + '9'.repeat(40) }),
+      getPublishingConvictionAgents: async () => [],
+    };
+    const { res, done } = runCtx('GET', '/api/pca/5/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).agents).toEqual([]);
+  });
+
+  it('GET /api/pca/:id/agents → 404 for an unknown account on a deployed adapter (existence-checked, never enumerates)', async () => {
+    let enumerated = false;
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async () => null,
+      getPublishingConvictionAgents: async () => { enumerated = true; return []; },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/9/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(404);
+    expect(enumerated).toBe(false);
+  });
+
+  it('GET /api/pca/:id/agents → 503 when the adapter lacks the PCA surface', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: false,
+      getPublishingConvictionAccountInfo: async () => null,
+    };
+    const { res, done } = runCtx('GET', '/api/pca/1/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('GET /api/pca/:id/agents → 503 when getInfo works but the enumerator is absent (facade null)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async () => ({ owner: '0x' + '9'.repeat(40) }),
+      getPublishingConvictionAgents: async () => null,
+    };
+    const { res, done } = runCtx('GET', '/api/pca/1/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('GET /api/pca/:id/agents → 503 on RPC transport exhaustion (sanitized body)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async () => {
+        const err: any = new Error(
+          'getAccountInfo failed on all configured RPC endpoints (https://rpc.example/v2/SECRETKEY): boom',
+        );
+        err.code = 'RPC_ENDPOINTS_EXHAUSTED';
+        err.rpcUrls = ['https://rpc.example/v2/SECRETKEY'];
+        throw err;
+      },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/1/agents', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(res.body).not.toContain('SECRETKEY');
+  });
+
+  it('GET /api/pca/:id/agents → 400 for a non-numeric id', async () => {
+    const { res, done } = runCtx('GET', '/api/pca/not-an-id/agents', {});
+    await done;
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1719,6 +1719,25 @@ export interface PcaAgentsResult {
 export const listPcaAgents = (accountId: string) =>
   getJson<PcaAgentsResult>(`/api/pca/${encodeURIComponent(accountId)}/agents`);
 
+export interface PcaAgentAccountResult {
+  /** Echoed checksummed address that was queried. */
+  agent: string;
+  /** The PCA this wallet is an approved publishing wallet on, or `null` if none. A
+   *  wallet is approved on at most one account, so this is a direct answer. */
+  accountId: string | null;
+}
+
+/**
+ * GAP-3 — resolve which PCA (if any) an operational wallet is an approved publishing
+ * wallet on (`GET /api/pca/agent/:address`). A faster/authoritative path than probing
+ * each tracked account; `accountId: null` = not a publishing agent anywhere. 400 =
+ * invalid address, 503 = capability/transport. NOTE: this is a discovery/optimization
+ * primitive only — coverage MUST still resolve via `fetchPca` → `classifyCoverage`
+ * (registered ≠ covered; the #1344 honesty line). `GET` is permissionless.
+ */
+export const pcaAgentAccount = (address: string) =>
+  getJson<PcaAgentAccountResult>(`/api/pca/agent/${encodeURIComponent(address)}`);
+
 /** Normalized, terminology-disciplined PCA error code (UI branches on this). */
 export type PcaErrorCode =
   | 'FEATURE_UNAVAILABLE'

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1703,6 +1703,22 @@ export const pcaTopUp = (accountId: string, tokens: string) =>
 export const pcaSettle = (accountId: string) =>
   post<PcaSettleResult>(`/api/pca/${encodeURIComponent(accountId)}/settle`, {});
 
+export interface PcaAgentsResult {
+  accountId: string;
+  /** The FULL set of approved publishing-wallet addresses (checksummed). `[]` = a
+   *  real 0-approved account, distinct from a 404 (unknown account). */
+  agents: string[];
+}
+
+/**
+ * B3 — list the approved publishing wallets on a PCA (the full on-chain enumerator,
+ * vs just this node's wallets the detail view can probe). Existence-checked like
+ * {@link fetchPca}: an unknown account 404s (so the caller distinguishes "no such
+ * account" from `agents: []`); 503 = capability/transport. `GET` is permissionless.
+ */
+export const listPcaAgents = (accountId: string) =>
+  getJson<PcaAgentsResult>(`/api/pca/${encodeURIComponent(accountId)}/agents`);
+
 /** Normalized, terminology-disciplined PCA error code (UI branches on this). */
 export type PcaErrorCode =
   | 'FEATURE_UNAVAILABLE'

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1767,10 +1767,10 @@ export interface PcaErrorInfo {
   message: string;
   /**
    * B10: the conviction account a wallet is ALREADY approved on, surfaced on
-   * `AgentAlreadyRegistered`. The daemon doesn't return it yet
-   * (`classifyPcaRevert` discards it — pca.ts:50), so this is `undefined` today
-   * and the copy degrades to "another conviction account"; it lights up
-   * automatically once the route includes `existingAccountId`.
+   * `AgentAlreadyRegistered`. The P1 daemon NOW returns it (`resolveConflictingAccountId`
+   * + the register route populate it), so `describePcaError` names "PCA #M — deregister
+   * it there first". It is `undefined` only on the rare case the daemon can't resolve the
+   * id, where the copy degrades to "another conviction account".
    */
   existingAccountId?: string;
 }

--- a/packages/node-ui/src/ui/components/Pca/EligibilityVerdictBanner.tsx
+++ b/packages/node-ui/src/ui/components/Pca/EligibilityVerdictBanner.tsx
@@ -54,6 +54,7 @@ export function EligibilityVerdictBanner({
   verdict,
   accountId,
   discountBps,
+  accountUntracked = false,
   reasons = [],
   ownerPublish = false,
   variant = 'banner',
@@ -66,6 +67,10 @@ export function EligibilityVerdictBanner({
   verdict: PcaVerdict;
   accountId?: string;
   discountBps?: number;
+  /** GAP-3 (#1344) — the covering account is one this node doesn't track; the GREEN
+   *  copy names it honestly ("(not tracked by this node)") so it's never mistaken for
+   *  one of the user's tracked PCAs. */
+  accountUntracked?: boolean;
   /** Failed conditions, shown in the amber/danger banner ("Reason: …"). */
   reasons?: string[];
   /** #4 — when true (you own the target CG), append the escrow caveat. */
@@ -85,6 +90,9 @@ export function EligibilityVerdictBanner({
   const role = isLoud ? 'alert' : 'status';
   const ariaLive = isLoud ? 'assertive' : 'polite';
   const pcaLabel = accountId ? `PCA #${accountId}` : 'a conviction account';
+  // GAP-3 (#1344) — append the honest untracked note to the GREEN copy only (where a
+  // covering account is named); amber/danger never claim coverage so it'd read oddly there.
+  const trackedNote = accountUntracked ? ' (not tracked by this node)' : '';
   const disc = pctLabel(discountBps);
   // The escrow caveat can pre-empt BOTH a fall-through cost and a no-funds
   // failure (escrow pays, not the wallet), so it qualifies amber AND danger on
@@ -95,7 +103,7 @@ export function EligibilityVerdictBanner({
   if (variant === 'chip') {
     const chipLabel =
       verdict === 'eligible'
-        ? `Funded by ${pcaLabel}${disc ? ` (−${disc})` : ''}`
+        ? `Funded by ${pcaLabel}${trackedNote}${disc ? ` (−${disc})` : ''}`
         : verdict === 'fallthrough'
           ? '⚠ No PCA discount'
           : verdict === 'fallthrough-no-funds'
@@ -130,6 +138,7 @@ export function EligibilityVerdictBanner({
     message = (
       <>
         This publish will use {pcaLabel}
+        {trackedNote}
         {disc ? ` (−${disc})` : ''}.{ownerPublish ? `${escrowCaveat}.` : ''}
       </>
     );

--- a/packages/node-ui/src/ui/components/Pca/PcaAgentList.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PcaAgentList.tsx
@@ -56,17 +56,24 @@ export function PcaAgentList({
               trailing={
                 confirming ? (
                   <span className="v10-pca-agent-confirm">
-                    <span>Publishes from this wallet will pay the direct cost (and revert if it holds no TRAC). Remove?</span>
+                    {/* D (#1357) — when the wallet belongs to THIS node, removing it degrades
+                        this node's OWN publishes; name that explicitly vs a generic external wallet. */}
+                    <span>
+                      {isNode
+                        ? 'This is one of this node’s own signing wallets — its publishes will pay the direct cost (and revert if it holds no TRAC). Remove?'
+                        : 'Publishes from this wallet will pay the direct cost (and revert if it holds no TRAC). Remove?'}
+                    </span>
                     <button
                       type="button"
                       className="v10-pca-card-btn"
                       data-testid="pca-deregister-btn"
+                      aria-label={`Confirm removing ${addr}`}
                       onClick={() => onConfirmRemove(addr)}
                       disabled={removeBusy}
                     >
                       {removeBusy ? 'Removing…' : 'Yes, remove'}
                     </button>
-                    <button type="button" className="v10-pca-card-btn" onClick={onCancelRemove} disabled={removeBusy}>
+                    <button type="button" className="v10-pca-card-btn" aria-label={`Cancel removing ${addr}`} onClick={onCancelRemove} disabled={removeBusy}>
                       Cancel
                     </button>
                   </span>
@@ -86,6 +93,7 @@ export function PcaAgentList({
                     <button
                       type="button"
                       className="v10-pca-card-btn"
+                      aria-label={`Remove ${addr}`}
                       onClick={() => onAskRemove(addr)}
                       disabled={!ownerIsPrimary}
                       title={ownerTitle}

--- a/packages/node-ui/src/ui/components/Pca/PcaAgentList.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PcaAgentList.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { WalletRow } from './WalletRow.js';
+
+const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
+
+export interface PcaAgentListProps {
+  /** The FULL approved publishing-wallet set (checksummed), from `listPcaAgents` (B3). */
+  agents: string[];
+  /** This node's operational wallets — the ones in `agents` get a "this node" badge. */
+  nodeWallets: string[];
+  /** Owner-gated: Remove is enabled only when the node owner is the primary wallet (§8A). */
+  ownerIsPrimary: boolean;
+  /** Tooltip explaining why Remove is disabled (when not owner-primary). */
+  ownerTitle?: string;
+  /** The address currently mid remove-confirm (consequence-naming two-step), if any. */
+  confirmRemove: string | null;
+  onAskRemove: (addr: string) => void;
+  onCancelRemove: () => void;
+  onConfirmRemove: (addr: string) => void;
+  removeBusy: boolean;
+  /** Explorer base URL for a per-address link (omitted when the node has none). */
+  explorer?: string | null;
+}
+
+/**
+ * B3 — the FULL list of approved publishing wallets on a PCA (the chain enumerator,
+ * via `GET /api/pca/:id/agents`), replacing P0's probe-only "this node's wallets"
+ * view + the count-only caveat. Every listed wallet IS approved, so each carries an
+ * owner-gated Remove (deregister) reusing the detail view's confirm flow; wallets
+ * belonging to this node are badged. The caller renders the empty / loading /
+ * graceful-degrade states — this component only renders a non-empty list.
+ */
+export function PcaAgentList({
+  agents,
+  nodeWallets,
+  ownerIsPrimary,
+  ownerTitle,
+  confirmRemove,
+  onAskRemove,
+  onCancelRemove,
+  onConfirmRemove,
+  removeBusy,
+  explorer,
+}: PcaAgentListProps) {
+  return (
+    <div className="v10-pca-detail-agentlist" data-testid="pca-agent-list">
+      {agents.map((addr) => {
+        const isNode = nodeWallets.some((w) => eq(w, addr));
+        const confirming = eq(confirmRemove ?? undefined, addr);
+        return (
+          <div className="v10-pca-agent-row" data-testid="pca-agent-row" key={addr}>
+            <WalletRow
+              address={addr}
+              status={isNode ? 'approved · this node' : 'approved'}
+              statusTone="success"
+              trailing={
+                confirming ? (
+                  <span className="v10-pca-agent-confirm">
+                    <span>Publishes from this wallet will pay the direct cost (and revert if it holds no TRAC). Remove?</span>
+                    <button
+                      type="button"
+                      className="v10-pca-card-btn"
+                      data-testid="pca-deregister-btn"
+                      onClick={() => onConfirmRemove(addr)}
+                      disabled={removeBusy}
+                    >
+                      {removeBusy ? 'Removing…' : 'Yes, remove'}
+                    </button>
+                    <button type="button" className="v10-pca-card-btn" onClick={onCancelRemove} disabled={removeBusy}>
+                      Cancel
+                    </button>
+                  </span>
+                ) : (
+                  <>
+                    {explorer && (
+                      <a
+                        className="v10-pca-card-explorer"
+                        href={`${explorer}/address/${addr}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label={`View ${addr} on explorer`}
+                      >
+                        ↗
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      className="v10-pca-card-btn"
+                      onClick={() => onAskRemove(addr)}
+                      disabled={!ownerIsPrimary}
+                      title={ownerTitle}
+                    >
+                      Remove
+                    </button>
+                  </>
+                )
+              }
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Pca/index.ts
+++ b/packages/node-ui/src/ui/components/Pca/index.ts
@@ -14,6 +14,7 @@ export { HealthChip, HEALTH_CHIP_META } from './HealthChip.js';
 // constants) is imported DIRECTLY from the domain module `pca/health.js` by every
 // consumer, so the barrel no longer re-exports it.
 export { WalletRow, type WalletRowTone } from './WalletRow.js';
+export { PcaAgentList, type PcaAgentListProps } from './PcaAgentList.js';
 export { AddressCrux, DEFAULT_ADDRESS_CRUX_NOTE } from './AddressCrux.js';
 export {
   DiscountTierLadder,

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useFetch } from '../hooks.js';
-import { fetchWalletsBalances, fetchPca, fetchContextGraphs, fetchCurrentAgent } from '../api.js';
+import { fetchWalletsBalances, fetchPca, fetchContextGraphs, fetchCurrentAgent, pcaAgentAccount } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
 import { canonicalAgentDid } from '../lib/contextGraphSidebar.js';
 import { classifyCoverage } from '../pca/coverage.js';
@@ -13,6 +13,13 @@ interface WalletDetail {
   covered: boolean;
   accountId?: string;
   discountBps?: number;
+  /**
+   * GAP-3 Model B (#1344) — the covering account is one this node does NOT track
+   * (resolved via `pcaAgentAccount`). Drives the honest "(not tracked by this node)"
+   * label so covered-via-untracked never reads as one of the user's tracked PCAs.
+   * Only meaningful when `covered`.
+   */
+  coverUntracked: boolean;
   /**
    * #3 — the wallet IS an approved publishing wallet on this account, but the
    * account is swept/expired so it doesn't cover the publish. Lets the chip say
@@ -47,6 +54,8 @@ export interface PublishEligibility {
   /** The covering PCA + its discount, when GREEN. */
   accountId?: string;
   discountBps?: number;
+  /** GAP-3 (#1344) — the best covering account is one this node doesn't track. */
+  accountUntracked?: boolean;
   /** #4 — true only when this node owns the target CG (curator). */
   ownerPublish: boolean;
   /** Failed-condition phrases for the amber/danger message. */
@@ -104,21 +113,22 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
           const balanceUnknown = bal == null;
           const gasFunded = bal != null && Number(bal.eth) > 0;
           const hasTrac = bal != null && Number(bal.trac) > 0;
-          let cover: { accountId: string; discountBps: number } | undefined;
+          let cover: { accountId: string; discountBps: number; untracked: boolean } | undefined;
           let sawExpired = false;
           let sawInsolvent = false;
           let deadAccountId: string | undefined;
           let probeError = false;
+          // Fast-path: the accounts this node TRACKS (the common case; renders without
+          // a GAP-3 round-trip when the wallet is covered by a tracked PCA).
           for (const id of trackedIds) {
             const snap = await fetchPca(id, w).catch(() => null);
             // C1/#9 — a REJECTED probe (`null`) is "couldn't read", NOT a confirmed
             // not-registered. Distinguish them: a failed probe is inconclusive (→
             // neutral verdict), never a definitive fall-through DANGER at spend time.
             if (snap === null) { probeError = true; continue; }
-            // #1344 round-3 — ONE canonical classification; switch on its `outcome`
-            // discriminant (coarse P0, NOT remainingAllowance, P2/#1349). The probe is
-            // read from snap.probedKey internally. Behavior is byte-identical to the
-            // prior 5-field form.
+            // #1344 — ONE canonical classification; switch on its `outcome` discriminant
+            // (coarse P0, NOT remainingAllowance, P2/#1349). The probe is read from
+            // snap.probedKey internally.
             const c = classifyCoverage(snap);
             // S2/#9 — adapter gap OR an undefined registered → inconclusive ("couldn't
             // determine" → neutral verdict, never a definitive DANGER); a confirmed
@@ -126,7 +136,7 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
             if (c.outcome === 'inconclusive') { probeError = true; continue; }
             if (c.outcome === 'unregistered') continue;
             if (c.outcome === 'covers') {
-              cover = { accountId: id, discountBps: snap.discountBps };
+              cover = { accountId: id, discountBps: snap.discountBps, untracked: false };
               break; // breaks the tracked-id FOR loop (not a switch) — covered, stop probing.
             }
             // c.outcome === 'uncovered' — registered here but the account can't cover.
@@ -140,11 +150,48 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
             }
             if (!c.hasBudget) sawInsolvent = true;
           }
+
+          // GAP-3 Model B augment (#1344/#9) — the wallet looked UNREGISTERED on every
+          // tracked account (no probe error, no dead/budget finding), so its account (a
+          // wallet is approved on AT MOST ONE) is one this node does NOT track. Resolve
+          // it from chain truth and let classifyCoverage decide. GAP-3 is a DISCOVERY
+          // INPUT only: `registered ⇏ covered` (an untracked expired/insolvent/zero-budget
+          // account is NOT covered), so this only FIXES false-fallthroughs, never mints a
+          // false green. Bounded to one GAP-3 lookup per signing wallet; transport →
+          // inconclusive (never DANGER), `accountId: null` → confirmed fall-through.
+          if (!cover && !probeError && !sawExpired && !sawInsolvent) {
+            const acct = await pcaAgentAccount(w).catch(() => undefined);
+            if (acct === undefined) {
+              probeError = true; // couldn't confirm there's no untracked coverage (#9)
+            } else if (acct.accountId != null && !trackedIds.includes(acct.accountId)) {
+              const id = acct.accountId;
+              const snap = await fetchPca(id, w).catch(() => null);
+              if (snap === null) {
+                probeError = true;
+              } else {
+                const c = classifyCoverage(snap);
+                if (c.outcome === 'covers') {
+                  cover = { accountId: id, discountBps: snap.discountBps, untracked: true };
+                } else if (c.outcome === 'uncovered') {
+                  if (c.dead) { sawExpired = true; if (!deadAccountId) deadAccountId = id; }
+                  if (!c.hasBudget) sawInsolvent = true;
+                } else {
+                  // GAP-3 said registered on `id`, but the snapshot probe couldn't confirm
+                  // (adapter gap / race) → don't assert a fall-through (#9).
+                  probeError = true;
+                }
+              }
+            }
+            // acct.accountId == null (or already tracked) → confirmed: no untracked
+            // coverage → the fast-path's confirmed fall-through stands.
+          }
+
           return {
             wallet: w,
             covered: !!cover,
             accountId: cover?.accountId,
             discountBps: cover?.discountBps,
+            coverUntracked: cover?.untracked ?? false,
             deadAccountId: cover ? undefined : deadAccountId,
             inconclusive: !cover && probeError,
             // Q2 — set for COVERED wallets too: GREEN's gas check must tell a
@@ -246,6 +293,7 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
       loading,
       accountId: best?.accountId,
       discountBps: best?.discountBps,
+      accountUntracked: best?.coverUntracked,
       ownerPublish,
       reasons,
       conditions,

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -5,6 +5,7 @@ import {
   fetchWalletsBalances,
   fetchContextGraphs,
   registerContextGraph,
+  listPcaAgents,
   describePcaError,
   isRpcTransportError,
   HttpError,
@@ -16,6 +17,7 @@ import { formatTrac } from '../../lib/formatTrac.js';
 import {
   HealthChip,
   WalletRow,
+  PcaAgentList,
   AddressCrux,
   formatWeiToTrac,
   formatRelativeExpiry,
@@ -157,6 +159,10 @@ function DetailBody({
   const [approveOpen, setApproveOpen] = useState(false);
 
   const { data: cgData } = useFetch(fetchContextGraphs, [], 0);
+  // B3 — the FULL approved publishing-wallet set (chain enumerator). A 404/503/error
+  // degrades to the P0 probe-only "this node's wallets" view below (no crash).
+  const { data: agentsData, loading: agentsLoading, refresh: refreshAgents } =
+    useFetch(() => listPcaAgents(accountId), [accountId]);
   // O3 (corrects N3) — bind == register an UNREGISTERED CG with a PCA, forcing the
   // CURATED publish policy at registration (the backend governs bindability by
   // PUBLISH policy, not access policy — public-read + curated-publish is supported).
@@ -263,6 +269,7 @@ function DetailBody({
       setRemoveState({ busy: false, error: null, result: { message: `Removed ${addr}.` } });
       setConfirmRemove(null);
       refresh();
+      refreshAgents();
     } catch (err) {
       setRemoveState({ busy: false, error: describePcaError(err, { accountId })?.message ?? (err as Error)?.message ?? 'Remove failed.', result: null });
     }
@@ -370,29 +377,60 @@ function DetailBody({
         </div>
         {probeResult && <p className="v10-pca-detail-hint" role="status">{probeResult}</p>}
 
-        <p className="v10-pca-detail-subhead">This node’s wallets:</p>
-        <div className="v10-pca-detail-agentlist" data-testid="pca-agent-list">
-          {wallets.map((w) => (
-            <WalletProbeRow
-              key={w}
-              accountId={accountId}
-              wallet={w}
-              ownerIsPrimary={ownerIsPrimary}
-              ownerTitle={ownerTitle}
-              confirming={confirmRemove === w}
-              onAskRemove={() => setConfirmRemove(w)}
-              onCancelRemove={() => setConfirmRemove(null)}
-              onConfirmRemove={() => runRemove(w)}
-              removeBusy={removeState.busy}
-            />
-          ))}
-          {wallets.length === 0 && <p className="v10-pca-handshake-empty">No operational wallets on this node.</p>}
-        </div>
+        {agentsLoading && !agentsData ? (
+          <p className="v10-pca-detail-hint" role="status">Loading approved wallets…</p>
+        ) : agentsData ? (
+          // B3 — the FULL approved set (chain enumerator); the count-only caveat is retired.
+          <>
+            <p className="v10-pca-detail-subhead">Approved publishing wallets:</p>
+            {agentsData.agents.length > 0 ? (
+              <PcaAgentList
+                agents={agentsData.agents}
+                nodeWallets={wallets}
+                ownerIsPrimary={ownerIsPrimary}
+                ownerTitle={ownerTitle}
+                confirmRemove={confirmRemove}
+                onAskRemove={(a) => setConfirmRemove(a)}
+                onCancelRemove={() => setConfirmRemove(null)}
+                onConfirmRemove={(a) => runRemove(a)}
+                removeBusy={removeState.busy}
+                explorer={explorer}
+              />
+            ) : (
+              <div className="v10-pca-detail-agentlist" data-testid="pca-agent-list">
+                <p className="v10-pca-handshake-empty">No approved publishing wallets yet.</p>
+              </div>
+            )}
+          </>
+        ) : (
+          // Graceful degrade (B3 route absent / 503 / a 404 race after the snapshot
+          // loaded): the P0 probe-only view of THIS node's wallets + the count-only caveat.
+          <>
+            <p className="v10-pca-detail-subhead">This node’s wallets:</p>
+            <div className="v10-pca-detail-agentlist" data-testid="pca-agent-list">
+              {wallets.map((w) => (
+                <WalletProbeRow
+                  key={w}
+                  accountId={accountId}
+                  wallet={w}
+                  ownerIsPrimary={ownerIsPrimary}
+                  ownerTitle={ownerTitle}
+                  confirming={confirmRemove === w}
+                  onAskRemove={() => setConfirmRemove(w)}
+                  onCancelRemove={() => setConfirmRemove(null)}
+                  onConfirmRemove={() => runRemove(w)}
+                  removeBusy={removeState.busy}
+                />
+              ))}
+              {wallets.length === 0 && <p className="v10-pca-handshake-empty">No operational wallets on this node.</p>}
+            </div>
+            <p className="v10-pca-overview-caveat">
+              ⓘ The chain exposes how many wallets are approved, not the full list — only this node’s
+              wallets and any you probe are shown here.
+            </p>
+          </>
+        )}
         {removeState.error && <p className="v10-modal-error" role="alert">{removeState.error}</p>}
-        <p className="v10-pca-overview-caveat">
-          ⓘ The chain exposes how many wallets are approved, not the full list — only this node’s
-          wallets and any you probe are shown here.
-        </p>
         <button
           type="button"
           className="v10-pca-card-btn primary"
@@ -467,7 +505,7 @@ function DetailBody({
         <ApproveWalletsModal
           accountId={accountId}
           initialMode="self"
-          onClose={() => { setApproveOpen(false); refresh(); }}
+          onClose={() => { setApproveOpen(false); refresh(); refreshAgents(); }}
         />
       )}
     </div>

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -163,6 +163,11 @@ function DetailBody({
   // degrades to the P0 probe-only "this node's wallets" view below (no crash).
   const { data: agentsData, loading: agentsLoading, refresh: refreshAgents } =
     useFetch(() => listPcaAgents(accountId), [accountId]);
+  // A (#1357) — useFetch RETAINS the prior account's data on a failed re-fetch, so after
+  // switching PCAs a failed listPcaAgents for the NEW account would render the PREVIOUS
+  // account's wallets under the new header. The response echoes its accountId; only treat
+  // the data as current when it matches (both decimal id strings). Otherwise loading/degrade.
+  const agentsForThis = agentsData && agentsData.accountId === accountId ? agentsData : null;
   // O3 (corrects N3) — bind == register an UNREGISTERED CG with a PCA, forcing the
   // CURATED publish policy at registration (the backend governs bindability by
   // PUBLISH policy, not access policy — public-read + curated-publish is supported).
@@ -377,15 +382,15 @@ function DetailBody({
         </div>
         {probeResult && <p className="v10-pca-detail-hint" role="status">{probeResult}</p>}
 
-        {agentsLoading && !agentsData ? (
+        {agentsLoading && !agentsForThis ? (
           <p className="v10-pca-detail-hint" role="status">Loading approved wallets…</p>
-        ) : agentsData ? (
+        ) : agentsForThis ? (
           // B3 — the FULL approved set (chain enumerator); the count-only caveat is retired.
           <>
             <p className="v10-pca-detail-subhead">Approved publishing wallets:</p>
-            {agentsData.agents.length > 0 ? (
+            {agentsForThis.agents.length > 0 ? (
               <PcaAgentList
-                agents={agentsData.agents}
+                agents={agentsForThis.agents}
                 nodeWallets={wallets}
                 ownerIsPrimary={ownerIsPrimary}
                 ownerTitle={ownerTitle}
@@ -431,6 +436,10 @@ function DetailBody({
           </>
         )}
         {removeState.error && <p className="v10-modal-error" role="alert">{removeState.error}</p>}
+        {/* D2 (#1357) — surface the deregister success (was a dead state). */}
+        {removeState.result && (
+          <p className="v10-pca-detail-result" role="status" data-testid="pca-remove-result">{removeState.result.message}</p>
+        )}
         <button
           type="button"
           className="v10-pca-card-btn primary"
@@ -540,16 +549,20 @@ function WalletProbeRow({
           registered === true ? (
             confirming ? (
               <span className="v10-pca-agent-confirm">
-                <span>Publishes from this wallet will pay the direct cost (and revert if it holds no TRAC). Remove?</span>
-                <button type="button" className="v10-pca-card-btn" data-testid="pca-deregister-btn" onClick={onConfirmRemove} disabled={removeBusy}>
+                {/* D (#1357) — these degrade-path rows are ALL this node's own wallets, so
+                    name that consequence explicitly (deregistering your own signer degrades
+                    your own publishes). */}
+                <span>This is one of this node’s own signing wallets — its publishes will pay the direct cost (and revert if it holds no TRAC). Remove?</span>
+                <button type="button" className="v10-pca-card-btn" data-testid="pca-deregister-btn" aria-label={`Confirm removing ${wallet}`} onClick={onConfirmRemove} disabled={removeBusy}>
                   {removeBusy ? 'Removing…' : 'Yes, remove'}
                 </button>
-                <button type="button" className="v10-pca-card-btn" onClick={onCancelRemove} disabled={removeBusy}>Cancel</button>
+                <button type="button" className="v10-pca-card-btn" aria-label={`Cancel removing ${wallet}`} onClick={onCancelRemove} disabled={removeBusy}>Cancel</button>
               </span>
             ) : (
               <button
                 type="button"
                 className="v10-pca-card-btn"
+                aria-label={`Remove ${wallet}`}
                 onClick={onAskRemove}
                 disabled={!ownerIsPrimary}
                 title={ownerTitle}

--- a/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/GetSponsoredPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useFetch } from '../../hooks.js';
-import { fetchWalletsBalances, fetchPca, describePcaError } from '../../api.js';
+import { fetchWalletsBalances, fetchPca, pcaAgentAccount, describePcaError } from '../../api.js';
 import { formatEth, formatEthTooltip } from '../../lib/formatEth.js';
 import { usePcaStore } from '../../stores/pca.js';
 import { classifyCoverage } from '../../pca/coverage.js';
@@ -54,6 +54,26 @@ export function GetSponsoredPanel({ onClose }: { onClose: () => void }) {
 
   const trackAccount = usePcaStore((s) => s.trackAccount);
   const { copied, copy } = useCopy();
+
+  // GAP-3 discovery (#1344) — surface which PCA(s) already sponsor this node's wallets
+  // (chain truth, untracked by definition — that's the point of the edge panel). PURE
+  // discovery: it never auto-tracks (guardrail b) and never asserts coverage — it just
+  // pre-fills the manual "Check approval" so the edge doesn't need the core to hand over
+  // the id. A wallet is approved on at most one account; distinct non-null ids are shown.
+  const walletsKey = wallets.join(',');
+  const { data: discovered } = useFetch(
+    async () => {
+      const ws = wb?.wallets ?? [];
+      if (ws.length === 0) return [] as string[];
+      const ids = await Promise.all(
+        ws.map((w) => pcaAgentAccount(w).then((r) => r.accountId).catch(() => null)),
+      );
+      return Array.from(new Set(ids.filter((id): id is string => id != null)));
+    },
+    [walletsKey],
+    0,
+  );
+
   const [sponsorId, setSponsorId] = useState('');
   const [checking, setChecking] = useState(false);
   const [probeError, setProbeError] = useState<string | null>(null);
@@ -189,6 +209,16 @@ export function GetSponsoredPanel({ onClose }: { onClose: () => void }) {
         {/* Approval tracker */}
         <section className="v10-pca-detail-section">
           <h3 className="v10-pca-detail-section-title">Track your approval</h3>
+          {/* GAP-3 discovery — surface any sponsoring PCA we found on-chain; pre-fill the
+              check (the user confirms; nothing is auto-tracked). */}
+          {discovered && discovered.length > 0 && (
+            <p className="v10-pca-detail-hint" role="status" data-testid="pca-sponsor-discovered">
+              ◉ We found your wallet(s) already approved on {discovered.map((id) => `PCA #${id}`).join(', ')}.{' '}
+              <button type="button" className="v10-pca-card-btn" onClick={() => setSponsorId(discovered[0])}>
+                Check PCA #{discovered[0]}
+              </button>
+            </p>
+          )}
           <div className="v10-pca-detail-form">
             <input
               className="v10-form-input"

--- a/packages/node-ui/src/ui/pages/conviction/PublishEligibilityChip.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/PublishEligibilityChip.tsx
@@ -40,6 +40,7 @@ export function PublishEligibilityChip({ contextGraphId, id }: { contextGraphId:
         verdict={elig.verdict}
         accountId={elig.accountId}
         discountBps={elig.discountBps}
+        accountUntracked={elig.accountUntracked}
         ownerPublish={elig.ownerPublish}
         onWhy={() => setOpen((o) => !o)}
         whyExpanded={open}
@@ -51,6 +52,7 @@ export function PublishEligibilityChip({ contextGraphId, id }: { contextGraphId:
             verdict={elig.verdict}
             accountId={elig.accountId}
             discountBps={elig.discountBps}
+            accountUntracked={elig.accountUntracked}
             reasons={elig.reasons}
             ownerPublish={elig.ownerPublish}
           />
@@ -78,7 +80,9 @@ export function PublishEligibilityChip({ contextGraphId, id }: { contextGraphId:
                 address={w.wallet}
                 status={
                   w.covered
-                    ? 'covered'
+                    ? w.coverUntracked
+                      ? `covered via PCA #${w.accountId} (not tracked by this node)`
+                      : 'covered'
                     : w.inconclusive
                       ? 'couldn’t check PCA coverage — retry'
                       : w.balanceUnknown

--- a/packages/node-ui/test/pca-agent-list.test.ts
+++ b/packages/node-ui/test/pca-agent-list.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+//
+// B3 — PcaAgentList unit contract: the FULL approved-wallet list (chain enumerator)
+// renders one row per address, badges this node's wallets, and exposes an
+// owner-gated, consequence-naming Remove reusing the detail view's deregister flow.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PcaAgentList } from '../src/ui/components/Pca/index.js';
+
+const NODE = '0x9A3f000000000000000000000000000000000E41D';
+const EXTERNAL = '0xExternal0000000000000000000000000000A1b2';
+
+async function render(node: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { container, unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+const findBtn = (c: HTMLElement, text: string) =>
+  Array.from(c.querySelectorAll('button')).find((b) => b.textContent === text);
+
+const baseProps = {
+  agents: [NODE, EXTERNAL],
+  nodeWallets: [NODE],
+  ownerIsPrimary: true,
+  confirmRemove: null as string | null,
+  onAskRemove: vi.fn(),
+  onCancelRemove: vi.fn(),
+  onConfirmRemove: vi.fn(),
+  removeBusy: false,
+};
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('PcaAgentList (B3)', () => {
+  it('renders one row per approved wallet and badges this node’s wallet', async () => {
+    const { container, unmount } = await render(React.createElement(PcaAgentList, { ...baseProps }));
+    expect(container.querySelectorAll('[data-testid="pca-agent-row"]').length).toBe(2);
+    // The node-owned wallet is badged; the external approved wallet is plain "approved".
+    expect(container.textContent).toContain('approved · this node');
+    // The external row carries the full address in its accessible name (never glyph-only).
+    const groups = Array.from(container.querySelectorAll('[role="group"]')).map((g) => g.getAttribute('aria-label'));
+    expect(groups.some((l) => l?.includes(EXTERNAL))).toBe(true);
+    await unmount();
+  });
+
+  it('owner-gates Remove: disabled (with a reason title) when not owner-primary', async () => {
+    const { container, unmount } = await render(
+      React.createElement(PcaAgentList, { ...baseProps, ownerIsPrimary: false, ownerTitle: 'Owner-only' }),
+    );
+    const remove = findBtn(container, 'Remove')!;
+    expect(remove.disabled).toBe(true);
+    expect(remove.getAttribute('title')).toBe('Owner-only');
+    await unmount();
+  });
+
+  it('Remove asks for confirm; the consequence-naming confirm fires onConfirmRemove(addr)', async () => {
+    const onAskRemove = vi.fn();
+    const onConfirmRemove = vi.fn();
+    // First render: Remove triggers onAskRemove(addr).
+    const r1 = await render(React.createElement(PcaAgentList, { ...baseProps, onAskRemove }));
+    await act(async () => { findBtn(r1.container, 'Remove')!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onAskRemove).toHaveBeenCalledWith(NODE);
+    await r1.unmount();
+
+    // Confirming state: the consequence copy + deregister anchor; Yes fires onConfirmRemove(addr).
+    const r2 = await render(React.createElement(PcaAgentList, { ...baseProps, confirmRemove: NODE, onConfirmRemove }));
+    expect(r2.container.textContent).toContain('will pay the direct cost');
+    const yes = r2.container.querySelector('[data-testid="pca-deregister-btn"]') as HTMLButtonElement;
+    expect(yes).toBeTruthy();
+    await act(async () => { yes.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(onConfirmRemove).toHaveBeenCalledWith(NODE);
+    await r2.unmount();
+  });
+
+  it('renders a per-address explorer link only when an explorer base is provided', async () => {
+    const r1 = await render(React.createElement(PcaAgentList, { ...baseProps, explorer: 'https://exp' }));
+    const link = r1.container.querySelector('a.v10-pca-card-explorer') as HTMLAnchorElement;
+    expect(link?.getAttribute('href')).toBe(`https://exp/address/${NODE}`);
+    await r1.unmount();
+
+    const r2 = await render(React.createElement(PcaAgentList, { ...baseProps, explorer: null }));
+    expect(r2.container.querySelector('a.v10-pca-card-explorer')).toBeNull();
+    await r2.unmount();
+  });
+});

--- a/packages/node-ui/test/pca-agent-list.test.ts
+++ b/packages/node-ui/test/pca-agent-list.test.ts
@@ -81,6 +81,32 @@ describe('PcaAgentList (B3)', () => {
     await r2.unmount();
   });
 
+  // D (#1357) — removing one of THIS node's own wallets names that consequence;
+  // removing an external approved wallet keeps the generic copy.
+  it('confirm names "this node’s own signing wallets" only for node-owned rows', async () => {
+    const own = await render(React.createElement(PcaAgentList, { ...baseProps, confirmRemove: NODE }));
+    expect(own.container.textContent).toContain('one of this node’s own signing wallets');
+    await own.unmount();
+
+    const ext = await render(React.createElement(PcaAgentList, { ...baseProps, confirmRemove: EXTERNAL }));
+    expect(ext.container.textContent).not.toContain('one of this node’s own signing wallets');
+    expect(ext.container.textContent).toContain('will pay the direct cost'); // generic copy
+    await ext.unmount();
+  });
+
+  // D3 (#1357 a11y) — trailing controls carry a per-address accessible name.
+  it('trailing Remove / Confirm / Cancel buttons have per-address aria-labels', async () => {
+    const idle = await render(React.createElement(PcaAgentList, { ...baseProps }));
+    expect(idle.container.querySelector(`button[aria-label="Remove ${NODE}"]`)).toBeTruthy();
+    expect(idle.container.querySelector(`button[aria-label="Remove ${EXTERNAL}"]`)).toBeTruthy();
+    await idle.unmount();
+
+    const confirming = await render(React.createElement(PcaAgentList, { ...baseProps, confirmRemove: NODE }));
+    expect(confirming.container.querySelector(`button[aria-label="Confirm removing ${NODE}"]`)).toBeTruthy();
+    expect(confirming.container.querySelector(`button[aria-label="Cancel removing ${NODE}"]`)).toBeTruthy();
+    await confirming.unmount();
+  });
+
   it('renders a per-address explorer link only when an explorer base is provided', async () => {
     const r1 = await render(React.createElement(PcaAgentList, { ...baseProps, explorer: 'https://exp' }));
     const link = r1.container.querySelector('a.v10-pca-card-explorer') as HTMLAnchorElement;

--- a/packages/node-ui/test/pca-coverage-parity.test.ts
+++ b/packages/node-ui/test/pca-coverage-parity.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   fetchPca: vi.fn(),
   fetchContextGraphs: vi.fn(),
   fetchCurrentAgent: vi.fn(),
+  pcaAgentAccount: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -30,6 +31,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     fetchPca: mocks.fetchPca,
     fetchContextGraphs: mocks.fetchContextGraphs,
     fetchCurrentAgent: mocks.fetchCurrentAgent,
+    pcaAgentAccount: mocks.pcaAgentAccount,
   };
 });
 
@@ -109,6 +111,10 @@ beforeEach(() => {
   // S5 owner-publish escrow caveat off (not under test here).
   mocks.fetchContextGraphs.mockResolvedValue({ contextGraphs: [] });
   mocks.fetchCurrentAgent.mockResolvedValue({ agentDid: 'did:dkg:agent:0x' + '9'.repeat(40) });
+  // GAP-3 (#1344): the wallet is registered ON the fixture account, so the S5 augment
+  // never fires (the tracked fast-path resolves it) and S6 discovery is inert here —
+  // stub it so neither path hits a real fetch. Parity is about classifyCoverage, not GAP-3.
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: null });
 });
 afterEach(() => { document.body.innerHTML = ''; });
 

--- a/packages/node-ui/test/pca-detail-view.test.ts
+++ b/packages/node-ui/test/pca-detail-view.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchPca: vi.fn(),
   fetchWalletsBalances: vi.fn(),
   fetchContextGraphs: vi.fn(),
+  listPcaAgents: vi.fn(),
   pcaTopUp: vi.fn(),
   pcaSettle: vi.fn(),
   pcaRemoveAgent: vi.fn(),
@@ -77,6 +78,8 @@ beforeEach(() => {
   mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
     key ? { ...snap(), probedKey: { key, registered: key.toLowerCase() === W0.toLowerCase() } } : snap(),
   );
+  // B3 — default to the happy full-list path (W0 = this node's wallet, approved).
+  mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [W0] });
 });
 afterEach(() => { document.body.innerHTML = ''; });
 
@@ -137,6 +140,8 @@ describe('ConvictionDetailView §8A owner-gating', () => {
   // a false "NOT approved" (manual probe tool + the per-wallet row).
   it('the manual Probe and the wallet row both say "couldn’t determine" on a probe with no probedKey (M8)', async () => {
     mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    // The per-wallet probe ROW only exists in the B3-degrade fallback — force it.
+    mocks.listPcaAgents.mockRejectedValue(new HttpError(503, 'unavailable', { error: 'unavailable' }));
     mocks.fetchPca.mockImplementation(async () => snap()); // snap() never carries probedKey → registered null
     const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
     await waitForText(container, 'Check a wallet');
@@ -311,6 +316,61 @@ describe('ConvictionDetailView §8A owner-gating', () => {
     await act(async () => { btn(container, '[data-testid="pca-topup-btn"]').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await waitForText(container, 'greater than 0');
     expect(container.querySelector('[data-testid="pca-action-warning"]')).toBeNull();
+    await unmount();
+  });
+});
+
+// B3 — the S3 "Publishing wallets" section renders the FULL approved set from
+// listPcaAgents (GET /api/pca/:id/agents), retiring P0's count-only caveat, and
+// degrades to the probe-only this-node-wallets view when the route is unavailable.
+describe('ConvictionDetailView B3 — live approved-wallet table', () => {
+  const EXTERNAL = '0xExternal0000000000000000000000000000A1b2';
+  const OWNER_WB = { wallets: [W0], balances: [{ address: W0, eth: '1', trac: '5', symbol: 'TRAC' }], chainId: '84532', rpcUrl: null };
+
+  it('renders the FULL approved list (incl. wallets NOT on this node) and retires the count-only caveat', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [W0, EXTERNAL] });
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Approved publishing wallets:');
+    const rows = container.querySelectorAll('[data-testid="pca-agent-row"]');
+    expect(rows.length).toBe(2); // includes the EXTERNAL wallet the node can't probe
+    // The node's own wallet is badged; the caveat is gone once the full list renders.
+    expect(container.textContent).toContain('approved · this node');
+    expect(container.textContent).not.toContain('not the full list');
+    await unmount();
+  });
+
+  it('shows a real 0-approved empty state (200 + agents: []), still no caveat', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [] });
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'No approved publishing wallets yet.');
+    expect(container.textContent).not.toContain('not the full list');
+    await unmount();
+  });
+
+  it('degrades to the probe-only this-node view + count caveat when listPcaAgents fails (503/404)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.listPcaAgents.mockRejectedValue(new HttpError(503, 'unavailable', { error: 'unavailable' }));
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'This node’s wallets:');
+    // The P0 caveat is restored as the honest degrade signal.
+    expect(container.textContent).toContain('not the full list');
+    // The node's own wallet still resolves via the per-row probe (W0 → approved).
+    await waitForText(container, 'approved');
+    await unmount();
+  });
+
+  it('owner Remove on a listed wallet fires pcaRemoveAgent(id, addr) (full-list path)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue(OWNER_WB);
+    mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [W0] });
+    mocks.pcaRemoveAgent.mockResolvedValue({ accountId: '7', agent: W0, deregistered: true });
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Approved publishing wallets:');
+    await act(async () => { findBtn(container, 'Remove').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'will pay the direct cost');
+    await act(async () => { container.querySelector('[data-testid="pca-deregister-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(mocks.pcaRemoveAgent).toHaveBeenCalledWith('7', W0);
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-detail-view.test.ts
+++ b/packages/node-ui/test/pca-detail-view.test.ts
@@ -368,9 +368,28 @@ describe('ConvictionDetailView B3 — live approved-wallet table', () => {
     const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
     await waitForText(container, 'Approved publishing wallets:');
     await act(async () => { findBtn(container, 'Remove').dispatchEvent(new MouseEvent('click', { bubbles: true })); });
-    await waitForText(container, 'will pay the direct cost');
+    // D (#1357) — W0 is this node's own wallet, so the confirm names that consequence.
+    await waitForText(container, 'one of this node’s own signing wallets');
     await act(async () => { container.querySelector('[data-testid="pca-deregister-btn"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(mocks.pcaRemoveAgent).toHaveBeenCalledWith('7', W0);
+    // D2 (#1357) — the deregister success now renders (was a dead state).
+    await waitForText(container, 'Removed');
+    expect(container.querySelector('[data-testid="pca-remove-result"]')).toBeTruthy();
+    await unmount();
+  });
+
+  // A (#1357) — a failed listPcaAgents for the CURRENT account must NOT render a
+  // previous account's list. The guard keys the full-list render on agentsData.accountId
+  // === accountId; a mismatch (stale) falls through to the probe-only degrade.
+  it('A — stale agentsData (different accountId) does NOT render under the new header (degrades)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    // The list resolves for a DIFFERENT account than the one being viewed (#7).
+    mocks.listPcaAgents.mockResolvedValue({ accountId: '999', agents: [EXTERNAL] });
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    // Falls to the degrade (probe-only this-node view + caveat), NOT the stale list.
+    await waitForText(container, 'This node’s wallets:');
+    expect(container.textContent).toContain('not the full list'); // degrade caveat
+    expect(container.textContent).not.toContain(EXTERNAL.slice(0, 10)); // the stale wallet is NOT shown
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-get-sponsored.test.ts
+++ b/packages/node-ui/test/pca-get-sponsored.test.ts
@@ -11,11 +11,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   fetchWalletsBalances: vi.fn(),
   fetchPca: vi.fn(),
+  pcaAgentAccount: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
   const actual = await orig<typeof import('../src/ui/api.js')>();
-  return { ...actual, fetchWalletsBalances: mocks.fetchWalletsBalances, fetchPca: mocks.fetchPca };
+  return {
+    ...actual,
+    fetchWalletsBalances: mocks.fetchWalletsBalances,
+    fetchPca: mocks.fetchPca,
+    pcaAgentAccount: mocks.pcaAgentAccount,
+  };
 });
 
 const { GetSponsoredPanel } = await import('../src/ui/pages/conviction/GetSponsoredPanel.js');
@@ -54,6 +60,9 @@ beforeEach(() => {
   // N2 — the store is a module singleton seeded from localStorage; reset both.
   localStorage.clear();
   usePcaStore.setState({ trackedIds: [], createPending: null });
+  // GAP-3 discovery default: nothing discovered (keeps the existing manual-check tests
+  // deterministic — no real fetch). The discovery test overrides this.
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
 });
 afterEach(() => { document.body.innerHTML = ''; });
 
@@ -247,6 +256,27 @@ describe('GetSponsoredPanel', () => {
     const { container, unmount } = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
     await waitForText(container, 'Couldn’t load your wallets');
     expect(container.textContent).not.toContain('No operational wallets detected');
+    await unmount();
+  });
+
+  // GAP-3 discovery (#1344) — S6 surfaces the sponsoring PCA found on-chain (untracked
+  // by definition) and pre-fills the manual check WITHOUT auto-tracking (guardrail b).
+  it('GAP-3 — discovers + surfaces the sponsoring PCA, pre-fills the check, never auto-tracks', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({
+      wallets: [W0],
+      balances: [{ address: W0, eth: '0.08', trac: '0', symbol: 'TRAC' }],
+      chainId: '84532',
+      rpcUrl: null,
+    });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: '7' });
+    const { container, unmount } = await render(React.createElement(GetSponsoredPanel, { onClose: vi.fn() }));
+    await waitForText(container, 'already approved on PCA #7');
+    // Discovery must NOT auto-track (guardrail b) — only the explicit Check approval does.
+    expect(usePcaStore.getState().trackedIds).not.toContain('7');
+    // The "Check PCA #7" affordance pre-fills the manual sponsor-id input.
+    const checkDiscovered = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'Check PCA #7')!;
+    await act(async () => { checkDiscovered.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect((container.querySelector('input[aria-label="Sponsor account id"]') as HTMLInputElement).value).toBe('7');
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-panel-routing.test.ts
+++ b/packages/node-ui/test/pca-panel-routing.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchPca: vi.fn(),
   fetchWalletsBalances: vi.fn(),
   fetchContextGraphs: vi.fn(),
+  listPcaAgents: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -21,6 +22,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     fetchPca: mocks.fetchPca,
     fetchWalletsBalances: mocks.fetchWalletsBalances,
     fetchContextGraphs: mocks.fetchContextGraphs,
+    listPcaAgents: mocks.listPcaAgents,
   };
 });
 
@@ -58,6 +60,9 @@ beforeEach(() => {
   );
   mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
   mocks.fetchContextGraphs.mockResolvedValue({ contextGraphs: [] });
+  // B3 — the detail view fetches the approved-wallet list; mock it so the routing test
+  // doesn't hit a real fetch (graceful-degrade would still render, but cleaner without).
+  mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [W0] });
 });
 afterEach(() => {
   document.body.innerHTML = '';

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   fetchPca: vi.fn(),
   fetchContextGraphs: vi.fn(),
   fetchCurrentAgent: vi.fn(),
+  pcaAgentAccount: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -23,6 +24,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     fetchPca: mocks.fetchPca,
     fetchContextGraphs: mocks.fetchContextGraphs,
     fetchCurrentAgent: mocks.fetchCurrentAgent,
+    pcaAgentAccount: mocks.pcaAgentAccount,
   };
 });
 
@@ -56,6 +58,11 @@ beforeEach(() => {
   usePcaStore.setState({ trackedIds: ['7'], createPending: null });
   mocks.fetchContextGraphs.mockResolvedValue({ contextGraphs: [] });
   mocks.fetchCurrentAgent.mockResolvedValue({ agentDid: 'did:dkg:agent:0x' + '9'.repeat(40) });
+  // GAP-3 Model B default: NO untracked coverage. The augment only fires when a wallet
+  // is cleanly unregistered on every tracked account; this default makes those cases a
+  // CONFIRMED fall-through (accountId: null), preserving the pre-Model-B behavior. Tests
+  // that exercise untracked coverage override this per-wallet.
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
 });
 afterEach(() => { document.body.innerHTML = ''; });
 
@@ -460,6 +467,67 @@ describe('PublishEligibilityChip (S5)', () => {
     const why = container.querySelector('.v10-pca-verdict-why') as HTMLButtonElement;
     await act(async () => { why.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     await waitForText(container, 'registration escrow already covers it');
+    await unmount();
+  });
+
+  // GAP-3 Model B (#1344) — a signing wallet covered by an account this node DOESN'T
+  // track is resolved via pcaAgentAccount → fetchPca → classifyCoverage. The three
+  // "deliberate + tested" cases (the lead's required set):
+
+  // (i) wallet → UNTRACKED fundable account ⇒ GREEN, labelled "(not tracked)".
+  it('GAP-3 — wallet on an UNTRACKED fundable account resolves GREEN (fixes the false-fallthrough)', async () => {
+    usePcaStore.setState({ trackedIds: ['7'], createPending: null }); // tracks #7, NOT #9
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('100'));
+    // Unregistered on the tracked account #7; registered + healthy on the untracked #9.
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      const base = makePcaSnapshot({ accountId: id });
+      if (!key) return base;
+      return { ...base, probedKey: { key, registered: id === '9' } };
+    });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: '9' });
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'Funded by PCA #9');
+    expect(container.textContent).toContain('not tracked by this node');
+    expect(container.querySelector('[data-verdict="eligible"]')).toBeTruthy();
+    await unmount();
+  });
+
+  // (ii) wallet → UNTRACKED EXPIRED account ⇒ NOT covered (proves registered ⇏ covered):
+  // GAP-3 only DISCOVERS the account; classifyCoverage still decides, so a dead account
+  // can never mint a false green.
+  it('GAP-3 — wallet on an UNTRACKED EXPIRED account is NOT covered (registered ⇏ covered)', async () => {
+    usePcaStore.setState({ trackedIds: ['7'], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('50')); // has TRAC → amber, not danger
+    const expired = (id: string) =>
+      makePcaSnapshot({ accountId: id, expiresAtTimestamp: Math.floor(Date.now() / 1000) - 86_400 });
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      const base = id === '9' ? expired(id) : makePcaSnapshot({ accountId: id });
+      if (!key) return base;
+      return { ...base, probedKey: { key, registered: id === '9' } };
+    });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: '9' });
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'No PCA discount'); // amber fall-through, NOT eligible
+    expect(container.querySelector('[data-verdict="eligible"]')).toBeNull();
+    // The popover names the dead account it discovered (#3 "approved … but swept/expired").
+    const why = container.querySelector('.v10-pca-verdict-why') as HTMLButtonElement;
+    await act(async () => { why.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'approved on PCA #9, but it’s swept/expired');
+    await unmount();
+  });
+
+  // (iii) tracked fast-path UNCHANGED — a wallet covered by a TRACKED account resolves
+  // GREEN without the untracked label and WITHOUT a GAP-3 lookup (the augment is skipped).
+  it('GAP-3 — tracked coverage is unchanged (no untracked label, no GAP-3 call)', async () => {
+    usePcaStore.setState({ trackedIds: ['7'], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('100'));
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...makePcaSnapshot(), probedKey: { key, registered: true } } : makePcaSnapshot(),
+    );
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'Funded by PCA #7');
+    expect(container.textContent).not.toContain('not tracked by this node');
+    expect(mocks.pcaAgentAccount).not.toHaveBeenCalled(); // fast-path covered → augment skipped
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -530,4 +530,46 @@ describe('PublishEligibilityChip (S5)', () => {
     expect(mocks.pcaAgentAccount).not.toHaveBeenCalled(); // fast-path covered → augment skipped
     await unmount();
   });
+
+  // (iv) the GAP-3 lookup THROWS (transport) → inconclusive (neutral), NEVER DANGER
+  // (#9): a wallet unregistered on the tracked set whose reverse-map read fails can't
+  // be confirmed as a fall-through.
+  it('GAP-3 — pcaAgentAccount throws → unknown (neutral), not DANGER (#9)', async () => {
+    usePcaStore.setState({ trackedIds: ['7'], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('0')); // no TRAC — the worst case
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      const base = makePcaSnapshot({ accountId: id });
+      return key ? { ...base, probedKey: { key, registered: false } } : base; // unregistered on tracked
+    });
+    mocks.pcaAgentAccount.mockRejectedValue(new Error('agent route down'));
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'PCA status unknown');
+    expect(container.querySelector('[data-verdict="fallthrough-no-funds"]')).toBeNull();
+    expect(container.querySelector('[data-verdict="unknown"]')).toBeTruthy();
+    await unmount();
+  });
+
+  // (v) accountId:null is a CONFIRMED "on no PCA" → a definitive fall-through, split by
+  // balance (#6): has-TRAC → amber "pays direct"; no-TRAC → danger "will FAIL". (The
+  // balance signals still populate WalletDetail; only coverage moved to GAP-3.)
+  it('GAP-3 — accountId:null confirms fall-through: has-TRAC → amber, no-TRAC → danger (#6)', async () => {
+    usePcaStore.setState({ trackedIds: ['7'], createPending: null });
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      const base = makePcaSnapshot({ accountId: id });
+      return key ? { ...base, probedKey: { key, registered: false } } : base; // unregistered on tracked
+    });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: null }); // on NO account anywhere
+
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('50')); // has TRAC
+    const amber = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(amber.container, 'No PCA discount');
+    expect(amber.container.querySelector('[data-verdict="fallthrough"]')).toBeTruthy();
+    await amber.unmount();
+
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('0')); // no TRAC
+    const danger = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(danger.container, 'Publish will fail');
+    expect(danger.container.querySelector('[data-verdict="fallthrough-no-funds"]')).toBeTruthy();
+    await danger.unmount();
+  });
 });

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -572,4 +572,27 @@ describe('PublishEligibilityChip (S5)', () => {
     expect(danger.container.querySelector('[data-verdict="fallthrough-no-funds"]')).toBeTruthy();
     await danger.unmount();
   });
+
+  // C (#1357) — complements (ii): an UNTRACKED account that is LIVE (not expired) but has
+  // NO budget → 'uncovered' via the OTHER reason facet (sawInsolvent), still NOT covered.
+  // Proves registered⇏covered through the out-of-budget branch of the GAP-3 augment too.
+  it('GAP-3 — wallet on an UNTRACKED live-but-zero-budget account is NOT covered (out-of-budget)', async () => {
+    usePcaStore.setState({ trackedIds: ['7'], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('50')); // has TRAC → amber, not danger
+    const noBudget = (id: string) =>
+      makePcaSnapshot({ accountId: id, topUpBuffer: '0', topUpBufferTrac: '0', baseEpochAllowance: '0' }); // live, zero budget
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      const base = id === '9' ? noBudget(id) : makePcaSnapshot({ accountId: id });
+      if (!key) return base;
+      return { ...base, probedKey: { key, registered: id === '9' } }; // unregistered on tracked #7, registered on untracked #9
+    });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: '9' });
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'No PCA discount'); // amber fall-through, NOT eligible
+    expect(container.querySelector('[data-verdict="eligible"]')).toBeNull();
+    const why = container.querySelector('.v10-pca-verdict-why') as HTMLButtonElement;
+    await act(async () => { why.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'out of budget'); // the discovered account's reason facet
+    await unmount();
+  });
 });


### PR DESCRIPTION
P1 of the PCA node-UI: the daemon + chain-adapter + agent-facade gaps and their UI, wiring three review-converged P0 stubs to live chain data. **No contract change.** First chained sub-PR after #1344, into the `feat/pca-node-ui` integration branch.

## What's in

- **B3 — live approved-wallet table (S3).** New adapter `getPublishingConvictionAgents` (on-chain `getRegisteredAgents` via the `readContract` failover, `ethers.getAddress`-normalized, `[]` on CALL_EXCEPTION) → facade delegator → `GET /api/pca/:id/agents` (mirrors `GET :id`: **404** unknown id / `200 { accountId, agents: [] }` for a real zero-agent account / **503** capability/transport, transport-guard before revert) → `listPcaAgents` + the new `PcaAgentList` component. Replaces P0's probe-only view (retiring the "chain exposes only the count" caveat) with a full list + graceful degrade back to the probe view on absent/503/404.
- **GAP-3 — agent→account discovery (S5/S6).** New facade `getConvictionAgentAccountId` delegator → `GET /api/pca/agent/:address` (chain-scoped reverse map: `isAddress`→400, `0n`→`accountId: null`, declared before the generic `GET :id`) → `pcaAgentAccount`. **S5 (Model B):** resolves each signing wallet's *actual* registered account — including one this node doesn't track — via `pcaAgentAccount`→`fetchPca`→`classifyCoverage`, fixing a false-fallthrough where a wallet covered by an untracked account previously read "pays direct." **S6:** surfaces "approved on PCA #N" discovery (no auto-track).
- **B10 — cross-PCA conflict (S4).** The register `409` now carries `existingAccountId` (decoded revert arg, with a reverse-map fallback wrapped so it never masks the 409, emitted only when `> 0n`), so the S4 copy names "approved on PCA #M — deregister it there first." The frontend was already wired in P0; this lights it up.

## Safety / invariants

The #1344 coverage-honesty model holds as a hard invariant: GAP-3's `accountId` is a discovery **input** only — `registered ⇏ covered`; the verdict always comes from `classifyCoverage` on the resolved snapshot (an untracked expired/insolvent/zero-budget account is NOT covered; transport → inconclusive, never DANGER; `accountId: null` → confirmed fall-through). So Model B can only *fix* false-fallthroughs, never mint a false green. The S5 verdict block (gas-aware GREEN / funding-aware fall-through / balance-unknown / mixed-inconclusive) is untouched, and `hasTrac`/`gasFunded`/`balanceUnknown` still drive the amber-vs-danger split (invariant 6). Untracked coverage is labelled honestly ("not tracked by this node"); discovery never auto-tracks.

## Tests

Adapter (real-Hardhat enumerate/deregister/nonexistent — CI-gated), mock-parity 25/25 (checksum-normalize), facade 7/7, daemon-pca-routes 54/54 (B3 200/`[]`/404/503×3/400; GAP-3 200/null/400/503; B10 decoded-arg/reverse-map/neither/fallback-throw), node-ui (PcaAgentList, the S5 Model-B 3 cases incl. untracked-expired → not-covered, S6 discovery, B10 describePcaError). Full node-ui serial suite green (1691 pass / 38 skip / 0 fail).
