### PR TITLE
fix(pca): proxy hardware wallet RPC reads

### DIFF
--- a/network/mainnet-base.json
+++ b/network/mainnet-base.json
@@ -20,6 +20,11 @@
       "https://base-rpc.publicnode.com",
       "https://base.drpc.org"
     ],
+    "walletRpcUrls": [
+      "https://mainnet.base.org",
+      "https://base-rpc.publicnode.com",
+      "https://base.drpc.org"
+    ],
     "hubAddress": "0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13"
   },
   "autoUpdate": {

--- a/network/mainnet-gnosis.json
+++ b/network/mainnet-gnosis.json
@@ -22,6 +22,11 @@
       "https://gnosis-rpc.publicnode.com",
       "https://gnosis.drpc.org"
     ],
+    "walletRpcUrls": [
+      "https://rpc.gnosischain.com",
+      "https://gnosis-rpc.publicnode.com",
+      "https://gnosis.drpc.org"
+    ],
     "hubAddress": "0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f"
   },
   "autoUpdate": {

--- a/network/testnet.json
+++ b/network/testnet.json
@@ -26,6 +26,11 @@
       "https://base-sepolia-rpc.publicnode.com",
       "https://base-sepolia.drpc.org"
     ],
+    "walletRpcUrls": [
+      "https://sepolia.base.org",
+      "https://base-sepolia-rpc.publicnode.com",
+      "https://base-sepolia.drpc.org"
+    ],
     "hubAddress": "0xC056e67Da4F51377Ad1B01f50F655fFdcCD809F6",
     "chainId": "base:84532"
   },

--- a/packages/agent/src/dkg-agent-registry.ts
+++ b/packages/agent/src/dkg-agent-registry.ts
@@ -95,7 +95,7 @@ import {
   pickNetworkTunables,
 } from '@origintrail-official/dkg-core';
 import { GraphManager, PrivateContentStore, createTripleStore, type TripleStore, type TripleStoreConfig, type Quad, type LargeLiteralStorageConfig } from '@origintrail-official/dkg-storage';
