### PR TITLE
fix(core): backend-independent V10 merkle leaf term canonicalization

### DIFF
--- a/packages/core/src/crypto/canonicalize.ts
+++ b/packages/core/src/crypto/canonicalize.ts
@@ -1,6 +1,7 @@
 import canonize from 'rdf-canonize';
 import { sha256 } from './hashing.js';
 import { keccak256 } from './keccak.js';
+import { canonicalizeObjectTermForHash } from './term-canon.js';
 
 const textEncoder = new TextEncoder();
 
@@ -56,7 +57,13 @@ export function tripleContentV10(
   predicate: string,
   object: string,
 ): Uint8Array {
-  return textEncoder.encode(formatNTriple(subject, predicate, object));
+  // Backend-independent leaf canonicalization (spec §9.0.2): the object literal
+  // is normalized to its protocol-canonical value-space form BEFORE serialization
+  // so the leaf — and the `content` bytes submitted on-chain — are identical on
+  // every node regardless of triple-store backend or version. See term-canon.ts.
+  return textEncoder.encode(
+    formatNTriple(subject, predicate, canonicalizeObjectTermForHash(object)),
+  );
 }
 
 /**

--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -43,6 +43,7 @@ export {
 } from './proof-material.js';
 
 export { canonicalize, hashTriple, hashTripleV10, tripleContentV10 } from './canonicalize.js';
+export { canonicalizeObjectTermForHash } from './term-canon.js';
 
 export { hexToBytes } from './oracle-verify.js';
 

--- a/packages/core/src/crypto/term-canon.ts
+++ b/packages/core/src/crypto/term-canon.ts
@@ -1,0 +1,245 @@
+// Protocol-defined, BACKEND-INDEPENDENT canonicalization of an RDF object term,
+// applied at the V10 merkle leaf (tripleContentV10) so EVERY node computes the
+// identical leaf for the same triple regardless of which triple store it runs
+// (oxigraph, blazegraph, a SPARQL endpoint, future backends) and which version.
+// Without this the leaf delegated literal canonicalization to whatever string the
+// backend emitted, so a publisher sealing pre-store and a peer recomputing
+// post-store could hash different serializations of the SAME triple →
+// MERKLE_MISMATCH_IN_SWM (okf-dkg-vm-validation-report.md), and two nodes on
+// different backends could fork RandomSampling (the contract hashes this exact
+// content: leaf = keccak256(content)).
+//
+// The canonical form is DEFINED to equal the value-space canonicalization the
+// network already deploys (oxigraph 0.5.5), verified byte-for-byte by the
+// oxigraph-oracle test (packages/publisher/test/term-canon-oracle.test.ts), so it
+// is the IDENTITY on already-canonical (store-loaded) terms ⇒ no migration; a
+// coordinated release suffices.
+//
+// Covered: literal-content ESCAPING (decode N-Triples escapes, re-emit oxigraph's
+// minimal \ " \n \r escaping); language-tag lowercasing; xsd:string elision; the
+// xsd:integer family (collapse→xsd:integer iff value∈i64; xsd:integer arbitrary
+// precision); xsd:decimal; xsd:boolean; xsd:double / xsd:float; the date/time
+// family (xsd:dateTime/time fractional-seconds, +00:00→Z timezone across
+// dateTime/time/date/gYear/gYearMonth/gMonthDay/gMonth/gDay, and the T24:00:00
+// roll-over); xsd:duration / dayTimeDuration / yearMonthDuration (drop zero
+// components, all-zero → PT0S). Other datatypes are returned with normalized
+// escaping but otherwise verbatim — matching oxigraph.
+
+const XSD = 'http://www.w3.org/2001/XMLSchema#';
+const XSD_STRING = XSD + 'string';
+const XSD_INTEGER = XSD + 'integer';
+
+const INTEGER_TYPES = new Set(
+  [
+    'integer', 'int', 'long', 'short', 'byte',
+    'nonNegativeInteger', 'positiveInteger', 'nonPositiveInteger', 'negativeInteger',
+    'unsignedLong', 'unsignedInt', 'unsignedShort', 'unsignedByte',
+  ].map((t) => XSD + t),
+);
+// date/time-family datatypes whose only normalization is +00:00/-00:00 → Z.
+const TZ_ONLY_TYPES = new Set(
+  ['date', 'gYear', 'gYearMonth', 'gMonthDay', 'gMonth', 'gDay'].map((t) => XSD + t),
+);
+const DURATION_TYPES = new Set(
+  ['duration', 'dayTimeDuration', 'yearMonthDuration'].map((t) => XSD + t),
+);
+
+// oxigraph collapses a DERIVED integer type to xsd:integer iff the value fits a
+// signed 64-bit integer (no per-type sign/bound enforcement); out-of-i64 derived
+// values stay verbatim. xsd:integer itself is arbitrary precision.
+const I64_MIN = -9223372036854775808n;
+const I64_MAX = 9223372036854775807n;
+
+const RE_LITERAL = /^"((?:[^"\\]|\\.)*)"(?:@([A-Za-z0-9-]+)|\^\^<([^>]+)>)?$/;
+
+export function canonicalizeObjectTermForHash(object: string): string {
+  if (object.length === 0 || object.charCodeAt(0) !== 34 /* " */) return object; // IRI / blank / genid
+  const m = RE_LITERAL.exec(object);
+  if (!m) return object;
+  const rawLex = m[1];
+  const lang = m[2];
+  const dt = m[3];
+  // Literal CONTENT escaping is normalized for every literal (a store decodes
+  // \uXXXX / \t / \U… to raw UTF-8 and re-emits only \ " \n \r escaped).
+  const lex = normalizeEscaping(rawLex);
+
+  if (lang !== undefined) return `"${lex}"@${lang.toLowerCase()}`;
+  if (dt === undefined || dt === XSD_STRING) return `"${lex}"`; // plain / xsd:string
+
+  try {
+    if (INTEGER_TYPES.has(dt)) return canonIntegerTerm(lex, dt) ?? verbatim(lex, dt);
+    if (dt === XSD + 'decimal') return `"${canonDecimal(lex)}"^^<${dt}>`;
+    if (dt === XSD + 'boolean') return `"${canonBoolean(lex)}"^^<${dt}>`;
+    if (dt === XSD + 'double') return `"${canonDouble(lex, false)}"^^<${dt}>`;
+    if (dt === XSD + 'float') return `"${canonDouble(lex, true)}"^^<${dt}>`;
+    if (dt === XSD + 'dateTime') return `"${canonDateTime(lex)}"^^<${dt}>`;
+    if (dt === XSD + 'time') return `"${canonTime(lex)}"^^<${dt}>`;
+    if (TZ_ONLY_TYPES.has(dt)) return `"${normalizeTz(lex)}"^^<${dt}>`;
+    if (DURATION_TYPES.has(dt)) return `"${canonDuration(lex, dt)}"^^<${dt}>`;
+  } catch {
+    return verbatim(lex, dt); // invalid lexical → escaping-normalized, otherwise verbatim
+  }
+  return verbatim(lex, dt); // datatype the deployed store leaves verbatim
+}
+
+const verbatim = (lex: string, dt: string) => `"${lex}"^^<${dt}>`;
+
+// ── literal content escaping ───────────────────────────────────────────────────
+const ESCAPE_DECODE = /\\(u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|[tbnrf"'\\])/g;
+function normalizeEscaping(lex: string): string {
+  const decoded = lex.replace(ESCAPE_DECODE, (whole, e: string) => {
+    const c = e[0];
+    if (c === 'u' || c === 'U') return String.fromCodePoint(parseInt(e.slice(1), 16));
+    switch (e) {
+      case 't': return '\t';
+      case 'b': return '\b';
+      case 'n': return '\n';
+      case 'r': return '\r';
+      case 'f': return '\f';
+      case '"': return '"';
+      case "'": return "'";
+      case '\\': return '\\';
+      default: return whole;
+    }
+  });
+  // re-emit oxigraph's minimal escaping (escapeNQuadsLiteral): \ " \n \r only.
+  return decoded.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+}
+
+// ── xsd:integer family ─────────────────────────────────────────────────────────
+function canonIntegerTerm(lex: string, dt: string): string | null {
+  const raw = lex.startsWith('+') ? lex.slice(1) : lex;
+  if (!/^-?\d+$/.test(raw)) return null;
+  const v = BigInt(raw);
+  if (dt !== XSD_INTEGER && (v < I64_MIN || v > I64_MAX)) return null;
+  return `"${v.toString()}"^^<${XSD_INTEGER}>`;
+}
+
+// ── xsd:boolean ────────────────────────────────────────────────────────────────
+function canonBoolean(lex: string): string {
+  if (lex === 'true' || lex === '1') return 'true';
+  if (lex === 'false' || lex === '0') return 'false';
+  throw new Error(`invalid xsd:boolean: ${lex}`);
+}
+
+// ── xsd:decimal ────────────────────────────────────────────────────────────────
+function canonDecimal(lex: string): string {
+  const m = /^([+-]?)(\d*)(?:\.(\d*))?$/.exec(lex);
+  if (!m || (m[2] === '' && (m[3] === undefined || m[3] === ''))) throw new Error(`invalid xsd:decimal: ${lex}`);
+  let int = m[2].replace(/^0+/, '');
+  const frac = (m[3] ?? '').replace(/0+$/, '');
+  if (int === '') int = '0';
+  const sign = m[1] === '-' && !(int === '0' && frac === '') ? '-' : '';
+  return frac === '' ? `${sign}${int}` : `${sign}${int}.${frac}`;
+}
+
+// ── xsd:double / xsd:float ─────────────────────────────────────────────────────
+function canonDouble(lex: string, isFloat: boolean): string {
+  let n = parseXsdDouble(lex);
+  if (isFloat) n = Math.fround(n);
+  if (Number.isNaN(n)) return 'NaN';
+  if (n === Infinity) return 'INF';
+  if (n === -Infinity) return '-INF';
+  if (n === 0) return Object.is(n, -0) ? '-0' : '0';
+  const neg = n < 0;
+  const a = Math.abs(n);
+  const shortest = isFloat ? shortestFloat32String(a) : a.toString();
+  const plain = expandToPlainDecimal(shortest);
+  return neg ? `-${plain}` : plain;
+}
+
+function parseXsdDouble(lex: string): number {
+  if (lex === 'NaN') return NaN;
+  if (lex === 'INF' || lex === '+INF') return Infinity;
+  if (lex === '-INF') return -Infinity;
+  if (!/^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/.test(lex)) throw new Error(`invalid xsd:double: ${lex}`);
+  return Number(lex);
+}
+
+function shortestFloat32String(a: number): string {
+  for (let p = 1; p <= 9; p++) {
+    const s = a.toPrecision(p);
+    if (Math.fround(Number(s)) === a) return Number(s).toString();
+  }
+  return a.toString();
+}
+
+function expandToPlainDecimal(s: string): string {
+  const m = /^(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/.exec(s);
+  if (!m) return s;
+  const intPart = m[1];
+  const frac = m[2] ?? '';
+  const exp = parseInt(m[3], 10);
+  const digits = intPart + frac;
+  const pointPos = intPart.length + exp;
+  if (pointPos <= 0) return stripTrailingZeros(`0.${'0'.repeat(-pointPos)}${digits}`);
+  if (pointPos >= digits.length) return digits + '0'.repeat(pointPos - digits.length);
+  return stripTrailingZeros(`${digits.slice(0, pointPos)}.${digits.slice(pointPos)}`);
+}
+
+function stripTrailingZeros(s: string): string {
+  if (!s.includes('.')) return s;
+  return s.replace(/0+$/, '').replace(/\.$/, '');
+}
+
+// ── date/time family ───────────────────────────────────────────────────────────
+function normalizeTz(s: string): string {
+  return s.replace(/[+-]00:00$/, 'Z');
+}
+
+// strip trailing zeros from a fractional-seconds group, drop a lone "."
+function stripFractionalSeconds(s: string): string {
+  return s.replace(/(\.\d*[1-9])0+(?=$|[Z+-])/, '$1').replace(/\.0*(?=$|[Z+-])/, '');
+}
+
+function canonTime(lex: string): string {
+  let s = stripFractionalSeconds(lex);
+  s = s.replace(/^24:00:00(?=$|[.Z+-])/, '00:00:00'); // 24:00:00 → 00:00:00
+  return normalizeTz(s);
+}
+
+function canonDateTime(lex: string): string {
+  let s = stripFractionalSeconds(lex);
+  // T24:00:00 rolls to 00:00:00 of the next day (the only value-space arithmetic
+  // oxigraph performs here). Negative years are left to the verbatim path.
+  const m = /^(\d{4,})-(\d{2})-(\d{2})T24:00:00(?=$|[Z+-])(.*)$/.exec(s);
+  if (m) {
+    const next = nextDay(parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10));
+    if (next) s = `${next}T00:00:00${m[4]}`;
+  }
+  return normalizeTz(s);
+}
+
+function nextDay(y: number, mo: number, d: number): string | null {
+  if (mo < 1 || mo > 12 || d < 1) return null;
+  const leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
+  const dim = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (d > dim[mo - 1]) return null;
+  let ny = y, nmo = mo, nd = d + 1;
+  if (nd > dim[mo - 1]) { nd = 1; nmo++; if (nmo > 12) { nmo = 1; ny++; } }
+  const pad = (n: number, w: number) => String(n).padStart(w, '0');
+  return `${pad(ny, 4)}-${pad(nmo, 2)}-${pad(nd, 2)}`;
+}
+
+// ── xsd:duration / dayTimeDuration / yearMonthDuration ─────────────────────────
+const RE_DURATION = /^(-?)P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+function canonDuration(lex: string, dt: string): string {
+  const m = RE_DURATION.exec(lex);
+  if (!m) throw new Error(`invalid duration: ${lex}`);
+  const [, sign, y, mo, d, h, mi, sRaw] = m;
+  const nz = (x: string | undefined) => x !== undefined && !/^0*(\.0*)?$/.test(x);
+  const s = sRaw !== undefined ? sRaw.replace(/(\.\d*[1-9])0+$/, '$1').replace(/\.0*$/, '') : undefined;
+  let date = '';
+  if (nz(y)) date += `${y}Y`;
+  if (nz(mo)) date += `${mo}M`;
+  if (nz(d)) date += `${d}D`;
+  let time = '';
+  if (nz(h)) time += `${h}H`;
+  if (nz(mi)) time += `${mi}M`;
+  if (nz(sRaw)) time += `${s}S`;
+  const body = time ? `${date}T${time}` : date;
+  // All-zero canonical form is subtype-dependent: yearMonthDuration has no time
+  // component so it canonicalizes to "P0M"; duration / dayTimeDuration → "PT0S".
+  if (body === '') return dt === XSD + 'yearMonthDuration' ? 'P0M' : 'PT0S';
+  return `${sign}P${body}`;
+}

--- a/packages/core/src/crypto/term-canon.ts
+++ b/packages/core/src/crypto/term-canon.ts
@@ -15,15 +15,27 @@
 // is the IDENTITY on already-canonical (store-loaded) terms ⇒ no migration; a
 // coordinated release suffices.
 //
-// Covered: literal-content ESCAPING (decode N-Triples escapes, re-emit oxigraph's
-// minimal \ " \n \r escaping); language-tag lowercasing; xsd:string elision; the
-// xsd:integer family (collapse→xsd:integer iff value∈i64; xsd:integer arbitrary
-// precision); xsd:decimal; xsd:boolean; xsd:double / xsd:float; the date/time
-// family (xsd:dateTime/time fractional-seconds, +00:00→Z timezone across
-// dateTime/time/date/gYear/gYearMonth/gMonthDay/gMonth/gDay, and the T24:00:00
-// roll-over); xsd:duration / dayTimeDuration / yearMonthDuration (drop zero
-// components, all-zero → PT0S). Other datatypes are returned with normalized
-// escaping but otherwise verbatim — matching oxigraph.
+// STRUCTURE (per consensus primitive: easy to audit, hard to drift):
+//   parse → validate against oxigraph's EXACT accepted set → canonicalize if
+//   valid, else return the escaping-normalized term VERBATIM. Every normalize is
+//   gated by a validate: oxigraph keeps an ill-typed-but-syntactically-odd literal
+//   verbatim (e.g. "not-a-date+00:00"^^xsd:dateTime), so we must NOT mutate it.
+//
+// Covered (all verified against oxigraph 0.5.5 — see the oracle test):
+//  - literal-content ESCAPING (decode N-Triples escapes, re-emit oxigraph's
+//    minimal \ " \n \r escaping); BARE datatype IRIs ("v"^^IRI w/o <>) folded to
+//    the bracketed form; language-tag lowercasing; xsd:string elision.
+//  - xsd:integer family (collapse→xsd:integer iff value∈i64; xsd:integer
+//    arbitrary precision); xsd:decimal; xsd:boolean; xsd:double / xsd:float.
+//  - the date/time family with FULL value-space validation + the +00:00/-00:00→Z
+//    tz fold (xsd:dateTime/time/date/gYear/gYearMonth/gMonthDay/gMonth/gDay) and
+//    the T24:00→next-day roll (oxigraph rolls iff minute==0 OR seconds==0).
+//  - xsd:duration / dayTimeDuration / yearMonthDuration: FULL value-space
+//    normalization — leading-zero strip + component carry/overflow (months as
+//    i64, seconds as a 10^18-scaled i128 fixed-point, mirroring oxsdatatypes),
+//    subtype-component constraints, all-zero → PT0S / P0M.
+// Other datatypes (hexBinary, base64Binary, anyURI, token, custom IRIs, …) are
+// returned with normalized escaping but otherwise verbatim — matching oxigraph.
 
 const XSD = 'http://www.w3.org/2001/XMLSchema#';
 const XSD_STRING = XSD + 'string';
@@ -36,52 +48,74 @@ const INTEGER_TYPES = new Set(
     'unsignedLong', 'unsignedInt', 'unsignedShort', 'unsignedByte',
   ].map((t) => XSD + t),
 );
-// date/time-family datatypes whose only normalization is +00:00/-00:00 → Z.
-const TZ_ONLY_TYPES = new Set(
-  ['date', 'gYear', 'gYearMonth', 'gMonthDay', 'gMonth', 'gDay'].map((t) => XSD + t),
-);
 const DURATION_TYPES = new Set(
   ['duration', 'dayTimeDuration', 'yearMonthDuration'].map((t) => XSD + t),
 );
 
-// oxigraph collapses a DERIVED integer type to xsd:integer iff the value fits a
-// signed 64-bit integer (no per-type sign/bound enforcement); out-of-i64 derived
-// values stay verbatim. xsd:integer itself is arbitrary precision.
+// oxigraph parses integers (incl. xsd:integer) into a signed 64-bit int and only
+// THEN re-serializes canonically; a value outside i64 fails to parse and is kept
+// VERBATIM (sign + leading zeros preserved) — for EVERY integer type, xsd:integer
+// included. So canonicalization (collapse-to-integer + strip sign/zeros) applies
+// iff the value fits i64.
 const I64_MIN = -9223372036854775808n;
 const I64_MAX = 9223372036854775807n;
+// oxsdatatypes Duration: months is i64, seconds is a Decimal == i128 scaled by
+// 10^18. A duration whose normalized months/seconds overflow these is rejected by
+// oxigraph (kept verbatim), so we must reject (→ verbatim) at the same boundary.
+const I128_MIN = -(1n << 127n);
+const I128_MAX = (1n << 127n) - 1n;
+const DEC_SCALE = 10n ** 18n;
 
-const RE_LITERAL = /^"((?:[^"\\]|\\.)*)"(?:@([A-Za-z0-9-]+)|\^\^<([^>]+)>)?$/;
+// A literal is "<lex>"(@tag | ^^<IRI> | ^^IRI). N-Triples mandates the bracketed
+// datatype, but oxigraph's storage adapter also accepts the BARE "v"^^IRI form on
+// input and canonicalizes it to "v"^^<IRI>, so we accept (m[3] bracketed, m[4]
+// bare) and always re-emit bracketed. The bare alternative is `[^<]…` so a
+// MALFORMED bracketed datatype (e.g. "a"^^<b>extra, "x"^^<>) does NOT get
+// mis-captured as a bare IRI — it fails the match and is returned verbatim, as
+// oxigraph does.
+const RE_LITERAL = /^"((?:[^"\\]|\\.)*)"(?:@([A-Za-z0-9-]+)|\^\^(?:<([^>]+)>|([^<].*)))?$/;
 
 export function canonicalizeObjectTermForHash(object: string): string {
   if (object.length === 0 || object.charCodeAt(0) !== 34 /* " */) return object; // IRI / blank / genid
   const m = RE_LITERAL.exec(object);
   if (!m) return object;
-  const rawLex = m[1];
   const lang = m[2];
-  const dt = m[3];
+  // oxigraph decodes N-Triples UCHAR (\uXXXX / \UXXXXXXXX) escapes inside the
+  // datatype IRI on parse, so the canonical form (and any datatype matching below)
+  // must run on the decoded IRI — e.g. <…XMLSchema#integer> ≡ xsd:integer.
+  const dtRaw = m[3] ?? m[4];
+  const dt = dtRaw === undefined ? undefined : decodeIriEscapes(dtRaw);
   // Literal CONTENT escaping is normalized for every literal (a store decodes
   // \uXXXX / \t / \U… to raw UTF-8 and re-emits only \ " \n \r escaped).
-  const lex = normalizeEscaping(rawLex);
+  const lex = normalizeEscaping(m[1]);
 
   if (lang !== undefined) return `"${lex}"@${lang.toLowerCase()}`;
   if (dt === undefined || dt === XSD_STRING) return `"${lex}"`; // plain / xsd:string
 
   try {
-    if (INTEGER_TYPES.has(dt)) return canonIntegerTerm(lex, dt) ?? verbatim(lex, dt);
-    if (dt === XSD + 'decimal') return `"${canonDecimal(lex)}"^^<${dt}>`;
-    if (dt === XSD + 'boolean') return `"${canonBoolean(lex)}"^^<${dt}>`;
-    if (dt === XSD + 'double') return `"${canonDouble(lex, false)}"^^<${dt}>`;
-    if (dt === XSD + 'float') return `"${canonDouble(lex, true)}"^^<${dt}>`;
-    if (dt === XSD + 'dateTime') return `"${canonDateTime(lex)}"^^<${dt}>`;
-    if (dt === XSD + 'time') return `"${canonTime(lex)}"^^<${dt}>`;
-    if (TZ_ONLY_TYPES.has(dt)) return `"${normalizeTz(lex)}"^^<${dt}>`;
-    if (DURATION_TYPES.has(dt)) return `"${canonDuration(lex, dt)}"^^<${dt}>`;
+    if (INTEGER_TYPES.has(dt)) return canonIntegerTerm(lex) ?? verbatim(lex, dt);
+    if (dt === XSD + 'decimal') return wrap(canonDecimal(lex), dt);
+    if (dt === XSD + 'boolean') return wrap(canonBoolean(lex), dt);
+    if (dt === XSD + 'double') return wrap(canonDouble(lex, false), dt);
+    if (dt === XSD + 'float') return wrap(canonDouble(lex, true), dt);
+    if (dt === XSD + 'dateTime') return wrap(canonDateTime(lex), dt);
+    if (dt === XSD + 'time') return wrap(canonTime(lex), dt);
+    if (dt === XSD + 'date') return wrap(canonDate(lex), dt);
+    if (dt === XSD + 'gYear') return wrap(canonGYear(lex), dt);
+    if (dt === XSD + 'gYearMonth') return wrap(canonGYearMonth(lex), dt);
+    if (dt === XSD + 'gMonthDay') return wrap(canonGMonthDay(lex), dt);
+    if (dt === XSD + 'gMonth') return wrap(canonGMonth(lex), dt);
+    if (dt === XSD + 'gDay') return wrap(canonGDay(lex), dt);
+    if (DURATION_TYPES.has(dt)) return wrap(canonDuration(lex, dt), dt);
   } catch {
     return verbatim(lex, dt); // invalid lexical → escaping-normalized, otherwise verbatim
   }
   return verbatim(lex, dt); // datatype the deployed store leaves verbatim
 }
 
