### PR TITLE
Allow async publisher wallets without node identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ dkg ka write <name> -c <cg> --input-file <rdf-file>           # append RDF paylo
 dkg ka finalize <name> -c <cg>                                # seal the WM draft
 dkg ka share <name> -c <cg>                                   # share finalized WM to SWM
 dkg ka publish <name> -c <cg>                                 # sync publish from SWM to VM
-dkg ka publish-async <name> -c <cg>                           # enqueue VM publish from SWM to VM
+dkg ka publish-async <name> -c <cg> [--publisher-node-identity-id 0]  # enqueue VM publish
 dkg ka query <name> -c <cg>                                   # read KA WM quads
 dkg ka history <name> -c <cg>                                 # show lifecycle state/history
 dkg ka pull-from <name> -c <cg> --layer swm                   # seed WM from SWM or VM
@@ -272,10 +272,10 @@ dkg subscribe <cg>                       # subscribe to a CG's gossip topics
 
 # Async publisher (optional, for batching)
 dkg publisher enable                     # enable the async publisher
-dkg publisher publish-async <cg> <name>  # operational alias for dkg ka publish-async
+dkg publisher publish-async <cg> <name> [--publisher-node-identity-id 0]  # alias for dkg ka publish-async
 dkg publisher jobs                       # list publisher jobs
 dkg publisher stats                      # publisher throughput stats
-# publisher wallets must already have on-chain identities/profiles before they can claim VM publish jobs
+# publisher wallets need native gas plus PCA registration or TRAC; node identity is optional attribution
 
 # Code & memory indexing
 dkg index [directory]                    # index a code repo into the dev-coordination CG
@@ -480,6 +480,8 @@ For `sparql-http`:
 ## Funding
 
 Every setup flow persists your chosen network into `config.networkConfig`; the default for a fresh node is **mainnet-gnosis**.
+
+Async publisher wallets also need native gas, plus PCA agent registration or TRAC for direct spend.
 
 **Mainnet (gnosis / base) — no faucet.** Fund the node's operational wallets yourself with the chain's native gas token (xDAI on Gnosis, ETH on Base) and TRAC before publishing to Verified Memory. An edge node needs no funds just to run and sync; funds are only required to publish on-chain.
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,6 +38,7 @@
 * [Daemon Lifecycle](use-dkg/run-node.md)
 * [Publish & Query](use-dkg/publish-and-query.md)
 * [Knowledge Asset Lifecycle CLI](use-dkg/knowledge-asset-lifecycle.md)
+* [Async Publisher Wallets](use-dkg/async-publisher-wallets.md)
 * [OKF Import, Export, and Verify](use-dkg/okf.md)
 * [Funding](use-dkg/funding.md)
 * [Publishing Conviction](use-dkg/publishing-conviction.md)

--- a/docs/how-dkg-works/conviction-and-economics.md
+++ b/docs/how-dkg-works/conviction-and-economics.md
@@ -27,7 +27,7 @@ A Publishing Conviction Account lets a publisher commit TRAC for a fixed publish
 Current operator surface:
 
 ```bash
-dkg pca create --tokens 100000
+dkg pca create --tokens 100000 --primary-node <identityId>
 dkg pca register-agent <accountId> <agentAddress>
 dkg pca deregister-agent <accountId> <agentAddress>
 dkg pca funds <accountId> --tokens 50000
@@ -61,7 +61,7 @@ The current V10 contract tests pin the publishing discount ladder by committed T
 | 500,000        | 50%      |
 | 1,000,000+     | 75%      |
 
-Publishing can use the PCA path only when the publishing wallet is registered as an agent for the account and the publish window matches the account configuration. Otherwise the publisher path falls back to direct spend at the normal price.
+Publishing can use the PCA path only when the publishing wallet is registered as an agent for the account and the publish window matches the account configuration. The wallet still needs native gas. It does not need an on-chain node identity for PCA payment eligibility; node identity is optional publisher-node attribution. Otherwise the publisher path falls back to direct spend at the normal price.
 
 ## Curated Context Graphs and PCA
 

--- a/docs/references/api.md
+++ b/docs/references/api.md
@@ -38,4 +38,6 @@ Named Knowledge Assets use the lifecycle route family below. The active publishi
 | Read WM quads | `GET /api/knowledge-assets/{name}/wm/quads` |
 | Read lifecycle descriptor | `GET /api/knowledge-assets/{name}` |
 
+Both VM publish routes accept `options.publisherNodeIdentityIdOverride`. Use a non-negative decimal string; `0` means explicit no-attribution. Omit the option to use the publisher wallet's resolved default identity, which may also be `0`. Optional node attribution for a separate publisher wallet can be configured through `/api/operational-wallets`.
+
 For exact request bodies, response shapes, and MCP tool names, use [Node Skill](node-skill.md).

--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -45,7 +45,7 @@ dkg ka share <name> -c <cg> [--entity <uri...>]               # WM -> SWM
 dkg ka share-async <name> -c <cg>                             # enqueue async WM -> SWM share
 dkg ka share-jobs [--context-graph-id <cg>]                   # list async share jobs
 dkg ka publish <name> -c <cg>                                 # sync SWM -> VM publish
-dkg ka publish-async <name> -c <cg>                           # enqueue SWM -> VM publish
+dkg ka publish-async <name> -c <cg> [--publisher-node-identity-id 0]  # enqueue SWM -> VM publish
 dkg ka pull-from <name> -c <cg> --layer swm|vm                # seed WM from SWM or VM
 dkg ka discard <name> -c <cg>                                 # discard WM draft
 dkg ka query <name> -c <cg>                                   # read WM quads
@@ -67,10 +67,10 @@ dkg subscribe <cg>                       # subscribe to a CG's gossip topics
 
 # Async publisher (optional, for batching)
 dkg publisher enable                     # enable the async publisher
-dkg publisher publish-async <cg> <name>  # operational alias for dkg ka publish-async
+dkg publisher publish-async <cg> <name> [--publisher-node-identity-id 0]  # alias for dkg ka publish-async
 dkg publisher jobs                       # list publisher jobs
 dkg publisher stats                      # publisher throughput stats
-# publisher wallets must already have on-chain identities/profiles before they can claim VM publish jobs
+# publisher wallets need native gas plus PCA registration or TRAC; node identity is optional attribution
 
 # Code & memory indexing
 dkg index [directory]                    # index a code repo into the dev-coordination CG

--- a/docs/use-dkg/README.md
+++ b/docs/use-dkg/README.md
@@ -17,6 +17,7 @@ Use these routes when you want a node running, an agent connected, memory operat
 | Start, stop, and inspect the daemon | [Daemon Lifecycle](run-node.md) |
 | Write, publish, and query knowledge | [Publish and Query](publish-and-query.md) |
 | Drive named Knowledge Asset lifecycle commands | [Knowledge Asset Lifecycle CLI](knowledge-asset-lifecycle.md) |
+| Configure async publisher wallets | [Async Publisher Wallets](async-publisher-wallets.md) |
 | Import, export, and verify OKF bundles | [OKF Import, Export, and Verify](okf.md) |
 | Fund testnet wallets | [Funding](funding.md) |
 | Manage Publishing Conviction Accounts | [Publishing Conviction](publishing-conviction.md) |

--- a/docs/use-dkg/async-publisher-wallets.md
+++ b/docs/use-dkg/async-publisher-wallets.md
@@ -1,0 +1,61 @@
+---
+status: current
+version: v10
+audience: human+agent
+doc_type: how-to
+---
+
+# Async Publisher Wallets
+
+Async publisher wallets are transaction signers for queued Verifiable Memory publish jobs. They live in `publisher-wallets.json` under the DKG data directory and are managed with:
+
+```bash
+dkg publisher wallet add <privateKey>
+dkg publisher wallet list
+dkg publisher wallet remove <address>
+dkg publisher enable
+dkg publisher publish-async <context-graph-id> <name>
+```
+
+## Funding
+
+Every async publisher wallet needs the chain's native gas token because it submits on-chain transactions.
+
+For TRAC payment, choose one path:
+
+| Payment path | Wallet requirement |
+| --- | --- |
+| PCA-funded | Register the wallet address as a Publishing Conviction Account agent. |
+| Direct spend | Fund the wallet with enough TRAC and native gas. |
+
+If neither path is ready, the daemon can still start and claim jobs, but publish attempts will fail when the transaction reaches the chain.
+
+## Identity And Attribution
+
+An async publisher wallet does not need an on-chain node identity or profile to claim jobs.
+
+The daemon still reads each wallet's identity at startup:
+
+| Resolved identity | Behavior |
+| --- | --- |
+| `0` | Publish in no-attribution mode. |
+| `N > 0` | Use `N` as publisher-node attribution by default. |
+
+`publisherNodeIdentityId` is attribution metadata. It is not PCA eligibility, direct-spend eligibility, author identity, or ACK quorum identity.
+
+Use `--publisher-node-identity-id 0` when you want explicit no-attribution for one publish:
+
+```bash
+dkg ka publish-async notes -c my-project --publisher-node-identity-id 0
+dkg publisher publish-async my-project notes --publisher-node-identity-id 0
+```
+
+Use a non-zero override only when an operator intentionally wants the publish to carry a specific publisher-node attribution claim.
+
+## Optional Node Attribution Setup
+
+Core node profile setup creates an identity for the node's primary operational wallet. Separate async publisher wallets are not automatically attached to that identity.
+
+To make a separate publisher wallet resolve to a non-zero node identity, authorize it as an operational wallet for that node identity with the current `POST /api/operational-wallets` API route or an equivalent future CLI wrapper. If you do not need publisher-node attribution, leave the wallet identityless.
+
+ACK quorum still depends on core receiver identities and operational keys. Changing async publisher wallet attribution does not relax ACK requirements.

--- a/docs/use-dkg/funding.md
+++ b/docs/use-dkg/funding.md
@@ -13,6 +13,8 @@ Verifiable Memory publishing, updates, endorsement, verification, and other chai
 
 Your node's network is chosen at setup (default: **mainnet-gnosis**) and persisted as `config.networkConfig`; pass `--network <name>` to pick another (`mainnet-base`, `testnet`).
 
+Async publisher wallets also need native gas, plus PCA agent registration or TRAC for direct spend. Publisher wallet identity is optional attribution, not a funding prerequisite. See [Async Publisher Wallets](async-publisher-wallets.md).
+
 **On mainnet (gnosis / base) there is no faucet** — fund the node's operational wallets yourself with the chain's native gas token (xDAI on Gnosis, ETH on Base) and TRAC before publishing.
 
 **On testnet**, setup flows auto-fund the generated wallets when a faucet is configured (the bundled testnet config provides one); this is skipped automatically on mainnet:

--- a/docs/use-dkg/knowledge-asset-lifecycle.md
+++ b/docs/use-dkg/knowledge-asset-lifecycle.md
@@ -42,7 +42,7 @@ dkg ka publish notes -c my-project
 
 Use `dkg ka publish-async notes -c my-project` for an async VM publish job. `dkg publisher publish-async my-project notes` remains an operational alias.
 
-Async VM publish requires the async publisher to be enabled and backed by publisher wallets that already have on-chain identities/profiles. If the daemon reports a publisher wallet with no on-chain identity, provision that wallet before enabling the async publisher or remove it from `publisher-wallets.json`.
+Async VM publish requires the async publisher to be enabled and backed by publisher wallets with native gas plus PCA registration or TRAC for direct spend. Publisher wallet node identity is optional attribution: if the wallet resolves to identity `0`, the publish runs in no-attribution mode. Use `--publisher-node-identity-id 0` to force no-attribution for one publish. See [Async Publisher Wallets](async-publisher-wallets.md).
 
 ## Command Reference
 
@@ -60,7 +60,7 @@ Async VM publish requires the async publisher to be enabled and backed by publis
 | `dkg ka cancel-share-job <job-id>` | Cancel a queued/retrying share job |
 | `dkg ka recover-share-job <job-id>` | Recover a failed share job |
 | `dkg ka publish <name> -c <cg>` | Synchronously publish finalized, fully shared SWM to VM |
-| `dkg ka publish-async <name> -c <cg>` | Enqueue VM publish |
+| `dkg ka publish-async <name> -c <cg> [--publisher-node-identity-id 0]` | Enqueue VM publish |
 | `dkg ka pull-from <name> -c <cg> --layer swm|vm` | Seed WM from SWM or VM |
 | `dkg ka discard <name> -c <cg>` | Discard a WM draft |
 | `dkg ka query <name> -c <cg>` | Read WM quads |

--- a/docs/use-dkg/publish-and-query.md
+++ b/docs/use-dkg/publish-and-query.md
@@ -41,7 +41,7 @@ Use `dkg ka create notes -c "$CG" --input-file ./notes.ttl --share` when the loc
 
 Use `dkg ka share notes -c "$CG"` when you want to stop at Shared Working Memory without publishing to Verifiable Memory.
 
-Use `dkg ka publish-async notes -c "$CG"` to enqueue the Verifiable Memory publish after the KA has been finalized and fully shared to SWM. `dkg publisher publish-async "$CG" notes` remains an operational alias for the same async VM publish route.
+Use `dkg ka publish-async notes -c "$CG"` to enqueue the Verifiable Memory publish after the KA has been finalized and fully shared to SWM. `dkg publisher publish-async "$CG" notes` remains an operational alias for the same async VM publish route. See [Async Publisher Wallets](async-publisher-wallets.md) for funding and optional attribution identity setup.
 
 ## Agent shape
 

--- a/docs/use-dkg/publishing-conviction.md
+++ b/docs/use-dkg/publishing-conviction.md
@@ -14,7 +14,7 @@ Use this page for the current CLI/API surface. For the economics model, see [Con
 ## Create a PCA
 
 ```bash
-dkg pca create --tokens 100000
+dkg pca create --tokens 100000 --primary-node <identityId>
 ```
 
 The daemon EOA becomes the owner of the PCA NFT. Owner-gated write operations must be run from the node whose EOA owns that NFT.
@@ -25,7 +25,9 @@ The daemon EOA becomes the owner of the PCA NFT. Owner-gated write operations mu
 dkg pca register-agent <accountId> <agentAddress>
 ```
 
-The agent address must be a valid non-zero EVM address. The daemon verifies registration with an on-chain read after the transaction lands when the adapter supports it.
+The agent address must be a valid non-zero EVM address. Register the transaction-signing wallet address that will publish with the PCA. The daemon verifies registration with an on-chain read after the transaction lands when the adapter supports it.
+
+The agent wallet still needs native gas, but it does not need an on-chain node identity. Node identity is only publisher-node attribution; PCA payment eligibility comes from PCA agent registration.
 
 ## Deregister a Publishing Agent
 

--- a/docs/use-dkg/run-node.md
+++ b/docs/use-dkg/run-node.md
@@ -54,6 +54,8 @@ Before registration, fund the Core wallets for the selected network:
 | Other operational wallets | Native gas token for node operations and publishing |
 | Admin wallet | Native gas token for key-management transactions, including registering additional operational wallets |
 
+Async publisher wallets are separate transaction signers stored in `publisher-wallets.json`. They need native gas plus PCA registration or TRAC for direct spend, but they do not need to be operational wallets unless you want them to carry a node identity for publisher-node attribution. See [Async Publisher Wallets](async-publisher-wallets.md).
+
 On `testnet`, setup attempts to fund these generated wallets automatically when the faucet is reachable. On `mainnet-gnosis` and `mainnet-base`, fund them yourself. Use:
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -260,7 +260,7 @@ modes auto-renewal can't recover from:
 | `dkg ka share-async <name> -c <cg>` | Enqueue async WM-to-SWM share |
 | `dkg ka share-jobs [--context-graph-id <cg>]` | List async SWM share jobs |
 | `dkg ka publish <name> -c <cg>` | Synchronously publish an already finalized and fully shared KA from SWM to VM |
-| `dkg ka publish-async <name> -c <cg>` | Enqueue VM publish for an already finalized and fully shared KA |
+| `dkg ka publish-async <name> -c <cg> [--publisher-node-identity-id 0]` | Enqueue VM publish for an already finalized and fully shared KA |
 | `dkg ka pull-from <name> -c <cg> --layer swm\|vm` | Seed WM from SWM or VM |
 | `dkg ka discard <name> -c <cg>` | Discard a WM draft |
 | `dkg ka query <name> -c <cg>` | Read KA WM quads |
@@ -284,7 +284,7 @@ modes auto-renewal can't recover from:
 
 Run `dkg <command> --help` for per-command options.
 
-Async publisher wallets must already have on-chain identities/profiles before they can claim VM publish jobs. Fund and provision those wallets before enabling async publish, or remove unprovisioned wallets from `publisher-wallets.json`.
+Async publisher wallets need valid keys and native gas. Register the wallet as a PCA agent or fund TRAC for direct spend before expecting jobs to publish successfully. An on-chain node identity is optional publisher-node attribution; identity `0` is valid no-attribution mode. See [Async Publisher Wallets](../../docs/use-dkg/async-publisher-wallets.md).
 
 ## Source Workers
 

--- a/packages/cli/skills/dkg-node/SKILL.md
+++ b/packages/cli/skills/dkg-node/SKILL.md
@@ -781,16 +781,17 @@ CLI equivalents:
 ```bash
 dkg ka publish-async <name> -c <context-graph-id>
 dkg publisher publish-async <context-graph-id> <name>   # operational alias
+dkg publisher publish-async <context-graph-id> <name> --publisher-node-identity-id 0
 dkg publisher jobs
 dkg publisher job <job-id>
 dkg publisher stats
 ```
 
-Async publisher wallets must already have on-chain identities/profiles before they can claim VM publish jobs. If startup reports an unprovisioned publisher wallet, provision that wallet or remove it from `publisher-wallets.json` before retrying.
+Async publisher wallets need native gas plus PCA agent registration or TRAC for direct spend. They do not need on-chain identities/profiles to claim VM publish jobs. Identity `0` is valid no-attribution mode; a non-zero identity is optional publisher-node attribution only. Separate publisher wallets are not automatically attached to the node's Core identity; use `POST /api/operational-wallets` only when attribution to that node identity is desired. See `docs/use-dkg/async-publisher-wallets.md`.
 
 | Method | Route | Purpose |
 |---|---|---|
