### PR TITLE
feat(pca): P3 — PCA enumeration (GAP-1), auto-track edge self-heal, Renew via re-mint (S2b)

### DIFF
--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -95,7 +95,7 @@ import {
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type PcaAccountRelation } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -1541,6 +1541,16 @@ export class AgentRegistryMethods extends DKGAgentBase {
   ): Promise<bigint | null> {
     if (typeof this.chain.getConvictionAgentAccountId !== 'function') return null;
     return this.chain.getConvictionAgentAccountId(agent, opts);
+  }
+
+  /** GAP-1 — enumerate every PCA the given wallets relate to (owned + agent-on).
+   *  `null` when the adapter lacks the surface (daemon maps null → 503). */
+  async listPublishingConvictionAccountsForWallets(
+    this: DKGAgent,
+    wallets: string[],
+  ): Promise<PcaAccountRelation[] | null> {
+    if (typeof this.chain.listPublishingConvictionAccountsForWallets !== 'function') return null;
+    return this.chain.listPublishingConvictionAccountsForWallets(wallets);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -90,4 +90,20 @@ describe('DKGAgent V10 PCA facade', () => {
     expect(typeof ext.currentEpoch).toBe('number');
     expect(ext.remainingAllowance).toBe(ext.baseEpochAllowance + ext.topUpBuffer);
   });
+
+  it('listPublishingConvictionAccountsForWallets delegates (owned/agent/both); null when unsupported', async () => {
+    const owner = ethers.Wallet.createRandom();
+    const chain = new MockChainAdapter('mock:31337', owner.address);
+    const agent = await makeAgent(chain);
+    const created = await agent.createPublishingConvictionAccount(1_000n, 42n);
+    const w = ethers.Wallet.createRandom().address;
+    await agent.registerPublishingConvictionAgent(created!.accountId, w);
+
+    const mine = await agent.listPublishingConvictionAccountsForWallets([owner.address, w]);
+    const m = new Map(mine!.map((e) => [e.accountId, e.relation]));
+    expect(m.get(created!.accountId)).toBe('both'); // owner holds it + w is its agent
+
+    const none = await makeAgent(new NoChainAdapter());
+    expect(await none.listPublishingConvictionAccountsForWallets([owner.address])).toBeNull();
+  });
 });

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -7,9 +7,20 @@ import type { ethers } from 'ethers';
  * is caught at compile time, rather than only at runtime through the base-class
  * structural cast in `isConvictionFundedAgent`.
  */
+/** A PCA the node relates to (GAP-1): `owned` (a node wallet holds the NFT),
+ *  `agent` (a node op wallet is its registered publishing agent), or `both`. */
+export type PcaRelation = 'owned' | 'agent' | 'both';
+export interface PcaAccountRelation {
+  accountId: bigint;
+  relation: PcaRelation;
+}
+
 export interface ConvictionReader {
   getConvictionAgentAccountId(agent: string): Promise<bigint>;
   convictionAccountCanCover(accountId: bigint, baseCost: bigint): Promise<boolean>;
+  /** GAP-1 — enumerate every PCA the given wallets relate to (owned + agent-on),
+   *  deduped, relation-tagged, sorted by accountId asc. */
+  listPublishingConvictionAccountsForWallets(wallets: string[]): Promise<PcaAccountRelation[]>;
 }
 
 export interface IdentityProof {
@@ -899,6 +910,15 @@ export interface ChainAdapter {
    * publisher gracefully treats `undefined` as "no PCA path active".
    */
   getConvictionAgentAccountId?(agent: string, opts?: { strict?: boolean }): Promise<bigint>;
+
+  /**
+   * GAP-1 — enumerate every PCA the given wallets relate to: `owned` (the wallet
+   * holds the NFT, via ERC721Enumerable balanceOf+tokenOfOwnerByIndex since
+   * tokenId === accountId) and/or `agent` (the wallet is a registered publishing
+   * agent, via agentToAccountId). Deduped + relation-tagged + sorted asc.
+   * Read-only; surfaces read failures (does not fail-safe to a partial list).
+   */
+  listPublishingConvictionAccountsForWallets?(wallets: string[]): Promise<PcaAccountRelation[]>;
 
   /**
    * Returns the V10 NFT-backed PCA's `lockDurationEpochs` for the given

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -19,8 +19,10 @@ export interface ConvictionReader {
   getConvictionAgentAccountId(agent: string): Promise<bigint>;
   convictionAccountCanCover(accountId: bigint, baseCost: bigint): Promise<boolean>;
   /** GAP-1 — enumerate every PCA the given wallets relate to (owned + agent-on),
-   *  deduped, relation-tagged, sorted by accountId asc. */
-  listPublishingConvictionAccountsForWallets(wallets: string[]): Promise<PcaAccountRelation[]>;
+   *  deduped, relation-tagged, sorted by accountId asc. Optional: additive to the
+   *  published surface, consistent with the facade's typeof-guard (capability →
+   *  503) and the optional ChainAdapter decl. EVMChainAdapter + mock implement it. */
+  listPublishingConvictionAccountsForWallets?(wallets: string[]): Promise<PcaAccountRelation[]>;
 }
 
 export interface IdentityProof {

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -11,7 +11,7 @@
 
 import { EVMChainAdapterBase } from './evm-adapter-base.js';
 import { ethers, Contract } from 'ethers';
-import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader } from './chain-adapter.js';
+import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader, PcaAccountRelation } from './chain-adapter.js';
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 
@@ -461,5 +461,48 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       this.contracts.dkgPublishingConvictionNFT, 'pcaNFT.getRegisteredAgents', 'getRegisteredAgents', accountId,
     );
     return (raw ?? []).map((a) => ethers.getAddress(a));
+  }
+
+  /**
+   * GAP-1 — enumerate every PCA the given `wallets` relate to:
+   *   - OWNED: the wallet holds the NFT. `DKGPublishingConvictionNFT` is
+   *     ERC721Enumerable and tokenId === accountId, so `balanceOf` +
+   *     `tokenOfOwnerByIndex` enumerates owned accounts (no `tokensOfOwner`
+   *     getter exists — wallet-iteration is the cheapest correct path).
+   *   - AGENT: the wallet is a registered publishing agent (`agentToAccountId`,
+   *     via the strict GAP-3 lookup).
+   * Deduped, relation-tagged (owned/agent/both), sorted by accountId asc.
+   *
+   * Strict / #9: undeployed NFT throws `PcaUnavailableError` (route → 503); a
+   * CALL_EXCEPTION on any read SURFACES (not caught here), so a transient blip
+   * becomes a 503, never a partial/empty list a UI would read as "relates to
+   * nothing". A healthy read with no matches returns `[]`.
+   */
+  async listPublishingConvictionAccountsForWallets(wallets: string[]): Promise<PcaAccountRelation[]> {
+    await this.init();
+    const nft = this.contracts.dkgPublishingConvictionNFT;
+    if (!nft) throw new PcaUnavailableError();
+    const owned = new Set<bigint>();
+    const agent = new Set<bigint>();
+    for (const w of wallets) {
+      if (!ethers.isAddress(w)) continue;
+      const balance: bigint = BigInt(await this.readContract(
+        nft, 'pcaNFT.balanceOf', 'balanceOf', w,
+      ));
+      for (let i = 0n; i < balance; i++) {
+        const tokenId: bigint = BigInt(await this.readContract(
+          nft, 'pcaNFT.tokenOfOwnerByIndex', 'tokenOfOwnerByIndex', w, i,
+        ));
+        owned.add(tokenId);
+      }
+      const acctId = await this.getConvictionAgentAccountId(w, { strict: true });
+      if (acctId > 0n) agent.add(acctId);
+    }
+    const ids = [...new Set<bigint>([...owned, ...agent])].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    return ids.map((accountId) => {
+      const o = owned.has(accountId);
+      const g = agent.has(accountId);
+      return { accountId, relation: (o && g ? 'both' : o ? 'owned' : 'agent') as PcaAccountRelation['relation'] };
+    });
   }
 }

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -24,6 +24,7 @@ import type {
   OperationalWalletRegistrationResult,
   V10PublishingConvictionAccountInfo,
   VerifyACKIdentityResult,
+  PcaAccountRelation,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -673,6 +674,29 @@ export class MockChainAdapter implements ChainAdapter {
     const acct = this.convictionAccounts.get(accountId);
     if (!acct) return [];
     return [...acct.agents].map((k) => ethers.getAddress(k));
+  }
+
+  /** GAP-1 parity — enumerate PCAs the wallets relate to: OWNED (the account's
+   *  owner is the wallet) + AGENT (the reverse map). Deduped, relation-tagged,
+   *  sorted asc. */
+  async listPublishingConvictionAccountsForWallets(wallets: string[]): Promise<PcaAccountRelation[]> {
+    const owned = new Set<bigint>();
+    const agent = new Set<bigint>();
+    for (const w of wallets) {
+      if (!ethers.isAddress(w)) continue;
+      const key = ethers.getAddress(w).toLowerCase();
+      for (const [id, acct] of this.convictionAccounts) {
+        if (acct.owner.toLowerCase() === key) owned.add(id);
+      }
+      const acctId = this.agentToConvictionAccount.get(key);
+      if (acctId != null && acctId > 0n) agent.add(acctId);
+    }
+    const ids = [...new Set<bigint>([...owned, ...agent])].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    return ids.map((accountId) => {
+      const o = owned.has(accountId);
+      const g = agent.has(accountId);
+      return { accountId, relation: (o && g ? 'both' : o ? 'owned' : 'agent') as PcaAccountRelation['relation'] };
+    });
   }
 
   /** Mirrors `agentToAccountId`; `0n` for unregistered → publisher SDK

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -146,6 +146,29 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
     expect(agents).toEqual([checksummed]);
     expect(agents[0]).not.toBe(checksummed.toLowerCase()); // EIP-55, not lowercased
   });
+
+  it('listPublishingConvictionAccountsForWallets — owned / agent / both, deduped + sorted (GAP-1 parity)', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId: a1 } = await mock.createPublishingConvictionAccount(COMMITTED);
+    const { accountId: a2 } = await mock.createPublishingConvictionAccount(COMMITTED);
+    const w = ethers.Wallet.createRandom().address;
+    await mock.registerPublishingConvictionAgent(a1, w);
+
+    // SIGNER owns a1+a2, is an agent of neither → both 'owned'.
+    const owned = await mock.listPublishingConvictionAccountsForWallets([SIGNER]);
+    expect(owned.map((e) => e.relation)).toEqual(['owned', 'owned']);
+    // w owns nothing, agent on a1 → 'agent'.
+    expect(await mock.listPublishingConvictionAccountsForWallets([w])).toEqual([{ accountId: a1, relation: 'agent' }]);
+    // Combined → a1 'both', a2 'owned', deduped + sorted asc.
+    const combined = await mock.listPublishingConvictionAccountsForWallets([SIGNER, w]);
+    const m = new Map(combined.map((e) => [e.accountId, e.relation]));
+    expect(m.get(a1)).toBe('both');
+    expect(m.get(a2)).toBe('owned');
+    expect(combined).toHaveLength(2);
+    expect(combined.map((e) => e.accountId)).toEqual([a1, a2]); // sorted asc (1n, 2n)
+    // Unrelated wallet → [].
+    expect(await mock.listPublishingConvictionAccountsForWallets([ethers.Wallet.createRandom().address])).toEqual([]);
+  });
 });
 
 describe('MockChainAdapter — V10 conviction topUp/settle', () => {

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -157,6 +157,36 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(info!.remainingAllowance).toBeUndefined();
   });
 
+  it('listPublishingConvictionAccountsForWallets enumerates owned / agent / both, deduped + sorted (GAP-1)', async () => {
+    const owner = await fundedOwner();
+    const ownerAddr = owner.getSignerAddress();
+    const { accountId: a1 } = await owner.createPublishingConvictionAccount(COMMITTED);
+    const { accountId: a2 } = await owner.createPublishingConvictionAccount(COMMITTED);
+    const w = ethers.Wallet.createRandom().address;
+    await owner.registerPublishingConvictionAgent(a1, w); // w is a publishing agent on a1
+
+    // The owner wallet holds both NFTs and is an agent of neither → both 'owned'.
+    const ownedList = await owner.listPublishingConvictionAccountsForWallets([ownerAddr]);
+    const om = new Map(ownedList.map((e) => [e.accountId, e.relation]));
+    expect(om.get(a1)).toBe('owned');
+    expect(om.get(a2)).toBe('owned');
+    expect(ownedList).toHaveLength(2);
+
+    // w owns nothing, is an agent on a1 → 'agent'.
+    expect(await owner.listPublishingConvictionAccountsForWallets([w])).toEqual([{ accountId: a1, relation: 'agent' }]);
+
+    // Combined: a1 owned(owner)+agent(w) → 'both'; a2 'owned'. Deduped + sorted asc.
+    const combined = await owner.listPublishingConvictionAccountsForWallets([ownerAddr, w]);
+    const cm = new Map(combined.map((e) => [e.accountId, e.relation]));
+    expect(cm.get(a1)).toBe('both');
+    expect(cm.get(a2)).toBe('owned');
+    expect(combined).toHaveLength(2); // deduped (each account once)
+    expect(combined.map((e) => e.accountId)).toEqual([a1, a2].sort((x, y) => (x < y ? -1 : 1)));
+
+    // A wallet related to nothing → [].
+    expect(await owner.listPublishingConvictionAccountsForWallets([ethers.Wallet.createRandom().address])).toEqual([]);
+  });
+
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -507,6 +507,56 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     }
   }
 
+  // GET /api/pca/mine — enumerate every PCA the node relates to (owned + agent-on
+  // across the node's operational wallets, GAP-1). Read-only. Optional ?hydrate=1
+  // adds the serializeAccountInfo basics per account (best-effort per id). Matched
+  // EXACTLY before the generic GET :id below, else 'mine' would parse as an id.
+  if (req.method === 'GET' && path === '/api/pca/mine') {
+    if (!agent.supportsPublishingConvictionNft) {
+      return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+    }
+    const wallets = ctx.opWallets.wallets.map((w) => w.address);
+    try {
+      const accounts = await agent.listPublishingConvictionAccountsForWallets(wallets);
+      if (accounts === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      const hydrate = ctx.url.searchParams.get('hydrate') === '1';
+      if (!hydrate) {
+        return jsonResponse(res, 200, {
+          accounts: accounts.map((a) => ({ accountId: a.accountId.toString(), relation: a.relation })),
+        });
+      }
+      // Hydrate: add the snapshot basics per account. Best-effort per id — a
+      // single account's read failure leaves it as just {accountId, relation},
+      // never drops it or fails the whole list.
+      const hydrated: Array<Record<string, unknown>> = [];
+      for (const a of accounts) {
+        const entry: Record<string, unknown> = { accountId: a.accountId.toString(), relation: a.relation };
+        try {
+          const info = await agent.getPublishingConvictionAccountInfo(a.accountId);
+          if (info) Object.assign(entry, serializeAccountInfo(a.accountId, info));
+        } catch { /* per-account hydrate is best-effort */ }
+        hydrated.push(entry);
+      }
+      return jsonResponse(res, 200, { accounts: hydrated });
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (respondIfChainRpcTransportError(res, err)) return;
+      // A CALL_EXCEPTION here is a real enumeration read failure → 503 retryable,
+      // NOT a partial/empty list a UI would read as "relates to nothing" (#9).
+      if (err?.code === 'CALL_EXCEPTION') {
+        return jsonResponse(res, 503, {
+          error: 'PCA enumeration temporarily unavailable — chain read failed',
+          code: 'PCA_LOOKUP_READ_FAILED',
+        });
+      }
+      return jsonResponse(res, 500, {
+        error: `listPublishingConvictionAccountsForWallets failed: ${msg}`,
+      });
+    }
+  }
+
   // GET /api/pca/:id — V10 conviction NFT snapshot. Optional ?key=0x...
   // probes whether that address is a registered agent. Optional ?extended=1
   // adds the GAP-4/5 budget fields (primaryNode + current-epoch allowance);

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -19,7 +19,7 @@ function fakeReq(method: string, path: string, body?: unknown) {
   return req;
 }
 
