### PR TITLE
feat(pca): P2 — confirmed discount badge (B8), budget widget (GAP-4/5), confirmed-discount bell

### DIFF
--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1513,9 +1513,10 @@ export class AgentRegistryMethods extends DKGAgentBase {
 
   async getPublishingConvictionAccountInfo(this: DKGAgent,
     accountId: bigint,
+    opts?: { extended?: boolean },
   ): Promise<V10PublishingConvictionAccountInfo | null> {
     if (typeof this.chain.getPublishingConvictionAccountInfo !== 'function') return null;
-    return this.chain.getPublishingConvictionAccountInfo(accountId);
+    return this.chain.getPublishingConvictionAccountInfo(accountId, opts);
   }
 
   /** Enumerate registered publishing agents (operational wallets) for a PCA.

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -74,4 +74,20 @@ describe('DKGAgent V10 PCA facade', () => {
     const agent = await makeAgent(new NoChainAdapter());
     expect(await agent.getConvictionAgentAccountId(ethers.Wallet.createRandom().address)).toBeNull();
   });
+
+  it('getPublishingConvictionAccountInfo threads { extended } through to the adapter (GAP-4/5)', async () => {
+    const owner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', owner.address);
+    const agent = await makeAgent(chain);
+    const created = await agent.createPublishingConvictionAccount(1_000n, 42n);
+    // Default delegation omits the extended fields.
+    const base = (await agent.getPublishingConvictionAccountInfo(created!.accountId))!;
+    expect(base.primaryNode).toBeUndefined();
+    expect(base.remainingAllowance).toBeUndefined();
+    // Extended delegation surfaces them (mock stubs).
+    const ext = (await agent.getPublishingConvictionAccountInfo(created!.accountId, { extended: true }))!;
+    expect(ext.primaryNode).toBe(0n);
+    expect(typeof ext.currentEpoch).toBe('number');
+    expect(ext.remainingAllowance).toBe(ext.baseEpochAllowance + ext.topUpBuffer);
+  });
 });

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -145,6 +145,22 @@ export interface OnChainPublishResult {
   effectiveGasPrice?: bigint;
   gasCostWei?: bigint;
   tokenAmount?: bigint;
+  /**
+   * B8 — present only when this publish drew on a Publishing Conviction
+   * Account (the `CostCovered` event was emitted). The cost fields are bigint
+   * (serialized as decimal strings via the daemon's bigint→string JSON replacer);
+   * `epoch` is a small int (number). The UI derives the discount bps from
+   * `baseCost`/`discountedCost`. Absent for a normal (non-PCA) publish → the
+   * confirmed-discount badge degrades hidden.
+   */
+  convictionCostCovered?: {
+    accountId: bigint;
+    epoch: number;
+    baseCost: bigint;
+    discountedCost: bigint;
+    drawnFromEpoch: bigint;
+    drawnFromTopUp: bigint;
+  };
 }
 
 export interface UpdateKAParams {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -431,6 +431,16 @@ export interface V10PublishingConvictionAccountInfo {
   agentCount: number;
   lastSettledWindow: number;
   fullySwept: boolean;
+  // GAP-4/5 — populated ONLY when getInfo is called with `{ extended: true }`
+  // (the S3 budget widget; the publish hot path omits them → zero extra reads),
+  // and best-effort within that (an extended-read error leaves them undefined so
+  // the UI shows "unknown", distinct from `primaryNode === 0n` = "no node").
+  // primaryNode / lastPrimaryNodeChangeEpoch are `accounts()` [9]/[10] (RFC-51);
+  // remainingAllowance + currentEpoch are this epoch's spend headroom + index.
+  primaryNode?: bigint;
+  lastPrimaryNodeChangeEpoch?: number;
+  remainingAllowance?: bigint;
+  currentEpoch?: number;
 }
 
 // ----- V10 publish types -----
@@ -929,7 +939,7 @@ export interface ChainAdapter {
   deregisterPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<TxResult>;
   isPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<boolean>;
   settlePublishingConvictionAccount?(accountId: bigint): Promise<TxResult>;
-  getPublishingConvictionAccountInfo?(accountId: bigint): Promise<V10PublishingConvictionAccountInfo | null>;
+  getPublishingConvictionAccountInfo?(accountId: bigint, opts?: { extended?: boolean }): Promise<V10PublishingConvictionAccountInfo | null>;
 
   /**
    * Enumerate the operational wallets registered as publishing agents on

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -125,9 +125,13 @@ type ScanProvider = { provider: JsonRpcProvider; backendHead: number };
  * B8 — decode the `CostCovered` event from a publish receipt's logs via the
  * PublishingConviction LOGIC ABI (the event is emitted by the logic contract, a
  * different address than KA storage, so the KA-storage receipt loop skips it).
- * Returns the discount detail (all bigint, so the daemon's JSON replacer
- * stringifies them) when a publish drew on a Publishing Conviction Account, else
- * `undefined`. Exported for unit testing.
+ * Returns the discount detail (cost fields bigint → decimal strings via the
+ * daemon's JSON replacer; `epoch` a number) when a publish drew on a Publishing
+ * Conviction Account, else `undefined`. `coverPublishingCost` runs once per
+ * publish tx, so a (batch) publish emits ONE CostCovered covering the batch's
+ * total draw — this returns that single event (the "discount applied" badge is
+ * tx-level; a precise per-KA breakdown would be a future enhancement). Exported
+ * for unit testing.
  */
 export function decodeConvictionCostCovered(
   logs: ReadonlyArray<{ topics: ReadonlyArray<string>; data: string }>,

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -20,7 +20,7 @@ import { HubResolutionCache } from './hub-resolution-cache.js';
 import { KeyedSerializer } from './keyed-mutex.js';
 import { floorPublishTokenAmount } from '@origintrail-official/dkg-core';
 import { loadAbi } from './evm-adapter-abi.js';
-import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
+import { errorCode, errorMessage, errorStatus, isTooLowAllowanceError, enrichEvmError, getPcaLogicInterface, HUB_STALE_ERROR_MARKERS, isInsufficientFundsError, InsufficientPublisherFundsError, formatNoFundedPublisherWalletMessage, type PublisherWalletBalance } from './evm-adapter-errors.js';
 import { resolveRpcUrls, boundedRetryFetchRequest, withTimeout, isRetryableRpcError, assertSuccessfulReceipt, sleep } from './evm-adapter-rpc.js';
 import { rpcHost } from './rpc-failover-log.js';
 import { ChainRpcTransportError, createRpcTimeoutError } from './chain-rpc-transport-error.js';
@@ -120,6 +120,36 @@ export const CG_REGISTRY_REORG_BUFFER_BLOCKS = 50;
 const KA_HIGH_WATER_PAGE_TIMEOUT_MS = 15_000;
 
 type ScanProvider = { provider: JsonRpcProvider; backendHead: number };
+
+/**
+ * B8 — decode the `CostCovered` event from a publish receipt's logs via the
+ * PublishingConviction LOGIC ABI (the event is emitted by the logic contract, a
+ * different address than KA storage, so the KA-storage receipt loop skips it).
+ * Returns the discount detail (all bigint, so the daemon's JSON replacer
+ * stringifies them) when a publish drew on a Publishing Conviction Account, else
+ * `undefined`. Exported for unit testing.
+ */
+export function decodeConvictionCostCovered(
+  logs: ReadonlyArray<{ topics: ReadonlyArray<string>; data: string }>,
+): OnChainPublishResult['convictionCostCovered'] {
+  const pcaLogic = getPcaLogicInterface();
+  for (const log of logs) {
+    try {
+      const parsed = pcaLogic.parseLog({ topics: [...log.topics], data: log.data });
+      if (parsed?.name === 'CostCovered') {
+        return {
+          accountId: BigInt(parsed.args.accountId),
+          epoch: Number(parsed.args.epoch),
+          baseCost: BigInt(parsed.args.baseCost),
+          discountedCost: BigInt(parsed.args.discountedCost),
+          drawnFromEpoch: BigInt(parsed.args.drawnFromEpoch),
+          drawnFromTopUp: BigInt(parsed.args.drawnFromTopUp),
+        };
+      }
+    } catch { /* not a PublishingConviction event */ }
+  }
+  return undefined;
+}
 
 function normalizeScanPageSize(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 1
@@ -2619,6 +2649,11 @@ export class EVMChainAdapterBase {
       }
     }
 
+    // B8: when this publish drew on a PCA, decode the CostCovered event so the
+    // daemon can return a CONFIRMED post-publish discount (vs the P0 predictive
+    // estimate). Absent for a non-PCA publish → the UI badge degrades hidden.
+    const convictionCostCovered = decodeConvictionCostCovered(receipt.logs);
+
     const blockTimestamp = await this.getBlockTimestamp(receipt.blockNumber);
 
     return {
@@ -2637,6 +2672,7 @@ export class EVMChainAdapterBase {
       effectiveGasPrice: receipt.gasPrice ? BigInt(receipt.gasPrice) : undefined,
       gasCostWei: receipt.gasUsed && receipt.gasPrice ? BigInt(receipt.gasUsed) * BigInt(receipt.gasPrice) : undefined,
       tokenAmount: params.tokenAmount,
+      ...(convictionCostCovered ? { convictionCostCovered } : {}),
     };
   }
 

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -70,10 +70,16 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     if (!this.contracts.dkgPublishingConvictionNFT) return 0;
     if (accountId <= 0n) return 0;
     try {
-      // `accounts(uint256)` returns
-      // (committedTRAC, createdAtEpoch, expiresAtEpoch, createdAtTimestamp,
-      //  expiresAtTimestamp, lockDurationEpochs, discountBps,
-      //  lastSettledWindow, fullySwept). Pull index 5.
+      // `accounts(uint256)` returns, in order:
+      //  [0] committedTRAC          [1] createdAtEpoch
+      //  [2] expiresAtEpoch         [3] createdAtTimestamp
+      //  [4] expiresAtTimestamp     [5] lockDurationEpochs
+      //  [6] discountBps            [7] lastSettledWindow
+      //  [8] fullySwept             [9] primaryNode (uint72, OT-RFC-51)
+      //  [10] lastPrimaryNodeChangeEpoch
+      // Pull index 5 for the lock duration. (primaryNode [9] /
+      // lastPrimaryNodeChangeEpoch [10] were appended in the RFC-51 bump;
+      // `getAccountInfo` does not surface them — GAP-4 reads them here.)
       const tuple = await this.readContract(
         this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.accounts', 'accounts', accountId,
       );
@@ -279,7 +285,10 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     });
   }
 
-  async getPublishingConvictionAccountInfo(accountId: bigint): Promise<V10PublishingConvictionAccountInfo | null> {
+  async getPublishingConvictionAccountInfo(
+    accountId: bigint,
+    opts?: { extended?: boolean },
+  ): Promise<V10PublishingConvictionAccountInfo | null> {
     await this.init();
     // Undeployed NFT → capability error (503). null is reserved below
     // for a genuine account-missing revert so the route can disambiguate.
@@ -288,7 +297,7 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       const t = await this.readContract(
         this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getAccountInfo', 'getAccountInfo', accountId,
       );
-      return {
+      const info: V10PublishingConvictionAccountInfo = {
         owner: ethers.getAddress(t[0]),
         committedTRAC: BigInt(t[1]),
         baseEpochAllowance: BigInt(t[2]),
@@ -302,6 +311,35 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
         lastSettledWindow: Number(t[10]),
         fullySwept: Boolean(t[11]),
       };
+      // GAP-4/5 (opt-in; the S3 budget widget passes `extended`). The default
+      // path (incl. the `convictionAccountCanCover` publish hot path) skips
+      // this entirely — zero extra reads. FAIL-SOFT: an extended-read error
+      // must NOT null the account (core getAccountInfo already succeeded); the
+      // fields are simply left undefined so the UI shows them as unknown
+      // (distinct from primaryNode '0' = "no designated node"). primaryNode /
+      // lastPrimaryNodeChangeEpoch are `accounts()` [9]/[10] (RFC-51, not in
+      // getAccountInfo); remainingAllowance is the current epoch's headroom.
+      if (opts?.extended) {
+        try {
+          const acct = await this.readContract(
+            this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.accounts', 'accounts', accountId,
+          );
+          info.primaryNode = BigInt(acct[9]);
+          info.lastPrimaryNodeChangeEpoch = Number(acct[10]);
+          if (!this.contracts.chronos) {
+            this.contracts.chronos = await this.resolveContract('Chronos');
+          }
+          const currentEpoch: bigint = BigInt(await this.readContract(
+            this.contracts.chronos, 'chronos.getCurrentEpoch', 'getCurrentEpoch',
+          ));
+          info.currentEpoch = Number(currentEpoch);
+          info.remainingAllowance = BigInt(await this.readContract(
+            this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getRemainingAllowance',
+            'getRemainingAllowance', accountId, currentEpoch,
+          ));
+        } catch { /* extended enrichment is best-effort; leave fields undefined */ }
+      }
+      return info;
     } catch (err: any) {
       if (err?.code === 'CALL_EXCEPTION') return null;
       throw err;

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -560,13 +560,17 @@ export class MockChainAdapter implements ChainAdapter {
     return { accountId, ...this.txResult(true) };
   }
 
-  async getPublishingConvictionAccountInfo(accountId: bigint): Promise<V10PublishingConvictionAccountInfo | null> {
+  async getPublishingConvictionAccountInfo(
+    accountId: bigint,
+    opts?: { extended?: boolean },
+  ): Promise<V10PublishingConvictionAccountInfo | null> {
     const acct = this.convictionAccounts.get(accountId);
     if (!acct) return null;
-    return {
+    const baseEpochAllowance = acct.committedTRAC / BigInt(acct.lockDurationEpochs);
+    const info: V10PublishingConvictionAccountInfo = {
       owner: acct.owner,
       committedTRAC: acct.committedTRAC,
-      baseEpochAllowance: acct.committedTRAC / BigInt(acct.lockDurationEpochs),
+      baseEpochAllowance,
       createdAtEpoch: acct.createdAtEpoch,
       // Mock models boundary-aligned creation only; the contract's mid-epoch
       // round-up (epochAtTimestamp(expiresAtTimestamp-1)+1) is not modeled.
@@ -582,6 +586,16 @@ export class MockChainAdapter implements ChainAdapter {
       lastSettledWindow: 0,
       fullySwept: false,
     };
+    if (opts?.extended) {
+      // GAP-4/5 stubs — mock doesn't model RFC-51 per-node allocation
+      // (primaryNode 0n) or per-epoch decay; current-epoch headroom is the
+      // nominal base allowance + top-up buffer.
+      info.primaryNode = 0n;
+      info.lastPrimaryNodeChangeEpoch = 0;
+      info.currentEpoch = acct.createdAtEpoch;
+      info.remainingAllowance = baseEpochAllowance + acct.topUpBuffer;
+    }
+    return info;
   }
 
   private requireConvictionAccount(accountId: bigint) {

--- a/packages/chain/test/conviction-cost-covered-decode.test.ts
+++ b/packages/chain/test/conviction-cost-covered-decode.test.ts
@@ -1,0 +1,51 @@
+/**
+ * B8 — `decodeConvictionCostCovered` unit coverage (no chain needed).
+ *
+ * The CostCovered event is emitted by the PublishingConviction LOGIC contract
+ * (a different address than KA storage), so `createKnowledgeAssets` decodes it
+ * in a separate pass via the PCA logic ABI. A real PCA-covered publish needs a
+ * StorageACK quorum (multi-node), so the end-to-end 3-route surfacing is
+ * exercised on the CI devnet @mutating lane; here we pin the decode itself by
+ * round-tripping a synthesized log through the same interface.
+ */
+import { describe, it, expect } from 'vitest';
+import { decodeConvictionCostCovered } from '../src/evm-adapter-base.js';
+import { getPcaLogicInterface } from '../src/evm-adapter-errors.js';
+
+function costCoveredLog(values: bigint[]): { topics: string[]; data: string } {
+  const iface = getPcaLogicInterface();
+  const ev = iface.getEvent('CostCovered');
+  if (!ev) throw new Error('CostCovered event missing from PublishingConviction ABI');
+  const { topics, data } = iface.encodeEventLog(ev, values);
+  return { topics, data };
+}
+
+describe('decodeConvictionCostCovered (B8)', () => {
+  it('round-trips a CostCovered log into bigint discount detail', () => {
+    // accountId, epoch, baseCost, discountedCost, drawnFromEpoch, drawnFromTopUp
+    const log = costCoveredLog([7n, 42n, 1000n, 700n, 500n, 200n]);
+    expect(decodeConvictionCostCovered([log])).toEqual({
+      accountId: 7n,
+      epoch: 42,
+      baseCost: 1000n,
+      discountedCost: 700n,
+      drawnFromEpoch: 500n,
+      drawnFromTopUp: 200n,
+    });
+  });
+
+  it('returns undefined when there is no CostCovered log', () => {
+    expect(decodeConvictionCostCovered([])).toBeUndefined();
+    // An unrelated/garbage log is ignored, not thrown.
+    expect(decodeConvictionCostCovered([{ topics: ['0x' + '11'.repeat(32)], data: '0x' }])).toBeUndefined();
+  });
+
+  it('finds CostCovered among unrelated logs', () => {
+    const out = decodeConvictionCostCovered([
+      { topics: ['0x' + 'aa'.repeat(32)], data: '0x' },
+      costCoveredLog([1n, 2n, 3n, 4n, 5n, 6n]),
+    ]);
+    expect(out?.accountId).toBe(1n);
+    expect(out?.discountedCost).toBe(4n);
+  });
+});

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -38,6 +38,23 @@ describe('MockChainAdapter — V10 conviction account create/read', () => {
     expect(await mock.getPublishingConvictionAccountInfo(999n)).toBeNull();
   });
 
+  it('getPublishingConvictionAccountInfo extended adds GAP-4/5 fields; default omits them', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+
+    const base = (await mock.getPublishingConvictionAccountInfo(accountId))!;
+    expect(base.primaryNode).toBeUndefined();
+    expect(base.remainingAllowance).toBeUndefined();
+    expect(base.currentEpoch).toBeUndefined();
+    expect(base.lastPrimaryNodeChangeEpoch).toBeUndefined();
+
+    const ext = (await mock.getPublishingConvictionAccountInfo(accountId, { extended: true }))!;
+    expect(ext.primaryNode).toBe(0n); // mock doesn't model RFC-51 per-node allocation
+    expect(ext.lastPrimaryNodeChangeEpoch).toBe(0);
+    expect(typeof ext.currentEpoch).toBe('number');
+    expect(ext.remainingAllowance).toBe(ext.baseEpochAllowance + ext.topUpBuffer);
+  });
+
   it('lifecycle metadata is internally consistent: expiresAtEpoch = createdAtEpoch + lockDurationEpochs', async () => {
     const mock = new MockChainAdapter('mock:31337', SIGNER);
     const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -129,6 +129,34 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(ext.remainingAllowance!).toBeGreaterThan(0n);
   });
 
+  it('getPublishingConvictionAccountInfo extended is FAIL-SOFT: an extended-read throw leaves the core account intact', async () => {
+    const owner = await fundedOwner();
+    const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);
+
+    // Force the extended enrichment reads (accounts / Chronos / remaining
+    // allowance) to throw, while getAccountInfo (the core read) still succeeds.
+    const realRead = (owner as any).readContract.bind(owner);
+    (owner as any).readContract = async (contract: unknown, label: string, method: string, ...args: unknown[]) => {
+      if (method === 'accounts' || method === 'getCurrentEpoch' || method === 'getRemainingAllowance') {
+        const e: any = new Error('simulated extended-read failure');
+        e.code = 'CALL_EXCEPTION';
+        throw e;
+      }
+      return realRead(contract, label, method, ...args);
+    };
+
+    const info = await owner.getPublishingConvictionAccountInfo(accountId, { extended: true });
+    // Core account is returned intact (NOT nulled) — the extended block is a
+    // nested try that swallows the throw and leaves the extended fields unset.
+    expect(info).not.toBeNull();
+    expect(info!.committedTRAC).toBe(COMMITTED);
+    expect(info!.owner.toLowerCase()).toBe(owner.getSignerAddress().toLowerCase());
+    expect(info!.primaryNode).toBeUndefined();
+    expect(info!.lastPrimaryNodeChangeEpoch).toBeUndefined();
+    expect(info!.currentEpoch).toBeUndefined();
+    expect(info!.remainingAllowance).toBeUndefined();
+  });
+
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -109,6 +109,26 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(await owner.getConvictionAgentAccountId(wallet)).toBe(0n);
   });
 
+  it('getPublishingConvictionAccountInfo extended returns primaryNode + current-epoch allowance from chain; default omits', async () => {
+    const owner = await fundedOwner();
+    // A non-zero primaryNode proves the adapter reads accounts() index [9] (not
+    // a neighbouring slot). coreProfileId is a registered sharding-table node.
+    const primaryNode = BigInt(getSharedContext().coreProfileId);
+    const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED, primaryNode);
+
+    const base = (await owner.getPublishingConvictionAccountInfo(accountId))!;
+    expect(base.primaryNode).toBeUndefined();
+    expect(base.remainingAllowance).toBeUndefined();
+    expect(base.currentEpoch).toBeUndefined();
+
+    const ext = (await owner.getPublishingConvictionAccountInfo(accountId, { extended: true }))!;
+    expect(ext.primaryNode).toBe(primaryNode);
+    expect(typeof ext.lastPrimaryNodeChangeEpoch).toBe('number');
+    expect(typeof ext.currentEpoch).toBe('number');
+    expect(ext.currentEpoch!).toBeGreaterThan(0);
+    expect(ext.remainingAllowance!).toBeGreaterThan(0n);
+  });
+
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/cli/src/daemon/activity-notification.ts
+++ b/packages/cli/src/daemon/activity-notification.ts
@@ -25,7 +25,7 @@
  */
 
 import type { DashboardDB } from '@origintrail-official/dkg-node-ui';
-import { ASSERTION_ACTIVITY_TYPE, type AssertionActivityKind } from '@origintrail-official/dkg-node-ui';
+import { ASSERTION_ACTIVITY_TYPE, PCA_COST_COVERED_TYPE, type AssertionActivityKind } from '@origintrail-official/dkg-node-ui';
 
 /**
  * Cheap local membership gate for the cross-node (gossip) activity emitter
@@ -120,6 +120,59 @@ export function recordAssertionActivity(
     title: 'Assertion activity',
     message: `Assertion ${input.kind} in ${contextGraphId}`,
     source: 'activity',
+    contextGraphId,
+    meta: JSON.stringify(meta),
+  });
+}
+
+export interface ConvictionCostCoveredInput {
+  contextGraphId: string;
+  /** The publishing wallet (publish msg.sender) — the bell is scoped to it. */
+  publisherAddress: string;
+  accountId: bigint | string;
+  epoch: number;
+  baseCost: bigint | string;
+  discountedCost: bigint | string;
+  drawnFromEpoch: bigint | string;
+  drawnFromTopUp: bigint | string;
+}
+
+/**
+ * B8 confirmed-discount bell — record one `pca_cost_covered` row when a publish
+ * drew on a Publishing Conviction Account (the adapter decoded the on-chain
+ * CostCovered event). Wallet-scoped: the read path (`scopeNotifications`) only
+ * surfaces it to the publishing wallet (the discount is that wallet's business,
+ * not the whole CG's — invariant 3), upgrading the P0 predictive alert to a
+ * server-confirmed one. Resilient: a malformed CG / non-address publisher is a
+ * no-op (null) and the caller's try/catch swallows DB errors — the bell must
+ * never break a publish. Returns the inserted row id, or null.
+ */
+export function recordConvictionCostCovered(
+  dashDb: Pick<DashboardDB, 'insertNotification'>,
+  input: ConvictionCostCoveredInput,
+): number | null {
+  const contextGraphId = input.contextGraphId?.trim();
+  if (!contextGraphId) return null;
+  const publisher = input.publisherAddress?.trim();
+  if (!publisher || !EVM_ADDRESS_RE.test(publisher)) return null;
+  const accountId = String(input.accountId);
+  const meta = {
+    publisherAddress: publisher.toLowerCase(),
+    accountId,
+    epoch: input.epoch,
+    baseCost: String(input.baseCost),
+    discountedCost: String(input.discountedCost),
+    drawnFromEpoch: String(input.drawnFromEpoch),
+    drawnFromTopUp: String(input.drawnFromTopUp),
+  };
+  return dashDb.insertNotification({
+    ts: Date.now(),
+    type: PCA_COST_COVERED_TYPE,
+    // Display is rendered from the typed meta; title/message satisfy the schema
+    // and remain useful for generic log inspection.
+    title: 'Publishing discount applied',
+    message: `Publish to ${contextGraphId} drew on PCA #${accountId}`,
+    source: 'pca',
     contextGraphId,
     meta: JSON.stringify(meta),
   });

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -771,8 +771,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           actorAgentAddress: requestAgentAddress,
           subGraphName,
         });
-        recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
       }
