### PR TITLE
Fix folded private publish anchoring

### DIFF
--- a/devnet/pr1369-folded-private-ack/automated.test.ts
+++ b/devnet/pr1369-folded-private-ack/automated.test.ts
@@ -1,0 +1,221 @@
+/**
+ * GH #1369 devnet regression: folded public+private V10 publishes must collect
+ * live core StorageACKs and confirm on-chain.
+ *
+ * Preconditions:
+ *   ./scripts/devnet.sh start 6
+ *
+ * This suite uses a transient edge agent instead of a running daemon route so it
+ * can call DKGAgent.publish() with explicit privateQuads. The agent publishes
+ * into the already-registered devnet-test CG, connects to the live core nodes,
+ * and requires the result to be confirmed. A regression that drops
+ * privateMerkleRoots from the ACK request should fail here with missing/rejected
+ * ACKs instead of returning confirmed.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { DKG_ONTOLOGY, SYSTEM_CONTEXT_GRAPHS, contextGraphDataGraphUri, type KaNumberStore } from '@origintrail-official/dkg-core';
+import { DKGAgent, KaNumberAllocator } from '@origintrail-official/dkg-agent';
+import { GraphManager, OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import {
+  CONTEXT_GRAPH,
+  DEVNET_DIR,
+  RPC,
+  detectDevnet,
+  ensureAllIdentities,
+  getJson,
+  waitFor,
+  type DevnetNode,
+  type DevnetState,
+} from '../_bootstrap/harness.js';
+
+const CORE_COUNT = 4;
+
+class InMemoryKaNumberStore implements KaNumberStore {
+  private readonly next = new Map<string, bigint>();
+
+  allocate(authorAddress: string): bigint {
+    const key = authorAddress.toLowerCase();
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current + 1n);
+    return current;
+  }
+
+  reconcileFloor(authorAddress: string, nextNumberFloor: bigint): void {
+    const key = authorAddress.toLowerCase();
+    const current = this.next.get(key) ?? 0n;
+    this.next.set(key, current > nextNumberFloor ? current : nextNumberFloor);
+  }
+
+  peekNext(authorAddress: string): bigint {
+    return this.next.get(authorAddress.toLowerCase()) ?? 0n;
+  }
+}
+
+function makeKaNumberAllocator(): KaNumberAllocator {
+  return new KaNumberAllocator(new InMemoryKaNumberStore());
+}
+
+function readCoreMultiaddrs(): string[] {
+  const addrs: string[] = [];
+  for (let i = 1; i <= CORE_COUNT; i++) {
+    const path = `${DEVNET_DIR}/node${i}/multiaddr`;
+    if (!existsSync(path)) {
+      throw new Error(`Missing core node${i} multiaddr at ${path}; restart devnet with ./scripts/devnet.sh start 6`);
+    }
+    const addr = readFileSync(path, 'utf8').trim();
+    if (!addr) throw new Error(`Empty core node${i} multiaddr at ${path}`);
+    addrs.push(addr);
+  }
+  return addrs;
+}
+
+async function devnetTestCgOnChainId(node: DevnetNode): Promise<string> {
+  const { status, json } = await getJson(node, '/api/context-graph/list');
+  expect(status, JSON.stringify(json)).toBe(200);
+  const row = (json.contextGraphs as Array<{ id?: string; onChainId?: string }> | undefined)
+    ?.find((cg) => cg.id === CONTEXT_GRAPH);
+  expect(row?.onChainId, `${CONTEXT_GRAPH} must be registered on-chain by devnet bootstrap`).toMatch(/^[1-9]\d*$/);
+  return row!.onChainId!;
+}
+
+async function seedLocalContextGraph(store: OxigraphStore, onChainId: string): Promise<void> {
+  const gm = new GraphManager(store);
+  await gm.ensureContextGraph(CONTEXT_GRAPH);
+
+  const ontologyGraph = contextGraphDataGraphUri(SYSTEM_CONTEXT_GRAPHS.ONTOLOGY);
+  const contextGraphUri = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+  await store.insert([
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.RDF_TYPE,
+      object: DKG_ONTOLOGY.DKG_CONTEXT_GRAPH,
+      graph: ontologyGraph,
+    },
+    {
+      subject: contextGraphUri,
+      predicate: DKG_ONTOLOGY.SCHEMA_NAME,
+      object: '"Devnet Test"',
+      graph: ontologyGraph,
+    },
+    {
+      subject: contextGraphUri,
+      predicate: `${DKG_ONTOLOGY.DKG_CONTEXT_GRAPH}OnChainId`,
+      object: `"${onChainId}"`,
+      graph: ontologyGraph,
+    },
+  ]);
+}
+
+async function waitForDevnetPeers(agent: DKGAgent): Promise<void> {
+  for (const addr of readCoreMultiaddrs()) {
+    await agent.connectTo(addr).catch(() => undefined);
+  }
+
+  await waitFor(
+    'transient publisher to connect to at least 3 devnet core peers',
+    90_000,
+    2_000,
+    async () => {
+      const peers = ((agent as unknown as { node?: { libp2p?: { getPeers?: () => unknown[] } } })
+        .node?.libp2p?.getPeers?.() ?? []);
+      return peers.length >= 3 ? true : null;
+    },
+  );
+}
+
+let state: DevnetState;
+let node1: DevnetNode;
+let store: OxigraphStore;
+let agent: DKGAgent | undefined;
+let onChainContextGraphId = '';
+
+beforeAll(async () => {
+  const detected = await detectDevnet(6);
+  if (!detected) {
+    throw new Error('No devnet detected - run ./scripts/devnet.sh start 6 before this suite');
+  }
+  state = detected;
+  await ensureAllIdentities(state, CORE_COUNT);
+  node1 = state.nodes[1]!;
+  onChainContextGraphId = await devnetTestCgOnChainId(node1);
+
+  store = new OxigraphStore();
+  await seedLocalContextGraph(store, onChainContextGraphId);
+
+  agent = await DKGAgent.create({
+    name: 'PR1369FoldedPrivateAckDevnet',
+    listenHost: '127.0.0.1',
+    listenPort: 0,
+    bootstrapPeers: readCoreMultiaddrs(),
+    nodeRole: 'edge',
+    store,
+    syncSharedMemoryOnConnect: false,
+    kaNumberAllocator: makeKaNumberAllocator(),
+    chainConfig: {
+      rpcUrl: RPC,
+      hubAddress: state.addrs.Hub,
+      chainId: 'evm:31337',
+      operationalKeys: [node1.opWallets[0]!.privateKey],
+      adminPrivateKey: node1.admin.privateKey,
+    },
+  });
+  await agent.start();
+
+  const sub = agent.getSubscribedContextGraphs().get(CONTEXT_GRAPH);
+  (agent as unknown as {
+    setContextGraphSubscription: (id: string, next: unknown, opts?: { persist?: boolean }) => void;
+  }).setContextGraphSubscription(
+    CONTEXT_GRAPH,
+    { ...sub, subscribed: true, synced: true, onChainId: onChainContextGraphId },
+    { persist: false },
+  );
+
+  await waitForDevnetPeers(agent);
+}, 240_000);
+
+afterAll(async () => {
+  await agent?.stop().catch(() => undefined);
+  await store?.close?.().catch(() => undefined);
+});
+
+describe('GH #1369 folded private ACK devnet coverage', () => {
+  it('confirms a direct public+private publish with live core ACKs', async () => {
+    expect(agent).toBeDefined();
+    const nonce = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const subject = `urn:devnet:pr1369:${nonce}`;
+    const graph = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
+
+    const publicQuads: Quad[] = [
+      {
+        subject,
+        predicate: 'https://schema.org/name',
+        object: `"PR1369 folded private ${nonce}"`,
+        graph,
+      },
+    ];
+    const privateQuads: Quad[] = [
+      {
+        subject,
+        predicate: 'https://example.org/private/apiKey',
+        object: `"secret-${nonce}"`,
+        graph,
+      },
+      {
+        subject,
+        predicate: 'https://example.org/private/modelPath',
+        object: `"s3://private/pr1369/${nonce}"`,
+        graph,
+      },
+    ];
+
+    const result = await agent!.publish(CONTEXT_GRAPH, publicQuads, privateQuads, {
+      onChainContextGraphId,
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(result.onChainResult).toBeDefined();
+    expect(result.kaId).toBeGreaterThan(0n);
+    expect(result.kaManifest[0]?.privateTripleCount).toBe(privateQuads.length);
+  }, 180_000);
+});

--- a/devnet/pr1369-folded-private-ack/package.json
+++ b/devnet/pr1369-folded-private-ack/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@origintrail-official/dkg-devnet-pr1369-folded-private-ack",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:devnet": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@origintrail-official/dkg-agent": "workspace:*",
+    "@origintrail-official/dkg-core": "workspace:*",
+    "@origintrail-official/dkg-storage": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
+  }
+}

--- a/devnet/pr1369-folded-private-ack/vitest.config.ts
+++ b/devnet/pr1369-folded-private-ack/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    include: [resolve(import.meta.dirname, 'automated.test.ts')],
+    testTimeout: 600_000,
+    hookTimeout: 240_000,
+    pool: 'forks',
+    sequence: { concurrent: false },
+    globals: false,
+  },
+  resolve: {
+    modules: [
+      resolve(import.meta.dirname, '../../node_modules'),
+      'node_modules',
+    ],
+  },
+});

--- a/devnet/suites.json
+++ b/devnet/suites.json
@@ -6,6 +6,7 @@
     "pr1388-okf-integration",
     "ka-lifecycle-cli",
     "pr1366-pca-deposit-waiver",
+    "pr1369-folded-private-ack",
     "pr1387-bulk-register-agents",
     "pr1384-preserve-agents-on-transfer",
     "pr1370-admin-op-wallet"
@@ -17,6 +18,7 @@
     "edge-update-flow",
     "greenfield-10min",
     "pr1366-pca-deposit-waiver",
+    "pr1369-folded-private-ack",
     "pr1370-admin-op-wallet",
     "pr1384-preserve-agents-on-transfer",
     "pr1385-subgraph-rs",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:devnet:pr1388-okf-integration": "vitest run --config devnet/pr1388-okf-integration/vitest.config.ts",
     "test:devnet:ka-lifecycle-cli": "vitest run --config devnet/ka-lifecycle-cli/vitest.config.ts",
     "test:devnet:pr1366-pca-deposit-waiver": "vitest run --config devnet/pr1366-pca-deposit-waiver/vitest.config.ts",
+    "test:devnet:pr1369-folded-private-ack": "vitest run --config devnet/pr1369-folded-private-ack/vitest.config.ts",
     "test:devnet:pr1387-bulk-register-agents": "vitest run --config devnet/pr1387-bulk-register-agents/vitest.config.ts",
     "test:devnet:pr1384-preserve-agents-on-transfer": "vitest run --config devnet/pr1384-preserve-agents-on-transfer/vitest.config.ts",
     "test:devnet:pr1370-admin-op-wallet": "vitest run --config devnet/pr1370-admin-op-wallet/vitest.config.ts",

--- a/packages/agent/src/dkg-agent-base.ts
+++ b/packages/agent/src/dkg-agent-base.ts
@@ -1169,6 +1169,7 @@ export class DKGAgentBase {
   protected readonly onChainParticipantAgentsCache = new Map<string, string[]>();
   protected readonly peerHealth = new Map<string, PeerHealth>();
   protected readonly knownCorePeerIds = new Set<string>();
+  protected readonly knownCorePeerIdsV2 = new Set<string>();
   /**
    * Last chain-reported ACK quorum (ParametersStorage
    * minimumRequiredSignatures), refreshed by the V10 ACK provider before

--- a/packages/agent/src/dkg-agent-lifecycle.ts
+++ b/packages/agent/src/dkg-agent-lifecycle.ts
@@ -1287,16 +1287,12 @@ export class LifecycleSyncMethods extends DKGAgentBase {
               const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
               return ackHandler.handler(data, peerId);
             });
-            // OT-RFC-38 LU-11 / OT-RFC-39 — V2 protocol id. Same
-            // handler instance, distinct libp2p protocol. Publishers
-            // running the chunked emit path negotiate V2 explicitly
-            // so pre-LU-11 cores (V1-only) never see a V2 envelope;
-            // the handler dispatches on `intent.ackProtocolVersion`
-            // internally — V2 envelopes hit the chunked verify
-            // branch, V1 envelopes (if any ever arrive on the V2
-            // protocol id, which spec-conforming clients won't send)
-            // fall through to the legacy single-blob / public-CG
-            // paths.
+            // OT-RFC-38 LU-11 / OT-RFC-39 — V2 protocol id. Same handler
+            // instance, distinct libp2p protocol. Publishers negotiate V2 for
+            // chunked ciphertext commitments and folded-private field-20
+            // commitments, so V1-only cores never receive intents whose new
+            // fields they would silently ignore. The handler dispatches on the
+            // decoded intent shape internally.
             this.messenger.register(PROTOCOL_STORAGE_ACK_V2, async (data, peerIdStr) => {
               const peerId = { toString: () => peerIdStr, toBytes: () => new Uint8Array() };
               return ackHandler.handler(data, peerId);
@@ -2545,6 +2541,7 @@ export class LifecycleSyncMethods extends DKGAgentBase {
       syncingPeers: this.syncingPeers,
       getPeerProtocols: (peerId) => this.getPeerProtocols(peerId),
       knownCorePeerIds: this.knownCorePeerIds,
+      knownCorePeerIdsV2: this.knownCorePeerIdsV2,
       getSyncContextGraphs: () => this.config.syncContextGraphs ?? [],
       getSharedMemorySyncContextGraphs: async (peerId) => (await getSharedMemorySyncPlan(peerId)).eligibleContextGraphIds,
       syncFromPeer: (peerId, contextGraphIds) => this.syncFromPeerDetailed(
@@ -2739,6 +2736,14 @@ export class LifecycleSyncMethods extends DKGAgentBase {
     // with a not-yet-populated list and must not evict a known core.
     if (protocols.includes(PROTOCOL_STORAGE_ACK)) {
       this.knownCorePeerIds.add(peerId);
+    }
+    // V2 is a strict compatibility gate for field-20 folded-private ACKs. Keep
+    // empty-list races non-destructive, but clear stale V2 membership when
+    // identify delivers a populated protocol list without the V2 ACK protocol.
+    if (protocols.includes(PROTOCOL_STORAGE_ACK_V2)) {
+      this.knownCorePeerIdsV2.add(peerId);
+    } else if (protocols.length > 0) {
+      this.knownCorePeerIdsV2.delete(peerId);
     }
     if (!this.skippedNoSyncPeers.has(peerId)) return;
     if (!protocols.includes(PROTOCOL_SYNC)) return;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1435,6 +1435,11 @@ export class DKGAgent extends DKGAgentBase {
    * protocol negotiation (no handler registered), so over-asking is
    * cheap, while under-asking is fatal.
    *
+   * Folded-private publishes require `PROTOCOL_STORAGE_ACK_V2` because their
+   * PublishIntent carries field 20 (`privateMerkleRoots`). For that protocol we
+   * do not fall back to all connected peers: V1-only cores would silently ignore
+   * field 20 and recompute the wrong root during rolling upgrades.
+   *
    * Codex review (PR #1107): the quorum threshold here must track the
    * CHAIN's runtime `requiredACKs` (ParametersStorage
    * minimumRequiredSignatures), not the hard-coded default — on networks
@@ -1446,9 +1451,12 @@ export class DKGAgent extends DKGAgentBase {
    * read sees the current value; the default only covers the first call
    * on chains without the getter.
    */
