### PR TITLE
fix(node-ui): hide the Admin page entry point (icon + /admin route)

### DIFF
--- a/packages/node-ui/src/ui/components/Shell/Header.tsx
+++ b/packages/node-ui/src/ui/components/Shell/Header.tsx
@@ -66,13 +66,6 @@ const OBSERVABILITY_ICON = (
   </svg>
 );
 
-const ADMIN_ICON = (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-    <path d="M9 12l2 2 4-4" />
-  </svg>
-);
-
 export function Header() {
   const { theme, setTheme, leftCollapsed, toggleLeft, rightCollapsed, toggleRight } = useLayoutStore();
   const nodeStatus = useAgentsStore((s) => s.nodeStatus);
@@ -146,13 +139,9 @@ export function Header() {
           {OBSERVABILITY_ICON}
         </button>
 
-        <button
-          className="v10-header-icon-btn"
-          onClick={() => openTab({ id: 'admin', label: 'Admin', closable: true })}
-          title="Admin — keys, wallets, PCAs"
-        >
-          {ADMIN_ICON}
-        </button>
+        {/* Admin page entry hidden pending review — the page (Admin.tsx) and its
+            render path stay; re-enable by restoring this button + the /admin route
+            in useShellRouting.ts (revert the PR that hid it). */}
 
         <button
           className="v10-header-icon-btn"

--- a/packages/node-ui/src/ui/hooks/useShellRouting.ts
+++ b/packages/node-ui/src/ui/hooks/useShellRouting.ts
@@ -11,12 +11,12 @@ export const URL_PATH_TO_TAB: Record<string, { id: string; label: string }> = {
   '/observability': { id: 'operations', label: 'Observability' },
   '/operations': { id: 'operations', label: 'Observability' },
   '/settings': { id: 'settings', label: 'Settings' },
-  '/admin': { id: 'admin', label: 'Admin' },
+  // '/admin' deep-link intentionally omitted — the Admin page entry is hidden
+  // pending review (see Header.tsx). Restore this + the header button to re-enable.
 };
 export const TAB_TO_URL_PATH: Record<string, string> = {
   operations: '/observability',
   settings: '/settings',
-  admin: '/admin',
   dashboard: '/',
 };
 


### PR DESCRIPTION
## Why
The node-UI **Admin page** (added in #1370) was merged ahead of review. This hides its UI entry points so it isn't reachable, **without deleting the feature** — it can be re-enabled once it's signed off.

## What
- **Header** — removed the Admin **icon button** (and its now-unused `ADMIN_ICON` svg).
- **Routing** — dropped the `/admin` deep-link from `useShellRouting.ts` (both directions), so a direct `/admin` URL no longer opens the page either.

The page component (`Admin.tsx`) and its render branch in `PanelCenter.tsx` are **left intact** — there's just no way to open the `admin` tab. Re-enabling is a one-step restore of the header button + the route (i.e. revert this PR).

## Verification
- `node-ui` **1493 tests** pass (incl. `use-shell-routing`, `header-notifications`, `admin-page.dom`).
- `build:packages` 21/21; node-ui **UI build** clean.
- No e2e references the Admin icon, so the Playwright suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)