### PR TITLE
PCA HW sub-PR #1: edge-create + staked-node picker (no web3)

### DIFF
--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -1554,10 +1554,11 @@ export class AgentRegistryMethods extends DKGAgentBase {
   }
 
   /** B-staked-nodes (Stage-5) — the sharding table of designatable PCA primary
-   *  nodes. `null` when the adapter lacks the surface (daemon maps null → 503). */
-  async listDesignatableNodes(this: DKGAgent): Promise<ShardingTableNode[] | null> {
+   *  nodes. `opts.fresh` bypasses the adapter's TTL cache (M4). `null` when the
+   *  adapter lacks the surface (daemon maps null → 503). */
+  async listDesignatableNodes(this: DKGAgent, opts?: { fresh?: boolean }): Promise<ShardingTableNode[] | null> {
     if (typeof this.chain.listDesignatableNodes !== 'function') return null;
-    return this.chain.listDesignatableNodes();
+    return this.chain.listDesignatableNodes(opts);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -95,7 +95,7 @@ import {
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type PcaAccountRelation } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type PcaAccountRelation, type ShardingTableNode } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -1551,6 +1551,13 @@ export class AgentRegistryMethods extends DKGAgentBase {
   ): Promise<PcaAccountRelation[] | null> {
     if (typeof this.chain.listPublishingConvictionAccountsForWallets !== 'function') return null;
     return this.chain.listPublishingConvictionAccountsForWallets(wallets);
+  }
+
+  /** B-staked-nodes (Stage-5) — the sharding table of designatable PCA primary
+   *  nodes. `null` when the adapter lacks the surface (daemon maps null → 503). */
+  async listDesignatableNodes(this: DKGAgent): Promise<ShardingTableNode[] | null> {
+    if (typeof this.chain.listDesignatableNodes !== 'function') return null;
+    return this.chain.listDesignatableNodes();
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -106,4 +106,15 @@ describe('DKGAgent V10 PCA facade', () => {
     const none = await makeAgent(new NoChainAdapter());
     expect(await none.listPublishingConvictionAccountsForWallets([owner.address])).toBeNull();
   });
+
+  it('listDesignatableNodes delegates to the adapter; null when unsupported', async () => {
+    const chain = new MockChainAdapter('mock:31337', ethers.Wallet.createRandom().address);
+    const agent = await makeAgent(chain);
+    const nodes = await agent.listDesignatableNodes();
+    expect(nodes).not.toBeNull();
+    expect(nodes!.map((n) => n.identityId)).toEqual([42n, 57n, 61n]);
+
+    const none = await makeAgent(new NoChainAdapter());
+    expect(await none.listDesignatableNodes()).toBeNull();
+  });
 });

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { DKGAgent } from '../src/index.js';
 import { MockChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain';
@@ -116,5 +116,22 @@ describe('DKGAgent V10 PCA facade', () => {
 
     const none = await makeAgent(new NoChainAdapter());
     expect(await none.listDesignatableNodes()).toBeNull();
+  });
+
+  it('listDesignatableNodes forwards { fresh } through the facade bridge (TfJ)', async () => {
+    const chain = new MockChainAdapter('mock:31337', ethers.Wallet.createRandom().address);
+    const spy = vi.spyOn(chain, 'listDesignatableNodes');
+    const agent = await makeAgent(chain);
+
+    await agent.listDesignatableNodes({ fresh: true });
+    expect(spy).toHaveBeenLastCalledWith({ fresh: true }); // ?fresh propagates to the adapter
+
+    await agent.listDesignatableNodes();
+    expect(spy).toHaveBeenLastCalledWith(undefined); // no opts → undefined (adapter uses its cache)
+    spy.mockRestore();
+
+    // Unsupported adapter still short-circuits to null even with opts.
+    const none = await makeAgent(new NoChainAdapter());
+    expect(await none.listDesignatableNodes({ fresh: true })).toBeNull();
   });
 });

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -36,9 +36,10 @@ export interface ConvictionReader {
    *  503) and the optional ChainAdapter decl. EVMChainAdapter + mock implement it. */
   listPublishingConvictionAccountsForWallets?(wallets: string[]): Promise<PcaAccountRelation[]>;
   /** B-staked-nodes (Stage-5) — the full sharding table of designatable PCA
-   *  primary nodes, hash-ring order, TTL-cached adapter-side. Optional, same
-   *  rationale as above (facade typeof-guard / optional ChainAdapter decl). */
-  listDesignatableNodes?(): Promise<ShardingTableNode[]>;
+   *  primary nodes, hash-ring order, TTL-cached adapter-side. `opts.fresh`
+   *  bypasses the cache (M4: the create-revert recovery + picker Retry). Optional,
+   *  same rationale as above (facade typeof-guard / optional ChainAdapter decl). */
+  listDesignatableNodes?(opts?: { fresh?: boolean }): Promise<ShardingTableNode[]>;
 }
 
 export interface IdentityProof {
@@ -941,10 +942,11 @@ export interface ChainAdapter {
   /**
    * B-staked-nodes (Stage-5) — the full on-chain sharding table of nodes
    * designatable as a PCA `primaryNode`. Read-only; hash-ring order preserved;
-   * TTL-cached adapter-side (the table changes slowly). Optional for the same
-   * reason as the other PCA reads (mock-chain tests can omit it).
+   * TTL-cached adapter-side (the table changes slowly); `opts.fresh` bypasses
+   * the cache (M4). Optional for the same reason as the other PCA reads
+   * (mock-chain tests can omit it).
    */
-  listDesignatableNodes?(): Promise<ShardingTableNode[]>;
+  listDesignatableNodes?(opts?: { fresh?: boolean }): Promise<ShardingTableNode[]>;
 
   /**
    * Returns the V10 NFT-backed PCA's `lockDurationEpochs` for the given

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -15,6 +15,18 @@ export interface PcaAccountRelation {
   relation: PcaRelation;
 }
 
+/** A node from the on-chain sharding table, eligible to be designated as a
+ *  PCA `primaryNode` (B-staked-nodes, Stage-5 picker). `nodeId` is the on-chain
+ *  `bytes` self-reported id (hex string — display-only, hence the picker's
+ *  "unverified" tag); `identityId` is the value passed as `primaryNode`.
+ *  `ask`/`stake` are wei. Returned in the contract's hash-ring order. */
+export interface ShardingTableNode {
+  nodeId: string;
+  identityId: bigint;
+  ask: bigint;
+  stake: bigint;
+}
+
 export interface ConvictionReader {
   getConvictionAgentAccountId(agent: string): Promise<bigint>;
   convictionAccountCanCover(accountId: bigint, baseCost: bigint): Promise<boolean>;
@@ -23,6 +35,10 @@ export interface ConvictionReader {
    *  published surface, consistent with the facade's typeof-guard (capability →
    *  503) and the optional ChainAdapter decl. EVMChainAdapter + mock implement it. */
   listPublishingConvictionAccountsForWallets?(wallets: string[]): Promise<PcaAccountRelation[]>;
+  /** B-staked-nodes (Stage-5) — the full sharding table of designatable PCA
+   *  primary nodes, hash-ring order, TTL-cached adapter-side. Optional, same
+   *  rationale as above (facade typeof-guard / optional ChainAdapter decl). */
+  listDesignatableNodes?(): Promise<ShardingTableNode[]>;
 }
 
 export interface IdentityProof {
@@ -921,6 +937,14 @@ export interface ChainAdapter {
    * Read-only; surfaces read failures (does not fail-safe to a partial list).
    */
   listPublishingConvictionAccountsForWallets?(wallets: string[]): Promise<PcaAccountRelation[]>;
+
+  /**
+   * B-staked-nodes (Stage-5) — the full on-chain sharding table of nodes
+   * designatable as a PCA `primaryNode`. Read-only; hash-ring order preserved;
+   * TTL-cached adapter-side (the table changes slowly). Optional for the same
+   * reason as the other PCA reads (mock-chain tests can omit it).
+   */
+  listDesignatableNodes?(): Promise<ShardingTableNode[]>;
 
   /**
    * Returns the V10 NFT-backed PCA's `lockDurationEpochs` for the given

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -522,22 +522,31 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    * silent node drop. Hash-ring order is preserved; the UI sorts for display.
    *
    * TTL-cached (~30s) adapter-side, success-only (a throw never poisons the
-   * cache). Read failures SURFACE — a CALL_EXCEPTION/transport blip propagates
-   * to the route (→ 503 SHARDING_TABLE_READ_FAILED / 503-504), never a partial
-   * or empty list a picker would misread as "no stakeable nodes".
+   * cache). `opts.fresh` BYPASSES the cache and re-reads the chain (then
+   * repopulates the cache) — M4: the create `PrimaryNodeNotInShardingTable`
+   * revert recovery + the picker Retry call it so a just-rejected /
+   * just-(un)staked node isn't re-served for up to 30s. Read failures SURFACE —
+   * a CALL_EXCEPTION/transport blip propagates to the route (→ 503
+   * SHARDING_TABLE_READ_FAILED / 503-504), never a partial or empty list a
+   * picker would misread as "no stakeable nodes".
    *
    * The no-arg overload is resolved via the explicit `getFunction(...)`
    * signature so ethers v6 never confuses it with `getShardingTable(uint72,
    * uint72)`.
    */
-  async listDesignatableNodes(): Promise<ShardingTableNode[]> {
+  async listDesignatableNodes(opts?: { fresh?: boolean }): Promise<ShardingTableNode[]> {
     const now = Date.now();
     const cached = this.cachedDesignatableNodes;
-    if (cached && now - cached.cachedAt < ConvictionMethods.DESIGNATABLE_NODES_TTL_MS) {
+    if (!opts?.fresh && cached && now - cached.cachedAt < ConvictionMethods.DESIGNATABLE_NODES_TTL_MS) {
       return cached.value;
     }
     await this.init();
-    const shardingTable = await this.resolveContract('ShardingTable');
+    // N2: memoize the resolved logic contract (its address is immutable) so a
+    // TTL-cache miss doesn't re-hit the Hub each time.
+    if (!this.contracts.shardingTable) {
+      this.contracts.shardingTable = await this.resolveContract('ShardingTable');
+    }
+    const shardingTable = this.contracts.shardingTable;
     const raw = await this.readContractWith<ReadonlyArray<any>>(
       shardingTable,
       'shardingTable.getShardingTable',

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -565,12 +565,13 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       return cached.value;
     }
     await this.init();
-    // N2: memoize the resolved logic contract (its address is immutable) so a
-    // TTL-cache miss doesn't re-hit the Hub each time.
-    if (!this.contracts.shardingTable) {
-      this.contracts.shardingTable = await this.resolveContract('ShardingTable');
-    }
-    const shardingTable = this.contracts.shardingTable;
+    // TfA: resolve ShardingTable PER READ — do NOT memoize the handle. A Hub
+    // rotation of ShardingTable isn't on the rotation listener's allowlist, and
+    // `opts.fresh` only busts the node-list cache, so a cached handle would go
+    // stale (serving an old table) until daemon restart. Re-resolving each read
+    // (only on a node-list cache MISS — hits skip this entirely) costs one cheap
+    // Hub getContractAddress and is always rotation-correct. (Reverts N2.)
+    const shardingTable = await this.resolveContract('ShardingTable');
     const raw = await this.readContractWith<readonly RawShardingTableNode[]>(
       shardingTable,
       'shardingTable.getShardingTable',

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -15,6 +15,30 @@ import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader, Pc
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 
+/**
+ * ethers v6 returns a Solidity struct as a `Result`: it is BOTH array-indexable
+ * (positional) AND — when the ABI names the outputs — property-accessible. The
+ * `ShardingTable.getShardingTable()` ABI names them today; we normalize either
+ * shape so a future ABI regen that drops the names can't silently break the
+ * decode. Pure + exported for unit testing (R6); kills the `any` at the
+ * read boundary in `listDesignatableNodes`.
+ */
+export interface RawShardingTableNode extends ArrayLike<unknown> {
+  nodeId?: unknown;
+  identityId?: unknown;
+  ask?: unknown;
+  stake?: unknown;
+}
+
+export function toShardingTableNode(raw: RawShardingTableNode): ShardingTableNode {
+  return {
+    nodeId: String(raw.nodeId ?? raw[0]),
+    identityId: BigInt((raw.identityId ?? raw[1]) as bigint | number | string),
+    ask: BigInt((raw.ask ?? raw[2]) as bigint | number | string),
+    stake: BigInt((raw.stake ?? raw[3]) as bigint | number | string),
+  };
+}
+
 export class ConvictionMethods extends EVMChainAdapterBase implements ConvictionReader {
   // =====================================================================
   // Staking + Publishing Conviction Account legacy surface — ARCHIVED
@@ -547,23 +571,18 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       this.contracts.shardingTable = await this.resolveContract('ShardingTable');
     }
     const shardingTable = this.contracts.shardingTable;
-    const raw = await this.readContractWith<ReadonlyArray<any>>(
+    const raw = await this.readContractWith<readonly RawShardingTableNode[]>(
       shardingTable,
       'shardingTable.getShardingTable',
       (c) => c.getFunction('getShardingTable()').staticCall(),
     );
     const nodes: ShardingTableNode[] = [];
     for (const n of raw ?? []) {
-      const identityId = BigInt(n.identityId ?? n[1]);
+      const node = toShardingTableNode(n);
       // The no-arg read is sized to nodesCount() so it shouldn't pad, but a
       // zero identityId is never a real node — skip defensively.
-      if (identityId <= 0n) continue;
-      nodes.push({
-        nodeId: String(n.nodeId ?? n[0]),
-        identityId,
-        ask: BigInt(n.ask ?? n[2]),
-        stake: BigInt(n.stake ?? n[3]),
-      });
+      if (node.identityId <= 0n) continue;
+      nodes.push(node);
     }
     this.cachedDesignatableNodes = { value: nodes, cachedAt: now };
     return nodes;

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -11,7 +11,7 @@
 
 import { EVMChainAdapterBase } from './evm-adapter-base.js';
 import { ethers, Contract } from 'ethers';
-import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader, PcaAccountRelation } from './chain-adapter.js';
+import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader, PcaAccountRelation, ShardingTableNode } from './chain-adapter.js';
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 
@@ -504,5 +504,59 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       const g = agent.has(accountId);
       return { accountId, relation: (o && g ? 'both' : o ? 'owned' : 'agent') as PcaAccountRelation['relation'] };
     });
+  }
+
+  /** ~30s adapter-side TTL for the B-staked-nodes list. The sharding table
+   *  changes slowly and the picker polls it; this is a DEDICATED short TTL, not
+   *  the 1h publish-preflight cache. */
+  private static readonly DESIGNATABLE_NODES_TTL_MS = 30_000;
+  private cachedDesignatableNodes: { value: ShardingTableNode[]; cachedAt: number } | undefined;
+
+  /**
+   * B-staked-nodes (Stage-5) — the full sharding table of nodes designatable as
+   * a PCA `primaryNode`. Reads the no-arg `ShardingTable.getShardingTable()`,
+   * which returns the COMPLETE table: it sizes the read to the live
+   * `nodesCount()`, and `shardingTableSizeLimit` is an INSERT-enforced maximum
+   * (ShardingTable._insertNode reverts `ShardingTableIsFull` at `nodesCount >=
+   * limit`), never a read-truncation cap — so there is nothing to page and no
+   * silent node drop. Hash-ring order is preserved; the UI sorts for display.
+   *
+   * TTL-cached (~30s) adapter-side, success-only (a throw never poisons the
+   * cache). Read failures SURFACE — a CALL_EXCEPTION/transport blip propagates
+   * to the route (→ 503 SHARDING_TABLE_READ_FAILED / 503-504), never a partial
+   * or empty list a picker would misread as "no stakeable nodes".
+   *
+   * The no-arg overload is resolved via the explicit `getFunction(...)`
+   * signature so ethers v6 never confuses it with `getShardingTable(uint72,
+   * uint72)`.
+   */
+  async listDesignatableNodes(): Promise<ShardingTableNode[]> {
+    const now = Date.now();
+    const cached = this.cachedDesignatableNodes;
+    if (cached && now - cached.cachedAt < ConvictionMethods.DESIGNATABLE_NODES_TTL_MS) {
+      return cached.value;
+    }
+    await this.init();
+    const shardingTable = await this.resolveContract('ShardingTable');
+    const raw = await this.readContractWith<ReadonlyArray<any>>(
+      shardingTable,
+      'shardingTable.getShardingTable',
+      (c) => c.getFunction('getShardingTable()').staticCall(),
+    );
+    const nodes: ShardingTableNode[] = [];
+    for (const n of raw ?? []) {
+      const identityId = BigInt(n.identityId ?? n[1]);
+      // The no-arg read is sized to nodesCount() so it shouldn't pad, but a
+      // zero identityId is never a real node — skip defensively.
+      if (identityId <= 0n) continue;
+      nodes.push({
+        nodeId: String(n.nodeId ?? n[0]),
+        identityId,
+        ask: BigInt(n.ask ?? n[2]),
+        stake: BigInt(n.stake ?? n[3]),
+      });
+    }
+    this.cachedDesignatableNodes = { value: nodes, cachedAt: now };
+    return nodes;
   }
 }

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -130,6 +130,10 @@ export interface ContractCache {
    * Tracked at issue #831.
    */
   chronos?: Contract;
+  /** B-staked-nodes (Stage-5): memoized ShardingTable logic contract — its
+   *  address is immutable, so listDesignatableNodes resolves it once instead of
+   *  re-hitting the Hub on every TTL-cache miss. */
+  shardingTable?: Contract;
 }
 
 export function formatProviderContext(config: Pick<EVMAdapterConfig, 'chainId' | 'rpcUrl'>): string {

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -130,10 +130,6 @@ export interface ContractCache {
    * Tracked at issue #831.
    */
   chronos?: Contract;
-  /** B-staked-nodes (Stage-5): memoized ShardingTable logic contract — its
-   *  address is immutable, so listDesignatableNodes resolves it once instead of
-   *  re-hitting the Hub on every TTL-cache miss. */
-  shardingTable?: Contract;
 }
 
 export function formatProviderContext(config: Pick<EVMAdapterConfig, 'chainId' | 'rpcUrl'>): string {

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -701,8 +701,9 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   /** B-staked-nodes parity (Stage-5) — a small fixed sharding-table fixture in
-   *  hash-ring order. nodeId = hex `bytes`; identityId/ask/stake = bigint. */
-  async listDesignatableNodes(): Promise<ShardingTableNode[]> {
+   *  hash-ring order. nodeId = hex `bytes`; identityId/ask/stake = bigint. The
+   *  `fresh` opt is accepted for surface parity (the mock has no cache). */
+  async listDesignatableNodes(_opts?: { fresh?: boolean }): Promise<ShardingTableNode[]> {
     return [
       { nodeId: '0x6e6f64652d31', identityId: 42n, ask: 1_000_000_000_000_000_000n, stake: 250_000n * 10n ** 18n },
       { nodeId: '0x6e6f64652d32', identityId: 57n, ask: 2_000_000_000_000_000_000n, stake: 180_000n * 10n ** 18n },

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -25,6 +25,7 @@ import type {
   V10PublishingConvictionAccountInfo,
   VerifyACKIdentityResult,
   PcaAccountRelation,
+  ShardingTableNode,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -697,6 +698,16 @@ export class MockChainAdapter implements ChainAdapter {
       const g = agent.has(accountId);
       return { accountId, relation: (o && g ? 'both' : o ? 'owned' : 'agent') as PcaAccountRelation['relation'] };
     });
+  }
+
+  /** B-staked-nodes parity (Stage-5) — a small fixed sharding-table fixture in
+   *  hash-ring order. nodeId = hex `bytes`; identityId/ask/stake = bigint. */
+  async listDesignatableNodes(): Promise<ShardingTableNode[]> {
+    return [
+      { nodeId: '0x6e6f64652d31', identityId: 42n, ask: 1_000_000_000_000_000_000n, stake: 250_000n * 10n ** 18n },
+      { nodeId: '0x6e6f64652d32', identityId: 57n, ask: 2_000_000_000_000_000_000n, stake: 180_000n * 10n ** 18n },
+      { nodeId: '0x6e6f64652d33', identityId: 61n, ask: 1_500_000_000_000_000_000n, stake: 500_000n * 10n ** 18n },
+    ];
   }
 
   /** Mirrors `agentToAccountId`; `0n` for unregistered → publisher SDK

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { ethers } from 'ethers';
 import { MockChainAdapter } from '../src/mock-adapter.js';
+import { toShardingTableNode } from '../src/evm-adapter-conviction.js';
 
 const SIGNER = '0x1111111111111111111111111111111111111111';
 const COMMITTED = ethers.parseEther('10000');
@@ -181,6 +182,18 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
       expect(n.stake).toBeGreaterThan(0n);
       expect(n.ask).toBeGreaterThan(0n);
     }
+  });
+
+  it('toShardingTableNode normalizes both ethers Result shapes — named object + positional tuple (R6)', () => {
+    // Named-object shape (the ABI names the struct outputs today).
+    expect(toShardingTableNode({ nodeId: '0xab', identityId: 7n, ask: 1n, stake: 2n } as any))
+      .toEqual({ nodeId: '0xab', identityId: 7n, ask: 1n, stake: 2n });
+    // Positional-tuple shape (names dropped) — same result via the index fallback.
+    expect(toShardingTableNode(['0xab', 7n, 1n, 2n] as any))
+      .toEqual({ nodeId: '0xab', identityId: 7n, ask: 1n, stake: 2n });
+    // Mixed numeric/string inputs coerce to bigint.
+    expect(toShardingTableNode(['0xcd', '9', 3, 4n] as any))
+      .toEqual({ nodeId: '0xcd', identityId: 9n, ask: 3n, stake: 4n });
   });
 });
 

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -169,6 +169,19 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
     // Unrelated wallet → [].
     expect(await mock.listPublishingConvictionAccountsForWallets([ethers.Wallet.createRandom().address])).toEqual([]);
   });
+
+  it('listDesignatableNodes — fixture sharding table in hash-ring order (B-staked-nodes parity)', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const nodes = await mock.listDesignatableNodes();
+    expect(nodes).toHaveLength(3);
+    expect(nodes.map((n) => n.identityId)).toEqual([42n, 57n, 61n]); // order preserved (not sorted)
+    for (const n of nodes) {
+      expect(n.nodeId).toMatch(/^0x[0-9a-fA-F]+$/);
+      expect(typeof n.identityId).toBe('bigint');
+      expect(n.stake).toBeGreaterThan(0n);
+      expect(n.ask).toBeGreaterThan(0n);
+    }
+  });
 });
 
 describe('MockChainAdapter — V10 conviction topUp/settle', () => {

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -10,7 +10,7 @@
  * Conventions mirror chain-lifecycle-extra.test.ts: real EVMChainAdapter
  * over the shared Hardhat node, one snapshot per test for isolation.
  */
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ethers } from 'ethers';
@@ -209,6 +209,29 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     }
     // No zero-id padding leaks through (defensive trim holds).
     expect(nodes.every((n) => n.identityId > 0n)).toBe(true);
+  });
+
+  it('listDesignatableNodes TTL-caches (cache hit skips the read; ?fresh bypasses) and a throw does not poison it (M6)', async () => {
+    const reader = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const good = await reader.listDesignatableNodes(); // populate the cache + memoize the contract
+
+    // Cache hit: a 2nd call within the 30s TTL does NOT re-read the chain.
+    const spy = vi.spyOn(reader as any, 'readContractWith');
+    await reader.listDesignatableNodes();
+    expect(spy).not.toHaveBeenCalled();
+
+    // ?fresh bypasses the cache → exactly one underlying read.
+    await reader.listDesignatableNodes({ fresh: true });
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+
+    // Success-only / no-negative-cache: a throwing fresh read must leave the
+    // prior good value cached (the next non-fresh call still returns it).
+    const boom = vi.spyOn(reader as any, 'readContractWith')
+      .mockRejectedValueOnce(Object.assign(new Error('blip'), { code: 'CALL_EXCEPTION' }));
+    await expect(reader.listDesignatableNodes({ fresh: true })).rejects.toThrow();
+    boom.mockRestore();
+    expect(await reader.listDesignatableNodes()).toEqual(good);
   });
 
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -241,6 +241,20 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(await reader.listDesignatableNodes()).toEqual(refreshed); // unpoisoned
   });
 
+  it('listDesignatableNodes re-resolves ShardingTable per read — no stale handle after a Hub rotation (TfA)', async () => {
+    // The handle is NOT memoized: each read that reaches the chain (a node-list
+    // cache MISS — ?fresh forces one) re-resolves ShardingTable from the Hub, so
+    // a Hub rotation is picked up on the next read instead of a stale cached
+    // contract serving the old table until daemon restart.
+    const reader = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const resolveSpy = vi.spyOn(reader as any, 'resolveContract');
+    await reader.listDesignatableNodes({ fresh: true });
+    await reader.listDesignatableNodes({ fresh: true });
+    const stResolves = resolveSpy.mock.calls.filter((c: any[]) => c[0] === 'ShardingTable').length;
+    expect(stResolves).toBe(2); // re-resolved on each read, never memoized
+    resolveSpy.mockRestore();
+  });
+
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -211,27 +211,34 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(nodes.every((n) => n.identityId > 0n)).toBe(true);
   });
 
-  it('listDesignatableNodes TTL-caches (cache hit skips the read; ?fresh bypasses) and a throw does not poison it (M6)', async () => {
+  it('listDesignatableNodes TTL-caches, ?fresh REPOPULATES the cache, and a throw does not poison it (M6/R3)', async () => {
     const reader = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
-    const good = await reader.listDesignatableNodes(); // populate the cache + memoize the contract
+    const good = await reader.listDesignatableNodes(); // real read populates the cache
 
     // Cache hit: a 2nd call within the 30s TTL does NOT re-read the chain.
-    const spy = vi.spyOn(reader as any, 'readContractWith');
-    await reader.listDesignatableNodes();
-    expect(spy).not.toHaveBeenCalled();
+    const hitSpy = vi.spyOn(reader as any, 'readContractWith');
+    expect(await reader.listDesignatableNodes()).toEqual(good);
+    expect(hitSpy).not.toHaveBeenCalled();
+    hitSpy.mockRestore();
 
-    // ?fresh bypasses the cache → exactly one underlying read.
-    await reader.listDesignatableNodes({ fresh: true });
-    expect(spy).toHaveBeenCalledTimes(1);
-    spy.mockRestore();
+    // ?fresh BYPASSES *and REPOPULATES*: stub the underlying read to return a
+    // DISTINGUISHABLE table, then prove the next NON-fresh call serves it. (A
+    // bypass-without-repopulate would still return `good` here and pass falsely —
+    // this is the R3 strengthening over the same-fixture version.)
+    const refreshed = [{ nodeId: '0xfeed', identityId: 99999n, ask: 7n, stake: 8n }];
+    const rawRefreshed = refreshed.map((n) => [n.nodeId, n.identityId, n.ask, n.stake]); // ethers positional tuple
+    const freshSpy = vi.spyOn(reader as any, 'readContractWith').mockResolvedValueOnce(rawRefreshed);
+    expect(await reader.listDesignatableNodes({ fresh: true })).toEqual(refreshed);
+    expect(freshSpy).toHaveBeenCalledTimes(1);
+    freshSpy.mockRestore();
+    expect(await reader.listDesignatableNodes()).toEqual(refreshed); // cache now holds the refreshed value
 
-    // Success-only / no-negative-cache: a throwing fresh read must leave the
-    // prior good value cached (the next non-fresh call still returns it).
+    // No-negative-cache: a throwing fresh read leaves the last good (refreshed) value.
     const boom = vi.spyOn(reader as any, 'readContractWith')
       .mockRejectedValueOnce(Object.assign(new Error('blip'), { code: 'CALL_EXCEPTION' }));
     await expect(reader.listDesignatableNodes({ fresh: true })).rejects.toThrow();
     boom.mockRestore();
-    expect(await reader.listDesignatableNodes()).toEqual(good);
+    expect(await reader.listDesignatableNodes()).toEqual(refreshed); // unpoisoned
   });
 
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -187,6 +187,30 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(await owner.listPublishingConvictionAccountsForWallets([ethers.Wallet.createRandom().address])).toEqual([]);
   });
 
+  it('listDesignatableNodes reads the staked sharding table (no-arg overload) and maps NodeInfo (B-staked-nodes)', async () => {
+    // The shared Hardhat env pre-stakes the core node + 3 receivers into the
+    // sharding table (spawnHardhatEnv: "staked + ask set"), so the table is
+    // non-empty at baseline — this exercises the no-arg getShardingTable()
+    // overload + the on-chain NodeInfo decode/mapping against real data.
+    const reader = createEVMAdapter(HARDHAT_KEYS.CORE_OP);
+    const { receiverIds } = getSharedContext();
+
+    const nodes = await reader.listDesignatableNodes();
+    expect(nodes.length).toBeGreaterThanOrEqual(receiverIds.length);
+
+    // Every pre-staked receiver appears, mapped from the on-chain NodeInfo.
+    const byId = new Map(nodes.map((n) => [n.identityId, n]));
+    for (const rid of receiverIds) {
+      const node = byId.get(BigInt(rid));
+      expect(node, `receiver ${rid} should be in the sharding table`).toBeDefined();
+      expect(node!.nodeId).toMatch(/^0x[0-9a-fA-F]+$/); // on-chain bytes → hex
+      expect(node!.stake).toBeGreaterThan(0n);
+      expect(node!.ask).toBeGreaterThan(0n);
+    }
+    // No zero-id padding leaks through (defensive trim holds).
+    expect(nodes.every((n) => n.identityId > 0n)).toBe(true);
+  });
+
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -557,6 +557,63 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     }
   }
 
+  // GET /api/pca/designatable-nodes — B-staked-nodes (Stage-5). The full
+  // sharding table of nodes designatable as a PCA `primaryNode`, for the create
+  // wizard's PrimaryNodePicker. Read-only; the adapter reads the whole table
+  // (TTL-cached) and this route serves OFFSET pages: ?start=<0-based offset>
+  // &limit=<1..200, default 50>. Hash-ring order preserved (the UI sorts).
+  // Matched EXACTLY before the generic GET :id below, else 'designatable-nodes'
+  // parses as an accountId and 400s.
+  if (req.method === 'GET' && path === '/api/pca/designatable-nodes') {
+    if (!agent.supportsPublishingConvictionNft) {
+      return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+    }
+    const startRaw = ctx.url.searchParams.get('start');
+    const limitRaw = ctx.url.searchParams.get('limit');
+    const start = startRaw === null ? 0 : Number(startRaw);
+    const limit = limitRaw === null ? 50 : Number(limitRaw);
+    if (!Number.isInteger(start) || start < 0) {
+      return jsonResponse(res, 400, { error: 'Invalid start — must be a non-negative integer offset' });
+    }
+    if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
+      return jsonResponse(res, 400, { error: 'Invalid limit — must be an integer 1..200' });
+    }
+    try {
+      const all = await agent.listDesignatableNodes();
+      if (all === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      const total = all.length;
+      const page = all.slice(start, start + limit);
+      const nextStart = start + limit < total ? start + limit : null;
+      return jsonResponse(res, 200, {
+        nodes: page.map((n) => ({
+          nodeId: n.nodeId,
+          identityId: n.identityId.toString(),
+          ask: n.ask.toString(),
+          stake: n.stake.toString(),
+        })),
+        total,
+        nextStart,
+      });
+    } catch (err: any) {
+      const msg = err?.message ?? String(err);
+      if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+      if (respondIfChainRpcTransportError(res, err)) return;
+      // A CALL_EXCEPTION here is a sharding-table read failure → 503 retryable
+      // with a DEDICATED code (distinct from a PCA snapshot read), NOT a
+      // partial/empty list a picker would read as "no stakeable nodes".
+      if (err?.code === 'CALL_EXCEPTION') {
+        return jsonResponse(res, 503, {
+          error: 'Designatable-node list temporarily unavailable — sharding-table read failed',
+          code: 'SHARDING_TABLE_READ_FAILED',
+        });
+      }
+      return jsonResponse(res, 500, {
+        error: `listDesignatableNodes failed: ${msg}`,
+      });
+    }
+  }
+
   // GET /api/pca/:id — V10 conviction NFT snapshot. Optional ?key=0x...
   // probes whether that address is a registered agent. Optional ?extended=1
   // adds the GAP-4/5 budget fields (primaryNode + current-epoch allowance);

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -559,33 +559,15 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
 
   // GET /api/pca/designatable-nodes — B-staked-nodes (Stage-5). The full
   // sharding table of nodes designatable as a PCA `primaryNode`, for the create
-  // wizard's PrimaryNodePicker. Read-only; the adapter reads the whole table
-  // (TTL-cached) and this route serves OFFSET pages: ?start=<0-based offset>
-  // &limit=<1..200, route default 50; the FE fetches the whole table with
-  // limit=200, N3>. ?fresh=1 bypasses the adapter cache (M4). Hash-ring order
-  // preserved (the UI sorts). Matched EXACTLY before the generic GET :id below,
-  // else 'designatable-nodes' parses as an accountId and 400s.
+  // wizard's PrimaryNodePicker. Read-only; returns the WHOLE capped table
+  // (≤ shardingTableSizeLimit, default 500) in ONE response — no pagination
+  // (R4): the adapter reads + caches it whole and the UI drains it whole, so
+  // offset cursors bought no chain-work savings. ?fresh=1 bypasses the adapter
+  // cache (M4). Hash-ring order preserved (the UI sorts). Matched EXACTLY before
+  // the generic GET :id below, else 'designatable-nodes' parses as an accountId.
   if (req.method === 'GET' && path === '/api/pca/designatable-nodes') {
     if (!agent.supportsPublishingConvictionNft) {
       return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
-    }
-    const startRaw = ctx.url.searchParams.get('start');
-    const limitRaw = ctx.url.searchParams.get('limit');
-    // N5: strict decimal — reject hex/exponent/'+'/'' that Number() would coerce,
-    // so parsing matches the "non-negative integer" contract the error copy claims.
-    if (startRaw !== null && !/^\d+$/.test(startRaw)) {
-      return jsonResponse(res, 400, { error: 'Invalid start — must be a non-negative integer offset' });
-    }
-    if (limitRaw !== null && !/^\d+$/.test(limitRaw)) {
-      return jsonResponse(res, 400, { error: 'Invalid limit — must be an integer 1..200' });
-    }
-    const start = startRaw === null ? 0 : Number(startRaw);
-    const limit = limitRaw === null ? 50 : Number(limitRaw);
-    if (!Number.isInteger(start) || start < 0) {
-      return jsonResponse(res, 400, { error: 'Invalid start — must be a non-negative integer offset' });
-    }
-    if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
-      return jsonResponse(res, 400, { error: 'Invalid limit — must be an integer 1..200' });
     }
     // M4: ?fresh=1 bypasses the adapter's 30s TTL cache (and repopulates it) so
     // the create PrimaryNodeNotInShardingTable revert recovery + picker Retry
