### PR TITLE
feat(evm): PCA-backed CG registration-deposit waiver — quota-bounded (OT-RFC-53)

### DIFF
--- a/packages/evm-module/abi/ContextGraphWaiverStorage.json
+++ b/packages/evm-module/abi/ContextGraphWaiverStorage.json
@@ -1,0 +1,147 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "hubAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "OnlyContextGraphs",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddressHub",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newWaivedCount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "quota",
+        "type": "uint256"
+      }
+    ],
+    "name": "RegistrationDepositWaived",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "hub",
+    "outputs": [
+      {
+        "internalType": "contract Hub",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint96",
+        "name": "deposit",
+        "type": "uint96"
+      }
+    ],
+    "name": "tryConsumeWaiver",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "waivedCgCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/evm-module/abi/ContextGraphs.json
+++ b/packages/evm-module/abi/ContextGraphs.json
@@ -194,6 +194,31 @@
       },
       {
         "indexed": true,
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      }
+    ],
+    "name": "ContextGraphRegistrationDepositWaived",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "contextGraphId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "payer",
         "type": "address"

--- a/packages/evm-module/abi/IContextGraphWaiverStorage.json
+++ b/packages/evm-module/abi/IContextGraphWaiverStorage.json
@@ -1,0 +1,50 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint96",
+        "name": "deposit",
+        "type": "uint96"
+      }
+    ],
+    "name": "tryConsumeWaiver",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "waived",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      }
+    ],
+    "name": "waivedCgCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/evm-module/abi/IParamsMinPcaCommitment.json
+++ b/packages/evm-module/abi/IParamsMinPcaCommitment.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [],
+    "name": "minPcaCommitmentForCgWaiver",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/evm-module/abi/ParametersStorage.json
+++ b/packages/evm-module/abi/ParametersStorage.json
@@ -163,6 +163,19 @@
   },
   {
     "inputs": [],
+    "name": "minPcaCommitmentForCgWaiver",
+    "outputs": [
+      {
+        "internalType": "uint96",
+        "name": "",
+        "type": "uint96"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "minimumRequiredSignatures",
     "outputs": [
       {
@@ -339,6 +352,19 @@
       }
     ],
     "name": "setMaximumStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint96",
+        "name": "amount",
+        "type": "uint96"
+      }
+    ],
+    "name": "setMinPcaCommitmentForCgWaiver",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/evm-module/contracts/ContextGraphs.sol
+++ b/packages/evm-module/contracts/ContextGraphs.sol
@@ -83,6 +83,16 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
         uint96 amount
     );
 
+    /// @notice OT-RFC-53: emitted when the registration deposit is WAIVED because
+    ///         the CG is backed by a PCA the creator owns or is a registered
+    ///         agent of. The PCA's locked commitment is the anti-spam stake;
+    ///         the CG carries no own escrow and its publishing is funded by the PCA.
+    event ContextGraphRegistrationDepositWaived(
+        uint256 indexed contextGraphId,
+        uint256 indexed accountId,
+        address indexed creator
+    );
+
     /// @notice Emitted when an admin sweeps a CG's residual escrow to the pool.
     event ContextGraphEscrowSwept(uint256 indexed contextGraphId, uint96 amount);
 
@@ -196,12 +206,58 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
         // OT-RFC-53: anti-spam registration deposit, held as the CG's prepaid
         // publishing escrow. Skipped when ParametersStorage is unresolved
         // (deposit feature off) or the param is 0 (dormant default).
+        //
+        // WAIVER: a CG backed by a PCA the creator owns or is a registered agent
+        // of pays NO separate deposit — the PCA already locks real TRAC (a far
+        // larger anti-spam stake than the per-CG deposit) and funds the CG's
+        // publishing. The result is a zero-escrow CG, which is the same state a
+        // dormant deposit param already produces, so the consume path is
+        // unchanged (it falls through to the PCA). See _waivesRegistrationDeposit.
         if (address(parametersStorage) != address(0)) {
             uint96 deposit = parametersStorage.contextGraphRegistrationDeposit();
             if (deposit > 0) {
-                _pullRegistrationDeposit(contextGraphId, deposit);
+                if (_waivesRegistrationDeposit(publishAuthorityAccountId)) {
+                    emit ContextGraphRegistrationDepositWaived(
+                        contextGraphId, publishAuthorityAccountId, msg.sender
+                    );
+                } else {
+                    _pullRegistrationDeposit(contextGraphId, deposit);
+                }
             }
         }
+    }
+
+    /// @dev OT-RFC-53 deposit waiver authorization. Returns true when the CG is
+    ///      backed by PCA `accountId` AND the CALLER is its owner or a currently
+    ///      registered conviction agent. The caller check is EXPLICIT here:
+    ///      `_validatePCACoherence` only ties the stored authority to the owner,
+    ///      NOT `msg.sender`, so without this a third party could create a CG
+    ///      pointing at someone else's PCA and dodge the deposit. Fails CLOSED
+    ///      (charges the deposit) on any resolution/lookup failure.
+    function _waivesRegistrationDeposit(uint256 accountId) internal view returns (bool) {
+        if (accountId == 0) return false;
+        address nftAddr;
+        try hub.getContractAddress("DKGPublishingConvictionNFT") returns (address addr) {
+            nftAddr = addr;
+        } catch {
+            return false;
+        }
+        if (nftAddr == address(0)) return false;
+        IDKGPublishingConvictionNFT nft = IDKGPublishingConvictionNFT(nftAddr);
+        // Owner of the PCA NFT.
+        try nft.ownerOf(accountId) returns (address owner_) {
+            if (owner_ == msg.sender) return true;
+        } catch {
+            return false; // nonexistent account → not waivable
+        }
+        // Registered conviction agent. `agentToAccountId` returns the single PCA
+        // an agent is bound to (0 when unregistered), so equality is the check.
+        try nft.agentToAccountId(msg.sender) returns (uint256 boundAccount) {
+            if (boundAccount == accountId) return true;
+        } catch {
+            /* fall through → not waived */
+        }
+        return false;
     }
 
     // -----------------------------------------------------------------------

--- a/packages/evm-module/contracts/ContextGraphs.sol
+++ b/packages/evm-module/contracts/ContextGraphs.sol
@@ -227,13 +227,25 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
         }
     }
 
