### PR TITLE
[codex] Cover KA lifecycle update devnet flows

### DIFF
--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -331,6 +331,48 @@ async function assertWorkingMemorySubjectAbsent(
   expect(queryResultHasSubject(result, subject), `${label} query output: ${JSON.stringify(result)}`).toBe(false);
 }
 
+async function reopenEditFinalizeAndShare(
+  node: DevnetNode,
+  contextGraphId: string,
+  name: string,
+  layer: 'swm' | 'vm',
+  initialSubject: string,
+  update: { filePath: string; subject: string },
+  opts: { flowLabel: string; updateValue: string },
+): Promise<void> {
+  expectCliOk(
+    await runDkgCli(
+      node,
+      ['ka', 'pull-from', name, '-c', contextGraphId, '--layer', layer, '--on-conflict', 'replace', '--json'],
+      60_000,
+    ),
+    `ka pull-from ${layer} for ${opts.flowLabel}`,
+  );
+  await assertWorkingMemorySubjectPresent(
+    node,
+    contextGraphId,
+    name,
+    initialSubject,
+    `${opts.flowLabel} WM after pull-from`,
+  );
+
+  expectCliOk(
+    await runDkgCli(node, ['ka', 'write', name, '-c', contextGraphId, '--input-file', update.filePath], 60_000),
+    `ka write ${opts.flowLabel}`,
+  );
+  await assertWorkingMemorySubjectPresent(
+    node,
+    contextGraphId,
+    name,
+    update.subject,
+    `${opts.flowLabel} WM after edit`,
+  );
+
+  expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), `ka finalize ${opts.flowLabel}`);
+  expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), `ka share ${opts.flowLabel}`);
+  await assertSharedSubject(node, contextGraphId, update.subject, opts.updateValue);
+}
+
 beforeAll(async () => {
   const detected = await detectDevnet(6);
   if (!detected) {
@@ -493,31 +535,15 @@ describe('KA lifecycle CLI on devnet', () => {
       'ka create --share for SWM update',
     );
     await assertSharedSubject(node, contextGraphId, initial.subject, 'swm update initial');
-    await assertSubjectNotVisible(node, contextGraphId, update.subject, {
+    await assertSubjectNotVisible(node, contextGraphId, initial.subject, {
       view: 'verifiable-memory',
-      label: 'VM before SWM-only update publish',
+      label: 'VM after initial SWM-only share',
     });
 
-    expectCliOk(
-      await runDkgCli(
-        node,
-        ['ka', 'pull-from', name, '-c', contextGraphId, '--layer', 'swm', '--on-conflict', 'replace', '--json'],
-        60_000,
-      ),
-      'ka pull-from swm for SWM update',
-    );
-    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, initial.subject, 'SWM update WM after pull-from');
-
-    expectCliOk(
-      await runDkgCli(node, ['ka', 'write', name, '-c', contextGraphId, '--input-file', update.filePath], 60_000),
-      'ka write SWM update',
-    );
-    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, update.subject, 'SWM update WM after edit');
-
-    expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), 'ka finalize SWM update');
-    expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), 'ka share SWM update');
-
-    await assertSharedSubject(node, contextGraphId, update.subject, 'swm update edited');
+    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'swm', initial.subject, update, {
+      flowLabel: 'SWM update',
+      updateValue: 'swm update edited',
+    });
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
       view: 'verifiable-memory',
       label: 'VM after SWM-only update',
@@ -545,26 +571,10 @@ describe('KA lifecycle CLI on devnet', () => {
       label: 'VM before edited publish',
     });
 
-    expectCliOk(
-      await runDkgCli(
-        node,
-        ['ka', 'pull-from', name, '-c', contextGraphId, '--layer', 'vm', '--on-conflict', 'replace', '--json'],
-        60_000,
-      ),
-      'ka pull-from vm for VM update',
-    );
-    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, initial.subject, 'VM update WM after pull-from');
-
-    expectCliOk(
-      await runDkgCli(node, ['ka', 'write', name, '-c', contextGraphId, '--input-file', update.filePath], 60_000),
-      'ka write VM update',
-    );
-    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, update.subject, 'VM update WM after edit');
-
-    expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), 'ka finalize VM update');
-    expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), 'ka share VM update');
-
-    await assertSharedSubject(node, contextGraphId, update.subject, 'vm update edited');
+    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'vm', initial.subject, update, {
+      flowLabel: 'VM update',
+      updateValue: 'vm update edited',
+    });
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
       view: 'verifiable-memory',
       label: 'VM before edited publish after re-share',