@@ -594,18 +576,14 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     try {
       const all = await agent.listDesignatableNodes({ fresh });
       if (all === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
-      const total = all.length;
-      const page = all.slice(start, start + limit);
-      const nextStart = start + limit < total ? start + limit : null;
       return jsonResponse(res, 200, {
-        nodes: page.map((n) => ({
+        nodes: all.map((n) => ({
           nodeId: n.nodeId,
           identityId: n.identityId.toString(),
           ask: n.ask.toString(),
           stake: n.stake.toString(),
         })),
-        total,
-        nextStart,
+        total: all.length,
       });
     } catch (err: any) {
       const msg = err?.message ?? String(err);

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -561,15 +561,24 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
   // sharding table of nodes designatable as a PCA `primaryNode`, for the create
   // wizard's PrimaryNodePicker. Read-only; the adapter reads the whole table
   // (TTL-cached) and this route serves OFFSET pages: ?start=<0-based offset>
-  // &limit=<1..200, default 50>. Hash-ring order preserved (the UI sorts).
-  // Matched EXACTLY before the generic GET :id below, else 'designatable-nodes'
-  // parses as an accountId and 400s.
+  // &limit=<1..200, route default 50; the FE fetches the whole table with
+  // limit=200, N3>. ?fresh=1 bypasses the adapter cache (M4). Hash-ring order
+  // preserved (the UI sorts). Matched EXACTLY before the generic GET :id below,
+  // else 'designatable-nodes' parses as an accountId and 400s.
   if (req.method === 'GET' && path === '/api/pca/designatable-nodes') {
     if (!agent.supportsPublishingConvictionNft) {
       return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
     }
     const startRaw = ctx.url.searchParams.get('start');
     const limitRaw = ctx.url.searchParams.get('limit');
+    // N5: strict decimal — reject hex/exponent/'+'/'' that Number() would coerce,
+    // so parsing matches the "non-negative integer" contract the error copy claims.
+    if (startRaw !== null && !/^\d+$/.test(startRaw)) {
+      return jsonResponse(res, 400, { error: 'Invalid start — must be a non-negative integer offset' });
+    }
+    if (limitRaw !== null && !/^\d+$/.test(limitRaw)) {
+      return jsonResponse(res, 400, { error: 'Invalid limit — must be an integer 1..200' });
+    }
     const start = startRaw === null ? 0 : Number(startRaw);
     const limit = limitRaw === null ? 50 : Number(limitRaw);
     if (!Number.isInteger(start) || start < 0) {
@@ -578,8 +587,12 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
     if (!Number.isInteger(limit) || limit < 1 || limit > 200) {
       return jsonResponse(res, 400, { error: 'Invalid limit — must be an integer 1..200' });
     }
+    // M4: ?fresh=1 bypasses the adapter's 30s TTL cache (and repopulates it) so
+    // the create PrimaryNodeNotInShardingTable revert recovery + picker Retry
+    // re-read the chain instead of re-serving a stale just-rejected node.
+    const fresh = ctx.url.searchParams.get('fresh') === '1';
     try {
-      const all = await agent.listDesignatableNodes();
+      const all = await agent.listDesignatableNodes({ fresh });
       if (all === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       const total = all.length;
       const page = all.slice(start, start + limit);
@@ -599,10 +612,11 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
       if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       if (isPcaUnavailable(err, msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
       if (respondIfChainRpcTransportError(res, err)) return;
-      // A CALL_EXCEPTION here is a sharding-table read failure → 503 retryable
-      // with a DEDICATED code (distinct from a PCA snapshot read), NOT a
-      // partial/empty list a picker would read as "no stakeable nodes".
-      if (err?.code === 'CALL_EXCEPTION') {
+      // A CALL_EXCEPTION (read revert) or BAD_DATA (ABI/overload decode failure,
+      // L10) here is a sharding-table read failure → 503 retryable with a
+      // DEDICATED code (distinct from a PCA snapshot read), NOT a partial/empty
+      // list a picker would read as "no stakeable nodes".
+      if (err?.code === 'CALL_EXCEPTION' || err?.code === 'BAD_DATA') {
         return jsonResponse(res, 503, {
           error: 'Designatable-node list temporarily unavailable — sharding-table read failed',
           code: 'SHARDING_TABLE_READ_FAILED',

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -994,14 +994,14 @@ describe('daemon /api/pca V10 caller contract', () => {
     { nodeId: '0xcc', identityId: 61n, ask: 3n, stake: 500n },
   ];
 
-  it('GET /api/pca/designatable-nodes → 200 {nodes,total,nextStart}, bigints serialized, order preserved', async () => {
+  it('GET /api/pca/designatable-nodes → 200 {nodes,total} — the WHOLE table in one response (R4, no pagination)', async () => {
     const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
     const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
     await done;
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
     expect(body.total).toBe(3);
-    expect(body.nextStart).toBeNull(); // default limit 50 > total
+    expect(body).not.toHaveProperty('nextStart'); // pagination dropped (R4)
     expect(body.nodes).toEqual([
       { nodeId: '0xaa', identityId: '42', ask: '1', stake: '250' },
       { nodeId: '0xbb', identityId: '57', ask: '2', stake: '180' },
@@ -1009,38 +1009,22 @@ describe('daemon /api/pca V10 caller contract', () => {
     ]);
   });
 
-  it('GET /api/pca/designatable-nodes paginates via ?start & ?limit with nextStart', async () => {
+  it('GET /api/pca/designatable-nodes ignores legacy ?start/?limit (no pagination, no 400)', async () => {
     const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
-    const p1 = runCtx('GET', '/api/pca/designatable-nodes?start=0&limit=2', agent);
-    await p1.done;
-    const b1 = JSON.parse(p1.res.body);
-    expect(b1.nodes.map((n: any) => n.identityId)).toEqual(['42', '57']);
-    expect(b1.total).toBe(3);
-    expect(b1.nextStart).toBe(2);
-
-    const p2 = runCtx('GET', '/api/pca/designatable-nodes?start=2&limit=2', agent);
-    await p2.done;
-    const b2 = JSON.parse(p2.res.body);
-    expect(b2.nodes.map((n: any) => n.identityId)).toEqual(['61']);
-    expect(b2.nextStart).toBeNull(); // last page
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes?start=2&limit=1', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.nodes).toHaveLength(3); // full table regardless of legacy params
+    expect(body).not.toHaveProperty('nextStart');
   });
 
-  it('GET /api/pca/designatable-nodes → empty table {nodes:[],total:0,nextStart:null}', async () => {
+  it('GET /api/pca/designatable-nodes → empty table {nodes:[],total:0}', async () => {
     const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => [] };
     const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
     await done;
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ nodes: [], total: 0, nextStart: null });
-  });
-
-  it('GET /api/pca/designatable-nodes → 400 on invalid start/limit', async () => {
-    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
-    // N5: strict decimal — hex / exponent / leading '+' (URL-encoded) are rejected too.
-    for (const q of ['?start=-1', '?limit=0', '?limit=201', '?start=abc', '?limit=1.5', '?start=0x10', '?limit=1e2', '?start=%2B5']) {
-      const { res, done } = runCtx('GET', `/api/pca/designatable-nodes${q}`, agent);
-      await done;
-      expect(res.statusCode).toBe(400);
-    }
+    expect(JSON.parse(res.body)).toEqual({ nodes: [], total: 0 });
   });
 
   it('GET /api/pca/designatable-nodes → 503 when the adapter lacks the PCA surface (lookup not called)', async () => {

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -986,4 +986,97 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).accounts).toEqual([{ accountId: '5', relation: 'agent' }]);
   });
+
+  // ----- B-staked-nodes (Stage-5): GET /api/pca/designatable-nodes -----
+  const NODE_FIXTURE = [
+    { nodeId: '0xaa', identityId: 42n, ask: 1n, stake: 250n },
+    { nodeId: '0xbb', identityId: 57n, ask: 2n, stake: 180n },
+    { nodeId: '0xcc', identityId: 61n, ask: 3n, stake: 500n },
+  ];
+
+  it('GET /api/pca/designatable-nodes → 200 {nodes,total,nextStart}, bigints serialized, order preserved', async () => {
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.total).toBe(3);
+    expect(body.nextStart).toBeNull(); // default limit 50 > total
+    expect(body.nodes).toEqual([
+      { nodeId: '0xaa', identityId: '42', ask: '1', stake: '250' },
+      { nodeId: '0xbb', identityId: '57', ask: '2', stake: '180' },
+      { nodeId: '0xcc', identityId: '61', ask: '3', stake: '500' },
+    ]);
+  });
+
+  it('GET /api/pca/designatable-nodes paginates via ?start & ?limit with nextStart', async () => {
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
+    const p1 = runCtx('GET', '/api/pca/designatable-nodes?start=0&limit=2', agent);
+    await p1.done;
+    const b1 = JSON.parse(p1.res.body);
+    expect(b1.nodes.map((n: any) => n.identityId)).toEqual(['42', '57']);
+    expect(b1.total).toBe(3);
+    expect(b1.nextStart).toBe(2);
+
+    const p2 = runCtx('GET', '/api/pca/designatable-nodes?start=2&limit=2', agent);
+    await p2.done;
+    const b2 = JSON.parse(p2.res.body);
+    expect(b2.nodes.map((n: any) => n.identityId)).toEqual(['61']);
+    expect(b2.nextStart).toBeNull(); // last page
+  });
+
+  it('GET /api/pca/designatable-nodes → empty table {nodes:[],total:0,nextStart:null}', async () => {
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => [] };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ nodes: [], total: 0, nextStart: null });
+  });
+
+  it('GET /api/pca/designatable-nodes → 400 on invalid start/limit', async () => {
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
+    for (const q of ['?start=-1', '?limit=0', '?limit=201', '?start=abc', '?limit=1.5']) {
+      const { res, done } = runCtx('GET', `/api/pca/designatable-nodes${q}`, agent);
+      await done;
+      expect(res.statusCode).toBe(400);
+    }
+  });
+
+  it('GET /api/pca/designatable-nodes → 503 when the adapter lacks the PCA surface (lookup not called)', async () => {
+    let called = false;
+    const agent = { supportsPublishingConvictionNft: false, listDesignatableNodes: async () => { called = true; return []; } };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(called).toBe(false);
+  });
+
+  it('GET /api/pca/designatable-nodes → 503 SHARDING_TABLE_READ_FAILED on a CALL_EXCEPTION (dedicated code)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listDesignatableNodes: async () => { const e: any = new Error('sharding read failed'); e.code = 'CALL_EXCEPTION'; throw e; },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBe('SHARDING_TABLE_READ_FAILED');
+  });
+
+  it('GET /api/pca/designatable-nodes → 503 FEATURE_UNAVAILABLE when the facade returns null (no code)', async () => {
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => null };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBeUndefined();
+  });
+
+  it('route ordering: /api/pca/designatable-nodes is matched BEFORE the generic GET :id (not 400 as an id)', async () => {
+    // If the generic :id matcher ran first, "designatable-nodes" would parse as
+    // an accountId and 400 ("Invalid accountId"). A clean 200 proves the
+    // specific route is registered ahead of it.
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => [] };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+  });
 });

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -1035,7 +1035,8 @@ describe('daemon /api/pca V10 caller contract', () => {
 
   it('GET /api/pca/designatable-nodes → 400 on invalid start/limit', async () => {
     const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => NODE_FIXTURE };
-    for (const q of ['?start=-1', '?limit=0', '?limit=201', '?start=abc', '?limit=1.5']) {
+    // N5: strict decimal — hex / exponent / leading '+' (URL-encoded) are rejected too.
+    for (const q of ['?start=-1', '?limit=0', '?limit=201', '?start=abc', '?limit=1.5', '?start=0x10', '?limit=1e2', '?start=%2B5']) {
       const { res, done } = runCtx('GET', `/api/pca/designatable-nodes${q}`, agent);
       await done;
       expect(res.statusCode).toBe(400);
@@ -1078,5 +1079,57 @@ describe('daemon /api/pca V10 caller contract', () => {
     const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
     await done;
     expect(res.statusCode).toBe(200);
+  });
+
+  it('GET /api/pca/designatable-nodes threads ?fresh=1 to the facade (M4 cache-bust)', async () => {
+    const seen: Array<{ fresh?: boolean } | undefined> = [];
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listDesignatableNodes: async (opts?: { fresh?: boolean }) => { seen.push(opts); return NODE_FIXTURE; },
+    };
+    const a = runCtx('GET', '/api/pca/designatable-nodes?fresh=1', agent); await a.done;
+    const b = runCtx('GET', '/api/pca/designatable-nodes', agent); await b.done;
+    expect(a.res.statusCode).toBe(200);
+    expect(seen[0]).toEqual({ fresh: true });  // ?fresh=1 → bypass the adapter cache
+    expect(seen[1]).toEqual({ fresh: false }); // default → use the cache
+  });
+
+  it('GET /api/pca/designatable-nodes → 503 SHARDING_TABLE_READ_FAILED on a BAD_DATA decode failure (L10)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listDesignatableNodes: async () => { const e: any = new Error('could not decode result data'); e.code = 'BAD_DATA'; throw e; },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBe('SHARDING_TABLE_READ_FAILED');
+  });
+
+  it('GET /api/pca/designatable-nodes → 503 on an RPC transport exhaustion (L12)', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      listDesignatableNodes: async () => { throw Object.assign(new Error('all endpoints failed'), { code: 'RPC_ENDPOINTS_EXHAUSTED' }); },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body).code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+  });
+
+  it('GET /api/pca/designatable-nodes → 503 on no-chain and on PCA-unavailable (L12)', async () => {
+    const noChain = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => { throw new Error('No blockchain configured'); } };
+    const r1 = runCtx('GET', '/api/pca/designatable-nodes', noChain); await r1.done;
+    expect(r1.res.statusCode).toBe(503);
+
+    const unavail = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => { throw new Error('DKGPublishingConvictionNFT is not deployed on this Hub'); } };
+    const r2 = runCtx('GET', '/api/pca/designatable-nodes', unavail); await r2.done;
+    expect(r2.res.statusCode).toBe(503);
+  });
+
+  it('GET /api/pca/designatable-nodes → 500 on a generic (non-classified) error (L12)', async () => {
+    const agent = { supportsPublishingConvictionNft: true, listDesignatableNodes: async () => { throw new Error('boom'); } };
+    const { res, done } = runCtx('GET', '/api/pca/designatable-nodes', agent);
+    await done;
+    expect(res.statusCode).toBe(500);
   });
 });

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1799,6 +1799,40 @@ export interface PcaAgentAccountResult {
 export const pcaAgentAccount = (address: string) =>
   getJson<PcaAgentAccountResult>(`/api/pca/agent/${encodeURIComponent(address)}`);
 
+/**
+ * B-staked-nodes (§9.3) — one staked sharding-table node. `identityId` is the on-chain id
+ * a PCA designates as its `primaryNode`; `nodeId` is the network/peer id (display detail);
+ * `stake`/`ask` are wei strings. The sharding table is capped (`shardingTableSizeLimit`, ≤500)
+ * and the daemon serves it from a short TTL cache — the picker fetches it all + sorts/filters
+ * CLIENT-side (the `ask` column is dropped from display, L9). All ids/amounts are strings.
+ */
+export interface DesignatableNode {
+  nodeId: string;
+  identityId: string;
+  stake: string;
+  ask?: string;
+}
+
+export interface DesignatableNodesResult {
+  nodes: DesignatableNode[];
+  /** Total nodes in the sharding table (for the "showing N of total" hint). */
+  total: number;
+  /** Offset cursor for the next page, or null at the end. */
+  nextStart: string | null;
+}
+
+/**
+ * B-staked-nodes (§9.3) — the staked sharding-table nodes for the PrimaryNodePicker, via
+ * offset pagination over the daemon's TTL-cached read of the whole (≤500) table. `start`
+ * omitted = first page. A read failure surfaces `SHARDING_TABLE_READ_FAILED` (retryable —
+ * the picker shows a retry; `primaryNode` is required so edge can't proceed until it loads).
+ * `GET` is permissionless.
+ */
+export const listDesignatableNodes = (opts?: { start?: string; limit?: number }) =>
+  getJson<DesignatableNodesResult>(
+    `/api/pca/designatable-nodes?start=${encodeURIComponent(opts?.start ?? '')}&limit=${opts?.limit ?? 200}`,
+  );
+
 /** Normalized, terminology-disciplined PCA error code (UI branches on this). */
 export type PcaErrorCode =
   | 'FEATURE_UNAVAILABLE'

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1800,12 +1800,11 @@ export const pcaAgentAccount = (address: string) =>
   getJson<PcaAgentAccountResult>(`/api/pca/agent/${encodeURIComponent(address)}`);
 
 /**
- * B-staked-nodes (§9.3) — one staked sharding-table node. `identityId` (DECIMAL string) is the
- * on-chain id a PCA designates as its `primaryNode` (the value Create submits); `nodeId` is a HEX
- * string (on-chain `bytes`, the node's self-reported id → the "unverified" display label);
- * `stake`/`ask` are wei strings. The sharding table is capped (`shardingTableSizeLimit`, ≤500) and
- * the daemon serves it from a short TTL cache — the picker fetches it all + sorts/filters
- * CLIENT-side (the `ask` column is dropped from display, L9).
+ * B-staked-nodes (§9.3) — one staked sharding-table node, as the API returns it. `identityId`
+ * (DECIMAL string) is the on-chain id a PCA designates as its `primaryNode` (the value Create
+ * submits); `nodeId` is a HEX string (on-chain `bytes`, the node's self-reported id → the
+ * "unverified" display label); `stake`/`ask` are wei strings. R7: `ask` is REQUIRED — the route
+ * always sends it (the picker just doesn't display it, L9; its prop type omits `ask`).
  */
 export interface DesignatableNode {
   /** Hex string (`0x…`) — the node's self-reported id; display-only ("unverified"). */
@@ -1814,31 +1813,30 @@ export interface DesignatableNode {
   identityId: string;
   /** Wei string. */
   stake: string;
-  /** Wei string; returned by the route but dropped from display (L9). */
-  ask?: string;
+  /** Wei string; returned by the route, dropped from display (L9). */
+  ask: string;
 }
 
+/** R4 — the sharding table is ≤500, read+cached whole, and the UI drains it whole, so the route
+ *  returns the FULL list in one response (no offset pagination). */
 export interface DesignatableNodesResult {
   nodes: DesignatableNode[];
-  /** Total nodes in the sharding table (for the "showing N of total" hint). */
+  /** Total nodes in the sharding table. */
   total: number;
-  /** Next 0-based OFFSET to request, or null at the end. */
-  nextStart: number | null;
 }
 
 /**
  * B-staked-nodes (§9.3) — the staked sharding-table nodes for the PrimaryNodePicker. The daemon
- * reads the whole (≤500) table, TTL-caches it, and serves 0-based OFFSET pages (`start` is an
- * offset, NOT a startingIdentityId — the contract walk reverts on an unknown id). `start` omitted
- * = first page (0). A read failure 503s (`SHARDING_TABLE_READ_FAILED` / transport / capability) —
- * all retryable; the picker shows a retry, and `primaryNode` is required so edge can't proceed
- * until it loads. `fresh:true` (M4) BYPASSES the daemon's 30s TTL cache + repopulates it — used by
- * the picker Retry + the `PrimaryNodeNotInShardingTable` recovery so a just-(un)staked node is seen
- * immediately, not after the stale window. `GET` is permissionless.
+ * reads the whole (≤500) table, TTL-caches it, and returns it in ONE response (R4 — no pagination).
+ * A read failure 503s (`SHARDING_TABLE_READ_FAILED` / transport / capability) — all retryable; the
+ * picker shows a retry, and `primaryNode` is required so edge can't proceed until it loads.
+ * `fresh:true` (M4) BYPASSES the daemon's 30s TTL cache + repopulates it — used by the picker Retry
+ * + the `PrimaryNodeNotInShardingTable` recovery so a just-(un)staked node is seen immediately, not
+ * after the stale window. `GET` is permissionless.
  */
-export const listDesignatableNodes = (opts?: { start?: number; limit?: number; fresh?: boolean }) =>
+export const listDesignatableNodes = (opts?: { fresh?: boolean }) =>
   getJson<DesignatableNodesResult>(
-    `/api/pca/designatable-nodes?start=${opts?.start ?? 0}&limit=${opts?.limit ?? 200}${opts?.fresh ? '&fresh=1' : ''}`,
+    `/api/pca/designatable-nodes${opts?.fresh ? '?fresh=1' : ''}`,
   );
 
 /** Normalized, terminology-disciplined PCA error code (UI branches on this). */

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1800,11 +1800,11 @@ export const pcaAgentAccount = (address: string) =>
   getJson<PcaAgentAccountResult>(`/api/pca/agent/${encodeURIComponent(address)}`);
 
 /**
- * B-staked-nodes (§9.3) — one staked sharding-table node, as the API returns it. `identityId`
- * (DECIMAL string) is the on-chain id a PCA designates as its `primaryNode` (the value Create
- * submits); `nodeId` is a HEX string (on-chain `bytes`, the node's self-reported id → the
- * "unverified" display label); `stake`/`ask` are wei strings. R7: `ask` is REQUIRED — the route
- * always sends it (the picker just doesn't display it, L9; its prop type omits `ask`).
+ * One staked sharding-table node, as the API returns it. `identityId` (DECIMAL string) is the
+ * on-chain id a PCA designates as its `primaryNode` (the value Create submits); `nodeId` is a HEX
+ * string (on-chain `bytes`, the node's self-reported id → shown only as an "unverified" label);
+ * `stake`/`ask` are wei strings. `ask` is REQUIRED on the API type — the route always sends it; the
+ * picker just doesn't display it, so its separate prop type omits `ask` (don't loosen this contract).
  */
 export interface DesignatableNode {
   /** Hex string (`0x…`) — the node's self-reported id; display-only ("unverified"). */
@@ -1813,11 +1813,11 @@ export interface DesignatableNode {
   identityId: string;
   /** Wei string. */
   stake: string;
-  /** Wei string; returned by the route, dropped from display (L9). */
+  /** Wei string; returned by the route, not shown in the picker. */
   ask: string;
 }
 
-/** R4 — the sharding table is ≤500, read+cached whole, and the UI drains it whole, so the route
+/** The sharding table is capped (≤500), read+cached whole, and the UI drains it whole, so the route
  *  returns the FULL list in one response (no offset pagination). */
 export interface DesignatableNodesResult {
   nodes: DesignatableNode[];
@@ -1826,13 +1826,13 @@ export interface DesignatableNodesResult {
 }
 
 /**
- * B-staked-nodes (§9.3) — the staked sharding-table nodes for the PrimaryNodePicker. The daemon
- * reads the whole (≤500) table, TTL-caches it, and returns it in ONE response (R4 — no pagination).
- * A read failure 503s (`SHARDING_TABLE_READ_FAILED` / transport / capability) — all retryable; the
- * picker shows a retry, and `primaryNode` is required so edge can't proceed until it loads.
- * `fresh:true` (M4) BYPASSES the daemon's 30s TTL cache + repopulates it — used by the picker Retry
- * + the `PrimaryNodeNotInShardingTable` recovery so a just-(un)staked node is seen immediately, not
- * after the stale window. `GET` is permissionless.
+ * The staked sharding-table nodes for the PrimaryNodePicker. The daemon reads the whole (≤500) table,
+ * TTL-caches it, and returns it in ONE response (no pagination). A read failure 503s
+ * (`SHARDING_TABLE_READ_FAILED` / transport / capability) — all retryable; the picker shows a retry,
+ * and `primaryNode` is required so edge can't proceed until it loads. `fresh:true` BYPASSES the
+ * daemon's 30s TTL cache + repopulates it — used by the picker Retry + the
+ * `PrimaryNodeNotInShardingTable` recovery so a just-(un)staked node is seen immediately, not after
+ * the stale window. `GET` is permissionless.
  */
 export const listDesignatableNodes = (opts?: { fresh?: boolean }) =>
   getJson<DesignatableNodesResult>(

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1817,20 +1817,21 @@ export interface DesignatableNodesResult {
   nodes: DesignatableNode[];
   /** Total nodes in the sharding table (for the "showing N of total" hint). */
   total: number;
-  /** Offset cursor for the next page, or null at the end. */
-  nextStart: string | null;
+  /** Next 0-based OFFSET to request, or null at the end. */
+  nextStart: number | null;
 }
 
 /**
- * B-staked-nodes (§9.3) — the staked sharding-table nodes for the PrimaryNodePicker, via
- * offset pagination over the daemon's TTL-cached read of the whole (≤500) table. `start`
- * omitted = first page. A read failure surfaces `SHARDING_TABLE_READ_FAILED` (retryable —
- * the picker shows a retry; `primaryNode` is required so edge can't proceed until it loads).
- * `GET` is permissionless.
+ * B-staked-nodes (§9.3) — the staked sharding-table nodes for the PrimaryNodePicker. The daemon
+ * reads the whole (≤500) table, TTL-caches it, and serves 0-based OFFSET pages (`start` is an
+ * offset, NOT a startingIdentityId — the contract walk reverts on an unknown id). `start` omitted
+ * = first page (0). A read failure 503s (`PCA_LOOKUP_READ_FAILED` / transport / capability) — all
+ * retryable; the picker shows a retry, and `primaryNode` is required so edge can't proceed until
+ * it loads. `GET` is permissionless.
  */
-export const listDesignatableNodes = (opts?: { start?: string; limit?: number }) =>
+export const listDesignatableNodes = (opts?: { start?: number; limit?: number }) =>
   getJson<DesignatableNodesResult>(
-    `/api/pca/designatable-nodes?start=${encodeURIComponent(opts?.start ?? '')}&limit=${opts?.limit ?? 200}`,
+    `/api/pca/designatable-nodes?start=${opts?.start ?? 0}&limit=${opts?.limit ?? 200}`,
   );
 
 /** Normalized, terminology-disciplined PCA error code (UI branches on this). */

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1832,11 +1832,13 @@ export interface DesignatableNodesResult {
  * offset, NOT a startingIdentityId — the contract walk reverts on an unknown id). `start` omitted
  * = first page (0). A read failure 503s (`SHARDING_TABLE_READ_FAILED` / transport / capability) —
  * all retryable; the picker shows a retry, and `primaryNode` is required so edge can't proceed
- * until it loads. `GET` is permissionless.
+ * until it loads. `fresh:true` (M4) BYPASSES the daemon's 30s TTL cache + repopulates it — used by
+ * the picker Retry + the `PrimaryNodeNotInShardingTable` recovery so a just-(un)staked node is seen
+ * immediately, not after the stale window. `GET` is permissionless.
  */
-export const listDesignatableNodes = (opts?: { start?: number; limit?: number }) =>
+export const listDesignatableNodes = (opts?: { start?: number; limit?: number; fresh?: boolean }) =>
   getJson<DesignatableNodesResult>(
-    `/api/pca/designatable-nodes?start=${opts?.start ?? 0}&limit=${opts?.limit ?? 200}`,
+    `/api/pca/designatable-nodes?start=${opts?.start ?? 0}&limit=${opts?.limit ?? 200}${opts?.fresh ? '&fresh=1' : ''}`,
   );
 
 /** Normalized, terminology-disciplined PCA error code (UI branches on this). */

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1800,16 +1800,21 @@ export const pcaAgentAccount = (address: string) =>
   getJson<PcaAgentAccountResult>(`/api/pca/agent/${encodeURIComponent(address)}`);
 
 /**
- * B-staked-nodes (§9.3) — one staked sharding-table node. `identityId` is the on-chain id
- * a PCA designates as its `primaryNode`; `nodeId` is the network/peer id (display detail);
- * `stake`/`ask` are wei strings. The sharding table is capped (`shardingTableSizeLimit`, ≤500)
- * and the daemon serves it from a short TTL cache — the picker fetches it all + sorts/filters
- * CLIENT-side (the `ask` column is dropped from display, L9). All ids/amounts are strings.
+ * B-staked-nodes (§9.3) — one staked sharding-table node. `identityId` (DECIMAL string) is the
+ * on-chain id a PCA designates as its `primaryNode` (the value Create submits); `nodeId` is a HEX
+ * string (on-chain `bytes`, the node's self-reported id → the "unverified" display label);
+ * `stake`/`ask` are wei strings. The sharding table is capped (`shardingTableSizeLimit`, ≤500) and
+ * the daemon serves it from a short TTL cache — the picker fetches it all + sorts/filters
+ * CLIENT-side (the `ask` column is dropped from display, L9).
  */
 export interface DesignatableNode {
+  /** Hex string (`0x…`) — the node's self-reported id; display-only ("unverified"). */
   nodeId: string;
+  /** Decimal string — the on-chain identity; the value passed as `primaryNode`. */
   identityId: string;
+  /** Wei string. */
   stake: string;
+  /** Wei string; returned by the route but dropped from display (L9). */
   ask?: string;
 }
 

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1830,9 +1830,9 @@ export interface DesignatableNodesResult {
  * B-staked-nodes (§9.3) — the staked sharding-table nodes for the PrimaryNodePicker. The daemon
  * reads the whole (≤500) table, TTL-caches it, and serves 0-based OFFSET pages (`start` is an
  * offset, NOT a startingIdentityId — the contract walk reverts on an unknown id). `start` omitted
- * = first page (0). A read failure 503s (`PCA_LOOKUP_READ_FAILED` / transport / capability) — all
- * retryable; the picker shows a retry, and `primaryNode` is required so edge can't proceed until
- * it loads. `GET` is permissionless.
+ * = first page (0). A read failure 503s (`SHARDING_TABLE_READ_FAILED` / transport / capability) —
+ * all retryable; the picker shows a retry, and `primaryNode` is required so edge can't proceed
+ * until it loads. `GET` is permissionless.
  */
 export const listDesignatableNodes = (opts?: { start?: number; limit?: number }) =>
   getJson<DesignatableNodesResult>(

--- a/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
+++ b/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
@@ -93,7 +93,7 @@ export function useModalDismiss(open: boolean, onClose: () => void) {
         // If an inner combobox popup is OPEN, let IT handle Escape first (close the
         // popup), rather than closing the whole dialog and discarding its state. This
         // capture-phase window listener would otherwise win over the combobox's own
-        // bubble-phase handler (H1). Escape closes the innermost layer first; a second
+        // bubble-phase handler. Escape closes the innermost layer first; a second
         // Escape (popup now closed) dismisses the dialog.
         const dlg = dialogRef.current;
         if (dlg && dlg.querySelector('[role="combobox"][aria-expanded="true"]')) {

--- a/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
+++ b/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
@@ -90,15 +90,11 @@ export function useModalDismiss(open: boolean, onClose: () => void) {
     if (!open) return undefined;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        // If an inner combobox popup is OPEN, let IT handle Escape first (close the
-        // popup), rather than closing the whole dialog and discarding its state. This
-        // capture-phase window listener would otherwise win over the combobox's own
-        // bubble-phase handler. Escape closes the innermost layer first; a second
-        // Escape (popup now closed) dismisses the dialog.
-        const dlg = dialogRef.current;
-        if (dlg && dlg.querySelector('[role="combobox"][aria-expanded="true"]')) {
-          return; // no stopPropagation/onClose — the combobox's handler closes the popup
-        }
+        // Generic: Escape dismisses the dialog. An inner widget that owns its own
+        // layered Escape (e.g. a combobox popup that should close first) opts out by
+        // calling stopPropagation on its own keydown handler — this listener runs in the
+        // bubble phase, so a descendant's stopPropagation prevents it from firing. The
+        // hook itself stays free of any widget-specific knowledge.
         e.stopPropagation();
         onClose();
         return;
@@ -143,8 +139,11 @@ export function useModalDismiss(open: boolean, onClose: () => void) {
         first.focus();
       }
     };
-    window.addEventListener('keydown', onKeyDown, true);
-    return () => window.removeEventListener('keydown', onKeyDown, true);
+    // Bubble phase (not capture): a descendant widget can intercept Escape/Tab before it
+    // reaches here by calling stopPropagation in its own handler. Tab trapping is unaffected —
+    // preventDefault works in the bubble phase too.
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
   }, [open, onClose]);
 
   const onBackdropClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
+++ b/packages/node-ui/src/ui/components/Modals/useModalDismiss.ts
@@ -90,6 +90,15 @@ export function useModalDismiss(open: boolean, onClose: () => void) {
     if (!open) return undefined;
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        // If an inner combobox popup is OPEN, let IT handle Escape first (close the
+        // popup), rather than closing the whole dialog and discarding its state. This
+        // capture-phase window listener would otherwise win over the combobox's own
+        // bubble-phase handler (H1). Escape closes the innermost layer first; a second
+        // Escape (popup now closed) dismisses the dialog.
+        const dlg = dialogRef.current;
+        if (dlg && dlg.querySelector('[role="combobox"][aria-expanded="true"]')) {
+          return; // no stopPropagation/onClose — the combobox's handler closes the popup
+        }
         e.stopPropagation();
         onClose();
         return;

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -1,10 +1,17 @@
 import React, { useId, useMemo, useState } from 'react';
 import { formatWeiToTrac } from './format.js';
-import type { DesignatableNode } from '../../api.js';
 
-// The staked sharding-table node shape is the api.ts data type (re-exported here so the
-// Pca barrel keeps exporting it); `ask` is carried by the wire but dropped from display (L9).
-export type { DesignatableNode };
+// R7 — the picker's prop type is SEPARATE from the api `DesignatableNode` (which requires `ask`):
+// the picker only needs/displays these fields (no `ask`, dropped per L9). The api type is a
+// structural superset, so the parent can pass `DesignatableNode[]` straight in.
+export interface PrimaryNodeOption {
+  /** Hex string (`0x…`) — the node's self-reported id; display-only ("unverified"). */
+  nodeId: string;
+  /** Decimal string — the on-chain identity; the value passed as `primaryNode`. */
+  identityId: string;
+  /** Wei string. */
+  stake: string;
+}
 
 const CAP = 50;
 
@@ -28,7 +35,7 @@ export function PrimaryNodePicker({
   role,
   required = false,
 }: {
-  nodes: DesignatableNode[];
+  nodes: PrimaryNodeOption[];
   loading: boolean;
   error: boolean;
   onRetry: () => void;
@@ -60,7 +67,7 @@ export function PrimaryNodePicker({
   const shown = filtered.slice(0, CAP);
   const truncated = filtered.length > shown.length;
 
-  const select = (n: DesignatableNode) => {
+  const select = (n: PrimaryNodeOption) => {
     onChange(n.identityId);
     setQuery('');
     setOpen(false);

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -1,0 +1,271 @@
+import React, { useId, useMemo, useState } from 'react';
+import { formatWeiToTrac } from './format.js';
+
+/**
+ * A staked sharding-table node, as served by the daemon `B-staked-nodes` read route
+ * (`GET /api/pca/designatable-nodes`). `identityId` is the on-chain id designated as a
+ * PCA's `primaryNode`; `nodeId` is the network/peer id (display detail); `stake` is wei.
+ * (The api.ts wire type re-exports this once the route shape is locked.)
+ */
+export interface DesignatableNode {
+  nodeId: string;
+  identityId: string;
+  stake: string;
+}
+
+const CAP = 50;
+
+/**
+ * §3b — the always-visible, REQUIRED primary-node picker for Create/Renew. Purely
+ * PRESENTATIONAL: the parent fetches the staked-node list (daemon `B-staked-nodes`) and
+ * owns the value. The picked node receives the account's reward-weight credit; the
+ * creator gets only the discount — so the copy is honest about the DONATION (H6/M11/M12),
+ * the node id is the primary identifier (labels are node-supplied + unverified), and the
+ * `ask` column is dropped (L9). `value`/`onChange` carry the node's `identityId` — the
+ * exact `primaryNode` value the create submits.
+ */
+export function PrimaryNodePicker({
+  nodes,
+  loading,
+  error,
+  onRetry,
+  value,
+  onChange,
+  ownIdentityId,
+  role,
+}: {
+  nodes: DesignatableNode[];
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+  /** The selected node's `identityId` ('' = none picked yet). */
+  value: string;
+  onChange: (identityId: string) => void;
+  /** This node's OWN staked identityId, but only when it is present in `nodes` (the parent
+   *  does the M3 staked cross-check). null/undefined ⇒ edge / not-staked ⇒ no "this node". */
+  ownIdentityId?: string | null;
+  role?: 'core' | 'edge';
+}) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const [pasteVal, setPasteVal] = useState('');
+  const [pasteErr, setPasteErr] = useState<string | null>(null);
+  const listboxId = useId();
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return nodes;
+    return nodes.filter(
+      (n) => n.nodeId.toLowerCase().includes(q) || n.identityId.toLowerCase().includes(q),
+    );
+  }, [nodes, query]);
+  const shown = filtered.slice(0, CAP);
+  const truncated = filtered.length > shown.length;
+
+  const select = (n: DesignatableNode) => {
+    onChange(n.identityId);
+    setQuery('');
+    setOpen(false);
+    setActiveIdx(-1);
+    setPasteErr(null);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIdx((i) => Math.min(i + 1, shown.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      if (open && activeIdx >= 0 && shown[activeIdx]) {
+        e.preventDefault();
+        select(shown[activeIdx]);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+      setActiveIdx(-1);
+    }
+  };
+
+  const usePastedId = () => {
+    const id = pasteVal.trim();
+    if (!id) return;
+    const match = nodes.find((n) => n.identityId === id || n.nodeId === id);
+    if (!match) {
+      setPasteErr('Not a staked sharding-table node.');
+      return;
+    }
+    select(match);
+    setPasteVal('');
+  };
+
+  const selectedNode = value ? nodes.find((n) => n.identityId === value) : undefined;
+  const pickedOwn = value !== '' && ownIdentityId != null && value === ownIdentityId;
+  const pickedOther = value !== '' && (ownIdentityId == null || value !== ownIdentityId);
+  const isEdgeLike = role === 'edge' || ownIdentityId == null;
+
+  return (
+    <div className="v10-pca-node-picker" data-testid="pca-primary-node-picker">
+      {/* The §5 confusion-killer — primary node ≠ payer ≠ covered ≠ discount. */}
+      <p className="v10-pca-create-hint">
+        Primary node = where reward weight goes. It’s separate from which wallets publish and from
+        your discount.
+      </p>
+
+      {loading ? (
+        <p className="v10-pca-create-hint" role="status">Loading staked nodes…</p>
+      ) : error ? (
+        <div className="v10-modal-warning" role="status" data-testid="pca-primary-node-error">
+          Couldn’t load the staked-node list — a primary node is required to create.{' '}
+          <button
+            type="button"
+            className="v10-pca-card-btn"
+            data-testid="pca-primary-node-retry"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : nodes.length === 0 ? (
+        <p className="v10-pca-create-hint" role="status">No staked nodes found.</p>
+      ) : (
+        <>
+          <div className="v10-pca-node-picker-combo">
+            <input
+              type="text"
+              role="combobox"
+              aria-expanded={open}
+              aria-controls={listboxId}
+              aria-autocomplete="list"
+              aria-label="Search staked nodes"
+              aria-activedescendant={
+                open && activeIdx >= 0 && shown[activeIdx]
+                  ? `${listboxId}-opt-${shown[activeIdx].identityId}`
+                  : undefined
+              }
+              className="v10-form-input"
+              data-testid="pca-primary-node-search"
+              value={query}
+              placeholder="Search staked nodes by id…"
+              autoComplete="off"
+              onFocus={() => setOpen(true)}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setOpen(true);
+                setActiveIdx(-1);
+              }}
+              onKeyDown={onKeyDown}
+            />
+            {open && (
+              <ul role="listbox" id={listboxId} className="v10-pca-node-picker-list">
+                {shown.map((n, i) => {
+                  const selected = n.identityId === value;
+                  const isOwn = ownIdentityId != null && n.identityId === ownIdentityId;
+                  return (
+                    <li
+                      key={n.identityId}
+                      id={`${listboxId}-opt-${n.identityId}`}
+                      role="option"
+                      aria-selected={selected}
+                      data-testid="pca-primary-node-option"
+                      className={[
+                        'v10-pca-node-picker-option',
+                        i === activeIdx ? 'active' : '',
+                        selected ? 'selected' : '',
+                      ]
+                        .filter(Boolean)
+                        .join(' ')}
+                      aria-label={`Node ${n.identityId}, peer ${n.nodeId}, stake ${formatWeiToTrac(n.stake)} TRAC${isOwn ? ', this node' : ''}`}
+                      onMouseDown={(e) => {
+                        e.preventDefault(); // select before the input blurs
+                        select(n);
+                      }}
+                    >
+                      <span className="v10-pca-node-picker-id">#{n.identityId}</span>
+                      <span className="v10-pca-node-picker-peer" title={n.nodeId}>
+                        {n.nodeId}
+                      </span>
+                      <span className="badge" title="Node labels are not verified — match on id">
+                        unverified
+                      </span>
+                      <span className="v10-pca-node-picker-stake">
+                        {formatWeiToTrac(n.stake)} TRAC staked
+                      </span>
+                      {isOwn && <span className="v10-pca-node-picker-own">✓ this node</span>}
+                    </li>
+                  );
+                })}
+                {truncated && (
+                  <li className="v10-pca-node-picker-more" aria-disabled="true">
+                    showing {shown.length} of {filtered.length} — refine your search
+                  </li>
+                )}
+              </ul>
+            )}
+          </div>
+
+          {/* Paste-an-id convenience (NOT a replacement for the dropdown — #10/L11). */}
+          <div className="v10-pca-node-picker-paste">
+            <input
+              type="text"
+              className="v10-form-input"
+              data-testid="pca-primary-node-paste"
+              value={pasteVal}
+              placeholder="…or paste a node id"
+              aria-label="Paste a node id"
+              autoComplete="off"
+              onChange={(e) => {
+                setPasteVal(e.target.value);
+                setPasteErr(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  usePastedId();
+                }
+              }}
+            />
+            <button
+              type="button"
+              className="v10-pca-card-btn"
+              data-testid="pca-primary-node-paste-use"
+              onClick={usePastedId}
+            >
+              Use
+            </button>
+            {pasteErr && (
+              <p className="v10-pca-crux-error" role="alert" data-testid="pca-primary-node-paste-error">
+                {pasteErr}
+              </p>
+            )}
+          </div>
+
+          {value !== '' && (
+            <p className="v10-pca-create-hint" data-testid="pca-primary-node-selected">
+              Selected: node #{value}
+              {selectedNode ? ` (${formatWeiToTrac(selectedNode.stake)} TRAC staked)` : ''}
+              {pickedOwn && ' — ✓ this node'}
+            </p>
+          )}
+
+          {/* Honest reward-weight DONATION copy (H6/M11/M12). */}
+          {isEdgeLike ? (
+            <p className="v10-pca-create-hint" data-testid="pca-primary-node-donation">
+              You get the discount; the reward weight from this account accrues to the node you pick —
+              not to you.
+            </p>
+          ) : (
+            pickedOther && (
+              <p className="v10-pca-create-warn" role="status" data-testid="pca-primary-node-heads-up">
+                Reward weight will go to node #{value} instead of this node.
+              </p>
+            )
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -90,8 +90,15 @@ export function PrimaryNodePicker({
         select(shown[activeIdx]);
       }
     } else if (e.key === 'Escape') {
-      setOpen(false);
-      setActiveIdx(-1);
+      // The picker owns Escape while its popup is open: close just the popup and stop the
+      // event so the surrounding modal's Escape-to-dismiss doesn't also fire (a second
+      // Escape, popup now closed, falls through and dismisses the modal). This keeps the
+      // shared modal-dismiss hook generic — it has no combobox-specific knowledge.
+      if (open) {
+        e.stopPropagation();
+        setOpen(false);
+        setActiveIdx(-1);
+      }
     }
   };
 

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -75,6 +75,7 @@ export function PrimaryNodePicker({
       setActiveIdx((i) => Math.min(i + 1, shown.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
+      setOpen(true); // N8 — APG: Up also opens a closed popup
       setActiveIdx((i) => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       if (open && activeIdx >= 0 && shown[activeIdx]) {
@@ -88,9 +89,11 @@ export function PrimaryNodePicker({
   };
 
   const usePastedId = () => {
-    const id = pasteVal.trim();
-    if (!id) return;
-    const match = nodes.find((n) => n.identityId === id || n.nodeId === id);
+    // L7 — strip a leading '#' and match case-INSENSITIVELY (nodeId is a hex string; a pasted
+    // '#42' / mixed-case hex must still resolve a valid staked node).
+    const raw = pasteVal.trim().replace(/^#/, '');
+    if (!raw) return;
+    const match = nodes.find((n) => n.identityId === raw || n.nodeId.toLowerCase() === raw.toLowerCase());
     if (!match) {
       setPasteErr('Not a staked sharding-table node.');
       return;
@@ -115,7 +118,7 @@ export function PrimaryNodePicker({
       {loading ? (
         <p className="v10-pca-create-hint" role="status">Loading staked nodes…</p>
       ) : error ? (
-        <div className="v10-modal-warning" role="status" data-testid="pca-primary-node-error">
+        <div className="v10-modal-warning" role="alert" data-testid="pca-primary-node-error">
           Couldn’t load the staked-node list — a primary node is required to create.{' '}
           <button
             type="button"
@@ -125,6 +128,13 @@ export function PrimaryNodePicker({
           >
             Retry
           </button>
+          {/* L3 — surface the best-effort default (core fell back to its own id) so it isn't
+              invisible while the list is down. */}
+          {value !== '' && (
+            <p className="v10-pca-create-hint" data-testid="pca-primary-node-error-selected">
+              Using node #{value}{pickedOwn ? ' (this node)' : ''} for now — Retry to pick another.
+            </p>
+          )}
         </div>
       ) : nodes.length === 0 ? (
         <p className="v10-pca-create-hint" role="status">No staked nodes found.</p>
@@ -135,7 +145,7 @@ export function PrimaryNodePicker({
               type="text"
               role="combobox"
               aria-expanded={open}
-              aria-controls={listboxId}
+              aria-controls={open ? listboxId : undefined}
               aria-autocomplete="list"
               aria-label="Search staked nodes"
               aria-required={required}
@@ -159,7 +169,7 @@ export function PrimaryNodePicker({
               onKeyDown={onKeyDown}
             />
             {open && (
-              <ul role="listbox" id={listboxId} className="v10-pca-node-picker-list">
+              <ul role="listbox" id={listboxId} aria-label="Staked sharding-table nodes" className="v10-pca-node-picker-list">
                 {shown.map((n, i) => {
                   const selected = n.identityId === value;
                   const isOwn = ownIdentityId != null && n.identityId === ownIdentityId;
@@ -198,7 +208,8 @@ export function PrimaryNodePicker({
                   );
                 })}
                 {truncated && (
-                  <li className="v10-pca-node-picker-more" aria-disabled="true">
+                  // N6 — a non-option child of the listbox must not be an `option` to AT.
+                  <li role="presentation" className="v10-pca-node-picker-more">
                     showing {shown.length} of {filtered.length} — refine your search
                   </li>
                 )}

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -1,17 +1,10 @@
 import React, { useId, useMemo, useState } from 'react';
 import { formatWeiToTrac } from './format.js';
+import type { DesignatableNode } from '../../api.js';
 
-/**
- * A staked sharding-table node, as served by the daemon `B-staked-nodes` read route
- * (`GET /api/pca/designatable-nodes`). `identityId` is the on-chain id designated as a
- * PCA's `primaryNode`; `nodeId` is the network/peer id (display detail); `stake` is wei.
- * (The api.ts wire type re-exports this once the route shape is locked.)
- */
-export interface DesignatableNode {
-  nodeId: string;
-  identityId: string;
-  stake: string;
-}
+// The staked sharding-table node shape is the api.ts data type (re-exported here so the
+// Pca barrel keeps exporting it); `ask` is carried by the wire but dropped from display (L9).
+export type { DesignatableNode };
 
 const CAP = 50;
 

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -26,6 +26,7 @@ export function PrimaryNodePicker({
   onChange,
   ownIdentityId,
   role,
+  required = false,
 }: {
   nodes: DesignatableNode[];
   loading: boolean;
@@ -38,6 +39,9 @@ export function PrimaryNodePicker({
    *  does the M3 staked cross-check). null/undefined ⇒ edge / not-staked ⇒ no "this node". */
   ownIdentityId?: string | null;
   role?: 'core' | 'edge';
+  /** M1 — the field is mandatory (Create requires a primary node). Drives aria-required +
+   *  aria-invalid so AT announces that an unresolved pick blocks submit (disabled buttons don't). */
+  required?: boolean;
 }) {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
@@ -134,6 +138,8 @@ export function PrimaryNodePicker({
               aria-controls={listboxId}
               aria-autocomplete="list"
               aria-label="Search staked nodes"
+              aria-required={required}
+              aria-invalid={required && value === ''}
               aria-activedescendant={
                 open && activeIdx >= 0 && shown[activeIdx]
                   ? `${listboxId}-opt-${shown[activeIdx].identityId}`

--- a/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
+++ b/packages/node-ui/src/ui/components/Pca/PrimaryNodePicker.tsx
@@ -1,9 +1,9 @@
 import React, { useId, useMemo, useState } from 'react';
 import { formatWeiToTrac } from './format.js';
 
-// R7 — the picker's prop type is SEPARATE from the api `DesignatableNode` (which requires `ask`):
-// the picker only needs/displays these fields (no `ask`, dropped per L9). The api type is a
-// structural superset, so the parent can pass `DesignatableNode[]` straight in.
+// The picker's prop type is intentionally separate from the API's `DesignatableNode`: the picker
+// doesn't display `ask`, but the API always returns it (and requires it). This type is a structural
+// subset, so the parent can pass the API nodes straight in.
 export interface PrimaryNodeOption {
   /** Hex string (`0x…`) — the node's self-reported id; display-only ("unverified"). */
   nodeId: string;
@@ -16,13 +16,12 @@ export interface PrimaryNodeOption {
 const CAP = 50;
 
 /**
- * §3b — the always-visible, REQUIRED primary-node picker for Create/Renew. Purely
- * PRESENTATIONAL: the parent fetches the staked-node list (daemon `B-staked-nodes`) and
- * owns the value. The picked node receives the account's reward-weight credit; the
- * creator gets only the discount — so the copy is honest about the DONATION (H6/M11/M12),
- * the node id is the primary identifier (labels are node-supplied + unverified), and the
- * `ask` column is dropped (L9). `value`/`onChange` carry the node's `identityId` — the
- * exact `primaryNode` value the create submits.
+ * The always-visible, REQUIRED primary-node picker for Create/Renew. Purely presentational: the
+ * parent fetches the staked-node list and owns the value. The picked node receives the account's
+ * reward-weight credit while the creator gets only the discount, so the copy is honest that picking
+ * a node DONATES that reward weight to it. The node's identityId is the primary identifier (the
+ * self-reported nodeId is shown but marked "unverified"); the `ask` column is not displayed.
+ * `value`/`onChange` carry the node's `identityId` — the exact `primaryNode` value Create submits.
  */
 export function PrimaryNodePicker({
   nodes,
@@ -43,11 +42,12 @@ export function PrimaryNodePicker({
   value: string;
   onChange: (identityId: string) => void;
   /** This node's OWN staked identityId, but only when it is present in `nodes` (the parent
-   *  does the M3 staked cross-check). null/undefined ⇒ edge / not-staked ⇒ no "this node". */
+   *  cross-checks that the node is actually staked). null/undefined ⇒ edge / not-staked ⇒ no
+   *  "this node" affordance. */
   ownIdentityId?: string | null;
   role?: 'core' | 'edge';
-  /** M1 — the field is mandatory (Create requires a primary node). Drives aria-required +
-   *  aria-invalid so AT announces that an unresolved pick blocks submit (disabled buttons don't). */
+  /** The field is mandatory (Create requires a primary node). Drives aria-required + aria-invalid
+   *  so assistive tech announces that an unresolved pick blocks submit (a disabled button doesn't). */
   required?: boolean;
 }) {
   const [query, setQuery] = useState('');
@@ -82,7 +82,7 @@ export function PrimaryNodePicker({
       setActiveIdx((i) => Math.min(i + 1, shown.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setOpen(true); // N8 — APG: Up also opens a closed popup
+      setOpen(true); // Up also opens a closed popup (combobox keyboard convention)
       setActiveIdx((i) => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       if (open && activeIdx >= 0 && shown[activeIdx]) {
@@ -96,7 +96,7 @@ export function PrimaryNodePicker({
   };
 
   const usePastedId = () => {
-    // L7 — strip a leading '#' and match case-INSENSITIVELY (nodeId is a hex string; a pasted
+    // Strip a leading '#' and match case-INSENSITIVELY (nodeId is a hex string; a pasted
     // '#42' / mixed-case hex must still resolve a valid staked node).
     const raw = pasteVal.trim().replace(/^#/, '');
     if (!raw) return;
@@ -116,7 +116,7 @@ export function PrimaryNodePicker({
 
   return (
     <div className="v10-pca-node-picker" data-testid="pca-primary-node-picker">
-      {/* The §5 confusion-killer — primary node ≠ payer ≠ covered ≠ discount. */}
+      {/* Confusion-killer — primary node ≠ payer ≠ covered ≠ discount. */}
       <p className="v10-pca-create-hint">
         Primary node = where reward weight goes. It’s separate from which wallets publish and from
         your discount.
@@ -135,7 +135,7 @@ export function PrimaryNodePicker({
           >
             Retry
           </button>
-          {/* L3 — surface the best-effort default (core fell back to its own id) so it isn't
+          {/* Surface the best-effort default (core fell back to its own id) so it isn't
               invisible while the list is down. */}
           {value !== '' && (
             <p className="v10-pca-create-hint" data-testid="pca-primary-node-error-selected">
@@ -215,7 +215,7 @@ export function PrimaryNodePicker({
                   );
                 })}
                 {truncated && (
-                  // N6 — a non-option child of the listbox must not be an `option` to AT.
+                  // A non-option child of the listbox must not be an `option` to assistive tech.
                   <li role="presentation" className="v10-pca-node-picker-more">
                     showing {shown.length} of {filtered.length} — refine your search
                   </li>
@@ -224,7 +224,7 @@ export function PrimaryNodePicker({
             )}
           </div>
 
-          {/* Paste-an-id convenience (NOT a replacement for the dropdown — #10/L11). */}
+          {/* Paste-an-id convenience (NOT a replacement for the dropdown). */}
           <div className="v10-pca-node-picker-paste">
             <input
               type="text"
@@ -268,7 +268,7 @@ export function PrimaryNodePicker({
             </p>
           )}
 
-          {/* Honest reward-weight DONATION copy (H6/M11/M12). */}
+          {/* Honest reward-weight DONATION copy. */}
           {isEdgeLike ? (
             <p className="v10-pca-create-hint" data-testid="pca-primary-node-donation">
               You get the discount; the reward weight from this account accrues to the node you pick —

--- a/packages/node-ui/src/ui/components/Pca/index.ts
+++ b/packages/node-ui/src/ui/components/Pca/index.ts
@@ -32,3 +32,4 @@ export {
   type PcaVerdict,
 } from './EligibilityVerdictBanner.js';
 export { SponsorshipHandshake } from './SponsorshipHandshake.js';
+export { PrimaryNodePicker, type DesignatableNode } from './PrimaryNodePicker.js';

--- a/packages/node-ui/src/ui/components/Pca/index.ts
+++ b/packages/node-ui/src/ui/components/Pca/index.ts
@@ -32,4 +32,4 @@ export {
   type PcaVerdict,
 } from './EligibilityVerdictBanner.js';
 export { SponsorshipHandshake } from './SponsorshipHandshake.js';
-export { PrimaryNodePicker, type DesignatableNode } from './PrimaryNodePicker.js';
+export { PrimaryNodePicker, type PrimaryNodeOption } from './PrimaryNodePicker.js';

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -9,14 +9,15 @@ import { listDesignatableNodes, type DesignatableNode } from '../api.js';
 async function fetchAllDesignatableNodes(fresh = false): Promise<DesignatableNode[]> {
   const all: DesignatableNode[] = [];
   let start = 0; // 0-based offset cursor (Backend serves offset pages over the cached table)
-  // The table is ≤500; cap the page loop defensively so a misbehaving cursor (a nextStart that
-  // never goes null) can't spin forever.
-  for (let page = 0; page < 25; page++) {
+  // L11 — drive off the route's `total` (the sharding-table size is governance-mutable, so no magic
+  // page cap that could silently truncate). Stop when collected >= total or the cursor ends; the
+  // `guard` is only a defensive backstop against a pathological never-null cursor.
+  for (let guard = 0; guard < 100; guard++) {
     // M4 — bust the cache on the FIRST page only: `fresh=1` re-reads the chain AND repopulates the
     // daemon cache, so subsequent pages read the just-refreshed list.
-    const r = await listDesignatableNodes({ start, limit: 200, fresh: fresh && page === 0 });
+    const r = await listDesignatableNodes({ start, limit: 200, fresh: fresh && start === 0 });
     all.push(...r.nodes);
-    if (r.nextStart == null || r.nodes.length === 0) break;
+    if (r.nextStart == null || r.nodes.length === 0 || all.length >= r.total) break;
     start = r.nextStart;
   }
   return all;

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -1,27 +1,10 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useFetch } from '../hooks.js';
 import { listDesignatableNodes, type DesignatableNode } from '../api.js';
 
-// B-staked-nodes (§9.3) — the sharding table is capped (≤500) and the daemon serves it from a
-// short TTL cache, so the picker fetches it WHOLE (following the offset cursor) and does
-// search/filter + sort CLIENT-side. Backend returns hash-ring order; we sort by stake DESC.
-
-async function fetchAllDesignatableNodes(fresh = false): Promise<DesignatableNode[]> {
-  const all: DesignatableNode[] = [];
-  let start = 0; // 0-based offset cursor (Backend serves offset pages over the cached table)
-  // L11 — drive off the route's `total` (the sharding-table size is governance-mutable, so no magic
-  // page cap that could silently truncate). Stop when collected >= total or the cursor ends; the
-  // `guard` is only a defensive backstop against a pathological never-null cursor.
-  for (let guard = 0; guard < 100; guard++) {
-    // M4 — bust the cache on the FIRST page only: `fresh=1` re-reads the chain AND repopulates the
-    // daemon cache, so subsequent pages read the just-refreshed list.
-    const r = await listDesignatableNodes({ start, limit: 200, fresh: fresh && start === 0 });
-    all.push(...r.nodes);
-    if (r.nextStart == null || r.nodes.length === 0 || all.length >= r.total) break;
-    start = r.nextStart;
-  }
-  return all;
-}
+// B-staked-nodes (§9.3) — the sharding table is capped (≤500), read+cached whole, and returned in
+// ONE response (R4 — no pagination). The picker does search/filter + sort CLIENT-side. Backend
+// returns hash-ring order; we sort by stake DESC.
 
 const byStakeDesc = (a: DesignatableNode, b: DesignatableNode): number => {
   try {
@@ -42,21 +25,25 @@ export interface UseDesignatableNodes {
   refresh: () => void;
 }
 
-/** The staked-node list for the PrimaryNodePicker — fetched whole, sorted by stake desc. */
+/** The staked-node list for the PrimaryNodePicker — fetched whole (one shot), sorted by stake desc. */
 export function useDesignatableNodes(): UseDesignatableNodes {
   // M4 — the initial load uses the cache (fast); `refresh` (picker Retry + the
   // PrimaryNodeNotInShardingTable recovery) busts it via `fresh=1`. The ref is read inside the
   // fetcher closure so useFetch's own load/refresh picks up the current mode.
   const freshRef = useRef(false);
+  // L8 — surface "Loading…" during a Retry. useFetch doesn't toggle its `loading` on refresh, so
+  // track it here off the refresh promise (settles on success OR error — no stuck-true on a repeat error).
+  const [refreshing, setRefreshing] = useState(false);
   const { data, loading, error, refresh: rawRefresh } = useFetch(
-    () => fetchAllDesignatableNodes(freshRef.current),
+    () => listDesignatableNodes({ fresh: freshRef.current }).then((r) => r.nodes), // R4 — single fetch
     [],
     0,
   );
   const refresh = useCallback(() => {
     freshRef.current = true;
-    rawRefresh();
+    setRefreshing(true);
+    void Promise.resolve(rawRefresh()).finally(() => setRefreshing(false));
   }, [rawRefresh]);
   const nodes = useMemo(() => [...(data ?? [])].sort(byStakeDesc), [data]);
-  return { nodes, loading, error: error != null, refresh };
+  return { nodes, loading: loading || refreshing, error: error != null, refresh };
 }

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -26,12 +26,19 @@ export interface UseDesignatableNodes {
   refresh: () => void;
 }
 
-/** The staked-node list for the PrimaryNodePicker — fetched whole (one shot), sorted by stake desc. */
-export function useDesignatableNodes(): UseDesignatableNodes {
+/**
+ * The staked-node list for the PrimaryNodePicker — fetched whole (one shot), sorted by stake desc.
+ * `enabled` (default true) gates the one-shot load to the create form: the reconcile/success/
+ * status-unknown screens don't render the picker, so they must not start a sharding-table read. The
+ * initial load fires once, the first time `enabled` is true, and never re-fires on later phase
+ * toggles (form→creating→form); the explicit cache-busting `refresh()` is always available.
+ */
+export function useDesignatableNodes(enabled = true): UseDesignatableNodes {
   const [nodes, setNodes] = useState<DesignatableNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const mountedRef = useRef(true);
+  const didLoadRef = useRef(false);
 
   const load = useCallback(async (fresh: boolean) => {
     setLoading(true);
@@ -53,11 +60,17 @@ export function useDesignatableNodes(): UseDesignatableNodes {
 
   useEffect(() => {
     mountedRef.current = true;
-    void load(false);
     return () => {
       mountedRef.current = false;
     };
-  }, [load]);
+  }, []);
+
+  useEffect(() => {
+    if (enabled && !didLoadRef.current) {
+      didLoadRef.current = true;
+      void load(false);
+    }
+  }, [enabled, load]);
 
   const refresh = useCallback(() => {
     void load(true);

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
-import { useFetch } from '../hooks.js';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { listDesignatableNodes, type DesignatableNode } from '../api.js';
 
 // B-staked-nodes (§9.3) — the sharding table is capped (≤500), read+cached whole, and returned in
-// ONE response (R4 — no pagination). The picker does search/filter + sort CLIENT-side. Backend
-// returns hash-ring order; we sort by stake DESC.
+// ONE response (no pagination). The picker does search/filter + sort CLIENT-side; we sort by stake
+// DESC. This hook owns its own fetch lifecycle (one-shot load + an explicit cache-busting refresh)
+// rather than the shared useFetch, so `loading` covers the refresh too and nothing depends on a
+// hidden promise return — the picker's Retry + the create recovery both get honest loading feedback.
 
 const byStakeDesc = (a: DesignatableNode, b: DesignatableNode): number => {
   try {
@@ -20,30 +21,47 @@ export interface UseDesignatableNodes {
   nodes: DesignatableNode[];
   loading: boolean;
   /** A read failure (SHARDING_TABLE_READ_FAILED / transport) — the picker shows a retry; a
-   *  primary node is REQUIRED, so edge can't proceed until the list loads (Q1). */
+   *  primary node is REQUIRED, so edge can't proceed until the list loads. */
   error: boolean;
   refresh: () => void;
 }
 
 /** The staked-node list for the PrimaryNodePicker — fetched whole (one shot), sorted by stake desc. */
 export function useDesignatableNodes(): UseDesignatableNodes {
-  // M4 — the initial load uses the cache (fast); `refresh` (picker Retry + the
-  // PrimaryNodeNotInShardingTable recovery) busts it via `fresh=1`. The ref is read inside the
-  // fetcher closure so useFetch's own load/refresh picks up the current mode.
-  const freshRef = useRef(false);
-  // L8 — surface "Loading…" during a Retry. useFetch doesn't toggle its `loading` on refresh, so
-  // track it here off the refresh promise (settles on success OR error — no stuck-true on a repeat error).
-  const [refreshing, setRefreshing] = useState(false);
-  const { data, loading, error, refresh: rawRefresh } = useFetch(
-    () => listDesignatableNodes({ fresh: freshRef.current }).then((r) => r.nodes), // R4 — single fetch
-    [],
-    0,
-  );
+  const [nodes, setNodes] = useState<DesignatableNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const mountedRef = useRef(true);
+
+  const load = useCallback(async (fresh: boolean) => {
+    setLoading(true);
+    setError(false);
+    try {
+      // The initial load uses the daemon's cache (fast); a refresh sends `?fresh=1` to bypass +
+      // repopulate it (the picker Retry + the PrimaryNodeNotInShardingTable recovery).
+      const r = await listDesignatableNodes(fresh ? { fresh: true } : undefined);
+      if (mountedRef.current) setNodes([...r.nodes].sort(byStakeDesc));
+    } catch {
+      if (mountedRef.current) {
+        setNodes([]);
+        setError(true);
+      }
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void load(false);
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [load]);
+
   const refresh = useCallback(() => {
-    freshRef.current = true;
-    setRefreshing(true);
-    void Promise.resolve(rawRefresh()).finally(() => setRefreshing(false));
-  }, [rawRefresh]);
-  const nodes = useMemo(() => [...(data ?? [])].sort(byStakeDesc), [data]);
-  return { nodes, loading: loading || refreshing, error: error != null, refresh };
+    void load(true);
+  }, [load]);
+
+  return { nodes, loading, error, refresh };
 }

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -8,13 +8,13 @@ import { listDesignatableNodes, type DesignatableNode } from '../api.js';
 
 async function fetchAllDesignatableNodes(): Promise<DesignatableNode[]> {
   const all: DesignatableNode[] = [];
-  let start: string | undefined;
+  let start = 0; // 0-based offset cursor (Backend serves offset pages over the cached table)
   // The table is ≤500; cap the page loop defensively so a misbehaving cursor (a nextStart that
   // never goes null) can't spin forever.
   for (let page = 0; page < 25; page++) {
     const r = await listDesignatableNodes({ start, limit: 200 });
     all.push(...r.nodes);
-    if (!r.nextStart || r.nodes.length === 0) break;
+    if (r.nextStart == null || r.nodes.length === 0) break;
     start = r.nextStart;
   }
   return all;

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useFetch } from '../hooks.js';
 import { listDesignatableNodes, type DesignatableNode } from '../api.js';
 
@@ -6,13 +6,15 @@ import { listDesignatableNodes, type DesignatableNode } from '../api.js';
 // short TTL cache, so the picker fetches it WHOLE (following the offset cursor) and does
 // search/filter + sort CLIENT-side. Backend returns hash-ring order; we sort by stake DESC.
 
-async function fetchAllDesignatableNodes(): Promise<DesignatableNode[]> {
+async function fetchAllDesignatableNodes(fresh = false): Promise<DesignatableNode[]> {
   const all: DesignatableNode[] = [];
   let start = 0; // 0-based offset cursor (Backend serves offset pages over the cached table)
   // The table is ≤500; cap the page loop defensively so a misbehaving cursor (a nextStart that
   // never goes null) can't spin forever.
   for (let page = 0; page < 25; page++) {
-    const r = await listDesignatableNodes({ start, limit: 200 });
+    // M4 — bust the cache on the FIRST page only: `fresh=1` re-reads the chain AND repopulates the
+    // daemon cache, so subsequent pages read the just-refreshed list.
+    const r = await listDesignatableNodes({ start, limit: 200, fresh: fresh && page === 0 });
     all.push(...r.nodes);
     if (r.nextStart == null || r.nodes.length === 0) break;
     start = r.nextStart;
@@ -41,7 +43,19 @@ export interface UseDesignatableNodes {
 
 /** The staked-node list for the PrimaryNodePicker — fetched whole, sorted by stake desc. */
 export function useDesignatableNodes(): UseDesignatableNodes {
-  const { data, loading, error, refresh } = useFetch(fetchAllDesignatableNodes, [], 0);
+  // M4 — the initial load uses the cache (fast); `refresh` (picker Retry + the
+  // PrimaryNodeNotInShardingTable recovery) busts it via `fresh=1`. The ref is read inside the
+  // fetcher closure so useFetch's own load/refresh picks up the current mode.
+  const freshRef = useRef(false);
+  const { data, loading, error, refresh: rawRefresh } = useFetch(
+    () => fetchAllDesignatableNodes(freshRef.current),
+    [],
+    0,
+  );
+  const refresh = useCallback(() => {
+    freshRef.current = true;
+    rawRefresh();
+  }, [rawRefresh]);
   const nodes = useMemo(() => [...(data ?? [])].sort(byStakeDesc), [data]);
   return { nodes, loading, error: error != null, refresh };
 }

--- a/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
+++ b/packages/node-ui/src/ui/hooks/useDesignatableNodes.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useFetch } from '../hooks.js';
+import { listDesignatableNodes, type DesignatableNode } from '../api.js';
+
+// B-staked-nodes (§9.3) — the sharding table is capped (≤500) and the daemon serves it from a
+// short TTL cache, so the picker fetches it WHOLE (following the offset cursor) and does
+// search/filter + sort CLIENT-side. Backend returns hash-ring order; we sort by stake DESC.
+
+async function fetchAllDesignatableNodes(): Promise<DesignatableNode[]> {
+  const all: DesignatableNode[] = [];
+  let start: string | undefined;
+  // The table is ≤500; cap the page loop defensively so a misbehaving cursor (a nextStart that
+  // never goes null) can't spin forever.
+  for (let page = 0; page < 25; page++) {
+    const r = await listDesignatableNodes({ start, limit: 200 });
+    all.push(...r.nodes);
+    if (!r.nextStart || r.nodes.length === 0) break;
+    start = r.nextStart;
+  }
+  return all;
+}
+
+const byStakeDesc = (a: DesignatableNode, b: DesignatableNode): number => {
+  try {
+    const x = BigInt(a.stake);
+    const y = BigInt(b.stake);
+    return x === y ? 0 : x > y ? -1 : 1;
+  } catch {
+    return 0; // non-numeric stake — leave order unchanged
+  }
+};
+
+export interface UseDesignatableNodes {
+  nodes: DesignatableNode[];
+  loading: boolean;
+  /** A read failure (SHARDING_TABLE_READ_FAILED / transport) — the picker shows a retry; a
+   *  primary node is REQUIRED, so edge can't proceed until the list loads (Q1). */
+  error: boolean;
+  refresh: () => void;
+}
+
+/** The staked-node list for the PrimaryNodePicker — fetched whole, sorted by stake desc. */
+export function useDesignatableNodes(): UseDesignatableNodes {
+  const { data, loading, error, refresh } = useFetch(fetchAllDesignatableNodes, [], 0);
+  const nodes = useMemo(() => [...(data ?? [])].sort(byStakeDesc), [data]);
+  return { nodes, loading, error: error != null, refresh };
+}

--- a/packages/node-ui/src/ui/hooks/usePrimaryNodeSelection.ts
+++ b/packages/node-ui/src/ui/hooks/usePrimaryNodeSelection.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+// Owns ALL of the Create/Renew primary-node selection policy in one place (so the modal just wires
+// value/actions to the picker + submit, and sub-PR #2's wallet-managed create reuses it):
+//   - renew seed (a replacement starts on the expiring account's primary node),
+//   - core convenience default (pre-select this node ONLY when it's actually staked),
+//   - list-down best-effort fallback (default to own id; the create-time revert recovery is the net),
+//   - stale-default reconcile (a defaulted own id a loaded list doesn't contain is cleared),
+//   - rejected-node recovery — the load-bearing invariant: a node the chain rejected
+//     (PrimaryNodeNotInShardingTable) is CLEARED, never re-submittable on its numeric shape.
+
+export interface UsePrimaryNodeSelection {
+  /** The selected node's identityId ('' = none) — the value Create submits as `primaryNode`. */
+  primaryNode: string;
+  setPrimaryNode: (id: string) => void;
+  /** This node's own identityId WHEN confirmed staked (the cross-check); null otherwise. Drives the
+   *  picker's "this node" affordance + the core default. */
+  ownStaked: string | null;
+  /** A create reverted PrimaryNodeNotInShardingTable: clear the rejected node so it can't be
+   *  re-submitted. The prefill re-defaults to the core's own id only if it's still staked. */
+  onRejected: () => void;
+}
+
+export function usePrimaryNodeSelection(opts: {
+  /** Renew (re-mint) seeds the expiring account's primary node; undefined for a fresh create. */
+  seedPrimaryNode?: string;
+  /** Non-null = renew (re-mint). Renew owns its seed + the revert backstop, so the stale-default
+   *  reconcile (below) is fresh-create only. */
+  replacingAccountId?: string;
+  /** This node's own identityId from /api/status (used only to PRE-SELECT, never to gate). */
+  identityId?: string | null;
+  /** The loaded staked-node list (drives the staked cross-check + the stale-default reconcile). */
+  stakedNodes: readonly { identityId: string }[];
+  nodesError: boolean;
+  nodesLoading: boolean;
+}): UsePrimaryNodeSelection {
+  const { seedPrimaryNode, replacingAccountId, identityId, stakedNodes, nodesError, nodesLoading } = opts;
+  const [primaryNode, setPrimaryNode] = useState(seedPrimaryNode ?? '');
+
+  // This node's own identity counts as a default ONLY if it's actually IN the staked list
+  // (hasIdentity / identityId > 0 alone does NOT imply staked + in the sharding table).
+  const ownIdentity = identityId && identityId !== '0' ? String(identityId) : null;
+  const ownStaked = useMemo(
+    () => (ownIdentity && stakedNodes.some((n) => n.identityId === ownIdentity) ? ownIdentity : null),
+    [ownIdentity, stakedNodes],
+  );
+
+  // Pre-select (core convenience). Never overrides a seeded (renew) or already-picked value.
+  // Pre-select own id only when confirmed staked; if the list is DOWN, core best-effort defaults to
+  // its own id (the create-time revert recovery is the backstop). Edge (no own identity) → no default.
+  useEffect(() => {
+    if (primaryNode || !ownIdentity) return;
+    if (ownStaked) setPrimaryNode(ownStaked);
+    else if (nodesError) setPrimaryNode(ownIdentity);
+  }, [primaryNode, ownIdentity, ownStaked, nodesError]);
+
+  // Reconcile a STALE best-effort default: a list-down default (primaryNode = ownIdentity) that a
+  // successfully-loaded list does NOT contain is invalid → clear it so the picker re-prompts (else
+  // submit stays enabled on a bad id until the create-time revert). Fresh-create only.
+  useEffect(() => {
+    if (replacingAccountId || nodesError || nodesLoading || stakedNodes.length === 0) return;
+    if (ownIdentity && primaryNode === ownIdentity && !ownStaked) setPrimaryNode('');
+  }, [replacingAccountId, nodesError, nodesLoading, stakedNodes.length, ownIdentity, primaryNode, ownStaked]);
+
+  const onRejected = useCallback(() => setPrimaryNode(''), []);
+
+  return { primaryNode, setPrimaryNode, ownStaked, onRejected };
+}

--- a/packages/node-ui/src/ui/hooks/usePrimaryNodeSelection.ts
+++ b/packages/node-ui/src/ui/hooks/usePrimaryNodeSelection.ts
@@ -33,8 +33,11 @@ export function usePrimaryNodeSelection(opts: {
   stakedNodes: readonly { identityId: string }[];
   nodesError: boolean;
   nodesLoading: boolean;
+  /** Run the pre-select/reconcile policy only while the create form is active (default true).
+   *  The reconcile/success/status-unknown screens don't show the picker, so their effects no-op. */
+  enabled?: boolean;
 }): UsePrimaryNodeSelection {
-  const { seedPrimaryNode, replacingAccountId, identityId, stakedNodes, nodesError, nodesLoading } = opts;
+  const { seedPrimaryNode, replacingAccountId, identityId, stakedNodes, nodesError, nodesLoading, enabled = true } = opts;
   const [primaryNode, setPrimaryNode] = useState(seedPrimaryNode ?? '');
 
   // This node's own identity counts as a default ONLY if it's actually IN the staked list
@@ -49,18 +52,25 @@ export function usePrimaryNodeSelection(opts: {
   // Pre-select own id only when confirmed staked; if the list is DOWN, core best-effort defaults to
   // its own id (the create-time revert recovery is the backstop). Edge (no own identity) → no default.
   useEffect(() => {
-    if (primaryNode || !ownIdentity) return;
+    // Don't (re-)default while a (re)fetch is in flight. After a create-time rejection the modal
+    // clears the rejected id AND kicks a FRESH refetch in the same render batch (nodesLoading→true);
+    // this guard stops an immediate re-default to the STALE list's own id before the refreshed list
+    // (which drops the just-rejected node) arrives — so onRejected's clear holds durably.
+    if (!enabled || primaryNode || !ownIdentity || nodesLoading) return;
     if (ownStaked) setPrimaryNode(ownStaked);
     else if (nodesError) setPrimaryNode(ownIdentity);
-  }, [primaryNode, ownIdentity, ownStaked, nodesError]);
+  }, [enabled, primaryNode, ownIdentity, ownStaked, nodesError, nodesLoading]);
 
   // Reconcile a STALE best-effort default: a list-down default (primaryNode = ownIdentity) that a
   // successfully-loaded list does NOT contain is invalid → clear it so the picker re-prompts (else
-  // submit stays enabled on a bad id until the create-time revert). Fresh-create only.
+  // submit stays enabled on a bad id until the create-time revert). Fresh-create only. Once the load
+  // settles (not loading, not errored) the list is AUTHORITATIVE — including an EMPTY list: an empty
+  // table means the own id isn't designatable either, so the default must still be cleared (no
+  // length guard, else a 503→own-default then a successful empty retry would keep the bad id).
   useEffect(() => {
-    if (replacingAccountId || nodesError || nodesLoading || stakedNodes.length === 0) return;
+    if (!enabled || replacingAccountId || nodesError || nodesLoading) return;
     if (ownIdentity && primaryNode === ownIdentity && !ownStaked) setPrimaryNode('');
-  }, [replacingAccountId, nodesError, nodesLoading, stakedNodes.length, ownIdentity, primaryNode, ownStaked]);
+  }, [enabled, replacingAccountId, nodesError, nodesLoading, stakedNodes.length, ownIdentity, primaryNode, ownStaked]);
 
   const onRejected = useCallback(() => setPrimaryNode(''), []);
 

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -7,6 +7,7 @@ import {
   HttpError,
 } from '../../api.js';
 import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
+import { resolveWalletBinding } from '../../pca/walletBinding.js';
 import { PcaModalShell } from './PcaModalShell.js';
 import {
   AddressCrux,
@@ -16,7 +17,7 @@ import {
   type WalletRowTone,
 } from '../../components/Pca/index.js';
 
-type RowStatus = 'pending' | 'approved' | 'submitted' | 'skipped' | 'conflict' | 'cap' | 'error' | 'unverified';
+type RowStatus = 'pending' | 'approved' | 'submitted' | 'skipped' | 'sponsored' | 'conflict' | 'cap' | 'error' | 'unverified';
 interface Row {
   address: string;
   status: RowStatus;
@@ -31,6 +32,9 @@ const ROW_LABEL: Record<RowStatus, string> = {
   approved: 'approved on-chain',
   submitted: 'submitted — verify',
   skipped: 'already approved here (skipped)',
+  // B1 self-coverage — bound to a sponsor's PCA; intentionally left there (already discounted
+  // free), NOT moved. Distinct from 'skipped' (= already approved HERE).
+  sponsored: 'left on a sponsor’s PCA (already discounted free)',
   conflict: 'on another conviction account',
   cap: 'cap reached',
   error: 'failed',
@@ -43,6 +47,7 @@ const ROW_TONE: Record<RowStatus, WalletRowTone> = {
   approved: 'success',
   submitted: 'neutral',
   skipped: 'neutral',
+  sponsored: 'neutral',
   conflict: 'danger',
   cap: 'warn',
   error: 'danger',
@@ -66,6 +71,7 @@ export function ApproveWalletsModal({
   seedBulk,
   deregisterFrom,
   seedAgentsResolved,
+  selfCoverage,
 }: {
   accountId: string;
   initialMode?: 'self' | 'sponsor';
@@ -85,6 +91,14 @@ export function ApproveWalletsModal({
   /** S2b renew — whether the old account's agents loaded (`listPcaAgents`). `false` →
    *  the seed couldn't be pre-filled; the copy stops promising it and prompts manual entry. */
   seedAgentsResolved?: boolean;
+  /**
+   * B1 self-coverage (§9.5) — set when this is the post-create self-coverage of THIS node's
+   * own wallets. Each wallet is binding-probed PER-ROW just before its register: a wallet on a
+   * PCA the node OWNS is deregistered-first; a wallet on a PCA the node CAN'T own (a sponsor's)
+   * is SKIPPED (already discounted free), never burning a register. Distinct from `deregisterFrom`
+   * (renew's single old account) — here the old account varies per wallet.
+   */
+  selfCoverage?: boolean;
 }) {
   const { data: wb } = useFetch(fetchWalletsBalances, [], 0);
   const { data: snapshot } = useFetch(() => fetchPca(accountId), [accountId]);
@@ -93,6 +107,7 @@ export function ApproveWalletsModal({
   // Same daemon submitter in P0; keyed separately for the §9 wallet-owned future.
   const deregisterOwner = useOwnerActionSubmitter(deregisterFrom);
   const nodeWallets = wb?.wallets ?? [];
+  const ownerWallet = nodeWallets[0]; // the daemon EOA — what it can deregister-from (B1)
   const agentCount = snapshot?.agentCount ?? 0;
   const cap = Math.max(0, 100 - agentCount);
 
@@ -172,6 +187,23 @@ export function ApproveWalletsModal({
         // handling below surfaces a still-bound wallet as a conflict (#old) for recovery.
         if (deregisterFrom) {
           await deregisterOwner.deregisterAgent(deregisterFrom, addr).catch(() => {});
+        } else if (selfCoverage) {
+          // B1 self-coverage (§9.5) — the old account VARIES per wallet. Probe this wallet's
+          // binding right before its register: bound to a PCA the node CAN'T own (a sponsor's)
+          // → SKIP (already discounted free; don't burn a register/conflict); bound to a PCA
+          // the node OWNS → deregister-first; unbound → register. A probe that can't be read
+          // falls through to register (the B10 conflict handling below is the backstop, #9).
+          const b = await resolveWalletBinding(addr, ownerWallet);
+          if (b.boundTo && !b.canOwn && !b.inconclusive) {
+            setRows((r) => ({
+              ...r,
+              [addr]: { address: addr, status: 'sponsored', message: `Stays on PCA #${b.boundTo} — already discounted free.` },
+            }));
+            continue;
+          }
+          if (b.boundTo && b.canOwn) {
+            await owner.deregisterAgent(b.boundTo, addr).catch(() => {});
+          }
         }
         const res = await owner.registerAgent(accountId, addr);
         setRows((r) => ({
@@ -235,6 +267,7 @@ export function ApproveWalletsModal({
       confirmed: list.filter((r) => r.status === 'approved').length,
       submitted: list.filter((r) => r.status === 'submitted').length,
       skipped: list.filter((r) => r.status === 'skipped').length,
+      sponsored: list.filter((r) => r.status === 'sponsored').length,
       conflict: list.filter((r) => r.status === 'conflict').length,
       error: list.filter((r) => r.status === 'error' || r.status === 'cap').length,
       unverified: list.filter((r) => r.status === 'unverified').length,
@@ -358,7 +391,7 @@ export function ApproveWalletsModal({
                 <WalletRow
                   key={a}
                   address={a}
-                  status={row.message && (row.status === 'conflict' || row.status === 'error') ? row.message : ROW_LABEL[row.status]}
+                  status={row.message && (row.status === 'conflict' || row.status === 'error' || row.status === 'sponsored') ? row.message : ROW_LABEL[row.status]}
                   statusTone={ROW_TONE[row.status]}
                 />
               );
@@ -368,6 +401,7 @@ export function ApproveWalletsModal({
                 Approved {counts.confirmed} confirmed
                 {counts.submitted > 0 ? ` · ${counts.submitted} submitted (verify)` : ''}
                 {' '}· {counts.skipped} already here · {counts.conflict} conflict
+                {counts.sponsored > 0 ? ` · ${counts.sponsored} left on a sponsor’s PCA` : ''}
                 {counts.error > 0 ? ` · ${counts.error} failed` : ''}
                 {counts.unverified > 0 ? ` · ${counts.unverified} unverified` : ''} (of {order.length}).
               </p>

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -17,7 +17,7 @@ import {
   type WalletRowTone,
 } from '../../components/Pca/index.js';
 
-type RowStatus = 'pending' | 'approved' | 'submitted' | 'skipped' | 'sponsored' | 'conflict' | 'cap' | 'error' | 'unverified';
+type RowStatus = 'pending' | 'approved' | 'submitted' | 'skipped' | 'sponsored' | 'stranded' | 'conflict' | 'cap' | 'error' | 'unverified';
 interface Row {
   address: string;
   status: RowStatus;
@@ -35,6 +35,8 @@ const ROW_LABEL: Record<RowStatus, string> = {
   // B1 self-coverage — bound to a sponsor's PCA; intentionally left there (already discounted
   // free), NOT moved. Distinct from 'skipped' (= already approved HERE).
   sponsored: 'left on a sponsor’s PCA (already discounted free)',
+  // M5 — deregistered from the old PCA but the re-register failed: currently uncovered, recoverable.
+  stranded: 'removed from the old PCA, not yet on the new one — retry to finish',
   conflict: 'on another conviction account',
   cap: 'cap reached',
   error: 'failed',
@@ -48,6 +50,7 @@ const ROW_TONE: Record<RowStatus, WalletRowTone> = {
   submitted: 'neutral',
   skipped: 'neutral',
   sponsored: 'neutral',
+  stranded: 'warn',
   conflict: 'danger',
   cap: 'warn',
   error: 'danger',
@@ -178,6 +181,9 @@ export function ApproveWalletsModal({
         setRows((r) => ({ ...r, [addr]: { address: addr, status: 'error', message: 'stopped' } }));
         continue;
       }
+      // M5 — the old PCA we DEREGISTERED this wallet from (set only on a SUCCESSFUL deregister),
+      // so a subsequent register failure can be flagged "stranded" (off old, not on new) for retry.
+      let strandedFrom: string | null = null;
       try {
         // S2b renew (deregister-first, #1344 gate-HIGH): expiry doesn't clear
         // `agentToAccountId`, so a seeded old-PCA wallet is still bound there and
@@ -187,7 +193,11 @@ export function ApproveWalletsModal({
         // handling below surfaces a still-bound wallet as a conflict (#old) for recovery.
         if (deregisterFrom) {
           await deregisterOwner.deregisterAgent(deregisterFrom, addr).catch(() => {});
-        } else if (selfCoverage) {
+        } else if (selfCoverage && mode === 'self') {
+          // H2 (#9 safety) — gate on mode==='self': the mode radios stay enabled, so running this
+          // self-coverage deregister/skip logic on THIRD-PARTY (sponsor-mode) addresses would make a
+          // false "already discounted free" claim and could silently deregister a wallet off a PCA
+          // this node happens to own. Self-coverage applies to OUR wallets only.
           // B1 self-coverage (§9.5) — the old account VARIES per wallet. Probe this wallet's
           // binding right before its register: bound to a PCA the node CAN'T own (a sponsor's)
           // → SKIP (already discounted free; don't burn a register/conflict); bound to a PCA
@@ -202,7 +212,11 @@ export function ApproveWalletsModal({
             continue;
           }
           if (b.boundTo && b.canOwn) {
-            await owner.deregisterAgent(b.boundTo, addr).catch(() => {});
+            // M5 — record a SUCCESSFUL deregister so a later register failure reads as "stranded"
+            // (off old, not on new) with a retry, not a generic error. A FAILED deregister leaves
+            // the wallet on old → register conflicts → the B10 handling below recovers it.
+            try { await owner.deregisterAgent(b.boundTo, addr); strandedFrom = b.boundTo; }
+            catch { /* still bound to old — not stranded; register's conflict path recovers */ }
           }
         }
         const res = await owner.registerAgent(accountId, addr);
@@ -211,11 +225,19 @@ export function ApproveWalletsModal({
           [addr]: { address: addr, status: res.registered ? 'approved' : 'submitted', txHash: res.txHash },
         }));
       } catch (err) {
+        // M5 — if we'd already deregistered this wallet off its old PCA, a register failure leaves
+        // it off old + not on new (stranded). Tag it so the row offers "retry to finish" instead of
+        // a dead-end error. (NOT used for AgentAlreadyRegistered, which means it's still bound.)
+        const strandRow = (): Row => ({
+          address: addr,
+          status: 'stranded',
+          message: `Removed from PCA #${strandedFrom}, not yet on #${accountId} — retry to finish.`,
+        });
         // 403 → owner-gate failure: abort the WHOLE operation. W1 — sweep the later
         // not-yet-processed rows too, else they stay stuck on "approving…".
         if (err instanceof HttpError && err.status === 403) {
           setAborted(`This node isn’t the owner of PCA #${accountId} — approval aborted.`);
-          setRows((r) => markRemaining(r, { address: addr, status: 'error', message: 'owner-only' }, 'error', 'aborted'));
+          setRows((r) => markRemaining(r, strandedFrom ? strandRow() : { address: addr, status: 'error', message: 'owner-only' }, 'error', 'aborted'));
           break;
         }
         const info = describePcaError(err, { accountId });
@@ -249,7 +271,7 @@ export function ApproveWalletsModal({
         } else {
           setRows((r) => ({
             ...r,
-            [addr]: { address: addr, status: 'error', message: info?.message ?? (err as Error)?.message },
+            [addr]: strandedFrom ? strandRow() : { address: addr, status: 'error', message: info?.message ?? (err as Error)?.message },
           }));
         }
       }
@@ -268,6 +290,7 @@ export function ApproveWalletsModal({
       submitted: list.filter((r) => r.status === 'submitted').length,
       skipped: list.filter((r) => r.status === 'skipped').length,
       sponsored: list.filter((r) => r.status === 'sponsored').length,
+      stranded: list.filter((r) => r.status === 'stranded').length,
       conflict: list.filter((r) => r.status === 'conflict').length,
       error: list.filter((r) => r.status === 'error' || r.status === 'cap').length,
       unverified: list.filter((r) => r.status === 'unverified').length,
@@ -391,7 +414,7 @@ export function ApproveWalletsModal({
                 <WalletRow
                   key={a}
                   address={a}
-                  status={row.message && (row.status === 'conflict' || row.status === 'error' || row.status === 'sponsored') ? row.message : ROW_LABEL[row.status]}
+                  status={row.message && (row.status === 'conflict' || row.status === 'error' || row.status === 'sponsored' || row.status === 'stranded') ? row.message : ROW_LABEL[row.status]}
                   statusTone={ROW_TONE[row.status]}
                 />
               );
@@ -402,10 +425,22 @@ export function ApproveWalletsModal({
                 {counts.submitted > 0 ? ` · ${counts.submitted} submitted (verify)` : ''}
                 {' '}· {counts.skipped} already here · {counts.conflict} conflict
                 {counts.sponsored > 0 ? ` · ${counts.sponsored} left on a sponsor’s PCA` : ''}
+                {counts.stranded > 0 ? ` · ${counts.stranded} need a retry` : ''}
                 {counts.error > 0 ? ` · ${counts.error} failed` : ''}
                 {counts.unverified > 0 ? ` · ${counts.unverified} unverified` : ''} (of {order.length}).
               </p>
             )}
+          </div>
+        )}
+
+        {/* M5 — stranded recovery: a wallet was deregistered from its old PCA but its re-register
+            failed, so it's temporarily UNCOVERED. Surface it loudly + offer the one-click re-run
+            (the footer "Retry to finish" button re-runs the loop; the now-unbound wallet registers). */}
+        {done && counts.stranded > 0 && (
+          <div className="v10-modal-warning" role="alert" data-testid="pca-approve-stranded">
+            ⚠ {counts.stranded} wallet{counts.stranded === 1 ? ' was' : 's were'} removed from the old
+            PCA but not yet re-approved on #{accountId} — temporarily UNCOVERED. Click “Retry to finish”
+            to complete the move.
           </div>
         )}
 
@@ -443,6 +478,12 @@ export function ApproveWalletsModal({
             disabled={addresses.length === 0}
           >
             Approve {addresses.length} wallet{addresses.length === 1 ? '' : 's'}
+          </button>
+        ) : counts.stranded > 0 ? (
+          // M5 — one-click re-run to finish the stranded migrations. `run()` re-processes the
+          // selected wallets; a stranded one is now UNBOUND (we deregistered it) → it registers.
+          <button type="button" className="v10-modal-btn primary" data-testid="pca-approve-retry-stranded" onClick={run}>
+            Retry to finish
           </button>
         ) : null}
       </div>

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -32,10 +32,10 @@ const ROW_LABEL: Record<RowStatus, string> = {
   approved: 'approved on-chain',
   submitted: 'submitted — verify',
   skipped: 'already approved here (skipped)',
-  // B1 self-coverage — bound to a sponsor's PCA; intentionally left there (already discounted
+  // Self-coverage — bound to a sponsor's PCA; intentionally left there (already discounted
   // free), NOT moved. Distinct from 'skipped' (= already approved HERE).
   sponsored: 'left on a sponsor’s PCA (already discounted free)',
-  // M5 — deregistered from the old PCA but the re-register failed: currently uncovered, recoverable.
+  // Deregistered from the old PCA but the re-register failed: currently uncovered, recoverable.
   stranded: 'removed from the old PCA, not yet on the new one — retry to finish',
   conflict: 'on another conviction account',
   cap: 'cap reached',
@@ -58,13 +58,12 @@ const ROW_TONE: Record<RowStatus, WalletRowTone> = {
 };
 
 /**
- * S4 — Approve publishing wallets (self · sponsor). Self prefills this node's
- * operational wallets (the #11 "0/100 covers nothing" framing); sponsor is the
- * AddressCrux bulk paste. Approvals run as a SEQUENTIAL per-row loop in a
- * `role="status"` region with a Stop control. The 409-AgentAlreadyRegistered
- * branch re-probes THIS account: registered here → benign "skipped"; otherwise
- * it's a cross-account CONFLICT (never a benign skip) naming PCA #M when the
- * daemon surfaces existingAccountId (B10).
+ * Approve publishing wallets (self · sponsor). Self prefills this node's operational
+ * wallets ("0/100 covers nothing" framing); sponsor is the address bulk paste.
+ * Approvals run as a SEQUENTIAL per-row loop in a `role="status"` region with a Stop
+ * control. The 409-AgentAlreadyRegistered branch re-probes THIS account: registered
+ * here → benign "skipped"; otherwise it's a cross-account CONFLICT (never a benign skip)
+ * naming the existing PCA when the daemon surfaces its existingAccountId.
  */
 export function ApproveWalletsModal({
   accountId,
@@ -80,22 +79,22 @@ export function ApproveWalletsModal({
   initialMode?: 'self' | 'sponsor';
   onClose: () => void;
   onApproved?: () => void;
-  /** S2b renew — prefill the sponsor bulk-paste with the replaced account's agents,
+  /** Renew — prefill the sponsor bulk-paste with the replaced account's agents,
    *  so re-approving the same wallets on the new account is one step. */
   seedBulk?: string;
   /**
-   * S2b renew (#1344 gate-HIGH) — the OLD account these seeded wallets are still bound
+   * Renew (deregister-first, #1344) — the OLD account these seeded wallets are still bound
    * to on-chain. Account EXPIRY does NOT clear `agentToAccountId`, so re-approving a
    * seeded wallet on the new account would revert `AgentAlreadyRegistered`. When set,
    * each row is DEREGISTERED from this old account before being registered on the new
    * one. Its presence also marks the renew re-approval context (honest copy).
    */
   deregisterFrom?: string;
-  /** S2b renew — whether the old account's agents loaded (`listPcaAgents`). `false` →
+  /** Renew — whether the old account's agents loaded (`listPcaAgents`). `false` →
    *  the seed couldn't be pre-filled; the copy stops promising it and prompts manual entry. */
   seedAgentsResolved?: boolean;
   /**
-   * B1 self-coverage (§9.5) — set when this is the post-create self-coverage of THIS node's
+   * Self-coverage — set when this is the post-create self-coverage of THIS node's
    * own wallets. Each wallet is binding-probed PER-ROW just before its register: a wallet on a
    * PCA the node OWNS is deregistered-first; a wallet on a PCA the node CAN'T own (a sponsor's)
    * is SKIPPED (already discounted free), never burning a register. Distinct from `deregisterFrom`
@@ -106,11 +105,11 @@ export function ApproveWalletsModal({
   const { data: wb } = useFetch(fetchWalletsBalances, [], 0);
   const { data: snapshot } = useFetch(() => fetchPca(accountId), [accountId]);
   const owner = useOwnerActionSubmitter(accountId); // owner-action seam (P0: daemon submitter)
-  // S2b renew — the OLD account's owner-action submitter (free the wallet there first).
-  // Same daemon submitter in P0; keyed separately for the §9 wallet-owned future.
+  // Renew — the OLD account's owner-action submitter (free the wallet there first).
+  // Same daemon submitter today; keyed separately for the future wallet-owned signing branch.
   const deregisterOwner = useOwnerActionSubmitter(deregisterFrom);
   const nodeWallets = wb?.wallets ?? [];
-  const ownerWallet = nodeWallets[0]; // the daemon EOA — what it can deregister-from (B1)
+  const ownerWallet = nodeWallets[0]; // the daemon EOA — what it can deregister-from
   const agentCount = snapshot?.agentCount ?? 0;
   const cap = Math.max(0, 100 - agentCount);
 
@@ -181,23 +180,23 @@ export function ApproveWalletsModal({
         setRows((r) => ({ ...r, [addr]: { address: addr, status: 'error', message: 'stopped' } }));
         continue;
       }
-      // M5 — the old PCA we DEREGISTERED this wallet from (set only on a SUCCESSFUL deregister),
+      // The old PCA we DEREGISTERED this wallet from (set only on a SUCCESSFUL deregister),
       // so a subsequent register failure can be flagged "stranded" (off old, not on new) for retry.
       let strandedFrom: string | null = null;
       try {
-        // S2b renew (deregister-first, #1344 gate-HIGH): expiry doesn't clear
-        // `agentToAccountId`, so a seeded old-PCA wallet is still bound there and
-        // registerAgent(newId) would revert AgentAlreadyRegistered. Free it from the OLD
-        // account FIRST. Best-effort — an already-free wallet (AgentNotRegistered) or a
-        // transient failure just falls through to the register, whose AgentAlreadyRegistered
-        // handling below surfaces a still-bound wallet as a conflict (#old) for recovery.
+        // Renew (deregister-first, #1344): expiry doesn't clear `agentToAccountId`, so a seeded
+        // old-PCA wallet is still bound there and registerAgent(newId) would revert
+        // AgentAlreadyRegistered. Free it from the OLD account FIRST. Best-effort — an already-free
+        // wallet (AgentNotRegistered) or a transient failure just falls through to the register,
+        // whose AgentAlreadyRegistered handling below surfaces a still-bound wallet as a conflict
+        // (pointing at the old account) for recovery.
         if (deregisterFrom) {
           await deregisterOwner.deregisterAgent(deregisterFrom, addr).catch(() => {});
         } else if (selfCoverage && mode === 'self') {
-          // H2 (#9 safety) — gate on mode==='self': the mode radios stay enabled, so running this
+          // Honesty/safety gate on mode==='self': the mode radios stay enabled, so running this
           // self-coverage logic on THIRD-PARTY (sponsor-mode) addresses would mis-classify them.
-          // R5 — the per-wallet classification lives in the planner (walletBinding.ts); this loop
-          // just EXECUTES the plan. (Old account varies per wallet, unlike renew's deregisterFrom.)
+          // The per-wallet classification lives in the planner (walletBinding.ts); this loop just
+          // EXECUTES the plan. (Old account varies per wallet, unlike renew's deregisterFrom.)
           const plan = planSelfCoverage(await resolveWalletBinding(addr, ownerWallet));
           if (plan.kind === 'skipSponsored') {
             // Bound to a LIVE sponsor PCA → already discounted free; don't burn a register/conflict.
@@ -208,8 +207,8 @@ export function ApproveWalletsModal({
             continue;
           }
           if (plan.kind === 'conflictSponsorDead') {
-            // R1 (#9) — bound to an EXPIRED/swept sponsor PCA: NOT covering, and this node can't free
-            // it (not the owner). A distinct conflict — NEVER the benign "already discounted free" skip.
+            // Bound to an EXPIRED/swept sponsor PCA: NOT covering, and this node can't free it (not
+            // the owner). A distinct conflict — NEVER the benign "already discounted free" skip.
             setRows((r) => ({
               ...r,
               [addr]: { address: addr, status: 'conflict', message: `Approved on PCA #${plan.prevAccountId}, but it’s expired/swept (not covering) — ask its owner to deregister you; this node can’t free it.` },
@@ -217,9 +216,10 @@ export function ApproveWalletsModal({
             continue;
           }
           if (plan.kind === 'deregisterThenRegister') {
-            // M5 — record a SUCCESSFUL deregister so a later register failure reads as "stranded"
+            // Record a SUCCESSFUL deregister so a later register failure reads as "stranded"
             // (off old, not on new) with a retry, not a generic error. A FAILED deregister leaves
-            // the wallet on old → register conflicts → the B10 handling below recovers it.
+            // the wallet on old → register conflicts → the AgentAlreadyRegistered handling below
+            // recovers it.
             try { await owner.deregisterAgent(plan.prevAccountId, addr); strandedFrom = plan.prevAccountId; }
             catch { /* still bound to old — not stranded; register's conflict path recovers */ }
           }
@@ -231,7 +231,7 @@ export function ApproveWalletsModal({
           [addr]: { address: addr, status: res.registered ? 'approved' : 'submitted', txHash: res.txHash },
         }));
       } catch (err) {
-        // M5 — if we'd already deregistered this wallet off its old PCA, a register failure leaves
+        // If we'd already deregistered this wallet off its old PCA, a register failure leaves
         // it off old + not on new (stranded). Tag it so the row offers "retry to finish" instead of
         // a dead-end error. (NOT used for AgentAlreadyRegistered, which means it's still bound.)
         const strandRow = (): Row => ({
@@ -374,7 +374,7 @@ export function ApproveWalletsModal({
               {agentCount} → {agentCount + parsed.valid.length} of 100 after this
             </p>
             {deregisterFrom ? (
-              // S2b renew (#1344 [MEDIUM]) — these are the node's OWN carried-over wallets,
+              // Renew (#1344) — these are the node's OWN carried-over wallets,
               // not a third party, so the sponsor-can't-verify warning is wrong here.
               <div className="v10-modal-warning" data-testid="pca-renew-reapprove-note">
                 ⓘ Re-approving PCA #{deregisterFrom}’s wallets on #{accountId}. Each wallet is MOVED —
@@ -439,7 +439,7 @@ export function ApproveWalletsModal({
           </div>
         )}
 
-        {/* M5 — stranded recovery: a wallet was deregistered from its old PCA but its re-register
+        {/* Stranded recovery: a wallet was deregistered from its old PCA but its re-register
             failed, so it's temporarily UNCOVERED. Surface it loudly + offer the one-click re-run
             (the footer "Retry to finish" button re-runs the loop; the now-unbound wallet registers). */}
         {done && counts.stranded > 0 && (
@@ -451,7 +451,7 @@ export function ApproveWalletsModal({
         )}
 
         {/* Sponsor handoff after a run — third-party only; a renew re-approves the node's
-            OWN wallets (#1344 [MEDIUM]), so the "remind the other operator" handshake is off. */}
+            OWN wallets (#1344), so the "remind the other operator" handshake is off. */}
         {done && mode === 'sponsor' && !deregisterFrom && (
           <div className="v10-pca-approve-handoff">
             <div className="v10-modal-warning">
@@ -486,7 +486,7 @@ export function ApproveWalletsModal({
             Approve {addresses.length} wallet{addresses.length === 1 ? '' : 's'}
           </button>
         ) : counts.stranded > 0 ? (
-          // M5 — one-click re-run to finish the stranded migrations. `run()` re-processes the
+          // One-click re-run to finish the stranded migrations. `run()` re-processes the
           // selected wallets; a stranded one is now UNBOUND (we deregistered it) → it registers.
           <button type="button" className="v10-modal-btn primary" data-testid="pca-approve-retry-stranded" onClick={run}>
             Retry to finish

--- a/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ApproveWalletsModal.tsx
@@ -7,7 +7,7 @@ import {
   HttpError,
 } from '../../api.js';
 import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
-import { resolveWalletBinding } from '../../pca/walletBinding.js';
+import { resolveWalletBinding, planSelfCoverage } from '../../pca/walletBinding.js';
 import { PcaModalShell } from './PcaModalShell.js';
 import {
   AddressCrux,
@@ -195,29 +195,35 @@ export function ApproveWalletsModal({
           await deregisterOwner.deregisterAgent(deregisterFrom, addr).catch(() => {});
         } else if (selfCoverage && mode === 'self') {
           // H2 (#9 safety) — gate on mode==='self': the mode radios stay enabled, so running this
-          // self-coverage deregister/skip logic on THIRD-PARTY (sponsor-mode) addresses would make a
-          // false "already discounted free" claim and could silently deregister a wallet off a PCA
-          // this node happens to own. Self-coverage applies to OUR wallets only.
-          // B1 self-coverage (§9.5) — the old account VARIES per wallet. Probe this wallet's
-          // binding right before its register: bound to a PCA the node CAN'T own (a sponsor's)
-          // → SKIP (already discounted free; don't burn a register/conflict); bound to a PCA
-          // the node OWNS → deregister-first; unbound → register. A probe that can't be read
-          // falls through to register (the B10 conflict handling below is the backstop, #9).
-          const b = await resolveWalletBinding(addr, ownerWallet);
-          if (b.boundTo && !b.canOwn && !b.inconclusive) {
+          // self-coverage logic on THIRD-PARTY (sponsor-mode) addresses would mis-classify them.
+          // R5 — the per-wallet classification lives in the planner (walletBinding.ts); this loop
+          // just EXECUTES the plan. (Old account varies per wallet, unlike renew's deregisterFrom.)
+          const plan = planSelfCoverage(await resolveWalletBinding(addr, ownerWallet));
+          if (plan.kind === 'skipSponsored') {
+            // Bound to a LIVE sponsor PCA → already discounted free; don't burn a register/conflict.
             setRows((r) => ({
               ...r,
-              [addr]: { address: addr, status: 'sponsored', message: `Stays on PCA #${b.boundTo} — already discounted free.` },
+              [addr]: { address: addr, status: 'sponsored', message: `Stays on PCA #${plan.prevAccountId} — already discounted free.` },
             }));
             continue;
           }
-          if (b.boundTo && b.canOwn) {
+          if (plan.kind === 'conflictSponsorDead') {
+            // R1 (#9) — bound to an EXPIRED/swept sponsor PCA: NOT covering, and this node can't free
+            // it (not the owner). A distinct conflict — NEVER the benign "already discounted free" skip.
+            setRows((r) => ({
+              ...r,
+              [addr]: { address: addr, status: 'conflict', message: `Approved on PCA #${plan.prevAccountId}, but it’s expired/swept (not covering) — ask its owner to deregister you; this node can’t free it.` },
+            }));
+            continue;
+          }
+          if (plan.kind === 'deregisterThenRegister') {
             // M5 — record a SUCCESSFUL deregister so a later register failure reads as "stranded"
             // (off old, not on new) with a retry, not a generic error. A FAILED deregister leaves
             // the wallet on old → register conflicts → the B10 handling below recovers it.
-            try { await owner.deregisterAgent(b.boundTo, addr); strandedFrom = b.boundTo; }
+            try { await owner.deregisterAgent(plan.prevAccountId, addr); strandedFrom = plan.prevAccountId; }
             catch { /* still bound to old — not stranded; register's conflict path recovers */ }
           }
+          // plan.kind === 'register' (unbound / inconclusive) → fall through to register.
         }
         const res = await owner.registerAgent(accountId, addr);
         setRows((r) => ({

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
@@ -119,13 +119,25 @@ export function ConvictionOverview() {
           </button>
         </div>
         {role === 'edge' ? (
-          <button
-            type="button"
-            className="v10-pca-card-btn primary"
-            onClick={() => setSponsoredOpen(true)}
-          >
-            Share my wallet → get sponsored
-          </button>
+          // Sub-PR 1 (§5.6/§5.1) — edge can now create too: Get sponsored stays the
+          // PRIMARY/recommended-free CTA; Create is an available SECONDARY alongside it.
+          <div className="v10-pca-overview-cta-group">
+            <button
+              type="button"
+              className="v10-pca-card-btn primary"
+              onClick={() => setSponsoredOpen(true)}
+            >
+              Share my wallet → get sponsored
+            </button>
+            <button
+              type="button"
+              className="v10-pca-card-btn"
+              data-testid="pca-create-btn"
+              onClick={() => setCreateOpen(true)}
+            >
+              + Create a conviction account
+            </button>
+          </div>
         ) : (
           <button
             type="button"
@@ -277,11 +289,13 @@ function DiscoveredStrip({
 
 function OwnedEmpty({ role }: { role?: 'core' | 'edge' }) {
   if (role === 'edge') {
+    // Sub-PR 1 (§5.6) — edge CAN own a PCA now (by designating a staked node as primary).
+    // Get sponsored stays the recommended free path; creating is the available alternative.
     return (
       <EmptyState
         tone="neutral"
-        title="Edge nodes can’t own a Publishing Conviction Account"
-        description="Creating a PCA requires a staked core-node identity to set as its primary node. Get sponsored by a core node instead."
+        title="Get sponsored — or create your own"
+        description="The free path: have a core node approve your operational wallets (Get sponsored — no TRAC locked). You can also create your own conviction account by designating a staked node as its primary node — you get the discount, and the reward weight accrues to the node you pick."
       />
     );
   }

--- a/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/ConvictionOverview.tsx
@@ -52,7 +52,7 @@ export function ConvictionOverview() {
   const defaultFilter: ViewFilter = role === 'edge' ? 'approved' : 'owned';
   const filter = userFilter ?? defaultFilter;
   const [createOpen, setCreateOpen] = useState(false);
-  const [approve, setApprove] = useState<{ accountId: string; mode: 'self' | 'sponsor' } | null>(null);
+  const [approve, setApprove] = useState<{ accountId: string; mode: 'self' | 'sponsor'; selfCoverage?: boolean } | null>(null);
   const [sponsoredOpen, setSponsoredOpen] = useState(false);
 
   const owned = useMemo(() => accounts.filter((a) => a.classification === 'owned'), [accounts]);
@@ -211,7 +211,7 @@ export function ConvictionOverview() {
       {createOpen && (
         <CreatePcaModal
           onClose={() => { setCreateOpen(false); refresh(); }}
-          onApproveOwnWallets={(id) => { setCreateOpen(false); setApprove({ accountId: id, mode: 'self' }); }}
+          onApproveOwnWallets={(id) => { setCreateOpen(false); setApprove({ accountId: id, mode: 'self', selfCoverage: true }); }}
           onManage={(id) => { setCreateOpen(false); onManage(id); }}
           onGetSponsored={() => { setCreateOpen(false); setSponsoredOpen(true); }}
         />
@@ -220,6 +220,7 @@ export function ConvictionOverview() {
         <ApproveWalletsModal
           accountId={approve.accountId}
           initialMode={approve.mode}
+          selfCoverage={approve.selfCoverage}
           onClose={() => { setApprove(null); refresh(); }}
         />
       )}

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -177,10 +177,15 @@ export function CreatePcaModal({
       if (err instanceof HttpError && (err.status === 400 || isPcaFeatureUnavailable(err))) {
         clearCreatePending();
         const info = describePcaError(err);
-        // §9.4 #18 / Q1 — PrimaryNodeNotInShardingTable is RECOVERABLE, not terminal: the
-        // picked node was unstaked between picking and submit (or a list-down core best-effort
-        // default raced). Refetch the staked list so the picker re-prompts with fresh data.
-        if (info?.code === 'PrimaryNodeNotInShardingTable') refreshNodes();
+        // §9.4 #18 / Q1 / R2 — PrimaryNodeNotInShardingTable is RECOVERABLE, not terminal: the
+        // picked node was unstaked between picking and submit. CLEAR the rejected node AND refetch
+        // the list FRESH, so submit stays disabled until a still-listed node is picked (the prefill
+        // re-defaults to the core's own id only if it's still staked) — never re-submit the same
+        // rejected id on its numeric shape.
+        if (info?.code === 'PrimaryNodeNotInShardingTable') {
+          setPrimaryNode('');
+          refreshNodes();
+        }
         setError(info?.message ?? (err as Error)?.message ?? 'Create failed.');
         setPhase('form');
         return;
@@ -358,14 +363,26 @@ export function CreatePcaModal({
           </div>
         )}
 
-        {/* B1 (§9.5) — zero-self-coverage informed consent: every op wallet is already on a
-            sponsor's PCA, so this account discounts NONE of your own publishes. NOT a block. */}
+        {/* B1 (§9.5) — zero-self-coverage informed consent: every op wallet is already on another
+            PCA, so this account discounts NONE of your own publishes. NOT a block. (R1 — only the
+            ones on a LIVE sponsor PCA are actually "free"; dead ones get the separate warning below.) */}
         {b1.zeroSelfCoverage && (
           <div className="v10-modal-warning" role="alert" data-testid="pca-b1-zero-coverage">
-            ⚠ All of this node’s operational wallets are already approved on other PCAs — you
-            already get the discount, free. This new account will <strong>NOT</strong> discount your
-            own publishes. Create it only if you intend to <strong>sponsor other nodes</strong>;
-            otherwise getting sponsored is the free path and creating just locks your TRAC.
+            ⚠ All of this node’s operational wallets are already approved on other PCAs
+            {b1.sponsorBound.length > 0 ? ' (you already get the discount free where those are live)' : ''}.
+            This new account will <strong>NOT</strong> discount your own publishes. Create it only if
+            you intend to <strong>sponsor other nodes</strong>; otherwise getting sponsored is the free
+            path and creating just locks your TRAC.
+          </div>
+        )}
+        {/* R1 (#9) — wallets on an EXPIRED/swept sponsor PCA: NOT covered, and this node can't free
+            them (not the owner). Never claim "already free"; surface the honest, actionable state. */}
+        {b1.sponsorDead.length > 0 && (
+          <div className="v10-modal-warning" role="alert" data-testid="pca-b1-sponsor-dead">
+            ⚠ {b1.sponsorDead.length} of this node’s wallet(s) are approved on a sponsor’s PCA that’s
+            <strong> expired or swept</strong> — they’re <strong>not covered</strong>, and this node
+            can’t free them (it doesn’t own that account). Ask the sponsor to deregister you, then
+            re-approve them here — otherwise they stay uncovered.
           </div>
         )}
         {/* Partial case — some wallets stay on a sponsor's PCA (already free), not moved. */}

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -60,13 +60,13 @@ export function CreatePcaModal({
   const nodeStatus = useAgentsStore((s) => s.nodeStatus) as
     | { nodeRole?: string; hasIdentity?: boolean; identityId?: string; blockExplorerUrl?: string | null }
     | null;
-  // Sub-PR 1 (§9.3) — the edge/no-identity CREATE GATE is REMOVED: any node can create a
-  // PCA by designating a staked sharding-table node as its `primaryNode` (the picker, §3b).
-  // A node without its own staked identity gets a non-blocking explainer (not a hard block).
-  // `hasIdentity === false` (or edge) only drives that explainer now, never a gate.
+  // The edge/no-identity CREATE GATE is REMOVED: any node can create a PCA by designating a
+  // staked sharding-table node as its `primaryNode` (via the picker). A node without its own
+  // staked identity gets a non-blocking explainer (not a hard block); `hasIdentity === false`
+  // (or edge) only drives that explainer now, never a gate.
   const noOwnIdentity = nodeStatus?.nodeRole === 'edge' || nodeStatus?.hasIdentity === false;
-  // S1 — still fail CLOSED while status is loading/failed (nodeStatus null): create needs
-  // the owner wallet (double-mint marker) and status (picker pre-select / M3 cross-check)
+  // Still fail CLOSED while status is loading/failed (nodeStatus null): create needs the owner
+  // wallet (double-mint marker) and status (picker pre-select / own-staked cross-check)
   // resolved first. A financial mutation must not proceed on unknown eligibility.
   const statusUnknown = nodeStatus == null;
   const explorer = nodeStatus?.blockExplorerUrl ?? null;
@@ -77,7 +77,7 @@ export function CreatePcaModal({
   const ownerTrac = wb?.balances?.find((b) => b.address === ownerWallet)?.trac;
   const ownerTracNum = ownerTrac != null ? Number(ownerTrac) : NaN;
 
-  // B1 pre-flight wallet-binding probe (§9.5) — READ-ONLY, at wizard open. Surfaces the
+  // Pre-flight wallet-binding probe — READ-ONLY, at wizard open. Surfaces the
   // self-coverage outlook BEFORE the TRAC commit: if EVERY op wallet is already bound to a
   // sponsor's PCA, the new account would discount none of this node's own publishes (a loud
   // informed-consent warning — NOT a hard block; a node may create purely to sponsor others).
@@ -128,10 +128,10 @@ export function CreatePcaModal({
   const belowMinTier = amountValid && amountNum < 25_000;
   const estTier = useMemo(() => discountTierForTrac(amountValid ? amountNum : null), [amountNum, amountValid]);
   const primaryValid = /^\d+$/.test(primaryNode.trim()) && Number(primaryNode.trim()) > 0;
-  // L13: don't allow submit until the owner wallet has loaded — the durable
-  // double-mint marker is keyed on `ownerWallet`, so submitting before wallets
-  // resolve would skip persisting it (the in-session reconcile would still fire,
-  // but the refresh-survival guarantee wouldn't). Cheap belt-and-suspenders.
+  // Don't allow submit until the owner wallet has loaded — the durable double-mint
+  // marker is keyed on `ownerWallet`, so submitting before wallets resolve would skip
+  // persisting it (the in-session reconcile would still fire, but the refresh-survival
+  // guarantee wouldn't). Cheap belt-and-suspenders.
   const canSubmit =
     amountValid && !insufficient && primaryValid && !!ownerWallet && !statusUnknown && phase === 'form';
 
@@ -160,13 +160,12 @@ export function CreatePcaModal({
       if (err instanceof HttpError && (err.status === 400 || isPcaFeatureUnavailable(err))) {
         clearCreatePending();
         const info = describePcaError(err);
-        // §9.4 #18 / Q1 / R2 — PrimaryNodeNotInShardingTable is RECOVERABLE, not terminal: the
-        // picked node was unstaked between picking and submit. CLEAR the rejected node AND refetch
-        // the list FRESH, so submit stays disabled until a still-listed node is picked (the prefill
-        // re-defaults to the core's own id only if it's still staked) — never re-submit the same
-        // rejected id on its numeric shape.
+        // PrimaryNodeNotInShardingTable is RECOVERABLE, not terminal: the picked node was unstaked
+        // between picking and submit. CLEAR the rejected node AND refetch the list FRESH, so submit
+        // stays disabled until a still-listed node is picked (the prefill re-defaults to the core's
+        // own id only if it's still staked) — never re-submit the same rejected id on its numeric shape.
         if (info?.code === 'PrimaryNodeNotInShardingTable') {
-          onPrimaryNodeRejected(); // R2 — clear the rejected node so it can't be re-submitted
+          onPrimaryNodeRejected(); // clear the rejected node so it can't be re-submitted
           refreshNodes();
         }
         setError(info?.message ?? (err as Error)?.message ?? 'Create failed.');
@@ -346,9 +345,9 @@ export function CreatePcaModal({
           </div>
         )}
 
-        {/* B1 (§9.5) — zero-self-coverage informed consent: every op wallet is already on another
-            PCA, so this account discounts NONE of your own publishes. NOT a block. (R1 — only the
-            ones on a LIVE sponsor PCA are actually "free"; dead ones get the separate warning below.) */}
+        {/* Zero-self-coverage informed consent: every op wallet is already on another PCA, so this
+            account discounts NONE of your own publishes. NOT a block. (Only the ones on a LIVE
+            sponsor PCA are actually "free"; dead ones get the separate warning below.) */}
         {b1.zeroSelfCoverage && (
           <div className="v10-modal-warning" role="alert" data-testid="pca-b1-zero-coverage">
             ⚠ All of this node’s operational wallets are already approved on other PCAs
@@ -358,8 +357,8 @@ export function CreatePcaModal({
             path and creating just locks your TRAC.
           </div>
         )}
-        {/* R1 (#9) — wallets on an EXPIRED/swept sponsor PCA: NOT covered, and this node can't free
-            them (not the owner). Never claim "already free"; surface the honest, actionable state. */}
+        {/* Wallets on an EXPIRED/swept sponsor PCA: NOT covered, and this node can't free them
+            (not the owner). Never claim "already free"; surface the honest, actionable state. */}
         {b1.sponsorDead.length > 0 && (
           <div className="v10-modal-warning" role="alert" data-testid="pca-b1-sponsor-dead">
             ⚠ {b1.sponsorDead.length} of this node’s wallet(s) are approved on a sponsor’s PCA that’s
@@ -376,7 +375,7 @@ export function CreatePcaModal({
             (any already on a PCA you own are deregistered from it first).
           </div>
         )}
-        {/* M3 — own-bound migration must be disclosed: these wallets are MOVED off a PCA this node
+        {/* Own-bound migration must be disclosed: these wallets are MOVED off a PCA this node
             already owns. Independent of the sponsor-bound preview (fires even when sponsorBound===0). */}
         {!b1.zeroSelfCoverage && b1.ownBound.length > 0 && (
           <div className="v10-modal-warning" role="status" data-testid="pca-b1-own-bound">
@@ -387,8 +386,8 @@ export function CreatePcaModal({
           </div>
         )}
 
-        {/* S2b renew — HONEST framing (#9): this is a NEW separate account, not an
-            in-place extension; the old account's TRAC stays locked until its own expiry. */}
+        {/* Renew — HONEST framing: this is a NEW separate account, not an in-place
+            extension; the old account's TRAC stays locked until its own expiry. */}
         {replacingAccountId && (
           <div className="v10-modal-warning" role="status" data-testid="pca-renew-note">
             ⓘ This creates a <strong>new, separate</strong> account (a new id) — it does not extend or

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -367,6 +367,16 @@ export function CreatePcaModal({
             (any already on a PCA you own are deregistered from it first).
           </div>
         )}
+        {/* M3 — own-bound migration must be disclosed: these wallets are MOVED off a PCA this node
+            already owns. Independent of the sponsor-bound preview (fires even when sponsorBound===0). */}
+        {!b1.zeroSelfCoverage && b1.ownBound.length > 0 && (
+          <div className="v10-modal-warning" role="status" data-testid="pca-b1-own-bound">
+            ⚠ {b1.ownBound.length} of this node’s wallet(s) are already approved on a PCA you own.
+            Self-coverage will <strong>move</strong> them — deregister from that account, then approve
+            on the new one. The old account’s committed TRAC stays locked until its own expiry and
+            would then cover nothing, so only proceed if you’re replacing it.
+          </div>
+        )}
 
         {/* S2b renew — HONEST framing (#9): this is a NEW separate account, not an
             in-place extension; the old account's TRAC stays locked until its own expiry. */}
@@ -431,6 +441,7 @@ export function CreatePcaModal({
             onChange={setPrimaryNode}
             ownIdentityId={ownStaked}
             role={nodeStatus?.nodeRole === 'edge' ? 'edge' : nodeStatus?.nodeRole === 'core' ? 'core' : undefined}
+            required
           />
         </section>
 

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -130,6 +130,15 @@ export function CreatePcaModal({
     else if (nodesError) setPrimaryNode(ownIdentity);
   }, [primaryNode, ownIdentity, ownStaked, nodesError]);
 
+  // L2 — reconcile a STALE best-effort default: if the list was down (Q1 set primaryNode=ownIdentity)
+  // and a successful retry then loads a list that does NOT contain the own id, the pre-selection is
+  // invalid — clear it so the picker re-prompts (else submit stays enabled on a bad id until the
+  // create-time revert). Fresh-create only (renew owns its seed + the revert backstop).
+  useEffect(() => {
+    if (replacingAccountId || nodesError || nodesLoading || stakedNodes.length === 0) return;
+    if (ownIdentity && primaryNode === ownIdentity && !ownStaked) setPrimaryNode('');
+  }, [replacingAccountId, nodesError, nodesLoading, stakedNodes.length, ownIdentity, primaryNode, ownStaked]);
+
   const amountNum = AMOUNT_RE.test(tokens.trim()) ? Number(tokens.trim()) : NaN;
   const amountValid = Number.isFinite(amountNum) && amountNum > 0;
   const insufficient = amountValid && Number.isFinite(ownerTracNum) && amountNum > ownerTracNum;

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -57,12 +57,14 @@ export function CreatePcaModal({
   const nodeStatus = useAgentsStore((s) => s.nodeStatus) as
     | { nodeRole?: string; hasIdentity?: boolean; identityId?: string; blockExplorerUrl?: string | null }
     | null;
-  const gated = nodeStatus?.nodeRole === 'edge' || nodeStatus?.hasIdentity === false;
-  // S1 — the create gate fails OPEN while status is loading/failed (nodeStatus null):
-  // `gated` is false, so without this an edge/no-identity node could lock TRAC before
-  // the gate appears. A financial mutation must fail CLOSED on unknown eligibility —
-  // the write-side mirror of C1/O4/Q2. (`==` catches null+undefined; a resolved core
-  // is NOT unknown, so a legit core create isn't blocked.)
+  // Sub-PR 1 (§9.3) — the edge/no-identity CREATE GATE is REMOVED: any node can create a
+  // PCA by designating a staked sharding-table node as its `primaryNode` (the picker, §3b).
+  // A node without its own staked identity gets a non-blocking explainer (not a hard block).
+  // `hasIdentity === false` (or edge) only drives that explainer now, never a gate.
+  const noOwnIdentity = nodeStatus?.nodeRole === 'edge' || nodeStatus?.hasIdentity === false;
+  // S1 — still fail CLOSED while status is loading/failed (nodeStatus null): create needs
+  // the owner wallet (double-mint marker) and status (picker pre-select / M3 cross-check)
+  // resolved first. A financial mutation must not proceed on unknown eligibility.
   const statusUnknown = nodeStatus == null;
   const explorer = nodeStatus?.blockExplorerUrl ?? null;
 
@@ -156,33 +158,6 @@ export function CreatePcaModal({
     }
   };
 
-  // ----- Gated (edge / no staked identity) -----
-  if (gated) {
-    return (
-      <PcaModalShell onClose={onClose} testId="pca-create-modal" title="Create needs a staked core-node identity">
-        <div className="v10-modal-body">
-          <div className="v10-modal-warning">
-            Creating a Publishing Conviction Account requires a staked core-node identity to set as its
-            primary node — this node has none yet. An edge node gets a publishing discount by being
-            <strong> sponsored</strong>: share your operational wallets with a core node and have them
-            approve you on their account.
-          </div>
-        </div>
-        <div className="v10-modal-footer">
-          <button type="button" className="v10-modal-btn" onClick={onClose}>Close</button>
-          <button
-            type="button"
-            className="v10-modal-btn primary"
-            data-testid="pca-gated-get-sponsored"
-            onClick={onGetSponsored}
-          >
-            Get sponsored →
-          </button>
-        </div>
-      </PcaModalShell>
-    );
-  }
-
   // ----- Reconcile (double-mint guard) -----
   if (phase === 'reconcile') {
     const txUrl = explorer && pendingTxHash ? `${explorer}/tx/${pendingTxHash}` : undefined;
@@ -243,9 +218,9 @@ export function CreatePcaModal({
 
   // ----- Status unknown (loading / failed) — fail CLOSED (S1) -----
   // Placed AFTER the reconcile resume (a durable create-pending marker must still
-  // surface on a null-status reload) and before the form. `gated` is null-safe
-  // (false when nodeStatus is null), so it can't render the sponsorship gate while
-  // unknown — we never assert "edge"; we just show a neutral checking state.
+  // surface on a null-status reload) and before the form. We never assert "edge" while
+  // unknown — just a neutral checking state until status (owner wallet + identity for
+  // the picker pre-select) resolves.
   if (statusUnknown) {
     return (
       <PcaModalShell onClose={onClose} testId="pca-create-modal" title="Checking node eligibility…">
@@ -324,6 +299,21 @@ export function CreatePcaModal({
     >
       <div className="v10-modal-body">
         {error && <div className="v10-modal-error" role="alert">{error}</div>}
+
+        {/* Sub-PR 1 (§5.2 Step 1) — NON-BLOCKING explainer for a node without its own staked
+            identity (edge / no-identity). Create is NOT gated; this just surfaces the free
+            alternative. Never a redirect that prevents Create. */}
+        {noOwnIdentity && !replacingAccountId && (
+          <div className="v10-modal-tip" role="status" data-testid="pca-create-no-identity-note">
+            This node has no staked identity of its own — you can still create a PCA by choosing a
+            staked node as its primary node below (you get the discount; the reward weight accrues to
+            the node you pick).{' '}
+            <button type="button" className="v10-pca-card-btn" data-testid="pca-create-get-sponsored-link" onClick={onGetSponsored}>
+              Or get sponsored
+            </button>{' '}
+            — the free alternative (no TRAC locked).
+          </div>
+        )}
 
         {/* S2b renew — HONEST framing (#9): this is a NEW separate account, not an
             in-place extension; the old account's TRAC stays locked until its own expiry. */}

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -76,19 +76,7 @@ export function CreatePcaModal({
   const ownerWallet = wallets[0];
   const ownerTrac = wb?.balances?.find((b) => b.address === ownerWallet)?.trac;
   const ownerTracNum = ownerTrac != null ? Number(ownerTrac) : NaN;
-
-  // Pre-flight wallet-binding probe — READ-ONLY, at wizard open. Surfaces the
-  // self-coverage outlook BEFORE the TRAC commit: if EVERY op wallet is already bound to a
-  // sponsor's PCA, the new account would discount none of this node's own publishes (a loud
-  // informed-consent warning — NOT a hard block; a node may create purely to sponsor others).
-  // The per-wallet deregister-first then runs in the self-coverage loop (ApproveWalletsModal).
   const walletsKey = wallets.join(',');
-  const { data: bindings } = useFetch(
-    () => probeWalletBindings(wallets, ownerWallet),
-    [walletsKey, ownerWallet],
-    0,
-  );
-  const b1 = useMemo(() => selfCoverageOutlook(bindings ?? []), [bindings]);
 
   const owner = useOwnerActionSubmitter(); // owner-action seam (P0: daemon submitter)
   const finishCreate = usePcaStore((s) => s.finishCreate);
@@ -108,9 +96,25 @@ export function CreatePcaModal({
   const [pendingTxHash, setPendingTxHash] = useState<string | undefined>(createPending?.txHash);
   const [error, setError] = useState<string | null>(null);
 
+  // Form-only reads are gated to the form phase: the reconcile / status-unknown / success screens
+  // don't render the form, so they must not start the wallet-binding probe or the sharding-table read.
+  const formActive = phase === 'form' && !statusUnknown;
+
+  // Pre-flight wallet-binding probe — READ-ONLY, while the form is showing. Surfaces the
+  // self-coverage outlook BEFORE the TRAC commit: if EVERY op wallet is already bound to a
+  // sponsor's PCA, the new account would discount none of this node's own publishes (a loud
+  // informed-consent warning — NOT a hard block; a node may create purely to sponsor others).
+  // The per-wallet deregister-first then runs in the self-coverage loop (ApproveWalletsModal).
+  const { data: bindings } = useFetch(
+    () => (formActive ? probeWalletBindings(wallets, ownerWallet) : Promise.resolve([])),
+    [walletsKey, ownerWallet, formActive],
+    0,
+  );
+  const b1 = useMemo(() => selfCoverageOutlook(bindings ?? []), [bindings]);
+
   // §3b — the REQUIRED staked-node picker's list (B-staked-nodes; fetched whole, sorted desc).
   const { nodes: stakedNodes, loading: nodesLoading, error: nodesError, refresh: refreshNodes } =
-    useDesignatableNodes();
+    useDesignatableNodes(formActive);
   // All primary-node selection policy (renew seed / staked-default / list-down fallback / stale-clear
   // / rejected-node recovery) lives in one hook — the modal just wires value/actions to the picker.
   const { primaryNode, setPrimaryNode, ownStaked, onRejected: onPrimaryNodeRejected } = usePrimaryNodeSelection({
@@ -120,6 +124,7 @@ export function CreatePcaModal({
     stakedNodes,
     nodesError,
     nodesLoading,
+    enabled: formActive,
   });
 
   const amountNum = AMOUNT_RE.test(tokens.trim()) ? Number(tokens.trim()) : NaN;

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useFetch } from '../../hooks.js';
 import {
   fetchWalletsBalances,
@@ -12,6 +12,7 @@ import {
 import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
 import { probeWalletBindings, selfCoverageOutlook } from '../../pca/walletBinding.js';
 import { useDesignatableNodes } from '../../hooks/useDesignatableNodes.js';
+import { usePrimaryNodeSelection } from '../../hooks/usePrimaryNodeSelection.js';
 import { useAgentsStore } from '../../stores/agents.js';
 import { usePcaStore } from '../../stores/pca.js';
 import { DiscountTierLadder, discountTierForTrac, WalletRow, PrimaryNodePicker } from '../../components/Pca/index.js';
@@ -98,9 +99,8 @@ export function CreatePcaModal({
   // no-storage env), so the reconcile screen doesn't falsely claim it survives a refresh.
   const createPendingPersisted = usePcaStore((s) => s.createPendingPersisted);
 
-  // S2b renew — seed the commit amount + primary node from the expiring account.
+  // S2b renew — seed the commit amount from the expiring account.
   const [tokens, setTokens] = useState(seed?.tokens ?? '');
-  const [primaryNode, setPrimaryNode] = useState(seed?.primaryNode ?? '');
   // Resume the reconcile guard if a create is already in flight from a prior
   // session (durable marker) — never drop straight to a retryable form.
   const [phase, setPhase] = useState<Phase>(createPending ? 'reconcile' : 'form');
@@ -111,33 +111,16 @@ export function CreatePcaModal({
   // §3b — the REQUIRED staked-node picker's list (B-staked-nodes; fetched whole, sorted desc).
   const { nodes: stakedNodes, loading: nodesLoading, error: nodesError, refresh: refreshNodes } =
     useDesignatableNodes();
-  // M3 — this node's own identity counts as a default ONLY if it's actually IN the staked list
-  // (hasIdentity / identityId > 0 alone does NOT imply staked + in the sharding table).
-  const ownIdentity = nodeStatus?.identityId && nodeStatus.identityId !== '0' ? String(nodeStatus.identityId) : null;
-  const ownStaked = useMemo(
-    () => (ownIdentity && stakedNodes.some((n) => n.identityId === ownIdentity) ? ownIdentity : null),
-    [ownIdentity, stakedNodes],
-  );
-
-  // Pre-select the primary node (core convenience). Never overrides a seeded (renew) or
-  // already-picked value. M3: pre-select own id only when it's confirmed staked. Q1: if the
-  // list is DOWN, core best-effort defaults to its own id — the create-time
-  // PrimaryNodeNotInShardingTable revert (handled recoverably below) is the backstop. Edge
-  // (no own identity) gets NO default → a required pick.
-  useEffect(() => {
-    if (primaryNode || !ownIdentity) return;
-    if (ownStaked) setPrimaryNode(ownStaked);
-    else if (nodesError) setPrimaryNode(ownIdentity);
-  }, [primaryNode, ownIdentity, ownStaked, nodesError]);
-
-  // L2 — reconcile a STALE best-effort default: if the list was down (Q1 set primaryNode=ownIdentity)
-  // and a successful retry then loads a list that does NOT contain the own id, the pre-selection is
-  // invalid — clear it so the picker re-prompts (else submit stays enabled on a bad id until the
-  // create-time revert). Fresh-create only (renew owns its seed + the revert backstop).
-  useEffect(() => {
-    if (replacingAccountId || nodesError || nodesLoading || stakedNodes.length === 0) return;
-    if (ownIdentity && primaryNode === ownIdentity && !ownStaked) setPrimaryNode('');
-  }, [replacingAccountId, nodesError, nodesLoading, stakedNodes.length, ownIdentity, primaryNode, ownStaked]);
+  // All primary-node selection policy (renew seed / staked-default / list-down fallback / stale-clear
+  // / rejected-node recovery) lives in one hook — the modal just wires value/actions to the picker.
+  const { primaryNode, setPrimaryNode, ownStaked, onRejected: onPrimaryNodeRejected } = usePrimaryNodeSelection({
+    seedPrimaryNode: seed?.primaryNode,
+    replacingAccountId,
+    identityId: nodeStatus?.identityId,
+    stakedNodes,
+    nodesError,
+    nodesLoading,
+  });
 
   const amountNum = AMOUNT_RE.test(tokens.trim()) ? Number(tokens.trim()) : NaN;
   const amountValid = Number.isFinite(amountNum) && amountNum > 0;
@@ -183,7 +166,7 @@ export function CreatePcaModal({
         // re-defaults to the core's own id only if it's still staked) — never re-submit the same
         // rejected id on its numeric shape.
         if (info?.code === 'PrimaryNodeNotInShardingTable') {
-          setPrimaryNode('');
+          onPrimaryNodeRejected(); // R2 — clear the rejected node so it can't be re-submitted
           refreshNodes();
         }
         setError(info?.message ?? (err as Error)?.message ?? 'Create failed.');

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -11,9 +11,10 @@ import {
 } from '../../api.js';
 import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
 import { probeWalletBindings, selfCoverageOutlook } from '../../pca/walletBinding.js';
+import { useDesignatableNodes } from '../../hooks/useDesignatableNodes.js';
 import { useAgentsStore } from '../../stores/agents.js';
 import { usePcaStore } from '../../stores/pca.js';
-import { DiscountTierLadder, discountTierForTrac, WalletRow } from '../../components/Pca/index.js';
+import { DiscountTierLadder, discountTierForTrac, WalletRow, PrimaryNodePicker } from '../../components/Pca/index.js';
 import { PcaModalShell } from './PcaModalShell.js';
 import { formatTrac } from '../../lib/formatTrac.js';
 
@@ -100,7 +101,6 @@ export function CreatePcaModal({
   // S2b renew — seed the commit amount + primary node from the expiring account.
   const [tokens, setTokens] = useState(seed?.tokens ?? '');
   const [primaryNode, setPrimaryNode] = useState(seed?.primaryNode ?? '');
-  const [advanced, setAdvanced] = useState(false);
   // Resume the reconcile guard if a create is already in flight from a prior
   // session (durable marker) — never drop straight to a retryable form.
   const [phase, setPhase] = useState<Phase>(createPending ? 'reconcile' : 'form');
@@ -108,12 +108,27 @@ export function CreatePcaModal({
   const [pendingTxHash, setPendingTxHash] = useState<string | undefined>(createPending?.txHash);
   const [error, setError] = useState<string | null>(null);
 
-  // Prefill the primary node with this node's identity once status resolves.
+  // §3b — the REQUIRED staked-node picker's list (B-staked-nodes; fetched whole, sorted desc).
+  const { nodes: stakedNodes, loading: nodesLoading, error: nodesError, refresh: refreshNodes } =
+    useDesignatableNodes();
+  // M3 — this node's own identity counts as a default ONLY if it's actually IN the staked list
+  // (hasIdentity / identityId > 0 alone does NOT imply staked + in the sharding table).
+  const ownIdentity = nodeStatus?.identityId && nodeStatus.identityId !== '0' ? String(nodeStatus.identityId) : null;
+  const ownStaked = useMemo(
+    () => (ownIdentity && stakedNodes.some((n) => n.identityId === ownIdentity) ? ownIdentity : null),
+    [ownIdentity, stakedNodes],
+  );
+
+  // Pre-select the primary node (core convenience). Never overrides a seeded (renew) or
+  // already-picked value. M3: pre-select own id only when it's confirmed staked. Q1: if the
+  // list is DOWN, core best-effort defaults to its own id — the create-time
+  // PrimaryNodeNotInShardingTable revert (handled recoverably below) is the backstop. Edge
+  // (no own identity) gets NO default → a required pick.
   useEffect(() => {
-    if (!primaryNode && nodeStatus?.identityId && nodeStatus.identityId !== '0') {
-      setPrimaryNode(String(nodeStatus.identityId));
-    }
-  }, [nodeStatus?.identityId, primaryNode]);
+    if (primaryNode || !ownIdentity) return;
+    if (ownStaked) setPrimaryNode(ownStaked);
+    else if (nodesError) setPrimaryNode(ownIdentity);
+  }, [primaryNode, ownIdentity, ownStaked, nodesError]);
 
   const amountNum = AMOUNT_RE.test(tokens.trim()) ? Number(tokens.trim()) : NaN;
   const amountValid = Number.isFinite(amountNum) && amountNum > 0;
@@ -152,7 +167,12 @@ export function CreatePcaModal({
       // (FEATURE_UNAVAILABLE, not a transport RPC_* 503) qualify.
       if (err instanceof HttpError && (err.status === 400 || isPcaFeatureUnavailable(err))) {
         clearCreatePending();
-        setError(describePcaError(err)?.message ?? (err as Error)?.message ?? 'Create failed.');
+        const info = describePcaError(err);
+        // §9.4 #18 / Q1 — PrimaryNodeNotInShardingTable is RECOVERABLE, not terminal: the
+        // picked node was unstaked between picking and submit (or a list-down core best-effort
+        // default raced). Refetch the staked list so the picker re-prompts with fresh data.
+        if (info?.code === 'PrimaryNodeNotInShardingTable') refreshNodes();
+        setError(info?.message ?? (err as Error)?.message ?? 'Create failed.');
         setPhase('form');
         return;
       }
@@ -391,59 +411,27 @@ export function CreatePcaModal({
           <DiscountTierLadder committedTrac={amountValid ? amountNum : null} />
         </section>
 
-        {/* Section 2 — Primary node */}
+        {/* Section 2 — Primary node (§3b: the always-visible, REQUIRED staked-node picker) */}
         <section className="v10-pca-create-section">
           <h3 className="v10-pca-create-section-title">2 · Primary node</h3>
-          <div className="v10-form-group">
-            <label className="v10-form-label" htmlFor="pca-create-primary-node">
-              Primary node (publishing-reward allocation)
-            </label>
-            <input
-              id="pca-create-primary-node"
-              data-testid="pca-create-primary-node"
-              className="v10-form-input"
-              type="text"
-              value={primaryNode}
-              onChange={(e) => setPrimaryNode(e.target.value)}
-              placeholder="node identityId"
-              disabled={!advanced && !!nodeStatus?.identityId}
-              autoComplete="off"
-            />
-          </div>
-          {nodeStatus?.identityId && primaryNode === String(nodeStatus.identityId) && (
-            <p className="v10-pca-create-hint">✓ This node (identityId #{nodeStatus.identityId}).</p>
-          )}
-          {/* S2b renew (LOW) — the old account's primary node couldn't be read, so the field
+          {/* S2b renew (LOW) — the old account's primary node couldn't be read, so the picker
               fell back to THIS node. Surface it rather than silently defaulting. */}
           {replacingAccountId && seed?.primaryNodeUnknown && (
             <p className="v10-pca-create-hint" role="status" data-testid="pca-renew-primary-unknown">
-              ⓘ Couldn’t read PCA #{replacingAccountId}’s primary node — defaulting to this node. Change
-              it under Advanced if the replacement should point elsewhere.
+              ⓘ Couldn’t read PCA #{replacingAccountId}’s primary node — defaulting to this node. Pick a
+              different staked node below if the replacement should point elsewhere.
             </p>
           )}
-          <div className="v10-modal-tip">
-            <span className="v10-modal-tip-title">Primary node ≠ who pays and ≠ who’s covered.</span>{' '}
-            Pays the discounted cost → this account’s escrow. Covered to publish → the wallets you
-            approve. Reward weight → this primary node.
-          </div>
-          <button
-            type="button"
-            className="v10-pca-track-toggle"
-            aria-expanded={advanced}
-            aria-controls="pca-create-advanced"
-            onClick={() => setAdvanced((a) => !a)}
-          >
-            ▸ Advanced: point reward weight at a different node id
-          </button>
-          {/* F1/L5: the disclosed region carries the id the button references —
-              kept in the DOM (hidden when collapsed) so aria-controls resolves. */}
-          <div id="pca-create-advanced" hidden={!advanced}>
-            {advanced && (
-              <p className="v10-pca-create-hint">
-                The node id must already be in the sharding table, or creation reverts.
-              </p>
-            )}
-          </div>
+          <PrimaryNodePicker
+            nodes={stakedNodes}
+            loading={nodesLoading}
+            error={nodesError}
+            onRetry={refreshNodes}
+            value={primaryNode}
+            onChange={setPrimaryNode}
+            ownIdentityId={ownStaked}
+            role={nodeStatus?.nodeRole === 'edge' ? 'edge' : nodeStatus?.nodeRole === 'core' ? 'core' : undefined}
+          />
         </section>
 
         {/* Section 3 — Review */}

--- a/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
+++ b/packages/node-ui/src/ui/pages/conviction/CreatePcaModal.tsx
@@ -10,6 +10,7 @@ import {
   type PcaSnapshot,
 } from '../../api.js';
 import { useOwnerActionSubmitter } from '../../pca/ownerActions.js';
+import { probeWalletBindings, selfCoverageOutlook } from '../../pca/walletBinding.js';
 import { useAgentsStore } from '../../stores/agents.js';
 import { usePcaStore } from '../../stores/pca.js';
 import { DiscountTierLadder, discountTierForTrac, WalletRow } from '../../components/Pca/index.js';
@@ -73,6 +74,19 @@ export function CreatePcaModal({
   const ownerWallet = wallets[0];
   const ownerTrac = wb?.balances?.find((b) => b.address === ownerWallet)?.trac;
   const ownerTracNum = ownerTrac != null ? Number(ownerTrac) : NaN;
+
+  // B1 pre-flight wallet-binding probe (§9.5) — READ-ONLY, at wizard open. Surfaces the
+  // self-coverage outlook BEFORE the TRAC commit: if EVERY op wallet is already bound to a
+  // sponsor's PCA, the new account would discount none of this node's own publishes (a loud
+  // informed-consent warning — NOT a hard block; a node may create purely to sponsor others).
+  // The per-wallet deregister-first then runs in the self-coverage loop (ApproveWalletsModal).
+  const walletsKey = wallets.join(',');
+  const { data: bindings } = useFetch(
+    () => probeWalletBindings(wallets, ownerWallet),
+    [walletsKey, ownerWallet],
+    0,
+  );
+  const b1 = useMemo(() => selfCoverageOutlook(bindings ?? []), [bindings]);
 
   const owner = useOwnerActionSubmitter(); // owner-action seam (P0: daemon submitter)
   const finishCreate = usePcaStore((s) => s.finishCreate);
@@ -312,6 +326,25 @@ export function CreatePcaModal({
               Or get sponsored
             </button>{' '}
             — the free alternative (no TRAC locked).
+          </div>
+        )}
+
+        {/* B1 (§9.5) — zero-self-coverage informed consent: every op wallet is already on a
+            sponsor's PCA, so this account discounts NONE of your own publishes. NOT a block. */}
+        {b1.zeroSelfCoverage && (
+          <div className="v10-modal-warning" role="alert" data-testid="pca-b1-zero-coverage">
+            ⚠ All of this node’s operational wallets are already approved on other PCAs — you
+            already get the discount, free. This new account will <strong>NOT</strong> discount your
+            own publishes. Create it only if you intend to <strong>sponsor other nodes</strong>;
+            otherwise getting sponsored is the free path and creating just locks your TRAC.
+          </div>
+        )}
+        {/* Partial case — some wallets stay on a sponsor's PCA (already free), not moved. */}
+        {!b1.zeroSelfCoverage && b1.sponsorBound.length > 0 && (
+          <div className="v10-modal-tip" role="status" data-testid="pca-b1-preview">
+            ⓘ After creating, {b1.sponsorBound.length} of your wallet(s) stay on a sponsor’s PCA
+            (already discounted free) and won’t be moved; the rest are approved on the new account
+            (any already on a PCA you own are deregistered from it first).
           </div>
         )}
 

--- a/packages/node-ui/src/ui/pca/walletBinding.ts
+++ b/packages/node-ui/src/ui/pca/walletBinding.ts
@@ -1,16 +1,16 @@
 import { pcaAgentAccount, fetchPca } from '../api.js';
 import { isPcaDead, hasPcaBudget } from './coverage.js';
 
-// B1 pre-flight wallet-binding probe (PLAN §9.5) — READ-ONLY.
+// Pre-flight wallet-binding probe — READ-ONLY.
 //
-// Self-coverage collides with one-wallet-one-PCA (invariant 5): `registerAgent` reverts
+// Self-coverage collides with the one-wallet-one-PCA rule: `registerAgent` reverts
 // `AgentAlreadyRegistered` if a wallet is already bound, and `deregisterAgent` is owner-gated.
 // Before (and during) a create's self-coverage, we must know, per operational wallet, whether
 // it is: UNBOUND (register freely), bound to a PCA THIS NODE OWNS (deregister-first, then
-// register — hot→cold migration), or bound to a PCA the node CANNOT own (a sponsor's). #9: a
-// sponsor binding is "already discounted free" ONLY if that sponsor PCA actually COVERS — an
+// register — hot→cold migration), or bound to a PCA the node CANNOT own (a sponsor's). A sponsor
+// binding is "already discounted free" ONLY if that sponsor PCA actually COVERS — an
 // EXPIRED/insolvent one doesn't (the agent mapping persists but publishing falls to direct cost),
-// so it must NOT be skipped as free (R1). A probe that can't be read is INCONCLUSIVE — never
+// so it must NOT be skipped as free. A probe that can't be read is INCONCLUSIVE — never
 // asserted as unbound/ownable/covered (it must not drive a destructive deregister or a false claim).
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
@@ -21,11 +21,12 @@ export interface WalletBinding {
   boundTo: string | null;
   /** boundTo is owned by this node (owner == ownerWallet) → the daemon can deregister-first. */
   canOwn: boolean;
-  /** R1 — boundTo is LIVE (not expired/swept AND has budget), so the binding actually covers.
+  /** boundTo is LIVE (not expired/swept AND has budget), so the binding actually covers.
    *  Meaningful only when `boundTo != null`. A sponsor binding only counts as "already free" when
    *  this is true; a dead one is uncovered (and, being a sponsor's, unfreeable by this node). */
   boundLive: boolean;
-  /** The probe failed to resolve (transport / adapter gap) — treat as "couldn't read" (#9). */
+  /** The probe failed to resolve (transport / adapter gap) — treat as "couldn't read", never
+   *  asserted as covered/free. */
   inconclusive: boolean;
 }
 
@@ -36,7 +37,7 @@ export async function resolveWalletBinding(wallet: string, ownerWallet?: string)
   const boundTo = acct.accountId;
   if (boundTo == null) return { wallet, boundTo: null, canOwn: false, boundLive: false, inconclusive: false };
   // Bound — read the bound account's snapshot for ownership (the daemon signs with ownerWallet, so
-  // it can only deregister from a PCA it owns) AND coverage state (R1 — expiry/solvency).
+  // it can only deregister from a PCA it owns) AND coverage state (expiry/solvency).
   const snap = await fetchPca(boundTo).catch(() => null);
   if (snap === null) return { wallet, boundTo, canOwn: false, boundLive: false, inconclusive: true };
   return {
@@ -48,19 +49,20 @@ export async function resolveWalletBinding(wallet: string, ownerWallet?: string)
   };
 }
 
-/** Probe every operational wallet's binding (read-only). Used at wizard-open for the B1 preview. */
+/** Probe every operational wallet's binding (read-only). Used at wizard-open for the preview. */
 export async function probeWalletBindings(wallets: string[], ownerWallet?: string): Promise<WalletBinding[]> {
   return Promise.all(wallets.map((w) => resolveWalletBinding(w, ownerWallet)));
 }
 
 /**
- * R5 — the per-wallet self-coverage PLAN (classification only; the modal loop executes it). Folds
- * R1's expired-sponsor branch in. (Also the seam sub-PR #2's wallet-managed branch will reuse.)
+ * The per-wallet self-coverage PLAN (classification only; the modal loop executes it). The single
+ * source of self-coverage policy — the wizard preview and the wallet-managed signing branch both
+ * derive from this rather than re-classifying.
  *  - `register` — unbound, OR inconclusive (fall through to register; the AgentAlreadyRegistered
- *    backstop resolves a still-bound wallet — never asserted off an unread probe, #9).
+ *    backstop resolves a still-bound wallet — never asserted off an unread probe).
  *  - `deregisterThenRegister` — bound to a PCA THIS NODE OWNS → free it first, then register.
  *  - `skipSponsored` — bound to a LIVE sponsor PCA → already discounted free; leave it.
- *  - `conflictSponsorDead` (R1) — bound to an EXPIRED/insolvent sponsor PCA → NOT covered, and the
+ *  - `conflictSponsorDead` — bound to an EXPIRED/insolvent sponsor PCA → NOT covered, and the
  *    node can't free it (not the owner) → a distinct conflict (never the benign "already free" skip).
  */
 export type SelfCoverageAction =
@@ -72,18 +74,18 @@ export type SelfCoverageAction =
 export function planSelfCoverage(b: WalletBinding): SelfCoverageAction {
   if (b.inconclusive || b.boundTo == null) return { kind: 'register' };
   if (b.canOwn) return { kind: 'deregisterThenRegister', prevAccountId: b.boundTo };
-  // Sponsor-bound (not ownable): free only if the sponsor PCA actually covers (R1).
+  // Sponsor-bound (not ownable): free only if the sponsor PCA actually covers.
   return b.boundLive
     ? { kind: 'skipSponsored', prevAccountId: b.boundTo }
     : { kind: 'conflictSponsorDead', prevAccountId: b.boundTo };
 }
 
 /**
- * Self-coverage outlook from a set of bindings (the B1 wizard-open preview):
+ * Self-coverage outlook from a set of bindings (the wizard-open preview):
  *  - `selfCoverable` — wallets that CAN end up covered (unbound, or own-bound → deregister-first).
- *  - `ownBound` — bound to a PCA THIS NODE OWNS (M3: deregister-first MOVE — must be disclosed).
+ *  - `ownBound` — bound to a PCA THIS NODE OWNS (deregister-first MOVE — must be disclosed).
  *  - `sponsorBound` — bound to a LIVE sponsor PCA (already discounted free → skipped).
- *  - `sponsorDead` (R1) — bound to an EXPIRED/insolvent sponsor PCA (uncovered + unfreeable).
+ *  - `sponsorDead` — bound to an EXPIRED/insolvent sponsor PCA (uncovered + unfreeable).
  *  - `zeroSelfCoverage` — at least one wallet, NONE self-coverable, NONE inconclusive: the new PCA
  *    would discount NONE of this node's own publishes. Not a hard block (create-to-sponsor is valid)
  *    — drives a loud informed-consent warning.
@@ -106,9 +108,9 @@ export function selfCoverageOutlook(bindings: WalletBinding[]): {
   const registerable = ofKind('register'); // unbound OR inconclusive (fall through to register)
   const inconclusive = registerable.filter((b) => b.inconclusive);
   const unbound = registerable.filter((b) => !b.inconclusive);
-  const ownBound = ofKind('deregisterThenRegister'); // M3 migrate (own-bound)
+  const ownBound = ofKind('deregisterThenRegister'); // migrate (own-bound)
   const sponsorBound = ofKind('skipSponsored'); // already discounted free (live sponsor)
-  const sponsorDead = ofKind('conflictSponsorDead'); // R1 — uncovered + unfreeable (dead sponsor)
+  const sponsorDead = ofKind('conflictSponsorDead'); // uncovered + unfreeable (dead sponsor)
   const selfCoverable = [...unbound, ...ownBound]; // can end up covered (register or migrate-then-register)
   const zeroSelfCoverage =
     bindings.length > 0 && selfCoverable.length === 0 && inconclusive.length === 0;

--- a/packages/node-ui/src/ui/pca/walletBinding.ts
+++ b/packages/node-ui/src/ui/pca/walletBinding.ts
@@ -50,14 +50,18 @@ export async function probeWalletBindings(wallets: string[], ownerWallet?: strin
  */
 export function selfCoverageOutlook(bindings: WalletBinding[]): {
   selfCoverable: WalletBinding[];
+  /** Bound to a PCA THIS NODE OWNS — self-coverage DEREGISTERS it from there first (M3: must be
+   *  disclosed, since the old account's locked TRAC keeps running but would then cover nothing). */
+  ownBound: WalletBinding[];
   sponsorBound: WalletBinding[];
   inconclusive: WalletBinding[];
   zeroSelfCoverage: boolean;
 } {
   const selfCoverable = bindings.filter((b) => !b.inconclusive && (b.boundTo == null || b.canOwn));
+  const ownBound = bindings.filter((b) => b.canOwn); // canOwn ⇒ bound + owned + readable
   const sponsorBound = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn);
   const inconclusive = bindings.filter((b) => b.inconclusive);
   const zeroSelfCoverage =
     bindings.length > 0 && selfCoverable.length === 0 && inconclusive.length === 0;
-  return { selfCoverable, sponsorBound, inconclusive, zeroSelfCoverage };
+  return { selfCoverable, ownBound, sponsorBound, inconclusive, zeroSelfCoverage };
 }

--- a/packages/node-ui/src/ui/pca/walletBinding.ts
+++ b/packages/node-ui/src/ui/pca/walletBinding.ts
@@ -1,4 +1,5 @@
 import { pcaAgentAccount, fetchPca } from '../api.js';
+import { isPcaDead, hasPcaBudget } from './coverage.js';
 
 // B1 pre-flight wallet-binding probe (PLAN §9.5) — READ-ONLY.
 //
@@ -6,9 +7,11 @@ import { pcaAgentAccount, fetchPca } from '../api.js';
 // `AgentAlreadyRegistered` if a wallet is already bound, and `deregisterAgent` is owner-gated.
 // Before (and during) a create's self-coverage, we must know, per operational wallet, whether
 // it is: UNBOUND (register freely), bound to a PCA THIS NODE OWNS (deregister-first, then
-// register — hot→cold migration), or bound to a PCA the node CANNOT own (a sponsor's — skip,
-// it's already discounted free). #9: a probe that can't be read is INCONCLUSIVE — never
-// asserted as unbound/ownable (it must not drive a destructive deregister or a false claim).
+// register — hot→cold migration), or bound to a PCA the node CANNOT own (a sponsor's). #9: a
+// sponsor binding is "already discounted free" ONLY if that sponsor PCA actually COVERS — an
+// EXPIRED/insolvent one doesn't (the agent mapping persists but publishing falls to direct cost),
+// so it must NOT be skipped as free (R1). A probe that can't be read is INCONCLUSIVE — never
+// asserted as unbound/ownable/covered (it must not drive a destructive deregister or a false claim).
 
 const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
 
@@ -18,6 +21,10 @@ export interface WalletBinding {
   boundTo: string | null;
   /** boundTo is owned by this node (owner == ownerWallet) → the daemon can deregister-first. */
   canOwn: boolean;
+  /** R1 — boundTo is LIVE (not expired/swept AND has budget), so the binding actually covers.
+   *  Meaningful only when `boundTo != null`. A sponsor binding only counts as "already free" when
+   *  this is true; a dead one is uncovered (and, being a sponsor's, unfreeable by this node). */
+  boundLive: boolean;
   /** The probe failed to resolve (transport / adapter gap) — treat as "couldn't read" (#9). */
   inconclusive: boolean;
 }
@@ -25,14 +32,20 @@ export interface WalletBinding {
 /** Resolve one wallet's current binding (read-only). Used per-wallet in the self-coverage loop. */
 export async function resolveWalletBinding(wallet: string, ownerWallet?: string): Promise<WalletBinding> {
   const acct = await pcaAgentAccount(wallet).catch(() => undefined);
-  if (acct === undefined) return { wallet, boundTo: null, canOwn: false, inconclusive: true };
+  if (acct === undefined) return { wallet, boundTo: null, canOwn: false, boundLive: false, inconclusive: true };
   const boundTo = acct.accountId;
-  if (boundTo == null) return { wallet, boundTo: null, canOwn: false, inconclusive: false };
-  // Bound — determine ownability from the bound account's owner (the daemon signs with
-  // ownerWallet, so it can only deregister from a PCA whose owner == ownerWallet).
+  if (boundTo == null) return { wallet, boundTo: null, canOwn: false, boundLive: false, inconclusive: false };
+  // Bound — read the bound account's snapshot for ownership (the daemon signs with ownerWallet, so
+  // it can only deregister from a PCA it owns) AND coverage state (R1 — expiry/solvency).
   const snap = await fetchPca(boundTo).catch(() => null);
-  if (snap === null) return { wallet, boundTo, canOwn: false, inconclusive: true };
-  return { wallet, boundTo, canOwn: eq(snap.owner, ownerWallet), inconclusive: false };
+  if (snap === null) return { wallet, boundTo, canOwn: false, boundLive: false, inconclusive: true };
+  return {
+    wallet,
+    boundTo,
+    canOwn: eq(snap.owner, ownerWallet),
+    boundLive: !isPcaDead(snap) && hasPcaBudget(snap),
+    inconclusive: false,
+  };
 }
 
 /** Probe every operational wallet's binding (read-only). Used at wizard-open for the B1 preview. */
@@ -41,27 +54,54 @@ export async function probeWalletBindings(wallets: string[], ownerWallet?: strin
 }
 
 /**
- * Self-coverage outlook from a set of bindings:
+ * R5 — the per-wallet self-coverage PLAN (classification only; the modal loop executes it). Folds
+ * R1's expired-sponsor branch in. (Also the seam sub-PR #2's wallet-managed branch will reuse.)
+ *  - `register` — unbound, OR inconclusive (fall through to register; the AgentAlreadyRegistered
+ *    backstop resolves a still-bound wallet — never asserted off an unread probe, #9).
+ *  - `deregisterThenRegister` — bound to a PCA THIS NODE OWNS → free it first, then register.
+ *  - `skipSponsored` — bound to a LIVE sponsor PCA → already discounted free; leave it.
+ *  - `conflictSponsorDead` (R1) — bound to an EXPIRED/insolvent sponsor PCA → NOT covered, and the
+ *    node can't free it (not the owner) → a distinct conflict (never the benign "already free" skip).
+ */
+export type SelfCoverageAction =
+  | { kind: 'register' }
+  | { kind: 'deregisterThenRegister'; prevAccountId: string }
+  | { kind: 'skipSponsored'; prevAccountId: string }
+  | { kind: 'conflictSponsorDead'; prevAccountId: string };
+
+export function planSelfCoverage(b: WalletBinding): SelfCoverageAction {
+  if (b.inconclusive || b.boundTo == null) return { kind: 'register' };
+  if (b.canOwn) return { kind: 'deregisterThenRegister', prevAccountId: b.boundTo };
+  // Sponsor-bound (not ownable): free only if the sponsor PCA actually covers (R1).
+  return b.boundLive
+    ? { kind: 'skipSponsored', prevAccountId: b.boundTo }
+    : { kind: 'conflictSponsorDead', prevAccountId: b.boundTo };
+}
+
+/**
+ * Self-coverage outlook from a set of bindings (the B1 wizard-open preview):
  *  - `selfCoverable` — wallets that CAN end up covered (unbound, or own-bound → deregister-first).
- *  - `sponsorBound`  — bound to a PCA the node can't own (already discounted free → skipped).
- *  - `zeroSelfCoverage` — at least one wallet, NONE self-coverable, NONE inconclusive (every wallet
- *    is sponsor-bound): the new PCA would discount NONE of this node's own publishes. Not a hard
- *    block (a node may create purely to sponsor others) — drives a loud informed-consent warning.
+ *  - `ownBound` — bound to a PCA THIS NODE OWNS (M3: deregister-first MOVE — must be disclosed).
+ *  - `sponsorBound` — bound to a LIVE sponsor PCA (already discounted free → skipped).
+ *  - `sponsorDead` (R1) — bound to an EXPIRED/insolvent sponsor PCA (uncovered + unfreeable).
+ *  - `zeroSelfCoverage` — at least one wallet, NONE self-coverable, NONE inconclusive: the new PCA
+ *    would discount NONE of this node's own publishes. Not a hard block (create-to-sponsor is valid)
+ *    — drives a loud informed-consent warning.
  */
 export function selfCoverageOutlook(bindings: WalletBinding[]): {
   selfCoverable: WalletBinding[];
-  /** Bound to a PCA THIS NODE OWNS — self-coverage DEREGISTERS it from there first (M3: must be
-   *  disclosed, since the old account's locked TRAC keeps running but would then cover nothing). */
   ownBound: WalletBinding[];
   sponsorBound: WalletBinding[];
+  sponsorDead: WalletBinding[];
   inconclusive: WalletBinding[];
   zeroSelfCoverage: boolean;
 } {
   const selfCoverable = bindings.filter((b) => !b.inconclusive && (b.boundTo == null || b.canOwn));
   const ownBound = bindings.filter((b) => b.canOwn); // canOwn ⇒ bound + owned + readable
-  const sponsorBound = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn);
+  const sponsorBound = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn && b.boundLive);
+  const sponsorDead = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn && !b.boundLive);
   const inconclusive = bindings.filter((b) => b.inconclusive);
   const zeroSelfCoverage =
     bindings.length > 0 && selfCoverable.length === 0 && inconclusive.length === 0;
-  return { selfCoverable, ownBound, sponsorBound, inconclusive, zeroSelfCoverage };
+  return { selfCoverable, ownBound, sponsorBound, sponsorDead, inconclusive, zeroSelfCoverage };
 }

--- a/packages/node-ui/src/ui/pca/walletBinding.ts
+++ b/packages/node-ui/src/ui/pca/walletBinding.ts
@@ -1,0 +1,63 @@
+import { pcaAgentAccount, fetchPca } from '../api.js';
+
+// B1 pre-flight wallet-binding probe (PLAN §9.5) — READ-ONLY.
+//
+// Self-coverage collides with one-wallet-one-PCA (invariant 5): `registerAgent` reverts
+// `AgentAlreadyRegistered` if a wallet is already bound, and `deregisterAgent` is owner-gated.
+// Before (and during) a create's self-coverage, we must know, per operational wallet, whether
+// it is: UNBOUND (register freely), bound to a PCA THIS NODE OWNS (deregister-first, then
+// register — hot→cold migration), or bound to a PCA the node CANNOT own (a sponsor's — skip,
+// it's already discounted free). #9: a probe that can't be read is INCONCLUSIVE — never
+// asserted as unbound/ownable (it must not drive a destructive deregister or a false claim).
+
+const eq = (a?: string, b?: string) => !!a && !!b && a.toLowerCase() === b.toLowerCase();
+
+export interface WalletBinding {
+  wallet: string;
+  /** The accountId this wallet is currently an approved agent on, or null when unbound. */
+  boundTo: string | null;
+  /** boundTo is owned by this node (owner == ownerWallet) → the daemon can deregister-first. */
+  canOwn: boolean;
+  /** The probe failed to resolve (transport / adapter gap) — treat as "couldn't read" (#9). */
+  inconclusive: boolean;
+}
+
+/** Resolve one wallet's current binding (read-only). Used per-wallet in the self-coverage loop. */
+export async function resolveWalletBinding(wallet: string, ownerWallet?: string): Promise<WalletBinding> {
+  const acct = await pcaAgentAccount(wallet).catch(() => undefined);
+  if (acct === undefined) return { wallet, boundTo: null, canOwn: false, inconclusive: true };
+  const boundTo = acct.accountId;
+  if (boundTo == null) return { wallet, boundTo: null, canOwn: false, inconclusive: false };
+  // Bound — determine ownability from the bound account's owner (the daemon signs with
+  // ownerWallet, so it can only deregister from a PCA whose owner == ownerWallet).
+  const snap = await fetchPca(boundTo).catch(() => null);
+  if (snap === null) return { wallet, boundTo, canOwn: false, inconclusive: true };
+  return { wallet, boundTo, canOwn: eq(snap.owner, ownerWallet), inconclusive: false };
+}
+
+/** Probe every operational wallet's binding (read-only). Used at wizard-open for the B1 preview. */
+export async function probeWalletBindings(wallets: string[], ownerWallet?: string): Promise<WalletBinding[]> {
+  return Promise.all(wallets.map((w) => resolveWalletBinding(w, ownerWallet)));
+}
+
+/**
+ * Self-coverage outlook from a set of bindings:
+ *  - `selfCoverable` — wallets that CAN end up covered (unbound, or own-bound → deregister-first).
+ *  - `sponsorBound`  — bound to a PCA the node can't own (already discounted free → skipped).
+ *  - `zeroSelfCoverage` — at least one wallet, NONE self-coverable, NONE inconclusive (every wallet
+ *    is sponsor-bound): the new PCA would discount NONE of this node's own publishes. Not a hard
+ *    block (a node may create purely to sponsor others) — drives a loud informed-consent warning.
+ */
+export function selfCoverageOutlook(bindings: WalletBinding[]): {
+  selfCoverable: WalletBinding[];
+  sponsorBound: WalletBinding[];
+  inconclusive: WalletBinding[];
+  zeroSelfCoverage: boolean;
+} {
+  const selfCoverable = bindings.filter((b) => !b.inconclusive && (b.boundTo == null || b.canOwn));
+  const sponsorBound = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn);
+  const inconclusive = bindings.filter((b) => b.inconclusive);
+  const zeroSelfCoverage =
+    bindings.length > 0 && selfCoverable.length === 0 && inconclusive.length === 0;
+  return { selfCoverable, sponsorBound, inconclusive, zeroSelfCoverage };
+}

--- a/packages/node-ui/src/ui/pca/walletBinding.ts
+++ b/packages/node-ui/src/ui/pca/walletBinding.ts
@@ -96,11 +96,20 @@ export function selfCoverageOutlook(bindings: WalletBinding[]): {
   inconclusive: WalletBinding[];
   zeroSelfCoverage: boolean;
 } {
-  const selfCoverable = bindings.filter((b) => !b.inconclusive && (b.boundTo == null || b.canOwn));
-  const ownBound = bindings.filter((b) => b.canOwn); // canOwn ⇒ bound + owned + readable
-  const sponsorBound = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn && b.boundLive);
-  const sponsorDead = bindings.filter((b) => !b.inconclusive && b.boundTo != null && !b.canOwn && !b.boundLive);
-  const inconclusive = bindings.filter((b) => b.inconclusive);
+  // Derive the preview buckets FROM the single policy source (`planSelfCoverage`) — no parallel
+  // re-classification. Group bindings by their planned action; the only sub-split the planner
+  // intentionally collapses is unbound-vs-inconclusive (both → `register`), so we read the
+  // binding's `inconclusive` flag to separate those two within that group.
+  const planned = bindings.map((b) => ({ binding: b, kind: planSelfCoverage(b).kind }));
+  const ofKind = (k: SelfCoverageAction['kind']) => planned.filter((p) => p.kind === k).map((p) => p.binding);
+
+  const registerable = ofKind('register'); // unbound OR inconclusive (fall through to register)
+  const inconclusive = registerable.filter((b) => b.inconclusive);
+  const unbound = registerable.filter((b) => !b.inconclusive);
+  const ownBound = ofKind('deregisterThenRegister'); // M3 migrate (own-bound)
+  const sponsorBound = ofKind('skipSponsored'); // already discounted free (live sponsor)
+  const sponsorDead = ofKind('conflictSponsorDead'); // R1 — uncovered + unfreeable (dead sponsor)
+  const selfCoverable = [...unbound, ...ownBound]; // can end up covered (register or migrate-then-register)
   const zeroSelfCoverage =
     bindings.length > 0 && selfCoverable.length === 0 && inconclusive.length === 0;
   return { selfCoverable, ownBound, sponsorBound, sponsorDead, inconclusive, zeroSelfCoverage };

--- a/packages/node-ui/test/pca-api.test.ts
+++ b/packages/node-ui/test/pca-api.test.ts
@@ -18,6 +18,7 @@ import {
   isPcaReadFailed,
   fetchPca,
   fetchMyPcas,
+  listDesignatableNodes,
   createPca,
   pcaAddAgent,
   pcaRemoveAgent,
@@ -236,6 +237,16 @@ describe('PCA api helpers (transport shaping)', () => {
     fetchMock.mockResolvedValueOnce(ok({ accounts: [] }));
     await fetchMyPcas({ hydrate: true });
     expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/mine?hydrate=1');
+  });
+
+  it('listDesignatableNodes GETs /api/pca/designatable-nodes with start+limit (offset pagination)', async () => {
+    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
+    await listDesignatableNodes();
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/pca/designatable-nodes?start=&limit=200');
+
+    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
+    await listDesignatableNodes({ start: '7', limit: 50 });
+    expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/designatable-nodes?start=7&limit=50');
   });
 
   // T1 — a GET failure must throw an HttpError that CARRIES the body, so the tab-gate

--- a/packages/node-ui/test/pca-api.test.ts
+++ b/packages/node-ui/test/pca-api.test.ts
@@ -239,14 +239,14 @@ describe('PCA api helpers (transport shaping)', () => {
     expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/mine?hydrate=1');
   });
 
-  it('listDesignatableNodes GETs /api/pca/designatable-nodes with start+limit (offset pagination)', async () => {
+  it('listDesignatableNodes GETs /api/pca/designatable-nodes with a 0-based offset start + limit', async () => {
     fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
     await listDesignatableNodes();
-    expect(fetchMock.mock.calls[0]![0]).toBe('/api/pca/designatable-nodes?start=&limit=200');
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/pca/designatable-nodes?start=0&limit=200');
 
     fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
-    await listDesignatableNodes({ start: '7', limit: 50 });
-    expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/designatable-nodes?start=7&limit=50');
+    await listDesignatableNodes({ start: 200, limit: 50 });
+    expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/designatable-nodes?start=200&limit=50');
   });
 
   // T1 — a GET failure must throw an HttpError that CARRIES the body, so the tab-gate

--- a/packages/node-ui/test/pca-api.test.ts
+++ b/packages/node-ui/test/pca-api.test.ts
@@ -247,6 +247,11 @@ describe('PCA api helpers (transport shaping)', () => {
     fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
     await listDesignatableNodes({ start: 200, limit: 50 });
     expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/designatable-nodes?start=200&limit=50');
+
+    // M4 — fresh:true appends &fresh=1 (cache-bust); absent otherwise.
+    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
+    await listDesignatableNodes({ fresh: true });
+    expect(fetchMock.mock.calls[2]![0]).toBe('/api/pca/designatable-nodes?start=0&limit=200&fresh=1');
   });
 
   // T1 — a GET failure must throw an HttpError that CARRIES the body, so the tab-gate

--- a/packages/node-ui/test/pca-api.test.ts
+++ b/packages/node-ui/test/pca-api.test.ts
@@ -239,19 +239,15 @@ describe('PCA api helpers (transport shaping)', () => {
     expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/mine?hydrate=1');
   });
 
-  it('listDesignatableNodes GETs /api/pca/designatable-nodes with a 0-based offset start + limit', async () => {
-    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
+  it('listDesignatableNodes GETs the whole list in one shot (R4 — no pagination), +?fresh=1 on demand', async () => {
+    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0 }));
     await listDesignatableNodes();
-    expect(fetchMock.mock.calls[0]![0]).toBe('/api/pca/designatable-nodes?start=0&limit=200');
+    expect(fetchMock.mock.calls[0]![0]).toBe('/api/pca/designatable-nodes');
 
-    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
-    await listDesignatableNodes({ start: 200, limit: 50 });
-    expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/designatable-nodes?start=200&limit=50');
-
-    // M4 — fresh:true appends &fresh=1 (cache-bust); absent otherwise.
-    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0, nextStart: null }));
+    // M4 — fresh:true appends ?fresh=1 (cache-bust); absent otherwise.
+    fetchMock.mockResolvedValueOnce(ok({ nodes: [], total: 0 }));
     await listDesignatableNodes({ fresh: true });
-    expect(fetchMock.mock.calls[2]![0]).toBe('/api/pca/designatable-nodes?start=0&limit=200&fresh=1');
+    expect(fetchMock.mock.calls[1]![0]).toBe('/api/pca/designatable-nodes?fresh=1');
   });
 
   // T1 — a GET failure must throw an HttpError that CARRIES the body, so the tab-gate

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -241,6 +241,58 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     await unmount();
   });
 
+  // H2 (#9 safety) — selfCoverage logic must NOT run in sponsor mode: a third-party wallet on a
+  // PCA this node happens to own must NOT be silently deregistered, and no false "already free" skip.
+  it('H2 — selfCoverage does NOT run in sponsor mode (no silent third-party deregister)', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: ['0xnode1'], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: ADDR_A, accountId: '4' }); // ADDR_A bound to a PCA the node owns
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      if (id === '4') return { ...snap({ accountId: '4' }), owner: '0xnode1' }; // node owns #4
+      return key ? { ...snap(), probedKey: { key, registered: false } } : snap();
+    });
+    mocks.pcaAddAgent.mockRejectedValue(new HttpError(409, 'AgentAlreadyRegistered', { error: 'AgentAlreadyRegistered' }));
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, { accountId: '8', initialMode: 'sponsor', selfCoverage: true, onClose: vi.fn() }),
+    );
+    await waitForText(container, 'Wallet address(es)');
+    setTextarea(container.querySelector('[data-testid="pca-approve-address"]') as HTMLTextAreaElement, ADDR_A);
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'another conviction account'); // normal sponsor-mode conflict path
+    // The gate held: NO silent deregister of the third-party wallet, NO false self-coverage skip.
+    expect(mocks.pcaRemoveAgent).not.toHaveBeenCalled();
+    expect(container.querySelector('.v10-pca-approve-results')?.textContent).not.toContain('already discounted free');
+    await unmount();
+  });
+
+  // M5 — hot→cold migration: deregister succeeds then register fails → the wallet is STRANDED
+  // (off old, not on new); surfaced loudly with a one-click "Retry to finish" that completes it.
+  it('M5 — deregister-then-register-fail strands the wallet; Retry to finish recovers it', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [ADDR_A], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.pcaAgentAccount
+      .mockResolvedValueOnce({ agent: ADDR_A, accountId: '4' }) // run 1: own-bound
+      .mockResolvedValue({ agent: ADDR_A, accountId: null });   // run 2 (retry): now unbound
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) =>
+      id === '4' ? { ...snap({ accountId: '4' }), owner: ADDR_A } : (key ? { ...snap(), probedKey: { key, registered: true } } : snap()),
+    );
+    mocks.pcaRemoveAgent.mockResolvedValue({ accountId: '4', agent: ADDR_A, removed: true });
+    mocks.pcaAddAgent
+      .mockRejectedValueOnce(new HttpError(500, 'x', { error: 'boom' }))                            // run 1: register FAILS → stranded
+      .mockResolvedValue({ accountId: '8', agent: ADDR_A, registered: true, adapterSupported: true }); // run 2: succeeds
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, { accountId: '8', initialMode: 'self', selfCoverage: true, onClose: vi.fn() }),
+    );
+    await waitForText(container, 'slots used');
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'temporarily UNCOVERED'); // the stranded banner
+    expect(container.querySelector('[data-testid="pca-approve-stranded"]')).toBeTruthy();
+    // One-click retry finishes the migration.
+    await click(container.querySelector('[data-testid="pca-approve-retry-stranded"]')!);
+    await waitForText(container, 'approved on-chain');
+    expect(container.querySelector('[data-testid="pca-approve-stranded"]')).toBeNull();
+    await unmount();
+  });
+
   // M4 — a transient 500/network on a MIDDLE wallet must NOT abort and must NOT
   // tally as a benign skip: that row is a danger-tone failure, the loop continues,
   // and the remaining wallet still gets approved.

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   fetchPca: vi.fn(),
   pcaAddAgent: vi.fn(),
   pcaRemoveAgent: vi.fn(),
+  pcaAgentAccount: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -23,6 +24,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     fetchPca: mocks.fetchPca,
     pcaAddAgent: mocks.pcaAddAgent,
     pcaRemoveAgent: mocks.pcaRemoveAgent,
+    pcaAgentAccount: mocks.pcaAgentAccount,
   };
 });
 
@@ -76,6 +78,8 @@ beforeEach(() => {
   document.body.innerHTML = '';
   vi.clearAllMocks();
   mocks.fetchWalletsBalances.mockResolvedValue({ wallets: ['0xnode1'], balances: [], chainId: '84532', rpcUrl: null });
+  // B1 default: wallets bound to nothing (no self-coverage probe surprises in non-B1 tests).
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
 });
 afterEach(() => { document.body.innerHTML = ''; });
 
@@ -198,6 +202,42 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     await waitForText(container, 'add them manually');
     expect(container.querySelector('[data-testid="pca-renew-reapprove-note"]')?.textContent)
       .toContain('Couldn’t load PCA #4’s wallets');
+    await unmount();
+  });
+
+  // B1 self-coverage (§9.5) — the post-create self-coverage of THIS node's own wallets:
+  // an own-bound wallet is deregistered-first then registered; a sponsor-bound wallet is
+  // SKIPPED (already discounted free), never burning a register. The old account VARIES
+  // per wallet (unlike renew's single deregisterFrom).
+  it('B1 self-coverage: deregisters an own-bound wallet first, skips a sponsor-bound one', async () => {
+    const SPONSOR = '0xC0FFEE0000000000000000000000000000000001';
+    // Self mode approves the node's own wallets: ADDR_A (owner/daemon EOA) + ADDR_B.
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [ADDR_A, ADDR_B], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.pcaAgentAccount.mockImplementation(async (w: string) =>
+      w === ADDR_A ? { agent: w, accountId: '4' } : { agent: w, accountId: '9' },
+    );
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      if (id === '4') return { ...snap({ accountId: '4' }), owner: ADDR_A };   // own-bound → deregister-first
+      if (id === '9') return { ...snap({ accountId: '9' }), owner: SPONSOR };  // sponsor-bound → skip
+      return key ? { ...snap(), probedKey: { key, registered: true } } : snap(); // the new account (#8)
+    });
+    mocks.pcaRemoveAgent.mockResolvedValue({ accountId: '4', agent: ADDR_A, removed: true });
+    mocks.pcaAddAgent.mockResolvedValue({ accountId: '8', agent: ADDR_A, registered: true, adapterSupported: true });
+
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, { accountId: '8', initialMode: 'self', selfCoverage: true, onClose: vi.fn() }),
+    );
+    await waitForText(container, 'slots used');
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'already discounted free'); // the sponsor-bound skip copy
+
+    // Own-bound ADDR_A: deregistered from #4 FIRST, then registered on #8.
+    expect(mocks.pcaRemoveAgent).toHaveBeenCalledWith('4', ADDR_A);
+    expect(mocks.pcaAddAgent).toHaveBeenCalledWith('8', ADDR_A);
+    expect(mocks.pcaRemoveAgent.mock.invocationCallOrder[0]).toBeLessThan(mocks.pcaAddAgent.mock.invocationCallOrder[0]);
+    // Sponsor-bound ADDR_B: SKIPPED — never registered, never deregistered.
+    expect(mocks.pcaAddAgent).not.toHaveBeenCalledWith('8', ADDR_B);
+    expect(mocks.pcaRemoveAgent).not.toHaveBeenCalledWith('9', ADDR_B);
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -218,7 +218,8 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     );
     mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
       if (id === '4') return { ...snap({ accountId: '4' }), owner: ADDR_A };   // own-bound → deregister-first
-      if (id === '9') return { ...snap({ accountId: '9' }), owner: SPONSOR };  // sponsor-bound → skip
+      // sponsor-bound + LIVE (budget + unexpired) → "already discounted free" skip (R1).
+      if (id === '9') return { ...snap({ accountId: '9', baseEpochAllowance: '1000000000000000000000' }), owner: SPONSOR };
       return key ? { ...snap(), probedKey: { key, registered: true } } : snap(); // the new account (#8)
     });
     mocks.pcaRemoveAgent.mockResolvedValue({ accountId: '4', agent: ADDR_A, removed: true });
@@ -238,6 +239,29 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     // Sponsor-bound ADDR_B: SKIPPED — never registered, never deregistered.
     expect(mocks.pcaAddAgent).not.toHaveBeenCalledWith('8', ADDR_B);
     expect(mocks.pcaRemoveAgent).not.toHaveBeenCalledWith('9', ADDR_B);
+    await unmount();
+  });
+
+  // R1 (#9) — a wallet on an EXPIRED/swept sponsor PCA must NOT be skipped as "already discounted
+  // free": it's uncovered + unfreeable (not the owner) → a distinct conflict, never registered.
+  it('R1 — self-coverage: an EXPIRED sponsor binding → conflict (not "already free"), not registered', async () => {
+    const SPONSOR = '0xC0FFEE0000000000000000000000000000000001';
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [ADDR_A], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: ADDR_A, accountId: '9' });
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) =>
+      id === '9'
+        ? { ...snap({ accountId: '9', expiresAtTimestamp: 1, baseEpochAllowance: '1000000000000000000000' }), owner: SPONSOR } // EXPIRED sponsor
+        : (key ? { ...snap(), probedKey: { key, registered: true } } : snap()),
+    );
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, { accountId: '8', initialMode: 'self', selfCoverage: true, onClose: vi.fn() }),
+    );
+    await waitForText(container, 'slots used');
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'expired/swept'); // the R1 dead-sponsor conflict copy
+    expect(container.querySelector('.v10-pca-approve-results')?.textContent).not.toContain('already discounted free');
+    expect(mocks.pcaAddAgent).not.toHaveBeenCalled(); // not registered (can't free a sponsor's PCA)
+    expect(mocks.pcaRemoveAgent).not.toHaveBeenCalled(); // not deregistered (not the owner)
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-approve-modal.test.ts
+++ b/packages/node-ui/test/pca-approve-modal.test.ts
@@ -293,6 +293,28 @@ describe('ApproveWalletsModal — per-row mapping', () => {
     await unmount();
   });
 
+  // M10 — self-coverage: an UNREADABLE binding (the owner read fails → inconclusive) must NOT be
+  // skipped or deregistered; it falls through to registerAgent and the AgentAlreadyRegistered
+  // backstop resolves it (#9 — never assert "already free" off an unread probe).
+  it('M10 — self-coverage: an inconclusive binding falls through to register (conflict backstop), not skipped', async () => {
+    mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [ADDR_A], balances: [], chainId: '84532', rpcUrl: null });
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: ADDR_A, accountId: '9' }); // bound…
+    mocks.fetchPca.mockImplementation(async (id: string, key?: string) => {
+      if (id === '9') throw new Error('rpc'); // …but the owner read FAILS → inconclusive
+      return key ? { ...snap(), probedKey: { key, registered: false } } : snap(); // new account #8
+    });
+    mocks.pcaAddAgent.mockRejectedValue(new HttpError(409, 'AgentAlreadyRegistered', { error: 'AgentAlreadyRegistered' }));
+    const { container, unmount } = await render(
+      React.createElement(ApproveWalletsModal, { accountId: '8', initialMode: 'self', selfCoverage: true, onClose: vi.fn() }),
+    );
+    await waitForText(container, 'slots used');
+    await click(container.querySelector('[data-testid="pca-approve-submit"]')!);
+    await waitForText(container, 'another conviction account'); // register attempted → conflict backstop
+    expect(mocks.pcaAddAgent).toHaveBeenCalledWith('8', ADDR_A); // registered (not skipped)
+    expect(mocks.pcaRemoveAgent).not.toHaveBeenCalled(); // inconclusive → no deregister
+    await unmount();
+  });
+
   // M4 — a transient 500/network on a MIDDLE wallet must NOT abort and must NOT
   // tally as a benign skip: that row is a danger-tone failure, the loop continues,
   // and the remaining wallet still gets approved.

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -160,16 +160,67 @@ describe('CreatePcaModal', () => {
 
   // B1 (§9.5) — every op wallet already on a sponsor's PCA → a loud informed-consent warning
   // before the TRAC commit; NOT a hard block (a node may create purely to sponsor others).
-  it('B1 — all wallets sponsor-bound shows the zero-self-coverage warning, never blocks Create', async () => {
+  it('B1 — all wallets sponsor-bound shows the zero-self-coverage warning but NEVER blocks Create (H3)', async () => {
     mocks.pcaAgentAccount.mockResolvedValue({ agent: OWNER, accountId: '5' });
-    mocks.fetchPca.mockResolvedValue(snap({ accountId: '5', owner: '0xSPONSOR000000000000000000000000000beEf12' }));
+    // id '5' = the sponsor's PCA (binding owner read); any other id = the create read-back snapshot.
+    mocks.fetchPca.mockImplementation(async (id: string) =>
+      id === '5' ? snap({ accountId: '5', owner: '0xSPONSOR000000000000000000000000000beEf12' }) : snap({ discountBps: 3000 }),
+    );
+    mocks.createPca.mockResolvedValue({ accountId: '8', txHash: '0xabc', committedTokens: '100000.0' });
     const { container, unmount } = await render(
       React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
     );
     await waitForText(container, 'sponsor other nodes'); // the zero-coverage warning copy
     expect(container.querySelector('[data-testid="pca-b1-zero-coverage"]')).toBeTruthy();
-    // Informed consent, not a gate — the submit control is still present.
-    expect(container.querySelector('[data-testid="pca-create-submit"]')).toBeTruthy();
+    // Enter a valid amount (node #42 is pre-selected) — informed consent, NOT a gate.
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    const submit = container.querySelector('[data-testid="pca-create-submit"]') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false); // create proceeds despite zero-self-coverage
+    await click(submit);
+    await waitForText(container, 'PCA #8 created');
+    expect(mocks.createPca).toHaveBeenCalled();
+    await unmount();
+  });
+
+  // H1 — Escape closes the OPEN picker popup, not the whole Create modal (the modal's
+  // useModalDismiss must no-op while a combobox is expanded so committed state isn't discarded).
+  it('H1 — Escape with the picker open closes the popup, does NOT dismiss the modal', async () => {
+    const onClose = vi.fn();
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose, onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '50000');
+    const search = container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;
+    // React (root delegation) maps onFocus to the native bubbling `focusin`.
+    await act(async () => { search.dispatchEvent(new FocusEvent('focusin', { bubbles: true })); });
+    expect(container.querySelector('[role="listbox"]')).toBeTruthy(); // popup open
+    await act(async () => { search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); });
+    // Popup closed; modal NOT dismissed; the committed amount survives.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect((container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement).value).toBe('50000');
+    // A second Escape (popup now closed) DOES dismiss the modal.
+    await act(async () => { search.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); });
+    expect(onClose).toHaveBeenCalled();
+    await unmount();
+  });
+
+  // M3 — own-bound migration is disclosed even when no wallet is sponsor-bound.
+  it('M3 — own-bound-only wallets get a MOVE disclosure (no sponsor-bound preview needed)', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: OWNER, accountId: '3' });
+    // id '3' = a PCA THIS node owns (owner == OWNER) → own-bound; else = read-back snapshot.
+    mocks.fetchPca.mockImplementation(async (id: string) =>
+      id === '3' ? snap({ accountId: '3', owner: OWNER }) : snap({ discountBps: 3000 }),
+    );
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'already approved on a PCA you own');
+    expect(container.querySelector('[data-testid="pca-b1-own-bound"]')).toBeTruthy();
+    // Not the zero-coverage alarm (the wallet IS self-coverable via migration).
+    expect(container.querySelector('[data-testid="pca-b1-zero-coverage"]')).toBeNull();
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -101,21 +101,20 @@ afterEach(() => {
 });
 
 describe('CreatePcaModal', () => {
-  it('gates edge / no-identity nodes: reason-titled, no form, + a Get-sponsored CTA → S6', async () => {
+  // Sub-PR 1 (§5.2 Step 1) — the edge/no-identity HARD GATE is REMOVED: the wizard opens
+  // for all; a no-own-identity node gets a NON-BLOCKING explainer + a get-sponsored link.
+  it('edge / no-identity: the wizard OPENS (no hard gate) with a non-blocking get-sponsored explainer', async () => {
     useAgentsStore.getState().setNodeStatus({ nodeRole: 'edge', hasIdentity: false });
     const onGetSponsored = vi.fn();
     const { container, unmount } = await render(
       React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored }),
     );
-    await waitForText(container, 'requires a staked core-node identity');
-    // #4 — titled with the reason, not the generic "Create a PCA".
-    expect(container.querySelector('#pca-modal-title')?.textContent).toContain('staked core-node identity');
-    // #1 — zero wizard fields in the gated state.
-    expect(container.querySelector('[data-testid="pca-create-tokens"]')).toBeNull();
-    // #2 — a primary Get-sponsored CTA routes to S6.
-    const cta = container.querySelector('[data-testid="pca-gated-get-sponsored"]')!;
-    expect(cta).toBeTruthy();
-    await act(async () => { cta.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await waitForText(container, 'Commit amount (TRAC)'); // the form opens — no gate
+    expect(container.querySelector('[data-testid="pca-create-tokens"]')).toBeTruthy();
+    // Non-blocking explainer + a get-sponsored LINK (never a redirect that prevents Create).
+    expect(container.querySelector('[data-testid="pca-create-no-identity-note"]')).toBeTruthy();
+    const link = container.querySelector('[data-testid="pca-create-get-sponsored-link"]')!;
+    await act(async () => { link.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     expect(onGetSponsored).toHaveBeenCalled();
     await unmount();
   });
@@ -377,18 +376,21 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
-  it('S1 — delayed status → edge shows the sponsorship gate, never a live submit', async () => {
+  it('S1 — delayed status: checking (no live form) while unknown, then edge resolves → wizard opens', async () => {
     useAgentsStore.setState({ nodeStatus: null });
     const { container, unmount } = await render(
       React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
     );
     await waitForText(container, 'Checking node eligibility');
+    // Fail-closed while unknown — no live submit.
+    expect(container.querySelector('[data-testid="pca-create-submit"]')).toBeNull();
     await act(async () => {
       useAgentsStore.setState({ nodeStatus: { nodeRole: 'edge', hasIdentity: false } });
       await new Promise((r) => setTimeout(r, 0));
     });
-    await waitForText(container, 'requires a staked core-node identity');
-    expect(container.querySelector('[data-testid="pca-create-submit"]')).toBeNull();
+    // Edge now OPENS the wizard (no gate) — form + the non-blocking explainer.
+    await waitForText(container, 'Commit amount (TRAC)');
+    expect(container.querySelector('[data-testid="pca-create-no-identity-note"]')).toBeTruthy();
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -289,12 +289,15 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
-  // R2 — when the refreshed list NO LONGER contains the rejected node, the revert must CLEAR it (not
-  // re-enable submit on its numeric shape) — the user picks a still-listed node.
-  it('R2 — revert clears the rejected node when the fresh list excludes it (submit stays disabled)', async () => {
+  // R2 — the rejection handler clears the rejected node IMMEDIATELY (it does NOT wait for the fresh
+  // refetch): with the refetch held pending, submit is already disabled, the chip is gone, and a 2nd
+  // click can't re-submit the rejected id. Then the fresh list (without #42) resolves → still cleared.
+  it('R2 — rejection clears the rejected node before the fresh refetch resolves; a 2nd click cannot re-submit', async () => {
+    let resolveFresh!: (v: { nodes: any[]; total: number }) => void;
+    const freshPending = new Promise<{ nodes: any[]; total: number }>((res) => { resolveFresh = res; });
     mocks.listDesignatableNodes
       .mockResolvedValueOnce({ nodes: [{ nodeId: 'p42', identityId: '42', stake: '1000000000000000000000', ask: '0' }], total: 1 })
-      .mockResolvedValue({ nodes: [{ nodeId: 'p99', identityId: '99', stake: '1000000000000000000000', ask: '0' }], total: 1 }); // fresh: #42 unstaked
+      .mockReturnValueOnce(freshPending); // the fresh:true refetch stays PENDING
     mocks.createPca.mockRejectedValue(new HttpError(400, 'PrimaryNodeNotInShardingTable', { error: 'PrimaryNodeNotInShardingTable' }));
     const { container, unmount } = await render(
       React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
@@ -302,16 +305,96 @@ describe('CreatePcaModal', () => {
     await waitForText(container, 'node #42'); // #42 pre-selected from the initial list
     setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
     await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
-    await click(container.querySelector('[data-testid="pca-create-submit"]')!);
-    // Poll until the revert's fresh refetch lands (and the rejected #42 is cleared).
+    const submit = () => container.querySelector('[data-testid="pca-create-submit"]') as HTMLButtonElement;
+    await click(submit()!);
+    // Wait until the create rejects and the catch dispatches the fresh refetch (which stays pending).
     const started = Date.now();
     while (Date.now() - started < 1500 && !mocks.listDesignatableNodes.mock.calls.some((c) => c[0]?.fresh)) {
       await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
     }
     await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
-    // #42 is gone from the fresh list → cleared, NOT re-defaulted → submit disabled.
-    expect((container.querySelector('[data-testid="pca-create-submit"]') as HTMLButtonElement).disabled).toBe(true);
+
+    // BEFORE the fresh list resolves: back on the form, #42 already cleared (not re-defaulted off the
+    // stale list), submit disabled.
+    expect(container.querySelector('[data-testid="pca-create-tokens"]')).toBeTruthy(); // recoverable — on the form
     expect(container.querySelector('[data-testid="pca-primary-node-selected"]')).toBeNull();
+    expect(submit().disabled).toBe(true);
+
+    // A 2nd click while the fresh list is still loading cannot re-submit the rejected id.
+    const callsAfterReject = mocks.createPca.mock.calls.length;
+    await click(submit());
+    expect(mocks.createPca.mock.calls.length).toBe(callsAfterReject);
+
+    // The fresh list resolves WITHOUT #42 → still cleared, submit still disabled.
+    await act(async () => {
+      resolveFresh({ nodes: [{ nodeId: 'p99', identityId: '99', stake: '1000000000000000000000', ask: '0' }], total: 1 });
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(submit().disabled).toBe(true);
+    expect(container.querySelector('[data-testid="pca-primary-node-selected"]')).toBeNull();
+    await unmount();
+  });
+
+  // A successful but EMPTY staked list is authoritative: a 503 → list-down own-default (#42) that a
+  // retry can't find in the (empty) table must be CLEARED, not kept (else Create enables on a node
+  // that isn't designatable).
+  it('a retry returning an EMPTY staked list clears the list-down own-default (submit disabled)', async () => {
+    mocks.listDesignatableNodes
+      .mockRejectedValueOnce(new Error('SHARDING_TABLE_READ_FAILED')) // initial load fails → list-down
+      .mockResolvedValue({ nodes: [], total: 0 }); // retry succeeds but the table is empty
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    // List down → core best-effort defaults to its own id (#42) → submit ENABLED, retry shown.
+    await waitForText(container, 'Using node #42');
+    const submit = () => container.querySelector('[data-testid="pca-create-submit"]') as HTMLButtonElement;
+    expect(submit().disabled).toBe(false);
+
+    // Retry → the table comes back EMPTY → #42 isn't designatable → the default is cleared.
+    await click(container.querySelector('[data-testid="pca-primary-node-retry"]')!);
+    const started = Date.now();
+    while (Date.now() - started < 1500 && !mocks.listDesignatableNodes.mock.calls.some((c) => c[0]?.fresh)) {
+      await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+    }
+    await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
+    expect(submit().disabled).toBe(true);
+    await unmount();
+  });
+
+  // Phase gating — the reconcile / status-unknown / success screens must NOT start the form's reads
+  // (sharding-table + wallet-binding probe); only the live form does.
+  it('does NOT start designatable-node or wallet-binding reads in the reconcile phase', async () => {
+    usePcaStore.setState({ trackedIds: [], createPending: { ownerEoa: OWNER, submittedAt: Date.now() } });
+    const { unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+    expect(mocks.listDesignatableNodes).not.toHaveBeenCalled();
+    expect(mocks.pcaAgentAccount).not.toHaveBeenCalled();
+    await unmount();
+  });
+
+  it('does NOT start designatable-node or wallet-binding reads while node status is unknown', async () => {
+    useAgentsStore.setState({ nodeStatus: null } as any);
+    const { unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 30)); });
+    expect(mocks.listDesignatableNodes).not.toHaveBeenCalled();
+    expect(mocks.pcaAgentAccount).not.toHaveBeenCalled();
+    await unmount();
+  });
+
+  it('DOES start those reads on the live form (gating control)', async () => {
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
+    expect(mocks.listDesignatableNodes).toHaveBeenCalled();
+    expect(mocks.pcaAgentAccount).toHaveBeenCalled();
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -263,6 +263,28 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
+  // M4/M9 — a PrimaryNodeNotInShardingTable revert is RECOVERABLE: return to the form AND refetch
+  // the staked list with the cache-bust (fresh=1), so the just-unstaked node isn't re-served stale.
+  it('M4/M9 — PrimaryNodeNotInShardingTable revert returns to the form + refetches the list FRESH', async () => {
+    mocks.createPca.mockRejectedValue(new HttpError(400, 'PrimaryNodeNotInShardingTable', { error: 'PrimaryNodeNotInShardingTable' }));
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await click(container.querySelector('[data-testid="pca-create-submit"]')!);
+    // Poll until the recovery refetch fires (the create-error handler calls refreshNodes → fresh).
+    const started = Date.now();
+    while (Date.now() - started < 1500 && !mocks.listDesignatableNodes.mock.calls.some((c) => c[0]?.fresh)) {
+      await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+    }
+    expect(mocks.listDesignatableNodes).toHaveBeenCalledWith(expect.objectContaining({ fresh: true }));
+    // Recoverable, not terminal — still on the form (the amount field is present).
+    expect(container.querySelector('[data-testid="pca-create-tokens"]')).toBeTruthy();
+    await unmount();
+  });
+
   // S2b renew [MEDIUM] — on the renew path the success action re-approves the OLD account's
   // wallets (not a fresh "this node's wallets"), so the button is relabelled.
   it('S2b renew: relabels the success action to re-approve the OLD account’s wallets', async () => {

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -285,6 +285,28 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
+  // M8 — a FAILED create must never fire the self-coverage hand-off (onApproveOwnWallets); the
+  // self-coverage modal (with its deregister-first loop) only follows a CONFIRMED mint.
+  it('M8 — a failed create never opens self-coverage (onApproveOwnWallets not called)', async () => {
+    mocks.createPca.mockRejectedValue(new HttpError(400, 'InvalidAmount', { error: 'InvalidAmount' }));
+    const onApproveOwn = vi.fn();
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: onApproveOwn, onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await click(container.querySelector('[data-testid="pca-create-submit"]')!);
+    const started = Date.now();
+    while (Date.now() - started < 1000 && mocks.createPca.mock.calls.length === 0) {
+      await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+    }
+    await act(async () => { await new Promise((r) => setTimeout(r, 20)); }); // let the rejection settle
+    expect(mocks.createPca).toHaveBeenCalled();
+    expect(onApproveOwn).not.toHaveBeenCalled();
+    await unmount();
+  });
+
   // S2b renew [MEDIUM] — on the renew path the success action re-approves the OLD account's
   // wallets (not a fresh "this node's wallets"), so the button is relabelled.
   it('S2b renew: relabels the success action to re-approve the OLD account’s wallets', async () => {

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -162,9 +162,12 @@ describe('CreatePcaModal', () => {
   // before the TRAC commit; NOT a hard block (a node may create purely to sponsor others).
   it('B1 — all wallets sponsor-bound shows the zero-self-coverage warning but NEVER blocks Create (H3)', async () => {
     mocks.pcaAgentAccount.mockResolvedValue({ agent: OWNER, accountId: '5' });
-    // id '5' = the sponsor's PCA (binding owner read); any other id = the create read-back snapshot.
+    // id '5' = the sponsor's PCA (binding owner read) — LIVE (budget + unexpired) so it reads as
+    // "already discounted free" (R1); any other id = the create read-back snapshot.
     mocks.fetchPca.mockImplementation(async (id: string) =>
-      id === '5' ? snap({ accountId: '5', owner: '0xSPONSOR000000000000000000000000000beEf12' }) : snap({ discountBps: 3000 }),
+      id === '5'
+        ? snap({ accountId: '5', owner: '0xSPONSOR000000000000000000000000000beEf12', baseEpochAllowance: '1000000000000000000000' })
+        : snap({ discountBps: 3000 }),
     );
     mocks.createPca.mockResolvedValue({ accountId: '8', txHash: '0xabc', committedTokens: '100000.0' });
     const { container, unmount } = await render(
@@ -282,6 +285,57 @@ describe('CreatePcaModal', () => {
     expect(mocks.listDesignatableNodes).toHaveBeenCalledWith(expect.objectContaining({ fresh: true }));
     // Recoverable, not terminal — still on the form (the amount field is present).
     expect(container.querySelector('[data-testid="pca-create-tokens"]')).toBeTruthy();
+    await unmount();
+  });
+
+  // R2 — when the refreshed list NO LONGER contains the rejected node, the revert must CLEAR it (not
+  // re-enable submit on its numeric shape) — the user picks a still-listed node.
+  it('R2 — revert clears the rejected node when the fresh list excludes it (submit stays disabled)', async () => {
+    mocks.listDesignatableNodes
+      .mockResolvedValueOnce({ nodes: [{ nodeId: 'p42', identityId: '42', stake: '1000000000000000000000', ask: '0' }], total: 1 })
+      .mockResolvedValue({ nodes: [{ nodeId: 'p99', identityId: '99', stake: '1000000000000000000000', ask: '0' }], total: 1 }); // fresh: #42 unstaked
+    mocks.createPca.mockRejectedValue(new HttpError(400, 'PrimaryNodeNotInShardingTable', { error: 'PrimaryNodeNotInShardingTable' }));
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'node #42'); // #42 pre-selected from the initial list
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await click(container.querySelector('[data-testid="pca-create-submit"]')!);
+    // Poll until the revert's fresh refetch lands (and the rejected #42 is cleared).
+    const started = Date.now();
+    while (Date.now() - started < 1500 && !mocks.listDesignatableNodes.mock.calls.some((c) => c[0]?.fresh)) {
+      await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+    }
+    await act(async () => { await new Promise((r) => setTimeout(r, 20)); });
+    // #42 is gone from the fresh list → cleared, NOT re-defaulted → submit disabled.
+    expect((container.querySelector('[data-testid="pca-create-submit"]') as HTMLButtonElement).disabled).toBe(true);
+    expect(container.querySelector('[data-testid="pca-primary-node-selected"]')).toBeNull();
+    await unmount();
+  });
+
+  // R9 — edge-create integration: an edge node picks a staked node and creates with that primaryNode.
+  it('R9 — edge node picks a staked node via the picker and creates with primaryNode', async () => {
+    useAgentsStore.getState().setNodeStatus({ nodeRole: 'edge', hasIdentity: false, blockExplorerUrl: null });
+    mocks.listDesignatableNodes.mockResolvedValue({
+      nodes: [{ nodeId: 'p99', identityId: '99', stake: '5000000000000000000000', ask: '0' }], total: 1,
+    });
+    mocks.createPca.mockResolvedValue({ accountId: '8', txHash: '0xabc', committedTokens: '100000.0' });
+    mocks.fetchPca.mockResolvedValue(snap({ accountId: '8', discountBps: 3000 }));
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)'); // edge opens the wizard (no gate)
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    // Edge has no own-node default → pick #99 via the picker (open + select the option).
+    const search = container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;
+    await act(async () => { search.dispatchEvent(new FocusEvent('focusin', { bubbles: true })); });
+    const opt = container.querySelector('[data-testid="pca-primary-node-option"]') as HTMLElement;
+    await act(async () => { opt.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })); });
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    await click(container.querySelector('[data-testid="pca-create-submit"]')!);
+    await waitForText(container, 'PCA #8 created');
+    expect(mocks.createPca).toHaveBeenCalledWith({ tokens: '100000', primaryNode: '99' });
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   createPca: vi.fn(),
   fetchPca: vi.fn(),
   pcaAgentAccount: vi.fn(),
+  listDesignatableNodes: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -23,6 +24,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     createPca: mocks.createPca,
     fetchPca: mocks.fetchPca,
     pcaAgentAccount: mocks.pcaAgentAccount,
+    listDesignatableNodes: mocks.listDesignatableNodes,
   };
 });
 
@@ -97,6 +99,11 @@ beforeEach(() => {
   });
   // B1 default: the wallet is bound to nothing → no zero-coverage warning (and no real fetch).
   mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
+  // §3b picker list: this node's identity (#42) is staked → core pre-selects it (M3).
+  mocks.listDesignatableNodes.mockResolvedValue({
+    nodes: [{ nodeId: 'peerA', identityId: '42', stake: '1000000000000000000000', ask: '0' }],
+    total: 1, nextStart: null,
+  });
 });
 afterEach(() => {
   expect(fetchGuard).not.toHaveBeenCalled();
@@ -166,6 +173,45 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
+  // §3b/M3 — core pre-selects its OWN staked node only when its identity is in the list.
+  it('§3b/M3 — core pre-selects its own staked node when its identity is in the list', async () => {
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'node #42');
+    expect(container.querySelector('[data-testid="pca-primary-node-selected"]')?.textContent).toContain('✓ this node');
+    await unmount();
+  });
+
+  it('§3b/M3 — own identity NOT in the staked list → no default; primary node required (submit blocked)', async () => {
+    mocks.listDesignatableNodes.mockResolvedValue({
+      nodes: [{ nodeId: 'pX', identityId: '99', stake: '5000000000000000000', ask: '0' }], total: 1, nextStart: null,
+    });
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Commit amount (TRAC)');
+    setInputValue(container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement, '100000');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    // #42 isn't staked → no pre-selection → the required primary node blocks submit.
+    expect(container.querySelector('[data-testid="pca-primary-node-selected"]')).toBeNull();
+    expect((container.querySelector('[data-testid="pca-create-submit"]') as HTMLButtonElement).disabled).toBe(true);
+    await unmount();
+  });
+
+  it('Q1 — list-down: core best-effort defaults to its own id; the picker shows a retry', async () => {
+    mocks.listDesignatableNodes.mockRejectedValue(new HttpError(503, 'x', { code: 'SHARDING_TABLE_READ_FAILED' }));
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'Couldn’t load the staked-node list');
+    expect(container.querySelector('[data-testid="pca-primary-node-error"]')).toBeTruthy();
+    // The create-time PrimaryNodeNotInShardingTable revert is the backstop; core still defaults
+    // to its own id (#42) so the Review reflects it (Q1).
+    expect(container.textContent).toContain('#42');
+    await unmount();
+  });
+
   // S2b renew [MEDIUM] — on the renew path the success action re-approves the OLD account's
   // wallets (not a fresh "this node's wallets"), so the button is relabelled.
   it('S2b renew: relabels the success action to re-approve the OLD account’s wallets', async () => {
@@ -222,7 +268,9 @@ describe('CreatePcaModal', () => {
     expect(note.textContent).toContain('0/100');
     // Commit amount is seeded from the expiring account.
     expect((container.querySelector('[data-testid="pca-create-tokens"]') as HTMLInputElement).value).toBe('100000.0');
-    expect((container.querySelector('[data-testid="pca-create-primary-node"]') as HTMLInputElement).value).toBe('42');
+    // Primary node is seeded into the picker (shown as the selected node).
+    await waitForText(container, 'node #42');
+    expect(container.querySelector('[data-testid="pca-primary-node-selected"]')?.textContent).toContain('node #42');
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchWalletsBalances: vi.fn(),
   createPca: vi.fn(),
   fetchPca: vi.fn(),
+  pcaAgentAccount: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -21,6 +22,7 @@ vi.mock('../src/ui/api.js', async (orig) => {
     fetchWalletsBalances: mocks.fetchWalletsBalances,
     createPca: mocks.createPca,
     fetchPca: mocks.fetchPca,
+    pcaAgentAccount: mocks.pcaAgentAccount,
   };
 });
 
@@ -93,6 +95,8 @@ beforeEach(() => {
     balances: [{ address: OWNER, eth: '1', trac: '200000', symbol: 'TRAC' }],
     chainId: '84532', rpcUrl: null,
   });
+  // B1 default: the wallet is bound to nothing → no zero-coverage warning (and no real fetch).
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
 });
 afterEach(() => {
   expect(fetchGuard).not.toHaveBeenCalled();
@@ -144,6 +148,21 @@ describe('CreatePcaModal', () => {
     // The primary success action opens self-approval.
     await click(container.querySelector('[data-testid="pca-approve-own-wallets"]')!);
     expect(onApproveOwn).toHaveBeenCalledWith('7');
+    await unmount();
+  });
+
+  // B1 (§9.5) — every op wallet already on a sponsor's PCA → a loud informed-consent warning
+  // before the TRAC commit; NOT a hard block (a node may create purely to sponsor others).
+  it('B1 — all wallets sponsor-bound shows the zero-self-coverage warning, never blocks Create', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: OWNER, accountId: '5' });
+    mocks.fetchPca.mockResolvedValue(snap({ accountId: '5', owner: '0xSPONSOR000000000000000000000000000beEf12' }));
+    const { container, unmount } = await render(
+      React.createElement(CreatePcaModal, { onClose: vi.fn(), onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),
+    );
+    await waitForText(container, 'sponsor other nodes'); // the zero-coverage warning copy
+    expect(container.querySelector('[data-testid="pca-b1-zero-coverage"]')).toBeTruthy();
+    // Informed consent, not a gate — the submit control is still present.
+    expect(container.querySelector('[data-testid="pca-create-submit"]')).toBeTruthy();
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-create-modal.test.ts
+++ b/packages/node-ui/test/pca-create-modal.test.ts
@@ -186,9 +186,10 @@ describe('CreatePcaModal', () => {
     await unmount();
   });
 
-  // H1 — Escape closes the OPEN picker popup, not the whole Create modal (the modal's
-  // useModalDismiss must no-op while a combobox is expanded so committed state isn't discarded).
-  it('H1 — Escape with the picker open closes the popup, does NOT dismiss the modal', async () => {
+  // Escape closes the OPEN picker popup first, not the whole Create modal: the picker stops
+  // the event while its listbox is open (so committed state isn't discarded), and a second
+  // Escape — popup now closed — dismisses the modal. The shared dismiss hook stays generic.
+  it('Escape with the picker open closes the popup, does NOT dismiss the modal', async () => {
     const onClose = vi.fn();
     const { container, unmount } = await render(
       React.createElement(CreatePcaModal, { onClose, onApproveOwnWallets: vi.fn(), onManage: vi.fn(), onGetSponsored: vi.fn() }),

--- a/packages/node-ui/test/pca-designatable-nodes-hook.test.ts
+++ b/packages/node-ui/test/pca-designatable-nodes-hook.test.ts
@@ -43,15 +43,17 @@ beforeEach(() => {
 afterEach(() => { document.body.innerHTML = ''; });
 
 describe('useDesignatableNodes', () => {
-  it('follows the offset cursor across pages and sorts by stake DESC', async () => {
-    mocks.listDesignatableNodes.mockImplementation(async (opts?: { start?: number }) => {
-      const start = opts?.start ?? 0;
-      if (start === 0) return { nodes: [{ nodeId: 'a', identityId: '1', stake: '30' }], total: 3, nextStart: 1 };
-      if (start === 1) return { nodes: [{ nodeId: 'b', identityId: '2', stake: '90' }], total: 3, nextStart: 2 };
-      return { nodes: [{ nodeId: 'c', identityId: '3', stake: '10' }], total: 3, nextStart: null };
+  it('R4 — single fetch (no pagination) returns the whole list, sorted by stake DESC', async () => {
+    mocks.listDesignatableNodes.mockResolvedValue({
+      nodes: [
+        { nodeId: 'a', identityId: '1', stake: '30', ask: '0' },
+        { nodeId: 'b', identityId: '2', stake: '90', ask: '0' },
+        { nodeId: 'c', identityId: '3', stake: '10', ask: '0' },
+      ],
+      total: 3,
     });
     const { unmount } = await renderHook();
-    expect(mocks.listDesignatableNodes).toHaveBeenCalledTimes(3);
+    expect(mocks.listDesignatableNodes).toHaveBeenCalledTimes(1); // ONE fetch, no cursor loop
     expect(latest!.nodes.map((n) => n.identityId)).toEqual(['2', '1', '3']); // 90, 30, 10
     expect(latest!.error).toBe(false);
     await unmount();
@@ -59,23 +61,11 @@ describe('useDesignatableNodes', () => {
 
   it('non-numeric stake → byStakeDesc leaves order (no throw)', async () => {
     mocks.listDesignatableNodes.mockResolvedValue({
-      nodes: [{ nodeId: 'a', identityId: '1', stake: 'not-a-number' }, { nodeId: 'b', identityId: '2', stake: '5' }],
-      total: 2, nextStart: null,
+      nodes: [{ nodeId: 'a', identityId: '1', stake: 'not-a-number', ask: '0' }, { nodeId: 'b', identityId: '2', stake: '5', ask: '0' }],
+      total: 2,
     });
     const { unmount } = await renderHook();
     expect(latest!.nodes).toHaveLength(2); // did not throw
-    await unmount();
-  });
-
-  it('L11 — stops once it has collected `total`, even if nextStart is non-null', async () => {
-    mocks.listDesignatableNodes.mockImplementation(async (opts?: { start?: number }) =>
-      (opts?.start ?? 0) === 0
-        ? { nodes: [{ nodeId: 'a', identityId: '1', stake: '1' }, { nodeId: 'b', identityId: '2', stake: '2' }], total: 2, nextStart: 2 }
-        : { nodes: [{ nodeId: 'c', identityId: '3', stake: '3' }], total: 2, nextStart: null },
-    );
-    const { unmount } = await renderHook();
-    expect(latest!.nodes).toHaveLength(2);
-    expect(mocks.listDesignatableNodes).toHaveBeenCalledTimes(1); // stopped at total (no extra page)
     await unmount();
   });
 

--- a/packages/node-ui/test/pca-designatable-nodes-hook.test.ts
+++ b/packages/node-ui/test/pca-designatable-nodes-hook.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+//
+// M7 — useDesignatableNodes: the multi-page cursor-follow, the byStakeDesc client sort (BigInt +
+// non-numeric catch→0), and the L11 stop-at-`total` (no magic page cap). Mocks listDesignatableNodes.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ listDesignatableNodes: vi.fn() }));
+
+vi.mock('../src/ui/api.js', async (orig) => {
+  const actual = await orig<typeof import('../src/ui/api.js')>();
+  return { ...actual, listDesignatableNodes: mocks.listDesignatableNodes };
+});
+
+const { useDesignatableNodes } = await import('../src/ui/hooks/useDesignatableNodes.js');
+import type { UseDesignatableNodes } from '../src/ui/hooks/useDesignatableNodes.js';
+
+let latest: UseDesignatableNodes | null = null;
+function Harness() {
+  latest = useDesignatableNodes();
+  return null;
+}
+
+async function renderHook() {
+  latest = null;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(React.createElement(Harness)); });
+  for (let i = 0; i < 100 && (latest == null || latest.loading); i++) {
+    await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+  }
+  return { unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('useDesignatableNodes', () => {
+  it('follows the offset cursor across pages and sorts by stake DESC', async () => {
+    mocks.listDesignatableNodes.mockImplementation(async (opts?: { start?: number }) => {
+      const start = opts?.start ?? 0;
+      if (start === 0) return { nodes: [{ nodeId: 'a', identityId: '1', stake: '30' }], total: 3, nextStart: 1 };
+      if (start === 1) return { nodes: [{ nodeId: 'b', identityId: '2', stake: '90' }], total: 3, nextStart: 2 };
+      return { nodes: [{ nodeId: 'c', identityId: '3', stake: '10' }], total: 3, nextStart: null };
+    });
+    const { unmount } = await renderHook();
+    expect(mocks.listDesignatableNodes).toHaveBeenCalledTimes(3);
+    expect(latest!.nodes.map((n) => n.identityId)).toEqual(['2', '1', '3']); // 90, 30, 10
+    expect(latest!.error).toBe(false);
+    await unmount();
+  });
+
+  it('non-numeric stake → byStakeDesc leaves order (no throw)', async () => {
+    mocks.listDesignatableNodes.mockResolvedValue({
+      nodes: [{ nodeId: 'a', identityId: '1', stake: 'not-a-number' }, { nodeId: 'b', identityId: '2', stake: '5' }],
+      total: 2, nextStart: null,
+    });
+    const { unmount } = await renderHook();
+    expect(latest!.nodes).toHaveLength(2); // did not throw
+    await unmount();
+  });
+
+  it('L11 — stops once it has collected `total`, even if nextStart is non-null', async () => {
+    mocks.listDesignatableNodes.mockImplementation(async (opts?: { start?: number }) =>
+      (opts?.start ?? 0) === 0
+        ? { nodes: [{ nodeId: 'a', identityId: '1', stake: '1' }, { nodeId: 'b', identityId: '2', stake: '2' }], total: 2, nextStart: 2 }
+        : { nodes: [{ nodeId: 'c', identityId: '3', stake: '3' }], total: 2, nextStart: null },
+    );
+    const { unmount } = await renderHook();
+    expect(latest!.nodes).toHaveLength(2);
+    expect(mocks.listDesignatableNodes).toHaveBeenCalledTimes(1); // stopped at total (no extra page)
+    await unmount();
+  });
+
+  it('surfaces a read failure as error (retryable)', async () => {
+    mocks.listDesignatableNodes.mockRejectedValue(new Error('SHARDING_TABLE_READ_FAILED'));
+    const { unmount } = await renderHook();
+    expect(latest!.error).toBe(true);
+    expect(latest!.nodes).toEqual([]);
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/pca-designatable-nodes-hook.test.ts
+++ b/packages/node-ui/test/pca-designatable-nodes-hook.test.ts
@@ -69,6 +69,22 @@ describe('useDesignatableNodes', () => {
     await unmount();
   });
 
+  it('R4 robustness — surfaces the WHOLE set (>50 nodes) from the single fetch, sorted desc', async () => {
+    // 60 nodes (above the picker's 50-row display CAP). The HOOK must return ALL 60 — a future
+    // server-side cap/pagination re-introduction (only serving a page) would fail this.
+    const nodes = Array.from({ length: 60 }, (_, i) => ({
+      nodeId: `p${i}`, identityId: String(i + 1), stake: String(i + 1), ask: '0', // stake 1..60
+    }));
+    mocks.listDesignatableNodes.mockResolvedValue({ nodes, total: 60 });
+    const { unmount } = await renderHook();
+    expect(mocks.listDesignatableNodes).toHaveBeenCalledTimes(1); // one fetch, whole table
+    expect(latest!.nodes).toHaveLength(60);
+    // Sorted by stake DESC: identityId 60 (stake 60) … down to 1 (stake 1).
+    expect(latest!.nodes[0].identityId).toBe('60');
+    expect(latest!.nodes[59].identityId).toBe('1');
+    await unmount();
+  });
+
   it('surfaces a read failure as error (retryable)', async () => {
     mocks.listDesignatableNodes.mockRejectedValue(new Error('SHARDING_TABLE_READ_FAILED'));
     const { unmount } = await renderHook();

--- a/packages/node-ui/test/pca-detail-view.test.ts
+++ b/packages/node-ui/test/pca-detail-view.test.ts
@@ -17,6 +17,9 @@ const mocks = vi.hoisted(() => ({
   pcaSettle: vi.fn(),
   pcaRemoveAgent: vi.fn(),
   registerContextGraph: vi.fn(),
+  // The renew path renders the real CreatePcaModal → the §3b picker + B1 probe.
+  pcaAgentAccount: vi.fn(),
+  listDesignatableNodes: vi.fn(),
 }));
 
 vi.mock('../src/ui/api.js', async (orig) => {
@@ -80,6 +83,9 @@ beforeEach(() => {
   );
   // B3 — default to the happy full-list path (W0 = this node's wallet, approved).
   mocks.listPcaAgents.mockResolvedValue({ accountId: '7', agents: [W0] });
+  // Renew → real CreatePcaModal: stub the picker list + B1 probe (no real fetch).
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
+  mocks.listDesignatableNodes.mockResolvedValue({ nodes: [], total: 0, nextStart: null });
 });
 afterEach(() => { document.body.innerHTML = ''; });
 

--- a/packages/node-ui/test/pca-overview-wiring.test.ts
+++ b/packages/node-ui/test/pca-overview-wiring.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+//
+// TfO — ConvictionOverview wiring: the create-success hand-off must open ApproveWalletsModal in
+// SELF-COVERAGE mode ({ accountId, initialMode:'self', selfCoverage:true }) so the post-mint loop
+// runs the per-wallet deregister-first/skip plan. Mocks the two child modals to capture props, so
+// dropping the `selfCoverage` flag (or the mode) fails this test.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  fetchPca: vi.fn(),
+  fetchWalletsBalances: vi.fn(),
+  pcaAgentAccount: vi.fn(),
+  fetchMyPcas: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', async (orig) => {
+  const actual = await orig<typeof import('../src/ui/api.js')>();
+  return {
+    ...actual,
+    fetchPca: mocks.fetchPca,
+    fetchWalletsBalances: mocks.fetchWalletsBalances,
+    pcaAgentAccount: mocks.pcaAgentAccount,
+    fetchMyPcas: mocks.fetchMyPcas,
+  };
+});
+
+let approveProps: any = null;
+vi.mock('../src/ui/pages/conviction/CreatePcaModal.js', () => ({
+  CreatePcaModal: (props: any) =>
+    React.createElement(
+      'button',
+      { 'data-testid': 'mock-create-approve-own', onClick: () => props.onApproveOwnWallets('8') },
+      'approve own',
+    ),
+}));
+vi.mock('../src/ui/pages/conviction/ApproveWalletsModal.js', () => ({
+  ApproveWalletsModal: (props: any) => {
+    approveProps = props;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'mock-approve' },
+      `id=${props.accountId} mode=${props.initialMode} self=${String(props.selfCoverage)}`,
+    );
+  },
+}));
+
+const { ConvictionOverview } = await import('../src/ui/pages/conviction/ConvictionOverview.js');
+const { useAgentsStore } = await import('../src/ui/stores/agents.js');
+const { usePcaStore } = await import('../src/ui/stores/pca.js');
+
+async function render(node: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { container, unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+async function waitForText(c: HTMLElement, text: string) {
+  const started = Date.now();
+  while (Date.now() - started < 1500) {
+    if ((c.textContent ?? '').includes(text)) return;
+    await act(async () => { await new Promise((r) => setTimeout(r, 5)); });
+  }
+  throw new Error(`Timed out waiting for "${text}" in "${c.textContent}"`);
+}
+async function click(el: Element) {
+  await act(async () => { el.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+}
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+  localStorage.clear();
+  vi.clearAllMocks();
+  approveProps = null;
+  usePcaStore.setState({ trackedIds: [], createPending: null });
+  useAgentsStore.getState().setNodeStatus({ nodeRole: 'core', blockExplorerUrl: null });
+  mocks.fetchPca.mockResolvedValue({ accountId: '0', owner: '0xowner' });
+  mocks.fetchWalletsBalances.mockResolvedValue({ wallets: [], balances: [], chainId: '84532', rpcUrl: null });
+  mocks.pcaAgentAccount.mockResolvedValue({ agent: '', accountId: null });
+  mocks.fetchMyPcas.mockResolvedValue({ accounts: [] });
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('ConvictionOverview — create→self-coverage wiring', () => {
+  it('the create-success hand-off opens ApproveWalletsModal with selfCoverage=true (self mode)', async () => {
+    const { container, unmount } = await render(React.createElement(ConvictionOverview));
+    await waitForText(container, 'Publishing Conviction');
+    // Open Create (core), then fire the mint's "approve own wallets" hand-off.
+    await click(container.querySelector('[data-testid="pca-create-btn"]')!);
+    await click(container.querySelector('[data-testid="mock-create-approve-own"]')!);
+    await waitForText(container, 'id=8');
+    expect(approveProps).toMatchObject({ accountId: '8', initialMode: 'self', selfCoverage: true });
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/pca-overview.test.ts
+++ b/packages/node-ui/test/pca-overview.test.ts
@@ -185,6 +185,20 @@ describe('ConvictionOverview — S1 discovery', () => {
     await unmount();
   });
 
+  // Sub-PR 1 (§5.6/§5.1) — edge can now create: Get sponsored stays primary, Create is
+  // an available SECONDARY CTA alongside it (no longer edge-gated).
+  it('edge S1 offers Create alongside the (primary) Get-sponsored CTA', async () => {
+    useAgentsStore.getState().setNodeStatus({ nodeRole: 'edge', blockExplorerUrl: null });
+    const { container, unmount } = await render(React.createElement(ConvictionOverview));
+    await waitForText(container, 'Share my wallet → get sponsored');
+    const createBtn = container.querySelector('[data-testid="pca-create-btn"]') as HTMLButtonElement;
+    expect(createBtn).toBeTruthy();
+    expect(createBtn.textContent).toContain('Create a conviction account');
+    // Get sponsored stays the PRIMARY-styled action; Create is the secondary.
+    expect(createBtn.className).not.toContain('primary');
+    await unmount();
+  });
+
   it('classifies a tracked account the node owns under "Owned by me"', async () => {
     usePcaStore.setState({ trackedIds: ['7'], createPending: null });
     mocks.fetchWalletsBalances.mockResolvedValue({

--- a/packages/node-ui/test/pca-primary-node-picker.test.ts
+++ b/packages/node-ui/test/pca-primary-node-picker.test.ts
@@ -66,6 +66,18 @@ describe('PrimaryNodePicker', () => {
     await unmount();
   });
 
+  it('M1 — a required combobox exposes aria-required + aria-invalid until a node is picked', async () => {
+    const unpicked = await render(base({ required: true, value: '' }));
+    const input = unpicked.container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;
+    expect(input.getAttribute('aria-required')).toBe('true');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    await unpicked.unmount();
+    const picked = await render(base({ required: true, value: '22' }));
+    const input2 = picked.container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;
+    expect(input2.getAttribute('aria-invalid')).toBe('false');
+    await picked.unmount();
+  });
+
   it('search filters by id', async () => {
     const { container, unmount } = await render(base());
     const search = container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;

--- a/packages/node-ui/test/pca-primary-node-picker.test.ts
+++ b/packages/node-ui/test/pca-primary-node-picker.test.ts
@@ -78,6 +78,19 @@ describe('PrimaryNodePicker', () => {
     await picked.unmount();
   });
 
+  it('M11 — ArrowDown highlights an option (aria-activedescendant) and Enter selects it', async () => {
+    const onChange = vi.fn();
+    const { container, unmount } = await render(base({ onChange }));
+    const input = container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;
+    await focus(input); // open the popup
+    await act(async () => { input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })); });
+    // aria-activedescendant tracks the first option (node #11, as-passed order).
+    expect(input.getAttribute('aria-activedescendant')).toContain('-opt-11');
+    await act(async () => { input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })); });
+    expect(onChange).toHaveBeenCalledWith('11');
+    await unmount();
+  });
+
   it('search filters by id', async () => {
     const { container, unmount } = await render(base());
     const search = container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;

--- a/packages/node-ui/test/pca-primary-node-picker.test.ts
+++ b/packages/node-ui/test/pca-primary-node-picker.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+//
+// §3b — PrimaryNodePicker (presentational): the always-visible required staked-node
+// picker. Searchable combobox, node id primary + stake (NO ask), paste-id convenience,
+// "this node" indicator, reward-weight donation copy, and loading/error/empty states.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { PrimaryNodePicker } = await import('../src/ui/components/Pca/PrimaryNodePicker.js');
+import type { DesignatableNode } from '../src/ui/components/Pca/PrimaryNodePicker.js';
+
+const NODES: DesignatableNode[] = [
+  { nodeId: 'peerAAA', identityId: '11', stake: '50000000000000000000000' }, // 50000 TRAC
+  { nodeId: 'peerBBB', identityId: '22', stake: '120000000000000000000000' }, // 120000 TRAC
+  { nodeId: 'peerCCC', identityId: '33', stake: '7000000000000000000000' }, // 7000 TRAC
+];
+
+async function render(node: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  await act(async () => { root.render(node); });
+  return { container, unmount: async () => { await act(async () => root.unmount()); container.remove(); } };
+}
+async function click(el: Element) {
+  await act(async () => { el.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+}
+async function mouseDown(el: Element) {
+  await act(async () => { el.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })); });
+}
+async function focus(el: Element) {
+  // React (root delegation) maps onFocus to the native `focusin` event, which bubbles.
+  await act(async () => { el.dispatchEvent(new FocusEvent('focusin', { bubbles: true })); });
+}
+function setInput(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+const opts = (c: HTMLElement) => Array.from(c.querySelectorAll('[data-testid="pca-primary-node-option"]'));
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '';
+});
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('PrimaryNodePicker', () => {
+  function base(overrides: Partial<React.ComponentProps<typeof PrimaryNodePicker>> = {}) {
+    return React.createElement(PrimaryNodePicker, {
+      nodes: NODES, loading: false, error: false, onRetry: vi.fn(),
+      value: '', onChange: vi.fn(), ...overrides,
+    });
+  }
+
+  it('renders the staked nodes (id + stake) and never shows an ask column', async () => {
+    const { container, unmount } = await render(base());
+    await focus(container.querySelector('[data-testid="pca-primary-node-search"]')!);
+    const rows = opts(container);
+    expect(rows.length).toBe(3);
+    expect(container.textContent).toContain('#11');
+    expect(container.textContent).toContain('50000.00 TRAC staked'); // wei→TRAC
+    expect(container.textContent?.toLowerCase()).not.toContain('ask');
+    await unmount();
+  });
+
+  it('search filters by id', async () => {
+    const { container, unmount } = await render(base());
+    const search = container.querySelector('[data-testid="pca-primary-node-search"]') as HTMLInputElement;
+    await focus(search);
+    setInput(search, '22');
+    await act(async () => {});
+    const rows = opts(container);
+    expect(rows.length).toBe(1);
+    expect(rows[0]!.textContent).toContain('#22');
+    await unmount();
+  });
+
+  it('clicking an option calls onChange with its identityId', async () => {
+    const onChange = vi.fn();
+    const { container, unmount } = await render(base({ onChange }));
+    await focus(container.querySelector('[data-testid="pca-primary-node-search"]')!);
+    await mouseDown(opts(container).find((o) => o.textContent?.includes('#33'))!);
+    expect(onChange).toHaveBeenCalledWith('33');
+    await unmount();
+  });
+
+  it('marks the node’s own staked identity with a "this node" indicator', async () => {
+    const { container, unmount } = await render(base({ ownIdentityId: '22', role: 'core' }));
+    await focus(container.querySelector('[data-testid="pca-primary-node-search"]')!);
+    const ownRow = opts(container).find((o) => o.textContent?.includes('#22'))!;
+    expect(ownRow.textContent).toContain('✓ this node');
+    await unmount();
+  });
+
+  it('paste a valid id → onChange; an unknown id → inline error, no onChange', async () => {
+    const onChange = vi.fn();
+    const { container, unmount } = await render(base({ onChange }));
+    const paste = container.querySelector('[data-testid="pca-primary-node-paste"]') as HTMLInputElement;
+    setInput(paste, '11');
+    await click(container.querySelector('[data-testid="pca-primary-node-paste-use"]')!);
+    expect(onChange).toHaveBeenCalledWith('11');
+
+    onChange.mockClear();
+    setInput(paste, '999');
+    await click(container.querySelector('[data-testid="pca-primary-node-paste-use"]')!);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="pca-primary-node-paste-error"]')?.textContent)
+      .toContain('Not a staked sharding-table node');
+    await unmount();
+  });
+
+  it('shows the honest reward-weight donation copy for edge / no own identity', async () => {
+    const { container, unmount } = await render(base({ role: 'edge', value: '33' }));
+    expect(container.querySelector('[data-testid="pca-primary-node-donation"]')?.textContent)
+      .toContain('accrues to the node you pick');
+    await unmount();
+  });
+
+  it('core picking a node other than itself gets a heads-up (not the donation copy)', async () => {
+    const { container, unmount } = await render(base({ role: 'core', ownIdentityId: '11', value: '22' }));
+    expect(container.querySelector('[data-testid="pca-primary-node-heads-up"]')?.textContent)
+      .toContain('instead of this node');
+    expect(container.querySelector('[data-testid="pca-primary-node-donation"]')).toBeNull();
+    await unmount();
+  });
+
+  it('loading / error(+retry) / empty states', async () => {
+    const onRetry = vi.fn();
+    let h = await render(base({ loading: true }));
+    expect(h.container.textContent).toContain('Loading staked nodes');
+    expect(h.container.querySelector('[data-testid="pca-primary-node-search"]')).toBeNull();
+    await h.unmount();
+
+    h = await render(base({ error: true, onRetry }));
+    expect(h.container.querySelector('[data-testid="pca-primary-node-error"]')).toBeTruthy();
+    await click(h.container.querySelector('[data-testid="pca-primary-node-retry"]')!);
+    expect(onRetry).toHaveBeenCalled();
+    await h.unmount();
+
+    h = await render(base({ nodes: [] }));
+    expect(h.container.textContent).toContain('No staked nodes found');
+    await h.unmount();
+  });
+
+  it('exposes combobox + listbox roles (a11y)', async () => {
+    const { container, unmount } = await render(base());
+    const combo = container.querySelector('[role="combobox"]') as HTMLElement;
+    expect(combo).toBeTruthy();
+    await focus(combo);
+    expect(combo.getAttribute('aria-expanded')).toBe('true');
+    expect(container.querySelector('[role="listbox"]')).toBeTruthy();
+    expect(container.querySelectorAll('[role="option"]').length).toBe(3);
+    await unmount();
+  });
+});

--- a/packages/node-ui/test/pca-wallet-binding.test.ts
+++ b/packages/node-ui/test/pca-wallet-binding.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+//
+// B1 — the pre-flight wallet-binding probe (§9.5). Pure read-only logic: per op wallet,
+// resolve UNBOUND / own-bound (deregister-first) / sponsor-bound (skip) / inconclusive (#9),
+// and the self-coverage outlook that drives the zero-coverage informed-consent warning.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  pcaAgentAccount: vi.fn(),
+  fetchPca: vi.fn(),
+}));
+
+vi.mock('../src/ui/api.js', async (orig) => {
+  const actual = await orig<typeof import('../src/ui/api.js')>();
+  return { ...actual, pcaAgentAccount: mocks.pcaAgentAccount, fetchPca: mocks.fetchPca };
+});
+
+const { resolveWalletBinding, probeWalletBindings, selfCoverageOutlook } = await import('../src/ui/pca/walletBinding.js');
+
+const OWNER = '0x9A3f000000000000000000000000000000000E41D';
+const SPONSOR = '0x1111111111111111111111111111111111111111';
+const W = '0xWALLET00000000000000000000000000000000aa';
+
+beforeEach(() => { vi.clearAllMocks(); });
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('resolveWalletBinding', () => {
+  it('UNBOUND when the wallet is an agent on no account', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: null });
+    const b = await resolveWalletBinding(W, OWNER);
+    expect(b).toMatchObject({ boundTo: null, canOwn: false, inconclusive: false });
+    expect(mocks.fetchPca).not.toHaveBeenCalled(); // no owner read needed when unbound
+  });
+
+  it('own-bound (canOwn) when the bound account is owned by this node', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: '7' });
+    mocks.fetchPca.mockResolvedValue({ accountId: '7', owner: OWNER });
+    const b = await resolveWalletBinding(W, OWNER);
+    expect(b).toMatchObject({ boundTo: '7', canOwn: true, inconclusive: false });
+  });
+
+  it('sponsor-bound (NOT canOwn) when the bound account is owned by someone else', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: '9' });
+    mocks.fetchPca.mockResolvedValue({ accountId: '9', owner: SPONSOR });
+    const b = await resolveWalletBinding(W, OWNER);
+    expect(b).toMatchObject({ boundTo: '9', canOwn: false, inconclusive: false });
+  });
+
+  it('INCONCLUSIVE (#9) when the agent probe rejects — never asserted unbound/ownable', async () => {
+    mocks.pcaAgentAccount.mockRejectedValue(new Error('boom'));
+    const b = await resolveWalletBinding(W, OWNER);
+    expect(b).toMatchObject({ boundTo: null, canOwn: false, inconclusive: true });
+  });
+
+  it('INCONCLUSIVE when the owner read of a bound account fails (don’t assume ownable)', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: '9' });
+    mocks.fetchPca.mockRejectedValue(new Error('rpc'));
+    const b = await resolveWalletBinding(W, OWNER);
+    expect(b).toMatchObject({ boundTo: '9', canOwn: false, inconclusive: true });
+  });
+});
+
+describe('selfCoverageOutlook', () => {
+  const mk = (over: Partial<{ boundTo: string | null; canOwn: boolean; inconclusive: boolean }>) =>
+    ({ wallet: W, boundTo: null, canOwn: false, inconclusive: false, ...over });
+
+  it('zeroSelfCoverage when EVERY wallet is sponsor-bound (none coverable, none inconclusive)', async () => {
+    const o = selfCoverageOutlook([mk({ boundTo: '9' }), mk({ boundTo: '8' })]);
+    expect(o.zeroSelfCoverage).toBe(true);
+    expect(o.sponsorBound).toHaveLength(2);
+    expect(o.selfCoverable).toHaveLength(0);
+  });
+
+  it('NOT zeroSelfCoverage with any coverable wallet (unbound or own-bound)', async () => {
+    expect(selfCoverageOutlook([mk({ boundTo: null }), mk({ boundTo: '9' })]).zeroSelfCoverage).toBe(false);
+    expect(selfCoverageOutlook([mk({ boundTo: '7', canOwn: true }), mk({ boundTo: '9' })]).zeroSelfCoverage).toBe(false);
+  });
+
+  it('NOT zeroSelfCoverage while a probe is inconclusive (#9 — don’t assert "covers none")', async () => {
+    const o = selfCoverageOutlook([mk({ inconclusive: true }), mk({ boundTo: '9' })]);
+    expect(o.zeroSelfCoverage).toBe(false);
+    expect(o.inconclusive).toHaveLength(1);
+  });
+
+  it('empty wallet set → not zeroSelfCoverage', async () => {
+    expect(selfCoverageOutlook([]).zeroSelfCoverage).toBe(false);
+  });
+});
+
+describe('probeWalletBindings', () => {
+  it('resolves every wallet in parallel', async () => {
+    mocks.pcaAgentAccount.mockImplementation(async (w: string) =>
+      w === W ? { agent: w, accountId: '7' } : { agent: w, accountId: null },
+    );
+    mocks.fetchPca.mockResolvedValue({ accountId: '7', owner: OWNER });
+    const out = await probeWalletBindings([W, '0xother'], OWNER);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ boundTo: '7', canOwn: true });
+    expect(out[1]).toMatchObject({ boundTo: null });
+  });
+});

--- a/packages/node-ui/test/pca-wallet-binding.test.ts
+++ b/packages/node-ui/test/pca-wallet-binding.test.ts
@@ -86,6 +86,14 @@ describe('selfCoverageOutlook', () => {
   it('empty wallet set → not zeroSelfCoverage', async () => {
     expect(selfCoverageOutlook([]).zeroSelfCoverage).toBe(false);
   });
+
+  it('ownBound (M3) counts wallets on a PCA the node owns — the migration-disclosure source', async () => {
+    const o = selfCoverageOutlook([mk({ boundTo: '4', canOwn: true }), mk({ boundTo: '9' }), mk({ boundTo: null })]);
+    expect(o.ownBound).toHaveLength(1);
+    expect(o.ownBound[0].boundTo).toBe('4');
+    expect(o.sponsorBound).toHaveLength(1); // #9 (not ownable)
+    expect(o.selfCoverable).toHaveLength(2); // own-bound #4 (migrate) + unbound
+  });
 });
 
 describe('probeWalletBindings', () => {

--- a/packages/node-ui/test/pca-wallet-binding.test.ts
+++ b/packages/node-ui/test/pca-wallet-binding.test.ts
@@ -16,11 +16,16 @@ vi.mock('../src/ui/api.js', async (orig) => {
   return { ...actual, pcaAgentAccount: mocks.pcaAgentAccount, fetchPca: mocks.fetchPca };
 });
 
-const { resolveWalletBinding, probeWalletBindings, selfCoverageOutlook } = await import('../src/ui/pca/walletBinding.js');
+const { resolveWalletBinding, probeWalletBindings, selfCoverageOutlook, planSelfCoverage } = await import('../src/ui/pca/walletBinding.js');
 
 const OWNER = '0x9A3f000000000000000000000000000000000E41D';
 const SPONSOR = '0x1111111111111111111111111111111111111111';
 const W = '0xWALLET00000000000000000000000000000000aa';
+
+// Bound-account snapshot shapes for the R1 liveness read (isPcaDead + hasPcaBudget):
+const LIVE = { expiresAtTimestamp: 9_999_999_999, fullySwept: false, baseEpochAllowance: '1000', topUpBuffer: '0' };
+const DEAD_EXPIRED = { expiresAtTimestamp: 1, fullySwept: false, baseEpochAllowance: '1000', topUpBuffer: '0' };
+const DEAD_NOBUDGET = { expiresAtTimestamp: 9_999_999_999, fullySwept: false, baseEpochAllowance: '0', topUpBuffer: '0' };
 
 beforeEach(() => { vi.clearAllMocks(); });
 afterEach(() => { vi.clearAllMocks(); });
@@ -35,16 +40,24 @@ describe('resolveWalletBinding', () => {
 
   it('own-bound (canOwn) when the bound account is owned by this node', async () => {
     mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: '7' });
-    mocks.fetchPca.mockResolvedValue({ accountId: '7', owner: OWNER });
+    mocks.fetchPca.mockResolvedValue({ accountId: '7', owner: OWNER, ...LIVE });
     const b = await resolveWalletBinding(W, OWNER);
     expect(b).toMatchObject({ boundTo: '7', canOwn: true, inconclusive: false });
   });
 
-  it('sponsor-bound (NOT canOwn) when the bound account is owned by someone else', async () => {
+  it('sponsor-bound + LIVE (NOT canOwn, boundLive) when owned by someone else & covering', async () => {
     mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: '9' });
-    mocks.fetchPca.mockResolvedValue({ accountId: '9', owner: SPONSOR });
+    mocks.fetchPca.mockResolvedValue({ accountId: '9', owner: SPONSOR, ...LIVE });
     const b = await resolveWalletBinding(W, OWNER);
-    expect(b).toMatchObject({ boundTo: '9', canOwn: false, inconclusive: false });
+    expect(b).toMatchObject({ boundTo: '9', canOwn: false, boundLive: true, inconclusive: false });
+  });
+
+  it('R1 — sponsor-bound + EXPIRED/insolvent → boundLive FALSE (not "already free")', async () => {
+    mocks.pcaAgentAccount.mockResolvedValue({ agent: W, accountId: '9' });
+    mocks.fetchPca.mockResolvedValueOnce({ accountId: '9', owner: SPONSOR, ...DEAD_EXPIRED });
+    expect((await resolveWalletBinding(W, OWNER)).boundLive).toBe(false); // expired
+    mocks.fetchPca.mockResolvedValueOnce({ accountId: '9', owner: SPONSOR, ...DEAD_NOBUDGET });
+    expect((await resolveWalletBinding(W, OWNER)).boundLive).toBe(false); // no budget
   });
 
   it('INCONCLUSIVE (#9) when the agent probe rejects — never asserted unbound/ownable', async () => {
@@ -62,8 +75,9 @@ describe('resolveWalletBinding', () => {
 });
 
 describe('selfCoverageOutlook', () => {
-  const mk = (over: Partial<{ boundTo: string | null; canOwn: boolean; inconclusive: boolean }>) =>
-    ({ wallet: W, boundTo: null, canOwn: false, inconclusive: false, ...over });
+  // boundLive defaults TRUE (a bound wallet is on a LIVE account unless a test says otherwise).
+  const mk = (over: Partial<{ boundTo: string | null; canOwn: boolean; boundLive: boolean; inconclusive: boolean }>) =>
+    ({ wallet: W, boundTo: null, canOwn: false, boundLive: true, inconclusive: false, ...over });
 
   it('zeroSelfCoverage when EVERY wallet is sponsor-bound (none coverable, none inconclusive)', async () => {
     const o = selfCoverageOutlook([mk({ boundTo: '9' }), mk({ boundTo: '8' })]);
@@ -91,8 +105,33 @@ describe('selfCoverageOutlook', () => {
     const o = selfCoverageOutlook([mk({ boundTo: '4', canOwn: true }), mk({ boundTo: '9' }), mk({ boundTo: null })]);
     expect(o.ownBound).toHaveLength(1);
     expect(o.ownBound[0].boundTo).toBe('4');
-    expect(o.sponsorBound).toHaveLength(1); // #9 (not ownable)
+    expect(o.sponsorBound).toHaveLength(1); // #9 (live, not ownable)
     expect(o.selfCoverable).toHaveLength(2); // own-bound #4 (migrate) + unbound
+  });
+
+  it('R1 — a DEAD sponsor binding is sponsorDead (NOT sponsorBound "already free")', async () => {
+    const o = selfCoverageOutlook([mk({ boundTo: '9', boundLive: true }), mk({ boundTo: '8', boundLive: false })]);
+    expect(o.sponsorBound.map((b) => b.boundTo)).toEqual(['9']); // only the live one
+    expect(o.sponsorDead.map((b) => b.boundTo)).toEqual(['8']); // the expired/insolvent one
+  });
+});
+
+describe('planSelfCoverage (R5)', () => {
+  const mk = (over: Partial<{ boundTo: string | null; canOwn: boolean; boundLive: boolean; inconclusive: boolean }>) =>
+    ({ wallet: W, boundTo: null, canOwn: false, boundLive: true, inconclusive: false, ...over });
+
+  it('unbound → register; inconclusive → register (fall through to the backstop)', () => {
+    expect(planSelfCoverage(mk({ boundTo: null })).kind).toBe('register');
+    expect(planSelfCoverage(mk({ boundTo: '9', inconclusive: true })).kind).toBe('register');
+  });
+  it('own-bound → deregisterThenRegister(prevAccountId)', () => {
+    expect(planSelfCoverage(mk({ boundTo: '4', canOwn: true }))).toEqual({ kind: 'deregisterThenRegister', prevAccountId: '4' });
+  });
+  it('sponsor-bound + LIVE → skipSponsored', () => {
+    expect(planSelfCoverage(mk({ boundTo: '9', boundLive: true }))).toEqual({ kind: 'skipSponsored', prevAccountId: '9' });
+  });
+  it('R1 — sponsor-bound + DEAD → conflictSponsorDead (NOT skipSponsored)', () => {
+    expect(planSelfCoverage(mk({ boundTo: '9', boundLive: false }))).toEqual({ kind: 'conflictSponsorDead', prevAccountId: '9' });
   });
 });
 

--- a/packages/node-ui/test/use-modal-dismiss.test.ts
+++ b/packages/node-ui/test/use-modal-dismiss.test.ts
@@ -280,18 +280,39 @@ describe('useModalDismiss (BUG-017)', () => {
     expect(document.activeElement).toBe(last);
   });
 
-  it('uses capture phase so Escape inside a child <input> still closes the dialog (BUG-017 regression guard)', async () => {
+  it('Escape inside a child <input> bubbles up and still closes the dialog (BUG-017 regression guard)', async () => {
     const onClose = vi.fn();
     mount(true, onClose, React.createElement('input', { id: 'inside-input', defaultValue: '' }));
     await tick();
     const input = document.getElementById('inside-input') as HTMLInputElement;
     input.focus();
 
-    // Dispatch via input so the event starts at the input target. The
-    // hook listens at the window level with capture=true so Escape
-    // reaches the handler before any input keybinding could swallow
-    // it.
+    // Dispatch via the input so the event starts at the input target. The hook listens at
+    // the window level in the BUBBLE phase, so an Escape from a child that doesn't stop
+    // propagation reaches the handler and dismisses the dialog.
     input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does NOT special-case an expanded combobox child — Escape dismisses generically (no widget coupling)', async () => {
+    // Regression guard: a previous fix made the hook query for
+    // `[role="combobox"][aria-expanded="true"]` and no-op Escape when one was open,
+    // coupling the SHARED hook to combobox DOM internals. The hook is now generic — a
+    // widget that wants to own Escape must stop propagation in its OWN handler. A bare
+    // expanded combobox with no handler therefore does NOT suppress the dialog dismiss.
+    const onClose = vi.fn();
+    mount(
+      true,
+      onClose,
+      React.createElement('input', {
+        id: 'bare-combobox',
+        role: 'combobox',
+        'aria-expanded': 'true',
+        defaultValue: '',
+      }),
+    );
+    await tick();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Sub-PR #1 of the PCA hardware-wallet phase — edge-create + the staked-node picker (no web3)

Into the integration branch `feat/pca-node-ui`. This is the **first of two** sub-PRs adding hardware-wallet PCA support (per `agent-docs/publishing-conviction/PCA-IMPLEMENTATION-PLAN.md` §9); it is the **daemon-signed, no-web3 half**. Sub-PR #2 (`feat/pca-hw`) adds the browser-signing layer.

### What's in this PR
- **Edge nodes can now create PCAs.** The create-gate is removed — the Create wizard opens for any node (incl. edge / no-own-identity). An edge designates a **staked sharding-table node** as `primaryNode` (a node-pick is required; `primaryNode=0` is rejected by the daemon).
- **`PrimaryNodePicker`** — an always-visible, required, searchable node picker (combobox a11y; `#<identityId>` is the prominent verifiable id, peer `nodeId` secondary + "unverified" label, stake shown). Core auto-selects its own staked node when present in the live list (M3 cross-check); edge must pick. Honest reward-weight donation copy (an edge that picks a node donates that account's reward weight to it — it gets only the discount).
- **`GET /api/pca/designatable-nodes`** — new daemon read route serving the staked-node list via the on-chain `ShardingTable.getShardingTable()` (the table is capped at `shardingTableSizeLimit`, read whole in one call), adapter-side ~30s TTL cache, offset pagination `{nodes,total,nextStart}`, `?fresh=1` cache-bust, dedicated `SHARDING_TABLE_READ_FAILED` code. Registered before the generic `:id` matcher.
- **B1 pre-flight wallet-binding probe** — read-only at wizard open: per op wallet, unbound→register / own-bound→deregister-first / sponsor-bound→skip+warn / inconclusive→#9-safe. Deregister runs per-wallet **after a confirmed mint** (never before create). Zero-self-coverage shows a **loud informed-consent warning** (create-to-sponsor-others stays valid — not a hard block).
- Edge S1 surfaces "Create a conviction account" alongside the recommended-free "Get sponsored".

**No contract change.** Browser uses no web3 (the picker list is daemon-served).

### Quality
Built and gated per the per-phase protocol:
- A 7-lens adversarial code-gate (verdict PUSH-AFTER-FIXES) confirmed the core sound (B1 read-only probe, deregister-after-mint ordering, no-arg overload/decode, route-ordering, honest copy) and surfaced fixes — all applied before push: H1 (Escape no longer discards the Create form), H2 (self-coverage gated to `mode==='self'` — no silent third-party deregister), H3 (real invariant test), M3 (own-bound migration disclosure), M4 (`?fresh=1` cache-bust so the recoverable revert works), M5 (stranded-wallet recovery), M1 (aria-required/invalid), L1/L10/N2/N3/N5.
- **Tests green:** node-ui suite 1768/0; daemon-route 78; chain real-Hardhat 13; mock 28; facade 10; tsc clean across chain/agent/cli.
- Fast-follow during convergence (before merge): the remaining FE test-gaps (combobox-keyboard, hook, recoverable-revert, etc.) + a few LOW/NIT polish items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