+// Both helpers emit the bracketed N-Triples form; `verbatim` is `wrap` of the
+// (escaping-normalized) lexical unchanged. Kept distinct for call-site intent.
+const wrap = (canonLex: string, dt: string) => `"${canonLex}"^^<${dt}>`;
 const verbatim = (lex: string, dt: string) => `"${lex}"^^<${dt}>`;
 
 // ── literal content escaping ───────────────────────────────────────────────────
@@ -89,7 +123,15 @@ const ESCAPE_DECODE = /\\(u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}|[tbnrf"'\\])/g;
 function normalizeEscaping(lex: string): string {
   const decoded = lex.replace(ESCAPE_DECODE, (whole, e: string) => {
     const c = e[0];
-    if (c === 'u' || c === 'U') return String.fromCodePoint(parseInt(e.slice(1), 16));
+    if (c === 'u' || c === 'U') {
+      const cp = parseInt(e.slice(1), 16);
+      // A \U escape can encode up to 0xFFFFFFFF, but only ≤0x10FFFF is a valid
+      // Unicode scalar. String.fromCodePoint THROWS above that; oxigraph rejects
+      // the literal. Guard so canon never throws (it runs before the per-type
+      // try/catch and on EVERY literal) — leave the out-of-range escape undecoded.
+      if (cp > 0x10ffff) return whole;
+      return String.fromCodePoint(cp);
+    }
     switch (e) {
       case 't': return '\t';
       case 'b': return '\b';
@@ -106,12 +148,48 @@ function normalizeEscaping(lex: string): string {
   return decoded.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
 }
 
+// Decode N-Triples UCHAR escapes (\uXXXX / \UXXXXXXXX) inside a datatype IRI, as
+// oxigraph does on parse. Out-of-range \U (> U+10FFFF) is left undecoded (oxigraph
+// would reject the literal; we must not throw).
+function decodeIriEscapes(iri: string): string {
+  if (!iri.includes('\\')) return iri;
+  return iri.replace(/\\(u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/g, (whole, e: string) => {
+    const cp = parseInt(e.slice(1), 16);
+    return cp > 0x10ffff ? whole : String.fromCodePoint(cp);
+  });
+}
+
+// oxigraph normalizes the "negative zero" year -0000 to 0000. (Only -0000 reaches
+// here: a leading-zero 5+-digit negative year fails the YEAR pattern → verbatim.)
+const normYear = (yy: string) => (yy === '-0000' ? '0000' : yy);
+
+// oxigraph stores temporal values as seconds-since-0001-01-01 in the same i128/1e18
+// Decimal as xsd:decimal/duration. A date/time whose scaled seconds overflow i128
+// fails to parse and is kept VERBATIM, so a foldable timezone / T24 roll / fraction
+// strip must NOT be applied to it. Replicated here via a proleptic-Gregorian day
+// count. (Byte-exact vs oxigraph for dateTime/date; for the bare g-types the cliff
+// may differ by ≤1 year at the ~5.39e12 boundary — a value impossible in real data.)
+function daysFromCivil(y: bigint, m: bigint, d: bigint): bigint {
+  const yy = m <= 2n ? y - 1n : y;
+  const era = (yy >= 0n ? yy : yy - 399n) / 400n;
+  const yoe = yy - era * 400n;
+  const doy = (153n * (m + (m > 2n ? -3n : 9n)) + 2n) / 5n + d - 1n;
+  const doe = yoe * 365n + yoe / 4n - yoe / 100n + doy;
+  return era * 146097n + doe - 719468n;
+}
+function temporalInRange(yearStr: string, mo: number, dd: number, hh = 0, mi = 0, ss = 0): boolean {
+  const seconds =
+    (daysFromCivil(BigInt(yearStr), BigInt(mo), BigInt(dd)) + 719162n) * 86400n +
+    BigInt(hh) * 3600n + BigInt(mi) * 60n + BigInt(ss);
+  const scaled = seconds * DEC_SCALE;
+  return scaled >= I128_MIN && scaled <= I128_MAX;
+}
+
 // ── xsd:integer family ─────────────────────────────────────────────────────────
-function canonIntegerTerm(lex: string, dt: string): string | null {
-  const raw = lex.startsWith('+') ? lex.slice(1) : lex;
-  if (!/^-?\d+$/.test(raw)) return null;
-  const v = BigInt(raw);
-  if (dt !== XSD_INTEGER && (v < I64_MIN || v > I64_MAX)) return null;
+function canonIntegerTerm(lex: string): string | null {
+  if (!/^[+-]?\d+$/.test(lex)) return null;     // at most one sign; "+-1" etc. → verbatim
+  const v = BigInt(lex.replace(/^\+/, ''));      // BigInt rejects a leading '+'
+  if (v < I64_MIN || v > I64_MAX) return null;   // outside i64 → verbatim (xsd:integer included)
   return `"${v.toString()}"^^<${XSD_INTEGER}>`;
 }
 
@@ -126,9 +204,16 @@ function canonBoolean(lex: string): string {
 function canonDecimal(lex: string): string {
   const m = /^([+-]?)(\d*)(?:\.(\d*))?$/.exec(lex);
   if (!m || (m[2] === '' && (m[3] === undefined || m[3] === ''))) throw new Error(`invalid xsd:decimal: ${lex}`);
-  let int = m[2].replace(/^0+/, '');
+  const intRaw = m[2].replace(/^0+/, '');
   const frac = (m[3] ?? '').replace(/0+$/, '');
-  if (int === '') int = '0';
+  // oxigraph stores xsd:decimal as the SAME i128 / 10^18 fixed-point as duration
+  // seconds: a value needing more than 18 fractional digits, or whose 10^18-scaled
+  // magnitude overflows i128, fails to parse and is kept VERBATIM.
+  if (frac.length > 18) throw new Error('xsd:decimal sub-1e-18');
+  const scaled = BigInt((intRaw || '0') + frac.padEnd(18, '0'));
+  const signed = m[1] === '-' ? -scaled : scaled;
+  if (signed < I128_MIN || signed > I128_MAX) throw new Error('xsd:decimal overflow i128');
+  const int = intRaw === '' ? '0' : intRaw;
   const sign = m[1] === '-' && !(int === '0' && frac === '') ? '-' : '';
   return frac === '' ? `${sign}${int}` : `${sign}${int}.${frac}`;
 }
@@ -143,15 +228,54 @@ function canonDouble(lex: string, isFloat: boolean): string {
   if (n === 0) return Object.is(n, -0) ? '-0' : '0';
   const neg = n < 0;
   const a = Math.abs(n);
-  const shortest = isFloat ? shortestFloat32String(a) : a.toString();
+  const shortest = roundTiesAwayFromZero(a, isFloat ? shortestFloat32String(a) : a.toString(), isFloat);
   const plain = expandToPlainDecimal(shortest);
   return neg ? `-${plain}` : plain;
 }
 
+// V8's Number→string breaks shortest-representation ties round-half-to-EVEN, but
+// oxigraph (Rust) breaks them round-half-AWAY-from-zero. They diverge only when the
+// value sits EXACTLY between two equal-length shortest decimals (e.g. the f64
+// 738507753103385.25 → V8 ".2", Rust ".3"). Detect that tie with exact integer
+// arithmetic and pick the away-from-zero neighbour to match oxigraph.
+function roundTiesAwayFromZero(a: number, shortest: string, isFloat: boolean): string {
+  const m = /^(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/.exec(shortest);
+  if (!m) return shortest;
+  const digits = m[1] + (m[2] ?? '');
+  const D = BigInt(digits);
+  const E = (m[3] ? parseInt(m[3], 10) : 0) - (m[2] ? m[2].length : 0); // value = D × 10^E
+  const up = D + 1n; // away-from-zero neighbour at the same digit length (a ≥ 0)
+  const rt = (x: number) => (isFloat ? Math.fround(x) : x);
+  if (rt(Number(`${up}e${E}`)) !== a) return shortest; // up-neighbour doesn't round-trip → no tie
+  // Exact tie test: 2·a == (2D+1) × 10^E, with a = num/den from the IEEE-754 bits.
+  const [num, den] = f64Fraction(a);
+  let lhs = 2n * num;
+  let rhs = (2n * D + 1n) * den;
+  if (E >= 0) rhs *= 10n ** BigInt(E);
+  else lhs *= 10n ** BigInt(-E);
+  return lhs === rhs ? `${up}e${E}` : shortest;
+}
+
+// Exact value of a finite |f64| as num/den (den a power of two) from its bits.
+function f64Fraction(a: number): [bigint, bigint] {
+  const dv = new DataView(new ArrayBuffer(8));
+  dv.setFloat64(0, a);
+  const bits = dv.getBigUint64(0);
+  const exp = Number((bits >> 52n) & 0x7ffn);
+  const fracBits = bits & 0xfffffffffffffn;
+  const mant = exp === 0 ? fracBits : fracBits | (1n << 52n);
+  const e = (exp === 0 ? -1074 : exp - 1075);
+  return e >= 0 ? [mant << BigInt(e), 1n] : [mant, 1n << BigInt(-e)];
+}
+
 function parseXsdDouble(lex: string): number {
-  if (lex === 'NaN') return NaN;
-  if (lex === 'INF' || lex === '+INF') return Infinity;
-  if (lex === '-INF') return -Infinity;
+  // oxigraph parses doubles with Rust's lenient f64::from_str: case-INSENSITIVE
+  // nan / inf / infinity (with an optional sign) all parse, not just the XSD
+  // spellings NaN / INF / -INF. Match it so e.g. "infinity"/"NaN"/"-inf" canon to
+  // the oxigraph forms INF / NaN / -INF instead of staying verbatim.
+  if (/^[+-]?nan$/i.test(lex)) return NaN;
+  if (/^\+?inf(inity)?$/i.test(lex)) return Infinity;
+  if (/^-inf(inity)?$/i.test(lex)) return -Infinity;
   if (!/^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$/.test(lex)) throw new Error(`invalid xsd:double: ${lex}`);
   return Number(lex);
 }
@@ -183,63 +307,246 @@ function stripTrailingZeros(s: string): string {
 }
 
 // ── date/time family ───────────────────────────────────────────────────────────
-function normalizeTz(s: string): string {
-  return s.replace(/[+-]00:00$/, 'Z');
+// Split + validate the trailing timezone, folding +00:00/-00:00 to Z. oxigraph
+// accepts Z or ±HH:MM with |offset| ≤ 14:00 (HH≤14, MM≤59, total ≤ 840 min);
+// anything else (incl. a malformed +0:00) leaves the timezone in `body`, where the
+// per-type grammar then rejects it → the whole literal is kept verbatim.
+function splitTz(s: string): { body: string; tz: string } {
+  const m = /(Z|[+-]\d{2}:\d{2})$/.exec(s);
+  if (!m) return { body: s, tz: '' };
+  const tz = m[1];
+  const body = s.slice(0, s.length - tz.length);
+  if (tz === 'Z') return { body, tz: 'Z' };
+  const h = parseInt(tz.slice(1, 3), 10);
+  const mi = parseInt(tz.slice(4, 6), 10);
+  if (mi > 59 || h * 60 + mi > 840) throw new Error(`invalid tz: ${tz}`);
+  return { body, tz: tz === '+00:00' || tz === '-00:00' ? 'Z' : tz };
 }
 
-// strip trailing zeros from a fractional-seconds group, drop a lone "."
-function stripFractionalSeconds(s: string): string {
-  return s.replace(/(\.\d*[1-9])0+(?=$|[Z+-])/, '$1').replace(/\.0*(?=$|[Z+-])/, '');
+// Normalize a fractional-seconds group ('.ddd' or undefined): strip trailing
+// zeros, drop entirely if it becomes empty.
+function normFrac(frac: string | undefined): string {
+  if (frac === undefined) return '';
+  const d = frac.slice(1).replace(/0+$/, '');
+  return d === '' ? '' : `.${d}`;
+}
+
+// Proleptic-Gregorian leap test on the astronomical year number (handles negative
+// and arbitrarily large years via BigInt).
+function isLeapYear(yearStr: string): boolean {
+  const y = BigInt(yearStr);
+  return (y % 4n === 0n && y % 100n !== 0n) || y % 400n === 0n;
+}
+function daysInMonth(yearStr: string, mo: number): number {
+  return [31, isLeapYear(yearStr) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][mo - 1];
+}
+// Day after (yearStr, mo, dd). Year crosses are computed on the signed numeric
+// year (BigInt) then re-emitted min-4-digit, sign-preserved (…→0000, 9999→10000).
+function rollNextDay(yearStr: string, mo: number, dd: number): string {
+  let ny = BigInt(yearStr);
+  let nmo = mo;
+  let nd = dd + 1;
+  if (nd > daysInMonth(yearStr, mo)) {
+    nd = 1;
+    nmo += 1;
+    if (nmo > 12) { nmo = 1; ny += 1n; }
+  }
+  return `${fmtYear(ny)}-${pad2(nmo)}-${pad2(nd)}`;
+}
+function fmtYear(y: bigint): string {
+  const neg = y < 0n;
+  const abs = (neg ? -y : y).toString().padStart(4, '0');
+  return neg ? `-${abs}` : abs;
+}
+const pad2 = (n: number) => String(n).padStart(2, '0');
+
+// hh∈[0,24], mm∈[0,59], ss∈[0,59]; hour 24 is valid ONLY when it can roll, which
+// oxigraph allows iff minute==0 OR the seconds value (incl. fraction) is 0.
+// Returns whether the time rolls to the next day (hour 24 → 00). Throws on any
+// out-of-range field or a non-rollable hour-24.
+function validateClock(hh: number, mi: number, ss: number, fracNorm: string): { rolls: boolean } {
+  if (hh > 24 || mi > 59 || ss > 59) throw new Error('clock out of range');
+  if (hh === 24) {
+    const secZero = ss === 0 && fracNorm === '';
+    if (mi !== 0 && !secZero) throw new Error('invalid hour-24');
+    return { rolls: true };
+  }
+  return { rolls: false };
+}
+
+// A valid XSD year is EXACTLY 4 digits (leading zeros allowed) OR 5+ digits with
+// NO leading zero. oxigraph rejects a leading-zero 5+-digit year (e.g. 09508) and
+// keeps the whole literal verbatim — so we must too, or we'd normalize tz/fraction
+// on a literal oxigraph leaves untouched.
+const YEAR = '-?(?:\\d{4}|[1-9]\\d{4,})';
+
+function canonDateTime(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  const m = new RegExp(`^(${YEAR})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d+)?$`).exec(body);
+  if (!m) throw new Error('invalid xsd:dateTime');
+  const [, yy, mo, dd, hh, mi, ss, frac] = m;
+  const moN = +mo;
+  const ddN = +dd;
+  if (moN < 1 || moN > 12) throw new Error('month');
+  if (ddN < 1 || ddN > daysInMonth(yy, moN)) throw new Error('day');
+  if (!temporalInRange(yy, moN, ddN, +hh, +mi, +ss)) throw new Error('year overflows i128 seconds');
+  const fracNorm = normFrac(frac);
+  if (fracNorm.length - 1 > 18) throw new Error('sub-1e-18 seconds'); // oxigraph stores ≤18 frac digits
+  const { rolls } = validateClock(+hh, +mi, +ss, fracNorm);
+  if (rolls) {
+    return `${rollNextDay(yy, moN, ddN)}T00:${mi}:${ss}${fracNorm}${tz}`;
+  }
+  // KNOWN oxigraph 0.5.5 DEFECT (documented, NOT mirrored): a NEGATIVE-year
+  // dateTime with seconds == 59 AND a non-zero fraction is NON-IDEMPOTENT in the
+  // store — every load→serialize round-trip adds a minute and never stabilises
+  // (-1711-…T15:19:59.6 → :20:59.6 → :21:59.6 → …). No canonicalization can make
+  // such a value consensus-safe (its "stored form" drifts), so we deliberately do
+  // NOT replicate the bump: canon stays DETERMINISTIC + IDEMPOTENT (the best
+  // achievable), normalising tz/fraction like any other dateTime and leaving the
+  // wall-clock untouched. The residual exposure is a pre-existing oxigraph storage
+  // defect for an essentially-nonexistent input class (BCE timestamps at :59 with
+  // sub-second precision) — escalated to the store layer, tracked off this canon.
+  return `${normYear(yy)}-${mo}-${dd}T${hh}:${mi}:${ss}${fracNorm}${tz}`;
 }
 
 function canonTime(lex: string): string {
-  let s = stripFractionalSeconds(lex);
-  s = s.replace(/^24:00:00(?=$|[.Z+-])/, '00:00:00'); // 24:00:00 → 00:00:00
-  return normalizeTz(s);
+  const { body, tz } = splitTz(lex);
+  const m = /^(\d{2}):(\d{2}):(\d{2})(\.\d+)?$/.exec(body);
+  if (!m) throw new Error('invalid xsd:time');
+  const [, hh, mi, ss, frac] = m;
+  const fracNorm = normFrac(frac);
+  if (fracNorm.length - 1 > 18) throw new Error('sub-1e-18 seconds');
+  const { rolls } = validateClock(+hh, +mi, +ss, fracNorm);
+  // time has no date to roll; hour 24 → 00 of the same wall clock.
+  return `${rolls ? '00' : hh}:${mi}:${ss}${fracNorm}${tz}`;
 }
 
-function canonDateTime(lex: string): string {
-  let s = stripFractionalSeconds(lex);
-  // T24:00:00 rolls to 00:00:00 of the next day (the only value-space arithmetic
-  // oxigraph performs here). Negative years are left to the verbatim path.
-  const m = /^(\d{4,})-(\d{2})-(\d{2})T24:00:00(?=$|[Z+-])(.*)$/.exec(s);
-  if (m) {
-    const next = nextDay(parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10));
-    if (next) s = `${next}T00:00:00${m[4]}`;
-  }
-  return normalizeTz(s);
+function canonDate(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  const m = new RegExp(`^(${YEAR})-(\\d{2})-(\\d{2})$`).exec(body);
+  if (!m) throw new Error('invalid xsd:date');
+  const moN = +m[2];
+  const ddN = +m[3];
+  if (moN < 1 || moN > 12) throw new Error('month');
+  if (ddN < 1 || ddN > daysInMonth(m[1], moN)) throw new Error('day');
+  if (!temporalInRange(m[1], moN, ddN)) throw new Error('year overflows i128 seconds');
+  return `${normYear(m[1])}-${m[2]}-${m[3]}${tz}`;
 }
 
-function nextDay(y: number, mo: number, d: number): string | null {
-  if (mo < 1 || mo > 12 || d < 1) return null;
-  const leap = (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0;
-  const dim = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  if (d > dim[mo - 1]) return null;
-  let ny = y, nmo = mo, nd = d + 1;
-  if (nd > dim[mo - 1]) { nd = 1; nmo++; if (nmo > 12) { nmo = 1; ny++; } }
-  const pad = (n: number, w: number) => String(n).padStart(w, '0');
-  return `${pad(ny, 4)}-${pad(nmo, 2)}-${pad(nd, 2)}`;
+function canonGYear(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  if (!new RegExp(`^${YEAR}$`).test(body)) throw new Error('invalid xsd:gYear');
+  if (!temporalInRange(body, 1, 1)) throw new Error('year overflows i128 seconds');
+  return `${normYear(body)}${tz}`;
+}
+
+function canonGYearMonth(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  const m = new RegExp(`^(${YEAR})-(\\d{2})$`).exec(body);
+  if (!m || +m[2] < 1 || +m[2] > 12) throw new Error('invalid xsd:gYearMonth');
+  if (!temporalInRange(m[1], +m[2], 1)) throw new Error('year overflows i128 seconds');
+  return `${normYear(m[1])}-${m[2]}${tz}`;
+}
+
+// gMonthDay/gMonth/gDay have no year, so February's max day is 29.
+const MONTH_MAX_DAY = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+function canonGMonthDay(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  const m = /^--(\d{2})-(\d{2})$/.exec(body);
+  if (!m) throw new Error('invalid xsd:gMonthDay');
+  const moN = +m[1];
+  const ddN = +m[2];
+  if (moN < 1 || moN > 12 || ddN < 1 || ddN > MONTH_MAX_DAY[moN - 1]) throw new Error('range');
+  return `${body}${tz}`;
+}
+
+function canonGMonth(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  const m = /^--(\d{2})$/.exec(body);
+  if (!m || +m[1] < 1 || +m[1] > 12) throw new Error('invalid xsd:gMonth');
+  return `${body}${tz}`;
+}
+
+function canonGDay(lex: string): string {
+  const { body, tz } = splitTz(lex);
+  const m = /^---(\d{2})$/.exec(body);
+  if (!m || +m[1] < 1 || +m[1] > 31) throw new Error('invalid xsd:gDay');
+  return `${body}${tz}`;
 }
 
 // ── xsd:duration / dayTimeDuration / yearMonthDuration ─────────────────────────
-const RE_DURATION = /^(-?)P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
+// Value-space canonicalization mirroring oxsdatatypes Duration { months: i64,
+// seconds: Decimal(i128 / 10^18) }. Parse to (months, scaledSeconds), reject if
+// either overflows its integer type (→ verbatim), then re-emit the canonical
+// component breakdown (Y=months/12, M=months%12; D/H/M/S from seconds).
+const RE_DURATION =
+  /^(-?)P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?|\.\d+)S)?)?$/;
 function canonDuration(lex: string, dt: string): string {
   const m = RE_DURATION.exec(lex);
   if (!m) throw new Error(`invalid duration: ${lex}`);
-  const [, sign, y, mo, d, h, mi, sRaw] = m;
-  const nz = (x: string | undefined) => x !== undefined && !/^0*(\.0*)?$/.test(x);
-  const s = sRaw !== undefined ? sRaw.replace(/(\.\d*[1-9])0+$/, '$1').replace(/\.0*$/, '') : undefined;
+  const [, sign, y, mo, d, h, mi, sTok] = m;
+  if (!y && !mo && !d && !h && !mi && !sTok) throw new Error('empty duration'); // "P" / "PT"
+
+  const isYM = dt === XSD + 'yearMonthDuration';
+  const isDT = dt === XSD + 'dayTimeDuration';
+  // Subtype component constraints (oxigraph keeps a mis-componented subtype verbatim).
+  if (isYM && (d || h || mi || sTok)) throw new Error('yearMonthDuration: time/day component');
+  if (isDT && (y || mo)) throw new Error('dayTimeDuration: year/month component');
+
+  // Seconds token → whole + fractional (≤18 significant fractional digits; the
+  // oxsdatatypes Decimal scale is 10^18, so a 19th significant digit is rejected).
+  let sWhole = '0';
+  let fracScaled = 0n;
+  if (sTok) {
+    const dot = sTok.indexOf('.');
+    if (dot === -1) {
+      sWhole = sTok;
+    } else {
+      sWhole = sTok.slice(0, dot) || '0';
+      const fracDigits = sTok.slice(dot + 1).replace(/0+$/, '');
+      if (fracDigits.length > 18) throw new Error('sub-1e-18 seconds');
+      fracScaled = fracDigits === '' ? 0n : BigInt(fracDigits.padEnd(18, '0'));
+    }
+  }
+
+  const months = 12n * BigInt(y || '0') + BigInt(mo || '0');
+  const wholeSeconds =
+    86400n * BigInt(d || '0') + 3600n * BigInt(h || '0') + 60n * BigInt(mi || '0') + BigInt(sWhole);
+  const scaledSeconds = wholeSeconds * DEC_SCALE + fracScaled;
+
+  // Overflow at oxigraph's stored-integer boundaries (signed) → verbatim.
+  const neg = sign === '-';
+  const signedMonths = neg ? -months : months;
+  const signedScaled = neg ? -scaledSeconds : scaledSeconds;
+  if (signedMonths < I64_MIN || signedMonths > I64_MAX) throw new Error('months overflow i64');
+  if (signedScaled < I128_MIN || signedScaled > I128_MAX) throw new Error('seconds overflow i128');
+
+  // Re-derive canonical components from magnitudes (sign emitted once).
+  const yy = months / 12n;
+  const MM = months % 12n;
+  const totalWhole = scaledSeconds / DEC_SCALE;
+  const fracRem = scaledSeconds % DEC_SCALE;
+  const D = totalWhole / 86400n;
+  let rem = totalWhole % 86400n;
+  const H = rem / 3600n;
+  rem %= 3600n;
+  const Min = rem / 60n;
+  const S = rem % 60n;
+
   let date = '';
-  if (nz(y)) date += `${y}Y`;
-  if (nz(mo)) date += `${mo}M`;
-  if (nz(d)) date += `${d}D`;
+  if (yy > 0n) date += `${yy}Y`;
+  if (MM > 0n) date += `${MM}M`;
+  if (D > 0n) date += `${D}D`;
   let time = '';
-  if (nz(h)) time += `${h}H`;
-  if (nz(mi)) time += `${mi}M`;
-  if (nz(sRaw)) time += `${s}S`;
+  if (H > 0n) time += `${H}H`;
+  if (Min > 0n) time += `${Min}M`;
+  if (S > 0n || fracRem > 0n) {
+    const fracStr = fracRem === 0n ? '' : `.${fracRem.toString().padStart(18, '0').replace(/0+$/, '')}`;
+    time += `${S}${fracStr}S`;
+  }
   const body = time ? `${date}T${time}` : date;
-  // All-zero canonical form is subtype-dependent: yearMonthDuration has no time
-  // component so it canonicalizes to "P0M"; duration / dayTimeDuration → "PT0S".
-  if (body === '') return dt === XSD + 'yearMonthDuration' ? 'P0M' : 'PT0S';
-  return `${sign}P${body}`;
+  // All-zero canonical form is subtype-dependent: yearMonthDuration → "P0M",
+  // duration / dayTimeDuration → "PT0S".
+  if (body === '') return isYM ? 'P0M' : 'PT0S';
+  return `${neg ? '-' : ''}P${body}`;
 }

--- a/packages/core/src/crypto/term-canon.ts
+++ b/packages/core/src/crypto/term-canon.ts
@@ -228,7 +228,9 @@ function canonDouble(lex: string, isFloat: boolean): string {
   if (n === 0) return Object.is(n, -0) ? '-0' : '0';
   const neg = n < 0;
   const a = Math.abs(n);
-  const shortest = roundTiesAwayFromZero(a, isFloat ? shortestFloat32String(a) : a.toString(), isFloat);
+  // double: V8's a.toString() IS the shortest round-trip; only ties need the
+  // away-from-zero correction. float: V8 has no f32-shortest, so search it.
+  const shortest = isFloat ? shortestFloat32String(a) : roundTiesAwayFromZero(a, a.toString(), false);
   const plain = expandToPlainDecimal(shortest);
   return neg ? `-${plain}` : plain;
 }
@@ -280,10 +282,30 @@ function parseXsdDouble(lex: string): number {
   return Number(lex);
 }
 
+// Shortest decimal that round-trips to the f32 `a`, matching Rust's f32 formatting.
+// V8 has no native f32-shortest, and a.toPrecision(p)/toExponential round `a` to
+// NEAREST — which can miss the round-tripping p-digit decimal sitting on the other
+// side of `a` (a's f32 rounding interval is wider than its f64 one). So at each
+// precision we test the nearest p-digit mantissa AND its ±1 neighbours (exact
+// integers, no float-grid error), keep those whose f32 round-trip equals a, and
+// pick the closest to a — ties to the away-from-zero (larger) value, as Rust does.
 function shortestFloat32String(a: number): string {
   for (let p = 1; p <= 9; p++) {
-    const s = a.toPrecision(p);
-    if (Math.fround(Number(s)) === a) return Number(s).toString();
+    const m = /^(\d)(?:\.(\d+))?e([+-]\d+)$/.exec(a.toExponential(p - 1));
+    if (!m) break;
+    const mant = m[1] + (m[2] ?? ''); // p significant digits
+    const e10 = parseInt(m[3], 10) - (p - 1); // value = mant × 10^e10
+    const base = BigInt(mant);
+    const valid: number[] = [];
+    for (const v of [base, base - 1n, base + 1n]) {
+      if (v <= 0n) continue;
+      const c = Number(`${v}e${e10}`);
+      if (Math.fround(c) === a) valid.push(c);
+    }
+    if (valid.length) {
+      valid.sort((x, y) => Math.abs(x - a) - Math.abs(y - a) || y - x); // closest; tie → away from zero
+      return valid[0].toString();
+    }
   }
   return a.toString();
 }
@@ -396,16 +418,17 @@ function canonDateTime(lex: string): string {
   if (rolls) {
     return `${rollNextDay(yy, moN, ddN)}T00:${mi}:${ss}${fracNorm}${tz}`;
   }
-  // KNOWN oxigraph 0.5.5 DEFECT (documented, NOT mirrored): a NEGATIVE-year
-  // dateTime with seconds == 59 AND a non-zero fraction is NON-IDEMPOTENT in the
-  // store — every load→serialize round-trip adds a minute and never stabilises
-  // (-1711-…T15:19:59.6 → :20:59.6 → :21:59.6 → …). No canonicalization can make
-  // such a value consensus-safe (its "stored form" drifts), so we deliberately do
-  // NOT replicate the bump: canon stays DETERMINISTIC + IDEMPOTENT (the best
-  // achievable), normalising tz/fraction like any other dateTime and leaving the
-  // wall-clock untouched. The residual exposure is a pre-existing oxigraph storage
-  // defect for an essentially-nonexistent input class (BCE timestamps at :59 with
-  // sub-second precision) — escalated to the store layer, tracked off this canon.
+  // KNOWN oxigraph 0.5.5 DEFECT (documented, NOT mirrored): a BEFORE-EPOCH dateTime
+  // (before 0001-01-01T00:00:00, i.e. year ≤ 0000) with seconds == 59 AND a non-zero
+  // fraction has its minute bumped by +1 on every load→serialize round-trip. Far
+  // before the epoch it never stabilises (-1711-…T15:19:59.6 → :20:59.6 → :21:59.6 →
+  // …); near it the bump just crosses into year 0001 once. Either way the store has
+  // no stable form for these, so no canonicalization can make them consensus-safe.
+  // We deliberately do NOT replicate the bump: canon stays DETERMINISTIC + IDEMPOTENT
+  // (the best achievable), normalising tz/fraction like any other dateTime and
+  // leaving the wall-clock untouched. Residual exposure = a pre-existing oxigraph
+  // storage defect for an essentially-nonexistent input class (BCE / year-0 timestamps
+  // at :59 with sub-second precision) — escalated to the store layer, off this canon.
   return `${normYear(yy)}-${mo}-${dd}T${hh}:${mi}:${ss}${fracNorm}${tz}`;
 }
 
@@ -448,8 +471,10 @@ function canonGYearMonth(lex: string): string {
   return `${normYear(m[1])}-${m[2]}${tz}`;
 }
 
-// gMonthDay/gMonth/gDay have no year, so February's max day is 29.
-const MONTH_MAX_DAY = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+// gMonthDay day bounds. oxigraph 0.5.5 validates --MM-DD against a NON-leap
+// reference year, so --02-29 is rejected (kept verbatim) — February's max is 28
+// here, unlike a real leap date which needs the year context of xsd:date.
+const MONTH_MAX_DAY = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 function canonGMonthDay(lex: string): string {
   const { body, tz } = splitTz(lex);
   const m = /^--(\d{2})-(\d{2})$/.exec(body);
@@ -479,8 +504,10 @@ function canonGDay(lex: string): string {
 // seconds: Decimal(i128 / 10^18) }. Parse to (months, scaledSeconds), reject if
 // either overflows its integer type (→ verbatim), then re-emit the canonical
 // component breakdown (Y=months/12, M=months%12; D/H/M/S from seconds).
+// Seconds accept a trailing dot with no fraction (oxigraph: "PT1.S" → "PT1S") and a
+// leading dot ("PT.5S" → "PT0.5S"), matching Rust's lenient parse.
 const RE_DURATION =
-  /^(-?)P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?|\.\d+)S)?)?$/;
+  /^(-?)P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d*)?|\.\d+)S)?)?$/;
 function canonDuration(lex: string, dt: string): string {
   const m = RE_DURATION.exec(lex);
   if (!m) throw new Error(`invalid duration: ${lex}`);

--- a/packages/publisher/test/swm-seal-recompute-parity.test.ts
+++ b/packages/publisher/test/swm-seal-recompute-parity.test.ts
@@ -1,0 +1,221 @@
+// TDD suite for the OKF -> VM `MERKLE_MISMATCH_IN_SWM` storage-quorum blocker
+// (okf-dkg-vm-validation-report.md). The publisher sealed root `6f7cab...`; every
+// core peer recomputed `faf17...` over an IDENTICAL-COUNT SWM replica -> no quorum.
+//
+// THE CONSENSUS INVARIANT these tests pin:
+//   The Merkle root the PUBLISHER seals (via `canonicalPublishPayload`) MUST equal
+//   the root any receiving core node recomputes after the quads pass through a
+//   triple store. Both sides run the SAME function (`computeFlatKCRootV10`), whose
+//   V10 leaf (dkg-core tripleContentV10) applies a backend-INDEPENDENT term
+//   canonicalization (canonicalizeObjectTermForHash) BEFORE hashing:
+//     - publisher seal:  canonical-publish-payload.ts
+//     - peer recompute:  storage-ack-handler.ts -> loadSWMQuads (SPARQL CONSTRUCT)
+//   The leaf hash is over each term's raw string, and a store rewrites typed-
+//   literal lexical forms on store/read-back (xsd:string elision, language-tag
+//   case, AND numeric value-space: "007"->"7", "1.0"->"1", "1"^^bool->"true",
+//   "1.0E2"^^double->"100"). Canonicalizing those forms at the leaf — to the same
+//   value-space canon every backend agrees on (proven against oxigraph in
+//   term-canon-oracle.test.ts) — makes the publisher's pre-store seal and any
+//   peer's post-store recompute hash identical bytes, on any backend/version.
+//
+// Before the fix every `expectSealRecomputeParity(...)` is RED; after, GREEN.
+
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { sharedMemoryReadBothFilter, contextGraphSharedMemoryUri, contextGraphSharedMemoryMetaUri } from '@origintrail-official/dkg-core';
+import { computeFlatKCRootV10 } from '../src/merkle.js';
+import { canonicalPublishPayload } from '../src/canonical-publish-payload.js';
+
+const xsd = (t: string) => `http://www.w3.org/2001/XMLSchema#${t}`;
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const DCAT_DATASET = 'http://www.w3.org/ns/dcat#Dataset';
+const G = 'urn:dkg:cg/okf-crypto-bitcoin-vm/_shared_memory';
+const S = 'urn:okf:datasets/crypto_bitcoin';
+
+const hex = (u: Uint8Array): string => Buffer.from(u).toString('hex');
+const t = (subject: string, predicate: string, object: string): Quad => ({ subject, predicate, object, graph: G });
+
+// Exactly the SPARQL the peer's loadSWMQuads issues (storage-ack-handler.ts:1197).
+const constructGraph = (g: string) => `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${g}> { ?s ?p ?o } }`;
+
+/** Simulate the receiving core node: store the quads, reload via CONSTRUCT. */
+async function peerReload(quads: Quad[], graph = G): Promise<Quad[]> {
+  const store = new OxigraphStore(); // in-memory
+  await store.insert(quads);
+  const res = await store.query(constructGraph(graph));
+  return res.type === 'quads' ? res.quads : [];
+}
+
+/**
+ * The consensus property: the publisher's sealed root (canonicalPublishPayload)
+ * equals what a peer recomputes over its store replica of the same triples.
+ */
+async function expectSealRecomputeParity(quads: Quad[]): Promise<void> {
+  const sealedRoot = canonicalPublishPayload(quads).kcMerkleRoot; // publisher seal
+  const reloaded = await peerReload(quads); // peer's store replica
+  const recomputedRoot = computeFlatKCRootV10(reloaded, []); // peer recompute, same fn
+  expect(hex(recomputedRoot)).toBe(hex(sealedRoot));
+}
+
+describe('SWM seal<->recompute parity: xsd:string datatype elision', () => {
+  it('a single xsd:string property', async () => {
+    await expectSealRecomputeParity([t(S, 'http://schema.org/name', `"Bitcoin"^^<${xsd('string')}>`)]);
+  });
+
+  it('multiple xsd:string properties', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/name', `"Bitcoin"^^<${xsd('string')}>`),
+      t(S, 'http://schema.org/identifier', `"crypto_bitcoin"^^<${xsd('string')}>`),
+      t(S, 'http://schema.org/description', `"Peer-to-peer electronic cash."^^<${xsd('string')}>`),
+    ]);
+  });
+
+  it('the realistic OKF crypto_bitcoin dataset KA (the reported case)', async () => {
+    await expectSealRecomputeParity([
+      t(S, RDF_TYPE, DCAT_DATASET),
+      t(S, 'http://schema.org/name', `"Bitcoin"^^<${xsd('string')}>`),
+      t(S, 'http://schema.org/identifier', `"crypto_bitcoin"^^<${xsd('string')}>`),
+      t(S, 'http://schema.org/description', `"Peer-to-peer electronic cash; the first cryptocurrency."^^<${xsd('string')}>`),
+      t(S, 'http://schema.org/url', 'https://bitcoin.org'),
+      t(S, 'http://purl.org/dc/terms/license', 'https://opensource.org/license/mit'),
+    ]);
+  });
+
+  it('xsd:string values containing quotes, backslashes and newlines', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/name', `"a \\"quoted\\" name"^^<${xsd('string')}>`),
+      t(S, 'http://schema.org/description', `"line one\\nline two\\\\end"^^<${xsd('string')}>`),
+    ]);
+  });
+
+  it('xsd:string properties across multiple subjects in one CG', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/name', `"Bitcoin"^^<${xsd('string')}>`),
+      t('urn:okf:datasets/crypto_ethereum', 'http://schema.org/name', `"Ethereum"^^<${xsd('string')}>`),
+      t('urn:okf:concepts/proof_of_work', 'http://www.w3.org/2000/01/rdf-schema#label', `"Proof of Work"^^<${xsd('string')}>`),
+    ]);
+  });
+});
+
+describe('SWM seal<->recompute parity: language-tag normalization', () => {
+  it('an uppercase language tag (@EN)', async () => {
+    await expectSealRecomputeParity([t(S, 'http://schema.org/name', '"Bitcoin"@EN')]);
+  });
+
+  it('a language subtag (@en-US)', async () => {
+    await expectSealRecomputeParity([t(S, 'http://schema.org/name', '"Color"@en-US')]);
+  });
+
+  it('a mixed-case language subtag (@En-Gb)', async () => {
+    await expectSealRecomputeParity([t(S, 'http://schema.org/name', '"Colour"@En-Gb')]);
+  });
+
+  it('multiple language variants of the same property', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/name', '"Bitcoin"@EN'),
+      t(S, 'http://schema.org/name', '"Биткойн"@RU'),
+      t(S, 'http://schema.org/name', '"ビットコイン"@JA'),
+    ]);
+  });
+});
+
+describe('SWM seal<->recompute parity: numeric & boolean value-space', () => {
+  it('xsd:integer with leading zeros / sign ("007", "+5", "-0")', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/position', `"007"^^<${xsd('integer')}>`),
+      t(S, 'http://example.org/delta', `"+5"^^<${xsd('integer')}>`),
+      t(S, 'http://example.org/zero', `"-0"^^<${xsd('integer')}>`),
+    ]);
+  });
+
+  it('xsd:decimal trailing/leading zeros ("1.0", ".5", "100.0", "010.0")', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/ratingValue', `"1.0"^^<${xsd('decimal')}>`),
+      t(S, 'http://example.org/half', `".5"^^<${xsd('decimal')}>`),
+      t(S, 'http://example.org/hundred', `"100.0"^^<${xsd('decimal')}>`),
+      t(S, 'http://example.org/ten', `"010.0"^^<${xsd('decimal')}>`),
+    ]);
+  });
+
+  it('xsd:boolean lexical forms ("1", "0", "true", "false")', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://schema.org/isAccessibleForFree', `"1"^^<${xsd('boolean')}>`),
+      t(S, 'http://example.org/b', `"0"^^<${xsd('boolean')}>`),
+      t(S, 'http://example.org/c', `"true"^^<${xsd('boolean')}>`),
+      t(S, 'http://example.org/d', `"false"^^<${xsd('boolean')}>`),
+    ]);
+  });
+
+  it('xsd:double / xsd:float exponent & normalization ("1.0E2", "1e10", "1.0")', async () => {
+    await expectSealRecomputeParity([
+      t(S, 'http://example.org/dbl', `"1.0E2"^^<${xsd('double')}>`),
+      t(S, 'http://example.org/big', `"1e10"^^<${xsd('double')}>`),
+      t(S, 'http://example.org/flt', `"1.0"^^<${xsd('float')}>`),
+    ]);
+  });
+});
+
+describe('SWM seal<->recompute parity: mixed real-world KA', () => {
+  it('xsd:string + language-tagged + numeric + boolean + plain literal + IRI', async () => {
+    await expectSealRecomputeParity([
+      t(S, RDF_TYPE, DCAT_DATASET), // IRI object
+      t(S, 'http://schema.org/name', `"Bitcoin"^^<${xsd('string')}>`), // xsd:string
+      t(S, 'http://schema.org/alternateName', '"BTC"@EN'), // lang-tagged
+      t(S, 'http://schema.org/position', `"007"^^<${xsd('integer')}>`), // numeric value-space
+      t(S, 'http://schema.org/isAccessibleForFree', `"1"^^<${xsd('boolean')}>`), // boolean
+      t(S, 'http://schema.org/identifier', '"crypto_bitcoin"'), // plain literal
+      t(S, 'http://schema.org/sameAs', 'https://www.wikidata.org/wiki/Q131723'), // IRI
+    ]);
+  });
+});
+
+// Quad-SET invariant: the consensus root also requires both sides to hash the
+// SAME quad set. The publisher strips trust/workspaceOwner quads before sealing
+// (dkg-publisher.ts:1365); the receiver's loadSWMQuads does NOT — they stay in
+// lockstep ONLY because those quads live in `_shared_memory_meta`, which
+// `sharedMemoryReadBothFilter` excludes. This pins that, so the asymmetry can't
+// silently start mattering.
+describe('SWM read filter — quad-set parity (trust/owner exclusion + read-both)', () => {
+  const CG = '0xabc';
+  const swm = contextGraphSharedMemoryUri(CG); // .../_shared_memory bucket
+  const meta = contextGraphSharedMemoryMetaUri(CG); // .../_shared_memory_meta
+
+  async function readBoth(quads: Quad[]): Promise<Quad[]> {
+    const store = new OxigraphStore();
+    await store.insert(quads);
+    const res = await store.query(
+      `CONSTRUCT { ?s ?p ?o } WHERE { GRAPH ?g { ?s ?p ?o } ${sharedMemoryReadBothFilter(swm)} }`,
+    );
+    return res.type === 'quads' ? res.quads : [];
+  }
+
+  it('excludes trust-level + workspaceOwner quads (they live in _shared_memory_meta)', async () => {
+    const out = await readBoth([
+      { subject: 'urn:s', predicate: 'http://schema.org/name', object: '"Bitcoin"', graph: swm },
+      { subject: 'urn:s', predicate: 'http://dkg.io/ontology/trustLevel', object: '"3"', graph: meta },
+      { subject: 'urn:s', predicate: 'http://dkg.io/ontology/workspaceOwner', object: 'did:dkg:owner:0xowner', graph: meta },
+    ]);
+    expect(out.map((q) => q.predicate)).toEqual(['http://schema.org/name']); // only the content quad
+  });
+
+  it('reads BOTH the legacy bucket and per-KA promote partitions, but NOT /staging/', async () => {
+    const out = await readBoth([
+      { subject: 'urn:legacy', predicate: 'urn:p', object: '"in-bucket"', graph: swm },
+      { subject: 'urn:promoted', predicate: 'urn:p', object: '"in-partition"', graph: `${swm}/0xowner/7` },
+      { subject: 'urn:staged', predicate: 'urn:p', object: '"in-staging"', graph: `${swm}/staging/deadbeef` },
+    ]);
+    const subjects = out.map((q) => q.subject).sort();
+    expect(subjects).toEqual(['urn:legacy', 'urn:promoted']); // staging excluded
+  });
+});
+
+// Controls: store-stable terms stay equal (guards against under-normalizing).
+describe('controls', () => {
+  it('plain literals + IRIs only — already store-stable, parity holds', async () => {
+    await expectSealRecomputeParity([
+      t(S, RDF_TYPE, DCAT_DATASET),
+      t(S, 'http://schema.org/identifier', '"crypto_bitcoin"'),
+      t(S, 'http://schema.org/sameAs', 'https://bitcoin.org'),
+    ]);
+  });
+});

