### PR TITLE
feat(evm): preserve PCA agent allow-list across NFT transfer (OT-RFC-51)

### DIFF
--- a/packages/chain/abi/PublishingConviction.json
+++ b/packages/chain/abi/PublishingConviction.json
@@ -114,6 +114,22 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "NotAccountOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "caller",
         "type": "address"
@@ -330,6 +346,31 @@
       },
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cleared",
+        "type": "uint256"
+      }
+    ],
+    "name": "AgentsCleared",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
         "internalType": "uint40",
         "name": "epoch",
         "type": "uint40"
@@ -492,6 +533,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      }
+    ],
+    "name": "clearAgents",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -911,6 +911,7 @@ export interface ChainAdapter {
   topUpPublishingConvictionAccount?(accountId: bigint, amount: bigint): Promise<TxResult>;
   registerPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<TxResult>;
   deregisterPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<TxResult>;
+  clearPublishingConvictionAgents?(accountId: bigint): Promise<TxResult>;
   isPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<boolean>;
   settlePublishingConvictionAccount?(accountId: bigint): Promise<TxResult>;
   getPublishingConvictionAccountInfo?(accountId: bigint): Promise<V10PublishingConvictionAccountInfo | null>;

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -367,6 +367,29 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     });
   }
 
+  /**
+   * Bulk-clear EVERY registered agent of a PCA. Owner-gated on-chain (ownerOf
+   * == caller). Unlike register/deregister (NFT-wrapper methods), `clearAgents`
+   * lives on the PublishingConviction LOGIC contract — the non-upgradeable
+   * wrapper has no entry point for it — so resolve the logic directly. Note PCA
+   * transfers PRESERVE the allow-list; this is the explicit reset a new owner
+   * uses to drop inherited agents.
+   */
+  async clearPublishingConvictionAgents(accountId: bigint): Promise<TxResult> {
+    await this.init();
+    return this.pcaWrite(async () => {
+      const logic = await this.resolveContract('PublishingConviction');
+      const receipt = await this.sendContractTransaction(
+        logic,
+        'clearAgents',
+        [accountId],
+        this.signer,
+        'clear publishing conviction agents',
+      );
+      return { hash: receipt.hash, blockNumber: receipt.blockNumber, txIndex: receipt.index, success: receipt.status === 1 };
+    });
+  }
+
   async isPublishingConvictionAgent(accountId: bigint, agent: string): Promise<boolean> {
     await this.init();
     if (!this.contracts.dkgPublishingConvictionNFT) return false;

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -646,6 +646,17 @@ export class MockChainAdapter implements ChainAdapter {
     return this.txResult(true);
   }
 
+  // Owner-gated bulk reset. Mirrors PublishingConviction.clearAgents: clears the
+  // whole allow-list (preserved across transfer; this is the explicit reset).
+  async clearPublishingConvictionAgents(accountId: bigint): Promise<TxResult> {
+    const acct = this.requireConvictionOwner(accountId);
+    for (const key of acct.agents) {
+      this.agentToConvictionAccount.delete(key);
+    }
+    acct.agents.clear();
+    return this.txResult(true);
+  }
+
   async isPublishingConvictionAgent(accountId: bigint, agent: string): Promise<boolean> {
     if (!ethers.isAddress(agent)) return false;
     const acct = this.convictionAccounts.get(accountId);

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -274,7 +274,11 @@ const PINNED_DIGESTS: Record<string, string> = {
   // widened Account tuple, realized-publish credit removed / publishingAllocation rename.
   // Repinned: KC→KA rename of error InvalidConvictionKcEpochs → InvalidConvictionKaEpochs
   // (error selector change; contract bumped to 10.0.5).
-  PublishingConviction:         'a4d44a594509e508091b1f91adfb1d68bec65e38e497f054116493af327ff096',
+  // Repinned (preserve-agents-on-transfer, 10.0.6): added the owner-gated bulk
+  // `clearAgents(uint256)` + event `AgentsCleared(uint256,address,uint256)` +
+  // error `NotAccountOwner(uint256,address)` for the explicit allow-list reset
+  // (transfers now PRESERVE agents). Event/error surface change → new digest.
+  PublishingConviction:         '13281d751828dbb05603dc6a657e917f63680b4e0e052aa95a9d24392743d18a',
   // Updated OT-RFC-51: storage surface for the above — primaryNode field on the
   // widened Account tuple + the seeded per-epoch publishing allocation getters.
   PublishingConvictionStorage:  '7eeae71f0efd9183fce232ccc669227dfd70fe4f93b4663392a0a52c1ccba859',

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -104,6 +104,23 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
     expect((await mock.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(0);
   });
 
+  it('clearPublishingConvictionAgents bulk-removes every agent and frees the reverse map', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+    const agent1 = ethers.Wallet.createRandom().address;
+    const agent2 = ethers.Wallet.createRandom().address;
+    await mock.registerPublishingConvictionAgent(accountId, agent1);
+    await mock.registerPublishingConvictionAgent(accountId, agent2);
+    expect((await mock.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(2);
+
+    const cleared = await mock.clearPublishingConvictionAgents(accountId);
+    expect(cleared.success).toBe(true);
+    expect(await mock.isPublishingConvictionAgent(accountId, agent1)).toBe(false);
+    expect(await mock.isPublishingConvictionAgent(accountId, agent2)).toBe(false);
+    expect(await mock.getConvictionAgentAccountId(agent1)).toBe(0n);
+    expect((await mock.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(0);
+  });
+
   it('rejects re-registering an already-registered agent (N28 parity)', async () => {
     const mock = new MockChainAdapter('mock:31337', SIGNER);
     const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -88,6 +88,25 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect(await owner.getConvictionAgentAccountId(agent)).toBe(0n);
   });
 
+  it('clearPublishingConvictionAgents bulk-removes every agent (owner-gated, via the logic contract)', async () => {
+    const owner = await fundedOwner();
+    const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);
+
+    const agent1 = ethers.Wallet.createRandom().address;
+    const agent2 = ethers.Wallet.createRandom().address;
+    await owner.registerPublishingConvictionAgent(accountId, agent1);
+    await owner.registerPublishingConvictionAgent(accountId, agent2);
+    expect((await owner.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(2);
+
+    const cleared = await owner.clearPublishingConvictionAgents(accountId);
+    expect(cleared.success).toBe(true);
+
+    expect(await owner.isPublishingConvictionAgent(accountId, agent1)).toBe(false);
+    expect(await owner.isPublishingConvictionAgent(accountId, agent2)).toBe(false);
+    expect(await owner.getConvictionAgentAccountId(agent1)).toBe(0n);
+    expect((await owner.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(0);
+  });
+
   it('owner topUpPublishingConvictionAccount + settlePublishingConvictionAccount succeed and topUpBuffer updates', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/evm-module/abi/PublishingConviction.json
+++ b/packages/evm-module/abi/PublishingConviction.json
@@ -114,6 +114,22 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "NotAccountOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "caller",
         "type": "address"
@@ -330,6 +346,31 @@
       },
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cleared",
+        "type": "uint256"
+      }
+    ],
+    "name": "AgentsCleared",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
         "internalType": "uint40",
         "name": "epoch",
         "type": "uint40"
@@ -492,6 +533,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      }
+    ],
+    "name": "clearAgents",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/packages/evm-module/contracts/ContextGraphs.sol
+++ b/packages/evm-module/contracts/ContextGraphs.sol
@@ -451,9 +451,11 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
      *        authorization. Instead we LIVE-RESOLVE the current PCA NFT
      *        owner via `IDKGPublishingConvictionNFT.ownerOf(accountId)` and
      *        accept either (a) that live owner directly or (b) a registered
-     *        agent whose `agentToAccountId(publisher) == accountId`. Both
-     *        mappings on the NFT contract are cleared by the transfer hook,
-     *        so stale agent entries automatically stop authorizing.
+     *        agent whose `agentToAccountId(publisher) == accountId`. The live
+     *        owner check revokes the FORMER owner immediately on transfer. The
+     *        agent allow-list, however, is PRESERVED across transfer (it travels
+     *        with the PCA), so a former owner's registered agents retain publish
+     *        authority until the new owner calls `PublishingConviction.clearAgents`.
      *
      *      Branch order is IMPORTANT. Because the EOA/Safe branch matches on
      *      the stored authority snapshot, it MUST NOT run in PCA mode — an
@@ -534,9 +536,11 @@ contract ContextGraphs is INamed, IVersioned, ContractStatus, IInitializable, Re
             return false;
         }
 
-        // Registered agent of the authorized account. `agentToAccountId`
-        // is cleared by the NFT's `_update` transfer hook, so stale agent
-        // entries automatically stop authorizing post-transfer.
+        // Registered agent of the authorized account. The agent allow-list is
+        // PRESERVED across PCA transfer (it travels with the token), so a former
+        // owner's agents keep authorizing here until the new owner explicitly
+        // resets it via `PublishingConviction.clearAgents`. The former OWNER is
+        // still revoked immediately by the live `ownerOf` check above.
         uint256 publisherAccountId = IDKGPublishingConvictionNFT(nftAddr).agentToAccountId(publisher);
         return publisherAccountId != 0 && publisherAccountId == authorityAccountId;
     }

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -6,6 +6,7 @@ import {INamed} from "./interfaces/INamed.sol";
 import {IVersioned} from "./interfaces/IVersioned.sol";
 import {IInitializable} from "./interfaces/IInitializable.sol";
 import {IPublishingConvictionErrors} from "./interfaces/IPublishingConvictionErrors.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {ContractStatus} from "./abstract/ContractStatus.sol";
 import {Chronos} from "./storage/Chronos.sol";
 import {EpochStorage} from "./storage/EpochStorage.sol";
@@ -127,7 +128,7 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     //           are byte-identical, so seed and move stay net-zero on K_total.
     // 10.0.5 — KC→KA terminology: error InvalidConvictionKcEpochs → InvalidConvictionKaEpochs
     //          (error selector change; no behavior change).
-    string private constant _VERSION = "10.0.5";
+    string private constant _VERSION = "10.0.6";
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
     /// @notice EpochStorage shard ID for the staker reward pool. Mirrors
@@ -204,6 +205,12 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     );
     event AgentRegistered(uint256 indexed accountId, address indexed agent);
     event AgentDeregistered(uint256 indexed accountId, address indexed agent);
+    /// @notice Emitted when an owner bulk-clears a PCA's agent allow-list via
+    ///         `clearAgents`. `cleared` is the number of agents removed.
+    event AgentsCleared(uint256 indexed accountId, address indexed owner, uint256 cleared);
+
+    /// @notice The caller is not the current owner of `accountId`'s PCA NFT.
+    error NotAccountOwner(uint256 accountId, address caller);
     /// @notice OT-RFC-51: emitted when an account's designated primary node
     ///         changes (including the initial designation at creation, where
     ///         `oldNode == 0`).
@@ -850,13 +857,15 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
         }
     }
 