-function runCtx(method: string, rawPath: string, agent: any, body?: unknown) {
+function runCtx(method: string, rawPath: string, agent: any, body?: unknown, opWallets?: { wallets: Array<{ address: string }> }) {
   const res = fakeRes();
   // Mirror handle-request.ts: route on url.pathname, query lives on url.
   const url = new URL(`http://127.0.0.1${rawPath}`);
@@ -29,6 +29,8 @@ function runCtx(method: string, rawPath: string, agent: any, body?: unknown) {
     agent,
     path: url.pathname,
     url,
+    // GAP-1: GET /api/pca/mine reads the node's op wallet set.
+    opWallets: opWallets ?? { wallets: [] },
   } as unknown as RequestContext;
   return { res, done: handlePcaRoutes(ctx) };
 }
@@ -890,5 +892,83 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(extBody.remainingAllowance).toBe('8333');
     expect(extBody.remainingAllowanceTrac).toBe(ethers.formatEther(8333n));
     expect(extBody.currentEpoch).toBe(7);
+  });
+
+  // ----- GAP-1: GET /api/pca/mine (enumerate the node's PCAs) -----
+  it('GET /api/pca/mine → 200 {accounts:[{accountId,relation}]} from the node op wallets', async () => {
+    const w1 = '0x' + '1'.repeat(40);
+    const w2 = '0x' + '2'.repeat(40);
+    let askedWallets: string[] | undefined;
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listPublishingConvictionAccountsForWallets: async (w: string[]) => {
+        askedWallets = w;
+        return [{ accountId: 5n, relation: 'owned' }, { accountId: 7n, relation: 'both' }];
+      },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/mine', agent, undefined, { wallets: [{ address: w1 }, { address: w2 }] });
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      accounts: [{ accountId: '5', relation: 'owned' }, { accountId: '7', relation: 'both' }],
+    });
+    expect(askedWallets).toEqual([w1, w2]); // route passes the node's op wallet set
+  });
+
+  it('GET /api/pca/mine → 503 when the adapter lacks the PCA surface (lookup not called)', async () => {
+    let called = false;
+    const agent = {
+      supportsPublishingConvictionNft: false,
+      listPublishingConvictionAccountsForWallets: async () => { called = true; return []; },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/mine', agent, undefined, { wallets: [{ address: '0x' + '1'.repeat(40) }] });
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(called).toBe(false);
+  });
+
+  it('GET /api/pca/mine → 503 PCA_LOOKUP_READ_FAILED on a CALL_EXCEPTION (not a partial/empty list)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listPublishingConvictionAccountsForWallets: async () => {
+        const e: any = new Error('enumeration read failed'); e.code = 'CALL_EXCEPTION'; throw e;
+      },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/mine', agent, undefined, { wallets: [{ address: '0x' + '1'.repeat(40) }] });
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBe('PCA_LOOKUP_READ_FAILED');
+  });
+
+  it('GET /api/pca/mine?hydrate=1 merges the snapshot basics per account (best-effort)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listPublishingConvictionAccountsForWallets: async () => [{ accountId: 5n, relation: 'owned' }],
+      getPublishingConvictionAccountInfo: async () => ({
+        owner: '0x' + '9'.repeat(40), committedTRAC: 100n, baseEpochAllowance: 1n,
+        createdAtEpoch: 1, expiresAtEpoch: 9, createdAtTimestamp: 0, expiresAtTimestamp: 0,
+        discountBps: 500, topUpBuffer: 0n, agentCount: 0, lastSettledWindow: 0, fullySwept: false,
+      }),
+    };
+    const { res, done } = runCtx('GET', '/api/pca/mine?hydrate=1', agent, undefined, { wallets: [{ address: '0x' + '1'.repeat(40) }] });
+    await done;
+    expect(res.statusCode).toBe(200);
+    const acct = JSON.parse(res.body).accounts[0];
+    expect(acct.accountId).toBe('5');
+    expect(acct.relation).toBe('owned');
+    expect(acct.committedTRAC).toBe('100'); // serializeAccountInfo basics merged
+    expect(acct.discountBps).toBe(500);
+  });
+
+  it('GET /api/pca/mine?hydrate=1 keeps {accountId,relation} when a per-account snapshot read throws (best-effort)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listPublishingConvictionAccountsForWallets: async () => [{ accountId: 5n, relation: 'agent' }],
+      getPublishingConvictionAccountInfo: async () => { throw new Error('per-account read blip'); },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/mine?hydrate=1', agent, undefined, { wallets: [{ address: '0x' + '1'.repeat(40) }] });
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).accounts).toEqual([{ accountId: '5', relation: 'agent' }]);
   });
 });

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -927,6 +927,21 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(called).toBe(false);
   });
 
+  it('GET /api/pca/mine → 503 FEATURE_UNAVAILABLE when the facade returns null despite the capability flag', async () => {
+    // The capability flag is true (passes the gate) but the facade delegator
+    // returns null (chain lacks the method) — the route must still answer 503
+    // FEATURE_UNAVAILABLE, never a 200 empty list a UI would read as "relates to
+    // nothing". Distinct from the CALL_EXCEPTION 503 (no PCA_LOOKUP_READ_FAILED code).
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listPublishingConvictionAccountsForWallets: async () => null,
+    };
+    const { res, done } = runCtx('GET', '/api/pca/mine', agent, undefined, { wallets: [{ address: '0x' + '1'.repeat(40) }] });
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBeUndefined();
+  });
+
   it('GET /api/pca/mine → 503 PCA_LOOKUP_READ_FAILED on a CALL_EXCEPTION (not a partial/empty list)', async () => {
     const agent = {
       supportsPublishingConvictionNft: true,

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1741,6 +1741,29 @@ export const pcaTopUp = (accountId: string, tokens: string) =>
 export const pcaSettle = (accountId: string) =>
   post<PcaSettleResult>(`/api/pca/${encodeURIComponent(accountId)}/settle`, {});
 
+/** GAP-1 — one PCA this node relates to. `relation` is owned (NFT owner is a node
+ *  wallet) / agent (a node op wallet is a registered agent) / both. The snapshot
+ *  basics are present only with `?hydrate=1` (optional otherwise). */
+export interface MyPcaEntry
+  extends Partial<Pick<PcaSnapshot, 'owner' | 'committedTRACTrac' | 'expiresAtTimestamp' | 'agentCount' | 'discountBps'>> {
+  accountId: string;
+  relation: 'owned' | 'agent' | 'both';
+}
+
+export interface MyPcasResult {
+  accounts: MyPcaEntry[];
+}
+
+/**
+ * GAP-1 — enumerate the PCAs this node relates to (OWNED and/or AGENT-ON), replacing the
+ * tracked-id-only discovery. `?hydrate=1` includes the serializeAccountInfo basics
+ * (owner / committedTRACTrac / expiresAtTimestamp / agentCount / discountBps) so the
+ * discovered strip renders without a per-row `fetchPca`. 503 = capability/transport;
+ * `{ accounts: [] }` = no related PCAs. `GET` is permissionless.
+ */
+export const fetchMyPcas = (opts?: { hydrate?: boolean }) =>
+  getJson<MyPcasResult>(`/api/pca/mine${opts?.hydrate ? '?hydrate=1' : ''}`);
+
 export interface PcaAgentsResult {
   accountId: string;
   /** The FULL set of approved publishing-wallet addresses (checksummed). `[]` = a

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1860,6 +1860,20 @@ export function isPcaFeatureUnavailable(err: unknown): boolean {
   return err instanceof HttpError && err.status === 503 && !isRpcTransportError(err);
 }
 
+/**
+ * The PCA enumeration route's RETRYABLE chain-read failure: 503 with body code
+ * `PCA_LOOKUP_READ_FAILED` (a CALL_EXCEPTION mid-enumeration, NOT a capability gap).
+ * `isPcaFeatureUnavailable` can't tell it apart — both are non-transport 503s — so a
+ * caller distinguishing "couldn't load" from "not on this network" must check this
+ * first (and treat it like a transport blip: retry, never assert "you relate to none").
+ */
+export function isPcaReadFailed(err: unknown): boolean {
+  return (
+    err instanceof HttpError &&
+    (err.body as { code?: string } | undefined)?.code === 'PCA_LOOKUP_READ_FAILED'
+  );
+}
+
 // Code tokens the daemon embeds in the `{ error }` body (a bare code on a
 // contract revert, or a longer sentence like "NotAccountOwner — daemon EOA is
 // not the PCA owner"). Matched by word boundary, most-specific intent first.

--- a/packages/node-ui/src/ui/hooks/useDiscoveredPcas.ts
+++ b/packages/node-ui/src/ui/hooks/useDiscoveredPcas.ts
@@ -1,0 +1,117 @@
+import { useEffect, useMemo } from 'react';
+import { useFetch } from '../hooks.js';
+import {
+  fetchWalletsBalances,
+  pcaAgentAccount,
+  fetchMyPcas,
+  type MyPcaEntry,
+  type PcaSnapshot,
+} from '../api.js';
+import { usePcaStore } from '../stores/pca.js';
+
+/** A PCA this node RELATES to but may not have locally tracked (GAP-1). */
+export interface DiscoveredPca {
+  accountId: string;
+  /** owned (NFT owner is a node wallet) / agent (a node op wallet is approved here) / both. */
+  relation: 'owned' | 'agent' | 'both';
+  /** The node op wallet registered here (set for agent/both — drives the strip copy). */
+  agentWallet?: string;
+  /** Hydrated snapshot basics from `fetchMyPcas?hydrate=1`, when available. */
+  basics?: Partial<PcaSnapshot>;
+}
+
+export interface UseDiscoveredPcas {
+  /** Every related PCA (owned + agent-on), merged + deduped. */
+  discovered: DiscoveredPca[];
+  /** `discovered` minus the locally-tracked set — the "discovered, not tracked" strip. */
+  untracked: DiscoveredPca[];
+  loading: boolean;
+  refresh: () => void;
+}
+
+function basicsOf(m: MyPcaEntry): Partial<PcaSnapshot> {
+  const { accountId: _id, relation: _rel, ...rest } = m;
+  return rest;
+}
+
+function mergeRelation(a: DiscoveredPca['relation'], b: DiscoveredPca['relation']): DiscoveredPca['relation'] {
+  if (a === b) return a;
+  // owned + agent (in either order) → both; 'both' absorbs anything.
+  return 'both';
+}
+
+/**
+ * GAP-1 — discover the PCAs this node relates to, from two sources merged by accountId:
+ *  - AGENT-ON: each node op wallet → `pcaAgentAccount` reverse lookup (works today, no
+ *    new route) → relation 'agent' (+ the wallet, for the strip copy).
+ *  - OWNED (+agent/both): `fetchMyPcas({hydrate:true})` (the GAP-1 enumeration route;
+ *    degrades to [] until the route lands) → relation + snapshot basics.
+ *
+ * ★ AUTO-TRACK (#9-safe): a CONFIRMED agent-on discovery auto-adds its id to the tracked
+ * set so `usePublishEligibility` resolves and a pure-edge node's publish chip self-heals
+ * to GREEN with no manual step. Auto-track only makes the account RESOLVED — the verdict
+ * still routes through `classifyCoverage` (registered ⇏ covered), so this never asserts a
+ * discount; it only stops the false-fallthrough. (Owned discoveries are NOT auto-tracked —
+ * they surface in the strip with a [Track] affordance for the operator to choose.)
+ */
+export function useDiscoveredPcas(): UseDiscoveredPcas {
+  const trackedIds = usePcaStore((s) => s.trackedIds);
+  const trackAccount = usePcaStore((s) => s.trackAccount);
+
+  const { data, loading, refresh } = useFetch(
+    async () => {
+      // Agent-on via the per-wallet reverse lookup (no /api/pca/mine dependency).
+      const wb = await fetchWalletsBalances().catch(() => null);
+      const wallets = wb?.wallets ?? [];
+      const agentPairs = (
+        await Promise.all(
+          wallets.map(async (w) => {
+            const r = await pcaAgentAccount(w).catch(() => null);
+            return r?.accountId ? { accountId: r.accountId, wallet: w } : null;
+          }),
+        )
+      ).filter((p): p is { accountId: string; wallet: string } => p != null);
+      // Owned (+agent/both) via the enumeration route — degrades to [] until it lands.
+      const mine = await fetchMyPcas({ hydrate: true })
+        .then((r) => r.accounts)
+        .catch(() => [] as MyPcaEntry[]);
+      return { agentPairs, mine };
+    },
+    [],
+    0,
+  );
+
+  const discovered = useMemo<DiscoveredPca[]>(() => {
+    const map = new Map<string, DiscoveredPca>();
+    for (const m of data?.mine ?? []) {
+      map.set(m.accountId, { accountId: m.accountId, relation: m.relation, basics: basicsOf(m) });
+    }
+    for (const p of data?.agentPairs ?? []) {
+      const existing = map.get(p.accountId);
+      if (existing) {
+        existing.relation = mergeRelation(existing.relation, 'agent');
+        if (!existing.agentWallet) existing.agentWallet = p.wallet;
+      } else {
+        map.set(p.accountId, { accountId: p.accountId, relation: 'agent', agentWallet: p.wallet });
+      }
+    }
+    return [...map.values()];
+  }, [data]);
+
+  // ★ Auto-track confirmed agent-on (the edge self-heal). Idempotent: trackAccount skips
+  // ids already present, and a freshly-tracked id is filtered next pass — no loop.
+  useEffect(() => {
+    for (const d of discovered) {
+      if ((d.relation === 'agent' || d.relation === 'both') && !trackedIds.includes(d.accountId)) {
+        trackAccount(d.accountId);
+      }
+    }
+  }, [discovered, trackedIds, trackAccount]);
+
+  const untracked = useMemo(
+    () => discovered.filter((d) => !trackedIds.includes(d.accountId)),
+    [discovered, trackedIds],
+  );
+
+  return { discovered, untracked, loading, refresh };
+}

--- a/packages/node-ui/src/ui/hooks/useDiscoveredPcas.ts
+++ b/packages/node-ui/src/ui/hooks/useDiscoveredPcas.ts
@@ -4,6 +4,8 @@ import {
   fetchWalletsBalances,
   pcaAgentAccount,
   fetchMyPcas,
+  isPcaFeatureUnavailable,
+  isPcaReadFailed,
   type MyPcaEntry,
   type PcaSnapshot,
 } from '../api.js';
@@ -25,6 +27,13 @@ export interface UseDiscoveredPcas {
   discovered: DiscoveredPca[];
   /** `discovered` minus the locally-tracked set — the "discovered, not tracked" strip. */
   untracked: DiscoveredPca[];
+  /**
+   * GAP-1/#9 — the OWNED enumeration (`/api/pca/mine`) failed RETRYABLY (a transport
+   * blip or the route's 503 `PCA_LOOKUP_READ_FAILED`): the surface must offer a retry,
+   * NOT assert "you own none". False on success AND on a capability gap (no PCA on this
+   * network → silent, no strip). The agent-on half is independent of this flag.
+   */
+  ownedError: boolean;
   loading: boolean;
   refresh: () => void;
 }
@@ -71,11 +80,23 @@ export function useDiscoveredPcas(): UseDiscoveredPcas {
           }),
         )
       ).filter((p): p is { accountId: string; wallet: string } => p != null);
-      // Owned (+agent/both) via the enumeration route — degrades to [] until it lands.
-      const mine = await fetchMyPcas({ hydrate: true })
-        .then((r) => r.accounts)
-        .catch(() => [] as MyPcaEntry[]);
-      return { agentPairs, mine };
+      // Owned (+agent/both) via the enumeration route. A CAPABILITY 503 (PCA not on this
+      // network) → no strip, silent. A RETRYABLE failure — a transport blip OR the route's
+      // 503 `PCA_LOOKUP_READ_FAILED` chain read fail — must NOT collapse to "you own none"
+      // (#9): surface `ownedError` so the strip offers a retry instead of asserting empty.
+      // (A genuine 200 `{accounts:[]}` IS none.)
+      let mine: MyPcaEntry[] = [];
+      let ownedError = false;
+      try {
+        mine = (await fetchMyPcas({ hydrate: true })).accounts;
+      } catch (err) {
+        if (isPcaFeatureUnavailable(err) && !isPcaReadFailed(err)) {
+          mine = []; // capability gap — no PCA feature here; stay silent
+        } else {
+          ownedError = true; // read-fail / transport / unknown — couldn't load, not "none"
+        }
+      }
+      return { agentPairs, mine, ownedError };
     },
     [],
     0,