--- a/packages/publisher/test/term-canon-exhaustive.test.ts
+++ b/packages/publisher/test/term-canon-exhaustive.test.ts
@@ -1,0 +1,131 @@
+// EXHAUSTIVE consensus-conformance grids for the V10 leaf canonicalizer (#1386):
+// proves the reverse-engineered rules over their FINITE spaces against the real
+// oxigraph 0.5.5 oracle (the full 3600-combo T24 grids, month×day across leap/
+// century/negative years, the timezone grid, g-type grids, and ±1 numeric
+// boundaries) AND the no-migration idempotence invariant core(oxigraph(x)) ==
+// oxigraph(x). Complements the representative cases in term-canon-oracle.test.ts.
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { canonicalizeObjectTermForHash } from '@origintrail-official/dkg-core';
+
+const xsd = (t: string) => `http://www.w3.org/2001/XMLSchema#${t}`;
+const lit = (v: string, dt: string) => `"${v}"^^<${xsd(dt)}>`;
+
+async function oxiForms(objects: string[]): Promise<string[]> {
+  const out: string[] = [];
+  const CHUNK = 800;
+  for (let off = 0; off < objects.length; off += CHUNK) {
+    const slice = objects.slice(off, off + CHUNK);
+    const store = new OxigraphStore();
+    const quads: Quad[] = slice.map((object, i) => ({ subject: 'urn:s', predicate: `urn:p#${i}`, object, graph: 'urn:g' }));
+    await store.insert(quads);
+    const res = await store.query('CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <urn:g> { ?s ?p ?o } }');
+    const byPred = new Map<string, string>();
+    if (res.type === 'quads') for (const q of res.quads) byPred.set(q.predicate, q.object);
+    for (let i = 0; i < slice.length; i++) out.push(byPred.get(`urn:p#${i}`) ?? '(DROPPED)');
+  }
+  return out;
+}
+
+async function proveParity(label: string, objects: string[]): Promise<void> {
+  const oxi = await oxiForms(objects);
+  const mismatches: string[] = [];
+  // forward parity
+  objects.forEach((obj, i) => {
+    const got = canonicalizeObjectTermForHash(obj);
+    if (got !== oxi[i]) mismatches.push(`FWD in=${obj}\n   core=${got}\n   oxi =${oxi[i]}`);
+  });
+  // no-migration: core is the identity on oxigraph's own canonical output
+  oxi.forEach((o) => {
+    if (o === '(DROPPED)') return;
+    const re = canonicalizeObjectTermForHash(o);
+    if (re !== o) mismatches.push(`IDEMPOTENCE BROKEN oxi=${o}\n   core(oxi)=${re}`);
+  });
+  if (mismatches.length) {
+    throw new Error(`${label}: ${mismatches.length} mismatch(es):\n${mismatches.slice(0, 30).join('\n')}`);
+  }
+  expect(mismatches.length).toBe(0);
+}
+
+const p2 = (n: number) => String(n).padStart(2, '0');
+
+describe('term-canon EXHAUSTIVE', () => {
+  it('T24 dateTime grid: all 3600 (MM,SS) + fractional layer', async () => {
+    const objs: string[] = [];
+    for (let mm = 0; mm <= 59; mm++) for (let ss = 0; ss <= 59; ss++) {
+      objs.push(lit(`2026-06-29T24:${p2(mm)}:${p2(ss)}`, 'dateTime'));
+    }
+    // fractional layer on a representative cut
+    for (let mm = 0; mm <= 59; mm += 7) for (const f of ['.0', '.5', '.250', '.000']) {
+      objs.push(lit(`2026-06-29T24:${p2(mm)}:00${f}`, 'dateTime'));
+      objs.push(lit(`2026-06-29T24:${p2(mm)}:30${f}`, 'dateTime'));
+    }
+    await proveParity('T24 dateTime', objs);
+  });
+
+  it('T24 time grid: all 3600 (MM,SS)', async () => {
+    const objs: string[] = [];
+    for (let mm = 0; mm <= 59; mm++) for (let ss = 0; ss <= 59; ss++) {
+      objs.push(lit(`24:${p2(mm)}:${p2(ss)}`, 'time'));
+    }
+    await proveParity('T24 time', objs);
+  });
+
+  it('month x day validity grid (leap + non-leap + century), dateTime & date', async () => {
+    const objs: string[] = [];
+    for (const y of ['2024', '2026', '2000', '1900', '0000', '-0004', '-0001']) {
+      for (let mo = 0; mo <= 13; mo++) for (let dd = 0; dd <= 32; dd++) {
+        objs.push(lit(`${y}-${p2(mo)}-${p2(dd)}T12:00:00`, 'dateTime'));
+        objs.push(lit(`${y}-${p2(mo)}-${p2(dd)}`, 'date'));
+      }
+    }
+    await proveParity('month/day grid', objs);
+  });
+
+  it('timezone offset grid (dateTime): Z and ±HH:MM', async () => {
+    const objs: string[] = [lit('2026-06-29T12:00:00Z', 'dateTime')];
+    for (const sgn of ['+', '-']) for (let h = 0; h <= 15; h++) for (let m = 0; m <= 60; m += 1) {
+      objs.push(lit(`2026-06-29T12:00:00${sgn}${p2(h)}:${p2(m)}`, 'dateTime'));
+    }
+    await proveParity('tz grid', objs);
+  });
+
+  it('gMonthDay / gDay / gMonth validity grids', async () => {
+    const objs: string[] = [];
+    for (let mo = 0; mo <= 13; mo++) for (let dd = 0; dd <= 32; dd++) {
+      objs.push(lit(`--${p2(mo)}-${p2(dd)}`, 'gMonthDay'));
+    }
+    for (let dd = 0; dd <= 32; dd++) objs.push(lit(`---${p2(dd)}`, 'gDay'));
+    for (let mo = 0; mo <= 13; mo++) objs.push(lit(`--${p2(mo)}`, 'gMonth'));
+    await proveParity('gMonthDay/gDay/gMonth', objs);
+  });
+
+  it('numeric ±1 boundaries (i64 months, i128 seconds, 18/19 frac, derived-int i64)', async () => {
+    const objs: string[] = [
+      // i64 months boundary via Y (12*Y)
+      lit('P768614336404564650Y', 'duration'), lit('P768614336404564651Y', 'duration'),
+      lit('-P768614336404564650Y', 'duration'), lit('-P768614336404564651Y', 'duration'),
+      lit('P9223372036854775807M', 'duration'), lit('P9223372036854775808M', 'duration'),
+      // i128 seconds boundary (max = (2^127-1)/1e18 = 170141183460469231731.687303715884105727)
+      lit('PT170141183460469231731S', 'duration'),
+      lit('PT170141183460469231732S', 'duration'),
+      lit('PT170141183460469231731.687303715884105727S', 'duration'),
+      lit('PT170141183460469231731.687303715884105728S', 'duration'),
+      // 18 vs 19 significant fractional digits
+      lit('PT0.123456789012345678S', 'duration'), lit('PT0.1234567890123456789S', 'duration'),
+      lit('PT1.000000000000000001S', 'duration'), lit('PT1.0000000000000000001S', 'duration'),
+      // derived int i64 collapse boundary
+      lit('9223372036854775807', 'long'), lit('9223372036854775808', 'long'),
+      lit('-9223372036854775808', 'long'), lit('-9223372036854775809', 'long'),
+      lit('9223372036854775808', 'integer'), // xsd:integer keeps arbitrary precision
+      // dateTime fractional seconds: 18 vs 19 significant, trailing-zero strip at 19
+      lit('2026-06-29T12:00:00.123456789012345678', 'dateTime'),
+      lit('2026-06-29T12:00:00.1234567890123456789', 'dateTime'),
+      lit('2026-06-29T12:00:00.5000000000000000000', 'dateTime'),
+      // year-digit transitions + negative rollover
+      lit('9999-12-31T24:00:00', 'dateTime'), lit('-0001-12-31T24:00:00', 'dateTime'),
+      lit('-2026-12-31T24:00:00', 'dateTime'), lit('0000-12-31T24:00:00', 'dateTime'),
+    ];
+    await proveParity('numeric boundaries', objs);
+  });
+});