-  private getACKCandidatePeers(): string[] {
+  private getACKCandidatePeers(protocol: string = PROTOCOL_STORAGE_ACK): string[] {
     const peers = this.node.libp2p.getPeers();
     const connected = peers.map(p => p.toString()).filter(id => id !== this.peerId);
+    if (protocol === PROTOCOL_STORAGE_ACK_V2) {
+      return connected.filter(id => this.knownCorePeerIdsV2.has(id));
+    }
     const confirmedCore = connected.filter(id => this.knownCorePeerIds.has(id));
     const quorum = this.lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS;
     if (confirmedCore.length >= quorum) return confirmedCore;
@@ -1496,7 +1504,7 @@ export class DKGAgent extends DKGAgentBase {
         }
         return sendResult.response;
       },
-      getConnectedCorePeers: () => this.getACKCandidatePeers(),
+      getConnectedCorePeers: (protocol?: string) => this.getACKCandidatePeers(protocol),
       verifyIdentity: typeof this.chain.verifyACKIdentity === 'function'
         ? async (recoveredAddress: string, claimedIdentityId: bigint) => {
             try {
@@ -1677,7 +1685,7 @@ export class DKGAgent extends DKGAgentBase {
         }
         return sendResult.response;
       },
-      getConnectedCorePeers: () => this.getACKCandidatePeers(),
+      getConnectedCorePeers: (protocol?: string) => this.getACKCandidatePeers(protocol),
       verifyIdentity: typeof this.chain.verifyACKIdentity === 'function'
         ? async (recoveredAddress: string, claimedIdentityId: bigint) => {
             try {

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1548,6 +1548,7 @@ export class DKGAgent extends DKGAgentBase {
         catalogRoot: Uint8Array;
         catalogLeafCount: number;
       },
+      privateMerkleRoots?: Uint8Array[],
     ) => {
       // Fail loud on non-numeric or non-positive CG ids: V10 publish requires
       // a real on-chain context graph and the contract rejects `cgId == 0`
@@ -1628,7 +1629,7 @@ export class DKGAgent extends DKGAgentBase {
         contextGraphIdStr: contextGraphId,
         publisherPeerId: this.peerId,
         publicByteSize,
-        isPrivate: isEncryptedPayload === true,
+        isPrivate: isEncryptedPayload === true || (privateMerkleRoots?.length ?? 0) > 0,
         kaCount,
         rootEntities,
         chainId: chainIdBig,
@@ -1642,6 +1643,7 @@ export class DKGAgent extends DKGAgentBase {
         merkleLeafCount,
         isEncryptedPayload,
         catalogCommitment,
+        privateMerkleRoots,
       });
       return result.acks;
     };

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -1436,9 +1436,13 @@ export class DKGAgent extends DKGAgentBase {
    * cheap, while under-asking is fatal.
    *
    * Folded-private publishes require `PROTOCOL_STORAGE_ACK_V2` because their
-   * PublishIntent carries field 20 (`privateMerkleRoots`). For that protocol we
-   * do not fall back to all connected peers: V1-only cores would silently ignore
-   * field 20 and recompute the wrong root during rolling upgrades.
+   * PublishIntent carries field 20 (`privateMerkleRoots`). Prefer peers that
+   * explicitly advertise V2, but do not make peer-store protocol metadata the
+   * only gate: StorageACK handlers register after identity resolution, often
+   * after peers are already connected, and libp2p identify does not always
+   * refresh the stored protocol list. The actual compatibility gate remains
+   * the V2 wire protocol passed to `sendP2P`; V1-only peers fail negotiation
+   * and cannot silently sign against a public-only root.
    *
    * Codex review (PR #1107): the quorum threshold here must track the
    * CHAIN's runtime `requiredACKs` (ParametersStorage
@@ -1454,11 +1458,17 @@ export class DKGAgent extends DKGAgentBase {
   private getACKCandidatePeers(protocol: string = PROTOCOL_STORAGE_ACK): string[] {
     const peers = this.node.libp2p.getPeers();
     const connected = peers.map(p => p.toString()).filter(id => id !== this.peerId);
-    if (protocol === PROTOCOL_STORAGE_ACK_V2) {
-      return connected.filter(id => this.knownCorePeerIdsV2.has(id));
-    }
     const confirmedCore = connected.filter(id => this.knownCorePeerIds.has(id));
     const quorum = this.lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS;
+    if (protocol === PROTOCOL_STORAGE_ACK_V2) {
+      const v2Advertised = connected.filter(id => this.knownCorePeerIdsV2.has(id));
+      if (v2Advertised.length >= quorum) return v2Advertised;
+      const v2Set = new Set(v2Advertised);
+      const remainingConfirmedCore = confirmedCore.filter(id => !v2Set.has(id));
+      const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
+      const rest = connected.filter(id => !seen.has(id));
+      return [...v2Advertised, ...remainingConfirmedCore, ...rest];
+    }
     if (confirmedCore.length >= quorum) return confirmedCore;
     const rest = connected.filter(id => !this.knownCorePeerIds.has(id));
     return [...confirmedCore, ...rest];

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import {
   DKGNode, ProtocolRouter, GossipSubManager, TypedEventBus, DKGEvent,
   LibP2PNetwork, PeerResolver, StubNetworkStateRegistry,
-  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
+  PROTOCOL_ACCESS, PROTOCOL_PUBLISH, PROTOCOL_SYNC, PROTOCOL_QUERY_REMOTE, PROTOCOL_STORAGE_ACK, PROTOCOL_GET_CIPHERTEXT_CHUNK, PROTOCOL_VERIFY_PROPOSAL, PROTOCOL_JOIN_REQUEST,
   PROTOCOL_SWM_SENDER_KEY, PROTOCOL_SWM_UPDATE, PROTOCOL_SWM_SHARE_ACK, PROTOCOL_SWM_HOST_CATCHUP, PROTOCOL_MESSAGE,
   contextGraphPublishTopic, contextGraphWorkspaceTopic, contextGraphAppTopic, contextGraphUpdateTopic, contextGraphFinalizationTopic,
   contextGraphDataGraphUri, contextGraphMetaGraphUri, contextGraphWorkspaceGraphUri, contextGraphWorkspaceMetaGraphUri,
@@ -105,12 +105,13 @@ import {
   type AsyncPromoteQueue, type AsyncPromoteQueueConfig,
   type PromoteJob, type PromoteListFilter,
   wrapAsRpcPreconditionIfApplicable,
+  selectACKCandidatePeers,
   type PublishOptions, type PublishResult, type PhaseCallback, type KAMetadata, type CASCondition,
   // OT-RFC-43 A2/B3 — per-layer pointers + derived status helper.
   deriveStatus, type KaStatus,
   WM_CURRENT_ASSERTION_PRED, SWM_CURRENT_ASSERTION_PRED, VM_CURRENT_ASSERTION_PRED,
   KA_ID_PRED, RESERVED_UAL_PRED,
-  type CollectedACK, type V10CoreNodeACK, type LiftAuthorityProof, type LiftTransitionType,
+  type CollectedACK, type V10CoreNodeACK, type V10ACKProviderParams, type LiftAuthorityProof, type LiftTransitionType,
   type LiftRequest, type LiftRequestAuthorSeal,
   type WorkspaceAgentRecipient,
   type WorkspaceAgentRecipientResolution,
@@ -1457,21 +1458,14 @@ export class DKGAgent extends DKGAgentBase {
    */
   private getACKCandidatePeers(protocol: string = PROTOCOL_STORAGE_ACK): string[] {
     const peers = this.node.libp2p.getPeers();
-    const connected = peers.map(p => p.toString()).filter(id => id !== this.peerId);
-    const confirmedCore = connected.filter(id => this.knownCorePeerIds.has(id));
-    const quorum = this.lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS;
-    if (protocol === PROTOCOL_STORAGE_ACK_V2) {
-      const v2Advertised = connected.filter(id => this.knownCorePeerIdsV2.has(id));
-      if (v2Advertised.length >= quorum) return v2Advertised;
-      const v2Set = new Set(v2Advertised);
-      const remainingConfirmedCore = confirmedCore.filter(id => !v2Set.has(id));
-      const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
-      const rest = connected.filter(id => !seen.has(id));
-      return [...v2Advertised, ...remainingConfirmedCore, ...rest];
-    }
-    if (confirmedCore.length >= quorum) return confirmedCore;
-    const rest = connected.filter(id => !this.knownCorePeerIds.has(id));
-    return [...confirmedCore, ...rest];
+    return selectACKCandidatePeers({
+      connectedPeers: peers.map(p => p.toString()),
+      selfPeerId: this.peerId,
+      knownCorePeerIds: this.knownCorePeerIds,
+      knownCorePeerIdsV2: this.knownCorePeerIdsV2,
+      requiredACKs: this.lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS,
+      protocol,
+    });
   }
 
   /**
@@ -1546,28 +1540,7 @@ export class DKGAgent extends DKGAgentBase {
 
     const chain = this.chain;
 
-    return async (
-      merkleRoot: Uint8Array,
-      contextGraphId: string,
-      kaCount: number,
-      rootEntities: string[],
-      publicByteSize: bigint,
-      stagingQuads: Uint8Array | undefined,
-      epochs: number | undefined,
-      tokenAmount: bigint | undefined,
-      swmGraphId: string | undefined,
-      subGraphName: string | undefined,
-      merkleLeafCount: number,
-      isEncryptedPayload?: boolean,
-      // OT-RFC-49 / WS-D — when present, this is a curated publish: the
-      // committed PUBLIC `_catalog` commitment the core rebuilds + verifies
-      // over the inline catalog `stagingQuads` and that lands on-chain.
-      catalogCommitment?: {
-        catalogRoot: Uint8Array;
-        catalogLeafCount: number;
-      },
-      privateMerkleRoots?: Uint8Array[],
-    ) => {
+    return async (params: V10ACKProviderParams) => {
       // Fail loud on non-numeric or non-positive CG ids: V10 publish requires
       // a real on-chain context graph and the contract rejects `cgId == 0`
       // with `ZeroContextGraphId`. Reject `<= 0n` (not `=== 0n`) because
@@ -1581,11 +1554,11 @@ export class DKGAgent extends DKGAgentBase {
       // source SWM graph name and is NOT required to be numeric.
       let cgIdBigInt: bigint;
       try {
-        cgIdBigInt = BigInt(contextGraphId);
+        cgIdBigInt = BigInt(params.contextGraphId);
       } catch {
         throw new Error(
           `V10 ACK collection requires a numeric on-chain context graph id; ` +
-          `got '${contextGraphId}'. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
+          `got '${params.contextGraphId}'. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
         );
       }
       if (cgIdBigInt <= 0n) {
@@ -1594,9 +1567,9 @@ export class DKGAgent extends DKGAgentBase {
           `Register the CG on-chain via ContextGraphs.createContextGraph first.`,
         );
       }
-      if (!Number.isInteger(merkleLeafCount) || merkleLeafCount < 1) {
+      if (!Number.isInteger(params.merkleLeafCount) || params.merkleLeafCount < 1) {
         throw new Error(
-          `V10 ACK collection requires a positive integer merkleLeafCount; got ${merkleLeafCount}. ` +
+          `V10 ACK collection requires a positive integer merkleLeafCount; got ${params.merkleLeafCount}. ` +
           'Publishers must pass the V10 flat-KC leaf count computed by V10MerkleTree.',
         );
       }
@@ -1642,26 +1615,24 @@ export class DKGAgent extends DKGAgentBase {
       }
 
       const result = await collector.collect({
-        merkleRoot,
+        merkleRoot: params.merkleRoot,
         contextGraphId: cgIdBigInt,
-        contextGraphIdStr: contextGraphId,
+        contextGraphIdStr: params.contextGraphId,
         publisherPeerId: this.peerId,
-        publicByteSize,
-        isPrivate: isEncryptedPayload === true || (privateMerkleRoots?.length ?? 0) > 0,
-        kaCount,
-        rootEntities,
+        publicByteSize: params.publicByteSize,
+        isPrivate: params.ackMode.kind !== 'public',
+        kaCount: params.kaCount,
+        rootEntities: params.rootEntities,
         chainId: chainIdBig,
         kav10Address,
         requiredACKs,
-        stagingQuads,
-        epochs,
-        tokenAmount,
-        swmGraphId,
-        subGraphName,
-        merkleLeafCount,
-        isEncryptedPayload,
-        catalogCommitment,
-        privateMerkleRoots,
+        stagingQuads: params.stagingQuads,
+        epochs: params.epochs,
+        tokenAmount: params.tokenAmount,
+        swmGraphId: params.swmGraphId,
+        subGraphName: params.subGraphName,
+        merkleLeafCount: params.merkleLeafCount,
+        ackMode: params.ackMode,
       });
       return result.acks;
     };

--- a/packages/agent/src/sync/on-connect/sync-on-connect.ts
+++ b/packages/agent/src/sync/on-connect/sync-on-connect.ts
@@ -1,4 +1,4 @@
-import { createOperationContext, PROTOCOL_STORAGE_ACK, PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
+import { createOperationContext, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_SYNC, SYSTEM_CONTEXT_GRAPHS, type OperationContext } from '@origintrail-official/dkg-core';
 
 interface SyncProgressSummary {
   insertedTriples: number;
@@ -26,6 +26,7 @@ interface SyncOnConnectContext {
   syncingPeers: Set<string>;
   getPeerProtocols: (peerId: string) => Promise<string[]>;
   knownCorePeerIds: Set<string>;
+  knownCorePeerIdsV2?: Set<string>;
   getSyncContextGraphs: () => string[];
   getSharedMemorySyncContextGraphs?: (remotePeerId: string) => string[] | Promise<string[]>;
   syncFromPeer: (peerId: string, contextGraphIds?: string[]) => Promise<SyncFromPeerResult>;
@@ -135,6 +136,7 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
     syncingPeers,
     getPeerProtocols,
     knownCorePeerIds,
+    knownCorePeerIdsV2 = new Set<string>(),
     getSyncContextGraphs,
     getSharedMemorySyncContextGraphs,
     syncFromPeer,
@@ -199,6 +201,11 @@ export async function runSyncOnConnect(context: SyncOnConnectContext): Promise<S
       // would re-poison the ACK candidate pool that
       // `DKGAgent.getACKCandidatePeers` builds for the publisher.
       knownCorePeerIds.delete(remotePeer);
+    }
+    if (protocols.includes(PROTOCOL_STORAGE_ACK_V2)) {
+      knownCorePeerIdsV2.add(remotePeer);
+    } else if (protocols.length > 0) {
+      knownCorePeerIdsV2.delete(remotePeer);
     }
 
     const hasSync = protocols.includes(PROTOCOL_SYNC);

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -151,9 +151,12 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     a.knownCorePeerIdsV2.add(CORE[0]);
 
     a.handlePeerUpdateForSyncRetry(CORE[0], []);
+    expect(a.knownCorePeerIdsV2.has(CORE[0])).toBe(true);
     expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual(CORE);
 
     a.handlePeerUpdateForSyncRetry(CORE[0], [PROTOCOL_STORAGE_ACK]);
+    expect(a.knownCorePeerIdsV2.has(CORE[0])).toBe(false);
+    expect(a.knownCorePeerIds.has(CORE[0])).toBe(true);
     expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual(CORE);
   });
 });

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -7,14 +7,22 @@
 // above 3 signatures, a 3-strong confirmed-core subset is still below quorum —
 // returning only it re-introduces `pool_below_quorum`.
 import { describe, it, expect } from 'vitest';
+import { PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import { DKGAgent, MockChainAdapter, OxigraphStore } from './agent.shared';
 
 type AgentInternals = {
-  node: { libp2p: { getPeers: () => Array<{ toString(): string }> } };
+  node: {
+    libp2p: {
+      peerId: { toString(): string };
+      getPeers: () => Array<{ toString(): string }>;
+    };
+  };
   peerId: string;
   knownCorePeerIds: Set<string>;
+  knownCorePeerIdsV2: Set<string>;
   lastKnownRequiredACKs?: number;
-  getACKCandidatePeers: () => string[];
+  getACKCandidatePeers: (protocol?: string) => string[];
+  handlePeerUpdateForSyncRetry: (peerId: string, protocols: readonly string[]) => void;
 };
 
 const CORE = ['core-1', 'core-2', 'core-3', 'core-4'];
@@ -32,7 +40,10 @@ async function buildAgent(opts: {
   });
   const internals = agent as unknown as AgentInternals;
   internals.node = {
-    libp2p: { getPeers: () => opts.connected.map((id) => ({ toString: () => id })) },
+    libp2p: {
+      peerId: { toString: () => internals.peerId },
+      getPeers: () => opts.connected.map((id) => ({ toString: () => id })),
+    },
   };
   for (const id of opts.confirmedCores) internals.knownCorePeerIds.add(id);
   internals.lastKnownRequiredACKs = opts.lastKnownRequiredACKs;
@@ -93,8 +104,38 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     });
     const self = a.peerId;
     a.node = {
-      libp2p: { getPeers: () => [self, ...CORE.slice(0, 3)].map((id) => ({ toString: () => id })) },
+      libp2p: {
+        peerId: { toString: () => self },
+        getPeers: () => [self, ...CORE.slice(0, 3)].map((id) => ({ toString: () => id })),
+      },
     };
     expect(a.getACKCandidatePeers()).not.toContain(self);
+  });
+
+  it('V2 folded-private ACKs use only peers that advertised the V2 storage-ack protocol', async () => {
+    const a = await buildAgent({
+      confirmedCores: CORE,
+      connected: [...CORE, ...EDGE],
+      lastKnownRequiredACKs: 4,
+    });
+    a.knownCorePeerIdsV2.add(CORE[0]);
+    a.knownCorePeerIdsV2.add(CORE[2]);
+
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([CORE[0], CORE[2]]);
+  });
+
+  it('peer:update evicts stale V2 ACK capability only from populated protocol lists', async () => {
+    const a = await buildAgent({
+      confirmedCores: CORE,
+      connected: CORE,
+      lastKnownRequiredACKs: 4,
+    });
+    a.knownCorePeerIdsV2.add(CORE[0]);
+
+    a.handlePeerUpdateForSyncRetry(CORE[0], []);
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([CORE[0]]);
+
+    a.handlePeerUpdateForSyncRetry(CORE[0], [PROTOCOL_STORAGE_ACK]);
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([]);
   });
 });

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -130,7 +130,7 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     ]);
   });
 
-  it('V2 folded-private ACKs return only V2-advertised peers once they satisfy quorum', async () => {
+  it('V2 folded-private ACKs keep fallback candidates even when cached V2 metadata appears quorum-sized', async () => {
     const a = await buildAgent({
       confirmedCores: CORE,
       connected: [...CORE, ...EDGE],
@@ -139,7 +139,26 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     a.knownCorePeerIdsV2.add(CORE[0]);
     a.knownCorePeerIdsV2.add(CORE[2]);
 
-    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([CORE[0], CORE[2]]);
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([
+      CORE[0],
+      CORE[2],
+      CORE[1],
+      CORE[3],
+      ...EDGE,
+    ]);
+  });
+
+  it('V2 folded-private ACKs do not let stale identify metadata hide a connected upgraded core', async () => {
+    const a = await buildAgent({
+      confirmedCores: CORE,
+      connected: CORE,
+      lastKnownRequiredACKs: 3,
+    });
+    a.knownCorePeerIdsV2.add(CORE[0]);
+    a.knownCorePeerIdsV2.add(CORE[1]);
+    a.knownCorePeerIdsV2.add(CORE[2]);
+
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual(CORE);
   });
 
   it('peer:update evicts stale V2 ACK capability only from populated protocol lists', async () => {

--- a/packages/agent/test/ack-candidate-pool.test.ts
+++ b/packages/agent/test/ack-candidate-pool.test.ts
@@ -112,11 +112,29 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     expect(a.getACKCandidatePeers()).not.toContain(self);
   });
 
-  it('V2 folded-private ACKs use only peers that advertised the V2 storage-ack protocol', async () => {
+  it('V2 folded-private ACKs prefer advertised V2 peers, then keep enough candidates for wire negotiation', async () => {
     const a = await buildAgent({
       confirmedCores: CORE,
       connected: [...CORE, ...EDGE],
       lastKnownRequiredACKs: 4,
+    });
+    a.knownCorePeerIdsV2.add(CORE[0]);
+    a.knownCorePeerIdsV2.add(CORE[2]);
+
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([
+      CORE[0],
+      CORE[2],
+      CORE[1],
+      CORE[3],
+      ...EDGE,
+    ]);
+  });
+
+  it('V2 folded-private ACKs return only V2-advertised peers once they satisfy quorum', async () => {
+    const a = await buildAgent({
+      confirmedCores: CORE,
+      connected: [...CORE, ...EDGE],
+      lastKnownRequiredACKs: 2,
     });
     a.knownCorePeerIdsV2.add(CORE[0]);
     a.knownCorePeerIdsV2.add(CORE[2]);
@@ -133,9 +151,9 @@ describe('getACKCandidatePeers — quorum-aware confirmed-core shortcut (#1093 /
     a.knownCorePeerIdsV2.add(CORE[0]);
 
     a.handlePeerUpdateForSyncRetry(CORE[0], []);
-    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([CORE[0]]);
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual(CORE);
 
     a.handlePeerUpdateForSyncRetry(CORE[0], [PROTOCOL_STORAGE_ACK]);
-    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual([]);
+    expect(a.getACKCandidatePeers(PROTOCOL_STORAGE_ACK_V2)).toEqual(CORE);
   });
 });

--- a/packages/agent/test/e2e-finalization.test.ts
+++ b/packages/agent/test/e2e-finalization.test.ts
@@ -369,7 +369,7 @@ describe('E2E: workspace-first publish with real blockchain', () => {
 
     // Both entities should now be in the data graph
     const dataAll = await nodeA.query(
-      `SELECT ?s ?name WHERE { ?s <http://schema.org/name> ?name }`,
+      `SELECT DISTINCT ?s ?name WHERE { ?s <http://schema.org/name> ?name }`,
       CONTEXT_GRAPH,
     );
     const names = dataAll.bindings.map((b: any) => String(b['name']));
@@ -408,7 +408,7 @@ describe('E2E: workspace-first publish with real blockchain', () => {
 
     // Data graph should have the data
     const data = await nodeA.query(
-      `SELECT ?name WHERE { <${ENTITY_3}> <http://schema.org/name> ?name }`,
+      `SELECT DISTINCT ?name WHERE { <${ENTITY_3}> <http://schema.org/name> ?name }`,
       CONTEXT_GRAPH,
     );
     expect(data.bindings.length).toBe(1);

--- a/packages/agent/test/e2e-security.test.ts
+++ b/packages/agent/test/e2e-security.test.ts
@@ -483,7 +483,7 @@ describe('Access protocol round-trip', () => {
     const keypairB = await generateEd25519Keypair();
     const accessClient = new AccessClient(messengerFor(routerB), keypairB, nodeB.peerId);
 
-    expect(result.status).toBe('tentative');
+    expect(result.status).toBe('confirmed');
     const ka = result.kaManifest[0];
     expect(ka).toBeDefined();
     const accessResult = await accessClient.requestAccess(nodeA.peerId, `${result.ual}/${ka!.tokenId}`);

--- a/packages/agent/test/encrypt-inline-policy.test.ts
+++ b/packages/agent/test/encrypt-inline-policy.test.ts
@@ -428,6 +428,66 @@ describe('DKGAgent._publish inline encryption routing', () => {
     })]);
   });
 
+  it('routes direct encrypted private publishes to the publisher without an implicit catalog floor', async () => {
+    const encryptInlinePayload = recorder(async (plaintext: Uint8Array) => plaintext);
+    const encryptInlineChunked = recorder(() => undefined);
+    const publisherError = new Error(
+      'Encrypted inline publishes with privateQuads are not supported by the current V10 ACK model.',
+    );
+    const publisherPublish = recorder(async () => {
+      throw publisherError;
+    });
+    const agentLike = {
+      log: {
+        info: recorder(() => undefined),
+        warn: recorder(() => undefined),
+        error: recorder(() => undefined),
+        debug: recorder(() => undefined),
+      },
+      subscribedContextGraphs: new Set(['private-cg']),
+      contextGraphExists: recorder(async () => true),
+      createV10ACKProvider: recorder(() => undefined),
+      getContextGraphOnChainId: recorder(async () => '42'),
+      chain: {},
+      peerId: 'peer-1',
+      publisher: {
+        publish: publisherPublish,
+      },
+      broadcastPublish: recorder(async () => undefined),
+      emitPublicProjectionAfterPublish: recorder(async () => undefined),
+      _resolveEncryptInlinePayload: recorder(async () => encryptInlinePayload),
+      _resolveEncryptInlineChunked: recorder(async () => encryptInlineChunked),
+    } as any;
+
+    await expect((DKGAgent.prototype as any)._publish.call(
+      agentLike,
+      'private-cg',
+      [{ subject: 's', predicate: 'p', object: '"public"', graph: 'g' }],
+      [{ subject: 's', predicate: 'secret', object: '"private"', graph: 'g' }],
+      {
+        subGraphName: 'sg-private',
+        publisherNodeIdentityIdOverride: 0n,
+      },
+    )).rejects.toBe(publisherError);
+
+    expect(agentLike._resolveEncryptInlinePayload.calls.at(-1)).toEqual([
+      'private-cg',
+      'sg-private',
+      undefined,
+      undefined,
+      { aeadBindingContextGraphId: '42' },
+    ]);
+    const publishArgs = publisherPublish.calls.at(-1)?.[0];
+    expect(publishArgs).toEqual(expect.objectContaining({
+      contextGraphId: 'private-cg',
+      privateQuads: [{ subject: 's', predicate: 'secret', object: '"private"', graph: 'g' }],
+      publishContextGraphId: '42',
+      encryptInlinePayload,
+      encryptInlineChunked,
+    }));
+    expect(publishArgs).not.toHaveProperty('trustedNonManifestCatalogTriples');
+  });
+
   it('keeps caller-supplied mismatched onChainContextGraphId as an explicit policy target', async () => {
     const publisherPublish = recorder(async () => ({
       status: 'confirmed',

--- a/packages/agent/test/publish-jsonld.test.ts
+++ b/packages/agent/test/publish-jsonld.test.ts
@@ -170,10 +170,11 @@ describe('publishJsonLd', () => {
         'email': 'carol@example.org',
       },
     });
-    expect(result.status).toBe('tentative');
+    expect(result.status).toBe('confirmed');
 
     const publicName = await store.query(
-      `ASK { GRAPH <did:dkg:context-graph:split-test> { <http://example.org/Carol> <http://schema.org/name> ?name } }`,
+      `ASK { GRAPH ?g { <http://example.org/Carol> <http://schema.org/name> ?name }
+        FILTER((STRSTARTS(STR(?g), "did:dkg:context-graph:split-test/_verifiable_memory/") && !CONTAINS(STR(?g), "/staging/")) || STR(?g) = "did:dkg:context-graph:split-test") }`,
     );
     expect(publicName.type).toBe('boolean');
     if (publicName.type === 'boolean') expect(publicName.value).toBe(true);

--- a/packages/agent/test/storage-ack-protocol-extra.test.ts
+++ b/packages/agent/test/storage-ack-protocol-extra.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PROTOCOL_STORAGE_ACK } from '@origintrail-official/dkg-core';
+import { PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const AGENT_SRC = resolve(__dirname, '..', 'src');
@@ -38,9 +38,10 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
     // rc.9 PR-11: bumped to /dkg/10.0.1/* hard cutover (Universal
     // Messenger substrate; receiver dedup + envelope wrap mandatory).
     expect(PROTOCOL_STORAGE_ACK).toBe('/dkg/10.0.1/storage-ack');
+    expect(PROTOCOL_STORAGE_ACK_V2).toBe('/dkg/10.0.2/storage-ack');
   });
 
-  it('agent source registers PROTOCOL_STORAGE_ACK on the messenger substrate', () => {
+  it('agent source registers storage-ack V1 and V2 on the messenger substrate', () => {
     // The DKGAgent god class was split into per-subsystem mixin holders, so
     // the boot-time wiring (incl. this registration) now lives in a sibling
     // file (`dkg-agent-lifecycle.ts`) rather than `dkg-agent.ts`. Scan the
@@ -54,6 +55,8 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
     // decode + receiver-side dedup). Pin against the new shape.
     const registerRE = /messenger\.register\s*\(\s*PROTOCOL_STORAGE_ACK\s*,/;
     expect(combined).toMatch(registerRE);
+    const registerV2RE = /messenger\.register\s*\(\s*PROTOCOL_STORAGE_ACK_V2\s*,/;
+    expect(combined).toMatch(registerV2RE);
   });
 
   it('agent wires core-side StorageACK decline logging', () => {
@@ -88,15 +91,14 @@ describe('A-9: storage-ack protocol id (libp2p) pin', () => {
   it('protocol id is NOT accidentally registered on a different protocol version', () => {
     // Pins that no code path silently forks to /dkg/9.x or /dkg/11.x
     // storage-ack — such a drift would be invisible to callers but would
-    // break ACK handshakes. We look for any `/dkg/*/storage-ack` that is
-    // not exactly the current PROTOCOL_STORAGE_ACK.
+    // break ACK handshakes. We allow only the V1 and V2 storage-ack constants.
     const files = walk(AGENT_SRC);
     const offenders: string[] = [];
     const re = /['"`](\/dkg\/[^'"`]*?storage-ack)['"`]/g;
     for (const f of files) {
       const src = readFileSync(f, 'utf8');
       for (const m of src.matchAll(re)) {
-        if (m[1] !== PROTOCOL_STORAGE_ACK) {
+        if (m[1] !== PROTOCOL_STORAGE_ACK && m[1] !== PROTOCOL_STORAGE_ACK_V2) {
           offenders.push(`${f}: ${m[1]}`);
         }
       }

--- a/packages/agent/test/sync-on-connect-retry.test.ts
+++ b/packages/agent/test/sync-on-connect-retry.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter } from '@origintrail-official/dkg-chain';
-import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS } from '@origintrail-official/dkg-core';
+import { createOperationContext, PROTOCOL_SYNC, PROTOCOL_ACCESS, PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import { peerIdFromString } from '@libp2p/peer-id';
 import { runSyncOnConnect, SyncOnConnectPostSyncError } from '../src/sync/on-connect/sync-on-connect.js';
 import type { OperationContext } from '@origintrail-official/dkg-core';
@@ -41,6 +41,68 @@ async function flushMicrotasks(): Promise<void> {
 }
 
 describe('runSyncOnConnect callbacks', () => {
+  it('accepts omitted knownCorePeerIdsV2 for backwards-compatible call sites', async () => {
+    const remotePeer = freshPeerIdString();
+    const knownCorePeerIds = new Set<string>();
+
+    const outcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_STORAGE_ACK, PROTOCOL_STORAGE_ACK_V2, PROTOCOL_SYNC],
+      knownCorePeerIds,
+      getSyncContextGraphs: () => [],
+      syncFromPeer: async () => 1,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+    });
+
+    expect(outcome).toBe('synced');
+    expect(knownCorePeerIds.has(remotePeer)).toBe(true);
+  });
+
+  it('tracks and evicts V2 ACK capability from populated protocol lists', async () => {
+    const remotePeer = freshPeerIdString();
+    const knownCorePeerIds = new Set<string>();
+    const knownCorePeerIdsV2 = new Set<string>([remotePeer]);
+
+    const emptyIdentifyOutcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [],
+      knownCorePeerIds,
+      knownCorePeerIdsV2,
+      getSyncContextGraphs: () => [],
+      syncFromPeer: async () => 0,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+    });
+
+    expect(emptyIdentifyOutcome).toBe('skipped-no-sync');
+    expect(knownCorePeerIdsV2.has(remotePeer)).toBe(true);
+
+    const v1OnlyOutcome = await runSyncOnConnect({
+      remotePeer,
+      syncingPeers: new Set(),
+      getPeerProtocols: async () => [PROTOCOL_STORAGE_ACK, PROTOCOL_SYNC],
+      knownCorePeerIds,
+      knownCorePeerIdsV2,
+      getSyncContextGraphs: () => [],
+      syncFromPeer: async () => 1,
+      refreshMetaSyncedFlags: async () => {},
+      discoverContextGraphsFromStore: async () => 0,
+      syncSharedMemoryFromPeer: async () => 0,
+      logInfo: noopLog,
+    });
+
+    expect(v1OnlyOutcome).toBe('synced');
+    expect(knownCorePeerIds.has(remotePeer)).toBe(true);
+    expect(knownCorePeerIdsV2.has(remotePeer)).toBe(false);
+  });
+
   it('fires onPeerSkippedNoSync when the peer does not advertise PROTOCOL_SYNC', async () => {
     const remotePeer = freshPeerIdString();
     const skipped: Array<{ peerId: string; protocols: string[] }> = [];

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -70,11 +70,12 @@ import {
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets, KaNumberAllocator } from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
-import { computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
 import {
   DEFAULT_REQUIRED_ACKS,
   findReservedSubjectPrefix,
   isSkolemizedUri,
+  selectACKCandidatePeers,
   type AsyncKnowledgeAssetVmPublishExecutionInput,
   type AsyncLiftPublisherConfig,
 } from '@origintrail-official/dkg-publisher';
@@ -1845,27 +1846,16 @@ export async function runDaemonInner(
                 const knownCorePeerIds = (agent as any).knownCorePeerIds as
                   | Set<string>
                   | undefined;
-                const confirmedCore = knownCorePeerIds && knownCorePeerIds.size > 0
-                  ? allPeers.filter((id) => knownCorePeerIds.has(id))
-                  : [];
-                const quorum = (agent as any).lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS;
-                if (protocol === PROTOCOL_STORAGE_ACK_V2) {
-                  const knownCorePeerIdsV2 = (agent as any).knownCorePeerIdsV2 as
-                    | Set<string>
-                    | undefined;
-                  const v2Advertised = knownCorePeerIdsV2
-                    ? allPeers.filter((id) => knownCorePeerIdsV2.has(id))
-                    : [];
-                  if (v2Advertised.length >= quorum) return v2Advertised;
-                  const v2Set = new Set(v2Advertised);
-                  const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
-                  const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
-                  const rest = allPeers.filter((id) => !seen.has(id));
-                  return [...v2Advertised, ...remainingConfirmedCore, ...rest];
-                }
-                if (confirmedCore.length >= quorum) return confirmedCore;
-                const rest = allPeers.filter((id) => !confirmedCore.includes(id));
-                return [...confirmedCore, ...rest];
+                const knownCorePeerIdsV2 = (agent as any).knownCorePeerIdsV2 as
+                  | Set<string>
+                  | undefined;
+                return selectACKCandidatePeers({
+                  connectedPeers: allPeers,
+                  knownCorePeerIds,
+                  knownCorePeerIdsV2,
+                  requiredACKs: (agent as any).lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS,
+                  protocol,
+                });
               },
               log,
             }),

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -70,7 +70,7 @@ import {
 } from '@origintrail-official/dkg-chain';
 import { DKGAgent, loadOpWallets, KaNumberAllocator } from '@origintrail-official/dkg-agent';
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
-import { computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables } from '@origintrail-official/dkg-core';
+import { computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import {
   findReservedSubjectPrefix,
   isSkolemizedUri,

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -72,6 +72,7 @@ import { DKGAgent, loadOpWallets, KaNumberAllocator } from '@origintrail-officia
 import { isExternalBackend } from '@origintrail-official/dkg-storage';
 import { computeNetworkId, createOperationContext, createLogRedactor, DKGEvent, Logger, PayloadTooLargeError, GET_VIEWS, TrustLevel, validateSubGraphName, validateAssertionName, validateContextGraphId, isSafeIri, assertSafeIri, sparqlIri, contextGraphSharedMemoryUri, contextGraphAssertionUri, contextGraphMetaUri, DEFAULT_PROTOCOL_OUTBOX_BACKOFFS_MS, DEFAULT_PROTOCOL_OUTBOX_MAX_AGE_MS, pickNetworkTunables, PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
 import {
+  DEFAULT_REQUIRED_ACKS,
   findReservedSubjectPrefix,
   isSkolemizedUri,
   type AsyncKnowledgeAssetVmPublishExecutionInput,
@@ -1841,22 +1842,30 @@ export async function runDaemonInner(
                   .getPeers()
                   .map((p) => p.toString())
                   .filter((id) => id !== agent.peerId);
+                const knownCorePeerIds = (agent as any).knownCorePeerIds as
+                  | Set<string>
+                  | undefined;
+                const confirmedCore = knownCorePeerIds && knownCorePeerIds.size > 0
+                  ? allPeers.filter((id) => knownCorePeerIds.has(id))
+                  : [];
+                const quorum = (agent as any).lastKnownRequiredACKs ?? DEFAULT_REQUIRED_ACKS;
                 if (protocol === PROTOCOL_STORAGE_ACK_V2) {
                   const knownCorePeerIdsV2 = (agent as any).knownCorePeerIdsV2 as
                     | Set<string>
                     | undefined;
-                  return knownCorePeerIdsV2
+                  const v2Advertised = knownCorePeerIdsV2
                     ? allPeers.filter((id) => knownCorePeerIdsV2.has(id))
                     : [];
+                  if (v2Advertised.length >= quorum) return v2Advertised;
+                  const v2Set = new Set(v2Advertised);
+                  const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
+                  const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
+                  const rest = allPeers.filter((id) => !seen.has(id));
+                  return [...v2Advertised, ...remainingConfirmedCore, ...rest];
                 }
-                const knownCorePeerIds = (agent as any).knownCorePeerIds as
-                  | Set<string>
-                  | undefined;
-                if (knownCorePeerIds && knownCorePeerIds.size > 0) {
-                  const filtered = allPeers.filter((id) => knownCorePeerIds.has(id));
-                  if (filtered.length > 0) return filtered;
-                }
-                return allPeers;
+                if (confirmedCore.length >= quorum) return confirmedCore;
+                const rest = allPeers.filter((id) => !confirmedCore.includes(id));
+                return [...confirmedCore, ...rest];
               },
               log,
             }),

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1836,11 +1836,19 @@ export async function runDaemonInner(
                 }
                 return sendResult.response;
               },
-              getConnectedCorePeers: () => {
+              getConnectedCorePeers: (protocol?: string) => {
                 const allPeers = agent.node.libp2p
                   .getPeers()
                   .map((p) => p.toString())
                   .filter((id) => id !== agent.peerId);
+                if (protocol === PROTOCOL_STORAGE_ACK_V2) {
+                  const knownCorePeerIdsV2 = (agent as any).knownCorePeerIdsV2 as
+                    | Set<string>
+                    | undefined;
+                  return knownCorePeerIdsV2
+                    ? allPeers.filter((id) => knownCorePeerIdsV2.has(id))
+                    : [];
+                }
                 const knownCorePeerIds = (agent as any).knownCorePeerIds as
                   | Set<string>
                   | undefined;

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { DKGAgentWallet } from '@origintrail-official/dkg-agent';
 import { EVMChainAdapter, NoChainAdapter, mergeRpcUsageWindows, type ChainAdapter, type RpcUsageWindow } from '@origintrail-official/dkg-chain';
 import { TypedEventBus, type Ed25519Keypair } from '@origintrail-official/dkg-core';
-import { ACKCollector, AsyncLiftRunner, DKGPublisher, FileWorkspacePublicSnapshotStore, TripleStoreAsyncLiftPublisher, wrapAsRpcPreconditionIfApplicable, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherConfig, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
+import { ACKCollector, AsyncLiftRunner, DKGPublisher, FileWorkspacePublicSnapshotStore, TripleStoreAsyncLiftPublisher, wrapAsRpcPreconditionIfApplicable, type AsyncLiftPublishExecutionInput, type AsyncLiftPublisher, type AsyncLiftPublisherConfig, type AsyncLiftPublisherRecoveryResult, type LiftJobBroadcast, type LiftJobIncluded, type PublishOptions, type V10ACKProviderParams, type WorkspacePublicSnapshotStore } from '@origintrail-official/dkg-publisher';
 import { createTripleStore, type TripleStore } from '@origintrail-official/dkg-storage';
 import { loadNetworkConfig, resolveReadyChainConfig, type DkgConfig } from './config.js';
 import { loadPublisherWallets } from './publisher-wallets.js';
@@ -429,22 +429,7 @@ function createV10ACKProviderForPublisher(
     log: transport.log,
   });
 
-  return async (
-    merkleRoot,
-    contextGraphId,
-    kaCount,
-    rootEntities,
-    publicByteSize,
-    stagingQuads,
-    epochs,
-    tokenAmount,
-    swmGraphId,
-    subGraphName,
-    merkleLeafCount,
-    isEncryptedPayload,
-    catalogCommitment,
-    privateMerkleRoots,
-  ) => {
+  return async (params: V10ACKProviderParams) => {
     // Fail loud on non-numeric or non-positive CG ids. V10 publish requires
     // a real on-chain context graph; `ZeroContextGraphId` at
     // `KnowledgeAssetsV10.sol:379` rejects cgId 0 on chain. Reject `<= 0n`
@@ -455,11 +440,11 @@ function createV10ACKProviderForPublisher(
     // numeric.
     let cgIdBigInt: bigint;
     try {
-      cgIdBigInt = BigInt(contextGraphId);
+      cgIdBigInt = BigInt(params.contextGraphId);
     } catch {
       throw new Error(
         `Async V10 publish requires a numeric on-chain context graph id; ` +
-        `got '${contextGraphId}'. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
+        `got '${params.contextGraphId}'. Register the CG on-chain via ContextGraphs.createContextGraph first.`,
       );
     }
     if (cgIdBigInt <= 0n) {
@@ -468,9 +453,9 @@ function createV10ACKProviderForPublisher(
         `Register the CG on-chain via ContextGraphs.createContextGraph first.`,
       );
     }
-    if (!Number.isInteger(merkleLeafCount) || merkleLeafCount < 1) {
+    if (!Number.isInteger(params.merkleLeafCount) || params.merkleLeafCount < 1) {
       throw new Error(
-        `Async V10 publish requires a positive integer merkleLeafCount; got ${merkleLeafCount}. ` +
+        `Async V10 publish requires a positive integer merkleLeafCount; got ${params.merkleLeafCount}. ` +
         'Publishers must pass the V10 flat-KC leaf count computed by V10MerkleTree.',
       );
     }
@@ -503,26 +488,24 @@ function createV10ACKProviderForPublisher(
       throw wrapAsRpcPreconditionIfApplicable(err, 'getKnowledgeAssetsLifecycleAddress');
     }
     const result = await collector.collect({
-      merkleRoot,
+      merkleRoot: params.merkleRoot,
       contextGraphId: cgIdBigInt,
-      contextGraphIdStr: contextGraphId,
+      contextGraphIdStr: params.contextGraphId,
       publisherPeerId: transport.publisherPeerId,
-      publicByteSize,
-      isPrivate: isEncryptedPayload === true || (privateMerkleRoots?.length ?? 0) > 0,
-      kaCount,
-      rootEntities,
+      publicByteSize: params.publicByteSize,
+      isPrivate: params.ackMode.kind !== 'public',
+      kaCount: params.kaCount,
+      rootEntities: params.rootEntities,
       chainId: chainIdBig,
       kav10Address,
       requiredACKs,
-      stagingQuads,
-      epochs,
-      tokenAmount,
-      swmGraphId,
-      subGraphName,
-      merkleLeafCount,
-      isEncryptedPayload,
-      catalogCommitment,
-      privateMerkleRoots,
+      stagingQuads: params.stagingQuads,
+      epochs: params.epochs,
+      tokenAmount: params.tokenAmount,
+      swmGraphId: params.swmGraphId,
+      subGraphName: params.subGraphName,
+      merkleLeafCount: params.merkleLeafCount,
+      ackMode: params.ackMode,
     });
     return result.acks;
   };

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -443,6 +443,7 @@ function createV10ACKProviderForPublisher(
     merkleLeafCount,
     isEncryptedPayload,
     catalogCommitment,
+    privateMerkleRoots,
   ) => {
     // Fail loud on non-numeric or non-positive CG ids. V10 publish requires
     // a real on-chain context graph; `ZeroContextGraphId` at
@@ -507,7 +508,7 @@ function createV10ACKProviderForPublisher(
       contextGraphIdStr: contextGraphId,
       publisherPeerId: transport.publisherPeerId,
       publicByteSize,
-      isPrivate: isEncryptedPayload === true,
+      isPrivate: isEncryptedPayload === true || (privateMerkleRoots?.length ?? 0) > 0,
       kaCount,
       rootEntities,
       chainId: chainIdBig,
@@ -521,6 +522,7 @@ function createV10ACKProviderForPublisher(
       merkleLeafCount,
       isEncryptedPayload,
       catalogCommitment,
+      privateMerkleRoots,
     });
     return result.acks;
   };

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -31,7 +31,7 @@ interface ACKTransportFactory {
   publisherPeerId: string;
   gossipPublish: (topic: string, data: Uint8Array) => Promise<void>;
   sendP2P: (peerId: string, protocol: string, data: Uint8Array) => Promise<Uint8Array>;
-  getConnectedCorePeers: () => string[];
+  getConnectedCorePeers: (protocol?: string) => string[];
   log?: (message: string) => void;
 }
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -121,11 +121,12 @@ export const PROTOCOL_VERIFY_PROPOSAL = '/dkg/10.0.1/verify-proposal';
 export const PROTOCOL_VERIFY_APPROVAL = '/dkg/10.0.0/verify-approval';
 export const PROTOCOL_STORAGE_ACK = '/dkg/10.0.1/storage-ack';
 /**
- * OT-RFC-38 LU-11 / OT-RFC-39 — storage-ack protocol version that
- * carries `ciphertextChunksRoot` + `ciphertextChunkCount` +
- * `ackProtocolVersion` on `PublishIntent`. Pre-LU-11 nodes don't
- * register this handler so an LU-11 publisher falls back to V1 against
- * legacy peers (with no curated chunked-publish support there).
+ * OT-RFC-38 LU-11 / OT-RFC-39 and folded-private ACKs — storage-ack protocol
+ * version for PublishIntent fields that require capability gating beyond
+ * `/dkg/10.0.1/storage-ack`, including chunked ciphertext fields and field 20
+ * `privateMerkleRoots`. Pre-V2 nodes do not register this handler, so
+ * mixed-version clusters fail at protocol selection instead of silently
+ * ignoring new fields.
  */
 export const PROTOCOL_STORAGE_ACK_V2 = '/dkg/10.0.2/storage-ack';
 

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -87,7 +87,11 @@ export const PublishIntentSchema = new Type('PublishIntent')
   // RFC-39 random sampling and the prover verify against it. Additive
   // fields (18/19) — empty / 32 zero bytes + 0 on public-CG traffic.
   .add(new Field('catalogRoot', 18, 'bytes'))
-  .add(new Field('catalogLeafCount', 19, 'uint32'));
+  .add(new Field('catalogLeafCount', 19, 'uint32'))
+  // Folded public+private KAs expose only the per-entity private commitments to
+  // core ACK signers. Cores never see private plaintext, but they can recompute
+  // the exact KC root as hash(public subtree, collapse(private roots)).
+  .add(new Field('privateMerkleRoots', 20, 'bytes', 'repeated'));
 
 type Long = { low: number; high: number; unsigned: boolean };
 
@@ -189,6 +193,13 @@ export interface PublishIntentMsg {
    * modulus). Defaults to `0` on public-CG traffic.
    */
   catalogLeafCount?: number;
+  /**
+   * Per-entity private commitments for folded public+private KAs. These are
+   * 32-byte Merkle roots over private triples, not private plaintext. Public
+   * ACK handlers fold them into the claimed KC root while still verifying only
+   * the public quads they store.
+   */
+  privateMerkleRoots?: Uint8Array[];
 }
 
 /** Sent in `ackProtocolVersion` for LU-11 chunked ACKs. */

--- a/packages/core/src/proto/publish-intent.ts
+++ b/packages/core/src/proto/publish-intent.ts
@@ -90,7 +90,9 @@ export const PublishIntentSchema = new Type('PublishIntent')
   .add(new Field('catalogLeafCount', 19, 'uint32'))
   // Folded public+private KAs expose only the per-entity private commitments to
   // core ACK signers. Cores never see private plaintext, but they can recompute
-  // the exact KC root as hash(public subtree, collapse(private roots)).
+  // the exact KC root as hash(public subtree, collapse(private roots)). Sent
+  // only over `PROTOCOL_STORAGE_ACK_V2` so V1 cores never silently ignore the
+  // commitments during rolling upgrades.
   .add(new Field('privateMerkleRoots', 20, 'bytes', 'repeated'));
 
 type Long = { low: number; high: number; unsigned: boolean };
@@ -197,7 +199,8 @@ export interface PublishIntentMsg {
    * Per-entity private commitments for folded public+private KAs. These are
    * 32-byte Merkle roots over private triples, not private plaintext. Public
    * ACK handlers fold them into the claimed KC root while still verifying only
-   * the public quads they store.
+   * the public quads they store. Must be sent over `PROTOCOL_STORAGE_ACK_V2`;
+   * V1 peers are not compatible because they ignore field 20.
    */
   privateMerkleRoots?: Uint8Array[];
 }

--- a/packages/core/test/v10-constants.test.ts
+++ b/packages/core/test/v10-constants.test.ts
@@ -13,6 +13,7 @@ import {
   PROTOCOL_VERIFY_PROPOSAL,
   PROTOCOL_VERIFY_APPROVAL,
   PROTOCOL_STORAGE_ACK,
+  PROTOCOL_STORAGE_ACK_V2,
   DHT_PROTOCOL,
   contextGraphSharedMemoryTopic,
   contextGraphFinalizationTopic,
@@ -81,6 +82,10 @@ describe('V10 protocol stream IDs', () => {
 
   it('sync uses the /dkg/10.0.2/ prefix (taken back OFF the messenger substrate)', () => {
     expect(PROTOCOL_SYNC).toBe('/dkg/10.0.2/sync');
+  });
+
+  it('storage ACK V2 uses the /dkg/10.0.2/ prefix for field-20 capable ACKs', () => {
+    expect(PROTOCOL_STORAGE_ACK_V2).toBe('/dkg/10.0.2/storage-ack');
   });
 
   it('DHT protocol is unchanged', () => {

--- a/packages/core/test/v10-proto.test.ts
+++ b/packages/core/test/v10-proto.test.ts
@@ -502,6 +502,25 @@ describe('PublishIntent — LU-11 fields (ciphertextChunksRoot, ciphertextChunkC
     expect(decoded.ciphertextChunkCount ?? 0).toBe(0);
   });
 
+  it('folded-private privateMerkleRoots (field 20) round-trip and default empty', () => {
+    const pub = decodePublishIntent(encodePublishIntent(baseIntent()));
+    expect(pub.privateMerkleRoots ?? []).toHaveLength(0);
+
+    const privateMerkleRoots = [
+      new Uint8Array(32).fill(0x61),
+      new Uint8Array(32).fill(0x62),
+    ];
+    const folded: PublishIntentMsg = {
+      ...baseIntent(),
+      isPrivate: true,
+      privateMerkleRoots,
+    };
+    const decoded = decodePublishIntent(encodePublishIntent(folded));
+    expect(decoded.privateMerkleRoots).toHaveLength(2);
+    expect(new Uint8Array(decoded.privateMerkleRoots![0])).toEqual(privateMerkleRoots[0]);
+    expect(new Uint8Array(decoded.privateMerkleRoots![1])).toEqual(privateMerkleRoots[1]);
+  });
+
   it('ackProtocolVersion constants are stable wire values', () => {
     expect(ACK_PROTOCOL_VERSION_V1_LU5).toBe(1);
     expect(ACK_PROTOCOL_VERSION_V2_LU11).toBe(2);

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -237,6 +237,12 @@ export class ACKCollector {
       catalogRoot: Uint8Array;
       catalogLeafCount: number;
     };
+    /**
+     * Folded public+private publish commitments. These are private-data Merkle
+     * roots only; they let cores verify the folded KC root without private
+     * plaintext.
+     */
+    privateMerkleRoots?: readonly Uint8Array[];
   }): Promise<ACKCollectionResult> {
     const {
       merkleRoot, contextGraphId, contextGraphIdStr,
@@ -316,6 +322,14 @@ export class ACKCollector {
         `ACK collection failed: V10 publish requires exactly one Knowledge Asset (kaCount=1); got ${params.kaCount}`,
       );
     }
+    const privateMerkleRoots = params.privateMerkleRoots ?? [];
+    for (const [idx, root] of privateMerkleRoots.entries()) {
+      if (root.length !== 32) {
+        throw new Error(
+          `ACK collection failed: privateMerkleRoots[${idx}] must be 32 bytes, got ${root.length}`,
+        );
+      }
+    }
 
     // P2P intent includes staging quads so core nodes can verify inline.
     // Encrypted inline payloads are gated by this collector's exclusive
@@ -376,6 +390,9 @@ export class ACKCollector {
       isEncryptedPayload: params.isEncryptedPayload === true ? true : undefined,
       catalogRoot: params.catalogCommitment?.catalogRoot,
       catalogLeafCount: params.catalogCommitment?.catalogLeafCount,
+      privateMerkleRoots: privateMerkleRoots.length > 0
+        ? [...privateMerkleRoots]
+        : undefined,
     };
     const intentBytes = encodePublishIntent(p2pMsg);
 

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -20,6 +20,7 @@ import {
 } from '@origintrail-official/dkg-core';
 import { ethers } from 'ethers';
 import { QuorumUnmetError, type PeerOutcome } from './ack-errors.js';
+import type { V10ACKMode } from './publisher.js';
 
 /**
  * Why an ACK signer pre-flight rejected a recovered signer. Mirrors
@@ -87,6 +88,35 @@ export interface ACKCollectionResult {
   acks: CollectedACK[];
   merkleRoot: Uint8Array;
   contextGraphId: bigint;
+}
+
+export interface ACKCollectorParams {
+  merkleRoot: Uint8Array;
+  contextGraphId: bigint;
+  contextGraphIdStr: string;
+  publisherPeerId: string;
+  publicByteSize: bigint;
+  isPrivate: boolean;
+  kaCount: number;
+  rootEntities: string[];
+  /** Numeric EVM chain id (e.g. 31337n for hardhat). Required by the H5 prefix in the V10 ACK digest. */
+  chainId: bigint;
+  /** Deployed address of `KnowledgeAssetsV10`. Required by the H5 prefix in the V10 ACK digest. */
+  kav10Address: string;
+  requiredACKs?: number;
+  stagingQuads?: Uint8Array;
+  epochs?: number;
+  tokenAmount?: bigint;
+  /**
+   * Source SWM graph id. Different from `contextGraphIdStr` only on the
+   * remap flow where data lives under one graph name but is published to a
+   * different on-chain numeric id.
+   */
+  swmGraphId?: string;
+  subGraphName?: string;
+  /** V10 flat-KC Merkle leaf count (sorted + deduped); binds StorageACK to on-chain RandomSampling. */
+  merkleLeafCount: number;
+  ackMode: V10ACKMode;
 }
 
 /**
@@ -159,92 +189,7 @@ export class ACKCollector {
     this.deps = deps;
   }
 
-  async collect(params: {
-    merkleRoot: Uint8Array;
-    contextGraphId: bigint;
-    contextGraphIdStr: string;
-    publisherPeerId: string;
-    publicByteSize: bigint;
-    isPrivate: boolean;
-    kaCount: number;
-    rootEntities: string[];
-    /** Numeric EVM chain id (e.g. 31337n for hardhat). Required by the H5 prefix in the V10 ACK digest. */
-    chainId: bigint;
-    /** Deployed address of `KnowledgeAssetsV10`. Required by the H5 prefix in the V10 ACK digest. */
-    kav10Address: string;
-    requiredACKs?: number;
-    stagingQuads?: Uint8Array;
-    epochs?: number;
-    tokenAmount?: bigint;
-    /**
-     * Source SWM graph id. Different from `contextGraphIdStr` only on the
-     * `publishFromSharedMemory` remap flow where the data lives under one
-     * graph name but is published to a different on-chain numeric id.
-     * Peers use this to locate SWM data; the ACK digest still uses
-     * `contextGraphId`.
-     */
-    swmGraphId?: string;
-    /** Optional sub-graph name suffix appended to the SWM URI. */
-    subGraphName?: string;
-    /** V10 flat-KC Merkle leaf count (sorted + deduped); binds StorageACK to on-chain RandomSampling. */
-    merkleLeafCount: number;
-    /**
-     * OT-RFC-38 / LU-5. When `true`, `stagingQuads` is opaque AEAD ciphertext
-     * (curated-CG payload). Cores skip N-Quad parsing and merkle-root
-     * recompute; verify only that `stagingQuads.length === publicByteSize`.
-     * Defaults to `false` so the existing public-CG inline-quads path is
-     * unchanged.
-     */
-    isEncryptedPayload?: boolean;
-    /**
-     * OT-RFC-38 LU-11 / OT-RFC-39. When set, the publisher has fanned
-     * per-chunk ciphertexts via SWM gossip (one envelope per chunk,
-     * carrying `swmMessageIndex` + the chunked type marker) and the
-     * ACK request goes out on `PROTOCOL_STORAGE_ACK_V2` with empty
-     * `stagingQuads` + populated `ciphertextChunksRoot` /
-     * `ciphertextChunkCount` / `ackProtocolVersion = 2`. Required
-     * when `isEncryptedPayload === true` AND chunked emission was
-     * used; mutually exclusive with non-empty `stagingQuads`.
-     *
-     * **Cluster-wide V2 requirement** (Codex review on PR #715): this
-     * collector unconditionally dispatches chunked ACK requests over
-     * `PROTOCOL_STORAGE_ACK_V2` — there is NO automatic V1 fallback
-     * for cores in the quorum target that don't advertise V2. A core
-     * that only speaks `/dkg/10.0.1/storage-ack` will surface a
-     * libp2p "could not negotiate" send error here, which counts as a
-     * peer-unreachable failure against `requiredACKs`. The
-     * mixed-rc.11-rc.12 cluster case is therefore strictly an
-     * upgrade-window concern (a rc.11 core can't decode LU-11
-     * chunked gossip envelopes either, so it would fail upstream of
-     * this collector even with a V1 fallback). The operational
-     * assumption for rc.12 — and the rc.12 release runbook — is that
-     * every quorum-target core has been upgraded to LU-11 BEFORE the
-     * curator's first chunked publish. The OT-RFC-38 §A.1 host-mode
-     * reconciler converges the cluster within the per-CG window the
-     * curator sets; operators must respect that window before
-     * issuing curated publishes. A per-peer capability probe + V1
-     * downgrade is filed as a follow-up — see TODO(rc.12.1) below.
-     */
-    /**
-     * OT-RFC-49 / WS-D — the curated PUBLIC `_catalog` commitment (REPLACED
-     * the stripped ciphertext-chunks commitment). When present,
-     * `isEncryptedPayload` MUST be `true` and `stagingQuads` carries the
-     * catalog N-quads (plaintext, public). The collector packs
-     * `(catalogRoot, catalogLeafCount)` into the PublishIntent + the ACK
-     * digest; cores rebuild the same root over the inline catalog and DECLINE
-     * `CATALOG_ROOT_MISMATCH` on disagreement.
-     */
-    catalogCommitment?: {
-      catalogRoot: Uint8Array;
-      catalogLeafCount: number;
-    };
-    /**
-     * Folded public+private publish commitments. These are private-data Merkle
-     * roots only; they let cores verify the folded KC root without private
-     * plaintext.
-     */
-    privateMerkleRoots?: readonly Uint8Array[];
-  }): Promise<ACKCollectionResult> {
+  async collect(params: ACKCollectorParams): Promise<ACKCollectionResult> {
     const {
       merkleRoot, contextGraphId, contextGraphIdStr,
       publisherPeerId, publicByteSize, isPrivate,
@@ -303,7 +248,7 @@ export class ACKCollector {
     chainId: bigint;
     kav10Address: string;
     REQUIRED_ACKS: number;
-    params: Parameters<ACKCollector['collect']>[0];
+    params: ACKCollectorParams;
   }): Promise<ACKCollectionResult> {
     const {
       merkleRoot, contextGraphId, contextGraphIdStr,
@@ -323,25 +268,29 @@ export class ACKCollector {
         `ACK collection failed: V10 publish requires exactly one Knowledge Asset (kaCount=1); got ${params.kaCount}`,
       );
     }
-    const privateMerkleRoots = params.privateMerkleRoots ?? [];
+    const privateMerkleRoots = params.ackMode.kind === 'folded-private'
+      ? params.ackMode.privateMerkleRoots
+      : [];
+    const catalogCommitment = params.ackMode.kind === 'curated-catalog'
+      ? params.ackMode.catalogCommitment
+      : undefined;
+    if (
+      params.ackMode.kind === 'curated-catalog' &&
+      (params.ackMode as { privateMerkleRoots?: unknown }).privateMerkleRoots !== undefined
+    ) {
+      throw new Error(
+        'ACKCollector: privateMerkleRoots cannot be combined with curated-catalog ACK mode',
+      );
+    }
+    if (params.ackMode.kind === 'folded-private' && privateMerkleRoots.length === 0) {
+      throw new Error('ACK collection failed: folded-private ACK mode requires at least one privateMerkleRoot');
+    }
     for (const [idx, root] of privateMerkleRoots.entries()) {
       if (root.length !== 32) {
         throw new Error(
           `ACK collection failed: privateMerkleRoots[${idx}] must be 32 bytes, got ${root.length}`,
         );
       }
-    }
-    if (privateMerkleRoots.length > 0 && params.isEncryptedPayload === true) {
-      throw new Error(
-        'ACKCollector: privateMerkleRoots are only valid for folded-private public-CG ACKs; ' +
-        'curated/encrypted ACKs must use catalogCommitment without folded private roots',
-      );
-    }
-    if (privateMerkleRoots.length > 0 && params.catalogCommitment) {
-      throw new Error(
-        'ACKCollector: privateMerkleRoots cannot be combined with catalogCommitment; ' +
-        'choose folded-private or curated-catalog ACK mode',
-      );
     }
 
     // P2P intent includes staging quads so core nodes can verify inline.
@@ -358,12 +307,7 @@ export class ACKCollector {
     // commitment AND the inline catalog N-quads (plaintext, public) so the
     // core can rebuild + verify the catalog root self-contained. Surface a
     // mis-wired branch loudly rather than ship a half-formed intent.
-    if (params.catalogCommitment) {
-      if (!params.isEncryptedPayload) {
-        throw new Error(
-          'ACKCollector: catalogCommitment requires isEncryptedPayload=true (curated-CG-only path)',
-        );
-      }
+    if (catalogCommitment) {
       if (!params.stagingQuads || params.stagingQuads.length === 0) {
         throw new Error(
           'ACKCollector: catalogCommitment requires non-empty stagingQuads — ' +
@@ -371,14 +315,14 @@ export class ACKCollector {
           'rebuild and verify the catalog root',
         );
       }
-      if (params.catalogCommitment.catalogLeafCount <= 0) {
+      if (catalogCommitment.catalogLeafCount <= 0) {
         throw new Error(
-          `ACKCollector: catalogCommitment.catalogLeafCount must be positive; got ${params.catalogCommitment.catalogLeafCount}`,
+          `ACKCollector: catalogCommitment.catalogLeafCount must be positive; got ${catalogCommitment.catalogLeafCount}`,
         );
       }
-      if (params.catalogCommitment.catalogRoot.length !== 32) {
+      if (catalogCommitment.catalogRoot.length !== 32) {
         throw new Error(
-          `ACKCollector: catalogCommitment.catalogRoot must be 32 bytes; got ${params.catalogCommitment.catalogRoot.length}`,
+          `ACKCollector: catalogCommitment.catalogRoot must be 32 bytes; got ${catalogCommitment.catalogRoot.length}`,
         );
       }
     }
@@ -405,9 +349,9 @@ export class ACKCollector {
         : undefined,
       subGraphName: params.subGraphName,
       merkleLeafCount: params.merkleLeafCount,
-      isEncryptedPayload: params.isEncryptedPayload === true ? true : undefined,
-      catalogRoot: params.catalogCommitment?.catalogRoot,
-      catalogLeafCount: params.catalogCommitment?.catalogLeafCount,
+      isEncryptedPayload: params.ackMode.kind === 'curated-catalog' ? true : undefined,
+      catalogRoot: catalogCommitment?.catalogRoot,
+      catalogLeafCount: catalogCommitment?.catalogLeafCount,
       privateMerkleRoots: privateMerkleRoots.length > 0
         ? [...privateMerkleRoots]
         : undefined,
@@ -444,9 +388,9 @@ export class ACKCollector {
     }
     log(`[ACKCollector] Requesting ACKs from ${corePeers.length} core peers (need ${REQUIRED_ACKS})`);
 
-    const catalogRoot = params.catalogCommitment?.catalogRoot
+    const catalogRoot = catalogCommitment?.catalogRoot
       ?? new Uint8Array(32);
-    const catalogLeafCount = BigInt(params.catalogCommitment?.catalogLeafCount ?? 0);
+    const catalogLeafCount = BigInt(catalogCommitment?.catalogLeafCount ?? 0);
     const ackDigest = computePublishACKDigest(
       chainId,
       kav10Address,

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -1,5 +1,6 @@
 import {
   PROTOCOL_STORAGE_ACK,
+  PROTOCOL_STORAGE_ACK_V2,
   PROTOCOL_STORAGE_UPDATE_ACK,
   encodePublishIntent,
   encodeUpdateIntent,
@@ -37,7 +38,7 @@ export interface ACKVerifyResult {
 export interface ACKCollectorDeps {
   gossipPublish: (topic: string, data: Uint8Array) => Promise<void>;
   sendP2P: (peerId: string, protocol: string, data: Uint8Array) => Promise<Uint8Array>;
-  getConnectedCorePeers: () => string[];
+  getConnectedCorePeers: (protocol?: string) => string[];
   /**
    * Boolean ACK signer pre-flight. Backward-compatible legacy entry
    * point — when only this is provided the rejection log surfaces a
@@ -330,12 +331,25 @@ export class ACKCollector {
         );
       }
     }
+    if (privateMerkleRoots.length > 0 && params.isEncryptedPayload === true) {
+      throw new Error(
+        'ACKCollector: privateMerkleRoots are only valid for folded-private public-CG ACKs; ' +
+        'curated/encrypted ACKs must use catalogCommitment without folded private roots',
+      );
+    }
+    if (privateMerkleRoots.length > 0 && params.catalogCommitment) {
+      throw new Error(
+        'ACKCollector: privateMerkleRoots cannot be combined with catalogCommitment; ' +
+        'choose folded-private or curated-catalog ACK mode',
+      );
+    }
 
     // P2P intent includes staging quads so core nodes can verify inline.
-    // Encrypted inline payloads are gated by this collector's exclusive
-    // use of PROTOCOL_STORAGE_ACK (`/dkg/10.0.1/storage-ack`): pre-LU-5
-    // cores that only speak `/dkg/10.0.0/storage-ack` never receive field
-    // 14 ciphertext and therefore cannot misparse it as plaintext.
+    // Plain public and curated/catalog ACKs stay on PROTOCOL_STORAGE_ACK
+    // (`/dkg/10.0.1/storage-ack`): pre-LU-5 cores that only speak
+    // `/dkg/10.0.0/storage-ack` never receive field 14 ciphertext and
+    // therefore cannot misparse it as plaintext. Folded-private ACKs switch to
+    // V2 below because field 20 must be understood by every quorum peer.
     // `contextGraphId` on the wire is the TARGET numeric id peers will sign
     // the ACK against. `swmGraphId` (optional) is the SOURCE graph where
     // data lives in SWM — only set when the publisher is remapping a named
@@ -368,9 +382,13 @@ export class ACKCollector {
         );
       }
     }
-    // OT-RFC-49 collapsed the V2 chunked-ciphertext ACK path; the curated
-    // catalog ACK rides the V1 protocol with inline catalog stagingQuads.
-    const ackProtocolId = PROTOCOL_STORAGE_ACK;
+    // Folded-private ACKs require field 20 (`privateMerkleRoots`), so they ride
+    // the V2 storage-ack protocol. This makes mixed-version clusters fail at
+    // protocol/capability selection instead of dialing V1-only cores that would
+    // ignore field 20 and sign/decline against a public-only root.
+    const ackProtocolId = privateMerkleRoots.length > 0
+      ? PROTOCOL_STORAGE_ACK_V2
+      : PROTOCOL_STORAGE_ACK;
     const p2pMsg: PublishIntentMsg = {
       merkleRoot,
       contextGraphId: contextGraphIdStr,
@@ -401,7 +419,7 @@ export class ACKCollector {
     // that decode payloads as FinalizationMessages, causing decode errors.
     log(`[ACKCollector] Collecting ACKs via direct P2P (merkleRoot=${ethers.hexlify(merkleRoot).slice(0, 18)}...)`);
 
-    const corePeers = this.deps.getConnectedCorePeers();
+    const corePeers = this.deps.getConnectedCorePeers(ackProtocolId);
     if (corePeers.length === 0) {
       // Pre-dial impossibility — wrap in the typed surface but preserve
       // the legacy `ACK collection failed: no connected core peers` text
@@ -550,7 +568,7 @@ export class ACKCollector {
 
     log(`[ACKCollector] Collecting UPDATE ACKs via direct P2P (kaId=${kaId}, newMerkleRoot=${ethers.hexlify(newMerkleRoot).slice(0, 18)}...)`);
 
-    const corePeers = this.deps.getConnectedCorePeers();
+    const corePeers = this.deps.getConnectedCorePeers(PROTOCOL_STORAGE_UPDATE_ACK);
     if (corePeers.length === 0) {
       throw new QuorumUnmetError({
         collected: 0,

--- a/packages/publisher/src/ack-collector.ts
+++ b/packages/publisher/src/ack-collector.ts
@@ -116,7 +116,7 @@ export interface ACKCollectorParams {
   subGraphName?: string;
   /** V10 flat-KC Merkle leaf count (sorted + deduped); binds StorageACK to on-chain RandomSampling. */
   merkleLeafCount: number;
-  ackMode: V10ACKMode;
+  ackMode?: V10ACKMode;
 }
 
 /**
@@ -268,21 +268,22 @@ export class ACKCollector {
         `ACK collection failed: V10 publish requires exactly one Knowledge Asset (kaCount=1); got ${params.kaCount}`,
       );
     }
-    const privateMerkleRoots = params.ackMode.kind === 'folded-private'
-      ? params.ackMode.privateMerkleRoots
+    const ackMode = params.ackMode ?? { kind: 'public' as const };
+    const privateMerkleRoots = ackMode.kind === 'folded-private'
+      ? ackMode.privateMerkleRoots
       : [];
-    const catalogCommitment = params.ackMode.kind === 'curated-catalog'
-      ? params.ackMode.catalogCommitment
+    const catalogCommitment = ackMode.kind === 'curated-catalog'
+      ? ackMode.catalogCommitment
       : undefined;
     if (
-      params.ackMode.kind === 'curated-catalog' &&
-      (params.ackMode as { privateMerkleRoots?: unknown }).privateMerkleRoots !== undefined
+      ackMode.kind === 'curated-catalog' &&
+      (ackMode as { privateMerkleRoots?: unknown }).privateMerkleRoots !== undefined
     ) {
       throw new Error(
         'ACKCollector: privateMerkleRoots cannot be combined with curated-catalog ACK mode',
       );
     }
-    if (params.ackMode.kind === 'folded-private' && privateMerkleRoots.length === 0) {
+    if (ackMode.kind === 'folded-private' && privateMerkleRoots.length === 0) {
       throw new Error('ACK collection failed: folded-private ACK mode requires at least one privateMerkleRoot');
     }
     for (const [idx, root] of privateMerkleRoots.entries()) {
@@ -349,7 +350,7 @@ export class ACKCollector {
         : undefined,
       subGraphName: params.subGraphName,
       merkleLeafCount: params.merkleLeafCount,
-      isEncryptedPayload: params.ackMode.kind === 'curated-catalog' ? true : undefined,
+      isEncryptedPayload: ackMode.kind === 'curated-catalog' ? true : undefined,
       catalogRoot: catalogCommitment?.catalogRoot,
       catalogLeafCount: catalogCommitment?.catalogLeafCount,
       privateMerkleRoots: privateMerkleRoots.length > 0

--- a/packages/publisher/src/ack-peer-selection.ts
+++ b/packages/publisher/src/ack-peer-selection.ts
@@ -1,0 +1,33 @@
+import { PROTOCOL_STORAGE_ACK_V2 } from '@origintrail-official/dkg-core';
+
+export interface ACKCandidatePeerSelectionInput {
+  connectedPeers: readonly string[];
+  knownCorePeerIds?: ReadonlySet<string>;
+  knownCorePeerIdsV2?: ReadonlySet<string>;
+  requiredACKs: number;
+  protocol?: string;
+  selfPeerId?: string;
+}
+
+export function selectACKCandidatePeers(input: ACKCandidatePeerSelectionInput): string[] {
+  const connected = input.connectedPeers.filter((id) => id !== input.selfPeerId);
+  const confirmedCore = input.knownCorePeerIds
+    ? connected.filter((id) => input.knownCorePeerIds!.has(id))
+    : [];
+
+  if (input.protocol === PROTOCOL_STORAGE_ACK_V2) {
+    const v2Advertised = input.knownCorePeerIdsV2
+      ? connected.filter((id) => input.knownCorePeerIdsV2!.has(id))
+      : [];
+    if (v2Advertised.length >= input.requiredACKs) return v2Advertised;
+    const v2Set = new Set(v2Advertised);
+    const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
+    const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
+    const rest = connected.filter((id) => !seen.has(id));
+    return [...v2Advertised, ...remainingConfirmedCore, ...rest];
+  }
+
+  if (confirmedCore.length >= input.requiredACKs) return confirmedCore;
+  const rest = connected.filter((id) => !input.knownCorePeerIds?.has(id));
+  return [...confirmedCore, ...rest];
+}

--- a/packages/publisher/src/ack-peer-selection.ts
+++ b/packages/publisher/src/ack-peer-selection.ts
@@ -19,11 +19,12 @@ export function selectACKCandidatePeers(input: ACKCandidatePeerSelectionInput): 
     const v2Advertised = input.knownCorePeerIdsV2
       ? connected.filter((id) => input.knownCorePeerIdsV2!.has(id))
       : [];
-    if (v2Advertised.length >= input.requiredACKs) return v2Advertised;
     const v2Set = new Set(v2Advertised);
     const remainingConfirmedCore = confirmedCore.filter((id) => !v2Set.has(id));
     const seen = new Set([...v2Advertised, ...remainingConfirmedCore]);
     const rest = connected.filter((id) => !seen.has(id));
+    // Identify metadata can be stale. Prefer advertised V2 peers, but keep
+    // fallback candidates so wire negotiation, not cached metadata, is the gate.
     return [...v2Advertised, ...remainingConfirmedCore, ...rest];
   }
 

--- a/packages/publisher/src/async-lift-publish-result.ts
+++ b/packages/publisher/src/async-lift-publish-result.ts
@@ -54,6 +54,12 @@ export function mapPublishResultToLiftJobSuccess(params: {
   }
 
   if (!onChain) {
+    if ((publishResult as { localChainSkipReason?: unknown }).localChainSkipReason === 'private-no-acks') {
+      throw new Error(
+        'Async lift publish result cannot finalize legacy private-no-acks result as local success. ' +
+        'The publish targeted chain finalization but did not collect ACKs; keep the job terminal-failed or rerun publish.',
+      );
+    }
     if (publishResult.status === 'tentative') {
       // Honest local finalization: there is genuinely no chain to reach
       // (`no-chain` skip reason, or a legacy/no-chain-adapter node).

--- a/packages/publisher/src/async-lift-publish-result.ts
+++ b/packages/publisher/src/async-lift-publish-result.ts
@@ -54,20 +54,6 @@ export function mapPublishResultToLiftJobSuccess(params: {
   }
 
   if (!onChain) {
-    // GH #1013 — a private publish that failed to reach its chain-registered CG
-    // (no collectable ACKs) must NOT be reported as `finalized` with a
-    // provisional UAL. Fail honestly so callers can tell "stored locally, not on
-    // chain" from a real on-chain finalization. (Reaching chain for private CGs
-    // is the #1121 encryption work.) The data is still staged locally under the
-    // provisional UAL, surfaced in the error for debugging/recovery.
-    if (publishResult.status === 'tentative' && publishResult.localChainSkipReason === 'private-no-acks') {
-      throw new Error(
-        `Async publish to a chain-registered context graph could not reach Verifiable Memory: ` +
-        `private payload had no collectable storage ACKs (peers cannot see private data). ` +
-        `Data is staged locally under provisional UAL ${publishResult.ual} but is NOT on chain. ` +
-        `See GH #1013 (honesty) and GH #1121 (encrypted private async publish).`,
-      );
-    }
     if (publishResult.status === 'tentative') {
       // Honest local finalization: there is genuinely no chain to reach
       // (`no-chain` skip reason, or a legacy/no-chain-adapter node).
@@ -166,15 +152,6 @@ function classifyPublishFailureCode(
   lowerMessage: string,
   failedFromState: AsyncLiftPublishFailureInput['failedFromState'],
 ): LiftJobFailureMetadata['code'] {
-  // GH #1013/#1121 (Codex #1132 review): a private payload that could not reach
-  // Verifiable Memory (no collectable storage ACKs) is a DETERMINISTIC terminal
-  // failure — classifying it as the default retryable `rpc_unavailable` made the
-  // queue reset/retry forever a job that can never finalize until encrypted
-  // private async publish (#1121) lands. The message is emitted verbatim by
-  // mapPublishResultToLiftJobSuccess for this exact condition.
-  if (lowerMessage.includes('no collectable storage acks')) {
-    return 'private_unanchorable';
-  }
   if (lowerMessage.includes('timeout') || lowerMessage.includes('timed out')) {
     return failedFromState === 'included' ? 'finality_timeout' : 'tx_submit_timeout';
   }

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -4,7 +4,7 @@ import { enrichEvmError } from '@origintrail-official/dkg-chain';
 import type { EventBus, OperationContext } from '@origintrail-official/dkg-core';
 import { DKGEvent, Logger, createOperationContext, sha256, encodeWorkspacePublishRequest, encodeEncryptedWorkspacePayload, encryptWorkspacePayload, contextGraphDataUri, contextGraphDataGraphUri, contextGraphMetaUri, contextGraphAssertionUri, contextGraphLayerUri, MemoryLayer, assertionLifecycleUri, contextGraphSubGraphUri, contextGraphSubGraphMetaUri, SYSTEM_CONTEXT_GRAPHS, validateSubGraphName, isSafeIri, assertSafeIri, assertSafeRdfTerm, assertQuadLiteralsMutf8Safe, DKG_GOSSIP_MAX_MESSAGE_BYTES, SwmGossipPayloadTooLargeError, type Ed25519Keypair, buildAuthorAttestationTypedData, buildUpdateAuthorAttestationTypedData, AUTHOR_SCHEME_VERSION_V1, TrustLevel, TRUST_LEVEL_PREDICATE, assertNoUserAuthoredTrustLevelQuads, buildTrustLevelQuads, isTrustLevelQuad, DKG_ENTITY, DKG_ROOT_ENTITY_LEGACY, ENTITY_PRED_ALT, parseAssertionSealQuads, ASSERTION_SEAL_PREDICATES, sharedMemoryReadBothFilter, DKG_ONTOLOGY } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore } from '@origintrail-official/dkg-storage';
-import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK } from './publisher.js';
+import { DEFAULT_PUBLISH_EPOCHS, MAX_PUBLISH_EPOCHS, type Publisher, type PublishOptions, type PublishResult, type KAManifestEntry, type PhaseCallback, type V10CoreNodeACK, type V10ACKProviderParams, type V10ACKProviderObject, type LegacyV10ACKProvider } from './publisher.js';
 import { skolemizeByEntity } from './auto-partition.js';
 import { canonicalPublishPayload } from './canonical-publish-payload.js';
 import {
@@ -203,6 +203,47 @@ function resolvePublishEpochsOverride(value: number | undefined): number | undef
     throw new Error(`publishEpochs must be a positive uint32 integer, got ${String(value)}`);
   }
   return value;
+}
+
+function isLegacyV10ACKProvider(
+  provider: NonNullable<PublishOptions['v10ACKProvider']>,
+): provider is LegacyV10ACKProvider {
+  return provider.length > 1;
+}
+
+async function invokeV10ACKProvider(
+  provider: NonNullable<PublishOptions['v10ACKProvider']>,
+  params: V10ACKProviderParams,
+): Promise<V10CoreNodeACK[]> {
+  if (!isLegacyV10ACKProvider(provider)) {
+    return (provider as V10ACKProviderObject)(params);
+  }
+
+  if (params.ackMode.kind === 'folded-private') {
+    throw new Error(
+      'Folded-private V10 ACK collection requires object-form v10ACKProvider ' +
+      'so privateMerkleRoots reach the ACK collector.',
+    );
+  }
+
+  const catalogCommitment = params.ackMode.kind === 'curated-catalog'
+    ? params.ackMode.catalogCommitment
+    : undefined;
+  return provider(
+    params.merkleRoot,
+    params.contextGraphId,
+    params.kaCount,
+    params.rootEntities,
+    params.publicByteSize,
+    params.stagingQuads,
+    params.epochs,
+    params.tokenAmount,
+    params.swmGraphId,
+    params.subGraphName,
+    params.merkleLeafCount,
+    params.ackMode.kind === 'curated-catalog' ? true : undefined,
+    catalogCommitment,
+  );
 }
 
 function coercePublisherAddress(value: unknown): string | undefined {
@@ -2630,7 +2671,7 @@ export class DKGPublisher implements Publisher {
           if (!catalogCommitment || !stagingQuads || stagingQuads.length === 0) {
             throw new Error('Curated catalog ACK mode requires a non-empty catalog commitment and stagingQuads');
           }
-          v10ACKs = await v10ACKProvider({
+          v10ACKs = await invokeV10ACKProvider(v10ACKProvider, {
             ...commonACKParams,
             stagingQuads,
             ackMode: {
@@ -2642,7 +2683,7 @@ export class DKGPublisher implements Publisher {
             },
           });
         } else if (privateRoots.length > 0) {
-          v10ACKs = await v10ACKProvider({
+          v10ACKs = await invokeV10ACKProvider(v10ACKProvider, {
             ...commonACKParams,
             stagingQuads,
             ackMode: {
@@ -2651,7 +2692,7 @@ export class DKGPublisher implements Publisher {
             },
           });
         } else {
-          v10ACKs = await v10ACKProvider({
+          v10ACKs = await invokeV10ACKProvider(v10ACKProvider, {
             ...commonACKParams,
             stagingQuads,
             ackMode: { kind: 'public' },

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2341,9 +2341,10 @@ export class DKGPublisher implements Publisher {
     // For publishFromSharedMemory (publishContextGraphId set): data is already in
     // peers' SWM via shared memory gossip — do NOT send inline quads; core nodes
     // verify against their local SWM copy (preserving storage-attestation).
-    // Skipped for private publishes because StorageACKHandler cannot
-    // recompute private merkle roots from SWM data alone.
-    const hasPrivateData = privateRoots.length > 0;
+    // Folded public+private publishes send only the private Merkle roots on
+    // the ACK wire. Core nodes verify the public quads they store and fold
+    // those commitments into the claimed KC root without seeing private
+    // plaintext.
     const isPublishFromSharedMemory = !!options.fromSharedMemory;
     // OT-RFC-38 / LU-5: when an encryptInlinePayload hook is wired (curated
     // CGs only — DKGAgent resolves this from accessPolicy), ALWAYS send the
@@ -2596,7 +2597,6 @@ export class DKGPublisher implements Publisher {
     const v10ACKProvider = options.v10ACKProvider;
     const shouldCollectV10ACKs =
       v10ACKProvider !== undefined &&
-      !hasPrivateData &&
       canAttemptOnChainPublish;
     let v10ACKs: V10CoreNodeACK[] | undefined;
     if (shouldCollectV10ACKs) {
@@ -2617,6 +2617,7 @@ export class DKGPublisher implements Publisher {
           catalogCommitment
             ? { catalogRoot: catalogCommitment.root, catalogLeafCount: catalogCommitment.leafCount }
             : undefined,
+          privateRoots,
         );
         // PR5 ACK-provenance summary — one line per publish that names
         // every ACKing core and the LU-6 Phase B discovery path that
@@ -2658,8 +2659,6 @@ export class DKGPublisher implements Publisher {
       } finally {
         onPhase?.('collect_v10_acks', 'end');
       }
-    } else if (v10ACKProvider && hasPrivateData && canAttemptOnChainPublish) {
-      this.log.info(ctx, `V10 ACK collection skipped: publish contains private quads (${privateRoots.length} private roots)`);
     }
 
     // Resolve the target CG id bigint once for the whole V10 block so the
@@ -2747,9 +2746,8 @@ export class DKGPublisher implements Publisher {
       // Pre-PR2 this was the responsibility of the chain-failure
       // catch block via `generateTentativeMetadata`. PR2 deleted that
       // unconditional catch (failed *chain* publishes now write
-      // nothing locally), but the three intentional-local branches
-      // (`no on-chain CG id`, `chain not V10-ready`,
-      // `private data — no ACKs collectable`) all need the metadata
+      // nothing locally), but the two intentional-local branches
+      // (`no on-chain CG id`, `chain not V10-ready`) both need the metadata
       // to keep the local data-graph queryable. Replicating the
       // tentative-metadata generation here scopes the metadata write
       // exclusively to those intentional-skip branches and keeps the
@@ -2820,33 +2818,10 @@ export class DKGPublisher implements Publisher {
       await persistCatalogEntry();
     };
 
-    // RC11 / PR3: extra intentional-local-only branch for publishes
-    // with `hasPrivateData === true`. Peer ACK collection is
-    // *structurally* skipped at line 1954 above (`!hasPrivateData`
-    // gate) because peers can't see private payloads and therefore
-    // can't sign anything meaningful — there is no transport that
-    // could ever produce a valid V10 ACK quorum for these. They are
-    // NOT a real on-chain publish failure; they are a configuration
-    // where on-chain submission was never feasible in the first
-    // place. Routing them through `finalizeIntentionalLocalPublish`
-    // gives them the same intentional local-only behaviour the
-    // "no CG id" / "chain not V10-ready" branches above already
-    // guarantee.
-    //
-    // The structurally-similar "no v10ACKProvider wired" case is
-    // INTENTIONALLY NOT caught here. Per the plan that case is a
-    // configuration error in a publishing node (the daemon should
-    // wire one); it must surface as the loud
-    // "V10 ACKs required for on-chain publish" throw from the
-    // submit-branch guard so the operator notices instead of
-    // silently downgrading to tentative.
-    const noPathToOnChainACKs =
-      hasPrivateData && (!v10ACKs || v10ACKs.length === 0);
-
     // GH #1013 — record WHY a local-only publish skipped chain so the async
-    // lift can tell an honest local finalization (no chain) from a private
-    // publish that failed to reach the chain it should have.
-    let localChainSkipReason: 'no-chain' | 'private-no-acks' | undefined;
+    // lift can tell an honest local finalization (no chain) from a publish
+    // that failed to reach the chain it should have.
+    let localChainSkipReason: 'no-chain' | undefined;
     if (publisherContextGraphId === undefined) {
       this.log.warn(ctx, `No positive on-chain context graph id resolved from "${v10CgDomain}" — skipping on-chain publish`);
       localChainSkipReason = 'no-chain';
@@ -2855,14 +2830,6 @@ export class DKGPublisher implements Publisher {
       this.log.warn(ctx, 'Chain adapter is not V10-ready — skipping on-chain publish');
       localChainSkipReason = 'no-chain';
       await finalizeIntentionalLocalPublish('chain not V10-ready');
-    } else if (noPathToOnChainACKs) {
-      const reason = 'private data — no ACKs collectable (peers cannot see private payloads)';
-      this.log.warn(
-        ctx,
-        `Skipping on-chain submission: ${reason}. Storing locally as tentative.`,
-      );
-      localChainSkipReason = 'private-no-acks';
-      await finalizeIntentionalLocalPublish(reason);
     } else {
       const tokenAmount = precomputedTokenAmount;
       usedV10Path = true;
@@ -2886,8 +2853,8 @@ export class DKGPublisher implements Publisher {
       // / PR-A deliberately rethrows that failure instead of
       // downgrading to local tentative VM, so ACK-ready no-seal callers
       // get a clear contract error and no root data-graph write.
-      // Intentional local publishes (no on-chain CG id / non-V10 /
-      // private data) still bypass this branch and can remain tentative.
+      // Intentional local publishes (no on-chain CG id / non-V10)
+      // still bypass this branch and can remain tentative.
       // ─────────────────────────────────────────────────────────────
       if (
         options.precomputedAttestation &&

--- a/packages/publisher/src/dkg-publisher.ts
+++ b/packages/publisher/src/dkg-publisher.ts
@@ -2373,6 +2373,13 @@ export class DKGPublisher implements Publisher {
     // `useCuratedCatalog` gates the inline-catalog ACK path (cores rebuild the
     // catalog root from the inline plaintext and DECLINE on mismatch).
     const useCuratedCatalog = useEncryptedInline && catalogCommitment !== undefined;
+    if (useEncryptedInline && privateRoots.length > 0) {
+      throw new Error(
+        'Encrypted inline publishes with privateQuads are not supported by the current V10 ACK model. ' +
+        'The publisher can collect either curated-catalog ACKs or folded-private public-CG ACKs, ' +
+        'but not both in one publish without a mixed ACK mode that preserves curated confidentiality.',
+      );
+    }
     let stagingQuads: Uint8Array | undefined;
     let stagingByteSize = publicByteSize;
     if (useEncryptedInline) {
@@ -2607,18 +2614,49 @@ export class DKGPublisher implements Publisher {
         // the catalog footprint (`effectiveByteSize` == `catalogByteSize`) and
         // the curated commitment is `catalogCommitment`. For public CGs nothing
         // changed — `effectiveByteSize === publicByteSize` and no catalog.
-        v10ACKs = await v10ACKProvider(
-          kcMerkleRoot, v10CgDomain, kaCount, rootEntities,
-          effectiveByteSize, stagingQuads,
-          publishEpochs, precomputedTokenAmount,
-          swmGraphId, options.subGraphName,
-          kcMerkleLeafCount,
-          useCuratedCatalog,
-          catalogCommitment
-            ? { catalogRoot: catalogCommitment.root, catalogLeafCount: catalogCommitment.leafCount }
-            : undefined,
-          privateRoots,
-        );
+        const commonACKParams = {
+          merkleRoot: kcMerkleRoot,
+          contextGraphId: v10CgDomain,
+          kaCount,
+          rootEntities,
+          publicByteSize: effectiveByteSize,
+          epochs: publishEpochs,
+          tokenAmount: precomputedTokenAmount,
+          swmGraphId,
+          subGraphName: options.subGraphName,
+          merkleLeafCount: kcMerkleLeafCount,
+        };
+        if (useCuratedCatalog) {
+          if (!catalogCommitment || !stagingQuads || stagingQuads.length === 0) {
+            throw new Error('Curated catalog ACK mode requires a non-empty catalog commitment and stagingQuads');
+          }
+          v10ACKs = await v10ACKProvider({
+            ...commonACKParams,
+            stagingQuads,
+            ackMode: {
+              kind: 'curated-catalog',
+              catalogCommitment: {
+                catalogRoot: catalogCommitment.root,
+                catalogLeafCount: catalogCommitment.leafCount,
+              },
+            },
+          });
+        } else if (privateRoots.length > 0) {
+          v10ACKs = await v10ACKProvider({
+            ...commonACKParams,
+            stagingQuads,
+            ackMode: {
+              kind: 'folded-private',
+              privateMerkleRoots: privateRoots,
+            },
+          });
+        } else {
+          v10ACKs = await v10ACKProvider({
+            ...commonACKParams,
+            stagingQuads,
+            ackMode: { kind: 'public' },
+          });
+        }
         // PR5 ACK-provenance summary — one line per publish that names
         // every ACKing core and the LU-6 Phase B discovery path that
         // brought it to the curated CG. Lets an operator answer
@@ -3095,8 +3133,8 @@ export class DKGPublisher implements Publisher {
             merkleRoot: kcMerkleRoot,
             knowledgeAssetsAmount: kaCount,
             byteSize: effectiveByteSize,
-            catalogRoot: catalogCommitment?.root,
-            catalogLeafCount: catalogCommitment?.leafCount,
+            catalogRoot: useCuratedCatalog ? catalogCommitment?.root : undefined,
+            catalogLeafCount: useCuratedCatalog ? catalogCommitment?.leafCount : undefined,
             // PCA strict-equality: must match the value committed to the
             // ACK digest produced by the ACK collector
             // (`packages/publisher/src/ack-collector.ts:159` invokes

--- a/packages/publisher/src/index.ts
+++ b/packages/publisher/src/index.ts
@@ -71,9 +71,14 @@ export {
   ACKCollector,
   DEFAULT_REQUIRED_ACKS,
   type ACKCollectorDeps,
+  type ACKCollectorParams,
   type CollectedACK,
   type ACKCollectionResult,
 } from './ack-collector.js';
+export {
+  selectACKCandidatePeers,
+  type ACKCandidatePeerSelectionInput,
+} from './ack-peer-selection.js';
 export {
   ACKProviderError,
   RpcPreconditionError,

--- a/packages/publisher/src/lift-job-failures.ts
+++ b/packages/publisher/src/lift-job-failures.ts
@@ -45,7 +45,6 @@ export const LIFT_JOB_FAILURE_CODES = [
   'tx_submit_timeout',
   'tx_reverted',
   'insufficient_funds',
-  'private_unanchorable',
   'nonce_conflict',
   'inclusion_timeout',
   'finality_timeout',
@@ -102,11 +101,6 @@ export const LIFT_JOB_FAILURE_POLICIES: Record<LiftJobFailureCode, LiftJobFailur
   tx_submit_timeout: { code: 'tx_submit_timeout', phase: 'broadcast', mode: 'timeout', retryable: true, resolution: 'check_chain_then_finalize_or_reset', timeoutHandling: 'check_chain_then_finalize_or_reset' },
   tx_reverted: { code: 'tx_reverted', phase: 'broadcast', mode: 'terminal', retryable: false, resolution: 'fail_job' },
   insufficient_funds: { code: 'insufficient_funds', phase: 'broadcast', mode: 'terminal', retryable: false, resolution: 'fail_job' },
-  // GH #1013/#1121: a private payload that cannot reach Verifiable Memory (no
-  // collectable storage ACKs — peers can't see private data) is DETERMINISTIC,
-  // not a transient RPC blip. Terminal/fail_job so the queue stops retrying a
-  // job that can never finalize until encrypted private async publish (#1121).
-  private_unanchorable: { code: 'private_unanchorable', phase: 'broadcast', mode: 'terminal', retryable: false, resolution: 'fail_job' },
   nonce_conflict: { code: 'nonce_conflict', phase: 'broadcast', mode: 'retryable', retryable: true, resolution: 'reset_to_accepted' },
   inclusion_timeout: { code: 'inclusion_timeout', phase: 'confirmation', mode: 'timeout', retryable: true, resolution: 'check_chain_then_finalize_or_reset', timeoutHandling: 'check_chain_then_finalize_or_reset' },
   finality_timeout: { code: 'finality_timeout', phase: 'confirmation', mode: 'timeout', retryable: true, resolution: 'check_chain_then_finalize_or_reset', timeoutHandling: 'check_chain_then_finalize_or_reset' },
@@ -131,7 +125,6 @@ const LIFT_JOB_FAILURE_ALLOWED_STATES: Record<LiftJobFailureCode, readonly LiftJ
   tx_submit_timeout: ['broadcast'],
   tx_reverted: ['broadcast'],
   insufficient_funds: ['broadcast'],
-  private_unanchorable: ['broadcast'],
   nonce_conflict: ['broadcast'],
   inclusion_timeout: ['broadcast', 'included'],
   finality_timeout: ['included'],

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -50,70 +50,66 @@ export interface V10CoreNodeACK {
   subscriptionSource?: import('@origintrail-official/dkg-core').SubscriptionSource;
 }
 
+export interface V10CatalogACKCommitment {
+  catalogRoot: Uint8Array;
+  catalogLeafCount: number;
+}
+
 /**
- * Callback that collects V10 StorageACKs from 3 core nodes.
- * Called AFTER merkle root computation, BEFORE on-chain tx.
- *
- * Identifier split (remap support): `contextGraphId` is the TARGET on-chain
- * numeric CG id that the ACK digest and the on-chain tx use. `swmGraphId`
- * (optional) is the SOURCE graph where the data lives in SWM — peers load
- * quads from `<swmGraphId>` but sign the ACK over `<contextGraphId>`. When
- * omitted, peers fall back to `contextGraphId` for both.
- *
- * stagingQuads: optional N-Quads bytes to send inline to core nodes so
- * they can verify the merkle root without needing SWM pre-positioning.
- *
- * ACK modes are mutually exclusive:
- * - public: no `isEncryptedPayload`, no `catalogCommitment`, no private roots.
- * - folded-private: `privateMerkleRoots` present, `isEncryptedPayload !== true`.
- * - curated-catalog: `isEncryptedPayload === true` with `catalogCommitment`.
- * The collector and handler reject mixed folded-private + curated/encrypted
- * inputs because the curated branch cannot verify private roots.
+ * ACK modes are intentionally mutually exclusive:
+ * - public: ordinary public-CG ACKs; no private roots or catalog commitment.
+ * - folded-private: public-CG ACKs that fold private Merkle commitments into
+ *   the KC root without sending private plaintext to cores.
+ * - curated-catalog: curated-CG ACKs that sign the public `_catalog`
+ *   commitment. This mode cannot carry folded-private roots because cores
+ *   cannot verify both the curated catalog and private commitments today.
  */
-export type V10ACKProvider = (
-  merkleRoot: Uint8Array,
-  contextGraphId: string,
-  kaCount: number,
-  rootEntities: string[],
-  publicByteSize: bigint,
-  stagingQuads: Uint8Array | undefined,
-  epochs: number | undefined,
-  tokenAmount: bigint | undefined,
-  swmGraphId: string | undefined,
-  subGraphName: string | undefined,
+export type V10ACKMode =
+  | { kind: 'public' }
+  | { kind: 'folded-private'; privateMerkleRoots: readonly Uint8Array[] }
+  | { kind: 'curated-catalog'; catalogCommitment: V10CatalogACKCommitment };
+
+export interface V10ACKProviderBaseParams {
+  merkleRoot: Uint8Array;
+  /** TARGET on-chain numeric CG id that the ACK digest and on-chain tx use. */
+  contextGraphId: string;
+  kaCount: number;
+  rootEntities: string[];
+  publicByteSize: bigint;
+  epochs?: number;
+  tokenAmount?: bigint;
+  /**
+   * SOURCE graph where data lives in SWM. When omitted, peers fall back to
+   * `contextGraphId` for both source and target.
+   */
+  swmGraphId?: string;
+  subGraphName?: string;
   /** V10 flat-KC Merkle leaf count (sorted + deduped); binds ACK + on-chain KC to RandomSampling. */
-  merkleLeafCount: number,
-  /**
-   * OT-RFC-49 / WS-D — when `true`, this is a CURATED publish: `stagingQuads`
-   * carries the PUBLIC `_catalog` N-quads (plaintext — the catalog is public),
-   * and the private data is encrypted for MEMBERS only (off the ACK wire).
-   * Cores skip the flat-KC plaintext recompute (they don't hold the private
-   * data) and instead rebuild + verify the catalog root from `catalogCommitment`
-   * against the inline `stagingQuads`. Defaults to `false` so existing public-CG
-   * callers are unchanged.
-   */
-  isEncryptedPayload?: boolean,
-  /**
-   * OT-RFC-49 / WS-D — the CURATED PUBLIC `_catalog` commitment for this
-   * publish (REPLACED the stripped ciphertext-chunks commitment). When present,
-   * the publisher computed `computeCatalogRoot(catalogCommittedLeaves(...))`
-   * over the committed catalog leaf-set; the same `(catalogRoot, catalogLeafCount)`
-   * is signed into the V10 ACK digest, lands on-chain, and is what the core
-   * rebuilds over the inline catalog `stagingQuads` (DECLINE `CATALOG_ROOT_MISMATCH`
-   * on disagreement). Required when `isEncryptedPayload === true` AND the curated
-   * CG has a catalog entry; absent for public CGs.
-   */
-  catalogCommitment?: {
-    catalogRoot: Uint8Array;
-    catalogLeafCount: number;
-  },
-  /**
-   * Folded public+private KAs expose only private Merkle commitments to ACK
-   * signers. Cores use these 32-byte roots to recompute the claimed KC root
-   * together with the public quads they store, without seeing private plaintext.
-   */
-  privateMerkleRoots?: Uint8Array[],
-) => Promise<V10CoreNodeACK[]>;
+  merkleLeafCount: number;
+}
+
+export type V10ACKProviderParams =
+  | (V10ACKProviderBaseParams & {
+      ackMode: { kind: 'public' };
+      /** Optional N-Quads bytes to send inline so cores can verify without SWM pre-positioning. */
+      stagingQuads?: Uint8Array;
+    })
+  | (V10ACKProviderBaseParams & {
+      ackMode: { kind: 'folded-private'; privateMerkleRoots: readonly Uint8Array[] };
+      /** Public N-Quads bytes only. Private plaintext must never be sent. */
+      stagingQuads?: Uint8Array;
+    })
+  | (V10ACKProviderBaseParams & {
+      ackMode: { kind: 'curated-catalog'; catalogCommitment: V10CatalogACKCommitment };
+      /** Public `_catalog` N-Quads bytes. Curated private data stays encrypted off the ACK wire. */
+      stagingQuads: Uint8Array;
+    });
+
+/**
+ * Callback that collects V10 StorageACKs from core nodes.
+ * Called AFTER merkle root computation, BEFORE on-chain tx.
+ */
+export type V10ACKProvider = (params: V10ACKProviderParams) => Promise<V10CoreNodeACK[]>;
 
 /**
  * V10 update ACK provider: collects core node signatures over the update ACK

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -28,7 +28,9 @@ export type ReceiverSignatureProvider = (
 ) => Promise<ReceiverSignature[]>;
 
 /**
- * V10 core node ACK signature collected via /dkg/10.0.1/storage-ack.
+ * V10 core node ACK signature collected via storage-ack. Public/catalog ACKs
+ * use /dkg/10.0.1/storage-ack; folded-private ACKs require
+ * /dkg/10.0.2/storage-ack so field 20 support is capability-gated.
  * Spec §9.0.3: ACK = EIP-191(computePublishACKDigest(chainId, kav10Address,
  *   contextGraphId, merkleRoot, kaCount, byteSize, epochs, tokenAmount))
  */
@@ -60,6 +62,13 @@ export interface V10CoreNodeACK {
  *
  * stagingQuads: optional N-Quads bytes to send inline to core nodes so
  * they can verify the merkle root without needing SWM pre-positioning.
+ *
+ * ACK modes are mutually exclusive:
+ * - public: no `isEncryptedPayload`, no `catalogCommitment`, no private roots.
+ * - folded-private: `privateMerkleRoots` present, `isEncryptedPayload !== true`.
+ * - curated-catalog: `isEncryptedPayload === true` with `catalogCommitment`.
+ * The collector and handler reject mixed folded-private + curated/encrypted
+ * inputs because the curated branch cannot verify private roots.
  */
 export type V10ACKProvider = (
   merkleRoot: Uint8Array,
@@ -390,14 +399,9 @@ export interface PublishResult {
    * chain submission:
    *   - `no-chain`        — no on-chain CG id / chain not V10-ready: local is the
    *                         only possible outcome (an honest local finalization).
-   *   - `private-no-acks` — the CG IS chain-registered but a private payload
-   *                         couldn't collect storage ACKs, so it never reached the
-   *                         chain it should have. The async lift must NOT report
-   *                         this as `finalized` with a provisional UAL (#1013) —
-   *                         the real fix for reaching chain here is #1121.
    * Undefined on confirmed publishes and pre-#1013 results.
    */
-  localChainSkipReason?: 'no-chain' | 'private-no-acks';
+  localChainSkipReason?: 'no-chain';
   /** Public quads that were stored (used for broadcast — never includes private triples). */
   publicQuads?: Quad[];
   /** Set when KC is confirmed on-chain but context-graph registration failed. */

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -109,7 +109,31 @@ export type V10ACKProviderParams =
  * Callback that collects V10 StorageACKs from core nodes.
  * Called AFTER merkle root computation, BEFORE on-chain tx.
  */
-export type V10ACKProvider = (params: V10ACKProviderParams) => Promise<V10CoreNodeACK[]>;
+export type V10ACKProviderObject = (params: V10ACKProviderParams) => Promise<V10CoreNodeACK[]>;
+
+/**
+ * Compatibility shape for integrations that implemented the original
+ * positional callback contract before ACK mode became explicit. The object
+ * provider is the canonical form for new code; folded-private publishes require
+ * the object form because the old positional contract had no private-root slot.
+ */
+export type LegacyV10ACKProvider = (
+  merkleRoot: Uint8Array,
+  contextGraphId: string,
+  kaCount: number,
+  rootEntities: string[],
+  publicByteSize: bigint,
+  stagingQuads: Uint8Array | undefined,
+  epochs: number | undefined,
+  tokenAmount: bigint | undefined,
+  swmGraphId: string | undefined,
+  subGraphName: string | undefined,
+  merkleLeafCount: number,
+  isEncryptedPayload?: boolean,
+  catalogCommitment?: V10CatalogACKCommitment,
+) => Promise<V10CoreNodeACK[]>;
+
+export type V10ACKProvider = V10ACKProviderObject | LegacyV10ACKProvider;
 
 /**
  * V10 update ACK provider: collects core node signatures over the update ACK

--- a/packages/publisher/src/publisher.ts
+++ b/packages/publisher/src/publisher.ts
@@ -98,6 +98,12 @@ export type V10ACKProvider = (
     catalogRoot: Uint8Array;
     catalogLeafCount: number;
   },
+  /**
+   * Folded public+private KAs expose only private Merkle commitments to ACK
+   * signers. Cores use these 32-byte roots to recompute the claimed KC root
+   * together with the public quads they store, without seeing private plaintext.
+   */
+  privateMerkleRoots?: Uint8Array[],
 ) => Promise<V10CoreNodeACK[]>;
 
 /**

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -78,6 +78,21 @@ function catalogRootForAckDigest(root: Uint8Array | undefined): Uint8Array {
   return root;
 }
 
+function normalizePrivateMerkleRoots(
+  roots: readonly Uint8Array[] | undefined,
+): Uint8Array[] {
+  if (!roots || roots.length === 0) return [];
+  return roots.map((root, idx) => {
+    const bytes = root instanceof Uint8Array ? root : new Uint8Array(root);
+    if (bytes.length !== 32) {
+      throw new Error(
+        `StorageACK: privateMerkleRoots[${idx}] must be 32 bytes, got ${bytes.length}`,
+      );
+    }
+    return bytes;
+  });
+}
+
 function summarizeDeclineEntities(entities: readonly string[]): string {
   if (entities.length === 0) return '(none)';
   const visible = entities
@@ -652,6 +667,7 @@ export class StorageACKHandler {
     const merkleRoot = intent.merkleRoot instanceof Uint8Array
       ? intent.merkleRoot
       : new Uint8Array(intent.merkleRoot);
+    const privateMerkleRoots = normalizePrivateMerkleRoots(intent.privateMerkleRoots);
 
     const swmGraphUri = this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
 
@@ -919,7 +935,7 @@ export class StorageACKHandler {
         }
       }
 
-      const inMemoryRoot = computeFlatKCRoot(parsed, []);
+      const inMemoryRoot = computeFlatKCRoot(parsed, privateMerkleRoots);
       if (!bytesEqual(inMemoryRoot, merkleRoot)) {
         throw new Error(
           `Merkle root mismatch (inline quads): publisher=${ethers.hexlify(merkleRoot).slice(0, 18)}..., ` +
@@ -973,7 +989,7 @@ export class StorageACKHandler {
         );
       }
 
-      const recomputedRoot = computeFlatKCRoot(swmQuads, []);
+      const recomputedRoot = computeFlatKCRoot(swmQuads, privateMerkleRoots);
       if (!bytesEqual(recomputedRoot, merkleRoot)) {
         return this.encodeDecline(
           cgId,
@@ -1089,7 +1105,7 @@ export class StorageACKHandler {
       ? BigInt(intent.tokenAmountStr)
       : 0n;
 
-    const verifiedLeafCount = computeFlatKCMerkleLeafCountV10(swmQuads, []);
+    const verifiedLeafCount = computeFlatKCMerkleLeafCountV10(swmQuads, privateMerkleRoots);
     if (verifiedLeafCount === 0) {
       throw new Error(
         'StorageACK: empty Knowledge Asset payload (zero V10 Merkle leaves after sort+dedupe) — refusing ACK',

--- a/packages/publisher/src/storage-ack-handler.ts
+++ b/packages/publisher/src/storage-ack-handler.ts
@@ -668,6 +668,12 @@ export class StorageACKHandler {
       ? intent.merkleRoot
       : new Uint8Array(intent.merkleRoot);
     const privateMerkleRoots = normalizePrivateMerkleRoots(intent.privateMerkleRoots);
+    if (intent.isEncryptedPayload === true && privateMerkleRoots.length > 0) {
+      throw new Error(
+        'StorageACK: privateMerkleRoots are only valid for folded-private public-CG ACKs; ' +
+        'curated/encrypted ACKs must use catalogCommitment without folded private roots',
+      );
+    }
 
     const swmGraphUri = this.config.contextGraphSharedMemoryUri(swmGraphId, subGraphName);
 

--- a/packages/publisher/test/_helpers/acks.ts
+++ b/packages/publisher/test/_helpers/acks.ts
@@ -18,7 +18,7 @@
 import { ethers } from 'ethers';
 import { computePublishACKDigest } from '@origintrail-official/dkg-core';
 import type { EVMChainAdapter } from '@origintrail-official/dkg-chain';
-import type { V10ACKProvider, V10ACKProviderParams, V10CoreNodeACK, V10UpdateACKProvider } from '../../src/publisher.js';
+import type { V10ACKProviderObject, V10ACKProviderParams, V10CoreNodeACK, V10UpdateACKProvider } from '../../src/publisher.js';
 import { getSharedContext, HARDHAT_KEYS } from '../../../chain/test/evm-test-context.js';
 
 export interface InMemoryACKSigner {
@@ -71,7 +71,7 @@ export interface InMemoryACKProviderOptions {
  */
 export function makeInMemoryV10ACKProvider(
   opts: InMemoryACKProviderOptions,
-): V10ACKProvider {
+): V10ACKProviderObject {
   const { chainId, kav10Address, signers } = opts;
   if (signers.length === 0) {
     throw new Error('makeInMemoryV10ACKProvider: at least one signer required');
@@ -190,7 +190,7 @@ export function makeHardhatReceiverACKProvider(
   kav10Address: string,
   signerKeys: readonly [string, string, string],
   chainId: bigint = 31337n,
-): V10ACKProvider {
+): V10ACKProviderObject {
   if (ctx.receiverIds.length < 3) {
     throw new Error(
       `makeHardhatReceiverACKProvider: harness must have 3 receiver ids, got ${ctx.receiverIds.length}`,
@@ -222,8 +222,8 @@ export function makeHardhatReceiverACKProvider(
  * resolved before the call (typically: `beforeAll` already awaited
  * `chain.getKnowledgeAssetsLifecycleAddress()` and stashed it).
  */
-const _hardhatACKProviderCache = new Map<string, V10ACKProvider>();
-export function hardhatACKProvider(kav10Address: string): V10ACKProvider {
+const _hardhatACKProviderCache = new Map<string, V10ACKProviderObject>();
+export function hardhatACKProvider(kav10Address: string): V10ACKProviderObject {
   const cached = _hardhatACKProviderCache.get(kav10Address);
   if (cached) return cached;
   const provider = makeHardhatReceiverACKProvider(
@@ -260,7 +260,7 @@ export function hardhatACKProvider(kav10Address: string): V10ACKProvider {
 const _STUB_ACK_WALLET = new ethers.Wallet(
   '0x0000000000000000000000000000000000000000000000000000000000000001',
 );
-export function mockChainStubACKProvider(opts?: { identityId?: bigint }): V10ACKProvider {
+export function mockChainStubACKProvider(opts?: { identityId?: bigint }): V10ACKProviderObject {
   const identityId = opts?.identityId ?? 1n;
   return async (): Promise<V10CoreNodeACK[]> => {
     const sig = ethers.Signature.from(

--- a/packages/publisher/test/_helpers/acks.ts
+++ b/packages/publisher/test/_helpers/acks.ts
@@ -18,7 +18,7 @@
 import { ethers } from 'ethers';
 import { computePublishACKDigest } from '@origintrail-official/dkg-core';
 import type { EVMChainAdapter } from '@origintrail-official/dkg-chain';
-import type { V10ACKProvider, V10CoreNodeACK, V10UpdateACKProvider } from '../../src/publisher.js';
+import type { V10ACKProvider, V10ACKProviderParams, V10CoreNodeACK, V10UpdateACKProvider } from '../../src/publisher.js';
 import { getSharedContext, HARDHAT_KEYS } from '../../../chain/test/evm-test-context.js';
 
 export interface InMemoryACKSigner {
@@ -84,33 +84,23 @@ export function makeInMemoryV10ACKProvider(
     peerId: s.peerId ?? `in-memory-core-${s.identityId}`,
   }));
 
-  return async (
-    merkleRoot,
-    contextGraphIdStr,
-    kaCount,
-    _rootEntities,
-    publicByteSize,
-    _stagingQuads,
-    epochs,
-    tokenAmount,
-    _swmGraphId,
-    _subGraphName,
-    merkleLeafCount,
-    _isEncryptedPayload,
-  ): Promise<V10CoreNodeACK[]> => {
-    const cgId = resolveCgId(contextGraphIdStr);
+  return async (params: V10ACKProviderParams): Promise<V10CoreNodeACK[]> => {
+    const cgId = resolveCgId(params.contextGraphId);
+    const catalogCommitment = params.ackMode.kind === 'curated-catalog'
+      ? params.ackMode.catalogCommitment
+      : undefined;
     const digest = computePublishACKDigest(
       chainId,
       kav10Address,
       cgId,
-      merkleRoot,
-      BigInt(kaCount),
-      publicByteSize,
-      BigInt(epochs ?? 1),
-      tokenAmount ?? 0n,
-      BigInt(merkleLeafCount),
-      new Uint8Array(32),
-      0n,
+      params.merkleRoot,
+      BigInt(params.kaCount),
+      params.publicByteSize,
+      BigInt(params.epochs ?? 1),
+      params.tokenAmount ?? 0n,
+      BigInt(params.merkleLeafCount),
+      catalogCommitment?.catalogRoot ?? new Uint8Array(32),
+      BigInt(catalogCommitment?.catalogLeafCount ?? 0),
       false,
     );
 

--- a/packages/publisher/test/access-protocol.test.ts
+++ b/packages/publisher/test/access-protocol.test.ts
@@ -20,6 +20,7 @@ import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, createTestContextGraph, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { buildSeal } from './_helpers/seal.js';
+import { hardhatACKProvider } from './_helpers/acks.js';
 
 let CONTEXT_GRAPH = 'test-access';
 let GRAPH = `did:dkg:context-graph:${CONTEXT_GRAPH}`;
@@ -121,7 +122,11 @@ describe('Access Protocol', () => {
       contextGraphId: CONTEXT_GRAPH,
       ctx: { provider: _provider, kav10Address: _kav10Address },
     });
-    const result = await publisher.publish({ ...publishArgs, precomputedAttestation: seal });
+    const result = await publisher.publish({
+      ...publishArgs,
+      precomputedAttestation: seal,
+      v10ACKProvider: hardhatACKProvider(_kav10Address),
+    });
 
     return { result, bus, keypair };
   }
@@ -132,13 +137,10 @@ describe('Access Protocol', () => {
     const storeA = new OxigraphStore();
     const { result, bus } = await publishWithPrivate(storeA, { publisherPeerId: nodeA.peerId });
 
-    // RC11 / PR1: private-data publishes intentionally skip peer ACK
-    // collection (`dkg-publisher.ts:1937`) and the self-signed ACK
-    // fallback is deleted, so they correctly downgrade to `tentative`.
-    // The owner / non-owner access-control behaviour this test
-    // validates is local to nodeA's store + AccessHandler and is
-    // independent of on-chain confirmation.
-    expect(result.status).toBe('tentative');
+    // Folded public+private publishes now collect V10 ACKs and anchor on-chain.
+    // The owner / non-owner access-control behaviour this test validates is
+    // still local to nodeA's store + AccessHandler.
+    expect(result.status).toBe('confirmed');
     expect(result.kaManifest[0].privateTripleCount).toBe(2);
 
     const accessHandler = new AccessHandler(storeA, bus);
@@ -164,11 +166,7 @@ describe('Access Protocol', () => {
     const storeA = new OxigraphStore();
     const { result, bus } = await publishWithPrivate(storeA, { publisherPeerId: nodeB.peerId });
 
-    // RC11 / PR1: see sibling test above — tentative is the honest
-    // outcome for a private-data publish now that the self-signed ACK
-    // fallback is gone. The meta-graph + access-grant assertions below
-    // do not depend on on-chain confirmation.
-    expect(result.status).toBe('tentative');
+    expect(result.status).toBe('confirmed');
     expect(result.kaManifest[0].privateTripleCount).toBe(2);
     expect(result.kaManifest[0].privateMerkleRoot).toBeDefined();
     expect(result.kaManifest[0].privateMerkleRoot).toHaveLength(32);

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
-import { encodeStorageACK, computePublishACKDigest } from '@origintrail-official/dkg-core';
-import { computeFlatKCRootV10, computeFlatKCMerkleLeafCountV10 } from '../src/merkle.js';
+import { decodePublishIntent, encodeStorageACK, computePublishACKDigest } from '@origintrail-official/dkg-core';
+import { computeFlatKCRootV10, computeFlatKCMerkleLeafCountV10, computePrivateRootV10 } from '../src/merkle.js';
 import { ethers } from 'ethers';
 
 // Test H5 prefix inputs — must match what the collector passes into
@@ -102,6 +102,59 @@ describe('ACKCollector', () => {
       expect(ack.signatureR.length).toBe(32);
       expect(ack.signatureVS.length).toBe(32);
       expect(ack.nodeIdentityId).toBeGreaterThan(0n);
+    }
+  });
+
+  it('puts folded-private Merkle roots on the PublishIntent wire', async () => {
+    const privateRoot = computePrivateRootV10([
+      makeQuad('urn:a', 'urn:secret', '"hidden"'),
+    ])!;
+    const foldedRoot = computeFlatKCRootV10(testQuads, [privateRoot]);
+    const foldedLeafCount = computeFlatKCMerkleLeafCountV10(testQuads, [privateRoot]);
+    const seenPrivateRoots: Uint8Array[][] = [];
+
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (peerId, _protocol, data) => {
+        const decoded = decodePublishIntent(data);
+        seenPrivateRoots.push((decoded.privateMerkleRoots ?? []).map((root) => new Uint8Array(root)));
+
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const wallet = coreWallets[idx];
+        const { r, vs } = await signACK(wallet, testCGId, foldedRoot, 1, 100n, 1n, 0n, foldedLeafCount);
+        return encodeStorageACK({
+          merkleRoot: foldedRoot,
+          coreNodeSignatureR: r,
+          coreNodeSignatureVS: vs,
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot: foldedRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount: foldedLeafCount,
+      privateMerkleRoots: [privateRoot],
+    });
+
+    expect(result.acks).toHaveLength(3);
+    expect(seenPrivateRoots).toHaveLength(3);
+    for (const roots of seenPrivateRoots) {
+      expect(roots).toHaveLength(1);
+      expect(roots[0]).toEqual(privateRoot);
     }
   });
 

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -95,6 +95,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -161,7 +162,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount: foldedLeafCount,
-      privateMerkleRoots: [privateRoot],
+      ackMode: { kind: 'folded-private', privateMerkleRoots: [privateRoot] },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -216,6 +217,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -227,7 +229,7 @@ describe('ACKCollector', () => {
     ]);
   });
 
-  it('rejects folded-private roots combined with curated encrypted ACK mode', async () => {
+  it('rejects private roots smuggled into curated catalog ACK mode', async () => {
     const privateRoot = computePrivateRootV10([
       makeQuad('urn:a', 'urn:secret', '"hidden"'),
     ])!;
@@ -255,9 +257,16 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount: foldedLeafCount,
-      isEncryptedPayload: true,
-      privateMerkleRoots: [privateRoot],
-    })).rejects.toThrow('privateMerkleRoots are only valid for folded-private public-CG ACKs');
+      stagingQuads: new TextEncoder().encode('<urn:a> <urn:p> <urn:o> .'),
+      ackMode: {
+        kind: 'curated-catalog',
+        catalogCommitment: {
+          catalogRoot: new Uint8Array(32).fill(0x49),
+          catalogLeafCount: 1,
+        },
+        privateMerkleRoots: [privateRoot],
+      } as any,
+    })).rejects.toThrow('privateMerkleRoots cannot be combined with curated-catalog ACK mode');
   });
 
   it('deduplicates by peerId and nodeIdentityId', async () => {
@@ -297,6 +306,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -326,6 +336,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     })).rejects.toThrow('no connected core peers');
   });
 
@@ -357,6 +368,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     })).rejects.toThrow('V10 publish requires exactly one Knowledge Asset');
 
     expect(peerListCalls).toBe(0);
@@ -396,6 +408,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     })).rejects.toThrow('storage_ack_insufficient');
   });
 
@@ -457,6 +470,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -494,6 +508,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     })).rejects.toThrow('storage_ack_insufficient');
 
     for (const peerId of ['peer-0', 'peer-1', 'peer-2']) {
@@ -554,6 +569,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -627,6 +643,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -670,6 +687,7 @@ describe('ACKCollector', () => {
       chainId: TEST_CHAIN_ID,
       kav10Address: TEST_KAV10_ADDR,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     })).rejects.toThrow('storage_ack_insufficient');
   });
 });

--- a/packages/publisher/test/ack-collector.test.ts
+++ b/packages/publisher/test/ack-collector.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { ACKCollector, type ACKCollectorDeps } from '../src/ack-collector.js';
-import { decodePublishIntent, encodeStorageACK, computePublishACKDigest } from '@origintrail-official/dkg-core';
+import {
+  decodePublishIntent,
+  encodeStorageACK,
+  computePublishACKDigest,
+  PROTOCOL_STORAGE_ACK,
+  PROTOCOL_STORAGE_ACK_V2,
+} from '@origintrail-official/dkg-core';
 import { computeFlatKCRootV10, computeFlatKCMerkleLeafCountV10, computePrivateRootV10 } from '../src/merkle.js';
 import { ethers } from 'ethers';
 
@@ -112,10 +118,13 @@ describe('ACKCollector', () => {
     const foldedRoot = computeFlatKCRootV10(testQuads, [privateRoot]);
     const foldedLeafCount = computeFlatKCMerkleLeafCountV10(testQuads, [privateRoot]);
     const seenPrivateRoots: Uint8Array[][] = [];
+    const seenProtocols: string[] = [];
+    const requestedProtocols: Array<string | undefined> = [];
 
     const deps: ACKCollectorDeps = {
       gossipPublish: async () => {},
-      sendP2P: async (peerId, _protocol, data) => {
+      sendP2P: async (peerId, protocol, data) => {
+        seenProtocols.push(protocol);
         const decoded = decodePublishIntent(data);
         seenPrivateRoots.push((decoded.privateMerkleRoots ?? []).map((root) => new Uint8Array(root)));
 
@@ -130,7 +139,12 @@ describe('ACKCollector', () => {
           nodeIdentityId: idx + 1,
         });
       },
-      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      getConnectedCorePeers: (protocol?: string) => {
+        requestedProtocols.push(protocol);
+        return protocol === PROTOCOL_STORAGE_ACK_V2
+          ? ['peer-0', 'peer-1', 'peer-2']
+          : ['legacy-peer-0', 'legacy-peer-1', 'legacy-peer-2'];
+      },
       log: () => {},
     };
 
@@ -151,11 +165,99 @@ describe('ACKCollector', () => {
     });
 
     expect(result.acks).toHaveLength(3);
+    expect(requestedProtocols).toEqual([PROTOCOL_STORAGE_ACK_V2]);
+    expect(seenProtocols).toEqual([
+      PROTOCOL_STORAGE_ACK_V2,
+      PROTOCOL_STORAGE_ACK_V2,
+      PROTOCOL_STORAGE_ACK_V2,
+    ]);
     expect(seenPrivateRoots).toHaveLength(3);
     for (const roots of seenPrivateRoots) {
       expect(roots).toHaveLength(1);
       expect(roots[0]).toEqual(privateRoot);
     }
+  });
+
+  it('keeps public ACKs on the V1 storage-ack protocol', async () => {
+    const seenProtocols: string[] = [];
+    const requestedProtocols: Array<string | undefined> = [];
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async (peerId, protocol) => {
+        seenProtocols.push(protocol);
+        const idx = parseInt(peerId.replace('peer-', ''), 10);
+        const wallet = coreWallets[idx];
+        const { r, vs } = await signACK(wallet, testCGId, merkleRoot, 1, 100n);
+        return encodeStorageACK({
+          merkleRoot,
+          coreNodeSignatureR: r,
+          coreNodeSignatureVS: vs,
+          contextGraphId: testCGIdStr,
+          nodeIdentityId: idx + 1,
+        });
+      },
+      getConnectedCorePeers: (protocol?: string) => {
+        requestedProtocols.push(protocol);
+        return protocol === PROTOCOL_STORAGE_ACK ? ['peer-0', 'peer-1', 'peer-2'] : [];
+      },
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    const result = await collector.collect({
+      merkleRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: false,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount,
+    });
+
+    expect(result.acks).toHaveLength(3);
+    expect(requestedProtocols).toEqual([PROTOCOL_STORAGE_ACK]);
+    expect(seenProtocols).toEqual([
+      PROTOCOL_STORAGE_ACK,
+      PROTOCOL_STORAGE_ACK,
+      PROTOCOL_STORAGE_ACK,
+    ]);
+  });
+
+  it('rejects folded-private roots combined with curated encrypted ACK mode', async () => {
+    const privateRoot = computePrivateRootV10([
+      makeQuad('urn:a', 'urn:secret', '"hidden"'),
+    ])!;
+    const foldedRoot = computeFlatKCRootV10(testQuads, [privateRoot]);
+    const foldedLeafCount = computeFlatKCMerkleLeafCountV10(testQuads, [privateRoot]);
+    const deps: ACKCollectorDeps = {
+      gossipPublish: async () => {},
+      sendP2P: async () => {
+        throw new Error('sendP2P should not be called');
+      },
+      getConnectedCorePeers: () => ['peer-0', 'peer-1', 'peer-2'],
+      log: () => {},
+    };
+
+    const collector = new ACKCollector(deps);
+    await expect(collector.collect({
+      merkleRoot: foldedRoot,
+      contextGraphId: testCGId,
+      contextGraphIdStr: testCGIdStr,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 100n,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: ['urn:a'],
+      chainId: TEST_CHAIN_ID,
+      kav10Address: TEST_KAV10_ADDR,
+      merkleLeafCount: foldedLeafCount,
+      isEncryptedPayload: true,
+      privateMerkleRoots: [privateRoot],
+    })).rejects.toThrow('privateMerkleRoots are only valid for folded-private public-CG ACKs');
   });
 
   it('deduplicates by peerId and nodeIdentityId', async () => {

--- a/packages/publisher/test/ack-metrics.test.ts
+++ b/packages/publisher/test/ack-metrics.test.ts
@@ -67,6 +67,7 @@ const collectParams = {
   chainId: TEST_CHAIN_ID,
   kav10Address: TEST_KAV10_ADDR,
   merkleLeafCount,
+  ackMode: { kind: 'public' },
 };
 
 describe('quorumOutcomeFromError — classify on the structured prefix, not peer text', () => {

--- a/packages/publisher/test/async-lift-local-finalization-honesty.test.ts
+++ b/packages/publisher/test/async-lift-local-finalization-honesty.test.ts
@@ -1,14 +1,8 @@
 /**
- * Regression test for GH #1013 — "Private publishAsync can finalize locally
- * with provisional UAL but no on-chain provenance".
- * https://github.com/OriginTrail/dkg/issues/1013
- *
- * Fix: a `tentative` publish that skipped chain because a PRIVATE payload had
- * no collectable storage ACKs (`localChainSkipReason: 'private-no-acks'`) must
- * NOT be mapped to `finalized` with a provisional UAL — the caller asked for a
- * VM publish on a chain-registered CG and it never reached chain. It now fails
- * honestly (data is still staged locally under the provisional UAL, surfaced in
- * the error). A genuinely-local publish (`no-chain`) still finalizes(local).
+ * Local async finalization is only honest when there is genuinely no chain path
+ * for the publish. Folded private publishes now collect ACKs and confirm when
+ * V2-capable cores are available, so the remaining local success shape is the
+ * explicit `no-chain` branch (plus legacy results that predate the reason).
  */
 import { describe, expect, it } from 'vitest';
 import { mapPublishResultToLiftJobSuccess } from '../src/async-lift-publish-result.js';
@@ -25,19 +19,7 @@ function baseResult(over: Partial<PublishResult>): PublishResult {
   };
 }
 
-describe('GH #1013 — local async finalization honesty', () => {
-  it('does NOT finalize a private publish that could not reach its chain-registered CG', () => {
-    const res = baseResult({ status: 'tentative', localChainSkipReason: 'private-no-acks' });
-    expect(() => mapPublishResultToLiftJobSuccess({ publishResult: res, walletId: 'w1' }))
-      .toThrowError(/NOT on chain|could not reach Verifiable Memory/i);
-  });
-
-  it('the failure surfaces the provisional UAL so the local data is recoverable', () => {
-    const res = baseResult({ status: 'tentative', localChainSkipReason: 'private-no-acks' });
-    expect(() => mapPublishResultToLiftJobSuccess({ publishResult: res, walletId: 'w1' }))
-      .toThrowError(/tmq-provisional-1/);
-  });
-
+describe('local async finalization honesty', () => {
   it('still finalizes(local) for a genuinely no-chain publish', () => {
     const res = baseResult({ status: 'tentative', localChainSkipReason: 'no-chain' });
     const mapped = mapPublishResultToLiftJobSuccess({ publishResult: res, walletId: 'w1' });

--- a/packages/publisher/test/async-lift-local-finalization-honesty.test.ts
+++ b/packages/publisher/test/async-lift-local-finalization-honesty.test.ts
@@ -3,6 +3,8 @@
  * for the publish. Folded private publishes now collect ACKs and confirm when
  * V2-capable cores are available, so the remaining local success shape is the
  * explicit `no-chain` branch (plus legacy results that predate the reason).
+ * A legacy `private-no-acks` result is not honest local success: it targeted
+ * chain finalization but failed before ACK quorum.
  */
 import { describe, expect, it } from 'vitest';
 import { mapPublishResultToLiftJobSuccess } from '../src/async-lift-publish-result.js';
@@ -31,5 +33,15 @@ describe('local async finalization honesty', () => {
     const res = baseResult({ status: 'tentative', localChainSkipReason: undefined });
     const mapped = mapPublishResultToLiftJobSuccess({ publishResult: res, walletId: 'w1' });
     expect(mapped.status).toBe('finalized');
+  });
+
+  it('rejects legacy private-no-acks results instead of finalizing them as local success', () => {
+    const res = baseResult({
+      status: 'tentative',
+      localChainSkipReason: 'private-no-acks',
+    } as unknown as Partial<PublishResult>);
+
+    expect(() => mapPublishResultToLiftJobSuccess({ publishResult: res, walletId: 'w1' }))
+      .toThrow(/private-no-acks/);
   });
 });

--- a/packages/publisher/test/async-lift-publish-result.test.ts
+++ b/packages/publisher/test/async-lift-publish-result.test.ts
@@ -188,21 +188,4 @@ describe('async lift publish result mapping', () => {
     expect(failure.retryable).toBe(false);
   });
 
-  it('classifies a private-no-acks broadcast failure as TERMINAL, not retryable (Codex #1132 / GH #1013/#1121)', () => {
-    // Before the fix this generic broadcast-phase failure fell through to
-    // `rpc_unavailable` (retryable) and the queue retried forever a publish
-    // that can never reach VM until encrypted private async publish (#1121).
-    const failure = mapPublishExceptionToLiftJobFailure({
-      error: new Error(
-        'Async publish to a chain-registered context graph could not reach Verifiable Memory: ' +
-        'private payload had no collectable storage ACKs (peers cannot see private data).',
-      ),
-      failedFromState: 'broadcast',
-      errorPayloadRef: 'urn:error:private-no-acks',
-    });
-
-    expect(failure.code).toBe('private_unanchorable');
-    expect(failure.mode).toBe('terminal');
-    expect(failure.retryable).toBe(false);
-  });
 });

--- a/packages/publisher/test/async-lift-subtraction.test.ts
+++ b/packages/publisher/test/async-lift-subtraction.test.ts
@@ -103,7 +103,9 @@ describe('subtractFinalizedExactQuads', () => {
     };
   }
 
-  async function markTentativePublishConfirmed(result: { readonly ual: string; readonly status: string }): Promise<void> {
+  async function ensurePublishConfirmed(result: { readonly ual: string; readonly status: string }): Promise<void> {
+    if (result.status === 'confirmed') return;
+
     expect(result.status).toBe('tentative');
     await store.delete([getTentativeStatusQuad(result.ual, CONTEXT_GRAPH)]);
     await store.insert([getConfirmedStatusQuad(result.ual, CONTEXT_GRAPH)]);
@@ -172,17 +174,9 @@ describe('subtractFinalizedExactQuads', () => {
     expect(result.resolved.quads).toEqual([genreQuad]);
   });
 
-  // RC11 / PR3: private-data publishes are now routed to
-  // `finalizeIntentionalLocalPublish` (tentative status), because
-  // peers cannot see private payloads and so a V10 ACK quorum is
-  // structurally impossible. The subtraction logic gates on
-  // `?kc <dkg:status> "confirmed"`, so already-published private
-  // quads will NEVER be matched on subsequent submissions until
-  // the chain confirms them — which it can't for private-only
-  // publishes today. The public-only variant of this test
-  // ("removes only the exact finalized public quads and keeps the
-  // remainder") still passes and pins the load-bearing subtraction
-  // invariant.
+  // Legacy placeholder from the local-only private publish path. The IRI
+  // round-trip tests below now cover confirmed private subtraction with an
+  // ACK-backed folded public+private publish.
   it.skip('removes exact finalized public and private quads and returns an empty remainder for full no-op', async () => {});
 
   it('removes finalized private IRI-object quads after store round-trip normalization', async () => {
@@ -208,7 +202,7 @@ describe('subtractFinalizedExactQuads', () => {
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
-    await markTentativePublishConfirmed(publishResult);
+    await ensurePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,
@@ -245,7 +239,7 @@ describe('subtractFinalizedExactQuads', () => {
       privateQuads: validated.resolved.privateQuads,
       publisherPeerId: 'peer-1',
     });
-    await markTentativePublishConfirmed(publishResult);
+    await ensurePublishConfirmed(publishResult);
 
     const result = await subtractFinalizedExactQuads({
       store,

--- a/packages/publisher/test/dkg-publisher.test.ts
+++ b/packages/publisher/test/dkg-publisher.test.ts
@@ -246,7 +246,7 @@ describe('DKGPublisher', () => {
     }
   });
 
-  it('publishes with private triples (tentative under RC11 / PR1)', async () => {
+  it('publishes with private triples using folded-private ACKs', async () => {
     const result = await publishWS({
       contextGraphId: CONTEXT_GRAPH,
       quads: [q(ENTITY, 'http://schema.org/name', '"ImageBot"')],
@@ -257,15 +257,7 @@ describe('DKGPublisher', () => {
     expect(result.kaManifest[0].privateTripleCount).toBe(1);
     expect(result.kaManifest[0].privateMerkleRoot).toBeDefined();
     expect(result.kaManifest[0].privateMerkleRoot!).toHaveLength(32);
-    // RC11 / PR1: the publisher intentionally skips peer ACK collection
-    // when the publish carries private quads (StorageACKHandler cannot
-    // recompute private merkle roots from SWM data alone, see
-    // `dkg-publisher.ts:1785-1786`). With the self-signed ACK fallback
-    // deleted, private-data publishes now correctly downgrade to
-    // `tentative` instead of confirming via a single bogus
-    // `peerId: 'self'` ACK. The private merkle/manifest accounting we
-    // actually care about above is unaffected.
-    expect(result.status).toBe('tentative');
+    expect(result.status).toBe('confirmed');
   });
 
   it('rejects duplicate entity (exclusivity)', async () => {

--- a/packages/publisher/test/host-mode-quorum-bridge-1124.test.ts
+++ b/packages/publisher/test/host-mode-quorum-bridge-1124.test.ts
@@ -136,6 +136,7 @@ const collectArgs = {
   chainId: TEST_CHAIN_ID,
   kav10Address: TEST_KAV10_ADDR,
   merkleLeafCount,
+  ackMode: { kind: 'public' } as const,
 };
 
 describe('#1124 end-state: public-CG quorum is REACHED purely via non-member host-mode cores', () => {

--- a/packages/publisher/test/publish-lifecycle.test.ts
+++ b/packages/publisher/test/publish-lifecycle.test.ts
@@ -1053,27 +1053,11 @@ describe('Tentative publish UAL uniqueness', () => {
     const expectedPrivateRoot = computePrivateRootV10(privateQuads)!;
     let receivedPrivateRoots: Uint8Array[] | undefined;
     const realProvider = hardhatACKProvider(_kav10Address);
-    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (
-      merkleRoot, cgId, kaCount,
-      rootEntities, byteSize, stagingQuads,
-      epochs, tokenAmount,
-      swmGraphId, subGraphName,
-      merkleLeafCount,
-      isEncryptedPayload,
-      catalogCommitment,
-      privateMerkleRoots,
-    ) => {
-      receivedPrivateRoots = privateMerkleRoots?.map((root) => new Uint8Array(root));
-      return realProvider(
-        merkleRoot, cgId, kaCount,
-        rootEntities, byteSize, stagingQuads,
-        epochs, tokenAmount,
-        swmGraphId, subGraphName,
-        merkleLeafCount,
-        isEncryptedPayload,
-        catalogCommitment,
-        privateMerkleRoots,
-      );
+    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (params) => {
+      receivedPrivateRoots = params.ackMode.kind === 'folded-private'
+        ? params.ackMode.privateMerkleRoots.map((root) => new Uint8Array(root))
+        : undefined;
+      return realProvider(params);
     };
 
     const result = await pubS(publisher, {
@@ -1090,6 +1074,48 @@ describe('Tentative publish UAL uniqueness', () => {
     expect(result.kaManifest[0]?.privateMerkleRoot).toBeDefined();
     expect(receivedPrivateRoots).toHaveLength(1);
     expect(receivedPrivateRoots![0]).toEqual(expectedPrivateRoot);
+  });
+
+  it('rejects encrypted private publishes before ACK collection even without a catalog floor', async () => {
+    const store = new OxigraphStore();
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const curatedCg = String(await createTestContextGraph(chain, undefined, 1, 0));
+    const curatedGraph = `did:dkg:context-graph:${curatedCg}`;
+    const bus = new TypedEventBus();
+    const keypair = await generateEd25519Keypair();
+
+    const publisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store, chain, eventBus: bus, keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+    });
+
+    const entity = 'did:dkg:agent:CuratedFoldedPrivateUnsupported';
+    let ackCalled = false;
+    let encryptCalled = false;
+
+    await expect(pubS(publisher, {
+      contextGraphId: curatedCg,
+      publisherPeerId: '12D3KooWCuratedPrivateUnsupported',
+      quads: [
+        q(entity, 'http://schema.org/name', '"CuratedFoldedPrivateUnsupported"', curatedGraph),
+      ],
+      privateQuads: [
+        q(entity, 'http://dkg.io/ontology/secret', '"hidden"', curatedGraph),
+      ],
+      encryptInlinePayload: async (plaintext) => {
+        encryptCalled = true;
+        return plaintext;
+      },
+      v10ACKProvider: async () => {
+        ackCalled = true;
+        return [];
+      },
+    })).rejects.toThrow(/Encrypted inline publishes with privateQuads are not supported/);
+
+    expect(encryptCalled).toBe(false);
+    expect(ackCalled).toBe(false);
   });
 
   it('stores distinct KC metadata for each tentative publish', async () => {
@@ -1366,22 +1392,10 @@ describe('Tentative publish UAL uniqueness', () => {
     // succeeds — we still get to inspect everything the publisher
     // hands to the provider on the way through.
     const realProvider = hardhatACKProvider(_kav10Address);
-    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (
-      merkleRoot, cgId, kaCount,
-      rootEntities, byteSize, stagingQuads,
-      epochs, tokenAmount,
-      swmGraphId, subGraphName,
-      merkleLeafCount,
-    ) => {
-      receivedStagingQuads = stagingQuads;
-      receivedMerkleLeafCount = merkleLeafCount;
-      return realProvider(
-        merkleRoot, cgId, kaCount,
-        rootEntities, byteSize, stagingQuads,
-        epochs, tokenAmount,
-        swmGraphId, subGraphName,
-        merkleLeafCount,
-      );
+    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (params) => {
+      receivedStagingQuads = params.stagingQuads;
+      receivedMerkleLeafCount = params.merkleLeafCount;
+      return realProvider(params);
     };
 
     const phases: [string, 'start' | 'end'][] = [];

--- a/packages/publisher/test/publish-lifecycle.test.ts
+++ b/packages/publisher/test/publish-lifecycle.test.ts
@@ -984,10 +984,9 @@ describe('Tentative publish UAL uniqueness', () => {
     // RC11 / PR3: previously `publisherNodeIdentityId: 0n` was enough
     // to force tentative because the self-signed ACK fallback gated
     // on it. With the fallback deleted (PR1) and the
-    // "no-v10ACKProvider" case made loudly-throwing (PR3), the only
-    // honest paths to tentative are: (a) non-numeric CG id,
-    // (b) hasPrivateData, (c) chain not V10-ready. Use a non-numeric
-    // SWM CG label so each iteration goes through
+    // "no-v10ACKProvider" case made loudly-throwing (PR3), the honest
+    // paths to tentative are: (a) non-numeric CG id, (b) chain not V10-ready.
+    // Use a non-numeric SWM CG label so each iteration goes through
     // `finalizeIntentionalLocalPublish` via the "no on-chain CG id"
     // branch — preserves the UAL-uniqueness invariant this test
     // pins without re-introducing the deleted self-sign path.
@@ -1033,6 +1032,33 @@ describe('Tentative publish UAL uniqueness', () => {
     expect(result.status).toBe('confirmed');
     expect(result.ual).toBeTruthy();
     expect(result.ual).toContain('did:dkg:');
+  });
+
+  it('confirms folded public+private publishes on-chain when ACKs are available', async () => {
+    const store = new OxigraphStore();
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const bus = new TypedEventBus();
+    const keypair = await generateEd25519Keypair();
+
+    const publisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store, chain, eventBus: bus, keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+    });
+
+    const entity = 'did:dkg:agent:FoldedPrivateConfirm';
+    const result = await pubS(publisher, {
+      contextGraphId: CONTEXT_GRAPH,
+      publisherPeerId: '12D3KooWPrivateConfirm',
+      quads: [q(entity, 'http://schema.org/name', '"FoldedPrivateConfirm"')],
+      privateQuads: [q(entity, 'http://dkg.io/ontology/secret', '"hidden"')],
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(result.kaId > 0n).toBe(true);
+    expect(result.kaManifest[0]?.privateTripleCount).toBe(1);
+    expect(result.kaManifest[0]?.privateMerkleRoot).toBeDefined();
   });
 
   it('stores distinct KC metadata for each tentative publish', async () => {
@@ -1094,12 +1120,11 @@ describe('Tentative publish UAL uniqueness', () => {
   // mirror was dropped (zero readers); author attribution is now carried
   // solely by `prov:wasAttributedTo` on the KC row, which this test pins.
   //
-  // Both tests use the "private data — no ACKs collectable" intentional-
-  // local branch: a numeric on-chain CG + V10-ready chain means the
-  // publisher resolves a real `publisherSigner`, so the conditional
-  // spread of `authorAddress` (gated on either a precomputedAttestation
-  // or a resolved signer) is exercised end-to-end.
-  it('intentional-local tentative publish (private-data branch) attributes the author via prov:wasAttributedTo (RC11 / PR-A)', async () => {
+  // These tests use the non-on-chain-CG intentional-local branch. That branch
+  // does not resolve an on-chain publisher signer by context graph id, so this
+  // fixture supplies the author address through the precomputed attestation
+  // lane that production callers already use.
+  it('intentional-local tentative publish (no-chain branch) attributes the author via prov:wasAttributedTo (RC11 / PR-A)', async () => {
     const store = new OxigraphStore();
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const bus = new TypedEventBus();
@@ -1112,16 +1137,18 @@ describe('Tentative publish UAL uniqueness', () => {
       publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
 
-    const result = await publisher.publish({
-      contextGraphId: CONTEXT_GRAPH,
+    const localContextGraph = 'local-provenance-cg';
+    const localGraph = `did:dkg:context-graph:${localContextGraph}`;
+    const result = await publisher.publish(await _withSeal({
+      contextGraphId: localContextGraph,
       publisherPeerId: '12D3KooWTestProvenance',
       quads: [
-        q('did:dkg:agent:ProvenanceProbe', 'http://schema.org/name', '"ProvenanceProbe"'),
+        q('did:dkg:agent:ProvenanceProbe', 'http://schema.org/name', '"ProvenanceProbe"', localGraph),
       ],
       privateQuads: [
-        q('did:dkg:agent:ProvenanceProbe', 'http://dkg.io/ontology/secret', '"hidden"'),
+        q('did:dkg:agent:ProvenanceProbe', 'http://dkg.io/ontology/secret', '"hidden"', localGraph),
       ],
-    });
+    }, _author, { provider: _provider, kav10Address: _kav10Address }));
 
     expect(result.status).toBe('tentative');
 
@@ -1155,7 +1182,7 @@ describe('Tentative publish UAL uniqueness', () => {
     }
   });
 
-  it('intentional-local tentative publish (private-data branch) remaps _meta quads to options.targetMetaGraphUri (RC11 / PR-A)', async () => {
+  it('intentional-local tentative publish (no-chain branch) remaps _meta quads to options.targetMetaGraphUri (RC11 / PR-A)', async () => {
     const store = new OxigraphStore();
     const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
     const bus = new TypedEventBus();
@@ -1168,17 +1195,18 @@ describe('Tentative publish UAL uniqueness', () => {
       publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
     });
 
-    const defaultMetaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/_meta`;
-    const customMetaGraph = `did:dkg:context-graph:${CONTEXT_GRAPH}/sub-channel/_shared_memory_meta`;
+    const localContextGraph = 'local-meta-remap-cg';
+    const defaultMetaGraph = `did:dkg:context-graph:${localContextGraph}/_meta`;
+    const customMetaGraph = `did:dkg:context-graph:${localContextGraph}/sub-channel/_shared_memory_meta`;
 
     const result = await publisher.publish({
-      contextGraphId: CONTEXT_GRAPH,
+      contextGraphId: localContextGraph,
       publisherPeerId: '12D3KooWTestMetaRemap',
       quads: [
-        q('did:dkg:agent:MetaRemap', 'http://schema.org/name', '"MetaRemap"'),
+        q('did:dkg:agent:MetaRemap', 'http://schema.org/name', '"MetaRemap"', `did:dkg:context-graph:${localContextGraph}`),
       ],
       privateQuads: [
-        q('did:dkg:agent:MetaRemap', 'http://dkg.io/ontology/secret', '"hidden"'),
+        q('did:dkg:agent:MetaRemap', 'http://dkg.io/ontology/secret', '"hidden"', `did:dkg:context-graph:${localContextGraph}`),
       ],
       targetMetaGraphUri: customMetaGraph,
     });

--- a/packages/publisher/test/publish-lifecycle.test.ts
+++ b/packages/publisher/test/publish-lifecycle.test.ts
@@ -24,7 +24,7 @@ import { DKGPublisher } from '../src/dkg-publisher.js';
 import { PublishHandler } from '../src/publish-handler.js';
 import { ChainEventPoller } from '../src/chain-event-poller.js';
 import { autoPartition } from '../src/auto-partition.js';
-import { computeTripleHashV10 as computeTripleHash } from '../src/merkle.js';
+import { computePrivateRootV10, computeTripleHashV10 as computeTripleHash } from '../src/merkle.js';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, createTestContextGraph, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
@@ -1048,17 +1048,48 @@ describe('Tentative publish UAL uniqueness', () => {
     });
 
     const entity = 'did:dkg:agent:FoldedPrivateConfirm';
+    const publicQuads = [q(entity, 'http://schema.org/name', '"FoldedPrivateConfirm"')];
+    const privateQuads = [q(entity, 'http://dkg.io/ontology/secret', '"hidden"')];
+    const expectedPrivateRoot = computePrivateRootV10(privateQuads)!;
+    let receivedPrivateRoots: Uint8Array[] | undefined;
+    const realProvider = hardhatACKProvider(_kav10Address);
+    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (
+      merkleRoot, cgId, kaCount,
+      rootEntities, byteSize, stagingQuads,
+      epochs, tokenAmount,
+      swmGraphId, subGraphName,
+      merkleLeafCount,
+      isEncryptedPayload,
+      catalogCommitment,
+      privateMerkleRoots,
+    ) => {
+      receivedPrivateRoots = privateMerkleRoots?.map((root) => new Uint8Array(root));
+      return realProvider(
+        merkleRoot, cgId, kaCount,
+        rootEntities, byteSize, stagingQuads,
+        epochs, tokenAmount,
+        swmGraphId, subGraphName,
+        merkleLeafCount,
+        isEncryptedPayload,
+        catalogCommitment,
+        privateMerkleRoots,
+      );
+    };
+
     const result = await pubS(publisher, {
       contextGraphId: CONTEXT_GRAPH,
       publisherPeerId: '12D3KooWPrivateConfirm',
-      quads: [q(entity, 'http://schema.org/name', '"FoldedPrivateConfirm"')],
-      privateQuads: [q(entity, 'http://dkg.io/ontology/secret', '"hidden"')],
+      quads: publicQuads,
+      privateQuads,
+      v10ACKProvider,
     });
 
     expect(result.status).toBe('confirmed');
     expect(result.kaId > 0n).toBe(true);
     expect(result.kaManifest[0]?.privateTripleCount).toBe(1);
     expect(result.kaManifest[0]?.privateMerkleRoot).toBeDefined();
+    expect(receivedPrivateRoots).toHaveLength(1);
+    expect(receivedPrivateRoots![0]).toEqual(expectedPrivateRoot);
   });
 
   it('stores distinct KC metadata for each tentative publish', async () => {

--- a/packages/publisher/test/publish-lifecycle.test.ts
+++ b/packages/publisher/test/publish-lifecycle.test.ts
@@ -25,6 +25,7 @@ import { PublishHandler } from '../src/publish-handler.js';
 import { ChainEventPoller } from '../src/chain-event-poller.js';
 import { autoPartition } from '../src/auto-partition.js';
 import { computePrivateRootV10, computeTripleHashV10 as computeTripleHash } from '../src/merkle.js';
+import type { LegacyV10ACKProvider, V10ACKProviderParams } from '../src/publisher.js';
 import { ethers } from 'ethers';
 import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, revertSnapshot, createTestContextGraph, HARDHAT_KEYS } from '../../chain/test/evm-test-context.js';
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
@@ -1053,7 +1054,7 @@ describe('Tentative publish UAL uniqueness', () => {
     const expectedPrivateRoot = computePrivateRootV10(privateQuads)!;
     let receivedPrivateRoots: Uint8Array[] | undefined;
     const realProvider = hardhatACKProvider(_kav10Address);
-    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (params) => {
+    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (params: V10ACKProviderParams) => {
       receivedPrivateRoots = params.ackMode.kind === 'folded-private'
         ? params.ackMode.privateMerkleRoots.map((root) => new Uint8Array(root))
         : undefined;
@@ -1392,7 +1393,7 @@ describe('Tentative publish UAL uniqueness', () => {
     // succeeds — we still get to inspect everything the publisher
     // hands to the provider on the way through.
     const realProvider = hardhatACKProvider(_kav10Address);
-    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (params) => {
+    const v10ACKProvider: Parameters<DKGPublisher['publish']>[0]['v10ACKProvider'] = async (params: V10ACKProviderParams) => {
       receivedStagingQuads = params.stagingQuads;
       receivedMerkleLeafCount = params.merkleLeafCount;
       return realProvider(params);
@@ -1416,6 +1417,77 @@ describe('Tentative publish UAL uniqueness', () => {
 
     const started = phases.filter(([, s]) => s === 'start').map(([p]) => p);
     expect(started).toContain('collect_v10_acks');
+  });
+
+  it('V10: public publishes still support legacy positional v10ACKProvider callbacks', async () => {
+    const store = new OxigraphStore();
+    const chain = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const bus = new TypedEventBus();
+    const keypair = await generateEd25519Keypair();
+
+    const publisher = new DKGPublisher({
+      kaAllocator: makeTestKaAllocator(),
+      store, chain, eventBus: bus, keypair,
+      publisherPrivateKey: HARDHAT_KEYS.CORE_OP,
+      publisherNodeIdentityId: BigInt(getSharedContext().coreProfileId),
+    });
+
+    let receivedContextGraphId: string | undefined;
+    let receivedKaCount = 0;
+    let receivedRootEntities: string[] = [];
+    let receivedStagingQuads: Uint8Array | undefined;
+    let receivedMerkleLeafCount = 0;
+    const realProvider = hardhatACKProvider(_kav10Address);
+    const v10ACKProvider: LegacyV10ACKProvider = async (
+      merkleRoot,
+      contextGraphId,
+      kaCount,
+      rootEntities,
+      publicByteSize,
+      stagingQuads,
+      epochs,
+      tokenAmount,
+      swmGraphId,
+      subGraphName,
+      merkleLeafCount,
+      isEncryptedPayload,
+      catalogCommitment,
+    ) => {
+      receivedContextGraphId = contextGraphId;
+      receivedKaCount = kaCount;
+      receivedRootEntities = [...rootEntities];
+      receivedStagingQuads = stagingQuads;
+      receivedMerkleLeafCount = merkleLeafCount;
+      expect(isEncryptedPayload).toBeUndefined();
+      expect(catalogCommitment).toBeUndefined();
+      return realProvider({
+        merkleRoot,
+        contextGraphId,
+        kaCount,
+        rootEntities,
+        publicByteSize,
+        stagingQuads,
+        epochs,
+        tokenAmount,
+        swmGraphId,
+        subGraphName,
+        merkleLeafCount,
+        ackMode: { kind: 'public' },
+      });
+    };
+
+    const result = await pubS(publisher, {
+      contextGraphId: CONTEXT_GRAPH,
+      quads: [q(ENTITY, 'http://schema.org/name', '"Legacy ACK Provider"')],
+      v10ACKProvider,
+    });
+
+    expect(result.status).toBe('confirmed');
+    expect(receivedContextGraphId).toBe(CONTEXT_GRAPH);
+    expect(receivedKaCount).toBe(1);
+    expect(receivedRootEntities).toEqual([ENTITY]);
+    expect(receivedStagingQuads).toBeDefined();
+    expect(receivedMerkleLeafCount).toBeGreaterThan(0);
   });
 
   // -------------------------------------------------------------------------

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -25,7 +25,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { DKGPublisher } from '../src/dkg-publisher.js';
-import { DEFAULT_PUBLISH_EPOCHS, type V10ACKProvider } from '../src/publisher.js';
+import { DEFAULT_PUBLISH_EPOCHS, type V10ACKProvider, type V10ACKProviderParams } from '../src/publisher.js';
 import { generateConfirmedFullMetadata } from '../src/metadata.js';
 import { OxigraphStore } from '@origintrail-official/dkg-storage';
 import { TypedEventBus, generateEd25519Keypair } from '@origintrail-official/dkg-core';
@@ -167,7 +167,7 @@ interface AckEpochCapture {
 
 function captureACKInputs(capture: AckEpochCapture): V10ACKProvider {
   const provider = mockChainStubACKProvider();
-  return async (params) => {
+  return async (params: V10ACKProviderParams) => {
     capture.epochs = params.epochs;
     capture.tokenAmount = params.tokenAmount;
     return provider(params);

--- a/packages/publisher/test/publisher-no-random-wallet.test.ts
+++ b/packages/publisher/test/publisher-no-random-wallet.test.ts
@@ -167,10 +167,10 @@ interface AckEpochCapture {
 
 function captureACKInputs(capture: AckEpochCapture): V10ACKProvider {
   const provider = mockChainStubACKProvider();
-  return async (...args: Parameters<V10ACKProvider>) => {
-    capture.epochs = args[6];
-    capture.tokenAmount = args[7];
-    return provider(...args);
+  return async (params) => {
+    capture.epochs = params.epochs;
+    capture.tokenAmount = params.tokenAmount;
+    return provider(params);
   };
 }
 

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -3,6 +3,7 @@ import { StorageACKHandler, type StorageACKHandlerConfig } from '../src/storage-
 import {
   computeFlatKCRootV10 as computeFlatKCRoot,
   computeFlatKCMerkleLeafCountV10,
+  computePrivateRootV10,
 } from '../src/merkle.js';
 import {
   encodePublishIntent, decodeStorageACK, computePublishACKDigest,
@@ -190,6 +191,58 @@ describe('StorageACKHandler', () => {
       metrics.disable();
       rebuildMetrics();
     }
+  });
+
+  it('returns valid StorageACK for folded public+private data using private root commitments', async () => {
+    const publicQuads: Quad[] = [
+      makeQuad('urn:entity:private-folded', 'urn:p', 'urn:public'),
+    ];
+    const privateQuads: Quad[] = [
+      makeQuad('urn:entity:private-folded', 'urn:p', '"secret"'),
+    ];
+    const privateRoot = computePrivateRootV10(privateQuads)!;
+    const foldedRoot = computeFlatKCRoot(publicQuads, [privateRoot]);
+    const foldedLeafCount = computeFlatKCMerkleLeafCountV10(publicQuads, [privateRoot]);
+    const handler = await createHandler(publicQuads);
+
+    const intent = encodePublishIntent({
+      merkleRoot: foldedRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 300,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: ['urn:entity:private-folded'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: foldedLeafCount,
+      privateMerkleRoots: [privateRoot],
+    });
+
+    const response = await handler.handler(intent, fakePeerId);
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    expect(new Uint8Array(ack.merkleRoot)).toEqual(foldedRoot);
+
+    const digest = computePublishACKDigest(
+      TEST_CHAIN_ID,
+      TEST_KAV10_ADDR,
+      cgIdBigInt,
+      foldedRoot,
+      1n,
+      300n,
+      1n,
+      1000n,
+      BigInt(foldedLeafCount),
+    );
+    const recovered = ethers.recoverAddress(ethers.hashMessage(digest), {
+      r: ethers.hexlify(ack.coreNodeSignatureR instanceof Uint8Array
+        ? ack.coreNodeSignatureR : new Uint8Array(ack.coreNodeSignatureR)),
+      yParityAndS: ethers.hexlify(ack.coreNodeSignatureVS instanceof Uint8Array
+        ? ack.coreNodeSignatureVS : new Uint8Array(ack.coreNodeSignatureVS)),
+    });
+    expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
   });
 
   it('declines (BYTESIZE_UNDERCLAIM) when publicByteSize is below the real content lower bound', async () => {

--- a/packages/publisher/test/storage-ack-handler.test.ts
+++ b/packages/publisher/test/storage-ack-handler.test.ts
@@ -245,6 +245,100 @@ describe('StorageACKHandler', () => {
     expect(recovered.toLowerCase()).toBe(coreWallet.address.toLowerCase());
   });
 
+  it('returns valid StorageACK for inline folded public+private stagingQuads', async () => {
+    const publicQuads: Quad[] = [
+      makeQuad('urn:entity:inline-private-folded', 'urn:p', 'urn:public', 'did:dkg:context-graph:42'),
+    ];
+    const privateQuads: Quad[] = [
+      makeQuad('urn:entity:inline-private-folded', 'urn:p', '"secret"', 'did:dkg:context-graph:42'),
+    ];
+    const privateRoot = computePrivateRootV10(privateQuads)!;
+    const foldedRoot = computeFlatKCRoot(publicQuads, [privateRoot]);
+    const foldedLeafCount = computeFlatKCMerkleLeafCountV10(publicQuads, [privateRoot]);
+    const stagingQuads = new TextEncoder().encode(
+      publicQuads
+        .map((q) => `<${q.subject}> <${q.predicate}> <${q.object}> <${q.graph}> .`)
+        .join('\n'),
+    );
+    const handler = await createHandler([]);
+
+    const response = await handler.handler(encodePublishIntent({
+      merkleRoot: foldedRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: stagingQuads.length,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: ['urn:entity:inline-private-folded'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: foldedLeafCount,
+      stagingQuads,
+      privateMerkleRoots: [privateRoot],
+    }), fakePeerId);
+    const ack = decodeStorageACK(response);
+
+    expect(isStorageACKDecline(ack)).toBe(false);
+    expect(new Uint8Array(ack.merkleRoot)).toEqual(foldedRoot);
+  });
+
+  it('rejects inline folded public+private stagingQuads when private root commitment mismatches', async () => {
+    const publicQuads: Quad[] = [
+      makeQuad('urn:entity:inline-private-mismatch', 'urn:p', 'urn:public', 'did:dkg:context-graph:42'),
+    ];
+    const privateQuads: Quad[] = [
+      makeQuad('urn:entity:inline-private-mismatch', 'urn:p', '"secret"', 'did:dkg:context-graph:42'),
+    ];
+    const privateRoot = computePrivateRootV10(privateQuads)!;
+    const foldedRoot = computeFlatKCRoot(publicQuads, [privateRoot]);
+    const foldedLeafCount = computeFlatKCMerkleLeafCountV10(publicQuads, [privateRoot]);
+    const stagingQuads = new TextEncoder().encode(
+      publicQuads
+        .map((q) => `<${q.subject}> <${q.predicate}> <${q.object}> <${q.graph}> .`)
+        .join('\n'),
+    );
+    const wrongPrivateRoot = new Uint8Array(privateRoot);
+    wrongPrivateRoot[0] ^= 0xff;
+    const handler = await createHandler([]);
+
+    await expect(handler.handler(encodePublishIntent({
+      merkleRoot: foldedRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: stagingQuads.length,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: ['urn:entity:inline-private-mismatch'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: foldedLeafCount,
+      stagingQuads,
+      privateMerkleRoots: [wrongPrivateRoot],
+    }), fakePeerId)).rejects.toThrow('Merkle root mismatch (inline quads)');
+  });
+
+  it('rejects private root commitments on curated/encrypted ACK mode', async () => {
+    const privateRoot = computePrivateRootV10([
+      makeQuad('urn:entity:curated-mode-mix', 'urn:p', '"secret"'),
+    ])!;
+    const handler = await createHandler([]);
+
+    await expect(handler.handler(encodePublishIntent({
+      merkleRoot,
+      contextGraphId,
+      publisherPeerId: 'publisher-0',
+      publicByteSize: 1,
+      isPrivate: true,
+      kaCount: 1,
+      rootEntities: ['urn:entity:curated-mode-mix'],
+      epochs: 1,
+      tokenAmountStr: '1000',
+      merkleLeafCount: swmMerkleLeafCount,
+      isEncryptedPayload: true,
+      privateMerkleRoots: [privateRoot],
+    }), fakePeerId)).rejects.toThrow('privateMerkleRoots are only valid for folded-private public-CG ACKs');
+  });
+
   it('declines (BYTESIZE_UNDERCLAIM) when publicByteSize is below the real content lower bound', async () => {
     // The 3 fixture triples have Σ(|s|+|p|+|o|) = 69, a strict lower bound on
     // any valid N-Quads serialization. A claim of 1 (the byteSize=1 cost dodge)

--- a/packages/publisher/test/v10-ack-edge-cases.test.ts
+++ b/packages/publisher/test/v10-ack-edge-cases.test.ts
@@ -142,6 +142,7 @@ function buildCollectParams(overrides: Partial<Parameters<ACKCollector['collect'
     chainId: TEST_CHAIN_ID,
     kav10Address: TEST_KAV10_ADDR,
     merkleLeafCount: testMerkleLeafCount,
+    ackMode: { kind: 'public' },
     ...overrides,
   };
 }

--- a/packages/publisher/test/v10-remap-wire.test.ts
+++ b/packages/publisher/test/v10-remap-wire.test.ts
@@ -150,6 +150,7 @@ describe('V10 remap wire (PublishIntent.swmGraphId + subGraphName)', () => {
       subGraphName: SUB_GRAPH_NAME,
       stagingQuads,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(result.acks).toHaveLength(3);
@@ -262,6 +263,7 @@ describe('V10 remap wire (PublishIntent.swmGraphId + subGraphName)', () => {
       swmGraphId: TARGET_CG_ID_STR,
       stagingQuads,
       merkleLeafCount,
+      ackMode: { kind: 'public' },
     });
 
     expect(dispatchedIntent).toBeDefined();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,22 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  devnet/pr1369-folded-private-ack:
+    dependencies:
+      '@origintrail-official/dkg-agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
+      '@origintrail-official/dkg-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@origintrail-official/dkg-storage':
+        specifier: workspace:*
+        version: link:../../packages/storage
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(happy-dom@20.8.9(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   devnet/pr1370-admin-op-wallet:
     dependencies:
       ethers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ packages:
   - "devnet/pr1388-okf-integration"
   - "devnet/ka-lifecycle-cli"
   - "devnet/pr1366-pca-deposit-waiver"
+  - "devnet/pr1369-folded-private-ack"
   - "devnet/pr1387-bulk-register-agents"
   - "devnet/pr1384-preserve-agents-on-transfer"
   - "devnet/pr1370-admin-op-wallet"


### PR DESCRIPTION
## Summary

Fixes folded public+private V10 publishes so they can anchor on-chain instead of falling back to local tentative results.

The issue was that `DKGPublisher` skipped V10 ACK collection whenever private roots existed. This change threads private Merkle root commitments through the PublishIntent/ACK path so core nodes can recompute the folded KC root from public quads plus private commitments, without seeing private plaintext.

## Changes

- Add `privateMerkleRoots` to `PublishIntent`.
- Pass private root commitments through publisher, agent, CLI ACK provider, and ACK collector.
- Update `StorageACKHandler` to verify folded public+private roots.
- Remove the private-data local-only ACK skip branch.
- Add regression tests for proto round-trip, ACK collection, ACK verification, and confirmed folded public+private publish.

## Validation

- `pnpm --filter @origintrail-official/dkg-core exec vitest run test/v10-proto.test.ts`
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run --config vitest.ack-temp.config.ts`
- `pnpm --filter @origintrail-official/dkg-publisher exec vitest run test/publish-lifecycle.test.ts --silent`
- Builds passed for core, publisher, agent, CLI, and required dependencies.
- `git diff --check`

fix for https://github.com/OriginTrail/dkg/issues/1369