-| `POST` | `/api/knowledge-assets/{name}/vm/publish-async` | Enqueue VM publish for a named KA already shared to SWM. Body: `{ contextGraphId, options? }`. Returns `202 { jobId, status: "accepted" }`. |
+| `POST` | `/api/knowledge-assets/{name}/vm/publish-async` | Enqueue VM publish for a named KA already shared to SWM. Body: `{ contextGraphId, options? }`; `options.publisherNodeIdentityIdOverride: "0"` forces no-attribution. Returns `202 { jobId, status: "accepted" }`. |
 | `GET`  | `/api/publisher/jobs?status=...` | List jobs, optionally filtered by status. |
 | `GET`  | `/api/publisher/job?id=...` | Fetch one job's status. |
 | `GET`  | `/api/publisher/job-payload?id=...` | Fetch the prepared payload for internal raw LIFT jobs. Named lifecycle publish jobs return no raw payload. |

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -7,6 +7,8 @@ import {
   type KnowledgeAssetFinalizedPublishOptions,
 } from './finalized-publish-options.js';
 
+export type { KnowledgeAssetFinalizedPublishOptions } from './finalized-publish-options.js';
+
 export type QueryResult =
   | { type: 'bindings'; bindings: Array<Record<string, string>> }
   | { type: 'boolean'; value: boolean }

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -2,6 +2,10 @@ import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { readApiPort, readPid, isProcessRunning, configExists, loadConfig } from './config.js';
 import { loadTokens } from './auth.js';
+import {
+  finalizedPublishOptionsPayload,
+  type KnowledgeAssetFinalizedPublishOptions,
+} from './finalized-publish-options.js';
 
 export type QueryResult =
   | { type: 'bindings'; bindings: Array<Record<string, string>> }
@@ -18,17 +22,6 @@ export interface PreSignedAuthorAttestationPayload {
    */
   reservedKaId: string;
   signature: { r: string; vs: string };
-}
-
-export interface KnowledgeAssetFinalizedPublishOptions {
-  /**
-   * SDK-friendly spelling for the finalized publish cleanup flag. The
-   * knowledge-assets daemon route forwards `clearSharedMemoryAfter` to
-   * `publishFromFinalizedAssertion`, so the client translates before POST.
-   */
-  clearAfter?: boolean;
-  publishEpochs?: number;
-  publisherNodeIdentityIdOverride?: bigint;
 }
 
 export interface KnowledgeAssetWritableQuad {
@@ -140,32 +133,6 @@ export interface KnowledgeAssetShareJobView {
     retryable: boolean;
   };
   reason?: string;
-}
-
-const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
-  'clearAfter',
-  'publishEpochs',
-  'publisherNodeIdentityIdOverride',
-]);
-
-function finalizedPublishOptionsPayload(
-  options?: KnowledgeAssetFinalizedPublishOptions,
-  allowedExtraKeys: readonly string[] = [],
-): Record<string, unknown> | undefined {
-  if (!options) return undefined;
-  const unsupportedKeys = Object.keys(options).filter(
-    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
-  );
-  if (unsupportedKeys.length > 0) {
-    throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
-  }
-  const payload: Record<string, unknown> = {};
-  if (options.clearAfter !== undefined) payload.clearSharedMemoryAfter = options.clearAfter;
-  if (options.publishEpochs !== undefined) payload.publishEpochs = options.publishEpochs;
-  if (options.publisherNodeIdentityIdOverride !== undefined) {
-    payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
-  }
-  return Object.keys(payload).length > 0 ? payload : undefined;
 }
 
 function createAlsoPublishVmPayload(value: unknown): boolean | Record<string, unknown> {

--- a/packages/cli/src/api-client.ts
+++ b/packages/cli/src/api-client.ts
@@ -664,10 +664,11 @@ export class ApiClient {
     name: string,
     options?: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions,
   ): Promise<KnowledgeAssetPublishResponse> {
-    const publishOptions = finalizedPublishOptionsPayload(options, ['subGraphName']);
+    const { subGraphName, ...finalizedOptions } = options ?? {};
+    const publishOptions = finalizedPublishOptionsPayload(finalizedOptions);
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish`, {
       contextGraphId,
-      ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),
+      ...(subGraphName ? { subGraphName } : {}),
       ...(publishOptions ? { options: publishOptions } : {}),
     });
   }
@@ -677,10 +678,11 @@ export class ApiClient {
     name: string,
     options?: { subGraphName?: string } & KnowledgeAssetFinalizedPublishOptions,
   ): Promise<KnowledgeAssetPublishAsyncResponse> {
-    const publishOptions = finalizedPublishOptionsPayload(options, ['subGraphName']);
+    const { subGraphName, ...finalizedOptions } = options ?? {};
+    const publishOptions = finalizedPublishOptionsPayload(finalizedOptions);
     return this.post(`/api/knowledge-assets/${encodeURIComponent(name)}/vm/publish-async`, {
       contextGraphId,
-      ...(options?.subGraphName ? { subGraphName: options.subGraphName } : {}),
+      ...(subGraphName ? { subGraphName } : {}),
       ...(publishOptions ? { options: publishOptions } : {}),
     });
   }

--- a/packages/cli/src/cli-helpers.ts
+++ b/packages/cli/src/cli-helpers.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from './config.js';
 import { ApiClient } from './api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from './publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from './cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from './store-wizard.js';
 import { runConfiguredSourceWorker } from './source-worker-runner.js';
 import { batchEntityQuads } from './batching.js';

--- a/packages/cli/src/cli-option-parsers.ts
+++ b/packages/cli/src/cli-option-parsers.ts
@@ -1,4 +1,4 @@
-import { MAX_UINT72, MAX_UINT72_DECIMAL } from './protocol-limits.js';
+import { MAX_UINT72_DECIMAL, parseUint72Decimal } from './protocol-limits.js';
 
 export function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
   if (raw === undefined) return undefined;
@@ -13,11 +13,15 @@ export function parseOptionalNonNegativeBigInt(raw: unknown, flag: string): bigi
 }
 
 export function parseOptionalUint72BigInt(raw: unknown, flag: string): bigint | undefined {
-  const parsed = parseOptionalNonNegativeBigInt(raw, flag);
-  if (parsed !== undefined && parsed > MAX_UINT72) {
-    throw new Error(`${flag} must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)`);
+  if (raw === undefined) return undefined;
+  const parsed = parseUint72Decimal(String(raw));
+  if (!parsed.ok) {
+    if (parsed.reason === 'range') {
+      throw new Error(`${flag} must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)`);
+    }
+    throw new Error(`${flag} must be a non-negative integer`);
   }
-  return parsed;
+  return parsed.value;
 }
 
 export function parsePositiveMsOption(value: string, optionName: '--poll-interval' | '--error-backoff'): number {

--- a/packages/cli/src/cli-option-parsers.ts
+++ b/packages/cli/src/cli-option-parsers.ts
@@ -1,3 +1,5 @@
+import { MAX_UINT72, MAX_UINT72_DECIMAL } from './protocol-limits.js';
+
 export function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
   if (raw === undefined) return undefined;
   return parsePositiveIntegerValue(String(raw), flag);
@@ -8,6 +10,14 @@ export function parseOptionalNonNegativeBigInt(raw: unknown, flag: string): bigi
   const value = String(raw).trim();
   if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a non-negative integer`);
   return BigInt(value);
+}
+
+export function parseOptionalUint72BigInt(raw: unknown, flag: string): bigint | undefined {
+  const parsed = parseOptionalNonNegativeBigInt(raw, flag);
+  if (parsed !== undefined && parsed > MAX_UINT72) {
+    throw new Error(`${flag} must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)`);
+  }
+  return parsed;
 }
 
 export function parsePositiveMsOption(value: string, optionName: '--poll-interval' | '--error-backoff'): number {

--- a/packages/cli/src/cli-option-parsers.ts
+++ b/packages/cli/src/cli-option-parsers.ts
@@ -1,27 +1,6 @@
-import { MAX_UINT72_DECIMAL, parseUint72Decimal } from './protocol-limits.js';
-
 export function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
   if (raw === undefined) return undefined;
   return parsePositiveIntegerValue(String(raw), flag);
-}
-
-export function parseOptionalNonNegativeBigInt(raw: unknown, flag: string): bigint | undefined {
-  if (raw === undefined) return undefined;
-  const value = String(raw).trim();
-  if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a non-negative integer`);
-  return BigInt(value);
-}
-
-export function parseOptionalUint72BigInt(raw: unknown, flag: string): bigint | undefined {
-  if (raw === undefined) return undefined;
-  const parsed = parseUint72Decimal(String(raw));
-  if (!parsed.ok) {
-    if (parsed.reason === 'range') {
-      throw new Error(`${flag} must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)`);
-    }
-    throw new Error(`${flag} must be a non-negative integer`);
-  }
-  return parsed.value;
 }
 
 export function parsePositiveMsOption(value: string, optionName: '--poll-interval' | '--error-backoff'): number {

--- a/packages/cli/src/cli-option-parsers.ts
+++ b/packages/cli/src/cli-option-parsers.ts
@@ -1,0 +1,35 @@
+export function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
+  if (raw === undefined) return undefined;
+  return parsePositiveIntegerValue(String(raw), flag);
+}
+
+export function parseOptionalNonNegativeBigInt(raw: unknown, flag: string): bigint | undefined {
+  if (raw === undefined) return undefined;
+  const value = String(raw).trim();
+  if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a non-negative integer`);
+  return BigInt(value);
+}
+
+export function parsePositiveMsOption(value: string, optionName: '--poll-interval' | '--error-backoff'): number {
+  return parsePositiveIntegerValue(value, optionName, 'positive integer in milliseconds');
+}
+
+export function parsePositiveIntegerOption(value: string, optionName: string): number {
+  return parsePositiveIntegerValue(value, optionName);
+}
+
+function parsePositiveIntegerValue(
+  value: string,
+  optionName: string,
+  expectation = 'positive integer',
+): number {
+  const normalized = value.trim();
+  if (!/^[1-9]\d*$/.test(normalized)) {
+    throw new Error(`${optionName} must be a ${expectation}`);
+  }
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${optionName} must be a ${expectation}`);
+  }
+  return parsed;
+}

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/assertion.ts
+++ b/packages/cli/src/commands/assertion.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/ccl.ts
+++ b/packages/cli/src/commands/ccl.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/context-graph.ts
+++ b/packages/cli/src/commands/context-graph.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/epcis.ts
+++ b/packages/cli/src/commands/epcis.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/finalized-publish-command-options.ts
+++ b/packages/cli/src/commands/finalized-publish-command-options.ts
@@ -23,9 +23,5 @@ export function parseFinalizedPublishOptions(opts: ActionOpts): KnowledgeAssetFi
       publisherNodeIdentityIdOverride: '--publisher-node-identity-id',
     }, { quoteField: false }));
   }
-  const { publishEpochs, publisherNodeIdentityIdOverride } = parsed.options;
-  return {
-    ...(publishEpochs !== undefined ? { publishEpochs } : {}),
-    ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),
-  };
+  return parsed.options;
 }

--- a/packages/cli/src/commands/finalized-publish-options.ts
+++ b/packages/cli/src/commands/finalized-publish-options.ts
@@ -1,6 +1,9 @@
 import { Command } from 'commander';
-import type { KnowledgeAssetFinalizedPublishOptions } from '../api-client.js';
-import { parseOptionalPositiveInteger, parseOptionalUint72BigInt } from '../cli-option-parsers.js';
+import {
+  formatFinalizedPublishOptionError,
+  type KnowledgeAssetFinalizedPublishOptions,
+  normalizeFinalizedPublishOptions,
+} from '../finalized-publish-options.js';
 import type { ActionOpts } from '../cli-helpers.js';
 
 export function addFinalizedPublishOptions(command: Command): Command {
@@ -10,11 +13,17 @@ export function addFinalizedPublishOptions(command: Command): Command {
 }
 
 export function parseFinalizedPublishOptions(opts: ActionOpts): KnowledgeAssetFinalizedPublishOptions {
-  const publishEpochs = parseOptionalPositiveInteger(opts.publishEpochs, '--publish-epochs');
-  const publisherNodeIdentityIdOverride = parseOptionalUint72BigInt(
-    opts.publisherNodeIdentityId,
-    '--publisher-node-identity-id',
-  );
+  const parsed = normalizeFinalizedPublishOptions({
+    publishEpochs: opts.publishEpochs,
+    publisherNodeIdentityIdOverride: opts.publisherNodeIdentityId,
+  });
+  if (!parsed.ok) {
+    throw new Error(formatFinalizedPublishOptionError(parsed.error, {
+      publishEpochs: '--publish-epochs',
+      publisherNodeIdentityIdOverride: '--publisher-node-identity-id',
+    }, { quoteField: false }));
+  }
+  const { publishEpochs, publisherNodeIdentityIdOverride } = parsed.options;
   return {
     ...(publishEpochs !== undefined ? { publishEpochs } : {}),
     ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),

--- a/packages/cli/src/commands/finalized-publish-options.ts
+++ b/packages/cli/src/commands/finalized-publish-options.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import type { KnowledgeAssetFinalizedPublishOptions } from '../api-client.js';
+import { parseOptionalNonNegativeBigInt, parseOptionalPositiveInteger } from '../cli-option-parsers.js';
 import type { ActionOpts } from '../cli-helpers.js';
 
 export function addFinalizedPublishOptions(command: Command): Command {
@@ -18,20 +19,4 @@ export function parseFinalizedPublishOptions(opts: ActionOpts): KnowledgeAssetFi
     ...(publishEpochs !== undefined ? { publishEpochs } : {}),
     ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),
   };
-}
-
-function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
-  if (raw === undefined) return undefined;
-  const value = String(raw).trim();
-  if (!/^[1-9]\d*$/.test(value)) throw new Error(`${flag} must be a positive integer`);
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) throw new Error(`${flag} must be a positive integer`);
-  return parsed;
-}
-
-function parseOptionalNonNegativeBigInt(raw: unknown, flag: string): bigint | undefined {
-  if (raw === undefined) return undefined;
-  const value = String(raw).trim();
-  if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a non-negative integer`);
-  return BigInt(value);
 }

--- a/packages/cli/src/commands/finalized-publish-options.ts
+++ b/packages/cli/src/commands/finalized-publish-options.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import {
   formatFinalizedPublishOptionError,
   type KnowledgeAssetFinalizedPublishOptions,
-  normalizeFinalizedPublishOptions,
+  parseCliFinalizedPublishOptions,
 } from '../finalized-publish-options.js';
 import type { ActionOpts } from '../cli-helpers.js';
 