-    /// @dev OT-RFC-53 deposit waiver authorization. Returns true when the CG is
-    ///      backed by PCA `accountId` AND the CALLER is its owner or a currently
-    ///      registered conviction agent. The caller check is EXPLICIT here:
-    ///      `_validatePCACoherence` only ties the stored authority to the owner,
-    ///      NOT `msg.sender`, so without this a third party could create a CG
-    ///      pointing at someone else's PCA and dodge the deposit. Fails CLOSED
-    ///      (charges the deposit) on any resolution/lookup failure.
+    /// @dev OT-RFC-53 deposit waiver authorization. Returns true ONLY when the
+    ///      CG is backed by PCA `accountId` that is currently a LIVE, backed
+    ///      account AND the CALLER is its owner or a currently registered
+    ///      conviction agent. Two independent gates, both required:
+    ///
+    ///      1. ACTIVE PCA — the waiver's premise is that the PCA's locked TRAC
+    ///         is a larger anti-spam stake than the per-CG deposit. An EXPIRED
+    ///         or FULLY-SWEPT PCA has no live commitment, so it earns no waiver
+    ///         (else an owner could mint unlimited zero-deposit CGs against a
+    ///         dead account). `accounts()` returns zeros for a never-minted id
+    ///         (committedTRAC == 0 ⇒ rejected); expiry is timestamp-based,
+    ///         matching PublishingConviction.coverPublishingCost.
+    ///
+    ///      2. CALLER — the check is EXPLICIT here: `_validatePCACoherence` only
+    ///         ties the stored authority to the owner, NOT `msg.sender`, so
+    ///         without this a third party could point a CG at someone else's
+    ///         PCA and dodge the deposit.
+    ///
+    ///      Fails CLOSED (charges the deposit) on any resolution/lookup failure.
     function _waivesRegistrationDeposit(uint256 accountId) internal view returns (bool) {
         if (accountId == 0) return false;
         address nftAddr;
@@ -244,14 +256,37 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
         }
         if (nftAddr == address(0)) return false;
         IDKGPublishingConvictionNFT nft = IDKGPublishingConvictionNFT(nftAddr);
-        // Owner of the PCA NFT.
+
+        // Gate 1: the PCA must be a live, backed account (committed, unexpired,
+        // not fully swept). Tuple indices: 0=committedTRAC, 4=expiresAtTimestamp,
+        // 8=fullySwept.
+        try nft.accounts(accountId) returns (
+            uint96 committedTRAC,
+            uint40,
+            uint40,
+            uint40,
+            uint40 expiresAtTimestamp,
+            uint16,
+            uint16,
+            uint16,
+            bool fullySwept,
+            uint72,
+            uint40
+        ) {
+            if (committedTRAC == 0 || fullySwept) return false;
+            if (expiresAtTimestamp != 0 && block.timestamp >= expiresAtTimestamp) return false;
+        } catch {
+            return false;
+        }
+
+        // Gate 2: caller is the PCA owner, or a currently registered agent.
         try nft.ownerOf(accountId) returns (address owner_) {
             if (owner_ == msg.sender) return true;
         } catch {
             return false; // nonexistent account → not waivable
         }
