### PR TITLE
fix(query): DISTINCT on read-both graph unions — collapse dual-homed triples (#1270)

### DIFF
--- a/packages/query/src/dkg-query-engine.ts
+++ b/packages/query/src/dkg-query-engine.ts
@@ -2404,7 +2404,29 @@ function wrapWithGraphUnion(sparql: string, graphUris: string[]): string | null 
   const unionBranches = graphUris
     .map((g) => `{ GRAPH <${g}> { ${inner} } }`)
     .join(' UNION ');
-  return `${before} ${unionBranches} ${after}`;
+  // A read-both UNION scans data that is intentionally DUAL-HOMED — the canonical
+  // root graph AND the per-KA …/_verifiable_memory partitions (PR #1098 made the
+  // per-KA homes queryable, and finalization mirrors the canonical quads into the
+  // root graph). The SAME triple therefore matches in more than one branch and
+  // yields duplicate solution rows (the #1270 e2e-finalization "2 bindings"
+  // failure). Force SELECT DISTINCT to collapse those mirror duplicates. This is
+  // a no-op for a single graph (a graph is a set), which is why only the
+  // multi-branch path needs it; non-SELECT forms (CONSTRUCT/ASK/DESCRIBE) are
+  // returned unchanged.
+  return `${withSelectDistinct(before)} ${unionBranches} ${after}`;
+}
+
+/**
+ * Inject `DISTINCT` into the outer SELECT of a query prefix (the text up to and
+ * including the outer `WHERE {`), unless it is not a SELECT query or already
+ * carries DISTINCT/REDUCED. Sub-selects live inside the WHERE block, so the first
+ * SELECT in the prefix is always the outer query form.
+ */
+function withSelectDistinct(before: string): string {
+  return before.replace(
+    /\bSELECT\b(\s+)(?!DISTINCT\b|REDUCED\b)/i,
+    (_m, ws) => `SELECT${ws}DISTINCT `,
+  );
 }
 
 /**

--- a/packages/query/test/zzz-probe-dedup.test.ts
+++ b/packages/query/test/zzz-probe-dedup.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { OxigraphStore, type Quad } from '@origintrail-official/dkg-storage';
+import { DKGQueryEngine } from '../src/dkg-query-engine.js';
+
+const CG = 'finalization-chain-e2e';
+const ROOT = `did:dkg:context-graph:${CG}`;
+const PER_CGID = `${ROOT}/context/7`;            // <cg>/context/<ctxGraphId>
+const VM = `${ROOT}/_verifiable_memory/0xAA/1`;  // per-KA VM
+const ENTITY = 'urn:finalization-chain:entity:1';
+const NAME = 'http://schema.org/name';
+
+function q(s: string, p: string, o: string, g: string): Quad {
+  return { subject: s, predicate: p, object: o, graph: g };
+}
+
+const SPARQL = `SELECT ?name WHERE { <${ENTITY}> <${NAME}> ?name }`;
+
+// #1270: a scoped read-both query unions the canonical root graph with the
+// per-cgId and per-KA …/_verifiable_memory partitions. Finalization intentionally
+// DUAL-HOMES the same triple (PR #1098 + the canonical mirror), so the union must
+// collapse identical rows to ONE binding — else the e2e-finalization "B promotes"
+// query returns 2. wrapWithGraphUnion now emits SELECT DISTINCT for this reason.
+describe('scoped read-both query dedups dual-homed triples (#1270)', () => {
+  it('root + per-cgId partition', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q(ENTITY, NAME, '"Finalization Chain Draft"', ROOT),
+      q(ENTITY, NAME, '"Finalization Chain Draft"', PER_CGID),
+    ]);
+    const r = await engine.query(SPARQL, { contextGraphId: CG });
+    expect(r.bindings.length).toBe(1); // dual-homed triple collapses to ONE binding
+    expect(r.bindings[0]['name']).toBe('"Finalization Chain Draft"');
+  });
+
+  it('root + per-KA VM partition', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q(ENTITY, NAME, '"Finalization Chain Draft"', ROOT),
+      q(ENTITY, NAME, '"Finalization Chain Draft"', VM),
+    ]);
+    const r = await engine.query(SPARQL, { contextGraphId: CG });
+    expect(r.bindings.length).toBe(1); // dual-homed triple collapses to ONE binding
+    expect(r.bindings[0]['name']).toBe('"Finalization Chain Draft"');
+  });
+
+  it('root only', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q(ENTITY, NAME, '"Finalization Chain Draft"', ROOT),
+    ]);
+    const r = await engine.query(SPARQL, { contextGraphId: CG });
+    expect(r.bindings.length).toBe(1); // dual-homed triple collapses to ONE binding
+    expect(r.bindings[0]['name']).toBe('"Finalization Chain Draft"');
+  });
+
+  it('per-cgId + per-KA VM (no root)', async () => {
+    const store = new OxigraphStore();
+    const engine = new DKGQueryEngine(store);
+    await store.insert([
+      q(ENTITY, NAME, '"Finalization Chain Draft"', PER_CGID),
+      q(ENTITY, NAME, '"Finalization Chain Draft"', VM),
+    ]);
+    const r = await engine.query(SPARQL, { contextGraphId: CG });
+    expect(r.bindings.length).toBe(1); // dual-homed triple collapses to ONE binding
+    expect(r.bindings[0]['name']).toBe('"Finalization Chain Draft"');
+  });
+});


### PR DESCRIPTION
## Problem

`e2e-finalization.test.ts` "A enshrines on-chain; B receives finalization and promotes to canonical" flakes red on **main** (since the #1384/#1385 merges), and every open PR inherits it. The assertion `bData.bindings.length === 1` gets **2**: after B promotes, `SELECT ?name WHERE { <E> schema:name ?name }` returns the same triple twice.

This is **not** a regression from those PRs — none touches the finalization/SWM-read path. It's the open #1270 read-both dedup gap.

## Root cause

A scoped query (no explicit view) reads a `UNION` across the canonical root graph **and** the per-cgId / per-KA `…/_verifiable_memory` partitions (`wrapWithGraphUnion`). The data is **intentionally dual-homed** — PR #1098 made the per-KA VM partitions queryable for pre-subscribed peer recovery, and finalization mirrors the canonical quads into the root graph — so the same triple matches in two union branches. The union was emitted **without `DISTINCT`**, so identical solution rows weren't collapsed → duplicate bindings.

## Fix

`wrapWithGraphUnion` now emits `SELECT DISTINCT` for the multi-graph union branch.
- No-op for a single graph (a graph is a set), so only the union path needs it.
- `CONSTRUCT`/`ASK`/`DESCRIBE` untouched.
- The writes are unchanged — the data is correctly dual-homed; this is purely a **read-path** dedup.

## Tests
- Hardened the dedup probe into a strict regression test: each dual-home layout (root+per-cgId, **root+per-KA-VM** = the e2e's exact case, per-cgId+VM) must yield exactly **1** binding.
- Full query suite green (**285**).

## Impact
Unblocks CI for the in-flight 10.0.2 PRs (#1366 / #1370 / #1386 / #1387) that were inheriting this red from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