-import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type PcaAccountRelation, type ShardingTableNode, type PcaContracts } from '@origintrail-official/dkg-chain';
+import { EVMChainAdapter, NoChainAdapter, enrichEvmError, buildKnowledgeAssetUal, PcaUnavailableError, type EVMAdapterConfig, type ChainAdapter, type CreateContextGraphParams, type CreateOnChainContextGraphParams, type CreateOnChainContextGraphResult, type TxResult, type V10PublishingConvictionAccountInfo, type PcaAccountRelation, type ShardingTableNode, type PcaContracts, type PcaRpcMethod } from '@origintrail-official/dkg-chain';
 import {
   DKGPublisher, PublishHandler, SharedMemoryHandler, UpdateHandler, ChainEventPoller, AccessHandler, AccessClient,
   PublishJournal, StaleWriteError,
@@ -1473,6 +1473,11 @@ export class AgentRegistryMethods extends DKGAgentBase {
     return typeof this.chain.getPublishingConvictionAccountInfo === 'function';
   }
 
+  /** True when the adapter can serve the daemon's PCA browser-read RPC bridge. */
+  get supportsPublishingConvictionRpc(): boolean {
+    return typeof this.chain.requestPublishingConvictionRpc === 'function';
+  }
+
   // OT-RFC-51: `primaryNode` (the node identityId this PCA's committed TRAC
   // funds via the publishing factor) is REQUIRED — no silent `0n` default. A
   // PCA created with node 0 seeds no allocation to anyone, and the SDK exposes
@@ -1566,6 +1571,18 @@ export class AgentRegistryMethods extends DKGAgentBase {
   async getPublishingConvictionContracts(this: DKGAgent): Promise<PcaContracts | null> {
     if (typeof this.chain.getPublishingConvictionContracts !== 'function') return null;
     return this.chain.getPublishingConvictionContracts();
+  }
+
+  /** Daemon-internal JSON-RPC read bridge for PCA browser reads. The daemon
+   *  route owns the method allowlist and response shaping; the adapter owns the
+   *  provider/failover execution. */
+  async requestPublishingConvictionRpc(
+    this: DKGAgent,
+    method: PcaRpcMethod,
+    params?: unknown[],
+  ): Promise<unknown> {
+    if (typeof this.chain.requestPublishingConvictionRpc !== 'function') throw new PcaUnavailableError();
+    return this.chain.requestPublishingConvictionRpc(method, params);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/agent/src/dkg-agent-types.ts
+++ b/packages/agent/src/dkg-agent-types.ts
@@ -1011,6 +1011,8 @@ export interface DKGAgentConfig {
   chainConfig?: {
     rpcUrl: string;
     rpcUrls?: string[];
+    /** Public RPC URLs safe for wallet_addEthereumChain. Never use private operator RPC URLs here. */
+    walletRpcUrls?: string[];
     hubAddress: string;
     /** Optional TRAC token contract override. When omitted, the adapter resolves Hub.Token. */
     tokenAddress?: string;

--- a/packages/agent/src/dkg-agent.ts
+++ b/packages/agent/src/dkg-agent.ts
@@ -525,6 +525,7 @@ export class DKGAgent extends DKGAgentBase {
       const evmConfigBase = {
         rpcUrl: config.chainConfig.rpcUrl,
         rpcUrls: config.chainConfig.rpcUrls,
+        walletRpcUrls: config.chainConfig.walletRpcUrls,
         privateKey: opKeys[0],
         additionalKeys: opKeys.slice(1),
         hubAddress: config.chainConfig.hubAddress,

--- a/packages/agent/test/pca-v10-facade.test.ts
+++ b/packages/agent/test/pca-v10-facade.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { DKGAgent } from '../src/index.js';
-import { MockChainAdapter, NoChainAdapter } from '@origintrail-official/dkg-chain';
+import { MockChainAdapter, NoChainAdapter, PcaUnavailableError } from '@origintrail-official/dkg-chain';
 
 async function makeAgent(chain: MockChainAdapter | NoChainAdapter): Promise<DKGAgent> {
   return DKGAgent.create({
@@ -41,6 +41,15 @@ describe('DKGAgent V10 PCA facade', () => {
   it('supportsPublishingConvictionNft is false when the adapter lacks the V10 surface', async () => {
     const agent = await makeAgent(new NoChainAdapter());
     expect(agent.supportsPublishingConvictionNft).toBe(false);
+  });
+
+  it('supportsPublishingConvictionRpc reflects the adapter bridge capability', async () => {
+    const chain = new MockChainAdapter('mock:31337', ethers.Wallet.createRandom().address);
+    const agent = await makeAgent(chain);
+    expect(agent.supportsPublishingConvictionRpc).toBe(true);
+
+    const noChainAgent = await makeAgent(new NoChainAdapter());
+    expect(noChainAgent.supportsPublishingConvictionRpc).toBe(false);
   });
 
   it('getPublishingConvictionAgents delegates to the adapter (checksummed list)', async () => {
@@ -137,14 +146,35 @@ describe('DKGAgent V10 PCA facade', () => {
 
   it('getPublishingConvictionContracts delegates to the adapter; null when unsupported (sub-PR #2)', async () => {
     const chain = new MockChainAdapter('mock:31337', ethers.Wallet.createRandom().address);
+    const getContracts = vi.spyOn(chain, 'getPublishingConvictionContracts').mockResolvedValue({
+      nft: ethers.Wallet.createRandom().address,
+      token: ethers.Wallet.createRandom().address,
+      chainId: 'mock:31337',
+      rpcUrls: [],
+      walletRpcUrls: [],
+    });
     const agent = await makeAgent(chain);
     const c = await agent.getPublishingConvictionContracts();
     expect(c).not.toBeNull();
+    expect(getContracts).toHaveBeenCalledOnce();
     expect(c!.chainId).toBe('mock:31337');
     expect(c!.nft).toBe(ethers.getAddress(c!.nft)); // EIP-55 surfaced through the facade
-    expect(Array.isArray(c!.rpcUrls)).toBe(true);
+    expect(c!.rpcUrls).toEqual([]);
+    expect(c!.walletRpcUrls).toEqual([]);
 
     const none = await makeAgent(new NoChainAdapter());
     expect(await none.getPublishingConvictionContracts()).toBeNull();
+  });
+
+  it('requestPublishingConvictionRpc delegates to the adapter; unavailable when unsupported', async () => {
+    const chain = new MockChainAdapter('mock:31337', ethers.Wallet.createRandom().address);
+    const rpc = vi.fn(async () => '0x7a69');
+    (chain as any).requestPublishingConvictionRpc = rpc;
+    const agent = await makeAgent(chain);
+    await expect(agent.requestPublishingConvictionRpc('eth_chainId', [])).resolves.toBe('0x7a69');
+    expect(rpc).toHaveBeenCalledWith('eth_chainId', []);
+
+    const none = await makeAgent(new NoChainAdapter());
+    await expect(none.requestPublishingConvictionRpc('eth_chainId', [])).rejects.toBeInstanceOf(PcaUnavailableError);
   });
 });

--- a/packages/agent/vitest.unit.config.ts
+++ b/packages/agent/vitest.unit.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "test/swm/host-mode-store.test.ts",
       "test/swm/host-mode-key-canonicalization.test.ts",
       "test/profile-fix-verify.test.ts",
+      "test/pca-v10-facade.test.ts",
       "test/sync-verify-collapsed.test.ts",
       "test/durable-sync-since-threading.test.ts",
       "test/sync-responder-concurrent-interleaving.test.ts",

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -33,7 +33,10 @@ export interface ShardingTableNode {
  *  writes + ERC721Enumerable discovery + the mint-Transfer accountId parse),
  *  `token` = TRAC ERC-20 (the approve pre-step). Addresses EIP-55 checksummed.
  *  `chainId` is AS-IS (may be the compound `base:84532` form — the FE extracts
- *  the numeric tail for viem's Chain.id). `rpcUrls` feeds the viem transport.
+ *  the numeric tail for viem's Chain.id). `rpcUrls` is browser-safe read
+ *  transport metadata and MUST NOT expose operator/private adapter RPC URLs or
+ *  embedded provider keys; daemon HTTP bootstrap may replace it with its
+ *  same-origin proxy path.
  *  Logic/Hub/ShardingTable are intentionally excluded (no browser action
  *  touches them; the picker is daemon-served). */
 export interface PcaContracts {
@@ -41,7 +44,17 @@ export interface PcaContracts {
   token: string;
   chainId: string;
   rpcUrls: string[];
+  /** Optional public RPCs that may be handed to wallet_addEthereumChain. */
+  walletRpcUrls?: string[];
 }
+
+export type PcaRpcMethod =
+  | 'eth_chainId'
+  | 'eth_call'
+  | 'eth_getTransactionReceipt'
+  | 'eth_getTransactionByHash'
+  | 'eth_blockNumber'
+  | 'eth_getBlockByNumber';
 
 export interface ConvictionReader {
   getConvictionAgentAccountId(agent: string): Promise<bigint>;
@@ -59,6 +72,9 @@ export interface ConvictionReader {
   /** Browser-bootstrap contract addresses + chain params for the HW signing
    *  layer (sub-PR #2). Optional, same rationale as the other PCA reads. */
   getPublishingConvictionContracts?(): Promise<PcaContracts>;
+  /** Daemon-internal read-only JSON-RPC bridge for the browser-safe PCA RPC
+   *  proxy. HTTP routes own the method allowlist; adapters only perform reads. */
+  requestPublishingConvictionRpc?(method: PcaRpcMethod, params?: unknown[]): Promise<unknown>;
 }
 
 export interface IdentityProof {
@@ -968,13 +984,18 @@ export interface ChainAdapter {
   listDesignatableNodes?(opts?: { fresh?: boolean }): Promise<ShardingTableNode[]>;
 
   /**
-   * Browser-bootstrap contract addresses + chain params for the sub-PR #2 HW
-   * signing layer: { nft, token, chainId, rpcUrls } (EIP-55, chainId AS-IS).
-   * The minimal set the in-browser viem layer needs — no Hub/logic/ShardingTable
-   * (those aren't touched by any browser owner-action). Optional for the same
-   * reason as the other PCA reads.
+   * Browser-bootstrap contract addresses + browser-safe chain transport for the
+   * sub-PR #2 HW signing layer. The daemon boundary must not expose the raw
+   * operator/private adapter RPC URLs here.
    */
   getPublishingConvictionContracts?(): Promise<PcaContracts>;
+
+  /**
+   * Daemon-internal read-only JSON-RPC bridge used by `/api/pca/rpc`. The HTTP
+   * route owns the allowlist; adapters forward the allowed reads to their
+   * existing provider/failover layer without exposing endpoint URLs.
+   */
+  requestPublishingConvictionRpc?(method: PcaRpcMethod, params?: unknown[]): Promise<unknown>;
 
   /**
    * Returns the V10 NFT-backed PCA's `lockDurationEpochs` for the given

--- a/packages/chain/src/evm-adapter-base.ts
+++ b/packages/chain/src/evm-adapter-base.ts
@@ -369,6 +369,8 @@ export class EVMChainAdapterBase {
 
   protected readonly rpcUrls: string[];
 
+  protected readonly walletRpcUrls: string[];
+
   /**
    * The pure per-endpoint RPC transport mechanism. Owns the read-failover loop +
    * the named timeout-policy matrix + typed exhaustion; constructed with a LIVE
@@ -602,6 +604,11 @@ export class EVMChainAdapterBase {
 
   constructor(config: EVMAdapterConfig) {
     this.rpcUrls = resolveRpcUrls(config.rpcUrl, config.rpcUrls);
+    this.walletRpcUrls = Array.from(new Set(
+      (config.walletRpcUrls ?? [])
+        .map((url) => typeof url === 'string' ? url.trim() : '')
+        .filter((url) => /^https?:\/\//i.test(url)),
+    ));
     // Floor a finite `>= 1` value (so e.g. 10000.5 -> 10000, preserving the
     // window); only a `< 1` (or non-finite) value falls back to the default — a
     // fractional value in (0,1) must NOT floor to 0 (which makes pages Infinity).

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -11,7 +11,7 @@
 
 import { EVMChainAdapterBase } from './evm-adapter-base.js';
 import { ethers, Contract } from 'ethers';
-import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader, PcaAccountRelation, ShardingTableNode, PcaContracts } from './chain-adapter.js';
+import type { TxResult, V10PublishingConvictionAccountInfo, ConvictionReader, PcaAccountRelation, ShardingTableNode, PcaContracts, PcaRpcMethod } from './chain-adapter.js';
 import { PcaUnavailableError } from './pca-errors.js';
 import { enrichEvmError, getPcaLogicInterface } from './evm-adapter-errors.js';
 
@@ -600,6 +600,9 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
    *   - `token` = the TRAC ERC-20 the approve pre-step allows the wrapper to pull.
    * Both EIP-55 checksummed. `chainId` is returned AS-IS (may be the compound
    * `base:84532` form — the FE extracts the numeric tail for viem's Chain.id).
+   * `rpcUrls` contains only configured wallet-public endpoints. The daemon route
+   * replaces it with same-origin `/api/pca/rpc` for node-UI browser reads so
+   * configured operator RPC URLs/API keys never leave the node process.
    * Undeployed NFT/token → PcaUnavailableError (route → 503), the same
    * capability signal as the other PCA reads. NO Hub/logic/ShardingTable — no
    * browser owner-action touches them.
@@ -613,7 +616,13 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
       nft: ethers.getAddress(await nft.getAddress()),
       token: ethers.getAddress(await token.getAddress()),
       chainId: this.chainId,
-      rpcUrls: this.getRpcUrls(),
+      rpcUrls: [...this.walletRpcUrls],
+      walletRpcUrls: [...this.walletRpcUrls],
     };
+  }
+
+  async requestPublishingConvictionRpc(method: PcaRpcMethod, params: unknown[] = []): Promise<unknown> {
+    await this.init();
+    return this.readProvider(`pca rpc ${method}`, (provider) => provider.send(method, params));
   }
 }

--- a/packages/chain/src/evm-adapter-types.ts
+++ b/packages/chain/src/evm-adapter-types.ts
@@ -11,6 +11,12 @@ import type { ApprovalPolicy } from './chain-adapter.js';
 export interface EVMAdapterBaseConfig {
   rpcUrl: string;
   rpcUrls?: string[];
+  /**
+   * Public RPC endpoints safe to hand to browser wallets for
+   * `wallet_addEthereumChain`. These are intentionally separate from
+   * rpcUrl/rpcUrls, which may be private operator/provider endpoints.
+   */
+  walletRpcUrls?: string[];
   /** Primary operational wallet key (used for identity registration, staking, etc.) */
   privateKey: string;
   /** Additional operational wallet keys for parallel transaction submission. */

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -27,6 +27,7 @@ import type {
   PcaAccountRelation,
   ShardingTableNode,
   PcaContracts,
+  PcaRpcMethod,
 } from './chain-adapter.js';
 import {
   NoEligibleContextGraphError,
@@ -713,14 +714,34 @@ export class MockChainAdapter implements ChainAdapter {
   }
 
   /** Browser-bootstrap parity (sub-PR #2) — fixed checksummed addresses + the
-   *  mock chainId + rpcUrls. */
+   *  mock chainId. Browser RPC transport is daemon-owned, so the mock does not
+   *  expose adapter/private RPC endpoints here. */
   async getPublishingConvictionContracts(): Promise<PcaContracts> {
     return {
       nft: ethers.getAddress('0x' + '11'.repeat(20)),
       token: ethers.getAddress('0x' + '22'.repeat(20)),
       chainId: this.chainId,
-      rpcUrls: this.getRpcUrls(),
+      rpcUrls: [],
+      walletRpcUrls: [],
     };
+  }
+
+  async requestPublishingConvictionRpc(method: PcaRpcMethod, _params: unknown[] = []): Promise<unknown> {
+    switch (method) {
+      case 'eth_chainId': {
+        const tail = this.chainId.includes(':') ? this.chainId.split(':').pop()! : this.chainId;
+        return `0x${Number(tail).toString(16)}`;
+      }
+      case 'eth_blockNumber':
+        return `0x${this.nextBlock.toString(16)}`;
+      case 'eth_call':
+        return '0x' + '0'.repeat(64);
+      case 'eth_getBlockByNumber':
+        return { number: `0x${this.nextBlock.toString(16)}` };
+      case 'eth_getTransactionReceipt':
+      case 'eth_getTransactionByHash':
+        return null;
+    }
   }
 
   /** Mirrors `agentToAccountId`; `0n` for unregistered → publisher SDK

--- a/packages/chain/test/evm-adapter-pca-rpc.unit.test.ts
+++ b/packages/chain/test/evm-adapter-pca-rpc.unit.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { EVMChainAdapter, type EVMAdapterConfig } from '../src/evm-adapter.js';
+import { isChainRpcTransportError } from '../src/chain-rpc-transport-error.js';
+import { _resetRpcFailoverStatsForTest } from '../src/rpc-failover-log.js';
+
+const PK = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const HUB = '0x0000000000000000000000000000000000000001';
+
+function recorder<A extends unknown[], R>(impl: (...args: A) => R) {
+  const calls: A[] = [];
+  const fn = (...args: A): R => { calls.push(args); return impl(...args); };
+  return Object.assign(fn, { calls });
+}
+
+function minimalConfig(overrides: Partial<EVMAdapterConfig> = {}): EVMAdapterConfig {
+  return {
+    rpcUrl: 'https://primary.example',
+    privateKey: PK,
+    hubAddress: HUB,
+    chainId: 'evm:31337',
+    allowNoAdminSigner: true,
+    ...overrides,
+  };
+}
+
+function retryable429(): Error {
+  const err = new Error('429 too many requests');
+  (err as { status?: number }).status = 429;
+  return err;
+}
+
+type SendProvider = {
+  send: (method: string, params: unknown[]) => Promise<unknown>;
+};
+
+function pcaRpcAdapter(providers: SendProvider[], rpcUrls: string[]): EVMChainAdapter {
+  const adapter = new EVMChainAdapter(minimalConfig({ rpcUrl: rpcUrls[0], rpcUrls: rpcUrls.slice(1) }));
+  (adapter as unknown as { init: () => Promise<void> }).init = async () => undefined;
+  (adapter as unknown as { providers: SendProvider[] }).providers = providers;
+  (adapter as unknown as { rpcUrls: string[] }).rpcUrls = rpcUrls;
+  return adapter;
+}
+
+describe('EVMChainAdapter PCA RPC bridge', () => {
+  beforeEach(() => { _resetRpcFailoverStatsForTest(); });
+  afterEach(() => { _resetRpcFailoverStatsForTest(); });
+
+  it('requestPublishingConvictionRpc reads through the provider failover loop', async () => {
+    const primary = {
+      send: recorder(async () => { throw retryable429(); }),
+    };
+    const backup = {
+      send: recorder(async (method: string, params: unknown[]) => ({ method, params, endpoint: 'backup' })),
+    };
+    const adapter = pcaRpcAdapter(
+      [primary, backup],
+      ['https://primary.example/v2/SECRETKEY', 'https://backup.example'],
+    );
+
+    await expect(adapter.requestPublishingConvictionRpc('eth_chainId', []))
+      .resolves.toEqual({ method: 'eth_chainId', params: [], endpoint: 'backup' });
+
+    expect(primary.send.calls).toEqual([['eth_chainId', []]]);
+    expect(backup.send.calls).toEqual([['eth_chainId', []]]);
+  });
+
+  it('requestPublishingConvictionRpc surfaces typed host-only exhaustion when all endpoints fail', async () => {
+    const primary = {
+      send: recorder(async () => { throw retryable429(); }),
+    };
+    const backup = {
+      send: recorder(async () => { throw retryable429(); }),
+    };
+    const adapter = pcaRpcAdapter(
+      [primary, backup],
+      ['https://primary.example/v2/SECRETKEY', 'https://backup.example'],
+    );
+
+    let thrown: unknown;
+    try {
+      await adapter.requestPublishingConvictionRpc('eth_chainId', []);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(isChainRpcTransportError(thrown)).toBe(true);
+    expect(thrown).toMatchObject({ code: 'RPC_ENDPOINTS_EXHAUSTED' });
+    expect(String((thrown as Error).message)).toContain('primary.example');
+    expect(String((thrown as Error).message)).not.toContain('SECRETKEY');
+    expect(String((thrown as Error).message)).not.toContain('https://');
+    expect(primary.send.calls).toEqual([['eth_chainId', []]]);
+    expect(backup.send.calls).toEqual([['eth_chainId', []]]);
+  });
+
+  it('getPublishingConvictionContracts returns configured wallet-public RPCs without private adapter RPCs', async () => {
+    const adapter = new EVMChainAdapter(minimalConfig({
+      rpcUrl: 'https://private-rpc.example/v2/SECRETKEY',
+      walletRpcUrls: [' https://wallet-rpc.example/base-sepolia ', 'https://wallet-rpc.example/base-sepolia'],
+    }));
+    (adapter as unknown as { init: () => Promise<void> }).init = async () => undefined;
+    (adapter as unknown as {
+      contracts: {
+        dkgPublishingConvictionNFT: { getAddress: () => Promise<string> };
+        token: { getAddress: () => Promise<string> };
+      };
+    }).contracts = {
+      dkgPublishingConvictionNFT: { getAddress: async () => '0x' + '11'.repeat(20) },
+      token: { getAddress: async () => '0x' + '22'.repeat(20) },
+    };
+
+    const contracts = await adapter.getPublishingConvictionContracts();
+
+    expect(contracts.rpcUrls).toEqual(['https://wallet-rpc.example/base-sepolia']);
+    expect(contracts.walletRpcUrls).toEqual(['https://wallet-rpc.example/base-sepolia']);
+    expect(JSON.stringify(contracts)).not.toContain('SECRETKEY');
+    expect(JSON.stringify(contracts)).not.toContain('private-rpc.example');
+  });
+});

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { ethers } from 'ethers';
 import { MockChainAdapter } from '../src/mock-adapter.js';
 import { toShardingTableNode } from '../src/evm-adapter-conviction.js';
+import type { PcaRpcMethod } from '../src/chain-adapter.js';
 
 const SIGNER = '0x1111111111111111111111111111111111111111';
 const COMMITTED = ethers.parseEther('10000');
@@ -191,7 +192,37 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
     expect(c.token).toBe(ethers.getAddress(c.token));
     expect(c.nft).not.toBe(c.token);
     expect(c.chainId).toBe('mock:31337');
-    expect(Array.isArray(c.rpcUrls)).toBe(true);
+    expect(c.rpcUrls).toEqual([]);
+    expect(c.walletRpcUrls).toEqual([]);
+  });
+
+  it('getPublishingConvictionContracts does not leak SECRETKEY from adapter getRpcUrls', async () => {
+    class SecretRpcMock extends MockChainAdapter {
+      override getRpcUrls(): string[] {
+        return ['https://rpc.example/v2/SECRETKEY'];
+      }
+    }
+    const mock = new SecretRpcMock('mock:31337', SIGNER);
+    const c = await mock.getPublishingConvictionContracts();
+    expect(JSON.stringify(c)).not.toContain('SECRETKEY');
+    expect(JSON.stringify(c)).not.toContain('https://rpc.example');
+    expect(c.rpcUrls).toEqual([]);
+  });
+
+  it('requestPublishingConvictionRpc covers the full PCA RPC method union', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const methods: PcaRpcMethod[] = [
+      'eth_chainId',
+      'eth_call',
+      'eth_getTransactionReceipt',
+      'eth_getTransactionByHash',
+      'eth_blockNumber',
+      'eth_getBlockByNumber',
+    ];
+
+    for (const method of methods) {
+      await expect(mock.requestPublishingConvictionRpc(method, [])).resolves.not.toBeUndefined();
+    }
   });
 
   it('toShardingTableNode normalizes both ethers Result shapes — named object + positional tuple (R6)', () => {

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -271,7 +271,8 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(c.token).toBe(expectedToken); // the deployed TRAC, EIP-55 checksummed
     expect(c.nft).not.toBe(c.token);
     expect(c.chainId).toBe(reader.chainId);       // AS-IS, the adapter's configured chainId
-    expect(c.rpcUrls).toEqual(reader.getRpcUrls()); // the viem transport set
+    expect(c.rpcUrls).toEqual([]);                // raw operator RPC URLs stay daemon-internal
+    expect(c.walletRpcUrls).toEqual([]);
   });
 
   it('getPublishingConvictionAgents enumerates registered agents (checksummed) and reflects deregistration', async () => {

--- a/packages/chain/vitest.unit.config.ts
+++ b/packages/chain/vitest.unit.config.ts
@@ -19,9 +19,11 @@ export default defineConfig({
     // but do not follow the `.unit.test.ts` naming convention.
     include: [
       'test/**/*.unit.test.ts',
+      'test/evm-adapter-pca-rpc.unit.test.ts',
       'test/evm-adapter-pca-enrich.test.ts',
       'test/filter-error-console-suppressor.test.ts',
       'test/filter-error-silencer.test.ts',
+      'test/mock-adapter-publishing-conviction-v10.test.ts',
     ],
     exclude: ['**/node_modules/**', '**/dist/**'],
     testTimeout: 30_000,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -147,6 +147,8 @@ export interface NetworkConfig {
     type: 'evm';
     rpcUrl: string;
     rpcUrls?: string[];
+    /** Public RPC URLs safe to expose to browser wallets for wallet_addEthereumChain. */
+    walletRpcUrls?: string[];
     hubAddress: string;
     tokenAddress?: string;
     chainId: string;
@@ -230,6 +232,8 @@ export interface ChainConfig {
   rpcUrl: string;
   /** Ordered JSON-RPC backup endpoints. `rpcUrl` remains the primary endpoint. */
   rpcUrls?: string[];
+  /** Public RPC URLs safe to expose to browser wallets for wallet_addEthereumChain. */
+  walletRpcUrls?: string[];
   /** Hub contract address */
   hubAddress: string;
   /** Optional token contract address override. When omitted, resolve from Hub.Token. */
@@ -1143,15 +1147,15 @@ export function resolveChainConfig(
   // backups stay valid failover and must NOT be dropped. A non-loopback private
   // primary on the SAME chain still inherits the public backups; explicit
   // operator `rpcUrls` always win.
-  const operatorPinnedDifferentChain =
-    cfg?.rpcUrls === undefined &&
+  const operatorPinnedOffOverlayPrimary =
     typeof cfg?.rpcUrl === 'string' &&
     (
       isLoopbackRpcUrl(cfg.rpcUrl) ||
       (cfg?.chainId !== undefined && net?.chainId !== undefined && cfg.chainId !== net.chainId)
     );
+  const suppressInheritedBackups = cfg?.rpcUrls === undefined && operatorPinnedOffOverlayPrimary;
   const backupRpcUrls =
-    cfg?.rpcUrls ?? (operatorPinnedDifferentChain ? [] : net?.rpcUrls) ?? [];
+    cfg?.rpcUrls ?? (suppressInheritedBackups ? [] : net?.rpcUrls) ?? [];
   const orderedRpcUrls: string[] = [];
   for (const candidate of [primaryRpcUrl, ...backupRpcUrls]) {
     if (typeof candidate !== 'string') continue;
@@ -1162,6 +1166,15 @@ export function resolveChainConfig(
   if (orderedRpcUrls[0] !== undefined) merged.rpcUrl = orderedRpcUrls[0];
   if (orderedRpcUrls.length > 1 || cfg?.rpcUrls !== undefined || net?.rpcUrls !== undefined) {
     merged.rpcUrls = orderedRpcUrls.slice(1);
+  }
+  const walletRpcUrls = cfg?.walletRpcUrls ?? (operatorPinnedOffOverlayPrimary ? undefined : net?.walletRpcUrls);
+  if (walletRpcUrls !== undefined) {
+    merged.walletRpcUrls = Array.from(new Set(
+      walletRpcUrls
+        .filter((candidate): candidate is string => typeof candidate === 'string')
+        .map((candidate) => candidate.trim())
+        .filter(Boolean),
+    ));
   }
   const hubAddress = cfg?.hubAddress ?? net?.hubAddress;
   if (hubAddress !== undefined) merged.hubAddress = hubAddress;

--- a/packages/cli/src/daemon/lifecycle.ts
+++ b/packages/cli/src/daemon/lifecycle.ts
@@ -1362,6 +1362,7 @@ export async function runDaemonInner(
     chainConfig: chainBase?.rpcUrl && chainBase?.hubAddress ? {
       rpcUrl: chainBase.rpcUrl,
       rpcUrls: chainBase.rpcUrls,
+      walletRpcUrls: chainBase.walletRpcUrls,
       hubAddress: chainBase.hubAddress,
       tokenAddress: chainBase.tokenAddress,
       ...(opWallets.adminWallet

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -4,12 +4,46 @@
 import { ethers } from 'ethers';
 import {
   isPcaUnavailableError,
+  type PcaContracts,
+  type PcaRpcMethod,
   type V10PublishingConvictionAccountInfo,
 } from '@origintrail-official/dkg-chain';
-import { jsonResponse, readBody, SMALL_BODY_BYTES, respondIfChainRpcTransportError } from '../http-utils.js';
+import {
+  classifyChainRpcTransportStatus,
+  jsonResponse,
+  readBody,
+  SMALL_BODY_BYTES,
+  respondIfChainRpcTransportError,
+  sanitizeRpcMessage,
+} from '../http-utils.js';
 import type { RequestContext } from './context.js';
 
 const ZERO = '0x0000000000000000000000000000000000000000';
+const PCA_RPC_PROXY_PATH = '/api/pca/rpc';
+const PCA_RPC_ALLOWED_METHODS = new Set<PcaRpcMethod>([
+  'eth_chainId',
+  'eth_call',
+  'eth_getTransactionReceipt',
+  'eth_getTransactionByHash',
+  'eth_blockNumber',
+  'eth_getBlockByNumber',
+]);
+const PCA_RPC_NULL_RESULT_METHODS = new Set<PcaRpcMethod>([
+  'eth_getTransactionReceipt',
+  'eth_getTransactionByHash',
+  'eth_getBlockByNumber',
+]);
+const PCA_RPC_NFT_CALL_SELECTORS = new Set([
+  '0x70a08231', // balanceOf(address)
+  '0x2f745c59', // tokenOfOwnerByIndex(address,uint256)
+  '0x6352211e', // ownerOf(uint256)
+  '0xfe57623b', // getDiscountBps(uint96)
+]);
+const PCA_RPC_TOKEN_CALL_SELECTORS = new Set([
+  '0x70a08231', // balanceOf(address)
+  '0xdd62ed3e', // allowance(address,address)
+]);
+const PCA_RPC_MAX_BATCH = 20;
 const FEATURE_UNAVAILABLE_503 = {
   error:
     'Chain adapter does not expose V10 Publishing Conviction NFT methods — ' +
@@ -24,7 +58,160 @@ function safeParseJson(body: string): { ok: true; value: any } | { ok: false; er
   }
 }
 
-// Owner-gated write by a non-owner daemon EOA → 403 (distinct from 500
+// PCA RPC proxy guard: allow the browser HW layer's bounded read calls only.
+// Unsupported methods fail before any adapter delegation.
+type JsonRpcId = string | number | null;
+
+function jsonRpcId(value: unknown): JsonRpcId {
+  return typeof value === 'string' || typeof value === 'number' || value === null ? value : null;
+}
+
+function jsonRpcError(id: JsonRpcId, code: number, message: string, data?: unknown): Record<string, unknown> {
+  return {
+    jsonrpc: '2.0',
+    id,
+    error: {
+      code,
+      message,
+      ...(data !== undefined ? { data } : {}),
+    },
+  };
+}
+
+function jsonRpcSuccess(id: JsonRpcId, result: unknown): Record<string, unknown> {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function isPcaRpcMethod(method: string): method is PcaRpcMethod {
+  return PCA_RPC_ALLOWED_METHODS.has(method as PcaRpcMethod);
+}
+
+function walletRpcUrlsForResponse(contracts: PcaContracts): string[] {
+  return (contracts.walletRpcUrls ?? []).filter((rpcUrl) => /^https?:\/\//i.test(rpcUrl));
+}
+
+function supportsPcaRpcBridge(agent: RequestContext['agent']): boolean {
+  const candidate = agent as RequestContext['agent'] & {
+    supportsPublishingConvictionRpc?: unknown;
+    requestPublishingConvictionRpc?: unknown;
+  };
+  if (typeof candidate.supportsPublishingConvictionRpc === 'boolean') {
+    return candidate.supportsPublishingConvictionRpc;
+  }
+  return typeof candidate.requestPublishingConvictionRpc === 'function';
+}
+
+function pcaRpcEthCallError(params: unknown[] | undefined, contracts: Pick<PcaContracts, 'nft' | 'token'>): string | null {
+  if (!Array.isArray(params) || params.length === 0) return 'PCA RPC eth_call params must include a transaction object';
+  const tx = params[0];
+  if (!tx || typeof tx !== 'object' || Array.isArray(tx)) return 'PCA RPC eth_call params must include a transaction object';
+  const { to, data } = tx as { to?: unknown; data?: unknown };
+  if (typeof to !== 'string' || typeof data !== 'string' || !/^0x[0-9a-fA-F]+$/.test(data) || data.length < 10) {
+    return 'PCA RPC eth_call requires a target address and function selector';
+  }
+  let target: string;
+  let nft: string;
+  let token: string;
+  try {
+    target = ethers.getAddress(to).toLowerCase();
+    nft = ethers.getAddress(contracts.nft).toLowerCase();
+    token = ethers.getAddress(contracts.token).toLowerCase();
+  } catch {
+    return 'PCA RPC eth_call target address is invalid';
+  }
+  const selector = data.slice(0, 10).toLowerCase();
+  if (target === nft && PCA_RPC_NFT_CALL_SELECTORS.has(selector)) return null;
+  if (target === token && PCA_RPC_TOKEN_CALL_SELECTORS.has(selector)) return null;
+  return 'PCA RPC eth_call target or selector is not allowed';
+}
+
+function isHex32(value: unknown): value is string {
+  return typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value);
+}
+
+function isBlockQuantity(value: unknown): value is string {
+  return typeof value === 'string' && /^0x(?:0|[1-9a-fA-F][0-9a-fA-F]*)$/.test(value);
+}
+
+function pcaRpcParamsError(method: PcaRpcMethod, params: unknown[] | undefined): string | null {
+  const p = params ?? [];
+  switch (method) {
+    case 'eth_chainId':
+    case 'eth_blockNumber':
+      return p.length === 0 ? null : `PCA RPC ${method} does not accept params`;
+    case 'eth_getTransactionReceipt':
+    case 'eth_getTransactionByHash':
+      return p.length === 1 && isHex32(p[0]) ? null : `PCA RPC ${method} requires one 32-byte transaction hash`;
+    case 'eth_getBlockByNumber': {
+      if (p.length !== 2) return 'PCA RPC eth_getBlockByNumber requires block id and includeTransactions=false';
+      const block = p[0];
+      const includeTransactions = p[1];
+      const allowedBlock = block === 'latest' || block === 'safe' || block === 'finalized' || isBlockQuantity(block);
+      if (!allowedBlock || includeTransactions !== false) {
+        return 'PCA RPC eth_getBlockByNumber only allows latest/safe/finalized or hex block ids with includeTransactions=false';
+      }
+      return null;
+    }
+    case 'eth_call':
+      if (p.length < 1 || p.length > 2) return 'PCA RPC eth_call requires a transaction object and optional block id';
+      if (p.length === 2) {
+        const block = p[1];
+        const allowedBlock = block === 'latest' || block === 'safe' || block === 'finalized' || isBlockQuantity(block);
+        if (!allowedBlock) return 'PCA RPC eth_call only allows latest/safe/finalized or hex block ids';
+      }
+      return null;
+  }
+}
+
+async function handlePcaRpcRequest(
+  agent: RequestContext['agent'],
+  raw: unknown,
+): Promise<Record<string, unknown>> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return jsonRpcError(null, -32600, 'Invalid JSON-RPC request');
+  }
+  const request = raw as { id?: unknown; method?: unknown; params?: unknown };
+  const id = jsonRpcId(request.id ?? null);
+  if (typeof request.method !== 'string' || request.method.length === 0) {
+    return jsonRpcError(id, -32600, 'Invalid JSON-RPC method');
+  }
+  if (!isPcaRpcMethod(request.method)) {
+    return jsonRpcError(id, -32601, `PCA RPC method not allowed: ${request.method}`);
+  }
+  if (request.params !== undefined && !Array.isArray(request.params)) {
+    return jsonRpcError(id, -32602, 'PCA RPC params must be an array');
+  }
+  const paramsError = pcaRpcParamsError(request.method, request.params);
+  if (paramsError) return jsonRpcError(id, -32602, paramsError);
+  try {
+    if (request.method === 'eth_call') {
+      const contracts = await agent.getPublishingConvictionContracts();
+      if (contracts === null) return jsonRpcError(id, -32004, FEATURE_UNAVAILABLE_503.error);
+      const ethCallError = pcaRpcEthCallError(request.params, contracts);
+      if (ethCallError) return jsonRpcError(id, -32602, ethCallError);
+    }
+    const result = await agent.requestPublishingConvictionRpc(request.method, request.params ?? []);
+    if (result === null && !PCA_RPC_NULL_RESULT_METHODS.has(request.method)) {
+      return jsonRpcError(id, -32004, FEATURE_UNAVAILABLE_503.error);
+    }
+    return jsonRpcSuccess(id, result);
+  } catch (err: any) {
+    const transport = classifyChainRpcTransportStatus(err);
+    if (transport) {
+      return jsonRpcError(id, -32002, String(transport.body.error ?? 'Chain RPC transport unavailable'), {
+        code: transport.body.code,
+        ...(transport.body.txHash ? { txHash: transport.body.txHash } : {}),
+      });
+    }
+    const msg = sanitizeRpcMessage(err?.message ?? String(err));
+    if (isNoChain(msg) || isPcaUnavailable(err, msg)) {
+      return jsonRpcError(id, -32004, FEATURE_UNAVAILABLE_503.error);
+    }
+    return jsonRpcError(id, -32000, `PCA RPC read failed: ${msg}`);
+  }
+}
+
+// Owner-gated write by a non-owner daemon EOA -> 403 (distinct from 500
 // RPC / 503 no-chain). `NotAccountAdmin` kept for legacy parity.
 function isOwnerRevert(msg: string): boolean {
   return /NotAccountOwner|NotAccountAdmin/i.test(msg);
@@ -607,19 +794,22 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
   }
 
   // GET /api/pca/contracts — browser bootstrap (sub-PR #2 HW signing). Hands the
-  // in-browser viem layer the RESOLVED { nft, token, chainId, rpcUrls } it needs
-  // to submit owner-actions direct-to-contract, in ONE call (no in-browser Hub
-  // resolution — H2). nft/token are EIP-55; chainId is AS-IS (the FE extracts the
-  // numeric tail). Matched EXACTLY before the generic GET :id below, else
-  // 'contracts' parses as an accountId and 400s.
+  // in-browser viem layer resolved PCA addresses plus the same-origin daemon RPC
+  // proxy. Raw adapter RPC URLs may carry operator API keys, so they remain
+  // daemon-internal and never cross this HTTP boundary. Matched EXACTLY before
+  // the generic GET :id below, else 'contracts' parses as an accountId and 400s.
   if (req.method === 'GET' && path === '/api/pca/contracts') {
-    if (!agent.supportsPublishingConvictionNft) {
+    if (!agent.supportsPublishingConvictionNft || !supportsPcaRpcBridge(agent)) {
       return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
     }
     try {
       const contracts = await agent.getPublishingConvictionContracts();
       if (contracts === null) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
-      return jsonResponse(res, 200, contracts);
+      return jsonResponse(res, 200, {
+        ...contracts,
+        rpcUrls: [PCA_RPC_PROXY_PATH],
+        walletRpcUrls: walletRpcUrlsForResponse(contracts),
+      });
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       if (isNoChain(msg)) return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
@@ -635,9 +825,32 @@ export async function handlePcaRoutes(ctx: RequestContext): Promise<void> {
         });
       }
       return jsonResponse(res, 500, {
-        error: `getPublishingConvictionContracts failed: ${msg}`,
+        error: `getPublishingConvictionContracts failed: ${sanitizeRpcMessage(msg)}`,
       });
     }
+  }
+
+  // POST /api/pca/rpc - restricted JSON-RPC read proxy for the browser HW
+  // layer. It forwards only the read methods viem needs for PCA discovery,
+  // allowance reads, and receipt polling. It never exposes upstream URLs.
+  if (req.method === 'POST' && path === PCA_RPC_PROXY_PATH) {
+    if (!agent.supportsPublishingConvictionNft || !supportsPcaRpcBridge(agent)) {
+      return jsonResponse(res, 503, FEATURE_UNAVAILABLE_503);
+    }
+    const body = await readBody(req, SMALL_BODY_BYTES);
+    const parsed = safeParseJson(body);
+    if (!parsed.ok) return jsonResponse(res, 400, { error: parsed.error });
+    if (Array.isArray(parsed.value)) {
+      if (parsed.value.length === 0) {
+        return jsonResponse(res, 400, { error: 'JSON-RPC batch must contain at least one request' });
+      }
+      if (parsed.value.length > PCA_RPC_MAX_BATCH) {
+        return jsonResponse(res, 400, { error: `JSON-RPC batch must contain at most ${PCA_RPC_MAX_BATCH} requests` });
+      }
+      const responses = await Promise.all(parsed.value.map((item) => handlePcaRpcRequest(agent, item)));
+      return jsonResponse(res, 200, responses);
+    }
+    return jsonResponse(res, 200, await handlePcaRpcRequest(agent, parsed.value));
   }
 
   // GET /api/pca/:id — V10 conviction NFT snapshot. Optional ?key=0x...

--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -186,6 +186,7 @@ describe('loadNetworkConfig', () => {
         rpcUrl: 'https://mainnet.base.org',
         // Default multi-RPC backups shipped with the overlay (failover engine).
         rpcUrls: ['https://base-rpc.publicnode.com', 'https://base.drpc.org'],
+        walletRpcUrls: ['https://mainnet.base.org', 'https://base-rpc.publicnode.com', 'https://base.drpc.org'],
         hubAddress: '0x99Aa571fD5e681c2D27ee08A7b7989DB02541d13',
         // Relays populated + pre-deployment gate lifted (#1292).
         pending: false,
@@ -200,6 +201,7 @@ describe('loadNetworkConfig', () => {
         rpcUrl: 'https://rpc.gnosischain.com',
         // Default multi-RPC backups shipped with the overlay (failover engine).
         rpcUrls: ['https://gnosis-rpc.publicnode.com', 'https://gnosis.drpc.org'],
+        walletRpcUrls: ['https://rpc.gnosischain.com', 'https://gnosis-rpc.publicnode.com', 'https://gnosis.drpc.org'],
         hubAddress: '0x882D0BF07F956b1b94BBfe9E77F47c6fc7D4EC8f',
         // Relays populated + pre-deployment gate lifted (#1292).
         pending: false,
@@ -242,6 +244,7 @@ describe('loadNetworkConfig', () => {
         chainId: expected.chainId,
         rpcUrl: expected.rpcUrl,
         ...(expected.rpcUrls ? { rpcUrls: expected.rpcUrls } : {}),
+        ...(expected.walletRpcUrls ? { walletRpcUrls: expected.walletRpcUrls } : {}),
         hubAddress: expected.hubAddress,
       });
       // Non-relay prep fields are identical across all mainnets regardless of
@@ -648,7 +651,33 @@ describe('resolveChainConfig (field-level merge)', () => {
       // inherited so the adapter builds a multi-RPC FallbackProvider.
       expect(merged?.rpcUrl).toBe(primary);
       expect(merged?.rpcUrls).toEqual(backups);
+      expect(merged?.walletRpcUrls).toEqual([primary, ...backups]);
     }
+  });
+
+  it('keeps wallet-public RPCs separate from operator private RPC overrides', () => {
+    const merged = resolveChainConfig(
+      {
+        chain: {
+          rpcUrl: 'https://private-rpc.example/v2/SECRETKEY',
+          rpcUrls: ['https://private-backup.example/v2/SECRETKEY'],
+        },
+      },
+      {
+        chain: {
+          ...fullNetworkChain,
+          walletRpcUrls: [
+            ' https://wallet-public.example/rpc ',
+            'https://wallet-public.example/rpc',
+          ],
+        },
+      },
+    );
+
+    expect(merged?.rpcUrl).toBe('https://private-rpc.example/v2/SECRETKEY');
+    expect(merged?.rpcUrls).toEqual(['https://private-backup.example/v2/SECRETKEY']);
+    expect(merged?.walletRpcUrls).toEqual(['https://wallet-public.example/rpc']);
+    expect(JSON.stringify(merged?.walletRpcUrls)).not.toContain('SECRETKEY');
   });
 
   it('a single-RPC overlay (pre-deployment neuroweb) still resolves with NO rpcUrls (back-compat)', async () => {
@@ -703,6 +732,68 @@ describe('resolveChainConfig (field-level merge)', () => {
       expect(merged?.rpcUrl).toBe(localUrl);
       expect(merged?.rpcUrls ?? []).toEqual([]);
     }
+  });
+
+  it('does NOT inherit wallet-public RPCs behind a LOCAL or different-chain primary', () => {
+    const networkWithWalletRpcs = {
+      chain: {
+        ...fullNetworkChain,
+        walletRpcUrls: ['https://wallet-public.example/rpc'],
+      },
+    };
+
+    const local = resolveChainConfig(
+      { chain: { rpcUrl: 'http://127.0.0.1:8545' } },
+      networkWithWalletRpcs,
+    );
+    expect(local?.rpcUrl).toBe('http://127.0.0.1:8545');
+    expect(local?.rpcUrls ?? []).toEqual([]);
+    expect(local?.walletRpcUrls).toBeUndefined();
+
+    const differentChain = resolveChainConfig(
+      { chain: { rpcUrl: 'http://hardhat:8545', chainId: 'evm:31337' } },
+      networkWithWalletRpcs,
+    );
+    expect(differentChain?.rpcUrl).toBe('http://hardhat:8545');
+    expect(differentChain?.rpcUrls ?? []).toEqual([]);
+    expect(differentChain?.walletRpcUrls).toBeUndefined();
+
+    const localWithExplicitBackups = resolveChainConfig(
+      {
+        chain: {
+          rpcUrl: 'http://127.0.0.1:8545',
+          rpcUrls: ['http://127.0.0.1:8546'],
+        },
+      },
+      networkWithWalletRpcs,
+    );
+    expect(localWithExplicitBackups?.rpcUrls).toEqual(['http://127.0.0.1:8546']);
+    expect(localWithExplicitBackups?.walletRpcUrls).toBeUndefined();
+
+    const differentChainWithExplicitBackups = resolveChainConfig(
+      {
+        chain: {
+          rpcUrl: 'http://hardhat:8545',
+          rpcUrls: ['http://hardhat:8546'],
+          chainId: 'evm:31337',
+        },
+      },
+      networkWithWalletRpcs,
+    );
+    expect(differentChainWithExplicitBackups?.rpcUrls).toEqual(['http://hardhat:8546']);
+    expect(differentChainWithExplicitBackups?.walletRpcUrls).toBeUndefined();
+
+    const explicit = resolveChainConfig(
+      {
+        chain: {
+          rpcUrl: 'http://hardhat:8545',
+          chainId: 'evm:31337',
+          walletRpcUrls: [' http://wallet-rpc.local:8545 '],
+        },
+      },
+      networkWithWalletRpcs,
+    );
+    expect(explicit?.walletRpcUrls).toEqual(['http://wallet-rpc.local:8545']);
   });
 
   it('an explicit operator rpcUrls still wins even with a loopback primary', () => {

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { ethers } from 'ethers';
 import { NoChainAdapter, ChainRpcTransportError } from '@origintrail-official/dkg-chain';
 import { handlePcaRoutes } from '../src/daemon/routes/pca.js';
@@ -34,6 +34,10 @@ function runCtx(method: string, rawPath: string, agent: any, body?: unknown, opW
   } as unknown as RequestContext;
   return { res, done: handlePcaRoutes(ctx) };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('daemon /api/pca V10 caller contract', () => {
   it('POST /api/pca with tokens + primaryNode → 200 and forwards the node (OT-RFC-51)', async () => {
@@ -1119,21 +1123,46 @@ describe('daemon /api/pca V10 caller contract', () => {
 
   // ----- sub-PR #2: GET /api/pca/contracts (browser bootstrap) -----
   const CONTRACTS_FIXTURE = {
-    nft: '0x' + 'aB'.repeat(20),
-    token: '0x' + 'Cd'.repeat(20),
+    nft: ethers.getAddress('0x' + 'ab'.repeat(20)),
+    token: ethers.getAddress('0x' + 'cd'.repeat(20)),
     chainId: 'base:84532',
-    rpcUrls: ['https://rpc.example/1', 'https://rpc.example/2'],
+    rpcUrls: ['https://rpc.example/v2/SECRETKEY', 'https://rpc.example/2'],
+    walletRpcUrls: ['https://wallet-rpc.example/base-sepolia', '/api/pca/rpc', 'ws://wallet-rpc.example'],
   };
+  const contractsAgent = (overrides: Record<string, unknown>) => ({
+    supportsPublishingConvictionNft: true,
+    supportsPublishingConvictionRpc: true,
+    ...overrides,
+  });
 
-  it('GET /api/pca/contracts → 200 { nft, token, chainId, rpcUrls } verbatim (chainId AS-IS)', async () => {
-    const agent = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => CONTRACTS_FIXTURE };
+  it('GET /api/pca/contracts returns no wallet RPCs when the adapter omits them', async () => {
+    const agent = contractsAgent({
+      getPublishingConvictionContracts: async () => {
+        const { walletRpcUrls: _walletRpcUrls, ...contracts } = CONTRACTS_FIXTURE;
+        return contracts;
+      },
+    });
+    const { res, done } = runCtx('GET', '/api/pca/contracts', agent);
+    await done;
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).walletRpcUrls).toEqual([]);
+  });
+
+  it('GET /api/pca/contracts returns a same-origin RPC proxy and never leaks adapter URLs', async () => {
+    const agent = contractsAgent({ getPublishingConvictionContracts: async () => CONTRACTS_FIXTURE });
     const { res, done } = runCtx('GET', '/api/pca/contracts', agent);
     await done;
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
-    expect(body).toEqual(CONTRACTS_FIXTURE); // passed through 1:1
+    expect(body).toEqual({
+      ...CONTRACTS_FIXTURE,
+      rpcUrls: ['/api/pca/rpc'],
+      walletRpcUrls: ['https://wallet-rpc.example/base-sepolia'],
+    });
     expect(body.chainId).toBe('base:84532'); // compound, NOT pre-stripped
-    expect(Array.isArray(body.rpcUrls)).toBe(true);
+    expect(res.body).not.toContain('SECRETKEY');
+    expect(res.body).not.toContain('https://rpc.example');
+    expect(res.body).not.toContain('ws://wallet-rpc.example');
   });
 
   it('GET /api/pca/contracts → 503 when the adapter lacks the PCA surface (lookup not called)', async () => {
@@ -1145,8 +1174,21 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(called).toBe(false);
   });
 
+  it('GET /api/pca/contracts returns 503 when the daemon RPC bridge is unavailable', async () => {
+    let called = false;
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      supportsPublishingConvictionRpc: false,
+      getPublishingConvictionContracts: async () => { called = true; return CONTRACTS_FIXTURE; },
+    };
+    const { res, done } = runCtx('GET', '/api/pca/contracts', agent);
+    await done;
+    expect(res.statusCode).toBe(503);
+    expect(called).toBe(false);
+  });
+
   it('GET /api/pca/contracts → 503 FEATURE_UNAVAILABLE when the facade returns null (no code)', async () => {
-    const agent = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => null };
+    const agent = contractsAgent({ getPublishingConvictionContracts: async () => null });
     const { res, done } = runCtx('GET', '/api/pca/contracts', agent);
     await done;
     expect(res.statusCode).toBe(503);
@@ -1157,6 +1199,7 @@ describe('daemon /api/pca V10 caller contract', () => {
     for (const code of ['CALL_EXCEPTION', 'BAD_DATA']) {
       const agent = {
         supportsPublishingConvictionNft: true,
+        supportsPublishingConvictionRpc: true,
         getPublishingConvictionContracts: async () => { const e: any = new Error('addr read failed'); e.code = code; throw e; },
       };
       const { res, done } = runCtx('GET', '/api/pca/contracts', agent);
@@ -1167,26 +1210,368 @@ describe('daemon /api/pca V10 caller contract', () => {
   });
 
   it('GET /api/pca/contracts → 503 transport / 503 noChain+unavailable / 500 generic', async () => {
-    const transport = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => { throw Object.assign(new Error('exhausted'), { code: 'RPC_ENDPOINTS_EXHAUSTED' }); } };
+    const transport = contractsAgent({ getPublishingConvictionContracts: async () => { throw Object.assign(new Error('exhausted'), { code: 'RPC_ENDPOINTS_EXHAUSTED' }); } });
     const t = runCtx('GET', '/api/pca/contracts', transport); await t.done;
     expect(t.res.statusCode).toBe(503);
     expect(JSON.parse(t.res.body).code).toBe('RPC_ENDPOINTS_EXHAUSTED');
 
-    const noChain = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => { throw new Error('No blockchain configured'); } };
+    const noChain = contractsAgent({ getPublishingConvictionContracts: async () => { throw new Error('No blockchain configured'); } });
     const n = runCtx('GET', '/api/pca/contracts', noChain); await n.done;
     expect(n.res.statusCode).toBe(503);
 
-    const unavail = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => { throw new Error('DKGPublishingConvictionNFT is not deployed on this Hub'); } };
+    const unavail = contractsAgent({ getPublishingConvictionContracts: async () => { throw new Error('DKGPublishingConvictionNFT is not deployed on this Hub'); } });
     const u = runCtx('GET', '/api/pca/contracts', unavail); await u.done;
     expect(u.res.statusCode).toBe(503);
 
-    const generic = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => { throw new Error('boom'); } };
+    const generic = contractsAgent({
+      getPublishingConvictionContracts: async () => { throw new Error('boom https://rpc.example/v2/SECRETKEY'); },
+    });
     const g = runCtx('GET', '/api/pca/contracts', generic); await g.done;
     expect(g.res.statusCode).toBe(500);
+    expect(g.res.body).toContain('getPublishingConvictionContracts failed');
+    expect(g.res.body).not.toContain('SECRETKEY');
+    expect(g.res.body).not.toContain('https://rpc.example');
+  });
+
+  it('POST /api/pca/rpc forwards allowed read JSON-RPC without leaking upstream URLs', async () => {
+    const payload = { jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] };
+    const rpcMock = vi.fn(async (method: string, params: unknown[]) => {
+      expect(method).toBe('eth_chainId');
+      expect(params).toEqual([]);
+      return '0x14a34';
+    });
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, payload);
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ jsonrpc: '2.0', id: 1, result: '0x14a34' });
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(res.body).not.toContain('SECRETKEY');
+    expect(res.body).not.toContain('https://rpc.example');
+  });
+
+  it('POST /api/pca/rpc returns 503 when the daemon RPC bridge is unavailable', async () => {
+    const rpcMock = vi.fn();
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      supportsPublishingConvictionRpc: false,
+      requestPublishingConvictionRpc: rpcMock,
+    };
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_chainId',
+      params: [],
+    });
+    await done;
+
+    expect(res.statusCode).toBe(503);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/pca/rpc allows PCA-scoped eth_call and rejects unrelated eth_call before delegation', async () => {
+    const allowedCall = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_call',
+      params: [{ to: CONTRACTS_FIXTURE.nft, data: '0x70a08231' }, 'latest'],
+    };
+    const rejectedCall = {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'eth_call',
+      params: [{ to: '0x' + '33'.repeat(20), data: '0x70a08231' }, 'latest'],
+    };
+    const rpcMock = vi.fn(async () => '0x' + '0'.repeat(63) + '1');
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionContracts: async () => CONTRACTS_FIXTURE,
+      requestPublishingConvictionRpc: rpcMock,
+    };
+
+    const ok = runCtx('POST', '/api/pca/rpc', agent, allowedCall);
+    await ok.done;
+    expect(ok.res.statusCode).toBe(200);
+    expect(JSON.parse(ok.res.body)).toEqual({ jsonrpc: '2.0', id: 1, result: '0x' + '0'.repeat(63) + '1' });
+    expect(rpcMock).toHaveBeenCalledWith('eth_call', allowedCall.params);
+
+    rpcMock.mockClear();
+    const bad = runCtx('POST', '/api/pca/rpc', agent, rejectedCall);
+    await bad.done;
+    expect(bad.res.statusCode).toBe(200);
+    const body = JSON.parse(bad.res.body);
+    expect(body.error.code).toBe(-32602);
+    expect(body.error.message).toContain('target or selector is not allowed');
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/pca/rpc allows the browser PCA eth_call selectors with ABI-encoded calldata', async () => {
+    const nft = new ethers.Interface([
+      'function balanceOf(address owner) view returns (uint256)',
+      'function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)',
+      'function ownerOf(uint256 tokenId) view returns (address)',
+      'function getDiscountBps(uint96 accountId) view returns (uint16)',
+    ]);
+    const token = new ethers.Interface([
+      'function balanceOf(address owner) view returns (uint256)',
+      'function allowance(address owner, address spender) view returns (uint256)',
+    ]);
+    const owner = ethers.getAddress('0x' + '44'.repeat(20));
+    const spender = ethers.getAddress('0x' + '55'.repeat(20));
+    const cases = [
+      { to: CONTRACTS_FIXTURE.nft, data: nft.encodeFunctionData('balanceOf', [owner]) },
+      { to: CONTRACTS_FIXTURE.nft, data: nft.encodeFunctionData('tokenOfOwnerByIndex', [owner, 0n]) },
+      { to: CONTRACTS_FIXTURE.nft, data: nft.encodeFunctionData('ownerOf', [1n]) },
+      { to: CONTRACTS_FIXTURE.nft, data: nft.encodeFunctionData('getDiscountBps', [1n]) },
+      { to: CONTRACTS_FIXTURE.token, data: token.encodeFunctionData('balanceOf', [owner]) },
+      { to: CONTRACTS_FIXTURE.token, data: token.encodeFunctionData('allowance', [owner, spender]) },
+    ];
+    const rpcMock = vi.fn(async () => '0x');
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionContracts: async () => CONTRACTS_FIXTURE,
+      requestPublishingConvictionRpc: rpcMock,
+    };
+
+    for (const [index, call] of cases.entries()) {
+      const params = [{ to: call.to, data: call.data }, 'latest'];
+      const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+        jsonrpc: '2.0',
+        id: index + 1,
+        method: 'eth_call',
+        params,
+      });
+      await done;
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ jsonrpc: '2.0', id: index + 1, result: '0x' });
+      expect(rpcMock).toHaveBeenLastCalledWith('eth_call', params);
+    }
+    expect(rpcMock).toHaveBeenCalledTimes(cases.length);
+  });
+
+  it('POST /api/pca/rpc rejects over-broad eth_call params before adapter delegation', async () => {
+    const call = { to: CONTRACTS_FIXTURE.nft, data: '0x70a08231' };
+    const cases = [
+      { id: 1, method: 'eth_call', params: [call, 'pending'] },
+      { id: 2, method: 'eth_call', params: [call, { blockNumber: '0x1' }] },
+      { id: 3, method: 'eth_call', params: [call, 'latest', { [CONTRACTS_FIXTURE.nft]: { balance: '0x0' } }] },
+      { id: 4, method: 'eth_call', params: [call, 'safe', {}, {}] },
+    ];
+    const getContractsMock = vi.fn(async () => CONTRACTS_FIXTURE);
+    const rpcMock = vi.fn();
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      getPublishingConvictionContracts: getContractsMock,
+      requestPublishingConvictionRpc: rpcMock,
+    };
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, cases);
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(cases.length);
+    for (const response of body) {
+      expect(response.error.code).toBe(-32602);
+    }
+    expect(getContractsMock).not.toHaveBeenCalled();
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/pca/rpc supports viem-style JSON-RPC batches', async () => {
+    const payload = [
+      { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] },
+      { jsonrpc: '2.0', id: 2, method: 'eth_getBlockByNumber', params: ['latest', false] },
+    ];
+    const expected = [
+      { jsonrpc: '2.0', id: 1, result: '0x10' },
+      { jsonrpc: '2.0', id: 2, result: { number: '0x10' } },
+    ];
+    const rpcMock = vi.fn(async (method: string) => {
+      if (method === 'eth_blockNumber') return '0x10';
+      return { number: '0x10' };
+    });
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, payload);
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(expected);
+    expect(rpcMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('POST /api/pca/rpc rejects empty JSON-RPC batches before adapter delegation', async () => {
+    const rpcMock = vi.fn();
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, []);
+    await done;
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'JSON-RPC batch must contain at least one request' });
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/pca/rpc rejects oversized JSON-RPC batches before adapter delegation', async () => {
+    const rpcMock = vi.fn();
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+    const payload = Array.from({ length: 21 }, (_, i) => ({
+      jsonrpc: '2.0',
+      id: i + 1,
+      method: 'eth_blockNumber',
+      params: [],
+    }));
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, payload);
+    await done;
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'JSON-RPC batch must contain at most 20 requests' });
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/pca/rpc preserves null JSON-RPC results for pending transaction reads', async () => {
+    const rpcMock = vi.fn(async () => null);
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+      jsonrpc: '2.0',
+      id: 7,
+      method: 'eth_getTransactionReceipt',
+      params: ['0x' + '11'.repeat(32)],
+    });
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ jsonrpc: '2.0', id: 7, result: null });
+    expect(rpcMock).toHaveBeenCalledWith('eth_getTransactionReceipt', ['0x' + '11'.repeat(32)]);
+  });
+
+  it('POST /api/pca/rpc preserves null JSON-RPC results for missing block reads', async () => {
+    const rpcMock = vi.fn(async () => null);
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+      jsonrpc: '2.0',
+      id: 9,
+      method: 'eth_getBlockByNumber',
+      params: ['0xffffffffffff', false],
+    });
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ jsonrpc: '2.0', id: 9, result: null });
+    expect(rpcMock).toHaveBeenCalledWith('eth_getBlockByNumber', ['0xffffffffffff', false]);
+  });
+
+  it('POST /api/pca/rpc rejects over-broad non-PCA read params before adapter delegation', async () => {
+    const rpcMock = vi.fn();
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+    const cases = [
+      { id: 1, method: 'eth_chainId', params: ['latest'] },
+      { id: 2, method: 'eth_blockNumber', params: [false] },
+      { id: 3, method: 'eth_getTransactionReceipt', params: ['0x1234'] },
+      { id: 4, method: 'eth_getTransactionByHash', params: ['0x' + '11'.repeat(31)] },
+      { id: 5, method: 'eth_getBlockByNumber', params: ['latest', true] },
+      { id: 6, method: 'eth_getBlockByNumber', params: ['pending', false] },
+    ];
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, cases);
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(cases.length);
+    for (const response of body) {
+      expect(response.error.code).toBe(-32602);
+    }
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/pca/rpc maps unsupported facade nulls to feature-unavailable errors', async () => {
+    const rpcMock = vi.fn(async () => null);
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_chainId',
+      params: [],
+    });
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32004);
+    expect(body.error.message).toContain('Chain adapter does not expose V10 Publishing Conviction NFT methods');
+    expect(rpcMock).toHaveBeenCalledWith('eth_chainId', []);
+  });
+
+  it('POST /api/pca/rpc rejects write/admin JSON-RPC methods before adapter delegation', async () => {
+    const rpcMock = vi.fn();
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: rpcMock };
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_sendRawTransaction',
+      params: ['0xdead'],
+    });
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32601);
+    expect(body.error.message).toContain('eth_sendRawTransaction');
+    expect(res.body).not.toContain('SECRETKEY');
+  });
+
+  it('POST /api/pca/rpc maps transport failures to sanitized JSON-RPC errors', async () => {
+    const payload = { jsonrpc: '2.0', id: 1, method: 'eth_blockNumber', params: [] };
+    const err = new ChainRpcTransportError(
+      'RPC_ENDPOINTS_EXHAUSTED',
+      'all RPC endpoints failed (https://rpc.example/v2/SECRETKEY)',
+      { rpcUrls: ['https://rpc.example/v2/SECRETKEY'] },
+    );
+    const agent = { supportsPublishingConvictionNft: true, requestPublishingConvictionRpc: async () => { throw err; } };
+
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, payload);
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32002);
+    expect(body.error.data.code).toBe('RPC_ENDPOINTS_EXHAUSTED');
+    expect(res.body).not.toContain('SECRETKEY');
+    expect(res.body).not.toContain('https://rpc.example');
+  });
+
+  it('POST /api/pca/rpc sanitizes generic adapter errors', async () => {
+    const agent = {
+      supportsPublishingConvictionNft: true,
+      requestPublishingConvictionRpc: async () => {
+        throw new Error('boom https://rpc.example/v2/SECRETKEY');
+      },
+    };
+    const { res, done } = runCtx('POST', '/api/pca/rpc', agent, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_blockNumber',
+      params: [],
+    });
+    await done;
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain('PCA RPC read failed');
+    expect(res.body).not.toContain('SECRETKEY');
+    expect(res.body).not.toContain('https://rpc.example');
   });
 
   it('route ordering: /api/pca/contracts is matched BEFORE the generic GET :id (not 400 as an id)', async () => {
-    const agent = { supportsPublishingConvictionNft: true, getPublishingConvictionContracts: async () => CONTRACTS_FIXTURE };
+    const agent = contractsAgent({ getPublishingConvictionContracts: async () => CONTRACTS_FIXTURE });
     const { res, done } = runCtx('GET', '/api/pca/contracts', agent);
     await done;
     expect(res.statusCode).toBe(200); // a generic :id match would 400 "Invalid accountId"

--- a/packages/cli/vitest.unit.config.ts
+++ b/packages/cli/vitest.unit.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
           'test/trust-endpoint-validation.test.ts',
           'test/daemon/plugin-loader.test.ts',
           'test/daemon/routes/plugins.test.ts',
+          'test/daemon-pca-routes.test.ts',
           'test/auth.test.ts',
           // Pure logic — no hardhat needed. Adding to the unit config means
           // contributors can run it via `pnpm test:unit` in ~2s instead of

--- a/packages/node-ui/e2e/specs/publishing-conviction-hw-mock.spec.ts
+++ b/packages/node-ui/e2e/specs/publishing-conviction-hw-mock.spec.ts
@@ -11,7 +11,7 @@ const REGISTER_HASH = `0x${'e'.repeat(64)}`;
 const DEREGISTER_HASH = `0x${'f'.repeat(64)}`;
 const ACCOUNT_ID = '7';
 const REGISTERED_AGENT = '0x3333333333333333333333333333333333333333';
-const MOCK_RPC_PATH = '/mock-pca-rpc';
+const MOCK_RPC_PATH = '/api/pca/rpc';
 
 const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
 const ZERO_TOPIC = `0x${'0'.repeat(64)}`;
@@ -114,10 +114,48 @@ async function fulfillJson(route: Route, status: number, body: unknown) {
 
 async function installMockApis(page: Page) {
   let allowanceCalls = 0;
+  const handleMockRpc = async (route: Route) => {
+    const request = route.request();
+    const payload = await request.postDataJSON();
+    const calls = Array.isArray(payload) ? payload : [payload];
+    const results = calls.map((call) => {
+      const method = call.method as string;
+      const params = (call.params ?? []) as unknown[];
+      let result: unknown = '0x';
+      if (method === 'eth_chainId') result = quantity(84532);
+      if (method === 'eth_blockNumber') result = '0x123';
+      if (method === 'eth_getTransactionReceipt') result = receipt(String(params[0]));
+      if (method === 'eth_call') {
+        const tx = params[0] as { to?: string; data?: string };
+        const data = (tx.data ?? '').toLowerCase();
+        if (data.startsWith('0xdd62ed3e')) {
+          allowanceCalls += 1;
+          result = allowanceCalls === 1 ? uint256(0) : uint256(MAX_ALLOWANCE);
+        } else if (data.startsWith('0x70a08231')) {
+          result = uint256(1);
+        } else if (data.startsWith('0x2f745c59')) {
+          result = uint256(ACCOUNT_ID);
+        } else {
+          result = uint256(0);
+        }
+      }
+      return { jsonrpc: '2.0', id: call.id, result };
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(Array.isArray(payload) ? results : results[0]),
+    });
+  };
+
+  await page.route(`**${MOCK_RPC_PATH}`, handleMockRpc);
   await page.route('**/api/**', async (route) => {
     const url = new URL(route.request().url());
     const path = url.pathname;
 
+    if (path === MOCK_RPC_PATH) {
+      return handleMockRpc(route);
+    }
     if (path === '/api/status') {
       return fulfillJson(route, 200, {
         name: 'Mock PCA Core',
@@ -161,7 +199,8 @@ async function installMockApis(page: Page) {
         nft: NFT,
         token: TOKEN,
         chainId: 'base:84532',
-        rpcUrls: [`${url.origin}${MOCK_RPC_PATH}`],
+        rpcUrls: [MOCK_RPC_PATH],
+        walletRpcUrls: [],
       });
     }
     if (path === '/api/pca/designatable-nodes') {
@@ -201,40 +240,6 @@ async function installMockApis(page: Page) {
     }
 
     return fulfillJson(route, 200, {});
-  });
-
-  await page.route(`**${MOCK_RPC_PATH}`, async (route) => {
-    const request = route.request();
-    const payload = await request.postDataJSON();
-    const calls = Array.isArray(payload) ? payload : [payload];
-    const results = calls.map((call) => {
-      const method = call.method as string;
-      const params = (call.params ?? []) as unknown[];
-      let result: unknown = '0x';
-      if (method === 'eth_chainId') result = quantity(84532);
-      if (method === 'eth_blockNumber') result = '0x123';
-      if (method === 'eth_getTransactionReceipt') result = receipt(String(params[0]));
-      if (method === 'eth_call') {
-        const tx = params[0] as { to?: string; data?: string };
-        const data = (tx.data ?? '').toLowerCase();
-        if (data.startsWith('0xdd62ed3e')) {
-          allowanceCalls += 1;
-          result = allowanceCalls === 1 ? uint256(0) : uint256(MAX_ALLOWANCE);
-        } else if (data.startsWith('0x70a08231')) {
-          result = uint256(1);
-        } else if (data.startsWith('0x2f745c59')) {
-          result = uint256(ACCOUNT_ID);
-        } else {
-          result = uint256(0);
-        }
-      }
-      return { jsonrpc: '2.0', id: call.id, result };
-    });
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(Array.isArray(payload) ? results : results[0]),
-    });
   });
 }
 

--- a/packages/node-ui/src/ui/api.ts
+++ b/packages/node-ui/src/ui/api.ts
@@ -1844,8 +1844,8 @@ export const listDesignatableNodes = (opts?: { fresh?: boolean }) =>
  * The daemon resolves these via its Hub config (the browser does NOT re-resolve the Hub). Minimal
  * set: the NFT wrapper (every wallet-signed write + the ERC721Enumerable owned-PCA walk + the mint
  * `Transfer` accountId decode all target it), the TRAC token (approve/allowance), the chain id, and
- * the RPC endpoints for a viem publicClient. `nativeCurrency` is NOT here — the browser derives the
- * gas symbol from `nativeGasSymbol(chainId)`.
+ * the browser-safe RPC endpoints for a viem publicClient. `nativeCurrency` is NOT here — the browser
+ * derives the gas symbol from `nativeGasSymbol(chainId)`.
  */
 export interface PcaContracts {
   /** DKGPublishingConvictionNFT address (EIP-55). */
@@ -1855,8 +1855,10 @@ export interface PcaContracts {
   /** Chain id; may be the compound `"slug:chainId"` form (e.g. `"base:84532"`) — extract the numeric
    *  tail for the viem `Chain.id`. */
   chainId: string | number;
-  /** RPC endpoints for the viem publicClient (reads + receipt polling). */
+  /** Browser-safe RPC endpoints for the viem publicClient (reads + receipt polling). */
   rpcUrls: string[];
+  /** Optional wallet-public RPC endpoints safe to hand to wallet_addEthereumChain. */
+  walletRpcUrls?: string[];
 }
 
 /**

--- a/packages/node-ui/src/ui/stores/wallet.ts
+++ b/packages/node-ui/src/ui/stores/wallet.ts
@@ -74,6 +74,10 @@ export function isWrongNetwork(s: Pick<WalletState, 'address' | 'chainId' | 'exp
   return s.address != null && s.expectedChainId != null && s.chainId !== s.expectedChainId;
 }
 
+function rpcUrlsForWalletAdd(bootstrap: PcaContracts): string[] {
+  return (bootstrap.walletRpcUrls ?? []).filter((rpcUrl) => /^https?:\/\//i.test(rpcUrl));
+}
+
 let reconnectAttempted = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let discoverySubscribed = false;
@@ -192,6 +196,13 @@ export const useWalletStore = create<WalletState>((set, get) => {
         // 4902 = chain unknown to the wallet → offer to add it.
         if ((err as { code?: number })?.code === 4902) {
           const symbol = nativeGasSymbol(bootstrap.chainId);
+          const rpcUrls = rpcUrlsForWalletAdd(bootstrap);
+          if (rpcUrls.length === 0) {
+            throw new Error(
+              'Wallet does not know this chain and the node did not provide wallet-public RPC URLs. ' +
+              'Add the network in your wallet, then try again.',
+            );
+          }
           await provider.request({
             method: 'wallet_addEthereumChain',
             params: [
@@ -199,7 +210,7 @@ export const useWalletStore = create<WalletState>((set, get) => {
                 chainId: hex,
                 chainName: `chain-${numericChainId(bootstrap.chainId)}`,
                 nativeCurrency: { name: symbol, symbol, decimals: 18 },
-                rpcUrls: bootstrap.rpcUrls,
+                rpcUrls,
               },
             ],
           });

--- a/packages/node-ui/src/ui/web3/clients.ts
+++ b/packages/node-ui/src/ui/web3/clients.ts
@@ -18,6 +18,7 @@ import {
   type WalletClient,
 } from 'viem';
 import { nativeGasSymbol } from '../lib/nativeGasSymbol.js';
+import { authHeaders } from '../api.js';
 import { numericChainId } from './chainId.js';
 import type { Eip1193Provider } from './eip6963.js';
 
@@ -46,6 +47,22 @@ function publicClientCacheKey(chainId: string | number, rpcUrls: string[]): stri
   return `${numericChainId(chainId)}:${rpcUrls.join('|')}`;
 }
 
+function isSameOriginRpcUrl(url: string): boolean {
+  if (url.startsWith('/') && !url.startsWith('//')) return true;
+  if (typeof window === 'undefined' || !window.location?.origin) return false;
+  try {
+    return new URL(url, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function rpcFetchOptions(url: string): RequestInit | undefined {
+  if (!isSameOriginRpcUrl(url)) return undefined;
+  const headers = authHeaders();
+  return Object.keys(headers).length ? { headers } : undefined;
+}
+
 /**
  * A read client for the bootstrap chain (cached per chain id + RPC URL set). Transport tuning ported from
  * staking-ui: capped batching (public RPCs throttle/blackhole uncapped batches), an explicit
@@ -60,14 +77,16 @@ export function publicClientFor(chainId: string | number, rpcUrls: string[]): Pu
   const chain = synthesizeChain(chainId, rpcUrls);
   const multiRpc = rpcUrls.length > 1;
   const transport = fallback(
-    rpcUrls.map((url) =>
-      http(url, {
+    rpcUrls.map((url) => {
+      const fetchOptions = rpcFetchOptions(url);
+      return http(url, {
         batch: { batchSize: 20, wait: 16 },
         timeout: 8_000,
         retryCount: multiRpc ? 0 : 2,
         retryDelay: 200,
-      }),
-    ),
+        ...(fetchOptions ? { fetchOptions } : {}),
+      });
+    }),
     { retryCount: 1, retryDelay: 250 },
   );
   const client = createPublicClient({ chain, transport });

--- a/packages/node-ui/test/wallet-store.test.ts
+++ b/packages/node-ui/test/wallet-store.test.ts
@@ -18,7 +18,7 @@ const CONTRACTS: PcaContracts = {
   nft: `0x${'11'.repeat(20)}`,
   token: `0x${'22'.repeat(20)}`,
   chainId: 'base:84532',
-  rpcUrls: ['https://rpc.example'],
+  rpcUrls: ['/api/pca/rpc'],
 };
 
 function detail(rdns: string): Eip6963ProviderDetail {
@@ -108,5 +108,56 @@ describe('wallet store — bootstrap + connect lifecycle', () => {
     await useWalletStore.getState().switchToExpectedChain();
     expect(p.calls).toContain('wallet_switchEthereumChain');
     expect(useWalletStore.getState().chainId).toBe(84532); // mock applies the switch + emits chainChanged
+  });
+
+  it('does not offer the daemon read proxy to wallet_addEthereumChain when no wallet-public RPC is configured', async () => {
+    const p = new MockEip6963Provider({
+      rdns: 'io.metamask',
+      accounts: [`0x${'33'.repeat(20)}`],
+      chainId: 1,
+      handlers: {
+        wallet_switchEthereumChain: () => {
+          const err = new Error('Unknown chain') as Error & { code: number };
+          err.code = 4902;
+          throw err;
+        },
+      },
+    });
+
+    useWalletStore.getState().setBootstrap(CONTRACTS);
+    await useWalletStore.getState().connect(p.detail());
+    await expect(useWalletStore.getState().switchToExpectedChain()).rejects.toThrow(/wallet-public RPC URLs/i);
+    expect(p.calls).not.toContain('wallet_addEthereumChain');
+  });
+
+  it('uses explicit wallet-public RPC URLs when asking the wallet to add the bootstrap chain', async () => {
+    const addChainParams: unknown[] = [];
+    const p = new MockEip6963Provider({
+      rdns: 'io.metamask',
+      accounts: [`0x${'33'.repeat(20)}`],
+      chainId: 1,
+      handlers: {
+        wallet_switchEthereumChain: () => {
+          const err = new Error('Unknown chain') as Error & { code: number };
+          err.code = 4902;
+          throw err;
+        },
+        wallet_addEthereumChain: (params) => {
+          addChainParams.push(params);
+          return null;
+        },
+      },
+    });
+
+    useWalletStore.getState().setBootstrap({
+      ...CONTRACTS,
+      walletRpcUrls: ['https://public-rpc.example'],
+    });
+    await useWalletStore.getState().connect(p.detail());
+    await useWalletStore.getState().switchToExpectedChain();
+
+    expect(p.calls).toEqual(expect.arrayContaining(['wallet_switchEthereumChain', 'wallet_addEthereumChain']));
+    const addedChain = (addChainParams[0] as [{ rpcUrls: string[] }])[0];
+    expect(addedChain.rpcUrls).toEqual(['https://public-rpc.example']);
   });
 });

--- a/packages/node-ui/test/web3-clients.test.ts
+++ b/packages/node-ui/test/web3-clients.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it, afterEach } from 'vitest';
+// @vitest-environment happy-dom
+
+import { describe, expect, it, afterEach, vi } from 'vitest';
 
 import { numericChainId, chainIdHex } from '../src/ui/web3/chainId.js';
 import { synthesizeChain, publicClientFor, _resetClientCacheForTesting } from '../src/ui/web3/clients.js';
 
-afterEach(() => _resetClientCacheForTesting());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  _resetClientCacheForTesting();
+});
 
 describe('chainId helpers', () => {
   it('extracts the numeric tail from a compound id', () => {
@@ -38,6 +43,16 @@ describe('synthesizeChain', () => {
 });
 
 describe('publicClientFor', () => {
+  function headerValue(headers: HeadersInit | undefined, name: string): string | undefined {
+    if (!headers) return undefined;
+    if (headers instanceof Headers) return headers.get(name) ?? undefined;
+    if (Array.isArray(headers)) {
+      const found = headers.find(([key]) => key.toLowerCase() === name.toLowerCase());
+      return found?.[1];
+    }
+    return (headers as Record<string, string>)[name];
+  }
+
   it('returns a client pinned to the synthesized chain and caches per id + RPC URL set', () => {
     const a = publicClientFor('base:84532', ['https://rpc.example']);
     expect(a.chain?.id).toBe(84532);
@@ -47,5 +62,48 @@ describe('publicClientFor', () => {
     expect(c).not.toBe(a);
     const d = publicClientFor('100', ['https://rpc.gnosis']); // different id → new client
     expect(d).not.toBe(a);
+  });
+
+  it('can read through a same-origin relative PCA RPC URL in the browser', async () => {
+    const seenUrls: string[] = [];
+    const seenHeaders: Array<HeadersInit | undefined> = [];
+    (window as any).__DKG_TOKEN__ = 'tok-123';
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+      seenUrls.push(typeof input === 'string' ? input : input.toString());
+      seenHeaders.push(init?.headers);
+      const body = JSON.parse(String(init?.body ?? '{}')) as { id?: unknown } | Array<{ id?: unknown }>;
+      const responseBody = Array.isArray(body)
+        ? body.map((call) => ({ jsonrpc: '2.0', id: call.id, result: '0x14a34' }))
+        : { jsonrpc: '2.0', id: body.id, result: '0x14a34' };
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const client = publicClientFor('base:84532', ['/api/pca/rpc']);
+    await expect(client.request({ method: 'eth_chainId' })).resolves.toBe('0x14a34');
+    expect(seenUrls).toEqual(['/api/pca/rpc']);
+    expect(headerValue(seenHeaders[0], 'Authorization')).toBe('Bearer tok-123');
+  });
+
+  it('does not send the node bearer token to external RPC URLs', async () => {
+    const seenHeaders: Array<HeadersInit | undefined> = [];
+    (window as any).__DKG_TOKEN__ = 'tok-123';
+    vi.stubGlobal('fetch', async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenHeaders.push(init?.headers);
+      const body = JSON.parse(String(init?.body ?? '{}')) as { id?: unknown } | Array<{ id?: unknown }>;
+      const responseBody = Array.isArray(body)
+        ? body.map((call) => ({ jsonrpc: '2.0', id: call.id, result: '0x14a34' }))
+        : { jsonrpc: '2.0', id: body.id, result: '0x14a34' };
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const client = publicClientFor('base:84532', ['https://rpc.example']);
+    await expect(client.request({ method: 'eth_chainId' })).resolves.toBe('0x14a34');
+    expect(headerValue(seenHeaders[0], 'Authorization')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the PCA hardware-wallet bootstrap leak by keeping raw adapter/operator RPC URLs daemon-internal and serving node-UI browser reads through the bounded same-origin `/api/pca/rpc` proxy.
- Adds a separate `walletRpcUrls` path for public wallet chain-add endpoints, including shipped Base/Gnosis network defaults, so fresh-wallet unknown-chain setup can work without exposing private operator RPC URLs.
- Keeps direct `getPublishingConvictionContracts()` usable by returning configured wallet-public endpoints as browser-safe `rpcUrls`, while the daemon HTTP route still rewrites `rpcUrls` to `/api/pca/rpc`.
- Suppresses inherited wallet-public RPC defaults for local or different-chain operator overrides, including explicit operator adapter backups, unless the operator explicitly configures wallet RPCs.
- Tightens `/api/pca/rpc` to PCA-scoped `eth_call` selectors and bounded read params, including `eth_call` block/state-override rejection before adapter delegation.
- Fails closed when the daemon cannot serve the PCA RPC bridge, so `/api/pca/contracts` never advertises a dead `/api/pca/rpc` transport.
- Sends the node UI bearer token only to same-origin PCA RPC proxy transports; external wallet/public RPC URLs do not receive the token.

## Related

- Fixes #1374
- Follow-up to #1373

## Files changed

| File | What |
|------|------|
| `packages/cli/src/daemon/routes/pca.ts` | Adds `/api/pca/rpc`, same-origin contract bootstrap, method/param bounds, RPC-bridge capability gating, secret-safe errors, and wallet-public RPC filtering. |
| `packages/agent/src/dkg-agent*.ts` | Threads the daemon-internal PCA RPC bridge and wallet-public RPC config through the agent boundary; exposes the RPC bridge capability bit. |
| `packages/chain/src/evm-adapter-*`, `packages/chain/src/chain-adapter.ts`, `packages/chain/src/mock-adapter.ts` | Keeps private adapter RPC URLs internal, returns only configured wallet-public RPCs for direct contract bootstrap, and keeps mock bridge capability complete. |
| `network/*.json` | Adds wallet-public RPC defaults for Base mainnet, Gnosis mainnet, and Base Sepolia. |
| `packages/node-ui/src/ui/web3/clients.ts`, `packages/node-ui/e2e/*` | Uses `/api/pca/rpc` for viem reads, adds same-origin auth headers, and uses `walletRpcUrls` only for `wallet_addEthereumChain`; updates the HW mock lane. |
| `packages/*/test/*`, `packages/chain/vitest.unit.config.ts` | Covers leak prevention, JSON-RPC allowlist/bounds, wallet RPC propagation, off-overlay suppression, bridge availability, auth headers, selector coverage, direct facade transport, and HW mock browser reads. |

## Test plan

- [x] `pnpm --filter @origintrail-official/dkg exec vitest run -c vitest.unit.config.ts test/config.test.ts --reporter=dot` (80 passed)
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run -c vitest.unit.config.ts test/daemon-pca-routes.test.ts --reporter=dot` (100 passed)
- [x] `pnpm --filter @origintrail-official/dkg-chain exec vitest run -c vitest.unit.config.ts test/evm-adapter-pca-rpc.unit.test.ts test/mock-adapter-publishing-conviction-v10.test.ts --reporter=dot` (35 passed)
- [x] `pnpm --filter @origintrail-official/dkg-agent exec vitest run -c vitest.unit.config.ts test/pca-v10-facade.test.ts --reporter=dot` (14 passed)
- [x] `pnpm --filter @origintrail-official/dkg-chain exec vitest run -c vitest.unit.config.ts --reporter=dot` (configured chain unit suite passed)
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/web3-clients.test.ts --reporter=dot` (8 passed)
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec vitest run test/wallet-store.test.ts --reporter=dot` (included earlier in web3/wallet focused run)
- [x] `pnpm --filter @origintrail-official/dkg-node-ui exec playwright test --config playwright.hw-mock.config.ts` (7 passed)
- [x] `pnpm --filter @origintrail-official/dkg-chain run build`
- [x] `pnpm --filter @origintrail-official/dkg-agent run build`
- [x] `pnpm --filter @origintrail-official/dkg run build`
- [x] `pnpm --filter @origintrail-official/dkg-node-ui run build`
- [x] `git diff --check`

Known limitations: no live Base Sepolia spend was performed in this corrective PR; the attended spend remains part of the integration gate.