-    /// @notice Trigger lazy-settlement from the NFT wrapper's transfer
-    ///         hook AND clear every agent registration so the new owner
-    ///         starts with a clean slate. Restricted to the NFT.
-    /// @dev    `from`/`to` arguments are not used internally — the
-    ///         wrapper passes them so a future audit-friendly extension
-    ///         (e.g. emitting a wrapper-layer transfer-settle event with
-    ///         both endpoints) does not require an interface change.
+    /// @notice Trigger lazy-settlement from the NFT wrapper's transfer hook so
+    ///         billing is brought current at the ownership change. Restricted to
+    ///         the NFT.
+    /// @dev    The agent allow-list is intentionally PRESERVED across transfer —
+    ///         it travels with the PCA like the rest of the account's state. Use
+    ///         the owner-gated `clearAgents` to reset it explicitly (a new owner
+    ///         can drop inherited agents; an owner can wipe them before handing
+    ///         the PCA over). `from`/`to` are unused internally — the wrapper
+    ///         passes them so a future event extension needs no interface change.
     function onTransfer(
         uint256 accountId,
         address /* from */,
@@ -870,7 +879,6 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
                 _finalSweep(acct, accountId);
             }
         }
-        publishingConvictionStorage.clearAgents(accountId);
     }
 
     /// @notice Internal helper: sweep all CLOSED windows up to the