--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -9,9 +9,13 @@
  *   3. Stepwise `create -> write -> finalize -> share-async` drains through the
  *      SWM share-job surface, then `pull-from/query/discard` works on the
  *      reopened WM draft.
- *   4. `dkg publisher publish-async <context-graph> <name>` remains an
+ *   4. An SWM-only KA can be reopened from SWM, edited, finalized, and
+ *      re-shared without VM publishing.
+ *   5. A VM-published KA can be reopened from VM, edited, finalized, re-shared,
+ *      and published again as an update.
+ *   6. `dkg publisher publish-async <context-graph> <name>` remains an
  *      operational alias for async VM publish.
- *   5. Removed direct/legacy surfaces stay removed.
+ *   7. Removed direct/legacy surfaces stay removed.
  *
  * Preconditions:
  *   pnpm run build
@@ -260,6 +264,29 @@ async function waitForPublisherJobFinalized(
   return job;
 }
 
+async function publishKnowledgeAssetAsyncAndWait(
+  node: DevnetNode,
+  contextGraphId: string,
+  name: string,
+  label: string,
+  subGraphName?: string,
+): Promise<PublisherJobView> {
+  const args = ['ka', 'publish-async', name, '-c', contextGraphId, '--json'];
+  if (subGraphName) args.push('--sub-graph-name', subGraphName);
+
+  const publish = await runDkgCli(node, args, 60_000);
+  expectCliOk(publish, label);
+  const body = parseLastJsonBlock(publish.stdout, `${label} stdout`);
+  expect(body.jobId, `${label} response: ${publish.stdout}`).toBeTruthy();
+  expect(body.status).toBe('accepted');
+
+  return waitForPublisherJobFinalized(node, String(body.jobId), {
+    contextGraphId,
+    name,
+    ...(subGraphName ? { subGraphName } : {}),
+  });
+}
+
 function queryResultHasSubject(result: KnowledgeAssetQueryResult | null, subject: string): boolean {
   return (result?.quads ?? []).some((quad) => quad.subject === subject);
 }
@@ -383,31 +410,7 @@ describe('KA lifecycle CLI on devnet', () => {
       subGraphName,
     });
 
-    const publish = await runDkgCli(
-      node,
-      [
-        'ka',
-        'publish-async',
-        name,
-        '--context-graph-id',
-        contextGraphId,
-        '--sub-graph-name',
-        subGraphName,
-        '--json',
-      ],
-      60_000,
-    );
-    expectCliOk(publish, 'ka publish-async');
-    const body = parseLastJsonBlock(publish.stdout, 'ka publish-async stdout');
-    expect(body.jobId, `publish-async response: ${publish.stdout}`).toBeTruthy();
-    expect(body.status).toBe('accepted');
-    const publishJobId = String(body.jobId);
-
-    await waitForPublisherJobFinalized(node, publishJobId, {
-      contextGraphId,
-      name,
-      subGraphName,
-    });
+    await publishKnowledgeAssetAsyncAndWait(node, contextGraphId, name, 'ka publish-async', subGraphName);
     await assertVerifiableSubject(node, contextGraphId, subject, 'one-shot shared', subGraphName);
   });
 