-        // Registered conviction agent. `agentToAccountId` returns the single PCA
-        // an agent is bound to (0 when unregistered), so equality is the check.
+        // `agentToAccountId` returns the single PCA an agent is bound to (0 when
+        // unregistered), so equality is the membership check.
         try nft.agentToAccountId(msg.sender) returns (uint256 boundAccount) {
             if (boundAccount == accountId) return true;
         } catch {

--- a/packages/evm-module/contracts/ContextGraphs.sol
+++ b/packages/evm-module/contracts/ContextGraphs.sol
@@ -241,7 +241,7 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
     ///      deposit) on any resolution/call failure.
     function _tryWaiveRegistrationDeposit(uint256 accountId, uint96 deposit) internal returns (bool) {
         if (accountId == 0) return false;
-        address waiverAddr;
+        address waiverAddr = address(0);
         try hub.getContractAddress("ContextGraphWaiverStorage") returns (address addr) {
             waiverAddr = addr;
         } catch {

--- a/packages/evm-module/contracts/ContextGraphs.sol
+++ b/packages/evm-module/contracts/ContextGraphs.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {IDKGPublishingConvictionNFT} from "./interfaces/IDKGPublishingConvictionNFT.sol";
+import {IContextGraphWaiverStorage} from "./interfaces/IContextGraphWaiverStorage.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
 import {INamed} from "./interfaces/INamed.sol";
 import {IVersioned} from "./interfaces/IVersioned.sol";
@@ -207,16 +208,19 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
         // publishing escrow. Skipped when ParametersStorage is unresolved
         // (deposit feature off) or the param is 0 (dormant default).
         //
-        // WAIVER: a CG backed by a PCA the creator owns or is a registered agent
-        // of pays NO separate deposit — the PCA already locks real TRAC (a far
-        // larger anti-spam stake than the per-CG deposit) and funds the CG's
-        // publishing. The result is a zero-escrow CG, which is the same state a
-        // dormant deposit param already produces, so the consume path is
-        // unchanged (it falls through to the PCA). See _waivesRegistrationDeposit.
+        // WAIVER (quota-bounded): a CG backed by a PCA the creator owns or is a
+        // registered agent of can skip the deposit — but only up to the PCA's
+        // per-PCA quota (committedTRAC / deposit), enforced in
+        // ContextGraphWaiverStorage. So N deposit-free CGs still cost N×deposit
+        // of LOCKED PCA commitment (paid by the PCA instead of separate liquid
+        // TRAC), a sub-floor or dust PCA gets none, and a single PCA can no
+        // longer mint unlimited free CGs. A waived CG carries no escrow — the
+        // same state a dormant deposit produces — so the consume path is
+        // unchanged (it falls through to the PCA).
         if (address(parametersStorage) != address(0)) {
             uint96 deposit = parametersStorage.contextGraphRegistrationDeposit();
             if (deposit > 0) {
-                if (_waivesRegistrationDeposit(publishAuthorityAccountId)) {
+                if (_tryWaiveRegistrationDeposit(publishAuthorityAccountId, deposit)) {
                     emit ContextGraphRegistrationDepositWaived(
                         contextGraphId, publishAuthorityAccountId, msg.sender
                     );
@@ -227,72 +231,28 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
         }
     }
 
-    /// @dev OT-RFC-53 deposit waiver authorization. Returns true ONLY when the
-    ///      CG is backed by PCA `accountId` that is currently a LIVE, backed
-    ///      account AND the CALLER is its owner or a currently registered
-    ///      conviction agent. Two independent gates, both required:
-    ///
-    ///      1. ACTIVE PCA — the waiver's premise is that the PCA's locked TRAC
-    ///         is a larger anti-spam stake than the per-CG deposit. An EXPIRED
-    ///         or FULLY-SWEPT PCA has no live commitment, so it earns no waiver
-    ///         (else an owner could mint unlimited zero-deposit CGs against a
-    ///         dead account). `accounts()` returns zeros for a never-minted id
-    ///         (committedTRAC == 0 ⇒ rejected); expiry is timestamp-based,
-    ///         matching PublishingConviction.coverPublishingCost.
-    ///
-    ///      2. CALLER — the check is EXPLICIT here: `_validatePCACoherence` only
-    ///         ties the stored authority to the owner, NOT `msg.sender`, so
-    ///         without this a third party could point a CG at someone else's
-    ///         PCA and dodge the deposit.
-    ///
-    ///      Fails CLOSED (charges the deposit) on any resolution/lookup failure.
-    function _waivesRegistrationDeposit(uint256 accountId) internal view returns (bool) {
+    /// @dev OT-RFC-53 deposit waiver. Delegates eligibility + the per-PCA quota
+    ///      to ContextGraphWaiverStorage (co-located with its counter, off this
+    ///      contract's bytecode budget). The storage contract verifies the PCA
+    ///      is active/backed, meets the governance stake floor, that `msg.sender`
+    ///      (the CG creator) owns or is a registered agent of the PCA, and that
+    ///      the PCA's quota isn't exhausted — consuming one quota slot when it
+    ///      returns true. Resolved fresh via the Hub; fails CLOSED (charge the
+    ///      deposit) on any resolution/call failure.
+    function _tryWaiveRegistrationDeposit(uint256 accountId, uint96 deposit) internal returns (bool) {
         if (accountId == 0) return false;
-        address nftAddr;
-        try hub.getContractAddress("DKGPublishingConvictionNFT") returns (address addr) {
-            nftAddr = addr;
+        address waiverAddr;
+        try hub.getContractAddress("ContextGraphWaiverStorage") returns (address addr) {
+            waiverAddr = addr;
         } catch {
             return false;
         }
-        if (nftAddr == address(0)) return false;
-        IDKGPublishingConvictionNFT nft = IDKGPublishingConvictionNFT(nftAddr);
-
-        // Gate 1: the PCA must be a live, backed account (committed, unexpired,
-        // not fully swept). Tuple indices: 0=committedTRAC, 4=expiresAtTimestamp,
-        // 8=fullySwept.
-        try nft.accounts(accountId) returns (
-            uint96 committedTRAC,
-            uint40,
-            uint40,
-            uint40,
-            uint40 expiresAtTimestamp,
-            uint16,
-            uint16,
-            uint16,
-            bool fullySwept,
-            uint72,
-            uint40
-        ) {
-            if (committedTRAC == 0 || fullySwept) return false;
-            if (expiresAtTimestamp != 0 && block.timestamp >= expiresAtTimestamp) return false;
+        if (waiverAddr == address(0)) return false;
+        try IContextGraphWaiverStorage(waiverAddr).tryConsumeWaiver(accountId, msg.sender, deposit) returns (bool waived) {
+            return waived;
         } catch {
             return false;
         }
-
-        // Gate 2: caller is the PCA owner, or a currently registered agent.
-        try nft.ownerOf(accountId) returns (address owner_) {
-            if (owner_ == msg.sender) return true;
-        } catch {
-            return false; // nonexistent account → not waivable
-        }
-        // `agentToAccountId` returns the single PCA an agent is bound to (0 when
-        // unregistered), so equality is the membership check.
-        try nft.agentToAccountId(msg.sender) returns (uint256 boundAccount) {
-            if (boundAccount == accountId) return true;
-        } catch {
-            /* fall through → not waived */
-        }
-        return false;
     }
 
     // -----------------------------------------------------------------------

--- a/packages/evm-module/contracts/interfaces/IContextGraphWaiverStorage.sol
+++ b/packages/evm-module/contracts/interfaces/IContextGraphWaiverStorage.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+/**
+ * @title IContextGraphWaiverStorage
+ * @notice Minimal interface ContextGraphs uses to consume the OT-RFC-53
+ *         PCA-backed registration-deposit waiver. Kept minimal (one mutator +
+ *         the counter getter) to avoid pulling the full storage contract into
+ *         ContextGraphs' compilation unit / bytecode budget.
+ */
+interface IContextGraphWaiverStorage {
+    /// @notice CGs created with the deposit waived against PCA `accountId`.
+    function waivedCgCount(uint256 accountId) external view returns (uint256);
+
+    /// @notice Attempt to waive the registration deposit for a CG backed by PCA
+    ///         `accountId`, created by `creator`, when the current deposit is
+    ///         `deposit`. Returns true (and consumes one per-PCA quota slot)
+    ///         only when the PCA is active/backed, meets the governance stake
+    ///         floor, `creator` is its owner or a registered agent, and the
+    ///         PCA's quota (`committedTRAC / deposit`) is not exhausted.
+    ///         ContextGraphs-only.
+    function tryConsumeWaiver(
+        uint256 accountId,
+        address creator,
+        uint96 deposit
+    ) external returns (bool waived);
+}

--- a/packages/evm-module/contracts/storage/ContextGraphWaiverStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphWaiverStorage.sol
@@ -83,7 +83,9 @@ contract ContextGraphWaiverStorage is INamed, IVersioned, IContextGraphWaiverSto
         // for a never-minted id (committedTRAC == 0 ⇒ rejected). Expiry is
         // timestamp-based, matching coverPublishingCost. Tuple idx: 0=committed,
         // 4=expiresAtTimestamp, 8=fullySwept.
-        uint96 committedTRAC;
+        uint96 committedTRAC = 0;
+        // We read 3 of the 11 account-tuple fields on purpose.
+        // slither-disable-next-line unused-return
         try nft.accounts(accountId) returns (
             uint96 committed,
             uint40,
@@ -98,6 +100,8 @@ contract ContextGraphWaiverStorage is INamed, IVersioned, IContextGraphWaiverSto
             uint40
         ) {
             if (committed == 0 || fullySwept) return false;
+            // Timestamp expiry is intentional — mirrors coverPublishingCost.
+            // slither-disable-next-line timestamp
             if (expiresAtTimestamp != 0 && block.timestamp >= expiresAtTimestamp) return false;
             committedTRAC = committed;
         } catch {
@@ -116,7 +120,7 @@ contract ContextGraphWaiverStorage is INamed, IVersioned, IContextGraphWaiverSto
         // Gate 3: the CG creator is the PCA owner or a currently registered
         // agent. EXPLICIT caller check — ContextGraphs' coherence gate only ties
         // the stored authority to the owner, not the creator.
-        bool authorized;
+        bool authorized = false;
         try nft.ownerOf(accountId) returns (address owner_) {
             if (owner_ == creator) authorized = true;
         } catch {

--- a/packages/evm-module/contracts/storage/ContextGraphWaiverStorage.sol
+++ b/packages/evm-module/contracts/storage/ContextGraphWaiverStorage.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {HubDependent} from "../abstract/HubDependent.sol";
+import {INamed} from "../interfaces/INamed.sol";
+import {IVersioned} from "../interfaces/IVersioned.sol";
+import {IContextGraphWaiverStorage} from "../interfaces/IContextGraphWaiverStorage.sol";
+import {IDKGPublishingConvictionNFT} from "../interfaces/IDKGPublishingConvictionNFT.sol";
+
+/// @dev Minimal view over ParametersStorage for the one governance knob this
+///      contract reads (avoids importing the full ParametersStorage).
+interface IParamsMinPcaCommitment {
+    function minPcaCommitmentForCgWaiver() external view returns (uint96);
+}
+
+/**
+ * @title ContextGraphWaiverStorage
+ * @notice OT-RFC-53 spam-cap for the PCA-backed CG registration-deposit waiver.
+ *
+ *         A CG whose publish authority is a PCA the creator owns (or is a
+ *         registered agent of) can be created WITHOUT the 100-TRAC registration
+ *         deposit — but only up to a per-PCA quota of `committedTRAC / deposit`
+ *         CGs. That keeps the original per-CG anti-spam cost (N deposit-free CGs
+ *         require N×deposit of LOCKED PCA commitment), paid by the PCA's locked
+ *         TRAC instead of separate liquid TRAC. A governance stake floor
+ *         (ParametersStorage.minPcaCommitmentForCgWaiver) gates the perk to
+ *         serious PCAs and is the reason a 1-wei PCA can't unlock free CGs.
+ *
+ *         This is a NEW standalone contract because ContextGraphStorage is
+ *         already deployed (frozen) and the per-PCA waived-count is new data.
+ *         The eligibility logic lives here (co-located with its counter and
+ *         off ContextGraphs' bytecode budget); ContextGraphs calls
+ *         `tryConsumeWaiver` once and charges the deposit if it returns false.
+ *
+ *         `tryConsumeWaiver` mutates (it consumes a quota slot), so it is gated
+ *         to the live ContextGraphs contract only.
+ */
+contract ContextGraphWaiverStorage is INamed, IVersioned, IContextGraphWaiverStorage, HubDependent {
+    string private constant _NAME = "ContextGraphWaiverStorage";
+    string private constant _VERSION = "1.0.0";
+
+    /// @inheritdoc IContextGraphWaiverStorage
+    mapping(uint256 => uint256) public waivedCgCount;
+
+    /// @notice Emitted when a CG registration deposit is waived against a PCA.
+    event RegistrationDepositWaived(
+        uint256 indexed accountId,
+        address indexed creator,
+        uint256 newWaivedCount,
+        uint256 quota
+    );
+
+    /// @notice Only the live ContextGraphs contract may consume the waiver.
+    error OnlyContextGraphs(address caller);
+
+    constructor(address hubAddress) HubDependent(hubAddress) {}
+
+    function name() external pure virtual override returns (string memory) {
+        return _NAME;
+    }
+
+    function version() external pure virtual override returns (string memory) {
+        return _VERSION;
+    }
+
+    /// @inheritdoc IContextGraphWaiverStorage
+    function tryConsumeWaiver(
+        uint256 accountId,
+        address creator,
+        uint96 deposit
+    ) external override returns (bool) {
+        if (msg.sender != hub.getContractAddress("ContextGraphs")) {
+            revert OnlyContextGraphs(msg.sender);
+        }
+        if (accountId == 0 || deposit == 0) return false;
+
+        address nftAddr = hub.getContractAddress("DKGPublishingConvictionNFT");
+        if (nftAddr == address(0)) return false;
+        IDKGPublishingConvictionNFT nft = IDKGPublishingConvictionNFT(nftAddr);
+
+        // Gate 1: the PCA is a LIVE, backed account. accounts() returns zeros
+        // for a never-minted id (committedTRAC == 0 ⇒ rejected). Expiry is
+        // timestamp-based, matching coverPublishingCost. Tuple idx: 0=committed,
+        // 4=expiresAtTimestamp, 8=fullySwept.
+        uint96 committedTRAC;
+        try nft.accounts(accountId) returns (
+            uint96 committed,
+            uint40,
+            uint40,
+            uint40,
+            uint40 expiresAtTimestamp,
+            uint16,
+            uint16,
+            uint16,
+            bool fullySwept,
+            uint72,
+            uint40
+        ) {
+            if (committed == 0 || fullySwept) return false;
+            if (expiresAtTimestamp != 0 && block.timestamp >= expiresAtTimestamp) return false;
+            committedTRAC = committed;
+        } catch {
+            return false;
+        }
+
+        // Gate 2: governance stake floor — keeps the waiver a perk for real
+        // PCAs (and blocks the dust-PCA bypass). If ParametersStorage is
+        // unresolvable, fail closed (floor = max ⇒ not waived).
+        address psAddr = hub.getContractAddress("ParametersStorage");
+        if (psAddr == address(0)) return false;
+        if (committedTRAC < IParamsMinPcaCommitment(psAddr).minPcaCommitmentForCgWaiver()) {
+            return false;
+        }
+
+        // Gate 3: the CG creator is the PCA owner or a currently registered
+        // agent. EXPLICIT caller check — ContextGraphs' coherence gate only ties
+        // the stored authority to the owner, not the creator.
+        bool authorized;
+        try nft.ownerOf(accountId) returns (address owner_) {
+            if (owner_ == creator) authorized = true;
+        } catch {
+            return false; // nonexistent account
+        }
+        if (!authorized) {
+            try nft.agentToAccountId(creator) returns (uint256 boundAccount) {
+                if (boundAccount == accountId) authorized = true;
+            } catch {
+                /* not authorized */
+            }
+        }
+        if (!authorized) return false;
+
+        // Gate 4: per-PCA quota — at most committedTRAC / deposit deposit-free
+        // CGs, so N free CGs cost N×deposit of LOCKED commitment.
+        uint256 quota = uint256(committedTRAC) / uint256(deposit);
+        uint256 used = waivedCgCount[accountId];
+        if (used >= quota) return false;
+
+        unchecked {
+            waivedCgCount[accountId] = used + 1;
+        }
+        emit RegistrationDepositWaived(accountId, creator, used + 1, quota);
+        return true;
+    }
+}

--- a/packages/evm-module/contracts/storage/ParametersStorage.sol
+++ b/packages/evm-module/contracts/storage/ParametersStorage.sol
@@ -87,6 +87,18 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
     /// `publish` / `topUp` / NFT-transfer work.
     uint256 public constant MAX_PUBLISHING_CONVICTION_EPOCHS = 60;
 
+    /// @notice OT-RFC-53: minimum PCA `committedTRAC` required for a PCA-backed
+    ///         Context Graph to qualify for the registration-deposit WAIVER. The
+    ///         waiver lets a PCA's locked TRAC pay the per-CG anti-spam cost
+    ///         instead of separate liquid TRAC, but only up to a per-PCA quota
+    ///         (`committedTRAC / contextGraphRegistrationDeposit`); this floor
+    ///         keeps the perk to serious PCAs and blocks the dust-PCA bypass
+    ///         (a 1-wei PCA minting unlimited deposit-free CGs). Defaults to the
+    ///         first conviction discount tier (25k TRAC).
+    /// @dev    Declared at the END of the state variables ON PURPOSE: appending
+    ///         (not inserting) keeps every prior storage slot unchanged.
+    uint96 public minPcaCommitmentForCgWaiver;
+
     // @dev Only transactions by HubController owner or one of the owners of the MultiSig Wallet
     modifier onlyOwnerOrMultiSigOwner() {
         _checkOwnerOrMultiSigOwner();
@@ -127,6 +139,12 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
         // production automatically (no manual step, no silent-off) while keeping
         // test fixtures — which don't run that script — unaffected. Governance
         // can retune or disable it anytime.
+
+        // OT-RFC-53 waiver floor: unlike the deposit, this ships at a sane
+        // non-zero default (the first conviction discount tier, 25k TRAC) so the
+        // waiver is never accidentally floor-less. It is moot until the deposit
+        // is activated (the waiver path is gated on deposit > 0). Governance-tunable.
+        minPcaCommitmentForCgWaiver = 25_000 ether;
     }
 
     function name() external pure virtual override returns (string memory) {
@@ -233,6 +251,12 @@ contract ParametersStorage is INamed, IVersioned, HubDependent {
         contextGraphRegistrationDeposit = amount;
 
         emit ParameterChanged("contextGraphRegistrationDeposit", amount);
+    }
+
+    function setMinPcaCommitmentForCgWaiver(uint96 amount) external onlyOwnerOrMultiSigOwner {
+        minPcaCommitmentForCgWaiver = amount;
+
+        emit ParameterChanged("minPcaCommitmentForCgWaiver", amount);
     }
 
     function setProtocolTreasuryFee(uint16 protocolTreasuryFee_) external onlyOwnerOrMultiSigOwner {

--- a/packages/evm-module/deploy/active/049a_deploy_context_graph_waiver_storage.ts
+++ b/packages/evm-module/deploy/active/049a_deploy_context_graph_waiver_storage.ts
@@ -1,0 +1,15 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+
+// OT-RFC-53: spam-cap state + logic for the PCA-backed CG registration-deposit
+// waiver. ContextGraphs resolves it fresh via the Hub at create-time, so no
+// re-initialization of ContextGraphs is required when this is (re)deployed.
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  await hre.helpers.deploy({
+    newContractName: 'ContextGraphWaiverStorage',
+  });
+};
+
+export default func;
+func.tags = ['ContextGraphWaiverStorage', 'v10'];
+func.dependencies = ['Hub'];

--- a/packages/evm-module/deployments/parameters.json
+++ b/packages/evm-module/deployments/parameters.json
@@ -127,7 +127,9 @@
             "shardingTableSizeLimit": "500",
             "askUpperBoundFactor": "1467000000000000000",
             "askLowerBoundFactor": "533000000000000000",
-            "v81ReleaseEpoch": "6"
+            "v81ReleaseEpoch": "6",
+            "contextGraphRegistrationDeposit": "100000000000000000000",
+            "minPcaCommitmentForCgWaiver": "25000000000000000000000"
         },
         "Chronos": {
             "startTime": "1736812800",

--- a/packages/evm-module/test/unit/ParametersStorage.test.ts
+++ b/packages/evm-module/test/unit/ParametersStorage.test.ts
@@ -180,4 +180,35 @@ describe('@unit ParametersStorage contract', function () {
       ).to.be.revertedWith('Only Hub Owner, Hub, or Multisig Owner can call');
     });
   });
+
+  describe('minPcaCommitmentForCgWaiver (OT-RFC-53 waiver floor)', () => {
+    it('defaults to 25,000 TRAC', async () => {
+      expect(await ParametersStorage.minPcaCommitmentForCgWaiver()).to.equal(
+        hre.ethers.parseEther('25000'),
+      );
+    });
+
+    it('owner can set it, the value updates, and it emits ParameterChanged', async () => {
+      const v = hre.ethers.parseEther('5000');
+      const tx = await Hub.forwardCall(
+        await ParametersStorage.getAddress(),
+        ParametersStorageInterface.encodeFunctionData(
+          'setMinPcaCommitmentForCgWaiver',
+          [v],
+        ),
+      );
+      await expect(tx)
+        .to.emit(ParametersStorage, 'ParameterChanged')
+        .withArgs('minPcaCommitmentForCgWaiver', v);
+      expect(await ParametersStorage.minPcaCommitmentForCgWaiver()).to.equal(v);
+    });
+
+    it('setMinPcaCommitmentForCgWaiver reverts for non-owner', async () => {
+      await expect(
+        ParametersStorage.connect(accounts[1]).setMinPcaCommitmentForCgWaiver(
+          hre.ethers.parseEther('1'),
+        ),
+      ).to.be.revertedWith('Only Hub Owner, Hub, or Multisig Owner can call');
+    });
+  });
 });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -2324,4 +2324,86 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     expect(roots[0].merkleRoot).to.equal(publishRoot);
     expect(roots[1].merkleRoot).to.equal(newRoot);
   });
+
+  // --------------------------------------------------------------------------
+  // OT-RFC-53 — registration-deposit WAIVER for PCA-backed CGs.
+  // A CG whose publish authority is a PCA the CREATOR owns or is a registered
+  // agent of pays NO separate 100-TRAC deposit: the PCA already locks real TRAC
+  // (the anti-spam stake) and funds the CG's publishing. Caller authz is owner
+  // OR registered agent — NOT merely authority==owner (that would let a third
+  // party dodge the deposit against someone else's PCA).
+  // --------------------------------------------------------------------------
+  describe('OT-RFC-53 deposit waiver for PCA-backed CGs', () => {
+    const DEPOSIT = ethers.parseEther('100');
+
+    const setDeposit = async () => {
+      const Params = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+      await Params.connect(accounts[0]).setContextGraphRegistrationDeposit(DEPOSIT);
+    };
+    // Curated CG (publishPolicy 0) whose authority is `owner` and which is
+    // bound to PCA `accountId` — the PCA-authority shape the waiver keys on.
+    const createPcaCg = (caller: SignerWithAddress, owner: SignerWithAddress, accountId: bigint) =>
+      CGFacade.connect(caller).createContextGraph([], 0, 1, 0, owner.address, accountId, ethers.ZeroHash);
+
+    it('WAIVES the deposit when the PCA OWNER creates the CG (no TRAC pulled)', async () => {
+      await setDeposit();
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner);
+      const before = await Token.balanceOf(owner.address); // owner funded nothing for a deposit
+
+      await expect(createPcaCg(owner, owner, accountId))
+        .to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived')
+        .and.not.to.emit(CGFacade, 'ContextGraphRegistrationDeposited');
+
+      const cgId = await CGS.getLatestContextGraphId();
+      expect(await CGS.getRegistrationEscrow(cgId)).to.equal(0n); // no escrow
+      expect(await Token.balanceOf(owner.address)).to.equal(before); // nothing pulled
+    });
+
+    it('WAIVES the deposit when a REGISTERED AGENT of the PCA creates the CG', async () => {
+      await setDeposit();
+      const owner = accounts[1];
+      const agent = accounts[3];
+      const accountId = await createAccountFor(owner);
+      await NFT.connect(owner).registerAgent(accountId, agent.address);
+      expect(await NFT.agentToAccountId(agent.address)).to.equal(accountId);
+
+      const before = await Token.balanceOf(agent.address);
+      await expect(createPcaCg(agent, owner, accountId)) // authority must be the owner (coherence)
+        .to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+
+      const cgId = await CGS.getLatestContextGraphId();
+      expect(await CGS.getRegistrationEscrow(cgId)).to.equal(0n);
+      expect(await Token.balanceOf(agent.address)).to.equal(before);
+    });
+
+    it('does NOT waive for a non-owner non-agent — the deposit is still charged (caller guard)', async () => {
+      await setDeposit();
+      const owner = accounts[1];
+      const stranger = accounts[4];
+      const accountId = await createAccountFor(owner);
+
+      // Stranger sets authority=owner so the coherence gate passes, but is
+      // neither owner nor a registered agent → must pay. Unfunded → revert.
+      await expect(createPcaCg(stranger, owner, accountId)).to.be.reverted;
+
+      // Funded + approved, the stranger CAN create it — but is CHARGED (not waived).
+      await Token.mint(stranger.address, DEPOSIT);
+      await Token.connect(stranger).approve(await CGFacade.getAddress(), DEPOSIT);
+      await expect(createPcaCg(stranger, owner, accountId))
+        .to.emit(CGFacade, 'ContextGraphRegistrationDeposited')
+        .and.not.to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+      const cgId = await CGS.getLatestContextGraphId();
+      expect(await CGS.getRegistrationEscrow(cgId)).to.equal(DEPOSIT);
+    });
+
+    it('does NOT waive a CG with no PCA (accountId 0) — normal deposit applies', async () => {
+      await setDeposit();
+      const creator = accounts[5];
+      // No PCA designated → unfunded create reverts (deposit charged, not waived).
+      await expect(
+        CGFacade.connect(creator).createContextGraph([], 0, 0, 1, ethers.ZeroAddress, 0, ethers.ZeroHash),
+      ).to.be.reverted;
+    });
+  });
 });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -75,6 +75,7 @@ async function deployFixture(): Promise<Fixture> {
     'ContextGraphStorage',
     'ContextGraphs',
     'ContextGraphValueStorage',
+    'ContextGraphWaiverStorage',
     'DKGPublishingConvictionNFT',
     'DKGStakingConvictionNFT',
     'StakingV10',
@@ -2345,6 +2346,14 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
     const createPcaCg = (caller: SignerWithAddress, owner: SignerWithAddress, accountId: bigint) =>
       CGFacade.connect(caller).createContextGraph([], 0, 1, 0, owner.address, accountId, ethers.ZeroHash);
 
+    // Create a PCA with a SPECIFIC committed amount (createAccountFor is fixed at 50k).
+    const createAccountWith = async (owner: SignerWithAddress, amount: bigint): Promise<bigint> => {
+      await Token.mint(owner.address, amount);
+      await Token.connect(owner).approve(await NFT.getAddress(), amount);
+      await NFT.connect(owner).createAccount(amount, 0);
+      return NFT.totalSupply();
+    };
+
     it('WAIVES the deposit when the PCA OWNER creates the CG (no TRAC pulled)', async () => {
       await setDeposit();
       const owner = accounts[1];
@@ -2432,6 +2441,52 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       expect((await NFT.accounts(accountId))[8]).to.equal(true); // fullySwept
 
       await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+    });
+
+    // Review feedback (anti-spam): the waiver must NOT let one PCA mint unlimited
+    // free CGs. Two guards — a minimum-commitment floor and a per-PCA quota.
+    it('does NOT waive a PCA below the minimum-commitment floor — deposit charged', async () => {
+      await setDeposit(); // 100 TRAC; default floor = 25k
+      const owner = accounts[1];
+      const accountId = await createAccountWith(owner, ethers.parseEther('10000')); // < 25k floor
+      // Below floor → not waived → unfunded create reverts.
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+    });
+
+    it('waives only up to the per-PCA quota (committedTRAC / deposit), then charges', async () => {
+      const Params = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+      // deposit 25k, PCA 50k → quota = 2 (floor 25k still satisfied by 50k).
+      await Params.connect(accounts[0]).setContextGraphRegistrationDeposit(ethers.parseEther('25000'));
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner); // 50k committed
+
+      // First two are waived.
+      await expect(createPcaCg(owner, owner, accountId)).to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+      await expect(createPcaCg(owner, owner, accountId)).to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+      // Third exceeds the quota → charged → unfunded → revert.
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+
+      const Waiver = await hre.ethers.getContract('ContextGraphWaiverStorage');
+      expect(await (Waiver as any).waivedCgCount(accountId)).to.equal(2n);
+    });
+
+    it('waives a PCA exactly AT the floor (committed == minPcaCommitment) — pins < not <=', async () => {
+      await setDeposit(); // 100; default floor 25k
+      const owner = accounts[1];
+      const accountId = await createAccountWith(owner, ethers.parseEther('25000')); // == floor
+      await expect(createPcaCg(owner, owner, accountId)).to.emit(
+        CGFacade,
+        'ContextGraphRegistrationDepositWaived',
+      );
+    });
+
+    it('tryConsumeWaiver reverts for any caller other than ContextGraphs (counter anti-grief)', async () => {
+      const Waiver = await hre.ethers.getContract('ContextGraphWaiverStorage');
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner);
+      await expect(
+        (Waiver as any).connect(accounts[2]).tryConsumeWaiver(accountId, owner.address, ethers.parseEther('100')),
+      ).to.be.revertedWithCustomError(Waiver, 'OnlyContextGraphs');
     });
   });
 });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -2488,5 +2488,24 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
         (Waiver as any).connect(accounts[2]).tryConsumeWaiver(accountId, owner.address, ethers.parseEther('100')),
       ).to.be.revertedWithCustomError(Waiver, 'OnlyContextGraphs');
     });
