### PR TITLE
chore(release): bump to 10.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ All notable changes to the DKG V9 node are documented here. The format is based 
 - **`dkg init` runs from a monorepo / checkout clone again** (`packages/cli/src/cli.ts`). PR #753 (RFC-41 Bundle B1c) hard-refused `dkg init` from a monorepo checkout; that was over-strict — the CLI's home resolver (`dkgDir()` → `resolveDkgConfigHome`) already routes a clone to `~/.dkg-dev` (kept separate from an npm install's `~/.dkg`), the same home the local dev daemon resolves, so there was no real risk of divergence. The hard refusal (and its non-functional `DKG_HOME` escape) is replaced by a one-line notice showing which home is being written. Restores the pre-#753 dev workflow: a clone runs `dkg init` exactly like an npm install, differing only in the home directory.
 - **OpenClaw / Hermes / MCP setups now seed the `oxigraph-server` default on a fresh node** (`packages/core/src/ensure-dkg-node-config.ts`). The rc.15 `oxigraph-server` default previously reached only nodes set up via the `dkg init` store-wizard; the shared `ensureDkgNodeConfig` helper (used by `dkg openclaw/hermes/mcp setup`) left `store` unset, so those nodes fell back to `oxigraph-worker`. It now adopts `oxigraph-server` on a **fresh** install (no existing config) with no explicit store — matching the wizard default — while never rewriting an existing node's backend (which would force a store reset) and preserving any explicit `store` block.
 