@@ -1157,6 +1165,29 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     ) external onlyConvictionNFT {
         publishingConvictionStorage.removeAgent(accountId, agent);
         emit AgentDeregistered(accountId, agent);
+    }
+
+    /// @notice Clear ALL registered publishing agents for `accountId` in a single
+    ///         call — the owner-gated bulk counterpart to the per-agent
+    ///         `deregisterAgent`.
+    /// @dev    PCA NFT transfers PRESERVE the allow-list (it travels with the
+    ///         token; see `onTransfer`). This is the explicit reset: a new owner
+    ///         can drop an inherited allow-list, or an owner can wipe it before
+    ///         transferring the PCA to another party. Owner-validation is done
+    ///         HERE via `ownerOf` (not on the NFT wrapper, which is
+    ///         non-upgradeable and exposes no entry point for this) — so unlike
+    ///         `registerAgent`/`deregisterAgent` (gated by the wrapper), this is a
+    ///         direct owner-gated call. `ownerOf` reverts for a nonexistent
+    ///         account, so a bad id cannot reach the storage write; an
+    ///         unresolvable NFT (address 0) reverts the `ownerOf` call too.
+    function clearAgents(uint256 accountId) external {
+        address nftAddr = hub.getContractAddress("DKGPublishingConvictionNFT");
+        if (IERC721(nftAddr).ownerOf(accountId) != msg.sender) {
+            revert NotAccountOwner(accountId, msg.sender);
+        }
+        uint256 cleared = publishingConvictionStorage.agentCount(accountId);
+        publishingConvictionStorage.clearAgents(accountId);
+        emit AgentsCleared(accountId, msg.sender, cleared);
     }
 
     // ============================================================

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -326,6 +326,23 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
         _;
     }
 