+
+    // Review (otReviewAgent): the waiver depends on agent membership of the
+    // SPECIFIC backing PCA — `agentToAccountId(creator) == accountId`, not just
+    // "is a registered agent somewhere". An agent of a DIFFERENT PCA must not
+    // waive against this one.
+    it('does NOT waive when the caller is an agent of a DIFFERENT PCA (pins the equality check)', async () => {
+      await setDeposit(); // 100; floor 25k
+      const ownerA = accounts[1];
+      const ownerB = accounts[3];
+      const agentOfB = accounts[4];
+      const accountA = await createAccountFor(ownerA); // PCA #1 (50k)
+      const accountB = await createAccountFor(ownerB); // PCA #2 (50k)
+      await NFT.connect(ownerB).registerAgent(accountB, agentOfB.address); // agent of #2 only
+      expect(await NFT.agentToAccountId(agentOfB.address)).to.equal(accountB);
+
+      // agentOfB targets PCA #1 (ownerA's) → not its agent, not its owner →
+      // not waived → unfunded create reverts (deposit charged).
+      await expect(createPcaCg(agentOfB, ownerA, accountA)).to.be.reverted;
+    });
   });
 });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -2405,5 +2405,33 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
         CGFacade.connect(creator).createContextGraph([], 0, 0, 1, ethers.ZeroAddress, 0, ethers.ZeroHash),
       ).to.be.reverted;
     });
