### PR TITLE
fix(random-sampling): make RS proof extraction sub-graph aware (#1367)

### DIFF
--- a/packages/random-sampling/src/ka-extractor.ts
+++ b/packages/random-sampling/src/ka-extractor.ts
@@ -2,6 +2,10 @@ import {
   assertSafeIri,
   contextGraphDataUri,
   contextGraphMetaUri,
+  contextGraphLayerUri,
+  contextGraphSubGraphUri,
+  validateSubGraphName,
+  MemoryLayer,
   hashTripleV10,
   TRUST_LEVEL_PREDICATE,
   LEGACY_TRUST_LEVEL_PREDICATE,
@@ -48,6 +52,13 @@ export interface KCExtractionResult {
   contextGraphName: string;
   /** Data graph URI that contained the public triples. */
   dataGraph: string;
+  /**
+   * Sub-graph the KA's content was found in, or `undefined` for a CG-root KA
+   * (#1367). Discovered from `dkg:subGraphName` in `_meta`; lets the dRAG
+   * citation path see which sub-graph was resolved. Additive — pre-existing
+   * readers ignore it.
+   */
+  subGraphName?: string;
   /** UAL of the KC discovered via `dkg:batchId == kaId`. */
   ual: string;
   /** Root entities for each KA, in stable (sorted) order. */
@@ -155,11 +166,31 @@ export class KCDataMissingError extends Error {
  * Throws {@link KCNotFoundError}, {@link KCRootEntitiesNotFoundError},
  * or {@link KCDataMissingError} on the named failure modes — each is a
  * skip-this-period signal for the prover, not a retry.
+ *
+ * #1367 — sub-graph awareness. A KA published into a named sub-graph is
+ * sampled under the PARENT cgId (the chain has no sub-graph dimension) but
+ * its public data does NOT live in the per-cgId data graph above: the
+ * author keeps it in the per-KA verifiable-memory layer
+ * (`<cg>/<sub>/_verifiable_memory/<author>/<number>`) and a replica keeps
+ * it in the bare sub-graph graph (`<cg>/<sub>`). When the per-cgId graph
+ * yields nothing for a root we DISCOVER the sub-graph name from `_meta`
+ * (read-both: the per-cgId partition — populated on replicas — UNION the
+ * default label `_meta` — where the originator keeps it, because its
+ * per-cgId partition is the minimal `buildScopedMinimalMeta` shape that
+ * omits `dkg:subGraphName`) and fall back to those two graphs. This is a
+ * read-path change only: leaves are still `hashTripleV10` of the same
+ * triple content, so anchored roots are unchanged.
+ *
+ * `subGraphNameHint` short-circuits discovery for callers that already know
+ * the sub-graph (the dRAG citation path, which scans the graph URI first).
+ * It is ADDITIVE: the (a)→(b1)→(b2) cascade still runs, so a stale/empty
+ * hint can never cause under-inclusion or regress a root/remap KA.
  */
 export async function extractV10KCFromStore(
   store: TripleStore,
   cgId: bigint,
   kaId: bigint,
+  subGraphNameHint?: string,
 ): Promise<KCExtractionResult> {
   const cgIdStr = cgId.toString();
   // Map cgId (numeric) → local CG name via the ontology graph. The
@@ -254,23 +285,71 @@ export async function extractV10KCFromStore(
     throw new KCRootEntitiesNotFoundError(cgId, kaId, ual);
   }
 
-  // 3. Pull public triples per root entity. Same filter the publisher
-  //    used to gather SWM quads; keeps the leaf set bit-for-bit.
-  const triples: KCTriple[] = [];
-  for (const root of rootEntities) {
+  // 3. Pull public triples per root entity, with the #1367 sub-graph
+  //    cascade. For each root: read the per-cgId data graph (a) FIRST — the
+  //    sole home for CG-root and remapped KAs. Only when (a) yields nothing
+  //    for some root do we discover the sub-graph and fall back to the
+  //    per-KA verifiable-memory layer (b1, author publish) then the bare
+  //    sub-graph graph (b2, replica finalization). FIRST non-empty source
+  //    per root wins — never a UNION: two co-resident copies with divergent
+  //    literal escaping would not collapse under set semantics and would
+  //    inflate the leaf set → V10ProofLeafCountMismatch. The root+genid
+  //    subject filter and POST_PUBLISH_PREDICATES_TO_SKIP exclusion (the VM
+  //    layer carries self-attested trust stamps) apply to every source.
+  const readRoot = async (graph: string, root: string): Promise<KCTriple[]> => {
     const genidPrefix = `${root}/.well-known/genid/`;
     const result = await store.query(
       `CONSTRUCT { ?s ?p ?o } WHERE {
-         GRAPH <${dataGraph}> {
+         GRAPH <${graph}> {
            ?s ?p ?o .
            FILTER(?s = <${root}> || STRSTARTS(STR(?s), "${escapeSparqlString(genidPrefix)}"))
          }
        }`,
     );
-    if (result.type === 'quads') {
-      for (const q of result.quads) {
-        if (POST_PUBLISH_PREDICATES_TO_SKIP.has(q.predicate)) continue;
-        triples.push({ subject: q.subject, predicate: q.predicate, object: q.object });
+    if (result.type !== 'quads') return [];
+    const out: KCTriple[] = [];
+    for (const q of result.quads) {
+      if (POST_PUBLISH_PREDICATES_TO_SKIP.has(q.predicate)) continue;
+      out.push({ subject: q.subject, predicate: q.predicate, object: q.object });
+    }
+    return out;
+  };
+
+  const triples: KCTriple[] = [];
+  const emptyRoots: string[] = [];
+  for (const root of rootEntities) {
+    const fromRoot = await readRoot(dataGraph, root);
+    if (fromRoot.length > 0) triples.push(...fromRoot);
+    else emptyRoots.push(root);
+  }
+
+  // Hot path: CG-root / remapped KAs satisfy every root from (a), so we never
+  // discover or touch any sub-graph graph — identical work to pre-#1367.
+  let subGraphName: string | undefined;
+  if (emptyRoots.length > 0) {
+    subGraphName = await resolveSubGraphName(store, metaGraph, cgName, ual, subGraphNameHint);
+    if (subGraphName) {
+      // (author, number) is globally unique per chain (ka_numbers is keyed on
+      // author only; the contract reverts KaIdNamespaceMismatch otherwise), so
+      // these constructed URIs can only ever name THIS KA's graphs. All parts
+      // are safe-by-construction: cgName was assertSafeIri-probed in
+      // resolveContextGraphNameFromOnChainId, subGraphName is validateSubGraphName'd
+      // in resolveSubGraphName, author is hex and number is numeric — no
+      // store-returned IRI is interpolated into SPARQL.
+      const vmAuthor = '0x' + (kaId >> 96n).toString(16).padStart(40, '0');
+      const vmNumber = kaId & ((1n << 96n) - 1n);
+      const subSources = [
+        contextGraphLayerUri(cgName, MemoryLayer.VerifiableMemory, vmAuthor, vmNumber, subGraphName), // (b1)
+        contextGraphSubGraphUri(cgName, subGraphName), // (b2)
+      ];
+      for (const root of emptyRoots) {
+        for (const g of subSources) {
+          const fromSub = await readRoot(g, root);
+          if (fromSub.length > 0) {
+            triples.push(...fromSub);
+            break; // first non-empty source for THIS root — do not union the rest
+          }
+        }
       }
     }
   }
@@ -284,10 +363,46 @@ export async function extractV10KCFromStore(
   const leaves: Uint8Array[] = triples.map((t) => hashTripleV10(t.subject, t.predicate, t.object));
   for (const root of privateRoots) leaves.push(root);
 
-  return { contextGraphName: cgName, dataGraph, ual, rootEntities, triples, privateRoots, leaves };
+  return { contextGraphName: cgName, dataGraph, subGraphName, ual, rootEntities, triples, privateRoots, leaves };
 }
 
 // ── Internal helpers ───────────────────────────────────────────────────
+
+/**
+ * Resolve the sub-graph a KA's content lives in (#1367), or `undefined` for a
+ * CG-root KA. An explicit `hint` (dRAG citation path, which scanned the graph
+ * URI) short-circuits the query. Otherwise read `dkg:subGraphName` keyed on
+ * the UAL with a READ-BOTH union: the per-cgId `_meta` carries it on REPLICAS
+ * (the full confirmed meta is remapped there), while the ORIGINATOR keeps it
+ * only in the default label `_meta` — its per-cgId partition is the minimal
+ * `buildScopedMinimalMeta` shape, which omits `dkg:subGraphName`. Either source
+ * is validated before use; an absent/invalid value returns `undefined` so the
+ * caller safely degrades to root-only (a legacy sub-graph KA with no pointer
+ * simply stays `kc-not-synced`, never a wrong root).
+ */
+async function resolveSubGraphName(
+  store: TripleStore,
+  perCgIdMetaGraph: string,
+  cgName: string,
+  ual: string,
+  hint?: string,
+): Promise<string | undefined> {
+  if (hint) {
+    return validateSubGraphName(hint).valid ? hint : undefined;
+  }
+  const defaultMetaGraph = contextGraphMetaUri(cgName); // did:dkg:context-graph:<NAME>/_meta
+  const result = await store.query(
+    `SELECT ?sg WHERE {
+       { GRAPH <${perCgIdMetaGraph}> { <${ual}> <${DKG}subGraphName> ?sg } }
+       UNION
+       { GRAPH <${defaultMetaGraph}> { <${ual}> <${DKG}subGraphName> ?sg } }
+     } LIMIT 1`,
+  );
+  if (result.type !== 'bindings' || result.bindings.length === 0) return undefined;
+  const sg = stripQuotes(result.bindings[0]['sg'] ?? '');
+  if (!sg || !validateSubGraphName(sg).valid) return undefined;
+  return sg;
+}
 
 /**
  * Look up the local CG name for a given on-chain id.
@@ -397,7 +512,8 @@ export async function extractV10KCQuads(
   store: TripleStore,
   cgId: bigint,
   kaId: bigint,
+  subGraphNameHint?: string,
 ): Promise<Quad[]> {
-  const result = await extractV10KCFromStore(store, cgId, kaId);
+  const result = await extractV10KCFromStore(store, cgId, kaId, subGraphNameHint);
   return result.triples.map((t) => ({ ...t, graph: result.dataGraph }));
 }

--- a/packages/random-sampling/src/ka-extractor.ts
+++ b/packages/random-sampling/src/ka-extractor.ts
@@ -45,6 +45,14 @@ export interface KCTriple {
   subject: string;
   predicate: string;
   object: string;
+  /**
+   * Source graph the triple was actually read from (the per-cgId data graph,
+   * the per-KA VM layer, or the bare sub-graph graph — #1367). Additive; the
+   * V10 leaf hash excludes the graph, so this never affects proving — it exists
+   * so `extractV10KCQuads` can report the true graph instead of rewriting every
+   * row to the per-cgId data graph.
+   */
+  graph?: string;
 }
 
 export interface KCExtractionResult {
@@ -310,51 +318,77 @@ export async function extractV10KCFromStore(
     const out: KCTriple[] = [];
     for (const q of result.quads) {
       if (POST_PUBLISH_PREDICATES_TO_SKIP.has(q.predicate)) continue;
-      out.push({ subject: q.subject, predicate: q.predicate, object: q.object });
+      out.push({ subject: q.subject, predicate: q.predicate, object: q.object, graph });
     }
     return out;
   };
 
   const triples: KCTriple[] = [];
-  const emptyRoots: string[] = [];
+  const unresolvedRoots: string[] = [];
   for (const root of rootEntities) {
     const fromRoot = await readRoot(dataGraph, root);
     if (fromRoot.length > 0) triples.push(...fromRoot);
-    else emptyRoots.push(root);
+    else unresolvedRoots.push(root);
   }
 
   // Hot path: CG-root / remapped KAs satisfy every root from (a), so we never
   // discover or touch any sub-graph graph — identical work to pre-#1367.
   let subGraphName: string | undefined;
-  if (emptyRoots.length > 0) {
-    subGraphName = await resolveSubGraphName(store, metaGraph, cgName, ual, subGraphNameHint);
-    if (subGraphName) {
+  if (unresolvedRoots.length > 0) {
+    // #1367 sub-graph cascade for the still-unresolved roots: the per-KA
+    // verifiable-memory layer (b1, author publish) then the bare sub-graph graph
+    // (b2, replica finalization). FIRST non-empty source per root wins — never a
+    // UNION: two co-resident copies with divergent literal escaping would not
+    // collapse under set semantics and would inflate the leaf set →
+    // V10ProofLeafCountMismatch.
+    const resolveFrom = async (sg: string): Promise<void> => {
       // (author, number) is globally unique per chain (ka_numbers is keyed on
       // author only; the contract reverts KaIdNamespaceMismatch otherwise), so
-      // these constructed URIs can only ever name THIS KA's graphs. All parts
-      // are safe-by-construction: cgName was assertSafeIri-probed in
-      // resolveContextGraphNameFromOnChainId, subGraphName is validateSubGraphName'd
-      // in resolveSubGraphName, author is hex and number is numeric — no
+      // these constructed URIs can only ever name THIS KA's graphs. All parts are
+      // safe-by-construction: cgName was assertSafeIri-probed, sg is
+      // validateSubGraphName'd, author is hex and number numeric — no
       // store-returned IRI is interpolated into SPARQL.
       const vmAuthor = '0x' + (kaId >> 96n).toString(16).padStart(40, '0');
       const vmNumber = kaId & ((1n << 96n) - 1n);
       const subSources = [
-        contextGraphLayerUri(cgName, MemoryLayer.VerifiableMemory, vmAuthor, vmNumber, subGraphName), // (b1)
-        contextGraphSubGraphUri(cgName, subGraphName), // (b2)
+        contextGraphLayerUri(cgName, MemoryLayer.VerifiableMemory, vmAuthor, vmNumber, sg), // (b1)
+        contextGraphSubGraphUri(cgName, sg), // (b2)
       ];
-      for (const root of emptyRoots) {
+      for (const root of [...unresolvedRoots]) {
         for (const g of subSources) {
           const fromSub = await readRoot(g, root);
           if (fromSub.length > 0) {
             triples.push(...fromSub);
-            break; // first non-empty source for THIS root — do not union the rest
+            unresolvedRoots.splice(unresolvedRoots.indexOf(root), 1);
+            if (subGraphName === undefined) subGraphName = sg;
+            break;
           }
         }
       }
+    };
+
+    // The `subGraphNameHint` (dRAG citation path scanned the graph URI) is a
+    // FAST-PATH candidate, NOT authoritative: a stale or invalid hint must never
+    // hide the canonical `dkg:subGraphName` in `_meta`. Try the hint first, then
+    // fall back to the meta pointer for any root the hint can't satisfy.
+    const hint = subGraphNameHint && validateSubGraphName(subGraphNameHint).valid ? subGraphNameHint : undefined;
+    if (hint) await resolveFrom(hint);
+    if (unresolvedRoots.length > 0) {
+      const metaSg = await resolveSubGraphNameFromMeta(store, metaGraph, cgName, ual);
+      if (metaSg && metaSg !== hint) await resolveFrom(metaSg);
     }
   }
-  if (triples.length === 0) {
-    throw new KCDataMissingError(cgId, kaId, ual, rootEntities);
+
+  // Partial-root guard (#1367): if ANY root is still unresolved, the KA is not
+  // fully synced locally. Returning the partial set would build a V10 root over a
+  // SUBSET of leaves → mismatch with the on-chain root → on-chain `data-corrupted`
+  // on submit instead of a benign skip. Throw KCDataMissingError so the prover
+  // emits `kc-not-synced` and re-tries later.
+  if (unresolvedRoots.length > 0 || triples.length === 0) {
+    throw new KCDataMissingError(
+      cgId, kaId, ual,
+      unresolvedRoots.length > 0 ? unresolvedRoots : rootEntities,
+    );
   }
 
   // 4. Compute V10 leaves: public triples first, private sub-roots next.
@@ -369,27 +403,26 @@ export async function extractV10KCFromStore(
 // ── Internal helpers ───────────────────────────────────────────────────
 
 /**
- * Resolve the sub-graph a KA's content lives in (#1367), or `undefined` for a
- * CG-root KA. An explicit `hint` (dRAG citation path, which scanned the graph
- * URI) short-circuits the query. Otherwise read `dkg:subGraphName` keyed on
- * the UAL with a READ-BOTH union: the per-cgId `_meta` carries it on REPLICAS
- * (the full confirmed meta is remapped there), while the ORIGINATOR keeps it
- * only in the default label `_meta` — its per-cgId partition is the minimal
- * `buildScopedMinimalMeta` shape, which omits `dkg:subGraphName`. Either source
- * is validated before use; an absent/invalid value returns `undefined` so the
- * caller safely degrades to root-only (a legacy sub-graph KA with no pointer
- * simply stays `kc-not-synced`, never a wrong root).
+ * Resolve the CANONICAL sub-graph a KA's content lives in (#1367) from `_meta`,
+ * or `undefined` for a CG-root KA. Read `dkg:subGraphName` keyed on the UAL with
+ * a READ-BOTH union: the per-cgId `_meta` carries it on REPLICAS (the full
+ * confirmed meta is remapped there), while the ORIGINATOR keeps it only in the
+ * default label `_meta` — its per-cgId partition is the minimal
+ * `buildScopedMinimalMeta` shape, which omits `dkg:subGraphName`. The value is
+ * validated before use; an absent/invalid value returns `undefined` so the
+ * caller safely degrades (a legacy sub-graph KA with no pointer stays
+ * `kc-not-synced`, never a wrong root).
+ *
+ * The dRAG citation-path `hint` is handled by the CALLER as an additive
+ * fast-path candidate, never here — so a stale hint can never suppress this
+ * canonical lookup.
  */
-async function resolveSubGraphName(
+async function resolveSubGraphNameFromMeta(
   store: TripleStore,
   perCgIdMetaGraph: string,
   cgName: string,
   ual: string,
-  hint?: string,
 ): Promise<string | undefined> {
-  if (hint) {
-    return validateSubGraphName(hint).valid ? hint : undefined;
-  }
   const defaultMetaGraph = contextGraphMetaUri(cgName); // did:dkg:context-graph:<NAME>/_meta
   const result = await store.query(
     `SELECT ?sg WHERE {
@@ -515,5 +548,13 @@ export async function extractV10KCQuads(
   subGraphNameHint?: string,
 ): Promise<Quad[]> {
   const result = await extractV10KCFromStore(store, cgId, kaId, subGraphNameHint);
-  return result.triples.map((t) => ({ ...t, graph: result.dataGraph }));
+  // Report each triple's ACTUAL source graph (#1367): per-cgId data graph, per-KA
+  // VM layer, or bare sub-graph graph. Fall back to the per-cgId data graph only
+  // for any triple that predates source tagging.
+  return result.triples.map((t) => ({
+    subject: t.subject,
+    predicate: t.predicate,
+    object: t.object,
+    graph: t.graph ?? result.dataGraph,
+  }));
 }

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -1272,7 +1272,9 @@ describe('extractV10KCFromStore — #1367 sub-graph KA extraction', () => {
 
     const result = await extractV10KCFromStore(store, fixture.cgId, fixture.kaId, 'stray-hint');
     expect(result.subGraphName).toBeUndefined();
-    expect(result.triples).toEqual([{ subject: 'urn:e:root-ka', predicate: 'urn:p:name', object: '"root"' }]);
+    expect(result.triples.map(({ graph, ...t }) => t)).toEqual([{ subject: 'urn:e:root-ka', predicate: 'urn:p:name', object: '"root"' }]);
+    // #1367: source graph is tracked — a root KA reads only from the per-cgId data graph.
+    expect(result.triples.every((t) => t.graph === result.dataGraph)).toBe(true);
   });
 
   // ── Coverage (audit gaps) ──────────────────────────────────────────────
@@ -1370,8 +1372,59 @@ describe('extractV10KCFromStore — #1367 sub-graph KA extraction', () => {
     await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
     // Pointer present but INVALID (whitespace → validateSubGraphName rejects it).
     await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: 'bad name', target: 'default' });
-    // (a) empty + invalid pointer → resolveSubGraphName returns undefined → no
+    // (a) empty + invalid pointer → resolveSubGraphNameFromMeta returns undefined → no
     // sub-graph URI is ever constructed/read → safe degrade, never a wrong root.
     await expect(extractV10KCFromStore(store, CG_ID, KA_ID)).rejects.toBeInstanceOf(KCDataMissingError);
+  });
+
+  // ── #1367 review fixes ──────────────────────────────────────────────────
+
+  it('STALE HINT is additive, not authoritative: a stale-but-valid hint falls back to the canonical _meta subGraphName', async () => {
+    // The KA's real sub-graph is SUB; the dRAG citation path passes a stale hint
+    // ("stale") whose graphs hold nothing. The hint must NOT suppress the _meta
+    // pointer — else a synced KA gets reported missing (KCDataMissingError).
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    await seedGraphData(store, contextGraphSubGraphUri(CG_NAME, SUB), TRIPLES);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID, 'stale');
+
+    expect(result.subGraphName).toBe(SUB); // resolved via _meta, not the stale hint
+    expect(result.triples).toHaveLength(TRIPLES.length);
+    expectMatchesAnchor(result);
+  });
+
+  it('PARTIAL roots throw KCDataMissingError (benign skip) — never an incomplete leaf set', async () => {
+    // ROOT_A resolves from the sub-graph; ROOT_B has no data in ANY source. A
+    // partial set would build a V10 root over a SUBSET of leaves → mismatch with
+    // the on-chain root → data-corrupted on submit. The extractor must skip, not
+    // return the partial set.
+    const ROOT_A = 'urn:entity:rule-A';
+    const ROOT_B = 'urn:entity:rule-B';
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT_A, ROOT_B] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    await seedGraphData(store, contextGraphSubGraphUri(CG_NAME, SUB), [
+      { subject: ROOT_A, predicate: 'urn:p:name', object: '"A"' },
+    ]); // ROOT_B intentionally absent everywhere
+
+    await expect(extractV10KCFromStore(store, CG_ID, KA_ID)).rejects.toBeInstanceOf(KCDataMissingError);
+  });
+
+  it('extractV10KCQuads reports each triple ACTUAL source graph (not a rewrite to the per-cgId data graph)', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    const subGraph = contextGraphSubGraphUri(CG_NAME, SUB);
+    await seedGraphData(store, subGraph, TRIPLES);
+
+    const quads = await extractV10KCQuads(store, CG_ID, KA_ID);
+
+    expect(quads).toHaveLength(TRIPLES.length);
+    // Data lives in the bare sub-graph graph (b2) → quads must name THAT graph,
+    // not the per-cgId data graph.
+    expect(quads.every((q) => q.graph === subGraph)).toBe(true);
+    expect(quads.every((q) => q.graph === contextGraphDataUri(CG_NAME, CG_ID.toString()))).toBe(false);
   });
 });

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -31,6 +31,9 @@ import {
   verifyV10ProofMaterial,
   contextGraphDataUri,
   contextGraphMetaUri,
+  contextGraphLayerUri,
+  contextGraphSubGraphUri,
+  MemoryLayer,
 } from '@origintrail-official/dkg-core';
 import {
   extractV10KCFromStore,
@@ -1070,5 +1073,205 @@ describe('GH#842 / PR #845 — Codex review fixes', () => {
     if (rootsRes.type === 'bindings') {
       expect(new Set(rootsRes.bindings.map((b) => b['root']))).toEqual(new Set(['urn:new:a', 'urn:new:b']));
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// #1367 — sub-graph KAs are sampled but unprovable (RS read-path).
+//
+// A KA published into a named sub-graph is sampled under the PARENT cgId
+// (the chain has no sub-graph dimension) but its public data does NOT live
+// in the per-cgId data graph the extractor historically read. The author
+// keeps it in the per-KA verifiable-memory layer
+// (`<cg>/<sub>/_verifiable_memory/<author>/<number>`) and a replica keeps it
+// in the bare sub-graph graph (`<cg>/<sub>`). The fix makes the extractor
+// DISCOVER the sub-graph from `_meta` (read-both: per-cgId — populated on
+// replicas — UNION default label `_meta` — where the ORIGINATOR keeps it,
+// since its per-cgId partition is the minimal `buildScopedMinimalMeta` shape
+// that omits `dkg:subGraphName`) and fall back to those graphs per-root.
+//
+// These tests do NOT use `seedKC` (it writes straight into source (a), which
+// would FALSE-PASS with the bug present). They seed the sub-graph layouts
+// directly. Tests #1/#2 carry an escape-bearing object literal so the
+// insert→CONSTRUCT readback actually pins byte-exactness for the author and
+// replica paths (sub-graph content has never round-tripped through
+// extract→hash before, because it always failed earlier at KCDataMissing).
+// ─────────────────────────────────────────────────────────────────────────
+
+function escapeNQuads(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}
+// Backslash + embedded quote + newline: the literal class the swm-host
+// CONSTRUCT→insert backslash-doubling hazard would corrupt.
+const ESCAPE_OBJ = `"${escapeNQuads('a\\b"c\nx')}"`;
+
+function vmAuthorOf(kaId: bigint): string {
+  return '0x' + (kaId >> 96n).toString(16).padStart(40, '0');
+}
+function vmNumberOf(kaId: bigint): bigint {
+  return kaId & ((1n << 96n) - 1n);
+}
+
+/**
+ * Per-cgId minimal `_meta` exactly as `buildScopedMinimalMeta` writes it for
+ * a sub-graph publish: batchId (UAL resolution) + collapsed rootEntity rows
+ * on the UAL subject. Deliberately NO `dkg:subGraphName` — the originator's
+ * per-cgId partition omits it.
+ */
+async function seedScopedMinimalMeta(
+  store: OxigraphStore,
+  o: { cgName: string; cgId: bigint; ual: string; kaId: bigint; roots: string[] },
+): Promise<void> {
+  const metaGraph = contextGraphMetaUri(o.cgName, o.cgId.toString());
+  const quads: Quad[] = [
+    { subject: o.ual, predicate: `${DKG}batchId`, object: `"${o.kaId}"^^<${XSD}integer>`, graph: metaGraph },
+  ];
+  for (const root of o.roots) {
+    quads.push({ subject: o.ual, predicate: `${DKG}rootEntity`, object: root, graph: metaGraph });
+  }
+  await store.insert(quads);
+}
+
+/** Write `<ual> dkg:subGraphName "<name>"` to either the per-cgId or default label `_meta`. */
+async function seedSubGraphPointer(
+  store: OxigraphStore,
+  o: { cgName: string; cgId: bigint; ual: string; subGraphName: string; target: 'percgid' | 'default' },
+): Promise<void> {
+  const metaGraph = o.target === 'percgid'
+    ? contextGraphMetaUri(o.cgName, o.cgId.toString())
+    : contextGraphMetaUri(o.cgName);
+  await store.insert([
+    { subject: o.ual, predicate: `${DKG}subGraphName`, object: `"${o.subGraphName}"`, graph: metaGraph },
+  ]);
+}
+
+async function seedGraphData(
+  store: OxigraphStore,
+  graph: string,
+  triples: { subject: string; predicate: string; object: string }[],
+): Promise<void> {
+  await store.insert(triples.map((t) => ({ ...t, graph })));
+}
+
+describe('extractV10KCFromStore — #1367 sub-graph KA extraction', () => {
+  let store: OxigraphStore;
+  beforeEach(() => {
+    store = new OxigraphStore();
+  });
+
+  const CG_NAME = 'devnet-sg';
+  const CG_ID = 1234n;
+  const SUB = 'rules';
+  // Clean (author, number) decomposition: author 0x..01, number 5.
+  const KA_ID = (1n << 96n) | 5n;
+  const UAL = `did:dkg:hardhat:31337/${vmAuthorOf(KA_ID)}/${vmNumberOf(KA_ID)}`;
+  const ROOT = 'urn:entity:rule-1';
+  const TRIPLES = [
+    { subject: ROOT, predicate: 'urn:p:name', object: '"rule one"' },
+    { subject: ROOT, predicate: 'urn:p:note', object: ESCAPE_OBJ }, // byte-exactness probe
+  ];
+
+  function expectMatchesAnchor(result: { leaves: Uint8Array[] }): void {
+    const fixtureLeaves = TRIPLES.map((t) => hashTripleV10(t.subject, t.predicate, t.object));
+    expect(new V10MerkleTree(result.leaves).root).toEqual(new V10MerkleTree(fixtureLeaves).root);
+  }
+
+  it('AUTHOR layout: subGraphName only in DEFAULT label _meta, data in the per-KA VM layer (b1) — proves the read-both discovery', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    // Originator: per-cgId meta is the minimal shape (NO subGraphName)…
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    // …subGraphName lives ONLY in the default label _meta.
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'default' });
+    // Author data: per-KA VM layer (b1).
+    const vmGraph = contextGraphLayerUri(CG_NAME, MemoryLayer.VerifiableMemory, vmAuthorOf(KA_ID), vmNumberOf(KA_ID), SUB);
+    await seedGraphData(store, vmGraph, TRIPLES);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.ual).toBe(UAL);
+    expect(result.subGraphName).toBe(SUB);
+    expect(result.triples).toHaveLength(TRIPLES.length);
+    expectMatchesAnchor(result);
+  });
+
+  it('REPLICA layout (the operative RS case): subGraphName in per-cgId _meta, data in the bare sub-graph graph (b2)', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    // Replica remaps the FULL confirmed meta (incl. subGraphName) into per-cgId.
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    // Replica data: bare sub-graph graph (b2).
+    const sgGraph = contextGraphSubGraphUri(CG_NAME, SUB);
+    await seedGraphData(store, sgGraph, TRIPLES);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.subGraphName).toBe(SUB);
+    expect(result.triples).toHaveLength(TRIPLES.length);
+    expectMatchesAnchor(result);
+  });
+
+  it('throws KCDataMissingError (not a wrong root) when no source holds the data', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'default' });
+    // No data seeded in (a), (b1) or (b2).
+    await expect(extractV10KCFromStore(store, CG_ID, KA_ID)).rejects.toBeInstanceOf(KCDataMissingError);
+  });
+
+  it('CASCADE non-inflation: when (a) is non-empty the cascade STOPS there and never reads a divergent (b1) copy', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'default' });
+    // (a) per-cgId has the canonical triples…
+    await seedGraphData(store, contextGraphDataUri(CG_NAME, CG_ID.toString()), TRIPLES);
+    // …(b1) holds a BYTE-DIVERGENT copy of the same logical triple (extra escaping).
+    const vmGraph = contextGraphLayerUri(CG_NAME, MemoryLayer.VerifiableMemory, vmAuthorOf(KA_ID), vmNumberOf(KA_ID), SUB);
+    await seedGraphData(store, vmGraph, [
+      { subject: ROOT, predicate: 'urn:p:name', object: '"rule one"' },
+      { subject: ROOT, predicate: 'urn:p:note', object: `"${escapeNQuads('a\\b"c\nx')}EXTRA"` },
+      { subject: ROOT, predicate: 'urn:p:extra', object: '"should never be read"' },
+    ]);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    // Only (a) was read: exactly TRIPLES, never the divergent/extra (b1) rows.
+    expect(result.subGraphName).toBeUndefined(); // (a) satisfied every root → discovery never ran
+    expect(result.triples).toHaveLength(TRIPLES.length);
+    expectMatchesAnchor(result);
+  });
+
+  it('EXPLICIT HINT: short-circuits discovery when the meta pointer is absent (the dRAG citation path)', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    // NO subGraphName pointer anywhere — only the explicit hint can find the data.
+    const vmGraph = contextGraphLayerUri(CG_NAME, MemoryLayer.VerifiableMemory, vmAuthorOf(KA_ID), vmNumberOf(KA_ID), SUB);
+    await seedGraphData(store, vmGraph, TRIPLES);
+
+    const withHint = await extractV10KCFromStore(store, CG_ID, KA_ID, SUB);
+    expect(withHint.subGraphName).toBe(SUB);
+    expect(withHint.triples).toHaveLength(TRIPLES.length);
+    expectMatchesAnchor(withHint);
+
+    // Without the hint and without a meta pointer, it safely degrades to root-only.
+    await expect(extractV10KCFromStore(store, CG_ID, KA_ID)).rejects.toBeInstanceOf(KCDataMissingError);
+  });
+
+  it('ROOT-KA PARITY: a root KA (no subGraphName) extracts from (a) unchanged and reports subGraphName=undefined, even with a stray hint', async () => {
+    const ROOT_UAL = 'did:dkg:hardhat:31337/0xpub/77';
+    const fixture: KCFixture = {
+      cgId: 555n,
+      kaId: 77n,
+      ual: ROOT_UAL,
+      rootEntities: ['urn:e:root-ka'],
+      publicTriples: [{ subject: 'urn:e:root-ka', predicate: 'urn:p:name', object: '"root"' }],
+    };
+    await seedKC(store, fixture);
+    // A stale root VM-layer copy (no sub-graph) must NEVER be read for a root KA.
+    const rootVm = contextGraphLayerUri(`cg-${fixture.cgId}`, MemoryLayer.VerifiableMemory, vmAuthorOf(77n), vmNumberOf(77n));
+    await seedGraphData(store, rootVm, [{ subject: 'urn:e:root-ka', predicate: 'urn:p:name', object: '"STALE"' }]);
+
+    const result = await extractV10KCFromStore(store, fixture.cgId, fixture.kaId, 'stray-hint');
+    expect(result.subGraphName).toBeUndefined();
+    expect(result.triples).toEqual([{ subject: 'urn:e:root-ka', predicate: 'urn:p:name', object: '"root"' }]);
   });
 });

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -1274,4 +1274,78 @@ describe('extractV10KCFromStore — #1367 sub-graph KA extraction', () => {
     expect(result.subGraphName).toBeUndefined();
     expect(result.triples).toEqual([{ subject: 'urn:e:root-ka', predicate: 'urn:p:name', object: '"root"' }]);
   });
+
+  // ── Coverage (audit gaps) ──────────────────────────────────────────────
+
+  it('MULTI-ROOT (replica/b2): a 2-root sub-graph KC accumulates ALL roots — combined leaf set matches the anchor', async () => {
+    const ROOT_A = 'urn:entity:rule-A';
+    const ROOT_B = 'urn:entity:rule-B';
+    const triplesA = [{ subject: ROOT_A, predicate: 'urn:p:name', object: '"A"' }];
+    const triplesB = [
+      { subject: ROOT_B, predicate: 'urn:p:name', object: '"B"' },
+      { subject: ROOT_B, predicate: 'urn:p:note', object: ESCAPE_OBJ },
+    ];
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT_A, ROOT_B] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    await seedGraphData(store, contextGraphSubGraphUri(CG_NAME, SUB), [...triplesA, ...triplesB]);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.subGraphName).toBe(SUB);
+    expect(result.triples).toHaveLength(triplesA.length + triplesB.length);
+    // Both roots' triples present — compare the leaf SET (order-independent).
+    const hex = (ls: Uint8Array[]) => ls.map((l) => Buffer.from(l).toString('hex')).sort();
+    const anchor = [...triplesA, ...triplesB].map((t) => hashTripleV10(t.subject, t.predicate, t.object));
+    expect(hex(result.leaves)).toEqual(hex(anchor));
+  });
+
+  it('FALLBACK non-union: (a) empty and BOTH (b1)+(b2) hold the root — only (b1) is read, never unioned with (b2)', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'default' });
+    // (a) per-cgId data graph stays EMPTY.
+    // (b1) VM layer = the canonical copy.
+    const vmGraph = contextGraphLayerUri(CG_NAME, MemoryLayer.VerifiableMemory, vmAuthorOf(KA_ID), vmNumberOf(KA_ID), SUB);
+    await seedGraphData(store, vmGraph, TRIPLES);
+    // (b2) bare sub-graph = byte-divergent + an extra row that must NEVER be read.
+    await seedGraphData(store, contextGraphSubGraphUri(CG_NAME, SUB), [
+      { subject: ROOT, predicate: 'urn:p:name', object: '"rule one"' },
+      { subject: ROOT, predicate: 'urn:p:note', object: `"${escapeNQuads('a\\b"c\nx')}EXTRA"` },
+      { subject: ROOT, predicate: 'urn:p:extra', object: '"should never be read"' },
+    ]);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.subGraphName).toBe(SUB);
+    expect(result.triples).toHaveLength(TRIPLES.length); // (b1) only — not unioned with (b2)
+    expectMatchesAnchor(result);
+  });
+
+  it('skips a post-publish dkg:trustLevel stamp on the (b2) sub-graph source so leaf count stays bit-identical', async () => {
+    const TRUST_LEVEL_PREDICATE = 'http://dkg.io/ontology/trustLevel';
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    await seedGraphData(store, contextGraphSubGraphUri(CG_NAME, SUB), [
+      ...TRIPLES,
+      { subject: ROOT, predicate: TRUST_LEVEL_PREDICATE, object: '"5"' }, // post-publish stamp
+    ]);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.triples.map((t) => t.predicate)).not.toContain(TRUST_LEVEL_PREDICATE);
+    expect(result.triples).toHaveLength(TRIPLES.length); // stamp excluded on the sub-graph source too
+    expectMatchesAnchor(result);
+  });
+
+  it('an INVALID subGraphName pointer degrades to root-only (no wrong-URI read) → KCDataMissingError', async () => {
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });
+    // Pointer present but INVALID (whitespace → validateSubGraphName rejects it).
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: 'bad name', target: 'default' });
+    // (a) empty + invalid pointer → resolveSubGraphName returns undefined → no
+    // sub-graph URI is ever constructed/read → safe degrade, never a wrong root.
+    await expect(extractV10KCFromStore(store, CG_ID, KA_ID)).rejects.toBeInstanceOf(KCDataMissingError);
+  });
 });