+      // B8: the PCA spend is on-chain-confirmed whenever CostCovered was decoded
+      // (the mint happened) — record the discount even on a 207 partial publish
+      // (minted on-chain, CG-binding failed). No-ops when no PCA was drawn.
+      recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
       const chain = pub?.onChainResult;
       const kaManifest = Array.isArray(pub?.kaManifest) ? pub.kaManifest : [];
       return jsonResponse(res, httpStatus, {
@@ -1021,11 +1024,13 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           const { httpStatus, reason } = classifyVmPublish(pub);
           if (httpStatus === 200) {
             result.status = "vm-confirmed";
-            recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
           } else {
             result.status = httpStatus === 207 ? "vm-partial" : "vm-failed";
             errors.push({ phase: "vm-publish", error: sanitizeRpcMessage(reason ?? "VM publish did not confirm") });
           }
+          // B8: record the confirmed discount on ANY on-chain spend (mint
+          // happened → CostCovered present), including the 207/partial branch.
+          recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
         } catch (e: any) {
           errors.push({ phase: "vm-publish", error: sanitizeRpcMessage(e?.message ?? String(e)) });
         }
@@ -1466,8 +1471,11 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         if (httpStatus === 200) {
           // Activity attributed to the SEAL author (PR #971), not the requester.
           recordActivityAndNotify(ctx, { contextGraphId, kind: "published", actorAgentAddress: pub?.seal?.authorAddress ?? pub?.authorAddress ?? requestAgentAddress, subGraphName });
-          recordPcaDiscount(ctx, contextGraphId, pub?.onChainResult);
         }
+        // B8: the PCA spend is on-chain-confirmed whenever CostCovered was
+        // decoded — record it even on a 207 partial publish (minted, binding
+        // failed). No-ops when no PCA was drawn.
+        recordPcaDiscount(ctx, contextGraphId, pub?.onChainResult);
         // Full publish payload (PR #971) so clients can reconcile sealed↔minted.
         return jsonResponse(res, httpStatus, {
           kaId: pub?.kaId,

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -763,6 +763,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         ...(chain?.blockNumber !== undefined ? { blockNumber: chain.blockNumber } : {}),
         ...(chain?.batchId !== undefined ? { batchId: String(chain.batchId) } : {}),
         ...(chain?.publisherAddress ? { publisherAddress: chain.publisherAddress } : {}),
+        ...(chain?.convictionCostCovered ? { convictionCostCovered: chain.convictionCostCovered } : {}),
         ...(typeof pub?.contextGraphError === "string" ? { contextGraphError: pub.contextGraphError } : {}),
         ...(reason ? { error: reason } : {}),
       });
@@ -987,6 +988,8 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           result.kaId = pub?.kaId;
           result.ual = pub?.ual;
           result.txHash = pub?.onChainResult?.txHash;
+          // B8: surface the confirmed PCA discount when this publish drew on one.
+          if (pub?.onChainResult?.convictionCostCovered) result.convictionCostCovered = pub.onChainResult.convictionCostCovered;
           // PR #972: only a fully-confirmed publish is "vm-confirmed"; a partial
           // (207) or non-confirmed (502) outcome is flagged as a tail error so
           // the atomic response is a 207 rather than a misleading success.
@@ -1451,6 +1454,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
             : {}),
           ...(Array.isArray(pub?.kas) ? { kas: pub.kas } : {}),
           ...(pub?.onChainResult?.blockNumber !== undefined ? { blockNumber: pub.onChainResult.blockNumber } : {}),
+          ...(pub?.onChainResult?.convictionCostCovered ? { convictionCostCovered: pub.onChainResult.convictionCostCovered } : {}),
           ...(typeof pub?.contextGraphError === "string" ? { contextGraphError: pub.contextGraphError } : {}),
           ...(reason ? { error: reason } : {}),
         });

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -48,7 +48,7 @@ import {
   noFundedPublisherWalletBody,
 } from "../http-utils.js";
 import { validatePreSignedAuthorAttestation } from "./memory.js";
-import { recordAssertionActivity } from "../activity-notification.js";
+import { recordAssertionActivity, recordConvictionCostCovered } from "../activity-notification.js";
 import {
   handleKaImportArtifactResolve,
   handleKaImportArtifactRead,
@@ -114,6 +114,30 @@ function recordActivityAndNotify(
     ctx.emitNotification?.({ contextGraphId: input.contextGraphId, type: "assertion_activity" });
   } catch {
     /* activity/notification is advisory — never block the lifecycle op */
+  }
+}
+
+// B8 confirmed-discount bell. When a publish drew on a PCA (the adapter decoded
+// CostCovered onto onChainResult), record a wallet-scoped `pca_cost_covered`
+// row for the publishing wallet. Advisory — never blocks the publish.
+function recordPcaDiscount(ctx: RequestContext, contextGraphId: string, onChain: any): void {
+  const cc = onChain?.convictionCostCovered;
+  const publisher = onChain?.publisherAddress;
+  if (!cc || !publisher) return;
+  try {
+    recordConvictionCostCovered(ctx.dashDb, {
+      contextGraphId,
+      publisherAddress: publisher,
+      accountId: cc.accountId,
+      epoch: cc.epoch,
+      baseCost: cc.baseCost,
+      discountedCost: cc.discountedCost,
+      drawnFromEpoch: cc.drawnFromEpoch,
+      drawnFromTopUp: cc.drawnFromTopUp,
+    });
+    ctx.emitNotification?.({ contextGraphId, type: "pca_cost_covered" });
+  } catch {
+    /* confirmed-discount bell is advisory — never block the publish */
   }
 }
 const FINALIZE_ONLY_CREATE_FIELDS = [
@@ -747,6 +771,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           actorAgentAddress: requestAgentAddress,
           subGraphName,
         });
+        recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
       }
       const chain = pub?.onChainResult;
       const kaManifest = Array.isArray(pub?.kaManifest) ? pub.kaManifest : [];