+
+    // Review feedback: an EXPIRED or FULLY-SWEPT PCA has no live locked
+    // commitment, so it provides no anti-spam stake — the waiver must NOT apply
+    // (else the owner could mint unlimited zero-deposit CGs against a dead PCA).
+    it('does NOT waive when the PCA has EXPIRED (no live backing) — deposit charged', async () => {
+      await setDeposit();
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner);
+      const expiresAtTimestamp = (await NFT.accounts(accountId))[4]; // tuple idx 4
+      await time.increaseTo(Number(expiresAtTimestamp) + 1);
+
+      // Owner is unfunded for a deposit (committed TRAC is spent; no facade
+      // approval) → waiver denied → _pullRegistrationDeposit reverts.
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+    });
+
+    it('does NOT waive when the PCA has been FULLY SWEPT — deposit charged', async () => {
+      await setDeposit();
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner);
+      const expiresAtTimestamp = (await NFT.accounts(accountId))[4];
+      await time.increaseTo(Number(expiresAtTimestamp) + 1);
+      // Post-expiry settle sweeps the unused account's tail and marks it swept.
+      await NFT.connect(owner).settle(accountId);
+      expect((await NFT.accounts(accountId))[8]).to.equal(true); // fullySwept
+
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+    });
   });
 });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -2547,5 +2547,59 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       const cgId = await CGS.getLatestContextGraphId();
       expect(await CGS.getRegistrationEscrow(cgId)).to.equal(DEPOSIT); // charged, not free
     });