@@ -113,5 +134,5 @@ export function useDiscoveredPcas(): UseDiscoveredPcas {
     [discovered, trackedIds],
   );
 
-  return { discovered, untracked, loading, refresh };
+  return { discovered, untracked, ownedError: data?.ownedError ?? false, loading, refresh };
 }

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -24,10 +24,15 @@ const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLow
  */
 const NEGATIVE_CACHE_TTL_MS = 3 * 60_000;
 const noAgentAccount = new Map<string, number>();
+// LOW#1 — the wallet set from the last real fetch, so a fully-cached-negative node can
+// short-circuit BEFORE re-fetching balances (a non-PCA node shouldn't poll balances just
+// to re-skip every wallet). Refreshed on every actual fetch; bounded by the same TTL.
+let lastWalletSet: string[] = [];
 
 /** TEST-ONLY — clear the session negative cache between cases. */
 export function __resetAgentDiscoveryCache(): void {
   noAgentAccount.clear();
+  lastWalletSet = [];
 }
 
 /** TEST-ONLY — age every cached negative by `ms` (exercises the TTL without faking the clock). */
@@ -44,10 +49,24 @@ export function __ageAgentDiscoveryCache(ms: number): void {
  * `classifyCoverage` once the id is tracked, so this never asserts coverage (#9).
  */
 async function discoverAgentAccounts(): Promise<string[]> {
+  const now = Date.now();
+  // LOW#1 — if every wallet from the last fetch is still a FRESH confirmed-negative, there's
+  // nothing to discover: skip the balances fetch entirely (a non-PCA node would otherwise
+  // poll it per chip × per CG × per 30s just to re-skip). A wallet-set change or a TTL
+  // expiry below falls through to a real fetch + re-probe.
+  if (
+    lastWalletSet.length > 0 &&
+    lastWalletSet.every((w) => {
+      const ts = noAgentAccount.get(w.toLowerCase());
+      return ts != null && now - ts < NEGATIVE_CACHE_TTL_MS;
+    })
+  ) {
+    return [];
+  }
   const wb = await fetchWalletsBalances().catch(() => null);
   const wallets = wb?.wallets ?? [];
+  lastWalletSet = wallets;
   const found = new Set<string>();
-  const now = Date.now();
   await Promise.all(
     wallets.map(async (w) => {
       const key = w.toLowerCase();

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useFetch } from '../hooks.js';
 import { fetchWalletsBalances, fetchPca, fetchContextGraphs, fetchCurrentAgent, pcaAgentAccount } from '../api.js';
 import { usePcaStore } from '../stores/pca.js';
@@ -7,6 +7,53 @@ import { classifyCoverage } from '../pca/coverage.js';
 import type { PcaVerdict } from '../components/Pca/EligibilityVerdictBanner.js';
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
+
+/**
+ * Flag-2 (#1344) — session-level NEGATIVE cache for the publish-surface self-heal:
+ * signing wallets (lowercased) CONFIRMED to have NO agent-on PCA this session. The
+ * self-heal (below) discovers agent-on accounts by reverse-looking-up every wallet
+ * (`pcaAgentAccount`); without this, a non-PCA node would re-run those probes on
+ * every eligibility eval (per chip × per CG × per 30s poll). With it, a node that
+ * discovers nothing pays ~one probe per wallet per session. ONLY confirmed negatives
+ * are cached — a transport error stays uncached (so it retries) and a freshly-
+ * sponsored wallet is still picked up on a later poll until it caches negative.
+ */
+const noAgentAccount = new Set<string>();
+
+/** TEST-ONLY — clear the session negative cache between cases. */
+export function __resetAgentDiscoveryCache(): void {
+  noAgentAccount.clear();
+}
+
+/**
+ * Flag-2 self-heal discovery — the account ids this node is an approved AGENT on,
+ * reverse-resolved from its signing wallets. Returns the confirmed agent-on ids
+ * (deduped); skips wallets already known-negative this session and records new
+ * confirmed negatives. Health is NOT consulted here (a wallet is approved on at
+ * most one account regardless of liveness); the verdict still runs through
+ * `classifyCoverage` once the id is tracked, so this never asserts coverage (#9).
+ */
+async function discoverAgentAccounts(): Promise<string[]> {
+  const wb = await fetchWalletsBalances().catch(() => null);
+  const wallets = wb?.wallets ?? [];
+  const found = new Set<string>();
+  await Promise.all(
+    wallets.map(async (w) => {
+      const key = w.toLowerCase();
+      if (noAgentAccount.has(key)) return;
+      const acct = await pcaAgentAccount(w).catch(() => undefined);
+      // #9 — a REJECTED probe is "couldn't read", not a confirmed no-account: leave it
+      // uncached so the next poll retries (never silently suppresses a real sponsorship).
+      if (acct === undefined) return;
+      if (acct.accountId == null) {
+        noAgentAccount.add(key); // confirmed: this wallet is an agent on no PCA
+        return;
+      }
+      found.add(acct.accountId);
+    }),
+  );
+  return [...found];
+}
 
 interface WalletDetail {
   wallet: string;
@@ -65,6 +112,15 @@ export interface PublishEligibility {
   wallets: WalletDetail[];
 }
 
+/** Internal fetch payload. `discover` carries the flag-2 self-heal ids (only on the
+ *  nothing-tracked pass) for the auto-track effect to consume. */
+interface EligData {
+  wallets: WalletDetail[];
+  ownerPublish: boolean;
+  resolved: boolean;
+  discover?: string[];
+}
+
 /**
  * S5 publish-eligibility engine (UX §5.5). For a publish into `contextGraphId`,
  * probes every operational wallet × every tracked PCA and resolves the
@@ -81,10 +137,21 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
   const trackedIds = usePcaStore((s) => s.trackedIds);
   const idsKey = trackedIds.join(',');
 
-  const { data, loading } = useFetch(
+  const trackAccount = usePcaStore((s) => s.trackAccount);
+
+  const { data, loading } = useFetch<EligData>(
     async () => {
       if (trackedIds.length === 0) {
-        return { wallets: [] as WalletDetail[], ownerPublish: false, resolved: false };
+        // Flag-2 self-heal (#1344) — nothing tracked, but this node may be a sponsored
+        // AGENT on a PCA it never explicitly tracked (a pure-edge node that publishes
+        // from the project view without ever opening the conviction tab, so GAP-1's
+        // conviction-tab discovery never ran). Discover the agent-on accounts from the
+        // signing wallets and auto-track them (durable) — the chip then resolves on the
+        // next pass via the normal tracked path. #9: auto-track only makes the account
+        // RESOLVED; the verdict still runs classifyCoverage (registered ⇏ covered), so
+        // this fixes the false fall-through without ever minting a false green.
+        const discover = await discoverAgentAccounts();
+        return { wallets: [], ownerPublish: false, resolved: false, discover };
       }
       const wb = await fetchWalletsBalances().catch(() => null);
       const wallets = wb?.wallets ?? [];
@@ -209,6 +276,17 @@ export function usePublishEligibility(contextGraphId: string, intervalMs = 0): P
     [idsKey, contextGraphId],
     intervalMs,
   );
+
+  // Flag-2 — auto-track the discovered agent-on accounts (the durable publish-surface
+  // self-heal). Idempotent: trackAccount skips already-tracked ids, and once an id is
+  // tracked `trackedIds` is non-empty so the discovery branch never re-runs (the normal
+  // tracked path takes over) — no loop. `discover` is undefined on the normal pass.
+  const discover = data?.discover;
+  useEffect(() => {
+    for (const id of discover ?? []) {
+      if (!trackedIds.includes(id)) trackAccount(id);
+    }
+  }, [discover, trackedIds, trackAccount]);
 
   return useMemo<PublishEligibility>(() => {
     const wallets = data?.wallets ?? [];

--- a/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
+++ b/packages/node-ui/src/ui/hooks/usePublishEligibility.ts
@@ -9,20 +9,30 @@ import type { PcaVerdict } from '../components/Pca/EligibilityVerdictBanner.js';
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
 
 /**
- * Flag-2 (#1344) — session-level NEGATIVE cache for the publish-surface self-heal:
- * signing wallets (lowercased) CONFIRMED to have NO agent-on PCA this session. The
- * self-heal (below) discovers agent-on accounts by reverse-looking-up every wallet
- * (`pcaAgentAccount`); without this, a non-PCA node would re-run those probes on
- * every eligibility eval (per chip × per CG × per 30s poll). With it, a node that
- * discovers nothing pays ~one probe per wallet per session. ONLY confirmed negatives
- * are cached — a transport error stays uncached (so it retries) and a freshly-
- * sponsored wallet is still picked up on a later poll until it caches negative.
+ * Flag-2 (#1344) — TTL'd NEGATIVE cache for the publish-surface self-heal: signing
+ * wallets (lowercased) CONFIRMED to have NO agent-on PCA → the timestamp of that
+ * confirmation. The self-heal (below) discovers agent-on accounts by reverse-looking-up
+ * every wallet (`pcaAgentAccount`); without this, a non-PCA node would re-run those
+ * probes on every eligibility eval (per chip × per CG × per 30s poll). With it, a node
+ * that discovers nothing pays ~one probe per wallet per TTL.
+ *
+ * The TTL (not a permanent cache) is the fix for the mid-session-sponsorship gap: an
+ * operator can open the UI and THEN get sponsored, so a never-expiring negative would
+ * pin the chip un-resolved until reload. A re-probe after the TTL lets that self-heal.
+ * ONLY confirmed negatives are cached — a transport error stays uncached (retries next
+ * poll), and a wallet that turns positive drops its stale entry (#9 preserved).
  */
-const noAgentAccount = new Set<string>();
+const NEGATIVE_CACHE_TTL_MS = 3 * 60_000;
+const noAgentAccount = new Map<string, number>();
 
 /** TEST-ONLY — clear the session negative cache between cases. */
 export function __resetAgentDiscoveryCache(): void {
   noAgentAccount.clear();
+}
+
+/** TEST-ONLY — age every cached negative by `ms` (exercises the TTL without faking the clock). */
+export function __ageAgentDiscoveryCache(ms: number): void {
+  for (const [k, ts] of noAgentAccount) noAgentAccount.set(k, ts - ms);
 }
 
 /**
@@ -37,18 +47,21 @@ async function discoverAgentAccounts(): Promise<string[]> {
   const wb = await fetchWalletsBalances().catch(() => null);
   const wallets = wb?.wallets ?? [];
   const found = new Set<string>();
+  const now = Date.now();
   await Promise.all(
     wallets.map(async (w) => {
       const key = w.toLowerCase();
-      if (noAgentAccount.has(key)) return;
+      const negAt = noAgentAccount.get(key);
+      if (negAt != null && now - negAt < NEGATIVE_CACHE_TTL_MS) return; // fresh negative — skip
       const acct = await pcaAgentAccount(w).catch(() => undefined);
       // #9 — a REJECTED probe is "couldn't read", not a confirmed no-account: leave it
       // uncached so the next poll retries (never silently suppresses a real sponsorship).
       if (acct === undefined) return;
       if (acct.accountId == null) {
-        noAgentAccount.add(key); // confirmed: this wallet is an agent on no PCA
+        noAgentAccount.set(key, now); // (re)confirm negative + refresh the TTL window
         return;
       }
+      noAgentAccount.delete(key); // turned positive (e.g. just sponsored) — drop the stale entry
       found.add(acct.accountId);
     }),
   );

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -64,6 +64,8 @@ export function ApproveWalletsModal({
   onClose,
   onApproved,
   seedBulk,
+  deregisterFrom,
+  seedAgentsResolved,
 }: {
   accountId: string;
   initialMode?: 'self' | 'sponsor';
@@ -72,10 +74,24 @@ export function ApproveWalletsModal({
   /** S2b renew — prefill the sponsor bulk-paste with the replaced account's agents,
    *  so re-approving the same wallets on the new account is one step. */
   seedBulk?: string;
+  /**
+   * S2b renew (#1344 gate-HIGH) — the OLD account these seeded wallets are still bound
+   * to on-chain. Account EXPIRY does NOT clear `agentToAccountId`, so re-approving a
+   * seeded wallet on the new account would revert `AgentAlreadyRegistered`. When set,
+   * each row is DEREGISTERED from this old account before being registered on the new
+   * one. Its presence also marks the renew re-approval context (honest copy).
+   */
+  deregisterFrom?: string;
+  /** S2b renew — whether the old account's agents loaded (`listPcaAgents`). `false` →
+   *  the seed couldn't be pre-filled; the copy stops promising it and prompts manual entry. */
+  seedAgentsResolved?: boolean;
 }) {
   const { data: wb } = useFetch(fetchWalletsBalances, [], 0);
   const { data: snapshot } = useFetch(() => fetchPca(accountId), [accountId]);
   const owner = useOwnerActionSubmitter(accountId); // owner-action seam (P0: daemon submitter)
+  // S2b renew — the OLD account's owner-action submitter (free the wallet there first).
+  // Same daemon submitter in P0; keyed separately for the §9 wallet-owned future.
+  const deregisterOwner = useOwnerActionSubmitter(deregisterFrom);
   const nodeWallets = wb?.wallets ?? [];
   const agentCount = snapshot?.agentCount ?? 0;
   const cap = Math.max(0, 100 - agentCount);
@@ -148,6 +164,15 @@ export function ApproveWalletsModal({
         continue;
       }
       try {
+        // S2b renew (deregister-first, #1344 gate-HIGH): expiry doesn't clear
+        // `agentToAccountId`, so a seeded old-PCA wallet is still bound there and
+        // registerAgent(newId) would revert AgentAlreadyRegistered. Free it from the OLD
+        // account FIRST. Best-effort — an already-free wallet (AgentNotRegistered) or a
+        // transient failure just falls through to the register, whose AgentAlreadyRegistered
+        // handling below surfaces a still-bound wallet as a conflict (#old) for recovery.
+        if (deregisterFrom) {
+          await deregisterOwner.deregisterAgent(deregisterFrom, addr).catch(() => {});
+        }
         const res = await owner.registerAgent(accountId, addr);
         setRows((r) => ({
           ...r,
@@ -286,11 +311,27 @@ export function ApproveWalletsModal({
               {parsed.valid.length} valid · {parsed.invalid} invalid ·{' '}
               {agentCount} → {agentCount + parsed.valid.length} of 100 after this
             </p>
-            <div className="v10-modal-warning">
-              ⚠ We can only check the address is well-formed — we can’t verify it’s the node’s real
-              signing wallet. A typo / admin / author address still “approves” and burns a cap slot.
-              Confirm it shows ✓ in the other operator’s Get-sponsored panel.
-            </div>
+            {deregisterFrom ? (
+              // S2b renew (#1344 [MEDIUM]) — these are the node's OWN carried-over wallets,
+              // not a third party, so the sponsor-can't-verify warning is wrong here.
+              <div className="v10-modal-warning" data-testid="pca-renew-reapprove-note">
+                ⓘ Re-approving PCA #{deregisterFrom}’s wallets on #{accountId}. Each wallet is MOVED —
+                deregistered from #{deregisterFrom}, then approved on #{accountId} (two txs per wallet,
+                owner gas). Account expiry alone doesn’t free a wallet, so this is required to re-use them.
+                {seedAgentsResolved === false && (
+                  <>
+                    {' '}
+                    <strong>Couldn’t load PCA #{deregisterFrom}’s wallets — add them manually below.</strong>
+                  </>
+                )}
+              </div>
+            ) : (
+              <div className="v10-modal-warning">
+                ⚠ We can only check the address is well-formed — we can’t verify it’s the node’s real
+                signing wallet. A typo / admin / author address still “approves” and burns a cap slot.
+                Confirm it shows ✓ in the other operator’s Get-sponsored panel.
+              </div>
+            )}
           </section>
         )}
 
@@ -334,8 +375,9 @@ export function ApproveWalletsModal({
           </div>
         )}
 
-        {/* Sponsor handoff after a run */}
-        {done && mode === 'sponsor' && (
+        {/* Sponsor handoff after a run — third-party only; a renew re-approves the node's
+            OWN wallets (#1344 [MEDIUM]), so the "remind the other operator" handshake is off. */}
+        {done && mode === 'sponsor' && !deregisterFrom && (
           <div className="v10-pca-approve-handoff">
             <div className="v10-modal-warning">
               Remind the other operator: these wallets must hold NATIVE GAS to publish — the account

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -63,11 +63,15 @@ export function ApproveWalletsModal({
   initialMode = 'sponsor',
   onClose,
   onApproved,
+  seedBulk,
 }: {
   accountId: string;
   initialMode?: 'self' | 'sponsor';
   onClose: () => void;
   onApproved?: () => void;
+  /** S2b renew — prefill the sponsor bulk-paste with the replaced account's agents,
+   *  so re-approving the same wallets on the new account is one step. */
+  seedBulk?: string;
 }) {
   const { data: wb } = useFetch(fetchWalletsBalances, [], 0);
   const { data: snapshot } = useFetch(() => fetchPca(accountId), [accountId]);
@@ -78,7 +82,7 @@ export function ApproveWalletsModal({
 
   const [mode, setMode] = useState<'self' | 'sponsor'>(initialMode);
   const [unchecked, setUnchecked] = useState<Record<string, boolean>>({}); // self: opt-OUT set
-  const [bulk, setBulk] = useState('');
+  const [bulk, setBulk] = useState(seedBulk ?? ''); // S2b renew prefills the old account's agents
   const [rows, setRows] = useState<Record<string, Row>>({});
   const [order, setOrder] = useState<string[]>([]);
   const [running, setRunning] = useState(false);

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -166,18 +166,29 @@ function DetailBody({
   // S2b renew (re-mint replacement): the seeded create modal, then the chained
   // approve modal pre-filled with THIS (old) account's agents for one-step re-approval.
   const [renewOpen, setRenewOpen] = useState(false);
-  const [renewApprove, setRenewApprove] = useState<{ newAccountId: string; seedBulk: string } | null>(null);
+  // LOW#3 — in-flight while resolving the old agents (prevents a no-feedback gap).
+  const [renewChaining, setRenewChaining] = useState(false);
+  const [renewApprove, setRenewApprove] = useState<
+    { newAccountId: string; seedBulk: string; agentsResolved: boolean } | null
+  >(null);
   const openTab = useTabsStore((s) => s.openTab);
 
-  // After the renewal mint, chain into Approve seeded with the OLD account's agents
-  // (approvals don't carry over — re-approve them on the new id in one step).
+  // After the renewal mint, chain into Approve seeded with the OLD account's agents.
+  // Approvals don't carry over AND expiry doesn't free them (gate-HIGH), so the chained
+  // modal deregisters each from the old account before re-approving on the new id.
   const onRenewSuccess = (newAccountId: string) => {
+    // LOW#3 — close the create modal IMMEDIATELY so its success button can't be
+    // double-clicked into a second chain, and show an in-flight state while we resolve
+    // the old agents. `agentsResolved:false` (listPcaAgents failed) stops the next step
+    // from promising a pre-filled list it doesn't have.
+    setRenewOpen(false);
+    setRenewChaining(true);
     listPcaAgents(accountId)
-      .then((r) => r.agents)
-      .catch(() => [] as string[])
-      .then((oldAgents) => {
-        setRenewOpen(false);
-        setRenewApprove({ newAccountId, seedBulk: oldAgents.join('\n') });
+      .then((r) => ({ agents: r.agents, resolved: true }))
+      .catch(() => ({ agents: [] as string[], resolved: false }))
+      .then(({ agents, resolved }) => {
+        setRenewChaining(false);
+        setRenewApprove({ newAccountId, seedBulk: agents.join('\n'), agentsResolved: resolved });
       });
   };
 
@@ -581,6 +592,9 @@ function DetailBody({
             tokens: snapshot.committedTRACTrac,
             primaryNode:
               snapshot.primaryNode && snapshot.primaryNode !== '0' ? String(snapshot.primaryNode) : undefined,
+            // LOW — distinguish "extended read failed" (null) from a genuine "none" ('0'),
+            // so the modal can flag a silent fall-back to this node.
+            primaryNodeUnknown: snapshot.primaryNode == null,
           }}
           replacingAccountId={accountId}
           onClose={() => setRenewOpen(false)}
@@ -589,12 +603,21 @@ function DetailBody({
           onGetSponsored={() => setRenewOpen(false)}
         />
       )}
-      {/* S2b renew — chained Approve, pre-seeded with the OLD account's agents. */}
+      {/* LOW#3 — brief in-flight state between the mint and the seeded re-approval. */}
+      {renewChaining && (
+        <div className="lazy-spinner" role="status" data-testid="pca-renew-chaining">
+          Preparing re-approval…
+        </div>
+      )}
+      {/* S2b renew — chained Approve, pre-seeded with the OLD account's agents, which it
+          DEREGISTERS from the old account first (expiry doesn't free them — gate-HIGH). */}
       {renewApprove && (
         <ApproveWalletsModal
           accountId={renewApprove.newAccountId}
           initialMode="sponsor"
           seedBulk={renewApprove.seedBulk}
+          deregisterFrom={accountId}
+          seedAgentsResolved={renewApprove.agentsResolved}
           onClose={() => setRenewApprove(null)}
         />
       )}

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionDetailView.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../api.js';
 import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
 import { useAgentsStore } from '../../stores/agents.js';
+import { useTabsStore } from '../../stores/tabs.js';
 import { formatTrac } from '../../lib/formatTrac.js';
 import {
   HealthChip,
@@ -25,6 +26,7 @@ import {
 import { healthForSnapshot } from '../../pca/health.js';
 import { StatStrip } from '../../components/ContextGraphPrimitives.js';
 import { ApproveWalletsModal } from './ApproveWalletsModal.js';
+import { CreatePcaModal } from './CreatePcaModal.js';
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
 const ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
@@ -161,6 +163,23 @@ function DetailBody({
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const [removeState, setRemoveState] = useState<ActionState>(IDLE);
   const [approveOpen, setApproveOpen] = useState(false);
+  // S2b renew (re-mint replacement): the seeded create modal, then the chained
+  // approve modal pre-filled with THIS (old) account's agents for one-step re-approval.
+  const [renewOpen, setRenewOpen] = useState(false);
+  const [renewApprove, setRenewApprove] = useState<{ newAccountId: string; seedBulk: string } | null>(null);
+  const openTab = useTabsStore((s) => s.openTab);
+
+  // After the renewal mint, chain into Approve seeded with the OLD account's agents
+  // (approvals don't carry over — re-approve them on the new id in one step).
+  const onRenewSuccess = (newAccountId: string) => {
+    listPcaAgents(accountId)
+      .then((r) => r.agents)
+      .catch(() => [] as string[])
+      .then((oldAgents) => {
+        setRenewOpen(false);
+        setRenewApprove({ newAccountId, seedBulk: oldAgents.join('\n') });
+      });
+  };
 
   const { data: cgData } = useFetch(fetchContextGraphs, [], 0);
   // B3 — the FULL approved publishing-wallet set (chain enumerator). A 404/503/error
@@ -522,10 +541,23 @@ function DetailBody({
         <h3 className="v10-pca-detail-section-title">Lifecycle</h3>
         {(health === 'expiring' || health === 'expired') && (
           <p className="v10-pca-card-warn">
-            {formatRelativeExpiry(snapshot.expiresAtTimestamp)}. Top-up can’t extend the lock period —
-            create a replacement account from the overview when it expires.
+            {formatRelativeExpiry(snapshot.expiresAtTimestamp)}. The lock period can’t be extended —
+            Renew creates a fresh replacement account seeded from this one (the old TRAC stays locked
+            until its own expiry).
           </p>
         )}
+        {/* S2b — Renew = re-mint a REPLACEMENT (owner-signed create), emphasized as the
+            account nears/passes expiry. Honest copy lives in the seeded create modal (#9). */}
+        <button
+          type="button"
+          className={`v10-pca-card-btn${health === 'expiring' || health === 'expired' ? ' primary' : ''}`}
+          data-testid="pca-renew-btn"
+          onClick={() => setRenewOpen(true)}
+          disabled={!ownerIsPrimary}
+          title={ownerTitle}
+        >
+          Renew — create a replacement PCA
+        </button>
         <p className="v10-pca-detail-hint">
           ⓘ Transferring this account’s NFT to another wallet clears every approved publishing wallet —
           the new owner starts clean. (Out-of-band wallet op — no button here.)
@@ -540,6 +572,30 @@ function DetailBody({
           accountId={accountId}
           initialMode="self"
           onClose={() => { setApproveOpen(false); refresh(); refreshAgents(); }}
+        />
+      )}
+      {/* S2b renew — the seeded create modal (re-mint replacement). */}
+      {renewOpen && (
+        <CreatePcaModal
+          seed={{
+            tokens: snapshot.committedTRACTrac,
+            primaryNode:
+              snapshot.primaryNode && snapshot.primaryNode !== '0' ? String(snapshot.primaryNode) : undefined,
+          }}
+          replacingAccountId={accountId}
+          onClose={() => setRenewOpen(false)}
+          onApproveOwnWallets={onRenewSuccess}
+          onManage={(newId) => { setRenewOpen(false); openTab({ id: `conviction:${newId}`, label: `PCA #${newId}`, closable: true }); }}
+          onGetSponsored={() => setRenewOpen(false)}
+        />
+      )}
+      {/* S2b renew — chained Approve, pre-seeded with the OLD account's agents. */}
+      {renewApprove && (
+        <ApproveWalletsModal
+          accountId={renewApprove.newAccountId}
+          initialMode="sponsor"
+          seedBulk={renewApprove.seedBulk}
+          onClose={() => setRenewApprove(null)}
         />
       )}
     </div>

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
@@ -40,7 +40,9 @@ export function ConvictionOverview() {
   const { accounts, loading, covered, refresh, walletsInconclusive } = overview;
   // GAP-1 — PCAs this node relates to on-chain (owned + agent-on) beyond the locally
   // tracked set. Agent-on auto-tracks (edge self-heal); the rest surface in the strip.
-  const { untracked: discoveredUntracked } = useDiscoveredPcas();
+  // `ownedError` = the enumeration failed retryably (#9 — don't assert "you own none").
+  const { untracked: discoveredUntracked, ownedError: discoveredOwnedError, refresh: refreshDiscovered } =
+    useDiscoveredPcas();
 
   // O2 — DERIVED default so the filter auto-reacts to the async role (a useState
   // initializer runs ONCE, so an edge node whose status resolved AFTER mount stayed
@@ -171,6 +173,18 @@ export function ConvictionOverview() {
         <OwnedEmpty role={role} />
       ) : (
         <ApprovedEmpty />
+      )}
+
+      {/* GAP-1/#9 — the OWNED enumeration failed retryably: offer a retry instead of
+          silently asserting "you own none". (Agent-on discovery is independent and may
+          still have populated the strip below.) */}
+      {discoveredOwnedError && (
+        <section className="v10-pca-discovered" data-testid="pca-discovered-error" role="status">
+          <p className="v10-pca-overview-caveat">
+            ⓘ Couldn’t load your Publishing Conviction Accounts — any you own may still exist.{' '}
+            <button type="button" className="v10-pca-card-btn" onClick={() => refreshDiscovered()}>Retry</button>
+          </p>
+        </section>
       )}
 
       <DiscoveredStrip items={discoveredUntracked} onTrack={trackAccount} onManage={onManage} />

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
@@ -3,7 +3,8 @@ import { useAgentsStore } from '../../stores/agents.js';
 import { useTabsStore } from '../../stores/tabs.js';
 import { usePcaStore } from '../../stores/pca.js';
 import { usePcaOverview } from '../../hooks/usePcaOverview.js';
-import { DiscountTierLadder } from '../../components/Pca/index.js';
+import { useDiscoveredPcas, type DiscoveredPca } from '../../hooks/useDiscoveredPcas.js';
+import { DiscountTierLadder, truncateAddress } from '../../components/Pca/index.js';
 import { EmptyState } from '../../components/ContextGraphPrimitives.js';
 import { PcaAccountCard } from './PcaAccountCard.js';
 import { CreatePcaModal } from './CreatePcaModal.js';
@@ -37,6 +38,9 @@ export function ConvictionOverview() {
   const untrackAccount = usePcaStore((s) => s.untrackAccount);
   const overview = usePcaOverview();
   const { accounts, loading, covered, refresh, walletsInconclusive } = overview;
+  // GAP-1 — PCAs this node relates to on-chain (owned + agent-on) beyond the locally
+  // tracked set. Agent-on auto-tracks (edge self-heal); the rest surface in the strip.
+  const { untracked: discoveredUntracked } = useDiscoveredPcas();
 
   // O2 — DERIVED default so the filter auto-reacts to the async role (a useState
   // initializer runs ONCE, so an edge node whose status resolved AFTER mount stayed
@@ -169,11 +173,13 @@ export function ConvictionOverview() {
         <ApprovedEmpty />
       )}
 
+      <DiscoveredStrip items={discoveredUntracked} onTrack={trackAccount} onManage={onManage} />
+
       <TrackByIdDisclosure onTrack={trackAccount} />
 
       <p className="v10-pca-overview-foot">
-        ⓘ No “list my accounts” API yet — this view tracks ids you create or add. Owned vs approved
-        is resolved by probing your wallets.
+        ⓘ PCAs you own or whose approved wallet is one of this node’s are discovered from the chain;
+        ids you track persist across reloads. Approved-on accounts are tracked automatically.
       </p>
 
       {createOpen && (
@@ -193,6 +199,61 @@ export function ConvictionOverview() {
       )}
       {sponsoredOpen && <GetSponsoredPanel onClose={() => { setSponsoredOpen(false); refresh(); }} />}
     </div>
+  );
+}
+
+/**
+ * GAP-1 — the "discovered, not tracked" strip: PCAs this node relates to on-chain
+ * (owned + agent-on) that aren't in the locally-tracked set. Agent-on ones auto-track
+ * (so they don't linger here); this surfaces the rest (typically OWNED accounts created
+ * elsewhere) with a [Track] affordance. Renders nothing when there's nothing to surface.
+ */
+function DiscoveredStrip({
+  items,
+  onTrack,
+  onManage,
+}: {
+  items: DiscoveredPca[];
+  onTrack: (id: string) => void;
+  onManage: (id: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <section className="v10-pca-discovered" data-testid="pca-discovered-strip">
+      <h3 className="v10-pca-discovered-title">Discovered — not tracked here</h3>
+      <p className="v10-pca-overview-caveat">
+        ⓘ Found on-chain for this node’s wallets. Track to show them in the grid above.
+      </p>
+      {items.map((d) => {
+        const bps = d.basics?.discountBps;
+        return (
+          <div key={d.accountId} className="v10-pca-discovered-row" data-testid="pca-discovered-row">
+            <span className="v10-pca-discovered-label">
+              <button type="button" className="v10-notif-cg-link" onClick={() => onManage(d.accountId)}>
+                PCA #{d.accountId}
+              </button>{' '}
+              —{' '}
+              {d.relation === 'agent'
+                ? `your wallet ${d.agentWallet ? truncateAddress(d.agentWallet) : ''} is approved here`
+                : d.relation === 'both'
+                  ? 'you own this · your wallet is approved here'
+                  : 'you own this account'}
+              {typeof bps === 'number' && bps > 0 && (
+                <span className="badge badge-info"> ◉ {(bps / 100).toFixed(bps % 100 === 0 ? 0 : 1)}%</span>
+              )}
+            </span>
+            <button
+              type="button"
+              className="v10-pca-card-btn primary"
+              data-testid="pca-discovered-track"
+              onClick={() => onTrack(d.accountId)}
+            >
+              Track
+            </button>
+          </div>
+        );
+      })}
+    </section>
   );
 }
 

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
@@ -252,7 +252,11 @@ function DiscoveredStrip({
                 : d.relation === 'both'
                   ? 'you own this · your wallet is approved here'
                   : 'you own this account'}
-              {typeof bps === 'number' && bps > 0 && (
+              {/* 🟢/#9 — only show the discount on accounts this node actually DRAWS from
+                  (a wallet is an approved agent). On an owned-ONLY account no wallet is
+                  approved, so the account's tier isn't a discount this node realizes —
+                  showing "◉ %" there reads as a false "you'd get this %". */}
+              {(d.relation === 'agent' || d.relation === 'both') && typeof bps === 'number' && bps > 0 && (
                 <span className="badge badge-info"> ◉ {(bps / 100).toFixed(bps % 100 === 0 ? 0 : 1)}%</span>
               )}
             </span>

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -47,8 +47,10 @@ export function CreatePcaModal({
   /** Routes the gated (edge / no-identity) state to S6 Get-sponsored. */
   onGetSponsored: () => void;
   /** S2b renew — prefill the commit amount / primary node from an expiring account
-   *  (re-mint REPLACEMENT). The create flow is otherwise unchanged. */
-  seed?: { tokens?: string; primaryNode?: string };
+   *  (re-mint REPLACEMENT). The create flow is otherwise unchanged. `primaryNodeUnknown`
+   *  = the old account's primary node couldn't be read (extended snapshot failed), so the
+   *  field falls back to THIS node — surface that rather than silently defaulting (LOW). */
+  seed?: { tokens?: string; primaryNode?: string; primaryNodeUnknown?: boolean };
   /** S2b renew — the account being replaced; non-null drives the honest renew copy. */
   replacingAccountId?: string;
 }) {
@@ -300,7 +302,9 @@ export function CreatePcaModal({
             data-testid="pca-approve-own-wallets"
             onClick={() => onApproveOwnWallets(result.accountId)}
           >
-            Approve this node’s operational wallets
+            {replacingAccountId
+              ? `Re-approve PCA #${replacingAccountId}’s wallets`
+              : 'Approve this node’s operational wallets'}
           </button>
           <button type="button" className="v10-modal-btn" onClick={() => onManage(result.accountId)}>
             Manage PCA #{result.accountId}
@@ -385,6 +389,14 @@ export function CreatePcaModal({
           </div>
           {nodeStatus?.identityId && primaryNode === String(nodeStatus.identityId) && (
             <p className="v10-pca-create-hint">✓ This node (identityId #{nodeStatus.identityId}).</p>
+          )}
+          {/* S2b renew (LOW) — the old account's primary node couldn't be read, so the field
+              fell back to THIS node. Surface it rather than silently defaulting. */}
+          {replacingAccountId && seed?.primaryNodeUnknown && (
+            <p className="v10-pca-create-hint" role="status" data-testid="pca-renew-primary-unknown">
+              ⓘ Couldn’t read PCA #{replacingAccountId}’s primary node — defaulting to this node. Change
+              it under Advanced if the replacement should point elsewhere.
+            </p>
           )}
           <div className="v10-modal-tip">
             <span className="v10-modal-tip-title">Primary node ≠ who pays and ≠ who’s covered.</span>{' '}

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -38,12 +38,19 @@ export function CreatePcaModal({
   onApproveOwnWallets,
   onManage,
   onGetSponsored,
+  seed,
+  replacingAccountId,
 }: {
   onClose: () => void;
   onApproveOwnWallets: (accountId: string) => void;
   onManage: (accountId: string) => void;
   /** Routes the gated (edge / no-identity) state to S6 Get-sponsored. */
   onGetSponsored: () => void;
+  /** S2b renew — prefill the commit amount / primary node from an expiring account
+   *  (re-mint REPLACEMENT). The create flow is otherwise unchanged. */
+  seed?: { tokens?: string; primaryNode?: string };
+  /** S2b renew — the account being replaced; non-null drives the honest renew copy. */
+  replacingAccountId?: string;
 }) {
   const nodeStatus = useAgentsStore((s) => s.nodeStatus) as
     | { nodeRole?: string; hasIdentity?: boolean; identityId?: string; blockExplorerUrl?: string | null }
@@ -72,8 +79,9 @@ export function CreatePcaModal({
   // no-storage env), so the reconcile screen doesn't falsely claim it survives a refresh.
   const createPendingPersisted = usePcaStore((s) => s.createPendingPersisted);
 
-  const [tokens, setTokens] = useState('');
-  const [primaryNode, setPrimaryNode] = useState('');
+  // S2b renew — seed the commit amount + primary node from the expiring account.
+  const [tokens, setTokens] = useState(seed?.tokens ?? '');
+  const [primaryNode, setPrimaryNode] = useState(seed?.primaryNode ?? '');
   const [advanced, setAdvanced] = useState(false);
   // Resume the reconcile guard if a create is already in flight from a prior
   // session (durable marker) — never drop straight to a retryable form.
@@ -307,11 +315,23 @@ export function CreatePcaModal({
     <PcaModalShell
       onClose={onClose}
       testId="pca-create-modal"
-      title="Create a Publishing Conviction Account"
-      subtitle="Lock TRAC up front to publish at a discount."
+      title={replacingAccountId ? `Renew — new PCA to replace #${replacingAccountId}` : 'Create a Publishing Conviction Account'}
+      subtitle={replacingAccountId ? 'Re-mint a fresh account seeded from the expiring one.' : 'Lock TRAC up front to publish at a discount.'}
     >
       <div className="v10-modal-body">
         {error && <div className="v10-modal-error" role="alert">{error}</div>}
+
+        {/* S2b renew — HONEST framing (#9): this is a NEW separate account, not an
+            in-place extension; the old account's TRAC stays locked until its own expiry. */}
+        {replacingAccountId && (
+          <div className="v10-modal-warning" role="status" data-testid="pca-renew-note">
+            ⓘ This creates a <strong>new, separate</strong> account (a new id) — it does not extend or
+            reclaim PCA #{replacingAccountId}. The old account’s committed TRAC stays locked until its
+            own expiry (it can’t be withdrawn early), and the new account starts at <strong>0/100</strong>
+            approved wallets. The next step is pre-filled with the old account’s wallets for one-step
+            re-approval.
+          </div>
+        )}
 
         {/* Section 1 — Commitment */}
         <section className="v10-pca-create-section">

--- a/packages/node-ui/test/pca-api.test.ts
+++ b/packages/node-ui/test/pca-api.test.ts
@@ -15,7 +15,9 @@ import {
   describePcaError,
   isPcaFeatureUnavailable,
   isRpcTransportError,
+  isPcaReadFailed,
   fetchPca,
+  fetchMyPcas,
   createPca,
   pcaAddAgent,
   pcaRemoveAgent,
@@ -47,6 +49,17 @@ describe('describePcaError', () => {
     expect(
       isPcaFeatureUnavailable(new HttpError(503, 'x', { code: 'RPC_ENDPOINTS_EXHAUSTED' })),
     ).toBe(false);
+  });
+
+  it('isPcaReadFailed pins the retryable read-fail apart from a capability 503', () => {
+    // The /mine route's retryable chain-read failure — isPcaFeatureUnavailable can't
+    // tell it from a capability gap (both non-transport 503s), so this must.
+    const readFail = new HttpError(503, 'x', { code: 'PCA_LOOKUP_READ_FAILED' });
+    expect(isPcaReadFailed(readFail)).toBe(true);
+    expect(isPcaFeatureUnavailable(readFail)).toBe(true); // (documents the overlap the caller resolves)
+    expect(isPcaReadFailed(new HttpError(503, 'x', { error: 'FEATURE_UNAVAILABLE' }))).toBe(false);
+    expect(isPcaReadFailed(new HttpError(503, 'x', { code: 'RPC_ENDPOINTS_EXHAUSTED' }))).toBe(false);
+    expect(isPcaReadFailed(new Error('x'))).toBe(false);
   });
 
   it('isRpcTransportError detects RPC_* body codes regardless of status', () => {
@@ -213,6 +226,16 @@ describe('PCA api helpers (transport shaping)', () => {
     fetchMock.mockResolvedValueOnce(ok({ accountId: '1' }));
     await fetchPca('1');
     expect(fetchMock.mock.calls[2]![0]).toBe('/api/pca/1');
+  });
+
+  it('fetchMyPcas GETs /api/pca/mine, adding ?hydrate=1 only when requested', async () => {
+    fetchMock.mockResolvedValueOnce(ok({ accounts: [] }));
+    await fetchMyPcas();
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/pca/mine');
+
+    fetchMock.mockResolvedValueOnce(ok({ accounts: [] }));
+    await fetchMyPcas({ hydrate: true });
+    expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/mine?hydrate=1');
   });
 
   // T1 — a GET failure must throw an HttpError that CARRIES the body, so the tab-gate

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchWalletsBalances: vi.fn(),
   fetchPca: vi.fn(),
   pcaAddAgent: vi.fn(),
+  pcaRemoveAgent: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -21,6 +22,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     fetchWalletsBalances: mocks.fetchWalletsBalances,
     fetchPca: mocks.fetchPca,
     pcaAddAgent: mocks.pcaAddAgent,
+    pcaRemoveAgent: mocks.pcaRemoveAgent,
   };
 });
 
@@ -132,6 +134,70 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     await waitForText(container, 'Wallet address(es)');
     const ta = container.querySelector('[data-testid="pca-approve-address"]') as HTMLTextAreaElement;
     expect(ta.value).toBe([ADDR_A, ADDR_B].join('\n'));
+    await unmount();
+  });
+
+  // S2b renew [HIGH] — account EXPIRY does not clear agentToAccountId, so a seeded
+  // old-PCA wallet is still bound there. The renew chain must DEREGISTER it from the old
+  // account before registering on the new one, else registerAgent reverts AgentAlreadyRegistered.
+  it('S2b renew (deregister-first): frees each seeded wallet from the OLD account, then approves on the new', async () => {
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...snap(), probedKey: { key, registered: true } } : snap(),
+    );
+    mocks.pcaRemoveAgent.mockResolvedValue({ accountId: '4', agent: ADDR_A, removed: true });
+    mocks.pcaAddAgent.mockResolvedValue({ accountId: '8', agent: ADDR_A, registered: true, adapterSupported: true });
+
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, {
+        accountId: '8', deregisterFrom: '4', initialMode: 'sponsor', seedBulk: ADDR_A, onClose: vi.fn(),
+      }),
+    );
+    await waitForText(container, 'Wallet address(es)');
+    // [MEDIUM] — the renew note REPLACES the sponsor-can't-verify warning (these are the
+    // node's own carried-over wallets, not a third party).
+    expect(container.querySelector('[data-testid="pca-renew-reapprove-note"]')).toBeTruthy();
+    expect(container.textContent).not.toContain('can’t verify it’s the node’s real');
+
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'approved on-chain');
+    // deregister(old) ran BEFORE register(new) for the seeded wallet.
+    expect(mocks.pcaRemoveAgent).toHaveBeenCalledWith('4', ADDR_A);
+    expect(mocks.pcaAddAgent).toHaveBeenCalledWith('8', ADDR_A);
+    expect(mocks.pcaRemoveAgent.mock.invocationCallOrder[0]).toBeLessThan(mocks.pcaAddAgent.mock.invocationCallOrder[0]);
+    await unmount();
+  });
+
+  it('S2b renew: a failed deregister falls through to the register, whose B10 surfaces the still-bound wallet as a conflict', async () => {
+    // deregister(old) fails (e.g. not owner of old / transient); the wallet stays bound,
+    // so register(new) reverts AgentAlreadyRegistered → the existing B10 probe → conflict.
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...snap(), probedKey: { key, registered: false } } : snap(),
+    );
+    mocks.pcaRemoveAgent.mockRejectedValue(new HttpError(403, 'x', { error: 'NotAccountOwner' }));
+    mocks.pcaAddAgent.mockRejectedValue(new HttpError(409, 'AgentAlreadyRegistered', { error: 'AgentAlreadyRegistered' }));
+
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, {
+        accountId: '8', deregisterFrom: '4', initialMode: 'sponsor', seedBulk: ADDR_A, onClose: vi.fn(),
+      }),
+    );
+    await waitForText(container, 'Wallet address(es)');
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'another conviction account');
+    expect(mocks.pcaAddAgent).toHaveBeenCalledWith('8', ADDR_A); // register still attempted (recovery path)
+    await unmount();
+  });
+
+  it('S2b renew: when the old agents could not be loaded, the copy stops promising a pre-fill', async () => {
+    mocks.fetchPca.mockResolvedValue(snap());
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, {
+        accountId: '8', deregisterFrom: '4', initialMode: 'sponsor', seedBulk: '', seedAgentsResolved: false, onClose: vi.fn(),
+      }),
+    );
+    await waitForText(container, 'add them manually');
+    expect(container.querySelector('[data-testid="pca-renew-reapprove-note"]')?.textContent)
+      .toContain('Couldn’t load PCA #4’s wallets');
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -120,6 +120,21 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     await unmount();
   });
 
+  // S2b — the renew chain seeds the bulk paste with the OLD account's agents so
+  // re-approving them on the new account is one step.
+  it('S2b — seedBulk pre-fills the bulk paste for one-step re-approval', async () => {
+    mocks.fetchPca.mockResolvedValue(snap());
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, {
+        accountId: '8', initialMode: 'sponsor', seedBulk: [ADDR_A, ADDR_B].join('\n'), onClose: vi.fn(),
+      }),
+    );
+    await waitForText(container, 'Wallet address(es)');
+    const ta = container.querySelector('[data-testid="pca-approve-address"]') as HTMLTextAreaElement;
+    expect(ta.value).toBe([ADDR_A, ADDR_B].join('\n'));
+    await unmount();
+  });
+
   // M4 — a transient 500/network on a MIDDLE wallet must NOT abort and must NOT
   // tally as a benign skip: that row is a danger-tone failure, the loop continues,
   // and the remaining wallet still gets approved.

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -148,6 +148,30 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
+  // S2b — renew re-mints a REPLACEMENT: the modal is seeded from the expiring account
+  // and the copy is HONEST (#9) — a new separate account, the old TRAC stays locked.
+  it('S2b renew — seeds the amount/primary node + shows honest "new separate account" copy', async () => {
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, {
+        onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn(),
+        seed: { tokens: '100000.0', primaryNode: '42' },
+        replacingAccountId: '7',
+      }),
+    );
+    await waitForText(container, 'Renew');
+    // Title names the renew (not the generic create).
+    expect(container.querySelector('#pca-modal-title')?.textContent).toContain('Renew');
+    // Honest #9 framing: new SEPARATE account, names the replaced id, 0/100 approvals.
+    const note = container.querySelector('[data-testid="pca-renew-note"]')!;
+    expect(note.textContent).toContain('new, separate');
+    expect(note.textContent).toContain('#7');
+    expect(note.textContent).toContain('0/100');
+    // Commit amount is seeded from the expiring account.
+    expect((container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement).value).toBe('100000.0');
+    expect((container.querySelector('[data-testid="pca-create-primary-node"]') as HTMLInputElement).value).toBe('42');
+    await unmount();
+  });
+
   it('enters reconcile-before-retry on a 504 TIMEOUT and persists the create-pending marker', async () => {
     mocks.createPca.mockRejectedValue(new HttpError(504, 'TIMEOUT', { code: 'TIMEOUT', txHash: '0xdead' }));
     const { container, unmount } = await render(

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -148,6 +148,42 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
+  // S2b renew [MEDIUM] — on the renew path the success action re-approves the OLD account's
+  // wallets (not a fresh "this node's wallets"), so the button is relabelled.
+  it('S2b renew: relabels the success action to re-approve the OLD account’s wallets', async () => {
+    mocks.createPca.mockResolvedValue({ accountId: '8', txHash: '0xabc', committedTokens: '100000.0' });
+    mocks.fetchPca.mockResolvedValue(snap({ accountId: '8', discountBps: 3000 }));
+    const onApproveOwn = vi.fn();
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, {
+        onClose: vi.fn(), onApproveOwnWallets: onApproveOwn, onManage: vi.fn(), onGetSponsored: vi.fn(),
+        seed: { tokens: '100000.0', primaryNode: '99' }, replacingAccountId: '4',
+      }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    await click(container.querySelector('[data-testid="pca-create-submit"]')!);
+    await waitForText(container, 'PCA #8 created');
+    const btn = container.querySelector('[data-testid="pca-approve-own-wallets"]')!;
+    expect(btn.textContent).toContain('Re-approve PCA #4’s wallets');
+    await click(btn);
+    expect(onApproveOwn).toHaveBeenCalledWith('8');
+    await unmount();
+  });
+
+  // S2b renew [LOW] — when the old account's primary node couldn't be read, the field
+  // falls back to THIS node; surface that rather than silently defaulting.
+  it('S2b renew: flags a fall-back to this node when the old primary node couldn’t be read', async () => {
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, {
+        onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn(),
+        seed: { tokens: '100000.0', primaryNodeUnknown: true }, replacingAccountId: '4',
+      }),
+    );
+    await waitForText(container, 'Couldn’t read PCA #4’s primary node');
+    expect(container.querySelector('[data-testid="pca-renew-primary-unknown"]')).toBeTruthy();
+    await unmount();
+  });
+
   // S2b — renew re-mints a REPLACEMENT: the modal is seeded from the expiring account
   // and the copy is HONEST (#9) — a new separate account, the old TRAC stays locked.
   it('S2b renew — seeds the amount/primary node + shows honest "new separate account" copy', async () => {

--- a/packages/node-ui/test/pca-detail-view.test.ts
+++ b/packages/node-ui/test/pca-detail-view.test.ts
@@ -441,3 +441,28 @@ describe('ConvictionDetailView GAP-4/5 — budget widget + primaryNode', () => {
     await unmount();
   });
 });
+
+// S2b — the Renew CTA on the Lifecycle section opens a re-mint REPLACEMENT create modal,
+// seeded from this account + carrying the honest "new separate account" copy (#9).
+describe('ConvictionDetailView S2b — Renew', () => {
+  const OWNER_WB = { wallets: [W0], balances: [{ address: W0, eth: '1', trac: '5', symbol: 'TRAC' }], chainId: '84532', rpcUrl: null };
+
+  it('Renew opens the seeded replacement create modal with the honest copy', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue(OWNER_WB);
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...snap(), probedKey: { key, registered: true } } : snap(),
+    );
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Lifecycle');
+    const renewBtn = container.querySelector('[data-testid="pca-renew-btn"]') as HTMLButtonElement;
+    expect(renewBtn).toBeTruthy();
+    expect(renewBtn.disabled).toBe(false); // owner == wallets[0]
+    await act(async () => { renewBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'new, separate'); // the honest renew note
+    expect(container.querySelector('[data-testid="pca-renew-note"]')).toBeTruthy();
+    expect(container.querySelector('#pca-modal-title')?.textContent).toContain('Renew');
+    // Seeded from this account's committed amount (snap().committedTRACTrac).
+    expect((container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement).value).toBe('100000.0');
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/pca-overview.test.ts
+++ b/packages/node-ui/test/pca-overview.test.ts
@@ -258,7 +258,9 @@ describe('ConvictionOverview — S1 discovery', () => {
     const strip = container.querySelector('[data-testid="pca-discovered-strip"]') as HTMLElement;
     expect(strip.textContent).toContain('PCA #42');
     expect(strip.textContent).toContain('you own this account');
-    expect(strip.textContent).toContain('20%'); // hydrated discountBps
+    // 🟢/#9 — an OWNED-only account (no wallet approved) doesn't realize the discount, so
+    // the strip must NOT show "20%" there (it would read as a false "you'd get this %").
+    expect(strip.textContent).not.toContain('20%');
     await act(async () => {
       (strip.querySelector('[data-testid="pca-discovered-track"]') as HTMLButtonElement)
         .dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/packages/node-ui/test/pca-overview.test.ts
+++ b/packages/node-ui/test/pca-overview.test.ts
@@ -285,4 +285,45 @@ describe('ConvictionOverview — S1 discovery', () => {
     expect(container.querySelector('[data-testid="pca-discovered-strip"]')).toBeNull(); // → not in the strip
     await unmount();
   });
+
+  // GAP-1/#9 — a RETRYABLE /mine failure (503 PCA_LOOKUP_READ_FAILED) must NOT collapse
+  // to "you own none": the strip offers a retry, and a re-probe recovers.
+  it('GAP-1 — a retryable /mine read-fail shows a retry affordance, not a false "no PCAs"', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [WALLET0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.fetchMyPcas
+      .mockRejectedValueOnce(new HttpError(503, 'read failed', { code: 'PCA_LOOKUP_READ_FAILED' }))
+      .mockResolvedValue({ accounts: [{ accountId: '42', relation: 'owned', discountBps: 2000 }] });
+    const { container, unmount } = await render(React.createElement(ConvictionOverview));
+    const err = (await (async () => {
+      const started = Date.now();
+      while (Date.now() - started < 1500) {
+        const e = container.querySelector('[data-testid="pca-discovered-error"]');
+        if (e) return e as HTMLElement;
+        await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+      }
+      return null;
+    })());
+    expect(err).toBeTruthy();
+    expect(err!.textContent).toContain('Couldn’t load your Publishing Conviction Accounts');
+    // It did NOT assert the owned-empty state off the read failure.
+    expect(container.querySelector('[data-testid="pca-discovered-strip"]')).toBeNull();
+    // Retry → the second (successful) probe surfaces the owned PCA in the strip.
+    await act(async () => {
+      (err!.querySelector('button') as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await waitForText(container, 'PCA #42');
+    expect(container.querySelector('[data-testid="pca-discovered-error"]')).toBeNull();
+    await unmount();
+  });
+
+  it('GAP-1 — a CAPABILITY 503 on /mine stays silent (no retry banner, no strip)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [WALLET0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.fetchMyPcas.mockRejectedValue(new HttpError(503, 'x', { error: 'FEATURE_UNAVAILABLE' }));
+    const { container, unmount } = await render(React.createElement(ConvictionOverview));
+    await waitForText(container, 'Publishing Conviction'); // overview rendered
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+    expect(container.querySelector('[data-testid="pca-discovered-error"]')).toBeNull();
+    expect(container.querySelector('[data-testid="pca-discovered-strip"]')).toBeNull();
+    await unmount();
+  });
 });

--- a/packages/node-ui/test/pca-overview.test.ts
+++ b/packages/node-ui/test/pca-overview.test.ts
@@ -11,11 +11,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   fetchPca: vi.fn(),
   fetchWalletsBalances: vi.fn(),
+  pcaAgentAccount: vi.fn(),
+  fetchMyPcas: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
   const actual = await orig<typeof import('../src/ui/api.js')>();
-  return { ...actual, fetchPca: mocks.fetchPca, fetchWalletsBalances: mocks.fetchWalletsBalances };
+  return {
+    ...actual,
+    fetchPca: mocks.fetchPca,
+    fetchWalletsBalances: mocks.fetchWalletsBalances,
+    pcaAgentAccount: mocks.pcaAgentAccount,
+    fetchMyPcas: mocks.fetchMyPcas,
+  };
 });
 
 const { HttpError } = await import('../src/ui/api.js');
@@ -82,6 +90,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   usePcaStore.setState({ trackedIds: [], createPending: null });
   useAgentsStore.getState().setNodeStatus({ nodeRole: 'core', blockExplorerUrl: null });
+  // GAP-1 discovery defaults: nothing discovered (deterministic; no real fetch). Tests
+  // that exercise the discovered strip / auto-track override these.
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
+  mocks.fetchMyPcas.mockResolvedValue({ accounts: [] });
 });
 afterEach(() => {
   document.body.innerHTML = '';
@@ -231,6 +243,46 @@ describe('ConvictionOverview — S1 discovery', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(tab('Owned by me').getAttribute('aria-selected')).toBe('true'); // role default did NOT override
+    await unmount();
+  });
+
+  // GAP-1 — an OWNED PCA the node hasn't locally tracked surfaces in the "discovered,
+  // not tracked" strip with a [Track] action (owned does NOT auto-track).
+  it('GAP-1 — surfaces an owned, untracked PCA in the discovered strip with a Track action', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [WALLET0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.fetchMyPcas.mockResolvedValue({
+      accounts: [{ accountId: '42', relation: 'owned', discountBps: 2000, committedTRACTrac: '50000.0', expiresAtTimestamp: 9_999_999_999, agentCount: 0 }],
+    });
+    const { container, unmount } = await render(React.createElement(ConvictionOverview));
+    await waitForText(container, 'Discovered — not tracked here');
+    const strip = container.querySelector('[data-testid="pca-discovered-strip"]') as HTMLElement;
+    expect(strip.textContent).toContain('PCA #42');
+    expect(strip.textContent).toContain('you own this account');
+    expect(strip.textContent).toContain('20%'); // hydrated discountBps
+    await act(async () => {
+      (strip.querySelector('[data-testid="pca-discovered-track"]') as HTMLButtonElement)
+        .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(usePcaStore.getState().trackedIds).toContain('42');
+    await unmount();
+  });
+
+  // GAP-1 ★ AUTO-TRACK — a CONFIRMED agent-on discovery auto-adds to the tracked set
+  // (the pure-edge self-heal), so it does NOT linger in the strip.
+  it('GAP-1 — auto-tracks a confirmed agent-on PCA (edge self-heal), not left in the strip', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [WALLET0], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: WALLET0, accountId: '9' });
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      const base = { ...snapFixture(id), owner: '0xother0000000000000000000000000000000000' };
+      return key ? { ...base, probedKey: { key, registered: true } } : base;
+    });
+    const { container, unmount } = await render(React.createElement(ConvictionOverview));
+    const started = Date.now();
+    while (Date.now() - started < 1000 && !usePcaStore.getState().trackedIds.includes('9')) {
+      await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    }
+    expect(usePcaStore.getState().trackedIds).toContain('9'); // auto-tracked
+    expect(container.querySelector('[data-testid="pca-discovered-strip"]')).toBeNull(); // → not in the strip
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -29,6 +29,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
 });
 
 const { PublishEligibilityChip } = await import('../src/ui/pages/conviction/PublishEligibilityChip.js');
+const { __resetAgentDiscoveryCache } = await import('../src/ui/hooks/usePublishEligibility.js');
 const { usePcaStore } = await import('../src/ui/stores/pca.js');
 const { makePcaSnapshot } = await import('../src/ui/mocks/pca.js');
 
@@ -55,6 +56,7 @@ beforeEach(() => {
   (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
   document.body.innerHTML = '';
   vi.clearAllMocks();
+  __resetAgentDiscoveryCache(); // flag-2 self-heal cache is module-level — clear between cases
   usePcaStore.setState({ trackedIds: ['7'], createPending: null });
   mocks.fetchContextGraphs.mockResolvedValue({ contextGraphs: [] });
   mocks.fetchCurrentAgent.mockResolvedValue({ agentDid: 'did:dkg:agent:0x' + '9'.repeat(40) });
@@ -71,12 +73,52 @@ function walletsBalances(trac: string) {
 }
 
 describe('PublishEligibilityChip (S5)', () => {
-  it('renders nothing when the node tracks no PCA', async () => {
+  it('renders nothing when the node tracks no PCA and is an agent on none', async () => {
+    // Flag-2: nothing tracked + the self-heal discovers no agent-on PCA (default
+    // pcaAgentAccount → {accountId:null}) → no auto-track → no chip noise.
     usePcaStore.setState({ trackedIds: [], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('100'));
     const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
     await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
     expect(container.querySelector('[data-testid="pca-publish-eligibility"]')).toBeNull();
+    expect(usePcaStore.getState().trackedIds).toEqual([]);
     await unmount();
+  });
+
+  it('flag-2 self-heal: discovers + auto-tracks an agent-on PCA when nothing is tracked, then shows GREEN', async () => {
+    // A pure-edge node sponsored as an AGENT but tracking nothing: the publish-surface
+    // self-heal reverse-resolves the wallet → account #7, auto-tracks it (durable), and
+    // the chip resolves via the normal classifyCoverage path (#9 — no false green).
+    usePcaStore.setState({ trackedIds: [], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('100'));
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: '7' });
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...makePcaSnapshot(), probedKey: { key, registered: true } } : makePcaSnapshot(),
+    );
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(container, 'Funded by PCA #7');
+    expect(usePcaStore.getState().trackedIds).toContain('7');
+    await unmount();
+  });
+
+  it('flag-2 self-heal: a transport error on the agent probe leaves the wallet uncached (retry-able)', async () => {
+    // #9 — a rejected pcaAgentAccount is "couldn't read", NOT a confirmed no-account, so
+    // it must not be cached as negative (a later poll/sponsorship can still self-heal).
+    usePcaStore.setState({ trackedIds: [], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('100'));
+    mocks.pcaAgentAccount.mockRejectedValueOnce(new Error('boom')).mockResolvedValue({ agent: W0, accountId: '7' });
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...makePcaSnapshot(), probedKey: { key, registered: true } } : makePcaSnapshot(),
+    );
+    const { container, unmount } = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    // First pass rejects (uncached); the 30s poll isn't awaited here, so re-mount to force
+    // a fresh discovery pass — the wallet wasn't cached negative, so it now resolves.
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await unmount();
+    const second = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(second.container, 'Funded by PCA #7');
+    expect(usePcaStore.getState().trackedIds).toContain('7');
+    await second.unmount();
   });
 
   it('GREEN when every signing wallet is covered by a healthy PCA', async () => {

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -134,10 +134,13 @@ describe('PublishEligibilityChip (S5)', () => {
     await first.unmount();
 
     // Mid-TTL re-mount → cached negative is fresh → NOT re-probed (the bound holds).
+    // LOW#1: with the whole wallet set fresh-negative, even the balances fetch is skipped.
+    expect(mocks.fetchWalletsBalances).toHaveBeenCalledTimes(1);
     __ageAgentDiscoveryCache(1_000);
     const second = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
     await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
     expect(mocks.pcaAgentAccount).toHaveBeenCalledTimes(1); // skipped — still 1
+    expect(mocks.fetchWalletsBalances).toHaveBeenCalledTimes(1); // LOW#1 — balances not re-fetched
     await second.unmount();
 
     // Operator gets sponsored mid-session; once the entry ages past the TTL, the next pass

--- a/packages/node-ui/test/pca-publish-eligibility.test.ts
+++ b/packages/node-ui/test/pca-publish-eligibility.test.ts
@@ -29,7 +29,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
 });
 
 const { PublishEligibilityChip } = await import('../src/ui/pages/conviction/PublishEligibilityChip.js');
-const { __resetAgentDiscoveryCache } = await import('../src/ui/hooks/usePublishEligibility.js');
+const { __resetAgentDiscoveryCache, __ageAgentDiscoveryCache } = await import('../src/ui/hooks/usePublishEligibility.js');
 const { usePcaStore } = await import('../src/ui/stores/pca.js');
 const { makePcaSnapshot } = await import('../src/ui/mocks/pca.js');
 
@@ -119,6 +119,36 @@ describe('PublishEligibilityChip (S5)', () => {
     await waitForText(second.container, 'Funded by PCA #7');
     expect(usePcaStore.getState().trackedIds).toContain('7');
     await second.unmount();
+  });
+
+  it('flag-2 self-heal: a cached-negative wallet is skipped within the TTL, re-probed after it (mid-session sponsorship)', async () => {
+    // Pass 1: wallet is an agent on nothing → cached negative (default pcaAgentAccount → null).
+    usePcaStore.setState({ trackedIds: [], createPending: null });
+    mocks.fetchWalletsBalances.mockResolvedValue(walletsBalances('100'));
+    mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+      key ? { ...makePcaSnapshot(), probedKey: { key, registered: true } } : makePcaSnapshot(),
+    );
+    const first = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(mocks.pcaAgentAccount).toHaveBeenCalledTimes(1); // probed once, cached negative
+    await first.unmount();
+
+    // Mid-TTL re-mount → cached negative is fresh → NOT re-probed (the bound holds).
+    __ageAgentDiscoveryCache(1_000);
+    const second = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(mocks.pcaAgentAccount).toHaveBeenCalledTimes(1); // skipped — still 1
+    await second.unmount();
+
+    // Operator gets sponsored mid-session; once the entry ages past the TTL, the next pass
+    // RE-PROBES and the chip self-heals (the reason the cache is TTL'd, not permanent).
+    __ageAgentDiscoveryCache(60 * 60_000);
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W0, accountId: '7' });
+    const third = await render(React.createElement(PublishEligibilityChip, { contextGraphId: 'cg' }));
+    await waitForText(third.container, 'Funded by PCA #7');
+    expect(mocks.pcaAgentAccount).toHaveBeenCalledTimes(2); // re-probed after the TTL
+    expect(usePcaStore.getState().trackedIds).toContain('7');
+    await third.unmount();
   });
 
   it('GREEN when every signing wallet is covered by a healthy PCA', async () => {

--- a/packages/node-ui/test/pca-renew-chain.test.ts
+++ b/packages/node-ui/test/pca-renew-chain.test.ts
@@ -41,7 +41,7 @@ vi.mock('../src/ui/pages/conviction/ApproveWalletsModal.js', () => ({
     return React.createElement(
       'div',
       { 'data-testid': 'mock-approve' },
-      `id=${props.accountId} mode=${props.initialMode} seed=${props.seedBulk ?? ''}`,
+      `id=${props.accountId} mode=${props.initialMode} dereg=${props.deregisterFrom} resolved=${props.seedAgentsResolved} seed=${props.seedBulk ?? ''}`,
     );
   },
 }));
@@ -121,6 +121,25 @@ describe('ConvictionDetailView S2b — renew chain', () => {
     expect(approveProps.accountId).toBe('42');
     expect(approveProps.initialMode).toBe('sponsor');
     expect(approveProps.seedBulk).toBe(`${OLD_AGENT_A}\n${OLD_AGENT_B}`);
+    // [HIGH] — the chained Approve must deregister the seeded wallets from the OLD account
+    // (#7) first; expiry doesn't free them. And the resolve succeeded.
+    expect(approveProps.deregisterFrom).toBe('7');
+    expect(approveProps.seedAgentsResolved).toBe(true);
+    await unmount();
+  });
+
+  it('when the old agents fail to load, chains with agentsResolved=false and an empty seed (no false pre-fill)', async () => {
+    mocks.listPcaAgents.mockRejectedValue(new Error('boom')); // mount (B3) + the chain both fail
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Lifecycle');
+    const renewBtn = container.querySelector('[data-testid="pca-renew-btn"]') as HTMLButtonElement;
+    await act(async () => { renewBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const createApprove = container.querySelector('[data-testid="mock-create-approve"]') as HTMLButtonElement;
+    await act(async () => { createApprove.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'id=42');
+    expect(approveProps.seedAgentsResolved).toBe(false);
+    expect(approveProps.seedBulk).toBe('');
+    expect(approveProps.deregisterFrom).toBe('7');
     await unmount();
   });
 });

--- a/packages/node-ui/test/pca-renew-chain.test.ts
+++ b/packages/node-ui/test/pca-renew-chain.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+//
+// D2 — the S2b RENEW CHAIN (ConvictionDetailView): after the replacement mint, the
+// detail view resolves the OLD account's approved wallets (listPcaAgents) and opens
+// the chained Approve modal SEEDED with them, in 'sponsor' mode. The two child modals
+// are mocked to capture props, isolating the chain wiring (onRenewSuccess → renewApprove)
+// from the create/approve internals (each covered in its own suite).
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchPca: vi.fn(),
+  fetchWalletsBalances: vi.fn(),
+  fetchContextGraphs: vi.fn(),
+  listPcaAgents: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', async (orig) => {
+  const actual = await orig<typeof import('../src/ui/api.js')>();
+  return { ...actual, ...mocks };
+});
+
+// Capture the props the chain hands each modal (isolate the chain from modal internals).
+let createProps: any = null;
+let approveProps: any = null;
+vi.mock('../src/ui/pages/conviction/CreatePcaModal.js', () => ({
+  CreatePcaModal: (props: any) => {
+    createProps = props;
+    return React.createElement(
+      'button',
+      { 'data-testid': 'mock-create-approve', onClick: () => props.onApproveOwnWallets('42') },
+      'mock: approve own wallets',
+    );
+  },
+}));
+vi.mock('../src/ui/pages/conviction/ApproveWalletsModal.js', () => ({
+  ApproveWalletsModal: (props: any) => {
+    approveProps = props;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'mock-approve' },
+      `id=${props.accountId} mode=${props.initialMode} seed=${props.seedBulk ?? ''}`,
+    );
+  },
+}));
+
+const { ConvictionDetailView } = await import('../src/ui/pages/conviction/ConvictionDetailView.js');
+const { useAgentsStore } = await import('../src/ui/stores/agents.js');
+
+const W0 = '0x9A3f000000000000000000000000000000000E41D';
+const OLD_AGENT_A = '0xAAa0000000000000000000000000000000000001';
+const OLD_AGENT_B = '0xBbB0000000000000000000000000000000000002';
+
+function snap(over: Record<string, unknown> = {}) {
+  return {
+    accountId: '7', owner: W0, committedTRAC: '0', committedTRACTrac: '100000.0',
+    baseEpochAllowance: '850000000000000000000', topUpBuffer: '0', topUpBufferTrac: '12500.0',
+    createdAtEpoch: 1, expiresAtEpoch: 1560, createdAtTimestamp: 1, expiresAtTimestamp: 9_999_999_999,
+    discountBps: 3000, agentCount: 4, lastSettledWindow: 1283, fullySwept: false, ...over,
+  };
+}
+
+async function render(node: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { container, unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+async function waitForText(c: HTMLElement, text: string) {
+  const started = Date.now(); let last = '';
+  while (Date.now() - started < 1500) {
+    last = c.textContent ?? '';
+    if (last.includes(text)) return;
+    await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+  }
+  throw new Error(`Timed out waiting for "${text}" in "${last}"`);
+}
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+  createProps = null;
+  approveProps = null;
+  useAgentsStore.getState().setNodeStatus({ blockExplorerUrl: null });
+  mocks.fetchContextGraphs.mockResolvedValue({ contextGraphs: [] });
+  mocks.fetchPca.mockImplementation(async (_id: string, key?: string) =>
+    key ? { ...snap(), probedKey: { key, registered: true } } : snap(),
+  );
+  mocks.fetchWalletsBalances.mockResolvedValue({
+    wallets: [W0], balances: [{ address: W0, eth: '1', trac: '5', symbol: 'TRAC' }], chainId: '84532', rpcUrl: null,
+  });
+  mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [OLD_AGENT_A, OLD_AGENT_B] });
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('ConvictionDetailView S2b — renew chain', () => {
+  it('after the replacement mint, opens Approve seeded with the OLD account’s agents', async () => {
+    const { container, unmount } = await render(React.createElement(ConvictionDetailView, { accountId: '7' }));
+    await waitForText(container, 'Lifecycle');
+
+    // Open the seeded replacement-create modal (owner-gated; owner == wallets[0]).
+    const renewBtn = container.querySelector('[data-testid="pca-renew-btn"]') as HTMLButtonElement;
+    expect(renewBtn).toBeTruthy();
+    expect(renewBtn.disabled).toBe(false);
+    await act(async () => { renewBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    const createApprove = container.querySelector('[data-testid="mock-create-approve"]') as HTMLButtonElement;
+    expect(createApprove).toBeTruthy();
+    expect(createProps.replacingAccountId).toBe('7');
+    expect(createProps.seed?.tokens).toBe('100000.0'); // seeded from this account's committed amount
+
+    // Simulate the mint's "approve own wallets" success → the renew chain.
+    await act(async () => { createApprove.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'id=42'); // the chained Approve modal opened for the NEW id
+
+    // It resolved the OLD account's agents and seeded the sponsor bulk-paste with them.
+    expect(mocks.listPcaAgents).toHaveBeenCalledWith('7');
+    expect(approveProps.accountId).toBe('42');
+    expect(approveProps.initialMode).toBe('sponsor');
+    expect(approveProps.seedBulk).toBe(`${OLD_AGENT_A}\n${OLD_AGENT_B}`);
+    await unmount();
+  });
+});


### PR DESCRIPTION
## P3 — PCA enumeration (GAP-1) + Renew (S2b) + the tracks-nothing-edge fix

Third + final planned phase of the PCA node-UI (sub-PR into `feat/pca-node-ui`). **No contract change.**

### GAP-1 — "your PCAs" enumeration
- **Adapter** (`cd2d67bff`): `listPublishingConvictionAccountsForWallets(wallets)` → `[{ accountId, relation: owned|agent|both }]`. OWNED via ERC721Enumerable (`balanceOf`+`tokenOfOwnerByIndex`; `tokenId===accountId`; there is no `tokensOfOwner` getter so wallet-iteration is the cheapest correct path), AGENT-ON via the strict GAP-3 `getConvictionAgentAccountId`; deduped, relation-tagged, sorted. **#9:** a `CALL_EXCEPTION` surfaces (→ route 503), never a partial/empty "relates to nothing"; undeployed → `PcaUnavailableError`; healthy-empty → `[]`.
- **Route** (`bb2e0e923`): `GET /api/pca/mine` (owner = the node's op wallets; matched ahead of the generic `GET /:id`; capability-gated; `?hydrate=1` adds the snapshot basics; `CALL_EXCEPTION → 503 PCA_LOOKUP_READ_FAILED`).
- **UI** (`e26f07aec`): a `useDiscoveredPcas` hook + a "discovered, not tracked" strip in the conviction overview with a `[Track]` affordance.

### Auto-track edge self-heal (resolves the tracks-nothing-edge)
A **confirmed agent-on** discovery auto-tracks the account, so a sponsored pure-edge (which tracks no PCAs) sees its eligibility chip self-heal — both on the conviction tab (`e26f07aec`) and **at the publish surface** (`d7a0a3294`: `usePublishEligibility` runs the discovery + auto-track when nothing is tracked, with a session negative-cache so non-PCA nodes don't re-probe). **#9 preserved:** auto-track only makes the account RESOLVED — the verdict still runs `classifyCoverage` (registered ⇏ covered), so it never asserts coverage. Owned PCAs are not auto-tracked (they get `[Track]`).

### S2b — Renew (`d0a3efa22`)
There is no on-chain extend-lock (the V10 split removed it; only `topUp` exists, which adds budget but does not move expiry), so **Renew = re-mint a replacement**: create a new PCA seeded from the expiring one (committed TRAC + primary node), then chain into approve pre-seeded with the old account's agents. Owner-gated, reuses the create double-mint guard / 504-reconcile. **Honest copy (#9):** "a new, separate account — does not extend or reclaim the old one; the old TRAC stays locked until its own expiry; the new account starts 0/100." `topUp` reads "Add funds" (it can't extend the lock).

### Tests
real-Hardhat 11/11, daemon-pca-routes 64/64, mock-parity 27/27, facade 9/9, node-ui 1721. The live enumeration/renew end-to-end (against a live chain) defers to the integration→`main` whole-feature @mutating gate, the same pattern as P1/P2. No contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