@@ -996,6 +1021,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
           const { httpStatus, reason } = classifyVmPublish(pub);
           if (httpStatus === 200) {
             result.status = "vm-confirmed";
+            recordPcaDiscount(ctx, resolvedContextGraphId, pub?.onChainResult);
           } else {
             result.status = httpStatus === 207 ? "vm-partial" : "vm-failed";
             errors.push({ phase: "vm-publish", error: sanitizeRpcMessage(reason ?? "VM publish did not confirm") });
@@ -1440,6 +1466,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
         if (httpStatus === 200) {
           // Activity attributed to the SEAL author (PR #971), not the requester.
           recordActivityAndNotify(ctx, { contextGraphId, kind: "published", actorAgentAddress: pub?.seal?.authorAddress ?? pub?.authorAddress ?? requestAgentAddress, subGraphName });
+          recordPcaDiscount(ctx, contextGraphId, pub?.onChainResult);
         }
         // Full publish payload (PR #971) so clients can reconcile sealed↔minted.
         return jsonResponse(res, httpStatus, {

--- a/packages/cli/src/daemon/routes/notifications.ts
+++ b/packages/cli/src/daemon/routes/notifications.ts
@@ -11,7 +11,7 @@
 //   GET  /api/notifications        → scoped { notifications, badgeCount, scopeUnknown? }
 //   POST /api/notifications/read   → mark ids + digestKeys read (caller-scoped)
 
-import { scopeNotifications, type NotificationScopeContext } from '@origintrail-official/dkg-node-ui';
+import { scopeNotifications, PCA_COST_COVERED_TYPE, type NotificationScopeContext } from '@origintrail-official/dkg-node-ui';
 import { jsonResponse, readBody, SMALL_BODY_BYTES } from '../http-utils.js';
 import type { RequestContext } from './context.js';
 
@@ -87,28 +87,44 @@ async function resolveCallerScope(ctx: RequestContext, callerAddress: string): P
   return { callerAddress, memberCgIds, curatedCgIds, contextGraphNames };
 }
 
-/** Confirmation types — the caller's own outbound-request resolutions. */
-const CONFIRMATION_TYPES = ['join_approved', 'join_rejected'];
+/**
+ * Wallet-scoped notification types — the caller's OWN rows, which are NOT
+ * CG-membership-scoped and so must be fetched by TYPE + filtered by the
+ * caller's wallet (the member-CG read would miss them):
+ *   - join_approved/join_rejected (scoped by meta.agentAddress) — a rejected
+ *     requester is no longer a member of the rejected CG (R3-1).
+ *   - pca_cost_covered (scoped by meta.publisherAddress) — a confirmed PCA
+ *     discount belongs to the publishing wallet, which may NOT be a "member"
+ *     of the CG it published to (e.g. a sponsored edge publishing to a core's
+ *     CG). Without this, the bell would only fire for member-CG self-publishes.
+ */
+const CONFIRMATION_TYPES = ['join_approved', 'join_rejected', PCA_COST_COVERED_TYPE];
 const CONFIRMATION_READ_LIMIT = 200;
 
 /**
- * The caller's OWN join confirmations (join_approved/join_rejected). These are
- * emitted only on the requester's node and are NOT CG-membership-scoped — a
- * rejected requester is no longer a member of the rejected CG, so the member-CG
- * read (getNotificationsForContextGraphs) would drop every rejection (R3-1).
- * Read them by type, then keep only the rows whose meta.agentAddress is the
- * caller (multi-agent-node safety; scopeNotifications enforces the same).
+ * The lowercased wallet a wallet-scoped row belongs to: `meta.agentAddress`
+ * for join confirmations, `meta.publisherAddress` for pca_cost_covered.
+ */
+function walletOfConfirmationRow(r: { type: string; meta: string | null }): string | undefined {
+  let meta: { agentAddress?: unknown; publisherAddress?: unknown };
+  try {
+    meta = JSON.parse(r.meta ?? '{}');
+  } catch {
+    return undefined;
+  }
+  const raw = r.type === PCA_COST_COVERED_TYPE ? meta.publisherAddress : meta.agentAddress;
+  return typeof raw === 'string' ? raw.toLowerCase() : undefined;
+}
+
+/**
+ * The caller's OWN wallet-scoped rows (see CONFIRMATION_TYPES). Read by type,
+ * then keep only the rows whose owning wallet is the caller (multi-agent-node
+ * safety; scopeNotifications re-enforces the same scope at the wire layer).
  */
 function callerConfirmationRows(ctx: RequestContext, callerAddress: string) {
-  return ctx.dashDb.getNotificationsOfTypes(CONFIRMATION_TYPES, CONFIRMATION_READ_LIMIT).filter((r) => {
-    let metaAddr: unknown;
-    try {
-      metaAddr = (JSON.parse(r.meta ?? '{}') as { agentAddress?: unknown }).agentAddress;
-    } catch {
-      return false;
-    }
-    return typeof metaAddr === 'string' && metaAddr.toLowerCase() === callerAddress;
-  });
+  return ctx.dashDb
+    .getNotificationsOfTypes(CONFIRMATION_TYPES, CONFIRMATION_READ_LIMIT)
+    .filter((r) => walletOfConfirmationRow(r) === callerAddress);
 }
 
 export async function handleNotificationRoutes(ctx: RequestContext): Promise<void> {

--- a/packages/cli/src/daemon/routes/notifications.ts
+++ b/packages/cli/src/daemon/routes/notifications.ts
@@ -11,7 +11,7 @@
 //   GET  /api/notifications        → scoped { notifications, badgeCount, scopeUnknown? }
 //   POST /api/notifications/read   → mark ids + digestKeys read (caller-scoped)
 
-import { scopeNotifications, PCA_COST_COVERED_TYPE, type NotificationScopeContext } from '@origintrail-official/dkg-node-ui';
+import { scopeNotifications, type NotificationScopeContext } from '@origintrail-official/dkg-node-ui';
 import { jsonResponse, readBody, SMALL_BODY_BYTES } from '../http-utils.js';
 import type { RequestContext } from './context.js';
 
@@ -87,44 +87,43 @@ async function resolveCallerScope(ctx: RequestContext, callerAddress: string): P
   return { callerAddress, memberCgIds, curatedCgIds, contextGraphNames };
 }
 
-/**
- * Wallet-scoped notification types — the caller's OWN rows, which are NOT
- * CG-membership-scoped and so must be fetched by TYPE + filtered by the
- * caller's wallet (the member-CG read would miss them):
- *   - join_approved/join_rejected (scoped by meta.agentAddress) — a rejected
- *     requester is no longer a member of the rejected CG (R3-1).
- *   - pca_cost_covered (scoped by meta.publisherAddress) — a confirmed PCA
- *     discount belongs to the publishing wallet, which may NOT be a "member"
- *     of the CG it published to (e.g. a sponsored edge publishing to a core's
- *     CG). Without this, the bell would only fire for member-CG self-publishes.
- */
-const CONFIRMATION_TYPES = ['join_approved', 'join_rejected', PCA_COST_COVERED_TYPE];
+/** Confirmation types — the caller's own outbound-request resolutions. */
+const CONFIRMATION_TYPES = ['join_approved', 'join_rejected'];
 const CONFIRMATION_READ_LIMIT = 200;
 
 /**
- * The lowercased wallet a wallet-scoped row belongs to: `meta.agentAddress`
- * for join confirmations, `meta.publisherAddress` for pca_cost_covered.
+ * The caller's OWN join confirmations (join_approved/join_rejected). These are
+ * emitted only on the requester's node and are NOT CG-membership-scoped — a
+ * rejected requester is no longer a member of the rejected CG, so the member-CG
+ * read (getNotificationsForContextGraphs) would drop every rejection (R3-1).
+ * Read them by type, then keep only the rows whose meta.agentAddress is the
+ * caller (multi-agent-node safety; scopeNotifications enforces the same).
  */
-function walletOfConfirmationRow(r: { type: string; meta: string | null }): string | undefined {
-  let meta: { agentAddress?: unknown; publisherAddress?: unknown };
-  try {
-    meta = JSON.parse(r.meta ?? '{}');
-  } catch {
-    return undefined;
-  }
-  const raw = r.type === PCA_COST_COVERED_TYPE ? meta.publisherAddress : meta.agentAddress;
-  return typeof raw === 'string' ? raw.toLowerCase() : undefined;
+function callerConfirmationRows(ctx: RequestContext, callerAddress: string) {
+  return ctx.dashDb.getNotificationsOfTypes(CONFIRMATION_TYPES, CONFIRMATION_READ_LIMIT).filter((r) => {
+    let metaAddr: unknown;
+    try {
+      metaAddr = (JSON.parse(r.meta ?? '{}') as { agentAddress?: unknown }).agentAddress;
+    } catch {
+      return false;
+    }
+    return typeof metaAddr === 'string' && metaAddr.toLowerCase() === callerAddress;
+  });
 }
 
 /**
- * The caller's OWN wallet-scoped rows (see CONFIRMATION_TYPES). Read by type,
- * then keep only the rows whose owning wallet is the caller (multi-agent-node
- * safety; scopeNotifications re-enforces the same scope at the wire layer).
+ * The caller's OWN confirmed-discount rows (pca_cost_covered, B8). Also wallet-
+ * scoped + NOT CG-membership-scoped (the publishing wallet may not be a member
+ * of the CG it published to — a sponsored edge), but on a DEDICATED SQL-filtered
+ * fetch (`getPcaCostCoveredRowsForWallet`, by type + meta.publisherAddress) — NOT
+ * the shared join `getNotificationsOfTypes` window. Discount rows are higher
+ * volume (one per discounted publish vs rare joins), so cap-sharing would let a
+ * busy node's join/other volume age a non-member publisher's older discount rows
+ * out of the 200-window → hidden + unmarkable (#1365 round-2). The SQL already
+ * filters to the caller's wallet, so no JS post-filter is needed.
  */
-function callerConfirmationRows(ctx: RequestContext, callerAddress: string) {
-  return ctx.dashDb
-    .getNotificationsOfTypes(CONFIRMATION_TYPES, CONFIRMATION_READ_LIMIT)
-    .filter((r) => walletOfConfirmationRow(r) === callerAddress);
+function callerPcaDiscountRows(ctx: RequestContext, callerAddress: string) {
+  return ctx.dashDb.getPcaCostCoveredRowsForWallet(callerAddress, CONFIRMATION_READ_LIMIT);
 }
 
 export async function handleNotificationRoutes(ctx: RequestContext): Promise<void> {
@@ -157,6 +156,9 @@ export async function handleNotificationRoutes(ctx: RequestContext): Promise<voi
       const byId = new Map<number, (typeof memberRows)[number]>();
       for (const r of memberRows) byId.set(r.id, r);
       for (const r of callerConfirmationRows(ctx, callerAddress)) byId.set(r.id, r);
+      // ...PLUS the caller's own confirmed-discount rows on their OWN dedicated
+      // by-wallet fetch (not cap-shared with joins — #1365 round-2).
+      for (const r of callerPcaDiscountRows(ctx, callerAddress)) byId.set(r.id, r);
       const notifications = [...byId.values()];
 
       // Authoritative pending-join set per curated CG (G3 reconcile).
@@ -216,6 +218,8 @@ export async function handleNotificationRoutes(ctx: RequestContext): Promise<voi
       // Include the caller's own confirmations (not member-CG-scoped — R3-1) so
       // they can mark their join_approved/join_rejected rows read too.
       for (const r of callerConfirmationRows(ctx, callerAddress)) scopedIds.add(r.id);
+      // ...and their confirmed-discount rows (dedicated by-wallet fetch — r2).
+      for (const r of callerPcaDiscountRows(ctx, callerAddress)) scopedIds.add(r.id);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       return jsonResponse(res, 500, { error: `Failed to resolve notification scope: ${message}` });

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -183,6 +183,14 @@ function serializeAccountInfo(
     agentCount: info.agentCount,
     lastSettledWindow: info.lastSettledWindow,
     fullySwept: info.fullySwept,
+    // GAP-4/5 — present only on the extended read (S3 budget widget); omitted
+    // (not zeroed) when absent so the UI can tell "unknown" from a real value.
+    ...(info.primaryNode !== undefined ? { primaryNode: info.primaryNode.toString() } : {}),
+    ...(info.lastPrimaryNodeChangeEpoch !== undefined ? { lastPrimaryNodeChangeEpoch: info.lastPrimaryNodeChangeEpoch } : {}),
+    ...(info.remainingAllowance !== undefined
+      ? { remainingAllowance: info.remainingAllowance.toString(), remainingAllowanceTrac: ethers.formatEther(info.remainingAllowance) }
+      : {}),
+    ...(info.currentEpoch !== undefined ? { currentEpoch: info.currentEpoch } : {}),
   };
 }
 
@@ -500,7 +508,9 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
   }
 
   // GET /api/pca/:id — V10 conviction NFT snapshot. Optional ?key=0x...
-  // probes whether that address is a registered agent.
+  // probes whether that address is a registered agent. Optional ?extended=1
+  // adds the GAP-4/5 budget fields (primaryNode + current-epoch allowance);
+  // default-OFF so the hot S1/S5 polling path stays cheap (no extra reads).
   if (req.method === 'GET' && /^\/api\/pca\/[^/]+$/.test(path)) {
     const idStr = decodeURIComponent(path.split('/')[3] ?? '');
     const accountId = parseAccountId(idStr);
@@ -508,7 +518,8 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
       return jsonResponse(res, 400, { error: 'Invalid accountId — must be a non-negative integer' });
     }
     try {
-      const info = await agent.getPublishingConvictionAccountInfo(accountId);
+      const extended = ctx.url.searchParams.get('extended') === '1';
+      const info = await agent.getPublishingConvictionAccountInfo(accountId, { extended });
       if (info === null) {
         // null = view absent OR account missing; the facade capability
         // signal disambiguates (no chain surface → 503, else genuine 404).

--- a/packages/cli/test/activity-notification.test.ts
+++ b/packages/cli/test/activity-notification.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DashboardDB, ASSERTION_ACTIVITY_TYPE } from '@origintrail-official/dkg-node-ui';
+import { DashboardDB, ASSERTION_ACTIVITY_TYPE, PCA_COST_COVERED_TYPE } from '@origintrail-official/dkg-node-ui';
 import {
   recordAssertionActivity,
+  recordConvictionCostCovered,
   toActorAgentDid,
   localNodeInvolvedInContextGraph,
 } from '../src/daemon/activity-notification.js';
@@ -125,5 +126,51 @@ describe('localNodeInvolvedInContextGraph (CR-2 gossip gate)', () => {
 
   it('false for a blank contextGraphId', () => {
     expect(localNodeInvolvedInContextGraph(db, '  ')).toBe(false);
+  });
+});
+
+describe('recordConvictionCostCovered (B8 confirmed-discount bell)', () => {
+  const PUBLISHER = '0xAbCdEf0123456789012345678901234567890123';
+
+  it('persists a pca_cost_covered row with lowercased publisher + string cost fields', () => {
+    const id = recordConvictionCostCovered(db, {
+      contextGraphId: 'cg-1',
+      publisherAddress: PUBLISHER,
+      accountId: 7n,
+      epoch: 42,
+      baseCost: 1000n,
+      discountedCost: 700n,
+      drawnFromEpoch: 500n,
+      drawnFromTopUp: 200n,
+    });
+    expect(typeof id).toBe('number');
+
+    const { notifications } = db.getNotifications();
+    expect(notifications).toHaveLength(1);
+    const r = notifications[0];
+    expect(r.type).toBe(PCA_COST_COVERED_TYPE);
+    expect(r.context_graph_id).toBe('cg-1');
+    const meta = JSON.parse(r.meta!);
+    expect(meta).toMatchObject({
+      publisherAddress: PUBLISHER.toLowerCase(), // wallet-scoped match is case-insensitive
+      accountId: '7',
+      epoch: 42, // number
+      baseCost: '1000', // bigints → decimal strings
+      discountedCost: '700',
+      drawnFromEpoch: '500',
+      drawnFromTopUp: '200',
+    });
+  });
+
+  it('is a no-op (null) for a blank CG or a non-address publisher', () => {
+    expect(recordConvictionCostCovered(db, {
+      contextGraphId: '  ', publisherAddress: PUBLISHER, accountId: 1n, epoch: 1,
+      baseCost: 1n, discountedCost: 1n, drawnFromEpoch: 1n, drawnFromTopUp: 0n,
+    })).toBeNull();
+    expect(recordConvictionCostCovered(db, {
+      contextGraphId: 'cg-1', publisherAddress: 'not-an-address', accountId: 1n, epoch: 1,
+      baseCost: 1n, discountedCost: 1n, drawnFromEpoch: 1n, drawnFromTopUp: 0n,
+    })).toBeNull();
+    expect(db.getNotifications().notifications).toHaveLength(0);
   });
 });

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -855,4 +855,40 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(res.statusCode).toBe(409);
     expect(JSON.parse(res.body)).toEqual({ error: 'AgentAlreadyRegistered', accountId: '1' });
   });
+
+  // ----- GAP-4/5: GET /api/pca/:id?extended=1 (budget widget fields) -----
+  it('GET /api/pca/:id?extended=1 includes the GAP-4/5 fields; default GET :id omits them', async () => {
+    const baseInfo = {
+      owner: '0x' + '9'.repeat(40), committedTRAC: 100n, baseEpochAllowance: 1n,
+      createdAtEpoch: 1, expiresAtEpoch: 9, createdAtTimestamp: 0, expiresAtTimestamp: 0,
+      discountBps: 500, topUpBuffer: 0n, agentCount: 0, lastSettledWindow: 0, fullySwept: false,
+    };
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionAccountInfo: async (_id: bigint, opts?: { extended?: boolean }) =>
+        opts?.extended
+          ? { ...baseInfo, primaryNode: 42n, lastPrimaryNodeChangeEpoch: 3, remainingAllowance: 8333n, currentEpoch: 7 }
+          : baseInfo,
+    };
+
+    // Default: extended fields omitted (hot-poll path stays lean).
+    const def = runCtx('GET', '/api/pca/1', agent);
+    await def.done;
+    expect(def.res.statusCode).toBe(200);
+    const defBody = JSON.parse(def.res.body);
+    expect(defBody).not.toHaveProperty('primaryNode');
+    expect(defBody).not.toHaveProperty('remainingAllowance');
+    expect(defBody).not.toHaveProperty('currentEpoch');
+
+    // ?extended=1: fields present + typed (primaryNode/allowance strings, epochs numbers).
+    const ext = runCtx('GET', '/api/pca/1?extended=1', agent);
+    await ext.done;
+    expect(ext.res.statusCode).toBe(200);
+    const extBody = JSON.parse(ext.res.body);
+    expect(extBody.primaryNode).toBe('42');
+    expect(extBody.lastPrimaryNodeChangeEpoch).toBe(3);
+    expect(extBody.remainingAllowance).toBe('8333');
+    expect(extBody.remainingAllowanceTrac).toBe(ethers.formatEther(8333n));
+    expect(extBody.currentEpoch).toBe(7);
+  });
 });