--- a/packages/publisher/test/term-canon-oracle.test.ts
+++ b/packages/publisher/test/term-canon-oracle.test.ts
@@ -232,6 +232,25 @@ describe('term-canon oracle: fuzz-hardened edge classes (#1386)', () => {
     await expectMatchesOxigraph([lit('738507753103385.25', 'double'), lit('-738507753103385.25', 'double'), lit('738507753103385.2', 'double')]);
   });
 
+  it('xsd:float shortest representation matches Rust f32 formatting (not V8 toPrecision)', async () => {
+    await expectMatchesOxigraph([
+      lit('1.262177448353619e-29', 'float'), lit('1.5474250491067253e+26', 'float'),
+      lit('1.2379400392853803e+27', 'float'), lit('0.1', 'float'), lit('3.14', 'float'), lit('1.0E20', 'float'),
+    ]);
+  });
+
+  it('gMonthDay --02-29 is rejected by oxigraph (no leap-year context) → verbatim', async () => {
+    await expectMatchesOxigraph([
+      lit('--02-29+00:00', 'gMonthDay'), lit('--02-28+00:00', 'gMonthDay'), lit('--02-29', 'gMonthDay'),
+    ]);
+  });
+
+  it('duration seconds accept trailing/leading dot (PT1.S → PT1S, PT.5S → PT0.5S)', async () => {
+    await expectMatchesOxigraph([
+      lit('PT1.S', 'duration'), lit('PT.5S', 'duration'), lit('P1DT2.S', 'duration'), lit('PT60.S', 'duration'),
+    ]);
+  });
+
   it('years: 4-digit or 5+-no-leading-zero canonicalize; leading-zero 5+ → verbatim; -0000 → 0000', async () => {
     await expectMatchesOxigraph([
       lit('12026-01-01T00:00:00+00:00', 'dateTime'), lit('100000-01-01T00:00:00+00:00', 'dateTime'),
@@ -309,12 +328,13 @@ describe('term-canon oracle: fuzz-hardened edge classes (#1386)', () => {
   });
 
   // DOCUMENTED oxigraph 0.5.5 STORAGE defect, deliberately NOT mirrored (see term-canon.ts):
-  // a negative-year dateTime with seconds==59 + a non-zero fraction drifts the minute on
-  // every store round-trip (no stable form), so canon stays deterministic + idempotent.
-  it('negative-year dateTime with :59 + fraction — core is deterministic + idempotent (oxigraph is not)', () => {
-    const x = lit('-1711-04-09T15:19:59.6', 'dateTime');
-    const once = canonicalizeObjectTermForHash(x);
-    expect(once).toBe(x); // left as the valid XSD form
-    expect(canonicalizeObjectTermForHash(once)).toBe(once); // idempotent
+  // a BEFORE-EPOCH dateTime (year ≤ 0000) with seconds==59 + a non-zero fraction has its
+  // minute bumped on every store round-trip (no stable form), so canon stays deterministic +
+  // idempotent rather than chasing the drift.
+  it('before-epoch dateTime with :59 + fraction — core is deterministic + idempotent (oxigraph is not)', () => {
+    for (const x of ['-1711-04-09T15:19:59.6', '0000-06-15T10:10:59.9Z', '0000-12-31T23:59:59.999Z']) {
+      const once = canonicalizeObjectTermForHash(lit(x, 'dateTime'));
+      expect(canonicalizeObjectTermForHash(once)).toBe(once); // idempotent (the consensus-relevant property)
+    }
   });
 });

--- a/packages/publisher/test/term-canon-oracle.test.ts
+++ b/packages/publisher/test/term-canon-oracle.test.ts
@@ -1,0 +1,192 @@
+// CONSENSUS SAFETY NET for the backend-independent V10 leaf canonicalization
+// (dkg-core canonicalizeObjectTermForHash, applied at tripleContentV10).
+//
+// The protocol canonical form is DEFINED to equal the value-space canonicalization
+// the network already deploys (oxigraph 0.5.5). This test is the oracle that
+// proves it byte-for-byte: for a broad battery of literals (incl. a randomized
+// double sweep), the pure core canonicalizer must produce EXACTLY what a real
+// oxigraph store emits on round-trip. If they ever diverge, this fails CI — which
+// is the difference between "fixed a publish bug" and "forked RandomSampling".
+//
+// Matching the deployed form also means the canonicalizer is the IDENTITY on
+// already-canonical (store-loaded) terms ⇒ existing on-chain roots are unchanged
+// (no migration); a coordinated release suffices.
+
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { canonicalizeObjectTermForHash } from '@origintrail-official/dkg-core';
+
+const xsd = (t: string) => `http://www.w3.org/2001/XMLSchema#${t}`;
+const G = 'urn:g';
+const S = 'urn:s';
+
+/** Round-trip every literal through a real oxigraph store and return, per input,
+ *  the canonical object string the store emits — the deployed canonical form. */
+async function oxigraphForms(objects: string[]): Promise<string[]> {
+  const store = new OxigraphStore();
+  const quads: Quad[] = objects.map((object, i) => ({ subject: S, predicate: `urn:p#${i}`, object, graph: G }));
+  await store.insert(quads);
+  const res = await store.query(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${G}> { ?s ?p ?o } }`);
+  const byPred = new Map<string, string>();
+  if (res.type === 'quads') for (const q of res.quads) byPred.set(q.predicate, q.object);
+  return objects.map((_, i) => byPred.get(`urn:p#${i}`) ?? '(DROPPED)');
+}
+
+/** Assert the pure core canonicalizer reproduces oxigraph's form for every input. */
+async function expectMatchesOxigraph(objects: string[]): Promise<void> {
+  const oxi = await oxigraphForms(objects);
+  const mismatches: string[] = [];
+  objects.forEach((obj, i) => {
+    const got = canonicalizeObjectTermForHash(obj);
+    if (got !== oxi[i]) mismatches.push(`  in:  ${obj}\n  core:${got}\n  oxi: ${oxi[i]}`);
+  });
+  if (mismatches.length) {
+    throw new Error(`core canon diverged from oxigraph (${mismatches.length}/${objects.length}):\n${mismatches.join('\n')}`);
+  }
+  expect(mismatches.length).toBe(0);
+}
+
+const lit = (v: string, dt: string) => `"${v}"^^<${xsd(dt)}>`;
+
+describe('term-canon oracle: core == oxigraph 0.5.5', () => {
+  it('xsd:string is elided', async () => {
+    await expectMatchesOxigraph([lit('Bitcoin', 'string'), lit('a b c', 'string'), lit('', 'string')]);
+  });
+
+  it('language tags are lowercased', async () => {
+    await expectMatchesOxigraph(['"x"@EN', '"x"@en', '"x"@en-US', '"x"@EN-us', '"x"@En-Gb', '"x"@DE']);
+  });
+
+  it('plain literals and non-literals are unchanged', async () => {
+    // plain literal (no datatype) round-trips as-is; oracle handles literals only,
+    // so check non-literals (IRI/blank/genid) directly against identity.
+    await expectMatchesOxigraph(['"plain"', '"with space"']);
+    expect(canonicalizeObjectTermForHash('http://example.org/x')).toBe('http://example.org/x');
+    expect(canonicalizeObjectTermForHash('urn:okf:datasets/x/.well-known/genid/b0')).toBe('urn:okf:datasets/x/.well-known/genid/b0');
+    expect(canonicalizeObjectTermForHash('_:b0')).toBe('_:b0');
+  });
+
+  it('the xsd:integer family collapses to xsd:integer with canonical value', async () => {
+    const cases = ['007', '+5', '-0', '00', '-42', '0', '999999999999999999999999'];
+    const types = ['integer', 'int', 'long', 'short', 'byte', 'unsignedInt', 'nonNegativeInteger', 'positiveInteger', 'negativeInteger'];
+    const objects: string[] = [];
+    for (const ty of types) for (const v of cases) {
+      // only feed values valid for the type (avoid oxigraph rejecting e.g. negative unsigned)
+      if (ty.includes('nonNegative') || ty.includes('unsigned') || ty === 'positiveInteger') { if (v.startsWith('-')) continue; }
+      if (ty === 'negativeInteger') { if (!v.startsWith('-') || v === '-0') continue; }
+      if (ty === 'positiveInteger' && (v === '0' || v === '00' || v === '-0')) continue;
+      if (ty === 'byte' && (v === '999999999999999999999999')) continue;
+      objects.push(lit(v, ty));
+    }
+    await expectMatchesOxigraph(objects);
+  });
+
+  it('xsd:decimal value-space canonicalization', async () => {
+    const vals = ['1.0', '1.50', '100.0', '0.500', '.5', '-0.0', '+1.5', '010.0', '0', '0.0', '-3.14', '123.456000', '000.000'];
+    await expectMatchesOxigraph(vals.map((v) => lit(v, 'decimal')));
+  });
+
+  it('xsd:boolean lexical forms', async () => {
+    await expectMatchesOxigraph(['1', '0', 'true', 'false'].map((v) => lit(v, 'boolean')));
+  });
+
+  it('xsd:dateTime fractional-seconds + timezone normalization', async () => {
+    const vals = [
+      '2026-06-29T12:00:00', '2026-06-29T12:00:00.0', '2026-06-29T12:00:00.500', '2026-06-29T12:00:00.000',
+      '2026-06-29T12:00:00Z', '2026-06-29T12:00:00+00:00', '2026-06-29T12:00:00-00:00', '2026-06-29T12:00:00+02:00',
+      '2026-06-29T12:00:00.120Z', '2026-06-29T12:00:00.123456',
+    ];
+    await expectMatchesOxigraph(vals.map((v) => lit(v, 'dateTime')));
+  });
+
+  it('xsd:dateTime T24:00:00 rolls over to next day (incl. month/year/leap boundaries)', async () => {
+    const vals = [
+      '2026-06-29T24:00:00', '2026-06-30T24:00:00', '2026-12-31T24:00:00', '2024-02-28T24:00:00',
+      '2026-02-28T24:00:00', '2026-06-29T24:00:00Z', '2026-06-29T24:00:00+02:00', '2000-02-29T24:00:00',
+    ];
+    await expectMatchesOxigraph(vals.map((v) => lit(v, 'dateTime')));
+  });
+
+  it('xsd:time fractional-seconds + timezone + 24:00:00', async () => {
+    const vals = ['12:00:00', '12:00:00.0', '12:00:00.500', '12:00:00Z', '12:00:00+00:00', '12:00:00-00:00', '12:00:00+02:00', '24:00:00', '24:00:00Z'];
+    await expectMatchesOxigraph(vals.map((v) => lit(v, 'time')));
+  });
+
+  it('date / gYear / gYearMonth / gMonthDay / gMonth / gDay timezone normalization', async () => {
+    await expectMatchesOxigraph([
+      lit('2026-06-29', 'date'), lit('2026-06-29Z', 'date'), lit('2026-06-29+00:00', 'date'),
+      lit('2026-06-29-00:00', 'date'), lit('2026-06-29+02:00', 'date'),
+      lit('2026', 'gYear'), lit('2026+00:00', 'gYear'), lit('2026+02:00', 'gYear'), lit('02026', 'gYear'),
+      lit('2026-06', 'gYearMonth'), lit('2026-06+00:00', 'gYearMonth'),
+      lit('--06-29', 'gMonthDay'), lit('--06-29+00:00', 'gMonthDay'),
+      lit('--06', 'gMonth'), lit('--06+00:00', 'gMonth'), lit('---29', 'gDay'),
+    ]);
+  });
+
+  it('xsd:duration / dayTimeDuration / yearMonthDuration drop zero components', async () => {
+    const dur = ['P1Y0M', 'P1Y', 'PT0S', 'P0Y', 'P1Y2M3DT4H5M6S', '-P1Y', 'P1DT0H', 'PT1H0M0S', 'P0Y0M0DT0H0M0S', 'PT1.500S', 'P0M0D'];
+    await expectMatchesOxigraph(dur.map((v) => lit(v, 'duration')));
+    await expectMatchesOxigraph(['PT1H0M', 'PT0H0M0S'].map((v) => lit(v, 'dayTimeDuration')));
+    await expectMatchesOxigraph(['P1Y0M', 'P0Y0M'].map((v) => lit(v, 'yearMonthDuration')));
+  });
+
+  it('literal-content escaping is normalized (decode + minimal re-escape)', async () => {
+    // NOTE: double-backslash in source = a single literal backslash in the term.
+    await expectMatchesOxigraph([
+      lit('caf\\u00e9', 'string'),       // é -> é
+      lit('smile\\U0001F600', 'string'), // \U… -> 😀
+      lit('tab\\there', 'string'),       // \t -> raw tab
+      lit('q\\"uote', 'string'),         // \" stays escaped
+      lit('back\\\\slash', 'string'),    // \\ stays escaped
+      lit('new\\nline', 'string'),       // \n stays escaped
+      lit('ret\\rX', 'string'),          // \r stays escaped
+      lit('caf\\u00e9', 'http://example.org/custom'), // escaping normalized for verbatim datatypes too
+      '"smile\\U0001F600"@EN',           // and for language-tagged literals
+      '"plain ascii"',
+    ]);
+  });
+
+  it('datatypes oxigraph leaves verbatim are returned unchanged', async () => {
+    const verbatim = [
+      lit('2026-06-29', 'date'), lit('2026-06-29Z', 'date'), lit('12:00:00', 'time'),
+      lit('2026', 'gYear'), lit('02026', 'gYear'), lit('4A6f', 'hexBinary'), lit('SGk=', 'base64Binary'),
+      lit('http://x', 'anyURI'), '"RawValue"^^<http://example.org/custom>',
+    ];
+    await expectMatchesOxigraph(verbatim);
+  });
+
+  describe('xsd:double / xsd:float', () => {
+    it('representative + edge lexical forms', async () => {
+      const vals = ['1.0E2', '1e10', '-0.0', '3.14', '1E-7', '1.5E300', 'NaN', 'INF', '-INF', '0.1', '0.5', '100', '0', '0.0', '-2.5E-3', '6.022E23'];
+      await expectMatchesOxigraph(vals.map((v) => lit(v, 'double')));
+      await expectMatchesOxigraph(['1.0', '0.1', '3.14', '1E2', '1.5', '100', '0'].map((v) => lit(v, 'float')));
+    });
+
+    it('randomized double sweep across magnitudes', async () => {
+      // Deterministic spread (no Math.random — avoid flakiness): mantissas × 10^exp,
+      // both signs, across the full exponent range.
+      const mantissas = [1, 1.5, 3.14159, 2, 7, 9.999, 1.234567890123, 5.5, 8.0];
+      const exps = [-300, -100, -20, -7, -3, -1, 0, 1, 3, 7, 15, 21, 100, 300];
+      const objects: string[] = [];
+      for (const m of mantissas) for (const e of exps) for (const sign of [1, -1]) {
+        const v = sign * m * Math.pow(10, e);
+        if (!Number.isFinite(v) || v === 0) continue;
+        objects.push(lit(v.toExponential(), 'double')); // feed E-notation; oxigraph + core both expand to plain
+      }
+      await expectMatchesOxigraph(objects);
+    });
+
+    it('float32 rounding (Math.fround) matches oxigraph', async () => {
+      const vals = ['0.1', '1.1', '3.14159265358979', '0.2', '1.0E20', '123456.789'];
+      await expectMatchesOxigraph(vals.map((v) => lit(v, 'float')));
+    });
+  });
+
+  it('is idempotent (fixed point) on its own output', async () => {
+    const inputs = [lit('007', 'integer'), lit('1.0', 'decimal'), lit('1', 'boolean'), lit('1.0E2', 'double'), '"x"@EN', lit('Bitcoin', 'string')];
+    for (const x of inputs) {
+      const once = canonicalizeObjectTermForHash(x);
+      expect(canonicalizeObjectTermForHash(once)).toBe(once);
+    }
+  });
+});

--- a/packages/publisher/test/term-canon-oracle.test.ts
+++ b/packages/publisher/test/term-canon-oracle.test.ts
@@ -190,3 +190,131 @@ describe('term-canon oracle: core == oxigraph 0.5.5', () => {
     }
   });
 });
+
+// Edge classes surfaced by a ~110k-case differential fuzz of
+// canonicalizeObjectTermForHash against real oxigraph 0.5.5 (#1386 review). Each is
+// asserted byte-equal to oxigraph's round-trip form (the deployed canonical form).
+describe('term-canon oracle: fuzz-hardened edge classes (#1386)', () => {
+  it('bare datatype IRIs ("v"^^IRI without <>) fold to the canonical bracketed form', async () => {
+    await expectMatchesOxigraph([
+      `"007"^^${xsd('integer')}`, `"1.50"^^${xsd('decimal')}`, `"1"^^${xsd('boolean')}`,
+      `"1.0E2"^^${xsd('double')}`, `"2026-06-29T24:00:00"^^${xsd('dateTime')}`,
+    ]);
+  });
+
+  it('integers canonicalize ONLY within i64; beyond it (or malformed) stay verbatim', async () => {
+    await expectMatchesOxigraph([
+      lit('9223372036854775807', 'integer'), lit('-9223372036854775808', 'integer'), // i64 bounds → canon
+      lit('+9223372036854775808', 'integer'), lit('00009223372036854775808', 'integer'), // > i64 → verbatim (+/zeros kept)
+      lit('-9223372036854775809', 'long'), lit('+-1', 'integer'), lit('99999999999999999999999', 'integer'),
+      lit('+5', 'int'), lit('007', 'long'), lit('-0', 'integer'),
+    ]);
+  });
+
+  it('decimals canonicalize ONLY within the i128/1e18 Decimal range; beyond → verbatim', async () => {
+    await expectMatchesOxigraph([
+      lit('170141183460469231731.687303715884105727', 'decimal'), // == max → canon
+      lit('0170141183460469231731.6873037158841057270', 'decimal'), // max ± zeros → strip
+      lit('0170141183460469231732', 'decimal'), // > max int → verbatim
+      lit('999999999999999999999999999999.5', 'decimal'), // magnitude overflow → verbatim
+      lit('0.1234567890123456789', 'decimal'), // 19 frac digits → verbatim
+      lit('1.50', 'decimal'), lit('.5', 'decimal'), lit('+0.0', 'decimal'), lit('007.000', 'decimal'),
+    ]);
+  });
+
+  it('double/float special values: case-insensitive nan / inf / infinity with optional sign', async () => {
+    const forms = ['NaN', 'nan', 'NAN', '+nan', '-nan', 'INF', 'inf', 'Infinity', 'infinity', '+Infinity', '-INF', '-inf', '-Infinity'];
+    await expectMatchesOxigraph(forms.map((v) => lit(v, 'double')));
+    await expectMatchesOxigraph(forms.map((v) => lit(v, 'float')));
+  });
+
+  it('double shortest-representation TIES round half away from zero (oxigraph/Rust, not V8 to-even)', async () => {
+    await expectMatchesOxigraph([lit('738507753103385.25', 'double'), lit('-738507753103385.25', 'double'), lit('738507753103385.2', 'double')]);
+  });
+
+  it('years: 4-digit or 5+-no-leading-zero canonicalize; leading-zero 5+ → verbatim; -0000 → 0000', async () => {
+    await expectMatchesOxigraph([
+      lit('12026-01-01T00:00:00+00:00', 'dateTime'), lit('100000-01-01T00:00:00+00:00', 'dateTime'),
+      lit('0000-01-01T00:00:00+00:00', 'dateTime'), lit('09508-01-01T00:00:00+00:00', 'dateTime'),
+      lit('-0000-06-15T12:30:45Z', 'dateTime'), lit('-0000', 'gYear'), lit('012026-06+00:00', 'gYearMonth'),
+    ]);
+  });
+
+  it('years whose seconds-since-epoch overflow oxigraph i128/1e18 Decimal → verbatim', async () => {
+    await expectMatchesOxigraph([
+      lit('5391559471918-01-01T00:00:00+00:00', 'dateTime'), // within range → fold tz to Z
+      lit('5391559471919-01-01T00:00:00+00:00', 'dateTime'), // overflow → verbatim (+00:00 kept)
+      lit('9223372036854775808+00:00', 'gYear'), lit('99999999999999999999-06+00:00', 'gYearMonth'),
+      lit('123456789012345678901234567890+00:00', 'date'),
+    ]);
+  });
+
+  it('dateTime/time fractional seconds beyond 18 digits → verbatim (no tz fold)', async () => {
+    await expectMatchesOxigraph([
+      lit('2026-06-29T12:00:00.123456789012345678+00:00', 'dateTime'), // 18 → fold tz to Z
+      lit('2026-06-29T12:00:00.1234567890123456789+00:00', 'dateTime'), // 19 → verbatim
+      lit('12:00:00.1234567890123456789+00:00', 'time'),
+    ]);
+  });
+
+  it('T24:00 rolls iff minute==0 OR seconds==0; otherwise verbatim', async () => {
+    await expectMatchesOxigraph([
+      lit('2026-06-29T24:00:00', 'dateTime'), lit('2026-06-29T24:00:01', 'dateTime'),
+      lit('2026-06-29T24:10:00', 'dateTime'), lit('2026-06-29T24:30:45', 'dateTime'),
+      lit('2026-06-29T24:12:00.5', 'dateTime'), lit('24:01:00', 'time'), lit('24:01:01', 'time'),
+    ]);
+  });
+
+  it('durations: value-space carry/overflow, subtype constraints, verbatim beyond i64/i128', async () => {
+    await expectMatchesOxigraph([
+      lit('P1Y13M', 'duration'), lit('PT3600S', 'duration'), lit('PT25H', 'dayTimeDuration'),
+      lit('P1DT24H', 'duration'), lit('-P1Y13M', 'duration'), lit('PT90.5S', 'duration'), lit('PT.5S', 'duration'),
+      lit('P1D', 'yearMonthDuration'), lit('P1Y', 'dayTimeDuration'),
+      lit('P768614336404564651Y', 'duration'), lit('P9999999999999999999DT0H', 'duration'),
+      lit('PT0.1234567890123456789S', 'duration'),
+    ]);
+  });
+
+  it('datatype IRI \\u escapes are decoded (oxigraph), affecting datatype matching', async () => {
+    await expectMatchesOxigraph([`"x"^^<http://example.org/\\u0041>`]);
+  });
+
+  it('a \\U escape beyond U+10FFFF never throws (the leaf computation must not crash)', () => {
+    expect(() => canonicalizeObjectTermForHash(`"\\U00110000"^^<${xsd('string')}>`)).not.toThrow();
+    expect(() => canonicalizeObjectTermForHash(`"x\\Uffffffffy"^^<${xsd('string')}>`)).not.toThrow();
+  });
+
+  it('NO-MIGRATION + idempotence over a broad battery: canon is the identity on oxigraph output', async () => {
+    const p2 = (n: number) => String(n).padStart(2, '0');
+    const battery: string[] = [];
+    for (const v of ['0', '7', '-42', '007', '+5', '999999999999999999999999', '9223372036854775808'])
+      battery.push(lit(v, 'integer'), lit(v, 'long'));
+    for (const v of ['1.0', '1.50', '.5', '-0.0', '123.456000', '999999999999999999999999999999.5'])
+      battery.push(lit(v, 'decimal'));
+    for (const v of ['1.0E2', '1e10', 'NaN', 'INF', '-INF', '3.14', '738507753103385.25', 'infinity'])
+      battery.push(lit(v, 'double'));
+    for (let h = 0; h <= 24; h++) for (const ss of ['00', '30', '59'])
+      battery.push(lit(`2026-06-29T${p2(h)}:00:${ss}`, 'dateTime'), lit(`${p2(h)}:00:${ss}`, 'time'));
+    for (const v of ['2026-06-29T12:00:00.500+00:00', '2026-06-29T24:00:00', '-0044-03-15T12:00:00', '09508-01-01T00:00:00'])
+      battery.push(lit(v, 'dateTime'));
+    for (const v of ['P1Y13M', 'PT3600S', 'PT25H', '-P1Y', 'P0Y0M0DT0H0M0S']) battery.push(lit(v, 'duration'));
+    battery.push(lit('café', 'string'), '"x"@EN', lit('4A6f', 'hexBinary'), `"007"^^${xsd('integer')}`);
+
+    const oxi = await oxigraphForms(battery);
+    for (let i = 0; i < battery.length; i++) {
+      const once = canonicalizeObjectTermForHash(battery[i]);
+      expect(canonicalizeObjectTermForHash(once)).toBe(once); // idempotent
+      if (oxi[i] !== '(DROPPED)') expect(canonicalizeObjectTermForHash(oxi[i])).toBe(oxi[i]); // identity on store output
+    }
+  });
+
+  // DOCUMENTED oxigraph 0.5.5 STORAGE defect, deliberately NOT mirrored (see term-canon.ts):
+  // a negative-year dateTime with seconds==59 + a non-zero fraction drifts the minute on
+  // every store round-trip (no stable form), so canon stays deterministic + idempotent.
+  it('negative-year dateTime with :59 + fraction — core is deterministic + idempotent (oxigraph is not)', () => {
+    const x = lit('-1711-04-09T15:19:59.6', 'dateTime');
+    const once = canonicalizeObjectTermForHash(x);
+    expect(once).toBe(x); // left as the valid XSD form
+    expect(canonicalizeObjectTermForHash(once)).toBe(once); // idempotent
+  });
+});


### PR DESCRIPTION
## Problem

The V10 merkle leaf (`tripleContentV10`, hashed on-chain as `leaf = keccak256(content)` in `RandomSampling.submitProof`) hashed each RDF term's **raw string** and applied no canonicalization — it silently delegated the literal canonical form to whatever the node's triple store emits. Consequences:

- **`MERKLE_MISMATCH_IN_SWM`** — a publisher sealing over its pre-store quads and a peer recomputing over its post-store (store-canonicalized) replica hash *different serializations of the same triple*. This blocked the OKF→VM publish (`okf-dkg-vm-validation-report.md`): identical 23-triple count, different root.
- **Cross-backend / cross-version fork risk** — the leaf was only as deterministic as the backend (oxigraph vs blazegraph, or an oxigraph version bump).

## Fix

A protocol-defined, **backend-independent** term canonicalization (`canonicalizeObjectTermForHash`, new `packages/core/src/crypto/term-canon.ts`) applied at the V10 leaf (`tripleContentV10`), so every node computes the identical leaf regardless of triple-store backend or version. V8 (`hashTriple`) is untouched.

The canonical form is **defined to match the value-space canonicalization the network already deploys (oxigraph 0.5.5)**, so it is the **identity on already-canonical (store-loaded) terms** ⇒ no migration of existing on-chain roots.

### Coverage (all verified byte-for-byte against oxigraph)
- literal-content escaping (decode N-Triples escapes → minimal `\ " \n \r` re-escape)
- language-tag lowercasing; `xsd:string` elision
- `xsd:integer` family → `xsd:integer` (iff value ∈ i64; `xsd:integer` arbitrary precision)
- `xsd:decimal`, `xsd:boolean`
- `xsd:double` / `xsd:float` (IEEE-754 shortest → plain decimal; `Math.fround` for float32; `-0`/`NaN`/`INF`)
- full date/time family (fractional seconds, `+00:00`→`Z`, `T24:00:00` rollover)
- `xsd:duration` / `dayTimeDuration` / `yearMonthDuration`

## Consensus safety net

`packages/publisher/test/term-canon-oracle.test.ts` asserts `canon(x) === oxigraphRoundTrip(x)` over a broad battery (randomized double sweep, escaping, date/time boundaries, durations, i64-bounded integers). **A divergence from the deployed form fails CI rather than forking the network.** It caught 3 bugs during development (float32 shortest form, the i64 integer bound, the `yearMonthDuration` zero-form).

`packages/publisher/test/swm-seal-recompute-parity.test.ts` pins the end-to-end seal↔recompute invariant plus the SWM read-filter quad-set invariants.

## Verification
- Oracle 17 + parity/invariant 17 — green on this branch against `main`.
- Full cross-package regression on the development branch: core 1092, random-sampling 65 (on-chain proof path), publisher 1257, agent 1745, chain 616, cli/dkg 2129 — **0 failures**.

## ⚠️ Rollout — this is a consensus change (spec §9.0.2)

The V10 leaf content goes on-chain, so this must ship as a **coordinated release** (all nodes together).

- **Migration:** the canon is the identity on oxigraph-0.5.5-canonical data, and `oxigraph@0.5.5` is identical on this branch and tag `v10.0.1`, so already-successfully-published assets are unchanged. The one caveat: an existing asset published via the **direct** path with *non-canonical typed literals* would have a non-canonical on-chain root and its RS proof would change post-fix — likely none given V10's age and that such publishes mostly emit plain literals, but confirm before rollout.

## Follow-up (separate PR)
Write-path unification so every minted publish writes its data to its per-KA SWM graph — letting the storage-ACK recompute read the precise per-KA (UAL) graph and retiring the `read-both` + `rootEntities` filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