+## [10.0.2] - 2026-07-01
+
+**Google Open Knowledge Format (OKF) support.** The DKG can now turn a portable **Google Open Knowledge Format** bundle — Markdown + YAML frontmatter + untyped cross-links — into owned, cryptographically-provenanced RDF Knowledge Assets, and serialise a Context Graph cleanly back out to a conformant bundle. Alongside it: PCA agent- and operational-wallet management, a Context-Graph registration deposit waiver, sub-graph Random Sampling fixes, and backend-independent leaf canonicalization so a node can run on any SPARQL 1.1 store.
+
+### Added — Google OKF → DKG integration (#1388)
+
+- **`dkg okf import ./bundle`** maps a Google Open Knowledge Format bundle to owned, verifiable Knowledge Assets — **deterministic and offline** (no LLM, no network): the same bundle always yields identical triples and IRIs. OKF standardises *how* knowledge is written and exchanged but ships no verification, provenance or ownership layer; `@origintrail-official/dkg-okf` is the bridge that adds them, reconstructing the bundle's cross-concept link graph as RDF. The same portable Markdown, now provenanced, owned and shareable across agents.
+- **`--share`** finalizes the import into Shared Working Memory (free, team-visible); **`dkg okf verify`** gates the shared Context Graph against the source bundle per-predicate; **`dkg okf export <graph> ./out`** is a clean inverse that serialises a Context Graph back into a conformant OKF bundle. Ships as a new published package, `@origintrail-official/dkg-okf`.
+
+### Added — PCA agent & operational-wallet management (#1387, #1384, #1370)
+
+- **Bulk `registerAgents(uint256, address[])`** (#1387) — add many PCA agents in a single transaction instead of one-by-one.
+- **Agents are preserved when a PCA is transferred** (#1384) — a PublishingConviction account keeps its registered agents across ownership transfer.
+- **Node UI Admin page** (#1370) — manage operational wallets, PCAs and agent encryption keys from the Node UI via wallet-connect, gated to node-admin callers.
+
+### Added — Context-Graph registration deposit waiver (#1366)
+
+- An anti-spam Context-Graph registration deposit with a **waiver** for accounts holding a sufficient **active PublishingConviction commitment** (quota + minimum-commitment floor), pinned in the mainnet parameters.
+
+### Fixed — backend-independent V10 leaf canonicalization (#1386, #1399)
+
+- V10 merkle leaves are now computed from a **backend-independent value canon**, so nodes running **any SPARQL 1.1 store** (Oxigraph, Blazegraph, …) produce identical leaves for the same triple — Random Sampling no longer depends on which store backend a node runs. Validated against a live cross-backend oracle and a mixed-backend devnet. Spec: OT-RFC-57.
+
+### Fixed — sub-graph Random Sampling extraction (#1385)
+
+- The Random Sampling extractor now resolves a sub-graph Knowledge Asset's content across its data homes, so a KA published into a named sub-graph is extractable and provable (no `KCDataMissingError` stall).
+
+### Changed — Node UI (#1391)
+
+- Hide the Admin page entry point (icon + `/admin` route) by default.
+
 ## [10.0.0-rc.15] - 2026-06-03
 
 **Off-chain runtime release.** No Solidity changes since rc.13 — the Base Sepolia (chainId 84532) deployment is **unchanged**, the `chainResetMarker` stays `v10-rc12-ka-rename-2026-06-01`, and **no contract redeploy is required**. The sync protocol ID is **unchanged** (`/dkg/10.0.2/sync`), so rc.15 nodes interoperate with rc.14 peers — nodes upgrade in place with **no local-state wipe**. This release makes `oxigraph-server` the default store backend for **new** installs, fixes the Node UI Working-Memory scoped-query violation (and the SWM/VM bleed + reserved-meta false-positives it surfaced), reclaims the `node-ui.db` WAL on a running node, splits the `DKGAgent` god class into subsystem mixin holders, and lands typed publisher errors plus CI/bench hardening.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dkg-v10",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "dkgBuild": {

--- a/packages/adapter-elizaos/package.json
+++ b/packages/adapter-elizaos/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origintrail-official/dkg-adapter-elizaos",
-  "version": "10.0.1",
-  "description": "ElizaOS plugin adapter \u2014 turns any ElizaOS agent into a DKG V10 node",
+  "version": "10.0.2",
+  "description": "ElizaOS plugin adapter — turns any ElizaOS agent into a DKG V10 node",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapter-hermes/package.json
+++ b/packages/adapter-hermes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origintrail-official/dkg-adapter-hermes",
-  "version": "10.0.1",
-  "description": "Hermes Agent adapter \u2014 connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
+  "version": "10.0.2",
+  "description": "Hermes Agent adapter — connects Hermes AI agents to a DKG V10 node for verifiable shared memory",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-adapter-openclaw",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "OpenClaw plugin adapter for connecting a DKG V10 node and chat bridge to an OpenClaw agent",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-agent",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/chain/package.json
+++ b/packages/chain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-chain",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-core",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/epcis/package.json
+++ b/packages/epcis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-epcis",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/evm-module/package.json
+++ b/packages/evm-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-evm-module",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "DKG V10 smart contracts (forked from V8 dkg-evm-module)",
   "license": "Apache-2.0",
   "private": true,

--- a/packages/graph-viz/package.json
+++ b/packages/graph-viz/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@origintrail-official/dkg-graph-viz",
-  "version": "10.0.1",
-  "description": "RDF Knowledge Graph Visualizer \u2014 force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
+  "version": "10.0.2",
+  "description": "RDF Knowledge Graph Visualizer — force-directed graph rendering with hexagonal nodes, declarative view configs, RDF-native data loading, and SPARQL-driven views",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/kafka-plugin/package.json
+++ b/packages/kafka-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/kafka-plugin",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-dkg/package.json
+++ b/packages/mcp-dkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-mcp",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "MCP server that exposes the local DKG daemon (projects, sub-graphs, activity, chat) to Cursor, Claude Code, and any other MCP-aware coding assistant.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/network-sim/package.json
+++ b/packages/network-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-network-sim",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/node-ui/package.json
+++ b/packages/node-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-node-ui",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/okf/package.json
+++ b/packages/okf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-okf",
-  "version": "10.0.0-rc.16",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-publisher",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-query",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/random-sampling/package.json
+++ b/packages/random-sampling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-random-sampling",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@origintrail-official/dkg-storage",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump `10.0.1 → 10.0.2` (root umbrella + all 19 packages; `dkg-okf` aligned rc.16 → 10.0.2 for its first stable publish) + the 10.0.2 CHANGELOG entry. Baseline for tagging `v10.0.2`.

---

## 🌟 Highlight — Google Open Knowledge Format (OKF) support (#1388)

The DKG can now turn a portable **Google Open Knowledge Format** bundle — Markdown + YAML frontmatter + untyped cross-links — into **owned, cryptographically-provenanced RDF Knowledge Assets**, and serialise a Context Graph cleanly back out to a conformant bundle.

OKF standardises *how* knowledge is written and exchanged, but ships no verification, provenance or ownership layer. The new `@origintrail-official/dkg-okf` package is the bridge that adds all three — **deterministic and offline** (no LLM, no network): the same bundle always yields identical triples and IRIs.

```bash
dkg okf import ./bundle --dry-run --print-nquads          # deterministic preview, never touches a node
dkg okf import ./bundle --context-graph-id my-graph --share   # import → Shared Working Memory
dkg okf verify my-graph ./bundle                          # per-predicate integrity gate
dkg okf export my-graph ./out                             # clean inverse → conformant OKF bundle
```

## Also in 10.0.2 (fixes & improvements)

- **PCA agent & operational-wallet management** — bulk `registerAgents` in one tx (#1387), agents preserved on PCA transfer (#1384), and a Node UI Admin page for operational wallets / PCAs / agent keys via wallet-connect (#1370).
- **Context-Graph registration deposit waiver** (#1366) — anti-spam CG deposit with a waiver for accounts holding a sufficient active PublishingConviction commitment.
- **Backend-independent V10 leaf canonicalization** (#1386, #1399) — nodes running any SPARQL 1.1 store (Oxigraph, Blazegraph, …) now compute identical merkle leaves, so Random Sampling no longer depends on a node's store backend. Validated against a live cross-backend oracle + a mixed-backend devnet.
- **Sub-graph Random Sampling extraction** (#1385) — a KA published into a named sub-graph is now extractable and provable.
- **Node UI** (#1391) — hide the Admin page entry point by default.
- **Devnet coverage** (#1397) — network-level test suites for all of the above.

Full detail per PR in [CHANGELOG.md](CHANGELOG.md).

---

*Release-only change (versions + CHANGELOG). No runtime code changes in this PR.*