+
+    // Coverage (audit gap): the floor is GOVERNANCE-tunable and read LIVE by
+    // tryConsumeWaiver — a changed floor must flip the waiver decision end-to-end.
+    // The default-floor cases above can't catch a regression that hard-coded 25k.
+    it('floor is read live — lowering minPcaCommitmentForCgWaiver newly waives a sub-default PCA; raising it charges again', async () => {
+      const Params = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+      await setDeposit(); // 100; default floor 25k
+      const owner = accounts[1];
+      const accountId = await createAccountWith(owner, ethers.parseEther('10000')); // 10k — BELOW the 25k default
+
+      // At the default 25k floor a 10k PCA is NOT waived → charged → unfunded → revert.
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+
+      // Governance LOWERS the floor to 5k → 10k now clears it → the next CG is WAIVED.
+      await Params.connect(accounts[0]).setMinPcaCommitmentForCgWaiver(ethers.parseEther('5000'));
+      await expect(createPcaCg(owner, owner, accountId))
+        .to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+
+      // Governance RAISES the floor above the 10k commitment (to 50k) → the PCA
+      // fails the floor again → the next CG is charged (owner unfunded → revert).
+      await Params.connect(accounts[0]).setMinPcaCommitmentForCgWaiver(ethers.parseEther('50000'));
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+    });
+
+    // Coverage (audit gap): the fail-closed guard must also cover a waiver storage
+    // that is REGISTERED (resolves non-zero, passes the address(0) check at
+    // ContextGraphs.sol:250) but whose tryConsumeWaiver REVERTS internally — the
+    // inner catch at :253, a different branch than the unregistered case above.
+    // Trick: ContextGraphs reads the deposit through its CACHED parametersStorage
+    // pointer (still valid), but ContextGraphWaiverStorage reads ParametersStorage
+    // LIVE via the Hub. Removing ParametersStorage from the Hub therefore leaves
+    // the deposit read intact while making tryConsumeWaiver revert inside.
+    it('fail-closed: a REGISTERED waiver storage whose tryConsumeWaiver REVERTS → owner-eligible PCA CG is CHARGED', async () => {
+      await setDeposit(); // 100; floor 25k — stored on the ParametersStorage contract
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner); // 50k — would normally be waived for the owner
+
+      // ContextGraphWaiverStorage STAYS registered. Remove ParametersStorage from
+      // the Hub → the storage's live `minPcaCommitmentForCgWaiver()` read hits
+      // address(0) and reverts inside tryConsumeWaiver. ContextGraphs's cached
+      // parametersStorage pointer still serves the deposit read, so we reach the
+      // waiver branch and fall into the inner catch → charge.
+      await HubContract.connect(accounts[0]).removeContractByName('ParametersStorage');
+
+      // Fund the deposit so we can assert it is actually CHARGED (not merely an unfunded revert).
+      await Token.mint(owner.address, DEPOSIT);
+      await Token.connect(owner).approve(await CGFacade.getAddress(), DEPOSIT);
+
+      await expect(createPcaCg(owner, owner, accountId))
+        .to.emit(CGFacade, 'ContextGraphRegistrationDeposited')
+        .and.not.to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+      const cgId = await CGS.getLatestContextGraphId();
+      expect(await CGS.getRegistrationEscrow(cgId)).to.equal(DEPOSIT); // charged, not free
+    });
   });
 });

