### PR TITLE
feat(evm): bulk registerAgents — add many PCA agents in one tx

### DIFF
--- a/packages/chain/abi/PublishingConviction.json
+++ b/packages/chain/abi/PublishingConviction.json
@@ -863,6 +863,24 @@
         "type": "uint256"
       },
       {
+        "internalType": "address[]",
+        "name": "agents",
+        "type": "address[]"
+      }
+    ],
+    "name": "registerAgents",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
         "internalType": "uint72",
         "name": "newNode",
         "type": "uint72"

--- a/packages/chain/src/chain-adapter.ts
+++ b/packages/chain/src/chain-adapter.ts
@@ -912,6 +912,7 @@ export interface ChainAdapter {
   registerPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<TxResult>;
   deregisterPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<TxResult>;
   clearPublishingConvictionAgents?(accountId: bigint): Promise<TxResult>;
+  registerPublishingConvictionAgents?(accountId: bigint, agents: string[]): Promise<TxResult>;
   isPublishingConvictionAgent?(accountId: bigint, agent: string): Promise<boolean>;
   settlePublishingConvictionAccount?(accountId: bigint): Promise<TxResult>;
   getPublishingConvictionAccountInfo?(accountId: bigint): Promise<V10PublishingConvictionAccountInfo | null>;

--- a/packages/chain/src/evm-adapter-conviction.ts
+++ b/packages/chain/src/evm-adapter-conviction.ts
@@ -390,6 +390,27 @@ export class ConvictionMethods extends EVMChainAdapterBase implements Conviction
     });
   }
 