--- a/packages/cli/test/notifications-route-pca.test.ts
+++ b/packages/cli/test/notifications-route-pca.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #1365 round-1 🔴 — `pca_cost_covered` is WALLET-scoped, not CG-membership-
+ * scoped, so the read + mark-read paths must fetch it by the caller's wallet
+ * (not only via the member-CG read). A real PCA-covered publish needs a
+ * StorageACK quorum (multi-node) and the live daemon runs in a child process,
+ * so this drives `handleNotificationRoutes` directly with a fake ctx whose
+ * caller is a member of NO context graph — proving the by-wallet fetch
+ * (`callerConfirmationRows`) surfaces + marks-read the discount alert anyway.
+ */
+import { describe, it, expect } from 'vitest';
+import { handleNotificationRoutes } from '../src/daemon/routes/notifications.js';
+import type { RequestContext } from '../src/daemon/routes/context.js';
+
+const CALLER = '0xaaaa000000000000000000000000000000000001';
+const OTHER = '0xbbbb000000000000000000000000000000000002';
+const TOKEN = 'tok-caller';
+
+function fakeRes() {
+  const res: any = { statusCode: 0, body: '' };
+  res.writeHead = (s: number) => { res.statusCode = s; };
+  res.end = (b: string) => { res.body = b; };
+  return res;
+}
+function fakeReq(method: string, path: string, body?: unknown) {
+  const req: any = { method, url: path };
+  if (body !== undefined) {
+    req.__dkgPrebufferedBody = Buffer.from(typeof body === 'string' ? body : JSON.stringify(body));
+  }
+  return req;
+}
+
+function pcaRow(id: number, publisher: string, read = 0) {
+  return {
+    id, ts: 1000 + id, type: 'pca_cost_covered',
+    title: 'Publishing discount applied', message: 'm', source: 'pca', peer: null, read,
+    // A CG the caller is NOT a member of (sponsored-edge scenario).
+    context_graph_id: 'cg-published',
+    meta: JSON.stringify({
+      contextGraphId: 'cg-published', publisherAddress: publisher, accountId: '7', epoch: 42,
+      baseCost: '1000', discountedCost: '700', drawnFromEpoch: '500', drawnFromTopUp: '200',
+    }),
+  };
+}
+
+function makeCtx(method: string, path: string, dashDb: any, body?: unknown): { ctx: RequestContext; res: any } {
+  const res = fakeRes();
+  const url = new URL(`http://127.0.0.1${path}`);
+  const agent = {
+    resolveAgentByToken: () => `did:dkg:agent:${CALLER}`,
+    getDefaultAgentAddress: () => `did:dkg:agent:${CALLER}`,
+    // Caller curates / belongs to NOTHING → memberCgIds + curatedCgIds empty.
+    listContextGraphs: async () => [],
+    listPendingJoinRequests: async () => [],
+  };
+  const ctx = {
+    req: fakeReq(method, path, body), res, agent, dashDb,
+    path: url.pathname, url, requestToken: TOKEN,
+  } as unknown as RequestContext;
+  return { ctx, res };
+}
+
+describe('#1365 🔴 — pca_cost_covered is wallet-scoped in GET/POST /api/notifications', () => {
+  it('a NON-member publisher still receives its confirmed-discount alert (by-wallet fetch + badge)', async () => {
+    const dashDb = {
+      getNotificationsForContextGraphs: () => [],
+      getNotificationsOfTypes: (types: string[]) =>
+        types.includes('pca_cost_covered') ? [pcaRow(1, CALLER)] : [],
+    };
+    const { ctx, res } = makeCtx('GET', '/api/notifications', dashDb);
+    await handleNotificationRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.notifications).toHaveLength(1);
+    expect(body.notifications[0].type).toBe('pca_cost_covered');
+    expect(body.notifications[0].meta.publisherAddress).toBe(CALLER);
+    expect(body.notifications[0].meta.epoch).toBe(42);
+    expect(body.badgeCount).toBe(1);
+  });
+
+  it('drops the alert for a DIFFERENT publisher wallet (no cross-wallet leak)', async () => {
+    const dashDb = {
+      getNotificationsForContextGraphs: () => [],
+      getNotificationsOfTypes: () => [pcaRow(1, OTHER)],
+    };
+    const { ctx, res } = makeCtx('GET', '/api/notifications', dashDb);
+    await handleNotificationRoutes(ctx);
+    expect(JSON.parse(res.body).notifications).toHaveLength(0);
+  });
+
+  it('the non-member publisher can mark its PCA alert read (id in the caller-scoped set)', async () => {
+    let marked: number[] = [];
+    const dashDb = {
+      getNotificationsForContextGraphs: () => [],
+      getNotificationsOfTypes: () => [pcaRow(1, CALLER)],
+      getScopedNotificationRowIds: () => new Set<number>(), // no member-CG rows
+      markNotificationsRead: (ids: number[]) => { marked = ids; return ids.length; },
+      resolveActivityDigestRowIds: () => [],
+    };
+    const { ctx, res } = makeCtx('POST', '/api/notifications/read', dashDb, { ids: [1] });
+    await handleNotificationRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(marked).toContain(1);
+    expect(JSON.parse(res.body).marked).toBe(1);
+  });
+});

--- a/packages/cli/test/notifications-route-pca.test.ts
+++ b/packages/cli/test/notifications-route-pca.test.ts
@@ -1,11 +1,15 @@
 /**
- * #1365 round-1 🔴 — `pca_cost_covered` is WALLET-scoped, not CG-membership-
- * scoped, so the read + mark-read paths must fetch it by the caller's wallet
- * (not only via the member-CG read). A real PCA-covered publish needs a
- * StorageACK quorum (multi-node) and the live daemon runs in a child process,
- * so this drives `handleNotificationRoutes` directly with a fake ctx whose
- * caller is a member of NO context graph — proving the by-wallet fetch
- * (`callerConfirmationRows`) surfaces + marks-read the discount alert anyway.
+ * #1365 🔴 — `pca_cost_covered` is WALLET-scoped, not CG-membership-scoped, and
+ * (round-2) is fetched on a DEDICATED by-wallet query so a busy node's
+ * higher-volume join/other confirmations can't age a non-member publisher's
+ * older discount rows out of the shared window.
+ *
+ * A real PCA-covered publish needs a StorageACK quorum (multi-node) and the
+ * live daemon runs in a child process, so this drives `handleNotificationRoutes`
+ * directly with a fake `dashDb`/agent whose caller is a member of NO context
+ * graph — proving the dedicated `getPcaCostCoveredRowsForWallet` fetch surfaces
+ * + marks-read the discount alert, and that pca is NOT folded into the shared
+ * join `getNotificationsOfTypes` window.
  */
 import { describe, it, expect } from 'vitest';
 import { handleNotificationRoutes } from '../src/daemon/routes/notifications.js';
@@ -42,6 +46,21 @@ function pcaRow(id: number, publisher: string, read = 0) {
   };
 }
 