--- a/packages/evm-module/test/v10-pca-lifecycle.test.ts
+++ b/packages/evm-module/test/v10-pca-lifecycle.test.ts
@@ -2507,5 +2507,45 @@ describe('@integration V10 PCA lifecycle (DKGPublishingConvictionNFT)', function
       // not waived → unfunded create reverts (deposit charged).
       await expect(createPcaCg(agentOfB, ownerA, accountA)).to.be.reverted;
     });
+
+    // Coverage (audit gap): quota = committedTRAC / deposit is read on the LIVE
+    // deposit each call, so raising the deposit shrinks the remaining quota of a
+    // partially-used PCA.
+    it('quota recomputes on the LIVE deposit — raising the deposit shrinks remaining quota', async () => {
+      const Params = await hre.ethers.getContract<ParametersStorage>('ParametersStorage');
+      await Params.connect(accounts[0]).setContextGraphRegistrationDeposit(ethers.parseEther('25000')); // deposit 25k
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner); // 50k committed → quota 50k/25k = 2
+
+      // First is waived (used 1 of 2).
+      await expect(createPcaCg(owner, owner, accountId)).to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+      // Governance raises the deposit to 50k → quota recomputes to 50k/50k = 1;
+      // used 1 >= 1 → the next CG is CHARGED (owner unfunded → reverts).
+      await Params.connect(accounts[0]).setContextGraphRegistrationDeposit(ethers.parseEther('50000'));
+      await expect(createPcaCg(owner, owner, accountId)).to.be.reverted;
+    });
+
+    // Coverage (audit HIGH gap): if ContextGraphWaiverStorage is unresolvable in
+    // the Hub (not yet registered / deregistered) while the deposit is ON, the
+    // waiver must FAIL CLOSED — an owner-eligible CG is CHARGED, never free.
+    it('fail-closed: ContextGraphWaiverStorage unregistered in the Hub → owner-eligible PCA CG is CHARGED, not waived', async () => {
+      await setDeposit(); // 100 TRAC; floor 25k
+      const owner = accounts[1];
+      const accountId = await createAccountFor(owner); // 50k — would normally be waived for the owner
+
+      // Unregister the waiver storage from the Hub → ContextGraphs resolves
+      // address(0) → the fail-closed branch charges the deposit.
+      await HubContract.connect(accounts[0]).removeContractByName('ContextGraphWaiverStorage');
+
+      // Fund the deposit so we can assert it is actually CHARGED (not merely reverting unfunded).
+      await Token.mint(owner.address, DEPOSIT);
+      await Token.connect(owner).approve(await CGFacade.getAddress(), DEPOSIT);
+
+      await expect(createPcaCg(owner, owner, accountId))
+        .to.emit(CGFacade, 'ContextGraphRegistrationDeposited')
+        .and.not.to.emit(CGFacade, 'ContextGraphRegistrationDepositWaived');
+      const cgId = await CGS.getLatestContextGraphId();
+      expect(await CGS.getRegistrationEscrow(cgId)).to.equal(DEPOSIT); // charged, not free
+    });
   });
 });