+    /// @dev Owner-gate for the ONE direct-to-logic owner action (`clearAgents`).
+    ///      DELIBERATE, isolated exception to the usual pattern where owner
+    ///      validation lives on the NFT wrapper and logic is gated by
+    ///      `onlyConvictionNFT`: the wrapper is non-upgradeable and exposes no
+    ///      `clearAgents` entry point, so the bulk reset validates ownership
+    ///      here against the live `ownerOf`. Do NOT copy this for new agent
+    ///      operations — add those to the wrapper. `ownerOf` reverts for a
+    ///      nonexistent account (and for an unresolvable address(0) NFT), so a
+    ///      bad id cannot slip past this gate.
+    modifier onlyCurrentPcaOwner(uint256 accountId) {
+        address nftAddr = hub.getContractAddress("DKGPublishingConvictionNFT");
+        if (IERC721(nftAddr).ownerOf(accountId) != msg.sender) {
+            revert NotAccountOwner(accountId, msg.sender);
+        }
+        _;
+    }
+
     // ============================================================
     //                  Account lifecycle
     // ============================================================
@@ -1173,19 +1190,12 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     /// @dev    PCA NFT transfers PRESERVE the allow-list (it travels with the
     ///         token; see `onTransfer`). This is the explicit reset: a new owner
     ///         can drop an inherited allow-list, or an owner can wipe it before
-    ///         transferring the PCA to another party. Owner-validation is done
-    ///         HERE via `ownerOf` (not on the NFT wrapper, which is
-    ///         non-upgradeable and exposes no entry point for this) — so unlike
-    ///         `registerAgent`/`deregisterAgent` (gated by the wrapper), this is a
-    ///         direct owner-gated call. `ownerOf` reverts for a nonexistent
-    ///         account, so a bad id cannot reach the storage write; an
-    ///         unresolvable NFT (address 0) reverts the `ownerOf` call too.
-    function clearAgents(uint256 accountId) external {
-        address nftAddr = hub.getContractAddress("DKGPublishingConvictionNFT");
-        if (IERC721(nftAddr).ownerOf(accountId) != msg.sender) {
-            revert NotAccountOwner(accountId, msg.sender);
-        }
+    ///         transferring the PCA to another party.
+    function clearAgents(uint256 accountId) external onlyCurrentPcaOwner(accountId) {
         uint256 cleared = publishingConvictionStorage.agentCount(accountId);
+        // slither-disable-next-line reentrancy-events -- the callee is the trusted
+        // Hub-registered PublishingConvictionStorage (onlyContracts), state is
+        // written there before this event, and no value is transferred.
         publishingConvictionStorage.clearAgents(accountId);
         emit AgentsCleared(accountId, msg.sender, cleared);
     }

--- a/packages/evm-module/contracts/storage/PublishingConvictionStorage.sol
+++ b/packages/evm-module/contracts/storage/PublishingConvictionStorage.sol
@@ -191,8 +191,8 @@ contract PublishingConvictionStorage is INamed, IVersioned, HubDependent, IIniti
     mapping(uint256 => uint96) public topUpBalance;
 
     /// @notice Per-account agent enumeration. Kept as an array so the
-    ///         transfer hook on the NFT wrapper can iterate and clear
-    ///         every registration in one call. The agent-side reverse
+    ///         owner-gated `PublishingConviction.clearAgents` can iterate and
+    ///         clear every registration in one call. The agent-side reverse
     ///         map is `agentToAccountId`.
     mapping(uint256 => address[]) internal _registeredAgents;
 
@@ -410,10 +410,11 @@ contract PublishingConvictionStorage is INamed, IVersioned, HubDependent, IIniti
     }
 
     /// @notice Bulk-clear every agent registration under `accountId`.