@@ -13,9 +13,9 @@ export function addFinalizedPublishOptions(command: Command): Command {
 }
 
 export function parseFinalizedPublishOptions(opts: ActionOpts): KnowledgeAssetFinalizedPublishOptions {
-  const parsed = normalizeFinalizedPublishOptions({
+  const parsed = parseCliFinalizedPublishOptions({
     publishEpochs: opts.publishEpochs,
-    publisherNodeIdentityIdOverride: opts.publisherNodeIdentityId,
+    publisherNodeIdentityId: opts.publisherNodeIdentityId,
   });
   if (!parsed.ok) {
     throw new Error(formatFinalizedPublishOptionError(parsed.error, {

--- a/packages/cli/src/commands/finalized-publish-options.ts
+++ b/packages/cli/src/commands/finalized-publish-options.ts
@@ -1,0 +1,37 @@
+import { Command } from 'commander';
+import type { KnowledgeAssetFinalizedPublishOptions } from '../api-client.js';
+import type { ActionOpts } from '../cli-helpers.js';
+
+export function addFinalizedPublishOptions(command: Command): Command {
+  return command
+    .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs (default: 12; PCA-funded publishes may coerce to PCA lock duration)')
+    .option('--publisher-node-identity-id <id>', 'Publisher node identity id override; use 0 for no-attribution');
+}
+
+export function parseFinalizedPublishOptions(opts: ActionOpts): KnowledgeAssetFinalizedPublishOptions {
+  const publishEpochs = parseOptionalPositiveInteger(opts.publishEpochs, '--publish-epochs');
+  const publisherNodeIdentityIdOverride = parseOptionalNonNegativeBigInt(
+    opts.publisherNodeIdentityId,
+    '--publisher-node-identity-id',
+  );
+  return {
+    ...(publishEpochs !== undefined ? { publishEpochs } : {}),
+    ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),
+  };
+}
+
+function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = String(raw).trim();
+  if (!/^[1-9]\d*$/.test(value)) throw new Error(`${flag} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function parseOptionalNonNegativeBigInt(raw: unknown, flag: string): bigint | undefined {
+  if (raw === undefined) return undefined;
+  const value = String(raw).trim();
+  if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a non-negative integer`);
+  return BigInt(value);
+}

--- a/packages/cli/src/commands/finalized-publish-options.ts
+++ b/packages/cli/src/commands/finalized-publish-options.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import type { KnowledgeAssetFinalizedPublishOptions } from '../api-client.js';
-import { parseOptionalNonNegativeBigInt, parseOptionalPositiveInteger } from '../cli-option-parsers.js';
+import { parseOptionalPositiveInteger, parseOptionalUint72BigInt } from '../cli-option-parsers.js';
 import type { ActionOpts } from '../cli-helpers.js';
 
 export function addFinalizedPublishOptions(command: Command): Command {
@@ -11,7 +11,7 @@ export function addFinalizedPublishOptions(command: Command): Command {
 
 export function parseFinalizedPublishOptions(opts: ActionOpts): KnowledgeAssetFinalizedPublishOptions {
   const publishEpochs = parseOptionalPositiveInteger(opts.publishEpochs, '--publish-epochs');
-  const publisherNodeIdentityIdOverride = parseOptionalNonNegativeBigInt(
+  const publisherNodeIdentityIdOverride = parseOptionalUint72BigInt(
     opts.publisherNodeIdentityId,
     '--publisher-node-identity-id',
   );

--- a/packages/cli/src/commands/hermes.ts
+++ b/packages/cli/src/commands/hermes.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -33,7 +33,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -17,7 +17,7 @@ import {
   type ActionOpts,
 } from '../cli-helpers.js';
 import { parseOptionalPositiveInteger } from '../cli-option-parsers.js';
-import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-options.js';
+import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-command-options.js';
 
 const SHARE_JOB_STATES: readonly KnowledgeAssetShareJobState[] = [
   'queued',

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -16,6 +16,7 @@ import {
   loadStructuredFile,
   type ActionOpts,
 } from '../cli-helpers.js';
+import { parseOptionalPositiveInteger } from '../cli-option-parsers.js';
 import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-options.js';
 
 const SHARE_JOB_STATES: readonly KnowledgeAssetShareJobState[] = [
@@ -101,15 +102,6 @@ function parseFinalizeAuthorOptions(opts: ActionOpts): {
     ...(preSignedAuthorAttestation ? { preSignedAuthorAttestation } : {}),
     ...(schemeVersion !== undefined ? { schemeVersion } : {}),
   };
-}
-
-function parseOptionalPositiveInteger(raw: unknown, flag: string): number | undefined {
-  if (raw === undefined) return undefined;
-  const value = String(raw).trim();
-  if (!/^[1-9]\d*$/.test(value)) throw new Error(`${flag} must be a positive integer`);
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) throw new Error(`${flag} must be a positive integer`);
-  return parsed;
 }
 
 function parseShareEntities(opts: ActionOpts): string[] | undefined {

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -4,7 +4,6 @@ import {
   ApiClient,
   type KnowledgeAssetCreateOptions,
   type KnowledgeAssetCreateResponse,
-  type KnowledgeAssetFinalizedPublishOptions,
   type KnowledgeAssetPublishResponse,
   type KnowledgeAssetShareJobState,
   type KnowledgeAssetShareResponse,
@@ -17,7 +16,7 @@ import {
   loadStructuredFile,
   type ActionOpts,
 } from '../cli-helpers.js';
-import { parseNonNegativeBigIntOption } from '../publisher-runner.js';
+import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-options.js';
 
 const SHARE_JOB_STATES: readonly KnowledgeAssetShareJobState[] = [
   'queued',
@@ -113,23 +112,6 @@ function parseOptionalPositiveInteger(raw: unknown, flag: string): number | unde
   return parsed;
 }
 
-function parseOptionalBigInt(raw: unknown, flag: string): bigint | undefined {
-  if (raw === undefined) return undefined;
-  return parseNonNegativeBigIntOption(String(raw), flag);
-}
-
-function parsePublishOptions(opts: ActionOpts): KnowledgeAssetFinalizedPublishOptions {
-  const publishEpochs = parseOptionalPositiveInteger(opts.publishEpochs, '--publish-epochs');
-  const publisherNodeIdentityIdOverride = parseOptionalBigInt(
-    opts.publisherNodeIdentityId,
-    '--publisher-node-identity-id',
-  );
-  return {
-    ...(publishEpochs !== undefined ? { publishEpochs } : {}),
-    ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),
-  };
-}
-
 function parseShareEntities(opts: ActionOpts): string[] | undefined {
   if (!opts.entity || opts.entity.length === 0) return undefined;
   return opts.entity.map(String);
@@ -184,12 +166,6 @@ function addFinalizeAuthorOptions(command: Command): Command {
     .option('--author-agent-address <address>', 'Author agent EVM address for the seal')
     .option('--pre-signed-author-attestation <json-or-path>', 'Pre-signed AuthorAttestation JSON or file')
     .option('--scheme-version <n>', 'Author attestation scheme version');
-}
-
-function addPublishOptions(command: Command): Command {
-  return command
-    .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs')
-    .option('--publisher-node-identity-id <id>', 'Publisher node identity id override');
 }
 
 function publishNextCommand(name: string, contextGraphId: string, opts: ActionOpts): string {
@@ -503,7 +479,7 @@ export function registerKnowledgeAssetCommand(program: Command): void {
       console.log(`Recovered share job ${result.jobId}; state=${result.state}`);
     }));
 
-  addPublishOptions(addSubGraphOption(addContextGraphOption(
+  addFinalizedPublishOptions(addSubGraphOption(addContextGraphOption(
     kaCmd
       .command('publish <name>')
       .description('Publish an already finalized and fully shared Knowledge Asset from SWM to VM')
@@ -514,7 +490,7 @@ export function registerKnowledgeAssetCommand(program: Command): void {
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetPublish(contextGraphId, name, {
         ...(subGraphName(opts) ? { subGraphName: subGraphName(opts) } : {}),
-        ...parsePublishOptions(opts),
+        ...parseFinalizedPublishOptions(opts),
       });
       assertPublishComplete(result, name, contextGraphId);
       if (opts.json) {
@@ -529,7 +505,7 @@ export function registerKnowledgeAssetCommand(program: Command): void {
       if (result.status) console.log(`  Status:  ${result.status}`);
     }));
 
-  addPublishOptions(addSubGraphOption(addContextGraphOption(
+  addFinalizedPublishOptions(addSubGraphOption(addContextGraphOption(
     kaCmd
       .command('publish-async <name>')
       .description('Enqueue VM publish for an already finalized and fully shared Knowledge Asset')
@@ -540,7 +516,7 @@ export function registerKnowledgeAssetCommand(program: Command): void {
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetPublishAsync(contextGraphId, name, {
         ...(subGraphName(opts) ? { subGraphName: subGraphName(opts) } : {}),
-        ...parsePublishOptions(opts),
+        ...parseFinalizedPublishOptions(opts),
       });
       if (opts.json) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/commands/knowledge-asset.ts
+++ b/packages/cli/src/commands/knowledge-asset.ts
@@ -17,6 +17,7 @@ import {
   loadStructuredFile,
   type ActionOpts,
 } from '../cli-helpers.js';
+import { parseNonNegativeBigIntOption } from '../publisher-runner.js';
 
 const SHARE_JOB_STATES: readonly KnowledgeAssetShareJobState[] = [
   'queued',
@@ -114,9 +115,7 @@ function parseOptionalPositiveInteger(raw: unknown, flag: string): number | unde
 
 function parseOptionalBigInt(raw: unknown, flag: string): bigint | undefined {
   if (raw === undefined) return undefined;
-  const value = String(raw).trim();
-  if (!/^\d+$/.test(value)) throw new Error(`${flag} must be a non-negative integer`);
-  return BigInt(value);
+  return parseNonNegativeBigIntOption(String(raw), flag);
 }
 
 function parsePublishOptions(opts: ActionOpts): KnowledgeAssetFinalizedPublishOptions {

--- a/packages/cli/src/commands/lifecycle.ts
+++ b/packages/cli/src/commands/lifecycle.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -27,7 +27,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/network.ts
+++ b/packages/cli/src/commands/network.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/node-ops.ts
+++ b/packages/cli/src/commands/node-ops.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/openclaw.ts
+++ b/packages/cli/src/commands/openclaw.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/pca.ts
+++ b/packages/cli/src/commands/pca.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/publisher.ts
+++ b/packages/cli/src/commands/publisher.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-options.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';

--- a/packages/cli/src/commands/publisher.ts
+++ b/packages/cli/src/commands/publisher.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parseNonNegativeBigIntOption, parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';
@@ -103,6 +103,11 @@ import {
   runForegroundSupervisor,
 } from '../cli-supervisor.js';
 
+function parseOptionalPublisherNodeIdentityId(raw: unknown): bigint | undefined {
+  if (raw === undefined) return undefined;
+  return parseNonNegativeBigIntOption(String(raw), '--publisher-node-identity-id');
+}
+
 export function registerPublisherCommand(program: Command): void {
 const publisherCmd = program
   .command('publisher')
@@ -123,6 +128,8 @@ publisherWalletCmd
       console.log(`  File:    ${publisherWalletsPath(dkgDir())}`);
       console.log(`  Wallets: ${result.wallets.length}`);
       console.log(`  Address: ${result.wallets[result.wallets.length - 1]?.address}`);
+      console.log('  Funding: add native gas for transactions; register as a PCA agent or fund TRAC for direct spend.');
+      console.log('  Identity: optional; attach a node identity only when publisher-node attribution is desired.');
     } catch (err) {
       console.error(toErrorMessage(err));
       process.exit(1);
@@ -209,16 +216,19 @@ publisherCmd
   .description('Enqueue a named knowledge asset VM publish job')
   .option('--sub-graph <name>', 'Target sub-graph within the context graph')
   .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs (default: 12; PCA-funded publishes may coerce to PCA lock duration)')
+  .option('--publisher-node-identity-id <id>', 'Publisher node identity id override; use 0 for no-attribution')
   .action(async (contextGraph: string, name: string, opts: ActionOpts) => {
     try {
       const publishEpochs = opts.publishEpochs !== undefined
         ? parsePositiveIntegerOption(String(opts.publishEpochs), '--publish-epochs')
         : undefined;
+      const publisherNodeIdentityIdOverride = parseOptionalPublisherNodeIdentityId(opts.publisherNodeIdentityId);
 
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetPublishAsync(contextGraph, name, {
         ...(opts.subGraph ? { subGraphName: String(opts.subGraph) } : {}),
         ...(publishEpochs !== undefined ? { publishEpochs } : {}),
+        ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),
       });
 
       console.log('Knowledge asset publish job accepted:');

--- a/packages/cli/src/commands/publisher.ts
+++ b/packages/cli/src/commands/publisher.ts
@@ -30,7 +30,8 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parseNonNegativeBigIntOption, parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-options.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';
@@ -102,11 +103,6 @@ import {
   runDaemonSupervisor,
   runForegroundSupervisor,
 } from '../cli-supervisor.js';
-
-function parseOptionalPublisherNodeIdentityId(raw: unknown): bigint | undefined {
-  if (raw === undefined) return undefined;
-  return parseNonNegativeBigIntOption(String(raw), '--publisher-node-identity-id');
-}
 
 export function registerPublisherCommand(program: Command): void {
 const publisherCmd = program
@@ -211,24 +207,18 @@ publisherCmd
     }
   });
 
-publisherCmd
+addFinalizedPublishOptions(publisherCmd
   .command('publish-async <context-graph> <name>')
   .description('Enqueue a named knowledge asset VM publish job')
-  .option('--sub-graph <name>', 'Target sub-graph within the context graph')
-  .option('--publish-epochs <count>', 'On-chain publish lifetime in epochs (default: 12; PCA-funded publishes may coerce to PCA lock duration)')
-  .option('--publisher-node-identity-id <id>', 'Publisher node identity id override; use 0 for no-attribution')
+  .option('--sub-graph <name>', 'Target sub-graph within the context graph'))
   .action(async (contextGraph: string, name: string, opts: ActionOpts) => {
     try {
-      const publishEpochs = opts.publishEpochs !== undefined
-        ? parsePositiveIntegerOption(String(opts.publishEpochs), '--publish-epochs')
-        : undefined;
-      const publisherNodeIdentityIdOverride = parseOptionalPublisherNodeIdentityId(opts.publisherNodeIdentityId);
+      const publishOptions = parseFinalizedPublishOptions(opts);
 
       const client = await ApiClient.connect();
       const result = await client.knowledgeAssetPublishAsync(contextGraph, name, {
         ...(opts.subGraph ? { subGraphName: String(opts.subGraph) } : {}),
-        ...(publishEpochs !== undefined ? { publishEpochs } : {}),
-        ...(publisherNodeIdentityIdOverride !== undefined ? { publisherNodeIdentityIdOverride } : {}),
+        ...publishOptions,
       });
 
       console.log('Knowledge asset publish job accepted:');

--- a/packages/cli/src/commands/publisher.ts
+++ b/packages/cli/src/commands/publisher.ts
@@ -31,7 +31,7 @@ import {
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
 import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
-import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-options.js';
+import { addFinalizedPublishOptions, parseFinalizedPublishOptions } from './finalized-publish-command-options.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/query-catalog.ts
+++ b/packages/cli/src/commands/query-catalog.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/random-sampling.ts
+++ b/packages/cli/src/commands/random-sampling.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/source-worker.ts
+++ b/packages/cli/src/commands/source-worker.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -30,7 +30,7 @@ import {
   type AutoUpdateConfig,
 } from '../config.js';
 import { ApiClient } from '../api-client.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../cli-option-parsers.js';
 import { promptStoreBackend, applyStoreFlagsToConfig } from '../store-wizard.js';
 import { runConfiguredSourceWorker } from '../source-worker-runner.js';
 import { batchEntityQuads } from '../batching.js';

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -77,7 +77,7 @@ import { deriveStatus } from "@origintrail-official/dkg-publisher";
 import { validateAssertionName, contextGraphAssertionUri } from "@origintrail-official/dkg-core";
 import {
   formatFinalizedPublishOptionError,
-  normalizeFinalizedPublishOptions,
+  parseHttpFinalizedPublishOptions,
   type NormalizedFinalizedPublishOptions,
 } from "../../finalized-publish-options.js";
 
@@ -517,7 +517,7 @@ function resolveFinalizedPublishOptions(
   raw: unknown,
 ): NormalizedFinalizedPublishOptions | null {
   const { res } = ctx;
-  const parsed = normalizeFinalizedPublishOptions(raw);
+  const parsed = parseHttpFinalizedPublishOptions(raw);
   if (!parsed.ok) {
     jsonResponse(res, 400, { error: formatFinalizedPublishOptionError(parsed.error) });
     return null;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -75,6 +75,7 @@ import {
 import { AsyncLiftJobConflictError, PromoteJobConflictError } from "@origintrail-official/dkg-publisher";
 import { deriveStatus } from "@origintrail-official/dkg-publisher";
 import { validateAssertionName, contextGraphAssertionUri } from "@origintrail-official/dkg-core";
+import { MAX_UINT72, MAX_UINT72_DECIMAL } from "../../protocol-limits.js";
 
 const PREFIX = "/api/knowledge-assets";
 
@@ -549,7 +550,12 @@ function resolveFinalizedPublishOptions(
   if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
     const v = publishIntegerString(publisherNodeIdentityIdOverride, "publisherNodeIdentityIdOverride", res, { positive: false });
     if (v === null) return null;
-    resolvedPublisherIdentityOverride = BigInt(v);
+    const parsedPublisherIdentityOverride = BigInt(v);
+    if (parsedPublisherIdentityOverride > MAX_UINT72) {
+      jsonResponse(res, 400, { error: `"publisherNodeIdentityIdOverride" must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)` });
+      return null;
+    }
+    resolvedPublisherIdentityOverride = parsedPublisherIdentityOverride;
   }
 
   let resolvedPublishEpochs: number | undefined;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -75,7 +75,7 @@ import {
 import { AsyncLiftJobConflictError, PromoteJobConflictError } from "@origintrail-official/dkg-publisher";
 import { deriveStatus } from "@origintrail-official/dkg-publisher";
 import { validateAssertionName, contextGraphAssertionUri } from "@origintrail-official/dkg-core";
-import { MAX_UINT72, MAX_UINT72_DECIMAL } from "../../protocol-limits.js";
+import { MAX_UINT72_DECIMAL, parseUint72Decimal } from "../../protocol-limits.js";
 
 const PREFIX = "/api/knowledge-assets";
 
@@ -530,6 +530,21 @@ function publishIntegerString(
   return v;
 }
 
+function publishUint72IdentityId(value: unknown, field: string, res: RequestContext["res"]): bigint | null {
+  const v = publishIntegerString(value, field, res, { positive: false });
+  if (v === null) return null;
+  const parsed = parseUint72Decimal(v);
+  if (!parsed.ok) {
+    if (parsed.reason === "range") {
+      jsonResponse(res, 400, { error: `"${field}" must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)` });
+      return null;
+    }
+    jsonResponse(res, 400, { error: `"${field}" must be a non-negative integer (string or number)` });
+    return null;
+  }
+  return parsed.value;
+}
+
 // Validate + normalize the finalized-publish options BEFORE they reach
 // `publishFromFinalizedAssertion` (PR #971). Without this, malformed epochs /
 // identity overrides / flags flowed straight through and surfaced as opaque
@@ -548,14 +563,9 @@ function resolveFinalizedPublishOptions(
 
   let resolvedPublisherIdentityOverride: bigint | undefined;
   if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
-    const v = publishIntegerString(publisherNodeIdentityIdOverride, "publisherNodeIdentityIdOverride", res, { positive: false });
+    const v = publishUint72IdentityId(publisherNodeIdentityIdOverride, "publisherNodeIdentityIdOverride", res);
     if (v === null) return null;
-    const parsedPublisherIdentityOverride = BigInt(v);
-    if (parsedPublisherIdentityOverride > MAX_UINT72) {
-      jsonResponse(res, 400, { error: `"publisherNodeIdentityIdOverride" must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)` });
-      return null;
-    }
-    resolvedPublisherIdentityOverride = parsedPublisherIdentityOverride;
+    resolvedPublisherIdentityOverride = v;
   }
 
   let resolvedPublishEpochs: number | undefined;

--- a/packages/cli/src/daemon/routes/knowledge-assets.ts
+++ b/packages/cli/src/daemon/routes/knowledge-assets.ts
@@ -75,7 +75,11 @@ import {
 import { AsyncLiftJobConflictError, PromoteJobConflictError } from "@origintrail-official/dkg-publisher";
 import { deriveStatus } from "@origintrail-official/dkg-publisher";
 import { validateAssertionName, contextGraphAssertionUri } from "@origintrail-official/dkg-core";
-import { MAX_UINT72_DECIMAL, parseUint72Decimal } from "../../protocol-limits.js";
+import {
+  formatFinalizedPublishOptionError,
+  normalizeFinalizedPublishOptions,
+  type NormalizedFinalizedPublishOptions,
+} from "../../finalized-publish-options.js";
 
 const PREFIX = "/api/knowledge-assets";
 
@@ -451,10 +455,6 @@ async function resolveFinalizeStorageLane(
   }
 }
 
-// uint32 epoch ceiling (matches sibling routes memory.ts / publisher.ts). Not an
-// id encoder — the on-chain endEpoch is a uint40 but the publish API caps at uint32.
-const MAX_PUBLISH_EPOCHS = 0xffffffff;
-
 // PR #972 — classify a finalized-publish result into an HTTP status. On this
 // SYNCHRONOUS route a non-confirmed publish is a failure, not a normal in-flight
 // state ("no silent tentative downgrade"):
@@ -507,44 +507,6 @@ function validateFinalizedAssertionPublishShape(
   return true;
 }
 
-function publishIntegerString(
-  value: unknown,
-  field: string,
-  res: RequestContext["res"],
-  opts: { positive: boolean },
-): string | null {
-  if (typeof value !== "string" && typeof value !== "number") {
-    jsonResponse(res, 400, { error: `"${field}" must be a ${opts.positive ? "positive " : "non-negative "}integer (string or number)` });
-    return null;
-  }
-  if (typeof value === "number" && (!Number.isSafeInteger(value) || (opts.positive ? value <= 0 : value < 0))) {
-    jsonResponse(res, 400, { error: `"${field}" must be a ${opts.positive ? "positive " : "non-negative "}safe integer (string or number)` });
-    return null;
-  }
-  const v = typeof value === "string" ? value.trim() : String(value);
-  const pattern = opts.positive ? /^[1-9]\d*$/ : /^\d+$/;
-  if (!pattern.test(v)) {
-    jsonResponse(res, 400, { error: `"${field}" must be a ${opts.positive ? "positive " : "non-negative "}integer (string or number)` });
-    return null;
-  }
-  return v;
-}
-
-function publishUint72IdentityId(value: unknown, field: string, res: RequestContext["res"]): bigint | null {
-  const v = publishIntegerString(value, field, res, { positive: false });
-  if (v === null) return null;
-  const parsed = parseUint72Decimal(v);
-  if (!parsed.ok) {
-    if (parsed.reason === "range") {
-      jsonResponse(res, 400, { error: `"${field}" must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)` });
-      return null;
-    }
-    jsonResponse(res, 400, { error: `"${field}" must be a non-negative integer (string or number)` });
-    return null;
-  }
-  return parsed.value;
-}
-
 // Validate + normalize the finalized-publish options BEFORE they reach
 // `publishFromFinalizedAssertion` (PR #971). Without this, malformed epochs /
 // identity overrides / flags flowed straight through and surfaced as opaque
@@ -553,59 +515,20 @@ function publishUint72IdentityId(value: unknown, field: string, res: RequestCont
 function resolveFinalizedPublishOptions(
   ctx: RequestContext,
   raw: unknown,
-): Record<string, unknown> | null {
+): NormalizedFinalizedPublishOptions | null {
   const { res } = ctx;
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
-  const source = raw as Record<string, unknown>;
-  const { clearAfter, clearSharedMemoryAfter, publisherNodeIdentityIdOverride } = source;
-  const rawPublishEpochs = source.publishEpochs ?? source.epochs;
-  const publishEpochsField = source.publishEpochs !== undefined ? "publishEpochs" : "epochs";
-
-  let resolvedPublisherIdentityOverride: bigint | undefined;
-  if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
-    const v = publishUint72IdentityId(publisherNodeIdentityIdOverride, "publisherNodeIdentityIdOverride", res);
-    if (v === null) return null;
-    resolvedPublisherIdentityOverride = v;
-  }
-
-  let resolvedPublishEpochs: number | undefined;
-  if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
-    const v = publishIntegerString(rawPublishEpochs, publishEpochsField, res, { positive: true });
-    if (v === null) return null;
-    const n = Number(v);
-    if (!Number.isSafeInteger(n)) {
-      jsonResponse(res, 400, { error: `"${publishEpochsField}" is too large to safely represent as a JavaScript integer` });
-      return null;
-    }
-    if (n > MAX_PUBLISH_EPOCHS) {
-      jsonResponse(res, 400, { error: `"${publishEpochsField}" must be less than or equal to ${MAX_PUBLISH_EPOCHS}` });
-      return null;
-    }
-    resolvedPublishEpochs = n;
-  }
-
-  if (clearAfter !== undefined && typeof clearAfter !== "boolean") {
-    jsonResponse(res, 400, { error: '"clearAfter" must be a boolean when supplied' });
+  const parsed = normalizeFinalizedPublishOptions(raw);
+  if (!parsed.ok) {
+    jsonResponse(res, 400, { error: formatFinalizedPublishOptionError(parsed.error) });
     return null;
   }
-  if (clearSharedMemoryAfter !== undefined && typeof clearSharedMemoryAfter !== "boolean") {
-    jsonResponse(res, 400, { error: '"clearSharedMemoryAfter" must be a boolean when supplied' });
-    return null;
-  }
-  const clearValue = clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
-  return {
-    ...(clearValue !== undefined ? { clearSharedMemoryAfter: clearValue } : {}),
-    ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
-    ...(resolvedPublisherIdentityOverride !== undefined
-      ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
-      : {}),
-  };
+  return parsed.options;
 }
 
 function resolveInlineVmPublishOptions(
   ctx: RequestContext,
   source: Record<string, unknown>,
-): Record<string, unknown> | null {
+): NormalizedFinalizedPublishOptions | null {
   if (!validateFinalizedAssertionPublishShape(source, ctx.res)) return null;
   return resolveFinalizedPublishOptions(ctx, source);
 }
@@ -613,7 +536,7 @@ function resolveInlineVmPublishOptions(
 function resolveStandaloneVmPublishOptions(
   ctx: RequestContext,
   source: Record<string, unknown>,
-): Record<string, unknown> | null {
+): NormalizedFinalizedPublishOptions | null {
   if (!validateFinalizedAssertionPublishShape(source, ctx.res)) return null;
   const raw = source.options;
   if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -1392,11 +1315,7 @@ export async function handleKnowledgeAssetsRoutes(ctx: RequestContext): Promise<
       try {
         const opts = resolveStandaloneVmPublishOptions(ctx, parsed);
         if (opts === null) return;
-        const publishOptions = opts as {
-          publishEpochs?: number;
-          clearSharedMemoryAfter?: boolean;
-          publisherNodeIdentityIdOverride?: bigint;
-        };
+        const publishOptions = opts;
         const intent = await agent.resolveFinalizedAssertionVmPublishIntent(contextGraphId, name, {
           ...(subGraphName ? { subGraphName } : {}),
           ...(writePreflightCallerAgentAddress ? { agentAddress: writePreflightCallerAgentAddress } : {}),

--- a/packages/cli/src/daemon/routes/pca.ts
+++ b/packages/cli/src/daemon/routes/pca.ts
@@ -8,6 +8,7 @@ import {
 } from '@origintrail-official/dkg-chain';
 import { jsonResponse, readBody, SMALL_BODY_BYTES, respondIfChainRpcTransportError } from '../http-utils.js';
 import type { RequestContext } from './context.js';
+import { parseUint72Decimal } from '../../protocol-limits.js';
 
 const ZERO = '0x0000000000000000000000000000000000000000';
 const FEATURE_UNAVAILABLE_503 = {
@@ -90,8 +91,6 @@ function parseAccountId(idStr: string): bigint | null {
 // sentinel — but the daemon does not expose `setPrimaryNode`, so a PCA created
 // here with node 0 would be permanently inert (it funds nobody and cannot be
 // re-pointed). We therefore REQUIRE an explicit, non-zero node at creation.
-const MAX_UINT72 = (1n << 72n) - 1n;
-
 function parsePrimaryNode(raw: unknown): bigint | { error: string } {
   if (typeof raw === 'number') {
     // A uint72 identityId can exceed Number.MAX_SAFE_INTEGER. By the time we
@@ -109,16 +108,21 @@ function parsePrimaryNode(raw: unknown): bigint | { error: string } {
   if (!/^\d+$/.test(s)) {
     return { error: 'primaryNode must be a positive integer node identityId' };
   }
-  let id: bigint;
-  try {
-    id = BigInt(s);
-  } catch (e: any) {
-    return { error: `primaryNode parse error: ${e?.message ?? String(e)}` };
+  const parsed = parseUint72Decimal(s);
+  if (!parsed.ok) {
+    if (parsed.reason === 'range') {
+      return { error: 'primaryNode exceeds the uint72 node identityId range' };
+    }
+    return {
+      error: parsed.message
+        ? `primaryNode parse error: ${parsed.message}`
+        : 'primaryNode must be a positive integer node identityId',
+    };
   }
+  const id = parsed.value;
   if (id <= 0n) {
     return { error: 'primaryNode must be > 0 (0 designates no node; daemon-created PCAs must allocate to a node)' };
   }
-  if (id > MAX_UINT72) return { error: 'primaryNode exceeds the uint72 node identityId range' };
   return id;
 }
 

--- a/packages/cli/src/finalized-publish-options.ts
+++ b/packages/cli/src/finalized-publish-options.ts
@@ -20,8 +20,8 @@ export type FinalizedPublishOptionParseError =
   | { kind: 'uint72'; field: string }
   | { kind: 'boolean'; field: string };
 
-export type FinalizedPublishOptionParseResult =
-  | { ok: true; options: NormalizedFinalizedPublishOptions }
+export type FinalizedPublishOptionParseResult<TOptions> =
+  | { ok: true; options: TOptions }
   | { ok: false; error: FinalizedPublishOptionParseError };
 
 const SDK_FINALIZED_PUBLISH_OPTION_KEYS = new Set([
@@ -35,40 +35,57 @@ const MAX_PUBLISH_EPOCHS = 0xffffffff;
 export function parseCliFinalizedPublishOptions(raw: {
   publishEpochs?: unknown;
   publisherNodeIdentityId?: unknown;
-}): FinalizedPublishOptionParseResult {
-  return parseFinalizedPublishDomainOptions({
-    publishEpochs: parsePublishEpochs(raw.publishEpochs, 'publishEpochs'),
-    publisherNodeIdentityIdOverride: parsePublishUint72IdentityId(
-      raw.publisherNodeIdentityId,
-      'publisherNodeIdentityIdOverride',
-    ),
-  });
+}): FinalizedPublishOptionParseResult<KnowledgeAssetFinalizedPublishOptions> {
+  const publishEpochs = parsePublishEpochs(raw.publishEpochs, 'publishEpochs');
+  if (!publishEpochs.ok) return publishEpochs;
+  const publisherNodeIdentityIdOverride = parsePublishUint72IdentityId(
+    raw.publisherNodeIdentityId,
+    'publisherNodeIdentityIdOverride',
+  );
+  if (!publisherNodeIdentityIdOverride.ok) return publisherNodeIdentityIdOverride;
+
+  return {
+    ok: true,
+    options: {
+      ...(publishEpochs.value !== undefined ? { publishEpochs: publishEpochs.value } : {}),
+      ...(publisherNodeIdentityIdOverride.value !== undefined
+        ? { publisherNodeIdentityIdOverride: publisherNodeIdentityIdOverride.value }
+        : {}),
+    },
+  };
 }
 
-export function parseHttpFinalizedPublishOptions(raw: unknown): FinalizedPublishOptionParseResult {
+export function parseHttpFinalizedPublishOptions(
+  raw: unknown,
+): FinalizedPublishOptionParseResult<NormalizedFinalizedPublishOptions> {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ok: true, options: {} };
   const source = raw as Record<string, unknown>;
-  const hasClearAfter = source.clearAfter !== undefined;
   const hasPublishEpochs = source.publishEpochs !== undefined;
-  const clearAfter = parseClearSharedMemoryAfter(source.clearAfter, 'clearAfter');
-  const clearSharedMemoryAfter = parseClearSharedMemoryAfter(
-    source.clearSharedMemoryAfter,
-    'clearSharedMemoryAfter',
-  );
-  if (!clearAfter.ok) return clearAfter;
+  const clearSharedMemoryAfter = parseHttpClearMemoryAliases(source);
   if (!clearSharedMemoryAfter.ok) return clearSharedMemoryAfter;
+  const publishEpochs = parsePublishEpochs(
+    source.publishEpochs ?? source.epochs,
+    hasPublishEpochs ? 'publishEpochs' : 'epochs',
+  );
+  if (!publishEpochs.ok) return publishEpochs;
+  const publisherNodeIdentityIdOverride = parsePublishUint72IdentityId(
+    source.publisherNodeIdentityIdOverride,
+    'publisherNodeIdentityIdOverride',
+  );
+  if (!publisherNodeIdentityIdOverride.ok) return publisherNodeIdentityIdOverride;
 
-  return parseFinalizedPublishDomainOptions({
-    clearSharedMemoryAfter: hasClearAfter ? clearAfter : clearSharedMemoryAfter,
-    publishEpochs: parsePublishEpochs(
-      source.publishEpochs ?? source.epochs,
-      hasPublishEpochs ? 'publishEpochs' : 'epochs',
-    ),
-    publisherNodeIdentityIdOverride: parsePublishUint72IdentityId(
-      source.publisherNodeIdentityIdOverride,
-      'publisherNodeIdentityIdOverride',
-    ),
-  });
+  return {
+    ok: true,
+    options: {
+      ...(clearSharedMemoryAfter.value !== undefined
+        ? { clearSharedMemoryAfter: clearSharedMemoryAfter.value }
+        : {}),
+      ...(publishEpochs.value !== undefined ? { publishEpochs: publishEpochs.value } : {}),
+      ...(publisherNodeIdentityIdOverride.value !== undefined
+        ? { publisherNodeIdentityIdOverride: publisherNodeIdentityIdOverride.value }
+        : {}),
+    },
+  };
 }
 
 export function finalizedPublishOptionsPayload(
@@ -85,28 +102,40 @@ export function finalizedPublishOptionsPayload(
   if (!normalized.ok) {
     throw new Error(formatFinalizedPublishOptionError(normalized.error));
   }
-  return finalizedPublishDomainPayload(normalized.options);
+  return finalizedPublishSdkPayload(normalized.options);
 }
 
 function parseSdkFinalizedPublishOptions(
   options: KnowledgeAssetFinalizedPublishOptions,
-): FinalizedPublishOptionParseResult {
-  return parseFinalizedPublishDomainOptions({
-    clearSharedMemoryAfter: parseClearSharedMemoryAfter(options.clearAfter, 'clearAfter'),
-    publishEpochs: parsePublishEpochs(options.publishEpochs, 'publishEpochs'),
-    publisherNodeIdentityIdOverride: parsePublishUint72IdentityId(
-      options.publisherNodeIdentityIdOverride,
-      'publisherNodeIdentityIdOverride',
-    ),
-  });
+): FinalizedPublishOptionParseResult<KnowledgeAssetFinalizedPublishOptions> {
+  const clearAfter = parseClearSharedMemoryAfter(options.clearAfter, 'clearAfter');
+  if (!clearAfter.ok) return clearAfter;
+  const publishEpochs = parsePublishEpochs(options.publishEpochs, 'publishEpochs');
+  if (!publishEpochs.ok) return publishEpochs;
+  const publisherNodeIdentityIdOverride = parsePublishUint72IdentityId(
+    options.publisherNodeIdentityIdOverride,
+    'publisherNodeIdentityIdOverride',
+  );
+  if (!publisherNodeIdentityIdOverride.ok) return publisherNodeIdentityIdOverride;
+
+  return {
+    ok: true,
+    options: {
+      ...(clearAfter.value !== undefined ? { clearAfter: clearAfter.value } : {}),
+      ...(publishEpochs.value !== undefined ? { publishEpochs: publishEpochs.value } : {}),
+      ...(publisherNodeIdentityIdOverride.value !== undefined
+        ? { publisherNodeIdentityIdOverride: publisherNodeIdentityIdOverride.value }
+        : {}),
+    },
+  };
 }
 
-function finalizedPublishDomainPayload(
-  options: NormalizedFinalizedPublishOptions,
+function finalizedPublishSdkPayload(
+  options: KnowledgeAssetFinalizedPublishOptions,
 ): Record<string, unknown> | undefined {
   const payload: Record<string, unknown> = {};
-  if (options.clearSharedMemoryAfter !== undefined) {
-    payload.clearSharedMemoryAfter = options.clearSharedMemoryAfter;
+  if (options.clearAfter !== undefined) {
+    payload.clearSharedMemoryAfter = options.clearAfter;
   }
   if (options.publishEpochs !== undefined) {
     payload.publishEpochs = options.publishEpochs;
@@ -115,30 +144,6 @@ function finalizedPublishDomainPayload(
     payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
-}
-
-function parseFinalizedPublishDomainOptions(input: {
-  clearSharedMemoryAfter?: FinalizedPublishParsedOption<boolean>;
-  publishEpochs?: FinalizedPublishParsedOption<number>;
-  publisherNodeIdentityIdOverride?: FinalizedPublishParsedOption<bigint>;
-}): FinalizedPublishOptionParseResult {
-  const clearSharedMemoryAfter = input.clearSharedMemoryAfter ?? okValue(undefined);
-  if (!clearSharedMemoryAfter.ok) return clearSharedMemoryAfter;
-  const publishEpochs = input.publishEpochs ?? okValue(undefined);
-  if (!publishEpochs.ok) return publishEpochs;
-  const publisherNodeIdentityIdOverride = input.publisherNodeIdentityIdOverride ?? okValue(undefined);
-  if (!publisherNodeIdentityIdOverride.ok) return publisherNodeIdentityIdOverride;
-
-  return {
-    ok: true,
-    options: {
-      ...(clearSharedMemoryAfter.value !== undefined ? { clearSharedMemoryAfter: clearSharedMemoryAfter.value } : {}),
-      ...(publishEpochs.value !== undefined ? { publishEpochs: publishEpochs.value } : {}),
-      ...(publisherNodeIdentityIdOverride.value !== undefined
-        ? { publisherNodeIdentityIdOverride: publisherNodeIdentityIdOverride.value }
-        : {}),
-    },
-  };
 }
 
 export function formatFinalizedPublishOptionError(
@@ -206,6 +211,19 @@ function parseClearSharedMemoryAfter(
     return { ok: false, error: { kind: 'boolean', field } };
   }
   return okValue(value);
+}
+
+function parseHttpClearMemoryAliases(
+  source: Record<string, unknown>,
+): FinalizedPublishParsedOption<boolean> {
+  const clearAfter = parseClearSharedMemoryAfter(source.clearAfter, 'clearAfter');
+  if (!clearAfter.ok) return clearAfter;
+  const clearSharedMemoryAfter = parseClearSharedMemoryAfter(
+    source.clearSharedMemoryAfter,
+    'clearSharedMemoryAfter',
+  );
+  if (!clearSharedMemoryAfter.ok) return clearSharedMemoryAfter;
+  return source.clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
 }
 
 function parsePublishEpochs(

--- a/packages/cli/src/finalized-publish-options.ts
+++ b/packages/cli/src/finalized-publish-options.ts
@@ -24,7 +24,7 @@ export type FinalizedPublishOptionParseResult =
   | { ok: true; options: NormalizedFinalizedPublishOptions }
   | { ok: false; error: FinalizedPublishOptionParseError };
 
-const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
+const SDK_FINALIZED_PUBLISH_OPTION_KEYS = new Set([
   'clearAfter',
   'publishEpochs',
   'publisherNodeIdentityIdOverride',
@@ -32,51 +32,109 @@ const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
 
 const MAX_PUBLISH_EPOCHS = 0xffffffff;
 
+export function parseCliFinalizedPublishOptions(raw: {
+  publishEpochs?: unknown;
+  publisherNodeIdentityId?: unknown;
+}): FinalizedPublishOptionParseResult {
+  return parseFinalizedPublishDomainInput({
+    publishEpochs: raw.publishEpochs,
+    publishEpochsField: 'publishEpochs',
+    publisherNodeIdentityIdOverride: raw.publisherNodeIdentityId,
+    publisherNodeIdentityIdOverrideField: 'publisherNodeIdentityIdOverride',
+  });
+}
+
+export function parseHttpFinalizedPublishOptions(raw: unknown): FinalizedPublishOptionParseResult {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ok: true, options: {} };
+  const source = raw as Record<string, unknown>;
+  const hasClearAfter = source.clearAfter !== undefined;
+  const hasPublishEpochs = source.publishEpochs !== undefined;
+
+  return parseFinalizedPublishDomainInput({
+    clearSharedMemoryAfter: hasClearAfter ? source.clearAfter : source.clearSharedMemoryAfter,
+    clearField: hasClearAfter ? 'clearAfter' : 'clearSharedMemoryAfter',
+    publishEpochs: source.publishEpochs ?? source.epochs,
+    publishEpochsField: hasPublishEpochs ? 'publishEpochs' : 'epochs',
+    publisherNodeIdentityIdOverride: source.publisherNodeIdentityIdOverride,
+    publisherNodeIdentityIdOverrideField: 'publisherNodeIdentityIdOverride',
+  });
+}
+
 export function finalizedPublishOptionsPayload(
   options?: KnowledgeAssetFinalizedPublishOptions,
-  allowedExtraKeys: readonly string[] = [],
 ): Record<string, unknown> | undefined {
   if (!options) return undefined;
   const unsupportedKeys = Object.keys(options).filter(
-    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
+    (key) => !SDK_FINALIZED_PUBLISH_OPTION_KEYS.has(key),
   );
   if (unsupportedKeys.length > 0) {
     throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
   }
-  const normalized = normalizeFinalizedPublishOptions(options);
+  const normalized = parseSdkFinalizedPublishOptions(options);
   if (!normalized.ok) {
     throw new Error(formatFinalizedPublishOptionError(normalized.error));
   }
+  return finalizedPublishDomainPayload(normalized.options);
+}
+
+function parseSdkFinalizedPublishOptions(
+  options: KnowledgeAssetFinalizedPublishOptions,
+): FinalizedPublishOptionParseResult {
+  return parseFinalizedPublishDomainInput({
+    clearSharedMemoryAfter: options.clearAfter,
+    clearField: 'clearAfter',
+    publishEpochs: options.publishEpochs,
+    publishEpochsField: 'publishEpochs',
+    publisherNodeIdentityIdOverride: options.publisherNodeIdentityIdOverride,
+    publisherNodeIdentityIdOverrideField: 'publisherNodeIdentityIdOverride',
+  });
+}
+
+function finalizedPublishDomainPayload(
+  options: NormalizedFinalizedPublishOptions,
+): Record<string, unknown> | undefined {
   const payload: Record<string, unknown> = {};
-  if (normalized.options.clearSharedMemoryAfter !== undefined) {
-    payload.clearSharedMemoryAfter = normalized.options.clearSharedMemoryAfter;
+  if (options.clearSharedMemoryAfter !== undefined) {
+    payload.clearSharedMemoryAfter = options.clearSharedMemoryAfter;
   }
-  if (normalized.options.publishEpochs !== undefined) {
-    payload.publishEpochs = normalized.options.publishEpochs;
+  if (options.publishEpochs !== undefined) {
+    payload.publishEpochs = options.publishEpochs;
   }
-  if (normalized.options.publisherNodeIdentityIdOverride !== undefined) {
-    payload.publisherNodeIdentityIdOverride = normalized.options.publisherNodeIdentityIdOverride.toString();
+  if (options.publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride = options.publisherNodeIdentityIdOverride.toString();
   }
   return Object.keys(payload).length > 0 ? payload : undefined;
 }
 
-export function normalizeFinalizedPublishOptions(raw: unknown): FinalizedPublishOptionParseResult {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ok: true, options: {} };
-  const source = raw as Record<string, unknown>;
-  const { clearAfter, clearSharedMemoryAfter, publisherNodeIdentityIdOverride } = source;
-  const rawPublishEpochs = source.publishEpochs ?? source.epochs;
-  const publishEpochsField = source.publishEpochs !== undefined ? 'publishEpochs' : 'epochs';
+function parseFinalizedPublishDomainInput(input: {
+  clearSharedMemoryAfter?: unknown;
+  clearField?: string;
+  publishEpochs?: unknown;
+  publishEpochsField?: string;
+  publisherNodeIdentityIdOverride?: unknown;
+  publisherNodeIdentityIdOverrideField?: string;
+}): FinalizedPublishOptionParseResult {
+  const {
+    clearSharedMemoryAfter,
+    publisherNodeIdentityIdOverride,
+    publisherNodeIdentityIdOverrideField = 'publisherNodeIdentityIdOverride',
+  } = input;
+  const clearField = input.clearField ?? 'clearSharedMemoryAfter';
+  const publishEpochsField = input.publishEpochsField ?? 'publishEpochs';
 
   let resolvedPublisherIdentityOverride: bigint | undefined;
   if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
-    const parsed = parsePublishUint72IdentityId(publisherNodeIdentityIdOverride, 'publisherNodeIdentityIdOverride');
+    const parsed = parsePublishUint72IdentityId(
+      publisherNodeIdentityIdOverride,
+      publisherNodeIdentityIdOverrideField,
+    );
     if (!parsed.ok) return parsed;
     resolvedPublisherIdentityOverride = parsed.value;
   }
 
   let resolvedPublishEpochs: number | undefined;
-  if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
-    const v = publishIntegerString(rawPublishEpochs, publishEpochsField, true);
+  if (input.publishEpochs !== undefined && input.publishEpochs !== null) {
+    const v = publishIntegerString(input.publishEpochs, publishEpochsField, true);
     if (!v.ok) return v;
     const n = Number(v.value);
     if (!Number.isSafeInteger(n)) {
@@ -88,18 +146,14 @@ export function normalizeFinalizedPublishOptions(raw: unknown): FinalizedPublish
     resolvedPublishEpochs = n;
   }
 
-  if (clearAfter !== undefined && typeof clearAfter !== 'boolean') {
-    return { ok: false, error: { kind: 'boolean', field: 'clearAfter' } };
-  }
   if (clearSharedMemoryAfter !== undefined && typeof clearSharedMemoryAfter !== 'boolean') {
-    return { ok: false, error: { kind: 'boolean', field: 'clearSharedMemoryAfter' } };
+    return { ok: false, error: { kind: 'boolean', field: clearField } };
   }
 
-  const clearValue = clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
   return {
     ok: true,
     options: {
-      ...(clearValue !== undefined ? { clearSharedMemoryAfter: clearValue } : {}),
+      ...(clearSharedMemoryAfter !== undefined ? { clearSharedMemoryAfter } : {}),
       ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
       ...(resolvedPublisherIdentityOverride !== undefined
         ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }

--- a/packages/cli/src/finalized-publish-options.ts
+++ b/packages/cli/src/finalized-publish-options.ts
@@ -55,6 +55,8 @@ export function parseHttpFinalizedPublishOptions(raw: unknown): FinalizedPublish
     source.clearSharedMemoryAfter,
     'clearSharedMemoryAfter',
   );
+  if (!clearAfter.ok) return clearAfter;
+  if (!clearSharedMemoryAfter.ok) return clearSharedMemoryAfter;
 
   return parseFinalizedPublishDomainOptions({
     clearSharedMemoryAfter: hasClearAfter ? clearAfter : clearSharedMemoryAfter,

--- a/packages/cli/src/finalized-publish-options.ts
+++ b/packages/cli/src/finalized-publish-options.ts
@@ -36,11 +36,12 @@ export function parseCliFinalizedPublishOptions(raw: {
   publishEpochs?: unknown;
   publisherNodeIdentityId?: unknown;
 }): FinalizedPublishOptionParseResult {
-  return parseFinalizedPublishDomainInput({
-    publishEpochs: raw.publishEpochs,
-    publishEpochsField: 'publishEpochs',
-    publisherNodeIdentityIdOverride: raw.publisherNodeIdentityId,
-    publisherNodeIdentityIdOverrideField: 'publisherNodeIdentityIdOverride',
+  return parseFinalizedPublishDomainOptions({
+    publishEpochs: parsePublishEpochs(raw.publishEpochs, 'publishEpochs'),
+    publisherNodeIdentityIdOverride: parsePublishUint72IdentityId(
+      raw.publisherNodeIdentityId,
+      'publisherNodeIdentityIdOverride',
+    ),
   });
 }
 
@@ -49,14 +50,22 @@ export function parseHttpFinalizedPublishOptions(raw: unknown): FinalizedPublish
   const source = raw as Record<string, unknown>;
   const hasClearAfter = source.clearAfter !== undefined;
   const hasPublishEpochs = source.publishEpochs !== undefined;
+  const clearAfter = parseClearSharedMemoryAfter(source.clearAfter, 'clearAfter');
+  const clearSharedMemoryAfter = parseClearSharedMemoryAfter(
+    source.clearSharedMemoryAfter,
+    'clearSharedMemoryAfter',
+  );
 
-  return parseFinalizedPublishDomainInput({
-    clearSharedMemoryAfter: hasClearAfter ? source.clearAfter : source.clearSharedMemoryAfter,
-    clearField: hasClearAfter ? 'clearAfter' : 'clearSharedMemoryAfter',
-    publishEpochs: source.publishEpochs ?? source.epochs,
-    publishEpochsField: hasPublishEpochs ? 'publishEpochs' : 'epochs',
-    publisherNodeIdentityIdOverride: source.publisherNodeIdentityIdOverride,
-    publisherNodeIdentityIdOverrideField: 'publisherNodeIdentityIdOverride',
+  return parseFinalizedPublishDomainOptions({
+    clearSharedMemoryAfter: hasClearAfter ? clearAfter : clearSharedMemoryAfter,
+    publishEpochs: parsePublishEpochs(
+      source.publishEpochs ?? source.epochs,
+      hasPublishEpochs ? 'publishEpochs' : 'epochs',
+    ),
+    publisherNodeIdentityIdOverride: parsePublishUint72IdentityId(
+      source.publisherNodeIdentityIdOverride,
+      'publisherNodeIdentityIdOverride',
+    ),
   });
 }
 
@@ -80,13 +89,13 @@ export function finalizedPublishOptionsPayload(
 function parseSdkFinalizedPublishOptions(
   options: KnowledgeAssetFinalizedPublishOptions,
 ): FinalizedPublishOptionParseResult {
-  return parseFinalizedPublishDomainInput({
-    clearSharedMemoryAfter: options.clearAfter,
-    clearField: 'clearAfter',
-    publishEpochs: options.publishEpochs,
-    publishEpochsField: 'publishEpochs',
-    publisherNodeIdentityIdOverride: options.publisherNodeIdentityIdOverride,
-    publisherNodeIdentityIdOverrideField: 'publisherNodeIdentityIdOverride',
+  return parseFinalizedPublishDomainOptions({
+    clearSharedMemoryAfter: parseClearSharedMemoryAfter(options.clearAfter, 'clearAfter'),
+    publishEpochs: parsePublishEpochs(options.publishEpochs, 'publishEpochs'),
+    publisherNodeIdentityIdOverride: parsePublishUint72IdentityId(
+      options.publisherNodeIdentityIdOverride,
+      'publisherNodeIdentityIdOverride',
+    ),
   });
 }
 
@@ -106,57 +115,25 @@ function finalizedPublishDomainPayload(
   return Object.keys(payload).length > 0 ? payload : undefined;
 }
 
-function parseFinalizedPublishDomainInput(input: {
-  clearSharedMemoryAfter?: unknown;
-  clearField?: string;
-  publishEpochs?: unknown;
-  publishEpochsField?: string;
-  publisherNodeIdentityIdOverride?: unknown;
-  publisherNodeIdentityIdOverrideField?: string;
+function parseFinalizedPublishDomainOptions(input: {
+  clearSharedMemoryAfter?: FinalizedPublishParsedOption<boolean>;
+  publishEpochs?: FinalizedPublishParsedOption<number>;
+  publisherNodeIdentityIdOverride?: FinalizedPublishParsedOption<bigint>;
 }): FinalizedPublishOptionParseResult {
-  const {
-    clearSharedMemoryAfter,
-    publisherNodeIdentityIdOverride,
-    publisherNodeIdentityIdOverrideField = 'publisherNodeIdentityIdOverride',
-  } = input;
-  const clearField = input.clearField ?? 'clearSharedMemoryAfter';
-  const publishEpochsField = input.publishEpochsField ?? 'publishEpochs';
-
-  let resolvedPublisherIdentityOverride: bigint | undefined;
-  if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
-    const parsed = parsePublishUint72IdentityId(
-      publisherNodeIdentityIdOverride,
-      publisherNodeIdentityIdOverrideField,
-    );
-    if (!parsed.ok) return parsed;
-    resolvedPublisherIdentityOverride = parsed.value;
-  }
-
-  let resolvedPublishEpochs: number | undefined;
-  if (input.publishEpochs !== undefined && input.publishEpochs !== null) {
-    const v = publishIntegerString(input.publishEpochs, publishEpochsField, true);
-    if (!v.ok) return v;
-    const n = Number(v.value);
-    if (!Number.isSafeInteger(n)) {
-      return { ok: false, error: { kind: 'number-too-large', field: publishEpochsField } };
-    }
-    if (n > MAX_PUBLISH_EPOCHS) {
-      return { ok: false, error: { kind: 'max', field: publishEpochsField, max: MAX_PUBLISH_EPOCHS } };
-    }
-    resolvedPublishEpochs = n;
-  }
-
-  if (clearSharedMemoryAfter !== undefined && typeof clearSharedMemoryAfter !== 'boolean') {
-    return { ok: false, error: { kind: 'boolean', field: clearField } };
-  }
+  const clearSharedMemoryAfter = input.clearSharedMemoryAfter ?? okValue(undefined);
+  if (!clearSharedMemoryAfter.ok) return clearSharedMemoryAfter;
+  const publishEpochs = input.publishEpochs ?? okValue(undefined);
+  if (!publishEpochs.ok) return publishEpochs;
+  const publisherNodeIdentityIdOverride = input.publisherNodeIdentityIdOverride ?? okValue(undefined);
+  if (!publisherNodeIdentityIdOverride.ok) return publisherNodeIdentityIdOverride;
 
   return {
     ok: true,
     options: {
-      ...(clearSharedMemoryAfter !== undefined ? { clearSharedMemoryAfter } : {}),
-      ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
-      ...(resolvedPublisherIdentityOverride !== undefined
-        ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+      ...(clearSharedMemoryAfter.value !== undefined ? { clearSharedMemoryAfter: clearSharedMemoryAfter.value } : {}),
+      ...(publishEpochs.value !== undefined ? { publishEpochs: publishEpochs.value } : {}),
+      ...(publisherNodeIdentityIdOverride.value !== undefined
+        ? { publisherNodeIdentityIdOverride: publisherNodeIdentityIdOverride.value }
         : {}),
     },
   };
@@ -210,10 +187,47 @@ function publishIntegerString(
   return { ok: true, value: v };
 }
 
+type FinalizedPublishParsedOption<T> =
+  | { ok: true; value: T | undefined }
+  | { ok: false; error: FinalizedPublishOptionParseError };
+
+function okValue<T>(value: T | undefined): FinalizedPublishParsedOption<T> {
+  return { ok: true, value };
+}
+
+function parseClearSharedMemoryAfter(
+  value: unknown,
+  field: string,
+): FinalizedPublishParsedOption<boolean> {
+  if (value === undefined) return okValue(undefined);
+  if (typeof value !== 'boolean') {
+    return { ok: false, error: { kind: 'boolean', field } };
+  }
+  return okValue(value);
+}
+
+function parsePublishEpochs(
+  value: unknown,
+  field: string,
+): FinalizedPublishParsedOption<number> {
+  if (value === undefined || value === null) return okValue(undefined);
+  const v = publishIntegerString(value, field, true);
+  if (!v.ok) return v;
+  const n = Number(v.value);
+  if (!Number.isSafeInteger(n)) {
+    return { ok: false, error: { kind: 'number-too-large', field } };
+  }
+  if (n > MAX_PUBLISH_EPOCHS) {
+    return { ok: false, error: { kind: 'max', field, max: MAX_PUBLISH_EPOCHS } };
+  }
+  return okValue(n);
+}
+
 function parsePublishUint72IdentityId(
   value: unknown,
   field: string,
-): { ok: true; value: bigint } | { ok: false; error: FinalizedPublishOptionParseError } {
+): FinalizedPublishParsedOption<bigint> {
+  if (value === undefined || value === null) return okValue(undefined);
   const v = publishIntegerString(value, field, false);
   if (!v.ok) return v;
   const parsed = parseUint72Decimal(v.value);
@@ -223,5 +237,5 @@ function parsePublishUint72IdentityId(
       error: { kind: parsed.reason === 'range' ? 'uint72' : 'integer', field, positive: false },
     };
   }
-  return { ok: true, value: parsed.value };
+  return okValue(parsed.value);
 }

--- a/packages/cli/src/finalized-publish-options.ts
+++ b/packages/cli/src/finalized-publish-options.ts
@@ -1,0 +1,173 @@
+import { MAX_UINT72_DECIMAL, parseUint72Decimal } from './protocol-limits.js';
+
+export interface KnowledgeAssetFinalizedPublishOptions {
+  clearAfter?: boolean;
+  publishEpochs?: number;
+  publisherNodeIdentityIdOverride?: bigint;
+}
+
+export interface NormalizedFinalizedPublishOptions {
+  clearSharedMemoryAfter?: boolean;
+  publishEpochs?: number;
+  publisherNodeIdentityIdOverride?: bigint;
+}
+
+export type FinalizedPublishOptionParseError =
+  | { kind: 'integer'; field: string; positive: boolean }
+  | { kind: 'safe-integer'; field: string; positive: boolean }
+  | { kind: 'number-too-large'; field: string }
+  | { kind: 'max'; field: string; max: number }
+  | { kind: 'uint72'; field: string }
+  | { kind: 'boolean'; field: string };
+
+export type FinalizedPublishOptionParseResult =
+  | { ok: true; options: NormalizedFinalizedPublishOptions }
+  | { ok: false; error: FinalizedPublishOptionParseError };
+
+const FINALIZED_PUBLISH_OPTION_KEYS = new Set([
+  'clearAfter',
+  'publishEpochs',
+  'publisherNodeIdentityIdOverride',
+]);
+
+const MAX_PUBLISH_EPOCHS = 0xffffffff;
+
+export function finalizedPublishOptionsPayload(
+  options?: KnowledgeAssetFinalizedPublishOptions,
+  allowedExtraKeys: readonly string[] = [],
+): Record<string, unknown> | undefined {
+  if (!options) return undefined;
+  const unsupportedKeys = Object.keys(options).filter(
+    (key) => !FINALIZED_PUBLISH_OPTION_KEYS.has(key) && !allowedExtraKeys.includes(key),
+  );
+  if (unsupportedKeys.length > 0) {
+    throw new Error(`Unsupported finalized publish option(s): ${unsupportedKeys.join(', ')}`);
+  }
+  const normalized = normalizeFinalizedPublishOptions(options);
+  if (!normalized.ok) {
+    throw new Error(formatFinalizedPublishOptionError(normalized.error));
+  }
+  const payload: Record<string, unknown> = {};
+  if (normalized.options.clearSharedMemoryAfter !== undefined) {
+    payload.clearSharedMemoryAfter = normalized.options.clearSharedMemoryAfter;
+  }
+  if (normalized.options.publishEpochs !== undefined) {
+    payload.publishEpochs = normalized.options.publishEpochs;
+  }
+  if (normalized.options.publisherNodeIdentityIdOverride !== undefined) {
+    payload.publisherNodeIdentityIdOverride = normalized.options.publisherNodeIdentityIdOverride.toString();
+  }
+  return Object.keys(payload).length > 0 ? payload : undefined;
+}
+
+export function normalizeFinalizedPublishOptions(raw: unknown): FinalizedPublishOptionParseResult {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ok: true, options: {} };
+  const source = raw as Record<string, unknown>;
+  const { clearAfter, clearSharedMemoryAfter, publisherNodeIdentityIdOverride } = source;
+  const rawPublishEpochs = source.publishEpochs ?? source.epochs;
+  const publishEpochsField = source.publishEpochs !== undefined ? 'publishEpochs' : 'epochs';
+
+  let resolvedPublisherIdentityOverride: bigint | undefined;
+  if (publisherNodeIdentityIdOverride !== undefined && publisherNodeIdentityIdOverride !== null) {
+    const parsed = parsePublishUint72IdentityId(publisherNodeIdentityIdOverride, 'publisherNodeIdentityIdOverride');
+    if (!parsed.ok) return parsed;
+    resolvedPublisherIdentityOverride = parsed.value;
+  }
+
+  let resolvedPublishEpochs: number | undefined;
+  if (rawPublishEpochs !== undefined && rawPublishEpochs !== null) {
+    const v = publishIntegerString(rawPublishEpochs, publishEpochsField, true);
+    if (!v.ok) return v;
+    const n = Number(v.value);
+    if (!Number.isSafeInteger(n)) {
+      return { ok: false, error: { kind: 'number-too-large', field: publishEpochsField } };
+    }
+    if (n > MAX_PUBLISH_EPOCHS) {
+      return { ok: false, error: { kind: 'max', field: publishEpochsField, max: MAX_PUBLISH_EPOCHS } };
+    }
+    resolvedPublishEpochs = n;
+  }
+
+  if (clearAfter !== undefined && typeof clearAfter !== 'boolean') {
+    return { ok: false, error: { kind: 'boolean', field: 'clearAfter' } };
+  }
+  if (clearSharedMemoryAfter !== undefined && typeof clearSharedMemoryAfter !== 'boolean') {
+    return { ok: false, error: { kind: 'boolean', field: 'clearSharedMemoryAfter' } };
+  }
+
+  const clearValue = clearAfter !== undefined ? clearAfter : clearSharedMemoryAfter;
+  return {
+    ok: true,
+    options: {
+      ...(clearValue !== undefined ? { clearSharedMemoryAfter: clearValue } : {}),
+      ...(resolvedPublishEpochs !== undefined ? { publishEpochs: resolvedPublishEpochs } : {}),
+      ...(resolvedPublisherIdentityOverride !== undefined
+        ? { publisherNodeIdentityIdOverride: resolvedPublisherIdentityOverride }
+        : {}),
+    },
+  };
+}
+
+export function formatFinalizedPublishOptionError(
+  error: FinalizedPublishOptionParseError,
+  labels: Partial<Record<string, string>> = {},
+  opts: { quoteField?: boolean } = {},
+): string {
+  const label = labels[error.field] ?? error.field;
+  const field = opts.quoteField === false ? label : `"${label}"`;
+  switch (error.kind) {
+    case 'integer':
+      return `${field} must be a ${error.positive ? 'positive ' : 'non-negative '}integer (string or number)`;
+    case 'safe-integer':
+      return `${field} must be a ${error.positive ? 'positive ' : 'non-negative '}safe integer (string or number)`;
+    case 'number-too-large':
+      return `${field} is too large to safely represent as a JavaScript integer`;
+    case 'max':
+      return `${field} must be less than or equal to ${error.max}`;
+    case 'uint72':
+      return `${field} must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)`;
+    case 'boolean':
+      return `${field} must be a boolean when supplied`;
+  }
+}
+
+function publishIntegerString(
+  value: unknown,
+  field: string,
+  positive: boolean,
+): { ok: true; value: string } | { ok: false; error: FinalizedPublishOptionParseError } {
+  if (typeof value === 'bigint') {
+    if (positive ? value <= 0n : value < 0n) {
+      return { ok: false, error: { kind: 'integer', field, positive } };
+    }
+    return { ok: true, value: value.toString() };
+  }
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return { ok: false, error: { kind: 'integer', field, positive } };
+  }
+  if (typeof value === 'number' && (!Number.isSafeInteger(value) || (positive ? value <= 0 : value < 0))) {
+    return { ok: false, error: { kind: 'safe-integer', field, positive } };
+  }
+  const v = typeof value === 'string' ? value.trim() : String(value);
+  const pattern = positive ? /^[1-9]\d*$/ : /^\d+$/;
+  if (!pattern.test(v)) {
+    return { ok: false, error: { kind: 'integer', field, positive } };
+  }
+  return { ok: true, value: v };
+}
+
+function parsePublishUint72IdentityId(
+  value: unknown,
+  field: string,
+): { ok: true; value: bigint } | { ok: false; error: FinalizedPublishOptionParseError } {
+  const v = publishIntegerString(value, field, false);
+  if (!v.ok) return v;
+  const parsed = parseUint72Decimal(v.value);
+  if (!parsed.ok) {
+    return {
+      ok: false,
+      error: { kind: parsed.reason === 'range' ? 'uint72' : 'integer', field, positive: false },
+    };
+  }
+  return { ok: true, value: parsed.value };
+}

--- a/packages/cli/src/protocol-limits.ts
+++ b/packages/cli/src/protocol-limits.ts
@@ -1,0 +1,2 @@
+export const MAX_UINT72 = (1n << 72n) - 1n;
+export const MAX_UINT72_DECIMAL = MAX_UINT72.toString();

--- a/packages/cli/src/protocol-limits.ts
+++ b/packages/cli/src/protocol-limits.ts
@@ -1,2 +1,23 @@
 export const MAX_UINT72 = (1n << 72n) - 1n;
 export const MAX_UINT72_DECIMAL = MAX_UINT72.toString();
+
+export type Uint72DecimalParseResult =
+  | { ok: true; value: bigint }
+  | { ok: false; reason: 'format' | 'range' | 'parse'; message?: string };
+
+export function parseUint72Decimal(raw: string): Uint72DecimalParseResult {
+  const value = raw.trim();
+  if (!/^\d+$/.test(value)) {
+    return { ok: false, reason: 'format' };
+  }
+  let parsed: bigint;
+  try {
+    parsed = BigInt(value);
+  } catch (e: any) {
+    return { ok: false, reason: 'parse', message: e?.message ?? String(e) };
+  }
+  if (parsed > MAX_UINT72) {
+    return { ok: false, reason: 'range' };
+  }
+  return { ok: true, value: parsed };
+}

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -11,7 +11,13 @@ export interface PublisherRuntime {
   readonly runner: AsyncLiftRunner;
   readonly publisher: AsyncLiftPublisher;
   readonly walletIds: string[];
+  readonly walletIdentities: readonly PublisherWalletIdentity[];
   readonly stop: () => Promise<void>;
+}
+
+export interface PublisherWalletIdentity {
+  readonly address: string;
+  readonly identityId: bigint;
 }
 
 export interface PublisherInspector {
@@ -70,6 +76,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
       knowledgeAssetVmPublishPreflight: args.knowledgeAssetVmPublishPreflight,
     });
     await runtime.runner.start();
+    logPublisherWalletAttribution(runtime.walletIdentities, args.log);
     args.log(`Async publisher runner started (${runtime.walletIds.length} wallet${runtime.walletIds.length === 1 ? '' : 's'})`);
     return runtime;
   } catch (err: any) {
@@ -221,8 +228,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
 
   const eventBus = new TypedEventBus();
   const publishers = new Map<string, DKGPublisher>();
-  const attributedWallets: string[] = [];
-  const noAttributionWallets: string[] = [];
+  const walletIdentities: PublisherWalletIdentity[] = [];
 
   for (const wallet of publisherWallets.wallets) {
     const chain = args.chainBase
@@ -237,11 +243,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         })
       : new NoChainAdapter();
     const identityId = await chain.getIdentityId();
-    if (identityId === 0n) {
-      noAttributionWallets.push(wallet.address);
-    } else {
-      attributedWallets.push(`${wallet.address} (identityId=${identityId.toString()})`);
-    }
+    walletIdentities.push({ address: wallet.address, identityId });
     publishers.set(
       wallet.address,
       new DKGPublisher({
@@ -253,20 +255,6 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         publisherPrivateKey: wallet.privateKey,
         publicSnapshotStore: args.publicSnapshotStore,
       }),
-    );
-  }
-
-  if (attributedWallets.length > 0) {
-    const verb = attributedWallets.length === 1 ? 'has' : 'have';
-    console.info(
-      `[publisher] ${attributedWallets.length} publisher wallet${attributedWallets.length === 1 ? '' : 's'} ` +
-      `${verb} node attribution: ${attributedWallets.join(', ')}`,
-    );
-  }
-  if (noAttributionWallets.length > 0) {
-    console.info(
-      `[publisher] ${noAttributionWallets.length} publisher wallet${noAttributionWallets.length === 1 ? '' : 's'} ` +
-      `will publish in no-attribution mode (identityId=0): ${noAttributionWallets.join(', ')}`,
     );
   }
 
@@ -351,6 +339,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
     runner,
     publisher: asyncPublisher,
     walletIds: validWalletIds,
+    walletIdentities,
     stop: async () => {
       await runner.stop();
       if (args.closeStoreOnStop) {
@@ -358,6 +347,32 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
       }
     },
   };
+}
+
+function logPublisherWalletAttribution(
+  walletIdentities: readonly PublisherWalletIdentity[],
+  log: (message: string) => void,
+): void {
+  const attributedWallets = walletIdentities
+    .filter((wallet) => wallet.identityId !== 0n)
+    .map((wallet) => `${wallet.address} (identityId=${wallet.identityId.toString()})`);
+  const noAttributionWallets = walletIdentities
+    .filter((wallet) => wallet.identityId === 0n)
+    .map((wallet) => wallet.address);
+
+  if (attributedWallets.length > 0) {
+    const verb = attributedWallets.length === 1 ? 'has' : 'have';
+    log(
+      `[publisher] ${attributedWallets.length} publisher wallet${attributedWallets.length === 1 ? '' : 's'} ` +
+      `${verb} node attribution: ${attributedWallets.join(', ')}`,
+    );
+  }
+  if (noAttributionWallets.length > 0) {
+    log(
+      `[publisher] ${noAttributionWallets.length} publisher wallet${noAttributionWallets.length === 1 ? '' : 's'} ` +
+      `will publish in no-attribution mode (identityId=0): ${noAttributionWallets.join(', ')}`,
+    );
+  }
 }
 
 function createV10ACKProviderForPublisher(
@@ -533,22 +548,6 @@ function createChainRecoveryResolver(
       },
     };
   };
-}
-
-export function parsePositiveMsOption(value: string, optionName: '--poll-interval' | '--error-backoff'): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    throw new Error(`${optionName} must be a positive integer in milliseconds`);
-  }
-  return parsed;
-}
-
-export function parsePositiveIntegerOption(value: string, optionName: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    throw new Error(`${optionName} must be a positive integer`);
-  }
-  return parsed;
 }
 
 async function createPublisherStore(dataDir: string, config: DkgConfig): Promise<TripleStore> {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -18,7 +18,6 @@ export interface PublisherRuntime {
 export interface PublisherRuntimeWallet {
   readonly address: string;
   readonly identityId: bigint;
-  readonly publisher: DKGPublisher;
 }
 
 export interface PublisherInspector {
@@ -38,6 +37,10 @@ type PublishEncryptionFactory = (publishOptions: PublishOptions) =>
   | Promise<Pick<PublishOptions, 'encryptInlinePayload' | 'encryptInlineChunked'> | undefined>
   | Pick<PublishOptions, 'encryptInlinePayload' | 'encryptInlineChunked'>
   | undefined;
+
+interface ConfiguredPublisherWallet extends PublisherRuntimeWallet {
+  readonly publisher: DKGPublisher;
+}
 
 export async function startPublisherRuntimeIfEnabled(args: {
   dataDir: string;
@@ -228,7 +231,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
   }
 
   const eventBus = new TypedEventBus();
-  const wallets: PublisherRuntimeWallet[] = [];
+  const wallets: ConfiguredPublisherWallet[] = [];
 
   for (const wallet of publisherWallets.wallets) {
     const chain = args.chainBase
@@ -342,7 +345,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
     runner,
     publisher: asyncPublisher,
     walletIds: validWalletIds,
-    wallets,
+    wallets: wallets.map(({ address, identityId }) => ({ address, identityId })),
     stop: async () => {
       await runner.stop();
       if (args.closeStoreOnStop) {

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -551,14 +551,6 @@ export function parsePositiveIntegerOption(value: string, optionName: string): n
   return parsed;
 }
 
-export function parseNonNegativeBigIntOption(value: string, optionName: string): bigint {
-  const normalized = value.trim();
-  if (!/^\d+$/.test(normalized)) {
-    throw new Error(`${optionName} must be a non-negative integer`);
-  }
-  return BigInt(normalized);
-}
-
 async function createPublisherStore(dataDir: string, config: DkgConfig): Promise<TripleStore> {
   if (config.store) {
     const storeConfig = config.store as any;

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -11,13 +11,14 @@ export interface PublisherRuntime {
   readonly runner: AsyncLiftRunner;
   readonly publisher: AsyncLiftPublisher;
   readonly walletIds: string[];
-  readonly walletIdentities: readonly PublisherWalletIdentity[];
+  readonly wallets: readonly PublisherRuntimeWallet[];
   readonly stop: () => Promise<void>;
 }
 
-export interface PublisherWalletIdentity {
+export interface PublisherRuntimeWallet {
   readonly address: string;
   readonly identityId: bigint;
+  readonly publisher: DKGPublisher;
 }
 
 export interface PublisherInspector {
@@ -76,7 +77,7 @@ export async function startPublisherRuntimeIfEnabled(args: {
       knowledgeAssetVmPublishPreflight: args.knowledgeAssetVmPublishPreflight,
     });
     await runtime.runner.start();
-    logPublisherWalletAttribution(runtime.walletIdentities, args.log);
+    logPublisherWalletAttribution(runtime.wallets, args.log);
     args.log(`Async publisher runner started (${runtime.walletIds.length} wallet${runtime.walletIds.length === 1 ? '' : 's'})`);
     return runtime;
   } catch (err: any) {
@@ -227,8 +228,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
   }
 
   const eventBus = new TypedEventBus();
-  const publishers = new Map<string, DKGPublisher>();
-  const walletIdentities: PublisherWalletIdentity[] = [];
+  const wallets: PublisherRuntimeWallet[] = [];
 
   for (const wallet of publisherWallets.wallets) {
     const chain = args.chainBase
@@ -243,10 +243,10 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         })
       : new NoChainAdapter();
     const identityId = await chain.getIdentityId();
-    walletIdentities.push({ address: wallet.address, identityId });
-    publishers.set(
-      wallet.address,
-      new DKGPublisher({
+    wallets.push({
+      address: wallet.address,
+      identityId,
+      publisher: new DKGPublisher({
         store: args.store,
         chain,
         eventBus,
@@ -255,9 +255,12 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         publisherPrivateKey: wallet.privateKey,
         publicSnapshotStore: args.publicSnapshotStore,
       }),
-    );
+    });
   }
 
+  const publishers = new Map<string, DKGPublisher>(
+    wallets.map((wallet) => [wallet.address, wallet.publisher]),
+  );
   const hasChainRecovery = [...publishers.values()].some((p) => {
     const chain = (p as unknown as { chain?: { resolvePublishByTxHash?: unknown } }).chain;
     return typeof chain?.resolvePublishByTxHash === 'function';
@@ -339,7 +342,7 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
     runner,
     publisher: asyncPublisher,
     walletIds: validWalletIds,
-    walletIdentities,
+    wallets,
     stop: async () => {
       await runner.stop();
       if (args.closeStoreOnStop) {
@@ -350,13 +353,13 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
 }
 
 function logPublisherWalletAttribution(
-  walletIdentities: readonly PublisherWalletIdentity[],
+  wallets: readonly PublisherRuntimeWallet[],
   log: (message: string) => void,
 ): void {
-  const attributedWallets = walletIdentities
+  const attributedWallets = wallets
     .filter((wallet) => wallet.identityId !== 0n)
     .map((wallet) => `${wallet.address} (identityId=${wallet.identityId.toString()})`);
-  const noAttributionWallets = walletIdentities
+  const noAttributionWallets = wallets
     .filter((wallet) => wallet.identityId === 0n)
     .map((wallet) => wallet.address);
 

--- a/packages/cli/src/publisher-runner.ts
+++ b/packages/cli/src/publisher-runner.ts
@@ -221,7 +221,8 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
 
   const eventBus = new TypedEventBus();
   const publishers = new Map<string, DKGPublisher>();
-  const invalidWallets: string[] = [];
+  const attributedWallets: string[] = [];
+  const noAttributionWallets: string[] = [];
 
   for (const wallet of publisherWallets.wallets) {
     const chain = args.chainBase
@@ -236,9 +237,10 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
         })
       : new NoChainAdapter();
     const identityId = await chain.getIdentityId();
-    if (args.chainBase && identityId === 0n) {
-      invalidWallets.push(wallet.address);
-      continue;
+    if (identityId === 0n) {
+      noAttributionWallets.push(wallet.address);
+    } else {
+      attributedWallets.push(`${wallet.address} (identityId=${identityId.toString()})`);
     }
     publishers.set(
       wallet.address,
@@ -254,18 +256,17 @@ async function createPublisherRuntimeFromBase(args: PublisherRuntimeBaseArgs): P
     );
   }
 
-  if (invalidWallets.length > 0) {
-    if (publishers.size === 0) {
-      const noun = invalidWallets.length === 1 ? 'wallet is' : 'wallets are';
-      throw new Error(
-        `Publisher startup blocked: the following publisher ${noun} missing an on-chain identity: ${invalidWallets.join(', ')}. ` +
-        'Provision an on-chain profile/identity for each publisher wallet before enabling the async publisher, or remove it from publisher-wallets.json.',
-      );
-    }
-    const noun = invalidWallets.length === 1 ? 'wallet' : 'wallets';
-    console.warn(
-      `[publisher] Skipping ${invalidWallets.length} ${noun} missing on-chain identity: ${invalidWallets.join(', ')}. ` +
-      `Continuing with ${publishers.size} valid wallet(s).`,
+  if (attributedWallets.length > 0) {
+    const verb = attributedWallets.length === 1 ? 'has' : 'have';
+    console.info(
+      `[publisher] ${attributedWallets.length} publisher wallet${attributedWallets.length === 1 ? '' : 's'} ` +
+      `${verb} node attribution: ${attributedWallets.join(', ')}`,
+    );
+  }
+  if (noAttributionWallets.length > 0) {
+    console.info(
+      `[publisher] ${noAttributionWallets.length} publisher wallet${noAttributionWallets.length === 1 ? '' : 's'} ` +
+      `will publish in no-attribution mode (identityId=0): ${noAttributionWallets.join(', ')}`,
     );
   }
 
@@ -548,6 +549,14 @@ export function parsePositiveIntegerOption(value: string, optionName: string): n
     throw new Error(`${optionName} must be a positive integer`);
   }
   return parsed;
+}
+
+export function parseNonNegativeBigIntOption(value: string, optionName: string): bigint {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`${optionName} must be a non-negative integer`);
+  }
+  return BigInt(normalized);
 }
 
 async function createPublisherStore(dataDir: string, config: DkgConfig): Promise<TripleStore> {

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { ApiClient } from '../src/api-client.js';
+import type { KnowledgeAssetFinalizedPublishOptions } from '../src/api-client.js';
 
 const PORT = 8899;
 const originalDkgHome = process.env.DKG_HOME;
@@ -67,6 +68,20 @@ describe('ApiClient', () => {
   let client: ApiClient;
   const originalFetch = globalThis.fetch;
   let tempDir: string;
+
+  it('keeps finalized publish option types importable from api-client', () => {
+    const options: KnowledgeAssetFinalizedPublishOptions = {
+      clearAfter: true,
+      publishEpochs: 1,
+      publisherNodeIdentityIdOverride: 0n,
+    };
+
+    expect(options).toMatchObject({
+      clearAfter: true,
+      publishEpochs: 1,
+      publisherNodeIdentityIdOverride: 0n,
+    });
+  });
 
   beforeEach(async () => {
     client = new ApiClient(PORT, 'test-token');

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -692,6 +692,17 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(calls).toHaveLength(0);
   });
 
+  it('createKnowledgeAsset rejects daemon-only alsoPublishVm aliases before HTTP serialization', async () => {
+    const calls = track({ ok: true });
+    await expect(client.createKnowledgeAsset('cg', 'f', {
+      alsoPublishVm: { epochs: 3 },
+    } as any)).rejects.toThrow('Unsupported finalized publish option(s): epochs');
+    await expect(client.createKnowledgeAsset('cg', 'f', {
+      alsoPublishVm: { clearSharedMemoryAfter: true },
+    } as any)).rejects.toThrow('Unsupported finalized publish option(s): clearSharedMemoryAfter');
+    expect(calls).toHaveLength(0);
+  });
+
   it('createKnowledgeAsset rejects array alsoPublishVm before HTTP serialization', async () => {
     const calls = track({ ok: true });
     await expect(client.createKnowledgeAsset('cg', 'f', {
@@ -766,7 +777,8 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
       publisherNodeIdentityIdOverride: 123n,
     });
     expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/vm/publish`);
-    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({
+    const publishBody = JSON.parse(calls[0].opts.body as string);
+    expect(publishBody).toMatchObject({
       contextGraphId: 'cg',
       subGraphName: 'notes',
       options: {
@@ -775,6 +787,7 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
         publisherNodeIdentityIdOverride: '123',
       },
     });
+    expect(publishBody.options).not.toHaveProperty('subGraphName');
 
     calls = track({ jobId: 'job-1', status: 'accepted' });
     await client.knowledgeAssetPublishAsync('cg', 'f', {
@@ -784,7 +797,8 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
       publisherNodeIdentityIdOverride: 123n,
     });
     expect(calls[0].url).toBe(`${base}/api/knowledge-assets/f/vm/publish-async`);
-    expect(JSON.parse(calls[0].opts.body as string)).toMatchObject({
+    const publishAsyncBody = JSON.parse(calls[0].opts.body as string);
+    expect(publishAsyncBody).toMatchObject({
       contextGraphId: 'cg',
       subGraphName: 'notes',
       options: {
@@ -793,6 +807,7 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
         publisherNodeIdentityIdOverride: '123',
       },
     });
+    expect(publishAsyncBody.options).not.toHaveProperty('subGraphName');
   });
 
   it('knowledgeAssetFinalize can target WM or SWM layer', async () => {
@@ -855,6 +870,17 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     await expect(client.knowledgeAssetPublish('cg', 'f', {
       publishEpoch: 3,
     } as any)).rejects.toThrow('Unsupported finalized publish option(s): publishEpoch');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('knowledgeAssetPublish rejects daemon-only option aliases before HTTP serialization', async () => {
+    const calls = track({ ok: true });
+    await expect(client.knowledgeAssetPublish('cg', 'f', {
+      epochs: 3,
+    } as any)).rejects.toThrow('Unsupported finalized publish option(s): epochs');
+    await expect(client.knowledgeAssetPublishAsync('cg', 'f', {
+      clearSharedMemoryAfter: true,
+    } as any)).rejects.toThrow('Unsupported finalized publish option(s): clearSharedMemoryAfter');
     expect(calls).toHaveLength(0);
   });
 

--- a/packages/cli/test/api-client.test.ts
+++ b/packages/cli/test/api-client.test.ts
@@ -858,6 +858,14 @@ describe('ApiClient — GitHub-shaped knowledge-assets SDK (OT-RFC-43 §10.5)', 
     expect(calls).toHaveLength(0);
   });
 
+  it('knowledgeAssetPublish rejects publisher identity overrides above uint72 before HTTP serialization', async () => {
+    const calls = track({ ok: true });
+    await expect(client.knowledgeAssetPublish('cg', 'f', {
+      publisherNodeIdentityIdOverride: 4722366482869645213696n,
+    })).rejects.toThrow('publisherNodeIdentityIdOverride');
+    expect(calls).toHaveLength(0);
+  });
+
   it('knowledgeAssetPullFrom sends layer + onConflict', async () => {
     const calls = track({ wmDraft: 'open' });
     await client.knowledgeAssetPullFrom('cg', 'f', 'vm', { onConflict: 'replace' });

--- a/packages/cli/test/assertion-cli-smoke.test.ts
+++ b/packages/cli/test/assertion-cli-smoke.test.ts
@@ -311,10 +311,50 @@ describe.sequential('assertion CLI smoke', () => {
     expect(daemonCalls).toEqual([]);
   }, 15000);
 
-  it('enqueues a named KA async VM publish through the publisher CLI', async () => {
+  it('enqueues a named KA async VM publish through the shared CLI publish options', async () => {
     const env = { ...process.env, DKG_HOME: dkgHome, DKG_API_PORT: smokeApiPort };
 
-    const published = await execFileAsync('node', [
+    const publishedViaKa = await execFileAsync('node', [
+      CLI_ENTRY,
+      'ka',
+      'publish-async',
+      'paper',
+      '--context-graph-id',
+      'research',
+      '--sub-graph-name',
+      'lab',
+      '--publish-epochs',
+      '3',
+      '--publisher-node-identity-id',
+      '7',
+    ], { env });
+
+    expect(publishedViaKa.stdout).toContain('Knowledge asset publish job accepted:');
+    expect(publishedViaKa.stdout).toContain('Job ID:     job-cli-123');
+    expect(publishedViaKa.stdout).toContain('Status:     accepted');
+    expect(JSON.parse(lastPublishAsyncBody)).toEqual({
+      contextGraphId: 'research',
+      subGraphName: 'lab',
+      options: { publishEpochs: 3, publisherNodeIdentityIdOverride: '7' },
+    });
+
+    await execFileAsync('node', [
+      CLI_ENTRY,
+      'ka',
+      'publish-async',
+      'paper',
+      '--context-graph-id',
+      'research',
+      '--publisher-node-identity-id',
+      '0',
+    ], { env });
+
+    expect(JSON.parse(lastPublishAsyncBody)).toEqual({
+      contextGraphId: 'research',
+      options: { publisherNodeIdentityIdOverride: '0' },
+    });
+
+    const publishedViaAlias = await execFileAsync('node', [
       CLI_ENTRY,
       'publisher',
       'publish-async',
@@ -328,9 +368,9 @@ describe.sequential('assertion CLI smoke', () => {
       '7',
     ], { env });
 
-    expect(published.stdout).toContain('Knowledge asset publish job accepted:');
-    expect(published.stdout).toContain('Job ID:     job-cli-123');
-    expect(published.stdout).toContain('Status:     accepted');
+    expect(publishedViaAlias.stdout).toContain('Knowledge asset publish job accepted:');
+    expect(publishedViaAlias.stdout).toContain('Job ID:     job-cli-123');
+    expect(publishedViaAlias.stdout).toContain('Status:     accepted');
     expect(JSON.parse(lastPublishAsyncBody)).toEqual({
       contextGraphId: 'research',
       subGraphName: 'lab',

--- a/packages/cli/test/assertion-cli-smoke.test.ts
+++ b/packages/cli/test/assertion-cli-smoke.test.ts
@@ -11,6 +11,8 @@ import { tmpdir } from 'node:os';
 const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI_ENTRY = join(__dirname, '..', 'dist', 'cli.js');
+const MAX_UINT72_DECIMAL = '4722366482869645213695';
+const UINT72_OVERFLOW_DECIMAL = '4722366482869645213696';
 
 describe.sequential('assertion CLI smoke', () => {
   let dkgHome: string;
@@ -354,6 +356,22 @@ describe.sequential('assertion CLI smoke', () => {
       options: { publisherNodeIdentityIdOverride: '0' },
     });
 
+    await execFileAsync('node', [
+      CLI_ENTRY,
+      'ka',
+      'publish-async',
+      'paper',
+      '--context-graph-id',
+      'research',
+      '--publisher-node-identity-id',
+      MAX_UINT72_DECIMAL,
+    ], { env });
+
+    expect(JSON.parse(lastPublishAsyncBody)).toEqual({
+      contextGraphId: 'research',
+      options: { publisherNodeIdentityIdOverride: MAX_UINT72_DECIMAL },
+    });
+
     const publishedViaAlias = await execFileAsync('node', [
       CLI_ENTRY,
       'publisher',
@@ -390,6 +408,18 @@ describe.sequential('assertion CLI smoke', () => {
     expect(JSON.parse(lastPublishAsyncBody)).toEqual({
       contextGraphId: 'research',
       options: { publisherNodeIdentityIdOverride: '0' },
+    });
+
+    await expect(execFileAsync('node', [
+      CLI_ENTRY,
+      'publisher',
+      'publish-async',
+      'research',
+      'paper',
+      '--publisher-node-identity-id',
+      UINT72_OVERFLOW_DECIMAL,
+    ], { env })).rejects.toMatchObject({
+      stderr: expect.stringContaining(`--publisher-node-identity-id must be between 0 and ${MAX_UINT72_DECIMAL} (uint72)`),
     });
   }, 30000);
 

--- a/packages/cli/test/assertion-cli-smoke.test.ts
+++ b/packages/cli/test/assertion-cli-smoke.test.ts
@@ -324,6 +324,8 @@ describe.sequential('assertion CLI smoke', () => {
       'lab',
       '--publish-epochs',
       '3',
+      '--publisher-node-identity-id',
+      '7',
     ], { env });
 
     expect(published.stdout).toContain('Knowledge asset publish job accepted:');
@@ -332,7 +334,22 @@ describe.sequential('assertion CLI smoke', () => {
     expect(JSON.parse(lastPublishAsyncBody)).toEqual({
       contextGraphId: 'research',
       subGraphName: 'lab',
-      options: { publishEpochs: 3 },
+      options: { publishEpochs: 3, publisherNodeIdentityIdOverride: '7' },
+    });
+
+    await execFileAsync('node', [
+      CLI_ENTRY,
+      'publisher',
+      'publish-async',
+      'research',
+      'paper',
+      '--publisher-node-identity-id',
+      '0',
+    ], { env });
+
+    expect(JSON.parse(lastPublishAsyncBody)).toEqual({
+      contextGraphId: 'research',
+      options: { publisherNodeIdentityIdOverride: '0' },
     });
   }, 30000);
 

--- a/packages/cli/test/daemon-pca-routes.test.ts
+++ b/packages/cli/test/daemon-pca-routes.test.ts
@@ -179,6 +179,24 @@ describe('daemon /api/pca V10 caller contract', () => {
     expect(calls).toEqual([[ethers.parseEther('100'), BigInt(big)]]);
   });
 
+  it('POST /api/pca with primaryNode above uint72 returns 400 and does not call facade', async () => {
+    let called = false;
+    const agent = {
+      createPublishingConvictionAccount: async () => {
+        called = true;
+        return { accountId: 9n, hash: '0x', blockNumber: 1, success: true };
+      },
+    };
+    const { res, done } = runCtx('POST', '/api/pca', agent, {
+      tokens: '100',
+      primaryNode: '4722366482869645213696',
+    });
+    await done;
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/uint72/);
+    expect(called).toBe(false);
+  });
+
   it('POST /api/pca/:id/agent registers an agent → 200 with txHash', async () => {
     let registered: { id: bigint; agent: string } | null = null;
     const addr = '0x' + '1'.repeat(40);

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -42,6 +42,8 @@ import { createKnowledgeAssetVmPublishExecutor } from '../src/daemon/lifecycle.j
 
 const CG_ID = 'issue-1116-cg';
 const ASSERTION_NAME = 'seal-asset';
+const MAX_UINT72_DECIMAL = '4722366482869645213695';
+const UINT72_OVERFLOW_DECIMAL = '4722366482869645213696';
 
 describe('#1116 share/seal route error mapping (fake agent)', () => {
   let server: Server | undefined;
@@ -426,7 +428,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
     }
   });
 
-  it('vm/publish-async forwards non-default route options into the immutable intent', async () => {
+  it('vm/publish-async accepts uint72 publisher identity overrides into the immutable intent', async () => {
     const seenResolveOptions: any[] = [];
     const enqueuedIntents: any[] = [];
 
@@ -465,7 +467,7 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       },
     });
 
-    const res = await post('vm/publish-async', {
+    const zeroRes = await post('vm/publish-async', {
       contextGraphId: CG_ID,
       options: {
         publishEpochs: 2,
@@ -474,8 +476,8 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       },
     });
 
-    expect(res.status).toBe(202);
-    expect(res.body.jobId).toBe('job-options');
+    expect(zeroRes.status).toBe(202);
+    expect(zeroRes.body.jobId).toBe('job-options');
     expect(seenResolveOptions).toHaveLength(1);
     expect(seenResolveOptions[0]).toMatchObject({
       publishEpochs: 2,
@@ -487,6 +489,62 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       clearSharedMemoryAfter: true,
       publisherNodeIdentityIdOverride: '0',
     });
+
+    const maxRes = await post('vm/publish-async', {
+      contextGraphId: CG_ID,
+      options: {
+        publishEpochs: 2,
+        clearSharedMemoryAfter: true,
+        publisherNodeIdentityIdOverride: MAX_UINT72_DECIMAL,
+      },
+    });
+
+    expect(maxRes.status).toBe(202);
+    expect(maxRes.body.jobId).toBe('job-options');
+    expect(seenResolveOptions).toHaveLength(2);
+    expect(seenResolveOptions[1]).toMatchObject({
+      publishEpochs: 2,
+      clearSharedMemoryAfter: true,
+      publisherNodeIdentityIdOverride: BigInt(MAX_UINT72_DECIMAL),
+    });
+    expect(enqueuedIntents[1]).toMatchObject({
+      publishEpochs: 2,
+      clearSharedMemoryAfter: true,
+      publisherNodeIdentityIdOverride: MAX_UINT72_DECIMAL,
+    });
+  });
+
+  it('vm/publish-async rejects publisher identity overrides above uint72 before enqueue', async () => {
+    let resolveCalls = 0;
+    let enqueueCalls = 0;
+
+    await startWith({}, {
+      resolveFinalizedAssertionVmPublishIntent: async () => {
+        resolveCalls += 1;
+        throw new Error('resolve should not be called');
+      },
+      preflightKnowledgeAssetVmPublishSnapshot: async () => {
+        throw new Error('preflight should not be called');
+      },
+    }, {}, {
+      enqueueKnowledgeAssetVmPublish: async () => {
+        enqueueCalls += 1;
+        return 'job-should-not-exist';
+      },
+    });
+
+    const res = await post('vm/publish-async', {
+      contextGraphId: CG_ID,
+      options: {
+        publisherNodeIdentityIdOverride: UINT72_OVERFLOW_DECIMAL,
+      },
+    });
+
+    expect(res.status).toBe(400);
+    expect(String(res.body.error)).toContain('publisherNodeIdentityIdOverride');
+    expect(String(res.body.error)).toContain('uint72');
+    expect(resolveCalls).toBe(0);
+    expect(enqueueCalls).toBe(0);
   });
 
   it('vm/publish-async maps incompatible duplicate jobs to 409 with existingJobId', async () => {
@@ -1189,13 +1247,13 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
         }],
         finalize: true,
         alsoPublishVm: {
-          publisherNodeIdentityIdOverride: Number.MAX_SAFE_INTEGER + 1,
+          publisherNodeIdentityIdOverride: UINT72_OVERFLOW_DECIMAL,
         },
       });
 
       expect(unsafeIdentityRes.status).toBe(400);
       expect(String(unsafeIdentityRes.body.error)).toContain('publisherNodeIdentityIdOverride');
-      expect(String(unsafeIdentityRes.body.error)).toContain('safe integer');
+      expect(String(unsafeIdentityRes.body.error)).toContain('uint72');
       expect(createCalls).toHaveLength(0);
     });
 

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1339,6 +1339,33 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(publishCalls).toHaveLength(0);
     });
 
+    it('standalone vm/publish rejects malformed conflicting clear-memory aliases before publish', async () => {
+      const publishCalls: unknown[] = [];
+
+      await startWith(
+        {},
+        {
+          async publishFromFinalizedAssertion(_cg: string, _name: string, opts: unknown) {
+            publishCalls.push(opts);
+            throw new Error('publish should not be called');
+          },
+        },
+      );
+
+      const res = await post('vm/publish', {
+        contextGraphId: CG_ID,
+        options: {
+          clearAfter: false,
+          clearSharedMemoryAfter: 'true',
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('clearSharedMemoryAfter');
+      expect(String(res.body.error)).toContain('boolean');
+      expect(publishCalls).toHaveLength(0);
+    });
+
     it('standalone vm/publish rejects partial selection before publish', async () => {
       const publishCalls: unknown[] = [];
 

--- a/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
+++ b/packages/cli/test/knowledge-assets-1116-share-errors.test.ts
@@ -1286,6 +1286,59 @@ describe('#1116 share/seal route error mapping (fake agent)', () => {
       expect(seenOpts[0]).toMatchObject({ agentAddress: tokenAgentAddress });
     });
 
+    it('standalone vm/publish accepts uint72 publisher identity overrides into publish options', async () => {
+      const seenOpts: unknown[] = [];
+
+      await startWith(
+        {},
+        {
+          async publishFromFinalizedAssertion(_cg: string, _name: string, opts: unknown) {
+            seenOpts.push(opts);
+            return { status: 'confirmed', ual: 'did:dkg:test/1/46', kaId: '46' };
+          },
+        },
+      );
+
+      const res = await post('vm/publish', {
+        contextGraphId: CG_ID,
+        options: {
+          publisherNodeIdentityIdOverride: '0',
+        },
+      });
+
+      expect(res.status).toBe(200);
+      expect(seenOpts).toHaveLength(1);
+      expect(seenOpts[0]).toMatchObject({
+        publisherNodeIdentityIdOverride: 0n,
+      });
+    });
+
+    it('standalone vm/publish rejects publisher identity overrides above uint72 before publish', async () => {
+      const publishCalls: unknown[] = [];
+
+      await startWith(
+        {},
+        {
+          async publishFromFinalizedAssertion(_cg: string, _name: string, opts: unknown) {
+            publishCalls.push(opts);
+            throw new Error('publish should not be called');
+          },
+        },
+      );
+
+      const res = await post('vm/publish', {
+        contextGraphId: CG_ID,
+        options: {
+          publisherNodeIdentityIdOverride: UINT72_OVERFLOW_DECIMAL,
+        },
+      });
+
+      expect(res.status).toBe(400);
+      expect(String(res.body.error)).toContain('publisherNodeIdentityIdOverride');
+      expect(String(res.body.error)).toContain('uint72');
+      expect(publishCalls).toHaveLength(0);
+    });
+
     it('standalone vm/publish rejects partial selection before publish', async () => {
       const publishCalls: unknown[] = [];
 

--- a/packages/cli/test/publisher-wallets.test.ts
+++ b/packages/cli/test/publisher-wallets.test.ts
@@ -11,7 +11,7 @@ import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { DKGPublisher } from '@origintrail-official/dkg-publisher';
 import { addPublisherWallet, loadPublisherWallets, publisherWalletsPath, removePublisherWallet } from '../src/publisher-wallets.js';
 import { createPublisherInspector, createPublisherInspectorFromStore, createPublisherRuntime, createPublisherRuntimeFromAgent, startPublisherRuntimeIfEnabled } from '../src/publisher-runner.js';
-import { parsePositiveIntegerOption, parsePositiveMsOption } from '../src/cli-option-parsers.js';
+import { parseOptionalPositiveInteger, parsePositiveIntegerOption, parsePositiveMsOption } from '../src/cli-option-parsers.js';
 
 let _fileSnapshot: string;
 beforeAll(async () => {
@@ -265,7 +265,7 @@ describe('publisher wallets', () => {
       });
 
       expect(runtime.walletIds).toEqual([wallet.address]);
-      expect(runtime.walletIdentities).toEqual([{ address: wallet.address, identityId: 0n }]);
+      expect(runtime.wallets).toMatchObject([{ address: wallet.address, identityId: 0n }]);
     } finally {
       await runtime?.stop();
       await store.close();
@@ -295,10 +295,10 @@ describe('publisher wallets', () => {
       });
 
       expect(new Set(runtime.walletIds)).toEqual(new Set([identityfulWallet.address, identitylessWallet.address]));
-      expect(runtime.walletIdentities).toEqual(
+      expect(runtime.wallets).toEqual(
         expect.arrayContaining([
-          { address: identityfulWallet.address, identityId: BigInt(getSharedContext().coreProfileId) },
-          { address: identitylessWallet.address, identityId: 0n },
+          expect.objectContaining({ address: identityfulWallet.address, identityId: BigInt(getSharedContext().coreProfileId) }),
+          expect.objectContaining({ address: identitylessWallet.address, identityId: 0n }),
         ]),
       );
     } finally {
@@ -334,7 +334,7 @@ describe('publisher wallets', () => {
         log: (message) => logs.push(message),
       });
 
-      expect(runtime?.walletIdentities).toEqual([{ address: wallet.address, identityId: 0n }]);
+      expect(runtime?.wallets).toMatchObject([{ address: wallet.address, identityId: 0n }]);
       expect(logs.join('\n')).toContain('no-attribution mode');
       expect(logs.join('\n')).toContain(wallet.address);
     } finally {
@@ -396,7 +396,14 @@ describe('publisher wallets', () => {
 
   it('validates positive millisecond CLI options', () => {
     expect(parsePositiveMsOption('1000', '--poll-interval')).toBe(1000);
+    expect(parsePositiveMsOption(' 1000 ', '--poll-interval')).toBe(1000);
     expect(() => parsePositiveMsOption('0', '--poll-interval')).toThrow(
+      '--poll-interval must be a positive integer in milliseconds',
+    );
+    expect(() => parsePositiveMsOption('10ms', '--poll-interval')).toThrow(
+      '--poll-interval must be a positive integer in milliseconds',
+    );
+    expect(() => parsePositiveMsOption('9007199254740992', '--poll-interval')).toThrow(
       '--poll-interval must be a positive integer in milliseconds',
     );
     expect(() => parsePositiveMsOption('nan', '--error-backoff')).toThrow(
@@ -406,8 +413,26 @@ describe('publisher wallets', () => {
 
   it('validates positive integer CLI options', () => {
     expect(parsePositiveIntegerOption('10', '--max-retries')).toBe(10);
+    expect(parsePositiveIntegerOption(' 10 ', '--max-retries')).toBe(10);
     expect(() => parsePositiveIntegerOption('0', '--max-retries')).toThrow(
       '--max-retries must be a positive integer',
+    );
+    expect(() => parsePositiveIntegerOption('1.5', '--max-retries')).toThrow(
+      '--max-retries must be a positive integer',
+    );
+    expect(() => parsePositiveIntegerOption('9007199254740992', '--max-retries')).toThrow(
+      '--max-retries must be a positive integer',
+    );
+  });
+
+  it('validates optional positive integer CLI options', () => {
+    expect(parseOptionalPositiveInteger(undefined, '--limit')).toBeUndefined();
+    expect(parseOptionalPositiveInteger(' 25 ', '--limit')).toBe(25);
+    expect(() => parseOptionalPositiveInteger('10items', '--limit')).toThrow(
+      '--limit must be a positive integer',
+    );
+    expect(() => parseOptionalPositiveInteger('9007199254740992', '--limit')).toThrow(
+      '--limit must be a positive integer',
     );
   });
 

--- a/packages/cli/test/publisher-wallets.test.ts
+++ b/packages/cli/test/publisher-wallets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll, vi } from 'vitest';
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -10,7 +10,8 @@ import { createEVMAdapter, getSharedContext, createProvider, takeSnapshot, rever
 import { mintTokens } from '../../chain/test/hardhat-harness.js';
 import { DKGPublisher } from '@origintrail-official/dkg-publisher';
 import { addPublisherWallet, loadPublisherWallets, publisherWalletsPath, removePublisherWallet } from '../src/publisher-wallets.js';
-import { createPublisherInspector, createPublisherInspectorFromStore, createPublisherRuntime, createPublisherRuntimeFromAgent, startPublisherRuntimeIfEnabled, parsePositiveIntegerOption, parsePositiveMsOption } from '../src/publisher-runner.js';
+import { createPublisherInspector, createPublisherInspectorFromStore, createPublisherRuntime, createPublisherRuntimeFromAgent, startPublisherRuntimeIfEnabled } from '../src/publisher-runner.js';
+import { parsePositiveIntegerOption, parsePositiveMsOption } from '../src/cli-option-parsers.js';
 
 let _fileSnapshot: string;
 beforeAll(async () => {
@@ -248,7 +249,6 @@ describe('publisher wallets', () => {
     const store = await createTripleStore({ backend: 'oxigraph' });
     const keypair = await generateEd25519Keypair();
     const { rpcUrl, hubAddress } = getSharedContext();
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     let runtime: Awaited<ReturnType<typeof createPublisherRuntimeFromAgent>> | undefined;
 
     await addPublisherWallet(dataDir, wallet.privateKey);
@@ -265,10 +265,9 @@ describe('publisher wallets', () => {
       });
 
       expect(runtime.walletIds).toEqual([wallet.address]);
-      expect(infoSpy.mock.calls.flat().join('\n')).toContain('no-attribution mode');
+      expect(runtime.walletIdentities).toEqual([{ address: wallet.address, identityId: 0n }]);
     } finally {
       await runtime?.stop();
-      infoSpy.mockRestore();
       await store.close();
     }
   });
@@ -296,6 +295,48 @@ describe('publisher wallets', () => {
       });
 
       expect(new Set(runtime.walletIds)).toEqual(new Set([identityfulWallet.address, identitylessWallet.address]));
+      expect(runtime.walletIdentities).toEqual(
+        expect.arrayContaining([
+          { address: identityfulWallet.address, identityId: BigInt(getSharedContext().coreProfileId) },
+          { address: identitylessWallet.address, identityId: 0n },
+        ]),
+      );
+    } finally {
+      await runtime?.stop();
+      await store.close();
+    }
+  });
+
+  it('reports publisher wallet attribution through the daemon startup logger', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
+    const wallet = ethers.Wallet.createRandom();
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const keypair = await generateEd25519Keypair();
+    const logs: string[] = [];
+    let runtime: Awaited<ReturnType<typeof startPublisherRuntimeIfEnabled>> | undefined;
+
+    await addPublisherWallet(dataDir, wallet.privateKey);
+
+    try {
+      runtime = await startPublisherRuntimeIfEnabled({
+        dataDir,
+        config: {
+          name: 'test-node',
+          apiPort: 9200,
+          listenPort: 0,
+          nodeRole: 'edge',
+          contextGraphs: [],
+          publisher: { enabled: true },
+        },
+        store,
+        keypair,
+        chainBase: undefined,
+        log: (message) => logs.push(message),
+      });
+
+      expect(runtime?.walletIdentities).toEqual([{ address: wallet.address, identityId: 0n }]);
+      expect(logs.join('\n')).toContain('no-attribution mode');
+      expect(logs.join('\n')).toContain(wallet.address);
     } finally {
       await runtime?.stop();
       await store.close();

--- a/packages/cli/test/publisher-wallets.test.ts
+++ b/packages/cli/test/publisher-wallets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { describe, expect, it, beforeAll, afterAll, vi } from 'vitest';
 import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -242,6 +242,66 @@ describe('publisher wallets', () => {
     await store.close();
   });
 
+  it('bootstraps publisher runtime with an identityless publisher wallet on a reachable chain', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
+    const wallet = ethers.Wallet.createRandom();
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const keypair = await generateEd25519Keypair();
+    const { rpcUrl, hubAddress } = getSharedContext();
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    let runtime: Awaited<ReturnType<typeof createPublisherRuntimeFromAgent>> | undefined;
+
+    await addPublisherWallet(dataDir, wallet.privateKey);
+    await expect(createEVMAdapter(wallet.privateKey).getIdentityId()).resolves.toBe(0n);
+
+    try {
+      runtime = await createPublisherRuntimeFromAgent({
+        dataDir,
+        store,
+        keypair,
+        chainBase: { rpcUrl, hubAddress },
+        pollIntervalMs: 10,
+        errorBackoffMs: 10,
+      });
+
+      expect(runtime.walletIds).toEqual([wallet.address]);
+      expect(infoSpy.mock.calls.flat().join('\n')).toContain('no-attribution mode');
+    } finally {
+      await runtime?.stop();
+      infoSpy.mockRestore();
+      await store.close();
+    }
+  });
+
+  it('does not skip identityless wallets in a mixed publisher wallet pool', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
+    const identityfulWallet = new ethers.Wallet(HARDHAT_KEYS.CORE_OP);
+    const identitylessWallet = ethers.Wallet.createRandom();
+    const store = await createTripleStore({ backend: 'oxigraph' });
+    const keypair = await generateEd25519Keypair();
+    const { rpcUrl, hubAddress } = getSharedContext();
+    let runtime: Awaited<ReturnType<typeof createPublisherRuntimeFromAgent>> | undefined;
+
+    await addPublisherWallet(dataDir, identityfulWallet.privateKey);
+    await addPublisherWallet(dataDir, identitylessWallet.privateKey);
+
+    try {
+      runtime = await createPublisherRuntimeFromAgent({
+        dataDir,
+        store,
+        keypair,
+        chainBase: { rpcUrl, hubAddress },
+        pollIntervalMs: 10,
+        errorBackoffMs: 10,
+      });
+
+      expect(new Set(runtime.walletIds)).toEqual(new Set([identityfulWallet.address, identitylessWallet.address]));
+    } finally {
+      await runtime?.stop();
+      await store.close();
+    }
+  });
+
   it('skips daemon-integrated publisher startup with a warning when no wallets exist', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
     const store = await createTripleStore({ backend: 'oxigraph' });
@@ -270,7 +330,7 @@ describe('publisher wallets', () => {
     await store.close();
   });
 
-  it('fails fast when a publisher wallet has no on-chain identity (requires live chain)', async () => {
+  it('keeps chain RPC failures hard during publisher wallet identity resolution', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'dkg-publisher-runtime-'));
     const wallet = ethers.Wallet.createRandom();
     const store = await createTripleStore({ backend: 'oxigraph' });


### PR DESCRIPTION
## Summary

- Allow async publisher wallets whose resolved chain identity is `0` to stay active and publish in no-attribution mode instead of being skipped or blocking startup.
- Add `--publisher-node-identity-id` to `dkg publisher publish-async`, matching the KA async publish flow and accepting `0` as an explicit no-attribution override.
- Update CLI/API docs and the DKG node skill guidance so publisher wallet identity is documented as optional attribution, separate from PCA/direct-spend eligibility.

## Related

- Follow-up to `codex/ka-lifecycle-cli-alignment`

## Files changed

| File | What |
|------|------|
| `packages/cli/src/publisher-runner.ts` | Keeps identityless publisher wallets active, logs attributed vs no-attribution wallet pools, and exports shared non-negative BigInt option parsing. |
| `packages/cli/src/commands/publisher.ts` | Adds `--publisher-node-identity-id` to `publisher publish-async` and forwards the override to async publish requests. |
| `packages/cli/src/commands/knowledge-asset.ts` | Reuses the shared non-negative BigInt parser for KA publisher identity overrides. |
| `packages/cli/test/assertion-cli-smoke.test.ts` | Covers publisher CLI forwarding for non-zero and zero identity overrides. |
| `packages/cli/test/publisher-wallets.test.ts` | Covers identityless publisher wallets, mixed attributed/no-attribution pools, and hard RPC failures during identity resolution. |
| `docs/use-dkg/async-publisher-wallets.md` | Adds dedicated async publisher wallet setup and attribution guidance. |
| `README.md`, `packages/cli/README.md`, `docs/**`, `packages/cli/skills/dkg-node/SKILL.md` | Aligns docs around optional identity attribution and PCA/native-gas requirements. |

## Test plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --workspace-concurrency=1 --filter @origintrail-official/dkg-core --filter @origintrail-official/dkg-query --filter @origintrail-official/dkg-storage --filter @origintrail-official/dkg-chain --filter @origintrail-official/dkg-publisher run build`
- [x] `pnpm --filter @origintrail-official/dkg run build`
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/publisher-runner-lu11.test.ts test/api-client.test.ts --reporter dot`
- [x] `pnpm --filter @origintrail-official/dkg exec vitest run --config vitest.unit.config.ts test/assertion-cli-smoke.test.ts -t "enqueues a named KA async VM publish through the publisher CLI" --reporter dot`
- [x] `pnpm --filter @origintrail-official/dkg-publisher test -- test/async-lift-publish-options.test.ts --reporter dot`
- [x] `git diff --check upstream/codex/ka-lifecycle-cli-alignment...HEAD`
- [x] Before rebasing onto the refreshed lifecycle base, the targeted Hardhat-backed publisher wallet subset passed: `publisher-wallets.test.ts -t "identityless|mixed publisher wallet pool|chain RPC failures"`.
- [ ] Post-rebase local retry of that Hardhat-backed subset was blocked before test execution by stale local `localhost_contracts.json` deployment reuse (`Chronos` previous deployment lookup); CI should validate from a clean chain environment.