+  /**
+   * Bulk-register MULTIPLE agents on a PCA in one tx. Owner-gated on-chain
+   * (ownerOf == caller). Like clearAgents, `registerAgents` lives on the
+   * PublishingConviction LOGIC contract (the frozen NFT wrapper has no batch
+   * entry point). All-or-nothing: any invalid entry reverts the whole batch.
+   */
+  async registerPublishingConvictionAgents(accountId: bigint, agents: string[]): Promise<TxResult> {
+    await this.init();
+    return this.pcaWrite(async () => {
+      const logic = await this.resolveContract('PublishingConviction');
+      const receipt = await this.sendContractTransaction(
+        logic,
+        'registerAgents',
+        [accountId, agents],
+        this.signer,
+        'bulk-register publishing conviction agents',
+      );
+      return { hash: receipt.hash, blockNumber: receipt.blockNumber, txIndex: receipt.index, success: receipt.status === 1 };
+    });
+  }
+
   async isPublishingConvictionAgent(accountId: bigint, agent: string): Promise<boolean> {
     await this.init();
     if (!this.contracts.dkgPublishingConvictionNFT) return false;

--- a/packages/chain/src/mock-adapter.ts
+++ b/packages/chain/src/mock-adapter.ts
@@ -657,6 +657,32 @@ export class MockChainAdapter implements ChainAdapter {
     return this.txResult(true);
   }
 
+  // Owner-gated bulk add. Mirrors PublishingConviction.registerAgents: validates
+  // the WHOLE batch (zero / duplicate / cap) before any mutation — all-or-nothing.
+  async registerPublishingConvictionAgents(accountId: bigint, agents: string[]): Promise<TxResult> {
+    const acct = this.requireConvictionOwner(accountId);
+    const cap = MockChainAdapter.MOCK_MAX_AGENTS_PER_ACCOUNT;
+    const toAdd: string[] = [];
+    for (const agent of agents) {
+      if (agent === ethers.ZeroAddress) {
+        throw new Error('Mock: ZeroAgentAddress()');
+      }
+      const key = ethers.getAddress(agent).toLowerCase();
+      if (this.agentToConvictionAccount.has(key) || toAdd.includes(key)) {
+        throw new Error(`Mock: AgentAlreadyRegistered(${agent})`);
+      }
+      if (acct.agents.size + toAdd.length >= cap) {
+        throw new Error(`Mock: AgentCapReached(${accountId}, ${cap})`);
+      }
+      toAdd.push(key);
+    }
+    for (const key of toAdd) {
+      acct.agents.add(key);
+      this.agentToConvictionAccount.set(key, accountId);
+    }
+    return this.txResult(true);
+  }
+
   async isPublishingConvictionAgent(accountId: bigint, agent: string): Promise<boolean> {
     if (!ethers.isAddress(agent)) return false;
     const acct = this.convictionAccounts.get(accountId);

--- a/packages/chain/test/abi-pinning.test.ts
+++ b/packages/chain/test/abi-pinning.test.ts
@@ -277,8 +277,11 @@ const PINNED_DIGESTS: Record<string, string> = {
   // Repinned (preserve-agents-on-transfer, 10.0.6): added the owner-gated bulk
   // `clearAgents(uint256)` + event `AgentsCleared(uint256,address,uint256)` +
   // error `NotAccountOwner(uint256,address)` for the explicit allow-list reset
-  // (transfers now PRESERVE agents). Event/error surface change → new digest.
-  PublishingConviction:         '13281d751828dbb05603dc6a657e917f63680b4e0e052aa95a9d24392743d18a',
+  // (transfers now PRESERVE agents).
+  // Repinned (bulk-register-agents, 10.0.7): added owner-gated
+  // `registerAgents(uint256,address[])` (no new event/error — reuses
+  // AgentRegistered). Function surface change → new digest.
+  PublishingConviction:         '2f35f06c94b14f4137b5602d5fc58793bfe812bb5263c6545d9da50f479bdb29',
   // Updated OT-RFC-51: storage surface for the above — primaryNode field on the
   // widened Account tuple + the seeded per-epoch publishing allocation getters.
   PublishingConvictionStorage:  '7eeae71f0efd9183fce232ccc669227dfd70fe4f93b4663392a0a52c1ccba859',

--- a/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
+++ b/packages/chain/test/mock-adapter-publishing-conviction-v10.test.ts
@@ -121,6 +121,28 @@ describe('MockChainAdapter — V10 conviction agent register/deregister', () => 
     expect((await mock.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(0);
   });
 
+  it('registerPublishingConvictionAgents bulk-adds all agents (all-or-nothing on a duplicate)', async () => {
+    const mock = new MockChainAdapter('mock:31337', SIGNER);
+    const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);
+    const a1 = ethers.Wallet.createRandom().address;
+    const a2 = ethers.Wallet.createRandom().address;
+
+    const res = await mock.registerPublishingConvictionAgents(accountId, [a1, a2]);
+    expect(res.success).toBe(true);
+    expect(await mock.isPublishingConvictionAgent(accountId, a1)).toBe(true);
+    expect(await mock.isPublishingConvictionAgent(accountId, a2)).toBe(true);
+    expect((await mock.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(2);
+
+    // All-or-nothing: a batch containing an already-registered agent reverts and
+    // adds none of its entries.
+    const a3 = ethers.Wallet.createRandom().address;
+    await expect(
+      mock.registerPublishingConvictionAgents(accountId, [a3, a1]),
+    ).rejects.toThrow(/AgentAlreadyRegistered/);
+    expect(await mock.isPublishingConvictionAgent(accountId, a3)).toBe(false);
+    expect((await mock.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(2);
+  });
+
   it('rejects re-registering an already-registered agent (N28 parity)', async () => {
     const mock = new MockChainAdapter('mock:31337', SIGNER);
     const { accountId } = await mock.createPublishingConvictionAccount(COMMITTED);

--- a/packages/chain/test/publishing-conviction-account-v10.test.ts
+++ b/packages/chain/test/publishing-conviction-account-v10.test.ts
@@ -107,6 +107,24 @@ describe('V10 Publishing Conviction NFT — chain-adapter lifecycle', () => {
     expect((await owner.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(0);
   });
 
+  it('registerPublishingConvictionAgents bulk-adds multiple agents in one tx (owner-gated, via the logic contract)', async () => {
+    const owner = await fundedOwner();
+    const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);
+
+    const agent1 = ethers.Wallet.createRandom().address;
+    const agent2 = ethers.Wallet.createRandom().address;
+    const agent3 = ethers.Wallet.createRandom().address;
+
+    const res = await owner.registerPublishingConvictionAgents(accountId, [agent1, agent2, agent3]);
+    expect(res.success).toBe(true);
+
+    expect(await owner.isPublishingConvictionAgent(accountId, agent1)).toBe(true);
+    expect(await owner.isPublishingConvictionAgent(accountId, agent2)).toBe(true);
+    expect(await owner.isPublishingConvictionAgent(accountId, agent3)).toBe(true);
+    expect(await owner.getConvictionAgentAccountId(agent2)).toBe(accountId);
+    expect((await owner.getPublishingConvictionAccountInfo(accountId))!.agentCount).toBe(3);
+  });
+
   it('owner topUpPublishingConvictionAccount + settlePublishingConvictionAccount succeed and topUpBuffer updates', async () => {
     const owner = await fundedOwner();
     const { accountId } = await owner.createPublishingConvictionAccount(COMMITTED);

--- a/packages/evm-module/abi/PublishingConviction.json
+++ b/packages/evm-module/abi/PublishingConviction.json
@@ -863,6 +863,24 @@
         "type": "uint256"
       },
       {
+        "internalType": "address[]",
+        "name": "agents",
+        "type": "address[]"
+      }
+    ],
+    "name": "registerAgents",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "accountId",
+        "type": "uint256"
+      },
+      {
         "internalType": "uint72",
         "name": "newNode",
         "type": "uint72"

--- a/packages/evm-module/contracts/PublishingConviction.sol
+++ b/packages/evm-module/contracts/PublishingConviction.sol
@@ -128,7 +128,7 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
     //           are byte-identical, so seed and move stay net-zero on K_total.
     // 10.0.5 — KC→KA terminology: error InvalidConvictionKcEpochs → InvalidConvictionKaEpochs
     //          (error selector change; no behavior change).
-    string private constant _VERSION = "10.0.6";
+    string private constant _VERSION = "10.0.7";
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
     /// @notice EpochStorage shard ID for the staker reward pool. Mirrors
@@ -326,15 +326,15 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
         _;
     }
 
-    /// @dev Owner-gate for the ONE direct-to-logic owner action (`clearAgents`).
-    ///      DELIBERATE, isolated exception to the usual pattern where owner
-    ///      validation lives on the NFT wrapper and logic is gated by
+    /// @dev Owner-gate for the direct-to-logic BULK agent actions (`clearAgents`,
+    ///      `registerAgents`). DELIBERATE, isolated exception to the usual pattern
+    ///      where owner validation lives on the NFT wrapper and logic is gated by
     ///      `onlyConvictionNFT`: the wrapper is non-upgradeable and exposes no
-    ///      `clearAgents` entry point, so the bulk reset validates ownership
-    ///      here against the live `ownerOf`. Do NOT copy this for new agent
-    ///      operations — add those to the wrapper. `ownerOf` reverts for a
-    ///      nonexistent account (and for an unresolvable address(0) NFT), so a
-    ///      bad id cannot slip past this gate.
+    ///      batch entry point, so these validate ownership here against the live
+    ///      `ownerOf`. New SINGLE agent ops still belong on the wrapper; only the
+    ///      batch operations the frozen wrapper cannot host live here. `ownerOf`
+    ///      reverts for a nonexistent account (and for an unresolvable address(0)
+    ///      NFT), so a bad id cannot slip past this gate.
     modifier onlyCurrentPcaOwner(uint256 accountId) {
         address nftAddr = hub.getContractAddress("DKGPublishingConvictionNFT");
         if (IERC721(nftAddr).ownerOf(accountId) != msg.sender) {
@@ -1199,6 +1199,36 @@ contract PublishingConviction is INamed, IVersioned, ContractStatus, IInitializa
         publishingConvictionStorage.clearAgents(accountId);
         emit AgentsCleared(accountId, msg.sender, cleared);
     }
+
+    /// @notice Register MULTIPLE publishing agents for `accountId` in a single
+    ///         transaction — the owner-gated bulk counterpart to the per-agent
+    ///         `registerAgent`.
+    /// @dev    Direct-to-logic owner action (like `clearAgents`): the NFT wrapper
+    ///         is non-upgradeable and exposes no batch entry point. Each agent is
+    ///         validated EXACTLY as the single `registerAgent` path — non-zero,
+    ///         under the per-account cap (re-checked each iteration so the batch
+    ///         stops at the cap), and not already registered (PCS reverts
+    ///         AgentAlreadyRegistered, which also rejects in-array duplicates).
+    ///         ALL-OR-NOTHING: any invalid entry reverts the whole batch. Emits
+    ///         AgentRegistered per agent. Callee is the trusted Hub-registered
+    ///         PublishingConvictionStorage (onlyContracts).
+    // slither-disable-start reentrancy-events,calls-loop
+    function registerAgents(uint256 accountId, address[] calldata agents)
+        external
+        onlyCurrentPcaOwner(accountId)
+    {
+        uint256 cap = publishingConvictionStorage.maxAgentsPerAccount();
+        for (uint256 i = 0; i < agents.length; i++) {
+            address agent = agents[i];
+            if (agent == address(0)) revert ZeroAgentAddress();
+            if (publishingConvictionStorage.agentCount(accountId) >= cap) {
+                revert AgentCapReached(accountId, cap);
+            }
+            publishingConvictionStorage.addAgent(accountId, agent);
+            emit AgentRegistered(accountId, agent);
+        }
+    }
+    // slither-disable-end reentrancy-events,calls-loop
 
     // ============================================================
     //                  Discount tier ladder

--- a/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
+++ b/packages/evm-module/test/unit/DKGPublishingConvictionNFT.test.ts
@@ -1356,6 +1356,70 @@ describe('@unit DKGPublishingConvictionNFT', function () {
     });
   });
 
+  describe('registerAgents (owner-gated bulk add)', () => {
+    const createAccount = async (): Promise<bigint> => {
+      const amount = hre.ethers.parseEther('60000');
+      await TokenContract.approve(await NFT.getAddress(), amount);
+      await NFT.createAccount(amount, 0);
+      return NFT.totalSupply();
+    };
+
+    it('owner bulk-registers multiple agents and emits AgentRegistered per agent', async () => {
+      const id = await createAccount();
+      const agents = [accounts[3].address, accounts[4].address, accounts[5].address];
+
+      const tx = await LogicContract.registerAgents(id, agents);
+      for (const a of agents) {
+        await expect(tx).to.emit(LogicContract, 'AgentRegistered').withArgs(id, a);
+      }
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal(agents);
+      for (const a of agents) expect(await NFT.agentToAccountId(a)).to.equal(id);
+    });
+
+    it('reverts NotAccountOwner for a non-owner caller (nothing registered)', async () => {
+      const id = await createAccount();
+      await expect(
+        LogicContract.connect(accounts[5]).registerAgents(id, [accounts[3].address]),
+      ).to.be.revertedWithCustomError(LogicContract, 'NotAccountOwner');
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([]);
+    });
+
+    it('reverts ZeroAgentAddress on any zero-address entry — all-or-nothing', async () => {
+      const id = await createAccount();
+      await expect(
+        LogicContract.registerAgents(id, [accounts[3].address, hre.ethers.ZeroAddress]),
+      ).to.be.revertedWithCustomError(LogicContract, 'ZeroAgentAddress');
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([]); // first entry rolled back too
+    });
+
+    it('reverts AgentCapReached when the batch exceeds the per-account cap — all-or-nothing', async () => {
+      await NFT.setMaxAgentsPerAccount(2);
+      const id = await createAccount();
+      await expect(
+        LogicContract.registerAgents(id, [
+          accounts[3].address,
+          accounts[4].address,
+          accounts[5].address,
+        ]),
+      ).to.be.revertedWithCustomError(LogicContract, 'AgentCapReached');
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([]);
+    });
+
+    it('reverts AgentAlreadyRegistered on an in-array duplicate — all-or-nothing', async () => {
+      const id = await createAccount();
+      await expect(
+        LogicContract.registerAgents(id, [accounts[3].address, accounts[3].address]),
+      ).to.be.revertedWithCustomError(StorageContract, 'AgentAlreadyRegistered');
+      expect(await NFT.getRegisteredAgents(id)).to.deep.equal([]);
+    });
+
+    it('reverts for a nonexistent account (ownerOf reverts)', async () => {
+      await expect(
+        LogicContract.registerAgents(999, [accounts[3].address]),
+      ).to.be.reverted;
+    });
+  });
+
   // ======================================================================
   // I. Governance
   // ======================================================================


### PR DESCRIPTION
## Summary
Adds an owner-gated **`registerAgents(uint256 accountId, address[] agents)`** to `PublishingConviction` — register **multiple** publishing agents on a PCA in **one transaction** (the bulk-add counterpart to `clearAgents`).

Today `registerAgent` takes one agent per call and the NFT wrapper isn't a Multicall, so adding N agents is N txs (unless the PCA is Safe-owned and you batch in a Safe tx). This makes it native + atomic.

## Contract (`PublishingConviction`, logic, 10.0.6 → 10.0.7)
- `registerAgents` lives on the **logic** contract (the NFT wrapper is non-upgradeable and has no batch entry point), gated by the same **`onlyCurrentPcaOwner`** modifier introduced in #1384.
- Each agent validated exactly as the single `registerAgent`: **non-zero**, under the **per-account cap** (re-checked each iteration so the batch stops at the cap), and **not already registered** (PCS reverts `AgentAlreadyRegistered`, which also rejects in-array duplicates).
- **All-or-nothing** — any invalid entry reverts the whole batch. Emits `AgentRegistered` per agent (no new event/error).

## Chain layer
`EVMChainAdapter.registerPublishingConvictionAgents(accountId, agents)` → calls the logic contract; mock-adapter parity; chain ABI repinned + `abi-pinning` **[CH-5]** digest updated.

## Tests
- **evm (6):** bulk add + per-agent `AgentRegistered`; non-owner `NotAccountOwner` (nothing registered); zero-address all-or-nothing; cap-exceeded all-or-nothing; in-array duplicate all-or-nothing; nonexistent account.
- **chain:** real-chain bulk-add (3 agents, one tx) + mock all-or-nothing + parity. 20/20 build.

## ⚠️ Stacking + deploy
- **Stacked on #1384** (`feat/pca-preserve-agents-on-transfer`) — it reuses `onlyCurrentPcaOwner` + `NotAccountOwner`. **Merge #1384 first, then rebase this on main** (base will retarget to main).
- Ships a **separate `PublishingConviction` redeploy (10.0.7)** AFTER #1384's 10.0.6 — **NOT** part of today's deploy.
- The Admin-UI "add multiple agents" button is a follow-up in #1370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)