@@ -473,6 +476,102 @@ describe('KA lifecycle CLI on devnet', () => {
     expectCliOk(discarded, 'ka discard');
     expect(parseLastJsonBlock(discarded.stdout, 'ka discard stdout').discarded).toBe(true);
     await assertWorkingMemorySubjectAbsent(node, contextGraphId, name, subject, 'ka query after final discard');
+  });
+
+  it('updates an SWM-only KA by reopening from SWM and re-sharing the edited WM draft', async () => {
+    const { node, contextGraphId } = suite;
+    const name = unique('swm-update');
+    const initial = writeNtFixture(name, 'swm update initial');
+    const update = writeNtFixture(`${name}-update`, 'swm update edited');
+
+    expectCliOk(
+      await runDkgCli(
+        node,
+        ['ka', 'create', name, '-c', contextGraphId, '--input-file', initial.filePath, '--share'],
+        180_000,
+      ),
+      'ka create --share for SWM update',
+    );
+    await assertSharedSubject(node, contextGraphId, initial.subject, 'swm update initial');
+    await assertSubjectNotVisible(node, contextGraphId, update.subject, {
+      view: 'verifiable-memory',
+      label: 'VM before SWM-only update publish',
+    });
+
+    expectCliOk(
+      await runDkgCli(
+        node,
+        ['ka', 'pull-from', name, '-c', contextGraphId, '--layer', 'swm', '--on-conflict', 'replace', '--json'],
+        60_000,
+      ),
+      'ka pull-from swm for SWM update',
+    );
+    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, initial.subject, 'SWM update WM after pull-from');
+
+    expectCliOk(
+      await runDkgCli(node, ['ka', 'write', name, '-c', contextGraphId, '--input-file', update.filePath], 60_000),
+      'ka write SWM update',
+    );
+    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, update.subject, 'SWM update WM after edit');
+
+    expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), 'ka finalize SWM update');
+    expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), 'ka share SWM update');
+
+    await assertSharedSubject(node, contextGraphId, update.subject, 'swm update edited');
+    await assertSubjectNotVisible(node, contextGraphId, update.subject, {
+      view: 'verifiable-memory',
+      label: 'VM after SWM-only update',
+    });
+  });
+
+  it('updates a VM-published KA by reopening from VM and publishing the edited version', async () => {
+    const { node, contextGraphId } = suite;
+    const name = unique('vm-update');
+    const initial = writeNtFixture(name, 'vm update initial');
+    const update = writeNtFixture(`${name}-update`, 'vm update edited');
+
+    expectCliOk(
+      await runDkgCli(
+        node,
+        ['ka', 'create', name, '-c', contextGraphId, '--input-file', initial.filePath, '--share'],
+        180_000,
+      ),
+      'ka create --share for VM update',
+    );
+    await publishKnowledgeAssetAsyncAndWait(node, contextGraphId, name, 'ka publish-async initial VM update');
+    await assertVerifiableSubject(node, contextGraphId, initial.subject, 'vm update initial');
+    await assertSubjectNotVisible(node, contextGraphId, update.subject, {
+      view: 'verifiable-memory',
+      label: 'VM before edited publish',
+    });
+
+    expectCliOk(
+      await runDkgCli(
+        node,
+        ['ka', 'pull-from', name, '-c', contextGraphId, '--layer', 'vm', '--on-conflict', 'replace', '--json'],
+        60_000,
+      ),
+      'ka pull-from vm for VM update',
+    );
+    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, initial.subject, 'VM update WM after pull-from');
+
+    expectCliOk(
+      await runDkgCli(node, ['ka', 'write', name, '-c', contextGraphId, '--input-file', update.filePath], 60_000),
+      'ka write VM update',
+    );
+    await assertWorkingMemorySubjectPresent(node, contextGraphId, name, update.subject, 'VM update WM after edit');
+
+    expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), 'ka finalize VM update');
+    expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), 'ka share VM update');
+
+    await assertSharedSubject(node, contextGraphId, update.subject, 'vm update edited');
+    await assertSubjectNotVisible(node, contextGraphId, update.subject, {
+      view: 'verifiable-memory',
+      label: 'VM before edited publish after re-share',
+    });
+
+    await publishKnowledgeAssetAsyncAndWait(node, contextGraphId, name, 'ka publish-async edited VM update');
+    await assertVerifiableSubject(node, contextGraphId, update.subject, 'vm update edited');
   });
 
   it('publisher publish-async remains an operational alias for named KA VM publish', async () => {

--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -229,7 +229,7 @@ function publisherJobKey(job: PublisherJobView): string {
 
 async function assertNoPublisherJobForKnowledgeAsset(
   node: DevnetNode,
-  expected: { contextGraphId: string; name: string; subGraphName?: string },
+  expected: { contextGraphId: string; name: string },
 ): Promise<void> {
   const parsed = await listPublisherJobs(node);
   expect(
@@ -240,7 +240,7 @@ async function assertNoPublisherJobForKnowledgeAsset(
 
 async function assertNoNewPublisherJobForKnowledgeAsset(
   node: DevnetNode,
-  expected: { contextGraphId: string; name: string; subGraphName?: string },
+  expected: { contextGraphId: string; name: string },
   baseline: PublisherJobView[],
 ): Promise<void> {
   const baselineKeys = new Set(baseline.map(publisherJobKey));
@@ -477,7 +477,6 @@ describe('KA lifecycle CLI on devnet', () => {
     await assertNoPublisherJobForKnowledgeAsset(node, {
       contextGraphId,
       name,
-      subGraphName,
     });
 
     await publishKnowledgeAssetAsyncAndWait(node, contextGraphId, name, 'ka publish-async', subGraphName);

--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -101,7 +101,7 @@ function parseJobId(stdout: string, label = 'CLI output'): string {
   return jobId;
 }
 
-function writeNtFixture(name: string, value: string): { filePath: string; subject: string } {
+function writeNtFixture(name: string, value: string): { filePath: string; subject: string; value: string } {
   const dir = join(import.meta.dirname, 'turns');
   mkdirSync(dir, { recursive: true });
   const subject = `urn:test:ka-lifecycle-cli:${name}:${Date.now()}:${++fileCounter}`;
@@ -111,7 +111,7 @@ function writeNtFixture(name: string, value: string): { filePath: string; subjec
     `<${subject}> <${PREDICATE}> "${value}" .\n`,
     'utf8',
   );
-  return { filePath, subject };
+  return { filePath, subject, value };
 }
 
 async function assertSubjectVisible(
@@ -337,8 +337,8 @@ async function reopenEditFinalizeAndShare(
   name: string,
   layer: 'swm' | 'vm',
   initialSubject: string,
-  update: { filePath: string; subject: string },
-  opts: { flowLabel: string; updateValue: string },
+  update: { filePath: string; subject: string; value: string },
+  flowLabel: string,
 ): Promise<void> {
   expectCliOk(
     await runDkgCli(
@@ -346,31 +346,31 @@ async function reopenEditFinalizeAndShare(
       ['ka', 'pull-from', name, '-c', contextGraphId, '--layer', layer, '--on-conflict', 'replace', '--json'],
       60_000,
     ),
-    `ka pull-from ${layer} for ${opts.flowLabel}`,
+    `ka pull-from ${layer} for ${flowLabel}`,
   );
   await assertWorkingMemorySubjectPresent(
     node,
     contextGraphId,
     name,
     initialSubject,
-    `${opts.flowLabel} WM after pull-from`,
+    `${flowLabel} WM after pull-from`,
   );
 
   expectCliOk(
     await runDkgCli(node, ['ka', 'write', name, '-c', contextGraphId, '--input-file', update.filePath], 60_000),
-    `ka write ${opts.flowLabel}`,
+    `ka write ${flowLabel}`,
   );
   await assertWorkingMemorySubjectPresent(
     node,
     contextGraphId,
     name,
     update.subject,
-    `${opts.flowLabel} WM after edit`,
+    `${flowLabel} WM after edit`,
   );
 
-  expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), `ka finalize ${opts.flowLabel}`);
-  expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), `ka share ${opts.flowLabel}`);
-  await assertSharedSubject(node, contextGraphId, update.subject, opts.updateValue);
+  expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), `ka finalize ${flowLabel}`);
+  expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), `ka share ${flowLabel}`);
+  await assertSharedSubject(node, contextGraphId, update.subject, update.value);
 }
 
 beforeAll(async () => {
@@ -540,10 +540,7 @@ describe('KA lifecycle CLI on devnet', () => {
       label: 'VM after initial SWM-only share',
     });
 
-    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'swm', initial.subject, update, {
-      flowLabel: 'SWM update',
-      updateValue: 'swm update edited',
-    });
+    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'swm', initial.subject, update, 'SWM update');
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
       view: 'verifiable-memory',
       label: 'VM after SWM-only update',
@@ -571,10 +568,7 @@ describe('KA lifecycle CLI on devnet', () => {
       label: 'VM before edited publish',
     });
 
-    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'vm', initial.subject, update, {
-      flowLabel: 'VM update',
-      updateValue: 'vm update edited',
-    });
+    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'vm', initial.subject, update, 'VM update');
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
       view: 'verifiable-memory',
       label: 'VM before edited publish after re-share',

--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -411,7 +411,7 @@ describe('KA lifecycle CLI on devnet', () => {
     await assertVerifiableSubject(node, contextGraphId, subject, 'one-shot shared', subGraphName);
   });
 
-  it('stepwise lifecycle drains share-async, then pull-from/query/discard works', async () => {
+  it('stepwise lifecycle drains share-async, then pull-from reopens WM and discard clears the reopened draft', async () => {
     const { node, contextGraphId } = suite;
     const name = unique('stepwise');
     const { filePath, subject } = writeNtFixture(name, 'stepwise shared');
@@ -448,6 +448,7 @@ describe('KA lifecycle CLI on devnet', () => {
     });
 
     await assertSharedSubject(node, contextGraphId, subject, 'stepwise shared');
+    await assertWorkingMemorySubjectAbsent(node, contextGraphId, name, subject, 'ka query after share before pull-from');
 
     const jobs = await runDkgCli(
       node,
@@ -459,11 +460,6 @@ describe('KA lifecycle CLI on devnet', () => {
       parseLastJsonBlock(jobs.stdout, 'ka share-jobs stdout').jobs ?? []
     ) as Array<{ jobId?: string }>;
     expect(listed.some((job) => job.jobId === jobId), `share-jobs output: ${jobs.stdout}`).toBe(true);
-
-    const clearedBeforePull = await runDkgCli(node, ['ka', 'discard', name, '-c', contextGraphId, '--json'], 60_000);
-    expectCliOk(clearedBeforePull, 'ka discard before pull-from');
-    expect(parseLastJsonBlock(clearedBeforePull.stdout, 'ka discard before pull-from stdout').discarded).toBe(true);
-    await assertWorkingMemorySubjectAbsent(node, contextGraphId, name, subject, 'ka query after pre-pull discard');
 
     const pulled = await runDkgCli(
       node,

--- a/devnet/ka-lifecycle-cli/automated.test.ts
+++ b/devnet/ka-lifecycle-cli/automated.test.ts
@@ -208,24 +208,51 @@ function publisherJobTargetsKnowledgeAsset(
   job: PublisherJobView,
   expected: { contextGraphId: string; name: string },
 ): boolean {
+  // Match any subgraph for negative checks so wrong-subgraph publishes fail too.
   const request = job.request?.knowledgeAssetVmPublish;
   return job.request?.jobType === 'knowledge-asset-vm-publish' &&
     request?.contextGraphId === expected.contextGraphId &&
     request?.name === expected.name;
 }
 
-async function assertNoPublisherJobForKnowledgeAsset(
-  node: DevnetNode,
-  expected: { contextGraphId: string; name: string; subGraphName?: string },
-): Promise<void> {
+async function listPublisherJobs(node: DevnetNode): Promise<PublisherJobView[]> {
   const jobs = await runDkgCli(node, ['publisher', 'jobs'], 60_000);
   expectCliOk(jobs, 'publisher jobs');
   const parsed = JSON.parse(jobs.stdout.trim()) as PublisherJobView[];
   expect(Array.isArray(parsed), `publisher jobs output: ${jobs.stdout}`).toBe(true);
+  return parsed;
+}
+
+function publisherJobKey(job: PublisherJobView): string {
+  return job.jobId ?? JSON.stringify(job);
+}
+
+async function assertNoPublisherJobForKnowledgeAsset(
+  node: DevnetNode,
+  expected: { contextGraphId: string; name: string; subGraphName?: string },
+): Promise<void> {
+  const parsed = await listPublisherJobs(node);
   expect(
     parsed.some((job) => publisherJobTargetsKnowledgeAsset(job, expected)),
-    `publisher jobs unexpectedly contained a VM publish for ${expected.name}: ${jobs.stdout}`,
+    `publisher jobs unexpectedly contained a VM publish for ${expected.name}: ${JSON.stringify(parsed)}`,
   ).toBe(false);
+}
+
+async function assertNoNewPublisherJobForKnowledgeAsset(
+  node: DevnetNode,
+  expected: { contextGraphId: string; name: string; subGraphName?: string },
+  baseline: PublisherJobView[],
+): Promise<void> {
+  const baselineKeys = new Set(baseline.map(publisherJobKey));
+  const current = await listPublisherJobs(node);
+  const newMatches = current.filter(
+    (job) => publisherJobTargetsKnowledgeAsset(job, expected) &&
+      !baselineKeys.has(publisherJobKey(job)),
+  );
+  expect(
+    newMatches,
+    `publisher jobs unexpectedly gained a VM publish for ${expected.name}: ${JSON.stringify(current)}`,
+  ).toHaveLength(0);
 }
 
 async function waitForPublisherJobFinalized(
@@ -336,7 +363,7 @@ async function reopenEditFinalizeAndShare(
   contextGraphId: string,
   name: string,
   layer: 'swm' | 'vm',
-  initialSubject: string,
+  initial: { subject: string; value: string },
   update: { filePath: string; subject: string; value: string },
   flowLabel: string,
 ): Promise<void> {
@@ -352,7 +379,7 @@ async function reopenEditFinalizeAndShare(
     node,
     contextGraphId,
     name,
-    initialSubject,
+    initial.subject,
     `${flowLabel} WM after pull-from`,
   );
 
@@ -370,6 +397,7 @@ async function reopenEditFinalizeAndShare(
 
   expectCliOk(await runDkgCli(node, ['ka', 'finalize', name, '-c', contextGraphId], 60_000), `ka finalize ${flowLabel}`);
   expectCliOk(await runDkgCli(node, ['ka', 'share', name, '-c', contextGraphId], 180_000), `ka share ${flowLabel}`);
+  await assertSharedSubject(node, contextGraphId, initial.subject, initial.value);
   await assertSharedSubject(node, contextGraphId, update.subject, update.value);
 }
 
@@ -539,11 +567,19 @@ describe('KA lifecycle CLI on devnet', () => {
       view: 'verifiable-memory',
       label: 'VM after initial SWM-only share',
     });
+    await assertNoPublisherJobForKnowledgeAsset(node, {
+      contextGraphId,
+      name,
+    });
 
-    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'swm', initial.subject, update, 'SWM update');
+    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'swm', initial, update, 'SWM update');
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
       view: 'verifiable-memory',
       label: 'VM after SWM-only update',
+    });
+    await assertNoPublisherJobForKnowledgeAsset(node, {
+      contextGraphId,
+      name,
     });
   });
 
@@ -561,6 +597,10 @@ describe('KA lifecycle CLI on devnet', () => {
       ),
       'ka create --share for VM update',
     );
+    await assertNoPublisherJobForKnowledgeAsset(node, {
+      contextGraphId,
+      name,
+    });
     await publishKnowledgeAssetAsyncAndWait(node, contextGraphId, name, 'ka publish-async initial VM update');
     await assertVerifiableSubject(node, contextGraphId, initial.subject, 'vm update initial');
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
@@ -568,13 +608,19 @@ describe('KA lifecycle CLI on devnet', () => {
       label: 'VM before edited publish',
     });
 
-    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'vm', initial.subject, update, 'VM update');
+    const publisherJobsBeforeReshare = await listPublisherJobs(node);
+    await reopenEditFinalizeAndShare(node, contextGraphId, name, 'vm', initial, update, 'VM update');
     await assertSubjectNotVisible(node, contextGraphId, update.subject, {
       view: 'verifiable-memory',
       label: 'VM before edited publish after re-share',
     });
+    await assertNoNewPublisherJobForKnowledgeAsset(node, {
+      contextGraphId,
+      name,
+    }, publisherJobsBeforeReshare);
 
     await publishKnowledgeAssetAsyncAndWait(node, contextGraphId, name, 'ka publish-async edited VM update');
+    await assertVerifiableSubject(node, contextGraphId, initial.subject, 'vm update initial');
     await assertVerifiableSubject(node, contextGraphId, update.subject, 'vm update edited');
   });
 


### PR DESCRIPTION
## Summary

- Aligns the stepwise KA lifecycle devnet scenario with the intended lifecycle model by removing the redundant pre-pull `ka discard` after SWM share.
- Adds explicit SWM-only update coverage: reopen from SWM, write an additional fact in WM, finalize, re-share, and verify the edit lands in SWM without VM publishing.
- Adds explicit VM-published update coverage: publish a KA to VM, reopen from VM, write an additional fact, finalize, re-share, publish again via async VM publish, and verify the edit lands in VM.

## Related

- Related to #1424
- Follow-up issue for discard semantics: #1425
- Follow-up issue for documenting lifecycle update flows: #1426

## Files changed

| File | What |
|------|------|
| `devnet/ka-lifecycle-cli/automated.test.ts` | Aligns the SWM pull/discard scenario and adds CLI devnet coverage for SWM-only and VM-published KA update flows. |

## Test plan

- [x] `pnpm exec tsx -e "void import('./devnet/ka-lifecycle-cli/vitest.config.ts').then(() => console.log('ka lifecycle config import ok'))"`
- [x] `git diff --check` ? passed with the existing Windows LF/CRLF warning only.
- [x] `pnpm exec vitest run --config devnet/ka-lifecycle-cli/vitest.config.ts --reporter dot` ? suite discovered successfully and stopped at the expected no-devnet guard: `No devnet detected - run DEVNET_ENABLE_PUBLISHER=1 ./scripts/devnet.sh start 6 and pnpm run build before this suite.` Six tests are now discovered.
- [ ] Run the full live devnet KA lifecycle suite with a 6-node devnet.