-    ///         Used by the NFT wrapper's transfer hook so the new owner
-    ///         starts with a clean agent slate (no inherited authorities
-    ///         from the prior owner). Idempotent on accounts with no
-    ///         registered agents.
+    ///         Invoked by the owner-gated `PublishingConviction.clearAgents`
+    ///         (the explicit allow-list reset). NOTE: this is NOT called on NFT
+    ///         transfer — the agent allow-list is PRESERVED across transfer and
+    ///         travels with the PCA. Idempotent on accounts with no registered
+    ///         agents.
     function clearAgents(uint256 accountId) external onlyContracts {
         address[] storage agents = _registeredAgents[accountId];
         uint256 len = agents.length;

--- a/packages/evm-module/test/unit/ContextGraphs.test.ts
+++ b/packages/evm-module/test/unit/ContextGraphs.test.ts
@@ -706,9 +706,11 @@ describe('@unit ContextGraphs (facade)', () => {
   // now IGNORE the stored snapshot in PCA mode and live-resolve the current
   // NFT owner via `IDKGPublishingConvictionNFT.ownerOf(accountId)`.
   //
-  // Each test here documents the regression it blocks. Transferring the PCA
-  // NFT exercises the NFT contract's `_update` hook that clears agent
-  // mappings, so agent-based authorization paths also update in lockstep.
+  // Each test here documents the regression it blocks. NOTE: transferring the
+  // PCA NFT PRESERVES the agent allow-list (agents travel with the PCA; the
+  // reset is an explicit owner-gated `PublishingConviction.clearAgents` call).
+  // So the owner-drift fix below is what revokes the OLD owner on transfer,
+  // while a former owner's AGENTS retain authority until the new owner clears.
   describe('PCA transfer auth drift', () => {
     let alice: SignerWithAddress;        // original PCA owner + initial authority
     let bob: SignerWithAddress;          // new PCA owner after transfer
@@ -741,9 +743,9 @@ describe('@unit ContextGraphs (facade)', () => {
 
     async function transferPCA(from: SignerWithAddress, to: SignerWithAddress) {
       // Standard ERC-721 transfer. DKGPublishingConvictionNFT inherits
-      // from ERC721Enumerable, so `transferFrom` is available. The
-      // contract's `_update` hook clears `_registeredAgents` and
-      // `agentToAccountId` for pre-existing agents of this account.
+      // from ERC721Enumerable, so `transferFrom` is available. The `_update`
+      // hook settles billing but PRESERVES the agent allow-list (it travels
+      // with the PCA; reset is the explicit owner-gated clearAgents call).
       await NFT.connect(from).transferFrom(from.address, to.address, pcaAccountId);
     }
 
@@ -785,34 +787,33 @@ describe('@unit ContextGraphs (facade)', () => {
       expect(await Facade.isAuthorizedPublisher(cgId, stranger.address)).to.be.false;
     });
 
-    it('agents cleared on PCA transfer lose publish authority in lockstep', async () => {
+    it("a former owner's agent RETAINS publish authority after transfer until explicitly cleared", async () => {
       // Register Carol as an agent under Alice's PCA before the transfer.
       await NFT.connect(alice).registerAgent(pcaAccountId, carol.address);
-
-      // Pre-transfer: Carol is a registered agent of pcaAccountId, so the
-      // PCA branch authorizes her.
       expect(await Facade.isAuthorizedPublisher(cgId, carol.address)).to.be.true;
 
-      // Transfer. The NFT contract's `_update` hook clears the agent
-      // registrations for this token id (see DKGPublishingConvictionNFT.sol
-      // _update branch), so `agentToAccountId[carol] == 0` post-transfer.
+      // Transfer Alice -> Bob. The allow-list is PRESERVED (agents travel with
+      // the PCA), so Carol — Alice's agent — stays an agent of the account and
+      // remains authorized on Bob's PCA. This is the deliberate trade-off of
+      // preserve-on-transfer; the new owner resets it explicitly below.
       await transferPCA(alice, bob);
+      expect(await Facade.isAuthorizedPublisher(cgId, carol.address)).to.be.true;
 
-      // Post-transfer: Carol's agent mapping was cleared, so she is no
-      // longer authorized. Defense-in-depth: the facade's PCA branch
-      // would ALSO reject her (live owner is Bob, not Carol), but this
-      // test exercises the agent-clearing path specifically.
+      // Bob (the new owner) drops the inherited allow-list via the explicit
+      // owner-gated clearAgents — only THEN does Carol lose authority.
+      const Logic = await hre.ethers.getContract('PublishingConviction');
+      await Logic.connect(bob).clearAgents(pcaAccountId);
       expect(await Facade.isAuthorizedPublisher(cgId, carol.address)).to.be.false;
     });
 
     it('new PCA owner can register fresh agents post-transfer and they become authorized', async () => {
-      // Start from the cleared-state fixture: register Carol, transfer,
-      // confirm Carol was cleared.
+      // Register Carol under Alice, then transfer. The allow-list is PRESERVED,
+      // so Carol remains authorized under Bob's PCA.
       await NFT.connect(alice).registerAgent(pcaAccountId, carol.address);
       await transferPCA(alice, bob);
-      expect(await Facade.isAuthorizedPublisher(cgId, carol.address)).to.be.false;
+      expect(await Facade.isAuthorizedPublisher(cgId, carol.address)).to.be.true;
 
-      // Bob is now the PCA owner; he registers Dave as a fresh agent.
+      // Bob is now the PCA owner; he registers Dave as an ADDITIONAL agent.
       await NFT.connect(bob).registerAgent(pcaAccountId, dave.address);
 
       // Dave authorizes via the PCA-agent branch on live lookup.

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
@@ -1309,46 +1309,46 @@ describe('@unit DKGPublishingConvictionNFT', function () {
   // ======================================================================
 
   describe('clearAgents (explicit owner-gated reset)', () => {
-    it('owner clears the whole allow-list and emits AgentsCleared(count)', async () => {
+    // Create a PCA (id = totalSupply after mint) and register the given agents.
+    const createAccountWithAgents = async (...agents: string[]): Promise<bigint> => {
       const amount = hre.ethers.parseEther('60000');
       await TokenContract.approve(await NFT.getAddress(), amount);
       await NFT.createAccount(amount, 0);
-      await NFT.registerAgent(1, accounts[3].address);
-      await NFT.registerAgent(1, accounts[4].address);
+      const id = await NFT.totalSupply();
+      for (const a of agents) await NFT.registerAgent(id, a);
+      return id;
+    };
 
-      await expect(LogicContract.clearAgents(1))
+    it('owner clears the whole allow-list and emits AgentsCleared(count)', async () => {
+      const id = await createAccountWithAgents(accounts[3].address, accounts[4].address);
+
+      await expect(LogicContract.clearAgents(id))
         .to.emit(LogicContract, 'AgentsCleared')
-        .withArgs(1, accounts[0].address, 2);
+        .withArgs(id, accounts[0].address, 2);
 
-      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([]);
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([]);
       expect(await NFT.agentToAccountId(accounts[3].address)).to.equal(0n);
       expect(await NFT.agentToAccountId(accounts[4].address)).to.equal(0n);
     });
 
     it('a NEW owner can clear the inherited allow-list after transfer', async () => {
-      const amount = hre.ethers.parseEther('60000');
-      await TokenContract.approve(await NFT.getAddress(), amount);
-      await NFT.createAccount(amount, 0);
-      await NFT.registerAgent(1, accounts[3].address);
-      await NFT.transferFrom(accounts[0].address, accounts[7].address, 1);
-      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([accounts[3].address]); // preserved
+      const id = await createAccountWithAgents(accounts[3].address);
+      await NFT.transferFrom(accounts[0].address, accounts[7].address, id);
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([accounts[3].address]); // preserved
 
-      await LogicContract.connect(accounts[7]).clearAgents(1); // new owner drops it
-      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([]);
+      await LogicContract.connect(accounts[7]).clearAgents(id); // new owner drops it
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([]);
       expect(await NFT.agentToAccountId(accounts[3].address)).to.equal(0n);
     });
 
     it('reverts NotAccountOwner for a non-owner caller', async () => {
-      const amount = hre.ethers.parseEther('60000');
-      await TokenContract.approve(await NFT.getAddress(), amount);
-      await NFT.createAccount(amount, 0);
-      await NFT.registerAgent(1, accounts[3].address);
+      const id = await createAccountWithAgents(accounts[3].address);
 
       await expect(
-        LogicContract.connect(accounts[5]).clearAgents(1),
+        LogicContract.connect(accounts[5]).clearAgents(id),
       ).to.be.revertedWithCustomError(LogicContract, 'NotAccountOwner');
       // unchanged
-      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([accounts[3].address]);
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([accounts[3].address]);
     });
 
     it('reverts for a nonexistent account (ownerOf reverts)', async () => {
@@ -1554,7 +1554,7 @@ describe('@unit DKGPublishingConvictionNFT', function () {
       expect(sums2.total).to.equal(0n);
     });
 
-    it('NFT transfer auto-settles elapsed windows before clearing agents (pre-expiry)', async () => {
+    it('NFT transfer auto-settles elapsed windows (pre-expiry; agents preserved)', async () => {
       const committed = hre.ethers.parseEther('120000');
       const baseAllowance = committed / 12n;
       await TokenContract.approve(await NFT.getAddress(), committed);

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
@@ -1256,11 +1256,11 @@ describe('@unit DKGPublishingConvictionNFT', function () {
   });
 
   // ======================================================================
-  // H. ERC-721 behavior (agent clearing on transfer)
+  // H. ERC-721 behavior — agent allow-list PRESERVED across transfer
   // ======================================================================
 
-  describe('ERC-721 transferability', () => {
-    it('clears agent registrations on transfer', async () => {
+  describe('ERC-721 transferability — agents preserved across transfer', () => {
+    it('PRESERVES agent registrations on transferFrom (the allow-list travels with the PCA)', async () => {
       const amount = hre.ethers.parseEther('60000');
       await TokenContract.approve(await NFT.getAddress(), amount);
       await NFT.createAccount(amount, 0);
@@ -1269,18 +1269,90 @@ describe('@unit DKGPublishingConvictionNFT', function () {
 
       await NFT.transferFrom(accounts[0].address, accounts[7].address, 1);
 
-      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([]);
-      expect(await NFT.agentToAccountId(agent)).to.equal(0n);
+      expect(await NFT.ownerOf(1)).to.equal(accounts[7].address);
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([agent]); // preserved, not cleared
+      expect(await NFT.agentToAccountId(agent)).to.equal(1n); // still bound to the account
     });
 
-    it('new owner can register fresh agents after transfer', async () => {
+    it('PRESERVES agents on safeTransferFrom to an EOA (the standard-wallet path)', async () => {
+      const amount = hre.ethers.parseEther('60000');
+      await TokenContract.approve(await NFT.getAddress(), amount);
+      await NFT.createAccount(amount, 0);
+      const agent = accounts[3].address;
+      await NFT.registerAgent(1, agent);
+
+      await NFT['safeTransferFrom(address,address,uint256)'](
+        accounts[0].address,
+        accounts[7].address,
+        1,
+      );
+
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([agent]);
+    });
+
+    it('a new owner can ADD agents on top of the preserved list', async () => {
       const amount = hre.ethers.parseEther('60000');
       await TokenContract.approve(await NFT.getAddress(), amount);
       await NFT.createAccount(amount, 0);
       await NFT.registerAgent(1, accounts[3].address);
       await NFT.transferFrom(accounts[0].address, accounts[7].address, 1);
       await NFT.connect(accounts[7]).registerAgent(1, accounts[8].address);
-      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([accounts[8].address]);
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([
+        accounts[3].address,
+        accounts[8].address,
+      ]);
+    });
+  });
+
+  // ======================================================================
+  // H2. clearAgents — explicit owner-gated bulk reset (on the logic contract)
+  // ======================================================================
+
+  describe('clearAgents (explicit owner-gated reset)', () => {
+    it('owner clears the whole allow-list and emits AgentsCleared(count)', async () => {
+      const amount = hre.ethers.parseEther('60000');
+      await TokenContract.approve(await NFT.getAddress(), amount);
+      await NFT.createAccount(amount, 0);
+      await NFT.registerAgent(1, accounts[3].address);
+      await NFT.registerAgent(1, accounts[4].address);
+
+      await expect(LogicContract.clearAgents(1))
+        .to.emit(LogicContract, 'AgentsCleared')
+        .withArgs(1, accounts[0].address, 2);
+
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([]);
+      expect(await NFT.agentToAccountId(accounts[3].address)).to.equal(0n);
+      expect(await NFT.agentToAccountId(accounts[4].address)).to.equal(0n);
+    });
+
+    it('a NEW owner can clear the inherited allow-list after transfer', async () => {
+      const amount = hre.ethers.parseEther('60000');
+      await TokenContract.approve(await NFT.getAddress(), amount);
+      await NFT.createAccount(amount, 0);
+      await NFT.registerAgent(1, accounts[3].address);
+      await NFT.transferFrom(accounts[0].address, accounts[7].address, 1);
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([accounts[3].address]); // preserved
+
+      await LogicContract.connect(accounts[7]).clearAgents(1); // new owner drops it
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([]);
+      expect(await NFT.agentToAccountId(accounts[3].address)).to.equal(0n);
+    });
+
+    it('reverts NotAccountOwner for a non-owner caller', async () => {
+      const amount = hre.ethers.parseEther('60000');
+      await TokenContract.approve(await NFT.getAddress(), amount);
+      await NFT.createAccount(amount, 0);
+      await NFT.registerAgent(1, accounts[3].address);
+
+      await expect(
+        LogicContract.connect(accounts[5]).clearAgents(1),
+      ).to.be.revertedWithCustomError(LogicContract, 'NotAccountOwner');
+      // unchanged
+      expect(await NFT.getRegisteredAgents(1)).to.deep.equal([accounts[3].address]);
+    });
+
+    it('reverts for a nonexistent account (ownerOf reverts)', async () => {
+      await expect(LogicContract.clearAgents(999)).to.be.reverted;
     });
   });
 


### PR DESCRIPTION
## Summary
PCA NFT transfers now **preserve** the registered publishing-agent allow-list — it travels with the PCA (the ERC-721-conventional behavior). Resetting it is an **explicit owner-gated** `clearAgents` call. Previously every transfer silently wiped the allow-list inside `onTransfer`.

## Motivation
Verified on Gnosis mainnet (tx `0xbed3…30c0f`, PCA #4) that the deployed `PublishingConviction` v10.0.5 `onTransfer` invokes `clearAgents` on transfer — so a PCA carrying agents loses them on any standard wallet transfer. The intended behavior is for transfers (e.g. hot wallet → Safe/treasury) to keep their configuration.

## Changes — `PublishingConviction` (logic contract, 10.0.5 → 10.0.6)
- **`onTransfer`**: removed the unconditional `clearAgents(accountId)` call (kept lazy settle + final-sweep). Standard `transferFrom`/`safeTransferFrom` from any wallet now preserve agents — fully ERC-721 compliant (the hook is internal, never reverts in normal operation). No transfer-time "flag" is added: the ERC-721 `safeTransferFrom` signature is fixed and wallets only call the standard entrypoints.
- **New `clearAgents(uint256 accountId)`** — public, owner-gated (`ownerOf(accountId) == msg.sender`, else `NotAccountOwner`), bulk-clears via `storage.clearAgents`, emits `AgentsCleared(accountId, owner, count)`. A new owner can drop an inherited allow-list; an owner can wipe it before handing the PCA over. Lives on the logic contract because the NFT wrapper is non-upgradeable.
- Comment-only doc fixes at the live `ContextGraphs.isAuthorizedPublisher` auth site and on `PublishingConvictionStorage.clearAgents` (the old "cleared on transfer" prose is now false).

## ⚠️ Security trade-off (accepted)
A former owner's registered agents **retain publish authority** on the new owner's PCA until the new owner calls `clearAgents`. The former **owner** is revoked immediately (auth live-resolves `ownerOf`); the old owner gains **no** governance or fund-drain path (governance live-resolves the owner, never agents; `coverPublishingCost` only funds KAs / the staker pool). Safe for same-entity transfers; for arms-length transfers the relevant party clears agents explicitly (before or after).

## Verification
- **Tests:** NFT preserve + `clearAgents` (12); the `ContextGraphs` "PCA transfer auth drift" suite **flipped** to assert preserve + explicit reset (9); no regression (114 across NFT/conviction/lifecycle).
- **Adversarial 4-lens review** of the diff (security/auth, state/accounting, ERC-721, test-completeness), each finding independently refuted: **0 runtime issues** (state/accounting + ERC-721 clean; the new owner-gate has no approval/operator bypass, no reentrancy, reverts before the storage write for nonexistent/`address(0)`), **1 documentation defect** (stale auth-site comments) — fixed in this PR.

## Deploy
Single `PublishingConviction` redeploy (+ Hub re-register) + re-audit before mainnet. **Independent of #1366** (different contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)