+// Default fake dashDb: caller is in no member CG, no join confirmations, and the
+// dedicated by-wallet PCA fetch returns ONLY the caller's own rows (mirrors the
+// SQL `WHERE meta.publisherAddress = ?`). Override per test.
+function fakeDb(over: Record<string, any> = {}) {
+  return {
+    getNotificationsForContextGraphs: () => [],
+    getNotificationsOfTypes: () => [],
+    getPcaCostCoveredRowsForWallet: (w: string) => (w.toLowerCase() === CALLER ? [pcaRow(1, CALLER)] : []),
+    getScopedNotificationRowIds: () => new Set<number>(),
+    markNotificationsRead: (ids: number[]) => ids.length,
+    resolveActivityDigestRowIds: () => [],
+    ...over,
+  };
+}
+
 function makeCtx(method: string, path: string, dashDb: any, body?: unknown): { ctx: RequestContext; res: any } {
   const res = fakeRes();
   const url = new URL(`http://127.0.0.1${path}`);
@@ -59,14 +78,9 @@ function makeCtx(method: string, path: string, dashDb: any, body?: unknown): { c
   return { ctx, res };
 }
 
-describe('#1365 🔴 — pca_cost_covered is wallet-scoped in GET/POST /api/notifications', () => {
-  it('a NON-member publisher still receives its confirmed-discount alert (by-wallet fetch + badge)', async () => {
-    const dashDb = {
-      getNotificationsForContextGraphs: () => [],
-      getNotificationsOfTypes: (types: string[]) =>
-        types.includes('pca_cost_covered') ? [pcaRow(1, CALLER)] : [],
-    };
-    const { ctx, res } = makeCtx('GET', '/api/notifications', dashDb);
+describe('#1365 — pca_cost_covered is wallet-scoped via a dedicated fetch (GET/POST /api/notifications)', () => {
+  it('a NON-member publisher receives its confirmed-discount alert (+ badge)', async () => {
+    const { ctx, res } = makeCtx('GET', '/api/notifications', fakeDb());
     await handleNotificationRoutes(ctx);
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
@@ -77,11 +91,35 @@ describe('#1365 🔴 — pca_cost_covered is wallet-scoped in GET/POST /api/noti
     expect(body.badgeCount).toBe(1);
   });
 
-  it('drops the alert for a DIFFERENT publisher wallet (no cross-wallet leak)', async () => {
-    const dashDb = {
-      getNotificationsForContextGraphs: () => [],
-      getNotificationsOfTypes: () => [pcaRow(1, OTHER)],
-    };
+  it('does NOT fold pca into the shared join window, and an older PCA row survives many newer join confirmations (no cap-hiding, round-2)', async () => {
+    let typesAsked: string[] = [];
+    let pcaFetchedFor: string | undefined;
+    // The shared join window is "full" of newer join confirmations...
+    const joinRows = Array.from({ length: 200 }, (_, i) => ({
+      id: 1000 + i, ts: 50_000 + i, type: 'join_approved',
+      title: 'j', message: 'j', source: null, peer: null, read: 0,
+      context_graph_id: 'cg-x',
+      meta: JSON.stringify({ contextGraphId: 'cg-x', agentAddress: CALLER }),
+    }));
+    const dashDb = fakeDb({
+      getNotificationsOfTypes: (types: string[]) => { typesAsked = types; return joinRows; },
+      // ...but the OLDER discount row comes from its OWN dedicated fetch.
+      getPcaCostCoveredRowsForWallet: (w: string) => { pcaFetchedFor = w; return [pcaRow(1, CALLER)]; },
+    });
+    const { ctx, res } = makeCtx('GET', '/api/notifications', dashDb);
+    await handleNotificationRoutes(ctx);
+    const body = JSON.parse(res.body);
+    // pca is NOT in the cap-shared join fetch...
+    expect(typesAsked).not.toContain('pca_cost_covered');
+    // ...it's pulled by the dedicated by-wallet fetch...
+    expect(pcaFetchedFor?.toLowerCase()).toBe(CALLER);
+    // ...so the discount row is present despite the full join window.
+    expect(body.notifications.some((n: any) => n.type === 'pca_cost_covered')).toBe(true);
+  });
+
+  it('drops a wrong-wallet discount row at the wire layer (defense in depth)', async () => {
+    // Even if the fetch returned a foreign row, scopeNotifications re-enforces.
+    const dashDb = fakeDb({ getPcaCostCoveredRowsForWallet: () => [pcaRow(1, OTHER)] });
     const { ctx, res } = makeCtx('GET', '/api/notifications', dashDb);
     await handleNotificationRoutes(ctx);
     expect(JSON.parse(res.body).notifications).toHaveLength(0);
@@ -89,13 +127,7 @@ describe('#1365 🔴 — pca_cost_covered is wallet-scoped in GET/POST /api/noti
 
   it('the non-member publisher can mark its PCA alert read (id in the caller-scoped set)', async () => {
     let marked: number[] = [];
-    const dashDb = {
-      getNotificationsForContextGraphs: () => [],
-      getNotificationsOfTypes: () => [pcaRow(1, CALLER)],
-      getScopedNotificationRowIds: () => new Set<number>(), // no member-CG rows
-      markNotificationsRead: (ids: number[]) => { marked = ids; return ids.length; },
-      resolveActivityDigestRowIds: () => [],
-    };
+    const dashDb = fakeDb({ markNotificationsRead: (ids: number[]) => { marked = ids; return ids.length; } });
     const { ctx, res } = makeCtx('POST', '/api/notifications/read', dashDb, { ids: [1] });
     await handleNotificationRoutes(ctx);
     expect(res.statusCode).toBe(200);

--- a/packages/node-ui/src/db.ts
+++ b/packages/node-ui/src/db.ts
@@ -2268,6 +2268,30 @@ export class DashboardDB {
     ).all(...types, limit) as NotificationRow[];
   }
 
+  /**
+   * The caller's OWN confirmed-discount rows (`pca_cost_covered`, B8). Wallet-
+   * scoped, NOT CG-membership-scoped (the publishing wallet may not be a member
+   * of the CG it published to — a sponsored edge). Kept on a DEDICATED fetch
+   * (filtered in SQL by type + lowercased `meta.publisherAddress`) rather than
+   * the shared join-confirmation `getNotificationsOfTypes` window: discount rows
+   * are higher-volume (one per discounted publish vs rare join events), so
+   * cap-sharing would let a busy node's join/other volume age a publisher's older
+   * discount rows out of the window → hidden + unmarkable (#1365 round-2). The
+   * SQL pulls ONLY the caller's own rows under its own bound. The type literal
+   * mirrors `PCA_COST_COVERED_TYPE` (kept inline to avoid a notifications-scope
+   * import cycle into the DB layer).
+   */
+  getPcaCostCoveredRowsForWallet(walletAddress: string, limit = 200): NotificationRow[] {
+    const wallet = walletAddress.trim().toLowerCase();
+    if (!wallet) return [];
+    return this.db.prepare(
+      `SELECT * FROM notifications
+        WHERE type = 'pca_cost_covered'
+          AND lower(json_extract(meta, '$.publisherAddress')) = ?
+        ORDER BY ts DESC LIMIT ?`,
+    ).all(wallet, limit) as NotificationRow[];
+  }
+
   markNotificationsRead(ids?: number[]): number {
     if (ids && ids.length > 0) {
       const placeholders = ids.map(() => '?').join(',');

--- a/packages/node-ui/src/index.ts
+++ b/packages/node-ui/src/index.ts
@@ -38,7 +38,7 @@ export { OperationTracker } from './operation-tracker.js';
 export { MetricsCollector } from './metrics-collector.js';
 export type { MetricsSource } from './metrics-collector.js';
 export { handleNodeUIRequest } from './api.js';
-export { scopeNotifications } from './notifications-scope.js';
+export { scopeNotifications, PCA_COST_COVERED_TYPE } from './notifications-scope.js';
 export type {
   NotifWire,
   ScopedNotificationsResult,

--- a/packages/node-ui/src/notifications-scope.ts
+++ b/packages/node-ui/src/notifications-scope.ts
@@ -41,7 +41,10 @@ import {
 } from './db.js';
 
 const JOIN_TYPES = new Set(['join_request', 'join_approved', 'join_rejected']);
-const PANE_TYPES = new Set([...JOIN_TYPES, ASSERTION_ACTIVITY_TYPE]);
+/** B8 confirmed-discount alert — server-confirmed, wallet-scoped (the
+ *  publishing wallet's business, not the whole CG's; cf. invariant 3). */
+export const PCA_COST_COVERED_TYPE = 'pca_cost_covered';
+const PANE_TYPES = new Set([...JOIN_TYPES, ASSERTION_ACTIVITY_TYPE, PCA_COST_COVERED_TYPE]);
 
 export type NotifWire =
   | {
@@ -83,6 +86,26 @@ export type NotifWire =
         soleAuthor?: boolean;
         /** True when the sole author is the reading agent → render "You". */
         bySelf?: boolean;
+      };
+    }
+  | {
+      // B8 — a publish drew on a Publishing Conviction Account (CostCovered
+      // confirmed on-chain). Wallet-scoped to the publishing wallet. The UI
+      // derives the bps from baseCost/discountedCost.
+      type: 'pca_cost_covered';
+      id: number;
+      ts: number;
+      read: 0 | 1;
+      contextGraphId: string;
+      meta: {
+        contextGraphName?: string;
+        accountId: string;
+        epoch: number;
+        baseCost: string;
+        discountedCost: string;
+        drawnFromEpoch: string;
+        drawnFromTopUp: string;
+        publisherAddress: string;
       };
     };
 
@@ -169,6 +192,7 @@ export function scopeNotifications(
   const agentNameOf = (did: string): string | undefined => ctx.agentNames?.get(did);
 
   const joinWire: NotifWire[] = [];
+  const pcaWire: NotifWire[] = []; // B8 confirmed-discount alerts (wallet-scoped)
   // Dedup join_request to one row per (cg, agentAddress) — keep newest.
   const seenJoinRequest = new Map<string, number>(); // key → index in joinWire
   const activity = new Map<string, ActivityAccumulator>(); // digestKey → acc
@@ -213,6 +237,34 @@ export function scopeNotifications(
         acc.authors.add(actorDid);
         acc.lastAuthor = actorDid;
       }
+      continue;
+    }
+
+    if (row.type === PCA_COST_COVERED_TYPE) {
+      // Wallet-scoped (invariant 3): a confirmed discount is the PUBLISHING
+      // wallet's business, not the whole CG's — scope by publisherAddress ===
+      // caller (mirrors join_approved), fail closed if the caller is unknown.
+      // Placed BEFORE the join-family `meta.agentAddress` gate below (this row
+      // has `publisherAddress`, not `agentAddress`).
+      const publisher = asString(meta.publisherAddress);
+      if (!callerAddr || !publisher || lower(publisher) !== callerAddr) continue;
+      pcaWire.push({
+        type: 'pca_cost_covered',
+        id: row.id,
+        ts: row.ts,
+        read,
+        contextGraphId: cgId,
+        meta: {
+          ...(nameOf(cgId) ? { contextGraphName: nameOf(cgId) } : {}),
+          accountId: String(meta.accountId ?? ''),
+          epoch: Number(meta.epoch ?? 0),
+          baseCost: String(meta.baseCost ?? '0'),
+          discountedCost: String(meta.discountedCost ?? '0'),
+          drawnFromEpoch: String(meta.drawnFromEpoch ?? '0'),
+          drawnFromTopUp: String(meta.drawnFromTopUp ?? '0'),
+          publisherAddress: publisher,
+        },
+      });
       continue;
     }
 
@@ -297,7 +349,7 @@ export function scopeNotifications(
     });
   }
 
-  const notifications = [...joinWire, ...activityWire].sort((a, b) => b.ts - a.ts);
+  const notifications = [...joinWire, ...activityWire, ...pcaWire].sort((a, b) => b.ts - a.ts);
 
   // badgeCount = unread join_request + join_approved + activity digests.
   // join_rejected NEVER counts toward the badge (ux §2.4).

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -3337,11 +3337,27 @@ export interface AssertionActivityNotif extends NotifWireBase {
   };
 }
 
+/** B8 confirmed-discount bell row (P2) — a server-confirmed on-chain CostCovered
+ *  draw on one of THIS node's publishing wallets (wallet-scoped, mirrors
+ *  join_approved). Informational; counts toward the unread badge. `meta` reuses
+ *  {@link ConvictionCostCovered} plus the publishing wallet. `contextGraphId` is
+ *  optional (the locked wire shape). The P2 source is self-publish capture;
+ *  sponsored/owner-side draws are P3. */
+export interface PcaCostCoveredNotif {
+  type: 'pca_cost_covered';
+  id: number | string;
+  ts: number;
+  read: 0 | 1;
+  contextGraphId?: string;
+  meta: ConvictionCostCovered & { publisherAddress: string };
+}
+
 export type NotifWire =
   | JoinRequestNotif
   | JoinApprovedNotif
   | JoinRejectedNotif
-  | AssertionActivityNotif;
+  | AssertionActivityNotif
+  | PcaCostCoveredNotif;
 
 export interface NotificationsFeedResponse {
   /** Already scoped, type-allowlisted, activity-collapsed, join_request

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1988,12 +1988,33 @@ export function fileUrl(hash: string, contentType?: string): string {
   return `${BASE}/api/file/${encodeURIComponent(normalizedHash)}${params}`;
 }
 
+/**
+ * The post-publish CostCovered signal (B8) — decoded by the daemon from the on-chain
+ * `CostCovered(accountId, epoch, baseCost, discountedCost, drawnFromEpoch, drawnFromTopUp)`
+ * event and attached to the publish response when the publish drew on a PCA (absent
+ * otherwise → the badge degrades to hidden, #9). Lives at the api boundary so both the
+ * publish response and the `pca_cost_covered` bell meta reuse it. Wei amounts are decimal
+ * strings; `epoch` is a JSON number (uint40, fits safely in Number).
+ */
+export interface ConvictionCostCovered {
+  accountId: string;
+  epoch: number;
+  baseCost: string;
+  discountedCost: string;
+  drawnFromEpoch: string;
+  drawnFromTopUp: string;
+}
+
 export interface PublishResult {
   kaId: string;
   status: string;
   kas: { tokenId: string; rootEntity: string }[];
   txHash?: string;
   blockNumber?: number;
+  // B8 — the CONFIRMED post-publish discount, attached when this publish drew on a
+  // PCA (absent otherwise → DiscountAppliedBadge renders nothing, #9). Distinct from
+  // S5's pre-spend PREDICTION; the badge derives bps from baseCost/discountedCost.
+  convictionCostCovered?: ConvictionCostCovered;
   // Set when the daemon returned HTTP 207 (PR #972): the KA minted on-chain
   // (status "confirmed", txHash present) BUT the context-graph binding failed.
   // A PARTIAL publish — the asset is permanently on-chain, but it isn't linked

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1069,6 +1069,12 @@ export interface BatchPublishResult {
   // name/reason of each — `failures.length` is the failed count.
   failures: Array<{ name: string; subGraph?: string; error: string }>;
   sample: PublishResult | null; // a representative confirmed result for the headline
+  // B8 (#1365 round-3) — the CONFIRMED discount aggregated across the batch, NOT a
+  // property of the headline `sample` (which is picked for cleanliness, not discount).
+  // baseCost/discountedCost are SUMMED over every item that drew on a PCA, so the badge
+  // derives the blended % + the TRUE total saved; absent when no item drew one (→ badge
+  // hidden, #9). accountId/epoch name the first drawing item (single-PCA is the norm).
+  convictionCostCovered?: ConvictionCostCovered;
 }
 
 /**
@@ -1089,6 +1095,16 @@ export async function publishAssertionsToVm(
   let firstPartialError: string | undefined;
   const failures: BatchPublishResult['failures'] = [];
   let sample: PublishResult | null = null;
+  // B8 (#1365 round-3) — aggregate the CONFIRMED discount across the BATCH (the headline
+  // `sample` is picked for cleanliness, not discount, so a mixed batch could hide a real
+  // draw if the badge read it off `sample`). Sum baseCost/discountedCost over every item
+  // that drew on a PCA → blended % + true total saved; the first drawing item names the
+  // account/epoch.
+  let aggBase = 0n;
+  let aggDiscounted = 0n;
+  let aggDrawnEpoch = 0n;
+  let aggDrawnTopUp = 0n;
+  let firstCovered: ConvictionCostCovered | undefined;
   for (const a of items) {
     try {
       const res = await knowledgeAssetPublishWithSeal(
@@ -1107,6 +1123,18 @@ export async function publishAssertionsToVm(
       // Prefer a fully-clean sample (confirmed + txHash + no binding error) for the
       // headline; fall back to the first result otherwise.
       if (!sample || (pr.status === 'confirmed' && !!pr.txHash && !pr.contextGraphError)) sample = pr;
+      const cc = pr.convictionCostCovered;
+      if (cc) {
+        try {
+          aggBase += BigInt(cc.baseCost);
+          aggDiscounted += BigInt(cc.discountedCost);
+          aggDrawnEpoch += BigInt(cc.drawnFromEpoch);
+          aggDrawnTopUp += BigInt(cc.drawnFromTopUp);
+          if (!firstCovered) firstCovered = cc;
+        } catch {
+          // skip an un-parseable per-item event; never let it break the batch accounting.
+        }
+      }
     } catch (err: unknown) {
       const message =
         err instanceof SwmSubsetNotSealableError
@@ -1115,7 +1143,17 @@ export async function publishAssertionsToVm(
       failures.push({ name: a.name, ...(a.subGraph ? { subGraph: a.subGraph } : {}), error: message });
     }
   }
-  return { published, total: items.length, sealed, partial, partialError: firstPartialError, failures, sample };
+  const convictionCostCovered: ConvictionCostCovered | undefined = firstCovered
+    ? {
+        accountId: firstCovered.accountId,
+        epoch: firstCovered.epoch,
+        baseCost: aggBase.toString(),
+        discountedCost: aggDiscounted.toString(),
+        drawnFromEpoch: aggDrawnEpoch.toString(),
+        drawnFromTopUp: aggDrawnTopUp.toString(),
+      }
+    : undefined;
+  return { published, total: items.length, sealed, partial, partialError: firstPartialError, failures, sample, convictionCostCovered };
 }
 
 // --- Assertions (WM objects) ---

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -3349,7 +3349,7 @@ export interface PcaCostCoveredNotif {
   ts: number;
   read: 0 | 1;
   contextGraphId?: string;
-  meta: ConvictionCostCovered & { publisherAddress: string };
+  meta: ConvictionCostCovered & { publisherAddress: string; contextGraphName?: string };
 }
 
 export type NotifWire =

--- a/packages/node-ui/src/ui/components/Notifications/NotificationsPane.tsx
+++ b/packages/node-ui/src/ui/components/Notifications/NotificationsPane.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import type { UseNotificationsFeed } from '../../hooks/useNotificationsFeed.js';
 import type { PcaAlert } from '../../hooks/usePcaAlerts.js';
-import { JoinRequestRow, ActivityDigestRow, ConfirmationRow } from './rows.js';
+import { JoinRequestRow, ActivityDigestRow, ConfirmationRow, PcaCostCoveredRow } from './rows.js';
 
 export interface NotificationsPaneProps {
   feed: UseNotificationsFeed;
@@ -172,6 +172,9 @@ export function NotificationsPane({ feed, onOpenContextGraph, pcaAlerts = [], on
                         item={item}
                         onOpen={(cgId) => openAndMarkSeen(cgId, item.id)}
                       />
+                    ) : item.kind === 'pca_cost_covered' ? (
+                      // B8 (P2) — confirmed discount; informational, non-clickable.
+                      <PcaCostCoveredRow key={item.id} item={item} />
                     ) : (
                       <ConfirmationRow
                         key={item.id}

--- a/packages/node-ui/src/ui/components/Notifications/rows.tsx
+++ b/packages/node-ui/src/ui/components/Notifications/rows.tsx
@@ -337,24 +337,32 @@ export function PcaCostCoveredRow({
   try {
     const base = BigInt(item.covered.baseCost);
     const disc = BigInt(item.covered.discountedCost);
-    if (base > 0n && disc >= 0n && disc <= base) saved = formatWeiToTrac((base - disc).toString());
+    // STRICT (`disc < base`): a 0% draw (disc === base) is no saving → no "saved 0 TRAC".
+    if (base > 0n && disc >= 0n && disc < base) saved = formatWeiToTrac((base - disc).toString());
   } catch {
     saved = null;
   }
   const pca = `PCA #${item.covered.accountId}`;
   // Append the CG context when the daemon supplied it (meta.contextGraphName).
   const where = item.contextGraphName?.trim() ? ` in ${item.contextGraphName.trim()}` : '';
-  const detail = `${pct ? `−${pct}% ` : ''}via ${pca}${saved ? ` · saved ${saved} TRAC` : ''}${where}`;
+  // A genuine 0% draw (pct null but the event fired) still means the PCA COVERED the
+  // publish — surface that honestly WITHOUT a discount/saved claim (#9). Only a positive
+  // discount renders the "−X% … saved Y" copy.
+  const title = pct != null ? 'Publishing discount applied' : 'Publishing fee covered';
+  const detail =
+    pct != null
+      ? `−${pct}% via ${pca}${saved ? ` · saved ${saved} TRAC` : ''}${where}`
+      : `via ${pca}${where}`;
   const when = formatNotificationTimestamp(item.ts);
   return (
     <div
       className={`v10-notif-row v10-notif-row-confirm v10-notif-pca-discount${item.read ? '' : ' v10-notif-unread'}`}
       role="status"
-      aria-label={`Publishing discount applied, ${detail}${when ? `, ${when}` : ''}.`}
+      aria-label={`${title}, ${detail}${when ? `, ${when}` : ''}.`}
     >
       <span className="v10-notif-glyph v10-notif-glyph-approved" aria-hidden="true">◉</span>
       <span className="v10-notif-row-body" aria-hidden="true">
-        <span className="v10-notif-row-title">Publishing discount applied</span>
+        <span className="v10-notif-row-title">{title}</span>
         <span className="v10-notif-row-detail">{detail}</span>
       </span>
       <span className="v10-notif-time" aria-hidden="true" title={new Date(item.ts).toLocaleString()}>

--- a/packages/node-ui/src/ui/components/Notifications/rows.tsx
+++ b/packages/node-ui/src/ui/components/Notifications/rows.tsx
@@ -342,17 +342,19 @@ export function PcaCostCoveredRow({
     saved = null;
   }
   const pca = `PCA #${item.covered.accountId}`;
-  const detail = `${pct ? `−${pct}% ` : ''}via ${pca}${saved ? ` · saved ${saved} TRAC` : ''}`;
+  // Append the CG context when the daemon supplied it (meta.contextGraphName).
+  const where = item.contextGraphName?.trim() ? ` in ${item.contextGraphName.trim()}` : '';
+  const detail = `${pct ? `−${pct}% ` : ''}via ${pca}${saved ? ` · saved ${saved} TRAC` : ''}${where}`;
   const when = formatNotificationTimestamp(item.ts);
   return (
     <div
       className={`v10-notif-row v10-notif-row-confirm v10-notif-pca-discount${item.read ? '' : ' v10-notif-unread'}`}
       role="status"
-      aria-label={`Discount applied, ${detail}${when ? `, ${when}` : ''}.`}
+      aria-label={`Publishing discount applied, ${detail}${when ? `, ${when}` : ''}.`}
     >
       <span className="v10-notif-glyph v10-notif-glyph-approved" aria-hidden="true">◉</span>
       <span className="v10-notif-row-body" aria-hidden="true">
-        <span className="v10-notif-row-title">Discount applied</span>
+        <span className="v10-notif-row-title">Publishing discount applied</span>
         <span className="v10-notif-row-detail">{detail}</span>
       </span>
       <span className="v10-notif-time" aria-hidden="true" title={new Date(item.ts).toLocaleString()}>

--- a/packages/node-ui/src/ui/components/Notifications/rows.tsx
+++ b/packages/node-ui/src/ui/components/Notifications/rows.tsx
@@ -13,6 +13,7 @@
  */
 import React, { useState } from 'react';
 import { formatNotificationTimestamp } from '../../lib/formatTimestamp.js';
+import { convictionDiscountBps, formatWeiToTrac } from '../Pca/index.js';
 import type {
   JoinRequestItem,
   ActivityItem,
@@ -314,6 +315,49 @@ export function ConfirmationRow({
       aria-disabled="true"
     >
       {body}
+    </div>
+  );
+}
+
+// ─── PCA discount applied (informational, B8 confirmed) ──────────────────────
+
+/** B8 (P2) — the CONFIRMED post-publish discount bell row. Informational + non-
+ *  clickable (like the rejected confirmation), distinct from S5's predictive
+ *  "pending confirmation" alert: this is the on-chain CostCovered draw. Derives the
+ *  discount + saved amount from the event; falls back gracefully if the costs are
+ *  un-parseable (never asserts a bogus number — #9). */
+export function PcaCostCoveredRow({
+  item,
+}: {
+  item: Extract<ActivityItem, { kind: 'pca_cost_covered' }>;
+}) {
+  const bps = convictionDiscountBps(item.covered);
+  const pct = bps != null ? (bps / 100).toFixed(bps % 100 === 0 ? 0 : 1) : null;
+  let saved: string | null = null;
+  try {
+    const base = BigInt(item.covered.baseCost);
+    const disc = BigInt(item.covered.discountedCost);
+    if (base > 0n && disc >= 0n && disc <= base) saved = formatWeiToTrac((base - disc).toString());
+  } catch {
+    saved = null;
+  }
+  const pca = `PCA #${item.covered.accountId}`;
+  const detail = `${pct ? `−${pct}% ` : ''}via ${pca}${saved ? ` · saved ${saved} TRAC` : ''}`;
+  const when = formatNotificationTimestamp(item.ts);
+  return (
+    <div
+      className={`v10-notif-row v10-notif-row-confirm v10-notif-pca-discount${item.read ? '' : ' v10-notif-unread'}`}
+      role="status"
+      aria-label={`Discount applied, ${detail}${when ? `, ${when}` : ''}.`}
+    >
+      <span className="v10-notif-glyph v10-notif-glyph-approved" aria-hidden="true">◉</span>
+      <span className="v10-notif-row-body" aria-hidden="true">
+        <span className="v10-notif-row-title">Discount applied</span>
+        <span className="v10-notif-row-detail">{detail}</span>
+      </span>
+      <span className="v10-notif-time" aria-hidden="true" title={new Date(item.ts).toLocaleString()}>
+        {when}
+      </span>
     </div>
   );
 }

--- a/packages/node-ui/src/ui/components/Pca/DiscountAppliedBadge.tsx
+++ b/packages/node-ui/src/ui/components/Pca/DiscountAppliedBadge.tsx
@@ -1,19 +1,8 @@
 import React from 'react';
-
-/**
- * The post-publish CostCovered signal (B8). Decoded from the on-chain
- * `CostCovered(accountId, epoch, baseCost, discountedCost, drawnFromEpoch,
- * drawnFromTopUp)` event. Wei amounts are decimal strings.
- */
-export interface ConvictionCostCovered {
-  accountId: string;
-  /** Wire-serialized as a string (uint), like the other event fields. */
-  epoch: string;
-  baseCost: string;
-  discountedCost: string;
-  drawnFromEpoch: string;
-  drawnFromTopUp: string;
-}
+// B8 — the CostCovered wire type now lives at the api boundary (api.ts); re-export it
+// here so existing `components/Pca` importers (the barrel + mocks) keep resolving it.
+import type { ConvictionCostCovered } from '../../api.js';
+export type { ConvictionCostCovered };
 
 /**
  * The CONFIRMED discount in basis points, derived from the event (the bps

--- a/packages/node-ui/src/ui/components/Pca/DiscountAppliedBadge.tsx
+++ b/packages/node-ui/src/ui/components/Pca/DiscountAppliedBadge.tsx
@@ -8,8 +8,10 @@ export type { ConvictionCostCovered };
  * The CONFIRMED discount in basis points, derived from the event (the bps
  * isn't in the event itself): `10000 · (baseCost − discountedCost) / baseCost`.
  * BigInt math (uint96 wei can exceed `Number.MAX_SAFE_INTEGER`). Returns `null`
- * when the costs are missing/zero/un-parseable so the caller can hide rather
- * than assert a bogus 0%.
+ * when the costs are missing/zero/un-parseable OR when there is NO actual discount
+ * (`discounted >= base`) — a genuine 0% draw is reachable on-chain (the contract
+ * floors discountedCost back to baseCost, and discountBps==0 accounts exist), and
+ * must NOT render a bogus "−0%"/"saved 0" claim (#9). Only a POSITIVE discount returns.
  */
 export function convictionDiscountBps(covered: ConvictionCostCovered | null | undefined): number | null {
   if (!covered) return null;
@@ -21,7 +23,9 @@ export function convictionDiscountBps(covered: ConvictionCostCovered | null | un
   } catch {
     return null;
   }
-  if (base <= 0n || discounted < 0n || discounted > base) return null;
+  // `discounted >= base` (not `>`) → a 0% draw resolves to null, so the badge hides
+  // and the bell row drops the −%/saved rather than claiming a discount that isn't.
+  if (base <= 0n || discounted < 0n || discounted >= base) return null;
   // Round to nearest bps.
   return Number(((base - discounted) * 10000n + base / 2n) / base);
 }

--- a/packages/node-ui/src/ui/hooks/useNotificationsFeed.ts
+++ b/packages/node-ui/src/ui/hooks/useNotificationsFeed.ts
@@ -111,6 +111,7 @@ export type ActivityItem =
       kind: 'pca_cost_covered';
       id: number | string;
       cgId?: string;
+      contextGraphName?: string;
       covered: ConvictionCostCovered;
       publisherAddress: string;
       ts: number;
@@ -209,6 +210,7 @@ export function mapActivity(rows: NotifWire[]): ActivityItem[] {
         kind: 'pca_cost_covered',
         id: n.id,
         cgId: n.contextGraphId,
+        contextGraphName: n.meta.contextGraphName,
         covered: n.meta,
         publisherAddress: n.meta.publisherAddress,
         ts: n.ts,

--- a/packages/node-ui/src/ui/hooks/useNotificationsFeed.ts
+++ b/packages/node-ui/src/ui/hooks/useNotificationsFeed.ts
@@ -31,6 +31,7 @@ import {
   rejectJoinRequest,
   type NotifWire,
   type NotificationsFeedResponse,
+  type ConvictionCostCovered,
 } from '../api.js';
 // The scoped feed goes through the api-wrapper so the pane also resolves in
 // mock mode (withFallback). approve/reject/markRead are called directly on the
@@ -100,6 +101,18 @@ export type ActivityItem =
       id: number;
       cgId: string;
       contextGraphName?: string;
+      ts: number;
+      read: boolean;
+    }
+  | {
+      // B8 (P2) — a CONFIRMED on-chain CostCovered draw on one of this node's
+      // publishing wallets. Informational; `covered` carries the event so the row
+      // derives the discount + saved amount (reusing convictionDiscountBps).
+      kind: 'pca_cost_covered';
+      id: number | string;
+      cgId?: string;
+      covered: ConvictionCostCovered;
+      publisherAddress: string;
       ts: number;
       read: boolean;
     };
@@ -186,6 +199,18 @@ export function mapActivity(rows: NotifWire[]): ActivityItem[] {
         id: n.id as number,
         cgId: n.contextGraphId,
         contextGraphName: n.meta.contextGraphName,
+        ts: n.ts,
+        read: n.read === 1,
+      });
+    } else if (n.type === 'pca_cost_covered') {
+      // B8 (P2) — confirmed discount draw. `covered` = the CostCovered event (meta
+      // is a ConvictionCostCovered superset); the row derives the discount/saved.
+      out.push({
+        kind: 'pca_cost_covered',
+        id: n.id,
+        cgId: n.contextGraphId,
+        covered: n.meta,
+        publisherAddress: n.meta.publisherAddress,
         ts: n.ts,
         read: n.read === 1,
       });

--- a/packages/node-ui/src/ui/mocks/pca.ts
+++ b/packages/node-ui/src/ui/mocks/pca.ts
@@ -53,8 +53,9 @@ export const PCA_FIXTURES = {
 /** A B8 CostCovered event sample (baseCost 1000 → discountedCost 700 ⇒ 30%). */
 export const MOCK_COST_COVERED: ConvictionCostCovered = {
   accountId: '7',
-  // L10: epoch is wire-serialized as a string (uint), like the other fields.
-  epoch: '1284',
+  // P2 — epoch is a JSON number (uint40, fits safely in Number); the wei cost fields
+  // stay decimal strings. (Supersedes the P0 L10 all-strings note for epoch.)
+  epoch: 1284,
   baseCost: '1000',
   discountedCost: '700',
   drawnFromEpoch: '700',

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -84,7 +84,11 @@ const IDLE: ActionState = { busy: false, error: null, result: null };
  * txHash + a "still pending… verify here" escape.
  */
 export function ConvictionDetailView({ accountId }: { accountId: string }) {
-  const { data: snapshot, loading, error, refresh } = useFetch(() => fetchPca(accountId), [accountId]);
+  // GAP-4/5 — the S3 detail view opts into the EXTENDED snapshot (remainingAllowance /
+  // primaryNode / currentEpoch) for the budget widget. It's a single on-mount read (not a
+  // hot poll), so the extra readback cost is fine here; the fields are best-effort (absent
+  // on read-failure → the widget shows nothing, never a false value).
+  const { data: snapshot, loading, error, refresh } = useFetch(() => fetchPca(accountId, undefined, { extended: true }), [accountId]);
   const { data: wb, error: wbError, refresh: refreshWallets } = useFetch(fetchWalletsBalances, [], 0);
   const nodeStatus = useAgentsStore((s) => s.nodeStatus) as { blockExplorerUrl?: string | null } | null;
   const explorer = nodeStatus?.blockExplorerUrl ?? null;
@@ -307,8 +311,29 @@ function DetailBody({
         items={[
           { id: 'buffer', label: 'Top-up buffer', value: `${formatTrac(snapshot.topUpBufferTrac)} TRAC` },
           { id: 'per-epoch', label: 'TRAC per epoch', value: `${formatWeiToTrac(snapshot.baseEpochAllowance)} TRAC` },
+          // GAP-4/5 — the precise current-epoch remaining allowance (extended snapshot,
+          // best-effort). Display only — the coverage spine stays the coarse proxy (#1349
+          // is a separate decision). Omitted when the extended read didn't return it.
+          ...(snapshot.remainingAllowanceTrac != null
+            ? [{
+                id: 'remaining',
+                label: 'Remaining this epoch',
+                value: `${formatTrac(snapshot.remainingAllowanceTrac)} TRAC`,
+                tooltip: snapshot.currentEpoch != null ? `Current epoch ${snapshot.currentEpoch}` : undefined,
+              }]
+            : []),
           { id: 'wallets', label: 'Publishing wallets', value: `${snapshot.agentCount} / 100` },
           { id: 'expires', label: 'Expires', value: formatRelativeExpiry(snapshot.expiresAtTimestamp), tooltip: `Expiry epoch ${snapshot.expiresAtEpoch}` },
+          // GAP-4/5 — the node this PCA directs publishing-reward weight to. '0' = none set;
+          // ABSENT (read-failed) → omit, never a false value.
+          ...(snapshot.primaryNode != null
+            ? [{
+                id: 'primary-node',
+                label: 'Primary node',
+                value: snapshot.primaryNode === '0' ? 'None set' : `Node #${snapshot.primaryNode}`,
+                tooltip: snapshot.lastPrimaryNodeChangeEpoch != null ? `Last changed epoch ${snapshot.lastPrimaryNodeChangeEpoch}` : undefined,
+              }]
+            : []),
         ]}
       />
       <div className="v10-pca-detail-owner">

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -780,7 +780,7 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
       </div>
 
       {publishResult && (() => {
-        const { published, total, sealed, partial, partialError, failures, sample } = publishResult;
+        const { published, total, sealed, partial, partialError, failures, sample, convictionCostCovered } = publishResult;
         // "Clean" only when every asset published AND none came back as a 207
         // partial (minted on-chain but the CG binding failed).
         const allOk = published === total && published > 0 && partial === 0;
@@ -827,9 +827,10 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
                   an unfunded signer, or a chain adapter that isn&apos;t V10-ready).
                 </div>
               )}
-              {/* B8 — the CONFIRMED post-publish discount (from the on-chain CostCovered
-                  event). Renders nothing unless the publish drew on a PCA (#9). */}
-              <DiscountAppliedBadge convictionCostCovered={sample?.convictionCostCovered} />
+              {/* B8 — the CONFIRMED post-publish discount, aggregated across the BATCH (not
+                  off the headline `sample`, which is picked for cleanliness not discount —
+                  #1365 r3). Renders nothing unless some item drew on a PCA (#9). */}
+              <DiscountAppliedBadge convictionCostCovered={convictionCostCovered} />
             </div>
           </div>
         );

--- a/packages/node-ui/src/ui/views/MemoryLayerView.tsx
+++ b/packages/node-ui/src/ui/views/MemoryLayerView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, lazy, Suspense } from 'react';
 import { useFetch } from '../hooks.js';
 import { executeQuery, fetchStatus, listAssertions, promoteAssertion, publishAssertionsToVm, partialPublishWarning, describePromoteResult, describePromoteError, type AssertionInfo, type BatchPublishResult } from '../api.js';
 import { FilePreviewModal } from '../components/Modals/FilePreviewModal.js';
+import { DiscountAppliedBadge } from '../components/Pca/index.js';
 import { useMemoryGraphEvents } from '../hooks/useNodeEvents.js';
 import { memoryGraphLabels } from '../lib/memoryLabels.js';
 import { truncateMiddle } from '../lib/truncate.js';
@@ -826,6 +827,9 @@ export function PublishPanel({ contextGraphId, onPublished }: { contextGraphId: 
                   an unfunded signer, or a chain adapter that isn&apos;t V10-ready).
                 </div>
               )}
+              {/* B8 — the CONFIRMED post-publish discount (from the on-chain CostCovered
+                  event). Renders nothing unless the publish drew on a PCA (#9). */}
+              <DiscountAppliedBadge convictionCostCovered={sample?.convictionCostCovered} />
             </div>
           </div>
         );

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -1,11 +1,12 @@
 import React, { useId, useMemo, useState, useCallback, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { listAssertions, promoteAssertion, describePromoteError, knowledgeAssetFinalize, publishAssertionsToVm, partialPublishWarning } from '../../../api.js';
+import { listAssertions, promoteAssertion, describePromoteError, knowledgeAssetFinalize, publishAssertionsToVm, partialPublishWarning, type ConvictionCostCovered } from '../../../api.js';
 import type { MemoryEntity } from '../../../hooks/useMemoryEntities.js';
 import { useProjectProfileContext } from '../../../hooks/useProjectProfile.js';
 import { LAYER_CONFIG, entityMeta, layerNoun } from '../helpers.js';
 import { EmptyState, StatStrip, toneForLayer } from '../../../components/ContextGraphPrimitives.js';
 import { PublishEligibilityChip } from '../../../pages/conviction/PublishEligibilityChip.js';
+import { DiscountAppliedBadge } from '../../../components/Pca/index.js';
 
 // ─── Generative Widget Components ─────────────────────────────
 
@@ -114,6 +115,8 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete, o
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // B8 — the CONFIRMED post-publish discount from the VM publish response's sample.
+  const [costCovered, setCostCovered] = useState<ConvictionCostCovered | null>(null);
   const isWm = layer === 'wm';
   // S5 — the PCA eligibility verdict the publish button is aria-describedby'd to,
   // so a screen-reader user activating Publish hears the direct-cost/fail state.
@@ -129,6 +132,7 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete, o
     setBusy(true);
     setError(null);
     setResult(null);
+    setCostCovered(null);
     // Issue #864 (Codex review on #874) — track the in-flight
     // assertion so mid-loop failures surface "<name>: …" instead of
     // the generic "an assertion …".
@@ -186,6 +190,8 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete, o
           const tail = r.failures.length ? ` (${r.failures.length} assertion${r.failures.length === 1 ? '' : 's'} could not be published)` : '';
           const partialTail = r.partial > 0 ? ` — ⚠ ${r.partial}: ${partialPublishWarning(r.partialError)}` : '';
           setResult(`Published ${r.published} knowledge asset${r.published !== 1 ? 's' : ''} to Verifiable Memory${tail}${partialTail}`);
+          // B8 — surface the CONFIRMED discount when the publish drew on a PCA (absent → hidden).
+          setCostCovered(r.sample?.convictionCostCovered ?? null);
         } else if (assertions.length === 0) {
           setResult('Nothing to publish — promote assertions to Shared Memory first.');
         } else {
@@ -213,6 +219,10 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete, o
       </div>
       {result && <div data-testid="layer-action-result" style={{ fontSize: 11, color: 'var(--text-success)', marginBottom: 8 }}>✓ {result}</div>}
       {error && <div data-testid="layer-action-result" style={{ fontSize: 11, color: 'var(--text-danger)', marginBottom: 8 }}>✕ {error}</div>}
+      {/* B8 — the CONFIRMED post-publish discount (from the on-chain CostCovered event);
+          renders nothing unless this publish drew on a PCA (#9). Distinct from the S5
+          predictive chip below. */}
+      {!isWm && <DiscountAppliedBadge convictionCostCovered={costCovered} />}
       {/* S5 — PCA fall-through guard at the moment of spend (VM publish only). */}
       {!isWm && <PublishEligibilityChip contextGraphId={contextGraphId} id={verdictId} />}
       <div className="v10-decision-actions">

--- a/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
+++ b/packages/node-ui/src/ui/views/project/components/layer-widgets.tsx
@@ -190,8 +190,9 @@ export function LayerActionsWidget({ layer, count, contextGraphId, onComplete, o
           const tail = r.failures.length ? ` (${r.failures.length} assertion${r.failures.length === 1 ? '' : 's'} could not be published)` : '';
           const partialTail = r.partial > 0 ? ` — ⚠ ${r.partial}: ${partialPublishWarning(r.partialError)}` : '';
           setResult(`Published ${r.published} knowledge asset${r.published !== 1 ? 's' : ''} to Verifiable Memory${tail}${partialTail}`);
-          // B8 — surface the CONFIRMED discount when the publish drew on a PCA (absent → hidden).
-          setCostCovered(r.sample?.convictionCostCovered ?? null);
+          // B8 (#1365 r3) — the CONFIRMED discount aggregated across the BATCH (not off the
+          // headline sample, which is picked for cleanliness not discount). Absent → hidden.
+          setCostCovered(r.convictionCostCovered ?? null);
         } else if (assertions.length === 0) {
           setResult('Nothing to publish — promote assertions to Shared Memory first.');
         } else {

--- a/packages/node-ui/test/db.test.ts
+++ b/packages/node-ui/test/db.test.ts
@@ -1583,6 +1583,27 @@ describe('DashboardDB — V16 notifications.context_graph_id migration (A1)', ()
     expect(a.context_graph_id).toBe('cg-1');
     expect(b.context_graph_id).toBeNull();
   });
+
+  it('getPcaCostCoveredRowsForWallet returns ONLY the wallet rows, SQL-filtered, ts DESC, bounded, case-insensitive (#1365 r2)', () => {
+    const A = '0xaaaa000000000000000000000000000000000001';
+    const B = '0xbbbb000000000000000000000000000000000002';
+    const pca = (ts: number, publisher: string) => db.insertNotification({
+      ts, type: 'pca_cost_covered', title: 'd', message: 'd', contextGraphId: 'cg-pub',
+      meta: JSON.stringify({ publisherAddress: publisher.toLowerCase(), accountId: '7', epoch: 42 }),
+    });
+    pca(1000, A);
+    pca(3000, A);
+    pca(2000, B);
+
+    const rowsA = db.getPcaCostCoveredRowsForWallet(A);
+    expect(rowsA).toHaveLength(2);                          // only A's rows (B filtered out in SQL)
+    expect(rowsA.map((r) => r.ts)).toEqual([3000, 1000]);  // ts DESC
+    expect(db.getPcaCostCoveredRowsForWallet(B)).toHaveLength(1);
+    expect(db.getPcaCostCoveredRowsForWallet(A.toUpperCase())).toHaveLength(2); // case-insensitive
+    expect(db.getPcaCostCoveredRowsForWallet('0xcccc000000000000000000000000000000000003')).toHaveLength(0);
+    expect(db.getPcaCostCoveredRowsForWallet('  ')).toHaveLength(0); // blank → []
+    expect(db.getPcaCostCoveredRowsForWallet(A, 1)).toHaveLength(1); // bounded by limit
+  });
 });
 
 describe('DashboardDB — resolveActivityDigestRowIds (CR-3 digest read-marking)', () => {

--- a/packages/node-ui/test/layer-widgets-publish.test.ts
+++ b/packages/node-ui/test/layer-widgets-publish.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+//
+// B8 (#1365 round-3) — the SWM→VM publish CTA in `layer-widgets` (LayerActionsWidget)
+// renders the confirmed DiscountAppliedBadge from the BATCH-level convictionCostCovered,
+// NOT off the headline `sample` (which is chosen for cleanliness, not discount). This is
+// the layer-widgets badge render path the round-3 reviewer flagged as uncovered.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMocks = vi.hoisted(() => ({
+  listAssertions: vi.fn(),
+  publishAssertionsToVm: vi.fn(),
+  partialPublishWarning: vi.fn((d?: string) => (d ? `binding incomplete — ${d}` : 'binding incomplete')),
+}));
+
+vi.mock('../src/ui/api.js', async (orig) => ({
+  ...(await orig<typeof import('../src/ui/api.js')>()),
+  listAssertions: apiMocks.listAssertions,
+  publishAssertionsToVm: apiMocks.publishAssertionsToVm,
+  partialPublishWarning: apiMocks.partialPublishWarning,
+}));
+
+// The S5 PREDICTIVE chip is a separate surface (+ would pull in the PCA fetchers) — no-op
+// it so this test isolates the CONFIRMED badge render path.
+vi.mock('../src/ui/pages/conviction/PublishEligibilityChip.js', () => ({
+  PublishEligibilityChip: () => null,
+}));
+
+const { LayerActionsWidget } = await import('../src/ui/views/project/components/layer-widgets.js');
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function render(node: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { container, unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+async function flush() {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+const clickPublish = async (c: HTMLElement) =>
+  act(async () => { (c.querySelector('[data-testid="widget-publish-vm-btn"]') as HTMLButtonElement).click(); });
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+  apiMocks.listAssertions.mockResolvedValue([{ name: 'a', graphUri: 'g' }]);
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('LayerActionsWidget — B8 confirmed discount badge (#1365 r3)', () => {
+  it('renders the badge from the BATCH convictionCostCovered even when the clean sample has none', async () => {
+    apiMocks.publishAssertionsToVm.mockResolvedValue({
+      published: 1, total: 1, sealed: 0, partial: 0, failures: [],
+      sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' }, // clean, NO discount on the sample
+      convictionCostCovered: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0' },
+    });
+    const { container, unmount } = await render(
+      React.createElement(LayerActionsWidget, { layer: 'swm', count: 1, contextGraphId: 'cg' }),
+    );
+    await clickPublish(container);
+    await flush();
+    const badge = container.querySelector('[data-testid="pca-discount-badge"]');
+    expect(badge, 'badge renders from the batch field, not the sample').toBeTruthy();
+    expect(badge!.textContent).toContain('30%');
+    expect(badge!.textContent).toContain('PCA #7');
+    await unmount();
+  });
+
+  it('renders NO badge when the batch drew no discount (degrade-hidden #9)', async () => {
+    apiMocks.publishAssertionsToVm.mockResolvedValue({
+      published: 1, total: 1, sealed: 0, partial: 0, failures: [],
+      sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' },
+      // no convictionCostCovered on the batch
+    });
+    const { container, unmount } = await render(
+      React.createElement(LayerActionsWidget, { layer: 'swm', count: 1, contextGraphId: 'cg' }),
+    );
+    await clickPublish(container);
+    await flush();
+    expect(container.querySelector('[data-testid="pca-discount-badge"]')).toBeNull();
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/memory-layer-publish-panel.test.ts
+++ b/packages/node-ui/test/memory-layer-publish-panel.test.ts
@@ -184,15 +184,16 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
     await unmount();
   });
 
-  // B8 — the CONFIRMED post-publish discount badge lights up from the publish sample's
-  // convictionCostCovered (degrade-hidden when absent, #9).
-  it('B8 — renders the confirmed DiscountAppliedBadge when the sample carries convictionCostCovered', async () => {
+  // B8 (#1365 r3) — the CONFIRMED discount badge reads the BATCH-LEVEL convictionCostCovered,
+  // NOT the headline `sample` (which is picked for cleanliness, not discount). Regression
+  // guard: a CLEAN non-discount sample alongside a batch-level discount must still render.
+  it('B8 — renders the discount badge from the BATCH field even when the clean sample has no discount', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
-      published: 1, total: 1, sealed: 0, partial: 0, failures: [],
-      sample: {
-        status: 'confirmed', txHash: '0xtx', kaId: '0xka',
-        convictionCostCovered: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0' },
-      },
+      published: 2, total: 2, sealed: 0, partial: 0, failures: [],
+      // The headline sample is a clean, NON-discount item (the mixed-batch trap)…
+      sample: { status: 'confirmed', txHash: '0xtx', kaId: '0xka' },
+      // …but the batch DID draw a discount on another item → badge must render it.
+      convictionCostCovered: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0' },
     });
     const { container, unmount } = await render(
       React.createElement(PublishPanel, { contextGraphId: 'cg', onPublished: () => {} }),
@@ -201,13 +202,13 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
     await act(async () => { (container.querySelector('.v10-btn-promote-all') as HTMLButtonElement).click(); });
     await flush();
     const badge = container.querySelector('[data-testid="pca-discount-badge"]');
-    expect(badge, 'discount badge renders on a confirmed discounted publish').toBeTruthy();
+    expect(badge, 'discount badge renders from the batch field, not the sample').toBeTruthy();
     expect(badge!.textContent).toContain('30%'); // 10000*(1000-700)/1000 = 3000 bps
     expect(badge!.textContent).toContain('PCA #7');
     await unmount();
   });
 
-  it('B8 — renders NO discount badge when the sample omits convictionCostCovered (degrade-hidden #9)', async () => {
+  it('B8 — renders NO discount badge when the batch has no convictionCostCovered (degrade-hidden #9)', async () => {
     // cleanResult (default) has no convictionCostCovered → no false discount claim.
     const { container, unmount } = await render(
       React.createElement(PublishPanel, { contextGraphId: 'cg', onPublished: () => {} }),

--- a/packages/node-ui/test/memory-layer-publish-panel.test.ts
+++ b/packages/node-ui/test/memory-layer-publish-panel.test.ts
@@ -184,6 +184,41 @@ describe('MemoryLayerView PublishPanel (SWM → VM)', () => {
     await unmount();
   });
 
+  // B8 — the CONFIRMED post-publish discount badge lights up from the publish sample's
+  // convictionCostCovered (degrade-hidden when absent, #9).
+  it('B8 — renders the confirmed DiscountAppliedBadge when the sample carries convictionCostCovered', async () => {
+    apiMocks.publishAssertionsToVm.mockResolvedValue({
+      published: 1, total: 1, sealed: 0, partial: 0, failures: [],
+      sample: {
+        status: 'confirmed', txHash: '0xtx', kaId: '0xka',
+        convictionCostCovered: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0' },
+      },
+    });
+    const { container, unmount } = await render(
+      React.createElement(PublishPanel, { contextGraphId: 'cg', onPublished: () => {} }),
+    );
+    await flush();
+    await act(async () => { (container.querySelector('.v10-btn-promote-all') as HTMLButtonElement).click(); });
+    await flush();
+    const badge = container.querySelector('[data-testid="pca-discount-badge"]');
+    expect(badge, 'discount badge renders on a confirmed discounted publish').toBeTruthy();
+    expect(badge!.textContent).toContain('30%'); // 10000*(1000-700)/1000 = 3000 bps
+    expect(badge!.textContent).toContain('PCA #7');
+    await unmount();
+  });
+
+  it('B8 — renders NO discount badge when the sample omits convictionCostCovered (degrade-hidden #9)', async () => {
+    // cleanResult (default) has no convictionCostCovered → no false discount claim.
+    const { container, unmount } = await render(
+      React.createElement(PublishPanel, { contextGraphId: 'cg', onPublished: () => {} }),
+    );
+    await flush();
+    await act(async () => { (container.querySelector('.v10-btn-promote-all') as HTMLButtonElement).click(); });
+    await flush();
+    expect(container.querySelector('[data-testid="pca-discount-badge"]')).toBeNull();
+    await unmount();
+  });
+
   it('surfaces a per-KA failure (subset-not-sealable) via failures[] without crashing', async () => {
     apiMocks.publishAssertionsToVm.mockResolvedValue({
       published: 0, total: 1, sealed: 0, partial: 0,

--- a/packages/node-ui/test/notifications-feed.test.ts
+++ b/packages/node-ui/test/notifications-feed.test.ts
@@ -58,6 +58,17 @@ const rejected = (over: Partial<Extract<NotifWire, { type: 'join_rejected' }>> =
   ...over,
 });
 
+// B8 (P2) — confirmed-discount bell wire row.
+const pcaCovered = (over: Partial<Extract<NotifWire, { type: 'pca_cost_covered' }>> = {}): NotifWire => ({
+  type: 'pca_cost_covered',
+  id: 4,
+  ts: 1800,
+  read: 0,
+  contextGraphId: 'cg:d',
+  meta: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0', publisherAddress: '0xpub' },
+  ...over,
+});
+
 describe('mapJoinRequests', () => {
   it('extracts only join_request rows, newest-first', () => {
     const rows = [activity(), joinReq({ id: 10, ts: 100 }), joinReq({ id: 11, ts: 900 }), approved()];
@@ -76,6 +87,18 @@ describe('mapActivity', () => {
   it('maps digest + confirmations, newest-first, and drops join_request', () => {
     const out = mapActivity([joinReq(), activity({ ts: 2000 }), approved({ ts: 1500 }), rejected({ ts: 1200 })]);
     expect(out.map((i) => i.kind)).toEqual(['digest', 'join_approved', 'join_rejected']);
+  });
+
+  // B8 (P2) — the confirmed-discount row maps to a pca_cost_covered ActivityItem
+  // carrying the CostCovered event + the publishing wallet, newest-first with the rest.
+  it('maps a pca_cost_covered row (covered event + publisher), interleaved newest-first', () => {
+    const out = mapActivity([activity({ ts: 1000 }), pcaCovered({ ts: 1800 })]);
+    expect(out.map((i) => i.kind)).toEqual(['pca_cost_covered', 'digest']); // 1800 before 1000
+    const item = out[0];
+    if (item.kind !== 'pca_cost_covered') throw new Error('expected pca_cost_covered');
+    expect(item.covered).toMatchObject({ accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700' });
+    expect(item.publisherAddress).toBe('0xpub');
+    expect(item.read).toBe(false);
   });
 
   it('keeps the digestKey string id for digests', () => {
@@ -153,13 +176,14 @@ describe('selectInformationalUnreadIds (M8 — actionable rows never auto-clear)
     expect(ids).toEqual([]);
   });
 
-  it('includes unread informational ids (digests + approved + rejected)', () => {
+  it('includes unread informational ids (digests + approved + rejected + pca_cost_covered)', () => {
     const ids = selectInformationalUnreadIds([
       activity({ id: 'd1', read: 0 }),
       approved({ id: 10, read: 0 }),
       rejected({ id: 11, read: 0 }),
+      pcaCovered({ id: 12, read: 0 }), // B8 — confirmed discount counts toward the badge
     ]);
-    expect(ids).toEqual(['d1', 10, 11]);
+    expect(ids).toEqual(['d1', 10, 11, 12]);
   });
 
   it('excludes already-read informational rows', () => {

--- a/packages/node-ui/test/notifications-feed.test.ts
+++ b/packages/node-ui/test/notifications-feed.test.ts
@@ -65,7 +65,7 @@ const pcaCovered = (over: Partial<Extract<NotifWire, { type: 'pca_cost_covered' 
   ts: 1800,
   read: 0,
   contextGraphId: 'cg:d',
-  meta: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0', publisherAddress: '0xpub' },
+  meta: { contextGraphName: 'Delta', accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0', publisherAddress: '0xpub' },
   ...over,
 });
 
@@ -98,6 +98,7 @@ describe('mapActivity', () => {
     if (item.kind !== 'pca_cost_covered') throw new Error('expected pca_cost_covered');
     expect(item.covered).toMatchObject({ accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700' });
     expect(item.publisherAddress).toBe('0xpub');
+    expect(item.contextGraphName).toBe('Delta');
     expect(item.read).toBe(false);
   });
 

--- a/packages/node-ui/test/notifications-pane.dom.test.ts
+++ b/packages/node-ui/test/notifications-pane.dom.test.ts
@@ -213,6 +213,31 @@ describe('NotificationsPane — interaction + a11y (happy-dom)', () => {
     expect(buttonByText(/Mark all read/)).toBeUndefined();
   });
 
+  // B8 (P2) — the CONFIRMED PCA discount row renders the derived discount + saved amount
+  // + the account; informational + non-actionable (no approve/deny).
+  it('B8 — renders the confirmed PCA discount row (−% + saved + PCA #N)', () => {
+    const covered: ActivityItem = {
+      kind: 'pca_cost_covered',
+      id: 12,
+      cgId: 'cg:d',
+      covered: {
+        accountId: '7', epoch: 1284,
+        baseCost: '1000000000000000000000', discountedCost: '700000000000000000000', // 1000 → 700 TRAC ⇒ 30%
+        drawnFromEpoch: '700000000000000000000', drawnFromTopUp: '0',
+      },
+      publisherAddress: '0xpub0000000000000000000000000000000000pub',
+      ts: 1,
+      read: false,
+    };
+    render(makeFeed({ unread: 1, hasInformationalUnread: true, activity: [covered] }));
+    expect(container.textContent).toContain('Discount applied');
+    expect(container.textContent).toContain('30%');
+    expect(container.textContent).toContain('PCA #7');
+    expect(container.textContent).toContain('300'); // saved 300 TRAC
+    // Informational — no Approve/Deny actions on this row.
+    expect(buttonByText(/^Approve$/)).toBeUndefined();
+  });
+
   it('M9 frontend re-surface: a digest renders unread again after a load() returns read=0 for its digestKey', () => {
     const digest = (read: boolean): ActivityItem => ({
       kind: 'digest', id: 'activity:cg:a:promoted:42', cgId: 'cg:a',

--- a/packages/node-ui/test/notifications-pane.dom.test.ts
+++ b/packages/node-ui/test/notifications-pane.dom.test.ts
@@ -240,6 +240,30 @@ describe('NotificationsPane — interaction + a11y (happy-dom)', () => {
     expect(buttonByText(/^Approve$/)).toBeUndefined();
   });
 
+  // #9 — a genuine 0% draw (baseCost === discountedCost) still fired a CostCovered event
+  // (the PCA covered the publish), but there's NO discount: the row must say "covered"
+  // WITHOUT a "−0%"/"saved 0 TRAC" false claim.
+  it('B8 — a 0% draw renders "Publishing fee covered" with no −%/saved (#9)', () => {
+    const covered: ActivityItem = {
+      kind: 'pca_cost_covered',
+      id: 13,
+      cgId: 'cg:e',
+      covered: {
+        accountId: '9', epoch: 1300,
+        baseCost: '1000000000000000000000', discountedCost: '1000000000000000000000', // 0% effective
+        drawnFromEpoch: '0', drawnFromTopUp: '1000000000000000000000',
+      },
+      publisherAddress: '0xpub0000000000000000000000000000000000pub',
+      ts: 1,
+      read: false,
+    };
+    render(makeFeed({ unread: 1, hasInformationalUnread: true, activity: [covered] }));
+    expect(container.textContent).toContain('Publishing fee covered');
+    expect(container.textContent).toContain('PCA #9');
+    expect(container.textContent).not.toContain('%'); // no −0% (or any %) claim
+    expect(container.textContent).not.toContain('saved'); // no "saved 0 TRAC"
+  });
+
   it('M9 frontend re-surface: a digest renders unread again after a load() returns read=0 for its digestKey', () => {
     const digest = (read: boolean): ActivityItem => ({
       kind: 'digest', id: 'activity:cg:a:promoted:42', cgId: 'cg:a',

--- a/packages/node-ui/test/notifications-pane.dom.test.ts
+++ b/packages/node-ui/test/notifications-pane.dom.test.ts
@@ -226,14 +226,16 @@ describe('NotificationsPane — interaction + a11y (happy-dom)', () => {
         drawnFromEpoch: '700000000000000000000', drawnFromTopUp: '0',
       },
       publisherAddress: '0xpub0000000000000000000000000000000000pub',
+      contextGraphName: 'Delta',
       ts: 1,
       read: false,
     };
     render(makeFeed({ unread: 1, hasInformationalUnread: true, activity: [covered] }));
-    expect(container.textContent).toContain('Discount applied');
+    expect(container.textContent).toContain('Publishing discount applied');
     expect(container.textContent).toContain('30%');
     expect(container.textContent).toContain('PCA #7');
     expect(container.textContent).toContain('300'); // saved 300 TRAC
+    expect(container.textContent).toContain('Delta'); // CG context surfaced when present
     // Informational — no Approve/Deny actions on this row.
     expect(buttonByText(/^Approve$/)).toBeUndefined();
   });

--- a/packages/node-ui/test/notifications-scope.test.ts
+++ b/packages/node-ui/test/notifications-scope.test.ts
@@ -330,3 +330,52 @@ describe('scopeNotifications — join confirmations are caller-scoped, not membe
     expect(out.notifications).toHaveLength(0);
   });
 });
+
+describe('scopeNotifications — pca_cost_covered (B8, wallet-scoped)', () => {
+  function pcaRow(cgId: string, publisherAddress: string, ts: number, read = 0): NotificationRow {
+    return row({
+      type: 'pca_cost_covered',
+      ts,
+      read,
+      context_graph_id: cgId,
+      meta: JSON.stringify({
+        contextGraphId: cgId, publisherAddress, accountId: '7', epoch: 42,
+        baseCost: '1000', discountedCost: '700', drawnFromEpoch: '500', drawnFromTopUp: '200',
+      }),
+    });
+  }
+
+  it('surfaces a confirmed-discount alert to the publishing wallet', () => {
+    const out = scopeNotifications([pcaRow('cg-1', '0xme', 2000)], baseCtx());
+    expect(out.notifications).toHaveLength(1);
+    const n = out.notifications[0] as Extract<typeof out.notifications[number], { type: 'pca_cost_covered' }>;
+    expect(n.type).toBe('pca_cost_covered');
+    expect(n.meta).toMatchObject({
+      accountId: '7', epoch: 42, baseCost: '1000', discountedCost: '700', publisherAddress: '0xme',
+    });
+    expect(out.badgeCount).toBe(1);
+  });
+
+  it('drops the alert for a DIFFERENT wallet (wallet-scoped, NOT CG-membership)', () => {
+    // Same member CG, but a publish by another wallet → not this caller's business.
+    const out = scopeNotifications([pcaRow('cg-1', '0xsomeoneelse', 2000)], baseCtx());
+    expect(out.notifications).toHaveLength(0);
+    expect(out.badgeCount).toBe(0);
+  });
+
+  it('matches the publishing wallet case-insensitively', () => {
+    const out = scopeNotifications([pcaRow('cg-1', '0xME', 2000)], baseCtx({ selfAgentDid: 'did:dkg:agent:0xme' }));
+    expect(out.notifications).toHaveLength(1);
+  });
+
+  it('fails closed when the caller address is unknown', () => {
+    const out = scopeNotifications([pcaRow('cg-1', '0xme', 2000)], baseCtx({ selfAgentDid: undefined }));
+    expect(out.notifications).toHaveLength(0);
+  });
+
+  it('a read alert does not count toward the badge', () => {
+    const out = scopeNotifications([pcaRow('cg-1', '0xme', 2000, 1)], baseCtx());
+    expect(out.notifications).toHaveLength(1);
+    expect(out.badgeCount).toBe(0);
+  });
+});

--- a/packages/node-ui/test/pca-components.test.ts
+++ b/packages/node-ui/test/pca-components.test.ts
@@ -296,6 +296,18 @@ describe('DiscountAppliedBadge (B8, degrade-to-hidden)', () => {
       }),
     ).toBeNull();
     expect(convictionDiscountBps(null)).toBeNull();
+    // #9 — a genuine 0% draw (discountedCost === baseCost, reachable on-chain) → null,
+    // NOT 0, so the badge hides + the bell row drops the −% rather than claiming "−0%".
+    expect(
+      convictionDiscountBps({
+        accountId: '7',
+        epoch: 1,
+        baseCost: '1000',
+        discountedCost: '1000',
+        drawnFromEpoch: '0',
+        drawnFromTopUp: '0',
+      }),
+    ).toBeNull();
   });
 
   it('renders the confirmed discount + PCA #N when the field is present', async () => {
@@ -316,6 +328,20 @@ describe('DiscountAppliedBadge (B8, degrade-to-hidden)', () => {
     expect(badge.getAttribute('data-testid')).toBe('pca-discount-badge'); // e2e anchor
     expect(badge.textContent).toContain('30%');
     expect(badge.textContent).toContain('PCA #7');
+    await unmount();
+  });
+
+  it('renders NOTHING for a genuine 0% draw (baseCost === discountedCost) — no false −0% (#9)', async () => {
+    const { container, unmount } = await render(
+      React.createElement(DiscountAppliedBadge, {
+        convictionCostCovered: {
+          accountId: '7', epoch: 1,
+          baseCost: '1000', discountedCost: '1000', // 0% effective discount
+          drawnFromEpoch: '0', drawnFromTopUp: '0',
+        },
+      }),
+    );
+    expect(container.firstChild).toBeNull();
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-detail-view.test.ts
+++ b/packages/node-ui/test/pca-detail-view.test.ts
@@ -393,3 +393,51 @@ describe('ConvictionDetailView B3 — live approved-wallet table', () => {
     await unmount();
   });
 });
+
+// GAP-4/5 — the S3 detail view opts into the EXTENDED snapshot and renders a remaining-
+// allowance budget item + a primaryNode readout; both degrade-to-nothing when the
+// best-effort extended fields are absent (never a false value). Coverage spine unchanged.
+describe('ConvictionDetailView GAP-4/5 — budget widget + primaryNode', () => {
+  it('requests the EXTENDED snapshot (so the budget widget has remainingAllowance)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    const { unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    // The primary snapshot fetch (no key) opts in to extended; the per-wallet probes don't.
+    expect(mocks.fetchPca).toHaveBeenCalledWith('7', undefined, { extended: true });
+    await unmount();
+  });
+
+  it('renders remaining-allowance + primaryNode when the extended fields are present', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key
+        ? { ...snap(), probedKey: { key, registered: true } }
+        : snap({ remainingAllowance: '500000000000000000000', remainingAllowanceTrac: '500.0', currentEpoch: 1290, primaryNode: '42', lastPrimaryNodeChangeEpoch: 1288 }),
+    );
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Remaining this epoch');
+    expect(container.textContent).toContain('500');
+    expect(container.textContent).toContain('Node #42');
+    await unmount();
+  });
+
+  it('omits the budget widget items when the extended fields are absent (read-failed degrade)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    // default snap() carries no extended fields.
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Top-up buffer');
+    expect(container.textContent).not.toContain('Remaining this epoch');
+    expect(container.textContent).not.toContain('Primary node');
+    await unmount();
+  });
+
+  it('primaryNode "0" reads "None set" (vs a real node id)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [W0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...snap(), probedKey: { key, registered: true } } : snap({ primaryNode: '0' }),
+    );
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'None set');
+    expect(container.textContent).not.toContain('Node #');
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/ui-api-pure.test.ts
+++ b/packages/node-ui/test/ui-api-pure.test.ts
@@ -450,6 +450,32 @@ describe('UI API tests', () => {
       // ka 'b' was published under its sub-graph (name + subGraphName forwarded by the loop).
       const bPublish = requestLog.find(rq => rq.method === 'POST' && rq.url.includes('/api/knowledge-assets/b/vm/publish'));
       expect(JSON.parse(bPublish!.body).subGraphName).toBe('sg1');
+      // Neither KA drew on a PCA → no batch-level discount (badge stays hidden, #9).
+      expect(r.convictionCostCovered).toBeUndefined();
+    });
+
+    it('publishAssertionsToVm SUMS convictionCostCovered across the batch (#1365 r3 — not off the sample)', async () => {
+      // Both KAs draw a discount; the batch must SUM base/discounted (the true total saved),
+      // independent of which item becomes the headline `sample`.
+      responseOverrides.push({
+        match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/a/vm/publish'),
+        status: 200,
+        body: { kaId: '0xa', status: 'confirmed', txHash: '0xtxa', convictionCostCovered: { accountId: '7', epoch: 1284, baseCost: '1000', discountedCost: '700', drawnFromEpoch: '700', drawnFromTopUp: '0' } },
+      });
+      responseOverrides.push({
+        match: (url, method) => method === 'POST' && url.includes('/api/knowledge-assets/b/vm/publish'),
+        status: 200,
+        body: { kaId: '0xb', status: 'confirmed', txHash: '0xtxb', convictionCostCovered: { accountId: '7', epoch: 1285, baseCost: '2000', discountedCost: '1500', drawnFromEpoch: '1500', drawnFromTopUp: '0' } },
+      });
+
+      const r = await publishAssertionsToVm('cg-1', [{ name: 'a' }, { name: 'b' }]);
+
+      expect(r.convictionCostCovered).toBeDefined();
+      expect(r.convictionCostCovered!.accountId).toBe('7'); // first drawing item names the account
+      expect(r.convictionCostCovered!.epoch).toBe(1284);
+      expect(r.convictionCostCovered!.baseCost).toBe('3000'); // 1000 + 2000
+      expect(r.convictionCostCovered!.discountedCost).toBe('2200'); // 700 + 1500
+      expect(r.convictionCostCovered!.drawnFromEpoch).toBe('2200'); // 700 + 1500
     });
 
     it('publishAssertionsToVm collects each per-KA failure into failures[] (named) and keeps going', async () => {


### PR DESCRIPTION
## P2 — publish-path confirmed signals + adapter readback

Second phase of the PCA node-UI (sub-PR into the `feat/pca-node-ui` integration branch). Lights up the *confirmed* (post-publish / on-chain-readback) PCA surfaces on top of P0's predictive ones. **No contract change.**

### B8 — confirmed post-publish discount
- **Adapter** (`a396733b0`): `decodeConvictionCostCovered` — a separate pass over the publish receipt's logs via the PublishingConviction **logic** ABI (the event is emitted by the logic contract, a different address than KA storage, so the KA-storage receipt loop skips it). Sets `convictionCostCovered` on `OnChainPublishResult` (wei fields bigint → daemon-stringified; `epoch` a number; absent when the publish didn't draw on a PCA). Exported + unit-tested. One CostCovered per publish-tx (`coverPublishingCost` runs once — `067a86712`).
- **Routes**: all 3 publish builders emit `convictionCostCovered` top-level — direct `/api/knowledge-assets/publish`, `/vm/publish`, create+publish — absent for a non-PCA publish.
- **UI** (`f772ae6f4`): `DiscountAppliedBadge` (built in P0, degrade-to-hidden) now renders from the publish sample's `convictionCostCovered` at the PublishPanel result card + the SWM→VM CTA (the *confirmed* signal, distinct from S5's prediction). Derives `bps = 10000·(baseCost−discountedCost)/baseCost`; hidden when absent (#9).

### GAP-4/5 — extended getInfo (budget widget)
- **Adapter** (`eb3dbef5a`): `getPublishingConvictionAccountInfo(id, { extended? })` — **opt-in, default byte-identical** (the canCover hot path takes zero extra reads). When extended, reads `accounts()[9]` primaryNode / `[10]` lastPrimaryNodeChangeEpoch (RFC-51), the current epoch (Chronos) + `getRemainingAllowance`. **Fail-soft**: an extended-read error never nulls the account (the fields are left undefined = "unknown", distinct from `primaryNode 0` = "none set"). `GET /api/pca/:id?extended=1` opts in; the serializer omits-not-zeroes absent fields.
- **UI** (`8230919e9`): the S3 detail view opts into the extended snapshot (single on-mount read) and adds a "Remaining this epoch" + "Primary node" StatStrip item, omitted when absent (#9). **Coverage spine unchanged** — `remainingAllowance` is display-only; `classifyCoverage` keeps the coarse proxy (the precise-spendability upgrade is out of scope).

### Confirmed-discount bell
- **Daemon** (`0d5e084db`): a `pca_cost_covered` notification recorded on a self-publish that drew on a PCA (advisory — never blocks the publish). `scopeNotifications` surfaces it **wallet-scoped, fail-closed**: only to the publishing wallet (`meta.publisherAddress === caller`, mirroring `join_approved`; dropped if the caller is unknown or the wallet doesn't match) — invariant 3. Source = self-publish capture; owner-side cross-node sponsored-draw confirmation is deferred to P3.
- **UI** (`d76461cab`): `PcaCostCoveredRow` (informational, non-clickable, distinct from the P0 predictive alert) + the `useNotificationsFeed` mapping + badge inclusion. Degrades gracefully on un-parseable costs (no bogus number, #9).

### Tests
B8 decode 3/3, mock-parity 26/26, facade 8/8, daemon-pca-routes 59/59, real-Hardhat adapter 9/9, scope 27/27, recorder 14/14, node-ui 1710. The live B8-badge + bell *end-to-end* surfacing needs a real PCA-covered mint (multi-node StorageACK quorum) → covered by the CI devnet @mutating lane and the integration→`main` whole-feature gate (QA, attended) — the same deferral pattern as P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