### PR DESCRIPTION
## Summary
Lets a Context Graph backed by a PCA the creator **owns or is a registered conviction agent of** skip the 100-TRAC registration deposit — **bounded by a per-PCA quota + a minimum-commitment floor** so it can't be used to spam. The PCA's locked TRAC pays the per-CG anti-spam cost instead of separate liquid TRAC.

## The problem
`ContextGraphs._pullRegistrationDeposit` always `transferFrom(msg.sender)` the deposit, even when the CG designates a PCA — so a PCA-backed CG was double-charged and the creator needed separate liquid TRAC.

## Why not "move funds from the PCA"
The PCA's value is `committedTRAC`, prorated into per-epoch publishing allocations (OT-RFC-51) at creation — pulling it back out means unwinding live allocation schedules. So instead we **waive** the deposit but **meter it against the PCA's commitment** (below), which is economically equivalent without touching the allocation accounting.

## Anti-spam (the load-bearing part)
A naive full waiver would let a **1-wei PCA mint unlimited deposit-free CGs** (no min commitment, no per-owner CG cap) — nullifying OT-RFC-53. Two guards close this:
- **`minPcaCommitmentForCgWaiver`** — new `ParametersStorage` param, default **25k TRAC** (first discount tier), governance-tunable. Sub-floor / dust PCAs get **no** waiver.
- **Per-PCA quota = `committedTRAC / deposit`** — tracked in the new `ContextGraphWaiverStorage`. So **N deposit-free CGs cost N×deposit of *locked* commitment** — the same per-CG anti-spam cost, paid by the PCA. Quota is Sybil-resistant (total free CGs ∝ total TRAC locked).

The waiver also requires the PCA be **active** (committed > 0, unexpired, not fully-swept) — an expired/swept PCA has no live stake.

## Authorization
`tryConsumeWaiver` requires `creator == ownerOf(accountId) || agentToAccountId(creator) == accountId`. The explicit **caller** check is load-bearing — `_validatePCACoherence` only ties the stored *authority* to the owner, not the caller. The mutator is gated to the live `ContextGraphs` (counter anti-grief), and fails **closed** (charges the deposit) on any resolution/call failure.

## Architecture (why a new contract)
`ContextGraphStorage` is already deployed (frozen) and the per-PCA counter is new data, so the counter **and** the eligibility logic live in a new Hub-registered **`ContextGraphWaiverStorage`** (keeps it off `ContextGraphs`' bytecode budget — `ContextGraphs` is 8.5 KB). `minPcaCommitmentForCgWaiver` is appended at the **end** of `ParametersStorage` state vars (no storage-slot shift).

## ⚠️ Mainnet posture (correcting this PR's earlier note)
The deposit is **not dormant** — `998a_set_context_graph_registration_deposit.ts` activates it at **100 TRAC on every real-network deploy** (Base/Gnosis/NeuroWeb). So this is a regression fix to a live control; it must ship safely.

## Deploy ordering (coordinated, 3 contracts)
1. **Redeploy `ParametersStorage`** (carries `minPcaCommitmentForCgWaiver`; re-set all params; re-init its cachers).
2. **Deploy + Hub-register `ContextGraphWaiverStorage`**.
3. **Redeploy + re-init `ContextGraphs`** (it caches `parametersStorage`).

A partial/misordered deploy fails **closed** (charges the deposit) — safe, but the waiver silently won't activate until all three land. **Needs re-audit before mainnet.**

## Tests (`v10-pca-lifecycle.test.ts`)
10 waiver cases: owner-waived, agent-waived, non-owner charged, no-PCA charged, expired charged, fully-swept charged, below-floor charged, quota-exhaustion, at-floor boundary (`<` not `<=`), `OnlyContextGraphs` gate. No regression: pca-lifecycle 50, cg-registration-deposit 6, ParametersStorage 11, deploy-998a 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)