--- a/packages/random-sampling/test/ka-extractor.test.ts
+++ b/packages/random-sampling/test/ka-extractor.test.ts
@@ -1300,6 +1300,32 @@ describe('extractV10KCFromStore — #1367 sub-graph KA extraction', () => {
     expect(hex(result.leaves)).toEqual(hex(anchor));
   });
 
+  it('MULTI-ROOT mixed-source: one root from (a) per-cgId, another only from the sub-graph — both accumulate (per-root cascade)', async () => {
+    // Distinguishes a PER-ROOT cascade from a per-KC one: a per-KC cascade would
+    // see (a) non-empty (ROOT_A present), use (a) alone, and DROP ROOT_B.
+    const ROOT_A = 'urn:entity:rule-A';
+    const ROOT_B = 'urn:entity:rule-B';
+    const triplesA = [{ subject: ROOT_A, predicate: 'urn:p:name', object: '"A"' }];
+    const triplesB = [
+      { subject: ROOT_B, predicate: 'urn:p:name', object: '"B"' },
+      { subject: ROOT_B, predicate: 'urn:p:note', object: ESCAPE_OBJ },
+    ];
+    await seedOntology(store, CG_NAME, CG_ID);
+    await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT_A, ROOT_B] });
+    await seedSubGraphPointer(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, subGraphName: SUB, target: 'percgid' });
+    // ROOT_A lives in the (a) per-cgId data graph; ROOT_B only in the (b2) sub-graph source.
+    await seedGraphData(store, contextGraphDataUri(CG_NAME, CG_ID.toString()), triplesA);
+    await seedGraphData(store, contextGraphSubGraphUri(CG_NAME, SUB), triplesB);
+
+    const result = await extractV10KCFromStore(store, CG_ID, KA_ID);
+
+    expect(result.subGraphName).toBe(SUB); // discovered because ROOT_B was empty in (a)
+    expect(result.triples).toHaveLength(triplesA.length + triplesB.length);
+    const hex = (ls: Uint8Array[]) => ls.map((l) => Buffer.from(l).toString('hex')).sort();
+    const anchor = [...triplesA, ...triplesB].map((t) => hashTripleV10(t.subject, t.predicate, t.object));
+    expect(hex(result.leaves)).toEqual(hex(anchor));
+  });
+
   it('FALLBACK non-union: (a) empty and BOTH (b1)+(b2) hold the root — only (b1) is read, never unioned with (b2)', async () => {
     await seedOntology(store, CG_NAME, CG_ID);
     await seedScopedMinimalMeta(store, { cgName: CG_NAME, cgId: CG_ID, ual: UAL, kaId: KA_ID, roots: [ROOT] });


### PR DESCRIPTION
## What & why

Closes #1367.

Knowledge Assets published into a named **sub-graph** are registered for Random Sampling under the **parent** context-graph id (the EVM contracts have no sub-graph dimension), but the RS prover reads their content back from the **per-cgId data graph** — where sub-graph content does not live. So the prover resolves the UAL + root entities fine, then finds zero data triples → `KCDataMissingError` → returns `{kind:'kc-not-synced'}` and the challenge silently fails.

**Net effect:** any node that publishes (or replicates) KAs into a sub-graph fails RS challenges for that content, gets no proof-of-storage credit, and may be penalised for "missing" data it actually holds. The failure is swallowed as a sync gap, so it looks benign.

The on-chain merkle root is **already correct** for sub-graph content (V10 leaves hash triple content only — the graph term is excluded), so **this is fixable on the read path alone. No consensus / leaf-computation / write-path change.**

## Root cause

`extractV10KCFromStore` reads each root's triples from a single graph — `contextGraphDataUri(cgName, cgId)` = `did:dkg:context-graph:<NAME>/context/<cgId>`. For a sub-graph KA that graph is empty: the per-cgId data promotion recomputes its source VM graph **without** `subGraphName`, so sub-graph data is never copied there.

The non-obvious part — sub-graph public data has **three** real homes, and the one RS actually needs is the replica's:

| | Graph | Written by |
|---|---|---|
| **(a)** | `…/<NAME>/context/<cgId>` | root KAs (remap + same-graph). **Empty for sub-graph KAs** — the only graph the extractor read before this PR |
| **(b1)** | `…/<cg>/<sub>/_verifiable_memory/<author>/<number>` | **author** confirmed publish — `dkg-publisher.ts` (`contextGraphLayerUri(…, options.subGraphName)`) |
| **(b2)** | `…/<cg>/<sub>` (bare sub-graph graph) | **replica / finalization / chain-reconcile** — `finalization-handler.ts` (`dataGraph = subGraphName ? contextGraphSubGraphUri(...) : …`) |

RS challenges the **synced population**, not just the author, so **(b2) is the operative case**. A VM-suffix-only fix would have fixed authors and left every replica still failing.

## The fix

Make `extractV10KCFromStore` sub-graph aware on the read path:

1. **Discover `subGraphName` from `_meta` — read-both.** Query `<ual> dkg:subGraphName ?sg` over the per-cgId `_meta` **UNION** the default label `_meta` (`…/<NAME>/_meta`). This is load-bearing: on the **originator** of a sub-graph publish the per-cgId partition is the minimal `buildScopedMinimalMeta` shape, which **omits** `subGraphName` — the pointer survives only in the default label `_meta`. On **replicas** the full confirmed meta (incl. the pointer) is remapped into the per-cgId partition. Reading both covers both roles. (A per-cgId-only query — the obvious first cut — silently no-ops on the originator; there's a regression test that fails under exactly that mistake.)

2. **Per-root first-non-empty cascade**, not a UNION: for each root read **(a)** first; only when (a) is empty for that root do we discover the sub-graph and try **(b1)** then **(b2)**, taking the first non-empty source. A UNION is unsafe — a peer-synced KA can hold the same logical triple in two graphs with byte-divergent literal escaping (the documented `CONSTRUCT→INSERT` backslash-doubling hazard); set semantics would not collapse them → leaf-count inflation → `V10ProofLeafCountMismatchError`. The cascade reads (b) only when (a) missed, so it can never change a currently-accepted proof — only convert a today-rejected extraction into an accepted one.

3. **Hot-path gate:** discovery and all (b) work fire only when (a) came up empty for some root, so CG-root / remapped KAs (the bulk of RS draws) take a path byte-identical to today — zero extra queries.

URIs for (b1)/(b2) are **constructed** from the already-`assertSafeIri`-probed `cgName` + the `validateSubGraphName`'d sub + numeric author/number — no store-returned IRI is ever interpolated into SPARQL. `(author, number)` is globally unique per chain (`ka_numbers` is keyed on author only; the contract reverts `KaIdNamespaceMismatch` otherwise), so a constructed (b1) URI can only ever name *this* KA's graph. The existing root+genid subject filter and `POST_PUBLISH_PREDICATES_TO_SKIP` (trust-level) exclusion apply to every source.

Also adds an optional `subGraphName` **hint** (additive — the cascade still runs, so a stale/empty hint can never under-include or regress a root KA) that the dRAG citation path can thread since it scans the graph URI first, plus a `subGraphName` field on `KCExtractionResult`.

## Tests

6 new tests in `ka-extractor.test.ts` (they deliberately do **not** use the `seedKC` helper, which writes straight into source (a) and would false-pass with the bug present):

- **AUTHOR layout** — `subGraphName` only in the default label `_meta`, data in (b1). Proves the read-both discovery; **fails** under a per-cgId-only discovery.
- **REPLICA layout** — `subGraphName` in per-cgId `_meta`, data in (b2). The operative RS case.
- **No-source** → `KCDataMissingError` (skip the period, never a wrong root).
- **Cascade non-inflation** — same triple in (a) + a byte-divergent copy in (b1); only (a) is read.
- **Explicit hint** — short-circuits discovery when no meta pointer exists (the dRAG path); degrades to root-only without it.
- **Root-KA parity** — a root KA extracts from (a) unchanged, reports `subGraphName=undefined`, and never reads a stale root VM copy, even with a stray hint.

The AUTHOR/REPLICA tests carry an escape-bearing object literal (`a\b"c\n`) so the insert→CONSTRUCT readback actually pins byte-exactness — sub-graph content had never round-tripped through extract→hash before (it always failed earlier at `KCDataMissing`).

## Verification

- Full `random-sampling` suite **71/71 green** (incl. the hardhat e2e), `tsc --noEmit` clean.
- **Falsification check:** temporarily reverting to per-cgId-only discovery makes the AUTHOR test fail (proves the tests catch the bug and aren't false-passing); reverting the read-both/cascade restores green.
- The changed files are byte-identical on `main`, and the storage-layout invariants the fix relies on were re-verified against current `main` (the bug is still present there: extractor reads `GRAPH <dataGraph>` only; `buildScopedMinimalMeta` still omits `subGraphName`; replica still writes `contextGraphSubGraphUri` (b2); author still writes `contextGraphLayerUri(…subGraphName)` (b1)).

## Scope

- **Read-path only.** No change to `hashTripleV10` / `V10MerkleTree` / on-chain roots / the write path. The write-side asymmetry (author→VM-layer vs replica→bare sub-graph; the `subGraphName`-dropping promotion) is left as-is on purpose: "fixing" it would leak sub-graph triples into root-context queries and still wouldn't help already-published data.
- **Out of scope (follow-on):** re-enabling dRAG sub-graph **citations** (`gatherVerifiedFacts` currently scans root-only) — this PR only adds the optional hint that path will thread. Curated/catalog proving is CG-root-only by design and unaffected.
- **Acceptance gate to run on a devnet:** publish a KA into a sub-graph, then confirm RS reports `solved=true` on both the **author** and a **subscribed replica** node, with recomputed leaf count == on-chain `getMerkleLeafCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
